### PR TITLE
fix(cosh-ng): [shell] review marked on enter

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/session.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/session.rs
@@ -26,6 +26,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "Up/Down or j/k move · Enter resume · Space toggle clear mark · d review clear · Esc cancel"
         }
         MessageId::SessionPickerMarkedCount => "{count} marked",
+        MessageId::SessionPickerMarkedFooter => {
+            "Up/Down or j/k move · Enter review clear · Space toggle clear mark · d review clear · Esc cancel"
+        }
         MessageId::SessionClearConfirmTitle => "Confirm session clear",
         MessageId::SessionClearConfirmCountLine => {
             "The following {count} persisted session(s) will be deleted:"

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id.rs
@@ -104,4 +104,5 @@ collect_message_ids!([
     approval_system_control_ids,
     input_wait_hint_ids,
     startup_auth_hint_ids,
+    session_picker_footer_ids,
 ],);

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/session.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/message_id/session.rs
@@ -98,3 +98,15 @@ macro_rules! session_fresh_ids {
         );
     };
 }
+
+// Keep this new picker footer message in its own trailing segment so every
+// existing MessageId discriminant remains stable.
+macro_rules! session_picker_footer_ids {
+    ($next:ident, $remaining:tt, $($ids:ident,)*) => {
+        $next!(
+            $remaining,
+            $($ids,)*
+            SessionPickerMarkedFooter,
+        );
+    };
+}

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/mod.rs
@@ -184,16 +184,20 @@ mod tests {
         );
         assert_eq!(
             MessageId::ApprovalShellHandoffInputWaitTimeoutTitle as usize,
-            MessageId::ALL.len() - 11
+            MessageId::ALL.len() - 12
         );
         assert_eq!(
             MessageId::ShellInputWaitHintTimeoutForecastBody as usize,
-            MessageId::ALL.len() - 2
+            MessageId::ALL.len() - 3
         );
-        // The #2068 startup auth-hint segment is the current tail; tail
-        // ownership assertions move with each appended segment.
+        // The #2068 startup auth-hint segment remains ahead of the appended
+        // session-picker footer segment.
         assert_eq!(
             MessageId::StartupAuthHintLine as usize,
+            MessageId::ALL.len() - 2
+        );
+        assert_eq!(
+            MessageId::SessionPickerMarkedFooter as usize,
             MessageId::ALL.len() - 1
         );
     }

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/session.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/session.rs
@@ -20,6 +20,9 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
             "上/下或 j/k 移动 · Enter 恢复 · Space 切换清理标记 · d 打开清理确认 · Esc 取消"
         }
         MessageId::SessionPickerMarkedCount => "已标记 {count}",
+        MessageId::SessionPickerMarkedFooter => {
+            "上/下或 j/k 移动 · Enter 打开清理确认 · Space 切换清理标记 · d 打开清理确认 · Esc 取消"
+        }
         MessageId::SessionClearConfirmTitle => "确认清理会话",
         MessageId::SessionClearConfirmCountLine => "将删除以下 {count} 个持久化会话：",
         MessageId::SessionClearConfirmFooter => "Enter 或 y 确认 · Esc、Ctrl+C 或 n 取消",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -106,6 +106,7 @@ mod tests {
     use std::sync::mpsc;
 
     use super::*;
+    use crate::raw_input::{update_input_mode, RawObserverAction};
 
     fn question() -> RawInputCapture {
         RawInputCapture::Question {
@@ -139,6 +140,92 @@ mod tests {
             &*input_mode.lock().expect("input mode"),
             RawInputMode::Capture { generation: 7, .. }
         ));
+    }
+
+    #[test]
+    fn marked_session_enter_requests_delete_without_releasing_capture() {
+        let capture = RawInputCapture::Session {
+            id: "session-panel".to_string(),
+            option_count: 2,
+            selected: 0,
+            marked_for_clear: vec![true, false],
+            confirming_clear: false,
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
+            capture: capture.clone(),
+            generation: 7,
+            installed_at: std::time::Instant::now(),
+        }));
+        let (sender, receiver) = mpsc::channel();
+        let mut state = CardInputState::default();
+
+        let result = consume_captured_input(&mut state, &capture, 7, b"\n", &sender, &input_mode);
+
+        assert_eq!(result.generation, None);
+        assert!(result.remainder.is_empty());
+        assert_eq!(
+            receiver.recv().expect("session action"),
+            RawInputEvent::SessionDelete("session-panel".to_string())
+        );
+        assert!(receiver.try_recv().is_err());
+        assert!(matches!(
+            &*input_mode.lock().expect("input mode"),
+            RawInputMode::Capture { generation: 7, .. }
+        ));
+    }
+
+    #[test]
+    fn session_mark_refresh_preserves_generation_for_split_enter() {
+        let unmarked = RawInputCapture::Session {
+            id: "session-panel".to_string(),
+            option_count: 2,
+            selected: 0,
+            marked_for_clear: vec![false, false],
+            confirming_clear: false,
+        };
+        let marked = RawInputCapture::Session {
+            id: "session-panel".to_string(),
+            option_count: 2,
+            selected: 0,
+            marked_for_clear: vec![true, false],
+            confirming_clear: false,
+        };
+        let input_mode = Arc::new(Mutex::new(RawInputMode::Capture {
+            capture: unmarked.clone(),
+            generation: 7,
+            installed_at: std::time::Instant::now(),
+        }));
+        let (sender, receiver) = mpsc::channel();
+        let mut state = CardInputState::default();
+
+        let toggle = consume_captured_input(&mut state, &unmarked, 7, b" ", &sender, &input_mode);
+        assert!(!toggle.retry);
+        assert_eq!(toggle.generation, None);
+
+        update_input_mode(
+            &input_mode,
+            &RawObserverAction::CaptureInput(marked.clone()),
+            None,
+        );
+        assert!(matches!(
+            &*input_mode.lock().expect("input mode"),
+            RawInputMode::Capture {
+                capture,
+                generation: 7,
+                ..
+            } if capture == &marked
+        ));
+
+        let enter = consume_captured_input(&mut state, &marked, 7, b"\n", &sender, &input_mode);
+        assert!(!enter.retry);
+        assert_eq!(enter.generation, None);
+        assert_eq!(
+            receiver.try_iter().collect::<Vec<_>>(),
+            vec![
+                RawInputEvent::SessionToggle("session-panel".to_string(), 0),
+                RawInputEvent::SessionDelete("session-panel".to_string()),
+            ]
+        );
     }
 
     /// Stale-generation 竞态回归（评审 P1 追加）：旧 generation 的 Standard

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture.rs
@@ -20,6 +20,9 @@ pub(super) struct CardInputState {
     free_text: String,
     active_kind: Option<CardInputKind>,
     selected_options: Vec<usize>,
+    // Mirror toggles before emitting events so same-read Enter sees the
+    // effective marks.
+    session_marked_for_clear: Vec<bool>,
     pending_input: Vec<u8>,
     /// Multi-line draft state while a PromptDraft capture is active (#1721).
     draft: PromptDraftEditor,
@@ -166,6 +169,12 @@ impl CardInputState {
                 _ => String::new(),
             };
             self.selected_options.clear();
+            self.session_marked_for_clear = match capture {
+                RawInputCapture::Session {
+                    marked_for_clear, ..
+                } => marked_for_clear.clone(),
+                _ => Vec::new(),
+            };
             self.pending_input.clear();
             self.draft = match capture {
                 RawInputCapture::PromptDraft { initial_text, .. } => {
@@ -182,6 +191,7 @@ impl CardInputState {
         self.selected = 0;
         self.free_text.clear();
         self.selected_options.clear();
+        self.session_marked_for_clear.clear();
         self.pending_input.clear();
         self.draft = PromptDraftEditor::default();
         self.draft_paste = false;
@@ -465,6 +475,11 @@ impl CardInputState {
                                 }
                             }
                             b' ' if !*confirming_clear && self.selected < *option_count => {
+                                if let Some(marked) =
+                                    self.session_marked_for_clear.get_mut(self.selected)
+                                {
+                                    *marked = !*marked;
+                                }
                                 events
                                     .push(RawInputEvent::SessionToggle(id.clone(), self.selected));
                             }
@@ -625,6 +640,9 @@ impl CardInputState {
             } => {
                 if *confirming_clear {
                     return Some(RawInputEvent::SessionClearConfirm(id.clone()));
+                }
+                if self.session_marked_for_clear.iter().any(|marked| *marked) {
+                    return Some(RawInputEvent::SessionDelete(id.clone()));
                 }
                 if *option_count == 0 || self.selected >= *option_count {
                     return None;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/card_capture/tests.rs
@@ -592,6 +592,7 @@ fn session_capture_navigates_toggles_deletes_and_resumes() {
         id: "session-panel".to_string(),
         option_count: 3,
         selected: 0,
+        marked_for_clear: vec![false; 3],
         confirming_clear: false,
     };
     let mut state = CardInputState::default();
@@ -606,12 +607,52 @@ fn session_capture_navigates_toggles_deletes_and_resumes() {
         ]
     );
 
+    state.reset();
     state.apply_capture(&capture);
     assert_eq!(
         state.consume(&capture, b"\x1b[B\n"),
         vec![
-            RawInputEvent::SessionFocus("session-panel".to_string(), 2),
-            RawInputEvent::SessionResume("session-panel".to_string(), 2),
+            RawInputEvent::SessionFocus("session-panel".to_string(), 1),
+            RawInputEvent::SessionResume("session-panel".to_string(), 1),
+        ]
+    );
+}
+
+#[test]
+fn session_toggle_then_enter_uses_effective_marks_within_the_chunk() {
+    let unmarked = RawInputCapture::Session {
+        id: "session-panel".to_string(),
+        option_count: 2,
+        selected: 0,
+        marked_for_clear: vec![false, false],
+        confirming_clear: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&unmarked);
+
+    assert_eq!(
+        state.consume(&unmarked, b" \n"),
+        vec![
+            RawInputEvent::SessionToggle("session-panel".to_string(), 0),
+            RawInputEvent::SessionDelete("session-panel".to_string()),
+        ]
+    );
+
+    let marked = RawInputCapture::Session {
+        id: "session-panel".to_string(),
+        option_count: 2,
+        selected: 0,
+        marked_for_clear: vec![true, false],
+        confirming_clear: false,
+    };
+    let mut state = CardInputState::default();
+    state.apply_capture(&marked);
+
+    assert_eq!(
+        state.consume(&marked, b" \n"),
+        vec![
+            RawInputEvent::SessionToggle("session-panel".to_string(), 0),
+            RawInputEvent::SessionResume("session-panel".to_string(), 0),
         ]
     );
 }
@@ -622,6 +663,7 @@ fn session_clear_confirmation_accepts_and_cancels() {
         id: "session-panel".to_string(),
         option_count: 0,
         selected: 0,
+        marked_for_clear: Vec::new(),
         confirming_clear: true,
     };
     let mut state = CardInputState::default();

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode.rs
@@ -105,6 +105,16 @@ pub(crate) fn update_locked_input_mode(
             return;
         }
     }
+    if let (RawInputMode::Capture { capture, .. }, RawObserverAction::CaptureInput(next_capture)) =
+        (&mut *mode, action)
+    {
+        if capture.is_session_mark_refresh(next_capture) {
+            // Mark redraws do not change key routing, so in-flight input still
+            // belongs to this session card.
+            *capture = next_capture.clone();
+            return;
+        }
+    }
     if let RawInputMode::Capture {
         capture,
         generation,
@@ -475,6 +485,7 @@ mod tests {
             id: "session-panel".to_string(),
             option_count: 2,
             selected: 0,
+            marked_for_clear: vec![false; 2],
             confirming_clear: false,
         };
         update_input_mode(
@@ -493,6 +504,7 @@ mod tests {
             id: "session-panel".to_string(),
             option_count: 2,
             selected: 0,
+            marked_for_clear: vec![false; 2],
             confirming_clear: true,
         };
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mode/model.rs
@@ -228,6 +228,7 @@ pub enum RawInputCapture {
         id: String,
         option_count: usize,
         selected: usize,
+        marked_for_clear: Vec<bool>,
         confirming_clear: bool,
     },
     Consultation {
@@ -243,4 +244,31 @@ pub enum RawInputCapture {
         id: String,
         initial_text: String,
     },
+}
+
+impl RawInputCapture {
+    pub(super) fn is_session_mark_refresh(&self, next: &Self) -> bool {
+        matches!(
+            (self, next),
+            (
+                Self::Session {
+                    id: current_id,
+                    option_count: current_option_count,
+                    selected: current_selected,
+                    confirming_clear: current_confirming_clear,
+                    ..
+                },
+                Self::Session {
+                    id: next_id,
+                    option_count: next_option_count,
+                    selected: next_selected,
+                    confirming_clear: next_confirming_clear,
+                    ..
+                }
+            ) if current_id == next_id
+                && current_option_count == next_option_count
+                && current_selected == next_selected
+                && current_confirming_clear == next_confirming_clear
+        )
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -215,6 +215,15 @@ pub(crate) fn pending_card_capture(state: &InlineState) -> Option<RawInputCaptur
             id: session_panel.id.clone(),
             option_count: session_panel.sessions.len(),
             selected: session_panel.selected_option,
+            marked_for_clear: session_panel
+                .sessions
+                .iter()
+                .map(|session| {
+                    session_panel
+                        .selected_for_clear
+                        .contains(&session.session_id)
+                })
+                .collect(),
             confirming_clear: matches!(
                 session_panel.phase,
                 crate::slash::session::RuntimeSessionPanelPhase::ConfirmClear

--- a/src/cosh-ng/crates/cosh-shell/src/slash/session/panel.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/session/panel.rs
@@ -66,7 +66,12 @@ pub(super) fn render_current_session_panel<W: Write>(
                     ));
                 }
                 footer.push_str(" · ");
-                footer.push_str(state.i18n().t(MessageId::SessionPickerFooter));
+                let footer_message = if panel.selected_for_clear.is_empty() {
+                    MessageId::SessionPickerFooter
+                } else {
+                    MessageId::SessionPickerMarkedFooter
+                };
+                footer.push_str(state.i18n().t(footer_message));
                 (
                     state.i18n().t(MessageId::SessionTitle).to_string(),
                     body,

--- a/src/cosh-ng/crates/cosh-shell/src/slash/session/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/session/tests.rs
@@ -199,14 +199,25 @@ fn picker_panel_shows_short_ids_marked_count_and_key_semantics() {
         });
     let mut output = Vec::new();
 
+    assert!(matches!(
+        crate::runtime::controller::pending_card_capture(&state),
+        Some(crate::raw_input::RawInputCapture::Session {
+            marked_for_clear,
+            ..
+        }) if marked_for_clear == vec![true]
+    ));
     render_current_session_panel(&adapter, &mut state, &mut output).expect("render picker panel");
 
-    // Collapse renderer wrapping so contract assertions stay width-agnostic.
+    // Strip per-line borders before joining so wrapped footer text stays width-agnostic.
     let rendered = String::from_utf8(output).expect("UTF-8 picker panel");
-    let flat = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+    let flat = rendered
+        .lines()
+        .map(|line| line.trim_matches(|ch: char| ch == '│' || ch.is_whitespace()))
+        .collect::<Vec<_>>()
+        .join(" ");
     assert!(flat.contains("[x] 00000000… · first prompt"), "{rendered}");
     assert!(flat.contains("1/1 · 1 marked"), "{rendered}");
-    assert!(flat.contains("Enter resume"), "{rendered}");
+    assert!(flat.contains("Enter review clear"), "{rendered}");
     assert!(flat.contains("Space toggle clear mark"), "{rendered}");
     assert!(flat.contains("d review clear"), "{rendered}");
     assert!(!flat.contains("Space mark for clear"), "{rendered}");

--- a/src/cosh-ng/crates/cosh-shell/tests/logic/session_recovery.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/logic/session_recovery.rs
@@ -40,11 +40,24 @@ fn picker_footer_keeps_resume_and_clear_semantics_distinct() {
     assert!(en.contains("Esc cancel"), "{en}");
     assert!(!en.contains("Space mark for clear"), "{en}");
 
+    let marked = I18n::new(Language::EnUs).t(MessageId::SessionPickerMarkedFooter);
+    assert!(marked.contains("Enter review clear"), "{marked}");
+    assert!(marked.contains("Space toggle clear mark"), "{marked}");
+    assert!(marked.contains("d review clear"), "{marked}");
+    assert!(marked.contains("Esc cancel"), "{marked}");
+    assert!(!marked.contains("Enter resume"), "{marked}");
+
     let zh = I18n::new(Language::ZhCn).t(MessageId::SessionPickerFooter);
     assert!(zh.contains("Enter 恢复"), "{zh}");
     assert!(zh.contains("Space 切换清理标记"), "{zh}");
     assert!(zh.contains("d 打开清理确认"), "{zh}");
     assert!(zh.contains("Esc 取消"), "{zh}");
+
+    let marked_zh = I18n::new(Language::ZhCn).t(MessageId::SessionPickerMarkedFooter);
+    assert!(marked_zh.contains("Enter 打开清理确认"), "{marked_zh}");
+    assert!(marked_zh.contains("Space 切换清理标记"), "{marked_zh}");
+    assert!(marked_zh.contains("d 打开清理确认"), "{marked_zh}");
+    assert!(marked_zh.contains("Esc 取消"), "{marked_zh}");
 
     // The confirmation-phase footer stays a separate message: y/Enter only
     // deletes after `d` has opened the confirmation.

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/session.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/session.rs
@@ -55,13 +55,14 @@ fn raw_cli_session_list_prints_full_canonical_ids() {
 }
 
 #[test]
-fn raw_cli_session_picker_space_then_enter_resumes_without_deleting() {
+fn raw_cli_session_picker_space_then_enter_confirms_and_deletes_without_resuming() {
     let fixture = SessionFixture::new("picker-space-enter", FixtureMode::Ready);
     let output = fixture.run(
         &[],
         vec![
             (b"/session\n".to_vec(), Duration::from_millis(400)),
             (b" ".to_vec(), Duration::from_millis(300)),
+            (b"\n".to_vec(), Duration::from_millis(300)),
             (b"\n".to_vec(), Duration::from_millis(300)),
             (
                 b"echo after-space-enter\nexit\n".to_vec(),
@@ -70,11 +71,15 @@ fn raw_cli_session_picker_space_then_enter_resumes_without_deleting() {
         ],
     );
 
-    assert!(output.contains("Session selected"), "{output}");
-    assert!(output.contains(SESSION_ONE), "{output}");
-    assert!(!output.contains("Confirm session clear"), "{output}");
+    let request = fs::read_to_string(&fixture.clear_log).expect("clear request log");
+    assert!(output.contains("Confirm session clear"), "{output}");
+    assert!(request.contains(SESSION_ONE), "{request}");
+    assert!(!output.contains("Session selected"), "{output}");
+    assert!(
+        output.contains("Deleted 1 persisted session(s)"),
+        "{output}"
+    );
     assert!(output.contains("after-space-enter"), "{output}");
-    assert!(!fixture.clear_log.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Why

Marking sessions for clear and pressing Enter resumed the focused session
instead of entering the clear-confirmation flow. This contradicted the picker
state and could select a session when the user intended to clear marked items.

## What changed

- Normalize Enter to the existing delete action when the picker has clear marks.
- Keep unmarked Enter resume behavior and show state-aware picker hints.
- Replace the old resume contract with marked-clear and unmarked-resume coverage.

## Related issue

closes #1709

## User / Agent impact

With marked sessions, Enter now opens clear confirmation and a second Enter or
`y` performs the clear. Without marks, Enter continues to resume the focused
session.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The interactive Enter behavior changes only while clear marks exist. Existing
protection filtering, multi-select clearing, confirmation, and `d` behavior are
reused unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib` (1278 passed)
- `cargo test --package cosh-shell --test logic` (9 passed)
- `cargo test --package cosh-shell --test raw_cli session::raw_cli_session_picker_space_then_enter_confirms_and_deletes_without_resuming -- --exact`
- `crates/cosh-shell/scripts/check-layout.sh`

## Documentation and rollback

No standalone documentation changes are required because the picker footer is
updated with the behavior. Revert commit `cb1e6fef` to restore the previous
Enter behavior.
