### PR TITLE
feat(tokenless): add OpenCode adapter

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -14,11 +14,14 @@ Tokenless uses adapters to connect compression, command rewriting, and environme
 | Qoder | `qoder` | ✅ | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
 | Claude Code | `claude-code` | ✅ | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Used only when the replacement can remain text | — |
 | Codex | `codex` | ✅ | Replaces supported shell input | Keeps the original and adds analysis or a compressed alternative | Used to build that alternative | — |
+| OpenCode | `opencode` | ✅ | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
 | Qwen Code | `qwencode` | ✅ | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | ✅ |
 
 “—” means that the current adapter does not register that capability. The corresponding Tokenless CLI command may still be available.
 
 `additionalContext` is an additive hook field. The Tokenless source does not remove the original result on those paths; the final treatment also depends on the host implementation. A statistics record proves that a candidate became smaller, not that the host removed the original from its model request.
+
+OpenCode currently uses the bundled lifecycle scripts documented below. It is not registered with the `anolisa adapter enable` driver set in this release.
 
 ## Adapter processing rules
 
@@ -63,6 +66,8 @@ anolisa adapter enable tokenless qwencode
 ```
 
 Enable only frameworks that you use. When enabling more than one, run and verify each command separately.
+
+OpenCode is the exception to this section; use its bundled install script under [Manual integration after npm installation](#manual-integration-after-npm-installation).
 
 For OpenClaw, anolisa first attempts a normal install and does not add an unsafe-install bypass by default. If OpenClaw rejects the plugin on its safety scan, read the reported findings. Only after accepting them, retry explicitly:
 
@@ -112,7 +117,7 @@ The npm postinstall script attempts to copy adapter resources under:
 
 Confirm that this directory exists. Adapter copying is supplementary and fails open with a warning; a successful binary install can therefore exist without this copy. If it is absent, review the npm postinstall warning and prefer an anolisa-managed installation.
 
-An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, and Qwen Code provide their own install scripts:
+An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, and Qwen Code provide their own install scripts:
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh
@@ -122,6 +127,7 @@ For example:
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/claude-code/scripts/install.sh
+bash ~/.local/share/anolisa/adapters/tokenless/opencode/scripts/install.sh
 ```
 
 Uninstall the same adapter with:
@@ -173,6 +179,10 @@ The marketplace plugin takes effect after restarting Claude Code. The install sc
 ### Codex
 
 The plugin loads in a new Codex session. Close the old session and start a new one before verifying statistics. Its PostToolUse hook is additive: use statistics as candidate-compression telemetry, not as proof that the original Codex tool output left the prompt.
+
+### OpenCode
+
+OpenCode discovers global local plugins at startup. Use the bundled Tokenless lifecycle script described above, restart OpenCode after installation or removal, then run a tool call and inspect `tokenless stats list`. The script resolves the configuration directory from `TOKENLESS_OPENCODE_CONFIG_DIR`, then `OPENCODE_CONFIG_DIR`, then `XDG_CONFIG_HOME/opencode`, and finally `~/.config/opencode`. Installation creates only `plugins/tokenless.js` as a managed symlink and refuses to replace an unrelated file at that path.
 
 ### Qwen Code
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -14,11 +14,14 @@ Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。�
 | Qoder | `qoder` | ✅ | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
 | Claude Code | `claude-code` | ✅ | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 仅在替换结果可保持文本时使用 | — |
 | Codex | `codex` | ✅ | 替换受支持的 Shell 输入 | 保留原文，追加分析或压缩备选内容 | 用于生成该备选内容 | — |
+| OpenCode | `opencode` | ✅ | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
 | Qwen Code | `qwencode` | ✅ | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | ✅ |
 
 “—”表示当前 Adapter 没有注册此能力；对应的 Tokenless CLI 命令仍可能可用。
 
 `additionalContext` 是追加型 Hook 字段。在这些路径上，Tokenless 源码本身不会删除原始结果，最终处理方式还取决于宿主实现。统计记录只能证明压缩候选内容变小了，不能证明宿主已经从模型请求中移除原文。
+
+OpenCode 当前使用下文说明的随附生命周期脚本；本版本尚未把它注册到 `anolisa adapter enable` 的驱动集合。
 
 ## Adapter 处理规则
 
@@ -63,6 +66,8 @@ anolisa adapter enable tokenless qwencode
 ```
 
 只需启用实际使用的框架。为多个框架启用时，应逐个执行并分别验证。
+
+OpenCode 不适用本节，应使用 [npm 安装后的手动接入](#npm-安装后的手动接入)中的随附安装脚本。
 
 对于 OpenClaw，anolisa 会先尝试普通安装，默认不会加入 unsafe-install 覆盖参数。如果 OpenClaw 的安全扫描拒绝此 Plugin，应先阅读其报告；确认接受风险后，才显式重试：
 
@@ -112,7 +117,7 @@ npm 的 postinstall 脚本会尝试把 Adapter 资源复制到：
 
 应确认该目录确实存在。Adapter 复制属于补充步骤，失败时只输出警告，不会让二进制安装失败；因此可能出现命令可用但这里没有资源副本的情况。目录缺失时应检查 npm postinstall 警告，并优先改用 anolisa 管理的安装。
 
-npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex 和 Qwen Code 可以运行各自的安装脚本：
+npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode 和 Qwen Code 可以运行各自的安装脚本：
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh
@@ -122,6 +127,7 @@ bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/claude-code/scripts/install.sh
+bash ~/.local/share/anolisa/adapters/tokenless/opencode/scripts/install.sh
 ```
 
 卸载相同 Adapter：
@@ -173,6 +179,10 @@ Marketplace Plugin 在 Claude Code 重启后生效，也可以按照安装脚本
 ### Codex
 
 Plugin 在新的 Codex 会话中加载。关闭旧会话并重新启动后验证统计。它的 PostToolUse Hook 是追加型的：统计只能作为压缩候选遥测，不能证明原始 Codex 工具结果已离开 Prompt。
+
+### OpenCode
+
+OpenCode 会在启动时发现全局 Local Plugin。使用上文说明的 Tokenless 生命周期脚本安装或移除后应重启 OpenCode，再执行一次工具调用并检查 `tokenless stats list`。脚本依次从 `TOKENLESS_OPENCODE_CONFIG_DIR`、`OPENCODE_CONFIG_DIR`、`XDG_CONFIG_HOME/opencode`、`~/.config/opencode` 解析配置目录。安装只会创建托管的 `plugins/tokenless.js` 符号链接，若该路径已有无关文件则拒绝覆盖。
 
 ### Qwen Code
 

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -48,6 +48,7 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1
         qoder-install qoder-uninstall \
         claude-code-install claude-code-uninstall \
         codex-install codex-uninstall \
+        opencode-install opencode-uninstall \
         qwencode-install qwencode-uninstall \
         setup help \
         npm-package npm-package-all npm-publish \
@@ -193,6 +194,9 @@ test-integration:
 test-adapters:
 	@echo "==> Testing qoder adapter installer..."
 	bash tests/test-qoder-adapter-install.sh
+	@echo "==> Testing OpenCode adapter..."
+	bash tests/test-opencode-adapter-install.sh
+	node tests/test-opencode-plugin.mjs
 
 # Lint (rtk excluded — vendored third-party source)
 lint:
@@ -245,9 +249,9 @@ ADAPTER_ENV = ANOLISA_PREFIX=$(HOME)/.local \
               ANOLISA_COMPONENT=tokenless \
               ANOLISA_VERSION=$(VERSION)
 
-adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install claude-code-install codex-install qwencode-install
+adapter-install: cosh-extension-install openclaw-install hermes-install qoder-install claude-code-install codex-install opencode-install qwencode-install
 
-adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall claude-code-uninstall codex-uninstall qwencode-uninstall
+adapter-uninstall: cosh-extension-uninstall openclaw-uninstall hermes-uninstall qoder-uninstall claude-code-uninstall codex-uninstall opencode-uninstall qwencode-uninstall
 
 adapter-scan:
 	@echo "=== Tokenless Adapter Manifest ==="
@@ -336,6 +340,18 @@ codex-uninstall:
 	@echo "==> Uninstalling Codex plugin..."
 	@$(ADAPTER_ENV) ANOLISA_TARGET=codex bash $(CODEX_ADAPTER_DIR)/scripts/uninstall.sh
 
+# --- OpenCode ---
+OPENCODE_ADAPTER_DIR = $(SHARE_DIR)/opencode
+
+opencode-install:
+	@echo "==> Installing OpenCode plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=opencode bash $(OPENCODE_ADAPTER_DIR)/scripts/detect.sh || true
+	@$(ADAPTER_ENV) ANOLISA_TARGET=opencode bash $(OPENCODE_ADAPTER_DIR)/scripts/install.sh
+
+opencode-uninstall:
+	@echo "==> Uninstalling OpenCode plugin..."
+	@$(ADAPTER_ENV) ANOLISA_TARGET=opencode bash $(OPENCODE_ADAPTER_DIR)/scripts/uninstall.sh
+
 # --- Qwen Code ---
 QWENCODE_ADAPTER_DIR = $(SHARE_DIR)/qwencode
 
@@ -363,7 +379,7 @@ setup: install adapter-install
 	@echo "  Adapter (FHS):"
 	@echo "    $(SHARE_DIR)/"
 	@echo "  Registered:"
-	@echo "    cosh, openclaw, hermes, qoder, claude-code, codex, qwencode"
+	@echo "    cosh, openclaw, hermes, qoder, claude-code, codex, opencode, qwencode"
 	@echo ""
 	@echo "Verify:"
 	@echo "  tokenless --version"
@@ -426,7 +442,7 @@ help:
 	@echo "  fmt               Format code"
 	@echo "  clean             Clean build artifacts"
 	@echo "  adapter-scan      List registered adapter capabilities"
-	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder+claude-code+codex+qwencode)"
+	@echo "  adapter-install   Register all adapters (cosh+openclaw+hermes+qoder+claude-code+codex+opencode+qwencode)"
 	@echo "  adapter-uninstall Unregister all adapters"
 	@echo "  cosh-extension-install  Install cosh extension"
 	@echo "  cosh-extension-uninstall Uninstall cosh extension"
@@ -440,6 +456,8 @@ help:
 	@echo "  claude-code-uninstall Unregister Claude Code plugin"
 	@echo "  codex-install     Register Codex plugin via codex CLI"
 	@echo "  codex-uninstall   Unregister Codex plugin"
+	@echo "  opencode-install  Register OpenCode local plugin"
+	@echo "  opencode-uninstall Unregister OpenCode local plugin"
 	@echo "  qwencode-install  Register Qwen Code plugin via qwen CLI"
 	@echo "  qwencode-uninstall Unregister Qwen Code plugin"
 	@echo "  setup             Full setup: build + install + register adapters"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -11,7 +11,7 @@ Token-Less combines complementary strategies to minimize LLM token consumption:
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
 - **Tool Ready** — Pre-checks tool execution environments (binaries, configs, permissions, network), auto-fixes missing dependencies, and classifies execution failures as environment issues vs logic errors — reducing wasted retry tokens.
 
-Three integration paths are available:
+Framework integrations are available for:
 
 - **OpenClaw plugin** — covers command rewriting, response compression, and schema compression in one plugin.
 - **copilot-shell hook** — intercepts Shell commands via a PreToolUse hook and delegates to RTK for command rewriting + output filtering.
@@ -19,6 +19,7 @@ Three integration paths are available:
 - **Qoder CLI plugin** — Tool Ready, command rewriting, and response compression via Qoder's native hook system.
 - **Claude Code plugin** — RTK command rewriting, response/TOON compression, and Tool Ready via Claude Code's official plugin marketplace.
 - **Codex plugin** — response compression, TOON encoding, Tool Ready, and command rewriting via Codex's native hook system.
+- **OpenCode plugin** — schema/response/TOON compression, Tool Ready, and command rewriting via OpenCode's local plugin API.
 
 ## Features
 
@@ -36,6 +37,7 @@ Three integration paths are available:
 | Qoder CLI plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅ |
 | Claude Code plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅ |
 | Codex plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅ |
+| OpenCode plugin | — | Tool Ready ✅, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
 
 ## Applicable Scenarios & Expected Effects
@@ -82,8 +84,8 @@ Token-Less/
 ├── crates/tokenless-schema/   # Core library: SchemaCompressor + ResponseCompressor
 ├── crates/tokenless-ccr/      # Reversible compression stash (Compress-Cache-Retrieve)
 ├── crates/tokenless-cli/      # CLI binary: `tokenless` command (env-check, compress, retrieve, stats)
-├── adapters/tokenless/        # FHS adapter bundle (manifest, common, openclaw, hermes, qoder, claude-code, codex)
-│   ├── manifest.json            # Adapter manifest (cosh + openclaw + hermes + qoder + claude-code + codex)
+├── adapters/tokenless/        # FHS adapter bundle (manifest + framework integrations)
+│   ├── manifest.json            # Adapter manifest for supported frameworks
 │   ├── common/                  # Shared: hooks, spec, env-fix, commands, cosh-extension
 │   │   ├── hooks/               # copilot-shell hooks (tool-ready + rewrite + compression)
 │   │   ├── cosh-extension.json  # copilot-shell extension manifest (references common/hooks/)
@@ -94,7 +96,8 @@ Token-Less/
 │   ├── hermes/                  # Hermes Agent plugin + scripts
 │   ├── qoder/                   # Qoder CLI plugin + scripts
 │   ├── claude-code/             # Claude Code plugin + marketplace + hooks
-│   └── codex/                   # Codex plugin + scripts
+│   ├── codex/                   # Codex plugin + scripts
+│   └── opencode/                # OpenCode local plugin + scripts
 ├── third_party/rtk/           # RTK vendored source (justfile clone+patch from GitHub)
 ├── third_party/patches/      # Patches for vendored third_party sources
 ├── Makefile                   # Unified build system
@@ -398,6 +401,29 @@ The plugin registers hooks at four Codex events, covering four strategies:
 make codex-install
 ```
 
+## OpenCode Plugin
+
+The local plugin uses OpenCode's mutable tool hooks, so compressed output
+replaces the original model-visible response instead of being appended to it.
+
+| Strategy | Event | Action | Status |
+|---|---|---|---|
+| Tool Ready | `tool.execute.before` | Checks dependencies and blocks calls that cannot run | ✅ Active |
+| Command rewriting | `tool.execute.before` (bash) | Rewrites shell commands via RTK | ✅ Active |
+| Response + TOON compression | `tool.execute.after` | Replaces structured tool output with a smaller representation | ✅ Active |
+| Schema compression | `tool.definition` | Compresses tool descriptions and JSON Schemas | ✅ Active |
+
+Install the plugin globally, then restart OpenCode:
+
+```bash
+make opencode-install
+```
+
+The installer creates a `tokenless.js` symbolic link in OpenCode's global
+`plugins/` directory and never overwrites an existing unmanaged file. It honors
+`OPENCODE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and the explicit
+`TOKENLESS_OPENCODE_CONFIG_DIR` override.
+
 
 ## npm Install
 
@@ -421,7 +447,7 @@ Supports Linux and macOS on x86_64 and arm64.
 | `make lint` | Run clippy checks |
 | `make fmt` | Format code |
 | `make clean` | Clean build artifacts |
-| `make adapter-install` | Install all adapters (cosh + openclaw + hermes) |
+| `make adapter-install` | Install all available framework adapters |
 | `make adapter-uninstall` | Remove all adapters |
 | `make cosh-extension-install` | Install Copilot Shell extension |
 | `make cosh-extension-uninstall` | Remove Copilot Shell extension |
@@ -435,6 +461,8 @@ Supports Linux and macOS on x86_64 and arm64.
 | `make claude-code-uninstall` | Remove Claude Code plugin |
 | `make codex-install` | Install Codex plugin |
 | `make codex-uninstall` | Remove Codex plugin |
+| `make opencode-install` | Install OpenCode local plugin |
+| `make opencode-uninstall` | Remove OpenCode local plugin |
 | `make setup` | Full setup: build + install + all adapters |
 
 Override install paths:
@@ -454,6 +482,7 @@ make install BIN_DIR=/usr/local/bin
 | `adapters/tokenless/qoder/` | Qoder CLI adapter — plugin + detect/install/uninstall scripts |
 | `adapters/tokenless/claude-code/` | Claude Code adapter — marketplace + plugin + hooks dispatcher |
 | `adapters/tokenless/codex/` | Codex adapter — plugin + Python hook scripts |
+| `adapters/tokenless/opencode/` | OpenCode adapter — local JavaScript plugin + lifecycle scripts |
 | `third_party/rtk/` | RTK vendored source — command rewriting engine (justfile clone+patch) |
 | `third_party/patches/` | Patches for vendored third_party sources |
 | `Makefile` | Unified build system for the entire workspace |

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -59,6 +59,7 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 - **Qoder CLI 插件** — Tool Ready + 命令重写 + 响应压缩
 - **Claude Code 插件** — Tool Ready + 命令重写 + 响应压缩 + TOON
 - **Codex 插件** — Tool Ready + 命令重写 + 响应压缩 + TOON
+- **OpenCode 插件** — Tool Ready + 命令重写 + Schema/响应压缩 + TOON
 
 ## 快速开始
 
@@ -68,6 +69,21 @@ make setup
 ```
 
 安装完成后 `tokenless` 命令位于 `~/.local/bin`，RTK/TOON 辅助二进制同目录。
+
+### OpenCode 安装
+
+OpenCode 适配器通过 `tool.execute.before/after` 原生插件事件执行 Tool Ready、
+RTK 命令重写和响应/TOON 压缩，并通过 `tool.definition` 压缩工具 Schema。
+压缩后的响应会替换原始模型可见输出，避免重复占用上下文。
+
+```bash
+make opencode-install
+```
+
+安装器会在 OpenCode 全局 `plugins/` 目录中创建 `tokenless.js` 符号链接，
+不会覆盖同名的非托管文件。配置目录支持 `OPENCODE_CONFIG_DIR`、
+`XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
+安装后重启 OpenCode 即可加载插件。
 
 ## npm 安装
 
@@ -115,7 +131,7 @@ export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 - `crates/tokenless-schema/` — 核心库：SchemaCompressor + ResponseCompressor
 - `crates/tokenless-ccr/` — 可逆压缩缓存（Compress-Cache-Retrieve）
 - `crates/tokenless-cli/` — CLI 二进制
-- `adapters/tokenless/` — 适配器包（OpenClaw / Hermes / Qoder / Claude Code / Codex）
+- `adapters/tokenless/` — 适配器包（OpenClaw / Hermes / Qoder / Claude Code / Codex / OpenCode）
 - `third_party/rtk/` — RTK 命令重写引擎（vendored）
 
 ## 许可证

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tokenless response compression hook for Cosh-NG, Claude Code, and Qoder.
+"""Tokenless response compression hook for Cosh-NG, Claude Code, Qoder, and OpenCode.
 
 Reads a PostToolUse JSON from stdin, compresses the tool response
 via ``tokenless compress-response``, then optionally re-encodes to TOON
@@ -31,6 +31,9 @@ Output contract per agent:
     serialized as compact JSON because Qoder rejects object and array values.
     Qoder supports replacement for every tool, so compressed data is never
     appended beside the original.
+  - opencode: the adapter translates ``updatedToolOutput`` to OpenCode's
+    mutable ``tool.execute.after`` output. ``additionalContext`` remains
+    reserved for additive readiness and environment diagnostics.
   - cosh-ng: the compressed payload replaces the response via
     ``hookSpecificOutput.updatedToolResponse``.  Extract only ``llmContent``
     from wrapped responses; never include ``returnDisplay``.  Keep
@@ -84,6 +87,7 @@ _MIN_RESPONSE_CHARS = 200
 _CLAUDE_AGENT_ID = "claude-code"
 _CLAUDE_MIN_REPLACE_VERSION = (2, 1, 121)
 _QODER_AGENT_ID = "qoder-cli"
+_OPENCODE_AGENT_ID = "opencode"
 
 # Cache for `claude --version`, keyed on binary path+mtime+size so upgrades
 # invalidate it. Hooks run as a fresh process per tool call and spawning the
@@ -412,10 +416,10 @@ def main() -> None:
 
     # 17. Build response — dispatch by agent runtime.
     #
-    # Claude Code and Qoder support real tool-output replacement. Keep
+    # Claude Code, Qoder, and OpenCode support real tool-output replacement. Keep
     # additionalContext for additive diagnostics only; using it for compressed
     # data would leave the original result in context and increase token use.
-    if agent_id in {_CLAUDE_AGENT_ID, _QODER_AGENT_ID}:
+    if agent_id in {_CLAUDE_AGENT_ID, _QODER_AGENT_ID, _OPENCODE_AGENT_ID}:
         if agent_id == _CLAUDE_AGENT_ID and not _claude_supports_replacement():
             warn(
                 "Claude Code < 2.1.121 (or version unknown): "

--- a/src/tokenless/adapters/tokenless/manifest.json.in
+++ b/src/tokenless/adapters/tokenless/manifest.json.in
@@ -95,6 +95,23 @@
         "uninstall": "codex/scripts/uninstall.sh"
       }
     },
+    "opencode": {
+      "compatibleVersions": ">=1.0.0",
+      "capabilities": {
+        "hooks": [
+          "tool-ready",
+          "rewrite",
+          "compress-response",
+          "compress-toon",
+          "compress-schema"
+        ]
+      },
+      "actions": {
+        "detect":    "opencode/scripts/detect.sh",
+        "install":   "opencode/scripts/install.sh",
+        "uninstall": "opencode/scripts/uninstall.sh"
+      }
+    },
     "qwencode": {
       "compatibleVersions": ">=0.17.0",
       "capabilities": {

--- a/src/tokenless/adapters/tokenless/opencode/plugin.js
+++ b/src/tokenless/adapters/tokenless/opencode/plugin.js
@@ -1,0 +1,246 @@
+/**
+ * Tokenless integration for OpenCode's local plugin API.
+ *
+ * The adapter translates OpenCode's in-process hooks to the shared Tokenless
+ * JSON hook protocol, keeping compression and readiness behavior consistent
+ * with the other agent integrations.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const AGENT_ID = "opencode";
+const HOOK_TIMEOUT_MS = 15_000;
+const MAX_HOOK_OUTPUT_BYTES = 1024 * 1024;
+const MAX_CACHE_ENTRIES = 256;
+const PLUGIN_FILE = fileURLToPath(import.meta.url);
+const PLUGIN_DIR = dirname(realpathSync(PLUGIN_FILE));
+
+function isFile(path) {
+  try {
+    return existsSync(path) && statSync(path).isFile();
+  } catch {
+    // Hook discovery is fail-open so unreadable paths never block OpenCode startup.
+    return false;
+  }
+}
+
+function findHookRunner() {
+  const adapterDir = process.env.ANOLISA_ADAPTER_DIR;
+  const userHome = process.env.HOME && isAbsolute(process.env.HOME)
+    ? process.env.HOME
+    : homedir();
+  const candidates = [
+    process.env.TOKENLESS_HOOK_RUNNER,
+    adapterDir ? join(adapterDir, "common", "hooks", "run-hook.sh") : "",
+    // The installed plugin remains beside the shared adapter tree after its
+    // global registration symlink is resolved through PLUGIN_FILE.
+    join(PLUGIN_DIR, "..", "common", "hooks", "run-hook.sh"),
+    join(
+      userHome,
+      ".local",
+      "share",
+      "anolisa",
+      "adapters",
+      "tokenless",
+      "common",
+      "hooks",
+      "run-hook.sh",
+    ),
+    "/usr/local/share/anolisa/adapters/tokenless/common/hooks/run-hook.sh",
+    "/usr/share/anolisa/adapters/tokenless/common/hooks/run-hook.sh",
+  ];
+  return candidates.find((candidate) => candidate && isFile(candidate)) ?? null;
+}
+
+function parseHookOutput(raw) {
+  if (!raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function runHook(runner, hookName, payload) {
+  if (!runner) return Promise.resolve(null);
+  let serialized;
+  try {
+    serialized = JSON.stringify(payload);
+  } catch {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    let stdout = "";
+    let settled = false;
+    let child;
+    let timer;
+    try {
+      child = spawn("bash", [runner, hookName], {
+        env: {
+          ...process.env,
+          TOKENLESS_AGENT_ID: AGENT_ID,
+        },
+        stdio: ["pipe", "pipe", "ignore"],
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    timer = setTimeout(() => {
+      child.kill();
+      finish(null);
+    }, HOOK_TIMEOUT_MS);
+
+    child.on("error", () => finish(null));
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      if (stdout.length < MAX_HOOK_OUTPUT_BYTES) {
+        stdout += chunk.slice(0, MAX_HOOK_OUTPUT_BYTES - stdout.length);
+      }
+    });
+    child.on("close", (code) => {
+      finish(code === 0 ? parseHookOutput(stdout) : null);
+    });
+
+    child.stdin.on("error", () => {
+      child.kill();
+      finish(null);
+    });
+    child.stdin.end(serialized);
+  });
+}
+
+function toolPayload(input, args, toolResponse) {
+  const payload = {
+    session_id: input.sessionID,
+    tool_use_id: input.callID,
+    tool_call_id: input.callID,
+    tool_name: input.tool,
+    tool_input: args ?? {},
+  };
+  if (toolResponse !== undefined) payload.tool_response = toolResponse;
+  return payload;
+}
+
+function hookSpecificOutput(result) {
+  const output = result?.hookSpecificOutput;
+  return output && typeof output === "object" ? output : null;
+}
+
+function prependContext(context, content) {
+  if (typeof context !== "string" || !context) return content;
+  return content ? `${context}\n${content}` : context;
+}
+
+export const TokenlessPlugin = async () => {
+  const runner = findHookRunner();
+  const readinessContext = new Map();
+  const schemaCache = new Map();
+
+  const cacheValue = (cache, key, value) => {
+    if (cache.has(key)) {
+      cache.delete(key);
+    } else if (cache.size >= MAX_CACHE_ENTRIES) {
+      cache.delete(cache.keys().next().value);
+    }
+    cache.set(key, value);
+  };
+
+  const cachedValue = (cache, key) => {
+    if (!cache.has(key)) return undefined;
+    const value = cache.get(key);
+    cache.delete(key);
+    cache.set(key, value);
+    return value;
+  };
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      const payload = toolPayload(input, output.args);
+      const readyResult = await runHook(runner, "tool_ready_hook.sh", payload);
+      if (readyResult?.decision === "block") {
+        throw new Error(
+          readyResult.reason || "Tokenless reports that the tool is not ready",
+        );
+      }
+
+      const readyOutput = hookSpecificOutput(readyResult);
+      if (typeof readyOutput?.additionalContext === "string") {
+        cacheValue(
+          readinessContext,
+          `${input.sessionID}:${input.callID}`,
+          readyOutput.additionalContext,
+        );
+      }
+
+      if (input.tool !== "bash" || typeof output.args?.command !== "string") return;
+      const rewriteResult = await runHook(runner, "rewrite_hook.py", payload);
+      const rewritten = hookSpecificOutput(rewriteResult)?.updatedInput?.command;
+      if (typeof rewritten === "string" && rewritten) output.args.command = rewritten;
+    },
+
+    "tool.execute.after": async (input, output) => {
+      const key = `${input.sessionID}:${input.callID}`;
+      const readyContext = readinessContext.get(key);
+      readinessContext.delete(key);
+
+      const result = await runHook(
+        runner,
+        "compress_response_hook.py",
+        toolPayload(input, input.args, output.output),
+      );
+      const hookOutput = hookSpecificOutput(result);
+      const compressedOutput = hookOutput?.updatedToolOutput;
+      if (typeof compressedOutput === "string") {
+        output.output = compressedOutput;
+      }
+      const context = [readyContext, hookOutput?.additionalContext]
+        .filter((value) => typeof value === "string" && value)
+        .join("\n");
+      output.output = prependContext(context, output.output);
+    },
+
+    "tool.definition": async (input, output) => {
+      const declaration = {
+        name: input.toolID,
+        description: output.description,
+        parameters: output.parameters,
+      };
+      let cacheKey;
+      try {
+        cacheKey = JSON.stringify(declaration);
+      } catch {
+        return;
+      }
+      let tools = cachedValue(schemaCache, cacheKey);
+      if (!tools) {
+        const result = await runHook(runner, "compress_schema_hook.py", {
+          llm_request: { config: { tools: [declaration] } },
+        });
+        tools = hookSpecificOutput(result)?.llm_request?.config?.tools;
+        if (Array.isArray(tools)) cacheValue(schemaCache, cacheKey, tools);
+      }
+      if (!Array.isArray(tools) || tools.length !== 1 || tools[0]?.name !== input.toolID) {
+        return;
+      }
+
+      if (typeof tools[0].description === "string") output.description = tools[0].description;
+      if (tools[0].parameters && typeof tools[0].parameters === "object") {
+        output.parameters = tools[0].parameters;
+      }
+    },
+  };
+};

--- a/src/tokenless/adapters/tokenless/opencode/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/opencode/scripts/detect.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# detect.sh — Check whether OpenCode can load the Tokenless local plugin.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-opencode}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PLUGIN_SOURCE="$ADAPTER_DIR/opencode/plugin.js"
+
+OPENCODE_BIN="${OPENCODE_BIN:-}"
+if [ -z "$OPENCODE_BIN" ]; then
+    OPENCODE_BIN="$(command -v opencode 2>/dev/null || true)"
+fi
+
+if [ -z "$OPENCODE_BIN" ] || { [ ! -x "$OPENCODE_BIN" ] && ! command -v "$OPENCODE_BIN" >/dev/null 2>&1; }; then
+    echo "[${COMPONENT}] ${AGENT}: opencode CLI not found" >&2
+    exit 2
+fi
+if [ ! -f "$PLUGIN_SOURCE" ]; then
+    echo "[${COMPONENT}] ${AGENT}: plugin source missing: ${PLUGIN_SOURCE}" >&2
+    exit 2
+fi
+
+VERSION="$($OPENCODE_BIN --version 2>/dev/null || true)"
+if [ -z "$VERSION" ]; then
+    echo "[${COMPONENT}] ${AGENT}: opencode CLI did not report a version" >&2
+    exit 2
+fi
+
+CONFIG_HOME="${TOKENLESS_OPENCODE_CONFIG_DIR:-${OPENCODE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode}}"
+PLUGIN_LINK="$CONFIG_HOME/plugins/tokenless.js"
+if [ -L "$PLUGIN_LINK" ] && [ "$PLUGIN_LINK" -ef "$PLUGIN_SOURCE" ]; then
+    echo "[${COMPONENT}] ${AGENT}: ready (${VERSION})"
+    exit 0
+fi
+
+echo "[${COMPONENT}] ${AGENT}: detected (${VERSION}), plugin not installed"
+exit 1

--- a/src/tokenless/adapters/tokenless/opencode/scripts/install.sh
+++ b/src/tokenless/adapters/tokenless/opencode/scripts/install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# install.sh — Register Tokenless in OpenCode's global local-plugin directory.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-opencode}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PLUGIN_SOURCE="$ADAPTER_DIR/opencode/plugin.js"
+
+OPENCODE_BIN="${OPENCODE_BIN:-}"
+if [ -z "$OPENCODE_BIN" ]; then
+    OPENCODE_BIN="$(command -v opencode 2>/dev/null || true)"
+fi
+if [ -z "$OPENCODE_BIN" ] || { [ ! -x "$OPENCODE_BIN" ] && ! command -v "$OPENCODE_BIN" >/dev/null 2>&1; }; then
+    echo "[${COMPONENT}] opencode CLI not found — skipping ${AGENT} plugin installation."
+    exit 0
+fi
+if [ ! -f "$PLUGIN_SOURCE" ]; then
+    echo "[${COMPONENT}] ERROR: OpenCode plugin source not found: ${PLUGIN_SOURCE}" >&2
+    exit 1
+fi
+
+CONFIG_HOME="${TOKENLESS_OPENCODE_CONFIG_DIR:-${OPENCODE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode}}"
+PLUGIN_DIR="$CONFIG_HOME/plugins"
+PLUGIN_LINK="$PLUGIN_DIR/tokenless.js"
+
+is_managed_link() {
+    [ -L "$PLUGIN_LINK" ] && {
+        [ "$PLUGIN_LINK" -ef "$PLUGIN_SOURCE" ] ||
+            [ "$(readlink "$PLUGIN_LINK")" = "$PLUGIN_SOURCE" ]
+    }
+}
+
+if [ -e "$PLUGIN_LINK" ] || [ -L "$PLUGIN_LINK" ]; then
+    if is_managed_link; then
+        echo "[${COMPONENT}] ${AGENT} plugin already installed at ${PLUGIN_LINK}."
+        exit 0
+    fi
+    echo "[${COMPONENT}] ERROR: refusing to replace unmanaged path: ${PLUGIN_LINK}" >&2
+    exit 1
+fi
+
+if [ "${ANOLISA_DRY_RUN:-0}" = "1" ]; then
+    echo "DRY-RUN: ln -s ${PLUGIN_SOURCE} ${PLUGIN_LINK}"
+    exit 0
+fi
+
+mkdir -p "$PLUGIN_DIR"
+ln -s "$PLUGIN_SOURCE" "$PLUGIN_LINK"
+if ! is_managed_link; then
+    echo "[${COMPONENT}] ERROR: failed to verify OpenCode plugin link: ${PLUGIN_LINK}" >&2
+    exit 1
+fi
+
+echo "[${COMPONENT}] ${AGENT} plugin installed at ${PLUGIN_LINK}."
+echo "[${COMPONENT}] Restart OpenCode to load the plugin."

--- a/src/tokenless/adapters/tokenless/opencode/scripts/uninstall.sh
+++ b/src/tokenless/adapters/tokenless/opencode/scripts/uninstall.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# uninstall.sh — Remove only the OpenCode plugin link managed by Tokenless.
+set -euo pipefail
+
+AGENT="${ANOLISA_TARGET:-opencode}"
+COMPONENT="${ANOLISA_COMPONENT:-tokenless}"
+ADAPTER_DIR="${ANOLISA_ADAPTER_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+PLUGIN_SOURCE="$ADAPTER_DIR/opencode/plugin.js"
+CONFIG_HOME="${TOKENLESS_OPENCODE_CONFIG_DIR:-${OPENCODE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode}}"
+PLUGIN_LINK="$CONFIG_HOME/plugins/tokenless.js"
+
+is_managed_link() {
+    [ -L "$PLUGIN_LINK" ] && {
+        [ "$PLUGIN_LINK" -ef "$PLUGIN_SOURCE" ] ||
+            [ "$(readlink "$PLUGIN_LINK")" = "$PLUGIN_SOURCE" ]
+    }
+}
+
+if [ ! -e "$PLUGIN_LINK" ] && [ ! -L "$PLUGIN_LINK" ]; then
+    echo "[${COMPONENT}] ${AGENT} plugin is already absent."
+    exit 0
+fi
+if ! is_managed_link; then
+    echo "[${COMPONENT}] WARNING: leaving unmanaged path untouched: ${PLUGIN_LINK}" >&2
+    exit 0
+fi
+
+rm "$PLUGIN_LINK"
+echo "[${COMPONENT}] ${AGENT} plugin removed."

--- a/src/tokenless/tests/test-opencode-adapter-install.sh
+++ b/src/tokenless/tests/test-opencode-adapter-install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Regression tests for the OpenCode local-plugin lifecycle.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1" >&2; FAIL=$((FAIL + 1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ADAPTER_DIR="$SCRIPT_DIR/../adapters/tokenless"
+SANDBOX="$(mktemp -d -t tokenless-opencode-install-test.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+FAKE_HOME="$SANDBOX/home"
+FAKE_BIN="$SANDBOX/bin"
+ADAPTER_DIR="$SANDBOX/adapter root"
+CONFIG_DIR="$SANDBOX/config root/opencode"
+mkdir -p "$FAKE_HOME" "$FAKE_BIN" "$ADAPTER_DIR/opencode/scripts"
+cp "$SOURCE_ADAPTER_DIR/opencode/plugin.js" "$ADAPTER_DIR/opencode/plugin.js"
+cp "$SOURCE_ADAPTER_DIR/opencode/scripts/"*.sh "$ADAPTER_DIR/opencode/scripts/"
+
+cat > "$FAKE_BIN/opencode" <<'STUBEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+    echo "1.2.3-test"
+    exit 0
+fi
+exit 2
+STUBEOF
+chmod +x "$FAKE_BIN/opencode"
+
+export HOME="$FAKE_HOME"
+export PATH="$FAKE_BIN:$PATH"
+export ANOLISA_ADAPTER_DIR="$ADAPTER_DIR"
+export TOKENLESS_OPENCODE_CONFIG_DIR="$CONFIG_DIR"
+
+DETECT_SH="$ADAPTER_DIR/opencode/scripts/detect.sh"
+INSTALL_SH="$ADAPTER_DIR/opencode/scripts/install.sh"
+UNINSTALL_SH="$ADAPTER_DIR/opencode/scripts/uninstall.sh"
+PLUGIN_SOURCE="$ADAPTER_DIR/opencode/plugin.js"
+PLUGIN_LINK="$CONFIG_DIR/plugins/tokenless.js"
+
+if bash "$DETECT_SH" >/dev/null 2>&1; then
+    detect_rc=0
+else
+    detect_rc=$?
+fi
+if [ "$detect_rc" -eq 1 ]; then
+    pass "detect reports an installable OpenCode plugin"
+else
+    fail "detect returned $detect_rc before installation"
+fi
+
+if bash "$INSTALL_SH" >/dev/null; then
+    pass "OpenCode plugin installation succeeds"
+else
+    fail "OpenCode plugin installation failed"
+fi
+if [ -L "$PLUGIN_LINK" ] && [ "$(readlink "$PLUGIN_LINK")" = "$PLUGIN_SOURCE" ]; then
+    pass "installer creates the expected global plugin link"
+else
+    fail "installer did not create the managed plugin link"
+fi
+if bash "$DETECT_SH" >/dev/null; then
+    pass "detect recognizes the installed plugin"
+else
+    fail "detect did not recognize the installed plugin"
+fi
+if bash "$INSTALL_SH" >/dev/null; then
+    pass "OpenCode plugin installation is idempotent"
+else
+    fail "repeated OpenCode plugin installation failed"
+fi
+
+ADAPTER_ALIAS="$SANDBOX/adapter alias"
+ln -s "$ADAPTER_DIR" "$ADAPTER_ALIAS"
+export ANOLISA_ADAPTER_DIR="$ADAPTER_ALIAS"
+if bash "$DETECT_SH" >/dev/null; then
+    pass "detect recognizes the plugin through an adapter symlink"
+else
+    fail "detect rejected an equivalent adapter symlink"
+fi
+if bash "$INSTALL_SH" >/dev/null; then
+    pass "installer recognizes the plugin through an adapter symlink"
+else
+    fail "installer rejected an equivalent adapter symlink"
+fi
+
+if bash "$UNINSTALL_SH" >/dev/null; then
+    pass "OpenCode plugin uninstallation succeeds through an adapter symlink"
+else
+    fail "OpenCode plugin uninstallation failed"
+fi
+export ANOLISA_ADAPTER_DIR="$ADAPTER_DIR"
+if [ ! -e "$PLUGIN_LINK" ] && [ ! -L "$PLUGIN_LINK" ]; then
+    pass "uninstaller removes the managed plugin link"
+else
+    fail "uninstaller left the managed plugin link behind"
+fi
+if bash "$UNINSTALL_SH" >/dev/null; then
+    pass "OpenCode plugin uninstallation is idempotent"
+else
+    fail "repeated OpenCode plugin uninstallation failed"
+fi
+
+mkdir -p "$(dirname "$PLUGIN_LINK")"
+printf '%s\n' 'export const ForeignPlugin = async () => ({})' > "$PLUGIN_LINK"
+foreign_before="$(cksum "$PLUGIN_LINK")"
+if bash "$INSTALL_SH" >/dev/null 2>&1; then
+    fail "installer replaced an unmanaged plugin file"
+else
+    pass "installer refuses to replace an unmanaged plugin file"
+fi
+if bash "$UNINSTALL_SH" >/dev/null 2>&1; then
+    pass "uninstaller leaves an unmanaged plugin file without failing"
+else
+    fail "uninstaller failed for an unmanaged plugin file"
+fi
+if [ "$(cksum "$PLUGIN_LINK")" = "$foreign_before" ]; then
+    pass "unmanaged plugin file remains unchanged"
+else
+    fail "unmanaged plugin file was modified"
+fi
+
+echo ""
+echo "OpenCode adapter tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/src/tokenless/tests/test-opencode-plugin.mjs
+++ b/src/tokenless/tests/test-opencode-plugin.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TokenlessPlugin } from "../adapters/tokenless/opencode/plugin.js";
+
+const sandbox = mkdtempSync(join(tmpdir(), "tokenless-opencode-plugin-"));
+const runner = join(sandbox, "hook runner.sh");
+const log = join(sandbox, "hooks.log");
+
+writeFileSync(runner, `#!/usr/bin/env bash
+set -euo pipefail
+hook="\${1:?hook name required}"
+payload="$(cat)"
+printf '%s\\t%s\\n' "$hook" "$payload" >> "$TOKENLESS_TEST_LOG"
+case "$hook" in
+  tool_ready_hook.sh)
+    case "\${TOKENLESS_TEST_READY:-}" in
+      block) printf '%s\\n' '{"decision":"block","reason":"missing required dependency"}' ;;
+      partial) printf '%s\\n' '{"hookSpecificOutput":{"additionalContext":"[tokenless:ready] partial"}}' ;;
+      *) printf '%s\\n' '{}' ;;
+    esac
+    ;;
+  rewrite_hook.py)
+    printf '%s\\n' '{"hookSpecificOutput":{"updatedInput":{"command":"rtk git status"}}}'
+    ;;
+  compress_response_hook.py)
+    printf '%s\\n' '{"hookSpecificOutput":{"updatedToolOutput":"compressed-response","additionalContext":"[tokenless:env] warning"}}'
+    ;;
+  compress_schema_hook.py)
+    printf '%s\\n' '{"hookSpecificOutput":{"llm_request":{"config":{"tools":[{"name":"bash","description":"compressed description","parameters":{"type":"object","properties":{"command":{"type":"string"}}}}]}}}}'
+    ;;
+  *) printf '%s\\n' '{}' ;;
+esac
+`);
+
+process.env.TOKENLESS_HOOK_RUNNER = runner;
+process.env.TOKENLESS_TEST_LOG = log;
+
+try {
+  const hooks = await TokenlessPlugin();
+  process.env.TOKENLESS_TEST_READY = "partial";
+
+  const beforeInput = { tool: "bash", sessionID: "session-1", callID: "call-1" };
+  const beforeOutput = { args: { command: "git status" } };
+  await hooks["tool.execute.before"](beforeInput, beforeOutput);
+  assert.equal(beforeOutput.args.command, "rtk git status");
+
+  const afterOutput = { title: "bash", output: "original-response", metadata: {} };
+  await hooks["tool.execute.after"](
+    { ...beforeInput, args: beforeOutput.args },
+    afterOutput,
+  );
+  assert.equal(
+    afterOutput.output,
+    "[tokenless:ready] partial\n[tokenless:env] warning\ncompressed-response",
+  );
+
+  process.env.TOKENLESS_TEST_READY = "block";
+  await assert.rejects(
+    hooks["tool.execute.before"](
+      { tool: "bash", sessionID: "session-1", callID: "call-2" },
+      { args: { command: "cargo test" } },
+    ),
+    /missing required dependency/,
+  );
+
+  process.env.TOKENLESS_TEST_READY = "";
+  const definition = {
+    description: "A very long tool description",
+    parameters: { type: "object", title: "Bash", properties: {} },
+  };
+  await hooks["tool.definition"]({ toolID: "bash" }, definition);
+  assert.equal(definition.description, "compressed description");
+  assert.deepEqual(definition.parameters, {
+    type: "object",
+    properties: { command: { type: "string" } },
+  });
+
+  const repeatedDefinition = {
+    description: "A very long tool description",
+    parameters: { type: "object", title: "Bash", properties: {} },
+  };
+  await hooks["tool.definition"]({ toolID: "bash" }, repeatedDefinition);
+  assert.equal(repeatedDefinition.description, "compressed description");
+
+  const circularArgs = {};
+  circularArgs.self = circularArgs;
+  await hooks["tool.execute.before"](
+    { tool: "read", sessionID: "session-1", callID: "call-3" },
+    { args: circularArgs },
+  );
+
+  const records = readFileSync(log, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const separator = line.indexOf("\t");
+      return {
+        hook: line.slice(0, separator),
+        payload: JSON.parse(line.slice(separator + 1)),
+      };
+    });
+  const rewrite = records.find((record) => record.hook === "rewrite_hook.py");
+  assert.equal(rewrite.payload.session_id, "session-1");
+  assert.equal(rewrite.payload.tool_call_id, "call-1");
+  assert.equal(rewrite.payload.tool_name, "bash");
+  assert.equal(
+    records.filter((record) => record.hook === "compress_schema_hook.py").length,
+    1,
+  );
+
+  console.log("OpenCode plugin tests passed");
+} finally {
+  rmSync(sandbox, { recursive: true, force: true });
+}

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -371,6 +371,30 @@ class TestReplacementProtocol(unittest.TestCase):
         self.assertNotIn("additionalContext", hso,
                          "Qoder compressed content must not be additive")
 
+    def test_opencode_uses_string_replacement(self):
+        """OpenCode should receive a replacement that its plugin can apply."""
+        large_payload = _make_large_json_payload()
+
+        result = _run_hook(
+            {
+                "tool_name": "bash",
+                "tool_response": json.dumps(large_payload),
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="opencode",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertIsInstance(hso.get("updatedToolOutput"), str)
+        self.assertNotIn("additionalContext", hso,
+                         "OpenCode compressed content must not be additive")
+
     def test_replacement_is_smaller(self):
         """The replacement output should be smaller than the original."""
         large_payload = _make_large_json_payload(1000)

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -60,6 +60,9 @@ CLI, or run the install script: claude-code/scripts/install.sh
 Qwen Code plugin (RTK command rewriting, response/TOON compression, and Tool Ready
 environment pre-check) is available under /usr/share/anolisa/adapters/tokenless/qwencode/.
 Register it with `qwen extensions link`, or run the install script: qwencode/scripts/install.sh
+OpenCode plugin (schema/response/TOON compression, RTK command rewriting, and Tool
+Ready) is available under /usr/share/anolisa/adapters/tokenless/opencode/.
+Register it by running the install script: opencode/scripts/install.sh
 
 %prep
 %setup -q -n %{name}-%{version}
@@ -110,6 +113,7 @@ mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/claude-code/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/.codex-plugin
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts
+mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/scripts
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwencode/hooks
 mkdir -p %{buildroot}%{_datadir}/anolisa/adapters/tokenless/qwencode/scripts
 mkdir -p %{buildroot}%{_docdir}/tokenless
@@ -200,6 +204,12 @@ install -m 0755 adapters/tokenless/codex/scripts/detect.sh %{buildroot}%{_datadi
 install -m 0755 adapters/tokenless/codex/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 
+# Install OpenCode plugin (local JavaScript plugin + lifecycle scripts).
+install -m 0644 adapters/tokenless/opencode/plugin.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/
+install -m 0755 adapters/tokenless/opencode/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/scripts/
+install -m 0755 adapters/tokenless/opencode/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/scripts/
+install -m 0755 adapters/tokenless/opencode/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/scripts/
+
 # Install Qwen Code plugin (extension manifest + hooks + scripts).
 # qwen-extension.json is stamped from .in by `make stamp-adapter-templates`
 # during %build (transitive dep of build-openclaw-plugin).
@@ -256,6 +266,8 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %dir %{_datadir}/anolisa/adapters/tokenless/codex/.codex-plugin
 %dir %{_datadir}/anolisa/adapters/tokenless/codex/hooks
 %dir %{_datadir}/anolisa/adapters/tokenless/codex/scripts
+%dir %{_datadir}/anolisa/adapters/tokenless/opencode
+%dir %{_datadir}/anolisa/adapters/tokenless/opencode/scripts
 %dir %{_datadir}/anolisa/adapters/tokenless/qwencode
 %dir %{_datadir}/anolisa/adapters/tokenless/qwencode/hooks
 %dir %{_datadir}/anolisa/adapters/tokenless/qwencode/scripts
@@ -305,6 +317,11 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/uninstall.sh
+# OpenCode plugin — local JavaScript plugin + lifecycle scripts.
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/plugin.js
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/detect.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/install.sh
+%attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/uninstall.sh
 # Qwen Code plugin — extension manifest + hooks + scripts.
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/qwencode/qwen-extension.json
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/qwencode/hooks/run-hook.sh
@@ -367,7 +384,7 @@ fi
 hash -r 2>/dev/null || true
 
 %preun
-# On uninstall ($1=0): clean qodercli, codex, openclaw, and hermes plugins
+# On uninstall ($1=0): clean registered framework plugins.
 if [ $1 -eq 0 ]; then
     # --- Qoder CLI plugin cleanup ---
     # Let qodercli remove the user-scoped native plugin and its cache.
@@ -389,6 +406,12 @@ if [ $1 -eq 0 ]; then
             rm -rf "$cache_dir" || true
         fi
     done
+
+    # --- OpenCode plugin cleanup ---
+    OPENCODE_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/opencode/scripts/uninstall.sh"
+    if [ -x "$OPENCODE_SCRIPT" ]; then
+        bash "$OPENCODE_SCRIPT" || true
+    fi
 
     # --- Qwen Code plugin cleanup ---
     QWENCODE_SCRIPT="%{_datadir}/anolisa/adapters/tokenless/qwencode/scripts/uninstall.sh"


### PR DESCRIPTION
## Why

OpenCode users currently cannot apply Tokenless command rewriting or compression through the framework's native plugin hooks. This adds an adapter now that OpenCode exposes mutable tool execution and definition hooks suitable for real output replacement.

## What changed

- Add a local OpenCode plugin that bridges native hooks to the shared Tokenless JSON hook protocol.
- Map tool readiness and RTK rewriting to `tool.execute.before`, response/TOON compression to `tool.execute.after`, and schema compression to `tool.definition`.
- Add collision-safe detect/install/uninstall scripts, adapter manifest metadata, Make targets, RPM packaging, bilingual documentation, and regression tests.
- Keep failures fail-open with bounded hook output, timeouts, and caches.

## Related issue

no-issue: add framework support for the existing Tokenless component

## User / Agent impact

OpenCode users can install Tokenless as a global local plugin and reduce model-visible schema, command, and structured response tokens without duplicated output. Uninstall removes only the managed Tokenless symlink.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change is additive. Missing binaries, hooks, malformed output, and subprocess failures preserve OpenCode's original behavior.

## Validation

- `make test-integration test-adapters`
- `cargo fmt --all -- --check`
- Node and Bash syntax checks, `git diff --check`, and `bash scripts/docs-lint.sh`
- Real macOS OpenCode 1.18.13 run with tokenless 0.7.4 and rtk 0.43.0: command rewriting, schema compression, response compression, TOON replacement, and agent/session stats verified
- `make test-hooks`: 99/106 passed; seven existing host-specific assertions fail on macOS because temporary-HOME stats records are absent and the suite expects the Linux `dnf` manager label

## Documentation and rollback

Updated the English and Chinese component READMEs and canonical framework-integration guides. This PR does not register an OpenCode driver with the anolisa adapter manager; built-in manager support will follow in a separate PR. Run `make opencode-uninstall` to remove the managed plugin link; no OpenCode JSON configuration is rewritten.