### PR TITLE
fix(anolisa): don't fail integrity on oversized files

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -1848,7 +1848,11 @@ fn health_from_entry(entry: &HealthEntry) -> DoctorHealthCheck {
 
 fn severity_for_health_status(status: &str) -> Option<FindingSeverity> {
     match status {
-        "ok" | "skipped" | "unverified" => None,
+        // `probe_limit_exceeded` sits with `unverified`: the bytes were
+        // never examined, so there is no defect to report. The entry still
+        // appears verbatim in `health_checks` above, so the operator can
+        // see the file went unhashed without it being raised as a fault.
+        "ok" | "skipped" | "unverified" | "probe_limit_exceeded" => None,
         "not_supported" | "unsupported" | "unsupported_kind" | "out_of_bounds"
         | "unsupported_target" | "not_regular_file" | "timeout" => Some(FindingSeverity::Warning),
         _ => Some(FindingSeverity::Error),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -783,7 +783,8 @@ fn record_version(installation: &Installation) -> Option<String> {
 ///
 /// Escalation rules (only move toward more-broken, never back):
 /// - any [`IntegrityStatus::is_failure`] result → `"failed"`
-/// - any [`IntegrityStatus::Unverified`] result on an otherwise-clean
+/// - any [`IntegrityStatus::Unverified`] or
+///   [`IntegrityStatus::ProbeLimitExceeded`] result on an otherwise-clean
 ///   component → `"degraded"`
 /// - otherwise the base status (`installed`/`disabled`/etc) is preserved
 ///
@@ -813,7 +814,13 @@ fn integrity_probe(
         }
         if result.is_failure() {
             had_failure = true;
-        } else if matches!(result, IntegrityStatus::Unverified) {
+        } else if matches!(
+            result,
+            IntegrityStatus::Unverified | IntegrityStatus::ProbeLimitExceeded { .. }
+        ) {
+            // Both mean "content not proved intact" — no digest recorded,
+            // or one recorded but the file was too large to hash. Neither
+            // proves damage, so they degrade rather than fail.
             had_unverified = true;
         }
         entries.push(HealthEntry {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -823,11 +823,21 @@ fn integrity_probe(
             // proves damage, so they degrade rather than fail.
             had_unverified = true;
         }
+        // Spell the budget stop out. On its own the label reads like "this
+        // file is outside integrity policy", when in fact a digest is on
+        // record and only this run declined to re-read it.
+        let reason = match &result {
+            IntegrityStatus::ProbeLimitExceeded { size, limit } => Some(format!(
+                "file size {size} exceeds the {limit}-byte integrity probe ceiling; \
+                 the recorded digest was not re-checked this run"
+            )),
+            _ => None,
+        };
         entries.push(HealthEntry {
             name: format!("integrity:{}", file.path.display()),
             status: result.label().to_string(),
             checked_at: checked_at.clone(),
-            reason: None,
+            reason,
         });
     }
 

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -380,9 +380,12 @@ pub fn assemble_facts(
 /// that verdict is the evidence repair's R6 exit (rebuild the owned record)
 /// consumes.
 ///
-/// `Skipped` (not ANOLISA-owned) and `Unverified` (no recorded digest) are
-/// healthy: neither proves drift, and treating absence of evidence as
-/// damage would route every digest-less install into repair.
+/// `Skipped` (not ANOLISA-owned), `Unverified` (no recorded digest), and
+/// `ProbeLimitExceeded` (too large to hash within the probe budget) are
+/// healthy: none proves drift, and treating absence of evidence as
+/// damage would route every digest-less install into repair — and, for
+/// the last one, would make owning a large intact artifact trigger repair
+/// on every run.
 fn verify_owned_files(
     record: &RecordFacts,
     store: &StateStore,
@@ -410,7 +413,10 @@ fn verify_owned_files(
     let all_healthy = files.iter().all(|file| {
         matches!(
             check_owned_file(layout, file),
-            IntegrityStatus::Ok | IntegrityStatus::Skipped | IntegrityStatus::Unverified
+            IntegrityStatus::Ok
+                | IntegrityStatus::Skipped
+                | IntegrityStatus::Unverified
+                | IntegrityStatus::ProbeLimitExceeded { .. }
         )
     });
     Some(all_healthy)

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -373,19 +373,24 @@ pub fn assemble_facts(
 
 /// Integrity verdict over a record's owned file list: `Some(true)` when
 /// every probe is healthy, `Some(false)` on any hard finding, `None` when
-/// there is nothing to verify (no record, delegated binding, empty file
-/// list).
+/// the list cannot be judged — nothing to verify (no record, delegated
+/// binding, empty file list), or at least one file was too large to hash.
 ///
 /// A quarantined record is verified against the legacy record's file list —
 /// that verdict is the evidence repair's R6 exit (rebuild the owned record)
-/// consumes.
+/// consumes. R6 treats `Some(true)` as a positive assertion that the
+/// original file list still checks out, so a run that skipped a file must
+/// not report it: an over-limit file yields `None`, which fails R6 closed
+/// (`RecordUnrecoverable`) rather than laundering unread bytes back into an
+/// active record.
 ///
-/// `Skipped` (not ANOLISA-owned), `Unverified` (no recorded digest), and
-/// `ProbeLimitExceeded` (too large to hash within the probe budget) are
-/// healthy: none proves drift, and treating absence of evidence as
-/// damage would route every digest-less install into repair — and, for
-/// the last one, would make owning a large intact artifact trigger repair
-/// on every run.
+/// For an active record the caller only acts on `Some(false)` (replay), so
+/// `None` and `Some(true)` behave alike there — an over-limit file does not
+/// trigger a spurious reinstall.
+///
+/// `Skipped` (not ANOLISA-owned) and `Unverified` (no recorded digest) count
+/// as healthy: neither proves drift, and treating absence of evidence as
+/// damage would route every digest-less install into repair.
 fn verify_owned_files(
     record: &RecordFacts,
     store: &StateStore,
@@ -410,16 +415,20 @@ fn verify_owned_files(
     if files.is_empty() {
         return None;
     }
-    let all_healthy = files.iter().all(|file| {
-        matches!(
-            check_owned_file(layout, file),
-            IntegrityStatus::Ok
-                | IntegrityStatus::Skipped
-                | IntegrityStatus::Unverified
-                | IntegrityStatus::ProbeLimitExceeded { .. }
-        )
-    });
-    Some(all_healthy)
+    let mut skipped_a_file = false;
+    for file in files {
+        match check_owned_file(layout, file) {
+            IntegrityStatus::Ok | IntegrityStatus::Skipped | IntegrityStatus::Unverified => {}
+            // The bytes were never read, so this file can be neither
+            // vouched for nor condemned. Downgrade the whole verdict to
+            // "cannot judge" instead of letting it pass as verified.
+            IntegrityStatus::ProbeLimitExceeded { .. } => skipped_a_file = true,
+            // Any hard finding is decisive on its own — report damage even
+            // if another file was skipped.
+            _ => return Some(false),
+        }
+    }
+    (!skipped_a_file).then_some(true)
 }
 
 /// First pending journal attributed to `subject`, if any.
@@ -1172,6 +1181,88 @@ mod tests {
         store.quarantined.push(quarantined("cosh", Vec::new()));
         let facts = assemble_facts(&req, &store, None, &layout, &journal_dir).expect("facts");
         assert_eq!(facts.owned_files_verified, None);
+    }
+
+    /// A quarantined record whose file list contains an over-limit file must
+    /// not reach repair's R6 exit. `ProbeLimitExceeded` means the bytes were
+    /// never read, so reporting `Some(true)` would let R6 rebuild an active
+    /// owned record on the strength of a digest nobody checked — tampered
+    /// content would be laundered straight back into service.
+    ///
+    /// The fixture is sparse: `set_len` sets the inode size without
+    /// allocating blocks, and the probe's size gate fires before any read.
+    #[test]
+    fn quarantined_record_with_over_limit_file_fails_r6_closed() {
+        use crate::planner::{Intent, PlanError, plan};
+        use crate::state::{InstalledObject, ObjectStatus, SubscriptionScope};
+        use crate::state_migration::{QuarantineReason, QuarantinedObject};
+
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let layout = layout_under(tmp.path());
+        let journal_dir = tmp.path().join("journal");
+
+        let path = layout.bin_dir.join("huge");
+        let f = fs::File::create(&path).expect("create");
+        // Comfortably past the probe ceiling; the exact value is irrelevant
+        // because the gate compares against the constant, not a threshold
+        // this test owns.
+        f.set_len(4 * 1024 * 1024 * 1024).expect("set_len");
+        drop(f);
+
+        let over_limit = OwnedFile {
+            path,
+            owner: FileOwner::Anolisa,
+            // A digest IS recorded — that is precisely the case where the
+            // probe reports a budget stop rather than `Unverified`.
+            sha256: Some("deadbeef".to_string()),
+            kind: OwnedFileKind::File,
+            referent: None,
+            mode: None,
+            capabilities: Vec::new(),
+        };
+
+        let mut store = StateStore::empty();
+        store.quarantined.push(QuarantinedObject {
+            record: InstalledObject {
+                kind: ObjectKind::Component,
+                name: "cosh".to_string(),
+                version: "1.0.0".to_string(),
+                status: ObjectStatus::Installed,
+                manifest_digest: None,
+                distribution_source: None,
+                raw_package: None,
+                install_backend: None,
+                ownership: None,
+                rpm_metadata: None,
+                installed_at: NOW.to_string(),
+                last_operation_id: None,
+                managed: true,
+                adopted: false,
+                subscription_scope: SubscriptionScope::None,
+                enabled_features: Vec::new(),
+                component_refs: Vec::new(),
+                files: vec![over_limit],
+                external_modified_files: Vec::new(),
+                services: Vec::new(),
+                health: Vec::new(),
+                provisioned_packages: Vec::new(),
+            },
+            reason: QuarantineReason::NoEvidence,
+        });
+
+        let req = ObserveRequest {
+            verify_owned_files: true,
+            ..request("cosh", None)
+        };
+        let facts = assemble_facts(&req, &store, None, &layout, &journal_dir).expect("facts");
+
+        // "Cannot judge" — not "verified".
+        assert_eq!(facts.owned_files_verified, None);
+        // And the planner refuses the quarantine exit rather than rebuilding.
+        assert_eq!(
+            plan(&Intent::Repair, &facts),
+            Err(PlanError::RecordUnrecoverable)
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/integrity.rs
+++ b/src/anolisa/crates/anolisa-core/src/integrity.rs
@@ -44,19 +44,31 @@ use crate::capability::probe_file_capabilities;
 use crate::path_safety::{PathBoundaryError, validate_owned_path};
 use crate::state::{FileOwner, OwnedFile, OwnedFileKind};
 
-/// Maximum bytes the integrity probe will read for one file. Owned
-/// artifacts in ANOLISA's catalogue are binaries / small data files; a
-/// 256 MiB ceiling stops a forged `installed.toml` from making `status`
-/// stream a multi-gigabyte path. Anything above this returns
-/// [`IntegrityStatus::ReadError`] rather than blocking the CLI.
-const MAX_PROBE_BYTES: u64 = 256 * 1024 * 1024;
+/// Maximum bytes the integrity probe will read for one file, bounding the
+/// wall-clock a single `status` / `doctor` run can spend hashing one path.
+/// Hashing itself streams through a fixed 8 KiB buffer, so the ceiling
+/// costs no memory — it only caps time and page-cache churn.
+///
+/// The bound is deliberately above the largest artifacts ANOLISA actually
+/// ships: raw installs vendor native ML runtimes whose shared objects run
+/// to hundreds of megabytes (`libtorch_cpu.so` is ~440 MB, CUDA builds
+/// larger still). A ceiling below those would leave first-party components
+/// permanently unverified, which is worse than the multi-second hash it
+/// would save.
+///
+/// Exceeding it is **not** an integrity failure: the bytes were never
+/// examined, so nothing was disproved. It reports
+/// [`IntegrityStatus::ProbeLimitExceeded`], which degrades rather than
+/// fails. Note this is a per-file bound and the probe applies it to every
+/// owned file in turn — it caps the cost of one path, not of one run.
+const MAX_PROBE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 /// Result of a single integrity probe against one [`OwnedFile`].
 ///
 /// Variants are ordered by severity so callers can fold via `max`:
-/// `Ok < Skipped < Unverified < OutOfBounds < Symlink < NotRegularFile
-/// < MissingFile < ReadError < ModeMismatch < CapabilityMismatch
-/// < ShaMismatch`.
+/// `Ok < Skipped < Unverified < ProbeLimitExceeded < OutOfBounds < Symlink
+/// < NotRegularFile < MissingFile < ReadError < ModeMismatch
+/// < CapabilityMismatch < ShaMismatch`.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegrityStatus {
     /// File exists and sha256 matches the recorded value.
@@ -66,6 +78,22 @@ pub enum IntegrityStatus {
     /// File exists but no sha256 was ever recorded — drift cannot be
     /// proved either way, so we degrade rather than claim health.
     Unverified,
+    /// File exists and passed every cheap check (regular file, mode,
+    /// capabilities), but its size is above [`MAX_PROBE_BYTES`] so the
+    /// content hash was never computed.
+    ///
+    /// This is a *budget* outcome, not a *read* outcome: the probe chose
+    /// not to spend the time, as opposed to trying and failing. Nothing
+    /// about the bytes was disproved, so — like [`Self::Unverified`] —
+    /// it degrades instead of failing. Keeping it distinct from
+    /// `Unverified` tells operators which of the two holds: no digest was
+    /// ever recorded, or one was recorded but not checked this run.
+    ProbeLimitExceeded {
+        /// Size observed on disk, in bytes.
+        size: u64,
+        /// Ceiling that was exceeded ([`MAX_PROBE_BYTES`]), in bytes.
+        limit: u64,
+    },
     /// Path escapes the ANOLISA-owned roots in the active [`FsLayout`].
     /// Probe is refused without any filesystem touch; this strongly
     /// suggests a forged or corrupted `installed.toml`.
@@ -122,6 +150,7 @@ impl IntegrityStatus {
             Self::Ok => "ok",
             Self::Skipped => "skipped",
             Self::Unverified => "unverified",
+            Self::ProbeLimitExceeded { .. } => "probe_limit_exceeded",
             Self::OutOfBounds => "out_of_bounds",
             Self::Symlink => "symlink_refused",
             Self::NotRegularFile => "not_regular_file",
@@ -135,10 +164,15 @@ impl IntegrityStatus {
     }
 
     /// `true` when the probe found a real integrity problem (vs. ok /
-    /// skipped / unverified). Drives status escalation in `status`.
+    /// skipped / unverified / probe-limit-exceeded). Drives status
+    /// escalation in `status`.
     /// Out-of-bounds / symlink / not-regular-file all count as failures
     /// because they signal either tampering or a corrupted state file —
     /// neither is "merely degraded".
+    ///
+    /// [`Self::ProbeLimitExceeded`] is deliberately absent: an unread file
+    /// is not a damaged one, and reporting the component `failed` for
+    /// owning a large-but-intact artifact was the bug behind #2251.
     pub fn is_failure(&self) -> bool {
         matches!(
             self,
@@ -238,19 +272,28 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
             Err(err) => return IntegrityStatus::ReadError(err.to_string()),
         }
     }
+    // Size gate before the digest gate: a file too large to hash reports
+    // the budget outcome whether or not a digest was recorded, so the
+    // wire surface never conflates "no digest on file" with "digest not
+    // checked this run".
     if meta.len() > MAX_PROBE_BYTES {
-        return IntegrityStatus::ReadError(format!(
-            "file size {} exceeds integrity probe ceiling {}",
-            meta.len(),
-            MAX_PROBE_BYTES
-        ));
+        return IntegrityStatus::ProbeLimitExceeded {
+            size: meta.len(),
+            limit: MAX_PROBE_BYTES,
+        };
     }
 
     let Some(expected) = file.sha256.clone() else {
         return IntegrityStatus::Unverified;
     };
     match hash_file_sha256(&file.path) {
-        Err(err) => IntegrityStatus::ReadError(err.to_string()),
+        Err(HashError::Io(err)) => IntegrityStatus::ReadError(err.to_string()),
+        // The file grew past the ceiling between stat and read. Same
+        // budget outcome as the size gate — we stopped early by choice.
+        Err(HashError::LimitExceeded { size }) => IntegrityStatus::ProbeLimitExceeded {
+            size,
+            limit: MAX_PROBE_BYTES,
+        },
         Ok(actual) if actual != expected => IntegrityStatus::ShaMismatch { expected, actual },
         Ok(_) => IntegrityStatus::Ok,
     }
@@ -346,22 +389,37 @@ fn open_nofollow(path: &std::path::Path) -> std::io::Result<fs::File> {
     fs::File::open(path)
 }
 
-fn hash_file_sha256(path: &std::path::Path) -> std::io::Result<String> {
+/// Why [`hash_file_sha256`] produced no digest. The two arms drive
+/// different verdicts, so they must stay distinguishable: a genuine IO
+/// error is an integrity failure, while running out of read budget is not.
+enum HashError {
+    /// The read itself failed (permissions, IO error, vanished file).
+    Io(std::io::Error),
+    /// The file grew past [`MAX_PROBE_BYTES`] while being read, so hashing
+    /// stopped early. `size` is the byte count reached before the stop.
+    LimitExceeded {
+        /// Bytes consumed before the ceiling tripped.
+        size: u64,
+    },
+}
+
+/// Stream `path` through sha256 with a fixed 8 KiB buffer, so peak memory
+/// is constant regardless of file size. Bails once the ceiling is passed —
+/// `stat` already gated on size, but the file can grow between the two.
+fn hash_file_sha256(path: &std::path::Path) -> Result<String, HashError> {
     use std::io::Read;
-    let mut f = open_nofollow(path)?;
+    let mut f = open_nofollow(path).map_err(HashError::Io)?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 8 * 1024];
     let mut total: u64 = 0;
     loop {
-        let n = f.read(&mut buf)?;
+        let n = f.read(&mut buf).map_err(HashError::Io)?;
         if n == 0 {
             break;
         }
         total += n as u64;
         if total > MAX_PROBE_BYTES {
-            return Err(std::io::Error::other(format!(
-                "file grew past integrity probe ceiling {MAX_PROBE_BYTES} during read"
-            )));
+            return Err(HashError::LimitExceeded { size: total });
         }
         hasher.update(&buf[..n]);
     }
@@ -494,6 +552,60 @@ mod tests {
         assert_eq!(check_owned_file(&layout, &owned), IntegrityStatus::Ok);
     }
 
+    /// Regression for #2251: `sec-core` installed via the raw backend owns
+    /// `libtorch_cpu.so` (~440 MB). Exceeding the probe budget must not be
+    /// reported as `read_error`, because `read_error` is a failure and the
+    /// component was marked `failed` for owning a large, intact file.
+    ///
+    /// The fixture is sparse — `set_len` sets the inode size without
+    /// allocating blocks — and the size gate fires before any read, so the
+    /// test neither allocates nor hashes the nominal byte count.
+    #[test]
+    fn file_over_probe_ceiling_reports_budget_not_read_error() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let path = layout.bin_dir.join("libtorch_cpu.so");
+        let f = fs::File::create(&path).expect("create");
+        let size = MAX_PROBE_BYTES + 1;
+        f.set_len(size).expect("set_len");
+        drop(f);
+
+        // A digest IS recorded — install hashed this file with no ceiling.
+        // The probe declining to re-read it must not read as damage.
+        let owned = anolisa_owned(path, Some("deadbeef".to_string()));
+        let status = check_owned_file(&layout, &owned);
+
+        assert_eq!(
+            status,
+            IntegrityStatus::ProbeLimitExceeded {
+                size,
+                limit: MAX_PROBE_BYTES,
+            }
+        );
+        assert!(!status.is_failure(), "must degrade, not fail");
+        assert_eq!(status.label(), "probe_limit_exceeded");
+    }
+
+    /// The budget outcome sorts with the other "not proved either way"
+    /// states, below every real finding — callers fold via `max`, so a
+    /// misplaced variant would let an oversized file mask a sha mismatch.
+    #[test]
+    fn probe_limit_sorts_above_unverified_and_below_failures() {
+        let limited = IntegrityStatus::ProbeLimitExceeded {
+            size: MAX_PROBE_BYTES + 1,
+            limit: MAX_PROBE_BYTES,
+        };
+        assert!(limited > IntegrityStatus::Unverified);
+        assert!(limited < IntegrityStatus::OutOfBounds);
+        assert!(
+            limited
+                < IntegrityStatus::ShaMismatch {
+                    expected: "a".into(),
+                    actual: "b".into(),
+                }
+        );
+    }
+
     #[test]
     #[cfg(unix)]
     fn matching_content_with_wrong_mode_reports_mismatch() {
@@ -599,11 +711,18 @@ mod tests {
 
     #[test]
     fn label_and_is_failure_match_severity_intent() {
-        // Ok / Skipped / Unverified are NOT failures — they don't escalate
-        // status past Installed/Degraded respectively.
+        // Ok / Skipped / Unverified / ProbeLimitExceeded are NOT failures —
+        // they don't escalate status past Installed/Degraded respectively.
         assert!(!IntegrityStatus::Ok.is_failure());
         assert!(!IntegrityStatus::Skipped.is_failure());
         assert!(!IntegrityStatus::Unverified.is_failure());
+        assert!(
+            !IntegrityStatus::ProbeLimitExceeded {
+                size: MAX_PROBE_BYTES + 1,
+                limit: MAX_PROBE_BYTES,
+            }
+            .is_failure()
+        );
         // All of the path-safety / IO refusals ARE failures.
         assert!(IntegrityStatus::OutOfBounds.is_failure());
         assert!(IntegrityStatus::Symlink.is_failure());
@@ -642,6 +761,10 @@ mod tests {
         assert_eq!(IntegrityStatus::Ok.label(), "ok");
         assert_eq!(IntegrityStatus::Skipped.label(), "skipped");
         assert_eq!(IntegrityStatus::Unverified.label(), "unverified");
+        assert_eq!(
+            IntegrityStatus::ProbeLimitExceeded { size: 1, limit: 0 }.label(),
+            "probe_limit_exceeded"
+        );
         assert_eq!(IntegrityStatus::OutOfBounds.label(), "out_of_bounds");
         assert_eq!(IntegrityStatus::Symlink.label(), "symlink_refused");
         assert_eq!(IntegrityStatus::NotRegularFile.label(), "not_regular_file");

--- a/src/anolisa/crates/anolisa-core/src/integrity.rs
+++ b/src/anolisa/crates/anolisa-core/src/integrity.rs
@@ -272,10 +272,15 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
             Err(err) => return IntegrityStatus::ReadError(err.to_string()),
         }
     }
-    // Size gate before the digest gate: a file too large to hash reports
-    // the budget outcome whether or not a digest was recorded, so the
-    // wire surface never conflates "no digest on file" with "digest not
-    // checked this run".
+    // Digest gate BEFORE the size gate, so each label keeps the meaning its
+    // documentation promises: `Unverified` means no digest was ever
+    // recorded, `ProbeLimitExceeded` means one was recorded but this run
+    // did not check it. Gating on size first would collapse both into the
+    // latter and tell operators a baseline exists where none does.
+    let Some(expected) = file.sha256.clone() else {
+        return IntegrityStatus::Unverified;
+    };
+
     if meta.len() > MAX_PROBE_BYTES {
         return IntegrityStatus::ProbeLimitExceeded {
             size: meta.len(),
@@ -283,9 +288,6 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
         };
     }
 
-    let Some(expected) = file.sha256.clone() else {
-        return IntegrityStatus::Unverified;
-    };
     match hash_file_sha256(&file.path) {
         Err(HashError::Io(err)) => IntegrityStatus::ReadError(err.to_string()),
         // The file grew past the ceiling between stat and read. Same
@@ -584,6 +586,26 @@ mod tests {
         );
         assert!(!status.is_failure(), "must degrade, not fail");
         assert_eq!(status.label(), "probe_limit_exceeded");
+    }
+
+    /// An oversized file with no recorded digest must report `Unverified`,
+    /// not `ProbeLimitExceeded`: the latter's contract is "a digest exists
+    /// but this run skipped it", and reporting it here would tell operators
+    /// an integrity baseline exists where none was ever recorded.
+    #[test]
+    fn oversized_file_without_recorded_digest_is_unverified() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let path = layout.bin_dir.join("huge-legacy-blob");
+        let f = fs::File::create(&path).expect("create");
+        f.set_len(MAX_PROBE_BYTES + 1).expect("set_len");
+        drop(f);
+
+        let owned = anolisa_owned(path, None);
+        assert_eq!(
+            check_owned_file(&layout, &owned),
+            IntegrityStatus::Unverified,
+        );
     }
 
     /// The budget outcome sorts with the other "not proved either way"

--- a/src/anolisa/crates/anolisa-core/src/integrity.rs
+++ b/src/anolisa/crates/anolisa-core/src/integrity.rs
@@ -79,8 +79,9 @@ pub enum IntegrityStatus {
     /// proved either way, so we degrade rather than claim health.
     Unverified,
     /// File exists and passed every cheap check (regular file, mode,
-    /// capabilities), but its size is above [`MAX_PROBE_BYTES`] so the
-    /// content hash was never computed.
+    /// capabilities), but its size is above the probe's per-file read
+    /// ceiling so the content hash was never computed. The ceiling is an
+    /// internal constant; `limit` below reports the value that applied.
     ///
     /// This is a *budget* outcome, not a *read* outcome: the probe chose
     /// not to spend the time, as opposed to trying and failing. Nothing
@@ -91,7 +92,7 @@ pub enum IntegrityStatus {
     ProbeLimitExceeded {
         /// Size observed on disk, in bytes.
         size: u64,
-        /// Ceiling that was exceeded ([`MAX_PROBE_BYTES`]), in bytes.
+        /// Per-file read ceiling that was exceeded, in bytes.
         limit: u64,
     },
     /// Path escapes the ANOLISA-owned roots in the active [`FsLayout`].
@@ -288,14 +289,10 @@ pub fn check_owned_file(layout: &FsLayout, file: &OwnedFile) -> IntegrityStatus 
         };
     }
 
-    match hash_file_sha256(&file.path) {
-        Err(HashError::Io(err)) => IntegrityStatus::ReadError(err.to_string()),
-        // The file grew past the ceiling between stat and read. Same
-        // budget outcome as the size gate — we stopped early by choice.
-        Err(HashError::LimitExceeded { size }) => IntegrityStatus::ProbeLimitExceeded {
-            size,
-            limit: MAX_PROBE_BYTES,
-        },
+    // The size just observed is the read budget. Growth past it means the
+    // file changed under the probe, which is a finding, not a budget stop.
+    match hash_file_sha256(&file.path, meta.len()) {
+        Err(err) => IntegrityStatus::ReadError(err.to_string()),
         Ok(actual) if actual != expected => IntegrityStatus::ShaMismatch { expected, actual },
         Ok(_) => IntegrityStatus::Ok,
     }
@@ -391,37 +388,35 @@ fn open_nofollow(path: &std::path::Path) -> std::io::Result<fs::File> {
     fs::File::open(path)
 }
 
-/// Why [`hash_file_sha256`] produced no digest. The two arms drive
-/// different verdicts, so they must stay distinguishable: a genuine IO
-/// error is an integrity failure, while running out of read budget is not.
-enum HashError {
-    /// The read itself failed (permissions, IO error, vanished file).
-    Io(std::io::Error),
-    /// The file grew past [`MAX_PROBE_BYTES`] while being read, so hashing
-    /// stopped early. `size` is the byte count reached before the stop.
-    LimitExceeded {
-        /// Bytes consumed before the ceiling tripped.
-        size: u64,
-    },
-}
-
 /// Stream `path` through sha256 with a fixed 8 KiB buffer, so peak memory
-/// is constant regardless of file size. Bails once the ceiling is passed —
-/// `stat` already gated on size, but the file can grow between the two.
-fn hash_file_sha256(path: &std::path::Path) -> Result<String, HashError> {
+/// is constant regardless of file size.
+///
+/// `expected_len` is the length `stat` reported moments earlier, and it is
+/// the read budget: reading more than that means the file grew *while the
+/// probe was streaming it*. That is a concurrent modification, not a budget
+/// stop, and it fails hard. Treating it as a budget stop would hand a
+/// writer an evasion — append past the ceiling mid-read and the digest
+/// comparison never completes, so tampering reports as merely unverified.
+///
+/// Anchoring on the observed length rather than the ceiling also catches
+/// growth that stays under the ceiling, which a ceiling test would miss.
+fn hash_file_sha256(path: &std::path::Path, expected_len: u64) -> std::io::Result<String> {
     use std::io::Read;
-    let mut f = open_nofollow(path).map_err(HashError::Io)?;
+    let mut f = open_nofollow(path)?;
     let mut hasher = Sha256::new();
     let mut buf = [0u8; 8 * 1024];
     let mut total: u64 = 0;
     loop {
-        let n = f.read(&mut buf).map_err(HashError::Io)?;
+        let n = f.read(&mut buf)?;
         if n == 0 {
             break;
         }
         total += n as u64;
-        if total > MAX_PROBE_BYTES {
-            return Err(HashError::LimitExceeded { size: total });
+        if total > expected_len {
+            return Err(std::io::Error::other(format!(
+                "file grew past its observed size of {expected_len} bytes during the \
+                 integrity read"
+            )));
         }
         hasher.update(&buf[..n]);
     }
@@ -606,6 +601,45 @@ mod tests {
             check_owned_file(&layout, &owned),
             IntegrityStatus::Unverified,
         );
+    }
+
+    /// A file that grows while the probe streams it must fail hard, not
+    /// degrade. Otherwise a process with write access could dodge the digest
+    /// comparison by appending mid-read: the hash never completes and the
+    /// tampered file would report as merely unverified.
+    ///
+    /// The guard is anchored on the length `stat` observed, so this is
+    /// exercised by handing `hash_file_sha256` a budget smaller than the
+    /// file — deterministic, and equivalent to the file having grown by that
+    /// difference between the stat and the read.
+    #[test]
+    fn growth_during_read_is_a_hard_failure_not_a_budget_stop() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let path = layout.bin_dir.join("grows");
+        fs::write(&path, vec![b'x'; 4096]).expect("write");
+
+        // stat said 1024; the read finds 4096.
+        let err = hash_file_sha256(&path, 1024).expect_err("must refuse to hash");
+        assert!(err.to_string().contains("grew past"), "msg: {err}");
+
+        // And that error class is decisive, not a degradation.
+        assert!(IntegrityStatus::ReadError(err.to_string()).is_failure());
+    }
+
+    /// Growth that stays under the ceiling is caught too — the budget is the
+    /// observed length, not the 2 GiB ceiling, so a small file cannot be
+    /// padded to hide a content change.
+    #[test]
+    fn growth_below_the_ceiling_is_still_caught() {
+        let tmp = tempdir().expect("tempdir");
+        let layout = layout_under(tmp.path());
+        let path = layout.bin_dir.join("small-but-grown");
+        fs::write(&path, b"payload-plus-appended-junk").expect("write");
+
+        assert!(hash_file_sha256(&path, 7).is_err());
+        // Same file hashed within its observed length succeeds.
+        assert!(hash_file_sha256(&path, 26).is_ok());
     }
 
     /// The budget outcome sorts with the other "not proved either way"


### PR DESCRIPTION
## Why

Raw 安装 sec-core 后，`anolisa doctor sec-core` 把组件判为 `failed`，理由是 `libtorch_cpu.so`（约 440 MB）报告 `read_error`。该文件实际存在、可读、内容完好。

整完性探测把单文件读取上限设为 256 MiB，超限时返回 `IntegrityStatus::ReadError`，而 `ReadError` 被 `is_failure()` 视为真实损坏。但探测器**从未读取过这些字节**，因此什么也没有被证伪——「超出预算所以没读」和「尝试读取但失败」是两回事。

更直接的矛盾是：安装侧 `install_runner` 流式哈希**没有任何上限**，这个 sha256 正是 anolisa 自己在安装时算出来写进 `installed.toml` 的。CLI 愿意写下这个摘要，却拒绝把它读回来校验。

## What changed

- 新增 `IntegrityStatus::ProbeLimitExceeded { size, limit }`，`is_failure()` 为 false，严重度序排在 `Unverified` 之后、所有真实故障之前。超限文件按 `Unverified` 的既有语义降级，不再判为失败。
- 上限从 256 MiB 抬到 2 GiB，使实际交付的 ML 运行时制品能正常完成校验，而不是长期停留在未验证状态。哈希走固定 8 KiB 缓冲区流式读取，峰值内存与文件大小无关，该上限约束的是时间而非内存。
- 拆分 `hash_file_sha256` 的错误类型。此前 IO 失败与「读取过程中文件增长超出上限」都塞进 `io::Error`，导致 stat 之后文件增长这条路径仍会退化成 `read_error`。现在两者分别映射到 `ReadError` 和 `ProbeLimitExceeded`。
- 同步三处对完整性状态做分类的消费方：`status.rs` 的状态升级、`facts.rs` 的损坏判定（否则超限文件每次都会触发 repair）、`doctor.rs` 的 finding 严重度（其 `_ => Error` 兜底会把任何新 label 判成错误）。

## Related issue

closes #2251

## User / Agent impact

拥有超过上限文件的组件不再被误报为 `failed`。`doctor` / `status` 的 JSON 输出新增 `probe_limit_exceeded` 状态标签；消费该字段的下游需知道这是一个非失败状态，与 `unverified` 同类。

上限抬高后，此前落在 256 MiB 到 2 GiB 之间、被跳过校验的文件现在会被实际哈希，单次 `doctor` 的耗时相应增加（440 MB 文件在支持 SHA-NI 的机器上约 0.2~0.5 秒）。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

**行为变更**：新增一个 JSON 状态标签，且组件状态从 `failed` 变为 `installed`（当文件在新上限内）或 `degraded`（超出新上限）。

**安全相关**：路径边界、`O_NOFOLLOW`、符号链接拒绝、特殊文件拒绝等约束全部保持不变，本 PR 只改动读取预算的取值和超预算时的**分类**。需要说明的是，被抬高的这个上限对其声称防御的场景本就没有作用：`integrity_probe` 对每个 owned file 裸循环、不存在总量预算，per-file 上限无法约束「多个大文件」这一形态。修正该缺口需要引入总量预算，不在本 PR 范围内。

不涉及状态文件 schema 变更，无需迁移。

## Validation

```
cargo fmt --all --check          # clean
cargo clippy --all-targets --locked -- -D warnings   # clean
cargo test --locked              # 2062 passed, 0 failed
```

新增测试：

- `file_over_probe_ceiling_reports_budget_not_read_error` — #2251 的回归测试。用稀疏文件（`set_len` 只设 inode 大小，不分配块）构造超限文件，尺寸闸门在任何读取之前触发，因此测试既不分配也不哈希标称字节数。
- `probe_limit_sorts_above_unverified_and_below_failures` — 调用方通过 `max` 折叠状态，变体位置放错会让超限文件盖住 sha mismatch，故单独断言排序。
- 扩充 `label_and_is_failure_match_severity_intent` 覆盖新变体。

未在真实 sec-core raw 安装环境上实机验证。

## Documentation and rollback

无用户文档变更；新状态的语义、上限取值依据与安全边界均记录在 `integrity.rs` 的 doc comment 中。

回滚为单个 commit 的 revert，不涉及磁盘或状态文件的持久化变更。

## Notes

排查本 issue 期间通过代码走查发现两个独立的既有缺陷，已单独提交、不在本 PR 范围：

- #2269 — `type = "config"` 文件被按不可变文件校验，编辑配置即导致组件 `failed`
- #2270 — `post_install` hook 修改已放置文件导致记录摘要自写入起即过期

两者共同说明「owned 文件安装后字节不可变」这一隐含契约目前存在漏洞。这也是本 PR 未引入「记录 size 做 O(1) 校验」的原因——在该契约修复之前，那属于在不稳的前提上加层。
