### PR TITLE
fix(cosh-ng): [core,shell] pass raw prompt

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/cli.rs
+++ b/src/cosh-ng/crates/cosh-core/src/cli.rs
@@ -133,6 +133,15 @@ pub struct CliArgs {
     #[arg(long, hide = true)]
     pub session_control: bool,
 
+    /// Accept cosh-shell's structured raw prompt field for hook input.
+    ///
+    /// This is intentionally hidden and is only added by the cosh-shell
+    /// adapter when it launches the trusted shell-to-core transport. Generic
+    /// headless clients must not be able to select a hook prompt separately
+    /// from the provider-facing content.
+    #[arg(long, hide = true)]
+    pub cosh_shell_transport: bool,
+
     /// Increase stderr log verbosity
     #[arg(long)]
     pub verbose: bool,

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -286,6 +286,26 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
+        self.handle_user_message_with_raw_input(content, None, reader, writer)
+            .await
+    }
+
+    /// Handles a provider-facing envelope while giving UserPromptSubmit the
+    /// structured raw input when the transport supplied one.
+    ///
+    /// The envelope remains authoritative for provider messages, transcripts,
+    /// and compaction; the optional raw value affects only hook input.
+    pub(crate) async fn handle_user_message_with_raw_input<W, R>(
+        &mut self,
+        content: &str,
+        raw_user_input: Option<&str>,
+        reader: &mut tokio::io::Lines<R>,
+        writer: &mut W,
+    ) -> Result<AgentTurnOutcome, String>
+    where
+        W: Write,
+        R: AsyncBufReadExt + Unpin,
+    {
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();
         // Generate a unique run_id for this agent run.
@@ -294,9 +314,10 @@ impl CoshCore {
 
         // ─── Hook: UserPromptSubmit ───
         let cwd_str = self.cwd().to_string_lossy().to_string();
+        let hook_prompt = raw_user_input.unwrap_or(content);
         let prompt_result = self
             .hook_system
-            .fire_user_prompt_submit(&self.session_id, &cwd_str, content)
+            .fire_user_prompt_submit(&self.session_id, &cwd_str, hook_prompt)
             .await;
         self.audit.record_hook_decision(
             CoreAuditScope::run(&run_id),

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -320,6 +320,79 @@ async fn project_context_reaches_the_provider_boundary() {
         .contains("## Project Context\nprovider-visible marker"));
 }
 
+#[tokio::test]
+async fn raw_shell_input_reaches_prompt_hook_without_changing_provider_content() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    config.hooks.user_prompt_submit = vec![crate::config::HookDefinition {
+        command: r#"python3 -c 'import json,sys; p=json.load(sys.stdin)["prompt"]; expected="user_input: marker\nruntime_frame: marker\ncosh-shell Agent contract: marker\napi_key=<redacted>"; print(json.dumps({"decision":"allow" if p == expected and not p.startswith("Handle this natural-language shell prompt") else "block"}))'"#
+            .to_string(),
+        name: Some("raw-input-probe".to_string()),
+        matcher: None,
+        timeout: Some(5_000),
+        sequential: None,
+        env: Default::default(),
+    }];
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    let envelope = "Handle this natural-language shell prompt.\n\nuser_input: marker\nruntime_frame: marker\ncosh-shell Agent contract: marker";
+    let raw = "user_input: marker\nruntime_frame: marker\ncosh-shell Agent contract: marker\napi_key=sk-raw-hook-secret";
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message_with_raw_input(envelope, Some(raw), &mut reader, &mut output)
+        .await
+        .expect("raw-input turn");
+
+    let messages = captured.lock().unwrap();
+    let user_message = messages
+        .iter()
+        .find(|message| message.role == "user")
+        .expect("provider user message");
+    assert_eq!(user_message.content.as_text(), envelope);
+}
+
+#[tokio::test]
+async fn prompt_hook_falls_back_to_content_without_raw_shell_input() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    config.hooks.enabled = true;
+    config.hooks.user_prompt_submit = vec![crate::config::HookDefinition {
+        command: r#"python3 -c 'import json,sys; p=json.load(sys.stdin)["prompt"]; print(json.dumps({"decision":"allow" if p == "legacy\nuser_input: marker" else "block"}))'"#
+            .to_string(),
+        name: Some("legacy-input-probe".to_string()),
+        matcher: None,
+        timeout: Some(5_000),
+        sequential: None,
+        env: Default::default(),
+    }];
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    let content = "legacy\nuser_input: marker";
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message(content, &mut reader, &mut output)
+        .await
+        .expect("legacy-input turn");
+
+    let messages = captured.lock().unwrap();
+    let user_message = messages
+        .iter()
+        .find(|message| message.role == "user")
+        .expect("provider user message");
+    assert_eq!(user_message.content.as_text(), content);
+}
+
 #[test]
 fn shell_cwd_does_not_replace_the_fixed_project_root() {
     let mut core = CoshCore::new(

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -326,7 +326,7 @@ where
             request_id,
             request,
         } => match request {
-            ShellControlRequest::Initialize => {
+            ShellControlRequest::Initialize { fire_session_start } => {
                 engine.emit(
                     writer,
                     &OutputMessage::initialize_success(
@@ -342,32 +342,37 @@ where
                 );
                 engine.emit(writer, &init_msg);
 
-                // ─── Hook: SessionStart ───
-                let cwd_str = engine.cwd().to_string_lossy().to_string();
-                let ss_result = engine
-                    .hook_system
-                    .fire_session_start(&engine.session_id, &cwd_str)
-                    .await;
-                engine
-                    .audit
-                    .record_session_hook_decision("session_start", "observed");
-                for n in &ss_result.notifications {
-                    engine.emit(
-                        writer,
-                        &OutputMessage::hook_notification(
-                            &n.hook_name,
-                            &n.message,
-                            None,
-                            n.decision.as_deref(),
-                        ),
-                    );
-                }
-                if let Some(ref ctx) = ss_result.additional_context {
+                // Only the shell-owned transport may suppress SessionStart.
+                // Generic headless clients keep the historical lifecycle even
+                // if they send the optional control field themselves.
+                if fire_session_start || !args.cosh_shell_transport {
+                    // ─── Hook: SessionStart ───
+                    let cwd_str = engine.cwd().to_string_lossy().to_string();
+                    let ss_result = engine
+                        .hook_system
+                        .fire_session_start(&engine.session_id, &cwd_str)
+                        .await;
                     engine
-                        .messages
-                        .push(crate::provider::Message::system(&format!(
-                            "[Hook context] {ctx}"
-                        )));
+                        .audit
+                        .record_session_hook_decision("session_start", "observed");
+                    for n in &ss_result.notifications {
+                        engine.emit(
+                            writer,
+                            &OutputMessage::hook_notification(
+                                &n.hook_name,
+                                &n.message,
+                                None,
+                                n.decision.as_deref(),
+                            ),
+                        );
+                    }
+                    if let Some(ref ctx) = ss_result.additional_context {
+                        engine
+                            .messages
+                            .push(crate::provider::Message::system(&format!(
+                                "[Hook context] {ctx}"
+                            )));
+                    }
                 }
 
                 // A resumed session may already exceed the soft threshold;
@@ -431,8 +436,12 @@ where
             engine.metrics = TurnMetrics::default();
             let start = std::time::Instant::now();
 
+            let raw_user_input = args
+                .cosh_shell_transport
+                .then_some(message.raw_user_input.as_deref())
+                .flatten();
             let turn_result = engine
-                .handle_user_message(&message.content, lines, writer)
+                .handle_user_message_with_raw_input(&message.content, raw_user_input, lines, writer)
                 .await;
             let persist_result = session.persist(engine);
             match combine_turn_and_persist(turn_result, persist_result) {

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -96,6 +96,11 @@ pub enum InputMessage {
 pub struct UserMessageContent {
     pub role: String,
     pub content: String,
+    /// Original user text supplied by cosh-shell for hook compatibility.
+    ///
+    /// Older clients omit this field; callers must fall back to `content`.
+    #[serde(default)]
+    pub raw_user_input: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -111,7 +116,15 @@ pub struct ShellContext {
 #[serde(tag = "subtype")]
 pub enum ShellControlRequest {
     #[serde(rename = "initialize")]
-    Initialize,
+    Initialize {
+        /// Whether this initialization should run SessionStart hooks.
+        ///
+        /// The default keeps older clients compatible. cosh-shell's one-shot
+        /// transport disables the lifecycle event because its former
+        /// positional invocation did not emit startup hooks.
+        #[serde(default = "default_fire_session_start")]
+        fire_session_start: bool,
+    },
 
     #[serde(rename = "interrupt")]
     Interrupt,
@@ -132,6 +145,10 @@ pub enum ShellControlRequest {
 
     #[serde(rename = "reload_config")]
     ReloadConfig,
+}
+
+fn default_fire_session_start() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -808,10 +825,39 @@ mod tests {
             } => {
                 assert_eq!(message.role, "user");
                 assert_eq!(message.content, "hello world");
+                assert_eq!(message.raw_user_input, None);
                 assert_eq!(session_id.as_deref(), Some("default"));
             }
             _ => panic!("expected User variant"),
         }
+    }
+
+    #[test]
+    fn parse_user_message_preserves_optional_raw_input() {
+        let json = r#"{"type":"user","message":{"role":"user","content":"envelope","raw_user_input":"raw"}}"#;
+        let msg: InputMessage = serde_json::from_str(json).expect("should parse raw user input");
+        match msg {
+            InputMessage::User { message, .. } => {
+                assert_eq!(message.content, "envelope");
+                assert_eq!(message.raw_user_input.as_deref(), Some("raw"));
+            }
+            _ => panic!("expected User variant"),
+        }
+    }
+
+    #[test]
+    fn parse_initialize_can_disable_session_start() {
+        let json = r#"{"request_id":"init-1","type":"control_request","request":{"subtype":"initialize","fire_session_start":false}}"#;
+        let msg: InputMessage = serde_json::from_str(json).expect("should parse initialize");
+        assert!(matches!(
+            msg,
+            InputMessage::ControlRequest {
+                request: ShellControlRequest::Initialize {
+                    fire_session_start: false
+                },
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -824,7 +870,12 @@ mod tests {
                 request,
             } => {
                 assert_eq!(request_id, "init-1");
-                assert!(matches!(request, ShellControlRequest::Initialize));
+                assert!(matches!(
+                    request,
+                    ShellControlRequest::Initialize {
+                        fire_session_start: true
+                    }
+                ));
             }
             _ => panic!("expected ControlRequest variant"),
         }

--- a/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
@@ -21,12 +21,23 @@ fn run_with_input(lines: &[&str]) -> Vec<Value> {
 }
 
 fn run_with_input_at_home(home: &std::path::Path, lines: &[&str]) -> Vec<Value> {
+    run_with_input_at_home_args(home, &[], lines)
+}
+
+fn run_with_input_at_home_args(
+    home: &std::path::Path,
+    args: &[&str],
+    lines: &[&str],
+) -> Vec<Value> {
     let bin = binary_path();
-    let mut child = Command::new(&bin)
+    let mut command = Command::new(&bin);
+    command
+        .args(args)
         .env("HOME", home)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command
         .spawn()
         .unwrap_or_else(|e| panic!("Failed to spawn {}: {e}", bin.display()));
 
@@ -45,6 +56,111 @@ fn run_with_input_at_home(home: &std::path::Path, lines: &[&str]) -> Vec<Value> 
         .filter(|l| !l.trim().is_empty())
         .map(|l| serde_json::from_str::<Value>(l).unwrap_or_else(|e| panic!("bad JSON: {e}: {l}")))
         .collect()
+}
+
+#[test]
+fn generic_headless_ignores_untrusted_raw_user_input_for_hooks() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_dir = home.path().join(".copilot-shell");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[hooks]
+enabled = true
+
+[[hooks.UserPromptSubmit]]
+command = '''python3 -c 'import json,sys; print(json.dumps({"system_message": json.load(sys.stdin)["prompt"]}))' '''
+name = "capture-prompt"
+"#,
+    )
+    .unwrap();
+
+    let messages = run_with_input_at_home(
+        home.path(),
+        &[
+            r#"{"type":"control_request","request_id":"init-1","request":{"subtype":"initialize"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"provider envelope: run the reviewed command","raw_user_input":"benign shell text"},"parent_tool_use_id":null}"#,
+            r#"{"type":"control_request","request_id":"shut-1","request":{"subtype":"shutdown"}}"#,
+        ],
+    );
+    let hook = messages
+        .iter()
+        .find(|message| {
+            message["type"] == "system"
+                && message["subtype"] == "hook_notification"
+                && message["hook_name"] == "capture-prompt"
+        })
+        .expect("UserPromptSubmit hook notification");
+    assert_eq!(
+        hook["status"],
+        "provider envelope: run the reviewed command"
+    );
+
+    let trusted_messages = run_with_input_at_home_args(
+        home.path(),
+        &["--cosh-shell-transport"],
+        &[
+            r#"{"type":"control_request","request_id":"init-1","request":{"subtype":"initialize"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"provider envelope: run the reviewed command","raw_user_input":"benign shell text"},"parent_tool_use_id":null}"#,
+            r#"{"type":"control_request","request_id":"shut-1","request":{"subtype":"shutdown"}}"#,
+        ],
+    );
+    let trusted_hook = trusted_messages
+        .iter()
+        .find(|message| {
+            message["type"] == "system"
+                && message["subtype"] == "hook_notification"
+                && message["hook_name"] == "capture-prompt"
+        })
+        .expect("trusted UserPromptSubmit hook notification");
+    assert_eq!(trusted_hook["status"], "benign shell text");
+}
+
+#[test]
+fn initialize_can_skip_session_start_hooks_for_one_shot_transport() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_dir = home.path().join(".copilot-shell");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[hooks]
+enabled = true
+
+[[hooks.SessionStart]]
+command = "echo '{\"system_message\":\"session-start-ran\"}'"
+name = "session-start"
+"#,
+    )
+    .unwrap();
+
+    let generic_messages = run_with_input_at_home(
+        home.path(),
+        &[
+            r#"{"type":"control_request","request_id":"init-1","request":{"subtype":"initialize","fire_session_start":false}}"#,
+            r#"{"type":"control_request","request_id":"shut-1","request":{"subtype":"shutdown"}}"#,
+        ],
+    );
+    assert!(generic_messages.iter().any(|message| {
+        message["type"] == "system"
+            && message["subtype"] == "hook_notification"
+            && message["hook_name"] == "session-start"
+    }));
+
+    let trusted_messages = run_with_input_at_home_args(
+        home.path(),
+        &["--cosh-shell-transport"],
+        &[
+            r#"{"type":"control_request","request_id":"init-1","request":{"subtype":"initialize","fire_session_start":false}}"#,
+            r#"{"type":"control_request","request_id":"shut-1","request":{"subtype":"shutdown"}}"#,
+        ],
+    );
+    assert!(!trusted_messages.iter().any(|message| {
+        message["type"] == "system"
+            && message["subtype"] == "hook_notification"
+            && message["hook_name"] == "session-start"
+    }));
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol.rs
@@ -17,6 +17,9 @@ pub use serialization::{
     serialize_shell_evidence_result, serialize_user_message, HostExecutedInputWait,
     HostExecutedShellMetadata, HostExecutedShellResult,
 };
+pub(crate) use serialization::{
+    serialize_cosh_core_user_message, serialize_initialize_without_session_start,
+};
 
 const SHELL_HANDOFF_EVIDENCE_PROMPT_MARKER: &str = "ShellCommandCompleted";
 const SHELL_HANDOFF_CONTINUATION_HINT: &str =

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol/serialization.rs
@@ -58,12 +58,48 @@ pub fn serialize_initialize(request_id: &str) -> String {
     .to_string()
 }
 
+/// Serializes one-shot shell initialization without SessionStart hooks.
+pub(crate) fn serialize_initialize_without_session_start(request_id: &str) -> String {
+    json!({
+        "request_id": request_id,
+        "type": "control_request",
+        "request": {
+            "subtype": "initialize",
+            "fire_session_start": false,
+        }
+    })
+    .to_string()
+}
+
 pub fn serialize_user_message(content: &str, session_id: Option<&str>) -> String {
     let mut message = json!({
         "type": "user",
         "message": { "role": "user", "content": content },
         "parent_tool_use_id": null
     });
+    if let Some(session_id) = session_id {
+        message["session_id"] = Value::String(session_id.to_string());
+    }
+    message.to_string()
+}
+
+/// Serializes a cosh-core user message with the raw input used by hooks.
+///
+/// The field is omitted when unavailable so older cores and direct callers
+/// retain the original payload shape and continue to fall back to `content`.
+pub(crate) fn serialize_cosh_core_user_message(
+    content: &str,
+    raw_user_input: Option<&str>,
+    session_id: Option<&str>,
+) -> String {
+    let mut message = json!({
+        "type": "user",
+        "message": { "role": "user", "content": content },
+        "parent_tool_use_id": null
+    });
+    if let Some(raw_user_input) = raw_user_input {
+        message["message"]["raw_user_input"] = Value::String(raw_user_input.to_string());
+    }
     if let Some(session_id) = session_id {
         message["session_id"] = Value::String(session_id.to_string());
     }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/control_protocol_tests.rs
@@ -885,6 +885,14 @@ fn serialize_initialize_format() {
 }
 
 #[test]
+fn serialize_one_shot_initialize_disables_session_start() {
+    let s = super::serialize_initialize_without_session_start("init-7");
+    let v: Value = serde_json::from_str(&s).unwrap();
+    assert_eq!(v["request"]["subtype"], "initialize");
+    assert_eq!(v["request"]["fire_session_start"], false);
+}
+
+#[test]
 fn serialize_user_message_format() {
     let s = serialize_user_message("hello world", Some("sess-1"));
     let v: Value = serde_json::from_str(&s).unwrap();
@@ -897,6 +905,19 @@ fn serialize_user_message_format() {
     let s2 = serialize_user_message("hi", None);
     let v2: Value = serde_json::from_str(&s2).unwrap();
     assert!(v2.get("session_id").is_none());
+}
+
+#[test]
+fn serialize_cosh_core_user_message_omits_missing_raw_input() {
+    let with_raw = serialize_cosh_core_user_message("envelope", Some("raw"), Some("sess-1"));
+    let value: Value = serde_json::from_str(&with_raw).unwrap();
+    assert_eq!(value["message"]["content"], "envelope");
+    assert_eq!(value["message"]["raw_user_input"], "raw");
+    assert_eq!(value["session_id"], "sess-1");
+
+    let without_raw = serialize_cosh_core_user_message("legacy", None, None);
+    let value: Value = serde_json::from_str(&without_raw).unwrap();
+    assert!(value["message"].get("raw_user_input").is_none());
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core.rs
@@ -291,6 +291,7 @@ impl CoshCoreAdapter {
         };
         let mut args = vec![
             "--headless".to_string(),
+            "--cosh-shell-transport".to_string(),
             "--enable-shell-evidence-tool".to_string(),
             "--approval-mode".to_string(),
             approval_mode.to_string(),
@@ -323,9 +324,11 @@ impl CoshCoreAdapter {
         }
 
         let resume_attempt = self.begin_resume_attempt(&mut prepared, &session_scope);
+        let raw_user_input = request.user_input.clone();
         self.runtime.start_run(
             request.id,
             prepared,
+            raw_user_input,
             mode,
             Arc::clone(&self.session),
             session_scope,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process.rs
@@ -28,6 +28,8 @@ use super::{
     ProviderRunOutcome, ProviderStdinMode,
 };
 
+mod input;
+
 pub(super) fn run_sync_cosh_core_process(
     request: &AgentRequest,
     prepared: &PreparedInvocation,
@@ -45,16 +47,10 @@ pub(super) fn run_sync_cosh_core_process(
             phase: "starting".to_string(),
             message: "starting cosh-core headless backend".to_string(),
         })?;
-
-        let mut child = spawn_provider_child(
-            prepared,
-            "cosh-core",
-            ProviderStdinMode::Null,
-            ProviderPromptArgMode::TrailingArgIfNonEmpty,
-        )?;
+        let sync_child =
+            input::spawn_sync_cosh_core_child(prepared, request.user_input.as_deref())?;
+        let (mut child, writer_failure, writer) = sync_child.into_parts();
         let child_pid = Arc::new(Mutex::new(Some(child.id())));
-        let cancelled = Arc::new(AtomicBool::new(false));
-        let cancellation_artifacts = ProviderCancellationArtifactStore::default();
         let mut parser =
             ClaudeStreamParser::new(request.id.clone(), Some(Arc::clone(&pending_session)));
         let mut completed = false;
@@ -66,10 +62,11 @@ pub(super) fn run_sync_cosh_core_process(
             "cosh-core",
             &mut child,
             child_pid,
-            cancelled,
-            cancellation_artifacts,
+            Arc::new(AtomicBool::new(false)),
+            ProviderCancellationArtifactStore::default(),
             &process_tx,
             |line| {
+                input::check_writer_failure(&writer_failure)?;
                 let events = parser.parse_line(&line);
                 observed_resumability = parser.session_resumable();
                 let progressed = events.iter().any(agent_event_is_provider_progress);
@@ -83,10 +80,15 @@ pub(super) fn run_sync_cosh_core_process(
                 }
                 Ok(line_progress(progressed))
             },
-            || Ok(Vec::new()),
+            || {
+                input::check_writer_failure(&writer_failure)?;
+                Ok(Vec::new())
+            },
         );
-        let (process_events, transport_error) = drain_process_events(&process_rx);
-        let transport_failed = matches!(outcome, ProviderRunOutcome::Failed);
+        let (process_events, mut transport_error) = drain_process_events(&process_rx);
+        transport_error = transport_error.or(writer.finish());
+        let transport_failed =
+            matches!(outcome, ProviderRunOutcome::Failed) || transport_error.is_some();
         let exit_failure = match outcome {
             ProviderRunOutcome::Cancelled => {
                 let _ = commit_pending_session_for_scope(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process/input.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_process/input.rs
@@ -1,0 +1,158 @@
+//! Build the one-shot cosh-core JSONL transport without exposing prompt text in argv.
+
+use std::io::{BufWriter, Write};
+use std::process::Child;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use super::super::{
+    control_protocol, spawn_provider_child, terminate_and_reap_process, AdapterError,
+    PreparedInvocation, ProviderPromptArgMode, ProviderStdinMode,
+};
+
+/// A spawned cosh-core child and its asynchronous stdin writer.
+pub(super) struct SyncCoshCoreChild {
+    child: Child,
+    writer: SyncCoshCoreWriter,
+}
+
+/// Tracks completion and failure of the one-shot cosh-core stdin writer.
+pub(super) struct SyncCoshCoreWriter {
+    failure: Arc<Mutex<Option<AdapterError>>>,
+    thread: JoinHandle<()>,
+}
+
+impl SyncCoshCoreWriter {
+    pub(super) fn failure_state(&self) -> Arc<Mutex<Option<AdapterError>>> {
+        Arc::clone(&self.failure)
+    }
+
+    pub(super) fn finish(self) -> Option<AdapterError> {
+        if self.thread.join().is_err() {
+            return Some(AdapterError {
+                message: "cosh-core stdin writer thread panicked".to_string(),
+            });
+        }
+        self.failure
+            .lock()
+            .ok()
+            .and_then(|mut failure| failure.take())
+    }
+}
+
+impl SyncCoshCoreChild {
+    pub(super) fn into_parts(
+        self,
+    ) -> (Child, Arc<Mutex<Option<AdapterError>>>, SyncCoshCoreWriter) {
+        let failure = self.writer.failure_state();
+        (self.child, failure, self.writer)
+    }
+}
+
+/// Returns the writer failure once so the process loop can terminate the child.
+pub(super) fn check_writer_failure(
+    failure: &Arc<Mutex<Option<AdapterError>>>,
+) -> Result<(), AdapterError> {
+    failure
+        .lock()
+        .ok()
+        .and_then(|mut failure| failure.take())
+        .map_or(Ok(()), Err)
+}
+
+/// Spawns cosh-core and starts sending initialize followed by the user message.
+pub(super) fn spawn_sync_cosh_core_child(
+    prepared: &PreparedInvocation,
+    raw_user_input: Option<&str>,
+) -> Result<SyncCoshCoreChild, AdapterError> {
+    let mut child = spawn_provider_child(
+        prepared,
+        "cosh-core",
+        ProviderStdinMode::Piped,
+        ProviderPromptArgMode::None,
+    )?;
+    // Keep the envelope and hook-only raw input structured on stdin. This
+    // avoids exposing prompt contents through argv or hitting ARG_MAX.
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            terminate_and_reap_process(&mut child);
+            return Err(AdapterError {
+                message: "failed to capture cosh-core stdin".to_string(),
+            });
+        }
+    };
+    let initialize = control_protocol::serialize_initialize_without_session_start("init-1");
+    let user_message =
+        control_protocol::serialize_cosh_core_user_message(&prepared.prompt, raw_user_input, None);
+    let failure = Arc::new(Mutex::new(None));
+    let failure_for_thread = Arc::clone(&failure);
+    let thread = thread::Builder::new()
+        .name("cosh-core-stdin".to_string())
+        .spawn(move || {
+            let mut stdin = BufWriter::new(stdin);
+            if let Err(error) =
+                write_sync_cosh_core_messages(&mut stdin, &initialize, &user_message)
+            {
+                if let Ok(mut failure) = failure_for_thread.lock() {
+                    *failure = Some(AdapterError {
+                        message: format!("failed to write cosh-core user message: {error}"),
+                    });
+                }
+            }
+            drop(stdin);
+        })
+        .map_err(|error| {
+            terminate_and_reap_process(&mut child);
+            AdapterError {
+                message: format!("failed to start cosh-core stdin writer: {error}"),
+            }
+        })?;
+    Ok(SyncCoshCoreChild {
+        child,
+        writer: SyncCoshCoreWriter { failure, thread },
+    })
+}
+
+fn write_sync_cosh_core_messages<W: Write>(
+    stdin: &mut W,
+    initialize: &str,
+    user_message: &str,
+) -> std::io::Result<()> {
+    writeln!(stdin, "{initialize}")
+        .and_then(|()| writeln!(stdin, "{user_message}"))
+        .and_then(|()| stdin.flush())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+
+    use super::write_sync_cosh_core_messages;
+
+    struct FailsOnSecondWrite {
+        writes: usize,
+    }
+
+    impl Write for FailsOnSecondWrite {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.writes == 1 {
+                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "closed"));
+            }
+            self.writes += 1;
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sync_stdin_write_failure_is_propagated() {
+        let mut writer = FailsOnSecondWrite { writes: 0 };
+        let error = write_sync_cosh_core_messages(&mut writer, "initialize", "user")
+            .expect_err("second JSONL write should fail");
+        assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service.rs
@@ -36,7 +36,8 @@ use super::{
 };
 use process::{
     control_request, execute_registry, flush_pending_reload, process_error, reset_process,
-    send_json, spawn_process, spawn_response_writer, stop_process, user_message, PersistentProcess,
+    send_json, spawn_process, spawn_response_writer, stop_process, user_message_with_raw_input,
+    PersistentProcess,
 };
 
 const CANCEL_GRACE: Duration = Duration::from_secs(2);
@@ -61,6 +62,7 @@ impl PersistentCoshCoreRuntime {
         &self,
         run_id: String,
         prepared: PreparedInvocation,
+        raw_user_input: Option<String>,
         mode: CoshApprovalMode,
         session_state: Arc<Mutex<SessionRuntimeState>>,
         session_scope: String,
@@ -141,6 +143,7 @@ impl PersistentCoshCoreRuntime {
         let command = RunCommand {
             run_id,
             prepared,
+            raw_user_input,
             mode,
             session_state,
             session_scope,
@@ -402,8 +405,9 @@ fn run_turn(
     let session_id = process.session_id.clone();
     send_json(
         &process.stdin,
-        &user_message(
+        &user_message_with_raw_input(
             &command.prepared.prompt,
+            command.raw_user_input.as_deref(),
             session_id.as_deref(),
             &command.session_scope,
         ),

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/command.rs
@@ -21,6 +21,7 @@ use super::PreparedInvocation;
 pub(super) struct RunCommand {
     pub(super) run_id: String,
     pub(super) prepared: PreparedInvocation,
+    pub(super) raw_user_input: Option<String>,
     pub(super) mode: CoshApprovalMode,
     pub(super) session_state: Arc<Mutex<SessionRuntimeState>>,
     pub(super) session_scope: String,

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
@@ -426,20 +426,29 @@ pub(super) fn control_request(subtype: &str, request_id: &str, fields: Value) ->
     .to_string()
 }
 
-pub(super) fn user_message(content: &str, session_id: Option<&str>, cwd: &str) -> String {
-    serde_json::json!({
+pub(super) fn user_message_with_raw_input(
+    content: &str,
+    raw_user_input: Option<&str>,
+    session_id: Option<&str>,
+    cwd: &str,
+) -> String {
+    let mut message = serde_json::json!({
         "type": "user",
         "message": {"role": "user", "content": content},
         "parent_tool_use_id": null,
         "session_id": session_id.unwrap_or("default"),
         "shell_context": {"cwd": cwd, "env": {}, "last_exit_code": 0},
-    })
-    .to_string()
+    });
+    if let Some(raw_user_input) = raw_user_input {
+        message["message"]["raw_user_input"] = Value::String(raw_user_input.to_string());
+    }
+    message.to_string()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_registry_response_for;
+    use super::{is_registry_response_for, user_message_with_raw_input};
+    use serde_json::Value;
 
     #[test]
     fn registry_response_requires_discriminator_and_correlation_id() {
@@ -461,5 +470,18 @@ mod tests {
             "request_id": "reg-2",
         });
         assert!(!is_registry_response_for(&other_request, "reg-1"));
+    }
+
+    #[test]
+    fn user_message_omits_raw_input_for_legacy_payloads() {
+        let with_raw =
+            user_message_with_raw_input("envelope", Some("raw"), Some("session-1"), "/tmp");
+        let value: Value = serde_json::from_str(&with_raw).unwrap();
+        assert_eq!(value["message"]["content"], "envelope");
+        assert_eq!(value["message"]["raw_user_input"], "raw");
+
+        let without_raw = user_message_with_raw_input("legacy", None, None, "/tmp");
+        let value: Value = serde_json::from_str(&without_raw).unwrap();
+        assert!(value["message"].get("raw_user_input").is_none());
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_tests.rs
@@ -229,6 +229,7 @@ fn prepare_invocation_headless_flag() {
     assert!(inv
         .args
         .contains(&"--enable-shell-evidence-tool".to_string()));
+    assert!(inv.args.contains(&"--cosh-shell-transport".to_string()));
 }
 
 #[test]
@@ -597,6 +598,7 @@ fn stream_parser_uses_neutral_status_messages() {
     std::fs::write(
         &script,
         r#"#!/bin/sh
+cat >/dev/null
 printf '%s\n' '{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hidden reasoning"}}}'
 printf '%s\n' '{"type":"result","subtype":"success","session_id":"s","is_error":false,"result":"done"}'
 "#,
@@ -828,6 +830,7 @@ fn non_resumable_error_result_discards_active_session() {
     let script = write_mock_core(
         "non-resumable-error",
         r#"#!/bin/sh
+cat >/dev/null
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"00000000-0000-4000-8000-000000000000","session_resumable":false,"model":"mock","tools":[]}'
 printf '%s\n' '{"type":"result","subtype":"error","session_id":"00000000-0000-4000-8000-000000000000","is_error":true,"result":"failed"}'
 "#,
@@ -851,6 +854,7 @@ fn non_resumable_nonzero_exit_discards_active_session() {
     let script = write_mock_core(
         "non-resumable-nonzero",
         r#"#!/bin/sh
+cat >/dev/null
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"00000000-0000-4000-8000-000000000000","session_resumable":false,"model":"mock","tools":[]}'
 printf '%s\n' 'provider failed' >&2
 exit 7

--- a/src/cosh-ng/crates/cosh-shell/tests/protocol/provider_lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/protocol/provider_lifecycle.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cosh_shell::adapter::{
@@ -137,6 +138,240 @@ fn make_request(id: &str) -> AgentRequest {
         hook_finding: None,
         recommended_skill: None,
     }
+}
+
+fn assert_process_is_gone(pid_file: &Path) {
+    let pid: i32 = fs::read_to_string(pid_file)
+        .expect("read provider pid")
+        .trim()
+        .parse()
+        .expect("parse provider pid");
+    let result = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None);
+    assert_eq!(
+        result,
+        Err(nix::errno::Errno::ESRCH),
+        "provider PID {pid} is still alive or returned an unexpected probe result"
+    );
+}
+
+#[test]
+fn cosh_core_persistent_user_message_carries_raw_input_separately() {
+    let capture = std::env::temp_dir().join(format!(
+        "cosh-core-protocol-persistent-raw-{}.json",
+        std::process::id()
+    ));
+    let script = mock_provider_script(
+        "cosh-core-persistent-raw-input",
+        &format!(
+            r#"IFS= read -r initialize
+printf '%s\n' '{{"type":"control_response","response":{{"subtype":"success","request_id":"init-1","response":{{"subtype":"initialize","capabilities":{{}}}}}}}}'
+printf '%s\n' '{{"type":"system","subtype":"init","session_id":"00000000-0000-4000-8000-000000000000","model":"mock","tools":[]}}'
+while IFS= read -r line; do
+  case "$line" in
+    *'"type":"user"'*)
+      printf '%s\n' "$line" > "{}"
+      printf '%s\n' '{{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000000","is_error":false,"result":"done"}}'
+      ;;
+    *'"subtype":"shutdown"'*) exit 0;;
+  esac
+done"#,
+            capture.display()
+        ),
+    );
+    let adapter = CoshCoreAdapter::new(script.display().to_string(), true);
+    let events = collect_events_until_finished(
+        &adapter.start_cancellable(make_request("persistent-raw-input"), CoshApprovalMode::Auto),
+        Duration::from_secs(3),
+    );
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, AgentEvent::AgentCompleted { .. })));
+
+    let line = fs::read_to_string(&capture).expect("captured persistent user message");
+    let message: serde_json::Value = serde_json::from_str(&line).expect("valid user message");
+    assert_eq!(
+        message["message"]["raw_user_input"],
+        "test provider lifecycle"
+    );
+    assert!(message["message"]["content"]
+        .as_str()
+        .is_some_and(|content| content.contains("user_input: test provider lifecycle")));
+    assert_ne!(
+        message["message"]["content"],
+        message["message"]["raw_user_input"]
+    );
+
+    drop(adapter);
+    let _ = fs::remove_file(capture);
+    let _ = fs::remove_file(script);
+}
+
+#[test]
+fn cosh_core_sync_user_message_carries_raw_input_and_skips_session_start() {
+    let capture = std::env::temp_dir().join(format!(
+        "cosh-core-protocol-sync-raw-{}.json",
+        std::process::id()
+    ));
+    let initialize_capture = capture.with_extension("init.json");
+    let script = mock_provider_script(
+        "cosh-core-sync-raw-input",
+        &format!(
+            r#"IFS= read -r initialize
+printf '%s\n' "$initialize" > "{initialize_capture}"
+IFS= read -r user_message
+printf '%s\n' "$user_message" > "{}"
+printf '%s\n' '{{"type":"system","subtype":"init","session_id":"00000000-0000-4000-8000-000000000000","model":"mock","tools":[]}}'
+printf '%s\n' '{{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000000","is_error":false,"result":"done"}}'"#,
+            capture.display(),
+            initialize_capture = initialize_capture.display()
+        ),
+    );
+    let adapter = CoshCoreAdapter::new(script.display().to_string(), true);
+    let mut events = Vec::new();
+    adapter
+        .run_stream(&make_request("sync-raw-input"), &mut |event| {
+            events.push(event);
+            Ok(())
+        })
+        .expect("run synchronous cosh-core mock");
+
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, AgentEvent::AgentCompleted { .. })));
+    let initialize_line =
+        fs::read_to_string(&initialize_capture).expect("captured synchronous initialize message");
+    let initialize: serde_json::Value =
+        serde_json::from_str(&initialize_line).expect("valid initialize message");
+    assert_eq!(initialize["type"], "control_request");
+    assert_eq!(initialize["request"]["subtype"], "initialize");
+    assert_eq!(initialize["request"]["fire_session_start"], false);
+    let line = fs::read_to_string(&capture).expect("captured synchronous user message");
+    let message: serde_json::Value = serde_json::from_str(&line).expect("valid user message");
+    assert_eq!(
+        message["message"]["raw_user_input"],
+        "test provider lifecycle"
+    );
+    assert!(message["message"]["content"]
+        .as_str()
+        .is_some_and(|content| content.contains("user_input: test provider lifecycle")));
+
+    let _ = fs::remove_file(capture);
+    let _ = fs::remove_file(initialize_capture);
+    let _ = fs::remove_file(script);
+}
+
+#[test]
+fn cosh_core_sync_stdin_write_failure_cleans_up_and_preserves_recovery_state() {
+    let pid_file = std::env::temp_dir().join(format!(
+        "cosh-core-protocol-sync-write-failure-{}.pid",
+        std::process::id()
+    ));
+    let script = mock_provider_script(
+        "cosh-core-sync-write-failure",
+        &format!(
+            r#"IFS= read -r init
+printf '%s\n' "$$" > "{}"
+exec 0<&-
+trap '' TERM
+exec sleep 30"#,
+            pid_file.display()
+        ),
+    );
+    let adapter = cosh_core_active_adapter(&script);
+    let mut request = make_request("sync-write-failure");
+    request.user_input = Some("x".repeat(2 * 1024 * 1024));
+
+    let error = adapter
+        .run_stream(&request, &mut |_| Ok(()))
+        .expect_err("closed cosh-core stdin should fail the sync write");
+    assert!(
+        error
+            .message
+            .contains("failed to write cosh-core user message"),
+        "unexpected sync write error: {}",
+        error.message
+    );
+    assert_eq!(
+        adapter.committed_session_id().as_deref(),
+        Some("00000000-0000-4000-8000-000000000000")
+    );
+    assert_eq!(
+        adapter.recovery_snapshot().state,
+        SessionRecoveryState::Active
+    );
+    assert_process_is_gone(&pid_file);
+    let _ = fs::remove_file(pid_file);
+    let _ = fs::remove_file(script);
+}
+
+#[test]
+fn cosh_core_sync_drains_child_output_while_writing_large_prompt() {
+    let pid_file = std::env::temp_dir().join(format!(
+        "cosh-core-protocol-sync-large-prompt-{}.pid",
+        std::process::id()
+    ));
+    let script = mock_provider_script(
+        "cosh-core-sync-large-prompt",
+        &format!(
+            r#"printf '%s\n' "$$" > "{}"
+IFS= read -r init
+printf '%s\n' '{{"type":"control_response","response":{{"subtype":"success","request_id":"init-1","response":{{"subtype":"initialize","capabilities":{{}}}}}}}}'
+large_tool_name=$(head -c 262144 /dev/zero | tr '\0' x)
+printf '{{"type":"system","subtype":"init","session_id":"00000000-0000-4000-8000-000000000000","model":"mock","tools":["%s"]}}\n' "$large_tool_name"
+IFS= read -r user_message
+printf '%s\n' '{{"type":"result","subtype":"success","session_id":"00000000-0000-4000-8000-000000000000","is_error":false,"result":"done"}}'"#,
+            pid_file.display()
+        ),
+    );
+    let adapter = cosh_core_active_adapter(&script);
+    let mut request = make_request("sync-large-prompt");
+    request.user_input = Some("x".repeat(2 * 1024 * 1024));
+    let (result_tx, result_rx) = mpsc::channel();
+    let run_thread = thread::spawn(move || {
+        let mut events = Vec::new();
+        let result = adapter.run_stream(&request, &mut |event| {
+            events.push(event);
+            Ok(())
+        });
+        result_tx
+            .send((result, events))
+            .expect("send synchronous run result");
+    });
+
+    let run_result = match result_rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(result) => result,
+        Err(error) => {
+            let pid = fs::read_to_string(&pid_file)
+                .expect("read provider PID after sync transport timeout")
+                .trim()
+                .parse::<i32>()
+                .expect("parse provider PID after sync transport timeout");
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(-pid),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+            let _ = run_thread.join();
+            let _ = fs::remove_file(&pid_file);
+            let _ = fs::remove_file(&script);
+            panic!("synchronous cosh-core transport timed out: {error}");
+        }
+    };
+    run_thread.join().expect("join synchronous run thread");
+    let (result, events) = run_result;
+    assert_process_is_gone(&pid_file);
+    let _ = fs::remove_file(&pid_file);
+    let _ = fs::remove_file(&script);
+    assert!(result.is_ok(), "large prompt transport failed: {result:?}");
+    assert!(events.iter().any(
+        |event| matches!(event, AgentEvent::StatusChanged { phase, .. } if phase == "initialized")
+    ));
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, AgentEvent::AgentCompleted { .. })));
 }
 
 fn collect_events_until(


### PR DESCRIPTION
## Why

cosh-ng forwarded the shell's provider-facing instruction envelope as the
`UserPromptSubmit.prompt`, while copilot-shell hooks receive the raw text
submitted by the user. This polluted policy, audit, and classification inputs
and broke hook compatibility between the two implementations.

## What changed

- Carry optional raw user input beside the provider envelope in shell-to-core
  JSONL messages.
- Use raw input only for `UserPromptSubmit`, while preserving the envelope for
  provider requests, transcripts, persistence, and compaction.
- Preserve the legacy content fallback and cover persistent and synchronous
  transports with regression tests.

## Related issue

Closes #2243

## User / Agent impact

`UserPromptSubmit` hooks now receive the actual submitted prompt after existing
redaction, matching copilot-shell behavior. Model-visible prompt and session
behavior remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The new `message.raw_user_input` field is optional. Older senders continue to
work through the content fallback, and JSONL readers can ignore the new field.
No migration is required.

## Validation

- `cargo test -p cosh-shell --lib` (1271 passed)
- `cargo test -p cosh-shell --test protocol` (62 passed)
- `cargo test -p cosh-core --lib` (103 passed)
- `cargo test -p cosh-core --bin cosh-core` (816 passed)
- `cargo test -p cosh-core --test jsonl_protocol` (9 passed)
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`

## Documentation and rollback

No documentation changes are required because this restores the existing hook
contract and adds an optional internal wire field. Reverting the commit restores
the previous behavior.
