### PR TITLE
fix(tokenless): persist OpenClaw RTK context

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -192,7 +192,9 @@ test-integration:
 	python3 tests/test_rewrite_hook.py
 	python3 tests/test_resolve_agent_id.py
 
-test-adapters:
+test-adapters: build-openclaw-plugin
+	@echo "==> Testing openclaw RTK context propagation..."
+	node --test tests/test-openclaw-rtk-context.mjs
 	@echo "==> Testing qoder adapter installer..."
 	bash tests/test-qoder-adapter-install.sh
 	@echo "==> Testing OpenCode adapter..."

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -13,15 +13,24 @@
  *      Response Compression strips noise → TOON eliminates JSON format overhead.
  *
  * Stats are recorded automatically by tokenless compress-response.
- * Context is passed to subprocesses via a per-call env merge (buildEnv()) instead
- * of mutating process.env. Note: envContext itself is a module-level singleton,
- * so concurrent before_tool_call callbacks can still race on agentId/toolCallId.
- * Acceptable today because OpenClaw dispatches tool calls sequentially per
- * session; revisit if that changes.
+ * RTK rewrite and proxy processes receive the same per-call context snapshot;
+ * the rewrite-context file remains a compatibility fallback for launch paths
+ * that do not preserve exec environment overrides.
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, statSync, readFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
 
 // ---- Session ID mapping --------------------------------------------------------
@@ -33,16 +42,45 @@ const sessionMap: Map<string, string> = new Map();
 
 // ---- In-memory env context (replaces global process.env mutation) -------------
 
-const envContext: { agentId: string; sessionId: string; toolCallId: string } = {
+interface TokenlessCallContext {
+  agentId: string;
+  sessionId: string;
+  toolCallId: string;
+}
+
+const envContext: TokenlessCallContext = {
   agentId: "openclaw", sessionId: "", toolCallId: "",
 };
 
-function buildEnv(): Record<string, string> {
+function buildEnv(context: TokenlessCallContext = envContext): Record<string, string> {
   return {
     ...process.env as Record<string, string>,
-    TOKENLESS_AGENT_ID: envContext.agentId,
-    TOKENLESS_SESSION_ID: envContext.sessionId,
-    TOKENLESS_TOOL_USE_ID: envContext.toolCallId,
+    ...buildContextEnv(context),
+  };
+}
+
+function buildContextEnv(context: TokenlessCallContext): Record<string, string> {
+  return {
+    TOKENLESS_AGENT_ID: context.agentId,
+    TOKENLESS_SESSION_ID: context.sessionId,
+    TOKENLESS_TOOL_USE_ID: context.toolCallId,
+  };
+}
+
+function mergeExecContextEnv(
+  params: Record<string, unknown>,
+  context: TokenlessCallContext,
+): Record<string, string> {
+  const existingEnv = params.env;
+  const normalizedEnv = typeof existingEnv === "object"
+    && existingEnv !== null
+    && !Array.isArray(existingEnv)
+    ? existingEnv as Record<string, string>
+    : {};
+
+  return {
+    ...normalizedEnv,
+    ...buildContextEnv(context),
   };
 }
 
@@ -71,6 +109,10 @@ const SYSTEM_BIN = "/usr/local/bin";
 const SYSTEM_LIBEXEC = "/usr/local/libexec/anolisa/tokenless";
 const RPM_BIN = "/usr/bin";
 const USER_HOME = process.env.HOME && isAbsolute(process.env.HOME) ? process.env.HOME : null;
+const REWRITE_CONTEXT_DIR = USER_HOME ? join(USER_HOME, ".tokenless") : null;
+const REWRITE_CONTEXT_FILE = REWRITE_CONTEXT_DIR
+  ? join(REWRITE_CONTEXT_DIR, ".rewrite-context")
+  : null;
 const LOCAL_BIN = USER_HOME ? join(USER_HOME, ".local", "bin") : null;
 const LOCAL_ANOLISA_LIBEXEC = USER_HOME
   ? join(USER_HOME, ".local", "lib", "anolisa", "libexec", "tokenless")
@@ -180,13 +222,13 @@ function checkTokenless(): boolean {
 
 // ---- Subprocess helpers -------------------------------------------------------
 
-function tryRtkRewrite(command: string): string | null {
+function tryRtkRewrite(command: string, context: TokenlessCallContext): string | null {
   try {
     const result = spawnSync(rtkPath, ["rewrite", command], {
       encoding: "utf-8",
       timeout: 2000,
       stdio: ["ignore", "pipe", "pipe"],
-      env: buildEnv(),
+      env: buildEnv(context),
     });
     const rewritten = result.stdout?.trim();
     // Exit code protocol (from rtk rewrite_cmd.rs):
@@ -202,6 +244,49 @@ function tryRtkRewrite(command: string): string | null {
     return null;
   } catch {
     return null;
+  }
+}
+
+function writeRewriteContext(context: TokenlessCallContext): void {
+  if (!REWRITE_CONTEXT_DIR || !REWRITE_CONTEXT_FILE) {
+    console.warn("[tokenless:rtk] cannot persist rewrite context: HOME is unavailable");
+    return;
+  }
+
+  let fd: number | null = null;
+  try {
+    mkdirSync(REWRITE_CONTEXT_DIR, { recursive: true, mode: 0o700 });
+    // O_NOFOLLOW protects only the final component, so reject a symlinked parent.
+    if (!lstatSync(REWRITE_CONTEXT_DIR).isDirectory()) {
+      throw new Error(`rewrite context directory is not a directory: ${REWRITE_CONTEXT_DIR}`);
+    }
+    fd = openSync(
+      REWRITE_CONTEXT_FILE,
+      constants.O_WRONLY
+        | constants.O_CREAT
+        | constants.O_TRUNC
+        | constants.O_NOFOLLOW,
+      0o600,
+    );
+    // The open mode protects new files; fchmod also tightens an existing file.
+    fchmodSync(fd, 0o600);
+    writeFileSync(
+      fd,
+      `${context.agentId}\n${context.sessionId}\n${context.toolCallId}\n`,
+      "utf-8",
+    );
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    const suffix = code ? ` (${code})` : "";
+    console.warn(`[tokenless:rtk] cannot persist rewrite context${suffix}`);
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // The rewrite must proceed even if closing the fail-soft stats context fails.
+      }
+    }
   }
 }
 
@@ -479,19 +564,35 @@ export default {
         const command = event.params?.command;
         if (typeof command !== "string") return;
 
-        // Update env context for RTK and response compression
-        envContext.agentId = "openclaw";
-        if (ctx?.sessionId) envContext.sessionId = ctx.sessionId;
-        if (ctx?.toolCallId) envContext.toolCallId = ctx.toolCallId;
+        // Snapshot each call so a missing ID never inherits the previous tool call.
+        const callContext: TokenlessCallContext = {
+          agentId: "openclaw",
+          sessionId: ctx?.sessionId
+            || (ctx?.sessionKey && sessionMap.get(ctx.sessionKey))
+            || "",
+          toolCallId: ctx?.toolCallId || "",
+        };
+        Object.assign(envContext, callContext);
 
-        const rewritten = tryRtkRewrite(command);
+        const rewritten = tryRtkRewrite(command, callContext);
         if (!rewritten) return;
+
+        // Keep the established file protocol for older launch paths. Current
+        // OpenClaw exec processes receive the same context directly below, so
+        // concurrent sessions do not depend on this last-write-wins fallback.
+        writeRewriteContext(callContext);
 
         if (verbose) {
           console.log(`[tokenless:rtk] rewrite: ${command} -> ${rewritten}`);
         }
 
-        return { params: { ...event.params, command: rewritten } };
+        return {
+          params: {
+            ...event.params,
+            command: rewritten,
+            env: mergeExecContextEnv(event.params, callContext),
+          },
+        };
       },
       { priority: 10 },
     );

--- a/src/tokenless/tests/test-openclaw-rtk-context.mjs
+++ b/src/tokenless/tests/test-openclaw-rtk-context.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { after, beforeEach, test } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const sandbox = mkdtempSync(join(tmpdir(), "tokenless-openclaw-context-"));
+const fakeBinDir = join(sandbox, "bin");
+const contextDir = join(sandbox, ".tokenless");
+const contextFile = join(contextDir, ".rewrite-context");
+const redirectedContextDir = join(sandbox, "redirected-tokenless");
+const victimFile = join(sandbox, "symlink-victim");
+const originalHome = process.env.HOME;
+const originalPath = process.env.PATH;
+
+mkdirSync(fakeBinDir, { recursive: true });
+const fakeRtk = join(fakeBinDir, "rtk");
+writeFileSync(
+  fakeRtk,
+  `#!/bin/sh
+if [ "$1" = "rewrite" ]; then
+  if [ "$2" = "no-rewrite" ]; then
+    exit 1
+  fi
+  printf 'rtk optimized %s\n' "$2"
+  exit 0
+fi
+exit 1
+`,
+);
+chmodSync(fakeRtk, 0o755);
+
+process.env.HOME = sandbox;
+process.env.PATH = `${fakeBinDir}:${originalPath || ""}`;
+
+const pluginPath = resolve(testDir, "../adapters/tokenless/openclaw/dist/index.js");
+assert.equal(
+  existsSync(pluginPath),
+  true,
+  "OpenClaw plugin build missing; run `make build-openclaw-plugin` before this test",
+);
+const { default: plugin } = await import(pathToFileURL(pluginPath).href);
+
+const handlers = new Map();
+plugin.register({
+  config: {
+    rtk_enabled: true,
+    tool_ready_enabled: false,
+    response_compression_enabled: false,
+    toon_compression_enabled: false,
+    verbose: false,
+  },
+  on(name, handler) {
+    handlers.set(name, handler);
+  },
+});
+
+const beforeToolCall = handlers.get("before_tool_call");
+assert.equal(typeof beforeToolCall, "function", "before_tool_call hook was not registered");
+
+function invokeRewrite(command, context = {}) {
+  return beforeToolCall(
+    { toolName: "exec", params: { command } },
+    { toolName: "exec", ...context },
+  );
+}
+
+beforeEach(() => {
+  rmSync(contextDir, { recursive: true, force: true });
+  rmSync(redirectedContextDir, { recursive: true, force: true });
+  rmSync(victimFile, { force: true });
+});
+
+after(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("persists RTK context after a successful rewrite", () => {
+  const result = invokeRewrite("git status", {
+    sessionId: "session-123",
+    toolCallId: "tool-456",
+  });
+
+  assert.equal(result.params.command, "rtk optimized git status");
+  assert.deepEqual(result.params.env, {
+    TOKENLESS_AGENT_ID: "openclaw",
+    TOKENLESS_SESSION_ID: "session-123",
+    TOKENLESS_TOOL_USE_ID: "tool-456",
+  });
+  assert.equal(readFileSync(contextFile, "utf8"), "openclaw\nsession-123\ntool-456\n");
+  assert.equal(statSync(contextDir).mode & 0o777, 0o700);
+  assert.equal(statSync(contextFile).mode & 0o777, 0o600);
+});
+
+test("keeps rewritten exec context isolated across sessions", () => {
+  const first = beforeToolCall(
+    {
+      toolName: "exec",
+      params: {
+        command: "first command",
+        env: {
+          EXISTING_VALUE: "preserved",
+          TOKENLESS_TOOL_USE_ID: "stale-tool",
+        },
+      },
+    },
+    {
+      toolName: "exec",
+      sessionId: "session-a",
+      toolCallId: "tool-a",
+    },
+  );
+  const second = invokeRewrite("second command", {
+    sessionId: "session-b",
+    toolCallId: "tool-b",
+  });
+
+  assert.equal(first.params.command, "rtk optimized first command");
+  assert.deepEqual(first.params.env, {
+    EXISTING_VALUE: "preserved",
+    TOKENLESS_AGENT_ID: "openclaw",
+    TOKENLESS_SESSION_ID: "session-a",
+    TOKENLESS_TOOL_USE_ID: "tool-a",
+  });
+  assert.deepEqual(second.params.env, {
+    TOKENLESS_AGENT_ID: "openclaw",
+    TOKENLESS_SESSION_ID: "session-b",
+    TOKENLESS_TOOL_USE_ID: "tool-b",
+  });
+  assert.equal(first.params.env.TOKENLESS_TOOL_USE_ID, "tool-a");
+});
+
+test("does not persist context when RTK declines the rewrite", () => {
+  const result = invokeRewrite("no-rewrite", {
+    sessionId: "session-123",
+    toolCallId: "tool-456",
+  });
+
+  assert.equal(result, undefined);
+  assert.equal(existsSync(contextFile), false);
+});
+
+test("truncates existing context without reusing IDs from the previous call", () => {
+  invokeRewrite("first command", {
+    sessionId: "session-123",
+    toolCallId: "tool-456",
+  });
+  const result = invokeRewrite("second command");
+
+  assert.equal(result.params.command, "rtk optimized second command");
+  assert.equal(readFileSync(contextFile, "utf8"), "openclaw\n\n\n");
+});
+
+test("refuses a symlink without blocking the rewritten command", () => {
+  mkdirSync(contextDir, { recursive: true, mode: 0o700 });
+  writeFileSync(victimFile, "sentinel");
+  symlinkSync(victimFile, contextFile);
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+
+  let result;
+  try {
+    result = invokeRewrite("git status", {
+      sessionId: "session-123",
+      toolCallId: "tool-456",
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(result.params.command, "rtk optimized git status");
+  assert.equal(readFileSync(victimFile, "utf8"), "sentinel");
+  assert.equal(lstatSync(contextFile).isSymbolicLink(), true);
+  assert.equal(warnings.some((warning) => warning.includes("cannot persist rewrite context")), true);
+});
+
+test("refuses a symlinked context directory without blocking the rewrite", () => {
+  mkdirSync(redirectedContextDir, { recursive: true, mode: 0o700 });
+  symlinkSync(redirectedContextDir, contextDir, "dir");
+  const redirectedContextFile = join(redirectedContextDir, ".rewrite-context");
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+
+  let result;
+  try {
+    result = invokeRewrite("git status", {
+      sessionId: "session-123",
+      toolCallId: "tool-456",
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.equal(result.params.command, "rtk optimized git status");
+  assert.equal(existsSync(redirectedContextFile), false);
+  assert.equal(lstatSync(contextDir).isSymbolicLink(), true);
+  assert.equal(warnings.some((warning) => warning.includes("cannot persist rewrite context")), true);
+});


### PR DESCRIPTION
## Why

OpenClaw passes Tokenless attribution only to the short-lived `rtk rewrite` process, while the rewritten RTK proxy runs later without those environment variables. As a result, `rewrite-command` statistics lose their session and tool identifiers and cannot be correlated correctly by AgentSight.

## What changed

Persist the current OpenClaw agent, session, and tool identifiers through RTK's established `~/.tokenless/.rewrite-context` fallback after each successful rewrite. The write is fail-open, uses restrictive permissions, rejects final-component symlinks, and is covered by adapter regression tests wired into `make test-adapters`.

## Related issue

no-issue: reproduced and validated on the Tokenless/OpenClaw integration test host

## User / Agent impact

New OpenClaw RTK savings records retain their agent, session, and tool attribution. Existing statistics are unchanged and no historical migration is performed.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The plugin now writes a three-line context file using an existing RTK protocol. It creates new directories as `0700`, writes the file as `0600`, rejects final-component symlinks with `O_NOFOLLOW`, and keeps rewrite execution fail-open if persistence fails. The existing last-write-wins behavior remains unchanged.

## Validation

- `make test-adapters`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Manual OpenClaw/RTK test on `47.76.218.101`: the generated `rewrite-command` record contained the expected `openclaw` agent, session ID, and tool ID; Tokenless and AgentSight both reported `15.7K -> 6.4K` tokens for the isolated operation.

## Documentation and rollback

No documentation change is required because the context file protocol already exists. Roll back by reverting this commit; RTK continues to operate without the context file because persistence is fail-open.
