### PR TITLE
fix(cosh-ng): [shell] serialize handoffs

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/activity/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/activity/runtime_tests.rs
@@ -2579,12 +2579,9 @@ fn untracked_shell_handoff_closure_leaves_interactive_handoffs_untouched() {
 }
 
 #[test]
-fn untracked_shell_handoffs_share_prompt_boundary_when_emitted_in_same_cycle() {
-    // Boundary contract: handoffs emitted within the same prompt cycle (no
-    // ShellReady between their emission points) legitimately share the next
-    // ShellReady as their closure boundary. Forcing a distinct boundary per
-    // handoff would pin later handoffs to unrelated future prompts and
-    // misreport the evidence timeline.
+fn untracked_shell_handoffs_close_on_distinct_prompt_boundaries() {
+    // The transport owns one request sidecar and claim slot, so the second
+    // request remains approved until the first closes at its prompt boundary.
     let mut state = InlineState::default();
     for (command, approval_id) in [("ls -la /root/", "req-a"), ("df -h", "req-b")] {
         let request = ShellHandoffRequest::new(
@@ -2607,20 +2604,33 @@ fn untracked_shell_handoffs_share_prompt_boundary_when_emitted_in_same_cycle() {
         .shell_handoff_mut()
         .emit_next_approved(2)
         .expect("emit first handoff");
-    state
+    assert!(state
         .control
         .shell_handoff_mut()
         .emit_next_approved(2)
-        .expect("emit second handoff");
-    let events = vec![
+        .is_none());
+    let mut events = vec![
         untracked_test_event(ShellEventKind::ShellReady, None),
         untracked_test_event(ShellEventKind::ShellReady, None),
         untracked_test_event(ShellEventKind::ShellReady, None),
     ];
 
-    let ids = close_untracked_shell_handoffs(&mut state, &events);
+    let first_ids = close_untracked_shell_handoffs(&mut state, &events);
+    assert_eq!(first_ids, vec!["handoff-1"]);
+    assert!(state.control.shell_handoff().pending_front().is_none());
 
-    assert_eq!(ids, vec!["handoff-1", "handoff-2"]);
+    let second = state
+        .control
+        .shell_handoff_mut()
+        .emit_next_approved(events.len())
+        .expect("emit second handoff after first closure");
+    assert_eq!(second.approval_id, "req-b");
+    assert!(close_untracked_shell_handoffs(&mut state, &events).is_empty());
+
+    events.push(untracked_test_event(ShellEventKind::ShellReady, None));
+    let second_ids = close_untracked_shell_handoffs(&mut state, &events);
+
+    assert_eq!(second_ids, vec!["handoff-2"]);
     assert!(state.control.shell_handoff().pending_front().is_none());
     for id in ["handoff-1", "handoff-2"] {
         let row = state
@@ -2631,9 +2641,7 @@ fn untracked_shell_handoffs_share_prompt_boundary_when_emitted_in_same_cycle() {
             .expect("handoff row");
         assert_eq!(row.status, "completed_untracked");
     }
-    // Both closures produced recoverable evidence, and neither is lost: claims
-    // are handed out one per idle boundary, so two successive claims each yield
-    // exactly one.
+    // Both closures produced recoverable evidence, and neither is lost.
     assert_eq!(
         state
             .evidence
@@ -2681,20 +2689,24 @@ fn untracked_shell_handoff_emitted_after_boundary_stays_pending() {
         .shell_handoff_mut()
         .emit_next_approved(1)
         .expect("emit first handoff");
-    state
-        .control
-        .shell_handoff_mut()
-        .emit_next_approved(3)
-        .expect("emit second handoff");
     let events = vec![
         untracked_test_event(ShellEventKind::ShellReady, None),
         untracked_test_event(ShellEventKind::ShellReady, None),
         untracked_test_event(ShellEventKind::ShellReady, None),
     ];
+    assert_eq!(
+        close_untracked_shell_handoffs(&mut state, &events),
+        vec!["handoff-1"]
+    );
+    state
+        .control
+        .shell_handoff_mut()
+        .emit_next_approved(3)
+        .expect("emit second handoff");
 
     let ids = close_untracked_shell_handoffs(&mut state, &events);
 
-    assert_eq!(ids, vec!["handoff-1"]);
+    assert!(ids.is_empty(), "{ids:?}");
     let pending = state
         .control
         .shell_handoff()
@@ -3154,9 +3166,8 @@ fn activity_records_terminal_output_read_misroute_for_fenced_fallback() {
 }
 
 // #2142 review R5: a block carrying an explicit handoff token must decide by
-// that token alone. Two approved handoffs for the identical command sit in
-// the queue; the block claimed with the *second* request's token must not be
-// text-matched against the *first* (front) request.
+// that token alone. A block carrying another request's token must not be
+// text-matched against the pending request, even when the commands are equal.
 #[test]
 fn block_with_another_requests_token_does_not_close_the_front_handoff() {
     let mut state = InlineState::default();
@@ -3174,21 +3185,18 @@ fn block_with_another_requests_token_does_not_close_the_front_handoff() {
         )
         .expect("handoff request");
         requests.push(request.clone());
-        state
-            .control
-            .shell_handoff_mut()
-            .enqueue_approved_request(request);
+        if approval == "req-a" {
+            state
+                .control
+                .shell_handoff_mut()
+                .enqueue_approved_request(request);
+        }
     }
     state
         .control
         .shell_handoff_mut()
         .emit_next_approved(0)
         .expect("emit first handoff");
-    state
-        .control
-        .shell_handoff_mut()
-        .emit_next_approved(1)
-        .expect("emit second handoff");
     let block = CommandBlock {
         id: "cmd-second".to_string(),
         session_id: "session-1".to_string(),

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -380,6 +380,63 @@ mod tests {
     }
 
     #[test]
+    fn pending_shell_handoff_serializes_approved_requests() {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut state = InlineState::default();
+        state.agent_run.active = Some(test_active_run());
+        let first = ShellHandoffRequest::new(
+            "echo first",
+            "$ echo first",
+            "approved_provider_shell_tool",
+            "user",
+            "req-first",
+            "run-approved",
+            1,
+        )
+        .expect("first handoff request");
+        let second = ShellHandoffRequest::new(
+            "echo second",
+            "$ echo second",
+            "approved_provider_shell_tool",
+            "user",
+            "req-second",
+            "run-approved",
+            1,
+        )
+        .expect("second handoff request");
+        state
+            .control
+            .shell_handoff_mut()
+            .enqueue_approved_request(first.clone());
+        state
+            .control
+            .shell_handoff_mut()
+            .enqueue_approved_request(second.clone());
+
+        let first_action =
+            render_raw_inline_events(&[], &mut Vec::new(), &adapter, "zsh", &mut state)
+                .expect("emit first handoff");
+        assert_eq!(first_action, RawObserverAction::EmitToPty(first));
+
+        let second_action =
+            render_raw_inline_events(&[], &mut Vec::new(), &adapter, "zsh", &mut state)
+                .expect("hold second handoff until the first closes");
+
+        assert_eq!(second_action, RawObserverAction::RawPassthrough);
+
+        state
+            .control
+            .shell_handoff_mut()
+            .pop_pending()
+            .expect("close first handoff");
+        let third_action =
+            render_raw_inline_events(&[], &mut Vec::new(), &adapter, "zsh", &mut state)
+                .expect("emit second handoff after the first closes");
+
+        assert_eq!(third_action, RawObserverAction::EmitToPty(second));
+    }
+
+    #[test]
     #[allow(clippy::field_reassign_with_default)]
     fn pending_shell_handoff_restores_prompt_with_first_emit() {
         let adapter = AdapterInstance::Fake(FakeAgentAdapter);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/shell_handoff_state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/shell_handoff_state.rs
@@ -19,10 +19,17 @@ impl ShellHandoffState {
         });
     }
 
+    /// Emits one approved request only when no earlier request is still pending.
+    ///
+    /// The marker transport has one request sidecar and one parser claim slot,
+    /// so overlapping emissions would replace the first request's identity.
     /// `event_index` is the shell-event count observed when the handoff is
     /// written to the PTY; the untracked-closure fallback only considers
     /// `ShellReady` events strictly after this index.
     pub(crate) fn emit_next_approved(&mut self, event_index: usize) -> Option<ShellHandoffRequest> {
+        if !self.pending.is_empty() {
+            return None;
+        }
         let mut handoff = self.approved.pop_front()?;
         handoff.emitted_at = Some(Instant::now());
         handoff.emitted_at_event_index = Some(event_index);

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/input.rs
@@ -77,13 +77,34 @@ fn raw_cli_approval_application_cursor_arrow_updates_focus() {
 /// through the same resolution pipeline without further cards.
 #[test]
 fn raw_cli_turn_batch_consent_sweeps_queued_requests() {
-    let output = run_raw_cli_ask_with_delayed_input(vec![
-        (b"?? stream batch tool approval\n".to_vec(), Duration::ZERO),
-        // Move to "Allow all this turn" (index 1) once the card is up.
-        (b"\x1b[C".to_vec(), Duration::from_millis(5_000)),
-        (b"\n".to_vec(), Duration::from_millis(200)),
-        (b"exit\n".to_vec(), Duration::from_millis(3_000)),
-    ]);
+    assert_turn_batch_consent_serializes_handoffs(&[]);
+}
+
+#[test]
+fn raw_cli_zsh_turn_batch_consent_serializes_handoffs() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    assert_turn_batch_consent_serializes_handoffs(&["--shell", "zsh"]);
+}
+
+fn assert_turn_batch_consent_serializes_handoffs(args: &[&str]) {
+    let output = run_raw_cli_ask_with_args_and_marker_input(
+        args,
+        &[
+            ("cosh-osc$", b"?? stream batch tool approval\n"),
+            // Move to "Allow all this turn" (index 1) once the card is up.
+            ("Approval req-1", b"\x1b[C\n"),
+            (
+                "Command result analysis for req-3",
+                b"?? batch-handoff-follow-up\n",
+            ),
+            (
+                "Received shell prompt request: ?? batch-handoff-follow-up",
+                b"exit\n",
+            ),
+        ],
+    );
 
     assert!(output.contains("Allow all this turn"), "{output}");
     assert!(output.contains("Approved for this turn req-1"), "{output}");
@@ -92,6 +113,10 @@ fn raw_cli_turn_batch_consent_sweeps_queued_requests() {
     // The swept requests never present their own cards.
     assert!(!output.contains("Approval req-2"), "{output}");
     assert!(!output.contains("Approval req-3"), "{output}");
+    assert!(
+        output.contains("Received shell prompt request: ?? batch-handoff-follow-up"),
+        "a follow-up Agent run must start after every batched handoff closes: {output}"
+    );
     assert!(!output.contains("bash:"));
 }
 


### PR DESCRIPTION
## Why

PR #2151 introduced one-time claim tokens for shell handoff closure, but the runtime could still emit multiple approved handoffs in one batch. Because the transport and parser each retain only one active claim, later emissions could overwrite the first handoff state and leave the batch statically blocked.

## What changed

Serialize approved shell handoffs so the next request remains queued until the current foreground handoff closes. Add controller, activity, and raw CLI regressions covering ordered completion and post-batch follow-up turns on bash and zsh.

## Related issue

Closes #2225

## User / Agent impact

Batched shell calls complete in order without losing the active handoff claim or blocking later agent turns.

## Risk and compatibility

Low risk. The change narrows handoff scheduling to match the existing single-active-claim transport contract; public CLI and configuration remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo test --package cosh-shell --bins shell_handoff -- --nocapture`
- `cargo test --package cosh-shell --test raw_cli turn_batch_consent -- --nocapture`
- `crates/cosh-shell/scripts/check-layout.sh`

## Documentation and rollback

No documentation changes are required. Revert commit `b22c1593` to restore the previous scheduling behavior.