### PR TITLE
feat(sec-core): support block mode for openclaw code scanner hook

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/code-scanner.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/code-scanner.md
@@ -27,7 +27,7 @@ Install or deploy the adapter for the Agent you use as described in the [AgentSe
 | Codex | `true` / `false` | `observe`, `block` | Supported; default 10 seconds |
 | Cosh | `true` / `false` | `ask` only | Not supported; fixed at 10 seconds |
 | Hermes | `true` / `false` | `observe`, `block` | Not supported; uses capability `timeout` |
-| OpenClaw | `true` / `false` | `observe`, `ask` | Not supported; fixed at 10 seconds |
+| OpenClaw | `true` / `false` | `observe`, `ask`, `block` | Not supported; fixed at 10 seconds |
 
 `CODE_SCANNER_HOOK_ENABLED=false` skips hook input processing and CLI invocation. On Hermes and OpenClaw, a valid boolean environment value overrides capability `enabled`; an invalid value is treated as unset and falls back to capability configuration.
 
@@ -39,7 +39,7 @@ Install or deploy the adapter for the Agent you use as described in the [AgentSe
 
 Compatibility aliases are normalized before host capability checks: `debug` maps to `observe`, and `deny` maps to `block`. `warn`, invalid values, and modes unsupported by that host are treated as unset; these configuration diagnostics never enter stdout, system messages, or other HookOutput. Standalone scripts write bounded diagnostics to stderr, while Hermes/OpenClaw capabilities write them to the host logger.
 
-Consequently, Cosh keeps its fixed `ask` response when given `observe` or `block`; Codex and Hermes ignore `ask`; OpenClaw ignores `block` and its `deny` alias. The plugin then uses the same default or native configuration it would use if `CODE_SCANNER_MODE` were absent.
+Consequently, Cosh keeps its fixed `ask` response when given `observe` or `block`; Codex and Hermes ignore `ask`; OpenClaw supports `observe`, `ask`, and `block`, with `deny` normalized to `block`. Unsupported modes use the same default or native configuration the plugin would use if `CODE_SCANNER_MODE` were absent.
 
 ## Native Configuration Precedence
 
@@ -54,7 +54,7 @@ enable_block = false
 
 A supported `CODE_SCANNER_MODE` overrides `enable_block`; otherwise `enable_block=true` selects block and `false` selects observe.
 
-OpenClaw preserves `capabilities["scan-code"].enabled` and `codeScanRequireApproval`. A supported `CODE_SCANNER_MODE` overrides `codeScanRequireApproval`; otherwise `true` selects ask and `false` selects observe. Ordinary findings never return direct block in OpenClaw.
+OpenClaw preserves `capabilities["scan-code"].enabled` and `codeScanRequireApproval`. A supported `CODE_SCANNER_MODE` overrides `codeScanRequireApproval`; otherwise `true` selects ask and `false` selects observe. In `ask` mode, ordinary findings return `requireApproval`; in `block` mode, ordinary findings return `{ block: true, blockReason }`.
 
 ## Examples
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/openclaw-deploy.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/openclaw-deploy.md
@@ -169,7 +169,7 @@ Enable code-scan approval:
 openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval true
 ```
 
-For deployment-level overrides, `CODE_SCANNER_HOOK_ENABLED=true|false` takes precedence over `capabilities["scan-code"].enabled`, and `CODE_SCANNER_MODE=observe|ask` takes precedence over `codeScanRequireApproval`. Invalid or unsupported values, including `block`/`deny`, are treated as unset and fall back to plugin configuration. Ordinary findings do not support direct block; the existing self-protect rule remains a forced-block exception. OpenClaw does not consume `CODE_SCANNER_TIMEOUT` and keeps its fixed 10-second timeout.
+For deployment-level overrides, `CODE_SCANNER_HOOK_ENABLED=true|false` takes precedence over `capabilities["scan-code"].enabled`, and `CODE_SCANNER_MODE=observe|ask|block` takes precedence over `codeScanRequireApproval`. `debug` aliases `observe`, `deny` aliases `block`, and `warn` or invalid values are treated as unset and fall back to plugin configuration. In `ask` mode, ordinary findings return `requireApproval`; in `block` mode, ordinary findings return `{ block: true, blockReason }`. The existing self-protect rule remains a forced-block exception regardless of mode. OpenClaw does not consume `CODE_SCANNER_TIMEOUT` and keeps its fixed 10-second timeout.
 
 Enable PII deny blocking:
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/code-scanner.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/code-scanner.md
@@ -27,7 +27,7 @@ make build-cli
 | Codex | `true` / `false` | `observe`、`block` | 支持；默认 10 秒 |
 | Cosh | `true` / `false` | 仅 `ask` | 不支持；固定 10 秒 |
 | Hermes | `true` / `false` | `observe`、`block` | 不支持；使用 capability `timeout` |
-| OpenClaw | `true` / `false` | `observe`、`ask` | 不支持；固定 10 秒 |
+| OpenClaw | `true` / `false` | `observe`、`ask`、`block` | 不支持；固定 10 秒 |
 
 `CODE_SCANNER_HOOK_ENABLED=false` 会跳过 hook input 处理和 CLI 调用。在 Hermes 和 OpenClaw 中，合法布尔环境变量会覆盖 capability `enabled`；非法值等价于未设置，并回到 capability 配置。
 
@@ -39,7 +39,7 @@ make build-cli
 
 兼容别名会先完成归一化，再检查宿主能力：`debug` 映射为 `observe`，`deny` 映射为 `block`。`warn`、非法值以及宿主不支持的模式都等价于未设置；这些配置错配不会进入 stdout、systemMessage 或其他 HookOutput。独立脚本会向 stderr 记录 bounded diagnostic，Hermes/OpenClaw capability 会写宿主 logger。
 
-因此，Cosh 收到 `observe` 或 `block` 时仍保持固定 `ask`；Codex 和 Hermes 忽略 `ask`；OpenClaw 忽略 `block` 及其 `deny` 别名。随后插件使用未设置 `CODE_SCANNER_MODE` 时相同的默认值或原生配置。
+因此，Cosh 收到 `observe` 或 `block` 时仍保持固定 `ask`；Codex 和 Hermes 忽略 `ask`；OpenClaw 支持 `observe`、`ask` 和 `block`，其中 `deny` 会归一化为 `block`。不受支持的模式会使用未设置 `CODE_SCANNER_MODE` 时相同的默认值或原生配置。
 
 ## 原生配置优先级
 
@@ -54,7 +54,7 @@ enable_block = false
 
 受支持的 `CODE_SCANNER_MODE` 优先于 `enable_block`；否则 `enable_block=true` 选择 block，`false` 选择 observe。
 
-OpenClaw 保留 `capabilities["scan-code"].enabled` 和 `codeScanRequireApproval`。受支持的 `CODE_SCANNER_MODE` 优先于 `codeScanRequireApproval`；否则 `true` 选择 ask，`false` 选择 observe。OpenClaw 的普通 findings 不会返回 direct block。
+OpenClaw 保留 `capabilities["scan-code"].enabled` 和 `codeScanRequireApproval`。受支持的 `CODE_SCANNER_MODE` 优先于 `codeScanRequireApproval`；否则 `true` 选择 ask，`false` 选择 observe。在 `ask` 模式下，普通 findings 返回 `requireApproval`；在 `block` 模式下，普通 findings 返回 `{ block: true, blockReason }`。
 
 ## 示例
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/openclaw-deploy.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/openclaw-deploy.md
@@ -169,7 +169,7 @@ openclaw config set plugins.entries.agent-sec.config.promptScanBlock true
 openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval true
 ```
 
-如需部署级覆盖，`CODE_SCANNER_HOOK_ENABLED=true|false` 的优先级高于 `capabilities["scan-code"].enabled`，`CODE_SCANNER_MODE=observe|ask` 的优先级高于 `codeScanRequireApproval`。非法或不支持的值（包括 `block`/`deny`）等价于未设置，并回到插件配置。普通 findings 不支持直接 block；已有 self-protect 规则仍是强制 block 例外。OpenClaw 不消费 `CODE_SCANNER_TIMEOUT`，继续使用固定 10 秒超时。
+如需部署级覆盖，`CODE_SCANNER_HOOK_ENABLED=true|false` 的优先级高于 `capabilities["scan-code"].enabled`，`CODE_SCANNER_MODE=observe|ask|block` 的优先级高于 `codeScanRequireApproval`。`debug` 是 `observe` 的别名，`deny` 是 `block` 的别名，`warn` 或非法值等价于未设置，并回到插件配置。在 `ask` 模式下，普通 findings 返回 `requireApproval`；在 `block` 模式下，普通 findings 返回 `{ block: true, blockReason }`。已有 self-protect 规则仍是不受模式影响的强制 block 例外。OpenClaw 不消费 `CODE_SCANNER_TIMEOUT`，继续使用固定 10 秒超时。
 
 启用 PII deny 阻断：
 

--- a/src/agent-sec-core/docs/design/CODE_SCANNER_HOOKS_zh.md
+++ b/src/agent-sec-core/docs/design/CODE_SCANNER_HOOKS_zh.md
@@ -28,7 +28,7 @@
 | Codex | 支持 | 不支持 | 支持，输出既有 `decision=block` | `observe` |
 | Cosh | 不支持 | 支持，且是固定行为 | 不支持 | 固定 `ask` |
 | Hermes | 支持 | 不支持 | 支持，输出既有 `action=block` | 由 `enable_block` 推导 |
-| OpenClaw | 支持 | 支持，输出既有 `requireApproval` | 普通 findings 不支持 | 由 `codeScanRequireApproval` 推导 |
+| OpenClaw | 支持 | 支持，输出既有 `requireApproval` | 支持，输出既有 `{ block: true, blockReason }` | 由 `codeScanRequireApproval` 推导 |
 
 `block` 是环境变量中的规范名称。Qoder 和 Qwen Code 在宿主协议中仍返回 `permissionDecision=deny`；该返回结构是原有交互，不是新增模式。
 
@@ -39,7 +39,7 @@
 - `debug` → `observe`
 - `deny` → `block`
 
-归一化后必须再次检查宿主能力子集。例如，OpenClaw 收到 `deny` 后先归一化为 `block`，但普通 findings 不支持 direct block，因此该环境变量最终不生效，并回到原生配置。
+归一化后必须再次检查宿主能力子集。例如，Cosh 收到 `deny` 后先归一化为 `block`，但 Cosh 不支持 direct block，因此该环境变量最终不生效，并回到固定 `ask` 行为。
 
 `warn` 不属于 Code Scanner 可配置 MODE。`warn`、非法值和宿主不支持的值都等价于没有设置 `CODE_SCANNER_MODE`。配置错配诊断不得进入 stdout、systemMessage 或其他 HookOutput；独立脚本写 stderr，Hermes/OpenClaw capability 写宿主 logger。
 
@@ -52,7 +52,7 @@
 | Codex | 支持 | `observe/block` | 支持，默认 10 秒 |
 | Cosh | 支持 | 仅 `ask` 生效 | 不支持，固定 10 秒 |
 | Hermes | 支持 | `observe/block` | 不支持，使用 capability `timeout` |
-| OpenClaw | 支持 | `observe/ask` | 不支持，固定 10 秒 |
+| OpenClaw | 支持 | `observe/ask/block` | 不支持，固定 10 秒 |
 
 ### 4.1 `CODE_SCANNER_HOOK_ENABLED`
 
@@ -75,7 +75,7 @@ Qoder、Qwen Code、Codex 和 Cosh 未设置时默认启用。Hermes 和 OpenCla
 | Codex | 合法 `observe/block` env > 默认 `observe` |
 | Cosh | 仅 `ask` 有效；其他值回到固定 `ask` |
 | Hermes | 合法 `observe/block` env > `enable_block` > 默认 `observe` |
-| OpenClaw | 合法 `observe/ask` env > `codeScanRequireApproval` > 默认 `observe` |
+| OpenClaw | 合法 `observe/ask/block` env > `codeScanRequireApproval` > 默认 `observe` |
 
 ### 4.3 `CODE_SCANNER_TIMEOUT`
 
@@ -148,7 +148,7 @@ OpenClaw 保留以下配置：
 - `codeScanRequireApproval=false`：observe。
 - `codeScanRequireApproval=true`：ask，返回 `requireApproval`。
 
-合法 `CODE_SCANNER_HOOK_ENABLED` 可覆盖 `enabled`，合法 `CODE_SCANNER_MODE=observe|ask` 可覆盖 `codeScanRequireApproval`。`block`、其别名 `deny`、`warn` 和非法值等价于未设置，并回到 OpenClaw 配置。普通 findings 不得返回 `{block: true}`。
+合法 `CODE_SCANNER_HOOK_ENABLED` 可覆盖 `enabled`，合法 `CODE_SCANNER_MODE=observe|ask|block` 可覆盖 `codeScanRequireApproval`。`ask` 返回 `requireApproval`，`block` 及其别名 `deny` 返回 OpenClaw 既有 `{ block: true, blockReason }`。`warn` 和非法值等价于未设置，并回到 OpenClaw 配置。
 
 ## 6. Scanner Verdict 到 Hook 行为
 
@@ -170,7 +170,7 @@ Hermes 和 OpenClaw 已有专属 self-protect finding：
 - Hermes：`shell-self-protect-hermes`
 - OpenClaw：`shell-self-protect-openclaw`
 
-命中时无视 MODE，继续使用现有强制 block 返回。OpenClaw 的 self-protect block 不表示普通 findings 支持 `block` MODE。设置 `CODE_SCANNER_HOOK_ENABLED=false` 后整个 hook 不执行，因此也不会运行 self-protect 检查。
+命中时无视 MODE，继续使用现有强制 block 返回。设置 `CODE_SCANNER_HOOK_ENABLED=false` 后整个 hook 不执行，因此也不会运行 self-protect 检查。
 
 Qoder、Qwen Code 和 Cosh 没有 Code Scanner 专属 self-protect 分支。Codex 的 self-protect 分支当前保持禁用，因为 CLI 尚无 Codex 专属规则，不能误匹配其他 Agent 的规则。
 

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -325,7 +325,7 @@ Set `codeScanRequireApproval: true` to enable approval mode, which pops a confir
 openclaw config set plugins.entries.agent-sec.config.codeScanRequireApproval true
 ```
 
-`CODE_SCANNER_HOOK_ENABLED=true|false` overrides `capabilities["scan-code"].enabled`, and `CODE_SCANNER_MODE=observe|ask` overrides `codeScanRequireApproval`. `debug` aliases `observe`; unsupported `block`/`deny`, `warn`, and invalid values are treated as unset, emit a bounded host-logger diagnostic, and use the original plugin configuration. Ordinary findings never gain a direct-block response; the existing self-protect finding remains the only forced-block exception. OpenClaw keeps its fixed 10-second timeout and does not read `CODE_SCANNER_TIMEOUT`.
+`CODE_SCANNER_HOOK_ENABLED=true|false` overrides `capabilities["scan-code"].enabled`, and `CODE_SCANNER_MODE=observe|ask|block` overrides `codeScanRequireApproval`. `debug` aliases `observe`; `deny` aliases `block`. `ask` returns `requireApproval` for scanner `warn` / `deny` verdicts, while `block` returns OpenClaw's existing `{ block: true, blockReason }` response for those ordinary findings. `warn` and invalid values are treated as unset, emit a bounded host-logger diagnostic, and use the original plugin configuration. The existing self-protect finding remains a forced-block exception regardless of mode. OpenClaw keeps its fixed 10-second timeout and does not read `CODE_SCANNER_TIMEOUT`.
 
 ### Configuring `pii-scan-user-input`
 

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/code-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/code-scan.ts
@@ -18,13 +18,12 @@ export const codeScan: SecurityCapability = {
     const rawPolicy = process.env.CODE_SCANNER_MODE;
     const configuredPolicy = normalizeHookPolicy(rawPolicy, fallbackPolicy);
     const policy =
-      configuredPolicy === "observe" || configuredPolicy === "ask"
+      configuredPolicy === "observe" || configuredPolicy === "ask" || configuredPolicy === "block"
         ? configuredPolicy
         : fallbackPolicy;
     if (
       rawPolicy !== undefined &&
-      (!isHookPolicyValue(rawPolicy) ||
-        (configuredPolicy !== "observe" && configuredPolicy !== "ask"))
+      (!isHookPolicyValue(rawPolicy) || configuredPolicy === "warn")
     ) {
       api.logger.warn(
         `[scan-code] invalid or unsupported CODE_SCANNER_MODE=${JSON.stringify(rawPolicy.slice(0, 32))}; using ${policy}`,
@@ -77,8 +76,11 @@ export const codeScan: SecurityCapability = {
 
         if (verdict === "deny") {
           api.logger.warn(
-            `[scan-code] DENY (requireApproval=${policy === "ask" ? "true" : "false"}) — ${msg}`,
+            `[scan-code] DENY (policy=${policy}) — ${msg}`,
           );
+          if (policy === "block") {
+            return { block: true, blockReason: msg };
+          }
           if (policy === "ask") {
             return {
               requireApproval: {
@@ -93,6 +95,9 @@ export const codeScan: SecurityCapability = {
 
         if (verdict === "warn") {
           api.logger.warn(`[scan-code] WARN (policy=${policy}) — ${msg}`);
+          if (policy === "block") {
+            return { block: true, blockReason: msg };
+          }
           if (policy === "ask") {
             return {
               requireApproval: {

--- a/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/gateway-probes.mjs
+++ b/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/gateway-probes.mjs
@@ -487,6 +487,7 @@ async function runCodeApprovalPolicyCase({
   });
 
   {
+    const expectedPolicy = codeScanRequireApproval ? "ask" : "observe";
     const approvalPolls = [];
     const cliCallStart = await countJsonLines(cliLogPath);
     const modelRequestStart = mockModel.requests.length;
@@ -516,7 +517,7 @@ async function runCodeApprovalPolicyCase({
         await waitForGatewayLogSignals(gatewayLogPaths, DEFAULT_GATEWAY_TURN_TIMEOUT_MS, {
           scanCodeDeny: {
             command: POLICY_CODE_DENY_COMMAND,
-            requireApproval: codeScanRequireApproval,
+            policy: expectedPolicy,
           },
         })
       ).scanCodeDeny;
@@ -574,7 +575,7 @@ async function runCodeApprovalPolicyCase({
         await waitForGatewayLogSignals(gatewayLogPaths, 15_000, {
           scanCodeDeny: {
             command: POLICY_CODE_DENY_COMMAND,
-            requireApproval: codeScanRequireApproval,
+            policy: expectedPolicy,
           },
         })
       ).scanCodeDeny;
@@ -1164,9 +1165,9 @@ async function waitForGatewayLogSignals(logPaths, timeoutMs, expected = {}) {
       codeScanPass: /\[scan-code\].*pass/u.test(text),
     };
     if (expected.scanCodeDeny) {
-      const { command, requireApproval } = expected.scanCodeDeny;
+      const { command, policy } = expected.scanCodeDeny;
       if (
-        text.includes(`[scan-code] DENY (requireApproval=${requireApproval ? "true" : "false"})`) &&
+        text.includes(`[scan-code] DENY (policy=${policy})`) &&
         text.includes(`Command: ${command}`)
       ) {
         return {
@@ -1174,7 +1175,7 @@ async function waitForGatewayLogSignals(logPaths, timeoutMs, expected = {}) {
           scanCodeDeny: {
             observedAt: new Date().toISOString(),
             verdict: "deny",
-            requireApproval,
+            policy,
             command,
             logFiles: logPaths,
           },
@@ -1188,9 +1189,9 @@ async function waitForGatewayLogSignals(logPaths, timeoutMs, expected = {}) {
   }
   text = (await Promise.all(logPaths.map((file) => readTextIfExists(file)))).join("\n");
   if (expected.scanCodeDeny) {
-    const { command, requireApproval } = expected.scanCodeDeny;
+    const { command, policy } = expected.scanCodeDeny;
     throw new Error(
-      `gateway logs did not contain scan-code DENY requireApproval=${requireApproval} command=${JSON.stringify(command)}; files=${logPaths.join(", ")} tail=${text.slice(-2000)}`,
+      `gateway logs did not contain scan-code DENY policy=${policy} command=${JSON.stringify(command)}; files=${logPaths.join(", ")} tail=${text.slice(-2000)}`,
     );
   }
   throw new Error(

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/code-scan-test.ts
@@ -351,22 +351,39 @@ describe("scan-code", () => {
       assert.equal(result, undefined);
     });
 
-    it("unsupported block and deny modes use the original config fallback", async () => {
-      for (const mode of ["block", "deny"]) {
-        process.env.CODE_SCANNER_MODE = mode;
-        const { handler, logs } = registerAndGetHandler({ codeScanRequireApproval: true });
-        mockCli({
-          exitCode: 0,
-          stdout: '{"verdict":"deny","findings":[{"desc_zh":"危险"}]}',
-          stderr: "",
-        });
+    it("CODE_SCANNER_MODE=block overrides approval config and blocks warn findings", async () => {
+      process.env.CODE_SCANNER_MODE = "block";
+      const { handler, logs } = registerAndGetHandler({ codeScanRequireApproval: true });
+      mockCli({
+        exitCode: 0,
+        stdout: '{"verdict":"warn","findings":[{"desc_zh":"注意"}]}',
+        stderr: "",
+      });
 
-        const result = await handler(execEvent("risky-cmd"), {});
+      const result = await handler(execEvent("risky-cmd"), {});
 
-        assert.ok(result.requireApproval);
-        assert.equal(result.block, undefined);
-        assert.ok(logs.some((log) => log.includes("CODE_SCANNER_MODE") && log.includes(mode)));
-      }
+      assert.equal(result.block, true);
+      assert.equal(result.requireApproval, undefined);
+      assert.ok(result.blockReason.includes("[code-scanner] Detected 1 issue(s):"));
+      assert.ok(result.blockReason.includes("- 注意"));
+      assert.equal(logs.some((log) => log.includes("CODE_SCANNER_MODE")), false);
+    });
+
+    it("CODE_SCANNER_MODE=deny aliases block and blocks deny findings", async () => {
+      process.env.CODE_SCANNER_MODE = "deny";
+      const { handler, logs } = registerAndGetHandler({ codeScanRequireApproval: false });
+      mockCli({
+        exitCode: 0,
+        stdout: '{"verdict":"deny","findings":[{"desc_zh":"危险"}]}',
+        stderr: "",
+      });
+
+      const result = await handler(execEvent("risky-cmd"), {});
+
+      assert.equal(result.block, true);
+      assert.equal(result.requireApproval, undefined);
+      assert.ok(result.blockReason.includes("- 危险"));
+      assert.equal(logs.some((log) => log.includes("CODE_SCANNER_MODE")), false);
     });
 
     it("debug alias selects the existing observe interaction", async () => {


### PR DESCRIPTION
## Why

Code Scanner hook 在各 Agent 插件上应统一支持 observe/ask/block 三种交互模式，但此前 OpenClaw 的 code-scan capability 只实现了 observe/ask，导致 `CODE_SCANNER_MODE=block`（或其别名 `deny`）在 OpenClaw 上无法真正拦截高风险命令，与同一 hook 点上 PII checker 已支持的 block 模式不一致。

## What changed

- `code-scan.ts`：policy 归一化新增 `block` 分支；deny/warn verdict 在 `policy === "block"` 时返回 `{ block: true, blockReason }`，实现真正拦截。
- `code-scan-test.ts`：新增两个测试用例，验证 `CODE_SCANNER_MODE=block` 与其 `deny` 别名均能覆盖 approval 配置并拦截 deny/warn 结果。
- 同步更新 `openclaw-plugin/README.md`、`src/agent-sec-core/docs/design/CODE_SCANNER_HOOKS_zh.md` 以及 4 篇用户指南文档（en/zh 的 `code-scanner.md`、`openclaw-deploy.md`），将 OpenClaw 的 MODE 能力表格从 `observe,ask` 更新为 `observe,ask,block`。

## Related issue

no-issue: 内部能力补齐，无关联 issue

## User / Agent impact

OpenClaw 用户现在可以将 `CODE_SCANNER_MODE` 设为 `block`（或 `deny`），使 Code Scanner 命中 deny/warn 结果时直接拦截命令执行，而不再局限于 observe 记录或 ask 人工确认；未显式设置时行为保持不变。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

新增的 `block` 是原有 `CODE_SCANNER_MODE` 配置项的新增取值，默认行为（未配置时）不变；仅当用户主动设置为 `block`/`deny` 时才启用新的拦截语义。

## Validation

- `npm test`（`src/agent-sec-core/openclaw-plugin`）— 147 pass, 0 fail
- CodeReview subagent — 已完成，无高置信度问题

## Documentation and rollback

已同步更新 `openclaw-plugin/README.md`、`CODE_SCANNER_HOOKS_zh.md` 及 4 篇用户指南文档；如需回滚，仅需 revert `code-scan.ts` 中 `block` 分支及对应文档改动即可，不影响 observe/ask 已有行为。