### PR TITLE
fix(tokenless): address bot review comments on init command

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -274,6 +274,21 @@ tokenless init
 
 `tokenless init` reads the adapter manifest, runs each framework's `detect.sh`, and reports whether the adapter is ready, installable, or missing prerequisites — then runs `install.sh` for the selected framework.
 
+If the adapter directory is absent, `tokenless init` exits with an error:
+
+```
+Adapter directory not found.
+Install tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`.
+```
+
+Resolve this by installing the tokenless package first:
+
+```bash
+npm install -g anolisa-tokenless
+# or
+anolisa install tokenless
+```
+
 ### Manual install scripts
 
 OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, Qwen Code, and QwenPaw provide their own install scripts:

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -252,7 +252,31 @@ The npm postinstall script attempts to copy adapter resources under:
 
 Confirm that this directory exists. Adapter copying is supplementary and fails open with a warning; a successful binary install can therefore exist without this copy. If it is absent, review the npm postinstall warning and prefer an anolisa-managed installation.
 
-An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it. OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, Qwen Code, and QwenPaw provide their own install scripts:
+An npm install does not create an anolisa component installation record, so do not assume that `anolisa adapter enable` can manage it.
+
+### Quick setup with `tokenless init`
+
+After installing the npm package or building from source, run `tokenless init` to detect installed agent frameworks and guide adapter installation:
+
+```bash
+# Scan and display all framework statuses
+tokenless init --list
+
+# Install a specific adapter
+tokenless init --framework claude-code
+
+# Install all installable adapters (non-interactive)
+tokenless init --all
+
+# Interactive selection (when stdin is a terminal)
+tokenless init
+```
+
+`tokenless init` reads the adapter manifest, runs each framework's `detect.sh`, and reports whether the adapter is ready, installable, or missing prerequisites — then runs `install.sh` for the selected framework.
+
+### Manual install scripts
+
+OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, Qwen Code, and QwenPaw provide their own install scripts:
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -232,7 +232,31 @@ npm 的 postinstall 脚本会尝试把 Adapter 资源复制到：
 
 应确认该目录确实存在。Adapter 复制属于补充步骤，失败时只输出警告，不会让二进制安装失败；因此可能出现命令可用但这里没有资源副本的情况。目录缺失时应检查 npm postinstall 警告，并优先改用 anolisa 管理的安装。
 
-npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode、Qwen Code 和 QwenPaw 可以运行各自的安装脚本：
+npm 安装不会创建 anolisa 组件安装记录，因此不要假设 `anolisa adapter enable` 能管理这次安装。
+
+### 使用 `tokenless init` 快速设置
+
+安装 npm 包或从源码构建后，运行 `tokenless init` 检测已安装的 Agent 框架并引导适配器安装：
+
+```bash
+# 扫描并显示所有框架状态
+tokenless init --list
+
+# 安装指定适配器
+tokenless init --framework claude-code
+
+# 安装所有可安装的适配器（非交互模式）
+tokenless init --all
+
+# 交互式选择（stdin 为终端时）
+tokenless init
+```
+
+`tokenless init` 读取适配器清单，运行各框架的 `detect.sh`，报告适配器状态（就绪 / 可安装 / 缺少前置依赖），然后为选定框架执行 `install.sh`。
+
+### 手动安装脚本
+
+OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode、Qwen Code 和 QwenPaw 可以运行各自的安装脚本：
 
 ```bash
 bash ~/.local/share/anolisa/adapters/tokenless/<framework>/scripts/install.sh

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -254,6 +254,21 @@ tokenless init
 
 `tokenless init` 读取适配器清单，运行各框架的 `detect.sh`，报告适配器状态（就绪 / 可安装 / 缺少前置依赖），然后为选定框架执行 `install.sh`。
 
+若适配器目录不存在，`tokenless init` 将报错退出：
+
+```
+Adapter directory not found.
+Install tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`.
+```
+
+请先安装 tokenless 包再重试：
+
+```bash
+npm install -g anolisa-tokenless
+# 或
+anolisa install tokenless
+```
+
 ### 手动安装脚本
 
 OpenClaw、Hermes、Qoder、Claude Code、Codex、OpenCode、Qwen Code 和 QwenPaw 可以运行各自的安装脚本：

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "libc",
  "regex",
  "rusqlite",
+ "serde",
  "serde_json",
  "tempfile",
  "tokenless-ccr",

--- a/src/tokenless/crates/tokenless-cli/Cargo.toml
+++ b/src/tokenless/crates/tokenless-cli/Cargo.toml
@@ -17,6 +17,7 @@ tokenless-ccr = { path = "../tokenless-ccr" }
 tokenless-runtime = { path = "../tokenless-runtime" }
 dirs.workspace = true
 clap.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 toon-format.workspace = true
 chrono = { workspace = true, features = ["serde"] }

--- a/src/tokenless/crates/tokenless-cli/src/init.rs
+++ b/src/tokenless/crates/tokenless-cli/src/init.rs
@@ -1,0 +1,320 @@
+//! Community entry point — detect agent frameworks and install adapters.
+//!
+//! Scans the adapter directory for framework-specific `detect.sh` scripts,
+//! reports each framework's status, and optionally runs `install.sh` to
+//! register the tokenless adapter with the selected framework.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{self, IsTerminal as _, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+
+/// Sub-path from a share root to the tokenless adapter directory.
+const ADAPTER_SUBPATH: &str = "anolisa/adapters/tokenless";
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    targets: BTreeMap<String, ManifestTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestTarget {
+    #[serde(default)]
+    actions: Option<ManifestActions>,
+    #[serde(default)]
+    capabilities: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestActions {
+    detect: Option<String>,
+    install: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetectStatus {
+    Ready,
+    Installable,
+    MissingPrereqs,
+    NotChecked,
+}
+
+impl DetectStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Installable => "installable",
+            Self::MissingPrereqs => "missing prereqs",
+            Self::NotChecked => "n/a",
+        }
+    }
+}
+
+struct FrameworkInfo {
+    name: String,
+    status: DetectStatus,
+    capabilities: Vec<String>,
+    install_script: Option<String>,
+}
+
+/// Find the adapter directory by checking known locations.
+fn find_adapter_dir() -> Option<PathBuf> {
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".local/share").join(ADAPTER_SUBPATH);
+        if has_manifest(&p) {
+            return Some(p);
+        }
+    }
+    for prefix in ["/usr/share", "/usr/local/share"] {
+        let p = PathBuf::from(prefix).join(ADAPTER_SUBPATH);
+        if has_manifest(&p) {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn has_manifest(dir: &Path) -> bool {
+    dir.join("manifest.json").exists() || dir.join("manifest.json.in").exists()
+}
+
+/// Load and parse the adapter manifest. Falls back to the `.in` template
+/// (with `@VERSION@` left as-is) when the stamped copy is absent.
+fn load_manifest(adapter_dir: &Path) -> Result<Manifest, String> {
+    let manifest_path = adapter_dir.join("manifest.json");
+    let content = if manifest_path.exists() {
+        fs::read_to_string(&manifest_path)
+            .map_err(|e| format!("failed to read manifest.json: {}", e))?
+    } else {
+        fs::read_to_string(adapter_dir.join("manifest.json.in"))
+            .map_err(|e| format!("failed to read manifest.json.in: {}", e))?
+    };
+    serde_json::from_str(&content).map_err(|e| format!("failed to parse manifest: {}", e))
+}
+
+/// Extract hook names from the capabilities field for display.
+fn extract_hooks(cap: &Option<serde_json::Value>) -> Vec<String> {
+    match cap {
+        Some(serde_json::Value::Object(map)) => match map.get("hooks") {
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|h| h.as_str().map(String::from))
+                .collect(),
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
+/// Run `detect.sh` for a framework and interpret the tri-state exit code.
+fn run_detect(adapter_dir: &Path, name: &str, detect_script: &str) -> DetectStatus {
+    let script = adapter_dir.join(detect_script);
+    if !script.exists() {
+        return DetectStatus::NotChecked;
+    }
+    match Command::new("bash")
+        .arg(&script)
+        .env("ANOLISA_COMPONENT", "tokenless")
+        .env("ANOLISA_TARGET", name)
+        .env("ANOLISA_ADAPTER_DIR", adapter_dir)
+        .output()
+    {
+        Ok(out) => match out.status.code() {
+            Some(0) => DetectStatus::Ready,
+            Some(1) => DetectStatus::Installable,
+            _ => DetectStatus::MissingPrereqs,
+        },
+        Err(_) => DetectStatus::MissingPrereqs,
+    }
+}
+
+/// Run `install.sh` for a framework, streaming output to the terminal.
+fn run_install(adapter_dir: &Path, name: &str, install_script: &str) -> Result<(), String> {
+    let script = adapter_dir.join(install_script);
+    if !script.exists() {
+        return Err(format!("install script not found: {}", script.display()));
+    }
+    let status = Command::new("bash")
+        .arg(&script)
+        .env("ANOLISA_COMPONENT", "tokenless")
+        .env("ANOLISA_TARGET", name)
+        .env("ANOLISA_ADAPTER_DIR", adapter_dir)
+        .status()
+        .map_err(|e| format!("failed to run install.sh: {}", e))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "install.sh for {} exited with code {}",
+            name,
+            status.code().unwrap_or(-1)
+        ))
+    }
+}
+
+pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), (String, i32)> {
+    let adapter_dir = find_adapter_dir().ok_or_else(|| {
+        (
+            "Adapter directory not found.\nInstall tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`."
+                .to_string(),
+            1,
+        )
+    })?;
+
+    let manifest = load_manifest(&adapter_dir).map_err(|e| (e, 1))?;
+
+    let mut frameworks: Vec<FrameworkInfo> = Vec::new();
+    for (name, target) in &manifest.targets {
+        let caps = extract_hooks(&target.capabilities);
+        let actions = match &target.actions {
+            Some(a) => a,
+            None => {
+                frameworks.push(FrameworkInfo {
+                    name: name.clone(),
+                    status: DetectStatus::NotChecked,
+                    capabilities: caps,
+                    install_script: None,
+                });
+                continue;
+            }
+        };
+        let status = match &actions.detect {
+            Some(d) => run_detect(&adapter_dir, name, d),
+            None => DetectStatus::NotChecked,
+        };
+        frameworks.push(FrameworkInfo {
+            name: name.clone(),
+            status,
+            capabilities: caps,
+            install_script: actions.install.clone(),
+        });
+    }
+
+    frameworks.sort_by(|a, b| a.name.cmp(&b.name));
+
+    println!("\nTokenless Adapter Status\n");
+    println!("{:<14} {:<16} Hooks", "Framework", "Status");
+    println!("{:-<14} {:-<16} {:-<40}", "", "", "");
+    for fw in &frameworks {
+        let caps = if fw.capabilities.is_empty() {
+            "—".to_string()
+        } else {
+            fw.capabilities.join(", ")
+        };
+        println!("{:<14} {:<16} {}", fw.name, fw.status.label(), caps);
+    }
+    println!("\nAdapter directory: {}", adapter_dir.display());
+
+    // --framework: check/install one specific framework
+    if let Some(name) = &framework {
+        let fw = frameworks.iter().find(|f| &f.name == name);
+        match fw {
+            Some(f) if f.status == DetectStatus::Installable => {
+                if let Some(script) = &f.install_script {
+                    println!("\nInstalling {} adapter...", f.name);
+                    match run_install(&adapter_dir, &f.name, script) {
+                        Ok(()) => println!("{} adapter installed successfully.", f.name),
+                        Err(e) => {
+                            return Err((
+                                format!("{} adapter installation failed: {}", f.name, e),
+                                1,
+                            ));
+                        }
+                    }
+                } else {
+                    eprintln!("tokenless: no install script for {}", f.name);
+                }
+                return Ok(());
+            }
+            Some(f) if f.status == DetectStatus::Ready => {
+                println!("\n{} is already installed and ready.", f.name);
+                return Ok(());
+            }
+            Some(f) => {
+                return Err((
+                    format!(
+                        "{} is not installable (status: {})",
+                        f.name,
+                        f.status.label()
+                    ),
+                    1,
+                ));
+            }
+            None => {
+                return Err((format!("unknown framework: {}", name), 1));
+            }
+        }
+    }
+
+    if list_only {
+        print_install_hints();
+        return Ok(());
+    }
+
+    let installable: Vec<&FrameworkInfo> = frameworks
+        .iter()
+        .filter(|f| f.status == DetectStatus::Installable)
+        .collect();
+
+    if installable.is_empty() {
+        println!("\nNo frameworks are waiting for installation.");
+        return Ok(());
+    }
+
+    let to_install: Vec<&FrameworkInfo> = if all {
+        installable
+    } else if io::stdin().is_terminal() {
+        println!("\nInstallable frameworks:");
+        for (i, f) in installable.iter().enumerate() {
+            println!("  [{}] {}", i + 1, f.name);
+        }
+        print!("\nSelect a framework to install (number, 'a' for all, Enter to skip): ");
+        io::stdout().flush().ok();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).ok();
+        let input = input.trim();
+        if input.is_empty() {
+            println!("Skipping installation.");
+            return Ok(());
+        }
+        if input == "a" {
+            installable
+        } else if let Ok(n) = input.parse::<usize>() {
+            if n >= 1 && n <= installable.len() {
+                vec![installable[n - 1]]
+            } else {
+                return Err((format!("invalid selection: {}", input), 1));
+            }
+        } else {
+            return Err((format!("invalid selection: {}", input), 1));
+        }
+    } else {
+        print_install_hints();
+        return Ok(());
+    };
+
+    for fw in &to_install {
+        let script = match &fw.install_script {
+            Some(s) => s,
+            None => {
+                eprintln!("tokenless: no install script for {}", fw.name);
+                continue;
+            }
+        };
+        println!("\nInstalling {} adapter...", fw.name);
+        match run_install(&adapter_dir, &fw.name, script) {
+            Ok(()) => println!("{} adapter installed successfully.", fw.name),
+            Err(e) => eprintln!("{} adapter installation failed: {}", fw.name, e),
+        }
+    }
+
+    Ok(())
+}
+
+fn print_install_hints() {
+    println!("\nRun `tokenless init --framework <name>` to install a specific adapter.");
+    println!("Run `tokenless init --all` to install all installable adapters.");
+}

--- a/src/tokenless/crates/tokenless-cli/src/init.rs
+++ b/src/tokenless/crates/tokenless-cli/src/init.rs
@@ -123,7 +123,17 @@ fn run_detect(adapter_dir: &Path, name: &str, detect_script: &str) -> DetectStat
         .output()
     {
         Ok(out) => match out.status.code() {
-            Some(0) => DetectStatus::Ready,
+            Some(0) => {
+                // Some detectors (e.g. Codex) always exit 0 but emit
+                // {"installed": false} when the tool is absent.
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout.trim()) {
+                    if v.get("installed") == Some(&serde_json::Value::Bool(false)) {
+                        return DetectStatus::Installable;
+                    }
+                }
+                DetectStatus::Ready
+            }
             Some(1) => DetectStatus::Installable,
             _ => DetectStatus::MissingPrereqs,
         },
@@ -137,21 +147,32 @@ fn run_install(adapter_dir: &Path, name: &str, install_script: &str) -> Result<(
     if !script.exists() {
         return Err(format!("install script not found: {}", script.display()));
     }
-    let status = Command::new("bash")
+    let out = Command::new("bash")
         .arg(&script)
         .env("ANOLISA_COMPONENT", "tokenless")
         .env("ANOLISA_TARGET", name)
         .env("ANOLISA_ADAPTER_DIR", adapter_dir)
-        .status()
+        .output()
         .map_err(|e| format!("failed to run install.sh: {}", e))?;
-    if status.success() {
+    if out.status.success() {
         Ok(())
     } else {
-        Err(format!(
-            "install.sh for {} exited with code {}",
-            name,
-            status.code().unwrap_or(-1)
-        ))
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let stderr_snippet = stderr.trim();
+        if stderr_snippet.is_empty() {
+            Err(format!(
+                "install.sh for {} exited with code {}",
+                name,
+                out.status.code().unwrap_or(-1)
+            ))
+        } else {
+            Err(format!(
+                "install.sh for {} exited with code {}: {}",
+                name,
+                out.status.code().unwrap_or(-1),
+                stderr_snippet
+            ))
+        }
     }
 }
 
@@ -250,7 +271,6 @@ pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), 
     }
 
     if list_only {
-        print_install_hints();
         return Ok(());
     }
 
@@ -296,6 +316,7 @@ pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), 
         return Ok(());
     };
 
+    let mut failed: Vec<String> = Vec::new();
     for fw in &to_install {
         let script = match &fw.install_script {
             Some(s) => s,
@@ -307,8 +328,18 @@ pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), 
         println!("\nInstalling {} adapter...", fw.name);
         match run_install(&adapter_dir, &fw.name, script) {
             Ok(()) => println!("{} adapter installed successfully.", fw.name),
-            Err(e) => eprintln!("{} adapter installation failed: {}", fw.name, e),
+            Err(e) => {
+                eprintln!("{} adapter installation failed: {}", fw.name, e);
+                failed.push(fw.name.clone());
+            }
         }
+    }
+
+    if !failed.is_empty() {
+        return Err((
+            format!("installation failed for: {}", failed.join(", ")),
+            1,
+        ));
     }
 
     Ok(())

--- a/src/tokenless/crates/tokenless-cli/src/init.rs
+++ b/src/tokenless/crates/tokenless-cli/src/init.rs
@@ -61,7 +61,17 @@ struct FrameworkInfo {
 }
 
 /// Find the adapter directory by checking known locations.
+///
+/// An explicit `ANOLISA_ADAPTER_DIR` environment variable takes precedence,
+/// which also supports custom install prefixes outside the default Unix
+/// share paths.
 fn find_adapter_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("ANOLISA_ADAPTER_DIR") {
+        let p = PathBuf::from(dir);
+        if has_manifest(&p) {
+            return Some(p);
+        }
+    }
     if let Some(home) = dirs::home_dir() {
         let p = home.join(".local/share").join(ADAPTER_SUBPATH);
         if has_manifest(&p) {
@@ -124,15 +134,19 @@ fn run_detect(adapter_dir: &Path, name: &str, detect_script: &str) -> DetectStat
     {
         Ok(out) => match out.status.code() {
             Some(0) => {
-                // Some detectors (e.g. Codex) always exit 0 but emit
-                // {"installed": false} when the tool is absent.
+                // Detectors may emit JSON. Only treat the adapter as Ready
+                // when the output explicitly claims installed: true;
+                // otherwise prefer Installable so missing adapters are not
+                // silently reported as ready.
                 let stdout = String::from_utf8_lossy(&out.stdout);
                 if let Ok(v) = serde_json::from_str::<serde_json::Value>(stdout.trim()) {
-                    if v.get("installed") == Some(&serde_json::Value::Bool(false)) {
-                        return DetectStatus::Installable;
+                    match v.get("installed") {
+                        Some(&serde_json::Value::Bool(true)) => return DetectStatus::Ready,
+                        Some(&serde_json::Value::Bool(false)) => return DetectStatus::Installable,
+                        _ => {}
                     }
                 }
-                DetectStatus::Ready
+                DetectStatus::Installable
             }
             Some(1) => DetectStatus::Installable,
             _ => DetectStatus::MissingPrereqs,
@@ -177,9 +191,18 @@ fn run_install(adapter_dir: &Path, name: &str, install_script: &str) -> Result<(
 }
 
 pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), (String, i32)> {
+    if framework.is_some() && list_only {
+        return Err((
+            "--framework and --list cannot be used together".to_string(),
+            1,
+        ));
+    }
+
     let adapter_dir = find_adapter_dir().ok_or_else(|| {
         (
-            "Adapter directory not found.\nInstall tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`."
+            "Adapter directory not found.\n\
+             Install tokenless via `npm install -g anolisa-tokenless` or `anolisa install tokenless`.\n\
+             For a custom location, set ANOLISA_ADAPTER_DIR to the directory containing manifest.json."
                 .to_string(),
             1,
         )
@@ -246,9 +269,8 @@ pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), 
                         }
                     }
                 } else {
-                    eprintln!("tokenless: no install script for {}", f.name);
+                    return Err((format!("no install script configured for {}", f.name), 1));
                 }
-                return Ok(());
             }
             Some(f) if f.status == DetectStatus::Ready => {
                 println!("\n{} is already installed and ready.", f.name);
@@ -336,10 +358,7 @@ pub fn run(framework: Option<String>, all: bool, list_only: bool) -> Result<(), 
     }
 
     if !failed.is_empty() {
-        return Err((
-            format!("installation failed for: {}", failed.join(", ")),
-            1,
-        ));
+        return Err((format!("installation failed for: {}", failed.join(", ")), 1));
     }
 
     Ok(())

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! Tokenless CLI - LLM token optimization via schema and response compression.
 mod env_check;
+mod init;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
@@ -177,6 +178,18 @@ enum Commands {
         /// Output machine-readable JSON (for hook/plugin consumption)
         #[arg(long)]
         json: bool,
+    },
+    /// Detect installed agent frameworks and install tokenless adapters
+    Init {
+        /// Install a specific framework by name (e.g. claude-code, qoder)
+        #[arg(long)]
+        framework: Option<String>,
+        /// Install all installable frameworks without prompting
+        #[arg(long)]
+        all: bool,
+        /// List framework status without installing
+        #[arg(long)]
+        list: bool,
     },
 }
 
@@ -1091,6 +1104,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             json,
         } => {
             env_check::run(tool.as_deref(), all, fix, checklist, json)?;
+        }
+        Commands::Init {
+            framework,
+            all,
+            list,
+        } => {
+            init::run(framework, all, list)?;
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses all 6 bot review comments (2×P1 + 4×P2) on PR #2264.

### Changes

**P1 fixes:**
- `--list` mode no longer calls `print_install_hints()` — the flag semantics are "show status only", so install guidance was misleading
- `run_detect` now parses stdout JSON when exit code is 0: detectors like Codex that always exit 0 but emit `{"installed": false}` when the tool is absent are now correctly mapped to `Installable` instead of `Ready`, preventing false "already installed" reports for Qoder and Codex adapters

**P2 fixes:**
- `run_install` now uses `Command::output()` and includes captured stderr in the error message for easier community troubleshooting
- `--all` install loop now collects failures and returns `Err` at the end if any install failed, consistent with `--framework` behavior
- Removed `[Unreleased]` CHANGELOG entry — per the documentation standard, CHANGELOG summaries belong in release/version-bump PRs only
- Added documentation for the "adapter directory not found" error case with recovery steps, in both EN and ZH `framework-integration.md`

## Test plan

- [x] `cargo test` in `src/tokenless/crates/tokenless-cli` passes (257 passed, 2 ignored on current main)
- [x] `tokenless init --list` no longer shows install hints
- [ ] `tokenless init --framework codex` correctly detects Codex as installable when tokenless binary is absent
- [ ] `tokenless init --all` returns non-zero exit when any adapter install fails

## 测试情况（rebase onto main 0.7.7 冲突解决）

### 测试范围与执行命令

本次改动为将分支 rebase 到最新 main（含 0.7.7 版本 bump），冲突解决涉及
`docs/user-guide/{en,zh}/token-saving/tokenless/framework-integration.md`、
`src/tokenless/CHANGELOG.md`、`src/tokenless/Cargo.lock`、
`src/tokenless/crates/tokenless-cli/Cargo.toml`、
`src/tokenless/crates/tokenless-cli/src/main.rs`：

- `cargo check -p tokenless-cli` — 0 errors（工作区 71 crates 参与编译）
- `cargo test -p tokenless-cli` — 257 passed, 2 ignored, 0 failed（2 suites）
- `cargo fmt --check -p tokenless-cli` — 通过
- `cargo clippy -p tokenless-cli --all-targets` — 0 errors，无代码告警
- 冒烟验证（构建产物 `target/debug/tokenless`）：
  - 无 adapter 目录时 `init --list`：正确报错并给出安装/`ANOLISA_ADAPTER_DIR` 指引
  - 指向仓库内 `src/tokenless/adapters/tokenless` 时 `init --list`：正确输出各框架状态表（ready / installable / missing prereqs / n/a）与 hooks 列表，且不再打印 install hints

### 环境概要

- OS：Linux x86_64
- 工具链：rustc/cargo 1.94.1

### 冲突解决说明

- 版本号以 main 当前 0.7.7 为准（`Cargo.toml` workspace version 与 `Cargo.lock` 均为 0.7.7；PR 新增的 `serde` 依赖保留）
- `CHANGELOG.md`：main 侧完整保留 `[0.7.7]` 发布节；同时恢复本 PR 第 2 个 commit 的 P2 修复（移除 `[Unreleased]` 下的 init 条目）——该移除在之前一次 rebase 中丢失，导致 commit message 与实际 diff 不一致；现 PR 对 `CHANGELOG.md` 无净改动，符合文档规范（CHANGELOG 汇总仅属于 release/version-bump PR）
- `main.rs`、docs（en/zh）、`Cargo.toml`：自动合并，Init 子命令与 `mod init` 声明完整
- GitHub mergeable 状态已由 CONFLICTING 变为 MERGEABLE

### 未运行项清单

- Test plan 中 `--framework codex`（需移除已安装的 tokenless 二进制构造缺失场景）与 `--all` 失败传播两项未实际执行：二者会触发真实适配器安装或需要破坏当前环境，本次仅做冲突解决不宜改动环境；相关逻辑在 P1/P2 修复轮次中已按 review 意见实现
- init 命令本身暂无单元测试（仓库现状），本次未新增，以冒烟验证覆盖

