### PR TITLE
feat(blaze): maintain automatic warm capacity

### DIFF
--- a/src/blaze/crates/blaze-core/src/storage.rs
+++ b/src/blaze/crates/blaze-core/src/storage.rs
@@ -119,6 +119,30 @@ pub trait StorageProvider: Send + Sync {
         self.release(slot).await
     }
 
+    /// Report whether provider-owned slots can be inventoried and released by ID.
+    ///
+    /// Returning true promises both a complete [`Self::list_owned_ids`]
+    /// inventory for the provider's currently configured root and an
+    /// idempotent [`Self::release_by_id`] that can retry complete, missing,
+    /// and partially created slots. It does not identify a provider or root
+    /// recorded by another subsystem.
+    fn supports_owned_slot_inventory(&self) -> bool {
+        false
+    }
+
+    /// List every stable slot identifier currently owned by the provider.
+    ///
+    /// This is a point-in-time inventory. Callers that need a stable boundary
+    /// must serialize it with concurrent acquire and release operations.
+    /// Implementations must reject entries that cannot be classified as a
+    /// provider-owned slot. Callers use this inventory only when
+    /// [`Self::supports_owned_slot_inventory`] returns true.
+    async fn list_owned_ids(&self) -> Result<Vec<String>> {
+        Err(BlazeError::StorageError {
+            msg: "storage provider does not expose stable slot inventory".to_string(),
+        })
+    }
+
     /// Reconstruct a previously allocated slot from a stable instance id.
     ///
     /// Implementations must derive every returned path from their configured

--- a/src/blaze/crates/blazed/src/file_provider.rs
+++ b/src/blaze/crates/blazed/src/file_provider.rs
@@ -244,12 +244,29 @@ impl StorageProvider for FileStorageProvider {
         // Re-derive the canonical path from instances_dir + slot.id. Do not
         // trust path strings carried in a persisted or externally built slot.
         let canonical_dir = self.slot_for_id(&slot.id)?.instance_dir;
-        if canonical_dir.exists() {
-            tokio::fs::remove_dir_all(&canonical_dir)
-                .await
-                .map_err(|e| BlazeError::StorageError {
-                    msg: format!("release '{}': {}", slot.id, e),
-                })?;
+        match tokio::fs::symlink_metadata(&canonical_dir).await {
+            Ok(metadata) if metadata.file_type().is_dir() => {
+                tokio::fs::remove_dir_all(&canonical_dir)
+                    .await
+                    .map_err(|error| BlazeError::StorageError {
+                        msg: format!("release '{}': {error}", slot.id),
+                    })?;
+            }
+            Ok(_) => {
+                return Err(BlazeError::StorageError {
+                    msg: format!(
+                        "release '{}': refusing non-directory slot {}",
+                        slot.id,
+                        canonical_dir.display()
+                    ),
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(BlazeError::StorageError {
+                    msg: format!("release '{}': inspect: {error}", slot.id),
+                });
+            }
         }
         Ok(())
     }
@@ -257,6 +274,53 @@ impl StorageProvider for FileStorageProvider {
     async fn release_by_id(&self, instance_id: &str) -> Result<()> {
         let slot = self.slot_for_id(instance_id)?;
         self.release(slot).await
+    }
+
+    fn supports_owned_slot_inventory(&self) -> bool {
+        true
+    }
+
+    async fn list_owned_ids(&self) -> Result<Vec<String>> {
+        let mut entries = tokio::fs::read_dir(&self.instances_dir)
+            .await
+            .map_err(|error| BlazeError::StorageError {
+                msg: format!("inventory {}: {error}", self.instances_dir.display()),
+            })?;
+        let mut ids = Vec::new();
+        while let Some(entry) =
+            entries
+                .next_entry()
+                .await
+                .map_err(|error| BlazeError::StorageError {
+                    msg: format!("inventory {}: {error}", self.instances_dir.display()),
+                })?
+        {
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .await
+                .map_err(|error| BlazeError::StorageError {
+                    msg: format!("inventory {}: inspect: {error}", path.display()),
+                })?;
+            if !file_type.is_dir() {
+                return Err(BlazeError::StorageError {
+                    msg: format!(
+                        "inventory {}: unexpected non-directory entry",
+                        path.display()
+                    ),
+                });
+            }
+            let id = entry
+                .file_name()
+                .into_string()
+                .map_err(|_| BlazeError::StorageError {
+                    msg: format!("inventory {}: slot name is not UTF-8", path.display()),
+                })?;
+            validate_instance_id(&id)?;
+            ids.push(id);
+        }
+        ids.sort();
+        Ok(ids)
     }
 
     async fn reconstruct(&self, instance_id: &str) -> Result<StorageSlot> {
@@ -447,6 +511,7 @@ fn validate_instance_id(instance_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn probe_existing_dir_returns_true() {
@@ -501,6 +566,136 @@ mod tests {
         assert!(dir.exists());
         provider.release(slot).await.unwrap();
         assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn release_by_id_recovers_missing_and_partial_slots() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let id = Uuid::new_v4().to_string();
+        let missing_id = Uuid::new_v4().to_string();
+        provider.release_by_id(&missing_id).await.unwrap();
+        provider.release_by_id(&missing_id).await.unwrap();
+        let partial = tmp.path().join(&id);
+        tokio::fs::create_dir(&partial).await.unwrap();
+        tokio::fs::write(partial.join("rootfs.ext4"), b"partial")
+            .await
+            .unwrap();
+
+        provider.release_by_id(&id).await.unwrap();
+        provider.release_by_id(&id).await.unwrap();
+
+        assert!(!partial.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn release_by_id_rejects_non_directory_and_symlink_slots() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let id = Uuid::new_v4().to_string();
+        let slot_path = tmp.path().join(&id);
+        tokio::fs::write(&slot_path, b"not a directory")
+            .await
+            .unwrap();
+
+        let file_error = provider.release_by_id(&id).await.unwrap_err();
+        assert!(file_error.to_string().contains("refusing non-directory"));
+        assert!(slot_path.is_file());
+
+        tokio::fs::remove_file(&slot_path).await.unwrap();
+        let target = tempfile::TempDir::new().unwrap();
+        symlink(target.path(), &slot_path).unwrap();
+
+        let symlink_error = provider.release_by_id(&id).await.unwrap_err();
+        assert!(symlink_error.to_string().contains("refusing non-directory"));
+        assert!(std::fs::symlink_metadata(&slot_path).unwrap().is_symlink());
+        assert!(target.path().is_dir());
+    }
+
+    #[tokio::test]
+    async fn owned_slot_inventory_includes_partial_slots_in_stable_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let first = Uuid::new_v4().to_string();
+        let second = Uuid::new_v4().to_string();
+        tokio::fs::create_dir(tmp.path().join(&second))
+            .await
+            .unwrap();
+        tokio::fs::create_dir(tmp.path().join(&first))
+            .await
+            .unwrap();
+        tokio::fs::write(tmp.path().join(&second).join("rootfs.ext4"), b"partial")
+            .await
+            .unwrap();
+        let mut expected = vec![first, second];
+        expected.sort();
+
+        assert!(provider.supports_owned_slot_inventory());
+        assert_eq!(provider.list_owned_ids().await.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn owned_slot_inventory_rejects_non_directory_entries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let id = Uuid::new_v4().to_string();
+        tokio::fs::write(tmp.path().join(id), b"not a slot directory")
+            .await
+            .unwrap();
+
+        let error = provider.list_owned_ids().await.unwrap_err();
+
+        assert!(error.to_string().contains("unexpected non-directory"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn owned_slot_inventory_rejects_invalid_directory_names() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        tokio::fs::create_dir(tmp.path().join("invalid\\slot"))
+            .await
+            .unwrap();
+
+        let error = provider.list_owned_ids().await.unwrap_err();
+
+        assert!(error.to_string().contains("invalid instance_id"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn owned_slot_inventory_rejects_non_utf8_directory_names() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        tokio::fs::create_dir(tmp.path().join(OsString::from_vec(vec![0xff])))
+            .await
+            .unwrap();
+
+        let error = provider.list_owned_ids().await.unwrap_err();
+
+        assert!(error.to_string().contains("slot name is not UTF-8"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn owned_slot_inventory_rejects_linked_entries() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let provider = FileStorageProvider::new(tmp.path().to_path_buf());
+        let target = tempfile::TempDir::new().unwrap();
+        let id = Uuid::new_v4().to_string();
+        symlink(target.path(), tmp.path().join(id)).unwrap();
+
+        let error = provider.list_owned_ids().await.unwrap_err();
+
+        assert!(error.to_string().contains("unexpected non-directory"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

This draft will deliver bounded automatic warm capacity through the existing
sandbox create path.

The completed pull request will:

- prepare independently owned storage slots when `storage.pool_size` is positive;
- optionally start a backend and complete its readiness check when
  `storage.prefork = true`;
- let a compatible `POST /v1/sandboxes` request claim one ready slot;
- preserve one durable owner through build, claim, handoff, cleanup, restart,
  cancellation, and bounded shutdown; and
- keep incompatible or unavailable capacity on the existing cold-create path.

No management route or internal ownership field is added to the HTTP API.
The four existing `/v1/pools` compatibility routes remain unsupported.

**Draft status:** the current public head is still the one-commit
provider-owned slot-inventory foundation
(`afde1cd0e21759b110e390ecc55c285b760683bd`). It has no daemon production
caller and does not implement automatic warm capacity. Checks and reviews
attached to this head validate only that foundation.

A separate integration-only reconstruction reorganizes the earlier five-commit
development layout into four feature commits: durable cleanup authority;
automatic storage capacity with the provider inventory folded into its first
production consumer; backend preforking; and documentation. This reconstruction
is not the public pull-request head, is not a merge candidate, and cannot make
this pull request Ready while #2290 and #2471 remain open.

The corrected four-commit integration-only reconstruction has now completed
its private per-commit Linux validation matrix. The dependency correction was
limited to stale test-only interfaces; source and tree reconciliation confirmed
that the intended feature and documentation content were unchanged. These
results do not attach to the current public head and do not establish a merge
candidate. Any change to `main`, #2290, or #2471 makes this matrix historical
evidence.

For the complete feature, documentation will update the existing English and
Chinese component READMEs and runtime user guides, the annotated example
configuration, and the existing bilingual lifecycle-consistency and
storage-artifact-synchronization design documents. It will add no new design
document or changelog entry.

## Related Issue

Closes #2460

Refs #2284

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
  to stop working as expected)
- [x] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `blaze` (blaze)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [ ] My code follows the project's code style
- [ ] I have added tests that prove the feature works
- [ ] I have updated the documentation accordingly
- [ ] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

The current public foundation-only head has the following public results:

- [`CI / Components` run 31576556947](https://github.com/alibaba/anolisa/actions/runs/31576556947)
  succeeded.
- [`CI / PR Lint` run 31886788609](https://github.com/alibaba/anolisa/actions/runs/31886788609)
  succeeded, superseding the earlier checkout-only failure; the subsequent
  [body-update run 31932348141](https://github.com/alibaba/anolisa/actions/runs/31932348141)
  also succeeded.
- GitHub publishes `license/cla: success` for this public head.
- The [exact-head Codex review](https://github.com/alibaba/anolisa/pull/2285#issuecomment-5264061498)
  found no major issues at `afde1cd0e21759b110e390ecc55c285b760683bd`.

These results validate only the provider-inventory foundation. They do not
validate automatic warm capacity.

The corrected integration-only reconstruction completed a fresh native Linux
x86_64 matrix with Rust and Cargo 1.88, locked and offline dependencies, and
fresh source and build directories at every commit boundary. Its
integration-only dependency base passed both default and all-feature builds.
Each of the four feature commits passed formatting; locked and offline metadata;
default and all-feature workspace builds for all targets; strict default and
all-feature Clippy; serial default and all-feature workspace tests; strict
default and all-feature rustdoc; focused tests; and source and tree
reconciliation.

| Feature commit | Default tests | All-feature tests | Focused tests |
|---|---:|---:|---:|
| Durable cleanup authority | 349 | 384 | 24 |
| Automatic storage capacity | 361 | 406 | 24 |
| Backend preforking | 362 | 416 | 21 |
| Documentation | 362 | 416 | 64 |

The documentation commit also passed bilingual documentation lint and link
checks. Its documentation content and the intended feature trees were unchanged
by the dependency-only test correction. Every recorded command completed
normally; no result depends on a skipped command or an infrastructure failure.

This is private integration evidence only. It is not attached to the public
head and is not a merge candidate. Any change to `main`, #2290, or #2471 makes
this matrix historical evidence.

Before this draft can become ready, the published final head and its
current-main merge candidate must repeat the complete Linux contract, including
a real daemon smoke test for storage-only and preforked capacity.

## Dependencies

The startup inventory prerequisite from #2113 is already in `main`.

The complete feature depends on:

- #2290, which removes the incomplete reset and reusable-pool semantics; and
- #2471, which binds file storage to an opened root and closes publication
  races.

The unpublished integration-only reconstruction used these exact historical
inputs:

- `main` at `ba20d94d19a73e5b781cab0c687d4034ad0d0dae`;
- #2290 at `adbe1c1220b426e3340877c0599f31d9c2f4237c`; and
- #2471 at `03616fc0a18d06ec5d170df344e2dc2465e1ec10`.

Both dependency pull requests remain open. This Draft must not be merged or
marked Ready on the strength of that integration-only reconstruction.

After both dependencies merge, the four feature commits must be reconstructed
on the then-current exact `main`. The new public head and its newly generated
merge candidate must repeat the complete exact-head Linux validation, all
GitHub-hosted workflows, the public CLA status, and a fresh exact-head Codex
review before this Draft can be marked Ready.
