### PR TITLE
feat(tokenless): add 7u binary release packaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -785,6 +785,76 @@ jobs:
           cd src/tokenless
           cargo test --workspace -- --test-threads=1
 
+      - name: Validate release install script generation
+        run: |
+          cd src/tokenless
+          make release-install-script
+          bash -n dist/tokenless-*/install.sh
+          echo "install.sh syntax: OK"
+
+          INSTALL_SH=$(ls dist/tokenless-*/install.sh)
+          grep -q 'PREFIX must be an absolute path' "$INSTALL_SH" || { echo "FAIL: missing PREFIX validation"; exit 1; }
+          grep -q 'cp -r ' "$INSTALL_SH" || { echo "FAIL: missing cp -r"; exit 1; }
+          grep -qv 'cp -pr ' "$INSTALL_SH" || { echo "FAIL: still uses cp -pr"; exit 1; }
+          grep -q 'COSH_EXT_DIR' "$INSTALL_SH" || { echo "FAIL: missing cosh extension deployment"; exit 1; }
+          grep -q 'cosh-extension.json' "$INSTALL_SH" || { echo "FAIL: missing cosh-extension.json deployment"; exit 1; }
+          echo "install.sh content validation: OK"
+
+          # Smoke test the install script without a full release build.
+          STAGE=$(dirname "$INSTALL_SH")
+          TMPDIR=$(mktemp -d)
+          mkdir -p "$STAGE/bin" "$STAGE/libexec" "$STAGE/share/adapters/tokenless/common/hooks"
+          mkdir -p "$STAGE/share/adapters/tokenless/common/commands"
+          echo '#!/bin/sh' > "$STAGE/bin/tokenless"
+          echo '#!/bin/sh' > "$STAGE/libexec/rtk"
+          chmod +x "$STAGE/bin/tokenless" "$STAGE/libexec/rtk"
+          echo '[component]' > "$STAGE/share/component.toml"
+
+          # Relative PREFIX should be rejected.
+          if PREFIX=relative-prefix bash "$INSTALL_SH" 2>&1 | grep -q "PREFIX must be an absolute path"; then
+            echo "install.sh relative PREFIX rejection: OK"
+          else
+            echo "FAIL: install.sh did not reject relative PREFIX"
+            exit 1
+          fi
+
+          # Absolute PREFIX should succeed.
+          PREFIX="$TMPDIR/usr/local" bash "$INSTALL_SH"
+          test -x "$TMPDIR/usr/local/bin/tokenless" || { echo "FAIL: tokenless not installed"; exit 1; }
+          test -L "$TMPDIR/usr/local/bin/rtk" || { echo "FAIL: rtk symlink missing"; exit 1; }
+          test -d "$TMPDIR/usr/local/share/anolisa/extensions/tokenless" || { echo "FAIL: cosh ext dir missing"; exit 1; }
+          test -f "$TMPDIR/usr/local/share/anolisa/components/tokenless/component.toml" || { echo "FAIL: component.toml not installed"; exit 1; }
+          echo "install.sh smoke test: OK"
+          rm -rf "$TMPDIR"
+
+      - name: Validate release pre-flight guards
+        run: |
+          cd src/tokenless
+
+          # Test Cargo config guard: target override
+          mkdir -p .cargo
+          echo '[build]' > .cargo/config.toml
+          echo 'target = "x86_64-unknown-linux-gnu"' >> .cargo/config.toml
+          if bash scripts/build-release.sh --check-cargo-config 2>&1 | grep -q "sets \[build\] target"; then
+            echo "Cargo config target guard: OK"
+          else
+            echo "FAIL: Cargo config target guard not triggered"
+            exit 1
+          fi
+          rm -f .cargo/config.toml
+
+          # Test Cargo config guard: target-dir override
+          echo '[build]' > .cargo/config.toml
+          echo 'target-dir = "/tmp/custom-target"' >> .cargo/config.toml
+          if bash scripts/build-release.sh --check-cargo-config 2>&1 | grep -q "sets \[build\] target-dir"; then
+            echo "Cargo config target-dir guard: OK"
+          else
+            echo "FAIL: Cargo config target-dir guard not triggered"
+            exit 1
+          fi
+          rm -f .cargo/config.toml
+          rmdir .cargo 2>/dev/null || true
+
       # The benchmark suite is split into two standalone workspaces (each with an
       # empty [workspace] table in its Cargo.toml), so the --workspace commands
       # above never touch them. Exercise both explicitly: fmt, clippy and the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -795,7 +795,17 @@ jobs:
           INSTALL_SH=$(ls dist/tokenless-*/install.sh)
           grep -q 'PREFIX must be an absolute path' "$INSTALL_SH" || { echo "FAIL: missing PREFIX validation"; exit 1; }
           grep -q 'cp -r ' "$INSTALL_SH" || { echo "FAIL: missing cp -r"; exit 1; }
-          grep -qv 'cp -pr ' "$INSTALL_SH" || { echo "FAIL: still uses cp -pr"; exit 1; }
+          if grep -q 'cp -pr ' "$INSTALL_SH"; then echo "FAIL: still uses cp -pr"; exit 1; fi
+          # Self-test: prove the cp -pr guard actually fails when the banned
+          # command is present (regression guard for the grep -qv false-pass).
+          _FIXTURE=$(mktemp)
+          echo 'cp -pr src dst' > "$_FIXTURE"
+          if ! grep -q 'cp -pr ' "$_FIXTURE"; then
+            echo "FAIL: cp -pr guard does not detect the banned command"
+            exit 1
+          fi
+          rm -f "$_FIXTURE"
+          echo "cp -pr guard self-test: OK"
           grep -q 'COSH_EXT_DIR' "$INSTALL_SH" || { echo "FAIL: missing cosh extension deployment"; exit 1; }
           grep -q 'cosh-extension.json' "$INSTALL_SH" || { echo "FAIL: missing cosh-extension.json deployment"; exit 1; }
           echo "install.sh content validation: OK"
@@ -854,6 +864,42 @@ jobs:
           fi
           rm -f .cargo/config.toml
           rmdir .cargo 2>/dev/null || true
+
+          # Test Cargo config guard: ancestor directory target override.
+          # Cargo merges .cargo/config* from cwd up to the filesystem root;
+          # a parent [build] target would bypass the component-dir guard.
+          mkdir -p ../.cargo
+          echo '[build]' > ../.cargo/config.toml
+          echo 'target = "x86_64-unknown-linux-gnu"' >> ../.cargo/config.toml
+          if bash scripts/build-release.sh --check-cargo-config 2>&1 | grep -q "sets \[build\] target"; then
+            echo "Ancestor Cargo config target guard: OK"
+          else
+            echo "FAIL: ancestor Cargo config target guard not triggered"
+            exit 1
+          fi
+          rm -rf ../.cargo
+
+          # Test Cargo config guard: ancestor directory target-dir override
+          mkdir -p ../.cargo
+          echo '[build]' > ../.cargo/config.toml
+          echo 'target-dir = "/tmp/custom-target"' >> ../.cargo/config.toml
+          if bash scripts/build-release.sh --check-cargo-config 2>&1 | grep -q "sets \[build\] target-dir"; then
+            echo "Ancestor Cargo config target-dir guard: OK"
+          else
+            echo "FAIL: ancestor Cargo config target-dir guard not triggered"
+            exit 1
+          fi
+          rm -rf ../.cargo
+
+          # The release build must not call bare `make build`, which includes
+          # build-toon (a `cargo install` without --root that clobbers the
+          # caller's global cargo install root). toon is rebuilt in isolated
+          # staging during packaging instead.
+          if grep -Eq '^\s*make build\s*$' scripts/build-release.sh; then
+            echo "FAIL: build-release.sh calls bare 'make build' (global toon install)"
+            exit 1
+          fi
+          echo "Release build skips global toon install: OK"
 
       # The benchmark suite is split into two standalone workspaces (each with an
       # empty [workspace] table in its Cargo.toml), so the --workspace commands

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -15,3 +15,6 @@ adapters/tokenless/qwencode/qwen-extension.json
 # Python bytecode cache
 __pycache__/
 *.pyc
+
+# Release tarballs and staging directory
+dist/

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -35,6 +35,11 @@ ADAPTER_TEMPLATES := \
 COMPONENT_CONTRACT := .anolisa/component.toml
 ANOLISA_COMPONENT_MANIFEST := ../anolisa/manifests/components/tokenless/component.toml
 TOON_VER := 0.5.0
+# Architecture suffix for release tarball naming (derived from the Rust host
+# triple — more accurate than uname -m under Rosetta). Cross-architecture
+# builds are NOT supported: set up a native build environment for the target
+# arch instead, or pass CARGO_TARGET_TRIPLE and a matching --target to cargo.
+ARCH ?= $(shell rustc -vV 2>/dev/null | sed -n 's/^host: *\([^ -]*\).*/\1/p' || uname -m)
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
 .PHONY: build build-tokenless build-toon build-openclaw-plugin \
@@ -52,7 +57,8 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1
         qwencode-install qwencode-uninstall \
         setup help \
         npm-package npm-package-all npm-publish \
-        test-hooks
+        test-hooks \
+        release release-7u release-with-suffix release-install-script release-check-cargo-config
 
 # Default target
 all: build
@@ -231,6 +237,9 @@ dist: clean
 	tar czf ../tokenless-$(VERSION).tar.gz \
 	    --exclude='target' \
 	    --exclude='.git' \
+	    --exclude='tokenless/dist' \
+	    --exclude='node_modules' \
+	    --exclude='__pycache__' \
 	    -C .. tokenless
 	@tar_list=$$(tar -tzf ../tokenless-$(VERSION).tar.gz); \
 	for required in \
@@ -242,6 +251,28 @@ dist: clean
 		}; \
 	done
 	@echo "==> Tarball: ../tokenless-$(VERSION).tar.gz"
+
+# -----------------------------------------------------------------------------
+# Binary release tarballs
+# -----------------------------------------------------------------------------
+# Build tokenless, rtk and toon, then package into dist/tokenless-$(VERSION)-$(ARCH).tar.gz
+# with an embedded install.sh. Run on the target Linux distribution so the
+# resulting binaries link against the same glibc version.
+release: release-check-cargo-config
+	@bash scripts/build-release.sh
+
+# 7u-specific release tarball for Anolis OS 7u / Alibaba Cloud Linux 2 / el7.
+# Produces dist/tokenless-$(VERSION)-7u-$(ARCH).tar.gz.
+release-7u: release-check-cargo-config
+	@bash scripts/build-release.sh 7u
+
+# Generate the embedded install.sh without a full build (used by CI tests).
+release-install-script:
+	@bash scripts/build-release.sh --install-script-only
+
+# Verify no Cargo config overrides are active.
+release-check-cargo-config:
+	@bash scripts/build-release.sh --check-cargo-config
 
 # Adapter management — invokes detect/install/uninstall action scripts per the
 # ANOLISA FHS adapter spec.  Environment variables point to installed FHS paths.
@@ -462,6 +493,8 @@ help:
 	@echo "  qwencode-install  Register Qwen Code plugin via qwen CLI"
 	@echo "  qwencode-uninstall Unregister Qwen Code plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
+	@echo "  release           Build all + package release tarball"
+	@echo "  release-7u        Build all + package 7u release tarball"
 	@echo "  npm-package       Package for npm (current platform)"
 	@echo "  npm-package-all   Package for npm (all platforms)"
 	@echo "  npm-publish       Build and publish all npm packages"

--- a/src/tokenless/scripts/build-release.sh
+++ b/src/tokenless/scripts/build-release.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Build a tokenless binary release tarball.
+#
+# Usage:
+#   scripts/build-release.sh [distro-suffix]
+#
+# The optional distro-suffix is appended to the package directory and tarball
+# name, e.g.:
+#   scripts/build-release.sh          -> dist/tokenless-0.7.4-x86_64.tar.gz
+#   scripts/build-release.sh 7u       -> dist/tokenless-0.7.4-7u-x86_64.tar.gz
+#
+# The script is intended to run on the target Linux distribution so that the
+# resulting binaries are linked against the same glibc version. The "7u" suffix
+# denotes the Anolis OS 7u / Alibaba Cloud Linux 2 / el7 compatible build.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT_DIR}"
+
+VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+ARCH="$(rustc -vV 2>/dev/null | sed -n 's/^host: *\([^ -]*\).*/\1/p' || uname -m)"
+DISTRO_SUFFIX="${1:-}"
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+log()  { echo -e "\033[0;36m[INFO]\033[0m $*" >&2; }
+warn() { echo -e "\033[1;33m[WARN]\033[0m $*" >&2; }
+err()  { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
+
+# -----------------------------------------------------------------------------
+# Pre-flight guards
+# -----------------------------------------------------------------------------
+check_cargo_config() {
+    local fail=0
+    local cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
+    for cfg in ".cargo/config.toml" ".cargo/config" \
+               "${cargo_home}/config.toml" "${cargo_home}/config"; do
+        if [ -f "${cfg}" ]; then
+            if grep -qE '^\s*target\s*=' "${cfg}" 2>/dev/null; then
+                err "Cargo config ${cfg} sets [build] target."
+                fail=1
+            fi
+            if grep -qE '^\s*target-dir\s*=' "${cfg}" 2>/dev/null; then
+                err "Cargo config ${cfg} sets [build] target-dir."
+                fail=1
+            fi
+        fi
+    done
+    if [ "${fail}" -ne 0 ]; then
+        exit 1
+    fi
+}
+
+check_environment() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        err "release builds are only supported on Linux (current: $(uname -s))."
+        exit 1
+    fi
+
+    local host_arch
+    host_arch="$(rustc -vV 2>/dev/null | sed -n 's/^host: *\([^ -]*\).*/\1/p' || uname -m)"
+
+    if [ -n "${CARGO_BUILD_TARGET:-}" ]; then
+        err "CARGO_BUILD_TARGET is set to ${CARGO_BUILD_TARGET}."
+        err "release builds always use target/release/ — cross-compilation is not supported."
+        exit 1
+    fi
+
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+        err "CARGO_TARGET_DIR is set to ${CARGO_TARGET_DIR}."
+        err "release builds always read from target/release/ — custom target dirs are not supported."
+        exit 1
+    fi
+
+    if [ "${ARCH}" != "${host_arch}" ]; then
+        err "ARCH=${ARCH} does not match build host architecture (${host_arch})."
+        err "cross-architecture release builds are not supported."
+        exit 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Build
+# -----------------------------------------------------------------------------
+build_binaries() {
+    log "Building tokenless, rtk and openclaw plugin..."
+    make build
+}
+
+# -----------------------------------------------------------------------------
+# Generate install.sh
+# -----------------------------------------------------------------------------
+write_install_script() {
+    local pkg_dir="$1"
+    local install_sh="${pkg_dir}/install.sh"
+
+    cat > "${install_sh}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFIX="${PREFIX:-/usr/local}"
+
+# --- Preflight: PREFIX must be an absolute path ---
+case "$PREFIX" in
+    /*) ;;
+    *)  echo "ERROR: PREFIX must be an absolute path (got: $PREFIX)"; exit 1 ;;
+esac
+
+# --- Preflight: ensure BINDIR parent is a directory ---
+if [ -e "$PREFIX/bin" ] && [ ! -d "$PREFIX/bin" ]; then
+    echo "ERROR: $PREFIX/bin exists but is not a directory"; exit 1
+fi
+
+# Path layout — keep in sync with Makefile
+BINDIR="$PREFIX/bin"
+LIBEXECDIR="$PREFIX/libexec/anolisa/tokenless"
+SHARE_DIR="$PREFIX/share/anolisa/adapters/tokenless"
+COMPONENTS_DIR="$PREFIX/share/anolisa/components/tokenless"
+COSH_EXT_DIR="$PREFIX/share/anolisa/extensions/tokenless"
+
+echo "==> tokenless installer"
+echo "    Install prefix : $PREFIX"
+echo "    Binaries       : $BINDIR"
+echo "    Libexec        : $LIBEXECDIR"
+echo "    Adapters       : $SHARE_DIR"
+echo "    Cosh extension : $COSH_EXT_DIR"
+echo "    Note: this script will OVERWRITE rtk/toon symlinks in $BINDIR,"
+echo "          replace all files under $SHARE_DIR,"
+echo "          and replace the cosh extension at $COSH_EXT_DIR"
+echo "==> Installing tokenless from $SCRIPT_DIR ..."
+echo ""
+
+# --- Install binaries ---
+install -d -m 0755 "$BINDIR" "$LIBEXECDIR"
+install -m 0755 "$SCRIPT_DIR/bin/tokenless" "$BINDIR/"
+install -m 0755 "$SCRIPT_DIR/libexec/rtk" "$LIBEXECDIR/"
+
+# rtk symlink
+TARGET="$LIBEXECDIR/rtk"
+if [ -L "$BINDIR/rtk" ]; then
+    RTK_LINK=$(readlink "$BINDIR/rtk" || true)
+    case "$RTK_LINK" in
+        *"$PREFIX"*) ;;
+        *) echo "WARNING: $BINDIR/rtk is an existing symlink pointing to $RTK_LINK — will be overwritten" ;;
+    esac
+elif [ -e "$BINDIR/rtk" ]; then
+    echo "WARNING: $BINDIR/rtk already exists — will be overwritten"
+fi
+ln -sf "$TARGET" "$BINDIR/"
+
+# toon (conditional)
+if [ -f "$SCRIPT_DIR/libexec/toon" ]; then
+    install -m 0755 "$SCRIPT_DIR/libexec/toon" "$LIBEXECDIR/"
+    TARGET="$LIBEXECDIR/toon"
+    if [ -L "$BINDIR/toon" ]; then
+        TOON_LINK=$(readlink "$BINDIR/toon" || true)
+        case "$TOON_LINK" in
+            *"$PREFIX"*) ;;
+            *) echo "WARNING: $BINDIR/toon is an existing symlink pointing to $TOON_LINK — will be overwritten" ;;
+        esac
+    elif [ -e "$BINDIR/toon" ]; then
+        echo "WARNING: $BINDIR/toon already exists — will be overwritten"
+    fi
+    ln -sf "$TARGET" "$BINDIR/"
+else
+    # Clean up toon from a previous install when this release does not bundle it.
+    if [ -e "$LIBEXECDIR/toon" ]; then
+        rm -f "$LIBEXECDIR/toon"
+    fi
+    if [ -L "$BINDIR/toon" ]; then
+        TOON_LINK=$(readlink "$BINDIR/toon" 2>/dev/null || true)
+        TOON_REAL=$(cd "$BINDIR" && realpath -m "$TOON_LINK" 2>/dev/null || echo "$TOON_LINK")
+        TOON_EXPECT="$(realpath -m "$LIBEXECDIR/toon" 2>/dev/null || echo "$LIBEXECDIR/toon")"
+        if [ "$TOON_REAL" = "$TOON_EXPECT" ]; then
+            rm -f "$BINDIR/toon"
+            echo "NOTE: removed $BINDIR/toon symlink (no longer bundled)"
+        else
+            echo "NOTE: $BINDIR/toon is an external symlink ($TOON_LINK) — left untouched"
+        fi
+    fi
+fi
+
+# --- Adapter resources ---
+# Use cp -r (NOT cp -pr) to avoid preserving source file ownership.
+if [ -d "$SHARE_DIR" ] && [ "$(ls -A "$SHARE_DIR" 2>/dev/null)" ]; then
+    echo "WARNING: $SHARE_DIR is not empty — all contents will be replaced"
+fi
+rm -rf "$SHARE_DIR"
+install -d -m 0755 "$SHARE_DIR"
+cp -r "$SCRIPT_DIR/share/adapters/tokenless/." "$SHARE_DIR/"
+find "$SHARE_DIR" -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
+
+# --- Component contract ---
+if [ -f "$SCRIPT_DIR/share/component.toml" ]; then
+    install -d -m 0755 "$COMPONENTS_DIR"
+    install -m 0644 "$SCRIPT_DIR/share/component.toml" "$COMPONENTS_DIR/"
+fi
+
+# --- Cosh extension ---
+if [ -d "$COSH_EXT_DIR" ]; then
+    echo "NOTE: replacing existing cosh extension at $COSH_EXT_DIR"
+fi
+rm -rf "$COSH_EXT_DIR"
+install -d -m 0755 "$COSH_EXT_DIR/hooks" "$COSH_EXT_DIR/commands"
+if [ -d "$SHARE_DIR/common/hooks" ] && [ "$(ls -A "$SHARE_DIR/common/hooks" 2>/dev/null)" ]; then
+    cp -r "$SHARE_DIR/common/hooks/." "$COSH_EXT_DIR/hooks/"
+fi
+if [ -d "$SHARE_DIR/common/commands" ] && [ "$(ls -A "$SHARE_DIR/common/commands" 2>/dev/null)" ]; then
+    cp -r "$SHARE_DIR/common/commands/." "$COSH_EXT_DIR/commands/"
+fi
+if [ -f "$SHARE_DIR/common/cosh-extension.json" ]; then
+    install -m 0644 "$SHARE_DIR/common/cosh-extension.json" "$COSH_EXT_DIR/"
+fi
+find "$COSH_EXT_DIR" -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
+echo "==> cosh extension installed to $COSH_EXT_DIR"
+
+echo ""
+echo "==> Done. Run 'tokenless --version' to verify."
+echo "==> Cosh extension deployed to $COSH_EXT_DIR."
+echo "==> If cosh does not scan $PREFIX/share/anolisa/extensions by default,"
+echo "    you may need to configure cosh to include this extension path."
+EOF
+
+    sed -i "s/@VERSION@/${VERSION}/g" "${install_sh}"
+    chmod +x "${install_sh}"
+}
+
+# -----------------------------------------------------------------------------
+# Package
+# -----------------------------------------------------------------------------
+package_release() {
+    local pkg_name="tokenless-${VERSION}"
+    if [ -n "${DISTRO_SUFFIX}" ]; then
+        pkg_name="${pkg_name}-${DISTRO_SUFFIX}"
+    fi
+    local pkg_dir="dist/${pkg_name}"
+
+    log "Packaging ${pkg_name} for ${ARCH}..."
+    rm -rf "${pkg_dir}"
+    mkdir -p "${pkg_dir}/bin" \
+             "${pkg_dir}/libexec" \
+             "${pkg_dir}/share/adapters/tokenless" \
+             "${pkg_dir}/docs"
+
+    install -m 0755 target/release/tokenless "${pkg_dir}/bin/"
+    install -m 0755 third_party/rtk/target/release/rtk "${pkg_dir}/libexec/"
+
+    # toon: build into a private staging dir so we package the binary from THIS build.
+    local staging
+    staging="$(mktemp -d)"
+    if cargo install toon-format --version "${TOON_VER:-0.5.0}" --locked --root "${staging}" 2>"${staging}/install.err"; then
+        if [ -x "${staging}/bin/toon" ]; then
+            install -m 0755 "${staging}/bin/toon" "${pkg_dir}/libexec/toon"
+            log "Bundled toon $(${pkg_dir}/libexec/toon --version 2>/dev/null || echo "${TOON_VER:-0.5.0}")"
+        fi
+    else
+        warn "toon install failed — skipping (see ${staging}/install.err)"
+        cat "${staging}/install.err" >&2
+    fi
+    rm -rf "${staging}"
+
+    # Adapter resources (exclude build-only artifacts).
+    tar -cf - -C adapters/tokenless \
+        --exclude='node_modules' \
+        --exclude='.tsbuildinfo' \
+        --exclude='*.in' \
+        --exclude='tests' \
+        . | tar -xf - -C "${pkg_dir}/share/adapters/tokenless/"
+    find "${pkg_dir}/share/adapters/tokenless" \
+        -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
+
+    # Component contract, docs and license.
+    install -m 0644 .anolisa/component.toml "${pkg_dir}/share/component.toml"
+    install -m 0644 ../../docs/user-guide/en/token-saving/tokenless/user-manual.md \
+        "${pkg_dir}/docs/tokenless-user-manual-en.md"
+    install -m 0644 ../../docs/user-guide/zh/token-saving/tokenless/user-manual.md \
+        "${pkg_dir}/docs/tokenless-user-manual-zh.md"
+    install -m 0644 docs/response-compression.md "${pkg_dir}/docs/"
+    install -m 0644 LICENSE "${pkg_dir}/"
+
+    # Embedded install script.
+    write_install_script "${pkg_dir}"
+
+    rm -f "dist/${pkg_name}-${ARCH}.tar.gz"
+    tar czf "dist/${pkg_name}-${ARCH}.tar.gz" -C dist "${pkg_name}"
+    rm -rf "${pkg_dir}"
+
+    echo ""
+    log "Release tarball: dist/${pkg_name}-${ARCH}.tar.gz $(du -sh "dist/${pkg_name}-${ARCH}.tar.gz" | cut -f1)"
+    log "Extract and run ./install.sh to deploy."
+}
+
+# -----------------------------------------------------------------------------
+# Entry point
+# -----------------------------------------------------------------------------
+main() {
+    local arg="${1:-}"
+    case "${arg}" in
+        --check-cargo-config)
+            check_cargo_config
+            echo "OK: no Cargo config overrides detected"
+            exit 0
+            ;;
+        --install-script-only)
+            # Generate install.sh for the current VERSION (used by CI tests).
+            DISTRO_SUFFIX=""
+            pkg_dir="dist/tokenless-${VERSION}"
+            mkdir -p "${pkg_dir}"
+            write_install_script "${pkg_dir}"
+            exit 0
+            ;;
+        "")
+            DISTRO_SUFFIX=""
+            ;;
+        -*)
+            err "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            DISTRO_SUFFIX="${arg}"
+            ;;
+    esac
+
+    check_cargo_config
+    check_environment
+    build_binaries
+    package_release
+}
+
+main "$@"

--- a/src/tokenless/scripts/build-release.sh
+++ b/src/tokenless/scripts/build-release.sh
@@ -35,22 +35,45 @@ err()  { echo -e "\033[0;31m[ERROR]\033[0m $*" >&2; }
 # -----------------------------------------------------------------------------
 # Pre-flight guards
 # -----------------------------------------------------------------------------
+# Report a [build] target / target-dir override in a Cargo config file.
+# Returns 1 when an override is found (so the caller sets its fail flag),
+# 0 when the file is absent or clean — preserving the original behavior of
+# reporting every offending config in one pass rather than stopping early.
+_check_cargo_config_file() {
+    local cfg="$1"
+    [ -f "${cfg}" ] || return 0
+    local bad=0
+    if grep -qE '^\s*target\s*=' "${cfg}" 2>/dev/null; then
+        err "Cargo config ${cfg} sets [build] target."
+        bad=1
+    fi
+    if grep -qE '^\s*target-dir\s*=' "${cfg}" 2>/dev/null; then
+        err "Cargo config ${cfg} sets [build] target-dir."
+        bad=1
+    fi
+    return "${bad}"
+}
+
 check_cargo_config() {
     local fail=0
     local cargo_home="${CARGO_HOME:-${HOME}/.cargo}"
-    for cfg in ".cargo/config.toml" ".cargo/config" \
-               "${cargo_home}/config.toml" "${cargo_home}/config"; do
-        if [ -f "${cfg}" ]; then
-            if grep -qE '^\s*target\s*=' "${cfg}" 2>/dev/null; then
-                err "Cargo config ${cfg} sets [build] target."
-                fail=1
-            fi
-            if grep -qE '^\s*target-dir\s*=' "${cfg}" 2>/dev/null; then
-                err "Cargo config ${cfg} sets [build] target-dir."
-                fail=1
-            fi
-        fi
+    local dir
+
+    # Cargo merges .cargo/config* hierarchically from the cwd up to the
+    # filesystem root, plus $CARGO_HOME. A parent [build] target / target-dir
+    # would divert artifacts away from target/release/, so the release could
+    # package stale or host artifacts — walk every ancestor, not just the
+    # component dir.
+    dir="${ROOT_DIR}"
+    while :; do
+        _check_cargo_config_file "${dir}/.cargo/config.toml" || fail=1
+        _check_cargo_config_file "${dir}/.cargo/config" || fail=1
+        [ "${dir}" = "/" ] && break
+        dir="$(dirname "${dir}")"
     done
+    _check_cargo_config_file "${cargo_home}/config.toml" || fail=1
+    _check_cargo_config_file "${cargo_home}/config" || fail=1
+
     if [ "${fail}" -ne 0 ]; then
         exit 1
     fi
@@ -89,7 +112,10 @@ check_environment() {
 # -----------------------------------------------------------------------------
 build_binaries() {
     log "Building tokenless, rtk and openclaw plugin..."
-    make build
+    # Skip build-toon: `make build` runs `cargo install` without --root,
+    # clobbering the caller's global cargo install root. toon is rebuilt in
+    # isolated staging during packaging (see package_release).
+    make build-tokenless build-openclaw-plugin
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a self-contained binary release tarball for Anolis OS 7u / Alibaba Cloud Linux 2 / el7-compatible systems, alongside the existing generic `make release` target.

- New `scripts/build-release.sh` supports an optional distro suffix (e.g. `bash scripts/build-release.sh 7u`) and produces `dist/tokenless-<VERSION>-7u-<ARCH>.tar.gz`.
- `Makefile` adds `release`, `release-7u`, `release-install-script`, and `release-check-cargo-config` targets, plus an `ARCH` variable derived from the Rust host triple.
- `.gitignore` ignores the `dist/` staging directory.
- CI validates the embedded `install.sh` generation and the pre-flight guards that reject Cargo target/target-dir overrides.

## Test plan

- `make release-7u` builds `dist/tokenless-0.7.4-7u-x86_64.tar.gz` successfully.
- `cargo fmt --all -- --check` passes.
- `cargo clippy --workspace -- -D warnings` passes.
- `cargo test --workspace -- --test-threads=1` passes.