### PR TITLE
feat(tokenless): add init command for community onboarding

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -221,7 +221,31 @@ The npm postinstall script attempts to copy adapter resources under:
 
 Confirm that this directory exists. Adapter copying is supplementary and fails open with a warning; a successful binary install can therefore exist without this copy. If it is absent, review the npm postinstall warning and prefer an anolisa-managed installation.
 
-An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, and Qwen Code provide their own install scripts:
+An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it.
+
+### Quick setup with `tokenless init`
+
+After installing the npm package or building from source, run `tokenless init` to detect installed agent frameworks and guide adapter installation:
+
+```bash
+# Scan and display all framework statuses
+tokenless init --list
+
+# Install a specific adapter
+tokenless init --framework claude-code
+
+# Install all installable adapters (non-interactive)
+tokenless init --all
+
+# Interactive selection (when stdin is a terminal)
+tokenless init
+```
+
+`tokenless init` reads the adapter manifest, runs each framework's `detect.sh`, and reports whether the adapter is ready, installable, or missing prerequisites — then runs `install.sh` for the selected framework.
+
+### Manual install scripts
+
+OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, and Qwen Code provide their own install scripts:
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -207,7 +207,31 @@ npm 的 postinstall 脚本会尝试把 Adapter 资源复制到：
 
 应确认该目录确实存在。Adapter 复制属于补充步骤，失败时只输出警告，不会让二进制安装失败；因此可能出现命令可用但这里没有资源副本的情况。目录缺失时应检查 npm postinstall 警告，并优先改用 anolisa 管理的安装。
 
-npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode 和 Qwen Code 可以运行各自的安装脚本：
+npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。
+
+### 使用 `tokenless init` 快速设置
+
+安装 npm 包或从源码构建后，运行 `tokenless init` 检测已安装的 Agent 框架并引导适配器安装：
+
+```bash
+# 扫描并显示所有框架状态
+tokenless init --list
+
+# 安装指定适配器
+tokenless init --framework claude-code
+
+# 安装所有可安装的适配器（非交互模式）
+tokenless init --all
+
+# 交互式选择（stdin 为终端时）
+tokenless init
+```
+
+`tokenless init` 读取适配器清单，运行各框架的 `detect.sh`，报告适配器状态（就绪 / 可安装 / 缺少前置依赖），然后为选定框架执行 `install.sh`。
+
+### 手动安装脚本
+
+OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode 和 Qwen Code 可以运行各自的安装脚本：
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,10 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+### Added
+
+- `tokenless init` command: detects installed agent frameworks, reports adapter status (ready / installable / missing prerequisites), and runs the appropriate `install.sh` to register the tokenless adapter — providing a single entry point for community onboarding.
+
 ## [0.7.10] - 2026-08-19
 
 ### Added

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -847,6 +847,7 @@ dependencies = [
  "libc",
  "regex",
  "rusqlite",
+ "serde",
  "serde_json",
  "tempfile",
  "tokenless-ccr",

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -16,6 +16,7 @@ tokenless-ccr = { path = "../tokenless-ccr" }
 tokenless-runtime = { path = "../tokenless-runtime" }
 dirs.workspace = true
 clap.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 toon-format.workspace = true
 chrono = { workspace = true, features = ["serde"] }

--- a/src/tokenless/crates/tokenless-cli/src/init.rs
+++ b/src/tokenless/crates/tokenless-cli/src/init.rs
@@ -1,0 +1,320 @@
+//! Community entry point — detect agent frameworks and install adapters.
+//!
+//! Scans the adapter directory for framework-specific `detect.sh` scripts,
+//! reports each framework's status, and optionally runs `install.sh` to
+//! register the tokenless adapter with the selected framework.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, IsTerminal as _, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+
+/// Sub-path from a share root to the tokenless adapter directory.
+const ADAPTER_SUBPATH: &str = "anolisa/adapters/tokenless";
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    targets: BTreeMap<String, ManifestTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestTarget {
+    #[serde(default)]
+    actions: Option<ManifestActions>,
+    #[serde(default)]
+    capabilities: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestActions {
+    detect: Option<String>,
+    install: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetectStatus {
+    Ready,
+    Installable,
+    MissingPrereqs,
+    NotChecked,
+}
+
+impl DetectStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Installable => "installable",
+            Self::MissingPrereqs => "missing prereqs",
+            Self::NotChecked => "n/a",
+        }
+    }
+}
+
+struct FrameworkInfo {
+    name: String,
+    status: DetectStatus,
+    capabilities: Vec<String>,
+    install_script: Option<String>,
+}
+
+/// Find the adapter directory by checking known locations.
+fn find_adapter_dir() -> Option<PathBuf> {
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".local/share").join(ADAPTER_SUBPATH);
+        if has_manifest(&p) {
+            return Some(p);
+        }
+    }
+    for prefix in ["/usr/share", "/usr/local/share"] {
+        let p = PathBuf::from(prefix).join(ADAPTER_SUBPATH);
+        if has_manifest(&p) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn has_manifest(dir: &Path) -> bool {
+    dir.join("manifest.json").exists() || dir.join("manifest.json.in").exists()
+}
+
+/// Load and parse the adapter manifest. Falls back to the `.in` template
+/// (with `@VERSION@` left as-is) when the stamped copy is absent.
+fn load_manifest(adapter_dir: &Path) -> Result<Manifest, String> {
+    let manifest_path = adapter_dir.join("manifest.json");
+    let content = if manifest_path.exists() {
+        fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("failed to read manifest.json: {}", e))?
+    } else {
+        fs::read_to_string(adapter_dir.join("manifest.json.in"))
+            .map_err(|e| format!("failed to read manifest.json.in: {}", e))?
+    };
+    serde_json::from_str(&content).map_err(|e| format!("failed to parse manifest: {}", e))
+}
+
+/// Extract hook names from the capabilities field for display.
+fn extract_hooks(cap: &Option<serde_json::Value>) -> Vec<String> {
+    match cap {
+        Some(serde_json::Value::Object(map)) => match map.get("hooks") {
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|h| h.as_str().map(String::from))
+                .collect(),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+/// Run `detect.sh` for a framework and interpret the tri-state exit code.
+fn run_detect(adapter_dir: &Path, name: &str, detect_script: &str) -> DetectStatus {
+    let script = adapter_dir.join(detect_script);
+    if !script.exists() {
+        return DetectStatus::NotChecked;
+    }
+    match Command::new("bash")
+        .arg(&script)
+        .env("ANOLISA_COMPONENT", "tokenless")
+        .env("ANOLISA_TARGET", name)
+        .env("ANOLISA_ADAPTER_DIR", adapter_dir)
+        .output()
+    {
+        Ok(out) => match out.status.code() {
+            Some(0) => DetectStatus::Ready,
+            Some(1) => DetectStatus::Installable,
+            _ => DetectStatus::MissingPrereqs,
+        },
+        Err(_) => DetectStatus::MissingPrereqs,
+    }
+}
+
+/// Run `install.sh` for a framework, streaming output to the terminal.
+fn run_install(adapter_dir: &Path, name: &str, install_script: &str) -> Result<(), String> {
+    let script = adapter_dir.join(install_script);
+    if !script.exists() {
+        return Err(format!("install script not found: {}", script.display()));
+    }
+    let status = Command::new("bash")
+        .arg(&script)
+        .env("ANOLISA_COMPONENT", "tokenless")
+        .env("ANOLISA_TARGET", name)
+        .env("ANOLISA_ADAPTER_DIR", adapter_dir)
+        .status()
+        .map_err(|e| format!("failed to run install.sh: {}", e))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "install.sh for {} exited with code {}",
+            name,
+            status.code().unwrap_or(-1)
+        ))
+    }
+}
+
+pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), (String, i32)> {
+    let adapter_dir = find_adapter_dir().ok_or_else(|| {
+        (
+            "Adapter directory not found.\nInstall tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`."
+                .to_string(),
+            1,
+        )
+    })?;
+
+    let manifest = load_manifest(&adapter_dir).map_err(|e| (e, 1))?;
+
+    let mut frameworks: Vec<FrameworkInfo> = Vec::new();
+    for (name, target) in &manifest.targets {
+        let caps = extract_hooks(&target.capabilities);
+        let actions = match &target.actions {
+            Some(a) => a,
+            None => {
+                frameworks.push(FrameworkInfo {
+                    name: name.clone(),
+                    status: DetectStatus::NotChecked,
+                    capabilities: caps,
+                    install_script: None,
+                });
+                continue;
+            }
+        };
+        let status = match &actions.detect {
+            Some(d) => run_detect(&adapter_dir, name, d),
+            None => DetectStatus::NotChecked,
+        };
+        frameworks.push(FrameworkInfo {
+            name: name.clone(),
+            status,
+            capabilities: caps,
+            install_script: actions.install.clone(),
+        });
+    }
+
+    frameworks.sort_by(|a, b| a.name.cmp(&b.name));
+
+    println!("\nTokenless Adapter Status\n");
+    println!("{:<14} {:<16} Hooks", "Framework", "Status");
+    println!("{:-<14} {:-<16} {:-<40}", "", "", "");
+    for fw in &frameworks {
+        let caps = if fw.capabilities.is_empty() {
+            "—".to_string()
+        } else {
+            fw.capabilities.join(", ")
+        };
+        println!("{:<14} {:<16} {}", fw.name, fw.status.label(), caps);
+    }
+    println!("\nAdapter directory: {}", adapter_dir.display());
+
+    // --framework: check/install one specific framework
+    if let Some(name) = &framework {
+        let fw = frameworks.iter().find(|f| &f.name == name);
+        match fw {
+            Some(f) if f.status == DetectStatus::Installable => {
+                if let Some(script) = &f.install_script {
+                    println!("\nInstalling {} adapter...", f.name);
+                    match run_install(&adapter_dir, &f.name, script) {
+                        Ok(()) => println!("{} adapter installed successfully.", f.name),
+                        Err(e) => {
+                            return Err((
+                                format!("{} adapter installation failed: {}", f.name, e),
+                                1,
+                            ));
+                        }
+                    }
+                } else {
+                    eprintln!("tokenless: no install script for {}", f.name);
+                }
+                return Ok(());
+            }
+            Some(f) if f.status == DetectStatus::Ready => {
+                println!("\n{} is already installed and ready.", f.name);
+                return Ok(());
+            }
+            Some(f) => {
+                return Err((
+                    format!(
+                        "{} is not installable (status: {})",
+                        f.name,
+                        f.status.label()
+                    ),
+                    1,
+                ));
+            }
+            None => {
+                return Err((format!("unknown framework: {}", name), 1));
+            }
+        }
+    }
+
+    if list_only {
+        print_install_hints();
+        return Ok(());
+    }
+
+    let installable: Vec<&FrameworkInfo> = frameworks
+        .iter()
+        .filter(|f| f.status == DetectStatus::Installable)
+        .collect();
+
+    if installable.is_empty() {
+        println!("\nNo frameworks are waiting for installation.");
+        return Ok(());
+    }
+
+    let to_install: Vec<&FrameworkInfo> = if all {
+        installable
+    } else if io::stdin().is_terminal() {
+        println!("\nInstallable frameworks:");
+        for (i, f) in installable.iter().enumerate() {
+            println!("  [{}] {}", i + 1, f.name);
+        }
+        print!("\nSelect a framework to install (number, 'a' for all, Enter to skip): ");
+        io::stdout().flush().ok();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).ok();
+        let input = input.trim();
+        if input.is_empty() {
+            println!("Skipping installation.");
+            return Ok(());
+        }
+        if input == "a" {
+            installable
+        } else if let Ok(n) = input.parse::<usize>() {
+            if n >= 1 && n <= installable.len() {
+                vec![installable[n - 1]]
+            } else {
+                return Err((format!("invalid selection: {}", input), 1));
+            }
+        } else {
+            return Err((format!("invalid selection: {}", input), 1));
+        }
+    } else {
+        print_install_hints();
+        return Ok(());
+    };
+
+    for fw in &to_install {
+        let script = match &fw.install_script {
+            Some(s) => s,
+            None => {
+                eprintln!("tokenless: no install script for {}", fw.name);
+                continue;
+            }
+        };
+        println!("\nInstalling {} adapter...", fw.name);
+        match run_install(&adapter_dir, &fw.name, script) {
+            Ok(()) => println!("{} adapter installed successfully.", fw.name),
+            Err(e) => eprintln!("{} adapter installation failed: {}", fw.name, e),
+        }
+    }
+
+    Ok(())
+}
+
+fn print_install_hints() {
+    println!("\nRun `tokenless init --framework <name>` to install a specific adapter.");
+    println!("Run `tokenless init --all` to install all installable adapters.");
+}

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! Tokenless CLI - LLM token optimization via schema and response compression.
 mod env_check;
+mod init;
 mod mcp;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -147,6 +148,18 @@ enum Commands {
         /// Output machine-readable JSON (for hook/plugin consumption)
         #[arg(long)]
         json: bool,
+    },
+    /// Detect installed agent frameworks and install tokenless adapters
+    Init {
+        /// Install a specific framework by name (e.g. claude-code, qoder)
+        #[arg(long)]
+        framework: Option<String>,
+        /// Install all installable frameworks without prompting
+        #[arg(long)]
+        all: bool,
+        /// List framework status without installing
+        #[arg(long)]
+        list: bool,
     },
     /// Start the tokenless MCP stdio server (exposes `tokenless_retrieve` so
     /// an MCP-connected agent can recover stashed payloads on demand).
@@ -947,6 +960,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             json,
         } => {
             env_check::run(tool.as_deref(), all, fix, checklist, json)?;
+        }
+        Commands::Init {
+            framework,
+            all,
+            list,
+        } => {
+            init::run(framework, all, list)?;
         }
         Commands::Mcp(McpCommands::Serve) => {
             mcp::serve()?;


### PR DESCRIPTION
## Summary

Adds `tokenless init` — a community entry point that detects installed agent frameworks via each adapter's `detect.sh`, reports status (ready / installable / missing prereqs), and runs `install.sh` for the selected framework.

Community users installing via npm no longer need to manually locate and run adapter install scripts. `tokenless init` guides them through framework detection and adapter registration in one step.

### Flags

- `tokenless init` — interactive selection (when stdin is a terminal)
- `tokenless init --list` — list framework status without installing
- `tokenless init --framework <name>` — install a specific adapter
- `tokenless init --all` — install all installable adapters (non-interactive)

### Files changed

- `crates/tokenless-cli/src/init.rs` — new module (320 lines)
- `crates/tokenless-cli/src/main.rs` — register `Init` command and dispatch
- `crates/tokenless-cli/Cargo.toml` — add `serde` workspace dependency
- `CHANGELOG.md` — add unreleased entry
- `docs/user-guide/{en,zh}/token-saving/tokenless/framework-integration.md` — document `tokenless init` usage

## Test plan

- [x] `cargo build --release -p tokenless-cli` passes
- [x] `cargo test -p tokenless-cli` — 25 tests pass
- [x] `cargo clippy -p tokenless-cli` — no warnings
- [x] `tokenless init --help` shows the new subcommand
- [x] `tokenless init --list` shows helpful error when adapter dir not found