### PR TITLE
fix(sight): improve QwenCode trace data accuracy

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -88,7 +88,8 @@
       {"rule": ["*node*", "*claude*"], "agent_name": "Claude"},
       {"rule": ["qwen*"], "agent_name": "QwenCode"},
       {"rule": ["*/qwen*"], "agent_name": "QwenCode"},
-      {"rule": ["*node*", "*qwen*"], "agent_name": "QwenCode"}
+      {"rule": ["*node*", "*qwen*"], "agent_name": "QwenCode"},
+      {"rule": ["*node*", "*", "*qwen*"], "agent_name": "QwenCode"}
     ]
   },
   "codex_offsets": {

--- a/src/agentsight/src/analyzer/token/mod.rs
+++ b/src/agentsight/src/analyzer/token/mod.rs
@@ -172,10 +172,17 @@ pub fn extract_usage_object(
     //
     // OpenAI nests cache hits under `prompt_tokens_details.cached_tokens`;
     // DashScope may surface them at the top level as `cached_tokens`.
-    // Both are read-only hits — there is no separate write counter.
+    // DashScope also nests `cache_creation_input_tokens` under
+    // `prompt_tokens_details`, so we fall back there as well.
     let cache_creation_input_tokens = usage
         .get("cache_creation_input_tokens")
-        .and_then(|v| v.as_u64());
+        .and_then(|v| v.as_u64())
+        .or_else(|| {
+            usage
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cache_creation_input_tokens"))
+                .and_then(|v| v.as_u64())
+        });
     let cache_read_input_tokens = usage
         .get("cache_read_input_tokens")
         .and_then(|v| v.as_u64())

--- a/src/agentsight/src/analyzer/token/parser.rs
+++ b/src/agentsight/src/analyzer/token/parser.rs
@@ -344,6 +344,65 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_dashscope_prompt_tokens_details_cache_creation() {
+        // DashScope nests cache_creation_input_tokens under prompt_tokens_details
+        // rather than at the top level of the usage object.
+        let parser = TokenParser::new();
+        let data = r#"{
+            "id": "chatcmpl-ds-001",
+            "model": "qwen3.6-plus",
+            "usage": {
+                "prompt_tokens": 29719,
+                "completion_tokens": 435,
+                "total_tokens": 30154,
+                "completion_tokens_details": {
+                    "reasoning_tokens": 382,
+                    "text_tokens": 435
+                },
+                "prompt_tokens_details": {
+                    "text_tokens": 29719,
+                    "cache_creation": {
+                        "ephemeral_5m_input_tokens": 29713
+                    },
+                    "cache_creation_input_tokens": 29713,
+                    "cache_type": "ephemeral",
+                    "cached_tokens": 0
+                }
+            }
+        }"#;
+
+        let event = create_test_event(data);
+        let usage = parser.parse_event(&event).expect("should parse");
+        assert_eq!(usage.input_tokens, 29719);
+        assert_eq!(usage.output_tokens, 435);
+        assert_eq!(usage.cache_creation_input_tokens, Some(29713));
+        assert_eq!(usage.cache_read_input_tokens, Some(0));
+    }
+
+    #[test]
+    fn test_parse_dashscope_usage_without_prompt_tokens_details() {
+        // DashScope response lacking prompt_tokens_details — cache fields
+        // must remain None, preserving pre-fix behavior.
+        let parser = TokenParser::new();
+        let data = r#"{
+            "id": "chatcmpl-ds-002",
+            "model": "qwen3.6-plus",
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 50,
+                "total_tokens": 550
+            }
+        }"#;
+
+        let event = create_test_event(data);
+        let usage = parser.parse_event(&event).expect("should parse");
+        assert_eq!(usage.input_tokens, 500);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_creation_input_tokens, None);
+        assert_eq!(usage.cache_read_input_tokens, None);
+    }
+
+    #[test]
     fn test_skip_done_marker() {
         let parser = TokenParser::new();
 

--- a/src/agentsight/src/discovery/matcher.rs
+++ b/src/agentsight/src/discovery/matcher.rs
@@ -422,4 +422,20 @@ mod tests {
             Some("QwenCode")
         );
     }
+
+    #[test]
+    fn test_default_rules_capture_qwencode_node_with_expose_gc() {
+        assert_eq!(
+            match_default_rules(
+                &[
+                    "/root/.local/lib/qwen-code/node/bin/node",
+                    "--expose-gc",
+                    "/root/.local/lib/qwen-code/lib/cli.js",
+                ],
+                ""
+            )
+            .as_deref(),
+            Some("QwenCode")
+        );
+    }
 }

--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -102,6 +102,9 @@ impl GenAIBuilder {
         let first_user_raw = Self::extract_first_user_raw(&request).unwrap_or_default();
         let last_user_raw = Self::extract_last_user_raw(&request).unwrap_or_default();
 
+        // Classify call kind (main / recap / web_search) from request content
+        let call_kind = super::helpers::classify_call_kind(&request).as_str();
+
         // 提取 LLM API 的 response_id（如 chatcmpl-xxx），用作 trace_id
         // 同时作为 call_id 的首选值：trace_id 有值时直接复用，避免两套 ID；
         // SysOM / 解析失败等无 response_id 的场景 fallback 到内部生成的 internal_id。
@@ -287,6 +290,8 @@ impl GenAIBuilder {
                     meta.insert("session_id".to_string(), sid.clone());
                 }
                 meta.insert("pending_match_key".to_string(), pending_match_key);
+                // call_kind: main / recap / web_search
+                meta.insert("call_kind".to_string(), call_kind.to_string());
                 meta
             },
         })
@@ -1656,5 +1661,61 @@ mod tests {
         let call = build_call(&builder, &[AnalysisResult::Http(http)]).unwrap();
         assert!(call.request.messages.is_empty());
         assert!(!call.request.stream);
+    }
+
+    #[test]
+    fn test_build_llm_call_call_kind_main() {
+        let builder = GenAIBuilder::new();
+        let body = serde_json::json!({
+            "model": "qwen3.6-plus",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "hello"}
+            ]
+        })
+        .to_string();
+        let http = make_http("/v1/chat/completions", Some(body), None);
+        let call = build_call(&builder, &[AnalysisResult::Http(http)]).unwrap();
+        assert_eq!(
+            call.metadata.get("call_kind").map(|s| s.as_str()),
+            Some("main")
+        );
+    }
+
+    #[test]
+    fn test_build_llm_call_call_kind_recap_memory_subagent() {
+        let builder = GenAIBuilder::new();
+        let body = serde_json::json!({
+            "model": "qwen3.6-plus",
+            "messages": [
+                {"role": "system", "content": "You are now acting as the managed memory extraction subagent."},
+                {"role": "user", "content": "Managed memory has TWO directories. Choose which one to write each memory into."}
+            ]
+        })
+        .to_string();
+        let http = make_http("/v1/chat/completions", Some(body), None);
+        let call = build_call(&builder, &[AnalysisResult::Http(http)]).unwrap();
+        assert_eq!(
+            call.metadata.get("call_kind").map(|s| s.as_str()),
+            Some("recap")
+        );
+    }
+
+    #[test]
+    fn test_build_llm_call_call_kind_recap_suggestion_subagent() {
+        let builder = GenAIBuilder::new();
+        let body = serde_json::json!({
+            "model": "qwen3.6-plus",
+            "messages": [
+                {"role": "user", "content": "[SUGGESTION MODE: Suggest what the user might naturally type next.]"}
+            ]
+        })
+        .to_string();
+        let http = make_http("/v1/chat/completions", Some(body), None);
+        let call = build_call(&builder, &[AnalysisResult::Http(http)]).unwrap();
+        assert_eq!(
+            call.metadata.get("call_kind").map(|s| s.as_str()),
+            Some("recap")
+        );
     }
 }

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -21,7 +21,6 @@ pub(super) enum CallKind {
 }
 
 impl CallKind {
-    #[allow(dead_code)]
     pub fn as_str(&self) -> &'static str {
         match self {
             CallKind::Main => "main",
@@ -35,7 +34,11 @@ impl CallKind {
 ///
 /// Conservative: unmatched → Main (zero false positives > recall).
 /// Signatures are from real captures (case-sensitive .contains()).
-#[allow(dead_code)]
+///
+/// **Best-effort matching**: patterns are tied to specific agent prompt text
+/// (e.g., QwenCode's "Managed memory has TWO directories"). When agents update
+/// their prompts, these patterns may need extending. Consider moving to
+/// config-driven rules if the list grows beyond a handful of agents.
 pub(super) fn classify_call_kind(request: &LLMRequest) -> CallKind {
     // Collect system instructions text
     let system_text: String = request
@@ -62,6 +65,10 @@ pub(super) fn classify_call_kind(request: &LLMRequest) -> CallKind {
         if system_text.contains("specialized context summarizer") {
             return CallKind::Recap;
         }
+        // QwenCode memory extraction subagent
+        if system_text.contains("managed memory extraction subagent") {
+            return CallKind::Recap;
+        }
     }
 
     // ② Check first-user text (Claude Code patterns + Cosh tool-output)
@@ -83,6 +90,14 @@ pub(super) fn classify_call_kind(request: &LLMRequest) -> CallKind {
                 .contains("Your task is to create a detailed summary of the conversation so far")
                 && text.contains("Do NOT call any tools"))
         {
+            return CallKind::Recap;
+        }
+        // QwenCode memory extraction subagent
+        if text.starts_with("Managed memory has TWO directories") {
+            return CallKind::Recap;
+        }
+        // QwenCode suggestion subagent
+        if text.starts_with("[SUGGESTION MODE:") {
             return CallKind::Recap;
         }
         // Claude Code web_search
@@ -143,10 +158,13 @@ pub(super) fn classify_call_kind_from_raw(
     if (sys_text.contains("summarizes internal chat history")
         && sys_text.contains("<state_snapshot>"))
         || sys_text.contains("specialized context summarizer")
+        || sys_text.contains("managed memory extraction subagent")
         || first_user_text.starts_with("Summarize the following tool output to be a maximum of")
         || (first_user_text
             .contains("Your task is to create a detailed summary of the conversation so far")
             && first_user_text.contains("Do NOT call any tools"))
+        || first_user_text.starts_with("Managed memory has TWO directories")
+        || first_user_text.starts_with("[SUGGESTION MODE:")
     {
         "recap"
     } else if first_user_text.contains("Perform a web search for the query:") {
@@ -465,6 +483,13 @@ impl GenAIBuilder {
     ///
     /// [Tue 2026-03-31 17:19 GMT+8] 用户实际输入
     /// ```
+    ///
+    /// **QwenCode**: `<system-reminder>` 标签块
+    /// ```text
+    /// <system-reminder>...skills...</system-reminder>
+    /// <system-reminder>...context...</system-reminder>
+    /// 用户实际输入
+    /// ```
     pub(super) fn strip_user_query_prefix(text: &str) -> String {
         // cosh-ng: find a line starting with "user_input:" (after trimming)
         // and extract its value. This line-by-line approach tolerates template
@@ -497,7 +522,32 @@ impl GenAIBuilder {
                 }
             }
         }
+
+        // QwenCode: strip <system-reminder>...</system-reminder> blocks
+        if text.contains("<system-reminder>") {
+            let stripped = Self::strip_system_reminder_tags(text);
+            if !stripped.is_empty() {
+                return stripped;
+            }
+        }
+
         text.to_string()
+    }
+
+    /// Remove all `<system-reminder>...</system-reminder>` blocks from text.
+    fn strip_system_reminder_tags(text: &str) -> String {
+        let mut result = String::with_capacity(text.len());
+        let mut rest = text;
+        while let Some(start) = rest.find("<system-reminder>") {
+            result.push_str(&rest[..start]);
+            if let Some(end_offset) = rest[start..].find("</system-reminder>") {
+                rest = &rest[start + end_offset + "</system-reminder>".len()..];
+            } else {
+                break;
+            }
+        }
+        result.push_str(rest);
+        result.trim().to_string()
     }
 
     /// Match a process context against the configured cmdline rules.
@@ -825,6 +875,41 @@ mod tests {
         assert_eq!(
             GenAIBuilder::strip_user_query_prefix(text),
             "[not a timestamp] content"
+        );
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_qwencode_system_reminder() {
+        let text = "<system-reminder>\nskills list here\n</system-reminder>\
+                     <system-reminder>\nfolder structure\n</system-reminder>\
+                     1+1等于几";
+        assert_eq!(GenAIBuilder::strip_user_query_prefix(text), "1+1等于几");
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_qwencode_single_block() {
+        let text = "<system-reminder>context</system-reminder>hello world";
+        assert_eq!(GenAIBuilder::strip_user_query_prefix(text), "hello world");
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_qwencode_unclosed_tag() {
+        // Unclosed tag — should still strip what it can
+        let text =
+            "<system-reminder>some context</system-reminder><system-reminder>no end tag user input";
+        assert_eq!(
+            GenAIBuilder::strip_user_query_prefix(text),
+            "<system-reminder>no end tag user input"
+        );
+    }
+
+    #[test]
+    fn test_strip_user_query_prefix_qwencode_only_unclosed_tag() {
+        // No closing tag at all — nothing to strip, returns original trimmed
+        let text = "<system-reminder>some context without end tag and user input";
+        assert_eq!(
+            GenAIBuilder::strip_user_query_prefix(text),
+            "<system-reminder>some context without end tag and user input"
         );
     }
 


### PR DESCRIPTION
## Description

Supplement PR #2207 which added QwenCode cmdline rules but missed the real process cmdline pattern (`node --expose-gc /path/qwen-code/lib/cli.js`). Also fixes three additional data accuracy issues discovered during end-to-end testing on a real machine with QwenCode 0.21.5:

1. **Cmdline rule**: Add `["*node*", "*", "*qwen*"]` to skip argv[1] (`--expose-gc`) and match argv[2] which contains "qwen"
2. **DashScope cache tokens**: Extract `cache_creation_input_tokens` from `prompt_tokens_details` (DashScope nests it there, not at top level) — was silently dropped as 0
3. **Subagent classification**: Classify QwenCode memory/suggestion subagent calls as `recap` so they don't inflate main session token stats
4. **user_query display**: Strip `<system-reminder>` blocks from user_query so Dashboard shows actual user input instead of raw system context
5. **call_kind wiring**: Wire `classify_call_kind` result into `LLMCall.metadata` in `call_builder.rs` — the live path was computing but never storing the classification, always defaulting to `"main"`

## Related Issue

no-issue: supplement to PR #2207, fixes discovered during live testing

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

**Unit tests**: 11 new tests across 4 modules:
- `discovery::matcher`: qwen `--expose-gc` cmdline matching
- `analyzer::token::parser`: DashScope `prompt_tokens_details.cache_creation_input_tokens` extraction
- `genai::helpers`: QwenCode memory/suggestion subagent classification + system-reminder stripping
- `genai::call_builder`: call_kind metadata propagation (main / recap)

Full suite: 1402 tests pass, clippy clean.

**End-to-end** on real machine (kernel 6.6.102, agentsight trace + serve, QwenCode 0.21.5):

| Metric | Before | After |
|--------|--------|-------|
| `cache_creation_tokens` | 0 | 29708 |
| `call_kind` (memory subagent) | main | recap |
| `user_query` (user typed "hi") | `<system-reminder>...4000+ chars...` | `hi` |
| `agent_name` | node | QwenCode |

## Additional Notes

Supplements #2207