### PR TITLE
fix(tokenless): verify shared hook_utils API compat in Hermes adapter

### DIFF
--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -14,6 +14,7 @@ Activation is controlled by the Hermes plugin system — list ``tokenless`` in
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -76,13 +77,147 @@ def _validate_hooks_dir(path: str) -> str | None:
     return None
 
 
+# Symbols that must exist in the shared hook_utils module, paired with the
+# exact call shape this adapter uses at its hook entry points.  When a
+# candidate passes the trust check but ships an older hook_utils.py (e.g. a
+# stale install from a previous adapter version), the candidate is rejected and
+# the search continues to later paths.  The lifecycle migration made the Hermes
+# adapter a thin Core client, so the required symbols are the Protocol v2
+# request builders, the compress runner, and the Retrieve helpers this module
+# from-imports at load time.  The remaining load-time imports (resolve_binary,
+# SHELL_TOOLS, SKIP_TOOLS, and the local-path constants) predate Protocol v2,
+# so every module that ships the v2 API also ships them.  A module missing any
+# listed symbol would pass a narrower check and then raise ImportError at the
+# top-level from-import, after the candidate search has already ended — with no
+# fallback to later complete candidates.
+#
+# Symbol names alone are not enough: hook_utils has also changed *call
+# signatures* while keeping names stable.  ``build_post_tool_request`` took a
+# keyword-only ``retrieval_available`` flag until c2c7e580e replaced it with
+# the ``recovery`` mapping, so the module shipped by 9f109d559 exports all five
+# required symbols yet rejects the ``recovery=`` this adapter passes — the
+# plugin would import cleanly and every PostTool request would then die with
+# "unexpected keyword argument 'recovery'", again after the candidate search
+# has ended and with no fallback.  Each shape is therefore bound with
+# :func:`inspect.signature`; the values below are placeholders mirroring the
+# real call sites (``bind`` only checks arity and parameter names, so nothing
+# is ever called here).
+_HOOK_UTILS_CALL_SHAPES: tuple[tuple[str, tuple[Any, ...], dict[str, Any]], ...] = (
+    # on_compress_pre_tool:
+    #   build_pre_tool_request(args, AGENT_ID, tool_name, "command",
+    #                          session_id, tool_call_id,
+    #                          replace_arguments=False, block_and_suggest=True)
+    (
+        "build_pre_tool_request",
+        ({}, "", "", "", "", ""),
+        {"replace_arguments": False, "block_and_suggest": True},
+    ),
+    # on_transform_tool_result:
+    #   build_post_tool_request(content, AGENT_ID, tool_name, protocol_status,
+    #                           content_origin, output_optimization,
+    #                           result_kind=..., recovery=..., session_id=...,
+    #                           tool_use_id=..., replace_output=True,
+    #                           replace_with_text=True)
+    (
+        "build_post_tool_request",
+        ("", "", "", "", "", ""),
+        {
+            "result_kind": "tool",
+            "recovery": {"kind": "none"},
+            "session_id": "",
+            "tool_use_id": "",
+            "replace_output": True,
+            "replace_with_text": True,
+        },
+    ),
+    # Both hooks: run_compress(tokenless_bin, request, timeout, operation)
+    ("run_compress", ("", {}, 0, ""), {}),
+    # on_transform_tool_result: is_tokenless_retrieve_command(tool_name, args)
+    ("is_tokenless_retrieve_command", ("", {}), {}),
+    # on_transform_tool_result: tokenless_retrieve_command_available()
+    ("tokenless_retrieve_command_available", (), {}),
+)
+
+_HOOK_UTILS_REQUIRED_SYMBOLS = tuple(name for name, _, _ in _HOOK_UTILS_CALL_SHAPES)
+
+
+def _restore_cached_hook_utils(saved: Any) -> None:
+    """Reinstate the module cached before a trial import, or drop the trial."""
+    if saved is not None:
+        sys.modules["hook_utils"] = saved
+    else:
+        sys.modules.pop("hook_utils", None)
+
+
+def _call_shape_rejection(
+    symbol: Any, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str | None:
+    """Return why *symbol* cannot take the adapter call shape, else ``None``."""
+    try:
+        signature = inspect.signature(symbol)
+    except (TypeError, ValueError) as exc:
+        return f"{name} is not an introspectable callable ({exc})"
+    try:
+        signature.bind(*args, **kwargs)
+    except TypeError as exc:
+        # Name the shape the adapter needs, not only what the module offers:
+        # a renamed keyword (retrieval_available -> recovery) reports as a
+        # missing argument on some Python versions, which alone would not tell
+        # the reader which side of the contract moved.
+        return (
+            f"{name}{signature} rejects the adapter call shape "
+            f"({len(args)} positional, kwargs: {', '.join(sorted(kwargs)) or 'none'}): "
+            f"{exc}"
+        )
+    return None
+
+
+def _check_api_compat(candidate_dir: str) -> str | None:
+    """Trial-import hook_utils from *candidate_dir* and verify its API.
+
+    Returns ``None`` when the module loads, exposes every symbol in
+    :data:`_HOOK_UTILS_REQUIRED_SYMBOLS`, and every one of them accepts the
+    matching call shape in :data:`_HOOK_UTILS_CALL_SHAPES`; otherwise a
+    human-readable rejection reason.  On success the freshly imported module is
+    kept in ``sys.modules`` so the subsequent ``from hook_utils import …``
+    reuses it rather than a stale cached copy.  On rejection the ``sys.path``
+    mutation is cleaned up and the previously cached module (if any) is
+    restored so later candidates start from a clean state.
+    """
+    sys.path.insert(0, candidate_dir)
+    saved = sys.modules.pop("hook_utils", None)
+    try:
+        import hook_utils as _trial  # type: ignore[import-not-found]
+        missing = [s for s in _HOOK_UTILS_REQUIRED_SYMBOLS
+                   if not hasattr(_trial, s)]
+        if missing:
+            _restore_cached_hook_utils(saved)
+            return f"API mismatch: missing {', '.join(missing)}"
+        mismatched = []
+        for name, args, kwargs in _HOOK_UTILS_CALL_SHAPES:
+            reason = _call_shape_rejection(getattr(_trial, name), name, args, kwargs)
+            if reason is not None:
+                mismatched.append(reason)
+        if mismatched:
+            _restore_cached_hook_utils(saved)
+            return "API mismatch: " + "; ".join(mismatched)
+        # Success — keep the freshly imported module in sys.modules.
+        return None
+    except Exception as exc:
+        _restore_cached_hook_utils(saved)
+        return f"import failed: {exc}"
+    finally:
+        sys.path.pop(0)
+
+
+
 def _resolve_hook_utils() -> tuple[str, list[str]]:
     """Locate a trusted shared hooks directory and make it importable.
 
     Returns ``(resolved_path, candidate_list)``.  The resolved path is
     inserted at the front of ``sys.path`` so the shared ``hook_utils``
     module can be imported.  Raises :exc:`ImportError` when no candidate
-    passes the trust policy.
+    passes both the trust policy and the API compatibility check.
     """
     # Resolve real home from passwd DB for user-install fallback path
     # (NOT $HOME — env-controllable).
@@ -119,11 +254,17 @@ def _resolve_hook_utils() -> tuple[str, list[str]]:
     rejections: list[str] = []
     for candidate in candidates:
         reason = _validate_hooks_dir(candidate)
-        if reason is None:
-            resolved = os.path.realpath(candidate)
-            sys.path.insert(0, resolved)
-            return resolved, candidates
-        rejections.append(f"  - {candidate}: {reason}")
+        if reason is not None:
+            rejections.append(f"  - {candidate}: {reason}")
+            continue
+        # Trust check passed — verify API compat (version mismatch guard).
+        resolved = os.path.realpath(candidate)
+        api_reason = _check_api_compat(resolved)
+        if api_reason is not None:
+            rejections.append(f"  - {candidate}: {api_reason}")
+            continue
+        sys.path.insert(0, resolved)
+        return resolved, candidates
 
     raise ImportError(
         "tokenless: no trusted shared hook_utils module (common/hooks/) found.\n"

--- a/src/tokenless/tests/test_hermes_plugin_import.py
+++ b/src/tokenless/tests/test_hermes_plugin_import.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Regression tests for the Hermes plugin hook_utils resolution.
 
-Covers the review findings on PR #2058:
+Covers the review findings on PR #2058 and PR #2249:
 - P1-a: the hooks directory itself, its parent, and hook_utils.py must all
   be rejected when world-writable or foreign-owned (not just the parent).
 - P1-b: copy-installs must honor XDG_DATA_HOME (anolisa FsLayout::user
@@ -11,6 +11,21 @@ Covers the review findings on PR #2058:
 - P2: candidate list contains no empty placeholders; _validate_hooks_dir
   rejects relative/empty paths; the ImportError mentions trust-policy
   rejections, not just "missing".
+- PR #2249 P1: a trusted candidate shipping an older hook_utils.py that
+  lacks the Protocol v2 lifecycle symbols — or a v2-era module without the
+  newer Retrieve helpers — must be rejected by the API compatibility check
+  so the search continues to later candidates.
+- PR #2249 P2 (re-review): a trusted candidate whose hook_utils.py exports
+  every required symbol but with an older *call signature* — the
+  pre-c2c7e580e build_post_tool_request that takes keyword-only
+  `retrieval_available` instead of `recovery` — must be rejected by the same
+  check, so the search continues to later candidates instead of the plugin
+  importing cleanly and then failing every PostTool request.
+
+After the Hermes lifecycle migration the adapter is a thin Core client:
+RTK execution and rtk-prefix anchoring are owned by tokenless-runtime.
+There is no degraded mode anymore — an incompatible hook_utils
+fails the plugin import with a diagnostic instead.
 """
 
 import importlib.util
@@ -168,6 +183,311 @@ class CopyInstallResolutionTest(unittest.TestCase):
         else:
             # Later candidate won; the untrusted dir must not be selected.
             self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(hooks))
+
+
+class VersionMismatchTest(unittest.TestCase):
+    """Regression tests for shared hook_utils version mismatch (PR #2249 P1).
+
+    When a candidate passes the trust check (hook_utils.py exists, ownership
+    and permissions OK) but ships an older hook_utils that lacks the
+    Protocol v2 lifecycle symbols this adapter imports
+    (build_pre_tool_request, build_post_tool_request, run_compress,
+    is_tokenless_retrieve_command, tokenless_retrieve_command_available), the
+    candidate must be rejected with an "API mismatch" reason and the search
+    must continue to later candidates. When no compatible candidate exists,
+    the plugin import fails with a diagnostic — there is no degraded mode
+    anymore, because the lifecycle adapter delegates every feature to Core.
+
+    Symbol names alone are not a sufficient contract (PR #2249 P2
+    re-review): hook_utils replaced build_post_tool_request's keyword-only
+    `retrieval_available` with `recovery` in c2c7e580e, so the module from
+    9f109d559 exports all five required symbols and still cannot take the
+    adapter's PostTool call — it would be imported and then raise
+    "unexpected keyword argument 'recovery'" on the first request, with the
+    candidate search already finished. Those signature-skewed modules must be
+    rejected up front as well.
+
+    Also covers _check_api_compat's sys.modules behavior on success
+    (PR #2249 P2): the freshly imported module must stay cached instead
+    of a stale copy being restored.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="hermes-version-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        plugin_dir = os.path.join(self.tmp, "plugins", "tokenless")
+        os.makedirs(plugin_dir)
+        shutil.copy(_PLUGIN_SRC, plugin_dir)
+        self.plugin_copy = os.path.join(plugin_dir, "__init__.py")
+        self._saved_xdg = os.environ.get("XDG_DATA_HOME")
+
+    def tearDown(self):
+        if self._saved_xdg is None:
+            os.environ.pop("XDG_DATA_HOME", None)
+        else:
+            os.environ["XDG_DATA_HOME"] = self._saved_xdg
+
+    def _make_old_hooks_dir(self, base: str) -> str:
+        """Create a hooks dir whose hook_utils.py lacks the lifecycle API."""
+        hooks = os.path.join(base, "anolisa", "adapters", "tokenless", "common", "hooks")
+        os.makedirs(hooks, mode=0o755)
+        # Write a minimal hook_utils.py without the Protocol v2 builders
+        # (pre-lifecycle installs shipped exactly this shape).
+        with open(os.path.join(hooks, "hook_utils.py"), "w") as f:
+            f.write(
+                "# Old hook_utils without the Protocol v2 lifecycle API\n"
+                "def resolve_binary(name, *fallbacks): return None\n"
+            )
+        # Copy tool_categories.json (needed by some imports)
+        shutil.copy(
+            os.path.join(_HOOKS_SRC, "tool_categories.json"),
+            hooks,
+        )
+        os.chmod(hooks, 0o755)
+        return hooks
+
+    def _make_v2_era_hooks_dir(self, base: str) -> str:
+        """Create a hooks dir whose hook_utils.py has the Protocol v2
+        lifecycle builders but predates the Retrieve helpers (the shape
+        shipped between the lifecycle migration and the Retrieve feature).
+        """
+        hooks = os.path.join(base, "anolisa", "adapters", "tokenless", "common", "hooks")
+        os.makedirs(hooks, mode=0o755)
+        with open(os.path.join(hooks, "hook_utils.py"), "w") as f:
+            f.write(
+                "# v2-era hook_utils: lifecycle API present, Retrieve helpers absent\n"
+                "def resolve_binary(name, *fallbacks): return None\n"
+                "def build_pre_tool_request(*args, **kwargs): return {}\n"
+                "def build_post_tool_request(*args, **kwargs): return {}\n"
+                "def run_compress(*args, **kwargs): return None\n"
+            )
+        shutil.copy(
+            os.path.join(_HOOKS_SRC, "tool_categories.json"),
+            hooks,
+        )
+        os.chmod(hooks, 0o755)
+        return hooks
+
+    def _write_signature_skew_module(self, hooks: str) -> str:
+        """Write a faithful stand-in for the hook_utils.py that 9f109d559
+        shipped: every symbol this adapter from-imports at load time is
+        present, and four of the five required callables keep their current
+        signature — only build_post_tool_request still takes the
+        pre-c2c7e580e keyword-only `retrieval_available` instead of
+        `recovery`.  Such a module imports cleanly, so a name-only
+        compatibility check accepts it and the failure only surfaces on the
+        first PostTool request.
+        """
+        os.makedirs(hooks, mode=0o755)
+        with open(os.path.join(hooks, "hook_utils.py"), "w") as f:
+            f.write(
+                "# v2-era hook_utils, PostTool signature predates c2c7e580e\n"
+                "SHELL_TOOLS = {'shell', 'terminal'}\n"
+                "SKIP_TOOLS = set()\n"
+                "_RTK_FALLBACK = _RTK_LOCAL_LIB = _RTK_LOCAL_SHARE = ''\n"
+                "_TOKENLESS_FALLBACK = _TOKENLESS_LOCAL_LIB = ''\n"
+                "_TOKENLESS_LOCAL_SHARE = ''\n"
+                "def resolve_binary(name, *fallbacks): return None\n"
+                "def build_pre_tool_request(*args, **kwargs): return {}\n"
+                "def build_post_tool_request(\n"
+                "    content, agent_id, tool_name, status, content_origin,\n"
+                "    output_optimization, *, result_kind, retrieval_available,\n"
+                "    session_id='', tool_use_id='', replace_output=False,\n"
+                "    replace_with_text=False,\n"
+                "): return {}\n"
+                "def run_compress(*args, **kwargs): return None\n"
+                "def is_tokenless_retrieve_command(*args, **kwargs): return False\n"
+                "def tokenless_retrieve_command_available(): return False\n"
+            )
+        shutil.copy(
+            os.path.join(_HOOKS_SRC, "tool_categories.json"),
+            hooks,
+        )
+        os.chmod(hooks, 0o755)
+        return hooks
+
+    def _make_signature_skew_hooks_dir(self, base: str) -> str:
+        """Create a signature-skewed hooks dir in the anolisa data layout."""
+        hooks = os.path.join(base, "anolisa", "adapters", "tokenless", "common", "hooks")
+        return self._write_signature_skew_module(hooks)
+
+    def test_old_hooks_rejected_by_api_compat_check(self):
+        # A candidate whose hook_utils.py lacks the lifecycle builders must
+        # be rejected by _check_api_compat, not accepted and then crash on
+        # the top-level from-import.
+        xdg = os.path.join(self.tmp, "xdg-data")
+        old_hooks = self._make_old_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_old_hooks")
+        except ImportError as exc:
+            # No compatible candidate found — diagnostic mentions API mismatch.
+            self.assertIn("API mismatch", str(exc))
+            self.assertIn(old_hooks, str(exc))
+        else:
+            # A later candidate with the correct version won.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(old_hooks))
+
+    def test_no_compat_candidate_fails_with_api_mismatch(self):
+        # When no candidate provides the Protocol v2 symbols, the plugin
+        # must fail loudly with the API mismatch diagnostic instead of
+        # silently importing a stale hook_utils. (The pre-lifecycle version
+        # degraded to local fallbacks; Core now owns every feature, so an
+        # adapter without the lifecycle API has nothing useful to do.)
+        xdg = os.path.join(self.tmp, "xdg-data")
+        old_hooks = self._make_old_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_incompat")
+        except ImportError as exc:
+            msg = str(exc)
+            self.assertIn("API mismatch", msg)
+            self.assertIn(old_hooks, msg)
+            self.assertIn("build_pre_tool_request", msg)
+        else:
+            # A later, newer candidate won — never the stale one.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(old_hooks))
+
+    def test_v2_era_hooks_missing_retrieve_helpers_rejected(self):
+        # A historical module that already ships the Protocol v2 builders
+        # but predates the Retrieve helpers must be rejected too — otherwise
+        # it passes _check_api_compat and the plugin then dies on the
+        # top-level from-import of is_tokenless_retrieve_command /
+        # tokenless_retrieve_command_available, after the candidate search
+        # has ended, with no fallback to later complete candidates.
+        xdg = os.path.join(self.tmp, "xdg-data")
+        old_hooks = self._make_v2_era_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_v2_era")
+        except ImportError as exc:
+            msg = str(exc)
+            self.assertIn("API mismatch", msg)
+            self.assertIn("is_tokenless_retrieve_command", msg)
+            self.assertIn(old_hooks, msg)
+        else:
+            # A later, complete candidate won — never the v2-era one.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(old_hooks))
+
+    def test_check_api_compat_rejects_v2_era_module(self):
+        # Deterministic direct probe: a module with the three Protocol v2
+        # symbols but without the Retrieve helpers must be rejected, listing
+        # both missing helpers, and the previously cached complete module
+        # must stay in sys.modules untouched.
+        plugin = _load_plugin(_PLUGIN_SRC, "hermes_api_compat_v2_era")
+        v2_era = self._make_v2_era_hooks_dir(os.path.join(self.tmp, "v2-era"))
+        cached = sys.modules.get("hook_utils")
+        self.assertIsNotNone(cached, "plugin load must leave hook_utils cached")
+        reason = plugin._check_api_compat(v2_era)
+        self.assertIsNotNone(reason, "v2-era module must not pass the API check")
+        self.assertIn("API mismatch", reason)
+        self.assertIn("is_tokenless_retrieve_command", reason)
+        self.assertIn("tokenless_retrieve_command_available", reason)
+        # The rejected trial import must not clobber the cached module.
+        self.assertIs(sys.modules.get("hook_utils"), cached)
+
+    def test_check_api_compat_keeps_fresh_module_on_success(self):
+        # When _check_api_compat succeeds, the freshly imported module must
+        # stay in sys.modules — the old cached module must NOT be restored.
+        import types
+
+        plugin = _load_plugin(_PLUGIN_SRC, "hermes_api_compat_cache")
+
+        # Create a fake "old" module and put it in sys.modules
+        old_mod = types.ModuleType("hook_utils")
+        old_mod._STALE = True  # marker so we can detect it
+        sys.modules["hook_utils"] = old_mod
+
+        try:
+            # Trial-import from the real source-tree hooks dir
+            hooks_dir = os.path.realpath(_HOOKS_SRC)
+            reason = plugin._check_api_compat(hooks_dir)
+            self.assertIsNone(reason, "compatible candidate must pass API check")
+
+            # The module in sys.modules must be the fresh one, not old_mod
+            current = sys.modules.get("hook_utils")
+            self.assertIsNotNone(current, "module must remain in sys.modules")
+            self.assertFalse(
+                getattr(current, "_STALE", False),
+                "stale module was restored instead of fresh candidate",
+            )
+        finally:
+            sys.modules.pop("hook_utils", None)
+
+    def test_check_api_compat_rejects_signature_skewed_module(self):
+        # Deterministic direct probe: all five required symbols are present,
+        # but build_post_tool_request still takes `retrieval_available`, so
+        # the candidate must be rejected on its call shape instead of being
+        # accepted and blowing up on the first PostTool request.
+        plugin = _load_plugin(_PLUGIN_SRC, "hermes_api_compat_signature_skew")
+        skewed = self._make_signature_skew_hooks_dir(os.path.join(self.tmp, "skew"))
+        cached = sys.modules.get("hook_utils")
+        self.assertIsNotNone(cached, "plugin load must leave hook_utils cached")
+        reason = plugin._check_api_compat(skewed)
+        self.assertIsNotNone(
+            reason, "signature-skewed module must not pass the API check"
+        )
+        self.assertIn("API mismatch", reason)
+        self.assertIn("build_post_tool_request", reason)
+        self.assertIn("recovery", reason)
+        # The rejected trial import must not clobber the cached module.
+        self.assertIs(sys.modules.get("hook_utils"), cached)
+
+    def test_signature_skew_candidate_does_not_mask_later_complete_one(self):
+        # End-to-end repro of the review finding: the signature-skewed module
+        # sits in the highest-priority candidate (the source-tree relative
+        # path next to the copied plugin) and the complete current module sits
+        # in a later XDG candidate.  The search must skip the skewed one, and
+        # the selected module must really take the adapter's PostTool call.
+        skewed = self._write_signature_skew_module(
+            os.path.join(self.tmp, "plugins", "common", "hooks")
+        )
+        xdg = os.path.join(self.tmp, "xdg-data")
+        complete = _make_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+
+        plugin = _load_plugin(self.plugin_copy, "hermes_plugin_signature_skew")
+
+        self.assertEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(complete))
+        self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(skewed))
+        request = plugin.build_post_tool_request(
+            "model-visible output",
+            plugin.AGENT_ID,
+            "shell",
+            "success",
+            "tool",
+            "none",
+            result_kind="tool",
+            recovery={"kind": "shell"},
+            session_id="session-1",
+            tool_use_id="call-1",
+            replace_output=True,
+            replace_with_text=True,
+        )
+        self.assertEqual(request["protocol_version"], 2)
+        self.assertEqual(request["operation"], "post_tool")
+        self.assertEqual(
+            request["input"]["capabilities"]["recovery"], {"kind": "shell"}
+        )
+
+    def test_signature_skew_only_candidate_fails_with_diagnostic(self):
+        # When the only trusted candidate is signature-skewed, the plugin must
+        # fail loudly with the API mismatch diagnostic rather than import a
+        # module whose PostTool builder cannot take `recovery=`.
+        xdg = os.path.join(self.tmp, "xdg-data")
+        skewed = self._make_signature_skew_hooks_dir(xdg)
+        os.environ["XDG_DATA_HOME"] = xdg
+        try:
+            plugin = _load_plugin(self.plugin_copy, "hermes_plugin_skew_only")
+        except ImportError as exc:
+            msg = str(exc)
+            self.assertIn("API mismatch", msg)
+            self.assertIn("build_post_tool_request", msg)
+            self.assertIn(skewed, msg)
+        else:
+            # A later, complete candidate won — never the skewed one.
+            self.assertNotEqual(plugin._HOOK_UTILS_RESOLVED, os.path.realpath(skewed))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

Since the Hermes lifecycle migration the adapter is a thin Core client: at load time it imports the Protocol v2 request builders (`build_pre_tool_request`, `build_post_tool_request`), `run_compress`, and the Retrieve helpers (`is_tokenless_retrieve_command`, `tokenless_retrieve_command_available`) from the shared `hook_utils`. The PR #2058 trust check verifies candidate ownership/permissions, but it cannot distinguish a stale `hook_utils.py` left behind by an older adapter install — importing such a module breaks every PreTool/PostTool request with an opaque `ImportError`, or silently reuses a stale `sys.modules` cache.

- **`hermes/__init__.py`**: add `_HOOK_UTILS_REQUIRED_SYMBOLS` and `_check_api_compat` into the `_resolve_hook_utils` candidate loop. After a candidate passes the trust check, its `hook_utils` is trial-imported and the load-time symbols that distinguish adapter generations are required — the three Protocol v2 ones plus the two Retrieve helpers:
  - an incompatible candidate is rejected with an `API mismatch: missing …` reason and the search continues to later candidates (covering both historical shapes: pre-v2 modules, and v2-era modules without the Retrieve helpers);
  - when no compatible candidate exists, the plugin import fails with a diagnostic listing every rejection (there is no degraded mode anymore — the lifecycle adapter delegates every feature to Core);
  - on success the freshly imported module stays in `sys.modules` so the subsequent `from hook_utils import …` reuses it instead of a stale cached copy; on rejection the `sys.path` mutation is undone and the previous cache restored.
- **`tests/test_hermes_plugin_import.py`**: `VersionMismatchTest` covers the stale-candidate rejection for both historical shapes (`_make_old_hooks_dir` for pre-v2, `_make_v2_era_hooks_dir` for v2 builders without the Retrieve helpers), the no-compatible-candidate diagnostic, a direct `_check_api_compat` probe asserting a v2-era module is rejected listing both missing helpers while the cached complete module stays intact, and `_check_api_compat`'s sys.modules behavior on success (`test_check_api_compat_keeps_fresh_module_on_success`).

### Scope note (2026-09-07 review round)

This branch originally implemented adapter-side rtk-prefix anchoring for the pre-migration adapters (Refs #2123). After the Protocol v2 migration landed in main, RTK execution and prefix anchoring are owned by the Rust Core (`anchor_rtk_prefix` in `tokenless-runtime`, covered by `pre_tool_applies_rtk_exit_zero_and_anchors_path`), and both Hermes and OpenClaw go through `tokenless compress`. Per review, the adapter-side anchoring implementation was removed in full:

- the shared Python implementation in `hook_utils.py` (`_anchor_rtk_prefix`, word-span lexer, transparent-prefix config parsing/caching — 389 lines); the file is now identical to main;
- the OpenClaw helper `anchor-helpers.ts` (451 lines) and its dedicated test `test_openclaw_anchor.mjs`;
- the anchoring test classes in `test_hermes_plugin_import.py` (`AnchorRtkPrefixTest`, `AnchorTransparentPrefixTest`) and their `_load_shared_hook_utils` helper, keeping `test_check_api_compat_keeps_fresh_module_on_success` (now a method of `VersionMismatchTest`);
- the dedicated build/test entries: `tsconfig.json` include (back to `index.ts` only), the `test-openclaw-anchor` Makefile target, and its CI step.

What remains is the API compatibility guard above, as a single atomic commit on top of current main.

### Retrieve-symbol gap (2026-09-08 review round)

Review found the required-symbol tuple missed the two Retrieve helpers the plugin also from-imports at load time: a v2-era module (three Protocol v2 symbols, no Retrieve helpers) passed `_check_api_compat`, then the top-level from-import raised `ImportError` after the candidate search had ended — with no fallback to later complete candidates, and replacing a previously cached complete module. Both Retrieve helpers are now required symbols, and `VersionMismatchTest` reproduces the v2-era shape (candidate-loop fall-through plus a deterministic direct probe of `_check_api_compat`). Because the Core-side anchoring fix landed with the migration, this PR references rather than closes #2123 — maintainers can close it once verified against Core.

## Testing

Environment: Linux x86_64; Python 3.12.9 (CI runs 3.11; main's `test_hook_contract.py` uses ≥3.10 annotation syntax, which the local default 3.8 lacks), Node v22.21.1, npm 10.9.4.

| Command | Result |
|---|---|
| `make -C src/tokenless test-integration` | OK — 13 suites / 156 tests, 0 failures (1 skipped); includes `test_hermes_plugin_import.py` (16 tests) and `test_hook_contract.py` (17 tests) |
| `make -C src/tokenless test-adapters` | OK — openclaw plugin builds with the reverted `tsconfig.json`; lifecycle-v2 15/15; dsh bundle validated; qoder 17/17; opencode 13/13 + plugin tests; qwenpaw 32/32 |
| `git diff --check` | clean |
| repo-wide grep | no remaining references to `_anchor_rtk_prefix`, `anchorRtkPrefix`, `anchor-helpers`, `test_openclaw_anchor`, or `test-openclaw-anchor` |

Not run locally: RPM/npm packaging pipelines and macOS/win32-specific paths (covered by CI).

Refs #2123

