### PR TITLE
feat(anolisa): consume unified raw/RPM contract

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -605,6 +605,7 @@ fn handle_status(ctx: &CliContext, component: Option<&str>) -> Result<(), CliErr
 fn map_err(command: &str, err: AdapterError) -> CliError {
     match err {
         AdapterError::UnknownPlaceholder { .. }
+        | AdapterError::RelativeTemplateExpansion { .. }
         | AdapterError::UnknownFramework { .. }
         | AdapterError::AmbiguousFramework { .. }
         | AdapterError::UnsupportedAdapterType { .. }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -1628,6 +1628,7 @@ mod tests {
                 dest: binary.clone(),
                 mode: Some("0755".to_string()),
                 kind: FileKind::Executable,
+                render: None,
             }],
             &capabilities,
         );

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 
 use anolisa_core::download::{DownloadCache, DownloadError};
 use anolisa_core::install_runner::{
-    ResolvedInstallFile, SUPPORTED_ARTIFACT_TYPES, read_embedded_component_manifest_text,
+    RenderMode, RenderSpec, ResolvedInstallFile, SUPPORTED_ARTIFACT_TYPES,
+    read_embedded_component_manifest_text,
 };
 use anolisa_core::path_safety::validate_owned_path;
 use anolisa_core::{
@@ -19,7 +20,7 @@ use sha2::{Digest, Sha256};
 
 use crate::context::CliContext;
 use crate::repo_config::{
-    HostVars, RepoConfig, raw_artifact_url, raw_index_url, raw_relative_root,
+    HostVars, RepoConfig, raw_artifact_url, raw_index_url, raw_index_v2_url, raw_relative_root,
 };
 use crate::response::CliError;
 
@@ -52,6 +53,41 @@ pub(super) fn index_fetch_error(index_url: &str, err: DownloadError) -> CliError
     }
 }
 
+/// Whether a fetch failure means "this index file is not published", as
+/// opposed to a transport or repository fault. Only the former may fall
+/// back from `index-v2.toml` to `index.toml`: falling back on transient
+/// errors could silently downgrade a gen-2 repository to its gen-1 view.
+fn index_not_published(err: &DownloadError) -> bool {
+    match err {
+        DownloadError::HttpStatus { status, .. } => *status == 404 || *status == 410,
+        // file:// repositories surface a missing index as I/O NotFound.
+        DownloadError::Io { source, .. } => source.kind() == std::io::ErrorKind::NotFound,
+        _ => false,
+    }
+}
+
+/// Fetch the raw index, preferring the complete generation-2 file and
+/// falling back to `index.toml` only when the repository has not published
+/// one (split-index bootstrap; see `raw_index_v2_url`). Returns the URL the
+/// index was actually served from, for error attribution downstream.
+fn fetch_raw_index(
+    cache: &DownloadCache,
+    base_url: &str,
+) -> Result<(String, std::path::PathBuf), CliError> {
+    let v2_url = raw_index_v2_url(base_url);
+    match cache.fetch(&v2_url, None) {
+        Ok(downloaded) => Ok((v2_url, downloaded.cached_path)),
+        Err(err) if index_not_published(&err) => {
+            let v1_url = raw_index_url(base_url);
+            let downloaded = cache
+                .fetch(&v1_url, None)
+                .map_err(|err| index_fetch_error(&v1_url, err))?;
+            Ok((v1_url, downloaded.cached_path))
+        }
+        Err(err) => Err(index_fetch_error(&v2_url, err)),
+    }
+}
+
 pub(crate) fn resolve_raw(
     ctx: &CliContext,
     layout: &FsLayout,
@@ -64,25 +100,24 @@ pub(crate) fn resolve_raw(
         backend,
         base_url,
         version,
-        warnings,
+        mut warnings,
     } = inputs;
 
     // The index is always re-fetched (DownloadCache overwrites on conflict),
     // so a republished repo is picked up without a cache flush.
-    let index_url = raw_index_url(&base_url);
     let cache = DownloadCache::new(layout.cache_dir.clone());
-    let downloaded_index = cache
-        .fetch(&index_url, None)
-        .map_err(|err| index_fetch_error(&index_url, err))?;
+    let (index_url, cached_index_path) = fetch_raw_index(&cache, &base_url)?;
+    // Entry-tolerant parse: a row shaped for a future CLI fails closed for
+    // its own component (skipped, surfaced as a warning) instead of taking
+    // the whole shared index — and every unrelated component — down with it.
     // The unfiltered index is kept for error attribution: a pinned version
     // that only ships non-installable artifact types must be reported as
     // "published but not installable", not as unpublished.
-    let full_index = DistributionIndex::load(&downloaded_index.cached_path).map_err(|err| {
-        CliError::Runtime {
+    let (full_index, skipped_entries) = DistributionIndex::load_lenient(&cached_index_path)
+        .map_err(|err| CliError::Runtime {
             command: COMMAND.to_string(),
             reason: format!("failed to parse distribution index {index_url}: {err}"),
-        }
-    })?;
+        })?;
     let index = installable_raw_index(full_index.clone());
 
     // The index is keyed by the backend-native package name so that
@@ -98,6 +133,25 @@ pub(crate) fn resolve_raw(
         pkg_base: env.pkg_base.as_deref(),
         preferred_types: &[],
     };
+    // A skipped row that may answer this query forces a refusal *before*
+    // resolution: picking the best of the remaining rows could silently
+    // substitute an older parsable version for the one this build cannot
+    // read (and `update` could even downgrade). Rows for other components,
+    // targets, or non-matching pinned versions stay mere warnings.
+    if let Some(blocking) = skipped_entries.iter().find(|s| s.may_match(&query)) {
+        return Err(CliError::Runtime {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "distribution index {index_url} contains an entry for '{package}' this CLI cannot parse ({}); refusing to resolve '{package}' against the remaining entries to avoid a silent downgrade — run 'anolisa self-update' and retry",
+                blocking.reason
+            ),
+        });
+    }
+    warnings.extend(
+        skipped_entries
+            .into_iter()
+            .map(|s| format!("distribution index {index_url}: {}", s.reason)),
+    );
     let entry = index.resolve(&query).map_err(|err| {
         // A pinned version the installable index cannot satisfy gets a
         // dedicated refusal, symmetric with the rpm backend's version-pin
@@ -552,6 +606,60 @@ fn validate_manifest_contract_header(
             ),
         });
     }
+
+    validate_min_anolisa_version(manifest, &resolution.component, source)?;
+    Ok(())
+}
+
+/// Enforce the `[component.contract].min_anolisa_version` gate: refuse the
+/// contract when this CLI is older than the version it requires.
+///
+/// A contract may depend on install behavior (content rendering,
+/// backend-aware adapter roots, …) that an older CLI silently lacks —
+/// tolerant parsing would drop the unknown fields and install a broken
+/// result. Fail-closed: a `min_anolisa_version` that is not valid SemVer is
+/// rejected too, with no `--force` escape hatch.
+fn validate_min_anolisa_version(
+    manifest: &ComponentManifest,
+    component: &str,
+    source: InstallContractSource,
+) -> Result<(), CliError> {
+    validate_min_anolisa_version_against(manifest, component, source, env!("CARGO_PKG_VERSION"))
+}
+
+/// [`validate_min_anolisa_version`] with the CLI version injected, so tests
+/// can pin release-boundary scenarios (e.g. a released binary that predates
+/// a capability meeting the first contract that requires it) without
+/// depending on the workspace version at build time.
+fn validate_min_anolisa_version_against(
+    manifest: &ComponentManifest,
+    component: &str,
+    source: InstallContractSource,
+    current: &str,
+) -> Result<(), CliError> {
+    let Some(required) = manifest.contract.min_anolisa_version.as_deref() else {
+        return Ok(());
+    };
+    let required_version =
+        semver::Version::parse(required).map_err(|err| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "{} for component '{component}' declares min_anolisa_version '{required}', which is not a valid SemVer version: {err}",
+                source.label(),
+            ),
+        })?;
+    let current_version = semver::Version::parse(current).map_err(|err| CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!("cannot parse this CLI's own version '{current}': {err}"),
+    })?;
+    if current_version < required_version {
+        return Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "component '{component}' requires anolisa >= {required}, but this CLI is {current}; run 'anolisa self-update' and retry",
+            ),
+        });
+    }
     Ok(())
 }
 
@@ -684,14 +792,74 @@ fn resolve_manifest_files(
             }
             _ => spec.source.clone(),
         };
+        let render = resolve_render_spec(spec, component)?;
         files.push(ResolvedInstallFile {
             source,
             dest,
             mode: spec.mode.clone(),
             kind: spec.kind,
+            render,
         });
     }
     Ok(files)
+}
+
+/// Map a layout entry's `render` string onto a runner [`RenderSpec`].
+///
+/// Fail-closed on values this CLI does not implement: tolerant manifest
+/// parsing keeps read-only commands working, but installing without the
+/// requested rendering would place literal `{bindir}`-style placeholders
+/// (e.g. an unstartable systemd unit). Rendering targets a single regular
+/// file — a directory source or symlink entry with `render` is a contract
+/// defect and is rejected here with the same rationale.
+///
+/// This is the early, user-facing gate: it fires at contract-resolution
+/// time with `InvalidArgument` and full layout-entry context. The runner
+/// re-checks the same invariant defensively for callers that build
+/// [`ResolvedInstallFile`] directly (see `InstallRunner` symlink/directory
+/// validation); keep the two in sync when the rule changes.
+fn resolve_render_spec(
+    spec: &anolisa_core::manifest::InstallFileSpec,
+    component: &str,
+) -> Result<Option<RenderSpec>, CliError> {
+    let Some(raw) = spec.render.as_deref() else {
+        return Ok(None);
+    };
+    // Present-but-blank is a contract defect, not an undeclared render:
+    // treating it as `None` would copy the template verbatim and land
+    // literal placeholders — the exact failure `render` exists to prevent.
+    let render = raw.trim();
+    if render.is_empty() {
+        return Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "component '{component}' layout entry '{}' declares an empty render value; declare a supported mode (e.g. '{}') or remove the key",
+                spec.display(),
+                anolisa_core::manifest::RENDER_ANOLISA_PATHS_V1,
+            ),
+        });
+    }
+    let mode = RenderMode::parse(render).ok_or_else(|| CliError::InvalidArgument {
+        command: COMMAND.to_string(),
+        reason: format!(
+            "component '{component}' layout entry '{}' requests render '{render}', which this CLI does not support (supported: '{}'); run 'anolisa self-update' and retry",
+            spec.display(),
+            anolisa_core::manifest::RENDER_ANOLISA_PATHS_V1,
+        ),
+    })?;
+    if spec.kind == FileKind::Symlink || spec.source.as_deref().is_some_and(|s| s.ends_with('/')) {
+        return Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: format!(
+                "component '{component}' layout entry '{}' requests render '{render}', but render applies to single regular files — not directory sources or symlinks",
+                spec.display(),
+            ),
+        });
+    }
+    Ok(Some(RenderSpec {
+        mode,
+        component: component.to_string(),
+    }))
 }
 
 /// Render the manifest's `[[adapters]]` entries into install file mappings.
@@ -772,6 +940,7 @@ pub(crate) fn resolve_adapter_files(
             // bundle are not expressible in `[[adapters]]` in the MVP.
             mode: Some("0644".to_string()),
             kind: FileKind::Data,
+            render: None,
         });
     }
     Ok(files)
@@ -873,6 +1042,82 @@ mod tests {
     use anolisa_core::ComponentManifest;
     use anolisa_platform::fs_layout::FsLayout;
     use tempfile::tempdir;
+
+    /// Split-index bootstrap: a repository that publishes the complete
+    /// generation-2 index must be served from it, so gated entries are
+    /// visible to this CLI while pre-gate CLIs keep reading `index.toml`.
+    #[test]
+    fn fetch_raw_index_prefers_v2_when_published() {
+        let repo = tempdir().unwrap();
+        let root = repo.path().join("v1");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("index.toml"), "schema_version = 1\n").unwrap();
+        std::fs::write(root.join("index-v2.toml"), "schema_version = 2\n").unwrap();
+        let cache = tempdir().unwrap();
+        let dl = DownloadCache::new(cache.path().to_path_buf());
+        let (url, path) = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap();
+        assert!(url.ends_with("/index-v2.toml"), "got {url}");
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("schema_version = 2"));
+    }
+
+    /// A gen-1 repository (no `index-v2.toml`) keeps working unchanged.
+    #[test]
+    fn fetch_raw_index_falls_back_to_v1_when_v2_missing() {
+        let repo = tempdir().unwrap();
+        let root = repo.path().join("v1");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("index.toml"), "schema_version = 1\n").unwrap();
+        let cache = tempdir().unwrap();
+        let dl = DownloadCache::new(cache.path().to_path_buf());
+        let (url, path) = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap();
+        assert!(url.ends_with("/index.toml"), "got {url}");
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("schema_version = 1"));
+    }
+
+    /// With neither file published the error must attribute the miss to
+    /// `index.toml` (the canonical location), not to the optional v2 file.
+    #[test]
+    fn fetch_raw_index_reports_missing_repo_against_v1() {
+        let repo = tempdir().unwrap();
+        let root = repo.path().join("v1");
+        std::fs::create_dir_all(&root).unwrap();
+        let cache = tempdir().unwrap();
+        let dl = DownloadCache::new(cache.path().to_path_buf());
+        let err = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap_err();
+        let CliError::Runtime { reason, .. } = err else {
+            panic!("expected runtime error");
+        };
+        assert!(
+            reason.contains("local raw repository index not found"),
+            "got: {reason}"
+        );
+        assert!(reason.contains("index.toml"), "got: {reason}");
+        assert!(!reason.contains("index-v2.toml"), "got: {reason}");
+    }
+
+    /// Fallback is reserved for "not published"; transport faults on the v2
+    /// fetch must not silently downgrade a gen-2 repository to its v1 view.
+    #[test]
+    fn index_not_published_distinguishes_absence_from_faults() {
+        let http = |status| DownloadError::HttpStatus {
+            url: "https://example.invalid/index-v2.toml".to_string(),
+            status,
+        };
+        assert!(index_not_published(&http(404)));
+        assert!(index_not_published(&http(410)));
+        assert!(!index_not_published(&http(500)));
+        assert!(!index_not_published(&http(403)));
+        assert!(index_not_published(&DownloadError::Io {
+            path: std::path::PathBuf::from("/repo/v1/index-v2.toml"),
+            source: std::io::Error::from(std::io::ErrorKind::NotFound),
+        }));
+        assert!(!index_not_published(&DownloadError::Network {
+            url: "https://example.invalid/index-v2.toml".to_string(),
+            reason: "timed out".to_string(),
+        }));
+    }
 
     #[test]
     fn resolve_adapter_files_lays_bundle_under_datadir() {
@@ -1098,5 +1343,243 @@ mod tests {
         let manifest = ComponentManifest::from_toml_str(&toml).expect("parse manifest");
         let err = resolve_install_hooks(&manifest, &layout, "demo").expect_err("must error");
         assert!(matches!(err, CliError::Runtime { .. }));
+    }
+
+    // -- render mapping ------------------------------------------------------
+
+    fn render_manifest(entry: &str) -> ComponentManifest {
+        let toml = format!(
+            r#"
+            [component]
+            name = "sec-core"
+            version = "0.9.0"
+            [component.layout]
+            modes = ["system"]
+            {entry}
+        "#
+        );
+        ComponentManifest::from_toml_str(&toml).expect("parse manifest")
+    }
+
+    #[test]
+    fn resolve_manifest_files_maps_render_v1() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let manifest = render_manifest(
+            r#"
+            [[component.layout.files]]
+            source = "share/agent-sec-core.service.in"
+            target = "{userunitdir}/agent-sec-core.service"
+            render = "anolisa-paths-v1"
+        "#,
+        );
+        let files = resolve_manifest_files(&manifest, &layout, "sec-core").expect("resolve");
+        assert_eq!(
+            files[0].render,
+            Some(RenderSpec {
+                mode: RenderMode::AnolisaPathsV1,
+                component: "sec-core".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_manifest_files_rejects_unknown_render() {
+        // A render value this CLI does not implement must fail closed —
+        // copying the template verbatim would install an unstartable unit.
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let manifest = render_manifest(
+            r#"
+            [[component.layout.files]]
+            source = "share/unit.in"
+            target = "{datadir}/unit"
+            render = "anolisa-paths-v2"
+        "#,
+        );
+        let err = resolve_manifest_files(&manifest, &layout, "sec-core")
+            .expect_err("unknown render must be rejected");
+        match err {
+            CliError::InvalidArgument { reason, .. } => {
+                assert!(reason.contains("anolisa-paths-v2"), "got: {reason}");
+                assert!(reason.contains("self-update"), "got: {reason}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_manifest_files_rejects_render_on_directory_source() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let manifest = render_manifest(
+            r#"
+            [[component.layout.files]]
+            source = "share/tree/"
+            target = "{datadir}/tree/"
+            render = "anolisa-paths-v1"
+        "#,
+        );
+        let err = resolve_manifest_files(&manifest, &layout, "sec-core")
+            .expect_err("render on a directory source must be rejected");
+        assert!(
+            matches!(err, CliError::InvalidArgument { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_manifest_files_rejects_render_on_symlink() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let manifest = render_manifest(
+            r#"
+            [[component.layout.files]]
+            source = "{bindir}/real"
+            target = "{bindir}/link"
+            type = "symlink"
+            render = "anolisa-paths-v1"
+        "#,
+        );
+        let err = resolve_manifest_files(&manifest, &layout, "sec-core")
+            .expect_err("render on a symlink must be rejected");
+        assert!(
+            matches!(err, CliError::InvalidArgument { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_manifest_files_rejects_blank_render() {
+        // Present-but-blank must be rejected, not silently treated as
+        // undeclared — that would copy the template verbatim.
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        for value in ["", "   "] {
+            let manifest = render_manifest(&format!(
+                r#"
+            [[component.layout.files]]
+            source = "share/unit.in"
+            target = "{{datadir}}/unit"
+            render = "{value}"
+        "#
+            ));
+            let err = resolve_manifest_files(&manifest, &layout, "sec-core")
+                .expect_err("blank render must be rejected");
+            match err {
+                CliError::InvalidArgument { reason, .. } => {
+                    assert!(reason.contains("empty render"), "got: {reason}");
+                }
+                other => panic!("expected InvalidArgument, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_manifest_files_without_render_stays_none() {
+        let prefix = tempdir().unwrap();
+        let layout = FsLayout::system(Some(prefix.path().to_path_buf()));
+        let manifest = render_manifest(
+            r#"
+            [[component.layout.files]]
+            source = "bin/agent-sec-cli"
+            target = "{bindir}/agent-sec-cli"
+            type = "executable"
+        "#,
+        );
+        let files = resolve_manifest_files(&manifest, &layout, "sec-core").expect("resolve");
+        assert_eq!(files[0].render, None);
+    }
+
+    // -- min_anolisa_version gate --------------------------------------------
+
+    fn contract_manifest(min_version: Option<&str>) -> ComponentManifest {
+        let contract = match min_version {
+            Some(v) => format!("[component.contract]\nmin_anolisa_version = \"{v}\"\n"),
+            None => String::new(),
+        };
+        let toml = format!(
+            r#"
+            [component]
+            name = "sec-core"
+            version = "0.9.0"
+            {contract}
+        "#
+        );
+        ComponentManifest::from_toml_str(&toml).expect("parse manifest")
+    }
+
+    #[test]
+    fn min_anolisa_version_gate_accepts_absent_older_and_equal() {
+        let source = InstallContractSource::EmbeddedArtifact;
+        validate_min_anolisa_version(&contract_manifest(None), "sec-core", source)
+            .expect("absent field must pass");
+        validate_min_anolisa_version(&contract_manifest(Some("0.1.0")), "sec-core", source)
+            .expect("older requirement must pass");
+        let current = env!("CARGO_PKG_VERSION");
+        validate_min_anolisa_version(&contract_manifest(Some(current)), "sec-core", source)
+            .expect("equal requirement must pass");
+    }
+
+    #[test]
+    fn min_anolisa_version_gate_rejects_newer_requirement() {
+        let err = validate_min_anolisa_version(
+            &contract_manifest(Some("99.0.0")),
+            "sec-core",
+            InstallContractSource::EmbeddedArtifact,
+        )
+        .expect_err("a newer requirement must be rejected");
+        match err {
+            CliError::InvalidArgument { reason, .. } => {
+                assert!(reason.contains("99.0.0"), "got: {reason}");
+                assert!(
+                    reason.contains(env!("CARGO_PKG_VERSION")),
+                    "must name the current version: {reason}"
+                );
+                assert!(reason.contains("self-update"), "got: {reason}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn min_anolisa_version_gate_rejects_invalid_semver() {
+        // Fail-closed: a malformed requirement means the contract's intent
+        // is unknown; installing anyway could bypass the gate it wanted.
+        let err = validate_min_anolisa_version(
+            &contract_manifest(Some("not-a-version")),
+            "sec-core",
+            InstallContractSource::SidecarMeta,
+        )
+        .expect_err("invalid SemVer must be rejected");
+        match err {
+            CliError::InvalidArgument { reason, .. } => {
+                assert!(reason.contains("not-a-version"), "got: {reason}");
+                assert!(reason.contains("SemVer"), "got: {reason}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn min_anolisa_version_gate_protects_first_release_boundary() {
+        // Regression for the first contract that depends on unified-contract
+        // consumption (sec-core): the capability ships in 0.2.17, one
+        // release after 0.2.16 which predates rendering and this gate. A
+        // contract declaring 0.2.17 must be refused by a 0.2.16 CLI and
+        // accepted from 0.2.17 on — pinned with injected versions so the
+        // workspace version bump cannot silently invalidate the scenario.
+        let manifest = contract_manifest(Some("0.2.17"));
+        let source = InstallContractSource::EmbeddedArtifact;
+        let err = validate_min_anolisa_version_against(&manifest, "sec-core", source, "0.2.16")
+            .expect_err("a 0.2.16 CLI must refuse a contract requiring 0.2.17");
+        assert!(
+            matches!(err, CliError::InvalidArgument { .. }),
+            "got {err:?}"
+        );
+        validate_min_anolisa_version_against(&manifest, "sec-core", source, "0.2.17")
+            .expect("the release shipping the capability must pass");
+        validate_min_anolisa_version_against(&manifest, "sec-core", source, "0.3.0")
+            .expect("later releases must keep passing");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -1657,3 +1657,212 @@ fn install_no_conflict_when_conflicting_component_not_installed() {
     assert_eq!(installation.status, LifecycleStatus::Installed);
     assert_eq!(owned_artifact(installation).version, "0.11.0");
 }
+
+/// A future-shaped row for the *queried* component must refuse resolution
+/// instead of silently answering with an older parsable version: with
+/// 1.0.0 parsable and 2.0.0 unparsable, "latest" would otherwise select
+/// 1.0.0 — a silent downgrade for update, a stale install for install.
+#[test]
+fn skipped_newer_entry_refuses_latest_instead_of_downgrading() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "sec-core",
+        &["1.0.0"],
+        &["system"],
+    );
+    // Publish 2.0.0 with an entry shape this build cannot represent.
+    let env = anolisa_env::EnvService::detect();
+    let index_path = tmp.path().join("repo/v1/index.toml");
+    let mut index = std::fs::read_to_string(&index_path).expect("read index");
+    index.push_str(&format!(
+        r#"
+[[entries]]
+component = "sec-core"
+version = "2.0.0"
+channel = "stable"
+artifact_type = "hologram_v9"
+backend = "raw"
+url = "sec-core-2.0.0.tar.gz"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["system"]
+"#,
+        os = env.os,
+        arch = env.arch,
+    ));
+    std::fs::write(&index_path, index).expect("write index");
+
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let inputs = |version: Option<&'static str>| ResolveInputs {
+        component: "sec-core".to_string(),
+        package: "sec-core".to_string(),
+        backend: "raw".to_string(),
+        base_url: repo_url.clone(),
+        version,
+        warnings: Vec::new(),
+    };
+
+    // Latest: refuse — the unreadable 2.0.0 may be the answer.
+    let err = match resolve_raw(&ctx, &layout, &env, inputs(None)) {
+        Ok(_) => panic!("latest must refuse, not fall back to 1.0.0"),
+        Err(err) => err,
+    };
+    assert!(
+        err.reason().contains("cannot parse") && err.reason().contains("self-update"),
+        "refusal must explain the unparsable entry and hint self-update, got: {}",
+        err.reason()
+    );
+    assert!(
+        !err.reason().contains("not found"),
+        "must be a refusal, not a not-found, got: {}",
+        err.reason()
+    );
+
+    // Pinned 2.0.0: equally refused (that exact row is unreadable).
+    let err = match resolve_raw(&ctx, &layout, &env, inputs(Some("2.0.0"))) {
+        Ok(_) => panic!("pinned 2.0.0 must refuse"),
+        Err(err) => err,
+    };
+    assert!(
+        err.reason().contains("cannot parse"),
+        "got: {}",
+        err.reason()
+    );
+
+    // Pinned 1.0.0: an explicit choice of the parsable version resolves,
+    // and the skipped row stays visible as a warning.
+    let resolution =
+        resolve_raw(&ctx, &layout, &env, inputs(Some("1.0.0"))).expect("pinned 1.0.0 resolves");
+    assert_eq!(resolution.entry.version, "1.0.0");
+    assert!(
+        resolution
+            .warnings
+            .iter()
+            .any(|w| w.contains("skipped index entry")),
+        "skipped row must surface as a warning, got: {:?}",
+        resolution.warnings
+    );
+}
+
+/// A future-shaped row for an unrelated component neither blocks nor
+/// degrades resolution of the queried one; it only surfaces as a warning.
+#[test]
+fn skipped_unrelated_entry_keeps_component_resolvable() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "cosh",
+        &["1.2.3"],
+        &["system"],
+    );
+    let env = anolisa_env::EnvService::detect();
+    let index_path = tmp.path().join("repo/v1/index.toml");
+    let mut index = std::fs::read_to_string(&index_path).expect("read index");
+    index.push_str(&format!(
+        r#"
+[[entries]]
+component = "future-thing"
+version = "0.1.0"
+channel = "stable"
+artifact_type = "hologram_v9"
+backend = "raw"
+url = "future-thing-0.1.0.tar.gz"
+os = "{os}"
+arch = "{arch}"
+install_modes = ["system"]
+"#,
+        os = env.os,
+        arch = env.arch,
+    ));
+    std::fs::write(&index_path, index).expect("write index");
+
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "cosh".to_string(),
+            package: "cosh".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            version: None,
+            warnings: Vec::new(),
+        },
+    )
+    .expect("unrelated skipped row must not block");
+    assert_eq!(resolution.entry.version, "1.2.3");
+    assert!(
+        resolution
+            .warnings
+            .iter()
+            .any(|w| w.contains("future-thing")),
+        "skipped row must surface as a warning, got: {:?}",
+        resolution.warnings
+    );
+}
+
+/// A skipped row whose selectors are damaged (valid TOML, wrong shape —
+/// here `install_modes = [1]`) must still block "latest" for its
+/// component: partial recovery of the selector would under-block and
+/// reopen the silent downgrade this gate exists to prevent.
+#[test]
+fn skipped_row_with_malformed_selector_still_blocks_latest() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_local_repo_component_versions(
+        &tmp.path().join("repo"),
+        "sec-core",
+        &["1.0.0"],
+        &["system"],
+    );
+    let env = anolisa_env::EnvService::detect();
+    let index_path = tmp.path().join("repo/v1/index.toml");
+    let mut index = std::fs::read_to_string(&index_path).expect("read index");
+    index.push_str(&format!(
+        r#"
+[[entries]]
+component = "sec-core"
+version = "2.0.0"
+channel = "stable"
+artifact_type = "hologram_v9"
+backend = "raw"
+url = "sec-core-2.0.0.tar.gz"
+os = "{os}"
+arch = "{arch}"
+install_modes = [1]
+"#,
+        os = env.os,
+        arch = env.arch,
+    ));
+    std::fs::write(&index_path, index).expect("write index");
+
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let err = match resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "sec-core".to_string(),
+            package: "sec-core".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            version: None,
+            warnings: Vec::new(),
+        },
+    ) {
+        Ok(_) => panic!("malformed selector must not unblock a silent downgrade to 1.0.0"),
+        Err(err) => err,
+    };
+    assert!(
+        err.reason().contains("cannot parse") && err.reason().contains("self-update"),
+        "got: {}",
+        err.reason()
+    );
+}

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -674,6 +674,22 @@ pub fn raw_index_url(base_url: &str) -> String {
     format!("{}/index.toml", raw_root(base_url))
 }
 
+/// Generation-2 index location under the same raw distribution root.
+///
+/// `index-v2.toml` is a complete index (not a delta): clients that
+/// understand it read only this file, falling back to `index.toml` when the
+/// repository has not published one. Split-index bootstrap: entries whose
+/// embedded contract depends on ≥ 0.2.17 semantics (`render`,
+/// `min_anolisa_version` enforcement, backend adapter roots) are published
+/// only here, so released pre-0.2.17 CLIs — which parse the shared index
+/// atomically and would fail it wholesale on any entry shape they cannot
+/// represent — never observe them: they keep installing unrelated
+/// components from `index.toml` and resolve gated components as not-found
+/// (fail closed).
+pub fn raw_index_v2_url(base_url: &str) -> String {
+    format!("{}/index-v2.toml", raw_root(base_url))
+}
+
 /// Component identity index location under the raw repository root.
 ///
 /// `components.toml` is separate from raw `index.toml`: the former resolves a

--- a/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
@@ -148,7 +148,9 @@ impl ScopeFixture {
             SystemStateFailure::FutureSchema => {
                 let state =
                     std::fs::read_to_string(&self.system_state_path).expect("read system state");
-                let future = state.replacen("schema_version = 4", "schema_version = 6", 1);
+                // 7 is one past the newest schema this CLI accepts (v6,
+                // the anchored store format).
+                let future = state.replacen("schema_version = 4", "schema_version = 7", 1);
                 assert_ne!(future, state, "fixture must start at schema 4");
                 std::fs::write(&self.system_state_path, future).expect("future system state");
             }

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -50,6 +50,23 @@ pub enum AdapterError {
         template: String,
     },
 
+    /// A contract path template expanded to a relative path. Resolving it
+    /// would depend on the process working directory — whoever controls
+    /// the CWD would control which bundle is read — so the expansion is
+    /// rejected before any filesystem probe. Layout placeholders always
+    /// expand to absolute directories; a relative result means the
+    /// template was a bare relative path.
+    #[error(
+        "template \"{template}\" expands to the relative path \"{}\"; contract paths must be absolute or start with a layout placeholder",
+        .path.display()
+    )]
+    RelativeTemplateExpansion {
+        /// The template as declared in the contract.
+        template: String,
+        /// The relative expansion result.
+        path: PathBuf,
+    },
+
     /// No driver is registered for the requested framework.
     #[error("no built-in driver for framework '{framework}'")]
     UnknownFramework {
@@ -428,6 +445,19 @@ pub fn expand_layout_placeholders(
     layout: &FsLayout,
     extra_vars: &[(&str, &str)],
 ) -> Result<PathBuf, AdapterError> {
+    expand_layout_placeholders_str(template, layout, extra_vars).map(PathBuf::from)
+}
+
+/// String-level core of [`expand_layout_placeholders`].
+///
+/// Shared by path expansion (which wraps the result in a [`PathBuf`]) and
+/// file *content* rendering (`render = "anolisa-paths-v1"` layout entries),
+/// so both consume the identical placeholder vocabulary and cannot drift.
+pub fn expand_layout_placeholders_str(
+    template: &str,
+    layout: &FsLayout,
+    extra_vars: &[(&str, &str)],
+) -> Result<String, AdapterError> {
     let mut replacements: BTreeMap<&str, &Path> = BTreeMap::new();
 
     replacements.insert("bindir", &layout.bin_dir);
@@ -479,7 +509,7 @@ pub fn expand_layout_placeholders(
         }
     }
 
-    Ok(PathBuf::from(result))
+    Ok(result)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -179,6 +179,37 @@ impl AdapterClaim {
         allowed_external_roots: &[PathBuf],
         extra_owned_roots: &[PathBuf],
     ) -> Result<(), ClaimValidationError> {
+        self.validate_with_trust(layout, allowed_external_roots, extra_owned_roots, &[])
+    }
+
+    /// Like [`Self::validate_with_owned_roots`], with one more allowance:
+    /// a symlink target that is byte-for-byte **equal** to an entry of
+    /// `exact_symlink_targets` validates even though it is under none of
+    /// the owned roots.
+    ///
+    /// This carries the enable-time anchor (see
+    /// `StateStore::find_adapter_trust_root`): after an RPM update moves a
+    /// contract's external resource root, the prior receipt's target is no
+    /// longer derivable from the current contract, yet status/disable must
+    /// still be able to report and clean it up, and re-enable must migrate
+    /// it. Exact equality is deliberate — an entry here authorizes one
+    /// path, never a subtree, so a forged anchor (e.g. `/etc`) cannot
+    /// widen validation to paths beneath it (e.g. `/etc/cron.d/evil`).
+    /// Relative entries never match: anchors are recorded absolute.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`ClaimValidationError`] encountered: an owned
+    /// path outside ANOLISA roots, an external path outside every
+    /// `allowed_external_roots` entry, a traversal/symlink escape, or an
+    /// invalid plugin id.
+    pub fn validate_with_trust(
+        &self,
+        layout: &FsLayout,
+        allowed_external_roots: &[PathBuf],
+        extra_owned_roots: &[PathBuf],
+        exact_symlink_targets: &[PathBuf],
+    ) -> Result<(), ClaimValidationError> {
         if let Some(pid) = &self.plugin_id {
             validate_plugin_id(pid)?;
         }
@@ -187,6 +218,7 @@ impl AdapterClaim {
                 layout,
                 allowed_external_roots,
                 extra_owned_roots,
+                exact_symlink_targets,
             )?;
             match &resource.kind {
                 ClaimResourceKind::FrameworkPlugin { framework, .. }
@@ -204,6 +236,32 @@ impl AdapterClaim {
             }
         }
         Ok(())
+    }
+
+    /// True when validating this receipt actually depends on external
+    /// symlink-target trust: some [`ClaimResourceKind::Symlink`] resource
+    /// has a *target* that does not validate as ANOLISA-owned (primary
+    /// layout roots plus `trusted_owned_roots`).
+    ///
+    /// This is the Manager's anchor-persistence criterion. A receipt whose
+    /// symlink targets all re-validate from the static boundary on every
+    /// run — or one with no symlink resources at all (every driver but
+    /// Codex today) — never reads an anchor back, so persisting one would
+    /// only bump the state schema for nothing. The check reuses the same
+    /// owned-target validation as [`ClaimResource::validate_with_owned_roots`],
+    /// so the persistence condition cannot drift from the consumption
+    /// condition.
+    pub fn requires_external_symlink_trust(
+        &self,
+        layout: &FsLayout,
+        trusted_owned_roots: &[PathBuf],
+    ) -> bool {
+        self.resources.iter().any(|res| match &res.kind {
+            ClaimResourceKind::Symlink { target, .. } => {
+                validate_owned_symlink_target(layout, target, trusted_owned_roots).is_err()
+            }
+            _ => false,
+        })
     }
 }
 
@@ -286,12 +344,13 @@ impl ClaimResource {
         layout: &FsLayout,
         allowed_external_roots: &[PathBuf],
     ) -> Result<(), ClaimValidationError> {
-        self.validate_with_owned_roots(layout, allowed_external_roots, &[])
+        self.validate_with_owned_roots(layout, allowed_external_roots, &[], &[])
     }
 
     /// Like [`Self::validate`], but trusts `extra_owned_roots` as additional
-    /// ANOLISA-owned locations for a symlink *target*. See
-    /// [`AdapterClaim::validate_with_owned_roots`] for the trust contract.
+    /// ANOLISA-owned locations for a symlink *target*, and
+    /// `exact_symlink_targets` as byte-for-byte target allowances. See
+    /// [`AdapterClaim::validate_with_trust`] for the trust contract.
     ///
     /// # Errors
     ///
@@ -301,6 +360,7 @@ impl ClaimResource {
         layout: &FsLayout,
         allowed_external_roots: &[PathBuf],
         extra_owned_roots: &[PathBuf],
+        exact_symlink_targets: &[PathBuf],
     ) -> Result<(), ClaimValidationError> {
         match &self.kind {
             ClaimResourceKind::OwnedPath { path } => {
@@ -339,6 +399,16 @@ impl ClaimResource {
                         source,
                     },
                 )?;
+                // Anchor allowance: equality only, absolute only — an
+                // anchored path never authorizes anything beneath it. See
+                // [`AdapterClaim::validate_with_trust`].
+                if target.is_absolute()
+                    && exact_symlink_targets
+                        .iter()
+                        .any(|allowed| allowed == target)
+                {
+                    return Ok(());
+                }
                 validate_owned_symlink_target(layout, target, extra_owned_roots).map_err(|source| {
                     ClaimValidationError::OwnedPath {
                         id: self.id.clone(),
@@ -1697,6 +1767,34 @@ mod tests {
             matches!(err, ClaimValidationError::OwnedPath { .. }),
             "got {err:?}"
         );
+    }
+
+    /// The anchor-persistence criterion: only a symlink *target* outside
+    /// the static owned boundary requires external trust. Receipts whose
+    /// targets validate as owned — or without symlink resources at all
+    /// (every driver but Codex) — never do, so the Manager persists no
+    /// anchor for them.
+    #[test]
+    fn requires_external_symlink_trust_only_for_out_of_boundary_targets() {
+        let layout = FsLayout::system(None);
+        // The sample target lives under the primary layout's owned roots.
+        assert!(!sample_codex_claim().requires_external_symlink_trust(&layout, &[]));
+
+        let mut claim = sample_codex_claim();
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/opt/vendor/plugin");
+            }
+        }
+        assert!(claim.requires_external_symlink_trust(&layout, &[]));
+        // A Manager-trusted extra owned root covering the target lifts it.
+        assert!(!claim.requires_external_symlink_trust(&layout, &[PathBuf::from("/opt/vendor")]));
+
+        // No symlink resources left: external trust is never required.
+        claim
+            .resources
+            .retain(|r| !matches!(r.kind, ClaimResourceKind::Symlink { .. }));
+        assert!(!claim.requires_external_symlink_trust(&layout, &[]));
     }
 
     /// A forged receipt cannot self-authorize a symlink target by also

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -299,7 +299,9 @@ impl FrameworkDriver for CodexDriver {
             reason: Some(detect.reason.clone()),
             resource: None,
         });
-        conditions.push(bundle_match_condition(claim));
+        let bundle_condition = bundle_match_condition(claim);
+        let bundle_status = bundle_condition.status;
+        conditions.push(bundle_condition);
 
         // Symlink presence is a reliable filesystem check independent of
         // the CLI.
@@ -309,7 +311,8 @@ impl FrameworkDriver for CodexDriver {
         conditions.push(AdapterCondition {
             kind: AdapterConditionKind::SymlinkPresent,
             status: bool_status(symlink_ok),
-            reason: (!symlink_ok).then(|| "plugin symlink missing or retargeted".to_string()),
+            reason: (!symlink_ok)
+                .then(|| "plugin symlink missing, retargeted, or dangling".to_string()),
             resource: Some(ClaimResourceRef {
                 id: RES_SYMLINK.to_string(),
             }),
@@ -376,7 +379,14 @@ impl FrameworkDriver for CodexDriver {
             (ConditionStatus::Unknown, ConditionStatus::Unknown)
         };
 
-        let summary = summarize(claim.status, detect.detected, mkt_status, plugin_status);
+        let summary = summarize(
+            claim.status,
+            detect.detected,
+            bool_status(symlink_ok),
+            bundle_status,
+            mkt_status,
+            plugin_status,
+        );
         Ok(AdapterStatusReport {
             summary,
             conditions,
@@ -723,10 +733,13 @@ fn list_contains_token(stdout: &str, token: &str) -> bool {
         .any(|line| line.split_whitespace().any(|t| t == token))
 }
 
-/// True when `link` is a symlink resolving to `target`.
+/// True when `link` is a symlink resolving to `target` and the target
+/// still exists. A dangling link — exactly what an RPM update that moves
+/// the resource root leaves behind — must not count as present: codex
+/// cannot load plugin files through it.
 fn symlink_points_to(link: &Path, target: &Path) -> bool {
     std::fs::read_link(link)
-        .map(|dest| dest == target)
+        .map(|dest| dest == target && target.exists())
         .unwrap_or(false)
 }
 
@@ -763,11 +776,16 @@ fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
     }
 }
 
-/// Roll signals into a summary. Healthy requires the framework detected and
-/// both marketplace and plugin verified present.
+/// Roll signals into a summary. Healthy requires the framework detected,
+/// the plugin symlink functional, the resource bundle verified unchanged,
+/// and both marketplace and plugin verified present — a broken symlink or
+/// a drifted/vanished bundle means codex is not actually serving this
+/// plugin, so registration alone must not report Healthy.
 fn summarize(
     claim_status: ClaimStatus,
     detected: bool,
+    symlink: ConditionStatus,
+    bundle: ConditionStatus,
     marketplace: ConditionStatus,
     plugin: ConditionStatus,
 ) -> AdapterSummary {
@@ -777,11 +795,14 @@ fn summarize(
     if !detected {
         return AdapterSummary::Degraded;
     }
-    match (marketplace, plugin) {
-        (ConditionStatus::True, ConditionStatus::True) => AdapterSummary::Healthy,
-        (ConditionStatus::False, _) | (_, ConditionStatus::False) => AdapterSummary::Degraded,
-        _ => AdapterSummary::Unknown,
+    let signals = [symlink, bundle, marketplace, plugin];
+    if signals.contains(&ConditionStatus::False) {
+        return AdapterSummary::Degraded;
     }
+    if signals.contains(&ConditionStatus::Unknown) {
+        return AdapterSummary::Unknown;
+    }
+    AdapterSummary::Healthy
 }
 
 #[cfg(test)]
@@ -860,6 +881,46 @@ mod tests {
             "anolisa-tokenless"
         ));
         assert!(!list_contains_token("", "anolisa-tokenless"));
+    }
+
+    #[test]
+    fn summarize_folds_symlink_and_bundle_signals() {
+        use ConditionStatus::{False, True, Unknown};
+        let s = |symlink, bundle, mkt, plugin| {
+            summarize(ClaimStatus::Enabled, true, symlink, bundle, mkt, plugin)
+        };
+        // Registration alone must not report Healthy: a broken symlink or
+        // a drifted bundle degrades even with both registrations intact.
+        assert_eq!(s(False, Unknown, True, True), AdapterSummary::Degraded);
+        assert_eq!(s(True, False, True, True), AdapterSummary::Degraded);
+        // Undecidable drift is Unknown, not Healthy.
+        assert_eq!(s(True, Unknown, True, True), AdapterSummary::Unknown);
+        assert_eq!(s(True, True, True, True), AdapterSummary::Healthy);
+        // CleanupFailed and framework-missing keep their priority.
+        assert_eq!(
+            summarize(ClaimStatus::CleanupFailed, true, True, True, True, True),
+            AdapterSummary::CleanupFailed
+        );
+        assert_eq!(
+            summarize(ClaimStatus::Enabled, false, True, True, True, True),
+            AdapterSummary::Degraded
+        );
+    }
+
+    #[test]
+    fn dangling_symlink_does_not_count_as_present() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("bundle");
+        std::fs::create_dir(&target).expect("target");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        assert!(symlink_points_to(&link, &target));
+        // An RPM update that moves the root leaves exactly this behind.
+        std::fs::remove_dir(&target).expect("remove target");
+        assert!(
+            !symlink_points_to(&link, &target),
+            "dangling symlink must not count as present"
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -42,7 +42,7 @@ use super::driver::{
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
-use crate::domain::{Installation, LifecycleStatus};
+use crate::domain::{Installation, LifecycleStatus, NativePm, ProviderBinding};
 use crate::lock::InstallLock;
 use crate::manifest::ComponentManifest;
 use crate::state::ObjectKind;
@@ -200,6 +200,91 @@ pub struct StatusReport {
     pub entries: Vec<StatusEntry>,
 }
 
+/// Declaration state of `[adapters.backends.rpm].resource_root` for one
+/// framework entry — the single source of truth for the three-valued
+/// semantics (undeclared / declared-but-blank / usable). Every consumer
+/// matches on it, so absent and blank can never be conflated again (a
+/// blank root is a contract defect: enable rejects it and scan must not
+/// fall back to the raw `dest`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum RpmRootDecl {
+    /// Key not declared: RPM provenance falls back to the raw `dest`.
+    Absent,
+    /// Declared but blank after trimming — fail closed everywhere.
+    Blank,
+    /// Declared with a placeholder outside the RPM vocabulary
+    /// (`{datadir}`, `{component}`) — fail closed everywhere. Any other
+    /// layout placeholder (`{bindir}`, `{libexecdir}`, …) expands
+    /// against the *consuming* manager's layout: a user-mode manager
+    /// consuming a system RPM contract would resolve it under the user
+    /// prefix, misreporting the package payload as missing or — worse —
+    /// selecting a caller-writable bundle in place of the package-owned
+    /// one.
+    Unsupported {
+        /// The declared template (trimmed).
+        template: String,
+        /// The first offending placeholder (without braces).
+        placeholder: String,
+    },
+    /// Declared with a usable template (trimmed, non-empty).
+    Declared(String),
+}
+
+impl RpmRootDecl {
+    /// Classify a raw declaration value (as read from the manifest).
+    fn from_raw(raw: Option<&str>) -> Self {
+        match raw {
+            None => Self::Absent,
+            Some(value) => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    Self::Blank
+                } else if let Some(placeholder) = unsupported_rpm_placeholder(trimmed) {
+                    Self::Unsupported {
+                        template: trimmed.to_string(),
+                        placeholder,
+                    }
+                } else {
+                    Self::Declared(trimmed.to_string())
+                }
+            }
+        }
+    }
+
+    /// The usable template, when one is declared.
+    fn declared(&self) -> Option<&str> {
+        match self {
+            Self::Declared(root) => Some(root),
+            Self::Absent | Self::Blank | Self::Unsupported { .. } => None,
+        }
+    }
+}
+
+/// First `{placeholder}` in `template` outside the vocabulary allowed for
+/// `[adapters.backends.rpm].resource_root`. An RPM payload path is
+/// scope-independent by definition: absolute (the package-owned path) or
+/// `{datadir}`-rooted (expanded against the datadir roots of the scope
+/// that owns the contract, plus `{component}`). Every other layout
+/// placeholder expands against the consuming manager's layout — the
+/// wrong scope whenever the contract is consumed cross-scope. Token
+/// scanning mirrors [`expand_layout_placeholders`](super::expand_layout_placeholders)
+/// (unterminated braces are left for the expander to handle).
+fn unsupported_rpm_placeholder(template: &str) -> Option<String> {
+    let mut search_from = 0;
+    while let Some(rel_open) = template[search_from..].find('{') {
+        let open = search_from + rel_open;
+        let Some(rel_close) = template[open..].find('}') else {
+            break;
+        };
+        let key = &template[open + 1..open + rel_close];
+        if key != "datadir" && key != "component" {
+            return Some(key.to_string());
+        }
+        search_from = open + rel_close + 1;
+    }
+    None
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct AdapterDecl {
     component: String,
@@ -210,6 +295,14 @@ struct AdapterDecl {
     /// expansion. Used by `scan` and `enable` to resolve the
     /// contract-driven resource root.
     dest: Option<String>,
+    /// `[adapters.backends.rpm].resource_root` declaration state.
+    /// Authoritative over [`dest`](Self::dest) when the component has RPM
+    /// provenance — a unified contract keeps `dest` for raw installs
+    /// while the RPM payload lives at a package-owned path.
+    rpm_root: RpmRootDecl,
+    /// Whether the component's installed record is RPM-delegated in the
+    /// visible root that owns this declaration.
+    rpm_provenance: bool,
     /// Bundle entry filename declared in the contract, if any. Scan uses
     /// it (like enable) to tell a real bundle directory from a stale
     /// leftover skeleton.
@@ -218,6 +311,106 @@ struct AdapterDecl {
     /// component contract was resolved. `dest` expansion is scoped to
     /// only these roots.
     scoped_datadir_roots: Vec<PathBuf>,
+}
+
+impl AdapterDecl {
+    /// Contract resource-root template effective for this declaration's
+    /// install provenance: an RPM-installed component reads its bundle
+    /// from the declared RPM resource root, everything else from `dest`.
+    fn effective_root_template(&self) -> Option<&str> {
+        if self.rpm_provenance
+            && let Some(root) = self.rpm_root.declared()
+        {
+            return Some(root);
+        }
+        self.dest.as_deref()
+    }
+
+    /// The RPM backend root this provenance depends on is declared but
+    /// unusable — blank, or using a placeholder outside the RPM
+    /// vocabulary — the same contract defect enable rejects. Scan must
+    /// report the resource as unavailable rather than fall back to
+    /// `dest`.
+    fn rpm_root_defective(&self) -> bool {
+        self.rpm_provenance
+            && matches!(
+                self.rpm_root,
+                RpmRootDecl::Blank | RpmRootDecl::Unsupported { .. }
+            )
+    }
+}
+
+/// Trust decision for the receipt symlink *targets* of one
+/// `(component, framework)`: the roots targets may resolve under, plus
+/// whether the two-source condition — RPM provenance recorded in state
+/// **and** a contract-declared `[adapters.backends.rpm].resource_root`
+/// — currently grants external-root trust. This is the single decision
+/// point shared by every claim-validation site (enable prior-receipt,
+/// pre-persist, apply, disable, status) and by the anchor lifecycle, so
+/// no call site can fall out of sync with the rule. Derived from the
+/// on-disk contract and state provenance — never from the receipt under
+/// validation — so a forged receipt cannot authorize its own target.
+struct ExternalRootTrust {
+    /// Roots a receipt's symlink targets may resolve under. Derived from
+    /// the contract only — the state anchor is deliberately not a member:
+    /// roots authorize subtrees, and a state-resident value must never
+    /// authorize more than itself.
+    target_roots: Vec<PathBuf>,
+    /// Enable-time anchor from state, honoured as an *exact-equality*
+    /// symlink-target allowance (see
+    /// [`AdapterClaim::validate_with_trust`]): it keeps the receipt of a
+    /// since-moved or since-removed external root reportable and
+    /// cleanable, while a forged anchor authorizes nothing beneath it and
+    /// no write outside anolisa's own layout.
+    anchor: Option<PathBuf>,
+    /// The two-source condition held. The enable-time anchor is
+    /// (re)written on enable exactly when this is true: a forged state
+    /// entry alone must not become durable.
+    anchor_eligible: bool,
+}
+
+impl ExternalRootTrust {
+    /// The anchor as an exact-target allowance slice for
+    /// [`AdapterClaim::validate_with_trust`].
+    fn exact_targets(&self) -> &[PathBuf] {
+        self.anchor.as_slice()
+    }
+
+    /// Persist or clear the enable-time anchor under the same
+    /// eligibility that governs anchor consumption — by construction the
+    /// write condition and the read condition can never diverge. The
+    /// anchor keeps a prior receipt validatable after an RPM update
+    /// moves the contract root, so re-enable can migrate it instead of
+    /// wedging on `OwnedPath`.
+    ///
+    /// An anchor is worth remembering only when the just-validated claim
+    /// actually depends on external symlink-target trust
+    /// ([`AdapterClaim::requires_external_symlink_trust`]): a receipt
+    /// whose targets all re-validate from the static boundary on every
+    /// run — or one with no symlink resources at all (every driver but
+    /// Codex today) — never reads its anchor back, and a redundant
+    /// anchor would bump the state schema to v6 for nothing, locking
+    /// released 0.2.16 CLIs out of all state commands on a path that
+    /// never needed trust migration.
+    fn sync_anchor(
+        &self,
+        state: &mut StateStore,
+        layout: &FsLayout,
+        claim: &AdapterClaim,
+        trusted_owned_roots: &[PathBuf],
+    ) {
+        if self.anchor_eligible
+            && claim.requires_external_symlink_trust(layout, trusted_owned_roots)
+        {
+            state.upsert_adapter_trust_root(
+                &claim.component,
+                &claim.framework,
+                claim.resource_root.clone(),
+            );
+        } else {
+            state.remove_adapter_trust_root(&claim.component, &claim.framework);
+        }
+    }
 }
 
 /// A state root paired with the datadir roots it may use for component
@@ -411,13 +604,20 @@ impl AdapterManager {
             if let Some(entry) = entries.get_mut(&key) {
                 entry.declared = true;
                 entry.adapter_type = declaration.adapter_type.clone();
-                // When the contract declares a custom dest, the
-                // contract-resolved path is authoritative — override the
-                // convention-discovered root (which may point elsewhere).
-                // If the contract dest directory does not exist, show
-                // resource_root = None (declared yes / resource absent).
-                if declaration.dest.is_some() {
-                    entry.resource_root = declaration.dest.as_deref().and_then(|dest| {
+                // When the contract declares a custom resource root for
+                // this provenance (raw `dest`, or the RPM backend root for
+                // an RPM-installed component), the contract-resolved path
+                // is authoritative — override the convention-discovered
+                // root (which may point elsewhere). If the contract
+                // directory does not exist, show resource_root = None
+                // (declared yes / resource absent).
+                if declaration.rpm_root_defective() {
+                    // Blank RPM root: enable will reject this contract, so
+                    // a stale raw `dest` bundle must not be reported as a
+                    // usable resource (declared yes / resource absent).
+                    entry.resource_root = None;
+                } else if declaration.effective_root_template().is_some() {
+                    entry.resource_root = declaration.effective_root_template().and_then(|dest| {
                         self.resolve_declared_scan_root(
                             &declaration.component,
                             &declaration.framework,
@@ -443,17 +643,21 @@ impl AdapterManager {
                 continue;
             }
 
-            // Not found in directory discovery — resolve from contract
-            // dest, if present.
-            let resource_root = declaration.dest.as_deref().and_then(|dest| {
-                self.resolve_declared_scan_root(
-                    &declaration.component,
-                    &declaration.framework,
-                    dest,
-                    declaration.bundle_entry.as_deref(),
-                    &declaration.scoped_datadir_roots,
-                )
-            });
+            // Not found in directory discovery — resolve from the
+            // provenance-effective contract root, if declared.
+            let resource_root = if declaration.rpm_root_defective() {
+                None
+            } else {
+                declaration.effective_root_template().and_then(|dest| {
+                    self.resolve_declared_scan_root(
+                        &declaration.component,
+                        &declaration.framework,
+                        dest,
+                        declaration.bundle_entry.as_deref(),
+                        &declaration.scoped_datadir_roots,
+                    )
+                })
+            };
 
             let (driver_available, framework_detected) =
                 self.driver_scan_facts(&declaration.framework);
@@ -559,7 +763,7 @@ impl AdapterManager {
         let _lock = InstallLock::acquire(&self.layout.lock_file)?;
         let mut state = self.load_state()?;
 
-        let (manifest, scoped_datadir_roots, contract_datadir_root) =
+        let (manifest, scoped_datadir_roots, contract_datadir_root, rpm_provenance) =
             self.load_visible_component_manifest(component, &state)?;
         let framework = self.resolve_framework(component, framework, &manifest)?;
 
@@ -650,7 +854,20 @@ impl AdapterManager {
             &manifest,
             &scoped_datadir_roots,
             contract_datadir_root.as_deref(),
+            rpm_provenance,
         )?;
+        // Receipt symlink targets must validate against roots derived from
+        // the on-disk contract and state provenance — never from the receipt
+        // itself. See [`ExternalRootTrust`] for the rule; every validation
+        // site below and the anchor lifecycle share this one decision.
+        let trust = self.external_root_trust(
+            component,
+            &manifest,
+            &framework,
+            &scoped_datadir_roots,
+            rpm_provenance,
+            &state,
+        );
         let skills = resolve_skill_sources(
             skill_specs,
             &self.layout,
@@ -761,22 +978,28 @@ impl AdapterManager {
         if let Some(prior) = state.find_adapter_claim(component, &framework).cloned() {
             // A forged prior receipt must not gain authority merely because a
             // driver preserves facts from it during re-enable.
-            prior.validate_with_owned_roots(
+            prior.validate_with_trust(
                 &self.layout,
                 &claim_allowed_roots,
-                &self.all_datadir_roots,
+                &trust.target_roots,
+                trust.exact_targets(),
             )?;
             driver.preserve_reenable_facts(&prior, &mut claim)?;
         }
         // Defense in depth: the driver must not emit a claim that points
         // outside its own declared roots. Reject before persisting.
-        claim.validate_with_owned_roots(
+        claim.validate_with_trust(
             &self.layout,
             &claim_allowed_roots,
-            &self.all_datadir_roots,
+            &trust.target_roots,
+            trust.exact_targets(),
         )?;
 
         state.upsert_adapter_claim(claim.clone());
+        // Anchor lifecycle shares the trust decision above: it is recorded
+        // exactly when the validated claim depends on an externally-targeted
+        // symlink, anything else clears a stale anchor.
+        trust.sync_anchor(&mut state, &self.layout, &claim, &self.all_datadir_roots);
         state.save(&self.state_path)?;
         let apply_result = {
             let mut progress = ManagerEnableProgress {
@@ -784,7 +1007,8 @@ impl AdapterManager {
                 state_path: &self.state_path,
                 layout: &self.layout,
                 allowed_external_roots: &claim_allowed_roots,
-                extra_owned_roots: &self.all_datadir_roots,
+                extra_owned_roots: &trust.target_roots,
+                exact_symlink_targets: trust.exact_targets(),
             };
             driver.apply_enable(&mut claim, &prepared, &ctx, &mut progress)
         };
@@ -970,10 +1194,12 @@ impl AdapterManager {
         };
 
         // Re-validate the receipt before acting on it (forged-state guard).
-        claim.validate_with_owned_roots(
+        let trust = self.external_root_trust_from_state(component, &framework, &state);
+        claim.validate_with_trust(
             &self.layout,
             &driver.allowed_external_roots(&ctx),
-            &self.all_datadir_roots,
+            &trust.target_roots,
+            trust.exact_targets(),
         )?;
 
         if dry_run {
@@ -995,6 +1221,8 @@ impl AdapterManager {
         let disable_notices = post_disable_notices(&claim);
         if claim_removed {
             state.remove_adapter_claim(component, &framework);
+            // The anchor exists to validate this receipt; drop it with it.
+            state.remove_adapter_trust_root(component, &framework);
             self.log_operation(&label, component, LogStatus::Ok, "adapter disabled", None);
         } else {
             // Keep the receipt so cleanup can be retried; mark it failed.
@@ -1134,10 +1362,12 @@ impl AdapterManager {
                 ops: &ops,
             };
 
-            claim.validate_with_owned_roots(
+            let trust = self.external_root_trust_from_state(&claim.component, &framework, &state);
+            claim.validate_with_trust(
                 &self.layout,
                 &driver.allowed_external_roots(&ctx),
-                &self.all_datadir_roots,
+                &trust.target_roots,
+                trust.exact_targets(),
             )?;
             let report = with_source_condition(driver.status(claim, &ctx)?, &source);
             entries.push(StatusEntry {
@@ -1180,8 +1410,8 @@ impl AdapterManager {
         framework: &str,
         current_state: &StateStore,
     ) -> SourceProbe {
-        let vr = match self.find_component_visible_root(component, current_state) {
-            Ok(Some(vr)) => vr,
+        let (vr, rpm) = match self.find_component_visible_root(component, current_state) {
+            Ok(Some((vr, rpm_provenance))) => (vr, rpm_provenance),
             Ok(None) => {
                 return source_missing(format!(
                     "no visible installed component '{component}' supplies this adapter"
@@ -1233,6 +1463,7 @@ impl AdapterManager {
             &manifest,
             &vr.contract_datadir_roots,
             contract_datadir_root.as_deref(),
+            rpm,
         ) {
             // resolve prefers a root with a valid bundle, so a winner that
             // still fails the bundle check means every candidate is a stale
@@ -1310,8 +1541,8 @@ impl AdapterManager {
         &self,
         component: &str,
         current_state: &StateStore,
-    ) -> Result<(ComponentManifest, Vec<PathBuf>, Option<PathBuf>), AdapterError> {
-        let vr = self
+    ) -> Result<(ComponentManifest, Vec<PathBuf>, Option<PathBuf>, bool), AdapterError> {
+        let (vr, rpm_provenance) = self
             .find_component_visible_root(component, current_state)?
             .ok_or_else(|| AdapterError::ComponentNotInstalled {
                 component: component.to_string(),
@@ -1341,6 +1572,7 @@ impl AdapterManager {
             manifest,
             vr.contract_datadir_roots.clone(),
             contract_datadir_root,
+            rpm_provenance,
         ))
     }
 
@@ -1348,25 +1580,29 @@ impl AdapterManager {
     /// an adapter-visible status ([`LifecycleStatus::Installed`]).
     /// Returns the full
     /// [`VisibleRoot`] so callers can scope contract resolution to the
-    /// paired datadir roots.
+    /// paired datadir roots, along with whether the record has RPM
+    /// provenance (delegated to the native RPM manager) — resource-root
+    /// resolution selects the backend-specific contract root from it.
     fn find_component_visible_root(
         &self,
         component: &str,
         current_state: &StateStore,
-    ) -> Result<Option<&VisibleRoot>, AdapterError> {
+    ) -> Result<Option<(&VisibleRoot, bool)>, AdapterError> {
         for vr in &self.visible_roots {
-            let visible = if vr.state_dir == self.layout.state_dir {
+            let found = if vr.state_dir == self.layout.state_dir {
                 current_state
                     .find(ObjectKind::Component, component)
-                    .is_some_and(is_adapter_visible)
+                    .filter(|i| is_adapter_visible(i))
+                    .map(rpm_provenance)
             } else {
                 let state_path = vr.state_dir.join("installed.toml");
                 Self::load_state_at(&state_path)?
                     .find(ObjectKind::Component, component)
-                    .is_some_and(is_adapter_visible)
+                    .filter(|i| is_adapter_visible(i))
+                    .map(rpm_provenance)
             };
-            if visible {
-                return Ok(Some(vr));
+            if let Some(rpm) = found {
+                return Ok(Some((vr, rpm)));
             }
         }
         Ok(None)
@@ -1386,8 +1622,9 @@ impl AdapterManager {
         current_state: &StateStore,
     ) -> (Vec<AdapterDecl>, Vec<String>) {
         let mut declarations = BTreeSet::new();
-        // Map component name → the VisibleRoot where it was first seen.
-        let mut component_vr: BTreeMap<String, &VisibleRoot> = BTreeMap::new();
+        // Map component name → the VisibleRoot where it was first seen,
+        // plus the RPM provenance of its installed record there.
+        let mut component_vr: BTreeMap<String, (&VisibleRoot, bool)> = BTreeMap::new();
         let mut warnings = Vec::new();
 
         for vr in &self.visible_roots {
@@ -1413,11 +1650,13 @@ impl AdapterManager {
                 .filter(|object| object.kind == ObjectKind::Component)
                 .filter(|object| is_adapter_visible(object))
             {
-                component_vr.entry(object.name.clone()).or_insert(vr);
+                component_vr
+                    .entry(object.name.clone())
+                    .or_insert((vr, rpm_provenance(object)));
             }
         }
 
-        for (component, vr) in &component_vr {
+        for (component, (vr, rpm)) in &component_vr {
             let resolved = match super::contract::resolve_component_contract_with_source(
                 component,
                 std::slice::from_ref(&vr.state_dir),
@@ -1483,6 +1722,14 @@ impl AdapterManager {
                             .map(str::trim)
                             .filter(|d| !d.is_empty())
                             .map(str::to_string),
+                        rpm_root: RpmRootDecl::from_raw(
+                            adapter
+                                .backends
+                                .rpm
+                                .as_ref()
+                                .and_then(|rpm| rpm.resource_root.as_deref()),
+                        ),
+                        rpm_provenance: *rpm,
                         bundle_entry: declared_bundle_entry(&manifest, framework),
                         scoped_datadir_roots: scoped_roots.clone(),
                     });
@@ -1497,7 +1744,11 @@ impl AdapterManager {
     /// specific datadir root. The template may use layout placeholders
     /// (`{datadir}`, `{etcdir}`, …) and the extra variable `{component}`.
     ///
-    /// Returns `None` when the template is absent or empty.
+    /// The expansion must be absolute: layout placeholders always expand
+    /// to absolute directories, so a relative result means the template
+    /// was a bare relative path — probing it would resolve against the
+    /// process CWD, letting whoever controls the working directory decide
+    /// which bundle is read. Rejected before any filesystem access.
     fn expand_dest_template(
         &self,
         dest_template: &str,
@@ -1506,7 +1757,110 @@ impl AdapterManager {
     ) -> Result<PathBuf, AdapterError> {
         let mut layout = self.layout.clone();
         layout.datadir = datadir.to_path_buf();
-        super::expand_layout_placeholders(dest_template, &layout, &[("component", component)])
+        let path =
+            super::expand_layout_placeholders(dest_template, &layout, &[("component", component)])?;
+        if !path.is_absolute() {
+            return Err(AdapterError::RelativeTemplateExpansion {
+                template: dest_template.to_string(),
+                path,
+            });
+        }
+        Ok(path)
+    }
+
+    /// Build the [`ExternalRootTrust`] decision from an already-loaded
+    /// contract. The trusted set is the shared datadir roots, extended —
+    /// only under the two-source condition — with the contract's expanded
+    /// RPM root and the receipt's enable-time anchor.
+    fn external_root_trust(
+        &self,
+        component: &str,
+        manifest: &ComponentManifest,
+        framework: &str,
+        scoped_datadir_roots: &[PathBuf],
+        rpm_provenance: bool,
+        state: &StateStore,
+    ) -> ExternalRootTrust {
+        let mut target_roots = self.all_datadir_roots.clone();
+        // The anchor is read regardless of the two-source outcome: as an
+        // exact-equality allowance it is what keeps a stale external-root
+        // receipt reportable and cleanable after the RPM (or the whole
+        // contract) went away — while `anchor_eligible` below still gates
+        // whether enable may persist one.
+        let anchor = state
+            .find_adapter_trust_root(component, framework)
+            .map(Path::to_path_buf);
+        let template = match (rpm_provenance, rpm_root_decl(manifest, framework)) {
+            (true, RpmRootDecl::Declared(template)) => template,
+            // No RPM provenance, or no usable declared root (absent,
+            // blank, or an unsupported placeholder): validation stays
+            // exactly as strict as before the unified contract, and
+            // enable will clear any stale anchor.
+            _ => {
+                return ExternalRootTrust {
+                    target_roots,
+                    anchor,
+                    anchor_eligible: false,
+                };
+            }
+        };
+        // `{datadir}` templates expand under already-trusted roots; absolute
+        // RPM roots (the normal case, e.g. /opt/…) expand identically for
+        // every datadir and dedupe to one extra entry.
+        for datadir in scoped_datadir_roots
+            .iter()
+            .chain(std::iter::once(&self.layout.datadir))
+        {
+            if let Ok(path) = self.expand_dest_template(&template, component, datadir)
+                && !target_roots.contains(&path)
+            {
+                target_roots.push(path);
+            }
+        }
+        ExternalRootTrust {
+            target_roots,
+            anchor,
+            anchor_eligible: true,
+        }
+    }
+
+    /// [`Self::external_root_trust`] for receipt-only flows
+    /// (disable/status) that have not already loaded the component
+    /// manifest. When the contract is no longer visible (e.g. the
+    /// component was uninstalled before disable), the roots fall back to
+    /// the shared datadirs and only the exact-equality anchor allowance
+    /// survives — enough to report and clean up the stale receipt, while
+    /// a state file alone still cannot authorize any subtree or any
+    /// write outside anolisa's layout.
+    fn external_root_trust_from_state(
+        &self,
+        component: &str,
+        framework: &str,
+        state: &StateStore,
+    ) -> ExternalRootTrust {
+        match self.load_visible_component_manifest(component, state) {
+            Ok((manifest, scoped_datadir_roots, _contract_datadir_root, rpm_provenance)) => self
+                .external_root_trust(
+                    component,
+                    &manifest,
+                    framework,
+                    &scoped_datadir_roots,
+                    rpm_provenance,
+                    state,
+                ),
+            Err(_) => ExternalRootTrust {
+                target_roots: self.all_datadir_roots.clone(),
+                // The contract is gone, but the receipt may still point at
+                // an anchored external root; surfacing the anchor as an
+                // exact allowance is what lets status report it and
+                // disable clean it up instead of wedging on
+                // `ClaimValidation` forever.
+                anchor: state
+                    .find_adapter_trust_root(component, framework)
+                    .map(Path::to_path_buf),
+                anchor_eligible: false,
+            },
+        }
     }
 
     /// Resolve the adapter resource root for a component/framework using
@@ -1531,7 +1885,16 @@ impl AdapterManager {
     /// - When no expanded path exists, returns
     ///   [`AdapterError::ContractResourceRootNotFound`].
     ///
-    /// Convention fallback (`dest` absent):
+    /// Backend-aware selection: when `rpm_provenance` is true and the
+    /// contract declares `[adapters.backends.rpm].resource_root`, that
+    /// template replaces `dest` — an RPM payload lives at the
+    /// package-owned path (possibly outside every datadir root, e.g.
+    /// `/opt/…`), which the raw `dest` cannot describe. The declared RPM
+    /// root is as authoritative as an explicit `dest`: a missing directory
+    /// is [`AdapterError::ContractResourceRootNotFound`], never a silent
+    /// fallback to the raw dest or convention discovery.
+    ///
+    /// Convention fallback (no effective template):
     /// - Searches `{datadir}/adapters/<component>/<framework>/` across
     ///   **all** datadir roots via [`Self::discover_resource_root`].
     ///   The `effective_datadir` is `self.layout.datadir` (the primary
@@ -1543,8 +1906,51 @@ impl AdapterManager {
         manifest: &ComponentManifest,
         scoped_datadir_roots: &[PathBuf],
         contract_datadir_root: Option<&Path>,
+        rpm_provenance: bool,
     ) -> Result<(PathBuf, PathBuf), AdapterError> {
-        let dest_template = declared_dest(manifest, framework);
+        let dest_template = if rpm_provenance {
+            match rpm_root_decl(manifest, framework) {
+                // A declared-but-blank RPM root is a contract defect, not
+                // an undeclared backend: silently selecting the raw `dest`
+                // would point enable at a bundle the RPM never laid down.
+                // Fail closed (mirrors the empty-`render` rejection in raw
+                // install).
+                RpmRootDecl::Blank => {
+                    return Err(AdapterError::InvalidAdapterInput {
+                        component: component.to_string(),
+                        framework: framework.to_string(),
+                        reason: "[adapters.backends.rpm].resource_root is declared but empty; \
+                                 declare the RPM bundle path or remove the key"
+                            .to_string(),
+                    });
+                }
+                // A placeholder outside the RPM vocabulary would expand
+                // against the consuming manager's layout — the wrong scope
+                // whenever the contract is consumed cross-scope (e.g. a
+                // user-mode manager consuming a system RPM contract). Fail
+                // closed instead of probing a wrong-scope path.
+                RpmRootDecl::Unsupported {
+                    template,
+                    placeholder,
+                } => {
+                    return Err(AdapterError::InvalidAdapterInput {
+                        component: component.to_string(),
+                        framework: framework.to_string(),
+                        reason: format!(
+                            "[adapters.backends.rpm].resource_root \"{template}\" uses \
+                             placeholder '{{{placeholder}}}'; an RPM root must be an absolute \
+                             path or a {{datadir}}-rooted template (plus {{component}}) — \
+                             other layout placeholders would resolve against the consuming \
+                             scope's layout, not the contract's"
+                        ),
+                    });
+                }
+                RpmRootDecl::Declared(template) => Some(template),
+                RpmRootDecl::Absent => declared_dest(manifest, framework),
+            }
+        } else {
+            declared_dest(manifest, framework)
+        };
         let declared_entry = declared_bundle_entry(manifest, framework);
         match dest_template {
             Some(template) => {
@@ -1603,14 +2009,12 @@ impl AdapterManager {
                 let path = match last_expanded {
                     Some((p, _)) => p,
                     None => {
-                        // All expansions failed (unknown placeholder etc.)
-                        // — try expanding with the primary layout for the
-                        // error message.
-                        super::expand_layout_placeholders(
-                            &template,
-                            &self.layout,
-                            &[("component", component)],
-                        )?
+                        // All expansions failed (unknown placeholder,
+                        // relative result, …) — re-expand against the
+                        // primary datadir so the caller sees the actual
+                        // rejection instead of a generic not-found.
+                        let primary = self.layout.datadir.clone();
+                        self.expand_dest_template(&template, component, &primary)?
                     }
                 };
                 Err(AdapterError::ContractResourceRootNotFound {
@@ -1858,14 +2262,18 @@ struct ManagerEnableProgress<'a> {
     layout: &'a FsLayout,
     allowed_external_roots: &'a [PathBuf],
     extra_owned_roots: &'a [PathBuf],
+    /// Exact-equality symlink-target allowances (the enable-time anchor);
+    /// see [`AdapterClaim::validate_with_trust`].
+    exact_symlink_targets: &'a [PathBuf],
 }
 
 impl EnableProgress for ManagerEnableProgress<'_> {
     fn persist_claim(&mut self, claim: &AdapterClaim) -> Result<(), AdapterError> {
-        claim.validate_with_owned_roots(
+        claim.validate_with_trust(
             self.layout,
             self.allowed_external_roots,
             self.extra_owned_roots,
+            self.exact_symlink_targets,
         )?;
         self.state.upsert_adapter_claim(claim.clone());
         self.state.save(self.state_path)?;
@@ -2539,6 +2947,20 @@ fn declared_dest(manifest: &ComponentManifest, framework: &str) -> Option<String
         .map(str::to_string)
 }
 
+/// Classify the `[adapters.backends.rpm].resource_root` declaration of
+/// the first `[[adapters]]` entry whose `framework` matches. See
+/// [`RpmRootDecl`] for the three-valued semantics.
+fn rpm_root_decl(manifest: &ComponentManifest, framework: &str) -> RpmRootDecl {
+    RpmRootDecl::from_raw(
+        manifest
+            .adapters
+            .iter()
+            .find(|adapter| adapter.framework.as_deref().map(str::trim) == Some(framework))
+            .and_then(|adapter| adapter.backends.rpm.as_ref())
+            .and_then(|rpm| rpm.resource_root.as_deref()),
+    )
+}
+
 /// Extract the `adapter_type` from the first `[[adapters]]` entry whose
 /// `framework` matches. Returns `None` when the manifest omits the field
 /// (which the caller treats as defaulting to `"plugin"`).
@@ -2628,6 +3050,20 @@ fn validate_adapter_type_for_framework(
 /// Both fully-installed and adopted components should be adapter-visible.
 fn is_adapter_visible(installation: &Installation) -> bool {
     installation.status == LifecycleStatus::Installed
+}
+
+/// Whether an installed record is delegated to the native RPM manager
+/// (managed, adopted, or observed alike): its payload was placed by the
+/// RPM transaction, so adapter resource-root resolution must prefer the
+/// contract's `[adapters.backends.rpm].resource_root` over the raw `dest`.
+fn rpm_provenance(installation: &Installation) -> bool {
+    matches!(
+        installation.binding,
+        ProviderBinding::Delegated {
+            pm: NativePm::Rpm,
+            ..
+        }
+    )
 }
 
 /// Return the datadir root that supplied a resolved component contract.
@@ -4167,7 +4603,7 @@ entry = "cosh-extension.json"
         manager.all_datadir_roots = vec![first_datadir, second_datadir];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("tokenless", &state)
             .expect("load manifest");
         let (resolved, _) = manager
@@ -4177,6 +4613,7 @@ entry = "cosh-extension.json"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve");
         assert_eq!(
@@ -4240,7 +4677,7 @@ entry = ".qoder-plugin/plugin.json"
         manager.all_datadir_roots = vec![first_datadir, second_datadir];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("tokenless", &state)
             .expect("load manifest");
         let (resolved, _) = manager
@@ -4250,6 +4687,7 @@ entry = ".qoder-plugin/plugin.json"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve");
         assert_eq!(
@@ -4593,7 +5031,7 @@ entry = "custom-entry.json"
 
         // resolve_resource_root (used by enable) must return the custom path.
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         let (resolved, _effective_datadir) = manager
@@ -4603,11 +5041,498 @@ entry = "custom-entry.json"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve");
         assert_eq!(
             resolved, custom_root,
             "enable resource root must be the contract dest"
+        );
+    }
+
+    /// Contract TOML with a raw `dest` plus an RPM backend resource root.
+    fn contract_toml_with_rpm_root(name: &str, rpm_root: &str) -> String {
+        format!(
+            r#"
+[component]
+name = "{name}"
+version = "0.1.0"
+layer = "runtime"
+
+[[adapters]]
+framework = "openclaw"
+adapter_type = "plugin"
+plugin_id = "{name}"
+source = "adapters/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[adapters.backends.rpm]
+resource_root = "{rpm_root}"
+"#
+        )
+    }
+
+    /// Manager over one visible root, mirroring the scan/enable fixtures.
+    fn manager_for(
+        tmp: &std::path::Path,
+        state_dir: &std::path::Path,
+        datadir: &std::path::Path,
+    ) -> AdapterManager {
+        let layout = FsLayout::system(Some(tmp.to_path_buf()));
+        let mut manager = AdapterManager::new(layout, Some(tmp.to_path_buf()), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir: state_dir.to_path_buf(),
+            contract_datadir_roots: vec![datadir.to_path_buf()],
+        }];
+        manager.all_datadir_roots = vec![datadir.to_path_buf()];
+        manager
+    }
+
+    /// An RPM-installed component reads its bundle from the contract's
+    /// `[adapters.backends.rpm].resource_root`, not the raw `dest`.
+    #[test]
+    fn rpm_component_uses_declared_rpm_resource_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        // Adopted ⇒ RPM provenance in the migrated domain record.
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+
+        let rpm_root = tmp.path().join("opt/agent-sec/openclaw-plugin");
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", &rpm_root.to_string_lossy()),
+        );
+        // Bundle exists only at the RPM-provided path — the raw dest was
+        // never laid down because the payload came from the RPM.
+        std::fs::create_dir_all(&rpm_root).expect("mkdir rpm root");
+        std::fs::write(rpm_root.join("plugin.json"), b"{}").expect("write");
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+
+        // scan must surface the RPM root.
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan");
+        assert!(entry.declared);
+        assert_eq!(
+            entry.resource_root.as_ref(),
+            Some(&rpm_root),
+            "scan must select the RPM backend resource root"
+        );
+
+        // resolve_resource_root (used by enable) must return the RPM root.
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        assert!(rpm_provenance, "adopted RPM record must carry provenance");
+        let (resolved, _effective_datadir) = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect("resolve");
+        assert_eq!(
+            resolved, rpm_root,
+            "enable resource root must be the RPM backend root"
+        );
+    }
+
+    /// A declared RPM root that does not exist is an error — never a
+    /// silent fallback to the raw dest, even when that directory exists.
+    #[test]
+    fn rpm_component_missing_rpm_root_errors_without_dest_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+
+        let rpm_root = tmp.path().join("opt/agent-sec/openclaw-plugin");
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", &rpm_root.to_string_lossy()),
+        );
+        // Only the raw dest holds a bundle — e.g. a stale leftover from an
+        // earlier raw install. It must not shadow the missing RPM payload.
+        let dest_root = datadir.join("adapters/sec-core/openclaw");
+        std::fs::create_dir_all(&dest_root).expect("mkdir dest");
+        std::fs::write(dest_root.join("plugin.json"), b"{}").expect("write");
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan");
+        assert!(entry.declared);
+        assert!(
+            entry.resource_root.is_none(),
+            "scan must not fall back to the raw dest for an RPM install"
+        );
+
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        let err = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect_err("missing RPM root must fail, not fall back");
+        match &err {
+            AdapterError::ContractResourceRootNotFound { path, .. } => {
+                assert_eq!(path, &rpm_root, "error must point at the missing RPM root");
+            }
+            other => panic!("expected ContractResourceRootNotFound, got: {other}"),
+        }
+    }
+
+    /// Blank RPM root in scan: the declaration must surface as declared
+    /// with no usable resource, even when a stale raw `dest` bundle still
+    /// exists — scan must agree with the enable-time rejection instead of
+    /// advertising a root enable will refuse.
+    #[test]
+    fn scan_blank_rpm_root_hides_stale_raw_dest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", "   "),
+        );
+        // Stale raw bundle at the dest — must not be reported as usable.
+        let dest_root = datadir.join("adapters/sec-core/openclaw");
+        std::fs::create_dir_all(&dest_root).expect("mkdir dest");
+        std::fs::write(dest_root.join("plugin.json"), b"{}").expect("write");
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan");
+        assert!(entry.declared, "declaration must stay visible");
+        assert!(
+            entry.resource_root.is_none(),
+            "blank RPM root must not fall back to the stale raw dest, got {:?}",
+            entry.resource_root
+        );
+    }
+
+    /// A declared-but-blank RPM root is a contract defect: resolution must
+    /// fail closed instead of silently selecting the raw dest.
+    #[test]
+    fn rpm_component_blank_rpm_root_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", "  "),
+        );
+        // A valid bundle at the raw dest must NOT rescue the blank root.
+        let dest_root = datadir.join("adapters/sec-core/openclaw");
+        std::fs::create_dir_all(&dest_root).expect("mkdir dest");
+        std::fs::write(dest_root.join("plugin.json"), b"{}").expect("write");
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        let err = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect_err("blank rpm root must fail, not fall back to dest");
+        match &err {
+            AdapterError::InvalidAdapterInput { reason, .. } => {
+                assert!(
+                    reason.contains("resource_root") && reason.contains("empty"),
+                    "reason must name the defect: {reason}"
+                );
+            }
+            other => panic!("expected InvalidAdapterInput, got: {other}"),
+        }
+    }
+
+    /// `[adapters.backends.rpm].resource_root` vocabulary: absolute paths
+    /// and `{datadir}`/`{component}` templates are usable; any other
+    /// placeholder classifies as `Unsupported` — it would expand against
+    /// the consuming scope's layout, not the contract's.
+    #[test]
+    fn rpm_root_decl_rejects_non_datadir_placeholders() {
+        assert_eq!(
+            RpmRootDecl::from_raw(Some("/opt/agent-sec/openclaw-plugin/")),
+            RpmRootDecl::Declared("/opt/agent-sec/openclaw-plugin/".to_string())
+        );
+        assert_eq!(
+            RpmRootDecl::from_raw(Some("{datadir}/adapters/{component}/codex/")),
+            RpmRootDecl::Declared("{datadir}/adapters/{component}/codex/".to_string())
+        );
+        match RpmRootDecl::from_raw(Some("{libexecdir}/plugin")) {
+            RpmRootDecl::Unsupported { placeholder, .. } => assert_eq!(placeholder, "libexecdir"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+        // The alien placeholder wins even next to an allowed one.
+        match RpmRootDecl::from_raw(Some("{datadir}/{bindir}/x")) {
+            RpmRootDecl::Unsupported { placeholder, .. } => assert_eq!(placeholder, "bindir"),
+            other => panic!("expected Unsupported, got {other:?}"),
+        }
+    }
+
+    /// A non-`{datadir}` layout placeholder in the RPM root must fail
+    /// closed, never expand against the *consuming* manager's layout:
+    /// before this rule, `{libexecdir}/plugin` consumed cross-scope (e.g.
+    /// a user-mode manager reading a system RPM contract) resolved under
+    /// the consumer's prefix — misreporting the RPM payload as missing or
+    /// selecting a caller-writable bundle. A valid bundle planted at
+    /// exactly that wrong-scope path must not be selected.
+    #[test]
+    fn rpm_component_non_datadir_placeholder_rejected_not_wrong_scope() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", "{libexecdir}/plugin"),
+        );
+        // Bundle at the consuming layout's libexecdir — where the old
+        // expansion would have landed. It must stay unreachable.
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+        let wrong_scope = manager.layout.libexec_dir.join("plugin");
+        std::fs::create_dir_all(&wrong_scope).expect("mkdir wrong-scope bundle");
+        std::fs::write(wrong_scope.join("plugin.json"), b"{}").expect("write");
+
+        // scan: declared, but no usable resource.
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan");
+        assert!(entry.declared, "declaration must stay visible");
+        assert!(
+            entry.resource_root.is_none(),
+            "an unsupported placeholder must not resolve, got {:?}",
+            entry.resource_root
+        );
+
+        // enable-time resolution: hard error naming the placeholder.
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        let err = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect_err("unsupported placeholder must fail, not resolve wrong-scope");
+        match &err {
+            AdapterError::InvalidAdapterInput { reason, .. } => {
+                assert!(
+                    reason.contains("libexecdir"),
+                    "reason must name the placeholder: {reason}"
+                );
+            }
+            other => panic!("expected InvalidAdapterInput, got: {other}"),
+        }
+    }
+
+    /// A relative RPM root must be rejected before any filesystem probe:
+    /// probing it would resolve against the process CWD, so whoever
+    /// controls the working directory would control which bundle is read.
+    /// A valid bundle planted at exactly that CWD-relative path must not
+    /// be selected.
+    #[test]
+    fn rpm_component_relative_root_rejected_even_with_cwd_bundle() {
+        /// Removes the CWD bundle even when an assertion fails.
+        struct CwdBundle(std::path::PathBuf);
+        impl Drop for CwdBundle {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let rel_name = format!("anolisa-test-cwd-bundle-{}", std::process::id());
+        let cwd_bundle = std::env::current_dir().expect("cwd").join(&rel_name);
+        std::fs::create_dir_all(&cwd_bundle).expect("mkdir cwd bundle");
+        std::fs::write(cwd_bundle.join("plugin.json"), b"{}").expect("write");
+        let _cleanup = CwdBundle(cwd_bundle);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Adopted,
+        );
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", &rel_name),
+        );
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+
+        // scan: declared, but the relative root is not a usable resource.
+        let report = manager.scan().expect("scan");
+        let entry = report
+            .entries
+            .iter()
+            .find(|e| e.component == "sec-core" && e.framework == "openclaw")
+            .expect("sec-core/openclaw should be in scan");
+        assert!(
+            entry.resource_root.is_none(),
+            "a relative root must not resolve against the CWD, got {:?}",
+            entry.resource_root
+        );
+
+        // enable-time resolution: rejected before any filesystem probe.
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        let err = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect_err("relative root must fail even with a valid CWD bundle");
+        match &err {
+            AdapterError::RelativeTemplateExpansion { path, .. } => {
+                assert_eq!(path, &PathBuf::from(&rel_name));
+            }
+            other => panic!("expected RelativeTemplateExpansion, got: {other}"),
+        }
+    }
+
+    /// A raw-installed component keeps using `dest` even when the contract
+    /// also declares an RPM backend root (unified contract, raw install).
+    #[test]
+    fn raw_component_ignores_rpm_resource_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        // Installed ⇒ raw-managed provenance.
+        seed_installed_state(
+            &state_dir,
+            crate::state::InstallMode::System,
+            tmp.path(),
+            "sec-core",
+            ObjectStatus::Installed,
+        );
+
+        let rpm_root = tmp.path().join("opt/agent-sec/openclaw-plugin");
+        write_contract_with_content(
+            &datadir,
+            "sec-core",
+            &contract_toml_with_rpm_root("sec-core", &rpm_root.to_string_lossy()),
+        );
+        // Bundles exist at both roots; the raw install must pick dest.
+        let dest_root = datadir.join("adapters/sec-core/openclaw");
+        for root in [&dest_root, &rpm_root] {
+            std::fs::create_dir_all(root).expect("mkdir");
+            std::fs::write(root.join("plugin.json"), b"{}").expect("write");
+        }
+
+        let manager = manager_for(tmp.path(), &state_dir, &datadir);
+
+        let state = load_written_state(&state_dir.join("installed.toml"));
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
+            .load_visible_component_manifest("sec-core", &state)
+            .expect("load manifest");
+        assert!(!rpm_provenance, "raw install must not carry RPM provenance");
+        let (resolved, _effective_datadir) = manager
+            .resolve_resource_root(
+                "sec-core",
+                "openclaw",
+                &manifest,
+                &scoped_roots,
+                contract_datadir_root.as_deref(),
+                rpm_provenance,
+            )
+            .expect("resolve");
+        assert_eq!(
+            resolved, dest_root,
+            "raw install must keep the raw dest resource root"
         );
     }
 
@@ -4659,7 +5584,7 @@ entry = "custom-entry.json"
         // resolve_resource_root: must return ContractResourceRootNotFound,
         // NOT silently fall back to convention.
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         let err = manager
@@ -4669,6 +5594,7 @@ entry = "custom-entry.json"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect_err("must fail when contract dest directory is absent");
         assert!(
@@ -4735,7 +5661,7 @@ entry = "custom-entry.json"
 
         // resolve_resource_root must error, not fall back.
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         let err = manager
@@ -4745,6 +5671,7 @@ entry = "custom-entry.json"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect_err("must not fall back to convention");
         assert!(
@@ -4886,7 +5813,7 @@ source = "{datadir}/skills/code-scanner/"
 
         // Resolve resource root — must come from system datadir.
         let state = load_written_state(&manager.state_path);
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         let (resource_root, effective_datadir) = manager
@@ -4896,6 +5823,7 @@ source = "{datadir}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(resource_root, custom_root);
@@ -5074,7 +6002,7 @@ source = "{datadir}/skills/code-scanner/"
 
         // Verify resolve_resource_root returns the package datadir path.
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         let (resource_root, effective_datadir) = manager
@@ -5084,6 +6012,7 @@ source = "{datadir}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(
@@ -5157,7 +6086,7 @@ source = "{datadir}/skills/code-scanner/"
         manager.all_datadir_roots = vec![package_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
 
@@ -5169,6 +6098,7 @@ source = "{datadir}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(
@@ -5828,7 +6758,7 @@ source = "{{datadir}}/skills/code-scanner/"
         manager.all_datadir_roots = vec![local_datadir.clone(), pkg_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
 
@@ -5840,6 +6770,7 @@ source = "{{datadir}}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(
@@ -5945,7 +6876,7 @@ source = "{{datadir}}/skills/code-scanner/"
         manager.all_datadir_roots = vec![local_datadir.clone(), pkg_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         assert_eq!(
@@ -5961,6 +6892,7 @@ source = "{{datadir}}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(resource_root, abs_dest);
@@ -6063,7 +6995,7 @@ source = "{{datadir}}/skills/code-scanner/"
         manager.all_datadir_roots = vec![local_datadir.clone(), pkg_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         assert_eq!(
@@ -6079,6 +7011,7 @@ source = "{{datadir}}/skills/code-scanner/"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(resource_root, abs_dest);
@@ -6135,7 +7068,7 @@ source = "{{datadir}}/skills/code-scanner/"
         manager.all_datadir_roots = vec![pkg_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (_manifest, _scoped_roots, contract_datadir_root) = manager
+        let (_manifest, _scoped_roots, contract_datadir_root, _rpm_provenance) = manager
             .load_visible_component_manifest("sec-core", &state)
             .expect("load manifest");
         assert_eq!(
@@ -6220,7 +7153,7 @@ dest = "{datadir}/skills"
         // enable path: resolve_resource_root must also prefer the package
         // datadir.
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("os-skills", &state)
             .expect("load manifest");
         let (resource_root, effective_datadir) = manager
@@ -6230,6 +7163,7 @@ dest = "{datadir}/skills"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(
@@ -6293,7 +7227,7 @@ dest = "{datadir}/skills"
         manager.all_datadir_roots = vec![local_datadir.clone(), package_datadir.clone()];
 
         let state = load_written_state(&state_dir.join("installed.toml"));
-        let (manifest, scoped_roots, contract_datadir_root) = manager
+        let (manifest, scoped_roots, contract_datadir_root, rpm_provenance) = manager
             .load_visible_component_manifest("os-skills", &state)
             .expect("load manifest");
         let (resource_root, effective_datadir) = manager
@@ -6303,6 +7237,7 @@ dest = "{datadir}/skills"
                 &manifest,
                 &scoped_roots,
                 contract_datadir_root.as_deref(),
+                rpm_provenance,
             )
             .expect("resolve resource root");
         assert_eq!(

--- a/src/anolisa/crates/anolisa-core/src/distribution.rs
+++ b/src/anolisa/crates/anolisa-core/src/distribution.rs
@@ -158,6 +158,69 @@ impl<'de> Deserialize<'de> for ArtifactType {
     }
 }
 
+/// An index row that lenient loading could not represent, with the
+/// selector fields recovered best-effort from the raw TOML so callers can
+/// tell whether the row could have answered their query.
+///
+/// Fail-closed contract: a query that *may* match a skipped row must be
+/// refused rather than answered from the remaining rows — answering would
+/// silently substitute an older parsable version for the one this build
+/// cannot read (worst case: `update` downgrading an installed component).
+/// Unreadable selector fields are `None` and match conservatively.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedIndexEntry {
+    /// `component` field, when readable.
+    pub component: Option<String>,
+    /// `version` field, when readable.
+    pub version: Option<String>,
+    /// `channel` field, when readable.
+    pub channel: Option<String>,
+    /// `os` field, when readable.
+    pub os: Option<String>,
+    /// `arch` field, when readable.
+    pub arch: Option<String>,
+    /// `install_modes` field, when readable.
+    pub install_modes: Option<Vec<String>>,
+    /// Human-facing diagnostic (row position, component, parse error).
+    pub reason: String,
+}
+
+impl SkippedIndexEntry {
+    /// Whether this skipped row could have answered `q`, mirroring the
+    /// selector rules of [`DistributionIndex::resolve`] with `None`
+    /// (unreadable) fields treated as matching. A `version: None` query
+    /// ("latest") matches any skipped version of the component — the row
+    /// might be the newest — while a pinned query matches only its exact
+    /// version. `libc`/`pkg_base` are not recovered and never narrow the
+    /// answer, erring on refusal.
+    pub fn may_match(&self, q: &ResolveQuery<'_>) -> bool {
+        let component_matches = self.component.as_deref().is_none_or(|c| c == q.component);
+        let version_matches = match q.version {
+            Some(pinned) => self.version.as_deref().is_none_or(|v| v == pinned),
+            None => true,
+        };
+        let channel_matches = self
+            .channel
+            .as_deref()
+            .is_none_or(|c| c == q.channel.unwrap_or("stable"));
+        let os_matches = self.os.as_deref().is_none_or(|os| os == q.os);
+        let arch_matches = self
+            .arch
+            .as_deref()
+            .is_none_or(|arch| arch == q.arch || arch == "any");
+        let mode_matches = self
+            .install_modes
+            .as_ref()
+            .is_none_or(|modes| modes.iter().any(|m| m == q.install_mode));
+        component_matches
+            && version_matches
+            && channel_matches
+            && os_matches
+            && arch_matches
+            && mode_matches
+    }
+}
+
 /// Resolver query. Borrowed so callers can build it without allocating.
 #[derive(Debug, Clone)]
 pub struct ResolveQuery<'a> {
@@ -224,6 +287,116 @@ impl DistributionIndex {
     /// Parse from a TOML string. Returned error is the raw `toml` message.
     pub fn from_toml_str(s: &str) -> Result<Self, String> {
         toml::from_str(s).map_err(|e| e.to_string())
+    }
+
+    /// Load like [`Self::load`], but tolerate individually unparsable
+    /// entries instead of failing the whole index.
+    ///
+    /// Forward compatibility for consumers of a shared index: when a future
+    /// repository publishes an entry this build cannot represent (e.g. a new
+    /// `artifact_type`), that row is skipped while every other entry stays
+    /// installable; atomic parsing would instead reject the entire index and
+    /// break unrelated components. Callers MUST hold each returned
+    /// [`SkippedIndexEntry`] against their query via
+    /// [`SkippedIndexEntry::may_match`] and refuse to resolve when one may
+    /// match — otherwise a query for "latest" would silently fall back to
+    /// an older parsable version of the same component, which is a silent
+    /// downgrade, not fail-closed. File-level errors (I/O, TOML syntax,
+    /// malformed header) still fail the whole load: a damaged index is not
+    /// something to shop around in.
+    pub fn load_lenient(path: &Path) -> Result<(Self, Vec<SkippedIndexEntry>), DistributionError> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| DistributionError::Io(path.display().to_string(), e))?;
+        Self::from_toml_str_lenient(&content)
+            .map_err(|e| DistributionError::Parse(path.display().to_string(), e))
+    }
+
+    /// Entry-tolerant variant of [`Self::from_toml_str`]; see
+    /// [`Self::load_lenient`] for the compatibility rationale and the
+    /// obligation the skipped rows place on callers.
+    pub fn from_toml_str_lenient(s: &str) -> Result<(Self, Vec<SkippedIndexEntry>), String> {
+        /// Index shell with entries left as raw TOML values so one bad row
+        /// cannot poison the header or its siblings.
+        #[derive(Deserialize)]
+        struct LenientIndex {
+            schema_version: u32,
+            #[serde(default)]
+            channel: Option<String>,
+            #[serde(default)]
+            generated_at: Option<String>,
+            #[serde(default)]
+            expires_at: Option<String>,
+            #[serde(default)]
+            publisher: Option<String>,
+            #[serde(default)]
+            signature: Option<String>,
+            #[serde(default)]
+            entries: Vec<toml::Value>,
+        }
+
+        fn get_str(value: &toml::Value, key: &str) -> Option<String> {
+            value.get(key).and_then(|v| v.as_str()).map(str::to_owned)
+        }
+
+        let raw: LenientIndex = toml::from_str(s).map_err(|e| e.to_string())?;
+        let mut entries = Vec::with_capacity(raw.entries.len());
+        let mut skipped = Vec::new();
+        for (i, value) in raw.entries.into_iter().enumerate() {
+            // Selector fields are captured best-effort *before* the strict
+            // parse so a skipped row can still be matched against queries;
+            // a field too broken to read stays None and matches
+            // conservatively (see [`SkippedIndexEntry::may_match`]).
+            let component = get_str(&value, "component");
+            let version = get_str(&value, "version");
+            let channel = get_str(&value, "channel");
+            let os = get_str(&value, "os");
+            let arch = get_str(&value, "arch");
+            // All-or-nothing recovery: one non-string element makes the
+            // whole selector unreadable (`None`, matches conservatively).
+            // A partially recovered list would under-block — e.g. valid
+            // TOML `install_modes = [1]` recovered as an empty list
+            // matches no install mode, letting the skipped row bypass the
+            // downgrade gate.
+            let install_modes = value
+                .get("install_modes")
+                .and_then(|v| v.as_array())
+                .and_then(|modes| {
+                    modes
+                        .iter()
+                        .map(|m| m.as_str().map(str::to_owned))
+                        .collect::<Option<Vec<_>>>()
+                });
+            match value.try_into::<DistributionEntry>() {
+                Ok(entry) => entries.push(entry),
+                Err(e) => {
+                    let who = component
+                        .as_deref()
+                        .map(|c| format!(" (component '{c}')"))
+                        .unwrap_or_default();
+                    skipped.push(SkippedIndexEntry {
+                        component,
+                        version,
+                        channel,
+                        os,
+                        arch,
+                        install_modes,
+                        reason: format!("skipped index entry #{i}{who}: {e}"),
+                    });
+                }
+            }
+        }
+        Ok((
+            Self {
+                schema_version: raw.schema_version,
+                channel: raw.channel,
+                generated_at: raw.generated_at,
+                expires_at: raw.expires_at,
+                publisher: raw.publisher,
+                signature: raw.signature,
+                entries,
+            },
+            skipped,
+        ))
     }
 
     /// Serialize to TOML. Useful for tests and tooling.
@@ -744,6 +917,152 @@ mod tests {
         "#;
         let index = DistributionIndex::from_toml_str(toml_str).expect("parse");
         assert_eq!(index.entries[0].artifact_type, ArtifactType::TarGz);
+    }
+
+    /// Lenient loading skips only the rows this build cannot represent
+    /// (fail closed for their component) and keeps siblings installable;
+    /// strict parsing of the same document still fails atomically.
+    #[test]
+    fn lenient_parse_skips_unknown_entry_and_keeps_siblings() {
+        let toml_str = r#"
+            schema_version = 1
+            [[entries]]
+            component = "cosh"
+            version = "1.2.3"
+            channel = "stable"
+            artifact_type = "tar_gz"
+            backend = "tar"
+            url = "https://example.invalid/cosh.tar.gz"
+            os = "linux"
+            arch = "x86_64"
+            install_modes = ["user"]
+            [[entries]]
+            component = "future-thing"
+            version = "0.1.0"
+            channel = "stable"
+            artifact_type = "hologram_v9"
+            backend = "tar"
+            url = "https://example.invalid/future.tar.gz"
+            os = "linux"
+            arch = "x86_64"
+            install_modes = ["user"]
+        "#;
+        assert!(
+            DistributionIndex::from_toml_str(toml_str).is_err(),
+            "strict parse must stay atomic"
+        );
+        let (index, skipped) =
+            DistributionIndex::from_toml_str_lenient(toml_str).expect("lenient parse");
+        assert_eq!(index.entries.len(), 1);
+        assert_eq!(index.entries[0].component, "cosh");
+        assert_eq!(skipped.len(), 1);
+        assert!(
+            skipped[0].reason.contains("future-thing"),
+            "diagnostic should name the skipped component, got: {}",
+            skipped[0].reason
+        );
+        assert_eq!(skipped[0].component.as_deref(), Some("future-thing"));
+        assert_eq!(skipped[0].version.as_deref(), Some("0.1.0"));
+    }
+
+    /// A selector that is valid TOML but not the shape this build expects
+    /// (e.g. non-string elements in `install_modes`) must be recovered as
+    /// unreadable (`None`) — never as a partial list. `Some([])` would
+    /// match no install mode and let the row bypass the downgrade gate.
+    #[test]
+    fn lenient_parse_treats_malformed_selector_as_unreadable() {
+        let toml_str = r#"
+            schema_version = 1
+            [[entries]]
+            component = "sec-core"
+            version = "2.0.0"
+            channel = "stable"
+            artifact_type = "hologram_v9"
+            backend = "tar"
+            url = "https://example.invalid/sec-core.tar.gz"
+            os = "linux"
+            arch = "x86_64"
+            install_modes = [1]
+        "#;
+        let (index, skipped) =
+            DistributionIndex::from_toml_str_lenient(toml_str).expect("lenient parse");
+        assert!(index.entries.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(
+            skipped[0].install_modes, None,
+            "a partially readable selector must collapse to unreadable"
+        );
+        // And the unreadable selector must block conservatively.
+        let query = ResolveQuery {
+            component: "sec-core",
+            version: None,
+            channel: None,
+            install_mode: "user",
+            os: "linux",
+            arch: "x86_64",
+            libc: None,
+            pkg_base: None,
+            preferred_types: &[],
+        };
+        assert!(skipped[0].may_match(&query));
+    }
+
+    /// The fail-closed matcher: a skipped row blocks exactly the queries it
+    /// could have answered — same component and target (any version when
+    /// the query wants "latest", the exact version when pinned) — and
+    /// unreadable fields block conservatively.
+    #[test]
+    fn skipped_entry_may_match_mirrors_resolver_selectors() {
+        let skipped = SkippedIndexEntry {
+            component: Some("sec-core".to_string()),
+            version: Some("2.0.0".to_string()),
+            channel: Some("stable".to_string()),
+            os: Some("linux".to_string()),
+            arch: Some("x86_64".to_string()),
+            install_modes: Some(vec!["user".to_string()]),
+            reason: "skipped index entry #1 (component 'sec-core')".to_string(),
+        };
+        let query = |component: &'static str, version: Option<&'static str>| ResolveQuery {
+            component,
+            version,
+            channel: None,
+            install_mode: "user",
+            os: "linux",
+            arch: "x86_64",
+            libc: None,
+            pkg_base: None,
+            preferred_types: &[],
+        };
+        // "latest" for the same component: the skipped row might be newest.
+        assert!(skipped.may_match(&query("sec-core", None)));
+        // The pinned version the row itself advertises.
+        assert!(skipped.may_match(&query("sec-core", Some("2.0.0"))));
+        // A different pinned version is answerable from parsable rows.
+        assert!(!skipped.may_match(&query("sec-core", Some("1.0.0"))));
+        // Unrelated components are unaffected.
+        assert!(!skipped.may_match(&query("cosh", None)));
+        // Non-matching target never blocks.
+        let mut other_os = query("sec-core", None);
+        other_os.os = "darwin";
+        assert!(!skipped.may_match(&other_os));
+        // Unreadable selectors must block conservatively.
+        let opaque = SkippedIndexEntry {
+            component: None,
+            version: None,
+            channel: None,
+            os: None,
+            arch: None,
+            install_modes: None,
+            reason: "skipped index entry #0".to_string(),
+        };
+        assert!(opaque.may_match(&query("cosh", Some("1.0.0"))));
+    }
+
+    /// A syntactically damaged file must fail even in lenient mode: entry
+    /// tolerance is for schema evolution, not for corrupted downloads.
+    #[test]
+    fn lenient_parse_still_rejects_file_level_damage() {
+        assert!(DistributionIndex::from_toml_str_lenient("schema_version = [broken").is_err());
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -57,6 +57,11 @@ pub struct ResolvedInstallFile {
     /// File role; [`FileKind::Symlink`] entries are created after the
     /// regular files instead of being extracted from the artifact.
     pub kind: FileKind,
+    /// Content-rendering request from the manifest `render` key. `None`
+    /// places the archive bytes verbatim. Rendering runs before the
+    /// installed sha256 is computed, so state records the bytes that
+    /// actually land on disk.
+    pub render: Option<RenderSpec>,
 }
 
 impl ResolvedInstallFile {
@@ -68,7 +73,39 @@ impl ResolvedInstallFile {
             dest,
             mode: None,
             kind: FileKind::Data,
+            render: None,
         }
+    }
+}
+
+/// Content-rendering request carried on a [`ResolvedInstallFile`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderSpec {
+    /// Versioned rendering mode resolved from the manifest `render` value.
+    pub mode: RenderMode,
+    /// Component name substituted for the `{component}` placeholder,
+    /// mirroring destination-path expansion.
+    pub component: String,
+}
+
+/// Supported file content-rendering modes.
+///
+/// Each variant corresponds to one versioned manifest `render` value; the
+/// install resolver rejects values with no variant here so an unsupported
+/// contract fails closed instead of installing unrendered placeholders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderMode {
+    /// [`RENDER_ANOLISA_PATHS_V1`](crate::manifest::RENDER_ANOLISA_PATHS_V1):
+    /// substitute layout placeholders (`{bindir}`, `{datadir}`, … plus
+    /// `{component}`) inside UTF-8 file content against the final layout.
+    AnolisaPathsV1,
+}
+
+impl RenderMode {
+    /// Map a manifest `render` string to a supported mode. Returns `None`
+    /// for values this CLI does not implement — callers must reject those.
+    pub fn parse(value: &str) -> Option<Self> {
+        (value == crate::manifest::RENDER_ANOLISA_PATHS_V1).then_some(Self::AnolisaPathsV1)
     }
 }
 
@@ -171,6 +208,16 @@ pub enum InstallError {
     /// parsed as a component manifest.
     #[error("embedded component manifest could not be parsed: {0}")]
     EmbeddedManifestParse(String),
+
+    /// Content rendering (`render = "anolisa-paths-v1"`) failed for an entry.
+    #[error("cannot render '{path}': {reason}")]
+    Render {
+        /// Destination of the entry that could not be rendered.
+        path: PathBuf,
+        /// What was wrong (non-UTF-8 content, unknown placeholder, or a
+        /// render request on a non-regular entry).
+        reason: String,
+    },
 }
 
 /// Extract and parse the published install contract embedded in a tar.gz
@@ -464,6 +511,17 @@ impl<'a> InstallRunner<'a> {
     ) -> Result<(), InstallError> {
         let mut seen = BTreeSet::new();
         for link in links {
+            // A symlink has no content to render; a render request on one
+            // is a contract defect, not something to silently drop. The CLI
+            // rejects this earlier with contract context (raw install's
+            // render resolution); this re-check is defense-in-depth for
+            // callers constructing `ResolvedInstallFile` directly.
+            if link.render.is_some() {
+                return Err(InstallError::Render {
+                    path: link.dest.clone(),
+                    reason: "render applies to regular files, not symlinks".to_string(),
+                });
+            }
             let referent =
                 link.source
                     .as_deref()
@@ -498,6 +556,18 @@ impl<'a> InstallRunner<'a> {
             if let Some(source) = file.source.as_deref()
                 && archive_source_is_dir(source)
             {
+                // Rendering targets one regular file; a directory source
+                // fans out to arbitrarily many entries and would silently
+                // rewrite payloads the contract author never meant to
+                // template. Fail closed. Mirrors the CLI-side early check
+                // in raw install's render resolution; keep both in sync.
+                if file.render.is_some() {
+                    return Err(InstallError::Render {
+                        path: file.dest.clone(),
+                        reason: "render applies to single regular files, not directory sources"
+                            .to_string(),
+                    });
+                }
                 let prefix = normalize_archive_key(source);
                 let prefix = prefix.trim_end_matches('/');
                 let mut matched = false;
@@ -515,6 +585,7 @@ impl<'a> InstallRunner<'a> {
                             dest: file.dest.join(relative),
                             mode: file.mode.clone(),
                             kind: file.kind,
+                            render: None,
                         },
                         bytes.clone(),
                     ));
@@ -535,7 +606,8 @@ impl<'a> InstallRunner<'a> {
                     .ok_or_else(|| InstallError::MissingArchiveEntry {
                         basename: key.clone(),
                     })?;
-            expanded.push((file.clone(), bytes.clone()));
+            let bytes = self.rendered_bytes(file, bytes)?;
+            expanded.push((file.clone(), bytes));
         }
 
         let expanded_files: Vec<ResolvedInstallFile> =
@@ -543,6 +615,49 @@ impl<'a> InstallRunner<'a> {
         self.validate_install_targets(&expanded_files, destination_policy)?;
 
         Ok(expanded)
+    }
+
+    /// Apply the entry's content-rendering request to the archive bytes.
+    ///
+    /// No-op clone when the entry declares no `render`. For
+    /// [`RenderMode::AnolisaPathsV1`] the bytes must be UTF-8 text; layout
+    /// placeholders are substituted via the same expansion vocabulary used
+    /// for destination paths, so path and content semantics cannot drift.
+    fn rendered_bytes(
+        &self,
+        file: &ResolvedInstallFile,
+        bytes: &[u8],
+    ) -> Result<Vec<u8>, InstallError> {
+        let Some(spec) = file.render.as_ref() else {
+            return Ok(bytes.to_vec());
+        };
+        match spec.mode {
+            RenderMode::AnolisaPathsV1 => {
+                let text = std::str::from_utf8(bytes).map_err(|_| InstallError::Render {
+                    path: file.dest.clone(),
+                    reason: "content is not valid UTF-8 — anolisa-paths-v1 renders text files only"
+                        .to_string(),
+                })?;
+                let rendered = crate::adapter::expand_layout_placeholders_str(
+                    text,
+                    self.layout,
+                    &[("component", spec.component.as_str())],
+                )
+                .map_err(|err| {
+                    let reason = match err {
+                        crate::adapter::AdapterError::UnknownPlaceholder {
+                            placeholder, ..
+                        } => format!("content references unknown placeholder '{{{placeholder}}}'"),
+                        other => other.to_string(),
+                    };
+                    InstallError::Render {
+                        path: file.dest.clone(),
+                        reason,
+                    }
+                })?;
+                Ok(rendered.into_bytes())
+            }
+        }
     }
 
     fn validate_dest(&self, dest: &Path) -> Result<(), InstallError> {
@@ -637,6 +752,7 @@ impl PreparedSymlink {
             dest: self.dest.clone(),
             mode: None,
             kind: FileKind::Symlink,
+            render: None,
         }
     }
 }
@@ -1147,6 +1263,7 @@ mod tests {
                     dest: dest.clone(),
                     mode: None,
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect("install ok");
@@ -1183,6 +1300,7 @@ mod tests {
                     dest: dest_root.clone(),
                     mode: Some("0644".to_string()),
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect("install ok");
@@ -1228,6 +1346,7 @@ mod tests {
                     dest: dest.clone(),
                     mode: Some("0644".to_string()),
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect("install ok");
@@ -1255,6 +1374,7 @@ mod tests {
                     dest: dest.clone(),
                     mode: Some("not-octal".to_string()),
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect_err("must reject invalid mode");
@@ -1374,6 +1494,7 @@ mod tests {
                     dest: dest.clone(),
                     mode: None,
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect_err("must reject");
@@ -1405,6 +1526,7 @@ mod tests {
                     dest: dest.clone(),
                     mode: None,
                     kind: FileKind::Data,
+                    render: None,
                 }],
             )
             .expect_err("must reject");
@@ -1557,6 +1679,7 @@ mod tests {
             dest,
             mode: None,
             kind: FileKind::Symlink,
+            render: None,
         }
     }
 
@@ -1580,6 +1703,7 @@ mod tests {
                 dest: referent.clone(),
                 mode: Some("0755".into()),
                 kind: FileKind::Data,
+                render: None,
             },
             symlink_entry(&referent, link_dest.clone()),
         ];
@@ -1620,6 +1744,7 @@ mod tests {
                 dest: link_dest.clone(),
                 mode: None,
                 kind: FileKind::Symlink,
+                render: None,
             },
         ];
 
@@ -1741,5 +1866,193 @@ mod tests {
             .install_files("tar_gz", &cached, &files)
             .expect_err("must error");
         assert!(matches!(err, InstallError::NoDestinations));
+    }
+
+    // -- content rendering (`render = "anolisa-paths-v1"`) ------------------
+
+    fn render_entry(source: &str, dest: PathBuf) -> ResolvedInstallFile {
+        ResolvedInstallFile {
+            source: Some(source.to_string()),
+            dest,
+            mode: Some("0644".to_string()),
+            kind: FileKind::Data,
+            render: Some(RenderSpec {
+                mode: RenderMode::AnolisaPathsV1,
+                component: "sec-core".to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn render_substitutes_placeholders_and_hashes_rendered_bytes() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let template = "[Service]\nExecStart=\"{bindir}/agent-sec-daemon\" serve\nReadWritePaths=\"{datadir}\"\n";
+        let gz = build_tar_gz(&[("share/agent-sec-core.service.in", template.as_bytes())]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("agent-sec-core.service");
+        let outcome = runner
+            .install_files(
+                "tar_gz",
+                &cached,
+                &[render_entry(
+                    "share/agent-sec-core.service.in",
+                    dest.clone(),
+                )],
+            )
+            .expect("install ok");
+
+        let expected = template
+            .replace("{bindir}", &layout.bin_dir.to_string_lossy())
+            .replace("{datadir}", &layout.datadir.to_string_lossy());
+        let installed = fs::read_to_string(&dest).unwrap();
+        assert_eq!(installed, expected, "placeholders must be substituted");
+        assert!(
+            !installed.contains('{'),
+            "no literal placeholder may survive rendering"
+        );
+        // State records the sha256 of the *rendered* bytes, so integrity
+        // verification over the installed file passes.
+        assert_eq!(outcome.files[0].sha256, sha256_of(expected.as_bytes()));
+    }
+
+    #[test]
+    fn render_expands_component_variable() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("conf.in", b"root={datadir}/adapters/{component}\n")]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.etc_dir.join("conf");
+        runner
+            .install_files("tar_gz", &cached, &[render_entry("conf.in", dest.clone())])
+            .expect("install ok");
+        assert_eq!(
+            fs::read_to_string(&dest).unwrap(),
+            format!("root={}/adapters/sec-core\n", layout.datadir.display())
+        );
+    }
+
+    #[test]
+    fn render_unknown_placeholder_rejected() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("unit.in", b"ExecStart={no_such_dir}/daemon\n")]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("unit");
+        let err = runner
+            .install_files("tar_gz", &cached, &[render_entry("unit.in", dest.clone())])
+            .expect_err("must reject unknown placeholder");
+        match err {
+            InstallError::Render { path, reason } => {
+                assert_eq!(path, dest);
+                assert!(
+                    reason.contains("no_such_dir"),
+                    "reason must name the placeholder: {reason}"
+                );
+            }
+            other => panic!("expected Render, got {other:?}"),
+        }
+        assert!(!dest.exists(), "nothing may land on a failed render");
+    }
+
+    #[test]
+    fn render_non_utf8_content_rejected() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("blob.in", &[0xff, 0xfe, 0x00, 0x7b][..])]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("blob");
+        let err = runner
+            .install_files("tar_gz", &cached, &[render_entry("blob.in", dest.clone())])
+            .expect_err("must reject non-UTF-8 content");
+        match err {
+            InstallError::Render { path, reason } => {
+                assert_eq!(path, dest);
+                assert!(reason.contains("UTF-8"), "reason must say UTF-8: {reason}");
+            }
+            other => panic!("expected Render, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn render_on_directory_source_rejected() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("tree/file", b"x")]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("tree");
+        let err = runner
+            .install_files("tar_gz", &cached, &[render_entry("tree/", dest.clone())])
+            .expect_err("must reject render on a directory source");
+        match err {
+            InstallError::Render { path, .. } => assert_eq!(path, dest),
+            other => panic!("expected Render, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn render_on_symlink_rejected() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("bin/foo", b"x")]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let referent = layout.bin_dir.join("foo");
+        let link_dest = layout.bin_dir.join("foo-link");
+        let mut link = symlink_entry(&referent, link_dest.clone());
+        link.render = Some(RenderSpec {
+            mode: RenderMode::AnolisaPathsV1,
+            component: "sec-core".to_string(),
+        });
+        let files = vec![
+            ResolvedInstallFile {
+                source: Some("bin/foo".to_string()),
+                dest: referent,
+                mode: None,
+                kind: FileKind::Data,
+                render: None,
+            },
+            link,
+        ];
+        let err = runner
+            .install_files("tar_gz", &cached, &files)
+            .expect_err("must reject render on a symlink");
+        match err {
+            InstallError::Render { path, .. } => assert_eq!(path, link_dest),
+            other => panic!("expected Render, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn render_mode_parse_accepts_only_v1() {
+        assert_eq!(
+            RenderMode::parse("anolisa-paths-v1"),
+            Some(RenderMode::AnolisaPathsV1)
+        );
+        assert_eq!(RenderMode::parse("anolisa-paths-v2"), None);
+        assert_eq!(RenderMode::parse(""), None);
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -54,7 +54,10 @@ pub use adapter::manager::{
     AdapterManager, DisableOutcome, EnableOutcome, ScanReport, StatusReport,
 };
 pub use adapter::registry::DriverRegistry;
-pub use adapter::{AdapterError, DetectResult, detect_framework, expand_layout_placeholders};
+pub use adapter::{
+    AdapterError, DetectResult, detect_framework, expand_layout_placeholders,
+    expand_layout_placeholders_str,
+};
 pub use backup::{BackupEntry, BackupSet};
 pub use capability::{
     CapabilityError, CapabilityManager, CapabilityOutcome, CapabilityRequest, CapabilityRunOutcome,
@@ -80,7 +83,8 @@ pub use hooks::{
     run_hook, run_hooks,
 };
 pub use install_runner::{
-    InstallError, InstallOutcome, InstallRunner, InstalledFile, ResolvedInstallFile,
+    InstallError, InstallOutcome, InstallRunner, InstalledFile, RenderMode, RenderSpec,
+    ResolvedInstallFile,
 };
 pub use integrity::{IntegrityStatus, check_owned_file};
 pub use lifecycle::{

--- a/src/anolisa/crates/anolisa-core/src/manifest.rs
+++ b/src/anolisa/crates/anolisa-core/src/manifest.rs
@@ -19,6 +19,11 @@ use std::path::{Path, PathBuf};
 /// Default schema version applied when the TOML omits it.
 pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 
+/// Canonical `render` value for layout-placeholder content rendering
+/// (see [`InstallFileSpec::render`]). Single source of the wire spelling
+/// so contract authors, the install resolver, and docs cannot drift.
+pub const RENDER_ANOLISA_PATHS_V1: &str = "anolisa-paths-v1";
+
 // ---------------------------------------------------------------------------
 // ComponentManifest
 // ---------------------------------------------------------------------------
@@ -275,6 +280,17 @@ pub struct InstallFileSpec {
     /// [`FileKind::Data`]; legacy `[install]` files have no `type`.
     #[serde(default, skip_serializing_if = "is_default_file_kind")]
     pub kind: FileKind,
+    /// Content-rendering mode requested by the contract, e.g.
+    /// [`RENDER_ANOLISA_PATHS_V1`]. Declares that the installer MUST
+    /// substitute layout placeholders (`{bindir}`, `{datadir}`, …) inside
+    /// the file *content* against the final [`FsLayout`] before placing it
+    /// — relocatable systemd unit templates rely on this. The value is
+    /// versioned so the vocabulary can evolve without ambiguity; installers
+    /// reject values they do not implement. `None` copies bytes verbatim.
+    ///
+    /// [`FsLayout`]: anolisa_platform::fs_layout::FsLayout
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub render: Option<String>,
 }
 
 /// Skip serializing the default [`FileKind`] so round-tripped legacy manifests
@@ -627,6 +643,12 @@ pub struct AdapterSpec {
     /// Destination path after layout placeholder expansion.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dest: Option<String>,
+    /// `[adapters.backends]` — backend-specific resource-root overrides.
+    /// A unified raw/RPM contract keeps [`dest`](Self::dest) as the raw
+    /// install target while RPM payloads live at a package-owned path;
+    /// scan/enable select the root by the component's install provenance.
+    #[serde(default, skip_serializing_if = "AdapterBackendsSpec::is_empty")]
+    pub backends: AdapterBackendsSpec,
     /// Bundle description: how the driver should read the adapter's
     /// resource directory.
     #[serde(default, skip_serializing_if = "AdapterBundleSpec::is_empty")]
@@ -686,6 +708,40 @@ impl AdapterBundleSpec {
     fn is_empty(&self) -> bool {
         self.schema.is_none() && self.entry.is_none()
     }
+}
+
+/// `[adapters.backends]` — backend-specific adapter resource metadata for
+/// unified raw/RPM contracts. Only the RPM backend is defined today; the
+/// table shape leaves room for other native backends.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AdapterBackendsSpec {
+    /// `[adapters.backends.rpm]` — resource metadata for RPM-installed
+    /// components.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpm: Option<AdapterRpmBackendSpec>,
+}
+
+impl AdapterBackendsSpec {
+    /// True when no backend declares any metadata; the whole `[adapters.
+    /// backends]` table is then omitted on serialization so round-tripped
+    /// contracts without it stay byte-stable.
+    pub fn is_empty(&self) -> bool {
+        self.rpm.as_ref().is_none_or(|r| r.resource_root.is_none())
+    }
+}
+
+/// `[adapters.backends.rpm]` — adapter resource metadata consumed when the
+/// owning component was installed via the RPM backend.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AdapterRpmBackendSpec {
+    /// Read-only resource root holding the RPM-installed adapter bundle.
+    /// May use layout placeholders (`{datadir}`, …, plus `{component}`) or
+    /// be an absolute package-owned path such as
+    /// `/opt/agent-sec/openclaw-plugin/`. Scan/enable read the bundle from
+    /// here instead of expanding [`AdapterSpec::dest`]; ANOLISA never
+    /// writes under it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_root: Option<String>,
 }
 
 /// Compatibility metadata for an adapter entry. Lets packaging and the
@@ -1025,6 +1081,9 @@ struct LayoutFileRaw {
     /// Minimal-schema `type` → [`FileKind`]. Absent defaults to `Data`.
     #[serde(default, rename = "type")]
     kind: FileKind,
+    /// Content-rendering mode (see [`InstallFileSpec::render`]).
+    #[serde(default)]
+    render: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1113,6 +1172,13 @@ struct InstallFileRaw {
     /// symlinks; absent defaults to `Data`, keeping old files byte-stable.
     #[serde(default, rename = "type")]
     kind: FileKind,
+    /// Content-rendering mode (see [`InstallFileSpec::render`]). Parsed on
+    /// the legacy path too — both because serialized manifests round-trip
+    /// through `[install]`, and because silently dropping a declared
+    /// render would install literal placeholders (the failure this field
+    /// exists to prevent).
+    #[serde(default)]
+    render: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -1164,6 +1230,11 @@ struct AdapterRaw {
     source: Option<String>,
     #[serde(default)]
     dest: Option<String>,
+    // `[adapters.backends]` deserializes directly into the typed shape —
+    // simple and tolerant (`default` table, optional `rpm` sub-table) —
+    // same rationale as the top-level `[backends]`.
+    #[serde(default)]
+    backends: AdapterBackendsSpec,
     #[serde(default)]
     bundle: AdapterBundleRaw,
     #[serde(default)]
@@ -1293,6 +1364,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                     dest: f.target,
                     mode: f.mode,
                     kind: f.kind,
+                    render: f.render,
                 })
                 .filter(|f| f.install_path().is_some())
                 .collect();
@@ -1323,6 +1395,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                             dest: f.dest,
                             mode: f.mode,
                             kind: f.kind,
+                            render: f.render,
                         })
                         .filter(|f| f.install_path().is_some())
                         .collect();
@@ -1382,6 +1455,7 @@ impl From<ComponentManifestRaw> for ComponentManifest {
                 plugin_id: a.plugin_id,
                 source: a.source,
                 dest: a.dest,
+                backends: a.backends,
                 bundle: AdapterBundleSpec {
                     schema: a.bundle.schema,
                     entry: a.bundle.entry,
@@ -2473,6 +2547,67 @@ mod tests {
     }
 
     #[test]
+    fn layout_files_render_parses_and_round_trips() {
+        // Minimal-schema `render` reaches InstallFileSpec verbatim and
+        // survives serialization, so a snapshotted contract keeps the
+        // rendering request; entries without it stay `None` and omit the
+        // key on round-trip.
+        let m = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "sec-core"
+            version = "0.9.0"
+            [component.layout]
+            [[component.layout.files]]
+            source = "share/agent-sec-core.service.in"
+            target = "{userunitdir}/agent-sec-core.service"
+            render = "anolisa-paths-v1"
+            [[component.layout.files]]
+            source = "bin/agent-sec-cli"
+            target = "{bindir}/agent-sec-cli"
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(
+            m.install.files[0].render.as_deref(),
+            Some(RENDER_ANOLISA_PATHS_V1)
+        );
+        assert_eq!(m.install.files[1].render, None);
+
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(
+            m.install.files, m2.install.files,
+            "round-trip must preserve render"
+        );
+    }
+
+    #[test]
+    fn legacy_install_files_carry_render_too() {
+        // The legacy `[install]` path must not silently drop a declared
+        // render — that would install literal placeholders — and serialized
+        // manifests round-trip through this shape.
+        let m = ComponentManifest::from_toml_str(
+            r#"
+            [component]
+            name = "t"
+            version = "1.0.0"
+            [install]
+            modes = ["user"]
+            [[install.files]]
+            source = "share/unit.in"
+            dest = "{userunitdir}/unit.service"
+            render = "anolisa-paths-v1"
+        "#,
+        )
+        .expect("parse");
+        assert_eq!(
+            m.install.files[0].render.as_deref(),
+            Some(RENDER_ANOLISA_PATHS_V1)
+        );
+    }
+
+    #[test]
     fn health_spec_uses_declared_check_when_present() {
         let m = ComponentManifest::from_toml_str(
             r#"
@@ -2736,6 +2871,50 @@ mod tests {
         assert!(
             !serialized.contains("[compat]"),
             "empty compat must be skipped in serialization"
+        );
+        assert!(
+            !serialized.contains("[adapters.backends]"),
+            "empty backends must be skipped in serialization"
+        );
+    }
+
+    #[test]
+    fn adapter_backends_rpm_resource_root_parses_and_round_trips() {
+        // `[adapters.backends.rpm]` declares the read-only resource root an
+        // RPM install provides; it must parse alongside the raw `dest` and
+        // survive round-trip so snapshotted contracts keep both roots.
+        let toml_text = r#"
+            [component]
+            name = "sec-core"
+            version = "0.9.0"
+
+            [[adapters]]
+            framework = "openclaw"
+            source = "adapters/sec-core/openclaw"
+            dest = "{datadir}/adapters/{component}/openclaw/"
+
+            [adapters.backends.rpm]
+            resource_root = "/opt/agent-sec/openclaw-plugin/"
+        "#;
+        let m = ComponentManifest::from_toml_str(toml_text).expect("parse");
+        let a = &m.adapters[0];
+        assert_eq!(
+            a.dest.as_deref(),
+            Some("{datadir}/adapters/{component}/openclaw/")
+        );
+        assert_eq!(
+            a.backends
+                .rpm
+                .as_ref()
+                .and_then(|rpm| rpm.resource_root.as_deref()),
+            Some("/opt/agent-sec/openclaw-plugin/")
+        );
+
+        let serialized = toml::to_string_pretty(&m).expect("serialize");
+        let m2 = ComponentManifest::from_toml_str(&serialized).expect("re-parse");
+        assert_eq!(
+            m.adapters, m2.adapters,
+            "round-trip must preserve backend resource roots"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/state_store.rs
+++ b/src/anolisa/crates/anolisa-core/src/state_store.rs
@@ -29,11 +29,20 @@ use crate::state::{
 use crate::state_identity::repair_known_installation_identities;
 use crate::state_migration::{MigrationRule, QuarantinedObject, migrate_state};
 
-/// Schema version this store reads natively and always writes.
+/// Baseline schema version: what this store writes when no schema-v6
+/// feature is in use, and the newest version pre-anchor readers accept.
 pub const STORE_SCHEMA_VERSION: u32 = 5;
 
-/// v5 on-disk wire shape. Kept private: the store is the API, the file
-/// layout is an implementation detail.
+/// Schema version written when [`StateStore::adapter_trust_roots`] is
+/// non-empty. Same wire shape as v5 plus the anchor array — bumped so
+/// pre-anchor writers (≤ 0.2.16) hit their `NewerSchema` guard and refuse
+/// the file instead of silently dropping the security-critical anchors on
+/// their next save.
+pub const STORE_SCHEMA_VERSION_ANCHORED: u32 = 6;
+
+/// v5/v6 on-disk wire shape. Kept private: the store is the API, the file
+/// layout is an implementation detail. v6 is v5 plus `adapter_trust_roots`;
+/// the version number on disk tracks whether that array is populated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StateFileV5 {
     schema_version: u32,
@@ -51,6 +60,36 @@ struct StateFileV5 {
     operations: Vec<OperationRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     adapter_claims: Vec<AdapterClaim>,
+    /// See [`AdapterTrustRoot`]. `default` keeps pre-anchor v5 files
+    /// loading; `skip_serializing_if` keeps files without anchors
+    /// byte-identical to before the field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    adapter_trust_roots: Vec<AdapterTrustRoot>,
+}
+
+/// Manager-written record of the external adapter resource root that was
+/// contract-validated at the receipt's last successful enable.
+///
+/// Receipt symlink targets are never trusted from the receipt itself (a
+/// forged receipt must not self-authorize). But a legitimate RPM update
+/// may move the resource root and refresh the contract snapshot while an
+/// enabled receipt still points at the old root — without this anchor,
+/// that receipt could no longer be validated for status/disable/re-enable
+/// and became permanently stuck. Only the Manager writes this record
+/// (enable upserts, disable removes); drivers never see it.
+///
+/// Despite the type name, validation consumes the anchor as an
+/// **exact-equality** symlink-target allowance, never as a root: a
+/// state-resident path (forgeable in user mode) authorizes only itself,
+/// nothing beneath it, and no write outside anolisa's own layout.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterTrustRoot {
+    /// Component the anchored receipt belongs to.
+    pub component: String,
+    /// Framework of the anchored receipt.
+    pub framework: String,
+    /// The contract-validated resource root at enable time.
+    pub root: PathBuf,
 }
 
 /// Minimal probe to route a file to the right parser without committing to
@@ -78,6 +117,9 @@ pub struct StateStore {
     pub operations: Vec<OperationRecord>,
     /// Adapter receipts written by `anolisa adapter enable`.
     pub adapter_claims: Vec<AdapterClaim>,
+    /// Enable-time trust anchors for adapter receipts (see
+    /// [`AdapterTrustRoot`]). Manager-written, never driver-supplied.
+    pub adapter_trust_roots: Vec<AdapterTrustRoot>,
     /// Audit trail of the load-boundary migration, when one ran.
     pub migration_audit: Vec<(String, MigrationRule)>,
     /// Names of legacy capability objects the migration dropped.
@@ -97,6 +139,7 @@ impl StateStore {
             backups: Vec::new(),
             operations: Vec::new(),
             adapter_claims: Vec::new(),
+            adapter_trust_roots: Vec::new(),
             migration_audit: Vec::new(),
             dropped_capabilities: Vec::new(),
             migrated_from_legacy: false,
@@ -197,16 +240,18 @@ impl StateStore {
 
         // Refuse files from a newer schema: serde would silently drop the
         // fields that schema keeps its records in, and the next save would
-        // rewrite the file as v5 — destroying data the newer writer owned.
-        if probe.schema_version > STORE_SCHEMA_VERSION {
+        // rewrite the file at our version — destroying data the newer
+        // writer owned.
+        if probe.schema_version > STORE_SCHEMA_VERSION_ANCHORED {
             return Err(StateError::NewerSchema {
                 path: path.to_path_buf(),
                 found: probe.schema_version,
-                supported: STORE_SCHEMA_VERSION,
+                supported: STORE_SCHEMA_VERSION_ANCHORED,
             });
         }
 
-        if probe.schema_version == STORE_SCHEMA_VERSION {
+        // v6 shares the v5 wire shape (plus anchors), so both parse here.
+        if probe.schema_version >= STORE_SCHEMA_VERSION {
             let file: StateFileV5 =
                 toml::from_str(&content).map_err(|source| StateError::Parse {
                     path: path.to_path_buf(),
@@ -222,6 +267,7 @@ impl StateStore {
                 backups: file.backups,
                 operations: file.operations,
                 adapter_claims: file.adapter_claims,
+                adapter_trust_roots: file.adapter_trust_roots,
                 migration_audit: Vec::new(),
                 dropped_capabilities: Vec::new(),
                 migrated_from_legacy: false,
@@ -248,6 +294,9 @@ impl StateStore {
             backups: legacy.backups,
             operations: legacy.operations,
             adapter_claims: legacy.adapter_claims,
+            // Legacy schemas predate trust anchors; receipts they carry
+            // resolve inside datadir roots, which need no anchor.
+            adapter_trust_roots: Vec::new(),
             migration_audit: migration.audit,
             dropped_capabilities: migration.dropped_capabilities,
             migrated_from_legacy: true,
@@ -260,7 +309,10 @@ impl StateStore {
         self.migrated_from_legacy
     }
 
-    /// Atomically persist the store as schema v5.
+    /// Atomically persist the store: schema v6 when trust anchors are
+    /// present (so pre-anchor writers refuse the file instead of dropping
+    /// them — see [`STORE_SCHEMA_VERSION_ANCHORED`]), plain v5 otherwise
+    /// (anchor-free files stay fully interchangeable with 0.2.16).
     ///
     /// If the on-disk file is still legacy (schema ≤ 4), its original bytes
     /// are first preserved as a `.v4.bak` sibling — exactly once: an
@@ -270,7 +322,11 @@ impl StateStore {
         self.backup_legacy_file(path)?;
 
         let file = StateFileV5 {
-            schema_version: STORE_SCHEMA_VERSION,
+            schema_version: if self.adapter_trust_roots.is_empty() {
+                STORE_SCHEMA_VERSION
+            } else {
+                STORE_SCHEMA_VERSION_ANCHORED
+            },
             updated_at: now_iso8601(),
             install_mode: self.install_mode,
             prefix: self.prefix.clone(),
@@ -280,6 +336,7 @@ impl StateStore {
             backups: self.backups.clone(),
             operations: self.operations.clone(),
             adapter_claims: self.adapter_claims.clone(),
+            adapter_trust_roots: self.adapter_trust_roots.clone(),
         };
         let content = toml::to_string_pretty(&file)?;
         write_atomic(path, content.as_bytes()).map_err(|source| StateError::Io {
@@ -415,6 +472,39 @@ impl StateStore {
             .iter()
             .position(|c| c.component == component && c.framework == framework)?;
         Some(self.adapter_claims.remove(idx))
+    }
+
+    /// Find the enable-time trust anchor for `(component, framework)`.
+    pub fn find_adapter_trust_root(&self, component: &str, framework: &str) -> Option<&Path> {
+        self.adapter_trust_roots
+            .iter()
+            .find(|a| a.component == component && a.framework == framework)
+            .map(|a| a.root.as_path())
+    }
+
+    /// Insert or replace the trust anchor for `(component, framework)`.
+    /// Called by the Manager only, with a contract-validated root.
+    pub fn upsert_adapter_trust_root(&mut self, component: &str, framework: &str, root: PathBuf) {
+        if let Some(slot) = self
+            .adapter_trust_roots
+            .iter_mut()
+            .find(|a| a.component == component && a.framework == framework)
+        {
+            slot.root = root;
+        } else {
+            self.adapter_trust_roots.push(AdapterTrustRoot {
+                component: component.to_string(),
+                framework: framework.to_string(),
+                root,
+            });
+        }
+    }
+
+    /// Drop the trust anchor for `(component, framework)`. Called when the
+    /// receipt it anchored is removed.
+    pub fn remove_adapter_trust_root(&mut self, component: &str, framework: &str) {
+        self.adapter_trust_roots
+            .retain(|a| !(a.component == component && a.framework == framework));
     }
 
     /// All adapter receipts for a component, across frameworks.
@@ -684,31 +774,80 @@ source_repo = "anolisa"
         assert_eq!(store.migration_audit.len(), 4);
     }
 
-    /// A file written by a newer schema must be refused, not read as v5:
-    /// serde would drop the newer schema's fields and the next save would
-    /// rewrite the file as v5, silently destroying that data.
+    /// A file written by a newer schema must be refused, not read as the
+    /// current shape: serde would drop the newer schema's fields and the
+    /// next save would rewrite the file, silently destroying that data.
     #[test]
     fn newer_schema_file_is_refused_and_left_untouched() {
         let tmp = tempfile::tempdir().expect("tmpdir");
-        let future_v6 = "schema_version = 6\n\
+        let future_v7 = "schema_version = 7\n\
                          updated_at = \"2026-07-20T00:00:00Z\"\n\
                          install_mode = \"system\"\n\
                          prefix = \"/\"\n\
                          anolisa_version = \"future\"\n\
                          future_only = \"must-survive\"\n";
-        let path = write_file(tmp.path(), "installed.toml", future_v6);
+        let path = write_file(tmp.path(), "installed.toml", future_v7);
 
-        let err = StateStore::load(&path, 1000).expect_err("v6 must be refused");
+        let err = StateStore::load(&path, 1000).expect_err("v7 must be refused");
         assert!(matches!(
             err,
             StateError::NewerSchema {
-                found: 6,
-                supported: STORE_SCHEMA_VERSION,
+                found: 7,
+                supported: STORE_SCHEMA_VERSION_ANCHORED,
                 ..
             }
         ));
         // Refusal is read-only: the newer writer's bytes are untouched.
-        assert_eq!(fs::read_to_string(&path).expect("read back"), future_v6);
+        assert_eq!(fs::read_to_string(&path).expect("read back"), future_v7);
+    }
+
+    /// Anchors force the schema to v6 on disk, so pre-anchor writers
+    /// (≤ 0.2.16, which refuse schemas newer than v5) fail closed instead
+    /// of silently deleting the security-critical anchor on their next
+    /// save. The anchors themselves must round-trip.
+    #[test]
+    fn anchored_state_round_trips_at_v6() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("installed.toml");
+        let mut store = StateStore::empty();
+        store.install_mode = InstallMode::System;
+        store.prefix = PathBuf::from("/");
+        store.upsert_adapter_trust_root("sec-core", "codex", PathBuf::from("/opt/sec-core"));
+        store.save(&path).expect("save anchored");
+
+        let content = fs::read_to_string(&path).expect("read back");
+        assert!(
+            content.contains("schema_version = 6"),
+            "anchored state must be marked v6, got:\n{content}"
+        );
+
+        let loaded = StateStore::load(&path, 0).expect("reload v6");
+        assert_eq!(
+            loaded.find_adapter_trust_root("sec-core", "codex"),
+            Some(Path::new("/opt/sec-core")),
+            "anchor must survive the round-trip"
+        );
+    }
+
+    /// Without anchors nothing changed on the wire: the file stays v5 and
+    /// fully interchangeable with pre-anchor writers.
+    #[test]
+    fn anchor_free_state_still_writes_v5() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("installed.toml");
+        let mut store = StateStore::empty();
+        store.install_mode = InstallMode::System;
+        store.prefix = PathBuf::from("/");
+        store.upsert_adapter_trust_root("sec-core", "codex", PathBuf::from("/opt/sec-core"));
+        store.remove_adapter_trust_root("sec-core", "codex");
+        store.save(&path).expect("save");
+
+        let content = fs::read_to_string(&path).expect("read back");
+        assert!(
+            content.contains("schema_version = 5"),
+            "anchor-free state must stay v5, got:\n{content}"
+        );
+        assert!(!content.contains("adapter_trust_roots"));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -213,6 +213,100 @@ fn expand_dest(dest: &str, datadir: &Path) -> PathBuf {
     PathBuf::from(expanded)
 }
 
+/// Stage a world whose component is RPM-installed (delegated provenance)
+/// and whose contract declares an `[adapters.backends.rpm].resource_root`
+/// outside every datadir root. The bundle exists only at that RPM root —
+/// the raw `dest` was never laid down, exactly like an RPM-only install.
+fn stage_rpm_backend(
+    framework: &str,
+    adapter_type: &str,
+    dest: &str,
+    stage_bundle: impl Fn(&Path),
+) -> World {
+    let root = tempfile::tempdir().expect("tempdir");
+    let prefix = root.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    let user_home = prefix.join("home");
+    std::fs::create_dir_all(&user_home).expect("home");
+
+    let resource_root = prefix.join("opt").join("tokenless-plugin");
+    std::fs::create_dir_all(&resource_root).expect("rpm root");
+    stage_bundle(&resource_root);
+
+    // RPM provenance: adopted object delegated to the rpm backend.
+    let state_path = layout.state_dir.join("installed.toml");
+    std::fs::create_dir_all(state_path.parent().unwrap()).expect("state dir");
+    std::fs::write(
+        &state_path,
+        format!(
+            r#"schema_version = 2
+updated_at = "2026-07-04T00:00:00Z"
+install_mode = "system"
+prefix = "{prefix}"
+anolisa_version = "0.1.20"
+
+[[objects]]
+kind = "component"
+name = "{COMPONENT}"
+version = "0.6.0"
+status = "adopted"
+install_backend = "rpm"
+ownership = "rpm_observed"
+managed = false
+adopted = true
+installed_at = "2026-07-04T00:00:00Z"
+"#,
+            prefix = prefix.display(),
+        ),
+    )
+    .expect("seed state");
+
+    let contract = format!(
+        r#"[component]
+name = "{COMPONENT}"
+version = "0.6.0"
+
+[component.layout]
+modes = ["system"]
+
+[[adapters]]
+framework = "{framework}"
+adapter_type = "{adapter_type}"
+plugin_id = "{COMPONENT}"
+dest = "{dest}"
+
+[adapters.backends.rpm]
+resource_root = "{rpm_root}/"
+"#,
+        rpm_root = resource_root.display(),
+    );
+    // Both discovery paths an adopted component may be read from: the
+    // saved manifest snapshot and the datadir contract the RPM ships.
+    for path in [
+        layout
+            .state_dir
+            .join("component-manifests")
+            .join(COMPONENT)
+            .join("component.toml"),
+        layout
+            .datadir
+            .join("components")
+            .join(COMPONENT)
+            .join("component.toml"),
+    ] {
+        std::fs::create_dir_all(path.parent().unwrap()).expect("contract dir");
+        std::fs::write(&path, &contract).expect("seed contract");
+    }
+
+    World {
+        _root: root,
+        prefix,
+        layout,
+        user_home,
+        resource_root,
+    }
+}
+
 fn write_exec(path: &Path, body: &str) {
     std::fs::write(path, body).expect("write script");
     let mut perms = std::fs::metadata(path).expect("meta").permissions();
@@ -535,6 +629,193 @@ fn codex_enable_records_argv_and_builds_marketplace() {
     );
 }
 
+/// Regression for the unified raw/RPM contract: an RPM-installed component
+/// whose contract declares `[adapters.backends.rpm].resource_root` outside
+/// every datadir must enable through the real production path — the
+/// receipt's marketplace symlink targets the external RPM root, and that
+/// target validates against contract-derived trust (never the receipt
+/// itself). status and disable keep working over the persisted receipt.
+#[test]
+fn codex_enable_rpm_backend_root_outside_datadir() {
+    let guard = EnvGuard::acquire();
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (_log, marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    let claim = match manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable must accept the contract-declared RPM root")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+
+    // The marketplace symlink targets the external RPM root.
+    let symlink = marketplace_root.join(COMPONENT);
+    assert_eq!(
+        std::fs::read_link(&symlink).expect("symlink"),
+        world.resource_root,
+        "symlink must point at the RPM-provided root"
+    );
+    assert!(
+        claim.resources.iter().any(|r| matches!(
+            &r.kind,
+            ClaimResourceKind::Symlink { target, .. } if target == &world.resource_root
+        )),
+        "receipt must record the RPM root as the symlink target"
+    );
+
+    // The persisted receipt keeps validating on the read paths.
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    let disabled = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(
+        !marketplace_root.exists(),
+        "marketplace dir removed on disable"
+    );
+    assert!(
+        world
+            .resource_root
+            .join(".codex-plugin/plugin.json")
+            .is_file(),
+        "disable must never touch the RPM-owned root"
+    );
+}
+
+/// Regression for RPM root migration: enable on root A, then an RPM update
+/// moves the payload to root B and refreshes the contract snapshot (A is
+/// removed). The enabled receipt still points at A — it must stay
+/// manageable: status keeps reporting (degraded, not an error), re-enable
+/// migrates the symlink to B, and disable cleans up. The enable-time trust
+/// anchor — not the receipt — is what keeps A trusted.
+#[test]
+fn codex_receipt_survives_rpm_root_migration() {
+    let guard = EnvGuard::acquire();
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (_log, marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable on root A");
+
+    // RPM update: payload moves A -> B (with updated content), contract
+    // snapshots point at B, A disappears.
+    let root_b = world.prefix.join("opt").join("tokenless-plugin-v2");
+    std::fs::create_dir_all(&root_b).expect("root B");
+    stage_codex_bundle(&root_b);
+    std::fs::write(root_b.join("README.md"), b"codex plugin v2\n").expect("v2 readme");
+    let contract = format!(
+        r#"[component]
+name = "{COMPONENT}"
+version = "0.7.0"
+
+[component.layout]
+modes = ["system"]
+
+[[adapters]]
+framework = "codex"
+adapter_type = "plugin"
+plugin_id = "{COMPONENT}"
+dest = "{{datadir}}/adapters/{{component}}/codex/"
+
+[adapters.backends.rpm]
+resource_root = "{root_b}/"
+"#,
+        root_b = root_b.display(),
+    );
+    for path in [
+        world
+            .layout
+            .state_dir
+            .join("component-manifests")
+            .join(COMPONENT)
+            .join("component.toml"),
+        world
+            .layout
+            .datadir
+            .join("components")
+            .join(COMPONENT)
+            .join("component.toml"),
+    ] {
+        std::fs::write(&path, &contract).expect("refresh contract");
+    }
+    std::fs::remove_dir_all(&world.resource_root).expect("remove root A");
+
+    // status must keep reporting the stale receipt, never fail claim
+    // validation — the receipt would otherwise be unmanageable. The
+    // summary must degrade: the marketplace symlink dangles at the
+    // vanished root A, so codex cannot actually serve the plugin no
+    // matter what its registration lists say.
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status must survive the root migration");
+    assert_eq!(status.entries.len(), 1);
+    assert_eq!(
+        status.entries[0].report.summary,
+        AdapterSummary::Degraded,
+        "a receipt pointing at a vanished root must not report Healthy"
+    );
+    let bundle = status.entries[0]
+        .report
+        .conditions
+        .iter()
+        .find(|c| c.kind == AdapterConditionKind::ResourceBundleMatches)
+        .expect("bundle condition present");
+    assert_ne!(
+        bundle.status,
+        ConditionStatus::True,
+        "vanished enable-time root must not verify as matching"
+    );
+
+    // re-enable migrates the marketplace symlink to root B.
+    let claim = match manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("re-enable must migrate to root B")
+    {
+        EnableOutcome::Enabled(c) => *c,
+        EnableOutcome::Planned { .. } => panic!("expected enabled"),
+    };
+    assert_eq!(
+        std::fs::read_link(marketplace_root.join(COMPONENT)).expect("symlink"),
+        root_b,
+        "symlink must be rewritten to the new RPM root"
+    );
+    assert!(claim.resources.iter().any(|r| matches!(
+        &r.kind,
+        ClaimResourceKind::Symlink { target, .. } if target == &root_b
+    )));
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(
+        status.entries[0].report.summary,
+        AdapterSummary::Healthy,
+        "re-enable on root B must restore Healthy"
+    );
+
+    let disabled = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect("disable");
+    assert!(disabled.claim_removed);
+    assert!(!marketplace_root.exists());
+}
+
 #[test]
 fn codex_dry_run_enable_writes_nothing() {
     let guard = EnvGuard::acquire();
@@ -655,6 +936,139 @@ fn codex_forged_resource_root_and_symlink_target_rejected() {
     assert!(
         matches!(err, AdapterError::ClaimValidation(_)),
         "got {err:?}"
+    );
+}
+
+/// A forged state file that plants both a trust anchor at /etc and a
+/// receipt symlink target inside it must still be rejected: the anchor is
+/// only honoured when the on-disk contract grants external-root trust for
+/// this provenance (RPM provenance + declared RPM root). For a raw
+/// component the state file alone is not a trust source.
+#[test]
+fn codex_forged_anchor_does_not_authorize_forged_target() {
+    let guard = EnvGuard::acquire();
+    // Real RPM provenance and a contract-declared external root: the one
+    // branch where the enable-time anchor is honoured. A forged anchor
+    // must still authorize nothing beneath itself — it is an
+    // exact-equality allowance, never a root.
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Tamper: replace the legitimate anchor with /etc AND point the
+    // symlink resource below it.
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    state.upsert_adapter_trust_root(COMPONENT, "codex", PathBuf::from("/etc"));
+    {
+        let claim = state
+            .adapter_claims
+            .iter_mut()
+            .find(|c| c.component == COMPONENT)
+            .expect("claim");
+        for res in &mut claim.resources {
+            if let ClaimResourceKind::Symlink { target, .. } = &mut res.kind {
+                *target = PathBuf::from("/etc/cron.d/evil");
+            }
+        }
+    }
+    state.save(&state_path).expect("save tampered state");
+
+    let err = manager
+        .status(Some(COMPONENT))
+        .expect_err("forged anchor must not authorize a target beneath it");
+    assert!(
+        matches!(err, AdapterError::ClaimValidation(_)),
+        "got {err:?}"
+    );
+    let err = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect_err("disable must refuse the forged target too");
+    assert!(
+        matches!(err, AdapterError::ClaimValidation(_)),
+        "got {err:?}"
+    );
+}
+
+/// Reverse lifecycle hole: after the RPM component is gone — bundle root,
+/// contract snapshots and installation record all removed — the enable-time
+/// anchor must keep the stale external-root receipt reportable and
+/// disable must clean it up rather than wedge on `ClaimValidation`.
+#[test]
+fn codex_stale_external_receipt_cleans_up_after_component_removal() {
+    let guard = EnvGuard::acquire();
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (_log, marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Simulate `rpm -e` plus `anolisa uninstall`: bundle root, both
+    // contract copies and the installation record disappear; only the
+    // adapter receipt and its anchor remain.
+    std::fs::remove_dir_all(&world.resource_root).expect("remove rpm root");
+    for path in [
+        world
+            .layout
+            .state_dir
+            .join("component-manifests")
+            .join(COMPONENT)
+            .join("component.toml"),
+        world
+            .layout
+            .datadir
+            .join("components")
+            .join(COMPONENT)
+            .join("component.toml"),
+    ] {
+        std::fs::remove_file(&path).expect("remove contract");
+    }
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    state.installations.retain(|i| i.name != COMPONENT);
+    state.save(&state_path).expect("save uninstalled state");
+
+    // status: reportable, not a validation failure.
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status must survive component removal");
+    assert_eq!(status.entries.len(), 1);
+
+    // disable: cleans up receipt, anchor and framework registration.
+    let outcome = manager
+        .disable(COMPONENT, Some("codex"), false)
+        .expect("disable must clean up the stale receipt");
+    assert!(outcome.claim_removed, "receipt must be removed");
+    let state = world.load_state();
+    assert!(
+        state.find_adapter_claim(COMPONENT, "codex").is_none(),
+        "receipt must be gone"
+    );
+    assert!(
+        state.find_adapter_trust_root(COMPONENT, "codex").is_none(),
+        "anchor must not outlive its receipt"
+    );
+    assert!(
+        !marketplace_root.join(COMPONENT).exists(),
+        "marketplace symlink must be cleaned up"
     );
 }
 
@@ -1932,5 +2346,157 @@ fn qoder_forged_settings_redirect_within_qoder_home_rejected() {
         std::fs::read_to_string(&decoy).expect("read decoy"),
         "{\"user\":\"data\"}",
         "the redirected file must be left untouched"
+    );
+}
+
+/// Anchors are for *external* roots only. An RPM-provenance contract whose
+/// `resource_root` lives inside the datadir is already covered by the
+/// static trust boundary — writing an anchor for it would needlessly bump
+/// the state schema to v6 and lock released 0.2.16 CLIs out of every state
+/// command on a path that never needed trust migration. The external-root
+/// counterpart must keep anchoring (and bumping to v6) as designed.
+#[test]
+fn codex_datadir_rpm_root_keeps_state_anchor_free_at_v5() {
+    let guard = EnvGuard::acquire();
+
+    // In-datadir declaration: RPM provenance, but the bundle sits under
+    // the always-trusted datadir.
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let datadir_root = world
+        .layout
+        .datadir
+        .join("adapters")
+        .join(COMPONENT)
+        .join("codex");
+    std::fs::create_dir_all(&datadir_root).expect("datadir bundle dir");
+    stage_codex_bundle(&datadir_root);
+    let contract = format!(
+        r#"[component]
+name = "{COMPONENT}"
+version = "0.6.0"
+
+[component.layout]
+modes = ["system"]
+
+[[adapters]]
+framework = "codex"
+adapter_type = "plugin"
+plugin_id = "{COMPONENT}"
+dest = "{{datadir}}/adapters/{{component}}/codex/"
+
+[adapters.backends.rpm]
+resource_root = "{{datadir}}/adapters/{{component}}/codex/"
+"#
+    );
+    for path in [
+        world
+            .layout
+            .state_dir
+            .join("component-manifests")
+            .join(COMPONENT)
+            .join("component.toml"),
+        world
+            .layout
+            .datadir
+            .join("components")
+            .join(COMPONENT)
+            .join("component.toml"),
+    ] {
+        std::fs::write(&path, &contract).expect("rewrite contract");
+    }
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+    world
+        .manager()
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable with in-datadir rpm root");
+    let state = world.load_state();
+    assert!(
+        state.find_adapter_trust_root(COMPONENT, "codex").is_none(),
+        "an in-datadir root must not be anchored"
+    );
+    let state_text = std::fs::read_to_string(world.layout.state_dir.join("installed.toml"))
+        .expect("read state file");
+    assert!(
+        state_text.contains("schema_version = 5"),
+        "anchor-free state must stay at v5, got:\n{}",
+        state_text.lines().take(3).collect::<Vec<_>>().join("\n")
+    );
+}
+
+/// External-root counterpart of
+/// [`codex_datadir_rpm_root_keeps_state_anchor_free_at_v5`]: a package-owned
+/// root outside the datadir still records its anchor and bumps to v6.
+#[test]
+fn codex_external_rpm_root_still_anchors_state_at_v6() {
+    let guard = EnvGuard::acquire();
+    let world = stage_rpm_backend(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+    world
+        .manager()
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable with external rpm root");
+    let state = world.load_state();
+    assert_eq!(
+        state
+            .find_adapter_trust_root(COMPONENT, "codex")
+            .map(|p| p.to_path_buf()),
+        Some(world.resource_root.clone()),
+        "an external root must be anchored"
+    );
+    let state_text = std::fs::read_to_string(world.layout.state_dir.join("installed.toml"))
+        .expect("read state file");
+    assert!(
+        state_text.contains("schema_version = 6"),
+        "anchored state must be written at v6, got:\n{}",
+        state_text.lines().take(3).collect::<Vec<_>>().join("\n")
+    );
+}
+
+/// The anchor is consumed only for symlink *targets*
+/// (`ClaimResourceKind::Symlink`), which today only Codex receipts
+/// contain. A claude-code receipt over the same kind of external RPM root
+/// records no symlink — an anchor for it would never be read back, only
+/// bump the state schema to v6 and lock released 0.2.16 CLIs out of every
+/// state command. It must stay anchor-free at v5.
+#[test]
+fn claude_code_external_rpm_root_needs_no_anchor_stays_v5() {
+    let guard = EnvGuard::acquire();
+    let world = stage_rpm_backend(
+        "claude-code",
+        "plugin",
+        "{datadir}/adapters/{component}/claude-code/",
+        stage_claude_bundle,
+    );
+    let fake = write_fake_claude(&world.prefix);
+    apply_claude_env(&guard, &world, &fake);
+    world
+        .manager()
+        .enable(COMPONENT, Some("claude-code"), false)
+        .expect("enable with external rpm root");
+    let state = world.load_state();
+    assert!(
+        state
+            .find_adapter_trust_root(COMPONENT, "claude-code")
+            .is_none(),
+        "a receipt without symlink resources must not be anchored"
+    );
+    let state_text = std::fs::read_to_string(world.layout.state_dir.join("installed.toml"))
+        .expect("read state file");
+    assert!(
+        state_text.contains("schema_version = 5"),
+        "anchor-free state must stay at v5, got:\n{}",
+        state_text.lines().take(3).collect::<Vec<_>>().join("\n")
     );
 }

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -176,6 +176,165 @@ Display behavior:
 - `--dry-run` previews the notices that a real operation would show, labeled
   as a preview; nothing is executed.
 
+## Content Rendering (`render`)
+
+A `[[component.layout.files]]` entry may request that ANOLISA render the
+file *content* against the final filesystem layout before placing it:
+
+```toml
+[[component.layout.files]]
+source = "share/anolisa/sec-core/agent-sec-core.service.in"
+target = "{userunitdir}/agent-sec-core.service"
+mode = "0644"
+render = "anolisa-paths-v1"
+```
+
+`anolisa-paths-v1` substitutes the same placeholder vocabulary used for
+destination paths — `{bindir}`, `{libdir}`, `{libexecdir}`, `{datadir}`,
+`{etcdir}`, `{statedir}`, `{logdir}`, `{cachedir}`, `{unitdir}`,
+`{userunitdir}` (and underscore aliases), plus `{component}` — inside the
+file content. This makes shipped templates such as systemd units
+relocatable: the rendered `ExecStart` and `ReadWritePaths` follow the
+install mode and any custom `--prefix` instead of hard-coding
+`/usr/local`.
+
+Rules:
+
+- `render` applies to a single regular file. Directory sources and
+  symlink entries must not declare it.
+- The content must be valid UTF-8; an unknown `{...}` token in the
+  content fails the install. Rendering is opt-in per entry, so files that
+  legitimately contain braces are unaffected unless they declare
+  `render`.
+- The value is versioned. An installer that does not implement the
+  declared value refuses the install rather than copying the template
+  verbatim; pair new `render` values with a matching
+  `min_anolisa_version`.
+- The recorded file digest covers the rendered bytes, so integrity
+  verification and repair operate on what is actually on disk.
+
+The RPM backend does not render: RPM packages expand paths in their spec
+at build time. `render` exists so the same source template serves both
+packagings.
+
+## Minimum CLI Version Gate
+
+`[component.contract].min_anolisa_version` declares the oldest ANOLISA
+CLI that can install the contract:
+
+```toml
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.2.17"
+```
+
+Raw install and update compare it (SemVer) against the running CLI and
+refuse the operation when the CLI is older, pointing the operator at
+`anolisa self-update`. A value that is not valid SemVer is also refused.
+There is no override flag: manifest parsing is tolerant, so an older CLI
+would otherwise silently drop fields such as `render` and install a
+broken result. Set the field to the **first released ANOLISA version
+that ships** whichever contract behavior the component depends on —
+never an earlier release that merely parses the field. Content
+rendering, this gate, and backend-specific adapter roots all ship in
+0.2.17; a contract using any of them must declare at least that.
+
+### Bootstrap: protecting CLIs older than the gate itself
+
+The gate only works once a CLI that evaluates it is running — released
+CLIs ≤ 0.2.16 parse tolerantly, so they would ignore both
+`min_anolisa_version` and `render` and install the raw template as-is.
+No contract-side hook can stop them (verified against a real 0.2.16
+build — repo `index.toml` `schema_version`, `components.toml` schema,
+and the manifest's own tolerant `schema_version` all do **not** stop an
+old CLI), so the protection lives in the distribution layout instead:
+
+- `v1/index.toml` — the generation-1 index. Must only ever contain
+  entries whose contracts pre-0.2.17 CLIs install correctly. This is
+  the only file those released binaries read, and they parse it
+  atomically: one entry shape they cannot represent would take every
+  unrelated component down with it.
+- `v1/index-v2.toml` — the complete generation-2 index (a full world
+  view, not a delta; publish both files from the same pipeline run).
+  Entries whose contracts depend on ≥ 0.2.17 semantics are published
+  **only** here. 0.2.17+ CLIs read this file when present and fall
+  back to `index.toml` when it is not.
+
+An old CLI therefore keeps installing unrelated components untouched
+and resolves a gated component as not-found — fail closed, no silent
+mis-install and no collateral breakage. From 0.2.17 the index is also
+parsed entry-tolerantly: a row this build cannot represent is skipped
+with a warning, and any request that row may have answered (same
+component and target; any version for "latest", the exact version when
+pinned) is refused with a `self-update` hint rather than answered from
+older parsable rows — skipping must never turn into a silent downgrade.
+This split is a one-time measure: future entry shapes will not need an
+`index-v3.toml`.
+
+### Downgrade and rollback with trust anchors
+
+Enabling an adapter whose resources live at an external RPM root
+records a trust anchor in `installed.toml` and bumps its schema to
+v6. Anchors are recorded only when the enabled receipt actually
+depends on external trust: it must contain a symlink resource whose
+*target* lies outside the trusted layout and datadir roots (today only
+the Codex driver records such a symlink). An RPM contract whose
+`resource_root` resolves inside the datadir, or an adapter whose
+receipt carries no symlink resources, needs no trust migration and
+keeps state at v5. Released
+0.2.16 binaries refuse a v6 state file read-only (by
+design — they would otherwise silently drop the anchor), so a direct
+binary downgrade while an anchored receipt exists leaves state
+commands refusing until the newer CLI runs again. The supported
+downgrade path is: `anolisa adapter disable` any adapters of
+RPM-provenance components with a declared
+`[adapters.backends.rpm].resource_root`, which removes their anchors
+— an anchor-free state is written back at schema v5, byte-compatible
+with 0.2.16 — then downgrade the binary. No data is lost either way;
+the v6 refusal is deliberate fail-closed, not corruption.
+
+## Backend-Specific Adapter Resource Roots
+
+For a unified raw/RPM contract, the adapter `dest` describes where a
+*raw* install lays the bundle — and, for raw installs, where
+`adapter enable` later reads it. An RPM package may carry the same
+bundle at a package-owned path instead. Declare that path per backend:
+
+```toml
+[[adapters]]
+framework = "openclaw"
+source = "adapters/sec-core/openclaw"
+dest = "{datadir}/adapters/{component}/openclaw/"
+
+[adapters.backends.rpm]
+resource_root = "/opt/agent-sec/openclaw-plugin/"
+```
+
+Selection follows the component's installed provenance recorded in
+state:
+
+- RPM-installed (managed, adopted, or observed) with a declared
+  `resource_root`: scan/status/enable read the bundle from that root. It
+  is read-only — ANOLISA never writes under it — and must be an
+  absolute path or a `{datadir}`-rooted template (plus `{component}`).
+  Other layout placeholders (`{bindir}`, `{libexecdir}`, …) are
+  rejected: they would expand against the *consuming* scope's layout
+  rather than the contract's — a user-mode manager consuming a system
+  RPM contract would resolve them under the user prefix. A template
+  whose expansion is not an absolute path is likewise rejected before
+  any filesystem probe: a relative root would resolve against the
+  process working directory.
+- RPM-installed without a declared `resource_root`: resolution falls
+  back to `dest` and convention discovery, as before.
+- Raw-installed: `dest` semantics are unchanged; the RPM root is
+  ignored.
+
+A declared root is authoritative for its backend. When the directory is
+missing or holds no valid bundle, the operation reports the expected
+path instead of silently falling back — a missing RPM payload is a
+packaging defect that must surface, not be masked by a stale raw
+leftover in `{datadir}`.
+
 ## Contract Template
 
 Use a shipped component manifest such as


### PR DESCRIPTION
## Why

Components are moving to a single contract that serves both raw (tar.gz) and RPM packagings (see the sec-core raw package work in #2133). ANOLISA currently cannot consume that contract: `render = "anolisa-paths-v1"` layout entries are parsed but never rendered (systemd units land with literal `{bindir}`/`{datadir}` and fail to start), `min_anolisa_version` is parsed but never enforced (an older CLI silently drops contract fields and installs a broken result), and adapter resource resolution only knows the raw `dest`, so `adapter enable` cannot find bundles shipped by an RPM.

## What changed

Teach the CLI the three unified-contract semantics, all fail-closed:

- **Content rendering**: layout entries with `render = "anolisa-paths-v1"` have layout placeholders (`{bindir}`, `{datadir}`, ..., `{component}`) substituted in the file content during raw install. Rendering happens before digest recording, so state carries the sha256 of the bytes on disk and integrity/repair work unchanged. Non-UTF-8 content, unknown placeholders, directory sources, and symlink entries are rejected; an unknown `render` value refuses the install with a `self-update` hint instead of copying the template verbatim.
- **Version gate**: raw install/update enforce `[component.contract].min_anolisa_version` (SemVer). An older CLI refuses with the required and current versions plus a `self-update` hint; malformed SemVer is also refused. No override flag.
- **Backend-aware adapter roots**: contracts may declare `[adapters.backends.rpm].resource_root`. For RPM-installed components (per state provenance), scan/status/enable read the bundle from that root; a declared-but-missing root reports the expected path instead of silently falling back to `dest`. The root must be an absolute path or a `{datadir}`-rooted template (plus `{component}`): other layout placeholders would expand against the consuming scope's layout instead of the contract's, and any expansion that is not absolute would resolve against the process CWD — both are rejected before any filesystem probe. Raw installs keep `dest` semantics unchanged, as do RPM installs without the declaration.

## Related issue

closes #2190

## User / Agent impact

- Raw installs of unified contracts now produce runnable systemd units under any install mode or `--prefix`.
- Installing a component whose contract requires a newer CLI now fails up front with an actionable `anolisa self-update` message (previously: silent partial install).
- `anolisa adapter scan/status/enable` resolve RPM-shipped adapter bundles; a missing RPM payload surfaces as a diagnosable error naming the expected path.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

New contract fields are opt-in; manifests without them behave exactly as before (verified by the existing suites). The version gate only rejects contracts that explicitly declare a newer `min_anolisa_version`, which is the declared intent of that field.

**Bootstrap for released ≤ 0.2.16 CLIs** is handled at the distribution layout, not per entry (their index parsing is atomic and unfixable retroactively): entries whose contracts depend on ≥ 0.2.17 semantics are published only in `v1/index-v2.toml` (a complete generation-2 index); `v1/index.toml` stays generation-1-clean. Old CLIs keep installing unrelated components untouched and resolve gated components as not-found. From this branch on, the index is parsed entry-tolerantly: an unparsable row is skipped with a warning, and any query that row *may* have answered (same component/target; any version for "latest", the exact version when pinned) is refused with a `self-update` hint rather than answered from older parsable rows — fail-closed without silent downgrades, and no `index-v3.toml` will ever be needed.

**Downgrade guidance** (v6 state): enabling an adapter over an external RPM root records a trust anchor and writes state schema v6, which a 0.2.16 binary refuses read-only (by design — it would silently drop the anchor). Anchors are written **only** when the validated receipt actually contains a symlink targeting outside the trusted roots (today only the Codex driver records one); in-datadir roots and symlink-free receipts (all other frameworks) keep state at v5. To downgrade: `anolisa adapter disable` the anchored adapters first (state returns to v5, byte-compatible with 0.2.16), then swap the binary. Documented in `docs/COMPONENT_CONTRACT.md`.

## Validation

- 51 new tests: `install/raw.rs` 14 (render mapping incl. blank-value rejection, version gate incl. a pinned 0.2.16→0.2.17 first-release-boundary regression, split-index fetch preference/fallback/miss-attribution and the not-published classifier), `install/tests/raw_e2e.rs` 3 (a future-shaped newer entry refuses "latest"/pinned-to-it instead of downgrading to the parsable older version, while pinning the older version still resolves; a malformed selector — `install_modes = [1]` — still blocks "latest"; an unrelated skipped row neither blocks nor degrades), `install_runner.rs` 7 (rendering, digest-over-rendered-bytes, rejection paths), `manifest.rs` 3 (schema round-trip), `distribution.rs` 4 (entry-tolerant parse skips only the alien row and recovers its selectors; malformed selectors collapse to unreadable and block conservatively; the `may_match` fail-closed matcher; file-level damage still fails), `adapter/manager.rs` 8 (provenance-based root selection, no-fallback/blank-root errors, blank-root scan, the RPM root template vocabulary, a non-`{datadir}` placeholder refused instead of resolving against the consuming scope's layout — with a decoy bundle planted at the would-be wrong-scope path — and a relative root refused even with a valid bundle planted at the CWD-relative path), `adapter/claim.rs` 1 (the anchor-persistence criterion: only out-of-boundary symlink targets require external trust), `adapter/codex.rs` 2 (summary folds symlink/bundle signals; a dangling symlink does not count as present), plus real `AdapterManager` e2e over an external RPM root (`adapter_frameworks.rs`, codex driver): enable → status → disable, an RPM root-migration lifecycle (enable on A, update moves to B, status reports **Degraded** — the dangling marketplace symlink and vanished bundle now fold into the summary — re-enable migrates and restores Healthy, disable cleans up), a forged-anchor rejection under **real RPM provenance** (`/etc` anchor + `/etc/cron.d/evil` target refused by both status and disable — the anchor is an exact-equality allowance, never a root), a stale-receipt cleanup after full component removal (contract + installation gone: status still reports, disable cleans receipt/anchor/symlink), and the anchor-scope trio (an in-datadir RPM `resource_root` writes no anchor and keeps state at v5; an external `/opt`-style Codex root anchors and bumps to v6; a claude-code receipt over the same external root records no symlink, so it stays anchor-free at v5).
- Bootstrap verified against a **real 0.2.16 build** (git worktree of `ec25d516`) over a mixed `file://` repository (`index.toml` gen-1-only + `index-v2.toml` with the gated component): the old CLI installs the unrelated component from the same repo untouched, resolves the gated component as not-found with zero files leaked; this branch prefers `index-v2.toml`, enforces the version gate e2e (`requires anolisa >= 0.2.17` against a 0.2.16-versioned build), renders on admit, falls back cleanly on a gen-1-only repo, and — with a future-shaped 2.0.0 entry published next to a parsable 1.0.0 — refuses "latest" with a `cannot parse`/`self-update` error and installs nothing instead of silently downgrading. Contract-side hooks were each tried against the real 0.2.16 binary and do NOT stop it (repo `index.toml` `schema_version`, `components.toml` schema, manifest `schema_version`) — hence the split-index design; the earlier `tar_gz_v2` unknown-variant gate was dropped for its whole-index blast radius. A 0.2.16 binary also refuses the new v6 (anchored) state file read-only, as designed.
- `cargo test --workspace`: 2023 passed, 0 failed; `cargo clippy --workspace --all-targets` and `cargo doc --no-deps` clean.
- Local end-to-end run against a `file://` raw repository with the real binary (user mode): rendered unit verified byte-for-byte against the recorded digest, version gate and unknown-render refusals verified with no files leaked, adapter scan resolves the raw `dest`, uninstall removes everything.

## Documentation and rollback

`docs/COMPONENT_CONTRACT.md` gains sections for content rendering, the minimum CLI version gate, backend-specific adapter resource roots, the split-index bootstrap layout, and the v6-state downgrade path. CHANGELOG entries are deferred to the next release version-bump PR per `specs/documentation-standard.md`. Single commit; revert restores prior behavior for anchor-free state (new contract fields fall back to being parsed-but-ignored); with anchored receipts, disable them first as documented above.
