### PR TITLE
fix(anolisa): trust codex hooks on enable

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -11,6 +11,9 @@
 //! codex plugin add <plugin>@<marketplace>
 //! ```
 //!
+//! After installation, hook-bearing plugins are trusted through Codex's
+//! app-server so they also work in non-interactive `codex exec` sessions.
+//!
 //! `disable` reverses this via `codex plugin remove` /
 //! `codex plugin marketplace remove` and then removes the marketplace
 //! directory (which contains the symlink). All CLI, file, and symlink IO
@@ -18,6 +21,8 @@
 //!
 //! Env contract: `CODEX_BIN` overrides the executable (tests point it at a
 //! fake CLI); `XDG_DATA_HOME` relocates the marketplace base.
+
+mod hook_trust;
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -146,7 +151,7 @@ impl FrameworkDriver for CodexDriver {
         let layout = MarketplaceLayout::resolve(bundle, ctx)?;
         let add_cmd = build_marketplace_add_cmd(&layout.root);
         let plugin_cmd = build_plugin_add_cmd(&layout.plugin_ref());
-        let actions = vec![
+        let mut actions = vec![
             format!(
                 "write codex marketplace manifest {}",
                 layout.manifest().display()
@@ -159,6 +164,12 @@ impl FrameworkDriver for CodexDriver {
             format!("register codex marketplace '{}'", layout.marketplace),
             format!("add codex plugin '{}'", layout.plugin_ref()),
         ];
+        if bundle_declares_hooks(bundle, ctx) {
+            actions.push(format!(
+                "trust hooks declared by codex plugin '{}'",
+                layout.plugin_ref()
+            ));
+        }
         Ok(DriverPlan {
             framework: self.name().to_string(),
             component: ctx.component.clone(),
@@ -280,6 +291,12 @@ impl FrameworkDriver for CodexDriver {
                 program,
                 reason: cli_failure_reason("plugin add", &output),
             });
+        }
+        if bundle_declares_hooks_for_root(
+            &claim.resource_root,
+            ctx.declared_bundle_entry.as_deref(),
+        ) {
+            establish_hook_trust(ctx, &layout)?;
         }
         Ok(())
     }
@@ -574,6 +591,37 @@ impl MarketplaceLayout {
     fn plugin_ref(&self) -> String {
         format!("{}@{}", self.plugin, self.marketplace)
     }
+}
+
+fn bundle_declares_hooks(bundle: &AdapterBundle, ctx: &DriverCtx) -> bool {
+    bundle_declares_hooks_for_root(&bundle.resource_root, ctx.declared_bundle_entry.as_deref())
+}
+
+fn bundle_declares_hooks_for_root(resource_root: &Path, declared_entry: Option<&str>) -> bool {
+    hook_trust::bundle_declares_hooks(
+        resource_root,
+        &resource_root.join(declared_entry.unwrap_or(CODEX_PLUGIN_MANIFEST)),
+    )
+}
+
+/// Trust only the hooks Codex attributes to the plugin just installed.
+fn establish_hook_trust(ctx: &DriverCtx, layout: &MarketplaceLayout) -> Result<(), AdapterError> {
+    let program = codex_bin();
+    let output = ctx.ops.run_framework_rpc(hook_trust::list_session(
+        program.clone(),
+        CLI_TIMEOUT,
+        &layout.root,
+    ))?;
+    let Some(state) = hook_trust::plugin_trust_state(&program, &output, &layout.plugin_ref())?
+    else {
+        return Ok(());
+    };
+    let output = ctx.ops.run_framework_rpc(hook_trust::write_session(
+        program.clone(),
+        CLI_TIMEOUT,
+        state,
+    ))?;
+    hook_trust::confirm_write(&program, &output)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex/hook_trust.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex/hook_trust.rs
@@ -1,0 +1,392 @@
+//! Codex app-server requests used to trust installed plugin hooks.
+
+use serde::Deserialize;
+
+use crate::adapter::AdapterError;
+use crate::adapter::driver::{CliOutput, FrameworkCommand, FrameworkRpcSession};
+
+const ID_INITIALIZE: u32 = 0;
+const ID_OPERATION: u32 = 1;
+const DEFAULT_HOOKS_FILE: &str = "hooks/hooks.json";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HookEntry {
+    key: String,
+    current_hash: String,
+    source: String,
+    #[serde(default)]
+    plugin_id: Option<String>,
+    is_managed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct HooksListEntry {
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    hooks: Vec<HookEntry>,
+    #[serde(default)]
+    warnings: Vec<serde_json::Value>,
+    #[serde(default)]
+    errors: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HooksListResult {
+    #[serde(default)]
+    data: Vec<HooksListEntry>,
+}
+
+/// Build a session that asks Codex for hook identities in an isolated cwd.
+pub(super) fn list_session(
+    program: String,
+    timeout: std::time::Duration,
+    cwd: &std::path::Path,
+) -> FrameworkRpcSession {
+    rpc_session(
+        program,
+        timeout,
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{ID_OPERATION},"method":"hooks/list","params":{{"cwds":[{cwd}]}}}}"#,
+            cwd = json_string(&cwd.to_string_lossy()),
+        ),
+    )
+}
+
+/// Build one atomic upsert of the trusted hashes returned by Codex.
+pub(super) fn write_session(
+    program: String,
+    timeout: std::time::Duration,
+    trust_state: serde_json::Value,
+) -> FrameworkRpcSession {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": ID_OPERATION,
+        "method": "config/batchWrite",
+        "params": {
+            "edits": [{
+                "keyPath": "hooks.state",
+                "value": trust_state,
+                "mergeStrategy": "upsert"
+            }],
+            "reloadUserConfig": true
+        }
+    });
+    rpc_session(program, timeout, request.to_string())
+}
+
+fn rpc_session(
+    program: String,
+    timeout: std::time::Duration,
+    operation: String,
+) -> FrameworkRpcSession {
+    FrameworkRpcSession {
+        command: FrameworkCommand {
+            program,
+            args: vec!["app-server".to_string(), "--stdio".to_string()],
+            stdin: None,
+            env_set: Vec::new(),
+            env_remove: Vec::new(),
+            path_prepend: Vec::new(),
+            timeout,
+        },
+        requests: vec![initialize_request(), operation],
+        expected_responses: 2,
+    }
+}
+
+fn initialize_request() -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": ID_INITIALIZE,
+        "method": "initialize",
+        "params": {
+            "clientInfo": {
+                "name": "anolisa",
+                "version": env!("CARGO_PKG_VERSION")
+            }
+        }
+    })
+    .to_string()
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::Value::String(value.to_string()).to_string()
+}
+
+/// Extract this plugin's hook hashes from a successful `hooks/list` reply.
+///
+/// Returns `None` when every matching hook is managed externally. A missing
+/// plugin is an error because accepting an empty result would recreate the
+/// silent failure this trust step is intended to prevent.
+pub(super) fn plugin_trust_state(
+    program: &str,
+    output: &CliOutput,
+    plugin_ref: &str,
+) -> Result<Option<serde_json::Value>, AdapterError> {
+    let result = operation_result(program, "hooks/list", output)?;
+    let parsed: HooksListResult = serde_json::from_value(result).map_err(|source| {
+        framework_error(program, "hooks/list", format!("unexpected reply: {source}"))
+    })?;
+
+    let mut found = false;
+    let mut state = serde_json::Map::new();
+    for entry in parsed.data {
+        if let Some(diagnostic) = entry.errors.first().or_else(|| entry.warnings.first()) {
+            return Err(framework_error(
+                program,
+                "hooks/list",
+                format!(
+                    "hook discovery for '{}' reported: {}",
+                    entry.cwd.as_deref().unwrap_or("<unknown>"),
+                    render_diagnostic(diagnostic)
+                ),
+            ));
+        }
+        for hook in entry.hooks {
+            if hook.source != "plugin" || hook.plugin_id.as_deref() != Some(plugin_ref) {
+                continue;
+            }
+            found = true;
+            if !hook.is_managed {
+                state.insert(
+                    hook.key,
+                    serde_json::json!({ "trusted_hash": hook.current_hash }),
+                );
+            }
+        }
+    }
+
+    if !found {
+        return Err(framework_error(
+            program,
+            "hooks/list",
+            format!("reported no hooks for installed plugin '{plugin_ref}'"),
+        ));
+    }
+    Ok((!state.is_empty()).then_some(serde_json::Value::Object(state)))
+}
+
+/// Confirm that Codex persisted the trust-state update.
+pub(super) fn confirm_write(program: &str, output: &CliOutput) -> Result<(), AdapterError> {
+    let result = operation_result(program, "config/batchWrite", output)?;
+    match result.get("status").and_then(serde_json::Value::as_str) {
+        Some("ok") => Ok(()),
+        Some("okOverridden") => {
+            let metadata = result.get("overriddenMetadata");
+            let message = metadata
+                .and_then(|value| value.get("message"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("a higher-precedence configuration overrides hooks.state");
+            let layer = metadata
+                .and_then(|value| value.pointer("/overridingLayer/name"))
+                .map(render_diagnostic)
+                .unwrap_or_else(|| "<unknown>".to_string());
+            Err(framework_error(
+                program,
+                "config/batchWrite",
+                format!("hook trust was overridden by layer {layer}: {message}"),
+            ))
+        }
+        Some(status) => Err(framework_error(
+            program,
+            "config/batchWrite",
+            format!("reply returned unexpected write status '{status}'"),
+        )),
+        None => Err(framework_error(
+            program,
+            "config/batchWrite",
+            "reply did not confirm a write status".to_string(),
+        )),
+    }
+}
+
+fn operation_result(
+    program: &str,
+    operation: &str,
+    output: &CliOutput,
+) -> Result<serde_json::Value, AdapterError> {
+    for line in output.stdout.lines() {
+        let Ok(message) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if message.get("id").and_then(serde_json::Value::as_u64) != Some(u64::from(ID_OPERATION)) {
+            continue;
+        }
+        if let Some(error) = message.get("error") {
+            let detail = error
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown app-server error");
+            return Err(framework_error(program, operation, detail.to_string()));
+        }
+        return message.get("result").cloned().ok_or_else(|| {
+            framework_error(
+                program,
+                operation,
+                "reply contained neither result nor error".to_string(),
+            )
+        });
+    }
+
+    let reason = if output.timed_out {
+        "app-server timed out".to_string()
+    } else {
+        format!(
+            "app-server produced no reply (exit {:?}); stderr: {}",
+            output.status,
+            output
+                .stderr
+                .lines()
+                .map(str::trim)
+                .find(|line| !line.is_empty())
+                .unwrap_or("<empty>")
+        )
+    };
+    Err(framework_error(program, operation, reason))
+}
+
+fn framework_error(program: &str, operation: &str, reason: String) -> AdapterError {
+    AdapterError::FrameworkCli {
+        program: program.to_string(),
+        reason: format!("codex {operation} failed: {reason}"),
+    }
+}
+
+fn render_diagnostic(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string())
+}
+
+/// Whether the plugin bundle contains at least one declared hook handler.
+pub(super) fn bundle_declares_hooks(
+    resource_root: &std::path::Path,
+    plugin_manifest: &std::path::Path,
+) -> bool {
+    let manifest = std::fs::read_to_string(plugin_manifest)
+        .ok()
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok());
+    let explicit = manifest
+        .as_ref()
+        .and_then(|value| value.get("hooks"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+    let hooks_file = match explicit {
+        Some(path) => match safe_relative_path(path) {
+            Some(path) => resource_root.join(path),
+            None => return true,
+        },
+        None => resource_root.join(DEFAULT_HOOKS_FILE),
+    };
+    let Ok(contents) = std::fs::read_to_string(&hooks_file) else {
+        return explicit.is_some();
+    };
+    let Ok(document) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return true;
+    };
+    document
+        .get("hooks")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|events| {
+            events.values().try_fold(false, |found, groups| {
+                let groups = groups.as_array()?;
+                Some(
+                    found
+                        || groups.iter().any(|group| {
+                            group
+                                .get("hooks")
+                                .and_then(serde_json::Value::as_array)
+                                .is_some_and(|hooks| !hooks.is_empty())
+                        }),
+                )
+            })
+        })
+        .unwrap_or(true)
+}
+
+fn safe_relative_path(path: &str) -> Option<std::path::PathBuf> {
+    let mut safe = std::path::PathBuf::new();
+    for component in std::path::Path::new(path).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::Normal(part) => safe.push(part),
+            _ => return None,
+        }
+    }
+    (!safe.as_os_str().is_empty()).then_some(safe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn output(stdout: &str) -> CliOutput {
+        CliOutput {
+            status: Some(0),
+            timed_out: false,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    #[test]
+    fn trusts_only_hooks_owned_by_the_target_plugin() {
+        let stdout = concat!(
+            "{\"id\":0,\"result\":{}}\n",
+            "{\"id\":1,\"result\":{\"data\":[{\"hooks\":[",
+            "{\"key\":\"mine\",\"currentHash\":\"sha256:a\",\"source\":\"plugin\",",
+            "\"pluginId\":\"p@m\",\"isManaged\":false},",
+            "{\"key\":\"other\",\"currentHash\":\"sha256:b\",\"source\":\"plugin\",",
+            "\"pluginId\":\"q@m\",\"isManaged\":false},",
+            "{\"key\":\"managed\",\"currentHash\":\"sha256:c\",\"source\":\"plugin\",",
+            "\"pluginId\":\"p@m\",\"isManaged\":true}",
+            "],\"warnings\":[],\"errors\":[]}]}}\n"
+        );
+        let state = plugin_trust_state("codex", &output(stdout), "p@m")
+            .expect("valid reply")
+            .expect("unmanaged hook");
+        assert_eq!(
+            state,
+            serde_json::json!({ "mine": { "trusted_hash": "sha256:a" } })
+        );
+    }
+
+    #[test]
+    fn missing_target_plugin_is_not_silent_success() {
+        let stdout = "{\"id\":1,\"result\":{\"data\":[{\"hooks\":[]}]}}\n";
+        let error = plugin_trust_state("codex", &output(stdout), "p@m").expect_err("must fail");
+        assert!(error.to_string().contains("reported no hooks"));
+    }
+
+    #[test]
+    fn config_write_uses_one_safe_state_map_upsert() {
+        let session = write_session(
+            "codex".to_string(),
+            std::time::Duration::from_secs(60),
+            serde_json::json!({ "p@m:hooks/hooks.json:stop:0:0": {
+                "trusted_hash": "sha256:a"
+            }}),
+        );
+        let request: serde_json::Value =
+            serde_json::from_str(&session.requests[1]).expect("valid request");
+        assert_eq!(request["params"]["edits"][0]["keyPath"], "hooks.state");
+        assert_eq!(request["params"]["edits"][0]["mergeStrategy"], "upsert");
+    }
+
+    #[test]
+    fn empty_hooks_document_skips_trust_round_trip() {
+        let root = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(root.path().join("hooks")).expect("hooks directory");
+        std::fs::write(root.path().join("plugin.json"), "{}").expect("manifest");
+        std::fs::write(root.path().join(DEFAULT_HOOKS_FILE), r#"{"hooks":{}}"#)
+            .expect("hooks file");
+        assert!(!bundle_declares_hooks(
+            root.path(),
+            &root.path().join("plugin.json")
+        ));
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -329,6 +329,30 @@ pub struct FrameworkCommand {
     pub timeout: Duration,
 }
 
+/// One line-delimited JSON-RPC session with a framework server that speaks
+/// stdio.
+///
+/// Distinct from [`FrameworkCommand::stdin`], which writes its bytes and
+/// immediately closes the pipe: a request/response server treats that EOF as
+/// a shutdown signal and may drop requests it has not dispatched yet (Codex's
+/// `app-server` answers only `initialize` before tearing down). The runner
+/// therefore keeps stdin open until [`Self::expected_responses`] id-bearing
+/// replies have been read, then closes it so the child exits.
+#[derive(Debug, Clone)]
+pub struct FrameworkRpcSession {
+    /// Command that starts the server in stdio mode. Its
+    /// [`FrameworkCommand::timeout`] bounds the whole session, and its
+    /// [`FrameworkCommand::stdin`] is ignored in favor of
+    /// [`Self::requests`].
+    pub command: FrameworkCommand,
+    /// Serialized JSON-RPC request objects, written in order, one per line.
+    pub requests: Vec<String>,
+    /// How many id-bearing responses to await before closing the child's
+    /// stdin. A session that times out before reaching this count still
+    /// returns whatever was read, with `timed_out` set.
+    pub expected_responses: usize,
+}
+
 /// Captured output of a [`FrameworkCommand`]. stdout/stderr are truncated
 /// to a bounded size before being returned and logged.
 #[derive(Debug, Clone)]
@@ -360,6 +384,9 @@ impl CliOutput {
 /// Codex/Claude Code drivers, and [`read_file`](AdapterOps::read_file)
 /// landed with the Qoder driver (which must read the user's
 /// `settings.json` back before merging into it).
+/// [`run_framework_rpc`](AdapterOps::run_framework_rpc) landed with Codex
+/// hook trust, whose framework-side read and write are only reachable through
+/// the `codex app-server` JSON-RPC protocol.
 pub trait AdapterOps {
     /// Spawn a framework CLI with a timeout, capture and truncate its
     /// output, and record the invocation in the central log. The argv is
@@ -388,6 +415,27 @@ pub trait AdapterOps {
     /// [`AdapterError::FrameworkCli`] when the process cannot be spawned.
     fn run_framework_cli_json(&self, cmd: FrameworkCommand) -> Result<CliOutput, AdapterError> {
         self.run_framework_cli(cmd)
+    }
+
+    /// Drive a line-delimited JSON-RPC session against a framework server,
+    /// holding the child's stdin open until the expected replies arrive (see
+    /// [`FrameworkRpcSession`]). Returns the collected stdout lines under the
+    /// same bounded structured-output policy as
+    /// [`Self::run_framework_cli_json`].
+    ///
+    /// The default implementation refuses rather than degrading to
+    /// write-then-EOF, which would silently drop requests: an operation
+    /// provider that has not opted in must fail loudly.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::FrameworkCli`] when the process cannot be spawned or
+    /// the provider does not support RPC sessions.
+    fn run_framework_rpc(&self, session: FrameworkRpcSession) -> Result<CliOutput, AdapterError> {
+        Err(AdapterError::FrameworkCli {
+            program: session.command.program,
+            reason: "this operation provider does not support stdio JSON-RPC sessions".to_string(),
+        })
     }
 
     /// Recursively copy a directory tree from `src` to `dst`. The Manager

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -25,7 +25,7 @@
 //!    directory wins.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{Read, Write};
+use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::{self, JoinHandle};
@@ -38,7 +38,7 @@ use super::claim::{AdapterClaim, ClaimStatus};
 use super::driver::{
     AdapterCondition, AdapterConditionKind, AdapterOps, AdapterStatusReport, AdapterSummary,
     CliOutput, ConditionStatus, DisableReport, DriverCtx, DriverPlan, EnableProgress,
-    FrameworkCommand, HostEnv,
+    FrameworkCommand, FrameworkRpcSession, HostEnv,
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
@@ -2363,6 +2363,12 @@ impl AdapterOps for ManagerOps {
         Ok(output)
     }
 
+    fn run_framework_rpc(&self, session: FrameworkRpcSession) -> Result<CliOutput, AdapterError> {
+        let output = run_rpc_capture(&session, JSON_OUTPUT_CAP)?;
+        self.record(&session.command, &output);
+        Ok(output)
+    }
+
     fn copy_tree(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
         validate_ops_path(src, &self.allowed_roots)?;
         validate_ops_path(dst, &self.allowed_roots)?;
@@ -2728,6 +2734,269 @@ fn run_capture_with_stdout_cap(
         stdout: String::from_utf8_lossy(&stdout).into_owned(),
         stderr: String::from_utf8_lossy(&stderr).into_owned(),
     })
+}
+
+/// Drive a line-delimited JSON-RPC session, holding the server's stdin open
+/// until `session.expected_responses` id-bearing replies have been read (or
+/// the command timeout elapses), then closing it so the child exits.
+///
+/// stdout is read line-by-line on a worker thread rather than drained to EOF,
+/// because the close decision depends on what has already been answered — a
+/// server that only exits once its stdin closes would otherwise deadlock
+/// against a drain-to-EOF reader.
+fn run_rpc_capture(
+    session: &FrameworkRpcSession,
+    stdout_cap: usize,
+) -> Result<CliOutput, AdapterError> {
+    let cmd = &session.command;
+    let mut command = Command::new(&cmd.program);
+    command
+        .args(&cmd.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    for key in &cmd.env_remove {
+        command.env_remove(key);
+    }
+    for (key, value) in &cmd.env_set {
+        command.env(key, value);
+    }
+    if !cmd.path_prepend.is_empty() {
+        command.env("PATH", prepend_path(&cmd.path_prepend));
+    }
+
+    let mut child = crate::process::spawn_retry_etxtbsy(&mut command).map_err(|source| {
+        AdapterError::FrameworkCli {
+            program: cmd.program.clone(),
+            reason: format!("failed to spawn: {source}"),
+        }
+    })?;
+
+    let (Some(stdin), Some(stdout)) = (child.stdin.take(), child.stdout.take()) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(AdapterError::FrameworkCli {
+            program: cmd.program.clone(),
+            reason: "failed to open child stdio pipes".to_string(),
+        });
+    };
+    let stderr_handle = child.stderr.take().map(|r| spawn_drain(r, OUTPUT_CAP));
+
+    // The writer thread owns stdin and only drops it (signalling EOF) once
+    // `close_tx` is dropped by this thread.
+    let (close_tx, close_rx) = std::sync::mpsc::channel::<()>();
+    let payload: Vec<u8> = session
+        .requests
+        .iter()
+        .flat_map(|line| {
+            line.as_bytes()
+                .iter()
+                .copied()
+                .chain(std::iter::once(b'\n'))
+        })
+        .collect();
+    let writer = thread::spawn(move || {
+        let mut stdin = stdin;
+        let result = stdin.write_all(&payload).and_then(|()| stdin.flush());
+        // Park until the reader is done; `recv` returns Err on sender drop.
+        let _ = close_rx.recv();
+        result
+    });
+
+    enum RpcStdoutEvent {
+        Line(String),
+        LimitExceeded,
+        ReadFailed(String),
+    }
+
+    // A rendezvous channel prevents the reader from queuing output faster
+    // than this thread can account for it.
+    let (line_tx, line_rx) = std::sync::mpsc::sync_channel::<RpcStdoutEvent>(0);
+    let reader = thread::spawn(move || {
+        // Read at most one byte beyond the cap so overflow is detectable
+        // without allocating an arbitrarily large unterminated JSONL line.
+        let limit = (stdout_cap as u64).saturating_add(1);
+        let mut reader = std::io::BufReader::new(stdout).take(limit);
+        let mut total = 0usize;
+        let mut drain_after_disconnect = false;
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(read) => {
+                    total = total.saturating_add(read);
+                    if total > stdout_cap {
+                        drain_after_disconnect =
+                            line_tx.send(RpcStdoutEvent::LimitExceeded).is_err();
+                        break;
+                    }
+                    if line.ends_with('\n') {
+                        line.pop();
+                        if line.ends_with('\r') {
+                            line.pop();
+                        }
+                    }
+                    if line_tx.send(RpcStdoutEvent::Line(line)).is_err() {
+                        drain_after_disconnect = true;
+                        break;
+                    }
+                }
+                Err(source) => {
+                    let _ = line_tx.send(RpcStdoutEvent::ReadFailed(source.to_string()));
+                    break;
+                }
+            }
+        }
+        if drain_after_disconnect {
+            let mut reader = reader.into_inner();
+            let mut chunk = [0u8; 8192];
+            while reader.read(&mut chunk).is_ok_and(|read| read != 0) {
+                // Keep draining after the RPC exchange completes so the child
+                // can flush and exit without retaining any additional output.
+            }
+        }
+    });
+
+    let start = Instant::now();
+    let mut kept = String::new();
+    let mut answered = 0usize;
+    let mut timed_out = false;
+    let mut stdout_failure = None;
+    while answered < session.expected_responses {
+        let Some(remaining) = cmd.timeout.checked_sub(start.elapsed()) else {
+            timed_out = true;
+            break;
+        };
+        match line_rx.recv_timeout(remaining) {
+            Ok(RpcStdoutEvent::Line(line)) => {
+                if kept.len().saturating_add(line.len()).saturating_add(1) > stdout_cap {
+                    stdout_failure = Some(format!(
+                        "app-server stdout exceeded the {stdout_cap}-byte limit"
+                    ));
+                    break;
+                }
+                if is_rpc_response(&line) {
+                    answered += 1;
+                }
+                kept.push_str(&line);
+                kept.push('\n');
+            }
+            Ok(RpcStdoutEvent::LimitExceeded) => {
+                stdout_failure = Some(format!(
+                    "app-server stdout exceeded the {stdout_cap}-byte limit"
+                ));
+                break;
+            }
+            Ok(RpcStdoutEvent::ReadFailed(reason)) => {
+                stdout_failure = Some(format!("failed to read app-server stdout: {reason}"));
+                break;
+            }
+            // The server closed stdout (or died) before answering.
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                timed_out = true;
+                break;
+            }
+        }
+    }
+
+    // Unblock a reader waiting to publish another event. It will drain the
+    // pipe without retaining output once all expected replies are complete.
+    drop(line_rx);
+    // Closing stdin lets a well-behaved server flush and exit. If the
+    // exchange is incomplete, terminate the child before joining the writer:
+    // it may be blocked in `write_all` on a full pipe that the server stopped
+    // reading, and waiting for it first would defeat the session timeout.
+    drop(close_tx);
+    let incomplete = answered < session.expected_responses || stdout_failure.is_some();
+    let mut status = if incomplete {
+        match child.try_wait() {
+            Ok(Some(status)) => Some(status),
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                child.wait().ok()
+            }
+        }
+    } else {
+        None
+    };
+    let write_result = writer.join();
+    if !incomplete {
+        status = wait_bounded(&mut child, start, cmd.timeout);
+        if status.is_none() {
+            timed_out = true;
+        }
+    }
+    let _ = reader.join();
+    let mut stderr = String::from_utf8_lossy(&collect_drain(stderr_handle)).into_owned();
+
+    // A failed stdin write is a symptom, not the diagnosis: a server that does
+    // not implement the subcommand exits before the request lands, and EPIPE
+    // would mask its exit code and stderr. Note it and let the caller judge
+    // the exchange by the replies it did or did not get.
+    let write_note = match write_result {
+        Ok(Err(source)) => Some(format!("failed to write server stdin: {source}")),
+        Err(_) => Some("stdin writer thread panicked".to_string()),
+        Ok(Ok(())) => None,
+    };
+    if let Some(note) = write_note.filter(|_| answered < session.expected_responses) {
+        if !stderr.is_empty() && !stderr.ends_with('\n') {
+            stderr.push('\n');
+        }
+        stderr.push_str(&note);
+    }
+
+    if let Some(reason) = stdout_failure {
+        return Err(AdapterError::FrameworkCli {
+            program: cmd.program.clone(),
+            reason,
+        });
+    }
+
+    Ok(CliOutput {
+        status: status.and_then(|s| s.code()),
+        timed_out,
+        stdout: kept,
+        stderr,
+    })
+}
+
+/// Whether a server stdout line is a JSON-RPC *response* (carries an `id`)
+/// rather than a notification. Only responses count toward the session's
+/// expected reply count.
+fn is_rpc_response(line: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|value| value.get("id").cloned())
+        .is_some_and(|id| !id.is_null())
+}
+
+/// Reap `child` within what remains of `timeout` measured from `start`,
+/// killing it on expiry. Returns `None` when the child had to be killed.
+fn wait_bounded(
+    child: &mut std::process::Child,
+    start: Instant,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
 }
 
 /// Build a `PATH` value with `prepend` dirs in front of the current one.
@@ -3791,6 +4060,235 @@ mod tests {
         };
         let err = run_capture(&cmd).expect_err("spawn must fail");
         assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+    }
+
+    // -- run_rpc_capture ------------------------------------------------------
+
+    /// A server that answers one line per request while stdin stays open, then
+    /// exits on EOF — the shape `codex app-server --stdio` has.
+    fn echo_rpc_session(
+        requests: Vec<String>,
+        expected: usize,
+        timeout: Duration,
+    ) -> FrameworkRpcSession {
+        FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    r#"while IFS= read -r line; do
+                         id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+                         printf '{"method":"notify"}\n'
+                         printf '{"id":%s,"result":{}}\n' "$id"
+                       done"#
+                        .to_string(),
+                ],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout,
+            },
+            requests,
+            expected_responses: expected,
+        }
+    }
+
+    #[test]
+    fn run_rpc_capture_collects_every_reply_and_reaps_the_server() {
+        // The point of the RPC runner: a request written after `initialize`
+        // still gets answered, because stdin is held open until the replies
+        // arrive. Writing both lines and closing stdin — what
+        // `FrameworkCommand::stdin` does — loses the second one.
+        let session = echo_rpc_session(
+            vec![
+                r#"{"jsonrpc":"2.0","id":0,"method":"initialize"}"#.to_string(),
+                r#"{"jsonrpc":"2.0","id":1,"method":"hooks/list"}"#.to_string(),
+            ],
+            2,
+            Duration::from_secs(10),
+        );
+        let out = run_rpc_capture(&session, JSON_OUTPUT_CAP).expect("session runs");
+        assert!(!out.timed_out, "server must exit once stdin closes");
+        assert_eq!(out.status, Some(0));
+        let ids: Vec<Option<u64>> = out
+            .stdout
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|msg| msg.get("id").is_some())
+            .map(|msg| msg["id"].as_u64())
+            .collect();
+        assert_eq!(ids, vec![Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn run_rpc_capture_times_out_on_a_silent_server() {
+        let session = FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                // Replace the shell so killing the child also closes the
+                // captured pipes; the app-server itself is likewise the
+                // direct child in production.
+                args: vec!["-c".to_string(), "exec sleep 30".to_string()],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout: Duration::from_millis(150),
+            },
+            requests: vec![r#"{"jsonrpc":"2.0","id":1,"method":"hooks/list"}"#.to_string()],
+            expected_responses: 1,
+        };
+        let out = run_rpc_capture(&session, JSON_OUTPUT_CAP).expect("session runs");
+        assert!(out.timed_out, "a server that never answers must time out");
+        assert!(out.stdout.is_empty());
+    }
+
+    #[test]
+    fn run_rpc_capture_timeout_unblocks_a_full_stdin_pipe() {
+        let session = FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                args: vec!["-c".to_string(), "while :; do :; done".to_string()],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout: Duration::from_millis(150),
+            },
+            // Larger than ordinary pipe capacity: a server that never reads
+            // stdin leaves the writer blocked until the child is killed.
+            requests: vec!["x".repeat(2 * 1024 * 1024)],
+            expected_responses: 1,
+        };
+        let started = Instant::now();
+        let out = run_rpc_capture(&session, JSON_OUTPUT_CAP).expect("session runs");
+        assert!(out.timed_out);
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "writer join exceeded the bounded timeout: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn run_rpc_capture_returns_when_the_server_dies_early() {
+        // A codex too old to know `app-server` exits immediately. The runner
+        // must return the (empty) output rather than block for the timeout, so
+        // the driver can report the missing capability.
+        let session = FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "echo 'unrecognized subcommand' >&2; exit 2".to_string(),
+                ],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout: Duration::from_secs(30),
+            },
+            requests: vec![r#"{"jsonrpc":"2.0","id":1,"method":"hooks/list"}"#.to_string()],
+            expected_responses: 1,
+        };
+        let out = run_rpc_capture(&session, JSON_OUTPUT_CAP).expect("session runs");
+        assert!(!out.timed_out, "must not wait out the timeout");
+        assert_eq!(out.status, Some(2));
+        assert!(out.stderr.contains("unrecognized subcommand"));
+    }
+
+    #[test]
+    fn run_rpc_capture_rejects_stdout_over_limit() {
+        let session = FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    r#"IFS= read -r _; printf '{"id":1,"result":{"padding":"xxxxxxxx"}}\n'"#
+                        .to_string(),
+                ],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout: Duration::from_secs(10),
+            },
+            requests: vec![r#"{"jsonrpc":"2.0","id":1,"method":"hooks/list"}"#.to_string()],
+            expected_responses: 1,
+        };
+        let error = run_rpc_capture(&session, 16).expect_err("oversized response must fail");
+        assert!(error.to_string().contains("exceeded the 16-byte limit"));
+    }
+
+    #[test]
+    fn run_rpc_capture_rejects_unterminated_stdout_over_limit() {
+        let session = FrameworkRpcSession {
+            command: FrameworkCommand {
+                program: "/bin/sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "IFS= read -r _; printf '12345'; exec sleep 30".to_string(),
+                ],
+                stdin: None,
+                env_set: Vec::new(),
+                env_remove: Vec::new(),
+                path_prepend: Vec::new(),
+                timeout: Duration::from_secs(10),
+            },
+            requests: vec![r#"{"jsonrpc":"2.0","id":1,"method":"hooks/list"}"#.to_string()],
+            expected_responses: 1,
+        };
+        let started = Instant::now();
+        let error = run_rpc_capture(&session, 4).expect_err("unterminated stdout must fail");
+        assert!(error.to_string().contains("exceeded the 4-byte limit"));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "overflow handling exceeded the bounded timeout: {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn rpc_response_detection_ignores_notifications() {
+        assert!(is_rpc_response(r#"{"id":1,"result":{}}"#));
+        assert!(is_rpc_response(r#"{"id":1,"error":{"code":-1}}"#));
+        assert!(!is_rpc_response(r#"{"method":"configWarning"}"#));
+        assert!(!is_rpc_response(r#"{"id":null,"result":{}}"#));
+        assert!(!is_rpc_response("not json at all"));
+    }
+
+    #[test]
+    fn default_ops_refuse_rpc_sessions_rather_than_degrading() {
+        struct PlainOps;
+        impl AdapterOps for PlainOps {
+            fn run_framework_cli(&self, _cmd: FrameworkCommand) -> Result<CliOutput, AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn copy_tree(&self, _src: &Path, _dst: &Path) -> Result<(), AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn copy_file(&self, _src: &Path, _dst: &Path) -> Result<(), AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn remove_tree(&self, _path: &Path) -> Result<bool, AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn write_file(&self, _path: &Path, _contents: &[u8]) -> Result<(), AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn create_symlink(&self, _link: &Path, _target: &Path) -> Result<(), AdapterError> {
+                unreachable!("not exercised")
+            }
+            fn read_file(&self, _path: &Path) -> Result<Option<Vec<u8>>, AdapterError> {
+                unreachable!("not exercised")
+            }
+        }
+        let session = echo_rpc_session(Vec::new(), 0, Duration::from_secs(1));
+        let err = PlainOps
+            .run_framework_rpc(session)
+            .expect_err("the default must refuse");
+        assert!(err.to_string().contains("JSON-RPC"), "{err}");
     }
 
     // -- declared_adapter_type ------------------------------------------------

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -495,6 +495,16 @@ fn stage_codex_bundle(root: &Path) {
     std::fs::write(root.join("README.md"), b"codex plugin\n").expect("readme");
 }
 
+fn stage_codex_hook_bundle(root: &Path) {
+    stage_codex_bundle(root);
+    std::fs::create_dir_all(root.join("hooks")).expect("hooks directory");
+    std::fs::write(
+        root.join("hooks/hooks.json"),
+        br#"{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"true"}]}]}}"#,
+    )
+    .expect("hooks.json");
+}
+
 /// Fake `codex` CLI: appends each argv line to `$FAKE_CODEX_LOG` and keeps
 /// marketplace/plugin registries under `$FAKE_CODEX_STATE` so `list`
 /// reflects prior `add`/`remove` calls.
@@ -505,6 +515,27 @@ fn write_fake_codex(dir: &Path) -> PathBuf {
         r#"#!/bin/sh
 printf '%s\n' "$*" >> "$FAKE_CODEX_LOG"
 st="$FAKE_CODEX_STATE"; mkdir -p "$st" 2>/dev/null
+if [ "$1" = "app-server" ]; then
+  while IFS= read -r line; do
+    case "$line" in
+      *'"method":"initialize"'*) printf '{"id":0,"result":{}}\n' ;;
+      *'"method":"hooks/list"'*)
+        if [ "$FAKE_CODEX_FAIL" = "hooks" ]; then
+          printf '{"id":1,"result":{"data":[{"hooks":[],"warnings":[],"errors":[]}]}}\n'
+        else
+          printf '{"id":1,"result":{"data":[{"hooks":[{"key":"tokenless@anolisa-tokenless:hooks/hooks.json:pre_tool_use:0:0","currentHash":"sha256:trusted","source":"plugin","pluginId":"tokenless@anolisa-tokenless","isManaged":false}],"warnings":[],"errors":[]}]}}\n'
+        fi ;;
+      *'"method":"config/batchWrite"'*)
+        printf '%s\n' "$line" > "$st/trust-request"
+        if [ "$FAKE_CODEX_FAIL" = "write-overridden" ]; then
+          printf '{"id":1,"result":{"status":"okOverridden","overriddenMetadata":{"message":"hooks.state is managed","overridingLayer":{"name":"sessionFlags","version":"test"},"effectiveValue":{}}}}\n'
+        else
+          printf '{"id":1,"result":{"status":"ok"}}\n'
+        fi ;;
+    esac
+  done
+  exit 0
+fi
 if [ "$1" = "plugin" ] && [ "$2" = "marketplace" ]; then
   case "$3" in
     add)
@@ -629,6 +660,79 @@ fn codex_enable_records_argv_and_builds_marketplace() {
             .lines()
             .any(|l| l == "plugin marketplace remove anolisa-tokenless"),
         "disable must run `plugin marketplace remove`: {log_text}"
+    );
+}
+
+#[test]
+fn codex_enable_trusts_declared_hooks() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_hook_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+
+    world
+        .manager()
+        .enable(COMPONENT, Some("codex"), false)
+        .expect("enable");
+
+    let request: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(world.prefix.join("codex-state/trust-request"))
+            .expect("trust request"),
+    )
+    .expect("valid request");
+    assert_eq!(request["method"], "config/batchWrite");
+    assert_eq!(
+        request["params"]["edits"][0]["value"]["tokenless@anolisa-tokenless:hooks/hooks.json:pre_tool_use:0:0"]
+            ["trusted_hash"],
+        "sha256:trusted"
+    );
+}
+
+#[test]
+fn codex_enable_fails_when_declared_hooks_are_not_discovered() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_hook_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+    guard.set("FAKE_CODEX_FAIL", Path::new("hooks"));
+
+    let error = world
+        .manager()
+        .enable(COMPONENT, Some("codex"), false)
+        .expect_err("missing hooks must fail enable");
+    assert!(error.to_string().contains("reported no hooks"), "{error}");
+}
+
+#[test]
+fn codex_enable_fails_when_hook_trust_is_overridden() {
+    let guard = EnvGuard::acquire();
+    let world = stage(
+        "codex",
+        "plugin",
+        "{datadir}/adapters/{component}/codex/",
+        stage_codex_hook_bundle,
+    );
+    let fake = write_fake_codex(&world.prefix);
+    apply_codex_env(&guard, &world, &fake);
+    guard.set("FAKE_CODEX_FAIL", Path::new("write-overridden"));
+
+    let error = world
+        .manager()
+        .enable(COMPONENT, Some("codex"), false)
+        .expect_err("overridden hook trust must fail enable");
+    assert!(
+        error.to_string().contains("sessionFlags"),
+        "overriding layer must be actionable: {error}"
     );
 }
 


### PR DESCRIPTION
## Why

Codex silently filters plugin hooks until their current identity hashes are
trusted. The ANOLISA Codex driver installed plugins without establishing that
trust, so hook-bearing components appeared enabled but their hooks did not run
in headless `codex exec` sessions.

## What changed

- Query hook identities through Codex `hooks/list` after plugin installation.
- Atomically upsert only the installed plugin's hashes through
  `config/batchWrite`.
- Add bounded stdio JSON-RPC handling and fail when declared hooks are absent.

## Related issue

closes #2272

## User / Agent impact

`anolisa adapter enable <component> codex` now makes that component's hooks
available to subsequent non-interactive Codex sessions without a manual TUI
trust review. Hookless plugins keep their existing enable path.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

Trust is scoped to unmanaged hooks that Codex attributes to the plugin just
installed. Existing user hook state is merged rather than replaced, and
discovery or persistence failures fail enable instead of reporting silent
success.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- Real Codex 0.146.0 app-server smoke test for `hooks.state` persistence
- Rebased integration run: `cargo test -p anolisa-core --test adapter_frameworks codex`

## Documentation and rollback

No documentation change is required. Revert the commit to restore the previous
plugin-only enable flow.
