### PR TITLE
chore(anolisa): bump version to 0.2.17

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17] - 2026-08-05
+
+### Added
+
+- Raw installs can now render layout placeholders such as `{bindir}` and
+  `{datadir}` inside declared text files before placement, so shared package
+  templates follow the selected install scope and prefix. Integrity checks and
+  repair use the rendered bytes
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222)).
+
+### Changed
+
+- Raw repository resolution now prefers the generation-2 index when published
+  and enforces each component's minimum CLI version. Incompatible entries fail
+  with an `anolisa update self` hint instead of silently installing an older or
+  malformed result, while generation-1 repositories remain compatible
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222)).
+- RPM-backed adapter scan, status, and enable operations now use a declared
+  package-owned resource root and report a missing or invalid root instead of
+  falling back to stale raw files. Codex adapters that target an external RPM
+  root record a trust anchor; disable them before downgrading to `0.2.16`
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222)).
+
+### Fixed
+
+- Qoder native plugin bundles now use Qoder's own plugin lifecycle instead of
+  being copied or rewritten as legacy hook bundles. Existing same-ID plugins
+  across user and project scopes are protected, and unverified installs or
+  removals retain a retryable receipt rather than claiming or deleting user
+  state
+  ([#2221](https://github.com/alibaba/anolisa/pull/2221)).
+
 ## [0.2.16] - 2026-08-03
 
 ### Added
@@ -758,6 +790,35 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.17] - 2026-08-05
+
+### 新增
+
+- Raw 安装现可在放置声明的文本文件前渲染其中的 `{bindir}`、`{datadir}` 等
+  layout placeholder，使共享的软件包模板遵循所选安装 scope 与 prefix。
+  完整性检查和 repair 使用渲染后的字节
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222))。
+
+### 变更
+
+- Raw repository 解析现会在已发布时优先使用第二代 index，并强制检查各组件的
+  CLI 最低版本。不兼容的条目会给出 `anolisa update self` 提示并失败，而不会
+  静默安装较旧或格式错误的结果，同时保持对第一代 repository 的兼容
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222))。
+- RPM-backed adapter 的 scan、status 和 enable 操作现使用声明的软件包自有
+  resource root；root 缺失或无效时会明确报告，而不会回退到过期的 raw 文件。
+  目标位于外部 RPM root 的 Codex adapter 会记录 trust anchor；降级到
+  `0.2.16` 前需先 disable 这些 adapter
+  ([#2222](https://github.com/alibaba/anolisa/pull/2222))。
+
+### 修复
+
+- Qoder native plugin bundle 现使用 Qoder 自身的 plugin lifecycle，不再按
+  legacy hook bundle 复制或改写。User scope 和 project scope 中已有的同 ID
+  plugin 会受到保护；无法确认的安装或移除会保留可重试的 receipt，而不会认领或
+  删除用户状态
+  ([#2221](https://github.com/alibaba/anolisa/pull/2221))。
 
 ## [0.2.16] - 2026-08-03
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Mon Aug 03 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Aug 05 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Raw installs now render relocatable templates and reject incompatible contracts.
+- Generation-2 indexes prevent silent downgrade from unreadable entries.
+- RPM adapters now use package-owned roots and preserve external symlink trust.
+- Native Qoder plugins now use the framework lifecycle and protect existing registrations.
+
+* Mon Aug 03 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.16-1
 - Component updates now report adapter bundles that need follow-up.
 - Raw installs now work without rpm tooling on deb-family hosts that have no rpm database.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.16",
-    "@anolisa/cli-linux-arm64": "0.2.16",
-    "@anolisa/cli-darwin-arm64": "0.2.16"
+    "@anolisa/cli-linux-x64": "0.2.17",
+    "@anolisa/cli-linux-arm64": "0.2.17",
+    "@anolisa/cli-darwin-arm64": "0.2.17"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.2.17 needs one atomic release boundary for the merged native Qoder plugin lifecycle and unified raw/RPM component contract changes. Curating the release notes from the actual 0.2.16-to-HEAD range keeps published behavior accurate and every distribution channel aligned.

## What changed

- Bumped the Cargo workspace and all ANOLISA workspace packages to 0.2.17.
- Synchronized the root npm package, native optional dependencies, and every platform package at 0.2.17.
- Added semantically equivalent English and Chinese release notes for #2221 and #2222.
- Froze the previous RPM changelog row at 0.2.16 and opened the 0.2.17 release row.

## Related issue

no-issue: routine ANOLISA CLI release aggregation

## User / Agent impact

Users receive the native Qoder plugin lifecycle fix plus relocatable raw file rendering, generation-2 repository compatibility gates, and backend-specific RPM adapter resource roots. The version-bump commit itself adds no new runtime behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The release exposes already-merged contract behavior. Codex adapters targeting an external RPM root can record a v6 trust anchor; disable those adapters before downgrading the CLI to 0.2.16.

## Validation

- `python3 /home/jiawa.syx/.codex/skills/release-anolisa-cli/scripts/check_release.py --root src/anolisa --version 0.2.17 --previous 0.2.16`
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `target/debug/anolisa --version`
- `git diff --check`

## Documentation and rollback

Updated the bilingual component changelog and RPM changelog boundary. Before artifacts are published, revert the release commit to roll back; after publication, issue a subsequent release instead of rewriting 0.2.17. Disable externally anchored Codex adapters before a binary downgrade to 0.2.16.