### PR TITLE
chore(skill): bump version to 0.6.2

### DIFF
--- a/src/os-skills/CHANGELOG.md
+++ b/src/os-skills/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.2
+
+- Added the `ktuner` skill for deterministic kernel diagnosis, tuning, and rollback. (#1278)
+- Removed legacy OpenClaw and Hermes adapter scripts from source and RPM installs. (#1172)
+- Updated `anolisa-guide` with authenticated Skill Ledger recovery and tamper detection. (#2185)
+
 ## 0.6.1
 
 - Rewrote `sysom-diagnosis` skill and removed legacy CLI. (#1241)

--- a/src/os-skills/component.toml
+++ b/src/os-skills/component.toml
@@ -3,7 +3,7 @@ anolisa_min_version = "0.1.15"
 
 [component]
 name = "os-skills"
-version = "0.6.0"
+version = "0.6.2"
 layer = "runtime"
 domain = "tools"
 description = "Curated OS Skill library for agent runtimes"
@@ -110,6 +110,10 @@ source = "{datadir}/skills/alinux-admin/"
 [[adapters.openclaw.skills]]
 name = "backup-restore"
 source = "{datadir}/skills/backup-restore/"
+
+[[adapters.openclaw.skills]]
+name = "ktuner"
+source = "{datadir}/skills/ktuner/"
 
 [[adapters.openclaw.skills]]
 name = "regex-mastery"
@@ -223,6 +227,10 @@ source = "{datadir}/skills/alinux-admin/"
 [[adapters.hermes.skills]]
 name = "backup-restore"
 source = "{datadir}/skills/backup-restore/"
+
+[[adapters.hermes.skills]]
+name = "ktuner"
+source = "{datadir}/skills/ktuner/"
 
 [[adapters.hermes.skills]]
 name = "regex-mastery"

--- a/src/os-skills/cosh-extension.json
+++ b/src/os-skills/cosh-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "anolisa-os-skills",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "skills": "."
 }

--- a/src/os-skills/others/cosh-extension.json
+++ b/src/os-skills/others/cosh-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "anolisa-skills-others",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "skills": "."
 }

--- a/src/os-skills/system-admin/cosh-extension.json
+++ b/src/os-skills/system-admin/cosh-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "anolisa-skills-system-admin",
-  "version": "0.2.1",
+  "version": "0.6.2",
   "skills": "."
 }


### PR DESCRIPTION
## Why

Prepare the os-skills v0.6.2 source release and keep its published metadata
consistent with the capabilities added since v0.6.1.

## What changed

- Added the v0.6.2 component changelog.
- Bumped the root and changed category extension manifests to v0.6.2.
- Bumped the component contract and registered `ktuner` for OpenClaw and Hermes.

## Related issue

no-issue: release version synchronization

## User / Agent impact

Release metadata now advertises v0.6.2 consistently, and both framework
adapter declarations can discover the new `ktuner` skill.

## Risk and compatibility

- [x] Cross-component contract changed

Low risk. This updates static release metadata and extends both existing skill
lists without changing CLI behavior or removing compatibility.

## Validation

- `git diff --check`
- `jq empty` on all changed extension manifests
- Parsed `component.toml` with Python `tomllib`
- Verified OpenClaw and Hermes each declare all 27 packaged skills
- `make -C src/os-skills build`

## Documentation and rollback

The component changelog documents the v0.6.2 delta. Reverting the release bump
commit restores the previous metadata and adapter lists.
