### PR TITLE
feat(docs): streamline component onboarding

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,6 +20,18 @@ Verify:
 anolisa --version
 ```
 
+AgentSecCore's raw package requires `anolisa` 0.2.17 or later. Updating the
+CLI first lets it read the current component contract and choose the published
+raw package correctly:
+
+```bash
+# CLI installed by get.agentic-os.sh
+anolisa update self
+
+# RPM-owned CLI
+sudo anolisa update self
+```
+
 ---
 
 ## Explore Your Environment
@@ -36,24 +48,22 @@ anolisa list
 
 ## Install Components
 
-Install components on demand. The current `cosh-ng`, `agentsight`,
-`agent-sec-core`, `ws-ckpt`, and `skillfs` artifacts require system mode; the
-other examples below support user mode.
+Install components on demand. The current `cosh-ng`, `agentsight`, `sec-core`,
+`ws-ckpt`, and `skillfs` artifacts require system mode; the other examples
+below support user mode.
 
 ```bash
 # Token optimization (via anolisa CLI)
 anolisa install tokenless
-# Or via npm:
-# npm install -g anolisa-tokenless
 
 # Workspace checkpoints (btrfs COW)
 sudo anolisa --install-mode system install ws-ckpt
 
-# Observability (Linux system mode; includes the agentsight-enforcer service)
+# Observability (Linux system mode)
 sudo anolisa --install-mode system install agentsight
 
-# Security (requires sudo)
-sudo anolisa --install-mode system install agent-sec-core
+# Security runtime and adapter resources (Linux x86_64 system mode)
+sudo anolisa --install-mode system install sec-core
 
 # Persistent memory (MCP file-based)
 anolisa install agent-memory
@@ -77,6 +87,18 @@ Check health:
 anolisa status
 ```
 
+System services are placed during installation but are not started or enabled
+automatically. Start AgentSight under systemd when you are ready to collect
+events:
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+The main service starts tracing and the Dashboard together and brings up
+`agentsight-enforcer.service` as its dependency.
+
 ---
 
 ## Use Components
@@ -95,10 +117,9 @@ tokenless env-check --all
 ws-ckpt checkpoint -w ~/project -s v1 -m "initial"
 ws-ckpt rollback -w ~/project -s v1
 
-# Observability — trace Agent Token consumption
-sudo agentsight trace
-agentsight token --period week
-agentsight serve   # Web Dashboard: http://localhost:7396
+# Observability (the system service stores data as root)
+sudo agentsight token --period week
+# Web Dashboard: http://localhost:7396
 
 # Security — system hardening and skill verification
 agent-sec-cli harden --scan --config agentos_baseline
@@ -115,6 +136,7 @@ Bridge installed components to Agent frameworks (cosh / OpenClaw / Hermes):
 anolisa adapter scan                        # Discover installed frameworks
 anolisa adapter enable tokenless openclaw   # tokenless → OpenClaw
 anolisa adapter enable ws-ckpt hermes       # ws-ckpt → Hermes
+anolisa adapter enable sec-core openclaw    # AgentSecCore → OpenClaw
 ```
 
 ---

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -20,6 +20,17 @@ curl -fsSL https://get.agentic-os.sh | bash
 anolisa --version
 ```
 
+AgentSecCore 的 raw 包需要 `anolisa` 0.2.17 或更高版本。先更新 CLI，
+它才能读取当前的组件契约，并正确选中已发布的 raw 包。
+
+```bash
+# 通过 get.agentic-os.sh 安装的 CLI
+anolisa update self
+
+# 由 RPM 管理的 CLI
+sudo anolisa update self
+```
+
 ---
 
 ## 环境探测与组件安装
@@ -32,23 +43,21 @@ anolisa env
 anolisa list
 ```
 
-按需安装组件。当前 `cosh-ng`、`agentsight`、`agent-sec-core`、`ws-ckpt` 和
+按需安装组件。当前 `cosh-ng`、`agentsight`、`sec-core`、`ws-ckpt` 和
 `skillfs` 需要以 system 模式安装，其余示例支持 user 模式。
 
 ```bash
 # Token 优化
 anolisa install tokenless
-# 或通过 npm：
-# npm install -g anolisa-tokenless
 
 # 工作区快照（基于 btrfs COW）
 sudo anolisa --install-mode system install ws-ckpt
 
-# 可观测性（仅 Linux system mode；包含 agentsight-enforcer 服务）
+# 可观测性（Linux system mode）
 sudo anolisa --install-mode system install agentsight
 
-# 安全内核（需要 sudo）
-sudo anolisa --install-mode system install agent-sec-core
+# 安全运行时和 adapter 资源（Linux x86_64 system mode）
+sudo anolisa --install-mode system install sec-core
 
 # 持久记忆（MCP 文件形态）
 anolisa install agent-memory
@@ -72,6 +81,17 @@ sudo anolisa --install-mode system install cosh-ng
 anolisa status
 ```
 
+安装会放置 systemd 服务文件，不会自动启动或设置开机自启。准备开始
+采集时，再把 AgentSight 交给 systemd 管理。
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+主服务会一起启动 trace 和 Dashboard，并带起它依赖的
+`agentsight-enforcer.service`。
+
 ---
 
 ## 使用各组件
@@ -90,10 +110,9 @@ tokenless env-check --all
 ws-ckpt checkpoint -w ~/project -s v1 -m "initial"
 ws-ckpt rollback -w ~/project -s v1
 
-# 可观测性，追踪 Agent Token 消耗
-sudo agentsight trace
-agentsight token --period week
-agentsight serve   # Web Dashboard: http://localhost:7396
+# 可观测性，system 服务以 root 身份保存采集数据
+sudo agentsight token --period week
+# Web Dashboard：http://localhost:7396
 
 # 安全，系统加固与技能验证
 agent-sec-cli harden --scan --config agentos_baseline
@@ -110,6 +129,7 @@ agent-sec-cli skill-ledger status
 anolisa adapter scan                        # 发现已安装框架
 anolisa adapter enable tokenless openclaw   # tokenless → OpenClaw
 anolisa adapter enable ws-ckpt hermes       # ws-ckpt → Hermes
+anolisa adapter enable sec-core openclaw    # AgentSecCore → OpenClaw
 ```
 
 ---

--- a/docs/user-guide/en/agent-observability/agentsight.md
+++ b/docs/user-guide/en/agent-observability/agentsight.md
@@ -60,20 +60,27 @@ The bundled systemd launcher binds the Dashboard to `0.0.0.0`. Restrict port
 7396 with a firewall or security group before exposing the host to an
 untrusted network.
 
-For foreground troubleshooting, use two terminals and run both commands as
-the same user. The second command is not reached if both are entered
-sequentially because `agentsight trace` stays in the foreground:
+The service runs as root with a private umask and stores data under
+`/var/log/sysak/.agentsight`. Use `sudo` for CLI queries and Dashboard access
+commands that read this service-owned data.
+
+For foreground troubleshooting, stop the systemd unit first so it does not
+compete with a second tracer. Then use two terminals and run both commands as
+root. The second command is not reached if both are entered sequentially
+because `agentsight trace` stays in the foreground:
 
 ```bash
+sudo systemctl stop agentsight.service
+
 # Terminal 1
 sudo agentsight trace
 
 # Terminal 2: Start Dashboard
-agentsight serve
+sudo agentsight serve
 # Open http://localhost:7396 in browser
 
-# Show the Dashboard URL and auth token
-agentsight dashboard
+# Print the Dashboard URL and token; open the URL as your desktop user
+sudo agentsight dashboard --no-open
 ```
 
 > Localhost access is authentication-free; remote access requires a token, see [Dashboard Access & Authentication](#dashboard-access--authentication).
@@ -89,16 +96,16 @@ sudo agentsight trace
 ```
 
 > Requires root privileges. Captures SSL/TLS traffic, process events, and file operations.
-> Stop `agentsight.service` before starting a second foreground tracer.
+> Run `sudo systemctl stop agentsight.service` before starting a foreground tracer.
 
 ### agentsight serve — Start API & Dashboard
 
 ```bash
 # Default: bind to 127.0.0.1:7396
-agentsight serve
+sudo agentsight serve
 
 # Bind to all interfaces (remote access)
-agentsight serve --host 0.0.0.0 --port 7396
+sudo agentsight serve --host 0.0.0.0 --port 7396
 ```
 
 Run `serve` as the same user that runs `trace` so both commands resolve the
@@ -112,7 +119,7 @@ Dashboard token authentication is enabled by default:
 - **Localhost access** (loopback) bypasses authentication — just open `http://127.0.0.1:7396`.
 - **Remote access** requires a token: append `?token=<TOKEN>` to the browser URL, or set the `Authorization: Bearer <TOKEN>` HTTP header.
 - The token is auto-generated on the first `serve` startup (64 hex characters) and persisted to the `.dashboard_token` file next to the database (default `/var/log/sysak/.agentsight/.dashboard_token`); it is reused across restarts.
-- Run `agentsight dashboard` to view the access URL and token directly.
+- Run `sudo agentsight dashboard --no-open` to print the service-owned access URL and token, then open the URL as your desktop user.
 
 To disable authentication (only recommended on trusted internal networks), set in the config file:
 
@@ -127,11 +134,8 @@ To disable authentication (only recommended on trusted internal networks), set i
 Displays the Dashboard URL and auth token, then tries to open a browser. On ECS instances it also prints a security-group configuration guide.
 
 ```bash
-# Show URL and token (requires serve to be running)
-agentsight dashboard
-
-# Show info only, do not open a browser
-agentsight dashboard --no-open
+# Show URL and token without opening a root-owned browser
+sudo agentsight dashboard --no-open
 ```
 
 ### agentsight summary — Unified Overview
@@ -152,14 +156,13 @@ agentsight summary --last 168 --json
 
 ```bash
 # Today's usage
-agentsight token
+sudo agentsight token
 
 # Weekly comparison
-agentsight token --period week --compare
-
+sudo agentsight token --period week --compare
 
 # JSON output
-agentsight token --json
+sudo agentsight token --json
 ```
 
 ### agentsight audit — Query Audit Events

--- a/docs/user-guide/en/agent-observability/agentsight.md
+++ b/docs/user-guide/en/agent-observability/agentsight.md
@@ -22,11 +22,13 @@ AgentSight provides full-stack observability for AI Agents running on Linux:
 | OS | Linux |
 | Kernel | >= 5.8 (BTF support required) |
 | Privileges | root or CAP_BPF (for eBPF probes) |
-| Architecture | x86_64 / aarch64 |
+| ANOLISA raw package | Linux x86_64, system mode |
 
 > **macOS**: On macOS, AgentSight provides two commands — `trace` (trajectory collector that scans local JSONL session files, no eBPF) and `serve` (Dashboard viewer). All other eBPF-dependent commands are Linux-only.
 
 ## Installation
+
+Install the published component with the ANOLISA CLI:
 
 ```bash
 # Recommended (system mode required — eBPF needs root)
@@ -43,8 +45,27 @@ cd src/agentsight && make build-all
 
 ## Quick Start
 
+Use the systemd unit for a normal deployment. It runs eBPF tracing and the
+Dashboard together and starts the enforcer dependency in the required order:
+
 ```bash
-# Terminal 1: Start eBPF tracing (requires root)
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+Open `http://localhost:7396` after the service becomes active. Enabling the
+main unit also keeps AgentSight available after a reboot.
+
+The bundled systemd launcher binds the Dashboard to `0.0.0.0`. Restrict port
+7396 with a firewall or security group before exposing the host to an
+untrusted network.
+
+For foreground troubleshooting, use two terminals and run both commands as
+the same user. The second command is not reached if both are entered
+sequentially because `agentsight trace` stays in the foreground:
+
+```bash
+# Terminal 1
 sudo agentsight trace
 
 # Terminal 2: Start Dashboard
@@ -68,6 +89,7 @@ sudo agentsight trace
 ```
 
 > Requires root privileges. Captures SSL/TLS traffic, process events, and file operations.
+> Stop `agentsight.service` before starting a second foreground tracer.
 
 ### agentsight serve — Start API & Dashboard
 
@@ -79,7 +101,9 @@ agentsight serve
 agentsight serve --host 0.0.0.0 --port 7396
 ```
 
-> Ensure your firewall allows access to port 7396 if accessing remotely.
+Run `serve` as the same user that runs `trace` so both commands resolve the
+same data directory. Binding to `0.0.0.0` exposes the Dashboard on every
+interface; restrict network access before using that form.
 
 #### Dashboard Access & Authentication
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -17,7 +17,8 @@ AgentSecCore is an all-local security kernel for AI Agents. It runs entirely on 
 
 ## Prerequisites
 
-- Linux x86_64 for the ANOLISA raw package
+- Linux x86_64 or aarch64 for source and RPM installations
+- Linux x86_64 with system mode for the ANOLISA raw package
 - Python 3.11.6 (pinned)
 - ANOLISA CLI 0.2.17 or later
 - Root privileges for system-mode install
@@ -43,14 +44,23 @@ agent-sec-cli --version
 name, `agent-sec-core`:
 
 ```bash
-sudo yum install agent-sec-core
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
 ```
+
+Installing the CLI from YUM makes it available on sudo's system path. Adoption
+records the RPM in system state so the adapter manager can read the installed
+component contract.
 
 Developers building from source should use the repository-level entry point:
 
 ```bash
 ./scripts/build-all.sh --component sec-core
 ```
+
+The source build installs the runtime and integration resources in user paths,
+but it does not register `sec-core` in ANOLISA state. Do not follow it with
+`anolisa adapter enable`; use the source integration scripts documented below.
 
 ## Quick Start
 
@@ -333,9 +343,9 @@ agent-sec-cli events --summary
 
 ## Agent Framework Integration
 
-Package installation places the available adapters but does not change an
-agent framework's user configuration. Run adapter commands as the user who
-owns that framework's configuration:
+For an ANOLISA-managed raw package or an adopted RPM, installation places the
+available adapters but does not change an agent framework's user configuration.
+Run adapter commands as the user who owns that framework's configuration:
 
 ```bash
 anolisa adapter scan
@@ -344,6 +354,29 @@ anolisa adapter enable sec-core openclaw
 
 Replace `openclaw` with `hermes`, `qwencode`, `cosh`, `codex`, or `qoder` for
 the other packaged integrations.
+
+### Source-build Integration
+
+The default source build installs the cosh extension directly under
+`~/.copilot-shell/extensions/agent-sec-core`, so no separate cosh enable step
+is needed. Deploy another integration with its installed user-path script:
+
+```bash
+# OpenClaw
+bash ~/.local/lib/anolisa/sec-core/openclaw-plugin/scripts/deploy.sh
+
+# Hermes
+bash ~/.local/lib/anolisa/sec-core/hermes-plugin/scripts/deploy.sh
+
+# Qwen Code
+bash ~/.local/lib/anolisa/sec-core/qwen-code-extension/scripts/deploy.sh
+
+# Codex
+bash ~/.local/lib/anolisa/sec-core/codex-plugin/install.sh
+
+# Qoder
+bash ~/.local/lib/anolisa/sec-core/qoder-plugin/install.sh
+```
 
 ### OpenClaw
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -17,21 +17,39 @@ AgentSecCore is an all-local security kernel for AI Agents. It runs entirely on 
 
 ## Prerequisites
 
-- Linux (x86_64 or aarch64)
+- Linux x86_64 for the ANOLISA raw package
 - Python 3.11.6 (pinned)
+- ANOLISA CLI 0.2.17 or later
 - Root privileges for system-mode install
 
 ## Installation
 
+Update the CLI through its installation owner, then install the component in
+system mode:
+
 ```bash
-# Recommended (system mode required)
-sudo anolisa install agent-sec-core
+# CLI installed by get.agentic-os.sh
+anolisa update self
 
-# Alternative (Alinux, requires YUM repo)
+# RPM-owned CLI
+sudo anolisa update self
+
+sudo anolisa --install-mode system install sec-core
+sudo anolisa status sec-core
+agent-sec-cli --version
+```
+
+`sec-core` is the ANOLISA component name. The RPM keeps its existing package
+name, `agent-sec-core`:
+
+```bash
 sudo yum install agent-sec-core
+```
 
-# Source build (developers only)
-cd src/agent-sec-core && make build-cli
+Developers building from source should use the repository-level entry point:
+
+```bash
+./scripts/build-all.sh --component sec-core
 ```
 
 ## Quick Start
@@ -206,9 +224,9 @@ default; raw scan content is passed to `scan-pii` only through stdin, and notice
 only redacted evidence.
 
 ```bash
-# Explicitly block scanner deny verdicts at enforceable hook boundaries
-export PII_CHECKER_MODE=block
-./qwen-code-extension/scripts/deploy.sh
+# Enable the extension, then start Qwen Code with blocking enabled
+anolisa adapter enable sec-core qwencode
+PII_CHECKER_MODE=block qwen
 ```
 
 | Environment variable | Default | Behavior |
@@ -315,16 +333,24 @@ agent-sec-cli events --summary
 
 ## Agent Framework Integration
 
-### OpenClaw
-
-Deploy via script:
+Package installation places the available adapters but does not change an
+agent framework's user configuration. Run adapter commands as the user who
+owns that framework's configuration:
 
 ```bash
-# From installed path (RPM)
-/opt/agent-sec/openclaw-plugin/scripts/deploy.sh
+anolisa adapter scan
+anolisa adapter enable sec-core openclaw
+```
 
-# From source
-./openclaw-plugin/scripts/deploy.sh
+Replace `openclaw` with `hermes`, `qwencode`, `cosh`, `codex`, or `qoder` for
+the other packaged integrations.
+
+### OpenClaw
+
+Enable the adapter with ANOLISA:
+
+```bash
+anolisa adapter enable sec-core openclaw
 ```
 
 After deployment, configure:
@@ -342,14 +368,10 @@ openclaw gateway restart
 
 ### Hermes
 
-Deploy via script:
+Enable the adapter with ANOLISA:
 
 ```bash
-# From installed path (RPM)
-/opt/agent-sec/hermes-plugin/scripts/deploy.sh
-
-# From source
-./hermes-plugin/scripts/deploy.sh
+anolisa adapter enable sec-core hermes
 ```
 
 Plugin config at `~/.hermes/plugins/agent-sec-core-hermes-plugin/config.toml`:
@@ -377,14 +399,10 @@ policy = "ask"          # observe | warn | ask (default) | block
 
 ### Qwen Code
 
-Deploy and enable the user-scoped extension:
+Enable the user-scoped extension with ANOLISA:
 
 ```bash
-# From installed path (RPM)
-/opt/agent-sec/qwen-code-extension/scripts/deploy.sh
-
-# From source
-./qwen-code-extension/scripts/deploy.sh
+anolisa adapter enable sec-core qwencode
 ```
 
 The synchronous `PreToolUse` hook protects only model-triggered Qwen Code
@@ -437,7 +455,13 @@ preflight, background scan, cache, or automatic configuration repair.
 
 ### Copilot Shell (cosh)
 
-The cosh extension is installed automatically during `make install` or via RPM. No manual enablement required — hooks are loaded at cosh startup.
+For a package install, enable the adapter in the target user's configuration:
+
+```bash
+anolisa adapter enable sec-core cosh
+```
+
+Hooks are loaded when cosh starts.
 
 Extension path:
 - User install: `~/.copilot-shell/extensions/agent-sec-core/`

--- a/docs/user-guide/en/agent-security/agent-sec-core/code-scanner.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/code-scanner.md
@@ -6,7 +6,7 @@ Code Scanner hooks inspect shell or code tool calls before execution and reuse e
 
 ```bash
 # Recommended (system mode required)
-sudo anolisa install agent-sec-core
+sudo anolisa --install-mode system install sec-core
 
 # Alternative for Alinux systems with the YUM repository configured
 sudo yum install agent-sec-core

--- a/docs/user-guide/en/installation.md
+++ b/docs/user-guide/en/installation.md
@@ -28,6 +28,21 @@ After installation, verify:
 anolisa --version
 ```
 
+Before installing a component that uses the current raw package contract,
+update an older CLI through the tool that owns it:
+
+```bash
+# CLI installed by get.agentic-os.sh
+anolisa update self
+
+# RPM-owned CLI
+sudo anolisa update self
+```
+
+AgentSecCore requires `anolisa` 0.2.17 or later. The CLI reports an update hint
+and stops before changing the host when it cannot safely read a package
+contract.
+
 ---
 
 ## Step 2: Environment Detection
@@ -67,7 +82,7 @@ anolisa install <component>
 | `skillfs` | FUSE virtual skill filesystem | **system** |
 | `agent-memory` | MCP-based persistent memory | user, system |
 | `agentsight` | eBPF tracing and dashboard | **system** |
-| `agent-sec-core` | Security hardening | **system** |
+| `sec-core` | Local security runtime, scanners, and adapters | **system** |
 
 > **Note**: System-only components require `sudo` and an explicit system scope:
 > ```bash
@@ -81,6 +96,21 @@ sudo anolisa --install-mode system install cosh-ng
 cosh
 ```
 
+Use the component name `sec-core` with the ANOLISA CLI. The Alinux RPM keeps
+its package name `agent-sec-core`:
+
+```bash
+sudo anolisa --install-mode system install sec-core
+
+# If you install the RPM directly, let ANOLISA track it before adapter setup
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
+```
+
+Continue to [Step 4](#step-4-adapter-setup), then run
+`anolisa adapter enable sec-core <framework>` as the user who owns the target
+Agent configuration.
+
 ### Install All Components
 
 ```bash
@@ -89,10 +119,14 @@ anolisa install --all
 
 ### YUM Alternative (Alinux)
 
-For each component, you can also use YUM:
+For each component, you can also use YUM. Install the system CLI in the same
+transaction so sudo can find it without relying on a user-local PATH. A direct
+RPM installation does not create an ANOLISA state record, so adopt it before
+using lifecycle or adapter commands:
 
 ```bash
-sudo yum install <component>
+sudo yum install anolisa <rpm-package>
+sudo anolisa --install-mode system adopt <component>
 ```
 
 ---
@@ -120,11 +154,47 @@ ws-ckpt plugin install --runtime openclaw
 
 # ws-ckpt plugin for Hermes
 ws-ckpt plugin install --runtime hermes
+
+# AgentSecCore plugin for OpenClaw
+anolisa adapter enable sec-core openclaw
+```
+
+The system installation owns the component files. Adapter enablement runs as
+the user who owns the target Agent configuration, so it does not need `sudo`
+for a normal user-scoped framework installation.
+
+---
+
+## Step 5: Start Long-running Services
+
+Installing a component and starting its resident service are separate actions.
+AgentSight installs `agentsight.service` and its enforcer dependency without
+enabling either unit. Start the main unit when the machine is ready to collect
+events:
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+The main unit runs eBPF tracing and the Dashboard together as root and keeps its
+data private under `/var/log/sysak/.agentsight`. Use `sudo` for commands that
+query service data. For foreground troubleshooting, stop the unit first, then
+run the tracer and server as root in separate terminals:
+
+```bash
+sudo systemctl stop agentsight.service
+
+# Terminal 1
+sudo agentsight trace
+
+# Terminal 2
+sudo agentsight serve
 ```
 
 ---
 
-## Step 5: Verify Installation
+## Step 6: Verify Installation
 
 Check the status of all installed components:
 
@@ -174,7 +244,8 @@ anolisa update all
 ```
 
 `update all` updates recorded components but not the CLI binary. Use
-`anolisa update self` for the CLI.
+`anolisa update self` for a script-installed CLI or `sudo anolisa update self`
+for an RPM-owned CLI.
 
 ---
 

--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -22,10 +22,15 @@ Install the anolisa CLI first, then use it to install Tokenless:
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 anolisa --version
 anolisa install tokenless
 tokenless --version
 ```
+
+If `anolisa --version` succeeds, start with `anolisa install tokenless`. The
+PATH update above makes a fresh default installation available in the current
+shell; new login shells may already include `~/.local/bin`.
 
 ## 3. Start using Tokenless
 

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -39,6 +39,21 @@ Claude Code requires version 2.1.121 or later for `updatedToolOutput`. On older 
 
 ## Manage adapters with anolisa (recommended)
 
+These commands require an ANOLISA component record. If Tokenless was installed
+directly with YUM, record the RPM once before continuing:
+
+```bash
+sudo yum install anolisa
+sudo anolisa --install-mode system adopt tokenless
+```
+
+The YUM-installed CLI is available on sudo's system path; the user-local CLI
+installed by `get.agentic-os.sh` may be hidden by sudo's `secure_path`.
+
+Run the adapter commands below as the user who owns the target Agent
+configuration. A user-scoped adapter operation can discover the adopted system
+package while keeping the framework mutation in that user's configuration.
+
 ### 1. Scan frameworks
 
 ```bash
@@ -78,11 +93,9 @@ anolisa adapter enable tokenless openclaw \
 
 On OpenClaw releases where the underlying bypass is unsupported or a deprecated no-op, anolisa refuses this option; follow the error's `security.installPolicy` guidance instead.
 
-If Tokenless was installed in system mode, use the same scope:
-
-```bash
-sudo anolisa adapter enable tokenless <framework>
-```
+The component package may be system-scoped while the adapter receipt remains
+user-scoped. Use `sudo` only when the target framework configuration and its
+adapter receipt are intentionally owned by root.
 
 ### 3. Check status
 
@@ -99,11 +112,8 @@ Restart the target agent CLI or IDE afterwards. A running session normally does 
 anolisa adapter disable tokenless <framework>
 ```
 
-For system mode:
-
-```bash
-sudo anolisa adapter disable tokenless <framework>
-```
+Disable the adapter with the same user that enabled it. A root-owned receipt is
+the exception and requires `sudo` for both operations.
 
 Restart the target agent after disabling. All enabled adapters must be released before Tokenless can be uninstalled.
 

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -24,10 +24,12 @@ anolisa --dry-run install tokenless
 anolisa --dry-run --verbose install tokenless
 ```
 
-For a system-mode install, keep the same scope on all mutating anolisa commands:
+Run adapter diagnostics as the user who owns the target Agent configuration and
+adapter receipt. That user can inspect both user state and readable system
+state:
 
 ```bash
-sudo anolisa doctor tokenless
+anolisa doctor tokenless
 ```
 
 ## `tokenless: command not found`
@@ -100,7 +102,8 @@ Confirm that:
 
 - The target framework is detected.
 - The Tokenless adapter is enabled.
-- The adapter and component use the same user/system scope.
+- Adapter commands run as the user who owns the target framework configuration
+  and adapter receipt.
 - The agent CLI or IDE was restarted after enabling.
 
 ### 3. Verify the agent task
@@ -121,7 +124,9 @@ Common causes:
 
 - The target agent framework is not installed or detected.
 - The framework version does not meet the adapter requirement.
-- Tokenless is installed in system scope but the adapter mutation uses user scope, or vice versa.
+- The adapter command ran as a different user from the one that owns the target
+  framework configuration or adapter receipt.
+- A directly installed Tokenless RPM has not been adopted into ANOLISA state.
 - An npm installation has no anolisa component record, but `anolisa adapter enable` was used.
 - OpenClaw security policy rejected the plugin's required unsafe-install override.
 
@@ -133,6 +138,14 @@ anolisa --verbose adapter enable tokenless <framework>
 ```
 
 For npm installations, use [Framework integration · Manual integration after npm installation](framework-integration.md#manual-integration-after-npm-installation).
+
+For a directly installed RPM, create the missing state record, then rerun the
+adapter command as the target framework user:
+
+```bash
+sudo yum install anolisa
+sudo anolisa --install-mode system adopt tokenless
+```
 
 For an anolisa-managed installation, the first attempt does not bypass OpenClaw's safety scan. If the error specifically recommends it, review the findings and retry with:
 
@@ -261,14 +274,15 @@ No output is expected. Fully exit and restart Qoder IDE afterwards.
 If `dnf remove` or `rpm -e` was run directly:
 
 ```bash
-sudo anolisa repair tokenless
+sudo yum install anolisa
+sudo anolisa --install-mode system repair tokenless
 ```
 
 Follow the repair plan. Only when the RPM is still present and the output explicitly asks to recreate the record, run:
 
 ```bash
-sudo anolisa forget tokenless
-sudo anolisa adopt tokenless
+sudo anolisa --install-mode system forget tokenless
+sudo anolisa --install-mode system adopt tokenless
 ```
 
 `forget` deletes only anolisa state; it does not uninstall the RPM.

--- a/docs/user-guide/en/troubleshooting.md
+++ b/docs/user-guide/en/troubleshooting.md
@@ -100,7 +100,8 @@ anolisa env
 anolisa --verbose install tokenless
 
 # Alternative: use YUM
-sudo yum install tokenless
+sudo yum install anolisa tokenless
+sudo anolisa --install-mode system adopt tokenless
 ```
 
 ---

--- a/docs/user-guide/zh/agent-observability/agentsight.md
+++ b/docs/user-guide/zh/agent-observability/agentsight.md
@@ -59,20 +59,26 @@ sudo systemctl status agentsight.service
 systemd 自带的启动脚本会让 Dashboard 监听 `0.0.0.0`。主机接入不可信
 网络以前，请先通过防火墙或安全组限制 7396 端口。
 
-前台排查需要两个终端，两条命令也要使用同一个用户。
-`agentsight trace` 会一直占用前台，在同一个终端里顺序输入两条命令时，
-第二条命令不会开始运行。
+服务会以 root 身份和私有 umask 运行，数据保存在
+`/var/log/sysak/.agentsight`。CLI 查询和 Dashboard 访问命令读取这些数据时
+也要使用 `sudo`。
+
+前台排查前先停止 systemd 服务，避免两个 tracer 同时采集。随后打开两个
+终端，并以 root 身份运行两条命令。`agentsight trace` 会一直占用前台，
+在同一个终端里顺序输入两条命令时，第二条命令不会开始运行。
 
 ```bash
+sudo systemctl stop agentsight.service
+
 # 终端 1
 sudo agentsight trace
 
-# 终端 2: 启动 Dashboard
-agentsight serve
+# 终端 2，启动 Dashboard
+sudo agentsight serve
 # 浏览器访问 http://localhost:7396
 
-# 查看 Dashboard 访问地址与认证 Token
-agentsight dashboard
+# 输出 Dashboard 访问地址与 Token，再用桌面用户打开
+sudo agentsight dashboard --no-open
 ```
 
 > 本机（localhost）访问免认证；远程访问需要携带 Token，见[Dashboard 访问与认证](#dashboard-访问与认证)。
@@ -88,16 +94,16 @@ sudo agentsight trace
 ```
 
 > 需要 root 权限。捕获 SSL/TLS 流量、进程事件和文件操作。
-> 如果 `agentsight.service` 正在运行，先停止服务，再启动第二个前台 tracer。
+> 启动前台 tracer 前，先执行 `sudo systemctl stop agentsight.service`。
 
 ### agentsight serve — 启动 API 及 Dashboard
 
 ```bash
 # 默认绑定 127.0.0.1:7396
-agentsight serve
+sudo agentsight serve
 
 # 绑定所有接口（远程访问）
-agentsight serve --host 0.0.0.0 --port 7396
+sudo agentsight serve --host 0.0.0.0 --port 7396
 ```
 
 `serve` 和 `trace` 使用同一个运行用户时，才会解析到同一个数据目录。
@@ -111,7 +117,7 @@ Dashboard Token 认证默认开启：
 - **本机访问**（loopback）自动免认证，直接打开 `http://127.0.0.1:7396` 即可。
 - **远程访问**需携带 Token：浏览器 URL 追加 `?token=<TOKEN>`，或 HTTP 请求头设置 `Authorization: Bearer <TOKEN>`。
 - Token 在首次启动 `serve` 时自动生成（64 位十六进制），持久化于数据库同目录的 `.dashboard_token` 文件（默认 `/var/log/sysak/.agentsight/.dashboard_token`），重启后复用。
-- 使用 `agentsight dashboard` 命令可直接查看访问地址与 Token。
+- 使用 `sudo agentsight dashboard --no-open` 输出服务生成的访问地址与 Token，再用桌面用户打开该地址。
 
 如需关闭认证（仅建议在可信内网使用），在配置文件中设置：
 
@@ -126,11 +132,8 @@ Dashboard Token 认证默认开启：
 显示 Dashboard 访问地址、认证 Token，并尝试打开浏览器。在 ECS 实例上还会输出安全组放行指引。
 
 ```bash
-# 查看访问地址与 Token（需要 serve 已启动）
-agentsight dashboard
-
-# 仅显示信息，不打开浏览器
-agentsight dashboard --no-open
+# 输出访问地址与 Token，不以 root 身份打开浏览器
+sudo agentsight dashboard --no-open
 ```
 
 ### agentsight summary — 统一概览
@@ -151,14 +154,13 @@ agentsight summary --last 168 --json
 
 ```bash
 # 今日用量
-agentsight token
+sudo agentsight token
 
 # 本周 vs 上周对比
-agentsight token --period week --compare
-
+sudo agentsight token --period week --compare
 
 # JSON 格式输出
-agentsight token --json
+sudo agentsight token --json
 ```
 
 ### agentsight audit — 查询审计事件

--- a/docs/user-guide/zh/agent-observability/agentsight.md
+++ b/docs/user-guide/zh/agent-observability/agentsight.md
@@ -22,11 +22,13 @@ AgentSight 为运行在 Linux 上的 AI Agent 提供全栈可观测能力：
 | OS | Linux |
 | 内核 | >= 5.8（需要 BTF 支持） |
 | 权限 | root 或 CAP_BPF（eBPF 探针） |
-| 架构 | x86_64 / aarch64 |
+| ANOLISA raw 包 | Linux x86_64，system mode |
 
 > **macOS**：AgentSight 在 macOS 上提供 `trace`（轨迹采集器，扫描本地 JSONL 会话文件，无 eBPF）和 `serve`（Dashboard 查看器）两个命令；其余依赖 eBPF 的命令仅 Linux 可用。
 
 ## 安装
+
+首选 ANOLISA CLI 安装已发布的组件。
 
 ```bash
 # 首选（需要 system mode — eBPF 依赖 root）
@@ -43,8 +45,26 @@ cd src/agentsight && make build-all
 
 ## 快速开始
 
+普通部署直接使用 systemd。这个服务会一起运行 eBPF trace 和
+Dashboard，并按顺序带起 enforcer 依赖。
+
 ```bash
-# 终端 1: 启动 eBPF 追踪（需要 root）
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+服务进入 active 状态后，打开 `http://localhost:7396`。启用主服务后，
+主机重启也会自动拉起 AgentSight。
+
+systemd 自带的启动脚本会让 Dashboard 监听 `0.0.0.0`。主机接入不可信
+网络以前，请先通过防火墙或安全组限制 7396 端口。
+
+前台排查需要两个终端，两条命令也要使用同一个用户。
+`agentsight trace` 会一直占用前台，在同一个终端里顺序输入两条命令时，
+第二条命令不会开始运行。
+
+```bash
+# 终端 1
 sudo agentsight trace
 
 # 终端 2: 启动 Dashboard
@@ -68,6 +88,7 @@ sudo agentsight trace
 ```
 
 > 需要 root 权限。捕获 SSL/TLS 流量、进程事件和文件操作。
+> 如果 `agentsight.service` 正在运行，先停止服务，再启动第二个前台 tracer。
 
 ### agentsight serve — 启动 API 及 Dashboard
 
@@ -79,7 +100,9 @@ agentsight serve
 agentsight serve --host 0.0.0.0 --port 7396
 ```
 
-> 远程访问时请确保防火墙已放行对应端口。
+`serve` 和 `trace` 使用同一个运行用户时，才会解析到同一个数据目录。
+绑定 `0.0.0.0` 会将 Dashboard 暴露给所有网卡。在使用这种方式之前，
+需要先限制网络访问。
 
 #### Dashboard 访问与认证
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -17,21 +17,38 @@ AgentSecCore 是面向 AI Agent 的全本地安全内核，零 Token 消耗。�
 
 ## 前置条件
 
-- Linux（x86_64 或 aarch64）
+- ANOLISA raw 包支持 Linux x86_64
 - Python 3.11.6（固定版本）
+- ANOLISA CLI 0.2.17 或更高版本
 - 安装需要 root 权限（system mode）
 
 ## 安装
 
+先根据 CLI 的安装来源完成更新，再用 system mode 安装组件。
+
 ```bash
-# 首选（需要 system mode）
-sudo anolisa install agent-sec-core
+# 通过 get.agentic-os.sh 安装的 CLI
+anolisa update self
 
-# 备选（Alinux，需配置 YUM 源）
+# 由 RPM 管理的 CLI
+sudo anolisa update self
+
+sudo anolisa --install-mode system install sec-core
+sudo anolisa status sec-core
+agent-sec-cli --version
+```
+
+`sec-core` 是 ANOLISA 中的组件名。RPM 继续使用原有包名
+`agent-sec-core`。
+
+```bash
 sudo yum install agent-sec-core
+```
 
-# 源码编译（仅开发者）
-cd src/agent-sec-core && make build-cli
+从源码构建时，使用仓库级统一入口。
+
+```bash
+./scripts/build-all.sh --component sec-core
 ```
 
 ## 快速开始
@@ -204,9 +221,9 @@ Qwen Code extension 会扫描用户输入、工具输入、成功及失败的工
 脱敏 evidence。
 
 ```bash
-# 在可执行阻断的 hook 边界显式阻断 scanner deny verdict
-export PII_CHECKER_MODE=block
-./qwen-code-extension/scripts/deploy.sh
+# 启用扩展，再以阻断模式启动 Qwen Code
+anolisa adapter enable sec-core qwencode
+PII_CHECKER_MODE=block qwen
 ```
 
 | 环境变量 | 默认值 | 行为 |
@@ -309,16 +326,23 @@ agent-sec-cli events --summary
 
 ## Agent 框架集成
 
-### OpenClaw
-
-通过 deploy 脚本部署：
+安装包会放置可用的 adapter，但不会直接改动 Agent 框架的用户配置。
+请用拥有该框架配置的用户执行 adapter 命令。
 
 ```bash
-# 从已安装路径（RPM）
-/opt/agent-sec/openclaw-plugin/scripts/deploy.sh
+anolisa adapter scan
+anolisa adapter enable sec-core openclaw
+```
 
-# 从源码
-./openclaw-plugin/scripts/deploy.sh
+其他已打包的集成可以把 `openclaw` 换成 `hermes`、`qwencode`、`cosh`、
+`codex` 或 `qoder`。
+
+### OpenClaw
+
+使用 ANOLISA 启用 adapter。
+
+```bash
+anolisa adapter enable sec-core openclaw
 ```
 
 部署后配置：
@@ -336,14 +360,10 @@ openclaw gateway restart
 
 ### Hermes
 
-通过 deploy 脚本部署：
+使用 ANOLISA 启用 adapter。
 
 ```bash
-# 从已安装路径（RPM）
-/opt/agent-sec/hermes-plugin/scripts/deploy.sh
-
-# 从源码
-./hermes-plugin/scripts/deploy.sh
+anolisa adapter enable sec-core hermes
 ```
 
 插件配置位于 `~/.hermes/plugins/agent-sec-core-hermes-plugin/config.toml`：
@@ -371,14 +391,10 @@ policy = "ask"          # observe | warn | ask（默认）| block
 
 ### Qwen Code
 
-部署并启用 user scope 扩展：
+使用 ANOLISA 启用 user scope 扩展。
 
 ```bash
-# 从已安装路径（RPM）
-/opt/agent-sec/qwen-code-extension/scripts/deploy.sh
-
-# 从源码
-./qwen-code-extension/scripts/deploy.sh
+anolisa adapter enable sec-core qwencode
 ```
 
 同步 `PreToolUse` hook 只保护由模型触发的 Qwen Code `skill` Tool 调用，且仅覆盖
@@ -424,7 +440,13 @@ CLI 或密钥缺失、初始化失败、路径或 settings 不可访问或歧义
 
 ### Copilot Shell（cosh）
 
-cosh 扩展在 `make install` 或 RPM 安装时自动部署，无需手动启用 — cosh 启动时自动加载 hook。
+通过安装包部署时，在目标用户的配置中启用 adapter。
+
+```bash
+anolisa adapter enable sec-core cosh
+```
+
+cosh 启动时会加载 hook。
 
 扩展路径：
 - 用户安装：`~/.copilot-shell/extensions/agent-sec-core/`

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -17,7 +17,8 @@ AgentSecCore 是面向 AI Agent 的全本地安全内核，零 Token 消耗。�
 
 ## 前置条件
 
-- ANOLISA raw 包支持 Linux x86_64
+- 源码和 RPM 安装支持 Linux x86_64、aarch64
+- ANOLISA raw 包仅支持 Linux x86_64 和 system mode
 - Python 3.11.6（固定版本）
 - ANOLISA CLI 0.2.17 或更高版本
 - 安装需要 root 权限（system mode）
@@ -42,14 +43,22 @@ agent-sec-cli --version
 `agent-sec-core`。
 
 ```bash
-sudo yum install agent-sec-core
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
 ```
+
+从 YUM 安装 CLI 后，`sudo` 可以从系统路径找到 `anolisa`。`adopt` 会把 RPM
+写入 system 状态，adapter 管理器随后才能读取已安装组件的契约。
 
 从源码构建时，使用仓库级统一入口。
 
 ```bash
 ./scripts/build-all.sh --component sec-core
 ```
+
+源码构建会把运行时和集成资源安装到用户目录，但不会在 ANOLISA 状态中注册
+`sec-core`。这种安装方式不能继续执行 `anolisa adapter enable`，请使用下文的
+源码集成脚本。
 
 ## 快速开始
 
@@ -326,8 +335,9 @@ agent-sec-cli events --summary
 
 ## Agent 框架集成
 
-安装包会放置可用的 adapter，但不会直接改动 Agent 框架的用户配置。
-请用拥有该框架配置的用户执行 adapter 命令。
+通过 ANOLISA 管理的 raw 包或已执行 `adopt` 的 RPM 会放置可用 adapter，
+但不会直接改动 Agent 框架的用户配置。请用拥有该框架配置的用户执行
+adapter 命令。
 
 ```bash
 anolisa adapter scan
@@ -336,6 +346,29 @@ anolisa adapter enable sec-core openclaw
 
 其他已打包的集成可以把 `openclaw` 换成 `hermes`、`qwencode`、`cosh`、
 `codex` 或 `qoder`。
+
+### 源码集成入口
+
+默认源码构建会把 cosh 扩展直接安装到
+`~/.copilot-shell/extensions/agent-sec-core`，无需再执行启用命令。其他集成请
+运行用户目录中对应的脚本。
+
+```bash
+# OpenClaw
+bash ~/.local/lib/anolisa/sec-core/openclaw-plugin/scripts/deploy.sh
+
+# Hermes
+bash ~/.local/lib/anolisa/sec-core/hermes-plugin/scripts/deploy.sh
+
+# Qwen Code
+bash ~/.local/lib/anolisa/sec-core/qwen-code-extension/scripts/deploy.sh
+
+# Codex
+bash ~/.local/lib/anolisa/sec-core/codex-plugin/install.sh
+
+# Qoder
+bash ~/.local/lib/anolisa/sec-core/qoder-plugin/install.sh
+```
 
 ### OpenClaw
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/code-scanner.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/code-scanner.md
@@ -6,7 +6,7 @@ Code Scanner hook 会在 shell 或代码工具执行前进行检查，并复用�
 
 ```bash
 # 首选（需要 system mode）
-sudo anolisa install agent-sec-core
+sudo anolisa --install-mode system install sec-core
 
 # 备选（已配置 YUM 源的 Alinux 系统）
 sudo yum install agent-sec-core

--- a/docs/user-guide/zh/installation.md
+++ b/docs/user-guide/zh/installation.md
@@ -28,6 +28,20 @@ sudo yum install anolisa
 anolisa --version
 ```
 
+如果当前 CLI 较旧，先根据它的安装来源完成自更新，再安装使用新版 raw
+包契约的组件。
+
+```bash
+# 通过 get.agentic-os.sh 安装的 CLI
+anolisa update self
+
+# 由 RPM 管理的 CLI
+sudo anolisa update self
+```
+
+AgentSecCore 要求 `anolisa` 0.2.17 或更高版本。CLI 无法安全读取契约时，
+会先给出更新提示并停止安装，不会改动主机。
+
 ---
 
 ## 第二步 环境检测
@@ -68,7 +82,7 @@ anolisa install <component>
 | `skillfs` | FUSE 虚拟技能文件系统 | **system** |
 | `agent-memory` | 基于 MCP 的持久化记忆 | user、system |
 | `agentsight` | eBPF 追踪与 Dashboard | **system** |
-| `agent-sec-core` | 安全加固 | **system** |
+| `sec-core` | 本地安全运行时、scanner 和 adapter | **system** |
 
 > **注意** 仅支持 system 模式的组件需要 `sudo`，并且必须显式选择 system 范围。
 > ```bash
@@ -82,6 +96,20 @@ sudo anolisa --install-mode system install cosh-ng
 cosh
 ```
 
+ANOLISA CLI 使用组件名 `sec-core`。Alinux 的 RPM 包名仍然是
+`agent-sec-core`。
+
+```bash
+sudo anolisa --install-mode system install sec-core
+
+# 如果直接安装 RPM，配置 adapter 前先让 ANOLISA 记录该组件
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
+```
+
+随后进入[第四步](#第四步-配置适配器)，由拥有目标 Agent 配置的用户执行
+`anolisa adapter enable sec-core <framework>`。
+
 ### 安装全部组件
 
 ```bash
@@ -90,10 +118,13 @@ anolisa install --all
 
 ### YUM 替代方式（Alinux）
 
-每个组件也可通过 YUM 安装。
+每个组件也可通过 YUM 安装。请在同一条命令中安装 system CLI，避免 `sudo`
+依赖用户目录中的 `PATH`。直接安装 RPM 不会生成 ANOLISA 状态记录，继续使用
+组件生命周期或 adapter 命令前，需要先执行 `adopt`。
 
 ```bash
-sudo yum install <component>
+sudo yum install anolisa <rpm-package>
+sudo anolisa --install-mode system adopt <component>
 ```
 
 ---
@@ -121,11 +152,44 @@ ws-ckpt plugin install --runtime openclaw
 
 # ws-ckpt Hermes 插件
 ws-ckpt plugin install --runtime hermes
+
+# AgentSecCore OpenClaw 插件
+anolisa adapter enable sec-core openclaw
+```
+
+system 安装负责管理组件文件。adapter 需要写入当前用户的 Agent 配置，
+普通的 user scope 框架安装不需要 `sudo`。
+
+---
+
+## 第五步 启动常驻服务
+
+安装组件和启动常驻服务是两个动作。AgentSight 会安装
+`agentsight.service` 及其 enforcer 依赖，两个单元默认都不启用。
+主机准备开始采集时，再启动主服务。
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+主服务以 root 身份运行 eBPF trace 和 Dashboard，数据保存在仅 root 可读的
+`/var/log/sysak/.agentsight`。查询服务数据时也要使用 `sudo`。如需前台排查，
+先停止服务，再在两个终端中分别以 root 身份启动 tracer 和 server。
+
+```bash
+sudo systemctl stop agentsight.service
+
+# 终端 1
+sudo agentsight trace
+
+# 终端 2
+sudo agentsight serve
 ```
 
 ---
 
-## 第五步 验证安装
+## 第六步 验证安装
 
 查看所有已安装组件的状态。
 
@@ -173,8 +237,8 @@ anolisa update <component>
 anolisa update all
 ```
 
-`update all` 只更新已记录的组件，不更新 CLI；更新 CLI 请使用
-`anolisa update self`。
+`update all` 只更新已记录的组件，不更新 CLI。脚本安装的 CLI 使用
+`anolisa update self`，RPM 管理的 CLI 使用 `sudo anolisa update self`。
 
 ---
 

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -22,10 +22,15 @@ Tokenless 帮助 AI Agent 用更少的 Token 完成原来的工作。
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 anolisa --version
 anolisa install tokenless
 tokenless --version
 ```
+
+如果 `anolisa --version` 能正常返回，可以直接从 `anolisa install tokenless`
+开始。上面的 PATH 设置会让默认安装目录在当前 Shell 中立即生效，新的登录 Shell
+可能已经包含 `~/.local/bin`。
 
 ## 3. 开始使用 Tokenless
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -39,6 +39,20 @@ Claude Code 需要 2.1.121 或更高版本才能使用 `updatedToolOutput`。版
 
 ## 通过 anolisa 管理（推荐）
 
+这些命令需要 ANOLISA 组件记录。如果 Tokenless 是通过 YUM 直接安装的，
+继续操作前先记录该 RPM。
+
+```bash
+sudo yum install anolisa
+sudo anolisa --install-mode system adopt tokenless
+```
+
+YUM 安装的 CLI 位于 `sudo` 可见的系统路径。`get.agentic-os.sh` 安装在用户
+目录中的 CLI 可能会被 `sudo` 的 `secure_path` 隐藏。
+
+后续 adapter 命令请用拥有目标 Agent 配置的用户执行。user scope 的 adapter
+操作可以读取已采纳的 system 软件包，同时把框架改动留在当前用户的配置中。
+
 ### 1. 扫描框架
 
 ```bash
@@ -78,11 +92,8 @@ anolisa adapter enable tokenless openclaw \
 
 如果当前 OpenClaw 不支持底层覆盖参数，或已把它标记为无效的废弃选项，anolisa 会拒绝上述参数；此时应按照错误中的 `security.installPolicy` 指引处理。
 
-如果 Tokenless 通过 system mode 安装，请使用相同 scope：
-
-```bash
-sudo anolisa adapter enable tokenless <framework>
-```
+组件软件包可以安装在 system scope，adapter receipt 仍由当前用户管理。只有
+目标框架配置和 receipt 都明确归 root 所有时，才需要使用 `sudo`。
 
 ### 3. 检查状态
 
@@ -99,11 +110,8 @@ anolisa doctor tokenless
 anolisa adapter disable tokenless <framework>
 ```
 
-system mode 同样需要：
-
-```bash
-sudo anolisa adapter disable tokenless <framework>
-```
+请用启用 adapter 的同一用户执行禁用操作。只有 root 管理的 receipt 需要在
+两个操作中都使用 `sudo`。
 
 禁用后重启目标 Agent。卸载 Tokenless 前必须先释放所有已启用的 Adapter。
 

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -24,10 +24,11 @@ anolisa --dry-run install tokenless
 anolisa --dry-run --verbose install tokenless
 ```
 
-system mode 安装应在所有 anolisa 修改命令中保持相同 scope：
+请用拥有目标 Agent 配置和 adapter receipt 的用户运行 adapter 诊断。该用户
+可以同时查看 user 状态和可读的 system 状态。
 
 ```bash
-sudo anolisa doctor tokenless
+anolisa doctor tokenless
 ```
 
 ## `tokenless: command not found`
@@ -100,7 +101,7 @@ anolisa adapter status tokenless
 
 - 目标框架已被检测。
 - Tokenless Adapter 已启用。
-- Adapter 与组件使用相同的 user/system scope。
+- adapter 命令由目标框架配置和 receipt 的所属用户执行。
 - 启用后已经重启 Agent CLI 或 IDE。
 
 ### 3. 验证 Agent 任务
@@ -121,7 +122,8 @@ env | grep '^TOKENLESS_'
 
 - 目标 Agent 框架未安装或未被扫描到。
 - 框架版本不满足 Adapter 要求。
-- Tokenless 安装在 system scope，但用 user scope 修改 Adapter，反之亦然。
+- adapter 命令的执行用户与目标框架配置或 receipt 的所属用户不同。
+- 直接安装的 Tokenless RPM 尚未写入 ANOLISA 状态。
 - npm 安装没有 anolisa 组件记录，却尝试使用 `anolisa adapter enable`。
 - OpenClaw 安全策略拒绝 Plugin 所需的 unsafe-install 覆盖参数。
 
@@ -133,6 +135,14 @@ anolisa --verbose adapter enable tokenless <framework>
 ```
 
 npm 安装请使用[框架集成 · npm 安装后的手动接入](framework-integration.md#npm-安装后的手动接入)。
+
+直接安装 RPM 后，请先补充状态记录，再用拥有目标框架配置的用户重试 adapter
+命令。
+
+```bash
+sudo yum install anolisa
+sudo anolisa --install-mode system adopt tokenless
+```
 
 由 anolisa 管理的安装第一次不会绕过 OpenClaw 安全扫描。只有错误明确给出此建议时，才应在审查报告后重试：
 
@@ -261,14 +271,15 @@ grep -R -n 'QODER_TOKENLESS_HOOKS' \
 如果曾直接运行 `dnf remove` 或 `rpm -e`：
 
 ```bash
-sudo anolisa repair tokenless
+sudo yum install anolisa
+sudo anolisa --install-mode system repair tokenless
 ```
 
 按照 repair 输出的计划操作。只有在 RPM 仍存在且输出明确要求重建记录时，才依次执行：
 
 ```bash
-sudo anolisa forget tokenless
-sudo anolisa adopt tokenless
+sudo anolisa --install-mode system forget tokenless
+sudo anolisa --install-mode system adopt tokenless
 ```
 
 `forget` 只删除 anolisa 状态，不卸载 RPM。

--- a/docs/user-guide/zh/troubleshooting.md
+++ b/docs/user-guide/zh/troubleshooting.md
@@ -100,7 +100,8 @@ anolisa env
 anolisa --verbose install tokenless
 
 # 替代方式：使用 YUM
-sudo yum install tokenless
+sudo yum install anolisa tokenless
+sudo anolisa --install-mode system adopt tokenless
 ```
 
 ---

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -167,7 +167,8 @@ variable to `true` does not re-enable a capability disabled in plugin configurat
 
 ### Install AgentSecCore
 
-The published ANOLISA raw package supports Linux x86_64 and requires CLI
+Source and RPM installations support Linux x86_64 and aarch64. The published
+ANOLISA raw package is limited to Linux x86_64 in system mode and requires CLI
 version 0.2.17 or later. Update the CLI through its installation owner:
 
 ```bash
@@ -185,8 +186,13 @@ sudo anolisa status sec-core
 `agent-sec-core`:
 
 ```bash
-sudo yum install agent-sec-core
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
 ```
+
+Installing the CLI from YUM makes it available on sudo's system path. Adoption
+records the directly installed RPM in system state so adapter commands can read
+its component contract.
 
 Developers building from source should use the repository-level entry point:
 
@@ -194,8 +200,13 @@ Developers building from source should use the repository-level entry point:
 ./scripts/build-all.sh --component sec-core
 ```
 
-Package installation places the framework adapters. Enable one as the user
-who owns the target framework configuration:
+The source build installs runtime and integration resources in user paths but
+does not register the component in ANOLISA state. Use the installed integration
+scripts instead of `anolisa adapter enable`; see
+[Source-build Integration](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md#source-build-integration).
+
+An ANOLISA-managed raw package or adopted RPM places the framework adapters.
+Enable one as the user who owns the target framework configuration:
 
 ```bash
 anolisa adapter scan

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -165,6 +165,43 @@ variable to `true` does not re-enable a capability disabled in plugin configurat
 | **Python3** | >= 3.6 |
 | **Rust** | >= 1.91 (for building linux-sandbox) |
 
+### Install AgentSecCore
+
+The published ANOLISA raw package supports Linux x86_64 and requires CLI
+version 0.2.17 or later. Update the CLI through its installation owner:
+
+```bash
+# CLI installed by get.agentic-os.sh
+anolisa update self
+
+# RPM-owned CLI
+sudo anolisa update self
+
+sudo anolisa --install-mode system install sec-core
+sudo anolisa status sec-core
+```
+
+`sec-core` is the ANOLISA component name. The RPM keeps the package name
+`agent-sec-core`:
+
+```bash
+sudo yum install agent-sec-core
+```
+
+Developers building from source should use the repository-level entry point:
+
+```bash
+./scripts/build-all.sh --component sec-core
+```
+
+Package installation places the framework adapters. Enable one as the user
+who owns the target framework configuration:
+
+```bash
+anolisa adapter scan
+anolisa adapter enable sec-core openclaw
+```
+
 ### Run the Security Workflow
 
 ```bash
@@ -199,12 +236,6 @@ make build-sandbox
 
 The binary is output to `linux-sandbox/target/release/linux-sandbox`.
 
-### Install via RPM
-
-```bash
-sudo yum install agent-sec-core
-```
-
 ### Protect Qwen Code from PII leakage
 
 The Qwen Code extension scans user input, tool input/output, and final model output
@@ -216,8 +247,8 @@ legacy `PII_CHECKER_ENABLED` switch when the new enabled switch is absent. Faile
 are audit-only in Qwen Code 0.19.9, and scanner failures remain fail-open.
 
 ```bash
-export PII_CHECKER_MODE=block
-./qwen-code-extension/scripts/deploy.sh
+anolisa adapter enable sec-core qwencode
+PII_CHECKER_MODE=block qwen
 ```
 
 See [the Qwen Code extension guide](qwen-code-extension/README.md) for configuration and

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -163,6 +163,41 @@ capability。
 | **Python3** | >= 3.6 |
 | **Rust** | >= 1.91（用于构建 linux-sandbox） |
 
+### 安装 AgentSecCore
+
+已发布的 ANOLISA raw 包支持 Linux x86_64，需要使用 0.2.17 或更高版本的 CLI。
+请根据 CLI 的安装来源完成更新。
+
+```bash
+# 通过 get.agentic-os.sh 安装的 CLI
+anolisa update self
+
+# 由 RPM 管理的 CLI
+sudo anolisa update self
+
+sudo anolisa --install-mode system install sec-core
+sudo anolisa status sec-core
+```
+
+`sec-core` 是 ANOLISA 中的组件名，RPM 继续使用包名 `agent-sec-core`。
+
+```bash
+sudo yum install agent-sec-core
+```
+
+从源码构建时，使用仓库级统一入口。
+
+```bash
+./scripts/build-all.sh --component sec-core
+```
+
+安装包会放置框架 adapter。请用拥有目标框架配置的用户启用 adapter。
+
+```bash
+anolisa adapter scan
+anolisa adapter enable sec-core openclaw
+```
+
 ### 执行安全工作流
 
 ```bash
@@ -197,12 +232,6 @@ make build-sandbox
 
 二进制文件输出到 `linux-sandbox/target/release/linux-sandbox`。
 
-### RPM 安装
-
-```bash
-sudo yum install agent-sec-core
-```
-
 ### 防止 Qwen Code 泄露 PII
 
 Qwen Code extension 默认以 `PII_CHECKER_MODE=observe` 扫描用户输入、工具
@@ -214,8 +243,8 @@ Qwen Code 在新 enabled 开关缺失时
 失败时仍保持 fail-open。
 
 ```bash
-export PII_CHECKER_MODE=block
-./qwen-code-extension/scripts/deploy.sh
+anolisa adapter enable sec-core qwencode
+PII_CHECKER_MODE=block qwen
 ```
 
 配置项及工具/模型后置输出的阻断边界见

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -165,8 +165,9 @@ capability。
 
 ### 安装 AgentSecCore
 
-已发布的 ANOLISA raw 包支持 Linux x86_64，需要使用 0.2.17 或更高版本的 CLI。
-请根据 CLI 的安装来源完成更新。
+源码和 RPM 安装支持 Linux x86_64、aarch64。已发布的 ANOLISA raw 包仅支持
+Linux x86_64 和 system mode，需要使用 0.2.17 或更高版本的 CLI。请根据 CLI
+的安装来源完成更新。
 
 ```bash
 # 通过 get.agentic-os.sh 安装的 CLI
@@ -182,8 +183,12 @@ sudo anolisa status sec-core
 `sec-core` 是 ANOLISA 中的组件名，RPM 继续使用包名 `agent-sec-core`。
 
 ```bash
-sudo yum install agent-sec-core
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
 ```
+
+从 YUM 安装 CLI 后，`sudo` 可以从系统路径找到 `anolisa`。`adopt` 会把直接
+安装的 RPM 写入 system 状态，adapter 命令随后才能读取组件契约。
 
 从源码构建时，使用仓库级统一入口。
 
@@ -191,7 +196,12 @@ sudo yum install agent-sec-core
 ./scripts/build-all.sh --component sec-core
 ```
 
-安装包会放置框架 adapter。请用拥有目标框架配置的用户启用 adapter。
+源码构建会把运行时和集成资源安装到用户目录，但不会在 ANOLISA 状态中注册
+组件。请使用已安装的集成脚本，不要继续执行 `anolisa adapter enable`。具体入口见
+[源码集成入口](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md#源码集成入口)。
+
+通过 ANOLISA 管理的 raw 包或已执行 `adopt` 的 RPM 会放置框架 adapter。
+请用拥有目标框架配置的用户启用 adapter。
 
 ```bash
 anolisa adapter scan

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -97,18 +97,20 @@ sudo agentsight trace --daemon \
 
 Query token consumption data.
 
+When the Linux systemd service owns the data, run these queries with `sudo`:
+
 ```bash
 # Today's token usage
-agentsight token
+sudo agentsight token
 
 # This week, compared to last week
-agentsight token --period week --compare
+sudo agentsight token --period week --compare
 
 # Detailed breakdown by role and type
-agentsight token --detail
+sudo agentsight token --detail
 
 # JSON output
-agentsight token --json
+sudo agentsight token --json
 ```
 
 ### `agentsight audit`
@@ -184,11 +186,14 @@ make build-all
 Run the tracer and the API server in two separate terminals:
 
 ```bash
+# Stop the packaged tracer before starting a foreground tracer
+sudo systemctl stop agentsight.service
+
 # Terminal 1: start eBPF tracing (writes to SQLite)
 sudo agentsight trace
 
 # Terminal 2: start the API server (reads from the same SQLite)
-agentsight serve
+sudo agentsight serve
 ```
 
 **macOS** (trajectory collector only):
@@ -310,6 +315,11 @@ sudo systemctl status agentsight.service
 The main unit runs eBPF tracing and the Dashboard together and starts the
 enforcer dependency in the required order. Open `http://localhost:7396` after
 the service becomes active.
+
+The unit runs as root with `UMask=0077`, so its data under
+`/var/log/sysak/.agentsight` is private. Use `sudo` for CLI queries and
+Dashboard access commands that read service-owned data. Stop the unit before
+starting a foreground tracer.
 
 ### Build from Source
 

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -297,6 +297,20 @@ Installs:
 The RPM is a Linux system package. Its units are installed but not enabled by
 default; when both units run, AgentSight is ordered after the enforcer.
 
+### Start the Service
+
+Both package routes leave the units stopped and disabled. Start the main unit
+when you are ready to begin collection:
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+The main unit runs eBPF tracing and the Dashboard together and starts the
+enforcer dependency in the required order. Open `http://localhost:7396` after
+the service becomes active.
+
 ### Build from Source
 
 ```bash

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -286,6 +286,18 @@ sudo yum install agentsight
 RPM 是 Linux system 包。两个单元会随包安装，但默认不会启用；当两个单元都运行时，
 AgentSight 会排在 enforcer 之后启动。
 
+### 启动服务
+
+两种包安装都会让单元保持停止且不启用。准备开始采集时，再启动主服务。
+
+```bash
+sudo systemctl enable --now agentsight.service
+sudo systemctl status agentsight.service
+```
+
+主服务会一起运行 eBPF trace 和 Dashboard，并按顺序带起 enforcer 依赖。
+服务进入 active 状态后，打开 `http://localhost:7396`。
+
 ### 从源码构建
 
 ```bash

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -97,18 +97,20 @@ sudo agentsight trace --daemon \
 
 查询 Token 用量数据。
 
+Linux systemd 服务写入的数据由 root 管理，查询时需要使用 `sudo`。
+
 ```bash
 # 查看今日 Token 用量
-agentsight token
+sudo agentsight token
 
 # 本周用量，与上周对比
-agentsight token --period week --compare
+sudo agentsight token --period week --compare
 
 # 按角色和类型的详细分解
-agentsight token --detail
+sudo agentsight token --detail
 
 # JSON 格式输出
-agentsight token --json
+sudo agentsight token --json
 ```
 
 ### `agentsight audit`
@@ -184,11 +186,14 @@ make build-all
 在两个终端中分别运行追踪器和 API 服务器：
 
 ```bash
+# 启动前台 tracer 前，先停止软件包提供的服务
+sudo systemctl stop agentsight.service
+
 # 终端 1：启动 eBPF 追踪（写入 SQLite）
 sudo agentsight trace
 
 # 终端 2：启动 API 服务器（读取同一 SQLite 文件）
-agentsight serve
+sudo agentsight serve
 ```
 
 **macOS**（仅轨迹采集）：
@@ -297,6 +302,10 @@ sudo systemctl status agentsight.service
 
 主服务会一起运行 eBPF trace 和 Dashboard，并按顺序带起 enforcer 依赖。
 服务进入 active 状态后，打开 `http://localhost:7396`。
+
+该单元以 root 身份和 `UMask=0077` 运行，因此
+`/var/log/sysak/.agentsight` 中的数据仅 root 可读。查询服务数据或读取
+Dashboard 访问信息时需要使用 `sudo`。启动前台 tracer 前也要先停止该单元。
 
 ### 从源码构建
 

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -106,6 +106,52 @@ Token-Less/
 
 ## Quick Start
 
+Install the published component with the ANOLISA CLI:
+
+The install script places `anolisa` in `~/.local/bin`, and a user-mode
+Tokenless installation places `tokenless`, `rtk`, and `toon` in that same
+directory. Export it once if the current shell has not picked it up yet.
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash
+
+# Make the default install directory available in this shell
+export PATH="$HOME/.local/bin:$PATH"
+anolisa --version
+anolisa install tokenless
+tokenless --version
+```
+
+Alinux users with the YUM repository configured may install the RPM instead:
+
+```bash
+sudo yum install anolisa tokenless
+sudo anolisa --install-mode system adopt tokenless
+```
+
+Installing the CLI from the same YUM repository makes it available on sudo's
+system path. `adopt` then records the directly installed RPM in system state so
+adapter commands can use its component contract.
+
+Current public packages support Linux x86_64/aarch64 and macOS Apple Silicon.
+Intel macOS does not currently have a published package. The repository's npm
+packaging sources are for release construction and are not a public
+`anolisa-tokenless` installation route. The retained
+`@anolisa/tokenless-darwin-x64` optional-dependency entry describes a release
+build target; it does not indicate registry availability.
+
+ANOLISA-managed and adopted RPM installations place the available adapters
+without changing an Agent framework's user configuration. Run these commands
+as the user who owns that configuration, and enable only the adapter you need:
+
+```bash
+anolisa adapter scan
+anolisa adapter enable tokenless openclaw
+anolisa adapter status tokenless
+```
+
+Developers building from source can use:
+
 ```bash
 # Clone repo (no submodules needed)
 git clone <repo-url>
@@ -115,7 +161,8 @@ cd Token-Less
 make setup
 ```
 
-Both methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, and deploy the adapters (hooks + OpenClaw plugin + Hermes plugin).
+The source setup installs `tokenless` to `~/.local/bin`, places the `rtk` and
+`toon` helpers alongside it, and deploys all adapters for development.
 
 ## CLI Usage
 
@@ -424,15 +471,6 @@ The installer creates a `tokenless.js` symbolic link in OpenCode's global
 `OPENCODE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and the explicit
 `TOKENLESS_OPENCODE_CONFIG_DIR` override.
 
-
-## npm Install
-
-```bash
-npm install -g anolisa-tokenless
-```
-
-This automatically installs the correct prebuilt binaries (`tokenless`, `rtk`, `toon`) for your platform.
-Supports Linux and macOS on x86_64 and arm64.
 
 ## Build
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -63,12 +63,60 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 
 ## 快速开始
 
+首选 ANOLISA CLI 安装已发布的组件。
+
+安装脚本会把 `anolisa` 放到 `~/.local/bin`。user mode 安装的 `tokenless`、
+`rtk` 和 `toon` 也在这个目录。如果当前 Shell 还找不到命令，先把该目录加入
+`PATH`。
+
 ```bash
-# 完整安装：构建 + 安装二进制 + 部署所有适配器
+curl -fsSL https://get.agentic-os.sh | bash
+
+# 让默认安装目录在当前 Shell 中生效
+export PATH="$HOME/.local/bin:$PATH"
+anolisa --version
+anolisa install tokenless
+tokenless --version
+```
+
+已配置 YUM 源的 Alinux 用户也可以安装 RPM 包。
+
+```bash
+sudo yum install anolisa tokenless
+sudo anolisa --install-mode system adopt tokenless
+```
+
+从同一 YUM 源安装 CLI 后，`sudo` 可以从系统路径找到 `anolisa`。`adopt` 会把
+直接安装的 RPM 写入 system 状态，adapter 命令随后才能读取组件契约。
+
+当前公开软件包支持 Linux x86_64、aarch64 和 macOS Apple Silicon。Intel
+Mac 暂无已发布的软件包。仓库中的 npm packaging 目录用于构建发布产物，
+目前不能通过公开的 `anolisa-tokenless` npm 包安装。源码中保留的
+`@anolisa/tokenless-darwin-x64` optional dependency 只是发布构建目标，
+不代表 registry 中已有可安装的软件包。
+
+通过 ANOLISA 管理的安装或已执行 `adopt` 的 RPM 会放置可用 adapter，但不会
+直接改动 Agent 框架的用户配置。请用拥有该配置的用户执行以下命令，并且只启用
+准备使用的 adapter。
+
+```bash
+anolisa adapter scan
+anolisa adapter enable tokenless openclaw
+anolisa adapter status tokenless
+```
+
+从源码构建适合开发者。
+
+```bash
+git clone <repo-url>
+cd Token-Less
+
+# 完整安装，构建并安装二进制，随后部署所有 adapter
 make setup
 ```
 
-安装完成后 `tokenless` 命令位于 `~/.local/bin`，RTK/TOON 辅助二进制同目录。
+源码安装会把 `tokenless` 放在 `~/.local/bin`，`rtk` 和 `toon` 辅助
+二进制也位于同一个目录，并部署开发所需的全部 adapter。
 
 ### OpenCode 安装
 
@@ -84,15 +132,6 @@ make opencode-install
 不会覆盖同名的非托管文件。配置目录支持 `OPENCODE_CONFIG_DIR`、
 `XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
 安装后重启 OpenCode 即可加载插件。
-
-## npm 安装
-
-```bash
-npm install -g anolisa-tokenless
-```
-
-自动安装适合您平台的预编译二进制文件（`tokenless`、`rtk`、`toon`）。
-支持 Linux 和 macOS 的 x86_64 和 arm64 架构。
 
 ## 查看 Token 节省明细
 

--- a/src/tokenless/npm/README.md
+++ b/src/tokenless/npm/README.md
@@ -2,7 +2,12 @@
 
 LLM token optimization toolkit — schema/response compression, command rewriting, and tool environment readiness.
 
-## Install
+> **Release status:** These npm packages are private and are not currently
+> published to the public registry. This document describes the intended
+> package layout and post-publication workflow; its platform rows are build
+> targets, not a list of packages that users can install today.
+
+## Install after publication
 
 ```bash
 npm install -g anolisa-tokenless

--- a/website/scripts/check-links.mjs
+++ b/website/scripts/check-links.mjs
@@ -37,6 +37,13 @@ for (const htmlFile of htmlFiles) {
     errors.push(`${path.relative(buildDir, htmlFile)}: duplicate DOM id "${id}"`);
   }
 
+  const article = html.match(/<article\b[^>]*>([\s\S]*?)<\/article>/)?.[1] ?? '';
+  if (/<a\b[^>]*>\s*(?:中文版|English)\s*<\/a>/.test(article)) {
+    errors.push(
+      `${path.relative(buildDir, htmlFile)}: inline locale switch duplicates the navbar`,
+    );
+  }
+
   for (const match of html.matchAll(/<a\b[^>]*\shref="([^"]+)"/g)) {
     const href = match[1];
     if (/^(?:https?:|mailto:|tel:|javascript:)/.test(href)) continue;

--- a/website/scripts/prepare-docs.mjs
+++ b/website/scripts/prepare-docs.mjs
@@ -114,6 +114,32 @@ async function rewriteLinks(markdown, source) {
   return output;
 }
 
+function stripLocaleSwitchLinks(markdown) {
+  let inFence = false;
+  let dropFollowingBlank = false;
+  return markdown
+    .split('\n')
+    .filter((line) => {
+      if (/^\s*(```|~~~)/.test(line)) {
+        inFence = !inFence;
+        dropFollowingBlank = false;
+        return true;
+      }
+      if (inFence) return true;
+      if (dropFollowingBlank && /^[ \t]*\r?$/.test(line)) {
+        dropFollowingBlank = false;
+        return false;
+      }
+      dropFollowingBlank = false;
+      if (/^\[(?:中文版|English)\]\([^)]+\)[ \t]*\r?$/.test(line)) {
+        dropFollowingBlank = true;
+        return false;
+      }
+      return true;
+    })
+    .join('\n');
+}
+
 function makeMdxSafe(markdown) {
   let inFence = false;
   return markdown
@@ -243,7 +269,10 @@ const categoryPositions = {
 
 const documentPositions = {
   'user-guide/installation.md': 2,
+  'user-guide/user-entrypoint/copilot-shell/quickstart.md': 1,
   'user-guide/user-entrypoint/cosh-ng/quickstart.md': 2,
+  'user-guide/token-saving/tokenless/quickstart.md': 1,
+  'user-guide/agent-security/agent-sec-core/quickstart.md': 1,
   'user-guide/user-entrypoint/cosh-ng/mcp.md': 4,
   'user-guide/user-entrypoint/cosh-ng/configuration.md': 7,
   'user-guide/user-entrypoint/cosh-ng/supported-distros.md': 8,
@@ -290,7 +319,8 @@ async function writeCategories(outputRoot, documents, locale) {
 async function prepareLocale(documents, outputRoot, locale) {
   for (const document of documents) {
     const sourceMarkdown = await readFile(path.join(repoRoot, document.source), 'utf8');
-    const markdown = makeMdxSafe(await rewriteLinks(sourceMarkdown, document.source));
+    const websiteMarkdown = stripLocaleSwitchLinks(sourceMarkdown);
+    const markdown = makeMdxSafe(await rewriteLinks(websiteMarkdown, document.source));
     const output = path.join(outputRoot, document.target);
     await mkdir(path.dirname(output), {recursive: true});
     await writeFile(output, `${frontMatter(document, sourceMarkdown, locale)}${markdown}`);

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -35,7 +35,7 @@ const content = {
   zh: {
     badge: 'Agentic OS 1.0',
     lead: 'Agent 原生的操作系统层。',
-    hook: '一条命令，让 Agent 少烧 30–70% 的工具输出 token。',
+    hook: '一条命令，让 Agent 少烧 30～70% 的工具输出 token。',
     systemScope: '这只是操作系统为 Agent 做的一件事——它还让 Agent 跑得起、退得回、守得住。',
     statement: '操作系统的使用者已经改变。ANOLISA 让 Agent 成为系统中的一等公民。',
     installLabel: '一个入口，按需启用',
@@ -183,7 +183,7 @@ const scenarios = {
       name: 'Token Flow',
       title: '让 Token 消耗可测、可省',
       surfaceTitle: '不换 Harness，一行命令开始节省 Token',
-      proof: '30–70% 工具输出压缩*',
+      proof: '30～70% 工具输出压缩*',
       surfaceBody: '支持 Claude Code、Codex、Qoder 等，压缩后仍可取回原文。',
       body:
         '从上下文压缩、记忆复用到开销追踪，Token Flow 让 Agent 的 Token 使用更高效、更透明，并可按需接入现有工作流。',


### PR DESCRIPTION
## Why

The latest `anolisa` CLI release changed the recommended AgentSecCore
installation flow, while the AgentSight and Tokenless guides still left key
startup and installation choices implicit. The website documentation also had
two competing language-switch paths that behaved differently.

## What changed

- Put Tokenless, Copilot Shell, and AgentSecCore quick starts first in the
  documentation sidebar without changing the existing homepage narrative.
- Keep the website language switch in the top-right navigation by stripping
  inline repository language links during the documentation build, while
  preserving matching links inside fenced code blocks.
- Clarify AgentSight package installation, systemd startup, Dashboard exposure,
  and the two-terminal manual `trace` and `serve` workflow.
- Document the AgentSecCore `anolisa install sec-core` flow introduced in CLI
  0.2.17+, while preserving the `agent-sec-core` RPM package name and adapter
  setup details.
- Keep Tokenless on its supported `anolisa install tokenless` path, add PATH
  recovery and version checks, and make the ANOLISA, RPM, and source-build
  priority explicit.
- Use `30～70%` for the Chinese homepage percentage range while retaining the
  existing English copy and scenario framing.

Preview: https://kongche-jbw.github.io/anolisa/

## Related issue

no-issue: documentation onboarding and fork preview refinement

## User / Agent impact

Users can reach the main component quick starts earlier in the documentation,
follow the current AgentSecCore and AgentSight startup flows, and switch
languages consistently from the website navigation.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Documentation now reflects the released CLI behavior. No runtime code or
component interfaces changed, so compatibility risk is low.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `npm run validate:locales --prefix website`
- `npm run typecheck --prefix website`
- `SITE_URL=https://kongche-jbw.github.io BASE_URL=/anolisa/ npm run build --prefix website`
- `SITE_URL=https://kongche-jbw.github.io BASE_URL=/anolisa/ npm run check:links --prefix website`
- GitHub Pages deployment and live preview verification:
  https://github.com/kongche-jbw/anolisa/actions/runs/31343410819

## Documentation and rollback

Updated the bilingual root quick starts, component READMEs, user guides, and
website documentation build scripts. Reverting the three commits restores the
previous installation guidance and navigation behavior.
