### PR TITLE
fix(blaze): reclaim inactive operation locks

### DIFF
--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Recoverable sandbox create, warm activation, destroy, and startup cleanup.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use blaze_core::BlazeError;
@@ -76,7 +76,7 @@ pub struct ReconcileReport {
 pub struct SandboxManager {
     instances: Arc<Mutex<HashMap<Uuid, SandboxInstance>>>,
     backend_instances: Arc<Mutex<HashMap<Uuid, DynBackendInstance>>>,
-    operation_locks: Mutex<HashMap<Uuid, Arc<AsyncMutex<()>>>>,
+    operation_locks: Mutex<OperationLockRegistry>,
     pub(super) storage_sync_inflight: Arc<Mutex<HashSet<Uuid>>>,
     pub(super) storage_sync_permits: Arc<Semaphore>,
     pool: Arc<Mutex<PoolManager>>,
@@ -125,11 +125,6 @@ impl SandboxManager {
             mem_size,
             template_catalog,
         } = init;
-        let operation_locks = instances
-            .keys()
-            .copied()
-            .map(|id| (id, Arc::new(AsyncMutex::new(()))))
-            .collect();
         let instances = Arc::new(Mutex::new(instances));
         let backend_instances = Arc::new(Mutex::new(HashMap::new()));
         let pool = Arc::new(Mutex::new(pool));
@@ -143,7 +138,7 @@ impl SandboxManager {
             Self {
                 instances,
                 backend_instances,
-                operation_locks: Mutex::new(operation_locks),
+                operation_locks: Mutex::new(OperationLockRegistry::default()),
                 storage_sync_inflight: Arc::new(Mutex::new(HashSet::new())),
                 // The periodic worker is sequential. Retain that bound when a
                 // timed-out provider operation has to finish in the background.
@@ -164,17 +159,7 @@ impl SandboxManager {
 
     /// Return the async operation lock that serializes one sandbox mutation.
     pub fn operation_lock(&self, id: Uuid) -> Arc<AsyncMutex<()>> {
-        match self.operation_locks.lock() {
-            Ok(mut locks) => locks
-                .entry(id)
-                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-                .clone(),
-            Err(poisoned) => poisoned
-                .into_inner()
-                .entry(id)
-                .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-                .clone(),
-        }
+        operation_lock(&self.operation_locks, id)
     }
 
     pub(crate) fn backend_owner(&self, id: Uuid) -> Option<DynBackendInstance> {
@@ -1163,4 +1148,125 @@ impl SandboxManager {
 
 fn poisoned(name: &str) -> BlazeDaemonError {
     BlazeDaemonError::Internal(format!("{name} lock poisoned"))
+}
+
+const OPERATION_LOCK_PRUNE_BATCH: usize = 4;
+
+#[derive(Default)]
+struct OperationLockRegistry {
+    locks: HashMap<Uuid, Weak<AsyncMutex<()>>>,
+    prune_queue: VecDeque<Uuid>,
+}
+
+fn operation_lock(registry: &Mutex<OperationLockRegistry>, id: Uuid) -> Arc<AsyncMutex<()>> {
+    let mut registry = match registry.lock() {
+        Ok(registry) => registry,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let lock = match registry.locks.get(&id).and_then(Weak::upgrade) {
+        Some(lock) => lock,
+        None => {
+            let lock = Arc::new(AsyncMutex::new(()));
+            if registry.locks.insert(id, Arc::downgrade(&lock)).is_none() {
+                registry.prune_queue.push_back(id);
+            }
+            lock
+        }
+    };
+
+    // Bound cleanup work so one lookup never scans the complete live registry.
+    let candidates = registry.prune_queue.len().min(OPERATION_LOCK_PRUNE_BATCH);
+    for _ in 0..candidates {
+        let Some(candidate) = registry.prune_queue.pop_front() else {
+            break;
+        };
+        if registry
+            .locks
+            .get(&candidate)
+            .is_some_and(|candidate| candidate.strong_count() > 0)
+        {
+            registry.prune_queue.push_back(candidate);
+        } else {
+            registry.locks.remove(&candidate);
+        }
+    }
+    lock
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn operation_locks_reuse_live_entries_and_prune_dead_ones() {
+        let registry = Mutex::new(OperationLockRegistry::default());
+        let id = Uuid::new_v4();
+        let first = operation_lock(&registry, id);
+        let second = operation_lock(&registry, id);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(registry.lock().expect("registry lock").locks.len(), 1);
+
+        drop(first);
+        drop(second);
+        for _ in 0..256 {
+            drop(operation_lock(&registry, Uuid::new_v4()));
+        }
+
+        assert_eq!(registry.lock().expect("registry lock").locks.len(), 1);
+    }
+
+    #[test]
+    fn operation_lock_pruning_is_bounded() {
+        let registry = Mutex::new(OperationLockRegistry::default());
+        let locks = (0..(OPERATION_LOCK_PRUNE_BATCH * 3))
+            .map(|_| operation_lock(&registry, Uuid::new_v4()))
+            .collect::<Vec<_>>();
+        drop(locks);
+
+        let survivor_id = Uuid::new_v4();
+        let survivor = operation_lock(&registry, survivor_id);
+        {
+            let registry = registry.lock().expect("registry lock");
+            assert_eq!(registry.locks.len(), OPERATION_LOCK_PRUNE_BATCH * 2 + 1);
+        }
+
+        for _ in 0..OPERATION_LOCK_PRUNE_BATCH {
+            let reused = operation_lock(&registry, survivor_id);
+            assert!(Arc::ptr_eq(&survivor, &reused));
+        }
+
+        let registry = registry.lock().expect("registry lock");
+        assert_eq!(registry.locks.len(), 1);
+        assert_eq!(registry.prune_queue.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_operation_lock_requests_share_one_mutex() {
+        const REQUESTS: usize = 32;
+
+        let registry = Arc::new(Mutex::new(OperationLockRegistry::default()));
+        let barrier = Arc::new(Barrier::new(REQUESTS));
+        let id = Uuid::new_v4();
+        let handles = (0..REQUESTS)
+            .map(|_| {
+                let registry = registry.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    operation_lock(&registry, id)
+                })
+            })
+            .collect::<Vec<_>>();
+        let locks = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("operation lock request"))
+            .collect::<Vec<_>>();
+
+        assert!(locks.iter().all(|lock| Arc::ptr_eq(&locks[0], lock)));
+        assert_eq!(registry.lock().expect("registry lock").locks.len(), 1);
+    }
 }


### PR DESCRIPTION
## Why

The sandbox manager kept a strong operation-lock reference for every UUID it
had seen. Even after all holders and waiters finished, the registry retained
the lock object, so a long-running daemon accumulated historical entries.

Before this change, the table grew with every distinct sandbox ID and startup
preallocated permanent locks for persisted sandboxes. After this change, the
registry retains one shared lock only while a holder or waiter still owns it,
then reclaims expired entries through bounded work on later lookups.

## What changed

- Store weak references in the per-sandbox operation-lock registry.
- Maintain a cleanup queue and inspect at most four candidates per lookup.
- Stop preallocating permanent locks for persisted sandboxes at startup.
- Preserve one shared lock for concurrent requests using the same UUID.
- Add focused reclamation, bounded-cleanup, and 32-thread same-ID sharing tests.

### Commit

1. `d13cbf664349` — **reclaim inactive operation locks.** Replaces permanent
   strong registry ownership with weak references, adds fixed-batch cleanup,
   removes startup preallocation, and defines the reclamation and same-ID
   serialization invariants with focused tests.

These changes belong in one PR because the weak-reference representation,
bounded cleanup rule, startup behavior, and concurrent-sharing tests jointly
correct one in-memory ownership invariant. The PR does not change sandbox
state, runtime ownership, storage behavior, or request semantics.

### Still to do

1. None for the issue scope. Expired entries are intentionally reclaimed by
   later lock lookups instead of requiring a background task or synchronous
   cleanup when the final holder exits.

## Related issue

closes #2289

## User / Agent impact

No public API behavior changes. A long-running daemon can release inactive
per-sandbox lock objects while preserving serialization between concurrent
operations for the same sandbox.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The change is limited to the manager's in-memory operation-lock
registry.

## Validation

Exact commit: `d13cbf6643497242d240b086d7dcf1553f9ef1dd`

Parent: `717e63161d02967749c715a1ee6e7fc12c946ab5`

Tree: `1208e998fd3f59cccfd70824a0e67f3ddc9fb61e`

The exact commit was exported with `git archive`; the verified archive SHA-256
is:

`596cbdb39ee08a9c727b76749ee90f701aff08f63016ce739340b4203ce05d21`

Fresh Linux x86_64 source and separate initially empty default/all-feature
targets passed:

- `cargo fmt --all -- --check`
- default and all-feature locked workspace all-target builds
- default and all-feature strict workspace Clippy
- `cargo test --workspace --locked` — 52 core + 206 daemon tests
- `cargo test --workspace --all-features --locked` — 52 core + 216 daemon
  tests
- default and all-feature strict rustdoc
- `cargo test -p blazed --locked operation_lock -- --nocapture` — 4/4
- commitlint 19.8.1, trailer parsing, parent-to-head `git diff --check`, and
  public-boundary scan

All listed tests completed with zero failures. Hosted [Components](https://github.com/alibaba/anolisa/actions/runs/31373079054), [PR Lint](https://github.com/alibaba/anolisa/actions/runs/31373107683), and [CLA](https://cla-assistant.io/alibaba/anolisa?pullRequest=2291) checks passed. Complete-PR review also passed without findings for `d13cbf6643`: [review request](https://github.com/alibaba/anolisa/pull/2291#issuecomment-5238157570) and [review result](https://github.com/alibaba/anolisa/pull/2291#issuecomment-5238191940).

## Documentation and rollback

No documentation changes are required because the public contract and
persisted data are unchanged. Reverting the single commit restores permanent
strong registry ownership without requiring data conversion.
