### PR TITLE
feat(skillfs): allow skill meta passthrough

### DIFF
--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -18,7 +18,7 @@ Use SkillFS when you need:
 - default-view filtering plus `skill-discover` for secondary skills;
 - in-place policy and audit coverage for production access;
 - Skill Ledger integration for fallback and hidden runtime views;
-- `.skill-meta` protection from ordinary agent processes.
+- `.skill-meta` protection when a resolver or trusted writer integration is enabled.
 
 Do not in-place mount an existing hub workspace directly when that workspace
 also contains registry metadata such as `.hub` directories or external
@@ -65,8 +65,9 @@ SkillFS expects a source directory with one skill per child directory:
 The directory name is the canonical runtime skill id. The `name` field inside
 `SKILL.md` is display metadata and does not override the directory key.
 
-Do not treat `.skill-meta` as ordinary agent data. It stores SkillFS and ledger
-metadata and is hidden from ordinary callers.
+Do not use `.skill-meta` for agent application data. Security integrations use
+it for SkillFS and ledger metadata; without such an integration it remains an
+ordinary POSIX passthrough subtree for compatibility.
 
 ## Quick Start
 
@@ -225,8 +226,23 @@ In-place authoring supports newly created skill directories. A fresh directory
 does not expose a phantom `SKILL.md` before the manifest exists; once
 `SKILL.md` is written, SkillFS reparses it and exposes the compiled view.
 Pending or direct-final installs can preserve ordinary top-level skill
-directory metadata such as mode, timestamps, and ownership. `.skill-meta/**`
-remains restricted to trusted metadata paths.
+directory metadata such as mode, timestamps, and ownership.
+
+### Metadata Protection Modes
+
+`.skill-meta/**` mode is selected once per mount from the configured security
+integrations; `--security-mode` only selects in-place mount topology.
+
+| Active resolver | Enabled trusted writer | `.skill-meta/**` behavior |
+| --- | --- | --- |
+| no | no | Ordinary POSIX passthrough, including mutation, links, and `user.*` xattrs |
+| yes | either | Protected; hidden from untrusted callers and mutations require the trusted path |
+| no | yes | Protected; ordinary callers are hidden and the configured writer can perform supported metadata mutations |
+
+Migration note: deployments that previously relied on `.skill-meta` being
+implicitly hidden must enable `--security` with a resolver/activation mode or
+configure a trusted writer before exposing the mount to an agent. Startup
+diagnostics explicitly report passthrough mode when neither signal is present.
 
 Without security integration, skills read from the live source tree. When
 security activation is enabled, visibility is constrained by the active
@@ -688,7 +704,7 @@ shares the same file for compatibility.
 | --- | --- |
 | `--foreground` | Run in the foreground |
 | `--managed` | Start a detached supervised mount |
-| `--security-mode` | Require source and mountpoint to be the same path |
+| `--security-mode` | Require source and mountpoint to be the same path; does not itself protect `.skill-meta` |
 | `--skill-layout <MODE>` | `auto` (default, detect Hermes from source-root markers), `flat`, or `hermes`; `hermes` is incompatible with `--decision-command` |
 | `--security` | Enable security integration |
 | `--activation-mode file` | Consume activation JSON/xattr state |
@@ -722,8 +738,10 @@ Fallback intentionally reads a trusted snapshot under `.skill-meta`, not the
 live source tree.
 
 **`.skill-meta` is not listed.**
-This is expected for ordinary callers. Trusted peers can access metadata through
-the configured trusted path.
+An active resolver or enabled trusted writer placed the mount in protected
+mode. Trusted peers can access metadata through the configured trusted path. If
+neither integration is configured, `.skill-meta` is ordinary passthrough data;
+check the startup diagnostic if that is not what you observe.
 
 **Notify socket failures appear in logs.**
 Notify failures are warnings and do not stop FUSE service, but the external

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -17,7 +17,7 @@ fallback snapshot 或 hidden。
 - 需要 default view 过滤，并通过 `skill-discover` 发现 secondary skills；
 - 生产访问需要 in-place policy 和 audit 覆盖；
 - 需要对接 Skill Ledger，提供 fallback / hidden 运行时视图；
-- 需要保护 `.skill-meta`，避免普通 Agent 进程读取元数据。
+- 启用 resolver 或 trusted writer 集成后，需要保护 `.skill-meta`，避免普通 Agent 进程读取元数据。
 
 不要直接对已有 hub workspace 做 in-place mount，尤其是该 workspace 同时包含
 `.hub` 目录、外部 manifest 或 registry 元数据时。推荐分离 hub workspace 和
@@ -64,8 +64,8 @@ SkillFS 期望 source 目录下每个子目录对应一个 skill：
 目录名是权威运行时 skill id。`SKILL.md` frontmatter 里的 `name` 字段是展示元数据，
 不会覆盖目录 key。
 
-不要把 `.skill-meta` 当作普通 Agent 数据使用。它保存 SkillFS 和 ledger 元数据，
-对普通调用方隐藏。
+不要把 `.skill-meta` 用作 Agent 业务数据。安全集成会在其中保存 SkillFS 和 ledger
+元数据；未配置这类集成时，为兼容性它仍是普通 POSIX passthrough 子树。
 
 ## 快速开始
 
@@ -215,7 +215,22 @@ default view 会直接出现在挂载后的 skill 视图中。Secondary views �
 In-place authoring 支持新建 skill 目录。刚创建但尚未写入 manifest 的目录不会暴露
 phantom `SKILL.md`；写入 `SKILL.md` 后，SkillFS 会重新解析并暴露编译后的视图。
 Pending 或 direct-final install 可以保留普通顶层 skill 目录的 mode、timestamp 和
-ownership 等元数据。`.skill-meta/**` 仍只允许 trusted metadata path 访问。
+ownership 等元数据。
+
+### Metadata 保护模式
+
+每次 mount 会根据已配置的安全集成选择 `.skill-meta/**` 模式；`--security-mode`
+只选择 in-place mount 拓扑。
+
+| Active resolver | 启用的 trusted writer | `.skill-meta/**` 行为 |
+| --- | --- | --- |
+| 否 | 否 | 普通 POSIX passthrough，包括 mutation、link 和 `user.*` xattr |
+| 是 | 任意 | Protected；对不可信调用方隐藏，mutation 必须走 trusted path |
+| 否 | 是 | Protected；普通调用方不可见，配置的 writer 可执行受支持的 metadata mutation |
+
+迁移提示：以前依赖 `.skill-meta` 被隐式隐藏的部署，在向 Agent 暴露 mount 前必须通过
+resolver/activation mode 启用 `--security`，或配置 trusted writer。两种信号都没有
+时，启动诊断会明确报告 passthrough 模式。
 
 无安全集成时，skill 默认读取 live source 树。启用 security activation 后，
 可见性受 active mapping 限制：
@@ -617,7 +632,7 @@ mount-session summary 仍共享同一个文件。
 | --- | --- |
 | `--foreground` | 前台运行 |
 | `--managed` | 启动 detached supervised mount |
-| `--security-mode` | 要求 source 和 mountpoint 是同一路径 |
+| `--security-mode` | 要求 source 和 mountpoint 是同一路径；本身不保护 `.skill-meta` |
 | `--skill-layout <MODE>` | `auto`（默认，按 source-root marker 探测 Hermes）、`flat` 或 `hermes`；`hermes` 与 `--decision-command` 互斥 |
 | `--security` | 启用安全集成 |
 | `--activation-mode file` | 消费 activation JSON/xattr 状态 |
@@ -650,7 +665,9 @@ state。检查 notify 投递和 activation reload events。
 这是预期行为。Fallback 读取 `.skill-meta` 下的可信 snapshot，而不是 live source。
 
 **看不到 `.skill-meta`。**
-普通调用方看不到该目录是预期行为。可信 peer 可以通过配置的 trusted path 访问元数据。
+Active resolver 或启用的 trusted writer 使 mount 进入 protected 模式。可信 peer
+可以通过配置的 trusted path 访问元数据。如果两种集成都未配置，`.skill-meta` 应为
+普通 passthrough 数据；若实际行为不同，请检查启动诊断。
 
 **日志里出现 notify socket 失败。**
 Notify 失败只是 warning，不会停止 FUSE 服务，但外部 daemon 可能收不到 mutation

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -476,12 +476,15 @@ Two integration paths are supported:
 
 Related security surfaces:
 
-- `.skill-meta/**` is hidden from untrusted lookup/list/read paths and ordinary
-  mutation attempts are rejected. Trusted exact-path access can route to the
-  live source for metadata operations.
+- `.skill-meta/**` has a mount-scoped mode. It is ordinary POSIX passthrough
+  data when neither an active resolver nor an enabled trusted writer is
+  configured. Either integration signal enables protected mode: untrusted
+  lookup/list/read paths are hidden and ordinary mutations are rejected.
+  Trusted exact-path access can route to the live source for metadata work.
 - `--audit-log <PATH>` writes stable JSONL audit events.
 - `--security-mode` requires `SOURCE` and `MOUNTPOINT` to resolve to the same
-  directory so normal userspace access goes through FUSE policy and audit.
+  directory so normal userspace access goes through FUSE policy and audit. It
+  does not enable `.skill-meta` protected mode by itself.
 - `/.skillfs-inbox/<skill>/...` is an install/repair entry point for hidden or
   new skills; writes land in the source tree and completion can trigger the
   external security flow.

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -432,11 +432,14 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 
 相关安全能力：
 
-- `.skill-meta/**` 对不可信 lookup/list/read 路径隐藏，普通 mutation 会被拒绝。
+- `.skill-meta/**` 使用 mount-scoped 模式。没有 active resolver 且没有启用的
+  trusted writer 时，它是普通 POSIX passthrough 数据；任一集成信号存在时进入
+  protected 模式，对不可信 lookup/list/read 路径隐藏并拒绝普通 mutation。
   可信 exact-path access 可把 metadata 操作路由到 live source。
 - `--audit-log <PATH>` 写稳定 JSONL audit events。
 - `--security-mode` 要求 `SOURCE` 和 `MOUNTPOINT` 指向同一目录，使普通
-  userspace 访问都经过 FUSE policy 和 audit。
+  userspace 访问都经过 FUSE policy 和 audit；它本身不会启用 `.skill-meta`
+  protected 模式。
 - `/.skillfs-inbox/<skill>/...` 是 hidden 或 new skill 的安装/修复入口；
   写入落到 source，完成信号可触发外部安全流程。
 - `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -232,7 +232,9 @@ enum Commands {
         ///
         /// Use this when security policy or audit must cover normal source-path
         /// access. Without it, non-in-place mounts remain allowed but direct
-        /// writes to SOURCE bypass SkillFS.
+        /// writes to SOURCE bypass SkillFS. This flag selects mount topology;
+        /// `.skill-meta` protection additionally requires an active resolver
+        /// or enabled trusted writer.
         #[arg(long, help_heading = help_text::HEADING_SECURITY)]
         security_mode: bool,
 
@@ -1917,6 +1919,10 @@ async fn cmd_mount(
             }
             _ => None,
         };
+    let protects_skill_meta = active_resolver.is_some()
+        || trusted_writer_config
+            .as_ref()
+            .is_some_and(TrustedWriterConfig::is_enabled);
 
     // ── Trusted peer control socket: resolve the effective endpoint ──
     //
@@ -2035,11 +2041,20 @@ async fn cmd_mount(
         eprintln!("   or send SIGTERM / press Ctrl+C to stop this process.");
         if security_mode {
             eprintln!();
-            eprintln!("   --security-mode is enabled: SkillFS audit and policy now cover");
+            eprintln!("   --security-mode is enabled: source access now crosses SkillFS");
             eprintln!(
-                "   every read/write to '{}' that goes through userspace.",
+                "   for every userspace read/write to '{}'.",
                 source.display()
             );
+            if protects_skill_meta {
+                eprintln!("   '.skill-meta' protected mode is active because a security");
+                eprintln!("   resolver or trusted writer is enabled.");
+            } else {
+                eprintln!("⚠  No active resolver or trusted writer is enabled:");
+                eprintln!("   '.skill-meta' remains ordinary POSIX passthrough data.");
+                eprintln!("   Enable --security with a resolver/activation mode or configure");
+                eprintln!("   a trusted writer before relying on metadata protection.");
+            }
             if drift_enabled {
                 eprintln!(
                     "   --audit-log is also enabled: best-effort source drift observation is"
@@ -2056,8 +2071,8 @@ async fn cmd_mount(
         // Non-in-place / "compatibility" mount. SkillFS still serves the
         // virtual skill view at '{mountpoint}/skills/...', but the physical
         // source directory remains directly writable outside FUSE. Be
-        // explicit so an operator who relies on .skill-meta protection or
-        // the audit log knows where the boundary actually is.
+        // explicit so an operator who relies on policy or the audit log knows
+        // where the boundary actually is.
         warn!(
             source = %source.display(),
             mountpoint = %mountpoint.display(),
@@ -2068,7 +2083,7 @@ async fn cmd_mount(
         eprintln!("     source     = '{}'", source.display());
         eprintln!("     mountpoint = '{}'", mountpoint.display());
         eprintln!("   • Direct writes to the source path are NOT routed through SkillFS,");
-        eprintln!("     so '.skill-meta' protection and the audit log only cover");
+        eprintln!("     so SkillFS policy and the audit log only cover");
         eprintln!(
             "     operations that go through '{}'.",
             mountpoint.display()

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
@@ -16,6 +16,25 @@ use crate::symlink_policy;
 use crate::sys::errno;
 
 impl SkillFs {
+    fn should_reject_hidden_link_endpoint(&self, path_type: &PathType) -> bool {
+        match path_type {
+            PathType::Passthrough {
+                skill_name,
+                relative_path,
+            } => self.should_reject_hidden_write(skill_name, Some(relative_path)),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => self.should_reject_hermes_nested_hidden_write(
+                category,
+                skill_name,
+                Some(relative_path),
+            ),
+            _ => false,
+        }
+    }
+
     pub(in crate::fs) fn readlink_impl(&mut self, req: &Request, ino: u64, reply: ReplyData) {
         debug!(ino, "readlink");
         let path = match self.inodes.get_path(ino) {
@@ -55,6 +74,15 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => {
+                if let Some(false) = self.is_trusted_skill_meta_access(
+                    &PathType::Passthrough {
+                        skill_name: skill_name.clone(),
+                        relative_path: relative_path.clone(),
+                    },
+                    req,
+                ) {
+                    return reply.error(libc::ENOENT);
+                }
                 if is_skill_discover_path(&skill_name) {
                     // skill-discover virtual namespace contains no symlinks.
                     self.emit_event(
@@ -101,6 +129,15 @@ impl SkillFs {
                 skill_name,
                 relative_path,
             } => {
+                if let Some(false) = self.is_trusted_skill_meta_access(
+                    &PathType::InboxPassthrough {
+                        skill_name: skill_name.clone(),
+                        relative_path: relative_path.clone(),
+                    },
+                    req,
+                ) {
+                    return reply.error(libc::ENOENT);
+                }
                 if !Self::is_inbox_skill_name_allowed(&skill_name) {
                     self.emit_event(
                         SkillEvent::new(SkillEventKind::Readlink)
@@ -152,17 +189,39 @@ impl SkillFs {
             | PathType::CategoryPassthrough {
                 name,
                 relative_path,
-            }
-            | PathType::NestedPassthrough {
-                category: name,
-                skill_name: _,
-                relative_path,
             } => {
                 let physical = match self.resolve_physical_path(&path) {
                     Some(p) => p,
                     None => return reply.error(libc::ENOENT),
                 };
                 let _ = (&name, &relative_path);
+                match std::fs::read_link(&physical) {
+                    Ok(target) => {
+                        use std::os::unix::ffi::OsStrExt;
+                        reply.data(target.as_os_str().as_bytes());
+                    }
+                    Err(e) => reply.error(errno(&e)),
+                }
+            }
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => {
+                if let Some(false) = self.is_trusted_skill_meta_access(
+                    &PathType::NestedPassthrough {
+                        category: category.clone(),
+                        skill_name: skill_name.clone(),
+                        relative_path: relative_path.clone(),
+                    },
+                    req,
+                ) {
+                    return reply.error(libc::ENOENT);
+                }
+                let physical = match self.resolve_physical_path(&path) {
+                    Some(p) => p,
+                    None => return reply.error(libc::ENOENT),
+                };
                 match std::fs::read_link(&physical) {
                     Ok(target) => {
                         use std::os::unix::ffi::OsStrExt;
@@ -203,28 +262,45 @@ impl SkillFs {
         let path_type = self.parse_fuse_path(Path::new(&path_str));
         let target_str = target.display().to_string();
 
-        // Only Passthrough leaves under an ordinary skill may host a new
-        // symlink. Virtual paths keep their existing virtual semantics,
-        // which means SymlinkDir / SymlinkMd / Root / SkillsDir / Invalid
-        // remain EROFS as in S0.
-        let (skill_name, relative_path) = match &path_type {
-            PathType::Passthrough {
-                skill_name,
-                relative_path,
-            } => (skill_name.clone(), relative_path.clone()),
-            _ => {
-                self.ro_warn("symlink", &path_str);
-                self.emit_event(
-                    SkillEvent::new(SkillEventKind::SymlinkAttempt)
-                        .with_action(SkillEventAction::Rejected)
-                        .with_errno(libc::EROFS)
-                        .with_caller(req.uid(), req.gid())
-                        .with_detail(format!("class=virtual_link target={}", target_str)),
-                );
-                reply.error(libc::EROFS);
-                return;
-            }
-        };
+        // Only passthrough leaves under a real skill may host a new symlink.
+        // Virtual paths keep their existing virtual semantics, which means
+        // SymlinkDir / SymlinkMd / Root / SkillsDir / Invalid remain EROFS.
+        // Hermes nested skills use `category/skill` as their logical ID while
+        // retaining the nested physical root for boundary classification.
+        let (skill_name, relative_path, classification_root, classification_skill) =
+            match &path_type {
+                PathType::Passthrough {
+                    skill_name,
+                    relative_path,
+                } => (
+                    skill_name.clone(),
+                    relative_path.clone(),
+                    self.source_base(),
+                    skill_name.clone(),
+                ),
+                PathType::NestedPassthrough {
+                    category,
+                    skill_name,
+                    relative_path,
+                } => (
+                    Self::hermes_skill_id(category, skill_name),
+                    relative_path.clone(),
+                    self.source_base().join(category),
+                    skill_name.clone(),
+                ),
+                _ => {
+                    self.ro_warn("symlink", &path_str);
+                    self.emit_event(
+                        SkillEvent::new(SkillEventKind::SymlinkAttempt)
+                            .with_action(SkillEventAction::Rejected)
+                            .with_errno(libc::EROFS)
+                            .with_caller(req.uid(), req.gid())
+                            .with_detail(format!("class=virtual_link target={}", target_str)),
+                    );
+                    reply.error(libc::EROFS);
+                    return;
+                }
+            };
 
         // skill-discover is virtual and read-only regardless of the
         // physical layout, so refuse before any classifier work.
@@ -239,6 +315,14 @@ impl SkillFs {
                     .with_detail(format!("class=skill_discover target={}", target_str)),
             );
             reply.error(libc::EROFS);
+            return;
+        }
+
+        // A parent directory handle may outlive an activation transition.
+        // Recheck Hidden immediately before every link mutation instead of
+        // relying on the lookup that originally produced the handle.
+        if self.should_reject_hidden_link_endpoint(&path_type) {
+            reply.error(libc::ENOENT);
             return;
         }
 
@@ -304,23 +388,44 @@ impl SkillFs {
         // space sees when it constructs an absolute target, so we use it
         // for both. Relative targets are resolved against the parent of
         // the link path.
-        let source_root = self
-            .source
+        // Enumerate Hermes siblings through `source_base()` before
+        // canonicalization. In an in-place mount this stays on the pre-opened
+        // `/proc/self/fd/N` path and cannot recurse into the FUSE callback.
+        // Only real Skill leaves participate in cross-skill classification;
+        // ordinary category directories remain outside the Skill namespace.
+        let known_skill_names = if let PathType::NestedPassthrough { category, .. } = &path_type {
+            std::fs::read_dir(&classification_root)
+                .into_iter()
+                .flatten()
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let name = entry.file_name().into_string().ok()?;
+                    self.hermes_nested_is_skill(category, &name).then_some(name)
+                })
+                .collect::<Vec<_>>()
+        } else {
+            let store_guard = self.store.read();
+            store_guard
+                .list()
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        };
+        let source_root = classification_root
             .canonicalize()
-            .unwrap_or_else(|_| self.source.clone());
+            .unwrap_or_else(|_| classification_root.clone());
         let link_parent_for_classifier = source_root
-            .join(&skill_name)
+            .join(&classification_skill)
             .join(relative_path.parent().unwrap_or(Path::new("")));
-        let store_guard = self.store.read();
-        let known_skill_names: Vec<&str> = store_guard.list();
+        let known_skill_name_refs: Vec<&str> =
+            known_skill_names.iter().map(String::as_str).collect();
         let class = symlink_policy::classify_symlink_target(
             &source_root,
-            &skill_name,
-            &known_skill_names,
+            &classification_skill,
+            &known_skill_name_refs,
             &link_parent_for_classifier,
             target,
         );
-        drop(store_guard);
 
         let class_label = symlink_policy::symlink_class_label(&class);
         if !matches!(class, symlink_policy::SymlinkTargetClass::SameSkill) {
@@ -344,15 +449,10 @@ impl SkillFs {
             return;
         }
 
-        // Even when the target classifies as SameSkill, refuse if the
-        // lexical resolution lands inside `.skill-meta/**` or under any
-        // lifecycle reserved root (`.staging`, `.certified`,
-        // `.quarantine`, `.archive`). The link path itself is gated
-        // earlier, but a same-skill target could still point a fresh
-        // link at protected metadata or a hidden lifecycle namespace —
-        // following such a link from userspace would expose the
-        // protected payload to readers that only see the unprotected
-        // link path.
+        // In protected mode, refuse a same-skill target inside
+        // `.skill-meta/**`; following such a link from userspace would expose
+        // protected payload through an otherwise unprotected link path.
+        // Lifecycle roots remain rejected in both modes.
         let link_relative_parent = relative_path
             .parent()
             .map(|p| p.to_path_buf())
@@ -369,8 +469,9 @@ impl SkillFs {
                 .as_deref()
                 .map(is_reserved_lifecycle_name)
                 .unwrap_or(false);
-            if lands_in_skill_meta || lands_in_lifecycle {
-                let sensitive_label = if lands_in_skill_meta {
+            let protected_skill_meta_target = lands_in_skill_meta && self.protects_skill_meta();
+            if protected_skill_meta_target || lands_in_lifecycle {
+                let sensitive_label = if protected_skill_meta_target {
                     "same_skill_sensitive_target_skill_meta"
                 } else {
                     "same_skill_sensitive_target_lifecycle"
@@ -496,12 +597,21 @@ impl SkillFs {
         };
         let source_path_type = self.parse_fuse_path(Path::new(&source_path_str));
 
-        // Destination must be a passthrough leaf.
+        // Destination must be a passthrough leaf under a real skill. Hermes
+        // nested paths use the canonical `category/skill` logical ID.
         let (dst_skill, dst_rel) = match &new_path_type {
             PathType::Passthrough {
                 skill_name,
                 relative_path,
             } => (skill_name.clone(), relative_path.clone()),
+            PathType::NestedPassthrough {
+                category,
+                skill_name,
+                relative_path,
+            } => (
+                Self::hermes_skill_id(category, skill_name),
+                relative_path.clone(),
+            ),
             _ => {
                 self.ro_warn("link", &new_path_str);
                 self.emit_event(
@@ -523,11 +633,13 @@ impl SkillFs {
         // virtual /skills entry). Hardlinks pointing at a virtual file
         // would either pin compiled content to a real inode or duplicate
         // a virtual file that has no on-disk identity.
-        let (src_skill, src_rel) = match &source_path_type {
-            PathType::Passthrough {
+        let src_skill = match &source_path_type {
+            PathType::Passthrough { skill_name, .. } => skill_name.clone(),
+            PathType::NestedPassthrough {
+                category,
                 skill_name,
-                relative_path,
-            } => (skill_name.clone(), relative_path.clone()),
+                ..
+            } => Self::hermes_skill_id(category, skill_name),
             _ => {
                 self.emit_event(
                     SkillEvent::new(SkillEventKind::HardlinkAttempt)
@@ -560,6 +672,17 @@ impl SkillFs {
                     )),
             );
             reply.error(libc::EROFS);
+            return;
+        }
+
+        // Revalidate both endpoints because either inode/parent handle may
+        // have been acquired before the resolver transitioned the skill to
+        // Hidden. Linking from Hidden would leak an inode; linking into Hidden
+        // would mutate its live backing tree.
+        if self.should_reject_hidden_link_endpoint(&source_path_type)
+            || self.should_reject_hidden_link_endpoint(&new_path_type)
+        {
+            reply.error(libc::ENOENT);
             return;
         }
 
@@ -622,8 +745,14 @@ impl SkillFs {
             return;
         }
 
-        let src_physical = self.source_base().join(&src_skill).join(&src_rel);
-        let dst_physical = self.source_base().join(&dst_skill).join(&dst_rel);
+        let src_physical = match self.resolve_physical_path(&source_path_str) {
+            Some(path) => path,
+            None => return reply.error(libc::ENOENT),
+        };
+        let dst_physical = match self.resolve_physical_path(&new_path_str) {
+            Some(path) => path,
+            None => return reply.error(libc::ENOENT),
+        };
 
         // T2 hardlink scope: same-skill **ordinary regular files only**.
         // `symlink_metadata` deliberately does NOT follow symlinks, so a

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/xattr.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/xattr.rs
@@ -29,6 +29,9 @@ impl SkillFs {
         if !path_type_supports_xattr_passthrough(&path_type) {
             return reply.error(libc::EOPNOTSUPP);
         }
+        if let Some(false) = self.is_trusted_skill_meta_access(&path_type, req) {
+            return reply.error(libc::ENOENT);
+        }
         if Self::lifecycle_reservation(&path_type).is_some() {
             return reply.error(libc::EOPNOTSUPP);
         }
@@ -72,6 +75,9 @@ impl SkillFs {
 
         if !path_type_supports_xattr_passthrough(&path_type) {
             return reply.error(libc::EOPNOTSUPP);
+        }
+        if let Some(false) = self.is_trusted_skill_meta_access(&path_type, req) {
+            return reply.error(libc::ENOENT);
         }
         if Self::lifecycle_reservation(&path_type).is_some() {
             return reply.error(libc::EOPNOTSUPP);

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -36,6 +36,12 @@ mod paths;
 mod policy;
 mod read_resolution;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillMetaMode {
+    Passthrough,
+    Protected,
+}
+
 // ---------------------------------------------------------------------------
 // Filesystem Implementation
 // ---------------------------------------------------------------------------
@@ -72,9 +78,14 @@ pub struct SkillFs {
     sync_tx: Option<std::sync::mpsc::Sender<SyncEvent>>,
     /// Skill Security policy. The S1 default is
     /// [`SkillMetaProtectionPolicy`], which denies mutating operations
-    /// under `.skill-meta/**`. Embedders/tests can swap it for
+    /// under `.skill-meta/**` when the mount-scoped metadata mode is
+    /// protected. Embedders/tests can swap it for
     /// [`security::PermissivePolicy`] via [`SkillFs::with_policy`].
     policy: Arc<dyn SecurityPolicy>,
+    /// Whether an embedder explicitly replaced the default metadata policy.
+    /// Passthrough mode disables only the built-in `.skill-meta` rule; custom
+    /// policy decisions must still run for the now-ordinary subtree.
+    policy_overridden: bool,
     /// Skill Security event sink (Package S0 seam). Default drops events.
     event_sink: Arc<dyn SkillEventSink>,
     /// D1.1 ledger-driven active-skill mapping. When `Some`, the read
@@ -102,9 +113,7 @@ pub struct SkillFs {
     /// notifications to the external daemon. Notify failure is
     /// diagnostic only and never changes the active resolver.
     notify_controller: Option<Arc<NotifyController>>,
-    /// Trusted writer process gate. Default disabled, in
-    /// which case `.skill-meta/**` mutation falls through to the
-    /// existing [`SkillMetaProtectionPolicy`] deny path. When enabled
+    /// Trusted writer process gate. Default disabled. When enabled
     /// the gate compares the FUSE caller pid's resolved process name
     /// against the configured trusted writer name; on match,
     /// `.skill-meta/**` mutation is allowed and an audit
@@ -114,6 +123,10 @@ pub struct SkillFs {
     /// lifecycle reservation, virtual paths, `skill-discover`, or
     /// other policy.
     trusted_writer: TrustedWriterConfig,
+    /// Mount-scoped decision for the reserved metadata tree. This is derived
+    /// from integration state before the FUSE loop starts and never changes
+    /// in response to callback traffic or resolver socket activity.
+    skill_meta_mode: SkillMetaMode,
     /// Identity resolver paired with [`Self::trusted_writer`]. Default
     /// is the Linux `/proc/<pid>/comm` resolver; tests inject a
     /// deterministic in-memory resolver via
@@ -224,11 +237,13 @@ impl SkillFs {
             skill_layout: SkillLayout::Flat,
             sync_tx: Some(sync_tx),
             policy: Arc::new(SkillMetaProtectionPolicy),
+            policy_overridden: false,
             event_sink: Arc::new(NoopEventSink),
             active_resolver: None,
             refresh_controller: None,
             notify_controller: None,
             trusted_writer: TrustedWriterConfig::disabled(),
+            skill_meta_mode: SkillMetaMode::Passthrough,
             trusted_writer_identity: default_identity_resolver(),
             staging_matcher: None,
             staging_controller: None,
@@ -264,6 +279,7 @@ impl SkillFs {
     /// `SkillFs::new` callers that do not configure security.
     pub fn with_policy(mut self, policy: Arc<dyn SecurityPolicy>) -> Self {
         self.policy = policy;
+        self.policy_overridden = true;
         self
     }
 
@@ -306,6 +322,7 @@ impl SkillFs {
     /// live source and snapshots are strictly read-only.
     pub fn with_active_resolver(mut self, resolver: Arc<ActiveSkillResolver>) -> Self {
         self.active_resolver = Some(resolver);
+        self.update_skill_meta_mode();
         self
     }
 
@@ -343,7 +360,7 @@ impl SkillFs {
 
     /// Configure the Trusted writer gate.
     ///
-    /// When `config` is enabled (`expected_process_name = Some(...)`),
+    /// When `config` is enabled (`TrustedWriterConfig::is_enabled()`),
     /// `.skill-meta/**` mutation requests whose FUSE-caller pid
     /// resolves to the configured process name are allowed despite
     /// [`SkillMetaProtectionPolicy`] denying them. The bypass is
@@ -353,7 +370,21 @@ impl SkillFs {
     /// unaffected. Default is disabled.
     pub fn with_trusted_writer(mut self, config: TrustedWriterConfig) -> Self {
         self.trusted_writer = config;
+        self.update_skill_meta_mode();
         self
+    }
+
+    fn update_skill_meta_mode(&mut self) {
+        self.skill_meta_mode = if self.active_resolver.is_some() || self.trusted_writer.is_enabled()
+        {
+            SkillMetaMode::Protected
+        } else {
+            SkillMetaMode::Passthrough
+        };
+    }
+
+    pub(super) fn protects_skill_meta(&self) -> bool {
+        matches!(self.skill_meta_mode, SkillMetaMode::Protected)
     }
 
     /// Override the identity resolver used together with
@@ -892,11 +923,11 @@ impl Filesystem for SkillFs {
     // callers see a deterministic, non-leaking answer regardless of whether
     // a physical backing path happens to exist.
     //
-    // `.skill-meta/**` mutations route through the existing
-    // `SkillMetaProtectionPolicy` gate via `enforce_skill_meta`, which emits a
-    // `PolicyDenied` event and surfaces `EACCES`. Reads/list under
-    // `.skill-meta/**` follow physical errno so administrators can still
-    // inspect metadata xattrs through the mount.
+    // In protected mode, `.skill-meta/**` mutations route through the
+    // existing `SkillMetaProtectionPolicy` gate via `enforce_skill_meta`,
+    // which emits a `PolicyDenied` event and surfaces `EACCES`. In
+    // passthrough mode all metadata xattr operations follow the physical
+    // filesystem rules.
     //
     // Physical passthrough goes through the no-follow xattr syscalls
     // (`lgetxattr` / `lsetxattr` / `llistxattr` / `lremovexattr`) to match

--- a/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/policy.rs
@@ -79,6 +79,16 @@ impl SkillFs {
             _ => return None,
         };
 
+        // In the no-integration mount mode `.skill-meta/**` is an ordinary
+        // physical subtree. Bypass only this reserved-metadata gate; other
+        // lifecycle and path-safety checks remain in their callers.
+        if !self.protects_skill_meta()
+            && !self.policy_overridden
+            && is_skill_meta_path(relative_path)
+        {
+            return None;
+        }
+
         let ctx = PathPolicy::new(operation)
             .with_skill_name(Some(skill_name))
             .with_relative_path(Some(relative_path));
@@ -390,6 +400,9 @@ impl SkillFs {
         };
         if !is_skill_meta_path(relative_path) {
             return None;
+        }
+        if !self.protects_skill_meta() {
+            return Some(true);
         }
         Some(self.evaluate_trusted_writer(req).is_allowed())
     }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/read_resolution.rs
@@ -346,7 +346,7 @@ impl SkillFs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::security::{ActiveSkillResolver, ActiveTarget};
+    use crate::security::{ActiveSkillResolver, ActiveTarget, TrustedWriterConfig};
     use crate::{MountConfig, MountOptions, mount_background_configured};
     use parking_lot::RwLock;
     use skillfs_core::transform::TransformPipeline;
@@ -403,6 +403,88 @@ mod tests {
             TransformPipeline::empty(),
         )
         .with_active_resolver(Arc::new(resolver))
+    }
+
+    #[test]
+    fn skill_meta_protection_is_fixed_by_mount_configuration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path();
+        let resolver = || Arc::new(ActiveSkillResolver::new(source.to_path_buf()));
+
+        let cases = [
+            (false, TrustedWriterConfig::disabled(), false),
+            (true, TrustedWriterConfig::disabled(), true),
+            (
+                false,
+                TrustedWriterConfig::with_process_name("ledger"),
+                true,
+            ),
+            (true, TrustedWriterConfig::with_process_name("ledger"), true),
+        ];
+
+        for (active_resolver, trusted_writer, protected) in cases {
+            let store: SharedSkillStore = Arc::new(RwLock::new(SkillStore::new()));
+            let mut fs = SkillFs::new_with_pipeline(
+                source.to_path_buf(),
+                source.to_path_buf(),
+                store,
+                false,
+                TransformPipeline::empty(),
+            );
+            if active_resolver {
+                fs = fs.with_active_resolver(resolver());
+            }
+            fs = fs.with_trusted_writer(trusted_writer);
+            assert_eq!(
+                fs.protects_skill_meta(),
+                protected,
+                "active_resolver={active_resolver}, expected_protected={protected}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolver_state_changes_do_not_change_mount_metadata_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path();
+        let resolver = Arc::new(ActiveSkillResolver::new(source.to_path_buf()));
+        let store: SharedSkillStore = Arc::new(RwLock::new(SkillStore::new()));
+        let fs = SkillFs::new_with_pipeline(
+            source.to_path_buf(),
+            source.to_path_buf(),
+            store,
+            false,
+            TransformPipeline::empty(),
+        )
+        .with_active_resolver(resolver.clone());
+
+        assert!(fs.protects_skill_meta());
+        resolver.set(
+            "alpha",
+            ActiveTarget::Current {
+                source_dir: source.join("alpha"),
+            },
+        );
+        assert!(fs.protects_skill_meta());
+        resolver.forget("alpha");
+        assert!(fs.protects_skill_meta());
+    }
+
+    #[test]
+    fn disabled_trusted_writer_configuration_keeps_passthrough_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path();
+        let store: SharedSkillStore = Arc::new(RwLock::new(SkillStore::new()));
+        let fs = SkillFs::new_with_pipeline(
+            source.to_path_buf(),
+            source.to_path_buf(),
+            store,
+            false,
+            TransformPipeline::empty(),
+        )
+        .with_trusted_writer(TrustedWriterConfig::disabled());
+
+        assert!(!fs.protects_skill_meta());
     }
 
     /// The single-read `resolve_skill_read_pinned` must return a target and a

--- a/src/skillfs/crates/skillfs-fuse/src/mount.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/mount.rs
@@ -23,6 +23,19 @@ use crate::security::{
 };
 use crate::{FuseError, MountHandle, MountOptions, SkillFs};
 
+fn fuse_mount_options(options: &MountOptions) -> Vec<fuser::MountOption> {
+    let mut fuse_opts = vec![fuser::MountOption::NoAtime];
+    if options.allow_other {
+        fuse_opts.push(fuser::MountOption::AllowOther);
+        // Once callers from other UIDs can reach the mount, the kernel must
+        // enforce the backing attributes returned by SkillFS. Otherwise FUSE
+        // callbacks perform I/O with the daemon's credentials and can bypass
+        // the caller's POSIX permissions, including on `.skill-meta`.
+        fuse_opts.push(fuser::MountOption::DefaultPermissions);
+    }
+    fuse_opts
+}
+
 /// Runtime configuration for mount security features.
 #[derive(Default)]
 pub struct MountConfig {
@@ -193,11 +206,7 @@ fn mount_inner(
         }
     }
 
-    let mut fuse_opts: Vec<fuser::MountOption> = vec![];
-    fuse_opts.push(fuser::MountOption::NoAtime);
-    if options.allow_other {
-        fuse_opts.push(fuser::MountOption::AllowOther);
-    }
+    let fuse_opts = fuse_mount_options(&options);
 
     // Start from an empty pipeline and enable stages from configuration below.
     // This keeps `EnvironmentProfile::detect()` gated on the directive stage
@@ -678,4 +687,39 @@ pub fn mount_background_with_security_active_resolver_demo_refresh_and_trusted_w
         mountpoint: mountpoint.to_path_buf(),
         session: Some(handle),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_other_also_enables_kernel_permission_checks() {
+        let options = fuse_mount_options(&MountOptions {
+            allow_other: true,
+            ..MountOptions::default()
+        });
+
+        assert!(
+            options
+                .iter()
+                .any(|option| matches!(option, fuser::MountOption::AllowOther))
+        );
+        assert!(
+            options
+                .iter()
+                .any(|option| matches!(option, fuser::MountOption::DefaultPermissions))
+        );
+    }
+
+    #[test]
+    fn private_mount_keeps_userspace_permission_handling() {
+        let options = fuse_mount_options(&MountOptions::default());
+
+        assert!(
+            !options
+                .iter()
+                .any(|option| matches!(option, fuser::MountOption::DefaultPermissions))
+        );
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -413,3 +413,41 @@ pub(crate) fn find_common_path_prefix(paths: &[std::path::PathBuf]) -> Option<st
 pub(crate) fn is_skill_discover_path(skill_name: &str) -> bool {
     skill_name == "skill-discover"
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::is_skill_meta_path;
+
+    #[test]
+    fn skill_meta_is_a_flat_skill_relative_path() {
+        assert!(matches!(
+            parse_path_with_layout(Path::new("/skills/demo/.skill-meta/manifest.json"), false, SkillLayout::Flat),
+            PathType::Passthrough { skill_name, relative_path }
+                if skill_name == "demo" && relative_path == PathBuf::from(".skill-meta/manifest.json")
+        ));
+        assert!(!matches!(
+            parse_path_with_layout(Path::new("/skills/demo/.skill-meta2/manifest.json"), false, SkillLayout::Flat),
+            PathType::Passthrough { relative_path, .. } if is_skill_meta_path(&relative_path)
+        ));
+        assert!(!matches!(
+            parse_path_with_layout(Path::new("/skills/demo/docs/.skill-meta/manifest.json"), false, SkillLayout::Flat),
+            PathType::Passthrough { relative_path, .. } if is_skill_meta_path(&relative_path)
+        ));
+    }
+
+    #[test]
+    fn skill_meta_is_a_nested_hermes_skill_relative_path() {
+        assert!(matches!(
+            parse_path_with_layout(
+                Path::new("/skills/tools/demo/.skill-meta/manifest.json"),
+                false,
+                SkillLayout::Hermes,
+            ),
+            PathType::NestedPassthrough { category, skill_name, relative_path }
+                if category == "tools"
+                    && skill_name == "demo"
+                    && is_skill_meta_path(&relative_path)
+        ));
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -79,8 +79,9 @@
 //!   (see the CLI `--audit-log` flag).
 //!
 //! Package S0 added the seam. Package S1 plugs the first real policy,
-//! [`policy::SkillMetaProtectionPolicy`], into `SkillFs` as the default so
-//! `.skill-meta/**` is read-visible but mutation-protected by default.
+//! [`policy::SkillMetaProtectionPolicy`], into `SkillFs`; mount integration
+//! state now selects whether that metadata gate is protected or ordinary
+//! passthrough while the policy remains the default implementation.
 //! Package S2 adds the audit sink; the default `SkillFs` sink is still
 //! [`event::NoopEventSink`]. Package M0 layers the security-mode gate on
 //! top so audit/policy guarantees can be enforced by refusing to start a

--- a/src/skillfs/crates/skillfs-fuse/src/xattr.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/xattr.rs
@@ -36,6 +36,7 @@ pub(crate) fn xattr_namespace(name: &std::ffi::OsStr) -> XattrNamespace {
 pub(crate) fn path_type_supports_xattr_passthrough(path_type: &PathType) -> bool {
     match path_type {
         PathType::Passthrough { skill_name, .. } => !is_skill_discover_path(skill_name),
+        PathType::NestedPassthrough { .. } => true,
         _ => false,
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/activation_consumer_tests.rs
@@ -31,7 +31,7 @@ use skillfs_fuse::security::{
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available};

--- a/src/skillfs/crates/skillfs-fuse/tests/audit_event_stream_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/audit_event_stream_tests.rs
@@ -28,8 +28,8 @@ use std::time::Duration;
 use parking_lot::RwLock;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
 use skillfs_fuse::security::{
-    AuditConfig, InMemoryEventSink, JsonlFileAuditSink, SkillEventAction, SkillEventKind,
-    SkillEventSink,
+    ActiveSkillResolver, ActiveTarget, AuditConfig, InMemoryEventSink, JsonlFileAuditSink,
+    SkillEventAction, SkillEventKind, SkillEventSink,
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
@@ -47,6 +47,18 @@ struct AuditedMount {
 
 impl AuditedMount {
     fn new(seed: impl FnOnce(&Path), sink: Arc<dyn SkillEventSink>) -> Self {
+        Self::new_with_resolver(seed, sink, None)
+    }
+
+    fn new_protected(seed: impl FnOnce(&Path), sink: Arc<dyn SkillEventSink>) -> Self {
+        Self::new_with_resolver(seed, sink, Some("alpha"))
+    }
+
+    fn new_with_resolver(
+        seed: impl FnOnce(&Path),
+        sink: Arc<dyn SkillEventSink>,
+        protected_skill: Option<&str>,
+    ) -> Self {
         let source = tempfile::tempdir().expect("source tempdir");
         seed(source.path());
         let mountpoint = tempfile::tempdir().expect("mount tempdir");
@@ -54,6 +66,16 @@ impl AuditedMount {
         let mut store = SkillStore::new();
         store.load_from_directory(source.path(), &ParseConfig::default());
         let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let active_resolver = protected_skill.map(|skill| {
+            let resolver = ActiveSkillResolver::new(source.path().to_path_buf());
+            resolver.set(
+                skill,
+                ActiveTarget::Current {
+                    source_dir: source.path().join(skill),
+                },
+            );
+            Arc::new(resolver)
+        });
 
         let handle = mount_background_configured(
             mountpoint.path(),
@@ -63,6 +85,7 @@ impl AuditedMount {
             false,
             MountConfig {
                 event_sink: Some(sink),
+                active_resolver,
                 ..MountConfig::default()
             },
         )
@@ -122,7 +145,7 @@ fn skill_meta_denial_records_policy_denied_event_with_attribution() {
     skip_if_no_fuse!();
 
     let sink = Arc::new(InMemoryEventSink::new());
-    let mount = AuditedMount::new(
+    let mount = AuditedMount::new_protected(
         |dir| {
             create_skill_dir(dir, "alpha");
             // Pre-create the meta dir on the source so the FUSE-level write
@@ -232,12 +255,11 @@ fn passthrough_behavior_unchanged_with_audit_sink_attached() {
     // Removing must succeed.
     std::fs::remove_file(&path).expect("plain unlink must succeed");
 
-    // Untrusted .skill-meta access returns ENOENT.
+    // Passthrough mode also applies to metadata when no integration signal is
+    // configured.
     std::fs::create_dir_all(mount.source_path().join("alpha").join(".skill-meta")).unwrap();
     let meta_target = mount.passthrough("alpha", ".skill-meta/sig.json");
-    let err =
-        std::fs::write(&meta_target, b"x").expect_err(".skill-meta write must still be denied");
-    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    std::fs::write(&meta_target, b"x").expect(".skill-meta write must pass through");
 }
 
 #[test]
@@ -252,7 +274,7 @@ fn jsonl_file_sink_records_events_through_real_mount() {
     );
 
     {
-        let mount = AuditedMount::new(
+        let mount = AuditedMount::new_protected(
             |dir| {
                 create_skill_dir(dir, "alpha");
                 std::fs::create_dir_all(dir.join("alpha").join(".skill-meta")).unwrap();

--- a/src/skillfs/crates/skillfs-fuse/tests/audit_runtime_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/audit_runtime_tests.rs
@@ -156,9 +156,9 @@ fn default_runtime_config_does_not_enable_audit_logging() {
 /// Enabling audit through the runtime config records a representative event
 /// to the on-disk JSONL log via a real FUSE mount.
 ///
-/// We deliberately trigger an S1 `.skill-meta` denial because that path also
-/// exercises the policy → audit pipeline that S2's runtime wiring is meant
-/// to expose to operators.
+/// We deliberately write `.skill-meta` in the no-integration passthrough mode
+/// because that path exercises the runtime sink on the same metadata surface
+/// whose protected behavior is covered by resolver-enabled tests.
 #[test]
 fn explicit_audit_path_creates_jsonl_log_and_records_event() {
     skip_if_no_fuse!();
@@ -178,10 +178,10 @@ fn explicit_audit_path_creates_jsonl_log_and_records_event() {
         )
         .expect("enabled runtime config must mount cleanly");
 
-        // Untrusted .skill-meta access returns ENOENT.
+        // No resolver and no enabled trusted writer means metadata passes
+        // through as an ordinary physical subtree.
         let target = mount.passthrough("alpha", ".skill-meta/manifest.json");
-        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
-        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+        std::fs::write(&target, b"x").expect(".skill-meta passthrough write");
 
         // Produce a passthrough write to confirm allowed events flow
         // through the audit sink.
@@ -308,10 +308,9 @@ fn zero_queue_capacity_uses_default_capacity_through_runtime_helper() {
         )
         .expect("zero-capacity runtime config must mount cleanly");
 
-        // Untrusted .skill-meta access returns ENOENT.
+        // Metadata is also passthrough without either integration signal.
         let target = mount.passthrough("alpha", ".skill-meta/manifest.json");
-        let err = std::fs::write(&target, b"x").expect_err("must deny .skill-meta");
-        assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+        std::fs::write(&target, b"x").expect(".skill-meta passthrough write");
         // Trigger a passthrough event to confirm audit plumbing works.
         let _ = std::fs::write(mount.source_path().join("touchstone"), b"x");
         let path = mount.passthrough("alpha", "notes.txt");

--- a/src/skillfs/crates/skillfs-fuse/tests/common.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/common.rs
@@ -1,4 +1,4 @@
-//! Shared FUSE test harness for SkillFS Phase 1 acceptance tests.
+//! Shared FUSE test harness for SkillFS integration and acceptance tests.
 //!
 //! `MountFixture` owns the temp source dir, the optional separate mount-point,
 //! and the `MountHandle`. Drop verifies the FUSE mount is gone before `tempfile`
@@ -18,7 +18,9 @@ use std::time::Duration;
 use parking_lot::RwLock;
 use skillfs_core::os_adapter::OsAdapterStage;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
-use skillfs_fuse::security::SkillEventSink;
+use skillfs_fuse::security::{
+    ActiveSkillResolver, SecurityPolicy, SkillEventSink, enumerate_hermes_skill_ids,
+};
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -148,6 +150,129 @@ impl MountFixture {
         Self::mount_now(MountMode::Normal, source, Some(mountpoint))
     }
 
+    /// Mount in normal mode with kernel permission checks for cross-UID access.
+    pub fn normal_allow_other<F: FnOnce(&Path)>(seed: F) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+        Self::mount_normal_configured(
+            source,
+            mountpoint,
+            MountOptions {
+                allow_other: true,
+                ..MountOptions::default()
+            },
+            MountConfig::default(),
+        )
+    }
+
+    /// Mount in normal mode with an explicitly injected security policy.
+    pub fn normal_with_policy<F: FnOnce(&Path)>(seed: F, policy: Arc<dyn SecurityPolicy>) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+        Self::mount_normal_configured(
+            source,
+            mountpoint,
+            MountOptions::default(),
+            MountConfig {
+                policy: Some(policy),
+                ..MountConfig::default()
+            },
+        )
+    }
+
+    /// Mount a Hermes source on a separate normal-mode mountpoint.
+    pub fn normal_hermes<F: FnOnce(&Path)>(seed: F) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+        Self::mount_normal_configured(
+            source,
+            mountpoint,
+            MountOptions::default(),
+            MountConfig {
+                skill_layout: Some(skillfs_fuse::SkillLayout::Hermes),
+                ..MountConfig::default()
+            },
+        )
+    }
+
+    /// Mount a Hermes source with every discovered skill pinned as Current.
+    pub fn normal_hermes_with_active_resolver<F: FnOnce(&Path)>(seed: F) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+        let resolver = Arc::new(ActiveSkillResolver::new(source.path().to_path_buf()));
+        for skill_id in enumerate_hermes_skill_ids(source.path()) {
+            resolver.set(
+                &skill_id,
+                skillfs_fuse::security::ActiveTarget::Current {
+                    source_dir: source.path().join(&skill_id),
+                },
+            );
+        }
+        Self::mount_normal_configured(
+            source,
+            mountpoint,
+            MountOptions::default(),
+            MountConfig {
+                active_resolver: Some(resolver),
+                skill_layout: Some(skillfs_fuse::SkillLayout::Hermes),
+                ..MountConfig::default()
+            },
+        )
+    }
+
+    /// Mount in normal mode with an active resolver so reserved metadata stays
+    /// protected while the skill remains visible as `Current`.
+    pub fn normal_with_active_resolver<F: FnOnce(&Path)>(seed: F) -> Self {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let mountpoint = tempfile::tempdir().expect("mount tempdir");
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let resolver = Arc::new(ActiveSkillResolver::new(source.path().to_path_buf()));
+        for skill in std::fs::read_dir(source.path())
+            .expect("read source skills")
+            .flatten()
+            .filter(|entry| entry.path().is_dir())
+        {
+            let name = skill.file_name().to_string_lossy().to_string();
+            if name.starts_with('.') {
+                continue;
+            }
+            resolver.set(
+                &name,
+                skillfs_fuse::security::ActiveTarget::Current {
+                    source_dir: skill.path(),
+                },
+            );
+        }
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            false,
+            MountConfig {
+                active_resolver: Some(resolver),
+                ..MountConfig::default()
+            },
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+
+        Self {
+            mode: MountMode::Normal,
+            source,
+            mountpoint: Some(mountpoint),
+            handle: Some(handle),
+        }
+    }
+
     /// Like [`MountFixture::normal`] but builds the source tempdir under the
     /// caller-supplied `parent` directory instead of `$TMPDIR`. Tests that
     /// need a specific substrate capability (T3 `user.*` xattr passthrough
@@ -186,6 +311,50 @@ impl MountFixture {
             None,
             None,
             None,
+        )
+    }
+
+    /// Mount a real in-place Hermes source with discovered skills Current.
+    pub fn in_place_hermes_with_active_resolver<F: FnOnce(&Path)>(
+        seed: F,
+    ) -> (Self, Arc<ActiveSkillResolver>) {
+        let source = tempfile::tempdir().expect("source tempdir");
+        seed(source.path());
+        let resolver = Arc::new(ActiveSkillResolver::new(source.path().to_path_buf()));
+        for skill_id in enumerate_hermes_skill_ids(source.path()) {
+            resolver.set(
+                &skill_id,
+                skillfs_fuse::security::ActiveTarget::Current {
+                    source_dir: source.path().join(&skill_id),
+                },
+            );
+        }
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let handle = mount_background_configured(
+            source.path(),
+            source.path(),
+            shared,
+            MountOptions::default(),
+            true,
+            MountConfig {
+                active_resolver: Some(Arc::clone(&resolver)),
+                skill_layout: Some(skillfs_fuse::SkillLayout::Hermes),
+                ..MountConfig::default()
+            },
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+
+        (
+            Self {
+                mode: MountMode::InPlace,
+                source,
+                mountpoint: None,
+                handle: Some(handle),
+            },
+            resolver,
         )
     }
 
@@ -291,6 +460,33 @@ impl MountFixture {
         mountpoint: Option<tempfile::TempDir>,
     ) -> Self {
         Self::mount_now_with_layout(mode, source, mountpoint, None, None, None, None)
+    }
+
+    fn mount_normal_configured(
+        source: tempfile::TempDir,
+        mountpoint: tempfile::TempDir,
+        options: MountOptions,
+        config: MountConfig,
+    ) -> Self {
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let handle = mount_background_configured(
+            mountpoint.path(),
+            source.path(),
+            shared,
+            options,
+            false,
+            config,
+        )
+        .expect("mount_background_configured");
+        std::thread::sleep(Duration::from_millis(300));
+        Self {
+            mode: MountMode::Normal,
+            source,
+            mountpoint: Some(mountpoint),
+            handle: Some(handle),
+        }
     }
 
     fn mount_now_with_layout(

--- a/src/skillfs/crates/skillfs-fuse/tests/install_inbox_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/install_inbox_tests.rs
@@ -32,7 +32,7 @@ use skillfs_fuse::security::{
 };
 use skillfs_fuse::{MountConfig, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available};
@@ -505,7 +505,9 @@ fn skill_meta_under_inbox_is_denied_for_ordinary_installers() {
         MountOptions::default(),
         false,
         MountConfig {
-            active_resolver: None,
+            active_resolver: Some(Arc::new(ActiveSkillResolver::new(
+                source.path().to_path_buf(),
+            ))),
             ..MountConfig::default()
         },
     )

--- a/src/skillfs/crates/skillfs-fuse/tests/ledger_active_mapping_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/ledger_active_mapping_tests.rs
@@ -32,7 +32,7 @@ use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
 use skillfs_fuse::security::{ActiveSkillResolver, LedgerError, LedgerResolveResult};
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available};

--- a/src/skillfs/crates/skillfs-fuse/tests/ledger_demo_refresh_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/ledger_demo_refresh_tests.rs
@@ -36,7 +36,7 @@ use skillfs_fuse::security::{
 };
 use skillfs_fuse::{MountConfig, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available};

--- a/src/skillfs/crates/skillfs-fuse/tests/os_transform_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/os_transform_tests.rs
@@ -23,7 +23,7 @@ use skillfs_fuse::security::{
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::MountFixture;

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_link_fifo_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_link_fifo_tests.rs
@@ -1,21 +1,25 @@
 //! T2 integration coverage for safe link + FIFO compatibility.
 //!
 //! Package T2 enables:
-//!   * `symlink()` for `PathType::Passthrough` leaves whose target lexically
-//!     resolves to the same skill — every other classification is rejected
-//!     with `EACCES`;
+//!   * `symlink()` for flat and Hermes nested passthrough leaves whose target
+//!     lexically resolves to the same skill — every other classification is
+//!     rejected with `EACCES`;
 //!   * `link()` (hardlink) for same-skill ordinary passthrough regular files;
 //!   * `mknod()` for FIFOs only — sockets and device nodes are rejected with
 //!     `EPERM`.
 //!
-//! All three callbacks continue to honor `.skill-meta`, lifecycle namespaces,
-//! and `skill-discover`'s virtual read-only semantics. The tests below exercise
-//! each rule end-to-end through a real FUSE mount.
+//! All three callbacks continue to honor lifecycle namespaces and
+//! `skill-discover`'s virtual read-only semantics. Metadata links use ordinary
+//! path rules when the mount has no active resolver or enabled trusted writer;
+//! resolver-enabled protection is covered by the trusted metadata tests.
 
 use std::ffi::CString;
+use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::Path;
+
+use skillfs_fuse::security::ActiveTarget;
 
 mod common;
 
@@ -182,52 +186,122 @@ fn test_relative_escape_symlink_rejected() {
 }
 
 #[test]
-fn test_symlink_into_skill_meta_rejected() {
+fn test_symlink_inside_skill_meta_allowed_in_passthrough_mode() {
     skip_if_no_fuse!();
 
     let fx = MountFixture::normal(|src| {
         create_skill_dir(src, "alpha");
-        // Seed `.skill-meta` on disk so the parent directory exists for
-        // kernel-level lookup; the policy must still refuse the symlink
-        // creation regardless.
-        std::fs::create_dir_all(src.join("alpha").join(".skill-meta"))
-            .expect("seed .skill-meta dir");
+        let meta = src.join("alpha").join(".skill-meta");
+        std::fs::create_dir_all(&meta).expect("seed .skill-meta dir");
+        std::fs::write(meta.join("manifest.json"), b"meta").expect("seed manifest");
     });
 
     let link = fx
         .skill_path("alpha")
         .join(".skill-meta")
         .join("planted_link");
-    let err = raw_errno(std::os::unix::fs::symlink("anywhere", &link));
-    assert!(
-        err == libc::ENOENT || err == libc::EACCES,
-        ".skill-meta symlink must be rejected, got {err}"
+    std::os::unix::fs::symlink("manifest.json", &link)
+        .expect("passthrough symlink inside .skill-meta");
+    assert_eq!(
+        std::fs::read_to_string(&link).expect("read symlink in .skill-meta"),
+        "meta"
     );
 }
 
 #[test]
-fn test_symlink_target_into_skill_meta_rejected() {
+fn test_symlink_target_into_skill_meta_allowed_in_passthrough_mode() {
     skip_if_no_fuse!();
 
     // The link path itself is OK (under an ordinary subdir), but the
-    // **target** lexically resolves to the skill's `.skill-meta/**`.
-    // Following the link from userspace would expose the protected
-    // payload via an unprotected name, so T2 refuses with `EACCES`.
+    // **target** lexically resolves to the skill's `.skill-meta/**`. In
+    // passthrough mode this is an ordinary same-skill symlink.
     let fx = MountFixture::normal(|src| {
         create_skill_dir(src, "alpha");
-        std::fs::create_dir_all(src.join("alpha").join(".skill-meta"))
-            .expect("seed .skill-meta dir");
+        let meta = src.join("alpha").join(".skill-meta");
+        std::fs::create_dir_all(&meta).expect("seed .skill-meta dir");
+        std::fs::write(meta.join("secret"), b"secret").expect("seed metadata");
     });
     std::fs::create_dir(fx.skill_path("alpha").join("sub")).expect("mkdir sub");
 
     let link = fx.skill_path("alpha").join("sub").join("leak");
-    let err = raw_errno(std::os::unix::fs::symlink("../.skill-meta/secret", &link));
+    std::os::unix::fs::symlink("../.skill-meta/secret", &link)
+        .expect("passthrough symlink target in .skill-meta");
     assert_eq!(
-        err,
-        libc::EACCES,
-        "same-skill symlink whose target lands in .skill-meta must be EACCES, got {err}"
+        std::fs::read_to_string(&link).expect("read symlink target in .skill-meta"),
+        "secret"
     );
-    assert!(std::fs::symlink_metadata(&link).is_err());
+}
+
+#[test]
+fn test_real_in_place_hermes_metadata_symlink_does_not_reenter_fuse() {
+    skip_if_no_fuse!();
+
+    let fx = MountFixture::in_place_hermes(|src| {
+        create_skill_dir(&src.join("apple"), "apple-notes");
+        std::fs::create_dir_all(src.join("apple/apple-notes/.skill-meta"))
+            .expect("seed Hermes metadata");
+        std::fs::write(
+            src.join("apple/apple-notes/.skill-meta/manifest.json"),
+            b"{}",
+        )
+        .expect("seed manifest");
+    });
+    let meta = fx.skill_path("apple/apple-notes").join(".skill-meta");
+    let link = meta.join("manifest-link.json");
+
+    std::os::unix::fs::symlink("manifest.json", &link)
+        .expect("in-place Hermes symlink must complete without FUSE recursion");
+    assert_eq!(
+        std::fs::read_to_string(&link).expect("read in-place Hermes link"),
+        "{}"
+    );
+}
+
+#[test]
+fn test_hermes_hidden_transition_rechecks_stale_link_endpoints() {
+    skip_if_no_fuse!();
+
+    let (fx, resolver) = MountFixture::in_place_hermes_with_active_resolver(|src| {
+        create_skill_dir(&src.join("apple"), "apple-notes");
+        std::fs::write(src.join("apple/apple-notes/payload.txt"), b"payload")
+            .expect("seed payload");
+    });
+    let skill = fx.skill_path("apple/apple-notes");
+    let dir = std::fs::File::open(&skill).expect("open Current skill directory");
+    std::fs::metadata(skill.join("payload.txt")).expect("prime Current source inode");
+
+    resolver.set(
+        "apple/apple-notes",
+        ActiveTarget::Hidden {
+            reason: "review regression".to_string(),
+        },
+    );
+
+    let target = CString::new("payload.txt").unwrap();
+    let symlink_name = CString::new("hidden-symlink").unwrap();
+    let rc = unsafe { libc::symlinkat(target.as_ptr(), dir.as_raw_fd(), symlink_name.as_ptr()) };
+    assert_eq!(rc, -1, "stale parent fd must not create a Hidden symlink");
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ENOENT)
+    );
+
+    let source_name = CString::new("payload.txt").unwrap();
+    let hardlink_name = CString::new("hidden-hardlink").unwrap();
+    let rc = unsafe {
+        libc::linkat(
+            dir.as_raw_fd(),
+            source_name.as_ptr(),
+            dir.as_raw_fd(),
+            hardlink_name.as_ptr(),
+            0,
+        )
+    };
+    assert_eq!(rc, -1, "stale endpoints must not create a Hidden hardlink");
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::ENOENT)
+    );
 }
 
 #[test]
@@ -355,7 +429,7 @@ fn test_cross_skill_hardlink_rejected() {
 }
 
 #[test]
-fn test_hardlink_into_skill_meta_rejected() {
+fn test_hardlink_into_skill_meta_allowed_in_passthrough_mode() {
     skip_if_no_fuse!();
 
     let fx = MountFixture::normal(|src| {
@@ -367,10 +441,12 @@ fn test_hardlink_into_skill_meta_rejected() {
 
     let src = fx.skill_path("alpha").join("src.txt");
     let dst = fx.skill_path("alpha").join(".skill-meta").join("planted");
-    let err = raw_errno(std::fs::hard_link(&src, &dst));
-    assert!(
-        err == libc::ENOENT || err == libc::EACCES,
-        ".skill-meta hardlink must be rejected, got {err}"
+    std::fs::hard_link(&src, &dst).expect("metadata hardlink must use ordinary path rules");
+    assert_eq!(
+        std::fs::metadata(&dst)
+            .expect("hardlink destination")
+            .nlink(),
+        2
     );
 }
 

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_phase1_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_phase1_tests.rs
@@ -31,10 +31,98 @@
 use std::ffi::CString;
 use std::io::Write;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
+use std::sync::Arc;
+
+use skillfs_fuse::security::{PathPolicy, PolicyDecision, SecurityPolicy, SkillEventKind};
 
 mod common;
 
 use common::{MountFixture, MountMode, create_skill_dir, list_dir_names};
+
+#[derive(Debug)]
+struct DenyMetadataCreatePolicy;
+
+impl SecurityPolicy for DenyMetadataCreatePolicy {
+    fn check_path(&self, ctx: &PathPolicy<'_>) -> PolicyDecision {
+        if ctx.operation == SkillEventKind::Create
+            && ctx
+                .relative_path
+                .is_some_and(|path| path.starts_with(".skill-meta"))
+        {
+            PolicyDecision::deny(libc::EPERM, "custom metadata create policy")
+        } else {
+            PolicyDecision::allow()
+        }
+    }
+}
+
+#[test]
+fn test_passthrough_metadata_still_honors_injected_policy() {
+    skip_if_no_fuse!();
+
+    let fx = MountFixture::normal_with_policy(
+        |src| {
+            create_skill_dir(src, "alpha");
+            std::fs::create_dir_all(src.join("alpha/.skill-meta"))
+                .expect("seed metadata directory");
+        },
+        Arc::new(DenyMetadataCreatePolicy),
+    );
+    let target = fx.passthrough_path("alpha", ".skill-meta/blocked.json");
+
+    let error = std::fs::write(&target, b"{}").expect_err("custom policy must still run");
+    assert_eq!(error.raw_os_error(), Some(libc::EPERM));
+    assert!(
+        !fx.source_skill_path("alpha")
+            .join(".skill-meta/blocked.json")
+            .exists()
+    );
+}
+
+#[test]
+fn test_allow_other_enforces_metadata_permissions_for_other_uid() {
+    skip_if_no_fuse!();
+    if unsafe { libc::geteuid() } != 0 {
+        eprintln!("SKIP: cross-UID allow_other regression requires root");
+        return;
+    }
+
+    let fx = MountFixture::normal_allow_other(|src| {
+        std::fs::set_permissions(src, std::fs::Permissions::from_mode(0o755))
+            .expect("make source traversable");
+        create_skill_dir(src, "alpha");
+        let skill = src.join("alpha");
+        std::fs::set_permissions(&skill, std::fs::Permissions::from_mode(0o755))
+            .expect("make skill traversable");
+        let meta = skill.join(".skill-meta");
+        std::fs::create_dir(&meta).expect("seed metadata");
+        std::fs::set_permissions(&meta, std::fs::Permissions::from_mode(0o755))
+            .expect("make metadata directory traversable");
+        let secret = meta.join("secret.json");
+        std::fs::write(&secret, b"owner-only").expect("seed secret");
+        std::fs::set_permissions(&secret, std::fs::Permissions::from_mode(0o600))
+            .expect("make secret owner-only");
+    });
+    let target = fx.passthrough_path("alpha", ".skill-meta/secret.json");
+
+    let status = std::process::Command::new("/bin/sh")
+        .args(["-c", "printf bypassed > \"$1\"", "skillfs-review"])
+        .arg(&target)
+        .uid(65_534)
+        .gid(65_534)
+        .status()
+        .expect("run cross-UID writer");
+    assert!(!status.success(), "other UID must not bypass mode 0600");
+    assert_eq!(
+        std::fs::read(
+            fx.source_skill_path("alpha")
+                .join(".skill-meta/secret.json")
+        )
+        .expect("read backing secret"),
+        b"owner-only"
+    );
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // path/lookup (P0)
@@ -881,16 +969,15 @@ fn test_classify_symlink_target_relative_unknown_cases() {
 // Package S1: `.skill-meta` protection MVP
 // ─────────────────────────────────────────────────────────────────────────────
 //
-// `.skill-meta/**` under each skill is read-visible but mutation-protected by
-// default. These tests pin the FUSE-level behavior: read/stat/readdir keep
-// working, every documented mutation surface is rejected with `EACCES`, and
-// non-`.skill-meta` passthrough operations stay unaffected.
+// `.skill-meta/**` under each skill is read-visible but mutation-protected when
+// an active resolver is configured. These tests pin that protected mode at the
+// FUSE level; passthrough mode is covered by the metadata view tests.
 
 /// Seed a skill containing a small `.skill-meta` directory with a manifest and
 /// a nested signatures payload. Returns the fixture so tests can drive it.
 fn fixture_with_skill_meta(skill: &str) -> MountFixture {
     let skill_owned = skill.to_string();
-    MountFixture::normal(move |src| {
+    MountFixture::normal_with_active_resolver(move |src| {
         create_skill_dir(src, &skill_owned);
         let meta = src.join(&skill_owned).join(".skill-meta");
         std::fs::create_dir_all(meta.join("signatures")).expect("mkdir .skill-meta");

--- a/src/skillfs/crates/skillfs-fuse/tests/posix_xattr_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/posix_xattr_tests.rs
@@ -3,8 +3,9 @@
 //! Package T3 enables Linux `user.*` xattrs on **ordinary passthrough leaves**
 //! under a normal skill. Every other surface — virtual paths, compiled
 //! `SKILL.md`, `skill-discover`, lifecycle reserved roots — keeps deterministic
-//! "unsupported" semantics, and `.skill-meta/**` mutations remain blocked by
-//! the existing `SkillMetaProtectionPolicy` gate. Other xattr namespaces
+//! "unsupported" semantics. Resolver-enabled mounts keep `.skill-meta/**`
+//! mutations blocked by the existing `SkillMetaProtectionPolicy` gate. Other
+//! xattr namespaces
 //! (`security.*`, `trusted.*`, `system.*`, missing prefix) are rejected up
 //! front with `EOPNOTSUPP` so SkillFS does not become a back door for kernel
 //! / LSM-owned categories.
@@ -322,6 +323,96 @@ fn test_user_xattr_set_get_list_remove_on_passthrough_file() {
     );
 }
 
+#[test]
+fn test_user_xattr_set_get_list_remove_on_passthrough_skill_meta() {
+    skip_if_no_fuse!();
+
+    let fx = match mount_xattr_capable(|src| {
+        create_skill_dir(src, "alpha");
+        std::fs::create_dir_all(src.join("alpha/.skill-meta")).expect("seed .skill-meta");
+        std::fs::write(src.join("alpha/.skill-meta/manifest.json"), b"{}\n")
+            .expect("seed metadata");
+    }) {
+        Some(fx) => fx,
+        None => return,
+    };
+    let source_meta = fx.source_skill_path("alpha").join(".skill-meta");
+    if skip_if_user_xattr_unsupported(&source_meta) {
+        return;
+    }
+
+    let meta = fx.passthrough_path("alpha", ".skill-meta");
+    lsetxattr(&meta, "user.skillfs.meta", b"meta-attr", 0)
+        .expect("setxattr on passthrough .skill-meta");
+    assert_eq!(
+        lgetxattr(&meta, "user.skillfs.meta").expect("getxattr on .skill-meta"),
+        b"meta-attr"
+    );
+    assert!(
+        llistxattr(&meta)
+            .expect("listxattr on .skill-meta")
+            .contains(&"user.skillfs.meta".to_string())
+    );
+    lremovexattr(&meta, "user.skillfs.meta").expect("removexattr on .skill-meta");
+    assert_eq!(
+        lgetxattr(&meta, "user.skillfs.meta").expect_err("getxattr after remove"),
+        libc::ENODATA
+    );
+}
+
+#[test]
+fn test_hermes_skill_meta_xattr_roundtrip_in_passthrough_mode() {
+    skip_if_no_fuse!();
+
+    let fx = MountFixture::normal_hermes(|src| {
+        create_skill_dir(&src.join("apple"), "apple-notes");
+        std::fs::create_dir_all(src.join("apple/apple-notes/.skill-meta"))
+            .expect("seed Hermes metadata");
+    });
+    let source_meta = fx
+        .source_skill_path("apple/apple-notes")
+        .join(".skill-meta");
+    if skip_if_user_xattr_unsupported(&source_meta) {
+        return;
+    }
+    let meta = fx.skill_path("apple/apple-notes").join(".skill-meta");
+
+    lsetxattr(&meta, "user.skillfs.hermes", b"nested", 0)
+        .expect("setxattr on nested passthrough metadata");
+    assert_eq!(
+        lgetxattr(&meta, "user.skillfs.hermes").expect("get nested metadata xattr"),
+        b"nested"
+    );
+    lremovexattr(&meta, "user.skillfs.hermes").expect("remove nested metadata xattr");
+    assert_eq!(
+        lgetxattr(&meta, "user.skillfs.hermes").expect_err("removed xattr must be absent"),
+        libc::ENODATA
+    );
+}
+
+#[test]
+fn test_hermes_skill_meta_xattr_hidden_in_protected_mode() {
+    skip_if_no_fuse!();
+
+    let fx = MountFixture::normal_hermes_with_active_resolver(|src| {
+        create_skill_dir(&src.join("apple"), "apple-notes");
+        std::fs::create_dir_all(src.join("apple/apple-notes/.skill-meta"))
+            .expect("seed Hermes metadata");
+    });
+    let meta = fx.skill_path("apple/apple-notes").join(".skill-meta");
+
+    assert_eq!(
+        lsetxattr(&meta, "user.skillfs.hermes", b"blocked", 0)
+            .expect_err("protected nested metadata must be hidden"),
+        libc::ENOENT
+    );
+    assert_eq!(
+        lgetxattr(&meta, "user.skillfs.hermes")
+            .expect_err("protected nested metadata xattr must be hidden"),
+        libc::ENOENT
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 2. Ordinary passthrough directory: full user.* roundtrip
 // ─────────────────────────────────────────────────────────────────────────────
@@ -423,16 +514,15 @@ fn test_unsupported_namespaces_rejected_deterministically() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 4. `.skill-meta/**` mutation rejected with EACCES even for user.*.
-//    Read/list passes through to the physical errno (T3 choice — see
-//    callback comment in `lib.rs`).
+// 4. `.skill-meta/**` mutation rejected with EACCES even for user.* when the
+//    active resolver enables protected mode.
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_skill_meta_xattr_mutation_rejected_with_eacces() {
     skip_if_no_fuse!();
 
-    let fx = MountFixture::normal(|src| {
+    let fx = MountFixture::normal_with_active_resolver(|src| {
         create_skill_dir(src, "alpha");
     });
     std::fs::create_dir_all(fx.source_skill_path("alpha").join(".skill-meta"))

--- a/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/runtime_metrics_fuse_tests.rs
@@ -21,7 +21,7 @@ use skillfs_fuse::security::{
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available, telemetry_enabled};

--- a/src/skillfs/crates/skillfs-fuse/tests/security_mode_runtime_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/security_mode_runtime_tests.rs
@@ -35,7 +35,8 @@ use std::time::Duration;
 use parking_lot::RwLock;
 use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
 use skillfs_fuse::security::{
-    AuditRuntimeConfig, SecurityModeConfig, SecurityModeError, SkillEventSink,
+    ActiveSkillResolver, ActiveTarget, AuditRuntimeConfig, SecurityModeConfig, SecurityModeError,
+    SkillEventSink,
 };
 use skillfs_fuse::{MountConfig, MountHandle, MountOptions, mount_background_configured};
 
@@ -78,6 +79,15 @@ impl SecurityModeMount {
         security: &SecurityModeConfig,
         audit: &AuditRuntimeConfig,
     ) -> Result<Self, SetupError> {
+        Self::in_place_with_protection(seed, security, audit, false)
+    }
+
+    fn in_place_with_protection(
+        seed: impl FnOnce(&Path),
+        security: &SecurityModeConfig,
+        audit: &AuditRuntimeConfig,
+        protect_skill_meta: bool,
+    ) -> Result<Self, SetupError> {
         let source = tempfile::tempdir().expect("source tempdir");
         seed(source.path());
         let mount_path = source.path().to_path_buf();
@@ -91,6 +101,16 @@ impl SecurityModeMount {
         let mut store = SkillStore::new();
         store.load_from_directory(source.path(), &ParseConfig::default());
         let shared: SharedSkillStore = Arc::new(RwLock::new(store));
+        let active_resolver = protect_skill_meta.then(|| {
+            let resolver = ActiveSkillResolver::new(source.path().to_path_buf());
+            resolver.set(
+                "alpha",
+                ActiveTarget::Current {
+                    source_dir: source.path().join("alpha"),
+                },
+            );
+            Arc::new(resolver)
+        });
 
         let handle = mount_background_configured(
             &mount_path,
@@ -100,6 +120,7 @@ impl SecurityModeMount {
             true, // in_place
             MountConfig {
                 event_sink: sink,
+                active_resolver,
                 ..MountConfig::default()
             },
         )
@@ -227,6 +248,34 @@ fn security_mode_accepts_in_place_mount() {
     assert_eq!(read.as_slice(), b"hello");
 }
 
+/// `--security-mode` selects in-place topology; it does not by itself enable
+/// activation/trusted-writer metadata protection.
+#[test]
+fn security_mode_without_security_integration_passes_through_skill_meta() {
+    skip_if_no_fuse!();
+
+    let security = SecurityModeConfig::enabled_mode();
+    let audit = AuditRuntimeConfig::disabled();
+    let mount = SecurityModeMount::in_place(
+        |dir| {
+            create_skill_dir(dir, "alpha");
+            std::fs::create_dir_all(dir.join("alpha/.skill-meta"))
+                .expect("seed metadata directory");
+        },
+        &security,
+        &audit,
+    )
+    .expect("security mode must accept in-place mount");
+    let manifest = mount.skill_path("alpha").join(".skill-meta/manifest.json");
+
+    std::fs::write(&manifest, b"{\"mode\":\"passthrough\"}")
+        .expect("metadata is ordinary without a security integration");
+    assert_eq!(
+        std::fs::read_to_string(&manifest).expect("read metadata through mount"),
+        "{\"mode\":\"passthrough\"}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 2. Security mode rejects non-in-place mount BEFORE the FUSE event loop
 // ---------------------------------------------------------------------------
@@ -333,13 +382,14 @@ fn security_mode_composes_with_audit_runtime_config() {
     assert!(audit.is_enabled());
 
     {
-        let mount = SecurityModeMount::in_place(
+        let mount = SecurityModeMount::in_place_with_protection(
             |dir| {
                 create_skill_dir(dir, "alpha");
                 std::fs::create_dir_all(dir.join("alpha").join(".skill-meta")).unwrap();
             },
             &security,
             &audit,
+            true,
         )
         .expect("security mode + audit must compose on an in-place mount");
 

--- a/src/skillfs/crates/skillfs-fuse/tests/trusted_ledger_writer_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/trusted_ledger_writer_tests.rs
@@ -236,29 +236,23 @@ impl Drop for TrustedWriterFixture {
     }
 }
 
-/// Default-disabled config: `.skill-meta` access through the FUSE
-/// mount is hidden (ENOENT). Pre-existing deny is preserved; the
-/// view gate now hides `.skill-meta` entirely for untrusted callers.
+/// A present-but-disabled trusted-writer config does not enable protection;
+/// without an active resolver, `.skill-meta` is ordinary passthrough.
 #[test]
-fn default_disabled_config_keeps_skill_meta_denied() {
+fn default_disabled_config_keeps_skill_meta_in_passthrough_mode() {
     if !common::fuse_available() {
-        eprintln!("SKIP default_disabled_config_keeps_skill_meta_denied: FUSE not available");
+        eprintln!(
+            "SKIP default_disabled_config_keeps_skill_meta_in_passthrough_mode: FUSE not available"
+        );
         return;
     }
     let skill = "alpha";
     let fx = TrustedWriterFixture::mount_with_config(skill, None);
     let target = fx.skill_meta(skill).join("manifest.json");
-    let err =
-        std::fs::write(&target, b"{}\n").expect_err("write must fail with default-disabled gate");
-    assert_eq!(
-        err.raw_os_error(),
-        Some(libc::ENOENT),
-        "default-disabled gate must surface ENOENT, got {err:?}"
-    );
-    // The on-disk source must remain untouched.
+    std::fs::write(&target, b"{}\n").expect("disabled gate must pass through metadata writes");
     assert!(
-        !fx.source_skill_meta(skill).join("manifest.json").exists(),
-        "denied write must not have created the source-side file"
+        fx.source_skill_meta(skill).join("manifest.json").exists(),
+        "passthrough write must reach the source-side file"
     );
 }
 

--- a/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/trusted_skill_meta_view_tests.rs
@@ -13,6 +13,8 @@
 //!   files.
 //! * Symlink/hardlink/xattr boundaries remain unchanged.
 
+use std::ffi::CString;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,7 +28,7 @@ use skillfs_fuse::{
     MountConfig, MountHandle, MountOptions, SkillLayout, mount_background_configured,
 };
 
-#[path = "common/mod.rs"]
+#[path = "common.rs"]
 mod common;
 
 use crate::common::{create_skill_dir, fuse_available};
@@ -141,6 +143,50 @@ fn write_snapshot(
     dir
 }
 
+fn exercise_passthrough_metadata_lifecycle(meta: &Path) {
+    let versions = meta.join("versions");
+    let snapshot = versions.join("v000001");
+    std::fs::create_dir_all(&snapshot).expect("create .skill-meta snapshot tree");
+    std::fs::write(snapshot.join("SKILL.md"), b"snapshot body\n")
+        .expect("create snapshot metadata");
+
+    let listing = sorted_dir(&versions);
+    assert_eq!(listing, vec!["v000001"], "snapshot must be discoverable");
+
+    let current = meta.join("manifest.json");
+    let first = meta.join("manifest.json.tmp");
+    std::fs::write(&first, b"{\"version\":\"v000001\"}\n").expect("create metadata file");
+    std::fs::rename(&first, &current).expect("atomically publish metadata");
+
+    let current_c = CString::new(current.as_os_str().as_encoded_bytes())
+        .expect("metadata path must not contain NUL");
+    assert_eq!(
+        unsafe { libc::access(current_c.as_ptr(), libc::F_OK) },
+        0,
+        "access(F_OK) must see passthrough metadata"
+    );
+    std::fs::set_permissions(&current, std::fs::Permissions::from_mode(0o600))
+        .expect("set metadata permissions");
+
+    let next = meta.join("manifest.json.next");
+    std::fs::write(&next, b"{\"version\":\"v000002\"}\n").expect("update metadata");
+    std::fs::rename(&next, &current).expect("atomically replace metadata");
+    assert_eq!(
+        std::fs::read_to_string(&current).expect("read updated metadata"),
+        "{\"version\":\"v000002\"}\n"
+    );
+
+    std::fs::remove_file(&current).expect("delete metadata file");
+    std::fs::remove_file(snapshot.join("SKILL.md")).expect("delete snapshot payload");
+    std::fs::remove_dir(&snapshot).expect("remove snapshot directory");
+    std::fs::remove_dir(&versions).expect("remove versions directory");
+    std::fs::remove_dir(meta).expect("remove .skill-meta directory");
+    assert!(
+        !meta.exists(),
+        "metadata tree must be removable in passthrough"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixture
 // ─────────────────────────────────────────────────────────────────────────────
@@ -213,18 +259,18 @@ impl Drop for MetaViewFixture {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 1. Untrusted readdir does not show .skill-meta
+// 1. Without either integration signal, .skill-meta is ordinary passthrough
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn untrusted_readdir_hides_skill_meta() {
+fn passthrough_readdir_shows_skill_meta() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
     }
     let fx = MetaViewFixture::new(
         |src| seed_skill_with_meta(src, "alpha"),
-        None, // no trusted writer
+        None, // no trusted writer: passthrough mode
         |_| None,
     );
     let listing = sorted_dir(&fx.skill_dir("alpha"));
@@ -233,38 +279,38 @@ fn untrusted_readdir_hides_skill_meta() {
         "SKILL.md must be visible, got {listing:?}"
     );
     assert!(
-        !listing.contains(&".skill-meta".to_string()),
-        ".skill-meta must be hidden from readdir, got {listing:?}"
+        listing.contains(&".skill-meta".to_string()),
+        ".skill-meta must be visible in passthrough mode, got {listing:?}"
     );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 2. Untrusted exact .skill-meta lookup/open/read is denied
+// 2. Passthrough mode permits exact .skill-meta lookup/open/read
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn untrusted_exact_skill_meta_lookup_denied() {
+fn passthrough_exact_skill_meta_lookup_read_and_write() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
     }
     let fx = MetaViewFixture::new(|src| seed_skill_with_meta(src, "alpha"), None, |_| None);
     let meta_dir = fx.skill_meta("alpha");
-    let err =
-        std::fs::metadata(&meta_dir).expect_err("lookup of .skill-meta must fail for untrusted");
-    assert_eq!(
-        err.raw_os_error(),
-        Some(libc::ENOENT),
-        "expected ENOENT for untrusted .skill-meta lookup, got {err:?}"
-    );
+    std::fs::metadata(&meta_dir).expect("passthrough lookup of .skill-meta must succeed");
     let manifest = meta_dir.join("manifest.json");
-    let err = std::fs::read(&manifest)
-        .expect_err("read of .skill-meta/manifest.json must fail for untrusted");
-    assert_eq!(
-        err.raw_os_error(),
-        Some(libc::ENOENT),
-        "expected ENOENT for untrusted .skill-meta/manifest.json read, got {err:?}"
-    );
+    assert!(std::fs::read(&manifest).is_ok());
+    std::fs::write(&manifest, b"{\"updated\":true}\n")
+        .expect("passthrough write of .skill-meta must succeed");
+}
+
+#[test]
+fn passthrough_skill_meta_supports_full_metadata_lifecycle() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = MetaViewFixture::new(|src| create_skill_dir(src, "alpha"), None, |_| None);
+    exercise_passthrough_metadata_lifecycle(&fx.skill_meta("alpha"));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -630,16 +676,24 @@ fn trusted_inbox_skill_meta_read_succeeds() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 13. Untrusted parent listing still hides .skill-meta (regression guard)
+// 13. Active resolver keeps ordinary callers from seeing .skill-meta
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn untrusted_parent_listing_still_hides_skill_meta() {
+fn active_resolver_parent_listing_hides_skill_meta() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
     }
-    let fx = MetaViewFixture::new(|src| seed_skill_with_meta(src, "alpha"), None, |_| None);
+    let fx = MetaViewFixture::new(
+        |src| seed_skill_with_meta(src, "alpha"),
+        None,
+        |src| {
+            let resolver = ActiveSkillResolver::new(src.to_path_buf());
+            resolver.set_from_resolve(&current_result("alpha")).unwrap();
+            Some(Arc::new(resolver))
+        },
+    );
     let listing = sorted_dir(&fx.skill_dir("alpha"));
     assert!(
         !listing.contains(&".skill-meta".to_string()),
@@ -733,11 +787,11 @@ impl Drop for HermesMetaViewFixture {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// H1. Untrusted readdir of category/skill hides .skill-meta
+// H1. Without either integration signal, Hermes .skill-meta is passthrough
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn hermes_untrusted_readdir_hides_skill_meta() {
+fn hermes_passthrough_readdir_shows_skill_meta() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
@@ -753,18 +807,18 @@ fn hermes_untrusted_readdir_hides_skill_meta() {
         "SKILL.md must be visible, got {listing:?}"
     );
     assert!(
-        !listing.contains(&".skill-meta".to_string()),
-        ".skill-meta must be hidden from untrusted readdir, got {listing:?}"
+        listing.contains(&".skill-meta".to_string()),
+        ".skill-meta must be visible in passthrough mode, got {listing:?}"
     );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// H2. Untrusted exact path metadata/read for category/skill/.skill-meta/...
-//     returns ENOENT
+// H2. Passthrough exact path metadata/read for category/skill/.skill-meta/...
+//     succeeds
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn hermes_untrusted_exact_skill_meta_denied() {
+fn hermes_passthrough_exact_skill_meta_read_and_write() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
@@ -775,12 +829,66 @@ fn hermes_untrusted_exact_skill_meta_denied() {
         |_| None,
     );
     let meta_dir = fx.nested_skill_meta("apple", "apple-notes");
-    let err = std::fs::metadata(&meta_dir).expect_err("untrusted .skill-meta lookup must fail");
-    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    std::fs::metadata(&meta_dir).expect("passthrough .skill-meta lookup must succeed");
     let manifest = meta_dir.join("manifest.json");
-    let err =
-        std::fs::read(&manifest).expect_err("untrusted .skill-meta/manifest.json read must fail");
-    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
+    assert!(std::fs::read(&manifest).is_ok());
+    std::fs::write(&manifest, b"{\"updated\":true}\n")
+        .expect("passthrough nested .skill-meta write must succeed");
+}
+
+#[test]
+fn hermes_passthrough_skill_meta_supports_full_metadata_lifecycle() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = HermesMetaViewFixture::new(
+        |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
+        None,
+        |_| None,
+    );
+    exercise_passthrough_metadata_lifecycle(&fx.nested_skill_meta("apple", "apple-notes"));
+}
+
+#[test]
+fn hermes_passthrough_skill_meta_links_use_ordinary_rules() {
+    if !fuse_available() {
+        eprintln!("SKIP: FUSE not available");
+        return;
+    }
+    let fx = HermesMetaViewFixture::new(
+        |src| {
+            seed_hermes_with_meta(src, "apple", "apple-notes");
+            std::fs::write(src.join("apple/apple-notes/regular.txt"), b"regular\n").unwrap();
+        },
+        None,
+        |_| None,
+    );
+    let skill = fx.nested_skill_dir("apple", "apple-notes");
+    let meta = fx.nested_skill_meta("apple", "apple-notes");
+
+    let inside_meta = meta.join("manifest-link");
+    std::os::unix::fs::symlink("manifest.json", &inside_meta)
+        .expect("nested passthrough symlink inside metadata");
+    assert!(std::fs::read(&inside_meta).is_ok());
+
+    let target_meta = skill.join("metadata-link");
+    std::os::unix::fs::symlink(".skill-meta/manifest.json", &target_meta)
+        .expect("nested passthrough symlink to metadata");
+    assert!(std::fs::read(&target_meta).is_ok());
+
+    let hardlink_into_meta = meta.join("regular-link");
+    std::fs::hard_link(skill.join("regular.txt"), &hardlink_into_meta)
+        .expect("nested hardlink into metadata");
+    let hardlink_out_of_meta = skill.join("manifest-copy.json");
+    std::fs::hard_link(meta.join("manifest.json"), &hardlink_out_of_meta)
+        .expect("nested hardlink out of metadata");
+    assert_eq!(
+        std::fs::metadata(&hardlink_into_meta)
+            .expect("metadata hardlink")
+            .nlink(),
+        2
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -896,11 +1004,11 @@ fn hermes_trusted_hidden_meta_no_ordinary_files() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// H5. Untrusted write/create under nested .skill-meta is rejected
+// H5. An active resolver keeps untrusted nested .skill-meta writes rejected
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
-fn hermes_untrusted_write_nested_skill_meta_rejected() {
+fn hermes_active_resolver_write_nested_skill_meta_rejected() {
     if !fuse_available() {
         eprintln!("SKIP: FUSE not available");
         return;
@@ -908,7 +1016,16 @@ fn hermes_untrusted_write_nested_skill_meta_rejected() {
     let fx = HermesMetaViewFixture::new(
         |src| seed_hermes_with_meta(src, "apple", "apple-notes"),
         None,
-        |_| None,
+        |src| {
+            let resolver = ActiveSkillResolver::new(src.to_path_buf());
+            resolver.set(
+                "apple/apple-notes",
+                ActiveTarget::Current {
+                    source_dir: src.join("apple/apple-notes"),
+                },
+            );
+            Some(Arc::new(resolver))
+        },
     );
     let manifest = fx
         .nested_skill_meta("apple", "apple-notes")
@@ -950,8 +1067,8 @@ fn hermes_trusted_mutating_open_goes_through_policy() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// H7. Symlink/hardlink under nested .skill-meta remains rejected even for
-//     trusted writer, matching flat behavior
+// H7. Protected Hermes metadata still rejects symlink/hardlink operations,
+//     even when the trusted writer is configured
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
@@ -980,12 +1097,7 @@ fn hermes_trusted_meta_symlink_hardlink_rejected() {
         .join("link-to-regular");
     let err = std::os::unix::fs::symlink("../regular.txt", &link_path)
         .expect_err("symlink inside nested .skill-meta must be denied");
-    // Nested paths are rejected at the link-type gate (EROFS) since
-    // symlink_impl only accepts flat Passthrough targets.
-    assert!(
-        err.raw_os_error() == Some(libc::EACCES) || err.raw_os_error() == Some(libc::EROFS),
-        "expected EACCES or EROFS, got {err:?}"
-    );
+    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
     let dst = fx
         .nested_skill_dir("apple", "apple-notes")
         .join("manifest-copy.json");
@@ -995,8 +1107,5 @@ fn hermes_trusted_meta_symlink_hardlink_rejected() {
         &dst,
     )
     .expect_err("hardlink from nested .skill-meta must be denied");
-    assert!(
-        err.raw_os_error() == Some(libc::EACCES) || err.raw_os_error() == Some(libc::EROFS),
-        "expected EACCES or EROFS, got {err:?}"
-    );
+    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
 }

--- a/src/skillfs/docs/skillfs-filesystem-capability-record.md
+++ b/src/skillfs/docs/skillfs-filesystem-capability-record.md
@@ -63,7 +63,7 @@ for the security-provider integration path.
 | mkdir/rmdir/unlink/rename | Supported | Includes store sync for skill-level changes and rename flags where supported. |
 | PATH_MAX fallback | Supported | Uses parent-fd `*at` fallbacks for long physical paths. |
 | readlink / symlink identity | Supported | Physical symlink identity and raw target are preserved. |
-| symlink creation | Supported with policy | Allows relative same-skill targets; rejects absolute, cross-skill, outside-source, `.skill-meta`, lifecycle, and virtual targets. |
+| symlink creation | Supported with policy | Allows relative same-skill targets; rejects absolute, cross-skill, outside-source, lifecycle, and virtual targets. `.skill-meta` follows the mount's passthrough/protected mode. |
 | hardlink creation | Supported with policy | Allows same-skill regular-file links; rejects cross-skill, virtual, sensitive, directory, symlink, FIFO, and special-file sources. |
 | FIFO creation | Supported | `mknod` accepts FIFO only. |
 | device/socket mknod | Rejected | Block/char/socket/special nodes remain intentionally unsupported. |
@@ -71,7 +71,7 @@ for the security-provider integration path.
 | fallocate | Not implemented | Deferred. |
 | lseek `SEEK_DATA` / `SEEK_HOLE` | Not implemented | Deferred. |
 | copy_file_range | Not implemented | Deferred. |
-| full per-caller uid/gid enforcement | Not implemented | Requires broader FUSE permission and identity design. |
+| per-caller uid/gid enforcement | Partial | `allow_other` mounts enable kernel `default_permissions`; private mounts retain existing userspace checks. Broader identity-aware policy is not implemented. |
 
 ## Security Integration Capability Matrix
 
@@ -82,7 +82,7 @@ and write the resulting activation state.
 | Area | Status | SkillFS responsibility |
 | --- | --- | --- |
 | Policy/event skeleton | Supported | `SecurityPolicy`, `SkillEvent`, event sink abstractions. |
-| `.skill-meta/**` protection | Supported | Ordinary callers cannot mutate security metadata. |
+| `.skill-meta/**` protection | Supported, integration-gated | No active resolver and no enabled trusted writer selects ordinary POSIX passthrough. Either signal selects protected mode, hiding metadata from ordinary callers and denying untrusted mutation. `--security-mode` alone does not change this mode. |
 | JSONL audit stream | Supported | Optional best-effort audit sink. |
 | Runtime audit wiring | Supported | CLI can opt into audit JSONL and queue capacity. |
 | Security mount mode | Supported | Can require in-place mount for stronger coverage. |


### PR DESCRIPTION
## Why

SkillFS currently hides and protects `.skill-meta` even when no Skill Ledger
integration is configured. That prevents an independently deployed Ledger from
managing metadata through the SkillFS FUSE view in zero-integration coexistence
mode.

## What changed

- Derive one mount-scoped metadata policy from the presence of an active
  resolver or enabled trusted writer.
- Treat `.skill-meta` as ordinary passthrough content when both integration
  signals are absent, consistently across reads, listings, mutations, links,
  xattrs, and both rename endpoints.
- Preserve protected Current, Snapshot, Hidden, trusted-writer, and explicitly
  injected policy behavior for flat and Hermes layouts.
- Keep Hermes in-place link classification on the fd-bypass path and revalidate
  Hidden state at both link endpoints.
- Enable kernel permission checks for `allow_other` mounts so backing POSIX
  permissions remain authoritative across UIDs.
- Add FUSE regression coverage for all configuration combinations, metadata
  lifecycle operations, links, xattrs, resolver state changes, and real
  source-equals-mountpoint Hermes topology.

## Related issue

closes #2042

## User / Agent impact

Without an active resolver or enabled trusted writer, agents and independently
deployed Ledger processes now see `.skill-meta` as ordinary filesystem content
through SkillFS. Integrated deployments retain the existing hidden and
protected metadata view.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

This intentionally changes the default metadata behavior when neither
integration capability is configured. Deployments relying on implicit
`.skill-meta` protection must enable an active resolver or trusted writer.
`--security-mode` selects in-place topology only and does not enable metadata
protection by itself. The selected policy is fixed for the mount lifetime.

## Validation

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `scripts/test.sh` with real FUSE and managed-mount smoke coverage
- focused link/FIFO tests: 23/23 passed
- metadata view and lifecycle tests: 23/23 passed
- xattr tests: 11/11 passed
- security-mode runtime tests: 8/8 passed
- `cargo +1.86.0 doc --workspace --no-deps`
- `git diff --check`

The root-only multi-UID `allow_other` regression is included; it skips when
the local test runner is not root.

## Documentation and rollback

The bilingual README and user guide, CLI help/runtime diagnostics, and
capability record now document the passthrough/protected mode matrix and
migration requirement. Operators can retain the former protected behavior by
configuring an active resolver or trusted writer. Reverting this commit
restores unconditional metadata protection.
