### PR TITLE
fix(sight): treat pause_turn as normal SSE finish

### DIFF
--- a/src/agentsight/src/interruption/detector.rs
+++ b/src/agentsight/src/interruption/detector.rs
@@ -12,10 +12,14 @@ use super::types::{InterruptionEvent, InterruptionType};
 use crate::genai::semantic::{LLMCall, MessagePart, ToolUse};
 
 /// Whether the finish reason indicates a normal (non-truncated) end of generation.
+///
+/// `pause_turn` (Anthropic) means a long-running turn was paused by the server
+/// and will be resumed by the client; the SSE stream itself completed normally,
+/// so it must not be treated as truncation.
 fn is_normal_finish(reason: Option<&str>) -> bool {
     matches!(
         reason,
-        Some("stop" | "tool_calls" | "end_turn" | "tool_use" | "stop_sequence")
+        Some("stop" | "tool_calls" | "end_turn" | "tool_use" | "stop_sequence" | "pause_turn")
     )
 }
 
@@ -574,7 +578,7 @@ impl InterruptionDetector {
 
         // ── 8. SSE truncated ──────────────────────────────────────────────────
         // 严格条件：SSE 流 + 持续时间 >= 阈值 + 无正常终止标志 + 非 token-limit
-        // 正常终止标志：finish_reason 为 stop/tool_calls/end_turn/tool_use/stop_sequence
+        // 正常终止标志：finish_reason 为 stop/tool_calls/end_turn/tool_use/stop_sequence/pause_turn
         // token-limit (length/max_tokens) 由 rule 9/10 单独处理
         if is_sse
             && !is_normal_finish(finish_reason)
@@ -1453,6 +1457,54 @@ mod tests {
                 .iter()
                 .all(|e| e.interruption_type != InterruptionType::SseTruncated),
             "stop_sequence should not trigger SseTruncated"
+        );
+    }
+
+    #[test]
+    fn test_pause_turn_sse_not_reported_as_truncated() {
+        // SSE + finish_reason="pause_turn"（Anthropic 长轮次暂停，流是完整的）
+        // → 不产生 SseTruncated
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata
+            .insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 2_000_000_000;
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("pause_turn".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert!(
+            events
+                .iter()
+                .all(|e| e.interruption_type != InterruptionType::SseTruncated),
+            "pause_turn should not trigger SseTruncated"
+        );
+    }
+
+    #[test]
+    fn test_sse_unknown_finish_reason_still_truncated() {
+        // 守护 #1023 原行为：SSE + 非白名单 finish_reason（None 场景由
+        // test_detect_sse_truncated 覆盖，这里覆盖 Some(未知值)）仍报 SseTruncated
+        let detector = InterruptionDetector::default();
+        let mut call = make_base_call();
+        call.metadata
+            .insert("is_sse".to_string(), "true".to_string());
+        call.duration_ns = 2_000_000_000;
+        call.response.messages = vec![OutputMessage {
+            role: "assistant".to_string(),
+            parts: vec![],
+            name: None,
+            finish_reason: Some("some_unknown_reason".to_string()),
+        }];
+        let events = detector.detect(&call);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.interruption_type == InterruptionType::SseTruncated),
+            "non-whitelisted finish_reason should still trigger SseTruncated"
         );
     }
 

--- a/src/agentsight/src/interruption/types.rs
+++ b/src/agentsight/src/interruption/types.rs
@@ -18,7 +18,9 @@ pub enum InterruptionType {
     ServiceUnavailable,
     /// finish_reason == "content_filter" from LLM safety policy
     SafetyFilter,
-    /// SSE stream ended without finish_reason=stop/tool_calls ([DONE])
+    /// SSE stream ended without a normal finish_reason
+    /// (stop/tool_calls/end_turn/tool_use/stop_sequence/pause_turn)
+    /// and not due to a token-limit finish (length/max_tokens)
     SseTruncated,
     /// context_length_exceeded or similar context-bound errors
     ContextOverflow,


### PR DESCRIPTION
## Why

`is_normal_finish` in the interruption detector whitelists `stop | tool_calls | end_turn | tool_use | stop_sequence` but misses Anthropic's `pause_turn`. An SSE call ending with `pause_turn` and duration >= 1s — almost always true, since pause_turn turns are long-running by design — was deterministically misreported as `SseTruncated` (severity High) and fed grader findings as `RuntimeError` (#2313). PR #2283 fixed the turn-eviction consumer of finish_reason; this PR syncs the second consumer.

## What changed

Added `"pause_turn"` to the `is_normal_finish` whitelist in `src/agentsight/src/interruption/detector.rs`, synced the `SseTruncated` doc comment in `src/agentsight/src/interruption/types.rs` to the actual rule semantics, and added 2 discriminating tests: pause_turn + SSE + long-duration is no longer reported, while an unknown finish_reason still is (guarding the original #1023 behavior).

## Related issue

closes #2313

## User / Agent impact

`pause_turn` calls no longer produce false `SseTruncated` interruption events or grader `RuntimeError` findings. Genuine truncation detection is unchanged. No CLI, API, or configuration change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: one literal added to a whitelist plus a doc-comment sync; both consumers of finish_reason now agree on pause_turn.

## Validation

ECS (rustc 1.89.0 matching CI): `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` / `cargo doc` all pass; full suite 1526 passed (the single doctest failure in helpers.rs is pre-existing on origin/main and unrelated). Discriminating check verified by reverting the whitelist change: only the new pause_turn test fails. Three independent reviews (completeness / correctness / impact) found no P0/P1.

## Documentation and rollback

Doc comment on `SseTruncated` updated in the same commit; no user-facing documentation change needed. Revert the single commit to roll back.
