### PR TITLE
fix(sec-core): prevent adapter bytecode drift

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -134,6 +134,31 @@ source = "share/doc/sec-core/LICENSE"
 target = "{datadir}/doc/sec-core/LICENSE"
 mode = "0644"
 
+# Bytecode sweeper plus the lifecycle wrapper that invokes it. Delivered as
+# executables under the ANOLISA-owned hooks directory because `[[component
+# .hooks]]` scripts are path-validated against that root before they run.
+[[component.layout.files]]
+source = "share/anolisa/hooks/sec-core/clean-adapter-bytecode.sh"
+target = "{datadir}/hooks/{component}/clean-adapter-bytecode.sh"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "share/anolisa/hooks/sec-core/post-install.sh"
+target = "{datadir}/hooks/{component}/post-install.sh"
+mode = "0755"
+type = "executable"
+
+# One-shot sweep of pre-`python3 -B` bytecode left in adapter resource roots.
+# `strict` because the alternative is recording a healthy install whose
+# adapters then report drift over caches nobody removed; the RPM backend does
+# the same work from each hook subpackage's %post.
+[[component.hooks]]
+phase = "post_install"
+script = "{datadir}/hooks/{component}/post-install.sh"
+timeout_secs = 60
+strict = true
+
 [[component.services]]
 unit = "agent-sec-core.service"
 scope = "user"

--- a/src/agent-sec-core/Makefile
+++ b/src/agent-sec-core/Makefile
@@ -310,6 +310,11 @@ endif
 
 COMPONENT_DIR       ?= $(ANOLISA_DATADIR)/components/sec-core
 
+# Bounded __pycache__ sweeper. Run from the source tree (not BUILD_DIR) so it
+# is available to every install path, including rpmbuild's %install, which
+# stages via build-all and never runs stage-tools.
+CLEAN_ADAPTER_BYTECODE ?= tools/clean-adapter-bytecode.sh
+
 BINDIR              ?= $(PREFIX)/bin
 LIBDIR              ?= $(PREFIX)/lib/anolisa/sec-core
 LIBEXECDIR          ?= $(PREFIX)/libexec/anolisa/sec-core
@@ -412,12 +417,14 @@ install-qwen-code-extension: ## Install Qwen Code extension to target directory
 	chmod 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/scripts/*.sh
 	chmod 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/hooks/observability_hook.py
 	chmod 0755 $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)/hooks/skill_ledger_hook.py
+	$(CLEAN_ADAPTER_BYTECODE) $(DESTDIR)$(QWEN_CODE_EXTENSION_DIR)
 
 .PHONY: install-codex-plugin
 install-codex-plugin: ## Install codex-plugin hooks and install script
 	install -d -m 0755 $(DESTDIR)$(CODEX_PLUGIN_DIR)
 	cp -rp $(BUILD_DIR)/codex-plugin/. $(DESTDIR)$(CODEX_PLUGIN_DIR)/
 	chmod 0755 $(DESTDIR)$(CODEX_PLUGIN_DIR)/install.sh
+	$(CLEAN_ADAPTER_BYTECODE) $(DESTDIR)$(CODEX_PLUGIN_DIR)
 
 .PHONY: install-qoder-plugin
 install-qoder-plugin: ## Install qoder-plugin hooks and install script
@@ -425,6 +432,7 @@ install-qoder-plugin: ## Install qoder-plugin hooks and install script
 	cp -rp $(BUILD_DIR)/qoder-plugin/. $(DESTDIR)$(QODER_PLUGIN_DIR)/
 	chmod 0755 $(DESTDIR)$(QODER_PLUGIN_DIR)/install.sh
 	chmod 0755 $(DESTDIR)$(QODER_PLUGIN_DIR)/hooks/*.py
+	$(CLEAN_ADAPTER_BYTECODE) $(DESTDIR)$(QODER_PLUGIN_DIR)
 
 .PHONY: install-cosh-hook
 install-cosh-hook: ## Install cosh hooks (linux-sandbox + extension)
@@ -432,6 +440,20 @@ install-cosh-hook: ## Install cosh hooks (linux-sandbox + extension)
 	install -p -m 0755 $(BUILD_DIR)/linux-sandbox $(DESTDIR)$(BINDIR)/
 	install -d -m 0755 $(DESTDIR)$(EXTENSIONDIR)
 	cp -rp $(BUILD_DIR)/cosh-extension/. $(DESTDIR)$(EXTENSIONDIR)/
+	$(CLEAN_ADAPTER_BYTECODE) $(DESTDIR)$(EXTENSIONDIR)
+
+.PHONY: install-adapter-bytecode-tool
+install-adapter-bytecode-tool: ## Install the adapter bytecode sweeper to LIBEXECDIR
+	install -d -m 0755 $(DESTDIR)$(LIBEXECDIR)
+	install -p -m 0755 $(CLEAN_ADAPTER_BYTECODE) $(DESTDIR)$(LIBEXECDIR)/
+
+.PHONY: clean-adapter-bytecode
+clean-adapter-bytecode: ## Sweep __pycache__ bytecode from installed adapter roots
+	$(CLEAN_ADAPTER_BYTECODE) \
+		$(DESTDIR)$(QWEN_CODE_EXTENSION_DIR) \
+		$(DESTDIR)$(CODEX_PLUGIN_DIR) \
+		$(DESTDIR)$(QODER_PLUGIN_DIR) \
+		$(DESTDIR)$(EXTENSIONDIR)
 
 .PHONY: install-component-manifest
 install-component-manifest: ## Install component.toml to DESTDIR
@@ -450,7 +472,7 @@ install-systemd-user: ## Install agent-sec-core systemd user service
 	chmod 0644 $(DESTDIR)$(SYSTEMD_USER_UNIT_DIR)/agent-sec-core.service
 
 .PHONY: install-all
-install-all: install-cli-venv install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills ## Install all (user source build)
+install-all: install-cli-venv install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills install-adapter-bytecode-tool ## Install all (user source build)
 
 .PHONY: install-all-for-rpmbuild
 install-all-for-rpmbuild: OPENCLAW_PLUGIN_DIR := $(RPM_OPENCLAW_PLUGIN_DIR)
@@ -458,7 +480,7 @@ install-all-for-rpmbuild: HERMES_PLUGIN_DIR := $(RPM_HERMES_PLUGIN_DIR)
 install-all-for-rpmbuild: QWEN_CODE_EXTENSION_DIR := $(RPM_QWEN_CODE_EXTENSION_DIR)
 install-all-for-rpmbuild: CODEX_PLUGIN_DIR := $(RPM_CODEX_PLUGIN_DIR)
 install-all-for-rpmbuild: QODER_PLUGIN_DIR := $(RPM_QODER_PLUGIN_DIR)
-install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills install-component-manifest install-systemd-user ## Install all (RPM build)
+install-all-for-rpmbuild: install-cli-site install-cosh-hook install-codex-plugin install-qoder-plugin install-openclaw-plugin install-hermes-plugin install-qwen-code-extension install-skills install-component-manifest install-systemd-user install-adapter-bytecode-tool ## Install all (RPM build)
 
 # =============================================================================
 # UNINSTALL

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -26,6 +26,18 @@
 %global __requires_exclude_from /opt/agent-sec/lib/python3\.11/site-packages/.*
 %global __provides_exclude_from /opt/agent-sec/lib/python3\.11/site-packages/.*
 
+# One-shot __pycache__ sweep for an adapter resource root, run from each Python
+# hook subpackage's %%post so it happens on install AND upgrade, after the new
+# files land and before ANOLISA recomputes the adapter bundle digest.
+#
+# The hooks launch with `python3 -B`, which stops new caches from being
+# written, but `-B` does not stop CPython from importing bytecode already on
+# disk — pre-`-B` caches must be removed, not just prevented. If the sweep
+# fails, rpm reports the scriptlet failure and the caches stay, so the bundle
+# digest keeps reporting drift: never a silently healthy adapter sitting on
+# bytecode that nothing verified.
+%global sec_core_clean_bytecode /usr/local/libexec/anolisa/sec-core/clean-adapter-bytecode.sh
+
 Name:           agent-sec-core
 Version:        @VERSION@
 Release:        %{anolis_release}%{?dist}
@@ -84,6 +96,11 @@ Built with maturin as a Rust native Python extension.
 %defattr(0644,root,root,0755)
 %attr(0755,root,root) /usr/bin/agent-sec-cli
 %attr(0755,root,root) /usr/bin/agent-sec-daemon
+# Shared by every hook subpackage's %%post; owned here because they all
+# already Require agent-sec-cli.
+%attr(0755,root,root) /usr/local/libexec/anolisa/sec-core/clean-adapter-bytecode.sh
+%dir /usr/local/libexec/anolisa
+%dir /usr/local/libexec/anolisa/sec-core
 %{_userunitdir}/agent-sec-core.service
 /opt/agent-sec/lib/python3.11/site-packages/*
 %dir %{_datadir}/anolisa
@@ -121,6 +138,9 @@ The linux-sandbox binary provides secure sandboxed execution environments.
 %attr(0755,root,root) /usr/share/anolisa/extensions/agent-sec-core/hooks/*.py
 /usr/share/anolisa/extensions/agent-sec-core/
 %license LICENSE
+
+%post -n agent-sec-cosh-hook
+%{sec_core_clean_bytecode} /usr/share/anolisa/extensions/agent-sec-core
 
 # =============================================================================
 # Subpackage 3: agent-sec-openclaw-hook
@@ -182,6 +202,9 @@ managed Skill Ledger validation through Qwen Code command hooks.
 /opt/agent-sec/qwen-code-extension/
 %license LICENSE
 
+%post -n agent-sec-qwen-code-hook
+%{sec_core_clean_bytecode} /opt/agent-sec/qwen-code-extension
+
 # =============================================================================
 # Subpackage 6: agent-sec-skills
 # =============================================================================
@@ -217,6 +240,9 @@ and skill ledger verification for Codex agent.
 /opt/agent-sec/codex-plugin/
 %license LICENSE
 
+%post -n agent-sec-codex-hook
+%{sec_core_clean_bytecode} /opt/agent-sec/codex-plugin
+
 # =============================================================================
 # Subpackage 8: agent-sec-qoder-hook
 # =============================================================================
@@ -234,6 +260,9 @@ Qoder CLI security hooks providing agent-sec-core protection for Qoder agents.
 %attr(0755,root,root) /opt/agent-sec/qoder-plugin/install.sh
 /opt/agent-sec/qoder-plugin/
 %license LICENSE
+
+%post -n agent-sec-qoder-hook
+%{sec_core_clean_bytecode} /opt/agent-sec/qoder-plugin
 
 # =============================================================================
 # Main package has no files (metapackage)

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/code_scanner_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/code_scanner_hook.py",
             "timeout": 10,
             "statusMessage": "Scanning command for security issues..."
           }
@@ -16,12 +16,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/observability_hook.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
             "timeout": 10,
             "statusMessage": "Checking for PII in tool input..."
           }
@@ -33,25 +33,25 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/prompt_scanner_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/prompt_scanner_hook.py",
             "timeout": 10,
             "statusMessage": "Scanning prompt for injection attempts..."
           },
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
             "timeout": 10,
             "statusMessage": "Checking for PII in prompt..."
           },
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/skill_ledger_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/skill_ledger_hook.py",
             "timeout": 10,
             "statusMessage": "Checking skill integrity..."
           },
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/observability_hook.py",
             "timeout": 10
           }
         ]
@@ -62,13 +62,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/pii_checker_hook.py",
             "timeout": 10,
             "statusMessage": "Checking for PII in tool output..."
           },
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/observability_hook.py",
             "timeout": 10
           }
         ]
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py",
+            "command": "python3 -B ${PLUGIN_ROOT}/hooks/observability_hook.py",
             "timeout": 10
           }
         ]

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -9,7 +9,7 @@
           {
             "type": "command",
             "name": "skill-ledger",
-            "command": "python3 ${extensionPath}/hooks/skill_ledger_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/skill_ledger_hook.py",
             "timeout": 5000
           }
         ]
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${extensionPath}/hooks/code_scanner_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/code_scanner_hook.py",
             "name": "code-scanner",
             "description": "Scans tool code for security vulnerabilities",
             "timeout": 5000
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${extensionPath}/hooks/sandbox-guard.py",
+            "command": "python3 -B ${extensionPath}/hooks/sandbox-guard.py",
             "name": "sandbox-guard"
           }
         ]
@@ -41,7 +41,7 @@
           {
             "type": "command",
             "name": "pii-checker",
-            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/pii_checker_hook.py",
             "description": "Scans tool inputs for PII and credentials.",
             "timeout": 10000
           }
@@ -52,7 +52,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -65,14 +65,14 @@
           {
             "type": "command",
             "name": "prompt-scanner",
-            "command": "python3 ${extensionPath}/hooks/prompt_scanner_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/prompt_scanner_hook.py",
             "description": "Scans user prompts for prompt injection and jailbreak attempts.",
             "timeout": 10000
           },
           {
             "type": "command",
             "name": "pii-checker",
-            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/pii_checker_hook.py",
             "description": "Scans user prompts for PII and credentials.",
             "timeout": 10000
           }
@@ -83,7 +83,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -96,7 +96,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -109,7 +109,7 @@
           {
             "type": "command",
             "name": "pii-checker",
-            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/pii_checker_hook.py",
             "description": "Scans model responses for PII and credentials.",
             "timeout": 10000
           }
@@ -120,7 +120,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -133,7 +133,7 @@
           {
             "type": "command",
             "name": "pii-checker",
-            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/pii_checker_hook.py",
             "description": "Scans tool outputs for PII and credentials.",
             "timeout": 10000
           }
@@ -144,7 +144,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -157,7 +157,7 @@
           {
             "type": "command",
             "name": "pii-checker",
-            "command": "python3 ${extensionPath}/hooks/pii_checker_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/pii_checker_hook.py",
             "description": "Scans tool errors for PII and credentials.",
             "timeout": 10000
           }
@@ -168,7 +168,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${extensionPath}/hooks/sandbox-failure-handler.py",
+            "command": "python3 -B ${extensionPath}/hooks/sandbox-failure-handler.py",
             "name": "sandbox-failure-handler"
           }
         ]
@@ -178,7 +178,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }
@@ -191,7 +191,7 @@
           {
             "type": "command",
             "name": "observability-hook",
-            "command": "python3 ${extensionPath}/hooks/observability_hook.py",
+            "command": "python3 -B ${extensionPath}/hooks/observability_hook.py",
             "description": "Records cosh hook observability metrics.",
             "timeout": 5000
           }

--- a/src/agent-sec-core/packaging/raw/hooks/post-install.sh
+++ b/src/agent-sec-core/packaging/raw/hooks/post-install.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ANOLISA `post_install` hook for the raw backend.
+#
+# Runs after a raw install or update has placed sec-core's files, and before
+# `adapter status` / `AdapterClaim::bundle_match` re-derive an adapter's bundle
+# digest. Its only job is the one-shot bytecode sweep: the hooks now launch
+# with `python3 -B`, so no new caches appear, but `-B` does not stop CPython
+# from importing bytecode already on disk. A host upgraded from a pre-`-B`
+# release still carries those caches, and `remove_owned_files` leaves them
+# alone because the install record never tracked them.
+#
+# Declared `strict = true` in the component contract: if the sweep fails, the
+# install/update fails rather than recording a component whose adapters would
+# then report drift for reasons nobody swept.
+#
+# Takes no arguments — ANOLISA invokes lifecycle hooks bare — so the datadir is
+# derived from this script's own installed location
+# (`<datadir>/hooks/sec-core/post-install.sh`).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATADIR="$(cd "$HERE/../.." && pwd)"
+SWEEPER="$HERE/clean-adapter-bytecode.sh"
+
+if [ ! -x "$SWEEPER" ]; then
+    printf 'post-install: missing bytecode sweeper at %s\n' "$SWEEPER" >&2
+    exit 1
+fi
+
+# Exactly the raw adapter resource roots, matching the `dest` values in
+# `[[adapters]]`. Roots that are absent are skipped by the sweeper: not every
+# adapter is delivered on every host.
+#
+# Nothing outside these roots is touched. `{datadir}/skills` in particular is
+# shared with other components (os-skills, ws-ckpt, …): sweeping it would
+# delete bytecode sec-core does not own, and foreign non-bytecode content in
+# one of its `__pycache__` directories would fail this strict hook and roll a
+# sec-core update back for an unrelated component's files. Only the resource
+# roots feed an `AdapterClaim` bundle digest, so only they matter for #2252.
+exec "$SWEEPER" \
+    "$DATADIR/adapters/sec-core/openclaw" \
+    "$DATADIR/adapters/sec-core/hermes" \
+    "$DATADIR/adapters/sec-core/codex" \
+    "$DATADIR/adapters/sec-core/qoder" \
+    "$DATADIR/adapters/sec-core/qwencode" \
+    "$DATADIR/extensions/sec-core"

--- a/src/agent-sec-core/packaging/raw/package.sh
+++ b/src/agent-sec-core/packaging/raw/package.sh
@@ -59,6 +59,7 @@ normalize_modes() {
     find "$stage/lib/anolisa/sec-core/python3.11/runtime/bin" \
         -type f -exec chmod 0755 {} +
     find "$stage/adapters" "$stage/share/anolisa/skills" \
+        "$stage/share/anolisa/hooks" \
         -type f \( -name '*.sh' -o -name '*.py' \) -exec chmod 0755 {} +
 }
 
@@ -82,6 +83,7 @@ stage_payload() {
         "$stage/adapters/sec-core/cosh" \
         "$stage/share/anolisa/skills" \
         "$stage/share/anolisa/sec-core" \
+        "$stage/share/anolisa/hooks/sec-core" \
         "$stage/share/doc/sec-core"
 
     install -p -m 0644 "$CONTRACT" "$stage/.anolisa/component.toml"
@@ -96,6 +98,11 @@ stage_payload() {
         "$ROOT/packaging/systemd/agent-sec-core.service.in" \
         "$stage/share/anolisa/sec-core/agent-sec-core.service.in"
     install -p -m 0644 "$ROOT/LICENSE" "$stage/share/doc/sec-core/LICENSE"
+    # The `post_install` lifecycle hook and the sweeper it drives.
+    install -p -m 0755 "$ROOT/tools/clean-adapter-bytecode.sh" \
+        "$stage/share/anolisa/hooks/sec-core/clean-adapter-bytecode.sh"
+    install -p -m 0755 "$ROOT/packaging/raw/hooks/post-install.sh" \
+        "$stage/share/anolisa/hooks/sec-core/post-install.sh"
 
     copy_tree "$BUILD_DIR/site-packages" \
         "$stage/lib/anolisa/sec-core/python3.11/site-packages"
@@ -118,6 +125,18 @@ stage_payload() {
         -type d -name __pycache__ -prune -exec rm -rf {} +
     find "$stage/lib/anolisa/sec-core/python3.11" \
         -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+    # Adapter resource roots must ship without bytecode: a cache copied out of
+    # a dirty worktree would land in the digest ANOLISA records at enable time,
+    # and would be re-imported by CPython even though hooks now run with `-B`.
+    "$ROOT/tools/clean-adapter-bytecode.sh" \
+        "$stage/adapters/sec-core/openclaw" \
+        "$stage/adapters/sec-core/hermes" \
+        "$stage/adapters/sec-core/codex" \
+        "$stage/adapters/sec-core/qoder" \
+        "$stage/adapters/sec-core/qwencode" \
+        "$stage/adapters/sec-core/cosh" \
+        "$stage/share/anolisa/skills" ||
+        die "adapter bytecode sweep failed for $stage"
     validate_bundled_python \
         "$stage/lib/anolisa/sec-core/python3.11/runtime"
     if [ -n "$(find "$stage/lib/anolisa/sec-core/python3.11/runtime" \

--- a/src/agent-sec-core/qoder-plugin/hooks/hooks.json
+++ b/src/agent-sec-core/qoder-plugin/hooks/hooks.json
@@ -9,7 +9,7 @@
             "name": "agent-sec-observability",
             "description": "Records the agent run start for local security observability",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }
@@ -23,7 +23,7 @@
             "name": "agent-sec-pii-user-prompt",
             "description": "Scans user prompts for PII and credentials",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
             "timeout": 10,
             "statusMessage": "Checking prompt for PII..."
           },
@@ -32,7 +32,7 @@
             "name": "agent-sec-prompt-scan",
             "description": "Scans user prompts for injection and jailbreak attempts",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/prompt_scanner_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/prompt_scanner_hook.py"],
             "timeout": 15,
             "statusMessage": "Checking prompt for injection attacks..."
           }
@@ -48,7 +48,7 @@
             "name": "agent-sec-observability",
             "description": "Records a tool call before execution",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }
@@ -62,7 +62,7 @@
             "name": "agent-sec-skill-ledger",
             "description": "Validates local Skills with Skill Ledger before execution",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/skill_ledger_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/skill_ledger_hook.py"],
             "timeout": 10,
             "statusMessage": "Checking Skill trust status..."
           }
@@ -76,7 +76,7 @@
             "name": "agent-sec-code-scan-bash-command",
             "description": "Scans Bash commands for security issues before execution",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/code_scanner_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/code_scanner_hook.py"],
             "timeout": 10,
             "statusMessage": "Scanning command for security issues..."
           }
@@ -90,7 +90,7 @@
             "name": "agent-sec-pii-tool-input",
             "description": "Scans tool input for PII and credentials before execution",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
             "timeout": 10,
             "statusMessage": "Checking tool input for PII..."
           }
@@ -106,7 +106,7 @@
             "name": "agent-sec-observability",
             "description": "Records a successful tool call result",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }
@@ -120,7 +120,7 @@
             "name": "agent-sec-pii-tool-output",
             "description": "Scans tool output for PII and credentials before model context",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/pii_checker_hook.py"],
             "timeout": 10,
             "statusMessage": "Checking tool output for PII..."
           }
@@ -136,7 +136,7 @@
             "name": "agent-sec-observability",
             "description": "Records a failed tool call",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }
@@ -152,7 +152,7 @@
             "name": "agent-sec-observability",
             "description": "Records successful agent run completion",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }
@@ -168,7 +168,7 @@
             "name": "agent-sec-observability",
             "description": "Records failed agent run completion",
             "command": "python3",
-            "args": ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
+            "args": ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"],
             "timeout": 10,
             "async": true
           }

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -9,14 +9,14 @@
           {
             "type": "command",
             "name": "agent-sec-prompt-scanner",
-            "command": "python3 \"${extensionPath}${/}hooks${/}prompt_scanner_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}prompt_scanner_hook.py\"",
             "description": "Scan the Qwen Code user prompt for injection attacks",
             "timeout": 15000
           },
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code user prompt event",
             "timeout": 10000,
             "async": true
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Scan Qwen Code user prompts for PII and credentials",
             "timeout": 10000
           }
@@ -39,7 +39,7 @@
           {
             "type": "command",
             "name": "agent-sec-skill-ledger",
-            "command": "python3 \"${extensionPath}${/}hooks${/}skill_ledger_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}skill_ledger_hook.py\"",
             "description": "Check managed Qwen Code skills against Skill Ledger",
             "timeout": 10000
           }
@@ -51,7 +51,7 @@
           {
             "type": "command",
             "name": "agent-sec-code-scan-shell-command",
-            "command": "python3 \"${extensionPath}${/}hooks${/}code_scanner_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}code_scanner_hook.py\"",
             "description": "Scan Qwen Code shell commands for security issues before execution",
             "timeout": 10000,
             "statusMessage": "Scanning shell command for security issues..."
@@ -63,7 +63,7 @@
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code pre-tool event",
             "timeout": 10000,
             "async": true
@@ -71,7 +71,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Scan Qwen Code tool inputs for PII and credentials",
             "timeout": 10000
           }
@@ -84,7 +84,7 @@
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code successful tool event",
             "timeout": 10000,
             "async": true
@@ -92,7 +92,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Scan Qwen Code tool outputs for PII and credentials",
             "timeout": 10000
           }
@@ -105,7 +105,7 @@
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code failed tool event",
             "timeout": 10000,
             "async": true
@@ -113,7 +113,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Scan Qwen Code tool failures for PII and credentials",
             "timeout": 10000
           }
@@ -126,7 +126,7 @@
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code completed agent run",
             "timeout": 10000,
             "async": true
@@ -134,7 +134,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Scan Qwen Code model output for PII and credentials",
             "timeout": 10000
           }
@@ -147,7 +147,7 @@
           {
             "type": "command",
             "name": "agent-sec-observability",
-            "command": "python3 \"${extensionPath}${/}hooks${/}observability_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}observability_hook.py\"",
             "description": "Record the Qwen Code failed agent run",
             "timeout": 10000,
             "async": true
@@ -155,7 +155,7 @@
           {
             "type": "command",
             "name": "agent-sec-pii-checker",
-            "command": "python3 \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
+            "command": "python3 -B \"${extensionPath}${/}hooks${/}pii_checker_hook.py\"",
             "description": "Audit partial Qwen Code model output for PII and credentials",
             "timeout": 10000
           }

--- a/src/agent-sec-core/tests/packaging/test-package-raw.sh
+++ b/src/agent-sec-core/tests/packaging/test-package-raw.sh
@@ -26,7 +26,9 @@ install -d -m 0755 \
     "$BUILD/qoder-plugin/.qoder-plugin" \
     "$BUILD/qoder-plugin/hooks" \
     "$BUILD/qwen-code-extension/hooks" \
+    "$BUILD/qwen-code-extension/hooks/__pycache__" \
     "$BUILD/cosh-extension/hooks" \
+    "$BUILD/cosh-extension/hooks/__pycache__" \
     "$BUILD/skills/code-scanner" \
     "$BUILD/skills/prompt-scanner" \
     "$BUILD/skills/skill-ledger/references"
@@ -111,6 +113,13 @@ printf 'print("fixture")\n' > "$BUILD/qwen-code-extension/hooks/hook.py"
 cp "$ROOT/cosh-extension/cosh-extension.json" "$BUILD/cosh-extension/"
 printf 'print("fixture")\n' > "$BUILD/cosh-extension/hooks/hook.py"
 
+# A dirty worktree: bytecode beside the plugin sources the staging sweep must
+# drop before it reaches the tarball.
+printf '\xcb\r\r\nfixture' \
+    > "$BUILD/qwen-code-extension/hooks/__pycache__/hook.cpython-311.pyc"
+printf '\xcb\r\r\nfixture' \
+    > "$BUILD/cosh-extension/hooks/__pycache__/hook.cpython-311.pyc"
+
 for skill in code-scanner prompt-scanner skill-ledger; do
     printf '# %s\n' "$skill" > "$BUILD/skills/$skill/SKILL.md"
 done
@@ -147,6 +156,24 @@ test "$(stat -c '%a' \
     "$STAGE/lib/anolisa/sec-core/python3.11/runtime/bin/python3.11")" = "755"
 test "$(stat -c '%a' "$STAGE/.anolisa/component.toml")" = "644"
 test -z "$(find "$STAGE" -type l -print -quit)"
+
+# The `post_install` lifecycle hook and the sweeper it execs must ship, and
+# ship executable: they are the raw backend's only trigger for clearing
+# pre-`python3 -B` bytecode out of adapter resource roots (issue #2252).
+test "$(stat -c '%a' "$STAGE/share/anolisa/hooks/sec-core/post-install.sh")" = "755"
+test "$(stat -c '%a' \
+    "$STAGE/share/anolisa/hooks/sec-core/clean-adapter-bytecode.sh")" = "755"
+# No staged adapter payload may carry bytecode: it would enter the digest
+# ANOLISA records at enable time and be re-imported despite `-B`.
+if [ -n "$(find "$STAGE/adapters" -type d -name __pycache__ -print -quit)" ]; then
+    echo "ERROR: staged adapters carry __pycache__" >&2
+    exit 1
+fi
+if [ -n "$(find "$STAGE/adapters" -type f \
+    \( -name '*.pyc' -o -name '*.pyo' \) -print -quit)" ]; then
+    echo "ERROR: staged adapters carry Python bytecode" >&2
+    exit 1
+fi
 
 RPM_STAGE="$TMP/rpm-stage"
 MANIFEST_STAGE="$TMP/manifest-stage"

--- a/src/agent-sec-core/tests/packaging/test_adapter_bytecode.py
+++ b/src/agent-sec-core/tests/packaging/test_adapter_bytecode.py
@@ -1,0 +1,402 @@
+"""Adapter resource roots must stay free of CPython bytecode.
+
+ANOLISA records a digest of an adapter's resource root at ``adapter enable``
+time and re-derives it on ``adapter status``. Bytecode written by a Hook while
+it runs used to change that digest, so a healthy adapter turned ``degraded``
+just from being used (alibaba/anolisa#2252).
+
+The fix has two halves and both are asserted here:
+
+* every Python Hook launches with ``python3 -B``, so no new cache is written;
+* a bounded sweep removes caches that already exist, because ``-B`` stops
+  CPython from *writing* bytecode but not from *importing* bytecode it finds.
+
+Excluding caches from the digest instead is not an option: CPython imports a
+header-valid cache without reading its source, so bytecode kept out of the
+digest would be executable content that nothing verifies.
+"""
+
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SWEEPER = REPO_ROOT / "tools" / "clean-adapter-bytecode.sh"
+POST_INSTALL = REPO_ROOT / "packaging" / "raw" / "hooks" / "post-install.sh"
+CONTRACT = REPO_ROOT / ".anolisa" / "component.toml"
+
+# (framework, resource root, manifest path relative to that root, placeholder)
+FRAMEWORKS = [
+    ("qwencode", "qwen-code-extension", "qwen-extension.json", "${extensionPath}"),
+    (
+        "codex",
+        "codex-plugin/hooks-plugin",
+        "hooks/hooks.json",
+        "${PLUGIN_ROOT}",
+    ),
+    ("qoder", "qoder-plugin", "hooks/hooks.json", "${QODER_PLUGIN_ROOT}"),
+    ("cosh", "cosh-extension", "cosh-extension.json", "${extensionPath}"),
+]
+
+
+def _hook_argvs(root: Path, manifest_rel: str, placeholder: str) -> list[list[str]]:
+    """Expand every Python hook command in a manifest into a runnable argv."""
+    manifest = json.loads((root / manifest_rel).read_text(encoding="utf-8"))
+    argvs: list[list[str]] = []
+    for hook_groups in manifest["hooks"].values():
+        for group in hook_groups:
+            for hook in group.get("hooks", []):
+                command = hook.get("command")
+                if not isinstance(command, str):
+                    continue
+                # Qwen and Codex put the script in `command`; Qoder splits it
+                # into `command` + `args`. Both shapes normalize to one argv.
+                argv = shlex.split(command) + list(hook.get("args", []))
+                if not argv or "python" not in argv[0]:
+                    continue
+                argvs.append(
+                    [
+                        part.replace(placeholder, str(root)).replace("${/}", os.sep)
+                        for part in argv
+                    ]
+                )
+    assert argvs, f"no Python hooks found in {root / manifest_rel}"
+    return argvs
+
+
+def _tree_digest(root: Path) -> str:
+    """Mirror of ANOLISA's ``adapter::util::digest_tree`` encoding.
+
+    Files are hashed in sorted relative-path order as ``path\\0len\\0bytes``.
+    Kept in step with the Rust side deliberately: this is the value that
+    decides whether ``adapter status`` reports healthy or degraded.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        payload = path.read_bytes()
+        digest.update(str(path.relative_to(root)).encode())
+        digest.update(b"\0")
+        digest.update(len(payload).to_bytes(8, "little"))
+        digest.update(b"\0")
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _caches(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("__pycache__") if p.is_dir())
+
+
+def _run_hooks(argvs: list[list[str]], *, write_bytecode: bool) -> None:
+    """Run every hook once. Exit status is irrelevant — imports are the point.
+
+    A hook that fails without agent-sec-cli on PATH has still imported its
+    sibling modules, which is exactly when CPython would write a cache.
+    """
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    # An ambient PYTHONDONTWRITEBYTECODE would mask a missing `-B` and make the
+    # control run vacuous, so it is always cleared here.
+    env.pop("PYTHONDONTWRITEBYTECODE", None)
+    for argv in argvs:
+        if write_bytecode:
+            argv = [part for part in argv if part != "-B"]
+        subprocess.run(
+            [sys.executable if part == "python3" else part for part in argv],
+            input="{}\n",
+            capture_output=True,
+            check=False,
+            env=env,
+            text=True,
+            timeout=30,
+        )
+
+
+@pytest.mark.parametrize(
+    ("framework", "root_rel", "manifest_rel", "placeholder"), FRAMEWORKS
+)
+def test_every_python_hook_launches_with_dash_b(
+    framework: str, root_rel: str, manifest_rel: str, placeholder: str
+) -> None:
+    for argv in _hook_argvs(REPO_ROOT / root_rel, manifest_rel, placeholder):
+        assert "-B" in argv, f"{framework} hook must launch with -B: {argv}"
+        # `-B` only suppresses writes when the interpreter sees it as an
+        # option, i.e. before the script path.
+        assert argv.index("-B") < len(argv) - 1, f"-B must precede the script: {argv}"
+
+
+@pytest.mark.parametrize(
+    ("framework", "root_rel", "manifest_rel", "placeholder"), FRAMEWORKS
+)
+def test_hook_execution_writes_no_bytecode_and_keeps_digest(
+    framework: str,
+    root_rel: str,
+    manifest_rel: str,
+    placeholder: str,
+    tmp_path: Path,
+) -> None:
+    control = tmp_path / "control"
+    guarded = tmp_path / "guarded"
+    # The source tree is not necessarily clean: the hook unit tests import
+    # these modules in place, so a developer checkout usually carries
+    # __pycache__ already. Sweep both copies first, otherwise an inherited
+    # cache would be mistaken for one this test's hook run produced.
+    for copy in (control, guarded):
+        shutil.copytree(REPO_ROOT / root_rel, copy)
+        subprocess.run([str(SWEEPER), str(copy)], check=True, capture_output=True)
+        assert _caches(copy) == [], "fixture must start without bytecode"
+
+    # Control run: strip `-B` back out and confirm this framework's hooks do
+    # write caches. Without this the -B assertion below could pass simply
+    # because a hook crashed before importing anything.
+    _run_hooks(
+        _hook_argvs(control, manifest_rel, placeholder),
+        write_bytecode=True,
+    )
+    if not _caches(control):
+        pytest.skip(f"{framework} hooks import no local modules on this host")
+
+    before = _tree_digest(guarded)
+    _run_hooks(
+        _hook_argvs(guarded, manifest_rel, placeholder),
+        write_bytecode=False,
+    )
+
+    assert _caches(guarded) == [], (
+        f"{framework} hooks wrote bytecode into the resource root: "
+        f"{[str(p) for p in _caches(guarded)]}"
+    )
+    # Same statement from ANOLISA's point of view: the enable-time digest still
+    # matches, so `adapter status` stays healthy and re-enable is unnecessary.
+    assert _tree_digest(guarded) == before
+
+
+def _staged_root(root: Path) -> Path:
+    """A resource root carrying pre-`-B` bytecode, as an upgraded host would."""
+    (root / "hooks" / "__pycache__").mkdir(parents=True)
+    (root / "hooks" / "hook_config.py").write_text("CONFIG = 1\n")
+    (root / "hooks" / "__pycache__" / "hook_config.cpython-311.pyc").write_bytes(
+        b"\xcb\r\r\nstale"
+    )
+    (root / "hooks" / "__pycache__" / "hook_config.cpython-311.opt-1.pyo").write_bytes(
+        b"\xcb\r\r\nstale"
+    )
+    return root
+
+
+def test_sweep_removes_historical_caches(tmp_path: Path) -> None:
+    root = _staged_root(tmp_path / "qwencode")
+    proc = subprocess.run(
+        [str(SWEEPER), str(root)], capture_output=True, text=True, check=False
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert _caches(root) == []
+    assert (root / "hooks" / "hook_config.py").exists(), "sources must survive"
+
+
+def test_sweep_skips_roots_that_are_not_installed(tmp_path: Path) -> None:
+    proc = subprocess.run(
+        [str(SWEEPER), str(tmp_path / "absent")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+def test_sweep_fails_when_a_directory_cannot_be_enumerated(tmp_path: Path) -> None:
+    """An unreadable subtree must abort, never report a clean sweep.
+
+    Regression guard: enumerating through a process substitution hides find's
+    exit status, so a partial listing used to look like success.
+    """
+    root = _staged_root(tmp_path / "qwencode")
+    locked = root / "locked"
+    (locked / "__pycache__").mkdir(parents=True)
+    (locked / "__pycache__" / "x.cpython-311.pyc").write_bytes(b"\xcb\r\r\n")
+    locked.chmod(0o000)
+    try:
+        proc = subprocess.run(
+            [str(SWEEPER), str(root)], capture_output=True, text=True, check=False
+        )
+    finally:
+        locked.chmod(0o755)
+
+    assert proc.returncode == 1
+    assert "failed to enumerate" in proc.stderr
+
+
+def test_sweep_handles_paths_with_spaces(tmp_path: Path) -> None:
+    root = tmp_path / "qwencode"
+    cache = root / "hook dir" / "__pycache__"
+    cache.mkdir(parents=True)
+    (cache / "hook.cpython-311.pyc").write_bytes(b"\xcb\r\r\n")
+
+    proc = subprocess.run(
+        [str(SWEEPER), str(root)], capture_output=True, text=True, check=False
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert _caches(root) == []
+
+
+def test_sweep_is_bounded_to_pycache_bytecode(tmp_path: Path) -> None:
+    root = _staged_root(tmp_path / "qwencode")
+    # Shipped bytecode outside __pycache__ is a managed resource, not a cache.
+    (root / "shipped.pyc").write_bytes(b"\xcb\r\r\nshipped")
+    (root / "hooks" / "sibling.pyc").write_bytes(b"\xcb\r\r\nsibling")
+    # Anything else inside __pycache__ is the tampering signal the bundle
+    # digest exists to surface, so it must be preserved and reported.
+    (root / "hooks" / "__pycache__" / "payload.so").write_bytes(b"payload")
+
+    proc = subprocess.run(
+        [str(SWEEPER), str(root)], capture_output=True, text=True, check=False
+    )
+
+    assert proc.returncode == 1, "an unswept cache must fail loudly"
+    assert "non-bytecode content" in proc.stderr
+    assert (root / "hooks" / "__pycache__" / "payload.so").exists()
+    assert (root / "shipped.pyc").exists()
+    assert (root / "hooks" / "sibling.pyc").exists()
+    # The bytecode it *could* identify is still gone.
+    assert not (root / "hooks" / "__pycache__" / "hook_config.cpython-311.pyc").exists()
+
+
+def _contract() -> dict:
+    return tomllib.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_contract_declares_strict_post_install_sweep() -> None:
+    """The raw backend's only sweep trigger is this hook, so it must be strict.
+
+    RPM gets the same work from each hook subpackage's %post; raw relies on
+    ANOLISA running `post_install` after files land and before an adapter's
+    bundle digest is re-derived.
+    """
+    contract = _contract()
+    hooks = contract["component"]["hooks"]
+    post_install = [h for h in hooks if h["phase"] == "post_install"]
+    assert len(post_install) == 1, hooks
+    assert post_install[0]["script"].endswith("/post-install.sh")
+    assert post_install[0]["strict"] is True, "a silent sweep failure is the bug"
+
+    targets = {f["target"] for f in contract["component"]["layout"]["files"]}
+    assert "{datadir}/hooks/{component}/post-install.sh" in targets
+    assert (
+        "{datadir}/hooks/{component}/clean-adapter-bytecode.sh" in targets
+    ), "the hook is useless if the sweeper it execs is not delivered"
+
+
+def _install_raw_tree(datadir: Path) -> Path:
+    """Lay out an installed raw tree, hooks included, as ANOLISA would."""
+    hooks_dir = datadir / "hooks" / "sec-core"
+    hooks_dir.mkdir(parents=True)
+    for src in (POST_INSTALL, SWEEPER):
+        dest = hooks_dir / src.name
+        shutil.copy(src, dest)
+        dest.chmod(0o755)
+    return hooks_dir / POST_INSTALL.name
+
+
+def _declared_raw_roots(datadir: Path) -> list[Path]:
+    """Adapter resource roots the contract places under the raw datadir."""
+    roots = []
+    for adapter in _contract()["adapters"]:
+        dest = adapter["dest"].replace("{component}", "sec-core")
+        roots.append(Path(dest.replace("{datadir}", str(datadir))))
+    return roots
+
+
+def test_post_install_hook_sweeps_every_declared_adapter_root(tmp_path: Path) -> None:
+    """Old install carrying caches -> new version's hook runs -> caches gone.
+
+    Covers every `[[adapters]]` dest, so adding an adapter without adding its
+    root to the hook fails here instead of shipping a half-swept upgrade.
+    """
+    datadir = tmp_path / "share" / "anolisa"
+    hook = _install_raw_tree(datadir)
+
+    roots = _declared_raw_roots(datadir)
+    assert roots, "contract must declare adapters"
+    for root in roots:
+        cache = root / "hooks" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "hook_config.cpython-311.pyc").write_bytes(b"\xcb\r\r\nstale")
+        (root / "hooks" / "hook_config.py").write_text("CONFIG = 1\n")
+
+    proc = subprocess.run([str(hook)], capture_output=True, text=True, check=False)
+
+    assert proc.returncode == 0, proc.stderr
+    for root in roots:
+        assert _caches(root) == [], f"{root} still holds bytecode: {proc.stdout}"
+        assert (root / "hooks" / "hook_config.py").exists(), "sources must survive"
+
+
+def test_post_install_hook_fails_loudly_without_its_sweeper(tmp_path: Path) -> None:
+    datadir = tmp_path / "share" / "anolisa"
+    hook = _install_raw_tree(datadir)
+    (hook.parent / SWEEPER.name).unlink()
+
+    proc = subprocess.run([str(hook)], capture_output=True, text=True, check=False)
+
+    assert proc.returncode == 1
+    assert "missing bytecode sweeper" in proc.stderr
+
+
+def test_post_install_hook_leaves_shared_directories_alone(tmp_path: Path) -> None:
+    """The sweep must not reach outside sec-core's own resource roots.
+
+    `{datadir}/skills` is shared with other components. Sweeping it would
+    delete bytecode sec-core does not own, and foreign content in one of its
+    caches would fail this strict hook and roll back a sec-core update for an
+    unrelated component's files.
+    """
+    datadir = tmp_path / "share" / "anolisa"
+    hook = _install_raw_tree(datadir)
+    for root in _declared_raw_roots(datadir):
+        root.mkdir(parents=True, exist_ok=True)
+
+    shared = datadir / "skills" / "other-component" / "__pycache__"
+    shared.mkdir(parents=True)
+    foreign = shared / "helper.cpython-311.pyc"
+    foreign.write_bytes(b"\xcb\r\r\nnot ours")
+    # Content that would make the sweeper fail if it ever looked here.
+    (shared / "payload.so").write_bytes(b"payload")
+
+    proc = subprocess.run([str(hook)], capture_output=True, text=True, check=False)
+
+    assert proc.returncode == 0, proc.stderr
+    assert foreign.exists(), "another component's bytecode must survive"
+    assert (shared / "payload.so").exists()
+
+
+def test_post_install_hook_covers_only_contract_declared_roots() -> None:
+    """Every path the hook sweeps must be an `[[adapters]]` dest.
+
+    Pins the boundary the other way round from
+    `test_post_install_hook_sweeps_every_declared_adapter_root`: that one
+    catches a missing root, this one catches an added extra.
+    """
+    swept = {
+        line.strip().strip("\\").strip().strip('"').replace("$DATADIR/", "")
+        for line in POST_INSTALL.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith('"$DATADIR/')
+    }
+    declared = {
+        adapter["dest"]
+        .replace("{component}", "sec-core")
+        .replace("{datadir}/", "")
+        .rstrip("/")
+        for adapter in _contract()["adapters"]
+    }
+    assert swept, "hook must pass roots to the sweeper"
+    assert swept <= declared, f"swept paths outside the contract: {swept - declared}"

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_observability_hook.py
@@ -388,7 +388,7 @@ def test_hooks_config_registers_observability_for_four_codex_events():
         "PostToolUse",
         "Stop",
     }
-    command = "python3 ${PLUGIN_ROOT}/hooks/observability_hook.py"
+    command = "python3 -B ${PLUGIN_ROOT}/hooks/observability_hook.py"
 
     registered_events = set()
     for event_name, entries in config["hooks"].items():

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_observability_hook.py
@@ -517,5 +517,5 @@ def test_extension_registers_observability_hook_for_supported_events():
             if hook.get("name") == "observability-hook"
         ]
         assert commands == [
-            "python3 ${extensionPath}/hooks/observability_hook.py",
+            "python3 -B ${extensionPath}/hooks/observability_hook.py",
         ]

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_observability_hook.py
@@ -550,7 +550,7 @@ def test_hooks_config_registers_observability_for_all_supported_events() -> None
         "Stop",
         "StopFailure",
     }
-    expected_args = ["${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"]
+    expected_args = ["-B", "${QODER_PLUGIN_ROOT}/hooks/observability_hook.py"]
 
     assert set(config["hooks"]) == expected_events
     for event_name in expected_events:

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_plugin_framework.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_plugin_framework.py
@@ -167,7 +167,10 @@ def test_hooks_json_uses_qoder_plugin_wrapper() -> None:
     skill_ledger = next(entry for entry in pre_tool if entry["matcher"] == "Skill")
     hook = skill_ledger["hooks"][0]
     assert hook["name"] == "agent-sec-skill-ledger"
-    assert hook["args"] == ["${QODER_PLUGIN_ROOT}/hooks/skill_ledger_hook.py"]
+    assert hook["args"] == [
+        "-B",
+        "${QODER_PLUGIN_ROOT}/hooks/skill_ledger_hook.py",
+    ]
 
 
 def test_env_flag_enabled_accepts_only_true_false(monkeypatch) -> None:

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_code_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_code_scanner_hook.py
@@ -142,7 +142,7 @@ def test_manifest_mounts_code_scanner_as_independent_sync_pre_tool_hook() -> Non
     assert scanner_entry["matcher"] == "^run_shell_command$"
     scanner_hook = scanner_entry["hooks"][0]
     assert scanner_hook["command"] == (
-        'python3 "${extensionPath}${/}hooks${/}code_scanner_hook.py"'
+        'python3 -B "${extensionPath}${/}hooks${/}code_scanner_hook.py"'
     )
     assert scanner_hook["timeout"] == 10000
     assert "async" not in scanner_hook

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_observability_hook.py
@@ -505,7 +505,7 @@ def test_manifest_mounts_skill_ledger_code_scanner_observability_and_pii_hooks()
     assert skill_hook["name"] == "agent-sec-skill-ledger"
     assert "async" not in skill_hook
     assert skill_hook["command"] == (
-        'python3 "${extensionPath}${/}hooks${/}skill_ledger_hook.py"'
+        'python3 -B "${extensionPath}${/}hooks${/}skill_ledger_hook.py"'
     )
 
     scanner_group = pre_tool_entries[1]
@@ -515,7 +515,7 @@ def test_manifest_mounts_skill_ledger_code_scanner_observability_and_pii_hooks()
     scanner_hook = scanner_hooks[0]
     assert scanner_hook["name"] == "agent-sec-code-scan-shell-command"
     assert scanner_hook["command"] == (
-        'python3 "${extensionPath}${/}hooks${/}code_scanner_hook.py"'
+        'python3 -B "${extensionPath}${/}hooks${/}code_scanner_hook.py"'
     )
     assert scanner_hook["timeout"] == 10000
     assert "async" not in scanner_hook
@@ -533,7 +533,7 @@ def test_manifest_mounts_skill_ledger_code_scanner_observability_and_pii_hooks()
             prompt_scanner = hooks_by_name["agent-sec-prompt-scanner"]
             assert prompt_scanner.get("async") is None
             assert prompt_scanner["command"] == (
-                'python3 "${extensionPath}${/}hooks${/}prompt_scanner_hook.py"'
+                'python3 -B "${extensionPath}${/}hooks${/}prompt_scanner_hook.py"'
             )
             assert prompt_scanner["timeout"] == 15000
 
@@ -541,13 +541,13 @@ def test_manifest_mounts_skill_ledger_code_scanner_observability_and_pii_hooks()
         observability = hooks_by_name["agent-sec-observability"]
         assert observability["async"] is True
         assert observability["command"] == (
-            'python3 "${extensionPath}${/}hooks${/}observability_hook.py"'
+            'python3 -B "${extensionPath}${/}hooks${/}observability_hook.py"'
         )
         pii_checker = hooks_by_name["agent-sec-pii-checker"]
         assert "async" not in pii_checker
         assert pii_checker["timeout"] == 10000
         assert pii_checker["command"] == (
-            'python3 "${extensionPath}${/}hooks${/}pii_checker_hook.py"'
+            'python3 -B "${extensionPath}${/}hooks${/}pii_checker_hook.py"'
         )
         if event_name != "PreToolUse":
             assert len(entries) == 1

--- a/src/agent-sec-core/tools/clean-adapter-bytecode.sh
+++ b/src/agent-sec-core/tools/clean-adapter-bytecode.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Remove CPython bytecode caches from agent-sec-core adapter resource roots.
+#
+# The security hooks launch with `python3 -B`, which stops the interpreter from
+# *writing* new caches but does not stop it from *importing* a cache that is
+# already on disk. A resource root still holding pre-`-B` bytecode would keep
+# executing that bytecode, and would keep ANOLISA's adapter bundle digest away
+# from the value recorded at enable time. This one-shot sweep is therefore part
+# of the fix, not a cleanup nicety, and it must run before the bundle digest is
+# recomputed — never from a status/report path, which stays read-only.
+#
+# Bounded by construction: within each root only directories named
+# `__pycache__` are considered, and inside those only regular `*.pyc`/`*.pyo`
+# files are deleted. A `__pycache__` still holding anything else (a foreign
+# payload, a symlink pointing outside the bundle) is left in place and reported
+# as a failure: that content is exactly what the bundle digest must keep
+# flagging, so it must never be silently erased nor silently tolerated.
+#
+# Usage: clean-adapter-bytecode.sh <resource-root>...
+#
+# Exits 0 when every root is clean, 1 when any cache could not be fully
+# removed, and 2 on usage errors — so an install/update transaction fails
+# loudly instead of going on to record a healthy adapter over bytecode that
+# nothing verified.
+
+set -euo pipefail
+
+PROGRAM_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM_NAME <resource-root>...
+
+Removes __pycache__ directories and the *.pyc/*.pyo files inside them from the
+given agent-sec-core adapter resource roots. Roots that do not exist are
+skipped: not every adapter is installed on every host.
+EOF
+}
+
+note() {
+    printf '%s: %s\n' "$PROGRAM_NAME" "$*"
+}
+
+warn() {
+    printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+}
+
+# Sweep one resource root. Returns non-zero if any cache survived.
+sweep_root() {
+    local root="$1"
+    local failures=0
+    local cache_dir
+
+    if [ -L "$root" ]; then
+        warn "refusing to sweep '$root': resource root is a symbolic link"
+        return 1
+    fi
+    if [ ! -d "$root" ]; then
+        return 0
+    fi
+
+    # Enumerate into a file rather than `< <(find ...)`: a process
+    # substitution's exit status is invisible to the loop and to `set -e`, so a
+    # partial listing (EACCES on a subdirectory, EIO) would end the loop with
+    # failures=0 and report success over caches that were never examined.
+    # A command substitution would see the status but silently drops the NUL
+    # separators `-print0` depends on, so a temp file is the only form that
+    # keeps both properties.
+    #
+    # `-type d` matches the directory itself, never a symlink named
+    # `__pycache__`, so a link cannot redirect the deletion out of the bundle.
+    local listing="$WORK_DIR/listing"
+    if ! find "$root" -type d -name __pycache__ -print0 >"$listing"; then
+        warn "failed to enumerate '$root'; bytecode may remain"
+        return 1
+    fi
+
+    while IFS= read -r -d '' cache_dir; do
+        if ! find "$cache_dir" -maxdepth 1 -type f \
+            \( -name '*.pyc' -o -name '*.pyo' \) -delete; then
+            warn "failed to delete bytecode in '$cache_dir'"
+            failures=$((failures + 1))
+            continue
+        fi
+        # rmdir only succeeds on an empty directory, which is the check we
+        # want: anything left behind was not interpreter-written bytecode.
+        if ! rmdir "$cache_dir" 2>/dev/null; then
+            warn "'$cache_dir' still holds non-bytecode content; left in place for bundle-digest review"
+            failures=$((failures + 1))
+            continue
+        fi
+        note "removed $cache_dir"
+    done <"$listing"
+
+    [ "$failures" -eq 0 ]
+}
+
+if [ "$#" -lt 1 ]; then
+    usage >&2
+    exit 2
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+case "$1" in
+    -h | --help)
+        usage
+        exit 0
+        ;;
+esac
+
+status=0
+for resource_root in "$@"; do
+    if ! sweep_root "$resource_root"; then
+        status=1
+    fi
+done
+exit "$status"

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -31,10 +31,10 @@ use anolisa_core::state::{FileOwner, ObjectKind, OwnedFile, OwnedFileKind, Servi
 use anolisa_core::state_store::StateStore;
 use anolisa_core::transaction::restore_backup_file;
 use anolisa_core::{
-    CapabilityRequest, FileKind, ResolvedInstallFile, ResolvedLifecycleHooks, ServiceActivation,
-    ServiceRequest, ServiceRunOutcome, ServiceScope, apply_capabilities, apply_services,
-    capability_for_install_mode, deactivate_services, run_hooks, service_for_install_mode,
-    user_service_for_install_mode,
+    CapabilityRequest, FileKind, HookPhase, ResolvedInstallFile, ResolvedLifecycleHooks,
+    ServiceActivation, ServiceRequest, ServiceRunOutcome, ServiceScope, apply_capabilities,
+    apply_services, capability_for_install_mode, deactivate_services, resolve_manifest_hooks,
+    run_hooks, service_for_install_mode, user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 
@@ -99,6 +99,10 @@ pub(crate) struct RawReplayOps<'a> {
     /// Prepared artifact + resolved contract, set by `download_verify`.
     prepared: Option<PreparedInstall>,
     prepared_files: Option<PreparedFileSet>,
+    /// Incoming contract's `post_install` hooks, resolved by
+    /// `download_verify` so a contract authoring error fails before the
+    /// replay touches the host.
+    post_install_hooks: Vec<anolisa_core::HookSpec>,
     /// Files this run placed, set by `place_files`.
     placed: Vec<InstalledFile>,
     /// Manifest snapshot this run wrote, set by `place_files`.
@@ -145,6 +149,7 @@ impl<'a> RawReplayOps<'a> {
             prior,
             prepared: None,
             prepared_files: None,
+            post_install_hooks: Vec::new(),
             placed: Vec::new(),
             manifest_path: None,
             applied_capabilities: Vec::new(),
@@ -264,14 +269,28 @@ impl OwnedOps for RawReplayOps<'_> {
                 &prepared.files,
             )
             .map_err(|err| OwnedOpError(format!("failed to inspect verified payload: {err}")))?;
+        let manifest = anolisa_core::ComponentManifest::from_toml_str(&prepared.manifest_toml)
+            .map_err(|err| OwnedOpError(format!("failed to parse component manifest: {err}")))?;
+        // Resolve the incoming contract's post-install hooks here, while the
+        // host is still untouched: this step runs before `remove_owned_files`
+        // and `place_files`, so a pure contract error (unknown placeholder, a
+        // script path outside ANOLISA's roots) aborts without having modified
+        // anything — the same "contract error aborts before IO" property the
+        // fresh-install path gets from resolving hooks pre-lock.
+        self.post_install_hooks = resolve_manifest_hooks(
+            &manifest.install.hooks,
+            self.layout,
+            &self.component,
+            HookPhase::PostInstall,
+        )
+        .map_err(|err| {
+            OwnedOpError(format!(
+                "component '{}' has an invalid [[component.hooks]] script path: {err}",
+                self.component
+            ))
+        })?;
         let mut warnings = Vec::new();
         if self.runtime_preflight {
-            let manifest = anolisa_core::ComponentManifest::from_toml_str(&prepared.manifest_toml)
-                .map_err(|err| {
-                    OwnedOpError(format!(
-                        "failed to parse component manifest for preflight: {err}"
-                    ))
-                })?;
             warnings = super::provision::run_runtime_preflight(&manifest, &self.env, "update")
                 .map_err(|err| OwnedOpError(err.reason()))?;
         }
@@ -284,8 +303,41 @@ impl OwnedOps for RawReplayOps<'_> {
         Self::not_wired("runtime-dependency provisioning")
     }
 
+    /// Executes the `post_install` hooks resolved by `download_verify`.
+    ///
+    /// Only the *update* plan carries this step today; the repair plan
+    /// (`owned_replay_steps`) does not, so a repair still runs no hooks.
+    /// `post_install` is the phase that can repair state the new payload does
+    /// not overwrite: `remove_owned_files` drops only the files the prior
+    /// record tracked, leaving anything a component generated at runtime
+    /// (Python bytecode beside an installed Hook, for instance) in place. The
+    /// specs come from the *incoming* contract, not the prior one, so an
+    /// upgrade that newly declares the hook still gets it.
+    ///
+    /// `pre_install` stays unwired on purpose: no replay plan asks for it, and
+    /// a pre-phase hook would have to reason about a half-replaced tree.
     fn run_hook(&mut self, kind: HookKind) -> Result<StepSuccess, OwnedOpError> {
-        Self::not_wired(&format!("the {kind:?} hook phase"))
+        if kind != HookKind::PostInstall {
+            return Self::not_wired(&format!("the {kind:?} hook phase"));
+        }
+        if self.prepared.is_none() {
+            return Err(OwnedOpError(
+                "internal: post-install hook ran before payload preparation".to_string(),
+            ));
+        }
+        let specs = std::mem::take(&mut self.post_install_hooks);
+        let run = run_hooks(
+            &specs,
+            self.layout,
+            Some(&self.log),
+            &self.operation_id,
+            "cli",
+            self.ctx.install_mode.as_str(),
+        );
+        if let Some(failure) = run.hard_failure {
+            return Err(OwnedOpError(failure.summary()));
+        }
+        Ok(StepSuccess::with_warnings(run.warnings))
     }
 
     fn backup_files(&mut self) -> Result<StepSuccess, OwnedOpError> {

--- a/src/anolisa/crates/anolisa-cli/tests/update_adapter_actions.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/update_adapter_actions.rs
@@ -58,6 +58,38 @@ fn receipt_digest(root: &Path) -> Option<String> {
 }
 
 fn manifest(version: &str, with_adapter: bool) -> String {
+    manifest_with_hook(version, with_adapter, HookFixture::None)
+}
+
+/// A `post_install` hook that always fails, for the rollback path.
+const FAILING_HOOK: &[u8] = br#"#!/bin/sh
+echo "sweep failed" >&2
+exit 1
+"#;
+
+/// What the incoming v0.2.0 contract declares for `post_install`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HookFixture {
+    /// No hook at all.
+    None,
+    /// A hook that sweeps the bundle and records that it ran.
+    Sweeping,
+    /// A hook that exits non-zero.
+    Failing,
+    /// A contract authoring bug: the script path uses an unknown placeholder,
+    /// so it can never resolve and no script is shipped.
+    InvalidPath,
+}
+
+/// A non-`None` `hook` ships a `post_install` declaration, so the update
+/// path's hook slot can be observed end to end.
+fn manifest_with_hook(version: &str, with_adapter: bool, hook: HookFixture) -> String {
+    let with_hook = hook != HookFixture::None;
+    let script = if hook == HookFixture::InvalidPath {
+        "{no_such_placeholder}/post-install.sh"
+    } else {
+        "{datadir}/hooks/{component}/post-install.sh"
+    };
     let adapter = if with_adapter {
         format!(
             r#"
@@ -70,6 +102,33 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         )
     } else {
         String::new()
+    };
+    let hook_toml = if !with_hook {
+        String::new()
+    } else if hook == HookFixture::InvalidPath {
+        format!(
+            r#"
+[[component.hooks]]
+phase = "post_install"
+script = "{script}"
+strict = true
+"#
+        )
+    } else {
+        format!(
+            r#"
+[[component.layout.files]]
+source = "share/anolisa/hooks/{COMPONENT}/post-install.sh"
+target = "{script}"
+mode = "0755"
+type = "executable"
+
+[[component.hooks]]
+phase = "post_install"
+script = "{script}"
+strict = true
+"#
+        )
     };
     format!(
         r#"[component]
@@ -84,9 +143,21 @@ source = "bin/{COMPONENT}"
 target = "{{bindir}}/{COMPONENT}"
 mode = "0755"
 type = "executable"
-{adapter}"#
+{hook_toml}{adapter}"#
     )
 }
+
+/// Sweeps `__pycache__` from the adapter bundle and records that it ran.
+/// Derives the datadir from its own location, the way a component-shipped
+/// hook must: nothing is passed on the argv.
+const POST_INSTALL_HOOK: &[u8] = br#"#!/bin/sh
+set -eu
+here="$(cd "$(dirname "$0")" && pwd)"
+datadir="$(cd "$here/../.." && pwd)"
+find "$datadir/adapters/stale-demo/openclaw" -type d -name __pycache__ -prune \
+    -exec rm -rf {} +
+printf 'ran\n' > "$here/ran.marker"
+"#;
 
 fn tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
     use flate2::Compression;
@@ -124,6 +195,28 @@ struct UpdateFixture {
 
 impl UpdateFixture {
     fn new() -> Self {
+        Self::build(HookFixture::None)
+    }
+
+    /// Fixture whose *incoming* v0.2.0 contract declares a strict
+    /// `post_install` hook. The installed v0.1.0 snapshot does not, so this
+    /// also covers an upgrade that adds the hook.
+    fn with_post_install_hook() -> Self {
+        Self::build(HookFixture::Sweeping)
+    }
+
+    /// Same, but the hook exits non-zero, so the strict declaration must
+    /// abort the update and roll the installation back.
+    fn with_failing_post_install_hook() -> Self {
+        Self::build(HookFixture::Failing)
+    }
+
+    /// Incoming contract whose hook path can never resolve.
+    fn with_unresolvable_post_install_hook() -> Self {
+        Self::build(HookFixture::InvalidPath)
+    }
+
+    fn build(hook: HookFixture) -> Self {
         let tmp = tempfile::tempdir().expect("tempdir");
         let root = tmp.path();
         let system_prefix = root.join("system");
@@ -253,17 +346,21 @@ impl UpdateFixture {
         write_state(&system_layout, StateInstallMode::System, Vec::new());
 
         // A raw repo publishing v0.2.0 with a changed bundle.
-        let artifact = tar_gz(&[
-            (
-                ".anolisa/component.toml",
-                manifest("0.2.0", true).as_bytes(),
-            ),
-            (format!("bin/{COMPONENT}").as_str(), b"v2 binary\n"),
-            (
-                format!("adapters/{COMPONENT}/openclaw/plugin.json").as_str(),
-                b"v2",
-            ),
-        ]);
+        let hook_path = format!("share/anolisa/hooks/{COMPONENT}/post-install.sh");
+        let mut entries: Vec<(&str, &[u8])> = Vec::new();
+        let incoming_manifest = manifest_with_hook("0.2.0", true, hook);
+        entries.push((".anolisa/component.toml", incoming_manifest.as_bytes()));
+        let bin_entry = format!("bin/{COMPONENT}");
+        entries.push((bin_entry.as_str(), b"v2 binary\n"));
+        let bundle_entry = format!("adapters/{COMPONENT}/openclaw/plugin.json");
+        entries.push((bundle_entry.as_str(), b"v2"));
+        match hook {
+            HookFixture::Sweeping => entries.push((hook_path.as_str(), POST_INSTALL_HOOK)),
+            HookFixture::Failing => entries.push((hook_path.as_str(), FAILING_HOOK)),
+            // InvalidPath ships no script: the path never resolves.
+            HookFixture::None | HookFixture::InvalidPath => {}
+        }
+        let artifact = tar_gz(&entries);
         publish_raw_repo(&root.join("repo"), &user_layout, "0.2.0", &artifact);
 
         Self {
@@ -474,6 +571,172 @@ fn update_dry_run_reports_no_adapter_actions_and_changes_nothing() {
         std::fs::read(fixture.bundle_root.join("plugin.json")).expect("read bundle"),
         b"v1",
         "dry-run must not touch the bundle"
+    );
+    assert_eq!(
+        fixture.persisted_bundle_digest().as_deref(),
+        Some(fixture.enable_digest.as_str())
+    );
+}
+
+/// Regression for alibaba/anolisa#2252: a raw upgrade must be able to clear
+/// artifacts the payload does not own.
+///
+/// `remove_owned_files` only drops files the prior record tracked, so Python
+/// bytecode a Hook wrote beside its installed source survives the file
+/// replacement and keeps the adapter's bundle digest away from its
+/// enable-time value. The component's `post_install` hook is what removes it,
+/// which requires the update plan to carry the hook slot at all.
+#[test]
+fn update_runs_post_install_hook_and_clears_untracked_bytecode() {
+    let fixture = UpdateFixture::with_post_install_hook();
+
+    // Bytecode as a Hook run would have left it: inside the bundle, absent
+    // from the record's file list, so nothing else in the update removes it.
+    let cache = fixture.bundle_root.join("hooks").join("__pycache__");
+    std::fs::create_dir_all(&cache).expect("cache dir");
+    std::fs::write(
+        cache.join("hook_config.cpython-311.pyc"),
+        b"\xcb\r\r\nstale",
+    )
+    .expect("stale bytecode");
+
+    let output = fixture.run_update(&[]);
+    assert_success(&output);
+
+    let marker = fixture
+        .user_layout
+        .datadir
+        .join("hooks")
+        .join(COMPONENT)
+        .join("ran.marker");
+    assert!(
+        marker.exists(),
+        "post_install hook must run on the update path; stdout: {}",
+        stdout(&output)
+    );
+    assert!(
+        !cache.exists(),
+        "stale bytecode must be gone after the upgrade"
+    );
+    // The upgrade replaced the bundle, so the receipt legitimately reports
+    // drift — what must not happen is drift caused by leftover bytecode.
+    assert_eq!(
+        fixture.persisted_bundle_digest().as_deref(),
+        Some(fixture.enable_digest.as_str()),
+        "the receipt itself must survive the update unchanged"
+    );
+}
+
+/// A strict `post_install` hook that fails must abort the update and restore
+/// the prior installation — files, manifest snapshot, and record version.
+///
+/// `RawInstallOps` has its own strict-hook coverage, which says nothing about
+/// the replay port: only this path exercises `remove_owned_files` +
+/// `place_files` rollback with the backups the replay took.
+#[test]
+fn update_rolls_back_when_strict_post_install_hook_fails() {
+    let fixture = UpdateFixture::with_failing_post_install_hook();
+
+    let output = fixture.run_update(&[]);
+    assert!(
+        !output.status.success(),
+        "a failed strict hook must fail the update; stdout: {}",
+        stdout(&output)
+    );
+
+    // Prior payload restored, not the v0.2.0 one the hook aborted.
+    assert_eq!(
+        std::fs::read(fixture.user_layout.bin_dir.join(COMPONENT)).expect("read bin"),
+        b"v1 binary\n",
+        "the prior binary must be restored"
+    );
+    assert_eq!(
+        std::fs::read(fixture.bundle_root.join("plugin.json")).expect("read bundle"),
+        b"v1",
+        "the prior adapter bundle must be restored"
+    );
+
+    // The record still describes the installed version, and the receipt is
+    // untouched, so `adapter status` keeps reporting against v0.1.0.
+    let store = fixture.load_store();
+    let record = store
+        .find(anolisa_core::ObjectKind::Component, COMPONENT)
+        .expect("record must survive");
+    let version = match &record.binding {
+        anolisa_core::domain::ProviderBinding::Owned { artifact } => artifact.version.clone(),
+        other => panic!("expected an owned binding, got {other:?}"),
+    };
+    assert_eq!(version, "0.1.0", "a rolled-back update must not bump");
+    assert_eq!(
+        fixture.persisted_bundle_digest().as_deref(),
+        Some(fixture.enable_digest.as_str())
+    );
+
+    // The hook that failed must not have been left behind as an installed
+    // file of a version that never committed.
+    let snapshot =
+        FsLayout::component_manifest_snapshot_path(&fixture.user_layout.state_dir, COMPONENT);
+    let restored = std::fs::read_to_string(&snapshot).expect("read snapshot");
+    assert!(
+        !restored.contains("post_install"),
+        "the prior manifest snapshot must be restored: {restored}"
+    );
+}
+
+/// A contract-only error in the incoming hook declaration must abort before
+/// the replay modifies anything.
+///
+/// The hook specs are resolved during `download_verify`, which runs before
+/// `remove_owned_files` and `place_files`. Resolving them later would mean an
+/// unresolvable placeholder tore down the old payload first and only then
+/// entered rollback — the fresh-install path's "contract error aborts before
+/// IO" property, lost on update.
+#[test]
+fn update_rejects_unresolvable_hook_path_before_touching_the_host() {
+    let fixture = UpdateFixture::with_unresolvable_post_install_hook();
+    let bin = fixture.user_layout.bin_dir.join(COMPONENT);
+    let placed_before = std::fs::read(&bin).expect("read bin");
+
+    let output = fixture.run_update(&["--json"]);
+    assert!(
+        !output.status.success(),
+        "an unresolvable hook path must fail the update; stdout: {}",
+        stdout(&output)
+    );
+
+    // The step it failed at is the point of this test: `download and verify
+    // artifact` means the contract was rejected before any host mutation.
+    // Failing at the hook step instead would mean the old payload had already
+    // been removed and the new one placed.
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).expect("json");
+    let reason = envelope["error"]["reason"].as_str().expect("reason");
+    assert!(
+        reason.contains("failed at 'download and verify artifact'"),
+        "contract errors must abort at download-verify, not mid-replacement: {reason}"
+    );
+    assert!(
+        reason.contains("unknown placeholder 'no_such_placeholder'"),
+        "{reason}"
+    );
+
+    assert_eq!(
+        std::fs::read(&bin).expect("read bin"),
+        placed_before,
+        "the prior binary must never have been replaced"
+    );
+    assert_eq!(
+        std::fs::read(fixture.bundle_root.join("plugin.json")).expect("read bundle"),
+        b"v1",
+        "the prior bundle must never have been replaced"
+    );
+    assert!(
+        !fixture
+            .user_layout
+            .datadir
+            .join("hooks")
+            .join(COMPONENT)
+            .exists(),
+        "no v0.2.0 payload may have landed"
     );
     assert_eq!(
         fixture.persisted_bundle_digest().as_deref(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -18,8 +18,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use sha2::{Digest, Sha256};
-
 use super::AdapterError;
 use super::claim::{
     AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
@@ -30,6 +28,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
+use super::util::digest_tree;
 
 /// Default timeout for a Hermes CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -791,43 +790,6 @@ fn summarize(
     }
 }
 
-/// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
-fn digest_tree(root: &Path) -> Option<String> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in &files {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let bytes = std::fs::read(path).ok()?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0u8]);
-        hasher.update(&bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
-
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
 /// ISO 8601 UTC timestamp, second precision.
 fn now_iso8601() -> String {
     use chrono::{SecondsFormat, Utc};
@@ -988,22 +950,6 @@ mod tests {
             summarize(ClaimStatus::Enabled, true, ConditionStatus::Unknown),
             AdapterSummary::Unknown
         );
-    }
-
-    #[test]
-    fn digest_tree_is_stable_and_detects_change() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
-        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
-
-        let d1 = digest_tree(dir.path()).expect("digest");
-        let d2 = digest_tree(dir.path()).expect("digest again");
-        assert_eq!(d1, d2, "digest must be stable");
-
-        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
-        let d3 = digest_tree(dir.path()).expect("digest after change");
-        assert_ne!(d1, d3, "digest must change when a file changes");
     }
 
     // -- review fix coverage: lazy plugin_id, YAML entry, skills allowlist --

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -33,8 +33,6 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use sha2::{Digest, Sha256};
-
 use super::AdapterError;
 use super::claim::{
     AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
@@ -46,6 +44,7 @@ use super::driver::{
     DriverPlan, EnableProgress, FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable,
     find_binary_in_path,
 };
+use super::util::digest_tree;
 use crate::manifest::AdapterConfigSetSpec;
 
 /// Default timeout for an OpenClaw CLI invocation.
@@ -2570,43 +2569,6 @@ fn summarize(
     }
 }
 
-/// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
-fn digest_tree(root: &Path) -> Option<String> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in &files {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let bytes = std::fs::read(path).ok()?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0u8]);
-        hasher.update(&bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
-
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
 /// Build `openclaw config set <key> <value>`.
 fn build_config_set_cmd(
     key: &str,
@@ -3306,22 +3268,6 @@ mod tests {
             summarize(ClaimStatus::Enabled, true, ConditionStatus::Unknown),
             AdapterSummary::Unknown
         );
-    }
-
-    #[test]
-    fn digest_tree_is_stable_and_detects_change() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
-        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
-
-        let d1 = digest_tree(dir.path()).expect("digest");
-        let d2 = digest_tree(dir.path()).expect("digest again");
-        assert_eq!(d1, d2, "digest must be stable");
-
-        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
-        let d3 = digest_tree(dir.path()).expect("digest after change");
-        assert_ne!(d1, d3, "digest must change when a file changes");
     }
 
     // -- config set cmd -------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/util.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/util.rs
@@ -16,6 +16,12 @@ use super::driver::{CliOutput, ConditionStatus, FrameworkCommand};
 /// in sorted relative-path order as `path\0len\0bytes`. Returns `None` on
 /// any IO error so callers fall back to `Unknown` rather than a wrong
 /// verdict.
+///
+/// Every regular file counts, including derived artifacts such as
+/// `__pycache__/*.pyc`. Bytecode caches must not be filtered out on the
+/// strength of a sibling `.py`: CPython imports a header-valid cache without
+/// reading its source, so an excluded `.pyc` would be executable content that
+/// no integrity check covers.
 pub(crate) fn digest_tree(root: &Path) -> Option<String> {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_files(root, &mut files).ok()?;
@@ -95,4 +101,78 @@ pub(crate) fn display_command(cmd: &FrameworkCommand) -> String {
         s.push_str(a);
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal adapter bundle: a manifest plus a `hooks/` package, i.e. the
+    /// shape sec-core installs into an adapter resource root.
+    fn hook_bundle() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("anolisa-adapter.toml"), b"framework = 'x'")
+            .expect("write manifest");
+        std::fs::create_dir(dir.path().join("hooks")).expect("mkdir hooks");
+        std::fs::write(dir.path().join("hooks/hook_config.py"), b"CONFIG = 1\n")
+            .expect("write source");
+        std::fs::create_dir(dir.path().join("hooks/__pycache__")).expect("mkdir __pycache__");
+        dir
+    }
+
+    #[test]
+    fn digest_tree_is_stable_and_detects_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
+        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
+        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
+
+        let d1 = digest_tree(dir.path()).expect("digest");
+        let d2 = digest_tree(dir.path()).expect("digest again");
+        assert_eq!(d1, d2, "digest must be stable");
+
+        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
+        let d3 = digest_tree(dir.path()).expect("digest after change");
+        assert_ne!(d1, d3, "digest must change when a file changes");
+    }
+
+    /// Every file under a resource root counts, with no carve-out for derived
+    /// artifacts. Bytecode in particular must stay covered: CPython imports a
+    /// cache whose header `mtime`/`size` match the source without reading the
+    /// source at all, so a `.pyc` whose marshalled body was swapped executes
+    /// while the `.py` still looks clean. Keeping caches out of the resource
+    /// root is `agent-sec-core`'s job (`python3 -B` plus a bounded sweep in
+    /// the install/update transaction), not something this digest may assume.
+    #[test]
+    fn added_and_modified_resource_root_files_change_digest() {
+        let dir = hook_bundle();
+        let mut digest = digest_tree(dir.path()).expect("digest");
+
+        let cache = dir
+            .path()
+            .join("hooks/__pycache__/hook_config.cpython-311.pyc");
+        let steps: [(&str, &dyn Fn()); 4] = [
+            ("bytecode appears", &|| {
+                std::fs::write(&cache, b"\xcb\r\r\n\0\0\0\0honest").expect("write cache")
+            }),
+            ("bytecode body swapped under an intact source", &|| {
+                std::fs::write(&cache, b"\xcb\r\r\n\0\0\0\0tampered").expect("tamper cache")
+            }),
+            ("Python source edited", &|| {
+                std::fs::write(dir.path().join("hooks/hook_config.py"), b"CONFIG = 2\n")
+                    .expect("rewrite source")
+            }),
+            ("adapter manifest edited", &|| {
+                std::fs::write(dir.path().join("anolisa-adapter.toml"), b"framework = 'y'")
+                    .expect("rewrite manifest")
+            }),
+        ];
+
+        for (what, mutate) in steps {
+            mutate();
+            let next = digest_tree(dir.path()).expect("digest after change");
+            assert_ne!(digest, next, "digest must change when {what}");
+            digest = next;
+        }
+    }
 }

--- a/src/anolisa/crates/anolisa-core/src/planner.rs
+++ b/src/anolisa/crates/anolisa-core/src/planner.rs
@@ -566,6 +566,14 @@ fn plan_update(req: &UpdateRequest, facts: &Facts) -> Result<Plan, PlanError> {
                         Step::RemoveOwnedFiles,
                         Step::PlaceFiles,
                         Step::SetCapabilities,
+                        // Same slot as the install plan (after files and
+                        // capabilities, before services): `RemoveOwnedFiles`
+                        // only drops files the record tracks, so a component
+                        // whose payload leaves derived artifacts behind — e.g.
+                        // Python bytecode written next to an installed Hook —
+                        // needs its `post_install` hook on the update path too,
+                        // not just on first install.
+                        Step::RunHook(HookKind::PostInstall),
                         Step::RestartServices,
                         Step::WriteRecord(RecordWrite::Owned),
                     ])),
@@ -1252,6 +1260,10 @@ mod tests {
                 Step::RemoveOwnedFiles,
                 Step::PlaceFiles,
                 Step::SetCapabilities,
+                // Present on the update path, not just on install: an upgrade
+                // must be able to clean up artifacts the payload does not own
+                // (see the `post_install` slot in the install plan).
+                Step::RunHook(HookKind::PostInstall),
                 Step::RestartServices,
                 Step::WriteRecord(RecordWrite::Owned),
             ]


### PR DESCRIPTION
## Why

sec-core Python hooks can create `__pycache__/*.pyc` inside digest-managed
adapter resource roots. The next `anolisa adapter status` then reports a
healthy adapter as degraded even though no managed source or manifest changed.

The digest must continue covering every managed byte, so this fixes the writer
and cleans historical runtime caches instead of weakening integrity checks.

## What changed

- Run the Qwen, Codex, Qoder, and cosh Python hooks with `-B`.
- Add a bounded cache cleaner for sec-core adapter roots and use it in RPM and
  raw packaging/install flows.
- Execute strict incoming `post_install` hooks during raw updates, resolving
  them before host mutation and rolling back on failure.
- Keep the digest encoding and coverage unchanged while consolidating the
  shared digest implementation.
- Add regressions for cache safety boundaries, raw upgrade cleanup, early hook
  resolution, strict-hook rollback, and ordinary bundle drift detection.

## Related issue

Closes #2252

## User / Agent impact

Normal sec-core hook execution no longer changes adapter health. Upgrading a
historical raw or RPM installation removes safe derived bytecode caches from
the six contract-owned adapter roots. Source, manifest, symlink, orphan
bytecode, and foreign payload changes remain detectable.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

Cleanup is restricted to sec-core contract-declared adapter roots and only
removes validated Python cache content. A strict cleanup failure aborts and
rolls back the raw update. Raw `pre_install` and repair replay semantics are
unchanged; only update `post_install` is wired.

The bundle digest format and receipt schema are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --locked --test update_adapter_actions` — 8 passed
- `uv run --project agent-sec-cli pytest -q tests/packaging/test_adapter_bytecode.py`
  — 18 passed
- `tests/packaging/test-package-raw.sh`
- `bash -n` for the cleaner, raw hook, package script, and package test
- Earlier full anolisa gates passed: clippy, workspace tests, and cargo doc.
- Earlier sec-core suite result: 3535 passed and 3 pre-existing
  `time.tzset` failures on the local CPython build.
- `rpmspec` and `rpmbuild` are unavailable locally, so RPM macro/parser
  validation remains outstanding.

## Documentation and rollback

No user documentation changed. Reverting this commit restores the prior hook
and raw update behavior; the digest and receipt formats need no rollback.

## Draft blockers before Ready

- Bump sec-core from the already-published `0.9.0` in every version-bearing
  file so raw clients can select an actual update and run the cleanup hook.
- Set `min_anolisa_version` to the released anolisa version that contains this
  raw `post_install` support. It must be newer than the affected `0.2.17`
  release.
- Publish the coordinated sec-core artifact through `index-v2.toml` only;
  keep it out of the legacy index so older raw clients cannot select a package
  whose cleanup hook they do not execute.
- Run RPM parser/build validation in an environment with
  `rpmspec`/`rpmbuild`.

Keep this PR in Draft until the anolisa version, sec-core version, and catalog
publication are synchronized.