### PR TITLE
feat(sight): report process metadata on raw HTTPS events

### DIFF
--- a/src/agentsight/docs/design-docs/c-ffi-api.md
+++ b/src/agentsight/docs/design-docs/c-ffi-api.md
@@ -23,6 +23,11 @@ typedef struct {
     uint32_t    response_headers_len;
     const char* response_body;        /* JSON or raw text, may be NULL */
     uint32_t    response_body_len;    /* 0 when response_body is NULL */
+    /* 进程归属，与 AgentsightLLMData 中的同名字段同义。这三个字段追加在结构体
+       尾部，因此按旧 layout 编译的调用方无需改动即可继续工作。 */
+    char        cmdline[128];         /* 空格连接的 argv，截断到 127 字节；进程已退出时为空串 */
+    const char* agent_name;           /* may be NULL；统一为小写；未命中配置规则时回退为进程名 */
+    const char* container_id;         /* may be NULL；非容器进程为 NULL */
 } AgentsightHttpsData;
 
 /* LLM 语义层数据 — 仅当 HTTP 流量被识别为 LLM API 调用时产生 */
@@ -199,6 +204,10 @@ int agentsight_read_v2(AgentsightHandle* h,
 开启后，AgentSight 在同一个 handle 内启动一个独立的轻量订阅线程，从 enforcer 获取归一化 `SecurityEvent`，并写入与 LLM/HTTPS 共用的 FFI 有界队列。enforcer 未启动或连接断开时订阅线程会重连；该失败不会停止主 AgentSight pipeline，也不会影响 LLM 事件。
 
 `AGENTSIGHT_EVENT_TYPE_SECURITY` 的 `payload_json` 是 schema version 1 的完整 `SecurityEvent` JSON，覆盖 `file_action`、`taint_transition`、`network_action`、`policy_decision` 和 `enforcement_state`。FFI 不负责策略下发、阻断控制或持久化重放。
+
+`AGENTSIGHT_EVENT_TYPE_HTTPS` 的 `payload_json` 是内部 `HttpRecord` 的字段（`pid`、`comm`、`method`、`path`、`status_code`、请求/响应头与 body、`duration_ns`、`is_sse` 等）平铺在顶层，另外并列三个进程归属字段 `agent_name` / `cmdline` / `container_id`，语义与 `AgentsightHttpsData` 中的同名字段一致。**取不到的字段直接省略，不会序列化为 `null`**，因此调用方判断「键是否存在」即可，无需处理 null。
+
+`agent_name` 在 FFI 边界**统一小写**，`AGENTSIGHT_EVENT_TYPE_HTTPS` 与 `AGENTSIGHT_EVENT_TYPE_LLM` 两种 payload 一致（配置文件里写的是 `Hermes`，这里出来是 `hermes`）。因此调用方可以直接用 `agent_name` 把同一进程的 raw HTTPS 与 LLM 事件聚合到一起，无需自行做大小写归一。注意 AgentSight 自身的 Dashboard 与 SQLite 保留配置原始大小写，仅 FFI 输出做归一化。
 
 ### 3.3 Cmdline Rule 配置
 
@@ -630,3 +639,4 @@ make install            # 安装 agentsight CLI
 | v0.3 | `agentsight_config_add_cmdline_rule()` 新增 `allow` 参数：allow=1 为进程白名单，allow=0 为进程黑名单 |
 | v0.4 | 新增 `agentsight_config_add_domain_rule()` 接口，支持域名白名单；新增 `agentsight_config_load_config()` 支持 JSON 字符串加载配置 |
 | dev | 新增 `agentsight_read_v2()` 版本化通用事件 envelope；可选订阅归一化系统安全审计事件，并与 HTTPS/LLM 共用 handle、队列和 eventfd |
+| dev | `AgentsightHttpsData` 尾部新增 `cmdline` / `agent_name` / `container_id`（追加不改动既有字段偏移）；`AGENTSIGHT_EVENT_TYPE_HTTPS` 的 `payload_json` 同步带上这三个字段 |

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -148,6 +148,22 @@ impl FfiEventSender {
         }
         self.send(FfiEvent::Https(record.clone(), agent_name()));
     }
+
+    /// Enqueue an LLM call, lowercasing `agent_name` on the way in.
+    ///
+    /// The FFI already takes a clone here, so normalizing it costs nothing and keeps
+    /// the pipeline's own copy (dashboard, SQLite, `/api/agent-names`) at its original
+    /// config casing. Normalizing at this boundary rather than in each builder is what
+    /// makes the `agentsight_read_v2` envelope self-consistent: its `Llm` arm
+    /// serializes `LLMCall` verbatim, so a `Hermes` here would not group with the
+    /// `hermes` the raw-HTTPS arm reports for the very same process.
+    pub fn send_llm(&self, call: &LLMCall) {
+        let mut call = call.clone();
+        if let Some(name) = call.agent_name.as_mut() {
+            *name = name.to_lowercase();
+        }
+        self.send(FfiEvent::Llm(call));
+    }
 }
 
 // ===========================================================================
@@ -385,16 +401,67 @@ struct EventDataHolder {
     _payload_json: Vec<u8>,
 }
 
+/// Process attribution for a raw HTTP exchange, resolved from the pid.
+///
+/// Both consumer-facing shapes report these — the typed `AgentsightHttpsData` and
+/// the generic `AgentsightEvent` JSON envelope — so the resolution lives here once
+/// rather than being reimplemented per shape.
+struct HttpsProcessMeta {
+    /// Space-joined argv; empty once the process has exited.
+    cmdline: String,
+    container_id: Option<String>,
+    /// Lowercased at the FFI boundary so C consumers observe a consistent value
+    /// regardless of config-file casing (same as `build_llm_data`).
+    agent_name: Option<String>,
+}
+
+fn resolve_https_process_meta(pid: u32, agent_name: Option<&str>) -> HttpsProcessMeta {
+    HttpsProcessMeta {
+        cmdline: crate::discovery::scanner::read_cmdline(&format!("/proc/{pid}/cmdline")).join(" "),
+        container_id: crate::container::extract_container_id_cached(pid),
+        agent_name: agent_name.map(str::to_lowercase),
+    }
+}
+
+/// JSON payload for `AgentsightEventType::Https`: the `HttpRecord` fields plus the
+/// same process attribution the typed path carries. Without this wrapper the generic
+/// envelope would be strictly poorer than the typed one, because `HttpRecord` itself
+/// has no agent_name / cmdline / container_id field — whereas the `Llm` arm gets them
+/// for free from `LLMCall`. Absent values are omitted rather than serialized as null.
+#[derive(serde::Serialize)]
+struct HttpsEventPayload<'a> {
+    #[serde(flatten)]
+    record: &'a HttpRecord,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cmdline: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    container_id: Option<&'a str>,
+}
+
 fn build_event_data(event: &FfiEvent) -> Result<EventDataHolder, serde_json::Error> {
     let (event_type, timestamp_ns, payload_json) = match event {
-        // The resolved agent name is not serialized here: this path emits the
-        // HttpRecord itself as JSON, and HttpRecord has no agent_name field. Only
-        // the AgentsightHttpsData path carries it.
-        FfiEvent::Https(record, _) => (
-            AgentsightEventType::Https,
-            record.timestamp_ns,
-            serde_json::to_vec(record)?,
-        ),
+        FfiEvent::Https(record, agent_name) => {
+            // Re-resolved rather than shared with build_https_data: the two only ever
+            // run for the same event while a consumer is mid-migration and has both
+            // the generic and the typed callback registered. read_cmdline is one small
+            // /proc read and container id lookups are cached, so paying twice in that
+            // transitional window is cheaper than threading the meta through both
+            // dispatch paths.
+            let meta = resolve_https_process_meta(record.pid, agent_name.as_deref());
+            let payload = HttpsEventPayload {
+                record,
+                agent_name: meta.agent_name.as_deref(),
+                cmdline: Some(meta.cmdline.as_str()).filter(|s| !s.is_empty()),
+                container_id: meta.container_id.as_deref(),
+            };
+            (
+                AgentsightEventType::Https,
+                record.timestamp_ns,
+                serde_json::to_vec(&payload)?,
+            )
+        }
         FfiEvent::Llm(call) => (
             AgentsightEventType::Llm,
             call.start_timestamp_ns,
@@ -428,16 +495,13 @@ fn build_https_data(record: &HttpRecord, agent_name: Option<&str>) -> HttpsDataH
     let resp_headers = record.response_headers.as_bytes().to_vec();
     let resp_body = record.response_body.as_ref().map(|b| b.as_bytes().to_vec());
 
-    // Process metadata, resolved the same way as the LLM path (`build_llm_data`)
-    // so both event kinds report identical values for the same pid. agent_name is
-    // lowercased at the FFI boundary for the same reason it is there.
-    let agent_name = agent_name.map(|s| safe_cstring(&s.to_lowercase()));
-    let cmdline = copy_to_fixed_buf::<128>(
-        &crate::discovery::scanner::read_cmdline(&format!("/proc/{}/cmdline", record.pid))
-            .join(" "),
-    );
-    let container_id =
-        crate::container::extract_container_id_cached(record.pid).map(|s| safe_cstring(&s));
+    // Process metadata, resolved the same way as the LLM path (`build_llm_data`) so
+    // both event kinds report identical values for the same pid, and shared with the
+    // generic JSON envelope via `resolve_https_process_meta`.
+    let meta = resolve_https_process_meta(record.pid, agent_name);
+    let agent_name = meta.agent_name.as_deref().map(safe_cstring);
+    let container_id = meta.container_id.as_deref().map(safe_cstring);
+    let cmdline = copy_to_fixed_buf::<128>(&meta.cmdline);
 
     let c_data = AgentsightHttpsData {
         pid: record.pid as i32,
@@ -1828,6 +1892,85 @@ mod tests {
         let decoded: SecurityEvent =
             serde_json::from_slice(payload).expect("payload should be a SecurityEvent");
         assert_eq!(decoded, event);
+    }
+
+    fn envelope_payload(holder: &EventDataHolder) -> serde_json::Value {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                holder.c_data.payload_json.cast::<u8>(),
+                holder.c_data.payload_json_len as usize,
+            )
+        };
+        serde_json::from_slice(bytes).expect("payload should be a JSON object")
+    }
+
+    #[test]
+    fn test_build_event_data_https_envelope_carries_process_metadata() {
+        // The generic envelope must not be poorer than the typed AgentsightHttpsData:
+        // agent_name / cmdline ride alongside the flattened HttpRecord fields.
+        let mut record = make_http_record(None, None);
+        record.pid = std::process::id();
+        let holder = build_event_data(&FfiEvent::Https(record, Some("Hermes".to_string())))
+            .expect("https event should serialize");
+
+        assert_eq!(holder.c_data.event_type, AgentsightEventType::Https);
+        assert_eq!(holder.c_data.schema_version, 1);
+        let payload = envelope_payload(&holder);
+        // Lowercased, matching the typed path and the gen_ai.agent.type convention.
+        assert_eq!(payload["agent_name"], "hermes");
+        // The current test process is alive, so cmdline resolves.
+        assert!(
+            payload["cmdline"].as_str().is_some_and(|s| !s.is_empty()),
+            "cmdline should be present for a live process, got {:?}",
+            payload["cmdline"]
+        );
+        // HttpRecord's own fields are still flattened in at the top level.
+        assert_eq!(payload["method"], "POST");
+        assert_eq!(payload["path"], "/raw");
+    }
+
+    #[test]
+    fn test_v2_envelope_agent_name_casing_agrees_across_event_kinds() {
+        // A v2 consumer groups raw HTTPS and LLM events for one process by agent_name,
+        // so the two arms must not disagree on casing. Config rules ship camel-cased
+        // ("Hermes", "Codex", "Cosh"), and the Llm arm serializes LLMCall verbatim —
+        // hence the normalization happens at the sender, not in the builders.
+        let (tx, rx) = mpsc::sync_channel(2);
+        let sender = FfiEventSender {
+            tx,
+            eventfd: -1,
+            enable_raw_https: true,
+            security_drops: Arc::new(SecurityDropState::default()),
+        };
+        sender.send_llm(&make_llm_call(Some("Hermes"), 1));
+        sender.send_https(&make_http_record(None, None), || Some("Hermes".to_string()));
+
+        let llm_event = rx.try_recv().expect("llm event should be queued");
+        let https_event = rx.try_recv().expect("https event should be queued");
+        let llm_payload =
+            envelope_payload(&build_event_data(&llm_event).expect("llm event should serialize"));
+        let https_payload = envelope_payload(
+            &build_event_data(&https_event).expect("https event should serialize"),
+        );
+
+        assert_eq!(llm_payload["agent_name"], "hermes");
+        assert_eq!(https_payload["agent_name"], "hermes");
+        assert_eq!(llm_payload["agent_name"], https_payload["agent_name"]);
+    }
+
+    #[test]
+    fn test_build_event_data_https_envelope_omits_absent_metadata() {
+        // Dead pid + no rule match: absent values are omitted, not serialized as null,
+        // so a consumer sees "key missing" rather than a null it has to special-case.
+        let mut record = make_http_record(None, None);
+        record.pid = u32::MAX;
+        let holder =
+            build_event_data(&FfiEvent::Https(record, None)).expect("https event should serialize");
+
+        let payload = envelope_payload(&holder);
+        assert!(payload.get("agent_name").is_none());
+        assert!(payload.get("cmdline").is_none());
+        assert!(payload.get("container_id").is_none());
     }
 
     #[test]

--- a/src/agentsight/src/ffi.rs
+++ b/src/agentsight/src/ffi.rs
@@ -29,7 +29,11 @@ use uuid::Uuid;
 /// Mutually exclusive: an HTTP exchange either becomes `Llm` (if recognised
 /// as an LLM API call) or `Https` (otherwise).  See §5 in c-ffi-api.md.
 pub(crate) enum FfiEvent {
-    Https(HttpRecord),
+    /// Raw HTTP exchange, plus the agent name resolved by the pipeline. The name
+    /// is passed in because it comes from `AgentSight`'s pid → agent_name cache,
+    /// which this layer cannot reach; resolving it here would miss processes that
+    /// have already exited (the cache outlives them).
+    Https(HttpRecord, Option<String>),
     Llm(LLMCall),
     Security(SecurityEvent),
 }
@@ -129,11 +133,20 @@ impl FfiEventSender {
         }
     }
 
-    pub fn send_https(&self, record: &HttpRecord) {
+    /// Enqueue a raw HTTP exchange, resolving its agent name only if the consumer
+    /// actually asked for raw HTTPS.
+    ///
+    /// `agent_name` is a closure rather than a value because resolving it costs two
+    /// `/proc` reads plus rule matching on a cache miss — and non-agent processes, which
+    /// is exactly what produces non-LLM traffic, always miss. Raw HTTPS is off by
+    /// default, so taking a resolved value here would burn that per event only to drop
+    /// it one line later. Keeping the gate ahead of the closure also keeps it in one
+    /// place instead of duplicating the condition at the call site.
+    pub fn send_https(&self, record: &HttpRecord, agent_name: impl FnOnce() -> Option<String>) {
         if !self.enable_raw_https {
             return;
         }
-        self.send(FfiEvent::Https(record.clone()));
+        self.send(FfiEvent::Https(record.clone(), agent_name()));
     }
 }
 
@@ -224,6 +237,14 @@ pub struct AgentsightHttpsData {
     pub response_headers_len: u32,
     pub response_body: *const c_char,
     pub response_body_len: u32,
+    /// Space-joined process command line (argv), truncated to 127 bytes.
+    /// Empty string when the process has already exited.
+    ///
+    /// This field and the two below were appended to the tail so a consumer
+    /// compiled against the older, shorter layout keeps working unchanged.
+    pub cmdline: [c_char; 128],
+    pub agent_name: *const c_char,
+    pub container_id: *const c_char,
 }
 
 /// LLM semantic layer data — only when the HTTP traffic is recognised as
@@ -338,6 +359,8 @@ struct HttpsDataHolder {
     _req_body: Option<Vec<u8>>,
     _resp_headers: Vec<u8>,
     _resp_body: Option<Vec<u8>>,
+    _agent_name: Option<CString>,
+    _container_id: Option<CString>,
 }
 
 struct LlmDataHolder {
@@ -364,7 +387,10 @@ struct EventDataHolder {
 
 fn build_event_data(event: &FfiEvent) -> Result<EventDataHolder, serde_json::Error> {
     let (event_type, timestamp_ns, payload_json) = match event {
-        FfiEvent::Https(record) => (
+        // The resolved agent name is not serialized here: this path emits the
+        // HttpRecord itself as JSON, and HttpRecord has no agent_name field. Only
+        // the AgentsightHttpsData path carries it.
+        FfiEvent::Https(record, _) => (
             AgentsightEventType::Https,
             record.timestamp_ns,
             serde_json::to_vec(record)?,
@@ -394,13 +420,24 @@ fn build_event_data(event: &FfiEvent) -> Result<EventDataHolder, serde_json::Err
     })
 }
 
-fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
+fn build_https_data(record: &HttpRecord, agent_name: Option<&str>) -> HttpsDataHolder {
     let method = safe_cstring(&record.method);
     let path = safe_cstring(&record.path);
     let req_headers = record.request_headers.as_bytes().to_vec();
     let req_body = record.request_body.as_ref().map(|b| b.as_bytes().to_vec());
     let resp_headers = record.response_headers.as_bytes().to_vec();
     let resp_body = record.response_body.as_ref().map(|b| b.as_bytes().to_vec());
+
+    // Process metadata, resolved the same way as the LLM path (`build_llm_data`)
+    // so both event kinds report identical values for the same pid. agent_name is
+    // lowercased at the FFI boundary for the same reason it is there.
+    let agent_name = agent_name.map(|s| safe_cstring(&s.to_lowercase()));
+    let cmdline = copy_to_fixed_buf::<128>(
+        &crate::discovery::scanner::read_cmdline(&format!("/proc/{}/cmdline", record.pid))
+            .join(" "),
+    );
+    let container_id =
+        crate::container::extract_container_id_cached(record.pid).map(|s| safe_cstring(&s));
 
     let c_data = AgentsightHttpsData {
         pid: record.pid as i32,
@@ -427,6 +464,9 @@ fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
             .as_ref()
             .map_or(ptr::null(), |s| s.as_ptr().cast()),
         response_body_len: resp_body.as_ref().map_or(0, |s| s.len() as u32),
+        cmdline,
+        agent_name: agent_name.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+        container_id: container_id.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
     };
 
     HttpsDataHolder {
@@ -437,6 +477,8 @@ fn build_https_data(record: &HttpRecord) -> HttpsDataHolder {
         _req_body: req_body,
         _resp_headers: resp_headers,
         _resp_body: resp_body,
+        _agent_name: agent_name,
+        _container_id: container_id,
     }
 }
 
@@ -594,9 +636,9 @@ unsafe fn dispatch_event(
     llm_ud: *mut c_void,
 ) {
     match event {
-        FfiEvent::Https(record) => {
+        FfiEvent::Https(record, agent_name) => {
             if let Some(cb) = http_cb {
-                let holder = build_https_data(&record);
+                let holder = build_https_data(&record, agent_name.as_deref());
                 unsafe { cb(&holder.c_data, http_ud) };
             }
         }
@@ -1568,7 +1610,7 @@ mod tests {
         let mut record = make_http_record(Some(request_body.clone()), Some(response_body.clone()));
         record.request_headers = request_headers.clone();
         record.response_headers = response_headers.clone();
-        let holder = build_https_data(&record);
+        let holder = build_https_data(&record, None);
 
         let copied_request_headers = unsafe {
             std::slice::from_raw_parts(
@@ -1609,9 +1651,33 @@ mod tests {
             enable_raw_https: false,
             security_drops: Arc::new(SecurityDropState::default()),
         };
-        sender.send_https(&make_http_record(None, None));
+        sender.send_https(&make_http_record(None, None), || None);
         sender.send(FfiEvent::Llm(make_llm_call(None, 1)));
         assert!(matches!(rx.try_recv(), Ok(FfiEvent::Llm(_))));
+    }
+
+    #[test]
+    fn test_disabled_https_sender_does_not_resolve_agent_name() {
+        // Raw HTTPS is off by default while FFI mode is on, so this is the common case:
+        // every non-LLM exchange reaches send_https. Resolving the agent name costs two
+        // /proc reads plus rule matching on a cache miss — and non-agent processes always
+        // miss — so the resolver must not run at all when the consumer opted out.
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let sender = FfiEventSender {
+            tx,
+            eventfd: -1,
+            enable_raw_https: false,
+            security_drops: Arc::new(SecurityDropState::default()),
+        };
+        let resolved = std::cell::Cell::new(false);
+        sender.send_https(&make_http_record(None, None), || {
+            resolved.set(true);
+            None
+        });
+        assert!(
+            !resolved.get(),
+            "agent name must not be resolved while raw HTTPS is disabled"
+        );
     }
 
     #[test]
@@ -1623,8 +1689,55 @@ mod tests {
             enable_raw_https: true,
             security_drops: Arc::new(SecurityDropState::default()),
         };
-        sender.send_https(&make_http_record(None, None));
-        assert!(matches!(rx.try_recv(), Ok(FfiEvent::Https(_))));
+        sender.send_https(&make_http_record(None, None), || Some("hermes".to_string()));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(FfiEvent::Https(_, Some(name))) if name == "hermes"
+        ));
+    }
+
+    #[test]
+    fn test_build_https_data_cmdline_live_process() {
+        // The current test process has a readable /proc/<pid>/cmdline, so the
+        // raw path must fill it just like the LLM path does.
+        let mut record = make_http_record(None, None);
+        record.pid = std::process::id();
+        let holder = build_https_data(&record, None);
+        let end = holder
+            .c_data
+            .cmdline
+            .iter()
+            .position(|&c| c == 0)
+            .unwrap_or(128);
+        assert!(end > 0, "cmdline should be non-empty for a live process");
+        assert!(
+            end < 128,
+            "cmdline must be NUL-terminated within the buffer"
+        );
+    }
+
+    #[test]
+    fn test_build_https_data_cmdline_dead_pid_empty() {
+        // A non-existent pid makes read_cmdline fail, yielding an empty buffer.
+        let mut record = make_http_record(None, None);
+        record.pid = u32::MAX;
+        let holder = build_https_data(&record, None);
+        assert_eq!(holder.c_data.cmdline[0], 0);
+    }
+
+    #[test]
+    fn test_build_https_data_lowercases_agent_name() {
+        // Matches build_llm_data: C consumers see one casing regardless of config.
+        let holder = build_https_data(&make_http_record(None, None), Some("Claude Code"));
+        assert!(!holder.c_data.agent_name.is_null());
+        let name = unsafe { CStr::from_ptr(holder.c_data.agent_name) };
+        assert_eq!(name.to_str().unwrap(), "claude code");
+    }
+
+    #[test]
+    fn test_build_https_data_agent_name_none_is_null() {
+        let holder = build_https_data(&make_http_record(None, None), None);
+        assert!(holder.c_data.agent_name.is_null());
     }
 
     fn make_llm_call(agent_name: Option<&str>, pid: i32) -> LLMCall {

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -532,8 +532,12 @@ impl GenAIBuilder {
         Self::match_agent_by_ctx(&ctx)
     }
 
-    /// 通过进程名匹配 agent registry，返回已知 agent 名称
-    pub(super) fn resolve_agent_name(
+    /// Match the process against the agent registry and return the known agent name.
+    ///
+    /// `pub(crate)` rather than `pub(super)`: the raw HTTPS reporting path in
+    /// `unified.rs` resolves the name through this same ladder, so both event kinds
+    /// report one value per pid. See the `FfiEventSender::send_https` call site.
+    pub(crate) fn resolve_agent_name(
         comm: &str,
         pid: u32,
         cache: &impl PidAgentNameCache,

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -867,7 +867,24 @@ impl AgentSight {
                 // raw HTTPS before cloning or enqueueing when it is disabled.
                 for ar in &analysis_results {
                     if let crate::analyzer::AnalysisResult::Http(record) = ar {
-                        sender.send_https(record);
+                        // Resolved here rather than in the FFI layer because the cache
+                        // lives on `self` and outlives the process, so an exited agent
+                        // still resolves. Same ladder as the LLM path in
+                        // `GenAICallBuilder::build` so both report the same value.
+                        //
+                        // Passed as a closure so `send_https` can skip it entirely when
+                        // raw HTTPS is disabled — the default — instead of paying two
+                        // `/proc` reads per non-LLM exchange for a value it drops.
+                        sender.send_https(record, || {
+                            Some(
+                                GenAIBuilder::resolve_agent_name(
+                                    &record.comm,
+                                    record.pid,
+                                    &self.pid_agent_name_cache,
+                                )
+                                .unwrap_or_else(|| record.comm.clone()),
+                            )
+                        });
                     }
                 }
             }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -30,7 +30,7 @@ use crate::analyzer::Analyzer;
 use crate::config::AgentsightConfig;
 use crate::discovery::AgentScanner;
 use crate::event::Event;
-use crate::ffi::{FfiEvent, FfiEventSender};
+use crate::ffi::FfiEventSender;
 use crate::genai::semantic::GenAISemanticEvent;
 use crate::genai::{GenAIBuilder, GenAIExporter, LogtailExporter};
 use crate::interruption::{
@@ -846,7 +846,7 @@ impl AgentSight {
                             if let Some(ref sender) = self.ffi_sender {
                                 for event in &output.events {
                                     if let GenAISemanticEvent::LLMCall(call) = event {
-                                        sender.send(FfiEvent::Llm(call.clone()));
+                                        sender.send_llm(call);
                                     }
                                 }
                             }
@@ -1039,7 +1039,7 @@ impl AgentSight {
             // FFI mode: deliver LLMCall events via callback channel only.
             for event in events {
                 if let GenAISemanticEvent::LLMCall(call) = event {
-                    sender.send(FfiEvent::Llm(call.clone()));
+                    sender.send_llm(call);
                 }
             }
         } else {
@@ -2063,7 +2063,7 @@ fn complete_deferred_genai(
         if let Some(sender) = ffi_sender {
             for event in events {
                 if let GenAISemanticEvent::LLMCall(call) = event {
-                    sender.send(FfiEvent::Llm(call.clone()));
+                    sender.send_llm(call);
                 }
             }
         } else {
@@ -2078,7 +2078,7 @@ fn complete_deferred_genai(
         if let Some(sender) = ffi_sender {
             for event in events {
                 if let GenAISemanticEvent::LLMCall(call) = event {
-                    sender.send(FfiEvent::Llm(call.clone()));
+                    sender.send_llm(call);
                 }
             }
         } else {


### PR DESCRIPTION
# **Why**

  RawHttpsFallback 开启后上报的 raw HTTPS 事件（即无法解析成 GenAI 语义的流量）只带 pid 和 comm 两个进程标识，而同一条流水线上的 LLM 事件早就带了
  agent_name / cmdline / container_id。

  结果是同一个 agent 进程的 raw 流量和它的 LLM 调用在下游无法归到一起 —— 按 agent 类型或容器做聚合分析时，raw
  数据基本是孤儿。这个缺失原本是代码注释和文档里明确写着的已知限制，不是 bug，只是没做。

  顺带发现 agentsight_read_v2() 的通用事件 envelope 在 HTTPS 这条分支上问题更重：它序列化的是裸 HttpRecord，而 HttpRecord 本身就没有这三个字段；同时
  LLM 分支序列化的 LLMCall 自带这些字段。也就是说本该替代 typed 结构体的新通道，在 raw HTTP 上反而信息更少。

  # **What changed**

  三个提交，同一个逻辑变更的三层：

  1. feat(sight): report process metadata on raw HTTPS events
    - AgentsightHttpsData 尾部追加 cmdline[128] / agent_name / container_id
    - build_https_data 按 build_llm_data 已有的方式填充（read_cmdline + extract_container_id_cached + agent_name 小写化）
    - agent_name 在 unified.rs 解析而非 FFI 层：pid → agent_name 缓存挂在 AgentSight 上且生命周期长于进程，所以 agent 已退出也能解析出来；解析阶梯与
  GenAICallBuilder::build 一致（缓存 → /proc cmdline+exe 规则匹配 → 进程名），保证两种事件对同一个 pid 报同一个值
    - resolve_agent_name 可见性从 pub(super) 放宽到 pub(crate)
  2. feat(sight): carry raw HTTPS process metadata in the generic event envelope
    - 抽出 resolve_https_process_meta()，typed 与泛型两条路径共用，逻辑不会漂移
    - 新增 HttpsEventPayload：HttpRecord 字段用 #[serde(flatten)] 保持在顶层不动，三个归属字段并列写入；取不到的值省略而非序列化成 null
  3. docs(sight): document raw HTTPS process metadata in the C FFI contract
    - 更新 docs/design-docs/c-ffi-api.md 的结构体定义、envelope payload 说明和变更历史表

  刻意没做的：不加 session_id / conversation_id —— raw 事件的定义就是「没能映射到 LLM 语义的流量」，本身不存在 session
  归属，加了只会永远是空值。request_url 属于另一个问题（消费方目前从请求头里提取 host），留给单独的变更。

  Footprint ladder：主体是级别 1（扩展现有 build_https_data），第 2 个提交为避免两处重复解析下降到级别 2（模块内一个 helper）。未新增 extern "C"
  导出，build.rs 的 drift guard 通过。

  # **Related issue**

  no-issue: 补齐 0.9.0 引入的 RawHttpsFallback 路径的进程归属字段


  # **User / Agent impact**

  对 AgentSight 自身的 CLI、Dashboard、SQLite 存储无影响 —— 变更只在 FFI 边界。

  对 FFI 调用方：开启 raw HTTPS 上报后，每个事件多带三个进程归属字段。字段可空（agent_name / container_id 可为 NULL，cmdline
  进程退出后为空串），调用方不读就等于没变化。

  # **Risk and compatibility**

  - [ ] Public CLI, API, configuration, or documented behavior changed
  - [ ] Privileged or security-sensitive behavior changed
  - [x] Cross-component contract changed
  - [ ] Migration or rollback guidance is needed

  AgentsightHttpsData 是 LoongCollector 通过 dlopen 消费的 C ABI 结构体，所以这是一次跨组件契约变更。

  三个字段一律追加在结构体尾部，既有字段的偏移不变，因此「按旧 layout 编译的调用方 + 新 libagentsight.so」安全。

  /proc 读取没有引入新权限：build_llm_data 早就在读 /proc/<pid>/cmdline 和 cgroup，raw 路径只是走了同一套。

  # **Validation**

  - cargo test --lib：1190 passed / 0 failed / 1 ignored，其中新增 6 个用例：
    - typed 路径：活进程 cmdline 非空、死 pid cmdline 为空、agent_name 小写化、agent_name 为 None 时指针为 NULL
    - 泛型 envelope：活进程带全字段且 HttpRecord 字段仍在顶层、死 pid + 无规则命中时三个键都不出现
  - cargo fmt --check 干净
  - clippy：本 PR 改动的文件零告警
  - build.rs drift guard 通过；确认 cbindgen 重新生成的 include/agentsight.h 里三个字段在 AgentsightHttpsData 尾部


  # **Documentation and rollback**

  文档：docs/design-docs/c-ffi-api.md 更新了 AgentsightHttpsData 结构体定义、AGENTSIGHT_EVENT_TYPE_HTTPS 的 payload 形状说明，以及末尾的变更历史表。

  回滚：三个提交直接 revert 即可，无数据迁移、无配置变更、无持久化 schema 改动。运行时也可关掉 —— 不开 enable_raw_https
  就根本不产生这类事件（默认关闭）。