### PR TITLE
fix(anolisa): normalize legacy JSON output

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -10,7 +10,7 @@ use anolisa_platform::ipc::{SYSTEM_HELPER_SOCKET, recv_message, send_message};
 use anolisa_platform::privilege;
 
 use crate::context::CliContext;
-use crate::response::CliError;
+use crate::response::{CliError, render_json};
 
 #[derive(Parser)]
 pub struct OsbaseArgs {
@@ -314,7 +314,7 @@ fn handle_sandbox_list(json: bool) -> Result<(), CliError> {
         Ok(names) => {
             if json {
                 let data = serde_json::json!({ "scenarios": names });
-                println!("{}", serde_json::to_string_pretty(&data).unwrap());
+                render_json("osbase sandbox list", data)?;
             } else {
                 println!("Available sandbox scenarios (from sandbox.toml):");
                 println!();

--- a/src/anolisa/crates/anolisa-cli/src/commands/register.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/register.rs
@@ -7,7 +7,7 @@ use std::io::IsTerminal;
 
 use crate::commands::telemetry;
 use crate::context::CliContext;
-use crate::response::CliError;
+use crate::response::{CliError, render_json};
 
 #[derive(Parser)]
 #[command(args_conflicts_with_subcommands = true)]
@@ -181,8 +181,7 @@ fn handle_status(mgr: &RegistrationManager, json: bool) -> Result<(), CliError> 
     let sysom_active = mgr.is_sysom_registered();
 
     if json {
-        print_status_json(&state, &rec, &product_type, sysom_active);
-        return Ok(());
+        return print_status_json(&state, &rec, &product_type, sysom_active);
     }
 
     println!(
@@ -270,7 +269,7 @@ fn print_status_json(
     rec: &Option<anolisa_core::RegisterRecord>,
     product_type: &anolisa_core::ProductType,
     sysom_active: bool,
-) {
+) -> Result<(), CliError> {
     let state_str = if sysom_active && state != &ConsentState::Registered {
         "registered"
     } else {
@@ -307,7 +306,7 @@ fn print_status_json(
         obj["sysom_services_active"] = serde_json::Value::Bool(true);
     }
 
-    println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+    render_json("register status", obj)
 }
 
 // ── Utility functions ────────────────────────────────────────────────────────

--- a/src/anolisa/crates/anolisa-cli/tests/json_envelopes.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/json_envelopes.rs
@@ -1,0 +1,59 @@
+//! Subprocess coverage for the standard JSON response envelope.
+
+use serde_json::Value;
+
+mod common;
+
+fn run_json(arguments: &[&str]) -> Value {
+    let output = common::run(arguments);
+    assert_eq!(
+        Some(0),
+        output.status.code(),
+        "unexpected exit code; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout must be a JSON envelope: {error}; stdout: {}",
+            String::from_utf8_lossy(&output.stdout),
+        )
+    })
+}
+
+fn assert_success_envelope<'a>(value: &'a Value, command: &str) -> &'a Value {
+    assert_eq!(value.get("ok"), Some(&Value::Bool(true)));
+    assert_eq!(value.get("schema_version"), Some(&Value::from(1)));
+    assert_eq!(value.get("command").and_then(Value::as_str), Some(command));
+    assert!(value.get("error").is_none(), "success must not carry error");
+    value.get("data").expect("success envelope must carry data")
+}
+
+#[test]
+fn osbase_sandbox_list_json_uses_standard_envelope() {
+    let value = run_json(&["--json", "osbase", "sandbox", "list"]);
+    let data = assert_success_envelope(&value, "osbase sandbox list");
+
+    assert!(data.get("scenarios").is_some_and(Value::is_array));
+    assert!(
+        value.get("scenarios").is_none(),
+        "sandbox payload must be nested under data"
+    );
+}
+
+#[test]
+fn register_status_json_uses_standard_envelope() {
+    let value = run_json(&["--json", "register", "status"]);
+    let data = assert_success_envelope(&value, "register status");
+
+    // These fields are stable business data, while their values depend on the
+    // machine running the CLI and must not be pinned in an integration test.
+    assert!(data.get("product_type").is_some_and(Value::is_string));
+    assert!(data.get("consent_state").is_some_and(Value::is_string));
+    assert!(data.get("upload_active").is_some_and(Value::is_boolean));
+    assert!(
+        value.get("product_type").is_none()
+            && value.get("consent_state").is_none()
+            && value.get("upload_active").is_none(),
+        "registration payload must be nested under data"
+    );
+}


### PR DESCRIPTION
## Why

`anolisa --json osbase sandbox list` and `anolisa --json register status` emitted bare JSON objects instead of the standard CLI response envelope. Machine consumers expecting `ok`, `schema_version`, `command`, and `data` could not handle these two commands consistently.

## What changed

Both legacy JSON paths now use the shared `render_json` response renderer. Subprocess regression tests verify the envelope metadata, command labels, and that the existing business payloads are nested under `data`.

## Related issue

Closes #2317

## User / Agent impact

Machine consumers now receive the same versioned JSON envelope from these commands as from other `--json` commands. Consumers relying on the previous out-of-contract bare payload must read the fields under `data`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The change is limited to two JSON output paths. Human-readable output and business payload fields are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`

## Documentation and rollback

No documentation change is needed because the standard machine-readable JSON contract is unchanged. Reverting commit `444a1ac5` restores the previous behavior.