### PR TITLE
fix(blaze): bound HTTP request bodies

### DIFF
--- a/docs/user-guide/en/runtime/blaze.md
+++ b/docs/user-guide/en/runtime/blaze.md
@@ -98,6 +98,28 @@ and verify guest connectivity for the host environment.
 To disable the capability, set `enable_network = false` or remove the key, then
 destroy existing network-enabled sandboxes through the normal instance API.
 
+## HTTP Request Body Limits
+
+Blaze bounds every HTTP request body while reading it. Routes without a
+specialized envelope use a 1 MiB default, configurable as a positive byte
+count:
+
+```toml
+[api]
+max_body_bytes = 1048576
+```
+
+The daemon checks a declared `Content-Length` before reading the body and also
+checks the accumulated bytes from the stream. A missing or understated length
+therefore cannot bypass the limit. Malformed, empty, or conflicting length
+values return HTTP 400. A declared or observed body above the route limit
+returns HTTP 413 with `"code": "request_too_large"`.
+
+Guest exec, read, and write routes use their existing 22 MiB HTTP envelope
+limit instead of `api.max_body_bytes`. Their oversized-request code remains
+`"guest_request_too_large"`. The larger envelope accommodates up to 16 MiB of
+decoded file data plus base64 and JSON overhead.
+
 ## Guest Operations
 
 Guest operations are available only while a sandbox is `Running` and its

--- a/docs/user-guide/zh/runtime/blaze.md
+++ b/docs/user-guide/zh/runtime/blaze.md
@@ -83,6 +83,26 @@ Blaze 负责配置 sandbox 本地的网络路径。主机以外的路由和 DNS 
 如需关闭该能力，将 `enable_network` 设置为 `false` 或删除该配置项，再通过
 正常的 instance API 销毁已经启用网络的 sandbox。
 
+## HTTP 请求体上限
+
+Blaze 会在读取过程中限制每个 HTTP request body。没有专用 envelope 的路由
+默认使用 1 MiB 上限，可以通过正整数字节数配置：
+
+```toml
+[api]
+max_body_bytes = 1048576
+```
+
+daemon 会在读取 body 前检查声明的 `Content-Length`，并继续检查流式数据的
+累计字节数，因此缺少或低报长度不能绕过上限。长度格式错误、空值或冲突值
+返回 HTTP 400。声明大小或实际累计大小超过路由上限时，
+返回 HTTP 413 和 `"code": "request_too_large"`。
+
+Guest exec、read 和 write 路由继续使用原有的 22 MiB HTTP envelope 上限，
+不使用 `api.max_body_bytes`；对应的超限错误码仍是
+`"guest_request_too_large"`。较大的 envelope 用于容纳最多 16 MiB 的解码文件
+数据以及 base64 和 JSON 开销。
+
 ## Guest 操作
 
 只有 sandbox 处于 `Running` 且 backend 报告兼容的 guest endpoint 时，

--- a/src/blaze/README.md
+++ b/src/blaze/README.md
@@ -66,6 +66,21 @@ and a policies directory containing per-workload-class policy files.
 
 See `src/blaze/examples/` for annotated sample configurations.
 
+### API Request Limits
+
+Routes without a specialized request envelope accept up to 1 MiB by default.
+Set a positive byte limit in the daemon configuration:
+
+```toml
+[api]
+max_body_bytes = 1048576
+```
+
+The daemon rejects malformed or conflicting `Content-Length` values with HTTP
+400. It rejects a declared or streamed body above the applicable route limit
+with HTTP 413. Guest command and file routes retain their 22 MiB envelope limit
+so a 16 MiB file can be carried as base64 JSON.
+
 ### VM Resource Configuration
 
 Blaze resolves vCPU and memory settings using a three-layer fallback chain:

--- a/src/blaze/README_zh.md
+++ b/src/blaze/README_zh.md
@@ -64,6 +64,20 @@ daemon 读取 TOML 配置文件（默认：`/etc/anolisa/blaze/config.toml`）
 
 参见 `src/blaze/examples/` 获取带注释的示例配置。
 
+### API 请求上限
+
+没有专用 request envelope 的路由默认最多接收 1 MiB。可以在 daemon 配置中
+设置正整数字节数：
+
+```toml
+[api]
+max_body_bytes = 1048576
+```
+
+`Content-Length` 格式错误或多个值冲突时，daemon 返回 HTTP 400；声明大小或
+流式读取的累计大小超过对应路由上限时，返回 HTTP 413。Guest 命令与文件路由
+继续使用 22 MiB envelope 上限，以便通过 base64 JSON 传输 16 MiB 文件。
+
 ### VM 资源配置
 
 Blaze 使用三层回退链解析 vCPU 和内存设置：

--- a/src/blaze/crates/blaze-core/src/config.rs
+++ b/src/blaze/crates/blaze-core/src/config.rs
@@ -19,6 +19,11 @@ pub struct DaemonConfig {
     pub daemon: DaemonSection,
     #[serde(default)]
     pub listen: ListenSection,
+    /// Request-body limits for routes without a dedicated protocol envelope.
+    ///
+    /// Guest-operation routes retain their protocol-specific envelope limit.
+    #[serde(default)]
+    pub api: ApiSection,
     /// Backend name → binary path mapping (e.g. `firecracker = "/usr/bin/firecracker"`).
     #[serde(default)]
     pub backends: HashMap<String, PathBuf>,
@@ -61,6 +66,22 @@ pub struct ListenSection {
     /// Empty string or absent means remote API is disabled.
     #[serde(default)]
     pub http_addr: String,
+}
+
+/// HTTP API request limits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiSection {
+    /// Maximum body size for routes without a more specific envelope limit.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+}
+
+impl Default for ApiSection {
+    fn default() -> Self {
+        Self {
+            max_body_bytes: default_max_body_bytes(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -263,6 +284,13 @@ impl DaemonConfig {
 
     /// Validate cross-field invariants that serde cannot express.
     pub fn validate(&self) -> Result<()> {
+        if self.api.max_body_bytes == 0 {
+            return Err(BlazeError::ConfigError {
+                source: ConfigErrorSource::InvalidValue(
+                    "api.max_body_bytes must be greater than zero".to_string(),
+                ),
+            });
+        }
         validate_storage_paths(&self.storage.images_dir, &self.storage.instances_dir)?;
         self.storage.sync_schedule()?;
         self.storage.sync_timeout_duration()?;
@@ -499,6 +527,9 @@ fn default_policy_dir() -> PathBuf {
 fn default_on_load_error() -> PolicyLoadErrorMode {
     PolicyLoadErrorMode::Fail
 }
+fn default_max_body_bytes() -> usize {
+    1024 * 1024
+}
 fn default_pool_warm_ttl() -> String {
     "30m".to_string()
 }
@@ -557,6 +588,7 @@ mod tests {
         let cfg: DaemonConfig = toml::from_str("").expect("empty parses to defaults");
         assert_eq!(cfg.daemon.log_level, "info");
         assert_eq!(cfg.policy.on_load_error, PolicyLoadErrorMode::Fail);
+        assert_eq!(cfg.api.max_body_bytes, 1024 * 1024);
         assert!(cfg.backends.is_empty());
         assert_ne!(cfg.storage.images_dir, cfg.storage.instances_dir);
         assert_eq!(
@@ -587,6 +619,38 @@ mod tests {
         assert_eq!(cfg.daemon.log_level, "debug");
         assert_eq!(cfg.policy.on_load_error, PolicyLoadErrorMode::Warn);
         assert_eq!(cfg.backends.len(), 2);
+    }
+
+    #[test]
+    fn parses_api_body_limit() {
+        let cfg: DaemonConfig = toml::from_str(
+            r#"
+                [api]
+                max_body_bytes = 4096
+            "#,
+        )
+        .expect("api config");
+
+        assert_eq!(cfg.api.max_body_bytes, 4096);
+        cfg.validate().expect("positive body limit");
+    }
+
+    #[test]
+    fn rejects_zero_api_body_limit() {
+        let cfg: DaemonConfig = toml::from_str(
+            r#"
+                [api]
+                max_body_bytes = 0
+            "#,
+        )
+        .expect("api config");
+
+        let error = cfg.validate().expect_err("zero body limit");
+        assert!(
+            error
+                .to_string()
+                .contains("api.max_body_bytes must be greater than zero")
+        );
     }
 
     #[test]

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -18,7 +18,7 @@ use blaze_core::kernel::HookKind;
 use blaze_core::lifecycle::{SandboxInstance, SandboxState, StartPath};
 use blaze_core::policy::{ImageMetadata, RuntimeDecision, WorkloadClass};
 use blaze_core::pool::{PoolConfig, PoolKey};
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::body::{Body, Bytes, Incoming};
 use hyper::header::CONTENT_TYPE;
 use hyper::{Method, Request, Response, StatusCode};
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use crate::error::{BlazeDaemonError, Result};
 use crate::guest::MAX_GUEST_FILE_BYTES;
+use crate::request_body::{self, CollectError};
 use crate::sandbox::CreateSandbox;
 use crate::state::ServerState;
 
@@ -56,11 +57,22 @@ where
     let method = req.method().clone();
     let path = req.uri().path().to_string();
     let query = req.uri().query().unwrap_or("").to_string();
-    let limit = guest_body_route(&method, &path).then_some(MAX_GUEST_HTTP_BODY_BYTES);
+    let guest_route = guest_body_route(&method, &path);
+    let default_limit = state
+        .config
+        .lock()
+        .map(|config| config.api.max_body_bytes)
+        .map_err(|_| BlazeDaemonError::Internal("config lock poisoned".into()));
 
-    let response = match collect_body(req, limit).await {
-        Ok(body) => dispatch(&method, &path, &query, body, &state).await,
-        Err(e) => Err(e),
+    let response = match default_limit {
+        Ok(default_limit) => {
+            let limit = request_body_limit(guest_route, default_limit);
+            match request_body::collect(req, limit).await {
+                Ok(body) => dispatch(&method, &path, &query, body, &state).await,
+                Err(error) => Err(classify_body_error(error, guest_route)),
+            }
+        }
+        Err(error) => Err(error),
     };
 
     let resp = match response {
@@ -90,31 +102,28 @@ fn guest_body_route(method: &Method, path: &str) -> bool {
     )
 }
 
-async fn collect_body<B>(req: Request<B>, limit: Option<usize>) -> Result<Vec<u8>>
-where
-    B: Body<Data = Bytes> + Unpin,
-    B::Error: std::fmt::Display,
-{
-    let mut body = req.into_body();
-    let mut collected = Vec::new();
-    while let Some(frame) = body.frame().await {
-        let frame = frame
-            .map_err(|error| BlazeDaemonError::BadRequest(format!("request body: {error}")))?;
-        let Ok(data) = frame.into_data() else {
-            continue;
-        };
-        if let Some(limit) = limit
-            && collected.len().saturating_add(data.len()) > limit
-        {
-            return Err(crate::guest::GuestError::PayloadTooLarge {
-                actual: collected.len().saturating_add(data.len()),
+const fn request_body_limit(guest_route: bool, default_limit: usize) -> usize {
+    if guest_route {
+        MAX_GUEST_HTTP_BODY_BYTES
+    } else {
+        default_limit
+    }
+}
+
+fn classify_body_error(error: CollectError, guest_route: bool) -> BlazeDaemonError {
+    match error {
+        CollectError::BadRequest(message) => BlazeDaemonError::BadRequest(message),
+        CollectError::TooLarge { actual, limit } if guest_route => {
+            crate::guest::GuestError::PayloadTooLarge {
+                actual: usize::try_from(actual).unwrap_or(usize::MAX),
                 limit,
             }
-            .into());
+            .into()
         }
-        collected.extend_from_slice(&data);
+        CollectError::TooLarge { actual, limit } => {
+            BlazeDaemonError::RequestBodyTooLarge { actual, limit }
+        }
     }
-    Ok(collected)
 }
 
 const fn max_base64_len(decoded_bytes: usize) -> usize {
@@ -790,6 +799,7 @@ mod tests {
     use blaze_core::storage::{
         AcquireOpts, PoolStatus, StorageAcquireError, StorageProvider, StorageSlot,
     };
+    use http_body_util::BodyExt;
 
     use crate::file_provider::FileStorageProvider;
     #[cfg(target_os = "linux")]
@@ -972,6 +982,60 @@ mod tests {
             .to_bytes();
         let value = serde_json::from_slice(&body).expect("response json");
         (status, value)
+    }
+
+    #[test]
+    fn guest_routes_keep_their_larger_envelope_limit() {
+        assert_eq!(request_body_limit(false, 1024 * 1024), 1024 * 1024);
+        assert_eq!(
+            request_body_limit(true, 1024 * 1024),
+            MAX_GUEST_HTTP_BODY_BYTES
+        );
+    }
+
+    #[tokio::test]
+    async fn ordinary_routes_including_template_import_use_configured_body_limit() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut config = test_config(&temp);
+        config.api.max_body_bytes = 4;
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            config.storage.instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, false),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+
+        for path in ["/v1/sandboxes", "/v1/templates/import"] {
+            let (status, error) = handled_json(&state, Method::POST, path, b"12345".to_vec()).await;
+
+            assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "path {path}");
+            assert_eq!(error["status"], 413, "path {path}");
+            assert_eq!(error["code"], "request_too_large", "path {path}");
+            assert!(
+                error["error"]
+                    .as_str()
+                    .expect("error message")
+                    .contains("5 bytes exceeds 4"),
+                "path {path}"
+            );
+        }
+
+        let malformed = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/sandboxes")
+            .header(hyper::header::CONTENT_LENGTH, "invalid")
+            .body(Full::new(Bytes::new()))
+            .expect("request");
+        let response = handle_request(malformed, state)
+            .await
+            .expect("infallible response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     struct TransientReconstructStorage {
@@ -1884,6 +1948,7 @@ mod tests {
         let (status, error) = handled_json(&state, Method::POST, &path, envelope_body).await;
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(error["status"], 413);
+        assert_eq!(error["code"], "guest_request_too_large");
 
         let mut payload = vec![b'z'; MAX_GUEST_FILE_BYTES];
         let body = serde_json::to_vec(&json!({
@@ -2039,6 +2104,37 @@ mod tests {
             .to_bytes();
         let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
         assert_eq!(value["code"], "guest_timeout");
+    }
+
+    #[tokio::test]
+    async fn request_body_code_is_reserved_for_collector_limits() {
+        let response = error_response(&BlazeDaemonError::RequestBodyTooLarge {
+            actual: 5,
+            limit: 4,
+        });
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert_eq!(value["code"], "request_too_large");
+
+        let response = error_response(&BlazeDaemonError::PayloadTooLarge {
+            actual: 5,
+            limit: 4,
+        });
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("error json");
+        assert!(value.get("code").is_none());
     }
 
     #[tokio::test]

--- a/src/blaze/crates/blazed/src/error.rs
+++ b/src/blaze/crates/blazed/src/error.rs
@@ -63,6 +63,15 @@ pub enum BlazeDaemonError {
     #[error("request body too large: {actual} bytes exceeds {limit}")]
     PayloadTooLarge { actual: u64, limit: usize },
 
+    /// An HTTP request body exceeded the limit assigned to its API route.
+    #[error("request body too large: {actual} bytes exceeds {limit}")]
+    RequestBodyTooLarge {
+        /// Declared or observed request-body bytes.
+        actual: u64,
+        /// Maximum request-body bytes accepted by the route.
+        limit: usize,
+    },
+
     #[error("operation requires recovery: {0}")]
     RecoveryRequired(String),
 
@@ -94,6 +103,7 @@ impl BlazeDaemonError {
             BlazeDaemonError::Guest(crate::guest::GuestError::PayloadTooLarge { .. }) => {
                 Some("guest_request_too_large")
             }
+            BlazeDaemonError::RequestBodyTooLarge { .. } => Some("request_too_large"),
             BlazeDaemonError::Guest(crate::guest::GuestError::ResponseTooLarge { .. }) => {
                 Some("guest_response_too_large")
             }
@@ -109,7 +119,8 @@ impl BlazeDaemonError {
             BlazeDaemonError::NotFound(_) => 404,
             BlazeDaemonError::Conflict(_) => 409,
             BlazeDaemonError::ServiceUnavailable(_) => 503,
-            BlazeDaemonError::PayloadTooLarge { .. } => 413,
+            BlazeDaemonError::PayloadTooLarge { .. }
+            | BlazeDaemonError::RequestBodyTooLarge { .. } => 413,
             BlazeDaemonError::RecoveryRequired(_) => 500,
             BlazeDaemonError::HttpStatus { status, .. } => *status,
             BlazeDaemonError::Core(blaze_core::BlazeError::PolicyEvalError { .. })

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -16,6 +16,7 @@ mod failpoint;
 mod file_provider;
 mod guest;
 mod metrics;
+mod request_body;
 mod sandbox;
 mod spawner;
 mod state;

--- a/src/blaze/crates/blazed/src/request_body.rs
+++ b/src/blaze/crates/blazed/src/request_body.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Bounded HTTP request-body collection for daemon API routes.
+
+use http_body_util::BodyExt;
+use hyper::Request;
+use hyper::body::{Body, Bytes};
+use hyper::header::CONTENT_LENGTH;
+
+/// Request-body failures that are classified by the API layer.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CollectError {
+    /// A body header or stream could not be read as a valid request.
+    BadRequest(String),
+    /// The declared or observed body size exceeded the route limit.
+    TooLarge { actual: u64, limit: usize },
+}
+
+/// Collect a request body without buffering more than `limit` bytes.
+pub(crate) async fn collect<B>(req: Request<B>, limit: usize) -> Result<Vec<u8>, CollectError>
+where
+    B: Body<Data = Bytes> + Unpin,
+    B::Error: std::fmt::Display,
+{
+    if let Some(declared) = declared_body_length(&req)?
+        && declared > limit as u64
+    {
+        return Err(CollectError::TooLarge {
+            actual: declared,
+            limit,
+        });
+    }
+
+    let mut body = req.into_body();
+    let mut collected = Vec::new();
+    while let Some(frame) = body.frame().await {
+        let frame =
+            frame.map_err(|error| CollectError::BadRequest(format!("request body: {error}")))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        let actual = collected
+            .len()
+            .checked_add(data.len())
+            .ok_or(CollectError::TooLarge {
+                actual: u64::MAX,
+                limit,
+            })?;
+        if actual > limit {
+            return Err(CollectError::TooLarge {
+                actual: actual as u64,
+                limit,
+            });
+        }
+        collected.extend_from_slice(&data);
+    }
+    Ok(collected)
+}
+
+fn declared_body_length<B>(req: &Request<B>) -> Result<Option<u64>, CollectError> {
+    let mut declared = None;
+    for value in req.headers().get_all(CONTENT_LENGTH) {
+        let value = value
+            .to_str()
+            .map_err(|_| CollectError::BadRequest("invalid Content-Length".into()))?;
+        for item in value.split(',') {
+            let item = item.trim();
+            if item.is_empty() || !item.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(CollectError::BadRequest("invalid Content-Length".into()));
+            }
+            let length = item
+                .parse::<u64>()
+                .map_err(|_| CollectError::BadRequest("invalid Content-Length".into()))?;
+            match declared {
+                Some(previous) if previous != length => {
+                    return Err(CollectError::BadRequest(
+                        "conflicting Content-Length values".into(),
+                    ));
+                }
+                None => declared = Some(length),
+                _ => {}
+            }
+        }
+    }
+    Ok(declared)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::fmt;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
+
+    use hyper::body::Frame;
+    use hyper::header::{HeaderValue, TRANSFER_ENCODING};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestBodyError;
+
+    impl fmt::Display for TestBodyError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("test body failed")
+        }
+    }
+
+    impl std::error::Error for TestBodyError {}
+
+    struct TestBody {
+        frames: VecDeque<Result<Frame<Bytes>, TestBodyError>>,
+        polls: Arc<AtomicUsize>,
+        panic_when_exhausted: bool,
+    }
+
+    impl TestBody {
+        fn new(
+            frames: impl IntoIterator<Item = Result<Frame<Bytes>, TestBodyError>>,
+            polls: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                frames: frames.into_iter().collect(),
+                polls,
+                panic_when_exhausted: false,
+            }
+        }
+
+        fn panic_when_exhausted(mut self) -> Self {
+            self.panic_when_exhausted = true;
+            self
+        }
+    }
+
+    impl Body for TestBody {
+        type Data = Bytes;
+        type Error = TestBodyError;
+
+        fn poll_frame(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            let this = self.get_mut();
+            this.polls.fetch_add(1, Ordering::AcqRel);
+            match this.frames.pop_front() {
+                Some(frame) => Poll::Ready(Some(frame)),
+                None if this.panic_when_exhausted => {
+                    panic!("collector polled after the limit had already been exceeded")
+                }
+                None => Poll::Ready(None),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn accepts_body_at_declared_limit() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [
+                Ok(Frame::data(Bytes::from_static(b"ab"))),
+                Ok(Frame::data(Bytes::from_static(b"cd"))),
+            ],
+            polls.clone(),
+        );
+        let request = Request::builder()
+            .header(CONTENT_LENGTH, "4")
+            .body(body)
+            .expect("request");
+
+        assert_eq!(collect(request, 4).await.expect("body"), b"abcd");
+        assert_eq!(polls.load(Ordering::Acquire), 3);
+    }
+
+    #[tokio::test]
+    async fn rejects_large_content_length_before_polling_body() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [Ok(Frame::data(Bytes::from_static(b"body")))],
+            polls.clone(),
+        )
+        .panic_when_exhausted();
+        let request = Request::builder()
+            .header(CONTENT_LENGTH, "5")
+            .body(body)
+            .expect("request");
+
+        assert_eq!(
+            collect(request, 4).await,
+            Err(CollectError::TooLarge {
+                actual: 5,
+                limit: 4
+            })
+        );
+        assert_eq!(polls.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn accepts_matching_repeated_and_combined_content_lengths() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [Ok(Frame::data(Bytes::from_static(b"body")))],
+            polls.clone(),
+        );
+        let mut request = Request::new(body);
+        request
+            .headers_mut()
+            .append(CONTENT_LENGTH, HeaderValue::from_static("4"));
+        request
+            .headers_mut()
+            .append(CONTENT_LENGTH, HeaderValue::from_static("4, 4"));
+
+        assert_eq!(collect(request, 4).await.expect("body"), b"body");
+        assert_eq!(polls.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test]
+    async fn rejects_conflicting_content_lengths_before_polling_body() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new([], polls.clone()).panic_when_exhausted();
+        let mut request = Request::new(body);
+        request
+            .headers_mut()
+            .append(CONTENT_LENGTH, HeaderValue::from_static("3"));
+        request
+            .headers_mut()
+            .append(CONTENT_LENGTH, HeaderValue::from_static("4"));
+
+        assert_eq!(
+            collect(request, 4).await,
+            Err(CollectError::BadRequest(
+                "conflicting Content-Length values".into()
+            ))
+        );
+        assert_eq!(polls.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn rejects_conflicting_or_empty_content_length_lists() {
+        for value in ["3, 4", "4,", ",4"] {
+            let polls = Arc::new(AtomicUsize::new(0));
+            let body = TestBody::new([], polls.clone()).panic_when_exhausted();
+            let request = Request::builder()
+                .header(CONTENT_LENGTH, value)
+                .body(body)
+                .expect("request");
+
+            assert!(matches!(
+                collect(request, 4).await,
+                Err(CollectError::BadRequest(_))
+            ));
+            assert_eq!(polls.load(Ordering::Acquire), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_content_length_before_polling_body() {
+        for value in ["not-a-number", "+4", "-1", "4 0", "4.0"] {
+            let polls = Arc::new(AtomicUsize::new(0));
+            let body = TestBody::new([], polls.clone()).panic_when_exhausted();
+            let request = Request::builder()
+                .header(CONTENT_LENGTH, value)
+                .body(body)
+                .expect("request");
+
+            assert_eq!(
+                collect(request, 4).await,
+                Err(CollectError::BadRequest("invalid Content-Length".into()))
+            );
+            assert_eq!(polls.load(Ordering::Acquire), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn stops_undelimited_body_at_observed_limit() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [
+                Ok(Frame::data(Bytes::from_static(b"ab"))),
+                Ok(Frame::data(Bytes::from_static(b"cde"))),
+            ],
+            polls.clone(),
+        )
+        .panic_when_exhausted();
+        let request = Request::builder()
+            .header(TRANSFER_ENCODING, "chunked")
+            .body(body)
+            .expect("request");
+
+        assert_eq!(
+            collect(request, 4).await,
+            Err(CollectError::TooLarge {
+                actual: 5,
+                limit: 4
+            })
+        );
+        assert_eq!(polls.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test]
+    async fn stops_body_without_length_header_at_observed_limit() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [
+                Ok(Frame::data(Bytes::from_static(b"ab"))),
+                Ok(Frame::data(Bytes::from_static(b"cde"))),
+            ],
+            polls.clone(),
+        )
+        .panic_when_exhausted();
+
+        assert_eq!(
+            collect(Request::new(body), 4).await,
+            Err(CollectError::TooLarge {
+                actual: 5,
+                limit: 4
+            })
+        );
+        assert_eq!(polls.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test]
+    async fn ignores_underreported_length_and_stops_at_observed_limit() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body = TestBody::new(
+            [
+                Ok(Frame::data(Bytes::from_static(b"ab"))),
+                Ok(Frame::data(Bytes::from_static(b"cde"))),
+            ],
+            polls.clone(),
+        )
+        .panic_when_exhausted();
+        let request = Request::builder()
+            .header(CONTENT_LENGTH, "1")
+            .body(body)
+            .expect("request");
+
+        assert_eq!(
+            collect(request, 4).await,
+            Err(CollectError::TooLarge {
+                actual: 5,
+                limit: 4
+            })
+        );
+        assert_eq!(polls.load(Ordering::Acquire), 2);
+    }
+
+    #[tokio::test]
+    async fn reports_body_read_failures_as_bad_requests() {
+        let body = TestBody::new([Err(TestBodyError)], Arc::new(AtomicUsize::new(0)));
+
+        assert_eq!(
+            collect(Request::new(body), 4).await,
+            Err(CollectError::BadRequest(
+                "request body: test body failed".into()
+            ))
+        );
+    }
+}

--- a/src/blaze/examples/config.toml
+++ b/src/blaze/examples/config.toml
@@ -35,6 +35,14 @@ socket = "/run/blaze/api.sock"
 http_addr = ""
 
 # ---------------------------------------------------------------------------
+# HTTP API request limits.
+# ---------------------------------------------------------------------------
+[api]
+# Maximum body accepted by routes without a more specific envelope limit.
+# Default: 1 MiB.
+max_body_bytes = 1048576
+
+# ---------------------------------------------------------------------------
 # Backend binary paths.
 # Maps backend name → absolute path to the executable.
 # The daemon probes each configured backend at startup; backends whose


### PR DESCRIPTION
## Why

Guest exec, read, and write already use a bounded HTTP envelope, but daemon
routes without a dedicated envelope could still buffer the complete request
body before dispatch. That now includes template import, which accepts
operator-supplied JSON large enough to make the missing ordinary-route boundary
an immediate release concern.

The daemon needs one predictable per-request limit for ordinary routes without
reducing the larger envelope required for guest file transfer.

## What changed

**Before:**

- Guest exec/read/write stopped collecting above their existing 22 MiB
  envelope.
- Other routes, including template import, could collect until the peer stopped
  sending.
- Ordinary routes had no configurable body limit or stable size-error code.

**After:**

- Routes without a specialized envelope use the new positive
  `api.max_body_bytes` setting, which defaults to 1 MiB.
- One shared collector checks every declared `Content-Length` before polling
  the body and also stops when streamed bytes first cross the selected limit.
- Missing or understated lengths cannot bypass the streamed-byte check.
- Invalid, empty, or conflicting length values and body-read failures return
  HTTP 400; ordinary size violations return HTTP 413 with
  `request_too_large`.
- The `request_too_large` code is reserved for HTTP collection limits. Other
  payload-capacity failures may also return HTTP 413, but do not use this code.
- Guest exec/read/write retain their existing 22 MiB envelope and
  `guest_request_too_large` response.
- Tests prove that both an ordinary sandbox route and template import use the
  configured boundary before dispatch.
- The example configuration and bilingual component/user documentation define
  the same route-specific behavior.

The request flow becomes:

```text
HTTP request
    -> select route limit
       -> guest exec/read/write: existing 22 MiB envelope
       -> every other route: api.max_body_bytes
    -> validate all Content-Length values
    -> collect streamed frames only up to the selected limit
       -> malformed/read failure: 400
       -> declared or observed overflow: 413
       -> bounded body: dispatch route
```

### Commit

1. `9daea49ed7a8` — **bound daemon HTTP request bodies.** Adds the
   configuration contract, shared collector, 400/413 mapping, route-specific
   limit selection, focused tests, example, and bilingual documentation.

These changes belong in one PR because they implement one daemon-entry
boundary. The configuration selects the limit, the collector enforces it, the
API maps its result, and the tests and documentation define the same observable
contract. Splitting any of those pieces would leave either an unenforced
setting, an undocumented behavior change, or a collector without stable API
semantics.

### Still to do

1. Obtain maintainer approval and merge this fix before the target release is
   cut; the `fixes` linkage then closes #2292.

## Related issue

fixes #2292

## User and operator impact

Existing configurations remain valid and receive the 1 MiB ordinary-route
default. An ordinary request above that limit now receives HTTP 413 instead of
being fully buffered. Operators whose ordinary requests intentionally exceed
1 MiB can set a larger positive `api.max_body_bytes` value before deployment.

Guest command and file routes remain capped at 22 MiB independently of this
setting, so their existing 16 MiB decoded-file limit and error code do not
change. The new boundary applies per request; it does not cap aggregate memory
across concurrent requests.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Compatibility or rollback guidance is needed

The configuration field is optional and defaults through serde, so existing
files continue to parse. The compatibility change is intentional: ordinary
bodies above 1 MiB are rejected by default. Set `api.max_body_bytes` to a
suitable positive byte count before deployment when an existing caller needs a
larger ordinary payload. A zero value is rejected during configuration
validation.

## Validation

Exact public commit:
`9daea49ed7a8adc35a62b8b7db2d44079d61b230`

Tree:
`245ae6ae29f41d6a53969b3c5a9aab97aa07d391`

Parent:
`ba20d94d19a73e5b781cab0c687d4034ad0d0dae`

GitHub's merge ref is
`018e793fc7075e56c2a55aa0d41f159a2bf7afea`. Its ordered parents are the
current `main` commit and the exact public head, and it has the same tree as
the public head.

The public commit was downloaded from GitHub by exact SHA. The archive SHA-256
is:

`931b010307e2160095aed9c962edb70cff5e3a47e44b97eb8659ee3b05de5611`

The archive records the exact public commit, and an independent Git-object
reconstruction produced the expected tree. Native Linux x86_64 validation used
Rust and Cargo 1.88.0 with locked, offline dependencies and a separate fresh
target directory for each stage:

- `cargo fmt --all -- --check`;
- locked metadata for default and all-feature configurations;
- workspace all-target builds for default and all-feature configurations;
- strict Clippy for default and all-feature configurations with warnings
  denied;
- serial workspace tests: 314 passed by default
  (`blaze-core` 54 and `blazed` 260) and 332 passed with all features
  (`blaze-core` 54 and `blazed` 278), with 0 failures;
- strict rustdoc for default and all-feature configurations with warnings
  denied;
- 15/15 focused request-body, route-selection, configuration, and error-code
  tests.

Repository documentation naming and bilingual parity checks, relative-link
checks, commit-message and trailer checks, and the parent-to-head
`git diff --check` passed against the same tree and commit message. The source
tree was reconstructed again after validation and remained unchanged.

Hosted Components, Docs, Pages, and PR Lint passed for this exact head.
Review status is reported separately by GitHub.

## Documentation and rollback

The example configuration, component README in English and Chinese, and Blaze
user guide in English and Chinese document the default, override, response
status, and guest-route exception. CHANGELOG aggregation remains reserved for a
release version update.

To retain larger ordinary requests, set `api.max_body_bytes` to a suitable
positive byte count. Revert this commit to restore the previous ordinary-route
collection behavior.
