### PR TITLE
chore(anolisa): bump version to 0.2.18

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18] - 2026-08-06
+
+### Changed
+
+- Telemetry upload now treats `SLS_PROJECT_PREFIX` as an SLS project prefix
+  and appends the detected region, for example `anolisa-cn-hangzhou`.
+  Deployments that set the legacy `SLS_PROJECT` must migrate to
+  `SLS_PROJECT_PREFIX` so uploads reach their region-specific project
+  ([#2260](https://github.com/alibaba/anolisa/pull/2260)).
+
+### Fixed
+
+- Raw installs now stream only selected archive payloads through private,
+  disk-backed staging instead of retaining uncompressed contents in memory.
+  Large packages can install with bounded payload memory while preserving
+  atomic placement, rollback, cleanup, and digest verification
+  ([#2250](https://github.com/alibaba/anolisa/pull/2250)).
+- `anolisa status` and `anolisa doctor` now hash ANOLISA-owned files up to
+  2 GiB and treat larger files as unchecked and degraded instead of failed.
+  Intact components with large artifacts no longer appear damaged or trigger
+  spurious repair, while recovery still fails closed when verification is
+  required
+  ([#2271](https://github.com/alibaba/anolisa/pull/2271)).
+- Enabling a Codex adapter that declares hooks now discovers the installed
+  plugin's hook identities and atomically persists their trusted hashes, so
+  non-interactive `codex exec` sessions can run them. Missing hooks or
+  overridden trust settings stop enablement with actionable diagnostics
+  ([#2281](https://github.com/alibaba/anolisa/pull/2281)).
+
 ## [0.2.17] - 2026-08-05
 
 ### Added
@@ -790,6 +819,33 @@ Initial alpha release of the ANOLISA CLI.
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 ## [未发布]
+
+## [0.2.18] - 2026-08-06
+
+### 变更
+
+- Telemetry 上传现将 `SLS_PROJECT_PREFIX` 视为 SLS project prefix，并附加
+  检测到的 region，例如 `anolisa-cn-hangzhou`。设置旧 `SLS_PROJECT` 的部署
+  必须迁移至 `SLS_PROJECT_PREFIX`，以便将数据上传到相应 region 的 project
+  ([#2260](https://github.com/alibaba/anolisa/pull/2260))。
+
+### 修复
+
+- Raw 安装现仅将选中的 archive payload 通过私有、disk-backed staging 流式
+  处理，不再将解压后的内容保留在内存中。大型 package 可以使用有界的 payload
+  内存完成安装，同时保留 atomic placement、rollback、cleanup 和 digest
+  verification
+  ([#2250](https://github.com/alibaba/anolisa/pull/2250))。
+- `anolisa status` 和 `anolisa doctor` 现会 hash 最大 2 GiB 的 ANOLISA-owned
+  file，并将更大的 file 视为未检查和 degraded，而不是 failed。包含大型 artifact
+  的完整组件不再显示为损坏或触发多余的 repair，同时在必须完成 verification 的
+  recovery 场景中仍会 fail closed
+  ([#2271](https://github.com/alibaba/anolisa/pull/2271))。
+- Enable 声明了 hook 的 Codex adapter 时，现会发现已安装 plugin 的 hook
+  identity，并以 atomic 方式持久化其 trusted hash，使 non-interactive
+  `codex exec` session 可以运行这些 hook。缺失 hook 或被覆盖的 trust setting
+  会以可操作的诊断信息中止 enable
+  ([#2281](https://github.com/alibaba/anolisa/pull/2281))。
 
 ## [0.2.17] - 2026-08-05
 

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Aug 05 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Thu Aug 06 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Raw installs now use bounded-memory, disk-backed payload staging.
+- Telemetry now derives region-specific SLS projects from a project prefix.
+- Large intact artifacts no longer cause false integrity failures.
+- Codex adapter enablement now trusts installed plugin hooks.
+
+* Wed Aug 05 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.17-1
 - Raw installs now render relocatable templates and reject incompatible contracts.
 - Generation-2 indexes prevent silent downgrade from unreadable entries.
 - RPM adapters now use package-owned roots and preserve external symlink trust.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.17",
-    "@anolisa/cli-linux-arm64": "0.2.17",
-    "@anolisa/cli-darwin-arm64": "0.2.17"
+    "@anolisa/cli-linux-x64": "0.2.18",
+    "@anolisa/cli-linux-arm64": "0.2.18",
+    "@anolisa/cli-darwin-arm64": "0.2.18"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Prepare the ANOLISA CLI 0.2.18 release boundary after the user-visible changes merged since 0.2.17. Every distribution must publish the same version, and the release notes need to describe the final shipped behavior rather than intermediate fixes.

## What changed

- Bumped the Cargo workspace and all ANOLISA workspace lockfile entries to 0.2.18.
- Bumped the root npm package, native optional dependencies, and every platform package to 0.2.18.
- Curated semantically equivalent English and Chinese changelog entries from the complete 0.2.17-to-HEAD component range, with links to the implementing PRs.
- Added the new RPM changelog boundary and froze the previous row at 0.2.17.

## Related issue

no-issue: release metadata aggregation for ANOLISA CLI 0.2.18

## User / Agent impact

Published Cargo, npm, native platform, and RPM artifacts will report one consistent 0.2.18 version. The changelog documents bounded-memory raw installs, region-aware SLS project configuration, corrected large-file integrity reporting, and automatic Codex hook trust.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

This commit changes release metadata and documentation only; it adds no runtime behavior beyond the changes already merged to `main`. Deployments using the legacy `SLS_PROJECT` variable must migrate to `SLS_PROJECT_PREFIX`, as recorded in the bilingual changelog.

## Validation

- `python3 /home/jiawa.syx/.codex/skills/release-anolisa-cli/scripts/check_release.py --root /home/jiawa.syx/Code/Opensource/anolisa-main/src/anolisa --version 0.2.18 --previous 0.2.17`
- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `target/debug/anolisa --version` → `anolisa 0.2.18`
- `git diff --check`

## Documentation and rollback

Updated the English and Chinese sections of `src/anolisa/CHANGELOG.md` and the RPM history in `src/anolisa/anolisa.spec.in`. Before artifacts are published, rollback is a revert of this version-bump commit; after publication, corrections should ship in a follow-up release.