### PR TITLE
feat(sec-core): bump version to v0.10.0

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -2,7 +2,7 @@ manifest_version = 2
 
 [component]
 name = "sec-core"
-version = "0.9.0"
+version = "0.10.0"
 layer = "runtime"
 domain = "security"
 display_name = "Agent Security Core"

--- a/src/agent-sec-core/CHANGELOG.md
+++ b/src/agent-sec-core/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.10.0
+
+**Agent Hook Policy Controls**
+
+- Added code scanner enable flags for agent hooks. (#2001)
+- Unified hook policy controls across agent integrations. (#2141)
+- Added an observability hook environment toggle. (#2199)
+- Restored scanner mode environment variable names. (#2212)
+- Aligned code scanner hook flags across supported agent integrations. (#2229)
+- Added environment-based prompt scanner gating. (#2239)
+
+**OpenClaw Hook Integration**
+
+- Added block mode support for the OpenClaw code scanner hook. (#2242)
+
+**Prompt Scanner**
+
+- Widened prompt scan inbound text field coverage. (#2277)
+
+**Skill Ledger Runtime**
+
+- Added read-only skill analysis. (#2044)
+- Included raw skill directories in skill ledger checks. (#2201)
+- Authenticated manifests before loading skill package contents. (#2185)
+
+**Security Events & CLI**
+
+- Added session and run filters to agent-sec-cli events queries. (#2132)
+
+**Raw Packaging**
+
+- Added component-owned raw package build targets and archive validation. (#2133)
+- Updated raw hooks to use the bundled Python launcher. (#2255)
+
 ## 0.9.0
 
 **Qoder CLI & Qwen Code Hook Capability Expansion**

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pyo3",
 ]

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-sec-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Agent Security Core CLI - Native Rust extensions"
 license = "Apache-2.0"

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-sec-cli"
-version = "0.9.0"
+version = "0.10.0"
 description = "Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification for AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
@@ -1,3 +1,3 @@
 """Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -35,7 +35,7 @@ try:
 
     __version__ = get_version("agent-sec-cli")
 except Exception:
-    __version__ = "0.9.0"  # pragma: no cover
+    __version__ = "0.10.0"  # pragma: no cover
 
 app = typer.Typer(
     name="agent-sec-cli",

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -261,6 +261,9 @@ rm -rf $RPM_BUILD_ROOT
 make install-all-for-rpmbuild DESTDIR=$RPM_BUILD_ROOT
 
 %changelog
+* Fri Aug 07 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.0-1
+- Update version to 0.10.0
+
 * Fri Jul 24 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.9.0-1
 - Update version to 0.9.0
 

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, skill ledger integrity verification, and turn/tool observability."
 }

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "hooks": {
     "PreToolUse": [
       {

--- a/src/agent-sec-core/hermes-plugin/src/plugin.yaml
+++ b/src/agent-sec-core/hermes-plugin/src/plugin.yaml
@@ -1,5 +1,5 @@
 name: agent-sec-core-hermes-plugin
-version: 0.9.0
+version: 0.10.0
 description: "OS-level security guardrails for Hermes Agent — powered by agent-sec-cli"
 provides_hooks:
   - pre_llm_call

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-sec",
   "name": "Agent Security",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Security hooks powered by agent-sec-cli",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-sec-openclaw-plugin",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
+++ b/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Agent security core hooks for Qoder CLI."
 }

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core-qwen-code-extension",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "ANOLISA security integration for Qwen Code",
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Why

准备发布 agent-sec-core v0.10.0，需要将版本号同步到各组件清单文件，并补充对应的 CHANGELOG 与 RPM %changelog 记录。

## What changed

- 将 agent-sec-core 版本号从 0.9.0 提升到 0.10.0，同步更新 `component.toml`、`Cargo.toml`/`Cargo.lock`、`pyproject.toml`/`uv.lock`、`__init__.py`、`cli.py` 中的版本号
- 同步更新 Codex、Cosh、Hermes、OpenClaw（含 `package.json`/`package-lock.json`）、Qoder、Qwen Code 各插件清单文件中的版本号
- 在 `CHANGELOG.md` 中新增 0.10.0 版本条目，按交付能力维度记录本版本合入的 PR
- 在 `agent-sec-core.spec.in` 的 `%changelog` 中新增 `0.10.0-1` 版本条目

## Related issue

no-issue: 版本发布准备工作，无独立跟踪 issue

## User / Agent impact

None（本次改动仅为版本号同步与发布记录更新，不涉及运行时代码逻辑变化；具体功能变化见随附 CHANGELOG.md 中 0.10.0 条目所列 PR）

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk：纯版本号提升和发布材料更新，不涉及代码行为变化。

## Validation

- `git --no-pager diff --check -- src/agent-sec-core/CHANGELOG.md src/agent-sec-core/agent-sec-core.spec.in` — 通过，无 whitespace 问题
- 逐个核对 v0.10.0 涉及的 14 个已合入 PR 的正文与 files，确认 CHANGELOG 分组准确

## Documentation and rollback

已同步更新 `CHANGELOG.md` 与 `agent-sec-core.spec.in` 的 `%changelog`；如需回滚，直接 revert 本 commit 即可，不涉及运行时或安装行为变化，无需额外回滚步骤。