### PR TITLE
fix(cosh-ng): [core] recover context budget

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/configuration.md
@@ -124,10 +124,13 @@ ignored, leaving whatever the configuration files already resolved.
 
 ## Session Compaction
 
-Compaction keeps the persisted transcript complete and replaces only the
-model-visible prefix with a summary projection. The automatic and emergency
-paths retain recent runs according to `preserve_recent_runs`; an explicit
-`/session compact` may summarize the latest complete run.
+Long sessions eventually fill the model window with earlier replies and tool
+output. Compaction leaves the persisted transcript intact and replaces only an
+older, model-visible prefix with a summary. Normal automatic compaction keeps
+the number of recent runs set by `preserve_recent_runs`. Under emergency
+pressure, Core first uses that setting. When the safe boundary cannot reclaim
+enough space, it next protects one completed run and finally allows the latest
+completed run to be summarized. The active run always stays verbatim.
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
@@ -137,13 +140,32 @@ paths retain recent runs according to `preserve_recent_runs`; an explicit
 | `session.compaction.trigger_ratio` | `0.70` | Fraction of usable history that triggers automatic compaction |
 | `session.compaction.emergency_ratio` | `0.90` | Fraction that arms in-run emergency protection |
 | `session.compaction.target_ratio` | `0.30` | Best-effort retained-history target after compaction |
-| `session.compaction.preserve_recent_runs` | `2` | Complete recent runs kept verbatim by automatic and emergency compaction |
+| `session.compaction.preserve_recent_runs` | `2` | Complete recent runs kept verbatim during normal automatic compaction; emergency protection can retry with one and then with none reserved unconditionally |
 | `session.compaction.model_context_window` | model-derived | Explicit model context-window override |
-| `session.compaction.model_max_output_tokens` | model-derived | Explicit maximum-output reserve override |
+| `session.compaction.model_max_output_tokens` | see below | Explicit maximum model output size; sets both the reserved output budget and the `max_tokens` cap on the real provider request |
 
 Ratios must satisfy `target_ratio <= trigger_ratio <= emergency_ratio`.
-Invalid ratio groups fall back to the compiled defaults. See
-[Session Compaction](shell/session-compaction.md) for commands, safety
+Invalid ratio groups fall back to the compiled defaults.
+
+### Default output budget
+
+The reply budget does two jobs. Core subtracts it from the context window before
+pricing conversation history, and sends the same value to the provider as the
+`max_tokens` cap. The request limit therefore stays inside the output space
+already reserved for it. When `model_max_output_tokens` is unset, Core chooses
+the following default.
+
+| Case | Default |
+|------|---------|
+| Known model family | `min(model output capability, 16384)` |
+| Unknown model | `4096` |
+
+Core also limits the chosen value to half of the resolved context window. An
+explicit `model_max_output_tokens` replaces the table default but keeps this
+half-window limit. Raising it permits a longer reply and leaves less room for
+history. Lowering it gives history more room and shortens the longest reply.
+
+See [Session Compaction](shell/session-compaction.md) for commands, safety
 guarantees, and manual-versus-automatic behavior.
 
 ## MCP Servers

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-compaction.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/session-compaction.md
@@ -8,7 +8,7 @@ whose command output and Agent exchanges accumulate substantial context.
 
 ## Compact a Session Manually
 
-Run this command at the shell prompt:
+Run this command at the shell prompt.
 
 ```text
 /session compact
@@ -23,7 +23,7 @@ boundary when that already meets the target, but it may summarize through the
 latest completed run when necessary. It never includes an incomplete user
 turn or unfinished tool exchange in the summarized prefix.
 
-Use these commands while the job is active:
+Use these commands while the job is active.
 
 ```text
 /session compact status
@@ -46,9 +46,12 @@ Core waits for another complete run instead of starting a background job that
 would fail with `nothing_to_compact`.
 
 At 90% of the usable window, Core runs synchronous protection before the next
-provider request. It compacts only when a safe completed Agent-run prefix is
-available; otherwise it returns a typed context-limit error instead of sending
-an oversized request.
+provider request. It starts with the configured recent-run protection. If the
+safe boundary cannot reclaim enough space, Core retries with one completed run
+protected and then with the same boundary used by manual compaction. The active
+run remains verbatim throughout. A failed compaction attempt or an exhausted
+set of safe boundaries returns a typed context-limit error before Core sends an
+oversized request.
 
 ## Data and Safety Guarantees
 
@@ -83,6 +86,15 @@ preserve_recent_runs = 2
 # model_max_output_tokens = 8192
 ```
 
-`preserve_recent_runs` applies to automatic and emergency compaction, not to
-an explicit `/session compact`. See [Configuration](../configuration.md) for
-the complete setting reference.
+`preserve_recent_runs` controls normal automatic compaction. Emergency
+protection starts with the same value, then follows the fallback sequence
+described above. An explicit `/session compact` starts at the final policy and
+may summarize the latest completed run. None of these paths summarizes the
+active run.
+
+`model_max_output_tokens` is both the reply space reserved from the model window
+and the `max_tokens` cap sent to the provider. When it is unset, a known model
+uses `min(model output capability, 16384)` and an unknown model uses `4096`.
+Core limits either value to half of the resolved context window. Lowering the
+setting leaves more room for history and also shortens the longest reply. See
+[Configuration](../configuration.md) for the complete setting reference.

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/configuration.md
@@ -117,9 +117,11 @@ provider 对话中启动新的 Agent 请求，并获得同等的配置预算；�
 
 ## 会话压缩
 
-压缩会保留完整的持久化 transcript，只用摘要 projection 替换模型可见前缀。
-自动和 emergency 路径会按 `preserve_recent_runs` 保留最近 run；显式执行
-`/session compact` 时可以摘要最新的完整 run。
+会话跑久以后，早先的回复和工具输出会逐渐占满模型窗口。压缩不会删除持久化的完整
+transcript，它只把模型可见的较早前缀换成摘要。常规自动压缩会原样保留
+`preserve_recent_runs` 指定的最近 run。遇到 emergency 压力时，Core 先按这个配置
+尝试。当前安全边界腾出的空间仍然不够，它才会改为保留一个已完成 run，最后允许
+摘要最新的已完成 run。进行中的 run 始终原样保留。
 
 | 配置项 | 默认值 | 作用 |
 |--------|--------|------|
@@ -129,12 +131,31 @@ provider 对话中启动新的 Agent 请求，并获得同等的配置预算；�
 | `session.compaction.trigger_ratio` | `0.70` | 触发自动压缩的可用历史比例 |
 | `session.compaction.emergency_ratio` | `0.90` | 启用 run 内 emergency 保护的比例 |
 | `session.compaction.target_ratio` | `0.30` | 压缩后保留历史的尽力目标 |
-| `session.compaction.preserve_recent_runs` | `2` | 自动和 emergency 压缩原样保留的最近完整 run 数 |
+| `session.compaction.preserve_recent_runs` | `2` | 常规自动压缩原样保留的最近完整 run 数；emergency 保护可依次改为保留一个和不再无条件保留完整 run |
 | `session.compaction.model_context_window` | 根据模型确定 | 显式覆盖模型上下文窗口 |
-| `session.compaction.model_max_output_tokens` | 根据模型确定 | 显式覆盖最大输出预留 |
+| `session.compaction.model_max_output_tokens` | 见下文 | 显式覆盖模型最大输出规模；同时决定预留的输出预算和真实 provider 请求的 `max_tokens` 上限 |
 
 比例必须满足 `target_ratio <= trigger_ratio <= emergency_ratio`。非法比例组合会
-回退到编译时默认值。命令、安全保证以及手动与自动行为差异详见
+回退到编译时默认值。
+
+### 默认输出预算
+
+回复预算有两个用途。Core 会先从上下文窗口中扣掉这部分空间，再计算可用于会话历史
+的额度；它也会把同一个值作为 provider 请求的 `max_tokens` 上限。这样，请求上限
+不会超过已经预留的输出空间。未设置 `model_max_output_tokens` 时，Core 使用下表中的
+默认值。
+
+| 情况 | 默认值 |
+|------|--------|
+| 已知模型系列 | `min(模型输出能力, 16384)` |
+| 未知模型 | `4096` |
+
+Core 还会把选出的值限制在已解析上下文窗口的一半以内。显式设置
+`model_max_output_tokens` 会替换表中的默认值，但仍受这个半窗口上限约束。调高后，
+模型可以回复得更长，留给历史的空间会减少。调低后，历史空间会增加，单次回复的
+最长长度也会随之缩短。
+
+命令、安全保证以及手动与自动行为差异详见
 [会话压缩](shell/session-compaction.md)。
 
 ## MCP Server

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-compaction.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/session-compaction.md
@@ -7,7 +7,7 @@
 
 ## 手动压缩会话
 
-在 Shell 提示符中执行：
+在 Shell 提示符中执行下面的命令。
 
 ```text
 /session compact
@@ -20,7 +20,7 @@
 边界，必要时也可以摘要到最新已完成 run。未完成的用户轮次或 tool exchange
 不会进入摘要前缀。
 
-任务运行期间可使用：
+任务运行期间可以使用下面的命令。
 
 ```text
 /session compact status
@@ -38,9 +38,11 @@ Agent run，因此首次自动压缩通常至少需要三个完整 run。
 仅超过阈值还不够。如果不存在新的安全前缀，Core 会等待下一个完整 run，而不会
 启动一个最终以 `nothing_to_compact` 失败的后台任务。
 
-达到可用窗口的 90% 时，Core 会在下一次 provider 请求前同步执行保护。只有存在
-安全的已完成 Agent run 前缀时才会压缩；否则会返回类型化的上下文上限错误，而
-不会发送超出窗口的请求。
+达到可用窗口的 90% 时，Core 会在下一次 provider 请求前同步执行保护。它先按配置
+保留最近 run。当前安全边界腾出的空间仍然不够，Core 会改为只保留一个已完成 run，
+再尝试手动压缩使用的安全边界。整个过程中，进行中的 run 都会原样保留。压缩调用
+失败或所有安全边界都无法腾出足够空间时，Core 会在发送超大请求前返回类型化的
+上下文上限错误。
 
 ## 数据与安全保证
 
@@ -66,11 +68,18 @@ emergency_ratio = 0.90
 target_ratio = 0.30
 preserve_recent_runs = 2
 
-# 可选的模型级覆盖：
+# 可选的模型级覆盖
 # auto_compact_token_limit = 89600
 # model_context_window = 128000
 # model_max_output_tokens = 8192
 ```
 
-`preserve_recent_runs` 只作用于自动和 Emergency 压缩，不限制显式
-`/session compact`。完整配置参考见[配置](../configuration.md)。
+`preserve_recent_runs` 控制常规自动压缩。Emergency 保护先使用同一个值，再按上文的
+顺序逐步放宽保留范围。显式 `/session compact` 直接使用最后一级策略，可以摘要最新
+的已完成 run。这些路径都不会摘要进行中的 run。
+
+`model_max_output_tokens` 既是从模型窗口中预留的回复空间，也是发给 provider 的
+`max_tokens` 上限。未设置时，已知模型系列取
+`min(模型输出能力, 16384)`，未知模型取 `4096`。Core 会把这两个值都限制在已解析
+上下文窗口的一半以内。调低该配置会给历史留出更多空间，也会缩短单次回复的最长
+长度。完整配置参考见[配置](../configuration.md)。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -86,9 +86,13 @@ shell; `/session clear ...` removes old entries after confirmation.
 `/session compact` summarizes any complete conversation prefix in the
 background, including a single completed Agent run, while the full transcript
 remains stored. Automatic compaction waits for both model-window pressure and
-a safe older-run boundary. Session recovery restores model-visible
-conversation context; historical terminal evidence is intentionally not
-restored. Records default to
+a safe older-run boundary. Core uses the same value for the reply space it
+reserves and the request's `max_tokens` cap. Without an override, a known model
+uses `min(model capability, 16384)` and an unknown model uses `4096`, with both
+limited to half the context window. Set
+`session.compaction.model_max_output_tokens` when a different reply allowance
+is needed. Session recovery restores model-visible conversation context;
+historical terminal evidence is intentionally not restored. Records default to
 `~/.copilot-shell/cosh-core/sessions/`; change the root with
 `session.persist_dir`. Project session settings and relative store paths are
 resolved from the workspace cosh-shell sends to Core. See the

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -83,7 +83,11 @@ ID、`/session list --all` 列出同一存储根下所有工作空间的会话�
 而无需重启 Shell；`/session clear ...` 会在确认后清理旧记录。会话恢复会还原
 模型可见的对话上下文，但不会伪装成已恢复历史终端证据。`/session compact`
 会在后台摘要任意完整对话前缀，包括仅有一个已完成 Agent run 的会话，同时保留
-完整 transcript。自动压缩则同时等待模型窗口压力和安全的旧 run 边界。记录默认保存在
+完整 transcript。自动压缩则同时等待模型窗口压力和安全的旧 run 边界。从模型窗口中
+预留的回复空间与请求发送的 `max_tokens` 上限使用同一个值。未设置覆盖值时，已知
+模型取 `min(模型能力, 16384)`，未知模型取 `4096`，两者都限制在上下文窗口的一半
+以内。需要调整单次回复额度时，可以设置
+`session.compaction.model_max_output_tokens`。记录默认保存在
 `~/.copilot-shell/cosh-core/sessions/`，可通过 `session.persist_dir` 修改
 根目录。项目会话配置和相对存储路径均从 cosh-shell 传给 Core 的工作空间解析。
 详见

--- a/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/boundary.rs
@@ -178,6 +178,22 @@ fn transcript_ends_with_complete_agent_run(messages: &[Message], run: RunSpan) -
         })
 }
 
+/// Reports whether the transcript's last Agent run is still in flight.
+///
+/// An exhausted emergency ladder means different things depending on this: with
+/// an active run the uncompactable remainder *is* that run, while without one
+/// every run is complete and already covered by the projection. A malformed
+/// transcript reports no active run; its real failure surfaces through the
+/// selection path as a [`BoundaryError`].
+pub(crate) fn has_active_run(messages: &[Message]) -> bool {
+    match group_agent_runs(messages) {
+        Ok(runs) => runs
+            .last()
+            .is_some_and(|run| !transcript_ends_with_complete_agent_run(messages, *run)),
+        Err(_) => false,
+    }
+}
+
 /// Reports whether automatic compaction can advance beyond the active
 /// projection while preserving the configured number of recent runs.
 ///
@@ -198,34 +214,62 @@ pub(crate) fn has_new_compactable_prefix(
         .is_some_and(|index| runs[index].start > compacted_through))
 }
 
-/// Selects the compaction cut for a transcript, or `None` when no safe cut
-/// frees at least one complete Agent run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// How much trailing verbatim history a compaction attempt must keep.
 ///
-/// At least `preserve_recent_runs` trailing runs are kept verbatim. Within
-/// that constraint the cut preserving the most history whose retained suffix
-/// still fits `target_tokens` wins; when nothing fits, semantic integrity
-/// wins and exactly `preserve_recent_runs` runs are preserved.
+/// This is the only difference between the manual, automatic, and emergency
+/// paths: all three select their cut through
+/// [`select_compacted_through_after`], so the boundary arithmetic and the
+/// safety invariants cannot drift between triggers.
 ///
-/// # Errors
-///
-/// Propagates [`BoundaryError`] so malformed transcripts are never compacted.
-pub(crate) fn select_compacted_through(
-    messages: &[Message],
-    preserve_recent_runs: usize,
-    target_tokens: u64,
-) -> Result<Option<usize>, BoundaryError> {
-    select_compacted_through_after(messages, preserve_recent_runs, target_tokens, 0)
+/// Neither variant may cut the active (incomplete) Agent run, and neither may
+/// split a tool-call/tool-result exchange.
+pub(crate) enum PreservationPolicy {
+    /// Keep at least this many trailing complete Agent runs verbatim.
+    ///
+    /// Values below one are raised to one: normal automatic compaction never
+    /// summarizes away the run the model is still reasoning about.
+    RecentRuns(usize),
+    /// Keep no complete run unconditionally; the latest *completed* run may be
+    /// summarized.
+    ///
+    /// Used by explicit manual compaction and as the last emergency fallback
+    /// before failing closed.
+    ThroughLatestCompletedRun,
 }
 
-/// Selects a safe cut strictly after an already compacted transcript prefix.
+/// Selects a safe cut under `policy`, strictly after an already compacted
+/// transcript prefix, or `None` when no safe cut frees a complete Agent run.
 ///
-/// This prevents a later compaction from selecting the active projection's
-/// boundary merely because its retained suffix still fits the target.
+/// Requiring a cut past `compacted_through` prevents a later compaction from
+/// re-selecting the active projection's boundary merely because its retained
+/// suffix still fits the target.
 ///
 /// # Errors
 ///
 /// Propagates [`BoundaryError`] so malformed transcripts are never compacted.
 pub(crate) fn select_compacted_through_after(
+    messages: &[Message],
+    policy: PreservationPolicy,
+    target_tokens: u64,
+    compacted_through: usize,
+) -> Result<Option<usize>, BoundaryError> {
+    match policy {
+        PreservationPolicy::RecentRuns(runs) => {
+            select_preserving_recent_runs(messages, runs, target_tokens, compacted_through)
+        }
+        PreservationPolicy::ThroughLatestCompletedRun => {
+            select_through_latest_completed_run(messages, target_tokens, compacted_through)
+        }
+    }
+}
+
+/// Selects a cut that keeps at least `preserve_recent_runs` trailing runs.
+///
+/// Within that constraint the cut preserving the most history whose retained
+/// suffix still fits `target_tokens` wins; when nothing fits, semantic
+/// integrity wins and exactly `preserve_recent_runs` runs are preserved.
+fn select_preserving_recent_runs(
     messages: &[Message],
     preserve_recent_runs: usize,
     target_tokens: u64,
@@ -244,18 +288,14 @@ pub(crate) fn select_compacted_through_after(
     Ok(choose_target_cut(messages, candidates, target_tokens))
 }
 
-/// Selects a manual compaction cut, including the transcript end when the
-/// latest Agent run is complete.
+/// Selects a cut that may reach the end of the latest *completed* Agent run,
+/// including the transcript end when the transcript has no active run.
 ///
-/// Manual compaction is an explicit request, so it does not reserve recent
-/// runs unconditionally. It still preserves as much verbatim history as the
-/// target permits and only summarizes the latest run when no earlier cut can
-/// satisfy the request.
-///
-/// # Errors
-///
-/// Propagates [`BoundaryError`] so malformed transcripts are never compacted.
-pub(crate) fn select_manual_compacted_through_after(
+/// No recent run is reserved unconditionally. As much verbatim history as the
+/// target permits is still preserved, and the latest completed run is only
+/// summarized when no earlier cut satisfies the target. An incomplete trailing
+/// run stops candidate generation, so the active run is never cut.
+fn select_through_latest_completed_run(
     messages: &[Message],
     target_tokens: u64,
     compacted_through: usize,
@@ -307,6 +347,34 @@ mod tests {
         ]
     }
 
+    /// Selects from the transcript start while preserving recent runs.
+    fn select_preserving(
+        messages: &[Message],
+        preserve_recent_runs: usize,
+        target_tokens: u64,
+    ) -> Result<Option<usize>, BoundaryError> {
+        select_compacted_through_after(
+            messages,
+            PreservationPolicy::RecentRuns(preserve_recent_runs),
+            target_tokens,
+            0,
+        )
+    }
+
+    /// Selects from the transcript start with no unconditionally reserved run.
+    fn select_latest_completed(
+        messages: &[Message],
+        target_tokens: u64,
+        compacted_through: usize,
+    ) -> Result<Option<usize>, BoundaryError> {
+        select_compacted_through_after(
+            messages,
+            PreservationPolicy::ThroughLatestCompletedRun,
+            target_tokens,
+            compacted_through,
+        )
+    }
+
     #[test]
     fn groups_simple_runs() {
         let mut messages = run_with_tools("first", "call-1");
@@ -337,7 +405,13 @@ mod tests {
         let runs = group_agent_runs(&messages).unwrap();
 
         assert_eq!(
-            select_compacted_through_after(&messages, 1, u64::MAX, runs[1].start).unwrap(),
+            select_compacted_through_after(
+                &messages,
+                PreservationPolicy::RecentRuns(1),
+                u64::MAX,
+                runs[1].start,
+            )
+            .unwrap(),
             Some(runs[2].start)
         );
     }
@@ -347,7 +421,7 @@ mod tests {
         let messages = run_with_tools("first", "call-1");
 
         assert_eq!(
-            select_manual_compacted_through_after(&messages, u64::MAX, 0).unwrap(),
+            select_latest_completed(&messages, u64::MAX, 0).unwrap(),
             Some(messages.len())
         );
     }
@@ -356,7 +430,7 @@ mod tests {
     fn manual_selection_only_cuts_complete_run_prefixes() {
         let user_only = vec![Message::user("unfinished")];
         assert_eq!(
-            select_manual_compacted_through_after(&user_only, u64::MAX, 0).unwrap(),
+            select_latest_completed(&user_only, u64::MAX, 0).unwrap(),
             None
         );
 
@@ -366,7 +440,7 @@ mod tests {
             Message::tool_result("call-1", "output", false),
         ];
         assert_eq!(
-            select_manual_compacted_through_after(&tool_tail, u64::MAX, 0).unwrap(),
+            select_latest_completed(&tool_tail, u64::MAX, 0).unwrap(),
             None
         );
 
@@ -374,7 +448,7 @@ mod tests {
         let first_run_end = older_complete.len();
         older_complete.push(Message::user("unfinished second run"));
         assert_eq!(
-            select_manual_compacted_through_after(&older_complete, u64::MAX, 0).unwrap(),
+            select_latest_completed(&older_complete, u64::MAX, 0).unwrap(),
             Some(first_run_end)
         );
     }
@@ -422,7 +496,7 @@ mod tests {
             group_agent_runs(&messages),
             Err(BoundaryError::MissingToolResults { index: 2 })
         );
-        assert!(select_compacted_through(&messages, 1, 0).is_err());
+        assert!(select_preserving(&messages, 1, 0).is_err());
     }
 
     #[test]
@@ -462,7 +536,7 @@ mod tests {
         for run in 0..5 {
             messages.extend(run_with_tools(&format!("prompt {run}"), &format!("c{run}")));
         }
-        let cut = select_compacted_through(&messages, 2, 0)
+        let cut = select_preserving(&messages, 2, 0)
             .expect("valid transcript")
             .expect("cut selected");
         // Five runs of four messages: preserving 2 runs cuts at index 12.
@@ -475,7 +549,7 @@ mod tests {
         for run in 0..5 {
             messages.extend(run_with_tools(&format!("prompt {run}"), &format!("c{run}")));
         }
-        let cut = select_compacted_through(&messages, 2, u64::MAX)
+        let cut = select_preserving(&messages, 2, u64::MAX)
             .expect("valid transcript")
             .expect("cut selected");
         // A huge budget keeps everything except the first run.
@@ -486,7 +560,7 @@ mod tests {
     fn refuses_to_cut_when_too_few_runs() {
         let messages = run_with_tools("only", "call-1");
         assert_eq!(
-            select_compacted_through(&messages, 2, 0).expect("valid transcript"),
+            select_preserving(&messages, 2, 0).expect("valid transcript"),
             None
         );
     }
@@ -498,7 +572,7 @@ mod tests {
             Message::tool_result("orphan", "x", false),
             Message::user("again"),
         ];
-        assert!(select_compacted_through(&messages, 1, 0).is_err());
+        assert!(select_preserving(&messages, 1, 0).is_err());
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/compaction/budget.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/budget.rs
@@ -17,8 +17,18 @@ use super::projection::{TokenMeasurement, TokenMeasurementSource};
 
 /// Conservative window applied when nothing better is known.
 const FALLBACK_CONTEXT_WINDOW: u64 = 32_768;
-/// Output reserve applied when neither user nor profile supplies one.
-const FALLBACK_MAX_OUTPUT_TOKENS: u64 = 8_192;
+/// Ceiling applied to a known model's hard output capability when deriving the
+/// default per-request output budget.
+///
+/// A documented maximum output is a *capability*, not a per-turn expectation.
+/// Charging the full capability to every request permanently donates that much
+/// window to output: a 131 072-token window with a 65 536-token capability
+/// keeps only ~40% of the window for history. Ordinary agent turns stay far
+/// below this ceiling, so the default budget caps the capability here and only
+/// an explicit user override may raise it.
+const DEFAULT_OUTPUT_BUDGET: u64 = 16_384;
+/// Per-request output budget for a model with no known output capability.
+const UNKNOWN_MODEL_OUTPUT_BUDGET: u64 = 4_096;
 /// Default agent session token limit; a differing value is user-explicit.
 const DEFAULT_SESSION_TOKEN_LIMIT: u64 = 128_000;
 /// Smallest burst reserve regardless of window size.
@@ -60,8 +70,18 @@ impl CapabilitySource {
 pub struct ModelCapability {
     /// Total model context window in tokens.
     pub context_window: u64,
-    /// Maximum output tokens reserved for one response.
-    pub max_output_tokens: u64,
+    /// Hard output ceiling the model family accepts, in tokens; `None` when the
+    /// model is unrecognized.
+    ///
+    /// This is the capability from the provider table, deliberately *not* the
+    /// amount budgeted per request — see [`Self::output_budget_tokens`].
+    pub output_capability_tokens: Option<u64>,
+    /// Output tokens budgeted for one ordinary request.
+    ///
+    /// Single source of truth for both [`ContextBudget::output_reserve`] and the
+    /// `max_tokens` actually sent in the provider request, so the budget can
+    /// never reserve less than a request is allowed to spend.
+    pub output_budget_tokens: u64,
     /// Provenance of the resolved values.
     pub source: CapabilitySource,
 }
@@ -71,38 +91,74 @@ impl ModelCapability {
     /// override, provider profile safety value, explicitly configured session
     /// token limit, then a conservative fallback marked as estimated.
     pub fn resolve(compaction: &CompactionConfig, session_token_limit: u64, model: &str) -> Self {
-        let max_output = compaction
-            .model_max_output_tokens
-            .filter(|value| *value > 0);
-        if let Some(window) = compaction.model_context_window.filter(|value| *value > 0) {
-            return Self {
-                context_window: window,
-                max_output_tokens: max_output
-                    .unwrap_or_else(|| profile_max_output(model))
-                    .min(window),
-                source: CapabilitySource::UserOverride,
-            };
-        }
-        if let Some(window) = profile_context_window(model) {
-            return Self {
-                context_window: window,
-                max_output_tokens: max_output.unwrap_or_else(|| profile_max_output(model)),
-                source: CapabilitySource::ProviderProfile,
-            };
-        }
-        if session_token_limit != DEFAULT_SESSION_TOKEN_LIMIT && session_token_limit > 0 {
-            return Self {
-                context_window: session_token_limit,
-                max_output_tokens: max_output.unwrap_or(FALLBACK_MAX_OUTPUT_TOKENS),
-                source: CapabilitySource::SessionTokenLimit,
-            };
-        }
+        let (context_window, source) =
+            resolve_context_window(compaction, session_token_limit, model);
         Self {
-            context_window: FALLBACK_CONTEXT_WINDOW,
-            max_output_tokens: max_output.unwrap_or(FALLBACK_MAX_OUTPUT_TOKENS),
-            source: CapabilitySource::ConservativeFallback,
+            context_window,
+            output_capability_tokens: profile_output_capability(model),
+            output_budget_tokens: resolve_output_budget(compaction, model, context_window),
+            source,
         }
     }
+
+    /// Output cap to send as `GenerateConfig::max_tokens` for one request.
+    ///
+    /// Reads the same resolved value the budget reserves, so lowering the
+    /// reserve can never leave the request authorized to spend more.
+    pub fn request_max_tokens(&self) -> u32 {
+        // `resolve_output_budget` already clamps into the u32 request range;
+        // the repeated bound keeps a hand-built capability safe too.
+        self.output_budget_tokens.min(u64::from(u32::MAX)) as u32
+    }
+}
+
+/// Resolves the context window `W` and records where the value came from.
+fn resolve_context_window(
+    compaction: &CompactionConfig,
+    session_token_limit: u64,
+    model: &str,
+) -> (u64, CapabilitySource) {
+    if let Some(window) = compaction.model_context_window.filter(|value| *value > 0) {
+        return (window, CapabilitySource::UserOverride);
+    }
+    if let Some(window) = profile_context_window(model) {
+        return (window, CapabilitySource::ProviderProfile);
+    }
+    if session_token_limit != DEFAULT_SESSION_TOKEN_LIMIT && session_token_limit > 0 {
+        return (session_token_limit, CapabilitySource::SessionTokenLimit);
+    }
+    (
+        FALLBACK_CONTEXT_WINDOW,
+        CapabilitySource::ConservativeFallback,
+    )
+}
+
+/// Shared resolution of the per-request output budget `O`.
+///
+/// Precedence:
+/// 1. an explicit `[session.compaction] model_max_output_tokens` override;
+/// 2. `min(model output capability, `[`DEFAULT_OUTPUT_BUDGET`]`)` for a known
+///    model family;
+/// 3. [`UNKNOWN_MODEL_OUTPUT_BUDGET`] for an unrecognized model.
+///
+/// The result is then bounded by `window / 2` — the window-safety limit the
+/// history budget relies on — and by the `u32` range of a provider request, so
+/// the same value can drive `ContextBudget::output_reserve` and
+/// `GenerateConfig::max_tokens` without either side rounding differently.
+///
+/// Adaptive sizing from observed output percentiles is deliberately out of
+/// scope; this only stops a capability ceiling from being charged every turn.
+fn resolve_output_budget(compaction: &CompactionConfig, model: &str, context_window: u64) -> u64 {
+    compaction
+        .model_max_output_tokens
+        .filter(|value| *value > 0)
+        .unwrap_or_else(|| {
+            profile_output_capability(model)
+                .map(|capability| capability.min(DEFAULT_OUTPUT_BUDGET))
+                .unwrap_or(UNKNOWN_MODEL_OUTPUT_BUDGET)
+        })
+        .min(context_window / 2)
+        .min(u64::from(u32::MAX))
 }
 
 /// Conservative window table for known model families.
@@ -131,14 +187,9 @@ fn profile_context_window(model: &str) -> Option<u64> {
         .map(|(_, window)| *window)
 }
 
-/// Output reserve for a model when the user has not supplied one explicitly.
-///
-/// Shares the same lookup table as `core.rs` so the budget's output reserve
-/// matches the `max_tokens` actually sent in the provider request.
-fn profile_max_output(model: &str) -> u64 {
-    model_max_output_tokens(model)
-        .map(|v| v as u64)
-        .unwrap_or(FALLBACK_MAX_OUTPUT_TOKENS)
+/// Hard output capability of a known model family, in tokens.
+fn profile_output_capability(model: &str) -> Option<u64> {
+    model_max_output_tokens(model).map(u64::from)
 }
 
 /// Conservative token estimate for text that never splits UTF-8 code points.
@@ -216,7 +267,10 @@ impl ContextBudget {
         config: &CompactionConfig,
     ) -> Self {
         let window = capability.context_window;
-        let output_reserve = capability.max_output_tokens.min(window / 2);
+        // The resolver already applied this bound; repeating it keeps the
+        // invariant for a hand-built capability and documents that the reserve
+        // may never claim more than half the window.
+        let output_reserve = capability.output_budget_tokens.min(window / 2);
         let burst_reserve = (window / 20).max(MIN_BURST_RESERVE);
         let usable_history = window
             .saturating_sub(prefix_tokens)
@@ -312,6 +366,21 @@ mod tests {
         CompactionConfig::default()
     }
 
+    /// Hand-builds a capability so threshold tests stay independent of the
+    /// model tables.
+    fn capability(
+        context_window: u64,
+        output_budget_tokens: u64,
+        source: CapabilitySource,
+    ) -> ModelCapability {
+        ModelCapability {
+            context_window,
+            output_capability_tokens: Some(output_budget_tokens),
+            output_budget_tokens,
+            source,
+        }
+    }
+
     #[test]
     fn capability_prefers_user_override() {
         let mut cfg = config();
@@ -346,12 +415,122 @@ mod tests {
     }
 
     #[test]
+    fn large_output_capability_is_not_charged_per_request() {
+        // #2240: the 65 536-token capability of qwen3.x-max used to be both the
+        // request cap and the reserve, leaving a 131 072-token window with only
+        // ~52K of usable history.
+        let capability =
+            ModelCapability::resolve(&config(), DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max");
+        assert_eq!(capability.context_window, 131_072);
+        assert_eq!(capability.output_capability_tokens, Some(65_536));
+        assert_eq!(capability.output_budget_tokens, DEFAULT_OUTPUT_BUDGET);
+        assert_eq!(capability.request_max_tokens(), 16_384);
+
+        // P mirrors the session reported in the issue.
+        let budget = ContextBudget::compute(capability, 6_251, &config());
+        assert_eq!(budget.output_reserve, 16_384);
+        assert_eq!(budget.usable_history, 101_884);
+        assert_eq!(budget.emergency_tokens, 91_695);
+        assert!(budget.usable_history > 100_000);
+    }
+
+    #[test]
+    fn output_reserve_and_request_cap_are_the_same_value() {
+        // Both sides must read the one resolver, for every provenance class:
+        // a request may never be authorized to spend more than was reserved.
+        let mut explicit_window = config();
+        explicit_window.model_context_window = Some(200_000);
+        let mut explicit_output = config();
+        explicit_output.model_max_output_tokens = Some(32_000);
+        let cases: [(&CompactionConfig, u64, &str); 5] = [
+            (&config(), DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max"),
+            (&config(), DEFAULT_SESSION_TOKEN_LIMIT, "gpt-4o"),
+            (&config(), DEFAULT_SESSION_TOKEN_LIMIT, "unknown-model"),
+            (&explicit_window, DEFAULT_SESSION_TOKEN_LIMIT, "gpt-4o"),
+            (&explicit_output, DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max"),
+        ];
+        for (cfg, session_limit, model) in cases {
+            let capability = ModelCapability::resolve(cfg, session_limit, model);
+            let budget = ContextBudget::compute(capability, 1_000, cfg);
+            assert_eq!(
+                u64::from(capability.request_max_tokens()),
+                budget.output_reserve,
+                "model {model} sends a different cap than it reserves"
+            );
+        }
+    }
+
+    #[test]
+    fn small_output_models_are_never_raised_to_the_default_ceiling() {
+        // The ceiling only lowers a large capability; it must not inflate a
+        // model that documents a smaller output limit.
+        for (model, expected) in [("gpt-4o", 8_192), ("deepseek-chat", 8_192)] {
+            let capability =
+                ModelCapability::resolve(&config(), DEFAULT_SESSION_TOKEN_LIMIT, model);
+            assert_eq!(
+                capability.output_budget_tokens, expected,
+                "model {model} output budget"
+            );
+            assert_eq!(capability.output_capability_tokens, Some(expected));
+        }
+    }
+
+    #[test]
+    fn unknown_models_share_one_safe_output_default() {
+        let capability =
+            ModelCapability::resolve(&config(), DEFAULT_SESSION_TOKEN_LIMIT, "brand-new-model");
+        assert_eq!(capability.output_capability_tokens, None);
+        assert_eq!(capability.output_budget_tokens, UNKNOWN_MODEL_OUTPUT_BUDGET);
+        assert_eq!(capability.request_max_tokens(), 4_096);
+        // The explicit-session-limit branch resolves the same default.
+        let sized = ModelCapability::resolve(&config(), 60_000, "brand-new-model");
+        assert_eq!(sized.output_budget_tokens, UNKNOWN_MODEL_OUTPUT_BUDGET);
+    }
+
+    #[test]
+    fn explicit_output_override_drives_both_reserve_and_request() {
+        let mut cfg = config();
+        cfg.model_max_output_tokens = Some(48_000);
+        let capability = ModelCapability::resolve(&cfg, DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max");
+        assert_eq!(capability.output_budget_tokens, 48_000);
+        assert_eq!(capability.request_max_tokens(), 48_000);
+        let budget = ContextBudget::compute(capability, 6_251, &cfg);
+        assert_eq!(budget.output_reserve, 48_000);
+        // The user override raises the reserve, so history shrinks accordingly.
+        assert_eq!(budget.usable_history, 131_072 - 6_251 - 48_000 - 6_553);
+    }
+
+    #[test]
+    fn extreme_output_configuration_never_overflows_or_exceeds_the_window() {
+        let mut cfg = config();
+        cfg.model_max_output_tokens = Some(u64::MAX);
+        cfg.model_context_window = Some(u64::MAX);
+        let capability = ModelCapability::resolve(&cfg, DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max");
+        assert_eq!(capability.output_budget_tokens, u64::from(u32::MAX));
+        assert_eq!(capability.request_max_tokens(), u32::MAX);
+
+        // A window smaller than the default budget still caps at W/2 on both
+        // sides, so no request can be larger than the window allows.
+        cfg.model_max_output_tokens = Some(u64::MAX);
+        cfg.model_context_window = Some(2_000);
+        let tiny = ModelCapability::resolve(&cfg, DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max");
+        assert_eq!(tiny.output_budget_tokens, 1_000);
+        assert_eq!(tiny.request_max_tokens(), 1_000);
+        let budget = ContextBudget::compute(tiny, 200, &cfg);
+        assert_eq!(budget.output_reserve, 1_000);
+        assert!(u64::from(tiny.request_max_tokens()) <= tiny.context_window);
+        assert_budget_is_sane(&budget);
+
+        // A zero or absent override falls back instead of reserving nothing.
+        cfg.model_max_output_tokens = Some(0);
+        cfg.model_context_window = None;
+        let zeroed = ModelCapability::resolve(&cfg, DEFAULT_SESSION_TOKEN_LIMIT, "qwen3.7-max");
+        assert_eq!(zeroed.output_budget_tokens, DEFAULT_OUTPUT_BUDGET);
+    }
+
+    #[test]
     fn budget_excludes_prefix_output_and_burst() {
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         let budget = ContextBudget::compute(capability, 12_000, &config());
         assert_eq!(budget.output_reserve, 8_000);
         assert_eq!(budget.burst_reserve, 5_000);
@@ -363,11 +542,7 @@ mod tests {
 
     #[test]
     fn thresholds_bound_trigger_and_emergency_semantics() {
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         let budget = ContextBudget::compute(capability, 12_000, &config());
         assert!(!budget.over_trigger(budget.trigger_tokens));
         assert!(budget.over_trigger(budget.trigger_tokens + 1));
@@ -379,11 +554,7 @@ mod tests {
     fn absolute_limit_is_clamped_into_model_budget() {
         let mut cfg = config();
         cfg.auto_compact_token_limit = Some(1_000_000);
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         let budget = ContextBudget::compute(capability, 12_000, &cfg);
         assert!(budget.trigger_tokens <= budget.usable_history);
         cfg.auto_compact_token_limit = Some(10_000);
@@ -399,11 +570,7 @@ mod tests {
 
     #[test]
     fn oversized_prefix_yields_zero_history_budget() {
-        let capability = ModelCapability {
-            context_window: 16_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::ConservativeFallback,
-        };
+        let capability = capability(16_000, 8_000, CapabilitySource::ConservativeFallback);
         let budget = ContextBudget::compute(capability, 20_000, &config());
         assert_eq!(budget.usable_history, 0);
         assert!(budget.over_emergency(0));
@@ -419,11 +586,7 @@ mod tests {
 
     #[test]
     fn non_finite_ratios_never_panic_and_keep_threshold_order() {
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             // Each field individually poisoned.
             for field in 0..3 {
@@ -451,11 +614,7 @@ mod tests {
 
     #[test]
     fn inverted_ratio_overrides_are_reordered_not_panicking() {
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         let mut cfg = config();
         cfg.trigger_ratio = 0.90;
         cfg.emergency_ratio = 0.20;
@@ -466,11 +625,7 @@ mod tests {
 
     #[test]
     fn legal_ratio_overrides_still_apply() {
-        let capability = ModelCapability {
-            context_window: 100_000,
-            max_output_tokens: 8_000,
-            source: CapabilitySource::UserOverride,
-        };
+        let capability = capability(100_000, 8_000, CapabilitySource::UserOverride);
         let mut cfg = config();
         cfg.trigger_ratio = 0.50;
         cfg.emergency_ratio = 0.80;

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine.rs
@@ -16,8 +16,7 @@ use crate::provider::ContentGenerator;
 use crate::session::{PersistedSession, ProviderSessionId, SessionError, SessionStore};
 
 use super::boundary::{
-    group_agent_runs, select_compacted_through_after, select_manual_compacted_through_after,
-    BoundaryError,
+    group_agent_runs, select_compacted_through_after, BoundaryError, PreservationPolicy,
 };
 use super::budget::{
     estimate_messages_tokens, estimate_text_tokens, measure_history, ContextBudget, ModelCapability,
@@ -71,6 +70,18 @@ impl CompactionTrigger {
             Self::Manual => "manual",
             Self::Auto => "auto",
             Self::Emergency => "emergency",
+        }
+    }
+
+    /// Default preservation policy for this trigger.
+    ///
+    /// Automatic and emergency compaction start from the configured recent-run
+    /// protection so a normal soft-threshold compaction stays quality-first;
+    /// the emergency preflight owns its own stricter fallbacks from there.
+    fn preservation(&self, preserve_recent_runs: usize) -> PreservationPolicy {
+        match self {
+            Self::Manual => PreservationPolicy::ThroughLatestCompletedRun,
+            Self::Auto | Self::Emergency => PreservationPolicy::RecentRuns(preserve_recent_runs),
         }
     }
 }
@@ -281,19 +292,12 @@ pub async fn compact_session(
         .as_ref()
         .map(|state| state.compacted_through)
         .unwrap_or(0);
-    let cut = match trigger {
-        CompactionTrigger::Manual => select_manual_compacted_through_after(
-            &session.messages,
-            budget.target_tokens,
-            previous_cut,
-        ),
-        CompactionTrigger::Auto | CompactionTrigger::Emergency => select_compacted_through_after(
-            &session.messages,
-            policy.preserve_recent_runs,
-            budget.target_tokens,
-            previous_cut,
-        ),
-    }?
+    let cut = select_compacted_through_after(
+        &session.messages,
+        trigger.preservation(policy.preserve_recent_runs),
+        budget.target_tokens,
+        previous_cut,
+    )?
     .ok_or(CompactionError::NothingToCompact)?;
 
     // 3. Bound the summarizer input by the summarizer model's own context
@@ -372,12 +376,19 @@ pub async fn compact_session(
 /// running process is the session's only writer; the resulting projection is
 /// committed together with the run's transcript at the next persist.
 ///
+/// `preservation` is supplied by the caller rather than read from the policy so
+/// the emergency preflight can degrade its protection step by step over the
+/// same selection and summarization engine the manual path uses.
+///
 /// `previous_revision` is the runtime's durable revision clock, which outlives
 /// any projection dropped by sanitization; the candidate takes the next value.
 ///
-/// Returns `None` when no safe cut exists, the revision clock is exhausted, or
-/// the candidate fails validation; the caller keeps its previous projection in
-/// every case.
+/// # Errors
+///
+/// Returns the [`CompactionError`] that stopped the attempt so the caller can
+/// distinguish "this policy protects every remaining run"
+/// ([`CompactionError::NothingToCompact`]) from a summarizer failure. The
+/// caller keeps its previous projection in every error case.
 pub(crate) async fn compact_in_memory(
     messages: &[crate::provider::Message],
     previous: Option<&CompactionState>,
@@ -386,23 +397,19 @@ pub(crate) async fn compact_in_memory(
     model: &str,
     config: &CoreConfig,
     target_tokens: u64,
-) -> Option<CompactionState> {
+    preservation: PreservationPolicy,
+) -> Result<CompactionState, CompactionError> {
     let policy = &config.session.compaction;
     if !policy.enabled {
-        return None;
+        return Err(CompactionError::Disabled);
     }
-    // Fail closed before any provider work; the caller's existing emergency
-    // path already treats `None` as "keep the current projection".
-    let revision = previous_revision.checked_add(1)?;
+    // Fail closed before any provider work.
+    let revision = previous_revision
+        .checked_add(1)
+        .ok_or(CompactionError::RevisionExhausted)?;
     let previous_cut = previous.map(|state| state.compacted_through).unwrap_or(0);
-    let cut = select_compacted_through_after(
-        messages,
-        policy.preserve_recent_runs,
-        target_tokens,
-        previous_cut,
-    )
-    .ok()
-    .flatten()?;
+    let cut = select_compacted_through_after(messages, preservation, target_tokens, previous_cut)?
+        .ok_or(CompactionError::NothingToCompact)?;
     // Emergency compaction shares the exact model-aware input budget used by
     // the manual/automatic engine path, so the three triggers cannot drift.
     let capability = ModelCapability::resolve(policy, config.agent.session_token_limit, model);
@@ -412,10 +419,9 @@ pub(crate) async fn compact_in_memory(
         previous_cut,
         cut,
         summary_input_token_budget(&capability),
-    )
-    .ok()?;
+    )?;
     let digest = source_digest(&messages[..cut]);
-    let summary = generate_summary(provider, model, &input).await.ok()?;
+    let summary = generate_summary(provider, model, &input).await?;
 
     let estimated_before = estimate_messages_tokens(&effective_messages(messages, previous));
     let candidate = CompactionState {
@@ -431,11 +437,11 @@ pub(crate) async fn compact_in_memory(
     };
     let estimated_after = estimate_messages_tokens(&effective_messages(messages, Some(&candidate)));
     if estimated_after >= estimated_before {
-        return None;
+        return Err(CompactionError::NotReducing);
     }
     let mut candidate = candidate;
     candidate.tokens_after = Some(measure_history(None, estimated_after));
-    Some(candidate)
+    Ok(candidate)
 }
 
 /// Clamps a selected cut so the projection never covers messages that the

--- a/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/engine/tests.rs
@@ -398,20 +398,37 @@ async fn compact_in_memory_reduces_and_respects_disabled_policy() {
     let messages = bulky_messages(5);
     let provider = summary_provider();
     let config = CoreConfig::default();
-    let candidate = compact_in_memory(&messages, None, 0, &provider, "mock-model", &config, 0)
-        .await
-        .expect("in-memory candidate");
+    let candidate = compact_in_memory(
+        &messages,
+        None,
+        0,
+        &provider,
+        "mock-model",
+        &config,
+        0,
+        PreservationPolicy::RecentRuns(config.session.compaction.preserve_recent_runs),
+    )
+    .await
+    .expect("in-memory candidate");
     assert!(candidate.compacted_through > 0);
     assert_eq!(candidate.revision, 1);
 
     let mut disabled = CoreConfig::default();
     disabled.session.compaction.enabled = false;
     let provider = summary_provider();
-    assert!(
-        compact_in_memory(&messages, None, 0, &provider, "mock-model", &disabled, 0)
-            .await
-            .is_none()
-    );
+    let error = compact_in_memory(
+        &messages,
+        None,
+        0,
+        &provider,
+        "mock-model",
+        &disabled,
+        0,
+        PreservationPolicy::RecentRuns(2),
+    )
+    .await
+    .expect_err("disabled policy");
+    assert_eq!(error.code(), "disabled");
 }
 
 #[tokio::test]
@@ -804,24 +821,35 @@ async fn emergency_compaction_continues_from_the_saved_revision_floor() {
     // Sanitization dropped the projection, so `previous` is `None` while the
     // runtime clock still remembers revision 4.
     let provider = summary_provider();
-    let candidate = compact_in_memory(&messages, None, 4, &provider, "mock-model", &config, 0)
-        .await
-        .expect("in-memory candidate");
+    let candidate = compact_in_memory(
+        &messages,
+        None,
+        4,
+        &provider,
+        "mock-model",
+        &config,
+        0,
+        PreservationPolicy::RecentRuns(2),
+    )
+    .await
+    .expect("in-memory candidate");
     assert_eq!(candidate.revision, 5);
 
     // An exhausted clock takes the existing fail-closed emergency path.
     let provider = summary_provider();
-    assert!(compact_in_memory(
+    let error = compact_in_memory(
         &messages,
         None,
         u64::MAX,
         &provider,
         "mock-model",
         &config,
-        0
+        0,
+        PreservationPolicy::RecentRuns(2),
     )
     .await
-    .is_none());
+    .expect_err("exhausted revision clock");
+    assert_eq!(error.code(), "revision_exhausted");
 }
 
 #[test]
@@ -890,6 +918,50 @@ async fn legacy_envelope_without_projection_starts_at_zero() {
         .await
         .expect("first compaction");
     assert_eq!(report.revision, 1);
+}
+
+#[tokio::test]
+async fn normal_auto_trigger_still_protects_two_recent_runs() {
+    // The soft-threshold path stays quality-first: with the default policy two
+    // complete runs are both protected, so automatic compaction declines even
+    // though the same transcript is compactable on request. Only the emergency
+    // ladder degrades below this (see `compaction::preflight::tests`).
+    let temp = tempfile::tempdir().unwrap();
+    let store = store(&temp);
+    let session = persisted(&store, 2);
+    let config = CoreConfig::default();
+    assert_eq!(config.session.compaction.preserve_recent_runs, 2);
+    assert!(
+        !super::super::boundary::has_new_compactable_prefix(&session.messages, 2, 0).unwrap(),
+        "the idle-boundary preflight must see no eligible prefix"
+    );
+
+    let provider = summary_provider();
+    let error = compact_session(
+        &store,
+        &session.session_id,
+        &provider,
+        &config,
+        1_000,
+        None,
+        CompactionTrigger::Auto,
+        None,
+    )
+    .await
+    .expect_err("both runs are protected");
+    assert_eq!(error.code(), "nothing_to_compact");
+    assert!(store
+        .load(&session.session_id)
+        .unwrap()
+        .compaction
+        .is_none());
+
+    // Manual compaction over the very same transcript keeps working.
+    let provider = summary_provider();
+    let (report, _) = compact(&store, &session, &provider, &config)
+        .await
+        .expect("manual compaction committed");
+    assert!(report.compacted_through > 0);
 }
 
 #[tokio::test]

--- a/src/cosh-ng/crates/cosh-core/src/compaction/preflight.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/preflight.rs
@@ -8,26 +8,184 @@ use crate::protocol::OutputMessage;
 use crate::provider::ContentGenerator;
 use crate::provider::Message;
 
-use super::budget::{ContextBudget, ModelCapability};
-use super::engine::compact_in_memory;
+use super::boundary::{has_active_run, PreservationPolicy};
+use super::budget::{estimate_messages_tokens, ContextBudget, ModelCapability};
+use super::engine::{compact_in_memory, CompactionError};
 use super::runtime::CompactionRuntime;
 
 /// Stable prefix identifying typed context-limit turn failures.
 pub(crate) const CONTEXT_LIMIT_ERROR_PREFIX: &str = "context_limit:";
 
+/// Maximum compaction attempts one preflight may issue before yielding control.
+///
+/// Large transcripts can require several bounded summary inputs to reclaim a
+/// safe prefix. Capping the work keeps one provider request from turning into
+/// an unbounded sequence of summarizer calls; a retry resumes from the last
+/// committed projection.
+const MAX_EMERGENCY_COMPACTION_ATTEMPTS: usize = 16;
+
+/// Why the emergency ladder could not bring the effective context back under
+/// the emergency threshold.
+///
+/// Kept distinct from [`CompactionError`] so the final `context_limit:` message
+/// names the real cause: a summarizer failure must never be reported as a
+/// missing safe split.
+#[derive(Debug)]
+enum EmergencyFailure {
+    /// No preservation policy produced a safe Agent-run split and nothing
+    /// outside the projection is large enough to explain the overflow: the
+    /// summary itself is what exceeds the threshold.
+    NoSafeSplit,
+    /// Every completed run is summarized and the remaining active, incomplete
+    /// run alone exceeds the threshold. Only reported when the uncompactable
+    /// tail was *measured* over the threshold, never inferred from the mere
+    /// presence of an active run.
+    ActiveRunTooLarge,
+    /// Everything compactable is summarized, and what is left — the summary
+    /// plus the still-verbatim tail — is over the threshold together, without
+    /// either part exceeding it alone.
+    IrreducibleRemainder,
+    /// Defensive fallback when the ladder ends without a terminal or
+    /// cut-specific failure while the reduced context is still over threshold.
+    StillOverEmergency,
+    /// Compaction kept making progress but reached the per-preflight attempt
+    /// limit before the effective context crossed back under the threshold.
+    AttemptLimitReached,
+    /// One attempt failed for a reason unrelated to boundary selection:
+    /// summarizer failure, empty summary, oversized input, or an exhausted
+    /// revision clock.
+    Attempt(CompactionError),
+}
+
+impl EmergencyFailure {
+    /// Stable machine-readable code appended to the emergency status line.
+    fn code(&self) -> &str {
+        match self {
+            Self::NoSafeSplit => "no_safe_split",
+            Self::ActiveRunTooLarge => "active_run_too_large",
+            Self::IrreducibleRemainder => "irreducible_remainder",
+            Self::StillOverEmergency => "still_over_emergency",
+            Self::AttemptLimitReached => "attempt_limit",
+            Self::Attempt(error) => error.code(),
+        }
+    }
+
+    /// Operator-facing explanation embedded in the `context_limit:` message.
+    fn detail(&self) -> String {
+        match self {
+            Self::NoSafeSplit => "no safe Agent-run split was available, even after allowing the \
+                 latest completed run to be summarized"
+                .to_string(),
+            Self::ActiveRunTooLarge => "every completed Agent run is already summarized and the \
+                 active run alone exceeds the threshold"
+                .to_string(),
+            Self::IrreducibleRemainder => "every compactable Agent run is already summarized and \
+                 the summary plus the remaining verbatim messages still exceed the threshold"
+                .to_string(),
+            Self::StillOverEmergency => {
+                "compaction succeeded but the reduced context is still over the threshold"
+                    .to_string()
+            }
+            Self::AttemptLimitReached => format!(
+                "compaction made progress but reached the per-request limit of \
+                 {MAX_EMERGENCY_COMPACTION_ATTEMPTS} compaction attempts"
+            ),
+            Self::Attempt(error) => error.to_string(),
+        }
+    }
+
+    /// Recovery advice matched to the cause.
+    ///
+    /// The deepest ladder rung already applies manual-compaction semantics — the
+    /// same preservation policy `/session compact` uses — so "compact manually"
+    /// is only actionable for a *transient* attempt failure. A deterministic
+    /// failure would repeat identically on a manual retry, and an exhausted
+    /// ladder has no compactable history left, so both point at a new session.
+    /// The attempt-limit case is different: it committed safe progress, so a
+    /// retry resumes from a strictly later cut.
+    fn recovery_hint(&self) -> &'static str {
+        const DETERMINISTIC: &str =
+            "start a new session, or raise the model context window if this model supports one";
+        match self {
+            Self::NoSafeSplit
+            | Self::ActiveRunTooLarge
+            | Self::IrreducibleRemainder
+            | Self::StillOverEmergency => DETERMINISTIC,
+            Self::AttemptLimitReached => {
+                "retry to continue compaction from the last safe projection, or start a new session"
+            }
+            Self::Attempt(error) if attempt_is_transient(error) => {
+                "retry, compact manually, or start a new session"
+            }
+            Self::Attempt(_) => DETERMINISTIC,
+        }
+    }
+}
+
+/// Whether re-running the same compaction could plausibly succeed.
+///
+/// Transient failures come from outside the transcript's shape — a provider or
+/// store hiccup, a cancelled stream, or a concurrent session change — so a
+/// retry or an explicit `/session compact` is worth suggesting. Everything else
+/// is a deterministic property of this transcript and window: the deepest rung
+/// already used manual semantics, so repeating it reproduces the same failure.
+fn attempt_is_transient(error: &CompactionError) -> bool {
+    match error {
+        // Provider-side or store-side; a retry may behave differently.
+        CompactionError::Provider(_)
+        | CompactionError::EmptySummary
+        | CompactionError::OversizedSummary
+        | CompactionError::Cancelled
+        | CompactionError::Conflict
+        | CompactionError::DigestMismatch
+        | CompactionError::Session(_) => true,
+        // Deterministic for this transcript, window, or configuration: the
+        // summary cannot pay for itself, the prefix cannot fit the summarizer
+        // input, the revision clock is spent, the transcript is malformed, or
+        // compaction is switched off. Manual compaction repeats the failure.
+        CompactionError::NotReducing
+        | CompactionError::OversizedInput
+        | CompactionError::RevisionExhausted
+        | CompactionError::Boundary(_)
+        | CompactionError::NothingToCompact
+        | CompactionError::Disabled => false,
+    }
+}
+
+/// Ordered emergency fallbacks, from quality-first to last-resort.
+///
+/// The configured recent-run protection is tried first so an emergency that can
+/// be resolved cheaply keeps the same verbatim history a normal automatic
+/// compaction would. Only when that reclaims nothing does the ladder drop to one
+/// protected run and finally to the manual-compaction semantics, which may
+/// summarize the latest *completed* run. The active run is never a candidate at
+/// any step.
+///
+/// Adjacent duplicates are removed so a `preserve_recent_runs` of 0 or 1 does
+/// not spend two identical attempts — and two summarizer calls — on the same cut.
+fn emergency_ladder(preserve_recent_runs: usize) -> Vec<PreservationPolicy> {
+    let mut ladder = vec![
+        PreservationPolicy::RecentRuns(preserve_recent_runs.max(1)),
+        PreservationPolicy::RecentRuns(1),
+        PreservationPolicy::ThroughLatestCompletedRun,
+    ];
+    ladder.dedup();
+    ladder
+}
+
 /// Emergency context preflight executed before every provider request.
 ///
 /// When the next request would cross the emergency threshold, compacts
-/// synchronously at this complete exchange boundary and commits the result
-/// into `runtime`. Returns a typed `context_limit:` error instead of
-/// submitting an oversized request when no safe split reclaims enough
-/// context.
+/// synchronously at this complete exchange boundary and commits the result into
+/// `runtime`. Walks [`emergency_ladder`], re-pricing the effective context after
+/// every committed projection, and only returns a typed `context_limit:` error
+/// once every safe degradation has been tried.
 ///
 /// # Errors
 ///
-/// Returns a `context_limit:`-prefixed message when the effective context
-/// still exceeds the emergency threshold after the in-memory compaction
-/// attempt.
+/// Returns a `context_limit:`-prefixed message classifying why the effective
+/// context still exceeds the emergency threshold. The prefix is a stable
+/// contract consumed by the shell's session-recovery path.
 pub(crate) async fn run_context_preflight<W: Write>(
     runtime: &mut CompactionRuntime,
     messages: &[Message],
@@ -47,31 +205,142 @@ pub(crate) async fn run_context_preflight<W: Write>(
         return Ok(());
     }
     emit_status(writer, "compaction_emergency_started");
-    let candidate = compact_in_memory(
-        messages,
-        runtime.state(),
-        runtime.revision(),
-        provider,
-        model,
-        config,
-        budget.target_tokens,
-    )
-    .await;
-    if let Some(candidate) = candidate {
-        runtime.commit_state(candidate);
+
+    // `terminal` short-circuits the ladder; `unresolved_cut` records the
+    // cut-specific reason the last evaluated step produced no projection.
+    let mut terminal: Option<EmergencyFailure> = None;
+    let mut unresolved_cut: Option<CompactionError> = None;
+    let mut attempts = 0;
+    'ladder: for preservation in emergency_ladder(policy.preserve_recent_runs) {
+        loop {
+            if attempts >= MAX_EMERGENCY_COMPACTION_ATTEMPTS {
+                terminal = Some(EmergencyFailure::AttemptLimitReached);
+                break 'ladder;
+            }
+            attempts += 1;
+            match compact_in_memory(
+                messages,
+                runtime.state(),
+                runtime.revision(),
+                provider,
+                model,
+                config,
+                budget.target_tokens,
+                preservation,
+            )
+            .await
+            {
+                Ok(candidate) => {
+                    runtime.commit_state(candidate);
+                    unresolved_cut = None;
+                    // A bounded summary input may cover only part of the cut
+                    // selected for this policy. Re-price the committed
+                    // projection, then repeat the same rung while it can still
+                    // advance before giving up any more recent-run protection.
+                    if !budget
+                        .over_emergency(runtime.effective_history_tokens(messages, prefix_tokens))
+                    {
+                        emit_status(writer, "compaction_emergency_completed");
+                        return Ok(());
+                    }
+                }
+                // Cut-specific outcomes: this policy protected too much
+                // history for the attempt to help, but a more aggressive rung
+                // summarizes a strictly longer prefix and may still succeed.
+                //
+                // `NothingToCompact` means no safe split existed under this
+                // policy. `NotReducing` means the chosen prefix was too small
+                // to pay for its own summary — e.g. summarizing a 1 KiB first
+                // run costs 2 KiB — while the next rung can absorb a much
+                // larger prefix and win.
+                Err(error @ (CompactionError::NothingToCompact | CompactionError::NotReducing)) => {
+                    unresolved_cut = Some(error);
+                    break;
+                }
+                // Anything else is not about boundary selection: degrading
+                // the policy cannot fix it and would only spend more summarizer
+                // calls, so fail closed reporting the actual cause.
+                // `OversizedInput` in particular only worsens with a longer
+                // prefix.
+                Err(error) => {
+                    terminal = Some(EmergencyFailure::Attempt(error));
+                    break 'ladder;
+                }
+            }
+        }
     }
+
+    let failure = terminal.unwrap_or_else(|| match unresolved_cut {
+        // The deepest rung still could not shrink the context: report the real
+        // cause rather than a boundary story.
+        Some(CompactionError::NotReducing) => {
+            EmergencyFailure::Attempt(CompactionError::NotReducing)
+        }
+        // The most permissive policy found no cut, so everything compactable is
+        // already summarized. Classify by what is *measurably* left over
+        // instead of assuming the active run is to blame.
+        Some(_) => classify_uncompactable_remainder(runtime, messages, &budget),
+        // Defensive fallback: every normal ladder exit records either a
+        // terminal failure or a cut-specific outcome.
+        None => EmergencyFailure::StillOverEmergency,
+    });
+
     let history_tokens = runtime.effective_history_tokens(messages, prefix_tokens);
-    if budget.over_emergency(history_tokens) {
-        emit_status(writer, "compaction_emergency_failed");
-        return Err(format!(
-            "{CONTEXT_LIMIT_ERROR_PREFIX} effective context (~{history_tokens} tokens) \
-             exceeds the emergency threshold ({} of {} usable history tokens) and no safe \
-             split reclaimed enough context; compact manually or start a new session",
-            budget.emergency_tokens, budget.usable_history
-        ));
+    emit_status(
+        writer,
+        &format!("compaction_emergency_failed:{}", failure.code()),
+    );
+    Err(format!(
+        "{CONTEXT_LIMIT_ERROR_PREFIX} effective context (~{history_tokens} tokens) exceeds the \
+         emergency threshold ({} of {} usable history tokens) and emergency compaction could not \
+         reclaim enough context ({}); {}",
+        budget.emergency_tokens,
+        budget.usable_history,
+        failure.detail(),
+        failure.recovery_hint()
+    ))
+}
+
+/// Classifies an exhausted ladder by the size of what could not be compacted.
+///
+/// Everything up to the projection's `compacted_through` is already represented
+/// by the summary, so the verbatim tail after it — normally the active,
+/// incomplete run — is the only history a further rung could have taken. The
+/// tail is measured against the emergency threshold instead of blaming the
+/// active run merely because one exists: a large persisted summary plus a modest
+/// active run exhausts the ladder just as well, and reporting that as
+/// "active run alone exceeds the threshold" would misdirect the operator.
+fn classify_uncompactable_remainder(
+    runtime: &CompactionRuntime,
+    messages: &[Message],
+    budget: &ContextBudget,
+) -> EmergencyFailure {
+    let compacted_through = runtime
+        .state()
+        .map(|state| state.compacted_through)
+        .unwrap_or(0)
+        .min(messages.len());
+    let tail = &messages[compacted_through..];
+    if tail.is_empty() {
+        // The projection already reaches the transcript end, so the snapshot
+        // itself is the whole effective context and what exceeds the threshold.
+        return EmergencyFailure::NoSafeSplit;
     }
-    emit_status(writer, "compaction_emergency_completed");
-    Ok(())
+    // History-only, matching `effective_history_tokens`, which excludes `P`.
+    let tail_tokens = estimate_messages_tokens(tail);
+    if has_active_run(messages) && budget.over_emergency(tail_tokens) {
+        // The still-verbatim tail on its own crosses the threshold, so no
+        // summary of the completed history could have saved this request.
+        return EmergencyFailure::ActiveRunTooLarge;
+    }
+    if compacted_through == 0 {
+        // Nothing was ever summarized and no safe split exists: the transcript
+        // shape itself, not an oversized summary, is the blocker.
+        return EmergencyFailure::NoSafeSplit;
+    }
+    // A summary exists and neither part alone is over the threshold; together
+    // they are.
+    EmergencyFailure::IrreducibleRemainder
 }
 
 /// Writes one system-status line to the protocol stream, mirroring
@@ -82,3 +351,6 @@ fn emit_status<W: Write>(writer: &mut W, status: &str) {
         let _ = writer.flush();
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/cosh-ng/crates/cosh-core/src/compaction/preflight/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/preflight/tests.rs
@@ -1,0 +1,662 @@
+//! Emergency preflight ladder tests.
+//!
+//! The ladder degrades `preserve_recent_runs` → 1 → "latest completed run may
+//! be summarized" and must never cut the active run, silently lose transcript
+//! messages, or misreport a summarizer failure as a missing split point.
+
+use super::*;
+use crate::compaction::projection::source_digest;
+use crate::config::CoreConfig;
+use crate::provider::mock::MockProvider;
+use crate::provider::Message;
+
+/// Runtime prefix used by every scenario; small enough to leave the window to
+/// the transcript.
+const PREFIX_TOKENS: u64 = 1_000;
+/// Explicit window so the thresholds are independent of the model tables.
+const WINDOW: u64 = 40_000;
+
+/// Config with an explicit window and the requested recent-run protection.
+fn config(preserve_recent_runs: usize) -> CoreConfig {
+    let mut config = CoreConfig::default();
+    config.session.compaction.model_context_window = Some(WINDOW);
+    config.session.compaction.preserve_recent_runs = preserve_recent_runs;
+    config
+}
+
+fn budget_for(config: &CoreConfig) -> ContextBudget {
+    let policy = &config.session.compaction;
+    let capability =
+        ModelCapability::resolve(policy, config.agent.session_token_limit, "mock-model");
+    ContextBudget::compute(capability, PREFIX_TOKENS, policy)
+}
+
+/// ASCII payload whose conservative estimate is about `tokens` tokens.
+///
+/// [`super::super::budget::estimate_messages_tokens`] charges four tokens of
+/// role overhead plus one token per four ASCII bytes.
+fn sized_text(label: &str, tokens: u64) -> String {
+    let filler = "x".repeat((tokens.saturating_sub(8) * 4) as usize);
+    format!("{label} {filler}")
+}
+
+/// A complete Agent run: user prompt plus a final assistant reply.
+fn complete_run(label: &str, tokens: u64) -> Vec<Message> {
+    let half = tokens / 2;
+    vec![
+        Message::user(&sized_text(label, half)),
+        Message::assistant(&sized_text(label, tokens - half)),
+    ]
+}
+
+/// An in-flight run: a user prompt whose assistant reply has not arrived.
+fn active_run(label: &str, tokens: u64) -> Vec<Message> {
+    vec![Message::user(&sized_text(label, tokens))]
+}
+
+fn summarizer() -> MockProvider {
+    // `repeat_text` never exhausts, so one provider can serve every rung.
+    MockProvider::repeat_text("## Objective and constraints\n- keep diagnosing")
+}
+
+struct Preflight {
+    runtime: CompactionRuntime,
+    result: Result<(), String>,
+    statuses: Vec<String>,
+}
+
+impl Preflight {
+    fn status_codes(&self) -> Vec<&str> {
+        self.statuses.iter().map(String::as_str).collect()
+    }
+
+    fn error(&self) -> &str {
+        self.result.as_ref().expect_err("preflight failed closed")
+    }
+}
+
+/// Runs the preflight over `messages` and captures the emitted status lines.
+async fn preflight(
+    messages: &[Message],
+    config: &CoreConfig,
+    provider: &dyn ContentGenerator,
+) -> Preflight {
+    preflight_resuming(messages, config, provider, None).await
+}
+
+/// Same as [`preflight`] but starts from an already committed projection, as a
+/// resumed session does.
+async fn preflight_resuming(
+    messages: &[Message],
+    config: &CoreConfig,
+    provider: &dyn ContentGenerator,
+    state: Option<crate::compaction::CompactionState>,
+) -> Preflight {
+    let mut runtime = CompactionRuntime::default();
+    let revision = state.as_ref().map(|state| state.revision).unwrap_or(0);
+    runtime.load_state(state, revision);
+    let mut writer: Vec<u8> = Vec::new();
+    let result = run_context_preflight(
+        &mut runtime,
+        messages,
+        provider,
+        "mock-model",
+        config,
+        PREFIX_TOKENS,
+        &mut writer,
+    )
+    .await;
+    let statuses = String::from_utf8_lossy(&writer)
+        .lines()
+        .filter_map(|line| {
+            serde_json::from_str::<serde_json::Value>(line)
+                .ok()?
+                .get("status")?
+                .as_str()
+                .map(ToOwned::to_owned)
+        })
+        .collect();
+    Preflight {
+        runtime,
+        result,
+        statuses,
+    }
+}
+
+/// Asserts the projection covers exactly what it claims and stays consistent.
+fn assert_projection_is_consistent(
+    runtime: &CompactionRuntime,
+    messages: &[Message],
+    expected_revision: u64,
+) {
+    let state = runtime.state().expect("projection committed");
+    assert_eq!(state.revision, expected_revision, "projection revision");
+    assert_eq!(runtime.revision(), expected_revision, "runtime clock");
+    assert_eq!(
+        state.source_digest,
+        source_digest(&messages[..state.compacted_through]),
+        "digest must cover exactly the summarized prefix"
+    );
+    assert!(super::super::boundary::is_safe_split_point(
+        messages,
+        state.compacted_through
+    ));
+}
+
+#[tokio::test]
+async fn degrades_from_two_preserved_runs_to_one() {
+    // The two most recent runs dominate the context, so preserving both cannot
+    // reclaim enough; dropping to one protected run can. #2240.
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 31_000));
+    messages.extend(active_run("third", 300));
+    let config = config(2);
+    let budget = budget_for(&config);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight.result.as_ref().expect("emergency recovered");
+
+    // Two rungs committed: run 0 first, then run 1.
+    assert_projection_is_consistent(&preflight.runtime, &messages, 2);
+    let state = preflight.runtime.state().expect("projection");
+    assert_eq!(
+        state.compacted_through, 4,
+        "the cut must stop at the active run's first message"
+    );
+    let history = preflight
+        .runtime
+        .effective_history_tokens(&messages, PREFIX_TOKENS);
+    assert!(
+        !budget.over_emergency(history),
+        "history {history} must be under the emergency threshold {}",
+        budget.emergency_tokens
+    );
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_completed"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn degrades_to_summarizing_the_latest_completed_run() {
+    // No active run: one protected run still leaves an oversized context, so
+    // the last rung must summarize the latest completed run too.
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 31_000));
+    let config = config(2);
+    let budget = budget_for(&config);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight.result.as_ref().expect("emergency recovered");
+
+    // Rung 1 (preserve 2) had no candidate at all, rung 2 compacted run 0 and
+    // rung 3 compacted run 1, so exactly two projections were committed.
+    assert_projection_is_consistent(&preflight.runtime, &messages, 2);
+    assert_eq!(
+        preflight
+            .runtime
+            .state()
+            .expect("projection")
+            .compacted_through,
+        messages.len()
+    );
+    assert!(!budget.over_emergency(
+        preflight
+            .runtime
+            .effective_history_tokens(&messages, PREFIX_TOKENS)
+    ));
+}
+
+#[tokio::test]
+async fn preserve_two_never_fails_a_transcript_manual_compaction_could_save() {
+    // A single oversized complete run: `preserve_recent_runs = 2` finds no cut,
+    // but `/session compact` would summarize it. The emergency path must reach
+    // the same conclusion instead of reporting context_limit.
+    let messages = complete_run("only", 33_000);
+    let config = config(2);
+    let budget = budget_for(&config);
+    assert!(budget.over_emergency(super::super::budget::estimate_messages_tokens(&messages)));
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight
+        .result
+        .as_ref()
+        .expect("the last rung must summarize the single completed run");
+    assert_projection_is_consistent(&preflight.runtime, &messages, 1);
+    assert_eq!(
+        preflight
+            .runtime
+            .state()
+            .expect("projection")
+            .compacted_through,
+        messages.len()
+    );
+}
+
+#[tokio::test]
+async fn repeats_a_policy_when_the_summary_input_only_allows_partial_progress() {
+    // Each run is about 160 KiB, so the 192 KiB summary-input ceiling can
+    // represent only one run per attempt. A fixed three-call ladder therefore
+    // stops while safe completed-run cuts still remain.
+    let mut messages = Vec::new();
+    for index in 0..30 {
+        messages.extend(complete_run(&format!("run {index}"), 40_000));
+    }
+    let mut config = config(2);
+    config.session.compaction.model_context_window = Some(1_000_000);
+    let budget = budget_for(&config);
+    assert!(budget.over_emergency(super::super::budget::estimate_messages_tokens(&messages)));
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+
+    assert!(
+        preflight.result.is_ok(),
+        "preflight must keep advancing while safe cuts remain: {:?}",
+        preflight.result
+    );
+    let state = preflight.runtime.state().expect("projection committed");
+    assert!(
+        state.revision
+            > emergency_ladder(config.session.compaction.preserve_recent_runs).len() as u64,
+        "recovery must require more than one call per ladder rung"
+    );
+    assert_projection_is_consistent(&preflight.runtime, &messages, state.revision);
+    assert!(!budget.over_emergency(
+        preflight
+            .runtime
+            .effective_history_tokens(&messages, PREFIX_TOKENS)
+    ));
+}
+
+#[tokio::test]
+async fn bounded_progress_stops_at_the_per_preflight_attempt_limit() {
+    // This window requires more bounded chunks than one preflight may request.
+    // The guard must preserve every committed cut, report the limit precisely,
+    // and leave another safe cut available for a subsequent retry.
+    let mut messages = Vec::new();
+    for index in 0..30 {
+        messages.extend(complete_run(&format!("run {index}"), 40_000));
+    }
+    let mut config = config(2);
+    config.session.compaction.model_context_window = Some(500_000);
+    let budget = budget_for(&config);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+
+    let error = preflight.error();
+    assert!(
+        error.contains(&format!(
+            "per-request limit of {MAX_EMERGENCY_COMPACTION_ATTEMPTS} compaction attempts"
+        )),
+        "{error}"
+    );
+    assert!(error.contains("retry to continue compaction"), "{error}");
+    assert_eq!(
+        preflight.runtime.revision(),
+        MAX_EMERGENCY_COMPACTION_ATTEMPTS as u64
+    );
+    let state = preflight.runtime.state().expect("latest safe projection");
+    assert_projection_is_consistent(
+        &preflight.runtime,
+        &messages,
+        MAX_EMERGENCY_COMPACTION_ATTEMPTS as u64,
+    );
+    assert!(budget.over_emergency(
+        preflight
+            .runtime
+            .effective_history_tokens(&messages, PREFIX_TOKENS)
+    ));
+    assert!(
+        super::super::boundary::select_compacted_through_after(
+            &messages,
+            PreservationPolicy::ThroughLatestCompletedRun,
+            budget.target_tokens,
+            state.compacted_through,
+        )
+        .expect("valid transcript")
+        .is_some(),
+        "the attempt limit, not boundary exhaustion, must stop this preflight"
+    );
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:attempt_limit"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn the_active_run_is_never_cut_or_summarized() {
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 31_000));
+    let active = active_run("in flight", 400);
+    messages.extend(active.clone());
+    let config = config(2);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight.result.as_ref().expect("emergency recovered");
+
+    let state = preflight.runtime.state().expect("projection");
+    assert!(
+        state.compacted_through <= messages.len() - active.len(),
+        "cut {} reached into the active run",
+        state.compacted_through
+    );
+    // The active prompt survives verbatim in the provider-visible context.
+    let effective = preflight.runtime.effective_messages(&messages);
+    assert_eq!(
+        effective
+            .last()
+            .expect("effective context")
+            .content
+            .as_text(),
+        active[0].content.as_text()
+    );
+}
+
+#[tokio::test]
+async fn single_oversized_active_run_fails_closed() {
+    // Nothing is complete, so no rung has a safe cut: the guard must refuse the
+    // request rather than send an oversized one.
+    let messages = active_run("huge in-flight prompt", 33_000);
+    let config = config(2);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(error.contains("active run alone exceeds"), "{error}");
+    assert!(
+        preflight.runtime.state().is_none(),
+        "no projection may be committed"
+    );
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:active_run_too_large"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn summarizer_failure_is_reported_as_a_provider_error() {
+    // Regression: a provider failure used to collapse into "no safe split".
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 31_000));
+    messages.extend(active_run("third", 300));
+    let config = config(2);
+
+    let preflight = preflight(&messages, &config, &MockProvider::partial_error()).await;
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(error.contains("summary generation failed"), "{error}");
+    assert!(!error.contains("no safe Agent-run split"), "{error}");
+    assert!(preflight.runtime.state().is_none());
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:provider_error"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn inflating_summary_is_reported_as_not_reducing() {
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 31_000));
+    messages.extend(active_run("third", 300));
+    let config = config(2);
+    // A summary larger than the ~5 000-token prefix it replaces, but still
+    // inside the 32 KiB persisted bound, so `not_reducing` is what rejects it.
+    let provider = MockProvider::repeat_text(&"inflated ".repeat(3_000));
+
+    let preflight = preflight(&messages, &config, &provider).await;
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(error.contains("did not reduce the context"), "{error}");
+    // Deterministic: the deepest rung already used manual-compaction semantics,
+    // so `/session compact` would reproduce this exact failure.
+    assert!(!error.contains("compact manually"), "{error}");
+    assert!(!error.contains("retry"), "{error}");
+    assert!(error.contains("start a new session"), "{error}");
+    assert!(preflight.runtime.state().is_none());
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:not_reducing"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn oversized_input_is_deterministic_and_does_not_suggest_manual_compaction() {
+    // One completed run larger than the model-aware summarizer input budget:
+    // no rung can render it, and a longer prefix only makes the input bigger,
+    // so manual compaction cannot help either.
+    let mut messages = complete_run("huge completed", 34_000);
+    messages.extend(active_run("in flight", 300));
+    let config = config(2);
+
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(error.contains("summarized without loss"), "{error}");
+    assert!(!error.contains("compact manually"), "{error}");
+    assert!(!error.contains("retry"), "{error}");
+    assert!(error.contains("start a new session"), "{error}");
+    assert!(preflight.runtime.state().is_none());
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:oversized_input"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_transient_provider_failure_still_suggests_retry_and_manual_compaction() {
+    // A summarizer hiccup is not a property of the transcript, so retrying or
+    // running `/session compact` explicitly is genuinely worth suggesting.
+    let mut messages = complete_run("first", 5_000);
+    messages.extend(complete_run("second", 25_000));
+    messages.extend(active_run("third", 300));
+    let config = config(2);
+
+    let preflight = preflight(&messages, &config, &MockProvider::partial_error()).await;
+
+    let error = preflight.error();
+    assert!(error.contains("summary generation failed"), "{error}");
+    assert!(error.contains("retry, compact manually"), "{error}");
+}
+
+#[tokio::test]
+async fn not_reducing_at_a_conservative_cut_still_degrades_and_recovers() {
+    // Regression: `NotReducing` is specific to the cut that was tried, not a
+    // verdict on the transcript. Summarizing only the tiny first run costs more
+    // than it reclaims, but a deeper rung absorbs the large second run and wins.
+    // Treating the first rung's `NotReducing` as terminal reported
+    // `context_limit` for a request the ladder could still save.
+    // Sized so the deep cut (first + second ≈ 30 000 tokens) still fits the
+    // model-aware summarizer input budget for this 40 000-token window, while
+    // the transcript as a whole (≈ 30 300) is over the emergency threshold.
+    let mut messages = complete_run("first", 1_200);
+    messages.extend(complete_run("second", 28_800));
+    messages.extend(active_run("third", 300));
+    let config = config(2);
+    // ~2 000 tokens: more than the 1 200-token first run (so the conservative
+    // rung inflates), far less than the 30 000-token prefix a deeper rung takes.
+    let provider = MockProvider::repeat_text(&"inflated ".repeat(900));
+
+    let preflight = preflight(&messages, &config, &provider).await;
+
+    assert!(
+        preflight.result.is_ok(),
+        "ladder must recover past a cut-specific NotReducing: {:?}",
+        preflight.result
+    );
+    // A projection was committed and it covers the large second run, not just
+    // the first one that could not pay for its own summary.
+    let state = preflight.runtime.state().expect("projection committed");
+    assert!(
+        state.compacted_through > 2,
+        "deeper rung must summarize past the first run: {}",
+        state.compacted_through
+    );
+    assert_projection_is_consistent(&preflight.runtime, &messages, 1);
+    // The effective context is back under the emergency threshold.
+    let budget = budget_for(&config);
+    assert!(!budget.over_emergency(
+        preflight
+            .runtime
+            .effective_history_tokens(&messages, PREFIX_TOKENS)
+    ));
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_completed"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn an_oversized_summary_with_nothing_left_to_cut_reports_no_safe_split() {
+    // Resumed session on a tiny window whose existing projection already covers
+    // the whole transcript: no rung has a candidate and there is no active run,
+    // so the snapshot itself is what exceeds the threshold.
+    let messages = complete_run("summarized", 400);
+    let mut config = config(2);
+    config.session.compaction.model_context_window = Some(8_000);
+    let state = crate::compaction::CompactionState {
+        revision: 3,
+        compacted_through: messages.len(),
+        summary: "prior context ".repeat(1_400),
+        model: "mock-model".to_string(),
+        prompt_version: super::super::projection::COMPACTION_PROMPT_VERSION,
+        source_digest: source_digest(&messages),
+        tokens_before: None,
+        tokens_after: None,
+        created_at_ms: 0,
+    };
+
+    let preflight =
+        preflight_resuming(&messages, &config, &summarizer(), Some(state.clone())).await;
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(error.contains("no safe Agent-run split"), "{error}");
+    // The pre-existing projection is untouched by a failed emergency.
+    assert_eq!(preflight.runtime.state(), Some(&state));
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:no_safe_split"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_summary_plus_a_modest_active_run_reports_an_irreducible_remainder() {
+    // A large persisted summary and an active run that is well under the
+    // threshold on its own exhaust the ladder together. Blaming the active run
+    // merely because one exists would misdirect the operator, so the measured
+    // remainder is classified as irreducible instead.
+    let mut messages = complete_run("summarized", 400);
+    let active_tokens = 23_000;
+    messages.extend(active_run("in flight", active_tokens));
+    let config = config(2);
+    let budget = budget_for(&config);
+    // ~8 000 tokens, just inside the 32 KiB persisted summary bound.
+    let state = crate::compaction::CompactionState {
+        revision: 4,
+        compacted_through: 2,
+        summary: "prior context ".repeat(2_285),
+        model: "mock-model".to_string(),
+        prompt_version: super::super::projection::COMPACTION_PROMPT_VERSION,
+        source_digest: source_digest(&messages[..2]),
+        tokens_before: None,
+        tokens_after: None,
+        created_at_ms: 0,
+    };
+    // Preconditions that make this case distinct from `active_run_too_large`:
+    // the tail alone is under the threshold, but with the summary it is over.
+    assert!(!budget.over_emergency(active_tokens));
+
+    let preflight =
+        preflight_resuming(&messages, &config, &summarizer(), Some(state.clone())).await;
+
+    let error = preflight.error();
+    assert!(error.starts_with(CONTEXT_LIMIT_ERROR_PREFIX), "{error}");
+    assert!(
+        error.contains("summary plus the remaining verbatim messages"),
+        "{error}"
+    );
+    assert!(!error.contains("active run alone exceeds"), "{error}");
+    // The deepest rung already used manual semantics, so manual compaction is
+    // not offered as the recovery path.
+    assert!(!error.contains("compact manually"), "{error}");
+    assert!(error.contains("start a new session"), "{error}");
+    assert_eq!(preflight.runtime.state(), Some(&state));
+    assert_eq!(
+        preflight.status_codes(),
+        vec![
+            "compaction_emergency_started",
+            "compaction_emergency_failed:irreducible_remainder"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn a_context_under_the_threshold_is_left_alone() {
+    let messages = complete_run("small", 500);
+    let config = config(2);
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight.result.as_ref().expect("no emergency");
+    assert!(preflight.runtime.state().is_none());
+    assert!(preflight.statuses.is_empty());
+}
+
+#[test]
+fn the_ladder_degrades_monotonically_without_duplicate_rungs() {
+    assert_eq!(
+        emergency_ladder(2),
+        vec![
+            PreservationPolicy::RecentRuns(2),
+            PreservationPolicy::RecentRuns(1),
+            PreservationPolicy::ThroughLatestCompletedRun,
+        ]
+    );
+    // A policy of 0 or 1 must not spend two identical summarizer calls.
+    for preserve in [0, 1] {
+        assert_eq!(
+            emergency_ladder(preserve),
+            vec![
+                PreservationPolicy::RecentRuns(1),
+                PreservationPolicy::ThroughLatestCompletedRun,
+            ],
+            "preserve_recent_runs = {preserve}"
+        );
+    }
+    assert_eq!(emergency_ladder(5).len(), 3);
+}
+
+#[tokio::test]
+async fn disabled_compaction_skips_the_guard_entirely() {
+    let messages = complete_run("only", 33_000);
+    let mut config = config(2);
+    config.session.compaction.enabled = false;
+    let preflight = preflight(&messages, &config, &summarizer()).await;
+    preflight
+        .result
+        .as_ref()
+        .expect("a disabled policy must not block the request");
+    assert!(preflight.statuses.is_empty());
+}

--- a/src/cosh-ng/crates/cosh-core/src/compaction/summarize.rs
+++ b/src/cosh-ng/crates/cosh-core/src/compaction/summarize.rs
@@ -371,7 +371,8 @@ mod tests {
     fn token_budget_derivation_reserves_prompt_output_and_margin() {
         let small = ModelCapability {
             context_window: 32_768,
-            max_output_tokens: 8_192,
+            output_capability_tokens: Some(8_192),
+            output_budget_tokens: 8_192,
             source: crate::compaction::budget::CapabilitySource::ProviderProfile,
         };
         let small_budget = summary_input_token_budget(&small);
@@ -382,7 +383,8 @@ mod tests {
         // A large-window model keeps a proportionally larger usable input.
         let large = ModelCapability {
             context_window: 200_000,
-            max_output_tokens: 8_192,
+            output_capability_tokens: Some(8_192),
+            output_budget_tokens: 8_192,
             source: crate::compaction::budget::CapabilitySource::ProviderProfile,
         };
         assert!(summary_input_token_budget(&large) > small_budget * 4);

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -273,15 +273,26 @@ pub struct CompactionConfig {
     /// Best-effort post-compaction fraction of the usable history budget.
     #[serde(default = "default_target_ratio")]
     pub target_ratio: f64,
-    /// Minimum recent complete Agent runs kept verbatim by automatic and
-    /// emergency compaction; at least one is always retained. Explicit manual
-    /// compaction may summarize the latest complete run.
+    /// Minimum recent complete Agent runs kept verbatim by normal automatic
+    /// compaction.
+    ///
+    /// Explicit manual compaction may summarize the latest complete run. So may
+    /// emergency protection as a last resort: rather than failing the request,
+    /// its fallback ladder degrades this value to one and then to
+    /// manual-compaction semantics, which reserves no complete run
+    /// unconditionally. The in-flight (incomplete) run is never summarized by
+    /// any path.
     #[serde(default = "default_preserve_recent_runs")]
     pub preserve_recent_runs: usize,
     /// Explicit user override for the model context window, in tokens.
     #[serde(default)]
     pub model_context_window: Option<u64>,
-    /// Explicit user override for the maximum model output reserve, in tokens.
+    /// Explicit user override for the model's maximum output size, in tokens.
+    ///
+    /// Drives both sides of the output accounting from one value: the reserve
+    /// `O` subtracted from the usable history budget, and the `max_tokens` cap
+    /// sent on the real provider request. Lowering it therefore frees history
+    /// budget *and* shortens the longest reply the model may produce.
     #[serde(default)]
     pub model_max_output_tokens: Option<u64>,
 }

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -12,7 +12,7 @@ use cosh_types::audit::{AuditOutcomeStatus, AuditProviderData, AuditToolData, Ou
 
 use crate::audit::{CoreAuditRecorder, CoreAuditScope};
 use crate::auth::is_auth_error;
-use crate::compaction::CompactionRuntime;
+use crate::compaction::{CompactionRuntime, ModelCapability};
 use crate::config::{self, CoreConfig};
 use crate::context::ContextBuilder;
 use crate::extension::{GenerationController, RuntimeGeneration, RuntimeSnapshot};
@@ -21,8 +21,7 @@ use crate::loop_detect::LoopDetector;
 use crate::metrics::TurnMetrics;
 use crate::protocol::{InputMessage, OutputMessage, ShellContext, ShellControlRequest};
 use crate::provider::{
-    token_limits::model_max_output_tokens, ContentGenerator, GenerateConfig, GenerateEvent,
-    Message, MAX_TOOL_CALL_INDEX,
+    ContentGenerator, GenerateConfig, GenerateEvent, Message, MAX_TOOL_CALL_INDEX,
 };
 use crate::tool::ask_user_question;
 use crate::tool::{SessionWorkspace, ToolContext, ToolKind, ToolRegistry, ToolResult};
@@ -443,9 +442,18 @@ impl CoshCore {
 
         let tool_decls = self.tools.declarations();
         let skill_summaries = self.tools.skill_summaries().await;
+        // One resolver drives both sides of the output accounting: the cap this
+        // request may spend and the `O` the compaction budget reserves for it.
+        // Deriving them separately let the budget reserve a model's whole output
+        // capability while the request still asked for it (#2240).
+        let capability = ModelCapability::resolve(
+            &self.config.session.compaction,
+            self.config.agent.session_token_limit,
+            &self.model,
+        );
         let generate_config = GenerateConfig {
             model: self.model.clone(),
-            max_tokens: model_max_output_tokens(&self.model).unwrap_or(4096),
+            max_tokens: capability.request_max_tokens(),
             temperature: None,
             // Usage reporting feeds compaction thresholds; the stream adapter
             // guarantees Usage is delivered before MessageEnd.

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -25,6 +25,93 @@ struct CountingShellTool {
 
 struct ExternalTool;
 
+/// Records the `GenerateConfig` of every agent-turn request it serves.
+struct ConfigRecordingProvider {
+    configs: Arc<Mutex<Vec<crate::provider::GenerateConfig>>>,
+}
+
+#[async_trait]
+impl crate::provider::ContentGenerator for ConfigRecordingProvider {
+    async fn generate(
+        &self,
+        _messages: &[crate::provider::Message],
+        _tools: &[crate::provider::ToolDeclaration],
+        config: &crate::provider::GenerateConfig,
+    ) -> Result<crate::provider::GenerateStream, String> {
+        self.configs.lock().unwrap().push(config.clone());
+        Ok(Box::pin(futures::stream::iter([
+            crate::provider::GenerateEvent::TextDelta("done".to_string()),
+            crate::provider::GenerateEvent::MessageEnd,
+        ])))
+    }
+
+    fn cancel(&self) {}
+}
+
+/// Runs one turn against `model` and returns the `max_tokens` actually sent
+/// together with the output reserve the compaction budget charged for it.
+async fn requested_and_reserved_output_tokens(
+    model: &str,
+    compaction: crate::config::CompactionConfig,
+) -> (u32, u64) {
+    let configs = Arc::new(Mutex::new(Vec::new()));
+    let provider = ConfigRecordingProvider {
+        configs: Arc::clone(&configs),
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.session.compaction = compaction.clone();
+    let session_token_limit = config.agent.session_token_limit;
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    core.model = model.to_string();
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+    core.handle_user_message("hello", &mut reader, &mut output)
+        .await
+        .expect("turn completes");
+
+    let capability =
+        crate::compaction::ModelCapability::resolve(&compaction, session_token_limit, model);
+    let budget = crate::compaction::ContextBudget::compute(capability, 1_000, &compaction);
+    let sent = configs.lock().unwrap();
+    assert_eq!(sent.len(), 1, "exactly one provider request per turn");
+    (sent[0].max_tokens, budget.output_reserve)
+}
+
+#[tokio::test]
+async fn request_max_tokens_matches_the_reserved_output_budget() {
+    // #2240: the request used to ask for the model's whole 65 536-token output
+    // capability while the budget reserved the same amount, leaving a
+    // 131 072-token window with only ~52K of usable history. Both sides now read
+    // one resolver, so they can never disagree.
+    let (requested, reserved) = requested_and_reserved_output_tokens(
+        "qwen3.7-max",
+        crate::config::CompactionConfig::default(),
+    )
+    .await;
+    assert_eq!(requested, 16_384, "max_tokens actually sent");
+    assert_eq!(u64::from(requested), reserved);
+
+    // An unknown model shares the conservative default on both sides.
+    let (requested, reserved) = requested_and_reserved_output_tokens(
+        "brand-new-model",
+        crate::config::CompactionConfig::default(),
+    )
+    .await;
+    assert_eq!(requested, 4_096);
+    assert_eq!(u64::from(requested), reserved);
+
+    // An explicit override raises both, never only one.
+    let overridden = crate::config::CompactionConfig {
+        model_max_output_tokens: Some(24_000),
+        ..Default::default()
+    };
+    let (requested, reserved) =
+        requested_and_reserved_output_tokens("qwen3.7-max", overridden).await;
+    assert_eq!(requested, 24_000);
+    assert_eq!(u64::from(requested), reserved);
+}
+
 #[derive(Default)]
 struct RecordingProvider {
     messages: Arc<Mutex<Vec<crate::provider::Message>>>,

--- a/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/mod.rs
@@ -195,6 +195,43 @@ impl Default for GenerateConfig {
     }
 }
 
+/// Request fields an OpenAI-compatible backend may honor as the output cap.
+///
+/// Both are clamped: a backend that ignores one may still honor the other, so
+/// leaving either unbounded would let the real request outspend the reserve.
+const OUTPUT_CAP_FIELDS: [&str; 2] = ["max_tokens", "max_completion_tokens"];
+
+/// Clamps every output-cap field already present in a serialized request body
+/// to `max_tokens`.
+///
+/// Request builders merge user-supplied `extra_params` into the body, and that
+/// merge can replace the resolved cap (`extra_params.max_tokens = 65536` while
+/// the compaction budget reserved 16K). Because the reserve `O` and this cap
+/// come from one resolver, a request permitted to exceed it would reintroduce
+/// the context-overflow mismatch. Call this *last*, after every merge, so the
+/// serialized value is authoritative.
+///
+/// A field that is absent stays absent — adding an alias could break a backend
+/// that rejects unknown fields. A lower explicit value is preserved (asking for
+/// less than the reserve is always safe); anything higher, or any non-numeric
+/// value, is replaced by `max_tokens`.
+pub(crate) fn clamp_output_cap_fields(body: &mut Value, max_tokens: u32) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    for field in OUTPUT_CAP_FIELDS {
+        let Some(value) = object.get_mut(field) else {
+            continue;
+        };
+        let within_cap = value
+            .as_u64()
+            .is_some_and(|requested| requested <= u64::from(max_tokens));
+        if !within_cap {
+            *value = Value::from(max_tokens);
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum GenerateEvent {
     TextDelta(String),

--- a/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/openai_compat.rs
@@ -157,6 +157,12 @@ impl OpenAICompatProvider {
 
         self.add_cache_control(&mut body);
 
+        // Last word on the output cap: `extra_params` above may have replaced
+        // the resolved `max_tokens` (or introduced the `max_completion_tokens`
+        // alias), which would let the wire request outspend the output reserve
+        // the compaction budget priced this request against (#2240).
+        super::clamp_output_cap_fields(&mut body, config.max_tokens);
+
         body
     }
 }
@@ -1167,6 +1173,90 @@ mod tests {
         let body = provider.build_request_body(&[], &[], &config);
         assert_eq!(body["enable_thinking"], true);
         assert_eq!(body["thinking_budget"], 4096);
+    }
+
+    #[test]
+    fn extra_params_cannot_raise_the_wire_output_cap() {
+        // Regression (#2240): the compaction budget reserves `O` from the same
+        // resolver that produced `max_tokens`, so the serialized request must
+        // never be able to spend more than that reserve. Both cap aliases are
+        // clamped because a backend may honor either one.
+        let provider = OpenAICompatProvider::new_generic("https://example.com/v1", "sk-test");
+        let config = GenerateConfig {
+            model: "test".to_string(),
+            max_tokens: 16_384,
+            extra_params: Some(serde_json::json!({
+                "max_tokens": 65_536u32,
+                "max_completion_tokens": 65_536u32,
+            })),
+            ..Default::default()
+        };
+
+        let body = provider.build_request_body(&[], &[], &config);
+
+        assert_eq!(body["max_tokens"], 16_384);
+        assert_eq!(body["max_completion_tokens"], 16_384);
+    }
+
+    #[test]
+    fn extra_params_cannot_raise_the_wire_cap_on_the_alias_field_profile() {
+        // The OpenAI profile serializes `max_completion_tokens`; extra_params
+        // must not raise it, nor sneak an unbounded `max_tokens` past the cap.
+        let provider = OpenAICompatProvider::new(
+            "https://api.openai.com/v1",
+            "sk-test",
+            Box::new(super::super::profile::OpenAIProfile),
+            false,
+        );
+        let config = GenerateConfig {
+            model: "o3".to_string(),
+            max_tokens: 8_192,
+            extra_params: Some(serde_json::json!({
+                "max_completion_tokens": 65_536u32,
+                "max_tokens": 65_536u32,
+            })),
+            ..Default::default()
+        };
+
+        let body = provider.build_request_body(&[], &[], &config);
+
+        assert_eq!(body["max_completion_tokens"], 8_192);
+        assert_eq!(body["max_tokens"], 8_192);
+    }
+
+    #[test]
+    fn extra_params_may_still_lower_the_wire_output_cap() {
+        // Asking for less than the reserve is always safe and is preserved.
+        let provider = OpenAICompatProvider::new_generic("https://example.com/v1", "sk-test");
+        let config = GenerateConfig {
+            model: "test".to_string(),
+            max_tokens: 16_384,
+            extra_params: Some(serde_json::json!({"max_tokens": 512u32})),
+            ..Default::default()
+        };
+
+        let body = provider.build_request_body(&[], &[], &config);
+
+        assert_eq!(body["max_tokens"], 512);
+        // The alias is not invented for a backend that never received it.
+        assert!(body.get("max_completion_tokens").is_none(), "{body}");
+    }
+
+    #[test]
+    fn non_numeric_extra_params_cap_is_replaced_by_the_reserve() {
+        // A string or null cap could be coerced by a backend; fail closed to
+        // the resolved reserve instead of forwarding it.
+        let provider = OpenAICompatProvider::new_generic("https://example.com/v1", "sk-test");
+        let config = GenerateConfig {
+            model: "test".to_string(),
+            max_tokens: 4_096,
+            extra_params: Some(serde_json::json!({"max_tokens": "65536"})),
+            ..Default::default()
+        };
+
+        let body = provider.build_request_body(&[], &[], &config);
+
+        assert_eq!(body["max_tokens"], 4_096);
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom.rs
@@ -151,6 +151,11 @@ impl SysomProvider {
             inner["instance_id"] = serde_json::json!(id);
         }
 
+        // Last word on the output cap: the `extra_params` merge above may have
+        // replaced the resolved `max_tokens`, which would let the wire request
+        // outspend the reserve the compaction budget priced it against (#2240).
+        super::clamp_output_cap_fields(&mut inner, config.max_tokens);
+
         // Wrap in llmParamString
         serde_json::json!({
             "llmParamString": inner.to_string()

--- a/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/provider/sysom/tests.rs
@@ -43,3 +43,63 @@ fn build_request_preserves_user_provided_secrets() {
     assert!(payload.contains(secret), "{payload}");
     assert!(!payload.contains("<redacted>"), "{payload}");
 }
+
+fn test_provider() -> SysomProvider {
+    SysomProvider {
+        endpoint: DEFAULT_ENDPOINT.to_string(),
+        credentials: std::sync::RwLock::new(SysomCredentials {
+            access_key_id: "test-id".to_string(),
+            access_key_secret: "test-secret".to_string(),
+            security_token: None,
+        }),
+        is_sts: false,
+        cancelled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        instance_id: None,
+    }
+}
+
+/// Parses the inner request the SysOM wrapper actually sends.
+fn wire_inner(body: &serde_json::Value) -> serde_json::Value {
+    serde_json::from_str(
+        body["llmParamString"]
+            .as_str()
+            .expect("llmParamString is a string"),
+    )
+    .expect("inner request is JSON")
+}
+
+#[test]
+fn extra_params_cannot_raise_the_wire_output_cap() {
+    // Regression (#2240): the compaction budget reserves `O` from the same
+    // resolver that produced `max_tokens`, so a wire request must never be
+    // allowed to spend more than the reserve — not even via extra_params.
+    let provider = test_provider();
+    let config = GenerateConfig {
+        max_tokens: 16_384,
+        extra_params: Some(serde_json::json!({
+            "max_tokens": 65_536u32,
+            "max_completion_tokens": 65_536u32,
+        })),
+        ..GenerateConfig::default()
+    };
+
+    let inner = wire_inner(&provider.build_request_body(&[], &[], &config));
+
+    assert_eq!(inner["max_tokens"], 16_384);
+    assert_eq!(inner["max_completion_tokens"], 16_384);
+}
+
+#[test]
+fn extra_params_may_still_lower_the_wire_output_cap() {
+    // Asking for less than the reserve is always safe and is preserved.
+    let provider = test_provider();
+    let config = GenerateConfig {
+        max_tokens: 16_384,
+        extra_params: Some(serde_json::json!({"max_tokens": 512u32})),
+        ..GenerateConfig::default()
+    };
+
+    let inner = wire_inner(&provider.build_request_body(&[], &[], &config));
+
+    assert_eq!(inner["max_tokens"], 512);
+}

--- a/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/compaction_lifecycle.rs
@@ -135,6 +135,15 @@ fn bulky_prompt(index: usize) -> String {
     )
 }
 
+/// A prompt large enough that two of them cross a 16 000-token window's
+/// emergency threshold on their own.
+fn huge_prompt(index: usize) -> String {
+    format!(
+        "operations step {index}: {}",
+        "inspect memory pressure 排查内存 ".repeat(600)
+    )
+}
+
 const MANUAL_POLICY: &str = r#"
 [session.compaction]
 enabled = true
@@ -513,6 +522,71 @@ auto_compact_token_limit = 1
         compaction_recommendation(&third).is_some(),
         "a newly eligible complete run should trigger compaction: {third:?}"
     );
+}
+
+#[test]
+fn emergency_preflight_recovers_under_the_default_recent_run_protection() {
+    let fixture = fixture();
+    // Exactly two Agent runs exist at the second turn's preflight: one complete
+    // run plus the in-flight prompt. `preserve_recent_runs = 2` therefore offers
+    // no candidate cut at all, which used to fail closed with `context_limit:`
+    // even though `/session compact` would have succeeded (#2240). The ladder
+    // must degrade to one protected run and recover.
+    configure(
+        &fixture,
+        "mock-compact-summary",
+        r#"
+[session.compaction]
+enabled = true
+auto = false
+preserve_recent_runs = 2
+model_context_window = 16000
+"#,
+    );
+
+    let first = json_lines(&run_core(&fixture, &[huge_prompt(0).as_str()]));
+    let session_id = session_id_of(&first);
+
+    let output = run_core(
+        &fixture,
+        &["--resume", session_id.as_str(), huge_prompt(1).as_str()],
+    );
+    let messages = json_lines(&output);
+    let statuses: Vec<&str> = messages
+        .iter()
+        .filter(|message| message["type"] == "system")
+        .filter_map(|message| message["status"].as_str())
+        .collect();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Self-validating: without this the assertions below would pass vacuously.
+    assert!(
+        statuses.contains(&"compaction_emergency_started"),
+        "the scenario never reached the emergency threshold: {statuses:?}"
+    );
+    assert!(
+        statuses.contains(&"compaction_emergency_completed"),
+        "emergency compaction did not degrade past preserve_recent_runs = 2: \
+         {statuses:?}\n{stdout}"
+    );
+    assert!(
+        !statuses
+            .iter()
+            .any(|status| status.starts_with("compaction_emergency_failed")),
+        "{statuses:?}"
+    );
+    assert!(!stdout.contains("context_limit:"), "{stdout}");
+
+    // The transcript stays complete; compaction only added a projection whose
+    // cut lands on the run boundary before the in-flight prompt.
+    let envelope = persisted_envelope(&fixture.store);
+    let transcript = envelope["messages"].as_array().expect("messages").len();
+    assert_eq!(transcript, 4);
+    let projection = envelope
+        .get("compaction")
+        .expect("a projection was committed");
+    assert_eq!(projection["revision"], 1);
+    assert_eq!(projection["compacted_through"], 2);
 }
 
 #[test]


### PR DESCRIPTION
## Why

Long cosh-ng sessions could hit `context_limit:` around 48K history tokens on
large-output models because the full model output capability was charged as the
per-request reserve. Emergency compaction also stopped after the configured
recent-run boundary even when the same safe cut used by manual compaction could
recover the request.

## What changed

- Resolve one per-request output budget for both context accounting and the
  provider wire cap, including a final clamp after `extra_params` are merged.
- Degrade emergency compaction from the configured preservation policy to one
  recent run and then manual-compaction semantics, without summarizing the
  active run.
- Report typed terminal causes and recovery hints, with regression coverage and
  bilingual documentation for the new defaults.

## Related issue

closes #2240

## User / Agent impact

Large-output models retain more usable conversation history by default, while
emergency pressure automatically reclaims every safe completed-run prefix
before failing. The active run remains verbatim, and users can explicitly tune
the maximum reply budget when longer outputs are required.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The default request cap is lower for models whose hard output capability is
larger than 16K. `session.compaction.model_max_output_tokens` can restore a
larger cap, and the shell continues to consume the stable `context_limit:`
failure prefix.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `cargo test -p cosh-core --bin cosh-core compaction::preflight::tests::`
  (15 passed)
- `cargo test -p cosh-core provider` (all matched targets passed)
- `./scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check up/main...HEAD`

No real-provider or ECS validation was requested; broader coverage is left to
CI.

## Documentation and rollback

Updated the cosh-ng README summaries and the English and Chinese configuration
and session-compaction guides. Reverting this commit restores the previous
budget and emergency-compaction behavior; users who only need the previous
reply allowance can instead raise `model_max_output_tokens` explicitly.
