### PR TITLE
fix(cosh-ng): [shell] dedupe hook notices

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/finish.rs
@@ -6,10 +6,12 @@ use crate::agent::events::{
     flush_cosh_request_filter_into_active_run, render_agent_structured_events,
     render_held_events_into_active_run, state_has_pending_interaction,
 };
-use crate::agent::governance::hook_notification_display_text;
+use crate::agent::governance::{
+    hook_notification_display_text, project_hook_notifications_for_display,
+};
 use crate::agent::run::{
     has_queued_run_before_held_text, start_agent_run_with_origin, start_pending_agent_run,
-    ActiveAgentRun, PendingRequestClass,
+    ActiveAgentRun, PendingHookNotification, PendingRequestClass,
 };
 use crate::recommendation::personal_integration::record_finished_agent_run;
 use crate::runtime::evidence_requests::{
@@ -90,32 +92,24 @@ pub(crate) fn finish_active_agent_run<W: Write>(
     // Drain any unconsumed pending hook notifications into deferred_events
     // (orphan case: hook returned block, so no ToolPermissionRequest was emitted)
     let i18n = I18n::new(active_run.language);
+    let run_id = active_run.request.id.clone();
     for notification in active_run.pending_hook_notifications.drain(..) {
-        let display_text = hook_notification_display_text(
-            &notification.hook_name,
-            &notification.message,
-            notification.decision.as_deref(),
-            &i18n,
-        );
-        active_run.deferred_events.push(GovernedEvent {
-            decision: GovernanceDecision::Display,
-            policy_decision: GovernancePolicyDecision::DisplayOnly,
-            event: AgentEvent::HookNotification {
-                run_id: active_run.request.id.clone(),
-                hook_name: notification.hook_name,
-                message: notification.message,
-                tool_use_id: notification.tool_use_id,
-                decision: notification.decision,
-            },
-            reason: "orphan hook notification".to_string(),
-            display_text,
-            auto_execute: false,
-        });
+        active_run
+            .deferred_events
+            .push(pending_hook_notification_event(
+                &run_id,
+                &notification,
+                &i18n,
+            ));
     }
     if !active_run.deferred_events.is_empty() {
+        // Projection is throwaway and display-only: `deferred_events` itself
+        // still holds every original notification for approval linking and
+        // audit.
+        let displayed = project_hook_notifications_for_display(&active_run.deferred_events, &i18n);
         active_run
             .renderer
-            .write_governed_events(output, &active_run.deferred_events)?;
+            .write_governed_events(output, &displayed)?;
     }
     let evidence_requests = record_cosh_requests_from_active_run(state, &mut active_run);
     for notice in &evidence_requests.notices {
@@ -240,16 +234,52 @@ fn render_recovery_deferred_context<W: Write>(
     active_run: &ActiveAgentRun,
     output: &mut W,
 ) -> std::io::Result<()> {
-    let events = active_run
+    let i18n = I18n::new(active_run.language);
+    let mut events = active_run
         .deferred_events
         .iter()
         .filter(|event| !governed_event_is_provider_timeout(event))
         .cloned()
         .collect::<Vec<_>>();
+    events.extend(
+        active_run
+            .pending_hook_notifications
+            .iter()
+            .map(|notification| {
+                pending_hook_notification_event(&active_run.request.id, notification, &i18n)
+            }),
+    );
     if events.is_empty() {
         return Ok(());
     }
+    let events = project_hook_notifications_for_display(&events, &i18n);
     active_run.renderer.write_governed_events(output, &events)
+}
+
+fn pending_hook_notification_event(
+    run_id: &str,
+    notification: &PendingHookNotification,
+    i18n: &I18n,
+) -> GovernedEvent {
+    GovernedEvent {
+        decision: GovernanceDecision::Display,
+        policy_decision: GovernancePolicyDecision::DisplayOnly,
+        event: AgentEvent::HookNotification {
+            run_id: run_id.to_string(),
+            hook_name: notification.hook_name.clone(),
+            message: notification.message.clone(),
+            tool_use_id: notification.tool_use_id.clone(),
+            decision: notification.decision.clone(),
+        },
+        reason: "orphan hook notification".to_string(),
+        display_text: hook_notification_display_text(
+            &notification.hook_name,
+            &notification.message,
+            notification.decision.as_deref(),
+            i18n,
+        ),
+        auto_execute: false,
+    }
 }
 
 fn render_recovery_context_before_notice<W: Write>(
@@ -318,7 +348,8 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::agent::run::{PendingAgentRequest, PendingHookNotification, PendingRequestClass};
+    use crate::agent::events::render_active_agent_event;
+    use crate::agent::run::{PendingAgentRequest, PendingRequestClass};
     use crate::runtime::state::InlineState;
     use crate::types::{AgentMode, AgentRequest, CommandBlock, CommandStatus, OutputRefs};
 
@@ -412,6 +443,88 @@ mod tests {
         assert!(rendered.contains("消息: 未提供消息"), "{rendered}");
         assert!(rendered.contains("决策: 未指定"), "{rendered}");
         assert!(!rendered.contains("unknown hook"), "{rendered}");
+    }
+
+    // #2197: a hook that fires on every tool call used to dump one three-line
+    // block per hit into the same Governance panel. The finish path must render
+    // the collapsed projection while `deferred_events` keeps every original.
+    #[test]
+    fn finish_collapses_repeated_allow_hook_notifications_into_one_line() {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut state = InlineState::default();
+        let mut active_run = active_run(&adapter, "run-1", Language::EnUs);
+        for _ in 0..3 {
+            active_run
+                .pending_hook_notifications
+                .push(PendingHookNotification {
+                    tool_use_id: Some("tool-1".to_string()),
+                    hook_name: "pii-checker".to_string(),
+                    message: "[pii-checker] card hit".to_string(),
+                    decision: Some("allow".to_string()),
+                });
+        }
+        state.agent_run.active = Some(active_run);
+        let mut output = Vec::new();
+
+        finish_active_agent_run(&mut state, &mut output, &adapter).expect("finish run");
+
+        let rendered = String::from_utf8_lossy(&output);
+        assert_eq!(rendered.matches("pii-checker").count(), 1, "{rendered}");
+        assert!(
+            rendered.contains("• pii-checker: card hit ×3"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("Decision: allow"), "{rendered}");
+    }
+
+    #[test]
+    fn recovery_context_collapses_allow_notices_and_omits_provider_timeout() {
+        let adapter = AdapterInstance::Fake(FakeAgentAdapter);
+        let mut active_run = active_run(&adapter, "run-1", Language::EnUs);
+        let mut ingress_output = Vec::new();
+        for _ in 0..3 {
+            render_active_agent_event(
+                &mut active_run,
+                AgentEvent::HookNotification {
+                    run_id: "run-1".to_string(),
+                    hook_name: "pii-checker".to_string(),
+                    message: "[pii-checker] card hit".to_string(),
+                    tool_use_id: Some("tool-1".to_string()),
+                    decision: Some("allow".to_string()),
+                },
+                &mut ingress_output,
+                None,
+            )
+            .expect("ingest hook notification");
+        }
+        render_active_agent_event(
+            &mut active_run,
+            AgentEvent::AgentFailed {
+                run_id: "run-1".to_string(),
+                error: "PROVIDER TIMEOUT MUST STAY HIDDEN".to_string(),
+                error_code: Some(PROVIDER_TIMEOUT_ERROR_CODE.to_string()),
+                max_turns: None,
+            },
+            &mut ingress_output,
+            None,
+        )
+        .expect("ingest provider timeout");
+        assert_eq!(active_run.pending_hook_notifications.len(), 3);
+        let mut output = Vec::new();
+
+        render_recovery_deferred_context(&active_run, &mut output)
+            .expect("render recovery context");
+
+        let rendered = String::from_utf8_lossy(&output);
+        assert_eq!(rendered.matches("pii-checker").count(), 1, "{rendered}");
+        assert!(
+            rendered.contains("• pii-checker: card hit ×3"),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("PROVIDER TIMEOUT MUST STAY HIDDEN"),
+            "{rendered}"
+        );
     }
 
     // Finishes an active `run-1` holding one text delta, with an approved handoff

--- a/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/governance.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     config::Language,
     i18n::{I18n, MessageId},
@@ -258,6 +260,116 @@ pub(crate) fn hook_notification_display_text(
             ("decision", decision),
         ],
     )
+}
+
+/// Builds the throwaway Governance-panel projection for one batch of governed
+/// events, collapsing repeated permissive hook notices into one weak line each.
+///
+/// Permissive notices (`allow` / `approve`) carry no decision for the user to
+/// make, so a hook that fires on every tool call floods the panel with byte
+/// identical three-line blocks (issue #2197). They collapse to
+/// `• {hook}: {message}` plus a ` ×N` hit count; every other decision —
+/// including an absent or unrecognized one — keeps the full multi-line form so
+/// blocked and asked-about actions stay equally prominent.
+///
+/// The returned events are for rendering only: callers must keep the input
+/// slice intact, because approval-card linking and the audit trail still need
+/// every original notification.
+// The lib facade compiles this module without the binary's `agent::finish`, so
+// the only non-test caller is invisible from that target.
+#[allow(dead_code)]
+pub(crate) fn project_hook_notifications_for_display(
+    events: &[GovernedEvent],
+    i18n: &I18n,
+) -> Vec<GovernedEvent> {
+    let mut projected: Vec<GovernedEvent> = Vec::with_capacity(events.len());
+    // Aggregation key -> (index into `projected`, hit count). Keyed on the
+    // normalized message rather than a digit-generalized shape: numbers such as
+    // the `[REDACTED_CARD:2603]` sample distinguish separate security hits and
+    // must never be merged away.
+    let mut collapsed: HashMap<(String, String), (usize, usize)> = HashMap::new();
+
+    for event in events {
+        let Some((hook_name, message)) = permissive_hook_notification_parts(event) else {
+            projected.push(event.clone());
+            continue;
+        };
+
+        let key = (
+            hook_name.trim().to_string(),
+            normalize_hook_message(hook_name, message),
+        );
+        if let Some((_, hits)) = collapsed.get_mut(&key) {
+            *hits += 1;
+            continue;
+        }
+
+        // First occurrence keeps its original position, so panel order still
+        // matches the order the hooks actually fired in.
+        let mut summary = event.clone();
+        summary.display_text = hook_notification_summary_line(&key.0, &key.1, i18n);
+        collapsed.insert(key, (projected.len(), 1));
+        projected.push(summary);
+    }
+
+    for (index, hits) in collapsed.into_values() {
+        if hits > 1 {
+            projected[index].display_text.push_str(&format!(" ×{hits}"));
+        }
+    }
+
+    projected
+}
+
+/// Returns the raw `(hook_name, message)` when this event is a hook
+/// notification whose decision only confirms that the run continued.
+fn permissive_hook_notification_parts(event: &GovernedEvent) -> Option<(&str, &str)> {
+    let AgentEvent::HookNotification {
+        hook_name,
+        message,
+        decision,
+        ..
+    } = &event.event
+    else {
+        return None;
+    };
+
+    let decision = decision.as_deref()?.trim();
+    (decision.eq_ignore_ascii_case("allow") || decision.eq_ignore_ascii_case("approve"))
+        .then_some((hook_name.as_str(), message.as_str()))
+}
+
+/// Normalizes a hook message for aggregation and single-line display: collapse
+/// whitespace runs, then drop a leading `[hook_name]` that exactly repeats the
+/// hook name the panel already prints.
+fn normalize_hook_message(hook_name: &str, message: &str) -> String {
+    let collapsed = message.split_whitespace().collect::<Vec<_>>().join(" ");
+    let hook_name = hook_name.trim();
+    if hook_name.is_empty() {
+        return collapsed;
+    }
+
+    if let Some(rest) = collapsed.strip_prefix(&format!("[{hook_name}]")) {
+        return rest.trim_start().to_string();
+    }
+    collapsed
+}
+
+/// Renders one collapsed permissive notice, reusing the localized fallbacks for
+/// an empty hook name or message.
+fn hook_notification_summary_line(hook_name: &str, message: &str, i18n: &I18n) -> String {
+    let hook_name = if hook_name.is_empty() {
+        i18n.t(MessageId::AgentGovernanceHookUnknown)
+    } else {
+        hook_name
+    };
+    let message = if message.is_empty() {
+        i18n.t(MessageId::AgentGovernanceHookNoMessage)
+    } else {
+        message
+    };
+
+    format!("• {hook_name}: {message}")
 }
 
 fn render_recommended_commands(commands: &[String], i18n: &I18n) -> String {

--- a/src/cosh-ng/crates/cosh-shell/src/agent/governance_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/governance_tests.rs
@@ -1,0 +1,316 @@
+//! Display-projection regressions for the Governance panel (issue #2197).
+//!
+//! Every test here drives the real governance pass first, so the projection is
+//! exercised against the same `GovernedEvent` shapes `finish` renders.
+
+use super::governance::{
+    govern_agent_events_with_language, project_hook_notifications_for_display,
+};
+use crate::config::Language;
+use crate::i18n::I18n;
+use crate::types::{AgentEvent, GovernedEvent, Policy};
+
+const PII_ALLOW_MESSAGE: &str = "[pii-checker] detected 2 sensitive items; type: credit_card; \
+     severity: warn; masked sample: [REDACTED_CARD:2603]; the request continues.";
+
+fn hook_event(hook_name: &str, message: &str, decision: Option<&str>) -> AgentEvent {
+    AgentEvent::HookNotification {
+        run_id: "run-1".to_string(),
+        hook_name: hook_name.to_string(),
+        message: message.to_string(),
+        tool_use_id: Some("tool-1".to_string()),
+        decision: decision.map(ToString::to_string),
+    }
+}
+
+/// Governs `events`, then projects them for display. Returns the governed input
+/// (untouched) alongside the projection so tests can assert on both.
+fn govern_and_project(
+    events: &[AgentEvent],
+    language: Language,
+) -> (Vec<GovernedEvent>, Vec<GovernedEvent>) {
+    let governed = govern_agent_events_with_language(events, &Policy::default(), language);
+    let projected = project_hook_notifications_for_display(&governed.events, &I18n::new(language));
+    (governed.events, projected)
+}
+
+fn display_texts(events: &[GovernedEvent]) -> Vec<&str> {
+    events
+        .iter()
+        .map(|event| event.display_text.as_str())
+        .collect()
+}
+
+#[test]
+fn hook_notification_projection_collapses_identical_allow_notices_with_hit_count() {
+    let events = vec![
+        hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow")),
+        hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow")),
+        hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow")),
+    ];
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(projected.len(), 1);
+    let line = &projected[0].display_text;
+    assert!(line.ends_with(" ×3"), "{line}");
+    // Collapsed notices are single-line weak hints: no `Decision: allow` row,
+    // and no duplicated `[pii-checker]` prefix beside the hook name.
+    assert_eq!(line.lines().count(), 1, "{line}");
+    assert!(
+        line.starts_with("• pii-checker: detected 2 sensitive items;"),
+        "{line}"
+    );
+    assert!(!line.contains("Decision"), "{line}");
+    assert!(!line.contains("[pii-checker]"), "{line}");
+    // Digits still distinguish the underlying security hit.
+    assert!(line.contains("[REDACTED_CARD:2603]"), "{line}");
+}
+
+#[test]
+fn hook_notification_projection_omits_hit_count_for_a_single_allow_notice() {
+    let events = vec![hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow"))];
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(projected.len(), 1);
+    assert!(
+        !projected[0].display_text.contains('×'),
+        "{:?}",
+        projected[0]
+    );
+}
+
+#[test]
+fn hook_notification_projection_keeps_distinct_detection_counts_as_separate_summaries() {
+    let two_items = PII_ALLOW_MESSAGE;
+    let one_item = "[pii-checker] detected 1 sensitive item; type: credit_card; \
+         severity: warn; masked sample: [REDACTED_CARD:2603]; the request continues.";
+    let mut events = vec![hook_event("pii-checker", two_items, Some("allow")); 3];
+    events.extend(vec![hook_event("pii-checker", one_item, Some("allow")); 9]);
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(projected.len(), 2);
+    let lines = display_texts(&projected);
+    assert!(
+        lines[0].contains("detected 2 sensitive items") && lines[0].ends_with(" ×3"),
+        "{lines:?}"
+    );
+    assert!(
+        lines[1].contains("detected 1 sensitive item") && lines[1].ends_with(" ×9"),
+        "{lines:?}"
+    );
+}
+
+// Redacted samples carry the digits that tell two security hits apart; merging
+// them would report one event where two happened.
+#[test]
+fn hook_notification_projection_keeps_distinct_redacted_numbers_apart() {
+    let events = vec![
+        hook_event(
+            "pii-checker",
+            "masked sample: [REDACTED_CARD:2603]",
+            Some("allow"),
+        ),
+        hook_event(
+            "pii-checker",
+            "masked sample: [REDACTED_CARD:9471]",
+            Some("allow"),
+        ),
+        hook_event(
+            "pii-checker",
+            "masked sample: [REDACTED_CARD:2603]",
+            Some("allow"),
+        ),
+    ];
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(
+        display_texts(&projected),
+        [
+            "• pii-checker: masked sample: [REDACTED_CARD:2603] ×2",
+            "• pii-checker: masked sample: [REDACTED_CARD:9471]",
+        ]
+    );
+}
+
+#[test]
+fn hook_notification_projection_keeps_different_hooks_apart() {
+    let events = vec![
+        hook_event("pii-checker", "same message", Some("allow")),
+        hook_event("secret-scanner", "same message", Some("allow")),
+        hook_event("pii-checker", "same message", Some("allow")),
+    ];
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(
+        display_texts(&projected),
+        [
+            "• pii-checker: same message ×2",
+            "• secret-scanner: same message",
+        ]
+    );
+}
+
+// Decisions that changed or gated the run must stay equally prominent even when
+// the text repeats verbatim: collapsing them would hide how often a command was
+// actually blocked.
+#[test]
+fn hook_notification_projection_keeps_blocking_hook_notification_decisions_expanded() {
+    let mut events = Vec::new();
+    for decision in ["block", "deny", "reject", "ask"] {
+        events.push(hook_event(
+            "sandbox-guard",
+            "blocked reboot",
+            Some(decision),
+        ));
+        events.push(hook_event(
+            "sandbox-guard",
+            "blocked reboot",
+            Some(decision),
+        ));
+    }
+
+    let (governed, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(projected.len(), 8);
+    assert_eq!(display_texts(&governed), display_texts(&projected));
+    assert_eq!(
+        projected[0].display_text,
+        "Hook: sandbox-guard\nMessage: blocked reboot\nDecision: block"
+    );
+    assert!(projected
+        .iter()
+        .all(|event| !event.display_text.contains('×')));
+}
+
+// `passthrough` is not a permissive verdict the panel may weaken, and an
+// unknown or absent decision must never be guessed at.
+#[test]
+fn hook_notification_projection_keeps_unrecognized_hook_notification_decisions_expanded() {
+    let events = vec![
+        hook_event("hook-a", "same message", Some("passthrough")),
+        hook_event("hook-a", "same message", Some("passthrough")),
+        hook_event("hook-b", "same message", Some("   ")),
+        hook_event("hook-b", "same message", Some("   ")),
+        hook_event("hook-c", "same message", None),
+        hook_event("hook-c", "same message", None),
+        hook_event("hook-d", "same message", Some("quarantine")),
+        hook_event("hook-d", "same message", Some("quarantine")),
+    ];
+
+    let (governed, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(display_texts(&governed), display_texts(&projected));
+    assert_eq!(
+        projected[2].display_text,
+        "Hook: hook-b\nMessage: same message\nDecision: unspecified"
+    );
+    assert_eq!(
+        projected[6].display_text,
+        "Hook: hook-d\nMessage: same message\nDecision: quarantine"
+    );
+}
+
+// Only an exact `[hook_name]` prefix is redundant with the hook column; any
+// other bracketed lead-in is real message content.
+#[test]
+fn hook_notification_projection_strips_only_the_exact_hook_notification_prefix() {
+    let events = vec![
+        hook_event("pii-checker", "[pii-checker] body", Some("allow")),
+        hook_event("pii-checker", "[pii-checker-v2] body", Some("allow")),
+        hook_event("pii-checker", "[other] body", Some("allow")),
+    ];
+
+    let (governed, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(
+        display_texts(&projected),
+        [
+            "• pii-checker: body",
+            "• pii-checker: [pii-checker-v2] body",
+            "• pii-checker: [other] body",
+        ]
+    );
+    // The stored event keeps the provider's original text verbatim.
+    assert!(matches!(
+        &governed[0].event,
+        AgentEvent::HookNotification { hook_name, message, decision, .. }
+            if hook_name == "pii-checker"
+                && message == "[pii-checker] body"
+                && decision.as_deref() == Some("allow")
+    ));
+}
+
+#[test]
+fn hook_notification_projection_reuses_localized_fallbacks_for_empty_hook_and_message() {
+    let events = vec![
+        hook_event("  ", "   ", Some(" ALLOW ")),
+        hook_event("  ", "   ", Some("Approve")),
+    ];
+
+    let (_, en) = govern_and_project(&events, Language::EnUs);
+    let (_, zh) = govern_and_project(&events, Language::ZhCn);
+
+    // Decision matching trims and ignores ASCII case, so both spellings land in
+    // the same summary.
+    assert_eq!(
+        display_texts(&en),
+        ["• unknown hook: no message provided ×2"]
+    );
+    assert_eq!(display_texts(&zh), ["• 未知 Hook: 未提供消息 ×2"]);
+}
+
+#[test]
+fn hook_notification_projection_preserves_first_seen_order_and_other_events() {
+    let events = vec![
+        AgentEvent::TextDelta {
+            run_id: "run-1".to_string(),
+            text: "answer".to_string(),
+        },
+        hook_event("pii-checker", "hit", Some("allow")),
+        AgentEvent::AgentCompleted {
+            run_id: "run-1".to_string(),
+            summary: "done".to_string(),
+        },
+        hook_event("pii-checker", "hit", Some("allow")),
+    ];
+
+    let (_, projected) = govern_and_project(&events, Language::EnUs);
+
+    assert_eq!(
+        display_texts(&projected),
+        ["answer", "• pii-checker: hit ×2", "done"]
+    );
+}
+
+// The projection is a temporary view: it must not replace the governed source
+// events or change the governance audit cardinality derived from them.
+#[test]
+fn hook_notification_projection_preserves_source_events_and_audit_cardinality() {
+    let events = vec![
+        hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow")),
+        hook_event("pii-checker", PII_ALLOW_MESSAGE, Some("allow")),
+        hook_event("sandbox-guard", "blocked reboot", Some("block")),
+    ];
+
+    let governed = govern_agent_events_with_language(&events, &Policy::default(), Language::EnUs);
+    let projected =
+        project_hook_notifications_for_display(&governed.events, &I18n::new(Language::EnUs));
+
+    assert_eq!(projected.len(), 2);
+    assert_eq!(governed.events.len(), 3);
+    assert_eq!(governed.audit.len(), 3);
+    assert_eq!(
+        governed.events[0].display_text,
+        format!("Hook: pii-checker\nMessage: {PII_ALLOW_MESSAGE}\nDecision: allow")
+    );
+    assert!(matches!(
+        &governed.events[0].event,
+        AgentEvent::HookNotification { message, decision, .. }
+            if message == PII_ALLOW_MESSAGE && decision.as_deref() == Some("allow")
+    ));
+}

--- a/src/cosh-ng/crates/cosh-shell/src/agent/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/public.rs
@@ -4,4 +4,8 @@ mod display;
 #[path = "governance.rs"]
 mod governance;
 
+#[cfg(test)]
+#[path = "governance_tests.rs"]
+mod governance_tests;
+
 pub use governance::{govern_agent_events, govern_agent_events_with_language, GovernanceOutput};


### PR DESCRIPTION
## Why

Repeated permissive hook notifications were rendered as identical three-line
Governance blocks at the end of an Agent run. A single PII finding could
therefore flood the terminal while carrying no additional decision for the
user.

## What changed

- Project repeated `allow` and `approve` hook notices into one weak summary
  line with an occurrence count.
- Preserve distinct messages, redacted identifiers, blocking decisions, raw
  governed events, and audit cardinality.
- Apply the projection to normal completion and recovery rendering, with
  focused regressions for both paths.

## Related issue

Closes #2197

## User / Agent impact

Repeated permissive notices now render as concise lines such as
`• pii-checker: card hit ×3`. Blocking, denying, asking, unknown, and missing
decisions retain the existing full `Hook` / `Message` / `Decision` display.

## Risk and compatibility

Low risk. The change is display-only and does not modify hook protocol events,
approval linking, or audit inputs. Aggregation remains scoped to one rendered
batch.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --bins agent::finish::tests::recovery_context_collapses_allow_notices_and_omits_provider_timeout -- --exact` (1 passed)
- `cargo test --package cosh-shell --bins agent::finish::tests::finish_collapses_repeated_allow_hook_notifications_into_one_line -- --exact` (1 passed)
- `cargo test --package cosh-shell --bins agent::finish::tests::finish_renders_orphan_hook_notification_with_fallbacks -- --exact` (1 passed)
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`

No ECS, real-provider, or manual TTY validation was run; those paths are left
to CI or follow-up validation.

## Documentation and rollback

No documentation changes are required. Revert commit
`7147d69a660e8a250680f4ac41fda5d99fd1b97d` to restore the previous rendering.