### PR TITLE
fix(sec-core): use bundled Python for raw hooks

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/alibaba/anolisa"
 
 [component.contract]
 schema_version = "1.0"
-min_anolisa_version = "0.2.16"
+min_anolisa_version = "0.2.17"
 
 [backends.rpm]
 package = "agent-sec-core"
@@ -52,13 +52,6 @@ name = "jq"
 kind = "system-package"
 probe = "jq --version"
 packages = { rpm = "jq", deb = "jq" }
-
-[[component.dependencies]]
-name = "python3"
-kind = "language-runtime"
-version = ">=3.11,<3.12"
-probe = "python3 --version"
-source = "system"
 
 [component.layout]
 modes = ["system"]

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -265,6 +265,22 @@ include = [
 
 ---
 
+## raw packaging
+
+### Adapter Python hooks
+
+- Keep Python hook commands in shared JSON manifests in the existing
+  `"command": "python3 ..."` form. `packaging/raw/adapt_payload.py` relies on that
+  form to rewrite staged raw hooks to `agent-sec-python`.
+- When adding, renaming, or removing a Python hook manifest, update
+  `RAW_HOOK_MANIFESTS` in both `packaging/raw/adapt_payload.py` and
+  `packaging/raw/verify_release.py`, plus the source/raw manifest lists and bypass
+  cases in `tests/packaging/test-package-raw.sh`.
+- Run `bash tests/packaging/test-package-raw.sh` after changing an adapter manifest
+  or the raw manifest inventory.
+
+---
+
 ## hermes-plugin
 
 ### 1. 项目概述

--- a/src/agent-sec-core/packaging/raw/adapt_payload.py
+++ b/src/agent-sec-core/packaging/raw/adapt_payload.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Adapt shared adapter manifests for the self-contained raw payload."""
+
+import argparse
+from pathlib import Path
+
+RAW_HOOK_MANIFESTS = (
+    Path("adapters/sec-core/codex/hooks/hooks.json"),
+    Path("adapters/sec-core/qoder/hooks/hooks.json"),
+    Path("adapters/sec-core/qwencode/qwen-extension.json"),
+    Path("adapters/sec-core/cosh/cosh-extension.json"),
+)
+
+
+def adapt_hook_manifest(path: Path) -> None:
+    """Replace native Python hook launchers in one staged JSON manifest."""
+    if not path.is_file():
+        raise SystemExit(f"ERROR: staged hook manifest not found: {path}")
+    content = path.read_text(encoding="utf-8")
+    adapted = content.replace(
+        '"command": "python3 ', '"command": "agent-sec-python '
+    ).replace('"command": "python3"', '"command": "agent-sec-python"')
+    if adapted == content:
+        raise SystemExit(f"ERROR: {path} has no native Python hook launcher")
+    path.write_text(adapted, encoding="utf-8")
+
+
+def adapt_payload(payload_root: Path) -> None:
+    """Apply raw-only hook launcher changes under ``payload_root``."""
+    for relative_path in RAW_HOOK_MANIFESTS:
+        adapt_hook_manifest(payload_root / relative_path)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("payload_root", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Adapt a staged raw payload in place."""
+    args = parse_args()
+    adapt_payload(args.payload_root.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent-sec-core/packaging/raw/assets/bin/agent-sec-python
+++ b/src/agent-sec-core/packaging/raw/assets/bin/agent-sec-python
@@ -11,7 +11,7 @@ if [ ! -x "$PYTHON" ]; then
     echo "ERROR: bundled Python runtime is missing: $PYTHON" >&2
     exit 127
 fi
-VERSION=$(PYTHONHOME="$RUNTIME" PYTHONNOUSERSITE=1 PYTHONDONTWRITEBYTECODE=1 \
+VERSION=$(PYTHONHOME="$RUNTIME" PYTHONNOUSERSITE=1 \
     "$PYTHON" -c 'import platform; print(platform.python_version())')
 if [ "$VERSION" != "3.11.6" ]; then
     echo "ERROR: bundled Python runtime must be 3.11.6, found $VERSION" >&2
@@ -20,6 +20,5 @@ fi
 
 PYTHONHOME="$RUNTIME" \
 PYTHONNOUSERSITE=1 \
-PYTHONDONTWRITEBYTECODE=1 \
 PYTHONPATH="$SITE_PACKAGES" \
     exec "$PYTHON" "$@"

--- a/src/agent-sec-core/packaging/raw/package.sh
+++ b/src/agent-sec-core/packaging/raw/package.sh
@@ -114,6 +114,8 @@ stage_payload() {
     copy_tree "$BUILD_DIR/cosh-extension" "$stage/adapters/sec-core/cosh"
     copy_tree "$BUILD_DIR/skills" "$stage/share/anolisa/skills"
 
+    python3 "$ROOT/packaging/raw/adapt_payload.py" "$stage"
+
     find "$stage/lib/anolisa/sec-core/python3.11" \
         -type d -name __pycache__ -prune -exec rm -rf {} +
     find "$stage/lib/anolisa/sec-core/python3.11" \
@@ -125,6 +127,8 @@ stage_payload() {
         die "bundled Python runtime contains a symbolic link"
     fi
     normalize_modes "$stage"
+    python3 "$ROOT/packaging/raw/verify_release.py" \
+        "$ROOT" "$CONTRACT" --payload-root "$stage" > /dev/null
 }
 
 resolve_epoch() {

--- a/src/agent-sec-core/packaging/raw/verify_release.py
+++ b/src/agent-sec-core/packaging/raw/verify_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate version-bearing metadata used by component-owned raw packaging."""
+"""Validate source metadata and staged output for raw packaging."""
 
 import argparse
 import json
@@ -13,20 +13,16 @@ SEMVER_PATTERN = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+NATIVE_PYTHON_PATTERN = re.compile(
+    r"(?<![\w./-])(?:[\w./-]+/)?python(?:\d+(?:\.\d+)*)?(?=$|[\s;&|()])"
+)
+
 REQUIRED_RUNTIME_DEPENDENCIES = {
     "bubblewrap",
     "gnupg",
     "jq",
     "nodejs",
-    "python3",
     "systemd",
-}
-
-PYTHON_RUNTIME_FIELDS = {
-    "kind": "language-runtime",
-    "version": ">=3.11,<3.12",
-    "probe": "python3 --version",
-    "source": "system",
 }
 
 RPM_RESOURCE_ROOTS = {
@@ -37,6 +33,13 @@ RPM_RESOURCE_ROOTS = {
     "qwencode": "/opt/agent-sec/qwen-code-extension/",
     "cosh": "{datadir}/extensions/agent-sec-core/",
 }
+
+RAW_HOOK_MANIFESTS = (
+    Path("adapters/sec-core/codex/hooks/hooks.json"),
+    Path("adapters/sec-core/qoder/hooks/hooks.json"),
+    Path("adapters/sec-core/qwencode/qwen-extension.json"),
+    Path("adapters/sec-core/cosh/cosh-extension.json"),
+)
 
 
 def read_toml(path: Path) -> dict[str, object]:
@@ -87,14 +90,10 @@ def verify_contract_metadata(contract: dict[str, object], contract_path: Path) -
             + ", ".join(missing_dependencies)
         )
 
-    python_runtime = dependencies_by_name["python3"]
-    for field, expected in PYTHON_RUNTIME_FIELDS.items():
-        actual = python_runtime.get(field)
-        if actual != expected:
-            raise SystemExit(
-                f"ERROR: {contract_path} python3 dependency {field} is "
-                f"{actual!r}, expected {expected!r}"
-            )
+    if "python3" in dependencies_by_name:
+        raise SystemExit(
+            f"ERROR: {contract_path} must not declare the bundled Python as a dependency"
+        )
 
     adapters = contract.get("adapters")
     if not isinstance(adapters, list):
@@ -181,18 +180,123 @@ def verify_versions(source_root: Path, contract_path: Path) -> str:
     return expected
 
 
+def collect_python_hook_commands(
+    document: object, location: str = "$"
+) -> list[tuple[str, str]]:
+    """Collect Python hook commands and native launchers in their arguments."""
+    commands: list[tuple[str, str]] = []
+    if isinstance(document, dict):
+        command = document.get("command")
+        args = document.get("args")
+        has_python_arg = isinstance(args, list) and any(
+            isinstance(arg, str) and ".py" in arg for arg in args
+        )
+        if isinstance(command, str) and (
+            ".py" in command
+            or has_python_arg
+            or NATIVE_PYTHON_PATTERN.search(command) is not None
+        ):
+            commands.append((f"{location}.command", command))
+        if isinstance(args, list):
+            commands.extend(
+                (f"{location}.args[{index}]", arg)
+                for index, arg in enumerate(args)
+                if isinstance(arg, str)
+                and NATIVE_PYTHON_PATTERN.search(arg) is not None
+            )
+        for key, value in document.items():
+            commands.extend(collect_python_hook_commands(value, f"{location}.{key}"))
+    elif isinstance(document, list):
+        for index, value in enumerate(document):
+            commands.extend(collect_python_hook_commands(value, f"{location}[{index}]"))
+    return commands
+
+
+def verify_raw_contract(payload_root: Path) -> None:
+    """Verify the staged raw contract does not require system Python."""
+    contract_path = payload_root / ".anolisa" / "component.toml"
+    contract = read_toml(contract_path)
+    component = contract.get("component")
+    dependencies = (
+        component.get("dependencies") if isinstance(component, dict) else None
+    )
+    if not isinstance(dependencies, list):
+        raise SystemExit(f"ERROR: {contract_path} has no component dependencies")
+    if any(
+        isinstance(dependency, dict) and dependency.get("name") == "python3"
+        for dependency in dependencies
+    ):
+        raise SystemExit(f"ERROR: {contract_path} still requires system python3")
+
+
+def verify_raw_hook_manifests(payload_root: Path) -> None:
+    """Verify every staged Python hook uses the bundled runtime launcher."""
+    adapter_root = payload_root / "adapters"
+    manifest_paths = sorted(adapter_root.rglob("*.json"))
+    expected_paths = {payload_root / relative for relative in RAW_HOOK_MANIFESTS}
+    missing_paths = sorted(
+        path for path in expected_paths if path not in manifest_paths
+    )
+    if missing_paths:
+        raise SystemExit(
+            "ERROR: raw payload is missing hook manifests: "
+            + ", ".join(str(path) for path in missing_paths)
+        )
+
+    hook_counts = dict.fromkeys(expected_paths, 0)
+    for manifest_path in manifest_paths:
+        try:
+            document = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise SystemExit(
+                f"ERROR: invalid JSON in {manifest_path}: {error}"
+            ) from error
+        for location, command in collect_python_hook_commands(document):
+            if NATIVE_PYTHON_PATTERN.search(command) is not None:
+                raise SystemExit(
+                    f"ERROR: {manifest_path} {location} bypasses agent-sec-python "
+                    f"with native Python: {command!r}"
+                )
+            if command != "agent-sec-python" and not command.startswith(
+                "agent-sec-python "
+            ):
+                raise SystemExit(
+                    f"ERROR: {manifest_path} {location} bypasses agent-sec-python: "
+                    f"{command!r}"
+                )
+            if manifest_path in hook_counts:
+                hook_counts[manifest_path] += 1
+
+    empty_manifests = sorted(path for path, count in hook_counts.items() if count == 0)
+    if empty_manifests:
+        raise SystemExit(
+            "ERROR: raw hook manifests declare no Python hooks: "
+            + ", ".join(str(path) for path in empty_manifests)
+        )
+
+
+def verify_raw_payload(payload_root: Path) -> None:
+    """Verify raw-only contract and adapter launcher invariants."""
+    verify_raw_contract(payload_root)
+    verify_raw_hook_manifests(payload_root)
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("source_root", type=Path)
     parser.add_argument("contract", type=Path)
+    parser.add_argument("--payload-root", type=Path)
     return parser.parse_args()
 
 
 def main() -> int:
     """Validate release metadata and print the canonical version."""
     args = parse_args()
-    print(verify_versions(args.source_root.resolve(), args.contract.resolve()))
+    version = verify_versions(args.source_root.resolve(), args.contract.resolve())
+    if args.payload_root is not None:
+        verify_raw_payload(args.payload_root.resolve())
+    print(version)
     return 0
 
 

--- a/src/agent-sec-core/tests/packaging/test-package-raw.sh
+++ b/src/agent-sec-core/tests/packaging/test-package-raw.sh
@@ -45,7 +45,7 @@ cat > "$BUILD/python-runtime/bin/python3.11.real" <<'EOF'
 if [ "${1:-}" = "-c" ]; then
     case "${2:-}" in
         *platform.python_version*)
-            [ "${PYTHONDONTWRITEBYTECODE:-}" = "1" ] || exit 9
+            [ -z "${PYTHONDONTWRITEBYTECODE:-}" ] || exit 9
             printf '3.11.6\n'
             exit 0
             ;;
@@ -147,6 +147,7 @@ test "$(stat -c '%a' \
     "$STAGE/lib/anolisa/sec-core/python3.11/runtime/bin/python3.11")" = "755"
 test "$(stat -c '%a' "$STAGE/.anolisa/component.toml")" = "644"
 test -z "$(find "$STAGE" -type l -print -quit)"
+cmp "$ROOT/.anolisa/component.toml" "$STAGE/.anolisa/component.toml"
 
 RPM_STAGE="$TMP/rpm-stage"
 MANIFEST_STAGE="$TMP/manifest-stage"
@@ -180,25 +181,70 @@ test "$(cat "$PYTHON_LOG.home")" = \
 test "$(cat "$PYTHON_LOG.path")" = \
     "$STAGE/lib/anolisa/sec-core/python3.11/site-packages"
 
-cmp "$ROOT/codex-plugin/hooks-plugin/hooks/hooks.json" \
+SOURCE_HOOK_MANIFESTS=(
+    "$ROOT/codex-plugin/hooks-plugin/hooks/hooks.json"
+    "$ROOT/qoder-plugin/hooks/hooks.json"
+    "$ROOT/qwen-code-extension/qwen-extension.json"
+    "$ROOT/cosh-extension/cosh-extension.json"
+)
+RAW_HOOK_MANIFESTS=(
     "$STAGE/adapters/sec-core/codex/hooks/hooks.json"
-cmp "$ROOT/qoder-plugin/hooks/hooks.json" \
     "$STAGE/adapters/sec-core/qoder/hooks/hooks.json"
-cmp "$ROOT/qwen-code-extension/qwen-extension.json" \
     "$STAGE/adapters/sec-core/qwencode/qwen-extension.json"
-cmp "$ROOT/cosh-extension/cosh-extension.json" \
     "$STAGE/adapters/sec-core/cosh/cosh-extension.json"
-for manifest in \
-    "$STAGE/adapters/sec-core/codex/hooks/hooks.json" \
-    "$STAGE/adapters/sec-core/qoder/hooks/hooks.json" \
-    "$STAGE/adapters/sec-core/qwencode/qwen-extension.json" \
-    "$STAGE/adapters/sec-core/cosh/cosh-extension.json"; do
-    grep -q '"command": "python3' "$manifest"
-    if grep -q '"command": "agent-sec-python' "$manifest"; then
-        echo "ERROR: staged adapter rewrote its native Python command: $manifest" >&2
+)
+for index in "${!RAW_HOOK_MANIFESTS[@]}"; do
+    source_manifest="${SOURCE_HOOK_MANIFESTS[$index]}"
+    raw_manifest="${RAW_HOOK_MANIFESTS[$index]}"
+    grep -Fq '"command": "python3' "$source_manifest"
+    if grep -Fq '"command": "agent-sec-python' "$source_manifest"; then
+        echo "ERROR: shared adapter source uses the raw launcher: $source_manifest" >&2
+        exit 1
+    fi
+    grep -Fq '"command": "agent-sec-python' "$raw_manifest"
+    if grep -Fq '"command": "python3' "$raw_manifest"; then
+        echo "ERROR: staged raw adapter still uses native Python: $raw_manifest" >&2
+        exit 1
+    fi
+    if cmp -s "$source_manifest" "$raw_manifest"; then
+        echo "ERROR: staged raw adapter was not adapted: $raw_manifest" >&2
         exit 1
     fi
 done
+
+if grep -Fq 'name = "python3"' "$STAGE/.anolisa/component.toml"; then
+    echo "ERROR: staged raw contract still requires system Python" >&2
+    exit 1
+fi
+if grep -Fq 'name = "python3"' "$ROOT/.anolisa/component.toml"; then
+    echo "ERROR: component contract still requires system Python" >&2
+    exit 1
+fi
+grep -Fq 'Requires:       python3 >= 3.11' "$ROOT/agent-sec-core.spec.in"
+grep -Fq 'Requires:       python3 < 3.12' "$ROOT/agent-sec-core.spec.in"
+
+FAKE_BIN="$TMP/fake-bin"
+FAKE_PYTHON_LOG="$TMP/fake-python.log"
+install -d -m 0755 "$FAKE_BIN"
+cat > "$FAKE_BIN/python3" <<'EOF'
+#!/bin/sh
+printf 'called\n' >> "$ANOLISA_FAKE_PYTHON_LOG"
+exit 99
+EOF
+chmod 0755 "$FAKE_BIN/python3"
+for hook in \
+    "$STAGE/adapters/sec-core/codex/hooks/hook.py" \
+    "$STAGE/adapters/sec-core/qoder/hooks/hook.py" \
+    "$STAGE/adapters/sec-core/qwencode/hooks/hook.py" \
+    "$STAGE/adapters/sec-core/cosh/hooks/hook.py"; do
+    ANOLISA_FAKE_PYTHON_LOG="$FAKE_PYTHON_LOG" \
+    ANOLISA_TEST_PYTHON_LOG="$PYTHON_LOG" \
+    PATH="$FAKE_BIN:$STAGE/bin:$PATH" \
+        agent-sec-python "$hook"
+    test "$(cat "$PYTHON_LOG")" = \
+        "$STAGE/lib/anolisa/sec-core/python3.11/runtime/bin/python3.11"
+done
+test ! -e "$FAKE_PYTHON_LOG"
 
 LIST="$TMP/tar-list.txt"
 tar -tzf "$OUT_ONE/$ARTIFACT" > "$LIST"
@@ -257,26 +303,37 @@ tar -xzOf "$OUT_ONE/$ARTIFACT" \
     ./adapters/sec-core/qwencode/qwen-extension.json > "$TMP/qwen-extension.json"
 tar -xzOf "$OUT_ONE/$ARTIFACT" \
     ./adapters/sec-core/cosh/cosh-extension.json > "$TMP/cosh-extension.json"
-cmp "$ROOT/codex-plugin/hooks-plugin/hooks/hooks.json" "$TMP/codex-hooks.json"
-cmp "$ROOT/qoder-plugin/hooks/hooks.json" "$TMP/qoder-hooks.json"
-cmp "$ROOT/qwen-code-extension/qwen-extension.json" "$TMP/qwen-extension.json"
-cmp "$ROOT/cosh-extension/cosh-extension.json" "$TMP/cosh-extension.json"
+for manifest in \
+    "$TMP/codex-hooks.json" \
+    "$TMP/qoder-hooks.json" \
+    "$TMP/qwen-extension.json" \
+    "$TMP/cosh-extension.json"; do
+    grep -Fq '"command": "agent-sec-python' "$manifest"
+    if grep -Fq '"command": "python3' "$manifest"; then
+        echo "ERROR: packaged raw adapter still uses native Python: $manifest" >&2
+        exit 1
+    fi
+done
 grep -Fq 'agent-sec-python' "$TMP/agent-sec-cli"
 grep -Fq 'lib/anolisa/sec-core/python3.11/runtime' "$TMP/agent-sec-python"
 grep -Fq 'lib/anolisa/sec-core/python3.11/site-packages' "$TMP/agent-sec-python"
+if grep -Fq 'PYTHONDONTWRITEBYTECODE' "$TMP/agent-sec-python"; then
+    echo "ERROR: packaged Python wrapper disables bytecode persistence" >&2
+    exit 1
+fi
 grep -Fq 'ExecStart="{bindir}/agent-sec-daemon" serve' "$TMP/service"
 grep -Fq 'ReadWritePaths="{datadir}"' "$TMP/service"
 grep -Fq 'render = "anolisa-paths-v1"' "$TMP/contract.toml"
-grep -Fq 'min_anolisa_version = "0.2.16"' "$TMP/contract.toml"
+grep -Fq 'min_anolisa_version = "0.2.17"' "$TMP/contract.toml"
 grep -Fq 'framework_version = ">=2026.4.14"' "$TMP/contract.toml"
 grep -Fq 'framework_version = ">=2026.4.24"' "$TMP/contract.toml"
 grep -Fq 'name = "systemd"' "$TMP/contract.toml"
 grep -Fq 'name = "nodejs"' "$TMP/contract.toml"
 grep -Fq 'name = "jq"' "$TMP/contract.toml"
-grep -Fq 'name = "python3"' "$TMP/contract.toml"
-grep -Fq 'kind = "language-runtime"' "$TMP/contract.toml"
-grep -Fq 'version = ">=3.11,<3.12"' "$TMP/contract.toml"
-grep -Fq 'probe = "python3 --version"' "$TMP/contract.toml"
+if grep -Fq 'name = "python3"' "$TMP/contract.toml"; then
+    echo "ERROR: packaged raw contract still requires system Python" >&2
+    exit 1
+fi
 test "$(grep -c 'min_anolisa_version' "$TMP/contract.toml")" = "1"
 if grep -Eq '/opt/agent-sec|/usr/(local/)?share/anolisa|/usr/local/bin' \
     "$TMP/agent-sec-cli" "$TMP/service"; then
@@ -298,6 +355,38 @@ if BUILD_DIR="$BAD_PYTHON_BUILD" \
     exit 1
 fi
 grep -Fq "bundled Python license manifest is invalid" "$TMP/bad-python.err"
+
+assert_raw_hook_bypass_rejected() {
+    local name="$1"
+    local hook_entry="$2"
+    local bad_build="$TMP/bad-hook-$name-build"
+
+    cp -a "$BUILD" "$bad_build"
+    printf '{"hooks":[%s]}\n' "$hook_entry" > \
+        "$bad_build/qwen-code-extension/unexpected-hooks.json"
+    if BUILD_DIR="$bad_build" \
+        DESTDIR="$TMP/bad-hook-$name-stage" \
+        TARGET_OS=linux \
+        TARGET_ARCH=x86_64 \
+            "$ROOT/packaging/raw/package.sh" stage \
+            > "$TMP/bad-hook-$name.out" 2> "$TMP/bad-hook-$name.err"; then
+        echo "ERROR: raw hook bypass unexpectedly succeeded: $name" >&2
+        exit 1
+    fi
+    grep -Fq "bypasses agent-sec-python" "$TMP/bad-hook-$name.err"
+}
+
+assert_raw_hook_bypass_rejected \
+    compound \
+    '{"command":"agent-sec-python hook.py && python3 -m unexpected_hook"}'
+assert_raw_hook_bypass_rejected \
+    env-command '{"command":"env python3 -m unexpected_hook"}'
+assert_raw_hook_bypass_rejected \
+    plain-python '{"command":"python -m unexpected_hook"}'
+assert_raw_hook_bypass_rejected \
+    env-args '{"command":"env","args":["python3","-m","unexpected_hook"]}'
+assert_raw_hook_bypass_rejected \
+    shell-args '{"command":"sh","args":["-c","python3 -m unexpected_hook"]}'
 
 VERIFY_SOURCE="$TMP/verify-source"
 VERSION_FILES=(
@@ -352,14 +441,22 @@ if python3 "$ROOT/packaging/raw/verify_release.py" \
 fi
 grep -Fq "missing runtime dependencies: systemd" "$TMP/bad.err"
 
-sed '/version = ">=3.11,<3.12"/d' \
-    "$ROOT/.anolisa/component.toml" > "$BAD_CONTRACT"
+cp "$ROOT/.anolisa/component.toml" "$BAD_CONTRACT"
+cat >> "$BAD_CONTRACT" <<'EOF'
+
+[[component.dependencies]]
+name = "python3"
+kind = "language-runtime"
+version = ">=3.11,<3.12"
+probe = "python3 --version"
+source = "system"
+EOF
 if python3 "$ROOT/packaging/raw/verify_release.py" \
     "$VERIFY_SOURCE" "$BAD_CONTRACT" > "$TMP/bad.out" 2> "$TMP/bad.err"; then
-    echo "ERROR: incomplete Python runtime dependency unexpectedly succeeded" >&2
+    echo "ERROR: system Python dependency unexpectedly succeeded" >&2
     exit 1
 fi
-grep -Fq "python3 dependency version is None" "$TMP/bad.err"
+grep -Fq "must not declare the bundled Python as a dependency" "$TMP/bad.err"
 
 sed '\|resource_root = "/opt/agent-sec/qoder-plugin/"|d' \
     "$ROOT/.anolisa/component.toml" > "$BAD_CONTRACT"


### PR DESCRIPTION
## Why

The raw packager copied shared adapter manifests verbatim, so Python hooks invoked the host `python3` even though the raw artifact already bundles CPython 3.11.6. This allowed installation and health checks to succeed while adapter hooks could fail later on hosts without a compatible system Python.

## What changed

- Rewrite the four staged raw adapter manifests to launch Python hooks through `agent-sec-python`.
- Validate the completed raw payload and reject Python hooks that bypass the bundled launcher.
- Remove `python3` from the component contract; RPM dependencies remain declared by the Spec.
- Raise the component contract's minimum ANOLISA version to `0.2.17`.
- Keep shared adapter manifests and RPM hook resources unchanged.

## Related issues

Closes #2253

Relates to #2252: raw hooks now run through `agent-sec-python`. The raw artifact excludes inherited build-time bytecode, but installed hooks may generate normal runtime `__pycache__` files, so this PR does not attempt to solve post-install adapter bundle drift. The RPM case remains out of scope.

## User / Agent impact

Raw installations can run Codex, Qoder, Qwen Code, and Cosh security hooks without a system Python. RPM behavior is unchanged. The bundled interpreter may persist bytecode normally after installation.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The component contract no longer advertises system Python because the raw payload owns that runtime. The packaging change is limited to raw staging and preserves the existing archive layout, permissions, and RPM resources.

## Validation

- `bash tests/packaging/test-package-raw.sh`
  - verifies deterministic archives
  - verifies all four staged manifests use `agent-sec-python`
  - verifies a failing `python3` at the front of `PATH` is not invoked
  - verifies packaging rejects newly added hooks that bypass the bundled launcher
  - verifies the wrapper does not disable runtime bytecode persistence
  - verifies inherited Python bytecode is excluded from the archive
- `make python-code-pretty`
- `ruff check --config agent-sec-cli/pyproject.toml packaging/raw/adapt_payload.py packaging/raw/verify_release.py`
- `isort --check-only --settings-path agent-sec-cli/pyproject.toml packaging/raw/adapt_payload.py packaging/raw/verify_release.py`
- `shellcheck packaging/raw/package.sh tests/packaging/test-package-raw.sh`
- `bash -n packaging/raw/package.sh tests/packaging/test-package-raw.sh`
- `git diff --check`

## Documentation and rollback

Developer guidance records the raw hook command form, manifest inventory synchronization, and required packaging regression. Revert commit `c22e0ec8` to restore the previous raw packaging behavior.
