### PR TITLE
fix(sight): keep turn open on tool-call stop

### DIFF
--- a/src/agentsight/src/genai/call_builder.rs
+++ b/src/agentsight/src/genai/call_builder.rs
@@ -157,8 +157,27 @@ impl GenAIBuilder {
             .and_then(|m| m.finish_reason.as_deref())
         {
             if Self::is_turn_terminal_finish_reason(reason) {
-                self.id_resolver
-                    .finish_conversation(&agent_name, pid_i32, &last_user_raw);
+                // Some providers (e.g. DashScope with forced tool_choice) report
+                // finish_reason "stop" even when the response carries tool calls.
+                // A response that still asks for tool execution means the turn is
+                // not over, so keep the conversation anchor alive.
+                // Both finish_reason and the tool-call probe read the last output
+                // message: for multi-choice responses the last choice is decisive,
+                // matching the SSE aggregation semantics (finish_reason comes from
+                // the last chunk).
+                let has_tool_call = response
+                    .messages
+                    .last()
+                    .map(|m| {
+                        m.parts
+                            .iter()
+                            .any(|p| matches!(p, MessagePart::ToolCall { .. }))
+                    })
+                    .unwrap_or(false);
+                if !has_tool_call {
+                    self.id_resolver
+                        .finish_conversation(&agent_name, pid_i32, &last_user_raw);
+                }
             }
         }
 
@@ -297,16 +316,21 @@ impl GenAIBuilder {
         })
     }
 
-    /// 判断 `finish_reason` 是否意味着本轮对话已经结束。
+    /// Returns whether a `finish_reason` value *by itself* marks the end of a turn.
     ///
-    /// `tool_calls`（OpenAI）/`tool_use`（Anthropic）/`function_call`（旧式 OpenAI）
-    /// 表示模型请求了工具调用，对话仍将在同一轮内继续；其余取值（`stop` /
-    /// `end_turn` / `length` / `max_tokens` / `content_filter` / `stop_sequence` 等）均意味着
-    /// 本轮对话已经得到最终回复，应视为轮结束。
+    /// `tool_calls` (OpenAI) / `tool_use` (Anthropic) / `function_call` (legacy
+    /// OpenAI) mean the model requested tool execution; `pause_turn` (Anthropic)
+    /// means a long-running turn was paused and will resume. Anything else
+    /// (`stop`, `end_turn`, `length`, ...) is treated as terminal.
+    ///
+    /// Note: the eviction site additionally checks whether the last assistant
+    /// message still carries a `MessagePart::ToolCall`; if so, the conversation
+    /// anchor is kept alive even for a terminal `finish_reason` (some providers,
+    /// e.g. DashScope with forced `tool_choice`, report `"stop"` for tool calls).
     fn is_turn_terminal_finish_reason(reason: &str) -> bool {
         !matches!(
             reason.to_ascii_lowercase().as_str(),
-            "tool_calls" | "tool_use" | "function_call"
+            "tool_calls" | "tool_use" | "function_call" | "pause_turn"
         )
     }
 
@@ -1716,6 +1740,241 @@ mod tests {
         assert_eq!(
             call.metadata.get("call_kind").map(|s| s.as_str()),
             Some("recap")
+        );
+    }
+
+    // ── Turn eviction vs. tool calls (issue #2262) ──────────────────────
+    //
+    // The conversation anchor must survive a response that still requests
+    // tool execution, even when the provider mislabels it with a terminal
+    // finish_reason such as "stop" (e.g. DashScope with forced tool_choice).
+
+    /// Builds an OpenAI-style request/response pair: a single user message
+    /// plus an assistant reply with the given finish_reason and tool_calls.
+    fn openai_turn_results(
+        user_text: &str,
+        response_id: &str,
+        finish_reason: &str,
+        tool_calls: Option<Vec<serde_json::Value>>,
+    ) -> Vec<AnalysisResult> {
+        let request = OpenAIRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![empty_chat_msg(MessageRole::User, Some(user_text))],
+            temperature: None,
+            max_tokens: None,
+            stream: None,
+            top_p: None,
+            n: None,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            user: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            seed: None,
+            logprobs: None,
+            top_logprobs: None,
+            parallel_tool_calls: None,
+        };
+        let mut assistant_msg = empty_chat_msg(MessageRole::Assistant, Some("ok"));
+        assistant_msg.tool_calls = tool_calls;
+        let response = OpenAIResponse {
+            id: response_id.to_string(),
+            object: "chat.completion".to_string(),
+            created: 0,
+            model: "gpt-4".to_string(),
+            choices: vec![OpenAIChoice {
+                index: 0,
+                message: assistant_msg,
+                finish_reason: Some(finish_reason.to_string()),
+                logprobs: None,
+            }],
+            usage: None,
+            system_fingerprint: None,
+        };
+        let parsed = ParsedApiMessage::OpenAICompletion {
+            request: Some(request),
+            response: Some(response),
+        };
+        let http = make_http("/v1/chat/completions", None, None);
+        vec![AnalysisResult::Http(http), AnalysisResult::Message(parsed)]
+    }
+
+    fn conv_id(builder: &GenAIBuilder, results: &[AnalysisResult]) -> String {
+        build_call(builder, results)
+            .unwrap()
+            .metadata
+            .get("conversation_id")
+            .unwrap()
+            .clone()
+    }
+
+    fn sample_tool_calls() -> Vec<serde_json::Value> {
+        vec![serde_json::json!({
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": "run_cmd", "arguments": "{}"}
+        })]
+    }
+
+    #[test]
+    fn test_tool_call_with_stop_finish_reason_keeps_turn_open() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-1", "stop", Some(sample_tool_calls())),
+        );
+        let second = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-2", "stop", Some(sample_tool_calls())),
+        );
+        assert_eq!(
+            first, second,
+            "a response carrying tool calls must not evict the conversation anchor"
+        );
+    }
+
+    #[test]
+    fn test_pure_text_stop_finish_reason_ends_turn() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(&builder, &openai_turn_results(user, "resp-1", "stop", None));
+        let second = conv_id(&builder, &openai_turn_results(user, "resp-2", "stop", None));
+        assert_ne!(
+            first, second,
+            "a pure-text terminal response must still evict the conversation anchor"
+        );
+    }
+
+    #[test]
+    fn test_empty_tool_calls_with_stop_ends_turn() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-1", "stop", Some(vec![])),
+        );
+        let second = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-2", "stop", Some(vec![])),
+        );
+        assert_ne!(
+            first, second,
+            "an empty tool_calls array yields no ToolCall part and must still end the turn"
+        );
+    }
+
+    #[test]
+    fn test_pause_turn_finish_reason_keeps_turn_open() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-1", "pause_turn", None),
+        );
+        let second = conv_id(
+            &builder,
+            &openai_turn_results(user, "resp-2", "pause_turn", None),
+        );
+        assert_eq!(
+            first, second,
+            "pause_turn means the turn will resume, so the anchor must survive"
+        );
+    }
+
+    /// Builds an OpenAI SSE exchange: request body with a single user message
+    /// and a streamed response whose tool_call arrives as fragmented deltas,
+    /// with the last chunk reporting finish_reason "stop".
+    fn sse_stop_tool_call_results(user_text: &str, response_id: &str) -> Vec<AnalysisResult> {
+        let request_body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": user_text}]
+        })
+        .to_string();
+        let sse_body = format!(
+            concat!(
+                r#"[{{"id":"{rid}","choices":[{{"delta":{{"tool_calls":"#,
+                r#"[{{"index":0,"id":"tc_1","function":{{"name":"run_cmd","arguments":"{{\"c"}}}}]}},"#,
+                r#""finish_reason":null}}]}},"#,
+                r#"{{"id":"{rid}","choices":[{{"delta":{{"tool_calls":"#,
+                r#"[{{"index":0,"function":{{"arguments":"md\":1}}"}}}}]}},"finish_reason":"stop"}}]}}]"#
+            ),
+            rid = response_id
+        );
+        let mut http = make_http("/v1/chat/completions", Some(request_body), Some(sse_body));
+        http.is_sse = true;
+        vec![AnalysisResult::Http(http)]
+    }
+
+    #[test]
+    fn test_sse_tool_call_with_stop_keeps_turn_open() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(&builder, &sse_stop_tool_call_results(user, "sse-resp-1"));
+        let second = conv_id(&builder, &sse_stop_tool_call_results(user, "sse-resp-2"));
+        assert_eq!(
+            first, second,
+            "an SSE-aggregated tool call with finish_reason stop must not evict the anchor"
+        );
+    }
+
+    /// Builds a SysOM exchange with a single user message and a tool_use
+    /// response; the SysOM path hardcodes finish_reason "stop".
+    fn sysom_tool_use_results(user_text: &str) -> Vec<AnalysisResult> {
+        let request = SysomRequest {
+            params: SysomLlmParams {
+                model: "qwen".to_string(),
+                messages: vec![SysMsg {
+                    role: "user".to_string(),
+                    content: user_text.to_string(),
+                    tool_call_id: None,
+                    name: None,
+                    tool_calls: None,
+                }],
+                stream: false,
+                temperature: None,
+                max_tokens: None,
+                top_p: None,
+                tools: None,
+                use_dashscope: None,
+            },
+        };
+        let response = SysomResponse {
+            id: Some("chatcmpl-xx".to_string()),
+            choices: vec![SysomResponseChoice {
+                message: SysomResponseMessage {
+                    content: "answer".to_string(),
+                    tool_use: Some(vec![SysomToolUseItem {
+                        index: 0,
+                        id: "tu_1".to_string(),
+                        item_type: "function".to_string(),
+                        function: SysomFunction {
+                            name: "calc".to_string(),
+                            arguments: r#"{"x":1}"#.to_string(),
+                        },
+                    }]),
+                },
+            }],
+        };
+        let parsed = ParsedApiMessage::SysomMessage {
+            request: Some(request),
+            response: Some(response),
+        };
+        let http = make_http("/api/v1/copilot/generate_copilot", None, None);
+        vec![AnalysisResult::Http(http), AnalysisResult::Message(parsed)]
+    }
+
+    #[test]
+    fn test_sysom_tool_use_with_stop_keeps_turn_open() {
+        let builder = GenAIBuilder::new();
+        let user = "same user text";
+        let first = conv_id(&builder, &sysom_tool_use_results(user));
+        let second = conv_id(&builder, &sysom_tool_use_results(user));
+        assert_eq!(
+            first, second,
+            "a SysOM tool_use response (hardcoded finish_reason stop) must not evict the anchor"
         );
     }
 }


### PR DESCRIPTION
## Why

AgentSight judged turn termination solely by the finish_reason literal. DashScope reports `"stop"` for forced `tool_choice` calls, so the conversation anchor was evicted mid-turn and every step opened a new turn (`step.id` stuck at 1, issue #2262).

## What changed

The eviction site in `src/agentsight/src/genai/call_builder.rs` now keeps the anchor when the last assistant message still carries a `MessagePart::ToolCall`, and `"pause_turn"` (Anthropic) joins the non-terminal whitelist. Interruption-time eviction and the 30-minute TTL fallback are unchanged.

## Related issue

closes #2262

## User / Agent impact

Turns produced by DashScope forced-tool-choice sessions are no longer split into single-step turns; `step.id` increments within one turn as expected. No CLI, API, or configuration change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: single-file change to turn-eviction heuristics; stale anchors are still covered by interruption eviction and the 30-minute TTL.

## Validation

ECS (kernel 6.6, rustc 1.89.0 matching CI): `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` all pass (1518 passed; the single doctest failure in helpers.rs is pre-existing on origin/main and unrelated). 6 new discriminating unit tests cover the eviction matrix: tool_call+stop keeps turn, pure-text stop ends turn, empty tool_calls ends turn, pause_turn keeps turn, SSE aggregation path, SysOM path. Reverting the fix makes the corresponding tests fail (discriminating signal verified).

## Documentation and rollback

No documentation change needed (internal heuristic). Revert the single commit to roll back.
