### PR TITLE
feat(ci): add sec-core Ubuntu raw install tests

### DIFF
--- a/.github/workflows/sec-core-raw-install-nightly-test.yaml
+++ b/.github/workflows/sec-core-raw-install-nightly-test.yaml
@@ -1,0 +1,48 @@
+name: sec-core-raw-install-nightly-test
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # UTC 16:00 = Beijing 00:00
+    - cron: "0 16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-ubuntu-raw:
+    name: E2E sec-core install (Ubuntu 22.04 / raw)
+    runs-on: anolisa-k8s-general-ci-x64
+    timeout-minutes: 60
+    steps:
+      - name: Prepare Ubuntu 22.04
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl git make tar python3-pip
+
+      - uses: actions/checkout@v4
+
+      - name: Install anolisa CLI
+        run: |
+          curl -fsSL https://get.agentic-os.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/anolisa" --version
+
+      - name: Install sec-core with anolisa
+        run: sudo "$HOME/.local/bin/anolisa" --install-mode system install sec-core --backend raw
+
+      - name: Verify sec-core installation
+        run: |
+          sudo "$HOME/.local/bin/anolisa" --install-mode system status sec-core
+          agent-sec-cli --version
+          agent-sec-daemon --help >/dev/null
+          linux-sandbox --help >/dev/null
+
+      - name: Install E2E test dependency
+        run: python3 -m pip install --quiet pytest
+
+      - name: Run sec-core E2E tests
+        run: make -C src/agent-sec-core test-e2e-rpm


### PR DESCRIPTION
## Why

需要先持续验证已发布的 sec-core 能否通过 anolisa CLI 在 Ubuntu 22.04 环境完成 raw 安装，并在真实安装环境中通过 E2E 测试。

## What changed

- 新增每日北京时间 00:00 触发的 sec-core Ubuntu raw 安装测试。
- 使用 `anolisa-k8s-general-ci-x64` runner 验证 Ubuntu 22.04 raw 安装路径。
- 支持面向 main 的 pull request 和手动触发。
- 安装完成后复用现有 Makefile target 执行 E2E 测试。
- 暂不覆盖 Alinux4 raw 和 RPM 路径；Alinux4 raw 的依赖自动安装问题已单独提交 Issue 跟进。

## Related issue

no-issue: 为 sec-core Ubuntu raw 发布包安装链路增加持续验证

## User / Agent impact

不改变运行时行为。维护者可通过 PR、手动触发和 nightly 任务及时发现 Ubuntu raw 发布包安装或 E2E 回归。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

CI 会在隔离 runner 中执行 system mode raw 安装。工作流权限限制为只读，不使用仓库密钥。

## Validation

- YAML 解析通过。
- Makefile E2E target 校验通过。
- `git diff --check` 通过。
- Alinux4 raw 自动依赖安装缺陷已作为 Issue 独立跟进，不纳入本次 CI 覆盖范围。

## Documentation and rollback

无需更新正式文档。删除该 workflow 即可回滚，不影响产品运行时。
