### PR TITLE
fix(tokenless): anchor rtk prefix in Hermes and OpenClaw rewrite paths

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -48,6 +49,49 @@ _RTK_LOCAL_SHARE = _user_path(
 _RTK_LOCAL_LIB = _user_path(".local", "lib", "anolisa", "tokenless", "rtk")
 
 _TOKENLESS_HELPER_BINARIES = frozenset({"rtk", "toon"})
+
+# Shell connectives that terminate a command-list / pipeline segment.
+_SEGMENT_OPS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _is_env_assignment(token: str) -> bool:
+    """Return True for a leading shell variable assignment (NAME=value)."""
+    name, sep, _ = token.partition("=")
+    if not sep or not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def anchor_rtk_prefix(rewritten: str, rtk_bin: str) -> str:
+    """Replace bare ``rtk`` wrapper tokens with the resolved binary path.
+
+    Shared implementation used by rewrite_hook.py and hermes/__init__.py.
+    See rewrite_hook._anchor_rtk_prefix for the full docstring.
+    """
+    lexer = shlex.shlex(rewritten, posix=False)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return rewritten
+
+    quoted = shlex.quote(rtk_bin)
+    result = list(tokens)
+    wrapped = False
+    for i, token in enumerate(tokens):
+        if token in _SEGMENT_OPS:
+            wrapped = False
+            continue
+        if _is_env_assignment(token):
+            continue
+        if not wrapped and token == "rtk":
+            result[i] = quoted
+            wrapped = True
+
+    return " ".join(result)
 
 
 def _known_binary_paths(name: str, home: str | None = None) -> tuple[str, ...]:

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -14,7 +14,6 @@ FHS spec: /usr/libexec/anolisa/tokenless/rtk.
 
 import json
 import os
-import shlex
 import subprocess
 import sys
 
@@ -27,6 +26,7 @@ from hook_utils import (
     _TOKENLESS_FALLBACK,
     _TOKENLESS_LOCAL_LIB,
     _TOKENLESS_LOCAL_SHARE,
+    anchor_rtk_prefix,
     forward_stderr,
     parse_version,
     resolve_agent_id,
@@ -41,73 +41,6 @@ from hook_utils import (
 
 _MIN_RTK_VERSION = (0, 35, 0)
 _AGENT_ID = resolve_agent_id()
-
-# Shell connectives that terminate a command-list / pipeline segment.
-# A bare `rtk` wrapper can appear at command start or right after one.
-_SEGMENT_OPS = frozenset({"&&", "||", ";", "|", "&"})
-
-
-def _is_env_assignment(token: str) -> bool:
-    """Return True for a leading shell variable assignment (NAME=value)."""
-    name, sep, _ = token.partition("=")
-    if not sep or not name:
-        return False
-    if not (name[0].isalpha() or name[0] == "_"):
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
-
-
-def _anchor_rtk_prefix(rewritten: str, rtk_bin: str) -> str:
-    """Replace bare `rtk` wrapper tokens with the resolved binary path.
-
-    rtk prints rewrites with a literal `rtk` prefix, which only resolves
-    when the shell executing the tool call has the rtk location on its
-    PATH. Agent runtimes with a trimmed PATH (e.g. IDE tool environments
-    without ~/.local/bin) would fail every rewritten command with exit
-    127 even though the hook resolved rtk successfully. Anchoring makes
-    the rewritten command self-contained.
-
-    The pass swaps the first unquoted `rtk` token of each segment — at
-    command start or right after `&&` / `||` / `;` / `|` / `&`,
-    optionally behind leading environment assignments or wrappers such
-    as `sudo`. It lexes with `posix=False` and no punctuation splitting,
-    so every token keeps its original surface: quoted patterns like
-    `grep -E 'foo|rtk bar'` are never modified, unquoted globs like
-    `*.txt` are not re-quoted into literals, fd redirections (`2>&1`,
-    `2>/dev/null`) and command substitutions (`$(date)`) stay intact,
-    and comment stripping is disabled so a `#` argument cannot truncate
-    the command. Connectives are recognized as whitespace-delimited
-    tokens; an unspaced `cmd1;cmd2` is not split, which only leaves
-    that segment's `rtk` unanchored (conservative, never corrupts).
-    Unparseable input is returned untouched.
-
-    Known limitation: a bare `rtk` token that is another command's
-    argument (e.g. `echo rtk done`) is indistinguishable from a wrapper
-    position inside the rtk-rewrite output domain and gets anchored.
-    Real rtk rewrites do not produce that shape, so this is accepted.
-    """
-    lexer = shlex.shlex(rewritten, posix=False)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    try:
-        tokens = list(lexer)
-    except ValueError:
-        return rewritten
-
-    quoted = shlex.quote(rtk_bin)
-    result = list(tokens)
-    wrapped = False
-    for i, token in enumerate(tokens):
-        if token in _SEGMENT_OPS:
-            wrapped = False
-            continue
-        if _is_env_assignment(token):
-            continue
-        if not wrapped and token == "rtk":
-            result[i] = quoted
-            wrapped = True
-
-    return " ".join(result)
 
 
 # -- main --------------------------------------------------------------------
@@ -200,7 +133,7 @@ def main() -> None:
     if not rewritten or rewritten == cmd:
         skip()
 
-    rewritten = _anchor_rtk_prefix(rewritten, rtk_bin)
+    rewritten = anchor_rtk_prefix(rewritten, rtk_bin)
 
     # 7. Build response
     # Emit both formats for runtime compatibility:

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -159,6 +159,7 @@ from hook_utils import (
     _RTK_FALLBACK,
     _RTK_LOCAL_SHARE,
     _RTK_LOCAL_LIB,
+    anchor_rtk_prefix,
     resolve_binary,
     warn as _warn_shared,
     try_parse_json as _try_parse_json,
@@ -410,6 +411,7 @@ def _try_rewrite(
     if not rewritten or rewritten == command:
         return None
 
+    rewritten = anchor_rtk_prefix(rewritten, rtk_bin)
     logger.info("tokenless: rtk rewrite %s → %s", command, rewritten)
     return {
         "action": "block",

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -178,6 +178,78 @@ function checkTokenless(): boolean {
   return tokenlessAvailable;
 }
 
+// Shell connectives that end a command-list / pipeline segment.
+const SEGMENT_OPS = new Set(["&&", "||", ";", "|", "&"]);
+
+function isEnvAssignment(token: string): boolean {
+  const eq = token.indexOf("=");
+  if (eq <= 0) return false;
+  const name = token.slice(0, eq);
+  if (!/^[A-Za-z_]/.test(name)) return false;
+  return /^[A-Za-z0-9_]+$/.test(name);
+}
+
+/**
+ * Replace bare `rtk` wrapper tokens with the resolved binary path.
+ *
+ * Ports Python hook_utils.anchor_rtk_prefix. Tokenises with a minimal
+ * shell-aware lexer (preserves quotes/globs verbatim, disables comment
+ * stripping) and replaces the first unquoted `rtk` in each pipeline
+ * segment with the absolute resolved path, making the rewritten command
+ * self-contained regardless of the agent tool-shell's PATH.
+ */
+export function anchorRtkPrefix(rewritten: string, resolvedRtkPath: string): string {
+  // Tokenise: split on whitespace, but keep quoted spans together and
+  // preserve all non-whitespace characters (globs, redirections, etc.).
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < rewritten.length) {
+    // Skip whitespace
+    if (rewritten[i] === " " || rewritten[i] === "\t") {
+      i++;
+      continue;
+    }
+    // Quoted span — collect until matching close quote
+    if (rewritten[i] === "'" || rewritten[i] === '"') {
+      const q = rewritten[i];
+      let j = i + 1;
+      while (j < rewritten.length && rewritten[j] !== q) j++;
+      tokens.push(rewritten.slice(i, j + 1));
+      i = j + 1;
+      continue;
+    }
+    // Unquoted token — collect until whitespace
+    let j = i;
+    while (j < rewritten.length && rewritten[j] !== " " && rewritten[j] !== "\t") {
+      if (rewritten[j] === "'" || rewritten[j] === '"') break; // switch to quoted
+      j++;
+    }
+    tokens.push(rewritten.slice(i, j));
+    i = j;
+  }
+
+  // Shell-quote the resolved binary path only if it contains special chars
+  const quoted = /[\s'"\\$`!#&;|<>(){}]/.test(resolvedRtkPath)
+    ? `'${resolvedRtkPath.replace(/'/g, "'\\''")}'`
+    : resolvedRtkPath;
+
+  let wrapped = false;
+  for (let idx = 0; idx < tokens.length; idx++) {
+    const tok = tokens[idx];
+    if (SEGMENT_OPS.has(tok)) {
+      wrapped = false;
+      continue;
+    }
+    if (isEnvAssignment(tok)) continue;
+    if (!wrapped && tok === "rtk") {
+      tokens[idx] = quoted;
+      wrapped = true;
+    }
+  }
+
+  return tokens.join(" ");
+}
+
 // ---- Subprocess helpers -------------------------------------------------------
 
 function tryRtkRewrite(command: string): string | null {
@@ -197,7 +269,7 @@ function tryRtkRewrite(command: string): string | null {
     //       user confirmation; in non-interactive hook context, treat as valid
     //       rewrite since the intent is token optimization, not permission gating)
     if ((result.status === 0 || result.status === 3) && rewritten && rewritten !== command) {
-      return rewritten;
+      return anchorRtkPrefix(rewritten, rtkPath);
     }
     return null;
   } catch {

--- a/src/tokenless/adapters/tokenless/openclaw/test_anchor_rtk_prefix.mjs
+++ b/src/tokenless/adapters/tokenless/openclaw/test_anchor_rtk_prefix.mjs
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for anchorRtkPrefix in index.ts.
+ *
+ * Run with: node test_anchor_rtk_prefix.mjs
+ * Uses node:test (Node.js >= 18). Mirrors the case matrix from
+ * tests/test_rewrite_hook.py to ensure consistent behaviour across adapters.
+ *
+ * The anchor logic is reimplemented inline so this file has no runtime
+ * dependency on the plugin's side-effecting binary checks.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// ---- Inline copy of anchorRtkPrefix (kept in sync with index.ts) ------------
+// This avoids importing index.ts and triggering its module-level binary checks.
+
+const SEGMENT_OPS = new Set(["&&", "||", ";", "|", "&"]);
+
+function isEnvAssignment(token) {
+  const eq = token.indexOf("=");
+  if (eq <= 0) return false;
+  const name = token.slice(0, eq);
+  if (!/^[A-Za-z_]/.test(name)) return false;
+  return /^[A-Za-z0-9_]+$/.test(name);
+}
+
+function anchorRtkPrefix(rewritten, resolvedRtkPath) {
+  const tokens = [];
+  let i = 0;
+  while (i < rewritten.length) {
+    if (rewritten[i] === " " || rewritten[i] === "\t") { i++; continue; }
+    if (rewritten[i] === "'" || rewritten[i] === '"') {
+      const q = rewritten[i];
+      let j = i + 1;
+      while (j < rewritten.length && rewritten[j] !== q) j++;
+      tokens.push(rewritten.slice(i, j + 1));
+      i = j + 1;
+      continue;
+    }
+    let j = i;
+    while (j < rewritten.length && rewritten[j] !== " " && rewritten[j] !== "\t") {
+      if (rewritten[j] === "'" || rewritten[j] === '"') break;
+      j++;
+    }
+    tokens.push(rewritten.slice(i, j));
+    i = j;
+  }
+
+  const quoted = /[\s'"\\$`!#&;|<>(){}]/.test(resolvedRtkPath)
+    ? `'${resolvedRtkPath.replace(/'/g, "'\\''")}'`
+    : resolvedRtkPath;
+
+  let wrapped = false;
+  for (let idx = 0; idx < tokens.length; idx++) {
+    const tok = tokens[idx];
+    if (SEGMENT_OPS.has(tok)) { wrapped = false; continue; }
+    if (isEnvAssignment(tok)) continue;
+    if (!wrapped && tok === "rtk") { tokens[idx] = quoted; wrapped = true; }
+  }
+
+  return tokens.join(" ");
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+const RTK = "/usr/local/lib/anolisa/tokenless/rtk";
+
+test("anchors bare rtk at command start", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk grep foo bar", RTK),
+    `${RTK} grep foo bar`,
+  );
+});
+
+test("anchors each segment in a pipeline (&&)", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk grep --cached foo && rtk git status", RTK),
+    `${RTK} grep --cached foo && ${RTK} git status`,
+  );
+});
+
+test("anchors after sudo wrapper", () => {
+  assert.equal(
+    anchorRtkPrefix("sudo rtk git status", RTK),
+    `sudo ${RTK} git status`,
+  );
+});
+
+test("anchors after env assignment", () => {
+  assert.equal(
+    anchorRtkPrefix("RUST_BACKTRACE=1 rtk cargo test", RTK),
+    `RUST_BACKTRACE=1 ${RTK} cargo test`,
+  );
+});
+
+test("anchors after single & (background connective)", () => {
+  assert.equal(
+    anchorRtkPrefix("git status & rtk grep foo", RTK),
+    `git status & ${RTK} grep foo`,
+  );
+});
+
+test("quoted rtk pattern inside single-quoted arg is untouched", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk grep -E 'foo|rtk bar' src/", RTK),
+    `${RTK} grep -E 'foo|rtk bar' src/`,
+  );
+});
+
+test("unquoted glob is preserved (not re-quoted)", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk grep foo *.txt", RTK),
+    `${RTK} grep foo *.txt`,
+  );
+});
+
+test("hash argument not treated as comment (preserved)", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk grep foo #include src/", RTK),
+    `${RTK} grep foo #include src/`,
+  );
+});
+
+test("fd merge redirection preserved (2>&1)", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk git log 2>&1 | rtk head", RTK),
+    `${RTK} git log 2>&1 | ${RTK} head`,
+  );
+});
+
+test("fd redirection to /dev/null preserved (2>/dev/null)", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk git status 2>/dev/null", RTK),
+    `${RTK} git status 2>/dev/null`,
+  );
+});
+
+test("command substitution token preserved ($(date))", () => {
+  assert.equal(
+    anchorRtkPrefix("rtk echo $(date)", RTK),
+    `${RTK} echo $(date)`,
+  );
+});
+
+test("path with spaces is shell-quoted", () => {
+  const rtk = "/home/user/my tools/rtk";
+  assert.equal(
+    anchorRtkPrefix("rtk git status", rtk),
+    `'/home/user/my tools/rtk' git status`,
+  );
+});
+
+test("non-rtk command is returned unchanged", () => {
+  assert.equal(
+    anchorRtkPrefix("git status", RTK),
+    "git status",
+  );
+});
+
+test("empty string is returned unchanged", () => {
+  assert.equal(anchorRtkPrefix("", RTK), "");
+});
+
+test("already-anchored path is not double-anchored", () => {
+  const already = `${RTK} git status`;
+  assert.equal(anchorRtkPrefix(already, RTK), already);
+});


### PR DESCRIPTION
## Description

Follow-up to #1975. That PR fixed the bare `rtk` prefix in `common/hooks/rewrite_hook.py` but two adapters shipped independent rewrite paths with the same latent defect:

- **Hermes** (`adapters/tokenless/hermes/__init__.py`, `_try_rewrite`): returned `proc.stdout.strip()` verbatim without anchoring.
- **OpenClaw** (`adapters/tokenless/openclaw/index.ts`, `tryRtkRewrite`): returned `result.stdout?.trim()` verbatim without anchoring.

In agent runtimes whose tool-shell PATH omits the rtk install location, the rewritten commands fail with exit 127 despite the hook resolving rtk successfully.

## Changes

- **`common/hooks/hook_utils.py`**: Extract `anchor_rtk_prefix` (with `_SEGMENT_OPS`, `_is_env_assignment`) from `rewrite_hook.py` into the shared utilities module so all Python adapters share one implementation.
- **`common/hooks/rewrite_hook.py`**: Import and delegate to `hook_utils.anchor_rtk_prefix`; remove the now-redundant local copy.
- **`hermes/__init__.py`**: Import `anchor_rtk_prefix` from `hook_utils`; call it on the rewritten command in `_try_rewrite` before returning the block message.
- **`openclaw/index.ts`**: Port the token-level anchor as `anchorRtkPrefix` (same posix=False-style lexer: preserves quotes/globs verbatim, disables comment stripping); call it from `tryRtkRewrite`.
- **`openclaw/test_anchor_rtk_prefix.mjs`**: 15 `node:test` unit tests covering wrapper (`sudo rtk`), env assignments, single `&`, quoted patterns, unquoted globs, fd redirections (`2>&1`, `2>/dev/null`), command substitutions, path-with-spaces quoting, and double-anchor prevention.

## Testing

```
# Python adapter tests (29 passed, 15 skipped)
cd src/tokenless
python3 -m pytest tests/test_rewrite_hook.py tests/test_hermes_plugin_import.py tests/test_resolve_agent_id.py -v

# OpenClaw anchor unit tests (15 passed)
node src/tokenless/adapters/tokenless/openclaw/test_anchor_rtk_prefix.mjs
```

All tests pass. The fix is identical in behaviour to #1975: anchoring is conservative (never corrupts unrecognised patterns), and unparseable input is returned untouched.

## Related

Closes #2123