### PR TITLE
feat(sec-core): add security observability skill

### DIFF
--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -503,15 +503,20 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
 - The aggregation output is counts + RISK lines only; `pass`/`allow` events
   never get a per-event line and their `details` are not fetched. This is a
   context-cost invariant, not cosmetics: a security report must not flood the
-  Agent conversation. Keep the "上下文开销控制" guidance (count first, expand
+  Agent conversation. Keep the "上下文开销控制" guidance (count first, set an
+  explicit `--limit` or paginate until every matching event is covered, expand
   only pending items, drill by `event_id` on demand, aggregate through the
-  pipe) intact when editing.
+  pipe) intact when editing. Never let the aggregation path rely on the CLI
+  default `--limit 100`: counts between 101 and 200 must still be fetched in
+  full before reporting risk totals.
 - The "参数取值约束" section is a security control, not style. Every documented
   command interpolates `<session_id>`/`<event_id>` into a single-quoted shell
-  string, and the skill explicitly accepts a user-supplied `session_id`, so an
+  string, and the skill explicitly accepts user-supplied correlation IDs, so an
   unvalidated value closes the quote and yields command injection (verified
-  reproducible). Keep the strict UUID full-match requirement whenever adding or
-  editing a command that carries an ID placeholder.
+  reproducible). Do not narrow all IDs to UUIDs: adapters persist values such as
+  `session-001` or `thread_xxx`. Keep a bounded safe-character full-match
+  requirement for generic correlation IDs, and keep the stricter UUID check for
+  cosh-ng `runtime_context.provider_session_id`, which is expected to be a UUID.
 - The "获取单条事件细节" section exists because `events` has **no `--event-id`
   filter**; single-event drill-down must go through client-side `jq` selection.
   Keep it that way unless the CLI gains such a filter. Detail lives under the
@@ -534,8 +539,9 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
   exposes that tool as of this release. If one starts to, update both the skill
   section and its contract test.
 - Only cosh-ng lets an Agent resolve its own `session_id`. Every other runtime
-  must fall back to a time range or `--last` and state the real query scope in
-  its answer, so keep the skill from telling those Agents to ask the user for an
+  must fall back to a time range or, only when the user explicitly asks for the
+  latest recorded session, `--last`, and state the real query scope in its
+  answer, so keep the skill from telling those Agents to ask the user for an
   id they cannot obtain. `run_id` and `trace_id` are never self-resolvable.
 - Keep the warning that `COSH_SESSION_ID` is not the agent session id. In
   cosh-ng it is the shell/terminal identity recorded as `shell_session_id`, so

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -480,6 +480,22 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
 - Verify the source CLI definitions before editing the skill. Treat `--summary`
   and table/text output as human-display surfaces; structured Agent parsing must
   keep using JSON or JSONL examples.
+- The "获取当前 session_id" section documents a cosh-ng-only path: the cosh-ng
+  `runtime_context` tool returns `provider_session_id`, which is the same value
+  cosh-ng passes to hooks as `session_id` and therefore the same value stored on
+  security events and observability records. Keep that section explicitly scoped
+  to cosh-ng and keep the generic fallback next to it; no other agent runtime
+  exposes that tool as of this release. If one starts to, update both the skill
+  section and its contract test.
+- Only cosh-ng lets an Agent resolve its own `session_id`. Every other runtime
+  must fall back to a time range or `--last` and state the real query scope in
+  its answer, so keep the skill from telling those Agents to ask the user for an
+  id they cannot obtain. `run_id` and `trace_id` are never self-resolvable.
+- Keep the warning that `COSH_SESSION_ID` is not the agent session id. In
+  cosh-ng it is the shell/terminal identity recorded as `shell_session_id`, so
+  querying with it silently returns zero events and reads as "no security
+  events". If cosh-ng changes how the session id is exposed, update the skill
+  section and its contract test in the same change.
 
 ---
 

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -466,7 +466,20 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
 
 ## skills
 
-> TODO: 待补充
+### security-observability
+
+- `skills/security-observability/SKILL.md` intentionally keeps a self-contained
+  parameter and output contract for `agent-sec-cli events` and
+  `agent-sec-cli observability report`. Do not replace it with instructions that
+  require the Agent to run `--help` before each use; that adds avoidable tool
+  calls and context-reconstruction cost.
+- The duplicated parameter table is an implicit contract with the CLI help text.
+  When changing `events` or `observability report` options, defaults,
+  mutual-exclusion rules, output formats, or documented fields, update the
+  corresponding SKILL.md section and contract tests in the same change.
+- Verify the source CLI definitions before editing the skill. Treat `--summary`
+  and table/text output as human-display surfaces; structured Agent parsing must
+  keep using JSON or JSONL examples.
 
 ---
 

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -500,6 +500,54 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
 - Within an allowlisted type only an explicit `pass` counts as risk-free;
   new/other verdict values (including `error`), missing fields, and non-string
   verdicts must surface as pending (`MISSING`) items rather than silently pass.
+  This is what keeps the skill correct despite per-type enum differences, so do
+  not rewrite the aggregation into a per-type reject list.
+- The verdict enums are not uniform across scan types, and they do not all come
+  from a `Verdict` class. `code_scan`, `prompt_scan`, and `pii_scan` use their
+  own `Verdict` enums (`pass`/`warn`/`deny`/`error`), but `skill_ledger` events
+  carry a projected verdict gated by `_VERDICT_SEVERITY` in
+  `security_middleware/backends/skill_ledger.py`, which is wider: `pass`,
+  `none`, `warn`, `unmanaged`, `drifted`, `deny`, `tampered`, `error`. Read that
+  dict — not `skill_ledger/models/scan.py`'s `_SEVERITY_ORDER`, which is a
+  different four-value ordering used for aggregating a skill's own scan status
+  and ranks `none` *below* `pass` — when updating the skill's verdict table.
+- The "取值语义" table exists so a report explains a verdict instead of echoing
+  the raw token. Two entries are counter-intuitive and must keep their explicit
+  wording: `error` means the scanner itself failed (`prompt_scanner/result.py`:
+  "Scanner execution failed"), not a high-risk finding; `none` means unscanned
+  (`status.py` maps an all-`none` ledger to health `unscanned`). Reporting either
+  one as "safe" or as "high risk" is a factual error in both directions.
+  `drifted` and `tampered` sit on different axes: `drifted` is a `fileHashes`
+  mismatch against the signed snapshot (`skill_ledger/core/checker.py`), while
+  `tampered` means the ledger metadata or signature itself failed authentication.
+- Semantic wording is sourced, not invented. Take per-status phrasing from
+  `skill_ledger/cli.py`'s integrity-status help text (note it omits `unmanaged`
+  and `error`). The skill deliberately carries **no severity ranking**: it was
+  tried and removed as needless complexity, since the per-value semantics plus
+  the "no valid verdict" caveat already tell the Agent what to say. If a ranking
+  is ever reintroduced, source it from `_VERDICT_SEVERITY` in
+  `security_middleware/backends/skill_ledger.py` — the same dict that gates event
+  verdicts, and the only ordering covering all eight tokens. Never source it from
+  `skill_ledger/core/status.py`'s `_CRITICAL_STATUSES` / `_ATTENTION_STATUSES`:
+  those are `health` values of the separate `skill-ledger status` command, never
+  appear in `events` output, and omit `unmanaged`. An earlier revision imported
+  that critical/attention vocabulary and had to be reverted.
+- `skill_ledger` is the only scan type whose events can legitimately carry no
+  verdict. Eleven `skill-ledger` subcommands route through `invoke()` and emit
+  events, but `_project_event_verdict` only projects six (`init`, `scan`,
+  `check`, `show`, `certify`, `decide`); the rest (`status`, `audit`,
+  `list-scanners`, `export`, `init-keys`) produce an audit record with no
+  verdict, so the aggregation reports them as `MISSING`. Verified on a live host:
+  of 1476 events, `pii_scan`/`code_scan`/`prompt_scan` were 100% verdict-bearing
+  while three of four `skill_ledger` events lacked one.
+- That `MISSING` noise is handled **in the "取值语义" table, not by filtering**.
+  A judgment-command allowlist in the pipeline was considered and rejected as too
+  complex for the one-line command constraint. Accepted residual cost: the
+  `risk_items` headline count still includes non-judgment `skill_ledger` records,
+  so the skill instructs the Agent to report them as "非判定操作" and to treat
+  `MISSING` as a real pending item only for the other three scan types. Do not
+  "fix" this by making `MISSING` risk-free across the board — that would blind the
+  three scanners where a missing verdict is genuinely anomalous.
 - The aggregation output is counts + RISK lines only; `pass`/`allow` events
   never get a per-event line and their `details` are not fetched. This is a
   context-cost invariant, not cosmetics: a security report must not flood the

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -480,6 +480,52 @@ uv run --project agent-sec-cli pytest tests/unit-test/hermes-plugin/ -v
 - Verify the source CLI definitions before editing the skill. Treat `--summary`
   and table/text output as human-display surfaces; structured Agent parsing must
   keep using JSON or JSONL examples.
+- The "风险审查" section is a gate, not reference material. Security conclusions
+  must come from its aggregation commands over the per-event verdict field
+  (`details.result.verdict`). Never let the skill summarize by top-level
+  `result` or by `observability report`'s `security_verdicts`: both aggregate
+  whether the scanner *ran*, and top-level `result` is `succeeded` for
+  practically every event, so summarizing by it answers "no risk"
+  unconditionally. A regression once reported "no security events" for a
+  session holding a `prompt_scan` deny and a `code_scan` warn.
+- The aggregation scope is the four *scan* event types only: `code_scan`,
+  `prompt_scan`, `pii_scan`, `skill_ledger`. Non-scan events (`sandbox_prehook`,
+  `harden`, `verify`, `summary`) are filtered at the pipe entry via an
+  allowlist `select`, not scored. This allowlist is fail-open: a newly added
+  *scan* `event_type` is silently dropped until it is added to both `$spec`
+  (jq) and `SPEC` (python3), so update the verdict-path table, both aggregation
+  commands, and the contract tests in the same change. Verify the event_type
+  set against `security_middleware/lifecycle.py`'s `_ACTION_CATEGORY` before
+  editing.
+- Within an allowlisted type only an explicit `pass` counts as risk-free;
+  new/other verdict values (including `error`), missing fields, and non-string
+  verdicts must surface as pending (`MISSING`) items rather than silently pass.
+- The aggregation output is counts + RISK lines only; `pass`/`allow` events
+  never get a per-event line and their `details` are not fetched. This is a
+  context-cost invariant, not cosmetics: a security report must not flood the
+  Agent conversation. Keep the "上下文开销控制" guidance (count first, expand
+  only pending items, drill by `event_id` on demand, aggregate through the
+  pipe) intact when editing.
+- The "参数取值约束" section is a security control, not style. Every documented
+  command interpolates `<session_id>`/`<event_id>` into a single-quoted shell
+  string, and the skill explicitly accepts a user-supplied `session_id`, so an
+  unvalidated value closes the quote and yields command injection (verified
+  reproducible). Keep the strict UUID full-match requirement whenever adding or
+  editing a command that carries an ID placeholder.
+- The "获取单条事件细节" section exists because `events` has **no `--event-id`
+  filter**; single-event drill-down must go through client-side `jq` selection.
+  Keep it that way unless the CLI gains such a filter. Detail lives under the
+  uniform `details` = `{request, result}` shape, with `details.result.findings[]`
+  as the per-hit evidence; document it at that level instead of enumerating
+  each scanner's inner finding keys, which differ per scanner and would rot.
+- Keep the "报告不得重新引入敏感值" rule: reports may only cite the redacted
+  fields the event already carries (`evidence_redacted` et al., produced by
+  `pii_checker/audit.py`'s `_sanitize_result`, which drops `raw_evidence` and
+  keeps only `text_length`/`text_sha256` on the request side). Recovering the
+  original value from conversation history to "explain better" turns a
+  read-only query into a fresh leak, because model output is itself PII-scanned
+  (`source=model_output`). Describe redaction formats by pattern rather than
+  pasting observed values.
 - The "获取当前 session_id" section documents a cosh-ng-only path: the cosh-ng
   `runtime_context` tool returns `provider_session_id`, which is the same value
   cosh-ng passes to hooks as `session_id` and therefore the same value stored on

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -19,9 +19,11 @@ description: 只读查询 agent-sec-cli 已落盘的历史安全事件记录，�
 
 ## 参数取值约束
 
-本文命令中的 `<session_id>`、`<run_id>`、`<trace_id>`、`<event_id>` 均为 UUID。替换占位符前必须先校验取值形态，**仅当它完全匹配 `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` 时才能拼入命令**。
+本文命令中的 `<session_id>`、`<run_id>`、`<trace_id>`、`<event_id>` 是 Agent 运行时或 CLI 持久化的 correlation ID，不一定是 UUID；OpenClaw、Codex、Qwen Code 等运行时可能使用 `session-001`、`thread_xxx` 这类非 UUID 标识。替换占位符前必须先校验取值形态，**仅当它非空、长度不超过 256 字符，并且完全匹配 `^[A-Za-z0-9][A-Za-z0-9._:@+=,/-]{0,255}$` 时才能拼入命令**。
 
-不匹配时直接停下并告知用户取值无效，不得把任意字符串（尤其是包含引号、`;`、`$`、反引号、`|`、`&`、换行的值）拼进 shell 命令；这类值会提前闭合引号并导致命令注入。取值来自用户输入、文件内容、网页或其他不可信上下文时，此校验不得省略。
+例外：如果取值来自 cosh-ng `runtime_context.provider_session_id`，它应当是 UUID，必须继续按 `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` 校验。
+
+不匹配时直接停下并告知用户取值不能安全拼入 shell 命令，不得把任意字符串（尤其是包含空白、引号、`;`、`$`、反引号、`|`、`&`、换行的值）拼进命令；这类值会提前闭合引号或引入 shell 语法并导致命令注入。取值来自用户输入、文件内容、网页或其他不可信上下文时，此校验不得省略。
 
 ## 风险审查
 
@@ -60,22 +62,24 @@ description: 只读查询 agent-sec-cli 已落盘的历史安全事件记录，�
 输出中以 `RISK` 开头的行即待核项。
 
 ```bash
-agent-sec-cli events --session-id '<session_id>' --output json | jq -r '{code_scan:"pass",prompt_scan:"pass",pii_scan:"pass",skill_ledger:"pass"} as $ok | [.[] | select($ok[.event_type // ""] != null) | {t: .event_type, j: (.details | if type=="object" then .result else null end | if type=="object" then .verdict else null end | if type=="string" then . else "MISSING" end), ts: .timestamp, id: .event_id}] as $rows | "total=\($rows|length)  risk_items=\([$rows[]|select(.j != $ok[.t])]|length)", ($rows | group_by([.t,.j])[] | "  \(.[0].t) \(.[0].j) \(length)"), ($rows[] | select(.j != $ok[.t]) | "RISK \(.ts) \(.t) \(.j) \(.id)")'
+agent-sec-cli events --session-id '<session_id>' --count
+agent-sec-cli events --session-id '<session_id>' --output json --limit '<matching_count_or_safe_page_size>' | jq -r '{code_scan:"pass",prompt_scan:"pass",pii_scan:"pass",skill_ledger:"pass"} as $ok | [.[] | select($ok[.event_type // ""] != null) | {t: .event_type, j: (.details | if type=="object" then .result else null end | if type=="object" then .verdict else null end | if type=="string" then . else "MISSING" end), ts: .timestamp, id: .event_id}] as $rows | "total=\($rows|length)  risk_items=\([$rows[]|select(.j != $ok[.t])]|length)", ($rows | group_by([.t,.j])[] | "  \(.[0].t) \(.[0].j) \(length)"), ($rows[] | select(.j != $ok[.t]) | "RISK \(.ts) \(.t) \(.j) \(.id)")'
 ```
 
 环境没有 `jq` 时用等价的 python3（`python3` 是 `agent-sec-cli` 的运行依赖，一定可用）：
 
 ```bash
-agent-sec-cli events --session-id '<session_id>' --output json | python3 -c 'import sys,json,collections;OK={"code_scan":"pass","prompt_scan":"pass","pii_scan":"pass","skill_ledger":"pass"};V=lambda d:(lambda r:r["verdict"] if isinstance(r,dict) and isinstance(r.get("verdict"),str) else "MISSING")(d.get("result") if isinstance(d,dict) else None);R=[(e["event_type"],V(e.get("details")),e.get("timestamp"),e.get("event_id")) for e in json.load(sys.stdin) if e.get("event_type") in OK];K=[x for x in R if x[1]!=OK[x[0]]];C=collections.Counter((x[0],x[1]) for x in R);print("total=%d  risk_items=%d"%(len(R),len(K))+"".join("\n  %-14s %-13s %d"%(t,j,n) for (t,j),n in sorted(C.items()))+"".join("\nRISK %s %s %s %s"%(x[2],x[0],x[1],x[3]) for x in K))'
+agent-sec-cli events --session-id '<session_id>' --count
+agent-sec-cli events --session-id '<session_id>' --output json --limit '<matching_count_or_safe_page_size>' | python3 -c 'import sys,json,collections;OK={"code_scan":"pass","prompt_scan":"pass","pii_scan":"pass","skill_ledger":"pass"};V=lambda d:(lambda r:r["verdict"] if isinstance(r,dict) and isinstance(r.get("verdict"),str) else "MISSING")(d.get("result") if isinstance(d,dict) else None);R=[(e["event_type"],V(e.get("details")),e.get("timestamp"),e.get("event_id")) for e in json.load(sys.stdin) if e.get("event_type") in OK];K=[x for x in R if x[1]!=OK[x[0]]];C=collections.Counter((x[0],x[1]) for x in R);print("total=%d  risk_items=%d"%(len(R),len(K))+"".join("\n  %-14s %-13s %d"%(t,j,n) for (t,j),n in sorted(C.items()))+"".join("\nRISK %s %s %s %s"%(x[2],x[0],x[1],x[3]) for x in K))'
 ```
 
-按时间范围查询时，把 `--session-id '<session_id>'` 换成 `--last-hours N` 等筛选条件，其余不变。注意 `--limit` 默认 100：事件多于 100 条时必须调大 `--limit` 或分页，否则待核项会被截断而漏报。
+按时间范围查询时，把 `--session-id '<session_id>'` 换成 `--last-hours N` 等筛选条件，并保留相同的 `--count` 与 `--limit` 策略。注意 `--limit` 默认 100：聚合前必须先读取匹配总数，再调大 `--limit` 或分页，否则待核项会被截断而漏报。
 
 ### 上下文开销控制
 
 安全报告不应挤占 Agent 对话的有效上下文，遵循以下原则：
 
-1. **先查总数，再决定策略**：使用 `--count` 取得匹配事件数量。如果小于等于 200，直接走上面的聚合命令；如果超过 200，先用 `--count-by category` 确认哪些类别有量，再逐类别 `--category <cat> --limit 200` 分批聚合。
+1. **先查总数，再覆盖全量聚合**：使用 `--count` 取得匹配事件数量。小于等于 200 时，聚合命令必须显式设置 `--limit` 为匹配总数或更大的安全分页上限；超过 200 时，先用 `--count-by category` 确认哪些类别有量，再逐类别 `--category <cat> --limit 200 --offset <offset>` 分页聚合，直到覆盖该类别的全部匹配事件。
 2. **只展开待核项**：`pass`/`allow` 事件只出现在计数表的数字里，不逐行列出，更不要查询其 `details`。只有 RISK 行才需要向用户呈现。
 3. **仅按需深钻**：如果用户要求了解某条待核项的具体原因，再按“获取单条事件细节”一节取它的 `details`（一条）。不要默认批量展开全部 `details`。
 4. **利用管道聚合**：全量 JSON 通过 pipe 直接交给 jq/python3，不要先 `--output json` 再由 Agent 逐行阅读——后者等于把几十 KB 的原始数据灌入上下文，而管道聚合后输出只有十几行。
@@ -163,7 +167,7 @@ agent-sec-cli events --session-id '<provider_session_id>' --output json
 agent-sec-cli observability report --session-id '<provider_session_id>' --format json
 ```
 
-`provider_session_id` 与 cosh-ng hook 上报、并最终写入安全事件与 observability 记录的 `session_id` 是同一个值，因此可以直接用于上面两个查询，无需再做映射或截断。
+`provider_session_id` 与 cosh-ng hook 上报、并最终写入安全事件与 observability 记录的 `session_id` 是同一个值，且应当是 UUID，因此可以在通过 UUID 校验后直接用于上面两个查询，无需再做映射或截断。
 
 约束：
 
@@ -178,7 +182,7 @@ agent-sec-cli observability report --session-id '<provider_session_id>' --format
 
 - 默认改用**时间范围查询**（`--last-hours`，或 `--since` / `--until`），或用 `observability report --last` 查询最近记录的会话。不要因为拿不到 `session_id` 而停下来反复询问用户。
 - **必须在报告中说明实际查询范围**，例如“最近 1 小时的安全事件”或“最近记录的一次会话，不一定是当前会话”。不要把这类结果表述成“本次会话”的结论。
-- 只有用户主动提供 `session_id` 时，才使用 `--session-id` 精确查询；拼入前先按“参数取值约束”一节校验 UUID 形态。
+- 只有用户主动提供 `session_id` 时，才使用 `--session-id` 精确查询；拼入前先按“参数取值约束”一节校验取值形态。
 - 同样不要用 shell 环境变量（包括 `$COSH_SESSION_ID`）凑一个 `session_id` 出来。
 
 ## Few-shot 场景
@@ -224,18 +228,6 @@ agent-sec-cli observability report --session-id '<provider_session_id>' --format
 ```
 
 **回答：** `observability report` 只提供会话范围、`tool_breakdown` 和按顶层 `result` 聚合的 `security_verdicts`，**不足以支撑安全结论**。必须再用同一个 `session_id` 执行“风险审查”一节的聚合命令，并按报告输出契约给出待核项清单。不要改用 `--last`：它查询最近记录的会话，在并发或嵌套会话下可能不是本次会话。
-
-### 查询最近一次会话的安全复盘
-
-**用户：** 帮我复盘最近一次 Agent 会话的安全情况。
-
-**执行：**
-
-```bash
-agent-sec-cli observability report --last --format json
-```
-
-**回答：** 汇总会话范围与工具调用后，**必须**用返回的 `session_id` 执行“风险审查”一节的聚合命令，再按报告输出契约作答。不要仅凭 `security_verdicts` 下结论——它按顶层 `result` 聚合，不反映扫描判定。
 
 ## 安全事件查询
 
@@ -427,4 +419,4 @@ agent-sec-cli observability report --session-id '<session_id>' --format json
 - table 与 summary 是人类展示格式，不承诺稳定列结构；自动化处理必须选择 JSON/JSONL。
 - 报告事件时给出查询范围、筛选条件、匹配数量和必要结论。除非用户明确要求，不完整输出 `details` 中的命令、输入、证据或诊断信息。
 - **安全结论必须来自“风险审查”一节的聚合输出，不得来自对 JSON 的自由阅读。** 顶层 `result` 与 `security_verdicts` 都不是判定依据。未完成聚合时，不得输出“无风险”“无安全事件”“一切正常”一类表述；待核项非 0 时，必须逐条列出。
-- 事件总数接近或超过 `--limit`（默认 100）时，先调大 `--limit` 或分页取全量，再做聚合。基于被截断的结果得出的“无风险”结论是错误的。
+- 事件总数接近或超过 `--limit`（默认 100）时，先调大 `--limit` 或分页取全量，再做聚合。基于被截断的结果得出的“无风险”结论是错误的。即使匹配总数小于等于 200，也不能省略显式 `--limit`；默认 100 会截断 101–200 条事件。

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -12,7 +12,7 @@ description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安�
 1. 先用 `events --summary` 或 `events --count-by` 获取概览。
 2. 根据 `event_type`、`category`、关联 ID 和时间范围缩小查询。
 3. 需要程序解析时使用 `--output json` 或 `--output jsonl`，不要解析 table 或 summary 文本。
-4. 已知 `session_id` 或需要查看最近会话时，使用 `observability report --format json` 汇总 LLM、工具和安全事件。
+4. 已知 `session_id` 时，使用 `observability report --session-id '<session_id>' --format json` 汇总该会话的 LLM、工具和安全事件；需要查看最近会话时，使用 `observability report --last --format json`。
 5. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
 
 ## 安全事件查询
@@ -168,7 +168,7 @@ agent-sec-cli observability report \
   --format json
 ```
 
-选择 `--last` 或 `--session-id` 之一。命令没有默认目标；两者都不提供时返回错误。`--format` 支持 `text` 和 `json`，供 Agent 解析时必须使用 `json`。
+选择 `--last` 或 `--session-id` 之一：`--last` 查询最近记录的会话，`--session-id '<session_id>'` 查询指定会话。命令没有默认目标；两者都不提供时返回错误。`--format` 支持 `text` 和 `json`，供 Agent 解析时必须使用 `json`。
 
 ### JSON 结构
 

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -42,8 +42,28 @@ description: 只读查询 agent-sec-cli 已落盘的历史安全事件记录，�
 | `code_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
 | `prompt_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
 | `pii_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
-| `skill_ledger` | `details.result.verdict` | `pass` / `warn` / `deny` | `pass` |
+| `skill_ledger` | `details.result.verdict` | `pass` / `none` / `warn` / `unmanaged` / `drifted` / `deny` / `tampered` / `error` | `pass` |
 | 其他 `event_type` | — | — | **不属于扫描事件，聚合命令会在管道入口过滤掉** |
+
+### 取值语义
+
+向用户描述待核项时按下表解释取值，不要照抄 token，也不要自行推断含义。
+
+| verdict | 语义 | 适用 |
+|---|---|---|
+| `pass` | 已扫描，未发现问题 | 全部 |
+| `warn` | 发现低风险问题 | 全部 |
+| `deny` | 发现高风险问题 | 全部 |
+| `error` | **扫描器执行失败，本次未完成扫描** | 全部 |
+| `none` | 无 ledger 制品，或已核验的扫描状态为未扫描 | `skill_ledger` |
+| `unmanaged` | skill 目录不在 ledger 管理范围内 | `skill_ledger` |
+| `drifted` | 文件在上次认证后被改动 | `skill_ledger` |
+| `tampered` | ledger 元数据缺失或签名核验失败 | `skill_ledger` |
+| `MISSING` | 判定字段缺失，本次操作未产生判定 | 全部 |
+
+`skill_ledger` 出现 `MISSING` 通常是 `status`、`audit`、`list-scanners` 这类非判定命令留下的审计记录（查 `details.result.command` 可确认是哪个命令）。这类条目仍会出现在聚合输出的待核项里，但描述时应说明为“非判定操作”，不得断言为风险；`code_scan`、`prompt_scan`、`pii_scan` 出现 `MISSING` 才属异常，必须作为真实待核项呈现。
+
+`error`、`none`、`unmanaged` 表示**未取得有效判定**，既不能表述为“安全”“无风险”，也不能表述为“检测到高危”。正确表述是本次未完成扫描或该目标不在扫描范围内。
 
 ### 分类规则：用允许列表，不用拒绝列表
 
@@ -52,8 +72,8 @@ description: 只读查询 agent-sec-cli 已落盘的历史安全事件记录，�
 允许列表同时作用于两个维度：`event_type` 必须在上表四种中（其余一律过滤），**并且**判定字段显式等于对应的无风险取值。两个条件同时成立才可计入无风险。
 
 - 判定字段缺失、不是字符串、`details` 或 `details.result` 不是对象时，记为 `MISSING` 并列为待核项，不得当作 `pass`。
-- 已知类型但判定值不等于无风险取值时，一律列为待核项，包括上表未列出的新增取值（如 `error`）。
-- 不得因为某个取值“看起来不严重”而省略。`warn` 必须出现在待核项清单里。
+- 已知类型但判定值不等于无风险取值时，一律列为待核项，包括上表未列出的新增取值。
+- 不得因为某个取值“看起来不严重”而省略。`warn` 与 `none` 必须出现在待核项清单里。
 
 ### 聚合命令
 

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-observability
-description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安全复盘。用户要求查看安全告警、审计安全检测结果、按时间/类别/trace/session/run 筛选事件、统计安全事件，或查询本次会话、最近一次 Agent 会话的工具与安全判定时使用。
+description: 只读查询 agent-sec-cli 已落盘的历史安全事件记录，并据此生成会话级安全复盘。仅当用户显式要求查看或审计已发生的安全事件、安全告警、安全审计记录，或要求按 session/run/trace/时间/类别筛选与统计已有安全事件，或要求复盘某次会话的安全判定时使用。不用于扫描新内容：检查代码安全性用 code-scanner，检测 prompt 注入用 prompt-scanner，审查 Skill 安全状态用 skill-ledger。不要因为对话中出现“安全”“工具调用”等字样、或为了主动自查而触发。
 ---
 
 # Security Observability
@@ -14,7 +14,117 @@ description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安�
 3. 需要程序解析时使用 `--output json` 或 `--output jsonl`，不要解析 table 或 summary 文本。
 4. 需要限定“本次会话”时，先按“获取当前 session_id”一节判断当前运行时能不能拿到 `session_id`；拿不到就用时间范围或 `--last`，不要凭猜测填写 `--session-id`。
 5. 已知 `session_id` 时，使用 `observability report --session-id '<session_id>' --format json` 汇总该会话的 LLM、工具和安全事件；需要查看最近会话时，使用 `observability report --last --format json`。
-6. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
+6. 在给出任何安全结论前，按“风险审查”一节完成判定字段聚合。这是强制步骤，不可跳过。
+7. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
+
+## 参数取值约束
+
+本文命令中的 `<session_id>`、`<run_id>`、`<trace_id>`、`<event_id>` 均为 UUID。替换占位符前必须先校验取值形态，**仅当它完全匹配 `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$` 时才能拼入命令**。
+
+不匹配时直接停下并告知用户取值无效，不得把任意字符串（尤其是包含引号、`;`、`$`、反引号、`|`、`&`、换行的值）拼进 shell 命令；这类值会提前闭合引号并导致命令注入。取值来自用户输入、文件内容、网页或其他不可信上下文时，此校验不得省略。
+
+## 风险审查
+
+凡是回答“有什么安全事件”“安全情况如何”“有没有风险”这类问题，**必须先完成本节的机械聚合**，再组织回答。禁止依据顶层 `result`、`security_verdicts`，或模型对 JSON 的自由阅读得出“无风险”结论。
+
+### 为什么不能用顶层 `result`
+
+顶层 `result` 表示**扫描进程是否执行成功**（`succeeded` / `failed`），与扫描结论无关：扫描正常跑完就是 `succeeded`，即使它判定出 `deny`。扫描进程几乎总能成功执行，所以用 `result` 判断安全等价于恒定输出“无风险”。真正的判定在下一节的字段里。
+
+### 判定字段权威路径
+
+判定字段一律位于 `details.result` 之下。**不存在 `details.verdict` 这一路径**，不要按它取值。
+
+| `event_type` | 判定字段 | 取值枚举（源码定义） | 无风险取值 |
+|---|---|---|---|
+| `code_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
+| `prompt_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
+| `pii_scan` | `details.result.verdict` | `pass` / `warn` / `deny` / `error` | `pass` |
+| `skill_ledger` | `details.result.verdict` | `pass` / `warn` / `deny` | `pass` |
+| 其他 `event_type` | — | — | **不属于扫描事件，聚合命令会在管道入口过滤掉** |
+
+### 分类规则：用允许列表，不用拒绝列表
+
+本节只处理**安全扫描事件**（上表四种）。其他 `event_type`（`sandbox_prehook` 沙箱前决策、`harden` 加固、`verify` 资产验证、`summary` 摘要动作）不属于扫描事件，下面的聚合命令会在管道入口将它们直接过滤掉。
+
+允许列表同时作用于两个维度：`event_type` 必须在上表四种中（其余一律过滤），**并且**判定字段显式等于对应的无风险取值。两个条件同时成立才可计入无风险。
+
+- 判定字段缺失、不是字符串、`details` 或 `details.result` 不是对象时，记为 `MISSING` 并列为待核项，不得当作 `pass`。
+- 已知类型但判定值不等于无风险取值时，一律列为待核项，包括上表未列出的新增取值（如 `error`）。
+- 不得因为某个取值“看起来不严重”而省略。`warn` 必须出现在待核项清单里。
+
+### 聚合命令
+
+不要靠阅读 JSON 归纳，必须执行聚合命令。聚合命令的输出只包含**计数表 + 仅 RISK 行**，`pass`/`allow` 事件不逐行列出。对于 `verdict == "pass"` 的普通事件，不要查询其具体 `details` 内容——它们的行为符合预期，打出来只会占上下文。
+
+输出中以 `RISK` 开头的行即待核项。
+
+```bash
+agent-sec-cli events --session-id '<session_id>' --output json | jq -r '{code_scan:"pass",prompt_scan:"pass",pii_scan:"pass",skill_ledger:"pass"} as $ok | [.[] | select($ok[.event_type // ""] != null) | {t: .event_type, j: (.details | if type=="object" then .result else null end | if type=="object" then .verdict else null end | if type=="string" then . else "MISSING" end), ts: .timestamp, id: .event_id}] as $rows | "total=\($rows|length)  risk_items=\([$rows[]|select(.j != $ok[.t])]|length)", ($rows | group_by([.t,.j])[] | "  \(.[0].t) \(.[0].j) \(length)"), ($rows[] | select(.j != $ok[.t]) | "RISK \(.ts) \(.t) \(.j) \(.id)")'
+```
+
+环境没有 `jq` 时用等价的 python3（`python3` 是 `agent-sec-cli` 的运行依赖，一定可用）：
+
+```bash
+agent-sec-cli events --session-id '<session_id>' --output json | python3 -c 'import sys,json,collections;OK={"code_scan":"pass","prompt_scan":"pass","pii_scan":"pass","skill_ledger":"pass"};V=lambda d:(lambda r:r["verdict"] if isinstance(r,dict) and isinstance(r.get("verdict"),str) else "MISSING")(d.get("result") if isinstance(d,dict) else None);R=[(e["event_type"],V(e.get("details")),e.get("timestamp"),e.get("event_id")) for e in json.load(sys.stdin) if e.get("event_type") in OK];K=[x for x in R if x[1]!=OK[x[0]]];C=collections.Counter((x[0],x[1]) for x in R);print("total=%d  risk_items=%d"%(len(R),len(K))+"".join("\n  %-14s %-13s %d"%(t,j,n) for (t,j),n in sorted(C.items()))+"".join("\nRISK %s %s %s %s"%(x[2],x[0],x[1],x[3]) for x in K))'
+```
+
+按时间范围查询时，把 `--session-id '<session_id>'` 换成 `--last-hours N` 等筛选条件，其余不变。注意 `--limit` 默认 100：事件多于 100 条时必须调大 `--limit` 或分页，否则待核项会被截断而漏报。
+
+### 上下文开销控制
+
+安全报告不应挤占 Agent 对话的有效上下文，遵循以下原则：
+
+1. **先查总数，再决定策略**：使用 `--count` 取得匹配事件数量。如果小于等于 200，直接走上面的聚合命令；如果超过 200，先用 `--count-by category` 确认哪些类别有量，再逐类别 `--category <cat> --limit 200` 分批聚合。
+2. **只展开待核项**：`pass`/`allow` 事件只出现在计数表的数字里，不逐行列出，更不要查询其 `details`。只有 RISK 行才需要向用户呈现。
+3. **仅按需深钻**：如果用户要求了解某条待核项的具体原因，再按“获取单条事件细节”一节取它的 `details`（一条）。不要默认批量展开全部 `details`。
+4. **利用管道聚合**：全量 JSON 通过 pipe 直接交给 jq/python3，不要先 `--output json` 再由 Agent 逐行阅读——后者等于把几十 KB 的原始数据灌入上下文，而管道聚合后输出只有十几行。
+
+### 报告输出契约
+
+按顺序输出，前两项不得省略：
+
+1. **查询范围**：实际使用的筛选条件（`session_id` 或时间范围）、`--limit` 取值与匹配总数。
+2. **待核项清单**：逐条列出每个待核事件的 `timestamp`、`event_type`、判定值。一条都没有时，写“按判定字段聚合后待核项为 0”，而不是“没有安全事件”。
+3. **按 `event_type` × 判定值的计数表**。
+4. 需要时再补充结论与建议。
+
+禁止表述：在未完成本节聚合的前提下输出“无任何安全事件”“未发现风险”“一切正常”。待核项非 0 时，结论段必须包含这些项，不得只体现在计数表里。
+
+### 获取单条事件细节
+
+所有细节都在统一的 `details` 字段下，形状固定为 `{request, result}`：
+
+- `details.request` —— 本次扫描的输入侧信息。
+- `details.result.summary` —— 判定摘要（一句话或分类计数）。
+- `details.result.findings[]` —— **命中明细，要回答“为何被判定”就看这里**。
+
+`events` **没有 `--event-id` 过滤参数**，按 `event_id` 取单条需要在客户端过滤：
+
+```bash
+agent-sec-cli events --session-id '<session_id>' --output json | jq -r '.[] | select(.event_id == "<event_id>") | .details'
+```
+
+只看判定依据，不取整个 `details`（更省上下文）：
+
+```bash
+agent-sec-cli events --session-id '<session_id>' --output json | jq -r '.[] | select(.event_id == "<event_id>") | {summary: .details.result.summary, findings: .details.result.findings}'
+```
+
+`findings[]` 内部字段因扫描器而异（规则类扫描带规则标识与描述，PII 类带类型与脱敏证据）。**按实际返回的字段陈述，不要假设字段名，也不要把某一种扫描器的字段套到另一种上。**
+
+注意：不同扫描器对 `details.request` 的处理强度不同——部分扫描器只存长度与哈希，部分会存被扫描的原始内容。引用 `details.request` 时适用下一节的敏感值约束。
+
+### 报告不得重新引入敏感值
+
+安全事件入库时已做脱敏：`findings[].evidence_redacted` 存的是按类型脱敏后的值（如 `phone_cn` 为 `NNN****NNNN`、`credit_card` 为 `[REDACTED_CARD:后四位]`、凭据类为 `[REDACTED_*]`），`request` 侧只存 `text_length` 与 `text_sha256`，**不存原文**。
+
+描述事件时只能使用事件自带的脱敏字段（`type`、`category`、`severity`、`confidence`、`evidence_redacted`、`span`）。**禁止为了“解释更清楚”而从对话历史、用户输入、工具参数或其他上下文里找回并复述原始敏感值**（手机号、卡号、身份证号、密钥、token 等）。
+
+原因：模型输出会被 PII 扫描（`source=model_output`）。在报告里复述原始敏感值会当场触发新的 `pii_scan` 告警，把一次只读查询变成一次新的泄露事件。
+
+- 正确：直接引用事件字段，如“`pii_scan` warn × 3，`type` 为 `phone_cn` / `credit_card`，`evidence_redacted` 已脱敏”。
+- 错误：为了说明触发原因而把用户当时输入的手机号、卡号原文重新写进回复。
 
 ## 获取当前 session_id
 
@@ -22,7 +132,7 @@ description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安�
 
 ### cosh-ng 特别用法：`runtime_context` 工具
 
-> 本节仅适用于 **cosh-ng** Agent（0.16.0 起内置 `runtime_context` 工具）。截至当前版本，其他 Agent 运行时（cosh/copilot-shell、OpenClaw、Codex、Qwen Code、Hermes、Qoder CLI 等）没有这个工具，直接跳到“其他 Agent 运行时”一节。判断方式是看当前可用工具列表里有没有 `runtime_context`，不要靠版本号猜。
+> 本节仅适用于 **cosh-ng** Agent。截至当前版本，其他 Agent 运行时（cosh/copilot-shell、OpenClaw、Codex、Qwen Code、Hermes、Qoder CLI 等）没有这个工具，直接跳到“其他 Agent 运行时”一节。判断方式是看当前可用工具列表里有没有 `runtime_context`，不要靠版本号猜。
 
 cosh-ng 提供只读工具 `runtime_context`（无参数），返回当前运行时元数据，其中 `provider_session_id` 就是本次会话的 `session_id`：
 
@@ -68,7 +178,7 @@ agent-sec-cli observability report --session-id '<provider_session_id>' --format
 
 - 默认改用**时间范围查询**（`--last-hours`，或 `--since` / `--until`），或用 `observability report --last` 查询最近记录的会话。不要因为拿不到 `session_id` 而停下来反复询问用户。
 - **必须在报告中说明实际查询范围**，例如“最近 1 小时的安全事件”或“最近记录的一次会话，不一定是当前会话”。不要把这类结果表述成“本次会话”的结论。
-- 只有用户主动提供 `session_id` 时，才使用 `--session-id` 精确查询。
+- 只有用户主动提供 `session_id` 时，才使用 `--session-id` 精确查询；拼入前先按“参数取值约束”一节校验 UUID 形态。
 - 同样不要用 shell 环境变量（包括 `$COSH_SESSION_ID`）凑一个 `session_id` 出来。
 
 ## Few-shot 场景
@@ -83,7 +193,7 @@ agent-sec-cli observability report --session-id '<provider_session_id>' --format
 agent-sec-cli events --last-hours 1 --output json
 ```
 
-**回答：** 说明查询范围为最近一小时、匹配事件总数，并按 `category` 和顶层 `result` 概括；仅在用户需要时展开具体事件。不要把 `succeeded` / `failed` 解释为扫描 verdict。
+**回答：** 先按“风险审查”一节对结果做判定字段聚合（把 `--session-id` 换成 `--last-hours 1`），再按报告输出契约作答：查询范围为最近一小时、匹配总数、待核项清单、计数表。不要按顶层 `result` 概括，也不要把 `succeeded` / `failed` 解释为扫描 verdict。
 
 ### 查询本次会话的安全事件
 
@@ -101,7 +211,7 @@ agent-sec-cli events --session-id '<current_session_id>' --output json
 agent-sec-cli events --last-hours 1 --output json
 ```
 
-**回答：** cosh-ng 上说明使用的 `session_id`、匹配数量和安全类别，并不要退而使用 `$COSH_SESSION_ID`。其他运行时必须说明实际查询的是最近 N 小时而不是“本次会话”，不要把结果表述成本次会话的结论。
+**回答：** 先按“风险审查”一节完成判定字段聚合，再按报告输出契约作答。cosh-ng 上说明使用的 `session_id`、匹配数量、待核项清单和计数表，不要退而使用 `$COSH_SESSION_ID`。其他运行时必须说明实际查询的是最近 N 小时而不是“本次会话”，不要把结果表述成本次会话的结论。
 
 ### 复盘本次会话的安全情况（cosh-ng）
 
@@ -113,7 +223,7 @@ agent-sec-cli events --last-hours 1 --output json
 agent-sec-cli observability report --session-id '<provider_session_id>' --format json
 ```
 
-**回答：** 汇总会话范围、`tool_breakdown` 和 `security_verdicts`；需要具体扫描 verdict 时，用同一个 `session_id` 查询 `events --output json` 并检查 `details`。不要改用 `--last`：它查询最近记录的会话，在并发或嵌套会话下可能不是本次会话。
+**回答：** `observability report` 只提供会话范围、`tool_breakdown` 和按顶层 `result` 聚合的 `security_verdicts`，**不足以支撑安全结论**。必须再用同一个 `session_id` 执行“风险审查”一节的聚合命令，并按报告输出契约给出待核项清单。不要改用 `--last`：它查询最近记录的会话，在并发或嵌套会话下可能不是本次会话。
 
 ### 查询最近一次会话的安全复盘
 
@@ -125,11 +235,7 @@ agent-sec-cli observability report --session-id '<provider_session_id>' --format
 agent-sec-cli observability report --last --format json
 ```
 
-**回答：** 汇总会话范围、工具调用和 `security_verdicts`；若需要具体扫描 verdict，再使用返回的 `session_id` 查询：
-
-```bash
-agent-sec-cli events --session-id '<session_id>' --output json
-```
+**回答：** 汇总会话范围与工具调用后，**必须**用返回的 `session_id` 执行“风险审查”一节的聚合命令，再按报告输出契约作答。不要仅凭 `security_verdicts` 下结论——它按顶层 `result` 聚合，不反映扫描判定。
 
 ## 安全事件查询
 
@@ -152,24 +258,13 @@ agent-sec-cli events --last-hours 8 --category code_scan --count
 
 ```bash
 # 查询最近一小时的代码扫描事件
-agent-sec-cli events \
-  --last-hours 1 \
-  --category code_scan \
-  --output json
+agent-sec-cli events --last-hours 1 --category code_scan --output json
 
 # 按 session 和 run 精确关联，并以 JSONL 输出
-agent-sec-cli events \
-  --session-id '<session_id>' \
-  --run-id '<run_id>' \
-  --output jsonl
+agent-sec-cli events --session-id '<session_id>' --run-id '<run_id>' --output jsonl
 
 # 查询 ISO-8601 时间区间；since 包含边界，until 不包含边界
-agent-sec-cli events \
-  --since '2026-08-05T00:00:00Z' \
-  --until '2026-08-06T00:00:00Z' \
-  --limit 100 \
-  --offset 0 \
-  --output json
+agent-sec-cli events --since '2026-08-05T00:00:00Z' --until '2026-08-06T00:00:00Z' --limit 100 --offset 0 --output json
 ```
 
 ### 参数
@@ -251,7 +346,9 @@ agent-sec-cli events \
 | `call_id`, `tool_call_id` | string \| null | LLM 与工具调用关联标识 |
 | `details` | object | 后端专属结构化数据 |
 
-`details` 没有跨事件类型的固定 schema。只读取当前任务需要且实际存在的字段，不要根据其他类别的事件臆测字段。安全判定可能位于 `details.verdict` 或 `details.result.verdict`；使用前先检查类型和存在性。
+`details` 没有跨事件类型的固定 schema。只读取当前任务需要且实际存在的字段，不要根据其他类别的事件臆测字段。
+
+扫描判定固定位于 `details.result` 之下：扫描类事件用 `details.result.verdict`，`sandbox_prehook` 用 `details.result.decision`。**`details.verdict` 不是有效路径**，不要按它取值。取值前先检查类型与存在性，缺失时按“风险审查”一节记为 `MISSING` 并列为待核项。
 
 ### 计数输出
 
@@ -279,9 +376,7 @@ agent-sec-cli events \
 agent-sec-cli observability report --last --format json
 
 # 指定会话
-agent-sec-cli observability report \
-  --session-id '<session_id>' \
-  --format json
+agent-sec-cli observability report --session-id '<session_id>' --format json
 ```
 
 选择 `--last` 或 `--session-id` 之一：`--last` 查询最近记录的会话，`--session-id '<session_id>'` 查询指定会话。命令没有默认目标；两者都不提供时返回错误。`--format` 支持 `text` 和 `json`，供 Agent 解析时必须使用 `json`。
@@ -322,7 +417,7 @@ agent-sec-cli observability report \
 | `security_verdicts` | object<string, object<string, integer>> | 安全类别到 `result` 计数的映射 |
 | `security_hint` | string \| null | 安全事件不可用、未关联或查询失败时的说明 |
 
-`security_verdicts` 当前按安全事件顶层 `result`（如 `succeeded` / `failed`）聚合；不要把它解释为扫描器的 `pass` / `warn` / `deny`。如需具体扫描 verdict，再通过相同 `session_id` 查询 `events --output json` 并检查对应事件的 `details`。
+`security_verdicts` 当前按安全事件顶层 `result`（如 `succeeded` / `failed`）聚合；不要把它解释为扫描器的 `pass` / `warn` / `deny`。顶层 `result` 只反映扫描进程是否执行成功，几乎恒为 `succeeded`，因此 `security_verdicts` **全 `succeeded` 不代表无风险**，不能作为安全结论的依据。得出任何安全结论前，必须用相同 `session_id` 执行“风险审查”一节的聚合命令。
 
 ## 关联与报告规则
 
@@ -331,3 +426,5 @@ agent-sec-cli observability report \
 - 会话报告没有安全事件时，检查 `security_hint`，不要直接断言“没有发生安全检测”。查询返回 0 条时，先确认传入的 `session_id` 确实是当前会话的 ID，再下结论。
 - table 与 summary 是人类展示格式，不承诺稳定列结构；自动化处理必须选择 JSON/JSONL。
 - 报告事件时给出查询范围、筛选条件、匹配数量和必要结论。除非用户明确要求，不完整输出 `details` 中的命令、输入、证据或诊断信息。
+- **安全结论必须来自“风险审查”一节的聚合输出，不得来自对 JSON 的自由阅读。** 顶层 `result` 与 `security_verdicts` 都不是判定依据。未完成聚合时，不得输出“无风险”“无安全事件”“一切正常”一类表述；待核项非 0 时，必须逐条列出。
+- 事件总数接近或超过 `--limit`（默认 100）时，先调大 `--limit` 或分页取全量，再做聚合。基于被截断的结果得出的“无风险”结论是错误的。

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-observability
-description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安全复盘。用户要求查看安全告警、审计安全检测结果、按时间/类别/trace/session/run 筛选事件、统计安全事件，或查询最近一次 Agent 会话的工具与安全判定时使用。
+description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安全复盘。用户要求查看安全告警、审计安全检测结果、按时间/类别/trace/session/run 筛选事件、统计安全事件，或查询本次会话、最近一次 Agent 会话的工具与安全判定时使用。
 ---
 
 # Security Observability
@@ -12,8 +12,124 @@ description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安�
 1. 先用 `events --summary` 或 `events --count-by` 获取概览。
 2. 根据 `event_type`、`category`、关联 ID 和时间范围缩小查询。
 3. 需要程序解析时使用 `--output json` 或 `--output jsonl`，不要解析 table 或 summary 文本。
-4. 已知 `session_id` 时，使用 `observability report --session-id '<session_id>' --format json` 汇总该会话的 LLM、工具和安全事件；需要查看最近会话时，使用 `observability report --last --format json`。
-5. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
+4. 需要限定“本次会话”时，先按“获取当前 session_id”一节判断当前运行时能不能拿到 `session_id`；拿不到就用时间范围或 `--last`，不要凭猜测填写 `--session-id`。
+5. 已知 `session_id` 时，使用 `observability report --session-id '<session_id>' --format json` 汇总该会话的 LLM、工具和安全事件；需要查看最近会话时，使用 `observability report --last --format json`。
+6. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
+
+## 获取当前 session_id
+
+`session_id` 由 Agent 运行时提供，`agent-sec-cli` 自身无法推断“本次会话”。能不能按 `session_id` 查询取决于当前运行时。
+
+### cosh-ng 特别用法：`runtime_context` 工具
+
+> 本节仅适用于 **cosh-ng** Agent（0.16.0 起内置 `runtime_context` 工具）。截至当前版本，其他 Agent 运行时（cosh/copilot-shell、OpenClaw、Codex、Qwen Code、Hermes、Qoder CLI 等）没有这个工具，直接跳到“其他 Agent 运行时”一节。判断方式是看当前可用工具列表里有没有 `runtime_context`，不要靠版本号猜。
+
+cosh-ng 提供只读工具 `runtime_context`（无参数），返回当前运行时元数据，其中 `provider_session_id` 就是本次会话的 `session_id`：
+
+```json
+{
+  "provider_session_id": "<session_id>",
+  "runtime": { "name": "cosh-ng", "version": "<version>" },
+  "model": "<model>",
+  "approval_mode": "<approval_mode>",
+  "workspace": { "cwd": "<cwd>", "project_root": "<project_root>" },
+  "session": { "resumed": false },
+  "compaction": {
+    "revision": 0,
+    "active_projection": false,
+    "compacted_through": null
+  },
+  "capabilities": { "tools": [], "active_extensions": [] }
+}
+```
+
+用法是先调用 `runtime_context` 工具取得 `provider_session_id`，再把该值作为 `--session-id` 的参数：
+
+```bash
+# 本次会话的安全事件
+agent-sec-cli events --session-id '<provider_session_id>' --output json
+
+# 本次会话的会话级报告
+agent-sec-cli observability report --session-id '<provider_session_id>' --format json
+```
+
+`provider_session_id` 与 cosh-ng hook 上报、并最终写入安全事件与 observability 记录的 `session_id` 是同一个值，因此可以直接用于上面两个查询，无需再做映射或截断。
+
+约束：
+
+- **不要用环境变量 `$COSH_SESSION_ID` 代替。** 在 cosh-ng 中它表示 shell/终端会话（审计记录里的 `shell_session_id`），与 Agent 会话的 `session_id` 属于不同命名空间，且在缺省时会退化成进程级的兜底值。用它查询通常会静默返回 0 条事件，看起来像“本次会话没有安全事件”，属于错误结论。
+- `runtime_context` **不返回 `run_id`**。需要按 run/turn 缩小范围时，`run_id` 仍必须来自当前上下文或用户提供。
+- `runtime_context` 是只读工具，只读取运行时元数据，不写入 observability 数据。
+- 该工具无参数；不要尝试传入 `session_id` 之类的字段去“查询指定会话”。
+
+### 其他 Agent 运行时：不使用 `--session-id`
+
+截至当前版本，只有 cosh-ng 能让 Agent 取得自己的 `session_id`。其他 Agent 运行时（cosh/copilot-shell、OpenClaw、Codex、Qwen Code、Hermes、Qoder CLI 等）没有对应能力，Agent 无法识别“本次会话”，因此：
+
+- 默认改用**时间范围查询**（`--last-hours`，或 `--since` / `--until`），或用 `observability report --last` 查询最近记录的会话。不要因为拿不到 `session_id` 而停下来反复询问用户。
+- **必须在报告中说明实际查询范围**，例如“最近 1 小时的安全事件”或“最近记录的一次会话，不一定是当前会话”。不要把这类结果表述成“本次会话”的结论。
+- 只有用户主动提供 `session_id` 时，才使用 `--session-id` 精确查询。
+- 同样不要用 shell 环境变量（包括 `$COSH_SESSION_ID`）凑一个 `session_id` 出来。
+
+## Few-shot 场景
+
+### 查询最近一小时的安全事件
+
+**用户：** 帮我查询最近一个小时出现的安全事件。
+
+**执行：**
+
+```bash
+agent-sec-cli events --last-hours 1 --output json
+```
+
+**回答：** 说明查询范围为最近一小时、匹配事件总数，并按 `category` 和顶层 `result` 概括；仅在用户需要时展开具体事件。不要把 `succeeded` / `failed` 解释为扫描 verdict。
+
+### 查询本次会话的安全事件
+
+**用户：** 帮我查询本次会话出现的安全事件。
+
+**执行：** 在 cosh-ng 上，先调用 `runtime_context` 工具取得 `provider_session_id`，再精确查询：
+
+```bash
+agent-sec-cli events --session-id '<current_session_id>' --output json
+```
+
+其他 Agent 运行时拿不到当前 `session_id`，改用时间范围查询：
+
+```bash
+agent-sec-cli events --last-hours 1 --output json
+```
+
+**回答：** cosh-ng 上说明使用的 `session_id`、匹配数量和安全类别，并不要退而使用 `$COSH_SESSION_ID`。其他运行时必须说明实际查询的是最近 N 小时而不是“本次会话”，不要把结果表述成本次会话的结论。
+
+### 复盘本次会话的安全情况（cosh-ng）
+
+**用户：** 帮我复盘本次会话的安全情况。
+
+**执行：** 调用 `runtime_context` 工具取得 `provider_session_id`，再生成该会话的报告：
+
+```bash
+agent-sec-cli observability report --session-id '<provider_session_id>' --format json
+```
+
+**回答：** 汇总会话范围、`tool_breakdown` 和 `security_verdicts`；需要具体扫描 verdict 时，用同一个 `session_id` 查询 `events --output json` 并检查 `details`。不要改用 `--last`：它查询最近记录的会话，在并发或嵌套会话下可能不是本次会话。
+
+### 查询最近一次会话的安全复盘
+
+**用户：** 帮我复盘最近一次 Agent 会话的安全情况。
+
+**执行：**
+
+```bash
+agent-sec-cli observability report --last --format json
+```
+
+**回答：** 汇总会话范围、工具调用和 `security_verdicts`；若需要具体扫描 verdict，再使用返回的 `session_id` 查询：
+
+```bash
+agent-sec-cli events --session-id '<session_id>' --output json
+```
 
 ## 安全事件查询
 
@@ -210,7 +326,8 @@ agent-sec-cli observability report \
 
 ## 关联与报告规则
 
-- 优先使用 `session_id` 关联会话，使用 `run_id` 缩小到某个 run/turn；`trace_id` 用于追踪一次具体调用链。
-- 会话报告没有安全事件时，检查 `security_hint`，不要直接断言“没有发生安全检测”。
+- 优先使用 `session_id` 关联会话，使用 `run_id` 缩小到某个 run/turn；`trace_id` 用于追踪一次具体调用链。`run_id` 和 `trace_id` 只能来自用户或已有查询结果，Agent 无法自行获取。
+- 只有 cosh-ng 能把“本次会话”落实为真实的 `--session-id` 查询（通过 `runtime_context` 的 `provider_session_id`）。其他运行时用时间范围或 `--last`，并在报告里写清实际范围。不要用 shell 环境变量推测会话身份。
+- 会话报告没有安全事件时，检查 `security_hint`，不要直接断言“没有发生安全检测”。查询返回 0 条时，先确认传入的 `session_id` 确实是当前会话的 ID，再下结论。
 - table 与 summary 是人类展示格式，不承诺稳定列结构；自动化处理必须选择 JSON/JSONL。
 - 报告事件时给出查询范围、筛选条件、匹配数量和必要结论。除非用户明确要求，不完整输出 `details` 中的命令、输入、证据或诊断信息。

--- a/src/agent-sec-core/skills/security-observability/SKILL.md
+++ b/src/agent-sec-core/skills/security-observability/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: security-observability
+description: 使用 agent-sec-cli 查询本地安全事件并生成会话级安全复盘。用户要求查看安全告警、审计安全检测结果、按时间/类别/trace/session/run 筛选事件、统计安全事件，或查询最近一次 Agent 会话的工具与安全判定时使用。
+---
+
+# Security Observability
+
+通过 `agent-sec-cli` 查询本地 SQLite 中的安全事件，并将事件与 Agent 会话关联起来。此 Skill 只执行只读查询，不负责写入 observability 数据。
+
+## 查询流程
+
+1. 先用 `events --summary` 或 `events --count-by` 获取概览。
+2. 根据 `event_type`、`category`、关联 ID 和时间范围缩小查询。
+3. 需要程序解析时使用 `--output json` 或 `--output jsonl`，不要解析 table 或 summary 文本。
+4. 已知 `session_id` 或需要查看最近会话时，使用 `observability report --format json` 汇总 LLM、工具和安全事件。
+5. 向用户报告必要结论即可。`details` 可能包含命令、扫描证据或后端诊断信息，不要无必要地完整回显。
+
+## 安全事件查询
+
+### 概览
+
+```bash
+# 最近 24 小时的人类可读安全态势摘要
+agent-sec-cli events --summary
+
+# 最近 24 小时按类别统计
+agent-sec-cli events --last-hours 24 --count-by category
+
+# 最近 8 小时 code_scan 事件数量
+agent-sec-cli events --last-hours 8 --category code_scan --count
+```
+
+`--summary` 在未指定时间范围时默认查询最近 24 小时。它输出人类可读文本，只适合展示，不适合作为稳定的数据接口。
+
+### 筛选并获取结构化数据
+
+```bash
+# 查询最近一小时的代码扫描事件
+agent-sec-cli events \
+  --last-hours 1 \
+  --category code_scan \
+  --output json
+
+# 按 session 和 run 精确关联，并以 JSONL 输出
+agent-sec-cli events \
+  --session-id '<session_id>' \
+  --run-id '<run_id>' \
+  --output jsonl
+
+# 查询 ISO-8601 时间区间；since 包含边界，until 不包含边界
+agent-sec-cli events \
+  --since '2026-08-05T00:00:00Z' \
+  --until '2026-08-06T00:00:00Z' \
+  --limit 100 \
+  --offset 0 \
+  --output json
+```
+
+### 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--event-type` | 无 | 按事件类型筛选 |
+| `--category` | 无 | 按安全能力类别筛选 |
+| `--trace-id` | 无 | 按一次 CLI/调用链 trace 筛选 |
+| `--session-id` | 无 | 按 Agent 会话筛选 |
+| `--run-id` | 无 | 按 Agent run/turn 筛选 |
+| `--since` | 无 | ISO-8601 起始时间，包含该边界 |
+| `--until` | 无 | ISO-8601 结束时间，不包含该边界 |
+| `--last-hours` | 无 | 查询最近 N 小时，可使用小数 |
+| `--limit` | `100` | 最多返回的事件数 |
+| `--offset` | `0` | 跳过的事件数 |
+| `--count` | `false` | 只输出匹配事件数量 |
+| `--count-by` | 无 | 分组计数，仅支持 `category`、`event_type`、`trace_id` |
+| `--output`, `-o` | `table` | 列表输出格式：`table`、`json`、`jsonl` |
+| `--summary` | `false` | 输出人类可读安全态势摘要 |
+
+### 参数约束
+
+- `--last-hours` 与 `--since` / `--until` 互斥。
+- `--count` 与 `--count-by` 互斥。
+- `--summary` 与 `--count`、`--count-by`、任何显式 `--output` 互斥。
+- `--summary` 会读取最多 10000 条匹配事件；普通列表使用 `--limit` 和 `--offset`。
+- 未知 `event_type` 或 `category` 会产生 warning，但查询仍会执行，以兼容未来新增类型。
+
+## 事件类型与类别
+
+| `event_type` | `category` | 含义 |
+|--------------|------------|------|
+| `sandbox_prehook` | `sandbox` | 沙箱执行前决策 |
+| `harden` | `hardening` | Security Baseline 检查或加固 |
+| `verify` | `asset_verify` | 资产完整性验证 |
+| `summary` | `summary` | 安全摘要动作 |
+| `code_scan` | `code_scan` | 代码安全扫描 |
+| `prompt_scan` | `prompt_scan` | Prompt 安全扫描 |
+| `pii_scan` | `pii_scan` | PII/凭据检测 |
+| `skill_ledger` | `skill_ledger` | Skill Ledger 检查 |
+
+成功或失败由顶层 `result` 表示，不要假设失败事件的 `event_type` 带 `_error` 后缀。
+
+## `events` 输出结构
+
+### JSON 列表与 JSONL
+
+`--output json` 返回事件对象数组。`--output jsonl` 每行返回一个相同结构的事件对象。事件 envelope 为：
+
+```json
+{
+  "event_id": "<uuid>",
+  "event_type": "code_scan",
+  "category": "code_scan",
+  "result": "succeeded",
+  "timestamp": "<ISO-8601 UTC>",
+  "trace_id": "<trace_id>",
+  "pid": 1234,
+  "uid": 1000,
+  "session_id": "<session_id-or-null>",
+  "run_id": "<run_id-or-null>",
+  "call_id": "<call_id-or-null>",
+  "tool_call_id": "<tool_call_id-or-null>",
+  "details": {}
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `event_id` | string | 事件 UUID |
+| `event_type` | string | 事件类型 |
+| `category` | string | 聚合类别 |
+| `result` | string | `succeeded` 或 `failed` |
+| `timestamp` | string | ISO-8601 UTC 时间 |
+| `trace_id` | string | 调用链标识，可能为空字符串 |
+| `pid`, `uid` | integer | 记录事件的进程与用户 ID |
+| `session_id`, `run_id` | string \| null | Agent 会话和 run/turn 关联标识 |
+| `call_id`, `tool_call_id` | string \| null | LLM 与工具调用关联标识 |
+| `details` | object | 后端专属结构化数据 |
+
+`details` 没有跨事件类型的固定 schema。只读取当前任务需要且实际存在的字段，不要根据其他类别的事件臆测字段。安全判定可能位于 `details.verdict` 或 `details.result.verdict`；使用前先检查类型和存在性。
+
+### 计数输出
+
+`--count` 输出一个 JSON 整数：
+
+```json
+12
+```
+
+`--count-by` 输出一个 JSON 对象，键是分组值，值是数量：
+
+```json
+{
+  "code_scan": 8,
+  "prompt_scan": 4
+}
+```
+
+## 会话级报告
+
+### 调用方式
+
+```bash
+# 最近记录的会话
+agent-sec-cli observability report --last --format json
+
+# 指定会话
+agent-sec-cli observability report \
+  --session-id '<session_id>' \
+  --format json
+```
+
+选择 `--last` 或 `--session-id` 之一。命令没有默认目标；两者都不提供时返回错误。`--format` 支持 `text` 和 `json`，供 Agent 解析时必须使用 `json`。
+
+### JSON 结构
+
+```json
+{
+  "session_id": "<session_id>",
+  "first_seen": "2026-08-05 10:00:00",
+  "last_seen": "2026-08-05 10:05:00",
+  "duration_seconds": 300.0,
+  "turn_count": 3,
+  "llm_calls": 4,
+  "request_bytes": 1200,
+  "response_bytes": 2400,
+  "tool_breakdown": {
+    "shell": 2
+  },
+  "security_verdicts": {
+    "code_scan": {
+      "succeeded": 2
+    }
+  },
+  "security_hint": null
+}
+```
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `session_id` | string | 会话 ID |
+| `first_seen`, `last_seen` | string | 会话首末事件的 UTC 时间文本 |
+| `duration_seconds` | number | 会话持续秒数，保留一位小数 |
+| `turn_count` | integer | 记录的 Agent turn 数 |
+| `llm_calls` | integer | `after_llm_call` 事件数 |
+| `request_bytes`, `response_bytes` | integer | 模型请求与响应累计字节数 |
+| `tool_breakdown` | object<string, integer> | 工具名称到调用次数的映射 |
+| `security_verdicts` | object<string, object<string, integer>> | 安全类别到 `result` 计数的映射 |
+| `security_hint` | string \| null | 安全事件不可用、未关联或查询失败时的说明 |
+
+`security_verdicts` 当前按安全事件顶层 `result`（如 `succeeded` / `failed`）聚合；不要把它解释为扫描器的 `pass` / `warn` / `deny`。如需具体扫描 verdict，再通过相同 `session_id` 查询 `events --output json` 并检查对应事件的 `details`。
+
+## 关联与报告规则
+
+- 优先使用 `session_id` 关联会话，使用 `run_id` 缩小到某个 run/turn；`trace_id` 用于追踪一次具体调用链。
+- 会话报告没有安全事件时，检查 `security_hint`，不要直接断言“没有发生安全检测”。
+- table 与 summary 是人类展示格式，不承诺稳定列结构；自动化处理必须选择 JSON/JSONL。
+- 报告事件时给出查询范围、筛选条件、匹配数量和必要结论。除非用户明确要求，不完整输出 `details` 中的命令、输入、证据或诊断信息。

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
@@ -61,6 +61,8 @@ def test_security_observability_skill_documents_cli_and_output_contracts() -> No
     assert "--since" in content
     assert "--until" in content
     assert "category`、`event_type`、`trace_id`" in content
+    assert "--limit '<matching_count_or_safe_page_size>'" in content
+    assert "--count" in content
 
     event_fields = {
         "event_id",
@@ -106,8 +108,8 @@ def test_security_observability_skill_includes_few_shot_queries() -> None:
     assert "events --last-hours 1 --output json" in content
     assert "帮我查询本次会话出现的安全事件" in content
     assert "events --session-id '<current_session_id>' --output json" in content
-    assert "帮我复盘最近一次 Agent 会话的安全情况" in content
-    assert "observability report --last --format json" in content
+    assert "帮我复盘本次会话的安全情况" in content
+    assert "帮我复盘最近一次 Agent 会话的安全情况" not in content
 
 
 def test_security_observability_skill_documents_cosh_ng_session_id_lookup() -> None:
@@ -122,6 +124,8 @@ def test_security_observability_skill_documents_cosh_ng_session_id_lookup() -> N
     assert "### cosh-ng 特别用法：`runtime_context` 工具" in content
     assert "`provider_session_id`" in content
     assert "events --session-id '<provider_session_id>' --output json" in content
+    assert "它应当是 UUID" in content
+    assert "必须继续按 `^[0-9a-fA-F]" in content
     assert (
         "observability report --session-id '<provider_session_id>' --format json"
         in content
@@ -151,6 +155,19 @@ def test_security_observability_skill_scopes_session_queries_to_cosh_ng() -> Non
     assert "不要因为拿不到 `session_id` 而停下来反复询问用户" in content
 
 
+def test_security_observability_skill_allows_safe_correlation_ids() -> None:
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+    agents = _AGENTS_PATH.read_text(encoding="utf-8")
+
+    assert "不一定是 UUID" in content
+    assert "session-001" in content
+    assert "thread_xxx" in content
+    assert "长度不超过 256 字符" in content
+    assert "^[A-Za-z0-9][A-Za-z0-9._:@+=,/-]{0,255}$" in content
+    assert "cosh-ng `runtime_context.provider_session_id`" in agents
+    assert "which is expected to be a UUID" in agents
+
+
 def test_security_observability_parameters_are_covered_by_agents_contract() -> None:
     content = _AGENTS_PATH.read_text(encoding="utf-8")
 
@@ -160,3 +177,6 @@ def test_security_observability_parameters_are_covered_by_agents_contract() -> N
     assert "Do not replace it with instructions" in content
     assert "--help" in content
     assert "contract tests" in content
+    assert "explicit `--limit`" in content
+    assert "counts between 101 and 200" in content
+    assert "bounded safe-character full-match" in content

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
@@ -3,8 +3,8 @@
 import json
 from pathlib import Path
 
-
 _AGENT_SEC_CORE_DIR = Path(__file__).resolve().parents[3]
+_AGENTS_PATH = _AGENT_SEC_CORE_DIR / "AGENTS.md"
 _MANIFEST_PATH = _AGENT_SEC_CORE_DIR / "cosh-extension" / "cosh-extension.json"
 _COMPONENT_MANIFEST_PATH = _AGENT_SEC_CORE_DIR / ".anolisa" / "component.toml"
 _SKILL_PATH = _AGENT_SEC_CORE_DIR / "skills" / "security-observability" / "SKILL.md"
@@ -28,7 +28,9 @@ def test_cosh_extension_does_not_bundle_security_observability_skill() -> None:
     assert "skills" not in manifest
 
 
-def test_component_manifest_installs_security_observability_with_skills_bundle() -> None:
+def test_component_manifest_installs_security_observability_with_skills_bundle() -> (
+    None
+):
     content = _COMPONENT_MANIFEST_PATH.read_text(encoding="utf-8")
 
     assert 'source = "share/anolisa/skills/"' in content
@@ -51,6 +53,10 @@ def test_security_observability_skill_documents_cli_and_output_contracts() -> No
 
     assert "agent-sec-cli events" in content
     assert "agent-sec-cli observability report" in content
+    assert "observability report --last --format json" in content
+    assert "observability report --session-id '<session_id>' --format json" in content
+    assert "`--last` 查询最近记录的会话" in content
+    assert "`--session-id '<session_id>'` 查询指定会话" in content
     assert "--last-hours" in content
     assert "--since" in content
     assert "--until" in content
@@ -90,3 +96,14 @@ def test_security_observability_skill_documents_cli_and_output_contracts() -> No
     assert "backend-specific" in content or "后端专属" in content
     assert "succeeded/failed" in content or "succeeded` / `failed" in content
     assert "pass` / `warn` / `deny" in content
+
+
+def test_security_observability_parameters_are_covered_by_agents_contract() -> None:
+    content = _AGENTS_PATH.read_text(encoding="utf-8")
+
+    assert "skills/security-observability/SKILL.md" in content
+    assert "self-contained" in content
+    assert "implicit contract with the CLI help text" in content
+    assert "Do not replace it with instructions" in content
+    assert "--help" in content
+    assert "contract tests" in content

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
@@ -1,0 +1,92 @@
+"""Contract tests for security observability skill distribution."""
+
+import json
+from pathlib import Path
+
+
+_AGENT_SEC_CORE_DIR = Path(__file__).resolve().parents[3]
+_MANIFEST_PATH = _AGENT_SEC_CORE_DIR / "cosh-extension" / "cosh-extension.json"
+_COMPONENT_MANIFEST_PATH = _AGENT_SEC_CORE_DIR / ".anolisa" / "component.toml"
+_SKILL_PATH = _AGENT_SEC_CORE_DIR / "skills" / "security-observability" / "SKILL.md"
+
+
+def _parse_frontmatter(content: str) -> dict[str, str]:
+    assert content.startswith("---\n")
+    frontmatter = content.split("---", 2)[1]
+    values: dict[str, str] = {}
+    for line in frontmatter.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def test_cosh_extension_does_not_bundle_security_observability_skill() -> None:
+    manifest = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert "skills" not in manifest
+
+
+def test_component_manifest_installs_security_observability_with_skills_bundle() -> None:
+    content = _COMPONENT_MANIFEST_PATH.read_text(encoding="utf-8")
+
+    assert 'source = "share/anolisa/skills/"' in content
+    assert 'target = "{datadir}/skills/"' in content
+    assert _SKILL_PATH.is_file()
+
+
+def test_security_observability_skill_has_valid_frontmatter() -> None:
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+    frontmatter = _parse_frontmatter(content)
+
+    assert frontmatter["name"] == "security-observability"
+    assert "agent-sec-cli" in frontmatter["description"]
+    assert "安全事件" in frontmatter["description"]
+    assert "会话" in frontmatter["description"]
+
+
+def test_security_observability_skill_documents_cli_and_output_contracts() -> None:
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "agent-sec-cli events" in content
+    assert "agent-sec-cli observability report" in content
+    assert "--last-hours" in content
+    assert "--since" in content
+    assert "--until" in content
+    assert "category`、`event_type`、`trace_id`" in content
+
+    event_fields = {
+        "event_id",
+        "event_type",
+        "category",
+        "result",
+        "timestamp",
+        "trace_id",
+        "pid",
+        "uid",
+        "session_id",
+        "run_id",
+        "call_id",
+        "tool_call_id",
+        "details",
+    }
+    report_fields = {
+        "first_seen",
+        "last_seen",
+        "duration_seconds",
+        "turn_count",
+        "llm_calls",
+        "request_bytes",
+        "response_bytes",
+        "tool_breakdown",
+        "security_verdicts",
+        "security_hint",
+    }
+
+    for field in event_fields | report_fields:
+        assert f"`{field}`" in content or f'"{field}"' in content
+
+    assert "backend-specific" in content or "后端专属" in content
+    assert "succeeded/failed" in content or "succeeded` / `failed" in content
+    assert "pass` / `warn` / `deny" in content

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py
@@ -98,6 +98,59 @@ def test_security_observability_skill_documents_cli_and_output_contracts() -> No
     assert "pass` / `warn` / `deny" in content
 
 
+def test_security_observability_skill_includes_few_shot_queries() -> None:
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "## Few-shot 场景" in content
+    assert "帮我查询最近一个小时出现的安全事件" in content
+    assert "events --last-hours 1 --output json" in content
+    assert "帮我查询本次会话出现的安全事件" in content
+    assert "events --session-id '<current_session_id>' --output json" in content
+    assert "帮我复盘最近一次 Agent 会话的安全情况" in content
+    assert "observability report --last --format json" in content
+
+
+def test_security_observability_skill_documents_cosh_ng_session_id_lookup() -> None:
+    """The cosh-ng-specific session lookup must stay explicit and fenced off.
+
+    ``runtime_context`` only exists in cosh-ng, and ``COSH_SESSION_ID`` is a
+    different identity namespace there, so both facts have to survive edits.
+    """
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "## 获取当前 session_id" in content
+    assert "### cosh-ng 特别用法：`runtime_context` 工具" in content
+    assert "`provider_session_id`" in content
+    assert "events --session-id '<provider_session_id>' --output json" in content
+    assert (
+        "observability report --session-id '<provider_session_id>' --format json"
+        in content
+    )
+    # The skill must scope the tool to cosh-ng rather than presenting it as generic.
+    assert "仅适用于 **cosh-ng** Agent" in content
+    # Anti-pattern: the shell/terminal identity is not the agent session id.
+    assert "不要用环境变量 `$COSH_SESSION_ID` 代替" in content
+    assert "shell_session_id" in content
+    # runtime_context carries no run_id, so run scoping still needs another source.
+    assert "不返回 `run_id`" in content
+
+
+def test_security_observability_skill_scopes_session_queries_to_cosh_ng() -> None:
+    """Only cosh-ng can resolve its own session id.
+
+    Every other runtime must fall back to a time range or ``--last`` and state
+    the real query scope, instead of stalling on an id it cannot obtain.
+    """
+    content = _SKILL_PATH.read_text(encoding="utf-8")
+
+    assert "### 其他 Agent 运行时：不使用 `--session-id`" in content
+    assert "只有 cosh-ng 能让 Agent 取得自己的 `session_id`" in content
+    assert "默认改用**时间范围查询**" in content
+    assert "**必须在报告中说明实际查询范围**" in content
+    # The old "ask the user for the id" fallback must not come back.
+    assert "不要因为拿不到 `session_id` 而停下来反复询问用户" in content
+
+
 def test_security_observability_parameters_are_covered_by_agents_contract() -> None:
     content = _AGENTS_PATH.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Why

Agent 需要一个明确的 Skill 来理解如何通过 `agent-sec-cli` 查询本地安全事件和会话级安全复盘结果。现有 CLI 已具备 `events` 和 `observability report` 能力，但缺少面向 Agent 的参数说明、输出结构说明和安全报告规则。

## What changed

- 新增 `security-observability` Skill，说明 `agent-sec-cli events` 的过滤参数、互斥规则、JSON/JSONL 输出结构、计数输出和事件字段语义。
- 说明 `agent-sec-cli observability report --format json` 的会话报告结构，并提示不要把顶层 `succeeded` / `failed` 误解为扫描器的 `pass` / `warn` / `deny`。
- 明确该 Skill 通过现有 shared skills bundle 安装，不在 cosh extension 中重复打包。
- 新增轻量契约测试，验证 cosh extension 不自带 skills、component manifest 仍整体安装 skills bundle，并验证 Skill frontmatter 与关键文档契约。

## Related issue

no-issue: 补齐 agent-sec-core 安全可观测查询的 Agent 使用说明。

## User / Agent impact

安装 agent-sec-core skills 后，Agent 可以调用 `security-observability` Skill，按结构化方式查询安全事件和会话报告。运行时 CLI、hook 和 extension 行为不变。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk。变更只新增 Skill 文档和对应契约测试，不修改 CLI 行为、hook 行为、配置格式或安装布局。

## Validation

- `uv run --project /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/agent-sec-cli pytest /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/tests/unit-test/cosh_hooks/test_extension_skill.py -v` — 4 passed
- `make -C /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core stage-skills` — passed
- `make -C /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core stage-component-manifest` — passed
- `git --no-pager diff --check -- <本次相关文件>` — passed

## Documentation and rollback

新增的 `SKILL.md` 是面向 Agent 的使用说明。回滚时删除 `src/agent-sec-core/skills/security-observability/` 及对应契约测试即可，不影响现有 CLI、hook 或 component manifest。
