### PR TITLE
fix(anolisa): exclude Python bytecode caches from adapter bundle digests

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -367,14 +367,28 @@ fn trusted_adapter_root(
 /// only after the referent canonicalizes under a trusted datadir root. Reading
 /// the canonical referent instead of reopening the link keeps a link swap from
 /// redirecting the privileged read after validation.
+///
+/// Runtime-derived Python bytecode caches (`__pycache__/`, `*.pyc`) are
+/// excluded, mirroring the receipt digest (#2252): a hook run between the
+/// before/after snapshots must not register as a bundle change.
 fn digest_bundle_tree(root: &Path, trusted_roots: &[PathBuf]) -> Option<String> {
     use sha2::{Digest, Sha256};
+
+    fn is_python_bytecode(path: &Path, is_dir: bool) -> bool {
+        if is_dir {
+            return path.file_name().is_some_and(|name| name == "__pycache__");
+        }
+        path.extension().is_some_and(|ext| ext == "pyc")
+    }
 
     fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
             let file_type = entry.file_type()?;
+            if is_python_bytecode(&path, file_type.is_dir()) {
+                continue;
+            }
             if file_type.is_dir() {
                 collect_files(&path, files)?;
             } else if file_type.is_file() || file_type.is_symlink() {

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -34,7 +34,7 @@ use serde_json::Value;
 use crate::path_safety::{PathBoundaryError, canonicalize_nearest_existing, validate_owned_path};
 use anolisa_platform::fs_layout::FsLayout;
 
-use super::util::digest_tree;
+use super::util::{SealVerdict, verify_seal};
 
 /// Schema version for the generic claim shape and [`ClaimResource`].
 /// Persisted in every receipt so a future on-disk migration can branch.
@@ -121,10 +121,14 @@ impl AdapterClaim {
     /// adapter actions branch on the same verdict, so the comparison lives
     /// with the receipt schema instead of being re-derived per caller.
     pub fn bundle_match(&self) -> BundleMatch {
-        match (&self.bundle_digest, digest_tree(&self.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => BundleMatch::Matched,
-            (Some(_), Some(_)) => BundleMatch::Changed,
-            _ => BundleMatch::Unknown,
+        match self
+            .bundle_digest
+            .as_deref()
+            .and_then(|recorded| verify_seal(recorded, &self.resource_root))
+        {
+            Some(SealVerdict::Matched) => BundleMatch::Matched,
+            Some(SealVerdict::Changed) => BundleMatch::Changed,
+            Some(SealVerdict::LegacyUndecidable) | None => BundleMatch::Unknown,
         }
     }
 
@@ -1025,6 +1029,7 @@ pub fn validate_config_key(key: &str) -> Result<(), super::AdapterError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapter::util::digest_tree;
 
     fn sample_claim() -> AdapterClaim {
         AdapterClaim {

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -43,7 +43,10 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{
+    SealVerdict, bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601,
+    verify_seal,
+};
 
 /// Default timeout for a Claude Code CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -672,17 +675,27 @@ fn list_contains_token(stdout: &str, token: &str) -> bool {
 /// Build the `ResourceBundleMatches` condition.
 fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
     let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+    match claim
+        .bundle_digest
+        .as_deref()
+        .and_then(|recorded| verify_seal(recorded, &claim.resource_root))
+    {
+        Some(SealVerdict::Matched) => AdapterCondition {
             kind,
             status: ConditionStatus::True,
             reason: None,
             resource: None,
         },
-        (Some(_), Some(_)) => AdapterCondition {
+        Some(SealVerdict::Changed) => AdapterCondition {
             kind,
             status: ConditionStatus::False,
             reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        Some(SealVerdict::LegacyUndecidable) => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
             resource: None,
         },
         _ => AdapterCondition {

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -32,7 +32,10 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{
+    SealVerdict, bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601,
+    verify_seal,
+};
 
 /// Default timeout for a Codex CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -754,17 +757,27 @@ fn claim_symlink(claim: &AdapterClaim) -> Option<(PathBuf, PathBuf)> {
 /// Build the `ResourceBundleMatches` condition.
 fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
     let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+    match claim
+        .bundle_digest
+        .as_deref()
+        .and_then(|recorded| verify_seal(recorded, &claim.resource_root))
+    {
+        Some(SealVerdict::Matched) => AdapterCondition {
             kind,
             status: ConditionStatus::True,
             reason: None,
             resource: None,
         },
-        (Some(_), Some(_)) => AdapterCondition {
+        Some(SealVerdict::Changed) => AdapterCondition {
             kind,
             status: ConditionStatus::False,
             reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        Some(SealVerdict::LegacyUndecidable) => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
             resource: None,
         },
         _ => AdapterCondition {

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -30,7 +30,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, digest_tree, now_iso8601};
+use super::util::{SealVerdict, bool_status, digest_tree, now_iso8601, verify_seal};
 
 /// Candidate binary names that indicate cosh is installed. `co` and
 /// `copilot` are the short/legacy aliases of the `cosh` CLI.
@@ -432,17 +432,27 @@ fn claim_extension_dir(claim: &AdapterClaim) -> Option<PathBuf> {
 /// root and comparing to the enable-time digest.
 fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
     let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+    match claim
+        .bundle_digest
+        .as_deref()
+        .and_then(|recorded| verify_seal(recorded, &claim.resource_root))
+    {
+        Some(SealVerdict::Matched) => AdapterCondition {
             kind,
             status: ConditionStatus::True,
             reason: None,
             resource: None,
         },
-        (Some(_), Some(_)) => AdapterCondition {
+        Some(SealVerdict::Changed) => AdapterCondition {
             kind,
             status: ConditionStatus::False,
             reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        Some(SealVerdict::LegacyUndecidable) => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
             resource: None,
         },
         _ => AdapterCondition {

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -442,17 +442,27 @@ impl HermesDriver {
     /// resource root and comparing to the enable-time digest.
     fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
         let kind = AdapterConditionKind::ResourceBundleMatches;
-        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+        match claim
+            .bundle_digest
+            .as_deref()
+            .and_then(|recorded| super::util::verify_seal(recorded, &claim.resource_root))
+        {
+            Some(super::util::SealVerdict::Matched) => AdapterCondition {
                 kind,
                 status: ConditionStatus::True,
                 reason: None,
                 resource: None,
             },
-            (Some(_), Some(_)) => AdapterCondition {
+            Some(super::util::SealVerdict::Changed) => AdapterCondition {
                 kind,
                 status: ConditionStatus::False,
                 reason: Some("resource bundle changed since enable".to_string()),
+                resource: None,
+            },
+            Some(super::util::SealVerdict::LegacyUndecidable) => AdapterCondition {
+                kind,
+                status: ConditionStatus::Unknown,
+                reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
                 resource: None,
             },
             _ => AdapterCondition {
@@ -792,9 +802,10 @@ fn summarize(
 }
 
 /// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
+/// hashed in sorted relative-path order as `path\0len\0bytes`.
+/// Runtime-derived Python bytecode caches are excluded (see
+/// [`super::util::is_python_bytecode`], #2252). Returns `None` on any IO
+/// error so callers fall back to `Unknown` rather than a wrong verdict.
 fn digest_tree(root: &Path) -> Option<String> {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_files(root, &mut files).ok()?;
@@ -819,6 +830,9 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
         let entry = entry?;
         let path = entry.path();
         let ft = entry.file_type()?;
+        if super::util::is_python_bytecode(&path, ft.is_dir()) {
+            continue;
+        }
         if ft.is_dir() {
             collect_files(&path, out)?;
         } else {

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -656,17 +656,27 @@ impl OpenClawDriver {
     /// resource root and comparing to the enable-time digest.
     fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
         let kind = AdapterConditionKind::ResourceBundleMatches;
-        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+        match claim
+            .bundle_digest
+            .as_deref()
+            .and_then(|recorded| super::util::verify_seal(recorded, &claim.resource_root))
+        {
+            Some(super::util::SealVerdict::Matched) => AdapterCondition {
                 kind,
                 status: ConditionStatus::True,
                 reason: None,
                 resource: None,
             },
-            (Some(_), Some(_)) => AdapterCondition {
+            Some(super::util::SealVerdict::Changed) => AdapterCondition {
                 kind,
                 status: ConditionStatus::False,
                 reason: Some("resource bundle changed since enable".to_string()),
+                resource: None,
+            },
+            Some(super::util::SealVerdict::LegacyUndecidable) => AdapterCondition {
+                kind,
+                status: ConditionStatus::Unknown,
+                reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
                 resource: None,
             },
             _ => AdapterCondition {
@@ -2571,9 +2581,10 @@ fn summarize(
 }
 
 /// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
+/// hashed in sorted relative-path order as `path\0len\0bytes`.
+/// Runtime-derived Python bytecode caches are excluded (see
+/// [`super::util::is_python_bytecode`], #2252). Returns `None` on any IO
+/// error so callers fall back to `Unknown` rather than a wrong verdict.
 fn digest_tree(root: &Path) -> Option<String> {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_files(root, &mut files).ok()?;
@@ -2598,6 +2609,9 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
         let entry = entry?;
         let path = entry.path();
         let ft = entry.file_type()?;
+        if super::util::is_python_bytecode(&path, ft.is_dir()) {
+            continue;
+        }
         if ft.is_dir() {
             collect_files(&path, out)?;
         } else {

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -36,7 +36,10 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{
+    SealVerdict, bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601,
+    verify_seal,
+};
 
 mod settings;
 
@@ -1681,17 +1684,27 @@ fn build_native_uninstall_cmd(program: &str, plugin: &str) -> FrameworkCommand {
 /// Build the `ResourceBundleMatches` condition.
 fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
     let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
+    match claim
+        .bundle_digest
+        .as_deref()
+        .and_then(|recorded| verify_seal(recorded, &claim.resource_root))
+    {
+        Some(SealVerdict::Matched) => AdapterCondition {
             kind,
             status: ConditionStatus::True,
             reason: None,
             resource: None,
         },
-        (Some(_), Some(_)) => AdapterCondition {
+        Some(SealVerdict::Changed) => AdapterCondition {
             kind,
             status: ConditionStatus::False,
             reason: Some("resource bundle changed since enable".to_string()),
+            resource: None,
+        },
+        Some(SealVerdict::LegacyUndecidable) => AdapterCondition {
+            kind,
+            status: ConditionStatus::Unknown,
+            reason: Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
             resource: None,
         },
         _ => AdapterCondition {

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
@@ -39,7 +39,10 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{
+    SealVerdict, bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601,
+    verify_seal,
+};
 
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 // tokenless declares the same floor; earlier Qwen releases expose the
@@ -1159,11 +1162,19 @@ fn parse_qwen_version(output: &str) -> Option<Version> {
 
 fn bundle_match_condition(claim: &AdapterClaim) -> (AdapterCondition, ConditionStatus) {
     let kind = AdapterConditionKind::ResourceBundleMatches;
-    let (status, reason) = match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => (ConditionStatus::True, None),
-        (Some(_), Some(_)) => (
+    let (status, reason) = match claim
+        .bundle_digest
+        .as_deref()
+        .and_then(|recorded| verify_seal(recorded, &claim.resource_root))
+    {
+        Some(SealVerdict::Matched) => (ConditionStatus::True, None),
+        Some(SealVerdict::Changed) => (
             ConditionStatus::False,
             Some("resource bundle changed since enable".to_string()),
+        ),
+        Some(SealVerdict::LegacyUndecidable) => (
+            ConditionStatus::Unknown,
+            Some("sealed by an earlier ANOLISA release and runtime caches changed since; re-enable to refresh the seal".to_string()),
         ),
         _ => (
             ConditionStatus::Unknown,

--- a/src/anolisa/crates/anolisa-core/src/adapter/util.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/util.rs
@@ -12,13 +12,104 @@ use sha2::{Digest, Sha256};
 
 use super::driver::{CliOutput, ConditionStatus, FrameworkCommand};
 
+/// True for Python bytecode caches CPython derives inside an executed
+/// tree: `__pycache__/` directories and stray `*.pyc` files.
+///
+/// Excluded from bundle digests: link-mode adapters (qwencode, codex)
+/// execute the resource root in place, so the first hook run writes
+/// bytecode caches into the very tree the enable-time digest sealed and
+/// flips a healthy adapter to degraded (#2252). Deliberately narrow — the
+/// manifest, hook sources, and every other managed file stay digested, so
+/// real tampering and same-version content changes remain detectable. The
+/// known residual (a planted `.pyc` is loadable yet undigested) is
+/// tracked in #2279 together with the broader staleness redesign.
+pub(crate) fn is_python_bytecode(path: &Path, is_dir: bool) -> bool {
+    if is_dir {
+        return path.file_name().is_some_and(|name| name == "__pycache__");
+    }
+    path.extension().is_some_and(|ext| ext == "pyc")
+}
+
+/// Seal prefix written by pre-exclusion releases: all files hashed,
+/// bytecode caches included.
+const LEGACY_SEAL_PREFIX: &str = "sha256:";
+/// Seal prefix for digests computed with bytecode caches excluded. The
+/// explicit semantics marker makes every future verdict deterministic: a
+/// v2 seal is always compared under exactly the semantics that wrote it.
+const SEAL_PREFIX: &str = "sha256/2:";
+
 /// SHA-256 digest of a directory tree, stable across runs: files are hashed
-/// in sorted relative-path order as `path\0len\0bytes`. Returns `None` on
-/// any IO error so callers fall back to `Unknown` rather than a wrong
+/// in sorted relative-path order as `path\0len\0bytes`. Runtime-derived
+/// Python bytecode caches are excluded (see [`is_python_bytecode`]), and
+/// the seal carries the [`SEAL_PREFIX`] semantics marker. Returns `None`
+/// on any IO error so callers fall back to `Unknown` rather than a wrong
 /// verdict.
 pub(crate) fn digest_tree(root: &Path) -> Option<String> {
+    Some(format!("{SEAL_PREFIX}{}", digest_hex(root, false)?))
+}
+
+/// Verdict of comparing an enable-time seal against the tree on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SealVerdict {
+    /// The tree provably matches the sealed state.
+    Matched,
+    /// The tree provably differs from the sealed state.
+    Changed,
+    /// Legacy seal (bytecode included at seal time) on a tree whose
+    /// bytecode caches have changed since: the original cache bytes are
+    /// unrecoverable, so runtime cache churn and real drift cannot be told
+    /// apart. Callers report Unknown with a re-enable hint — never a false
+    /// degrade, never a fake match.
+    LegacyUndecidable,
+}
+
+/// Compare an enable-time `recorded` seal against `root`.
+///
+/// A [`SEAL_PREFIX`] seal compares under the bytecode-excluding semantics
+/// that wrote it. A legacy seal (bare `sha256:`, written by pre-exclusion
+/// releases with bytecode included — notably the #2252 re-enable
+/// workaround population) is accepted when the tree reproduces it under
+/// either semantics: a digest is a binding commitment to one tree state,
+/// so any reproduction proves the tree unchanged. When neither reproduces
+/// it and the tree currently carries bytecode caches, the verdict is
+/// [`SealVerdict::LegacyUndecidable`]; without bytecode present both
+/// semantics hash the same files, so a mismatch is a real change. Returns
+/// `None` when the tree cannot be digested.
+pub(crate) fn verify_seal(recorded: &str, root: &Path) -> Option<SealVerdict> {
+    if let Some(sealed_hex) = recorded.strip_prefix(SEAL_PREFIX) {
+        return Some(if digest_hex(root, false)? == sealed_hex {
+            SealVerdict::Matched
+        } else {
+            SealVerdict::Changed
+        });
+    }
+    let Some(sealed_hex) = recorded.strip_prefix(LEGACY_SEAL_PREFIX) else {
+        // Unrecognized seal format: it cannot equal any digest this code
+        // computes, which is exactly what the pre-marker comparison would
+        // have concluded.
+        return Some(SealVerdict::Changed);
+    };
+    let current_hex = digest_hex(root, false)?;
+    if current_hex == sealed_hex {
+        return Some(SealVerdict::Matched);
+    }
+    let legacy_hex = digest_hex(root, true)?;
+    if legacy_hex == sealed_hex {
+        return Some(SealVerdict::Matched);
+    }
+    Some(if current_hex == legacy_hex {
+        SealVerdict::Changed
+    } else {
+        SealVerdict::LegacyUndecidable
+    })
+}
+
+/// Hex digest with bytecode caches either excluded (current sealing
+/// semantics) or included (pre-#2252 semantics, kept for legacy receipt
+/// comparison).
+fn digest_hex(root: &Path, include_bytecode: bool) -> Option<String> {
     let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
+    collect_files(root, include_bytecode, &mut files).ok()?;
     files.sort();
     let mut hasher = Sha256::new();
     for path in &files {
@@ -30,18 +121,26 @@ pub(crate) fn digest_tree(root: &Path) -> Option<String> {
         hasher.update([0u8]);
         hasher.update(&bytes);
     }
-    Some(format!("sha256:{:x}", hasher.finalize()))
+    Some(format!("{:x}", hasher.finalize()))
 }
 
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+/// Recursively collect regular-file paths under `dir`, skipping Python
+/// bytecode caches unless `include_bytecode`. Symlinks are not followed
+/// into directories (their link path is recorded as a file).
+fn collect_files(
+    dir: &Path,
+    include_bytecode: bool,
+    out: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         let ft = entry.file_type()?;
+        if !include_bytecode && is_python_bytecode(&path, ft.is_dir()) {
+            continue;
+        }
         if ft.is_dir() {
-            collect_files(&path, out)?;
+            collect_files(&path, include_bytecode, out)?;
         } else {
             out.push(path);
         }
@@ -95,4 +194,99 @@ pub(crate) fn display_command(cmd: &FrameworkCommand) -> String {
         s.push_str(a);
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_tree_ignores_python_bytecode_caches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("hook.py"), b"print('hi')").expect("write");
+        let sealed = digest_tree(dir.path()).expect("digest");
+
+        // A hook run derives bytecode caches inside the tree.
+        std::fs::create_dir(dir.path().join("__pycache__")).expect("mkdir");
+        std::fs::write(
+            dir.path().join("__pycache__/hook.cpython-311.pyc"),
+            b"bytecode",
+        )
+        .expect("pyc");
+        std::fs::write(dir.path().join("stray.pyc"), b"bytecode").expect("stray pyc");
+        assert_eq!(
+            digest_tree(dir.path()).as_deref(),
+            Some(sealed.as_str()),
+            "bytecode caches must not change the digest"
+        );
+
+        // Managed files stay digested: real changes are still detected.
+        std::fs::write(dir.path().join("hook.py"), b"print('changed')").expect("rewrite");
+        assert_ne!(
+            digest_tree(dir.path()).as_deref(),
+            Some(sealed.as_str()),
+            "source changes must still change the digest"
+        );
+    }
+
+    #[test]
+    fn verify_seal_handles_legacy_receipts_and_cache_churn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pyc = dir.path().join("__pycache__/hook.cpython-311.pyc");
+        std::fs::write(dir.path().join("hook.py"), b"print('hi')").expect("write");
+        std::fs::create_dir(dir.path().join("__pycache__")).expect("mkdir");
+        std::fs::write(&pyc, b"cache A").expect("pyc");
+
+        // A pre-exclusion release sealed this exact tree with bytecode
+        // included (the #2252 re-enable workaround population).
+        let legacy_sealed = format!(
+            "{LEGACY_SEAL_PREFIX}{}",
+            digest_hex(dir.path(), true).expect("legacy digest")
+        );
+        assert_eq!(
+            verify_seal(&legacy_sealed, dir.path()),
+            Some(SealVerdict::Matched),
+            "an unchanged tree must match its pre-exclusion seal after upgrade"
+        );
+
+        // A v2 seal of the same tree is deterministic under cache churn.
+        let sealed = digest_tree(dir.path()).expect("digest");
+        assert!(
+            sealed.starts_with(SEAL_PREFIX),
+            "new seals carry the marker"
+        );
+        assert_eq!(verify_seal(&sealed, dir.path()), Some(SealVerdict::Matched));
+        std::fs::write(&pyc, b"cache B").expect("regenerate pyc");
+        assert_eq!(
+            verify_seal(&sealed, dir.path()),
+            Some(SealVerdict::Matched),
+            "cache churn must not disturb a v2 seal"
+        );
+
+        // The legacy seal committed to cache A, which is gone: churn and
+        // drift are indistinguishable, so the verdict is undecidable —
+        // never a false Changed.
+        assert_eq!(
+            verify_seal(&legacy_sealed, dir.path()),
+            Some(SealVerdict::LegacyUndecidable)
+        );
+
+        // A genuine change is Changed under both seal generations once the
+        // ambiguity is gone (v2), and stays non-Matched for legacy.
+        std::fs::write(dir.path().join("hook.py"), b"print('changed')").expect("rewrite");
+        assert_eq!(verify_seal(&sealed, dir.path()), Some(SealVerdict::Changed));
+        assert_ne!(
+            verify_seal(&legacy_sealed, dir.path()),
+            Some(SealVerdict::Matched)
+        );
+
+        // Legacy seal on a bytecode-free tree: both semantics hash the
+        // same files, so a mismatch is decidably a real change.
+        std::fs::remove_file(&pyc).expect("rm pyc");
+        std::fs::remove_dir(dir.path().join("__pycache__")).expect("rmdir");
+        assert_eq!(
+            verify_seal(&legacy_sealed, dir.path()),
+            Some(SealVerdict::Changed)
+        );
+    }
 }

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -819,6 +819,188 @@ resource_root = "{root_b}/"
     assert!(!marketplace_root.exists());
 }
 
+/// Regression for #2252: codex (like qwencode) executes the resource root
+/// in place, so a hook run writes `__pycache__` bytecode caches into the
+/// very tree the enable-time digest sealed. The digest must ignore them —
+/// a healthy adapter must not degrade because its hooks ran.
+#[test]
+fn codex_status_stays_healthy_when_hooks_write_bytecode_caches() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    let (_log, _marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    // First hook run: CPython derives bytecode caches in the executed root.
+    let pycache = world.resource_root.join("hooks").join("__pycache__");
+    std::fs::create_dir_all(&pycache).expect("pycache dir");
+    std::fs::write(pycache.join("hook_config.cpython-311.pyc"), b"bytecode").expect("pyc");
+
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status after pycache");
+    assert_eq!(
+        status.entries[0].report.summary,
+        AdapterSummary::Healthy,
+        "runtime-derived bytecode caches must not degrade the adapter"
+    );
+    assert!(
+        status.entries[0]
+            .report
+            .conditions
+            .iter()
+            .any(|c| c.kind == AdapterConditionKind::ResourceBundleMatches
+                && c.status == ConditionStatus::True),
+        "the bundle condition must stay True"
+    );
+}
+
+/// A receipt sealed by a pre-exclusion release — with `__pycache__`
+/// already in the tree, as the #2252 re-enable workaround produced — must
+/// keep reporting Healthy after the ANOLISA upgrade: the digest comparison
+/// accepts a match under either the old (bytecode included) or the new
+/// (bytecode excluded) semantics. Genuine changes still degrade.
+#[test]
+fn codex_status_accepts_receipts_sealed_with_pre_exclusion_digests() {
+    /// The pre-exclusion digest algorithm: every file, no bytecode skip.
+    fn legacy_digest_tree(root: &Path) -> String {
+        use sha2::{Digest, Sha256};
+        fn collect(dir: &Path, out: &mut Vec<PathBuf>) {
+            for entry in std::fs::read_dir(dir).expect("read_dir") {
+                let entry = entry.expect("entry");
+                let path = entry.path();
+                if entry.file_type().expect("file_type").is_dir() {
+                    collect(&path, out);
+                } else {
+                    out.push(path);
+                }
+            }
+        }
+        let mut files = Vec::new();
+        collect(root, &mut files);
+        files.sort();
+        let mut hasher = Sha256::new();
+        for path in &files {
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            let bytes = std::fs::read(path).expect("read file");
+            hasher.update(rel.to_string_lossy().as_bytes());
+            hasher.update([0u8]);
+            hasher.update((bytes.len() as u64).to_le_bytes());
+            hasher.update([0u8]);
+            hasher.update(&bytes);
+        }
+        format!("sha256:{:x}", hasher.finalize())
+    }
+
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_bundle,
+    );
+    // Bytecode caches already exist at enable time: the tree state the
+    // pre-exclusion release sealed.
+    let pycache = world.resource_root.join("hooks").join("__pycache__");
+    std::fs::create_dir_all(&pycache).expect("pycache dir");
+    std::fs::write(pycache.join("hook_config.cpython-311.pyc"), b"bytecode").expect("pyc");
+
+    let fake = write_fake_codex(&world.prefix);
+    let (_log, _marketplace_root) = apply_codex_env(&guard, &world, &fake);
+
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    // Rewrite the receipt digest to what the pre-exclusion release would
+    // have recorded for this exact tree (bytecode included).
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let mut state = world.load_state();
+    let claim = state
+        .adapter_claims
+        .iter_mut()
+        .find(|claim| claim.component == COMPONENT && claim.framework == "codex")
+        .expect("codex claim");
+    claim.bundle_digest = Some(legacy_digest_tree(&world.resource_root));
+    state.save(&state_path).expect("save legacy-sealed receipt");
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(
+        status.entries[0].report.summary,
+        AdapterSummary::Healthy,
+        "an unchanged tree must not degrade because the seal predates the exclusion"
+    );
+
+    // A later hook run regenerates the bytecode cache (cache A -> cache B).
+    // The legacy seal committed to cache A, which is gone — churn and drift
+    // are indistinguishable, so the honest verdict is Unknown with the
+    // re-enable remedy, never a false Degraded.
+    std::fs::write(pycache.join("hook_config.cpython-311.pyc"), b"cache B")
+        .expect("regenerate pyc");
+    let status = manager.status(Some(COMPONENT)).expect("status after churn");
+    assert_ne!(
+        status.entries[0].report.summary,
+        AdapterSummary::Degraded,
+        "bytecode cache churn must not degrade a legacy-sealed receipt"
+    );
+    let bundle = status.entries[0]
+        .report
+        .conditions
+        .iter()
+        .find(|c| c.kind == AdapterConditionKind::ResourceBundleMatches)
+        .expect("bundle condition present");
+    assert_eq!(bundle.status, ConditionStatus::Unknown);
+    assert!(
+        bundle
+            .reason
+            .as_deref()
+            .is_some_and(|r| r.contains("re-enable")),
+        "the verdict must name the remedy: {:?}",
+        bundle.reason
+    );
+
+    // Re-enable reseals with the marked v2 semantics: cache churn becomes
+    // invisible and real drift detection returns.
+    manager
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("re-enable");
+    std::fs::write(pycache.join("hook_config.cpython-311.pyc"), b"cache C").expect("churn again");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status after reseal");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    std::fs::write(
+        world.resource_root.join("README.md"),
+        b"tampered plugin readme\n",
+    )
+    .expect("modify managed file");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status after change");
+    assert!(
+        status.entries[0]
+            .report
+            .conditions
+            .iter()
+            .any(|c| c.kind == AdapterConditionKind::ResourceBundleMatches
+                && c.status == ConditionStatus::False),
+        "real changes must fail the bundle condition on a v2 seal"
+    );
+}
+
 #[test]
 fn codex_dry_run_enable_writes_nothing() {
     let guard = EnvGuard::acquire();


### PR DESCRIPTION
## Problem

Fixes #2252.

Link-mode adapters (qwencode, codex) execute the resource root in place, so the first hook run writes `hooks/__pycache__/*.pyc` into the very tree the enable-time digest sealed. `adapter status` re-hashes the tree, sees the bytecode caches, and flips a healthy adapter to `degraded` / `resource bundle changed since enable` — running the installed hooks is enough to break the adapter's own health report.

## Change

Minimal mitigation, following the narrow exclusion direction #2252 itself proposes ("让 bundle digest 明确排除可安全识别的运行时派生文件"):

- `is_python_bytecode` (shared predicate): `__pycache__/` directories and stray `*.pyc` files are skipped by every bundle digest — `util::digest_tree` (cosh/codex/claude-code/qoder/qwencode), the openclaw and hermes private copies, and the system-update source snapshot (`digest_bundle_tree`).
- **Seal semantics marker + legacy compatibility** (from review): new seals are written as `sha256/2:<hex>` and always compare under the semantics that wrote them, so verdicts stay deterministic under any bytecode churn. Legacy seals (bare `sha256:`, bytecode included — notably the #2252 re-enable workaround population) are matched when the tree reproduces them under either semantics; on bytecode-free trees a mismatch is still decidably `Changed`. When a legacy seal's caches have churned, the original cache bytes are unrecoverable, so all comparison sites (`verify_seal`) report a distinct `Unknown` with `re-enable to refresh the seal` — never a false Degraded, never a fake Healthy. One re-enable reseals with the marker. Persisting the reseal automatically (status is read-only and lock-free) is recorded in #2279.
- Nothing else changes: the manifest, hook sources, and every other managed file stay digested, so real tampering and same-version content changes remain detectable exactly as before.

Known residual, deliberately accepted for the stopgap: a planted `.pyc` is loadable by CPython yet no longer digested. That, together with the broader staleness redesign (version-based receipts, copy-vs-source verification for copy-mode adapters), is tracked in #2279 as the formal follow-up.

## Testing

- `cargo test --workspace` green; clippy/fmt clean.
- `digest_tree_ignores_python_bytecode_caches` (unit): bytecode caches don't change the digest; source edits still do.
- `codex_status_stays_healthy_when_hooks_write_bytecode_caches` (e2e): enable → hook run writes `__pycache__` into the executed root → status stays `Healthy` with `ResourceBundleMatches=True`.
- `codex_status_accepts_receipts_sealed_with_pre_exclusion_digests` (e2e) + `verify_seal_handles_legacy_receipts_and_cache_churn` (unit): a legacy-sealed receipt stays `Healthy` on an unchanged tree; bytecode regeneration (cache A → B) yields `Unknown` + re-enable hint, never a false `Degraded`; after re-enable the v2 seal shrugs off further churn and a managed-file edit degrades.
