### PR TITLE
feat(tokenless): add curl and skill install methods

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -18,6 +18,8 @@ Savings vary by task. Short tasks or tasks that are mostly conversation may show
 
 ## 2. Install Tokenless
 
+### anolisa CLI
+
 Install the anolisa CLI first, then use it to install Tokenless:
 
 ```bash
@@ -25,6 +27,22 @@ curl -fsSL https://get.agentic-os.sh | bash
 anolisa --version
 anolisa install tokenless
 tokenless --version
+```
+
+### curl (standalone)
+
+If you only need the Tokenless CLI and framework adapters, install directly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+This uses npm when available and falls back to installing Node.js LTS via nvm if npm is missing.
+
+### npm
+
+```bash
+npm install -g anolisa-tokenless
 ```
 
 ## 3. Start using Tokenless

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -18,6 +18,8 @@ Tokenless 帮助 AI Agent 用更少的 Token 完成原来的工作。
 
 ## 2. 安装 Tokenless
 
+### anolisa CLI
+
 先安装 anolisa CLI，再用它安装 Tokenless：
 
 ```bash
@@ -25,6 +27,22 @@ curl -fsSL https://get.agentic-os.sh | bash
 anolisa --version
 anolisa install tokenless
 tokenless --version
+```
+
+### curl（独立安装）
+
+如果只需要 Tokenless CLI 和框架适配器，可直接安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+安装器会优先使用 npm；若未安装 npm，则通过 nvm 安装 Node.js LTS。
+
+### npm
+
+```bash
+npm install -g anolisa-tokenless
 ```
 
 ## 3. 开始使用 Tokenless

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -101,10 +101,28 @@ Token-Less/
 ├── third_party/rtk/           # RTK vendored source (justfile clone+patch from GitHub)
 ├── third_party/patches/      # Patches for vendored third_party sources
 ├── Makefile                   # Unified build system
-└── scripts/                    # Helper scripts
+├── install.sh                 # One-line curl installer for human users
+├── scripts/                   # Helper scripts
+└── skills/install-tokenless/  # Copilot Shell skill for agent-driven install
 ```
 
 ## Quick Start
+
+### curl (recommended for human users)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+The installer uses npm when available and falls back to installing Node.js LTS via nvm if npm is missing.
+
+### npm
+
+```bash
+npm install -g anolisa-tokenless
+```
+
+### Build from source
 
 ```bash
 # Clone repo (no submodules needed)
@@ -115,7 +133,19 @@ cd Token-Less
 make setup
 ```
 
-Both methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, and deploy the adapters (hooks + OpenClaw plugin + Hermes plugin).
+All methods install `tokenless` to `~/.local/bin`, helper binaries `rtk`/`toon` alongside it, and deploy the adapters (hooks + OpenClaw plugin + Hermes plugin).
+
+### Skill install (for agents)
+
+Agents can install Token-Less via the bundled skill. Clone the skill directory
+from the repository, then run the installer:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/alibaba/anolisa.git /tmp/anolisa-tokenless
+cd /tmp/anolisa-tokenless && git sparse-checkout set src/tokenless/skills/install-tokenless
+bash src/tokenless/skills/install-tokenless/scripts/install.sh
+rm -rf /tmp/anolisa-tokenless
+```
 
 ## CLI Usage
 
@@ -425,7 +455,17 @@ The installer creates a `tokenless.js` symbolic link in OpenCode's global
 `TOKENLESS_OPENCODE_CONFIG_DIR` override.
 
 
-## npm Install
+## Install Options
+
+### curl (recommended for human users)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+The installer detects the platform, uses npm when available, and falls back to installing Node.js LTS via nvm if npm is missing. It installs the correct prebuilt binaries (`tokenless`, `rtk`, `toon`) for Linux or macOS on x86_64 and arm64.
+
+### npm
 
 ```bash
 npm install -g anolisa-tokenless
@@ -433,6 +473,17 @@ npm install -g anolisa-tokenless
 
 This automatically installs the correct prebuilt binaries (`tokenless`, `rtk`, `toon`) for your platform.
 Supports Linux and macOS on x86_64 and arm64.
+
+### Skill install (for agents)
+
+Install Token-Less as a skill so agents can discover and run the installer:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/alibaba/anolisa.git /tmp/anolisa-tokenless
+cd /tmp/anolisa-tokenless && git sparse-checkout set src/tokenless/skills/install-tokenless
+bash src/tokenless/skills/install-tokenless/scripts/install.sh
+rm -rf /tmp/anolisa-tokenless
+```
 
 ## Build
 
@@ -486,6 +537,8 @@ make install BIN_DIR=/usr/local/bin
 | `third_party/rtk/` | RTK vendored source — command rewriting engine (justfile clone+patch) |
 | `third_party/patches/` | Patches for vendored third_party sources |
 | `Makefile` | Unified build system for the entire workspace |
+| `install.sh` | One-line curl installer for human users |
+| `skills/install-tokenless/` | Copilot Shell skill for agent-driven install |
 
 ## Prerequisites
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -63,12 +63,39 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 
 ## 快速开始
 
+### curl（推荐人类用户）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+安装器会优先使用 npm；若未安装 npm，则通过 nvm 安装 Node.js LTS。
+
+### npm
+
+```bash
+npm install -g anolisa-tokenless
+```
+
+### 源码构建
+
 ```bash
 # 完整安装：构建 + 安装二进制 + 部署所有适配器
 make setup
 ```
 
 安装完成后 `tokenless` 命令位于 `~/.local/bin`，RTK/TOON 辅助二进制同目录。
+
+### Skill 安装（面向 Agent）
+
+Agent 可通过附带的 skill 安装 Token-Less。从仓库克隆 skill 目录后运行安装器：
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/alibaba/anolisa.git /tmp/anolisa-tokenless
+cd /tmp/anolisa-tokenless && git sparse-checkout set src/tokenless/skills/install-tokenless
+bash src/tokenless/skills/install-tokenless/scripts/install.sh
+rm -rf /tmp/anolisa-tokenless
+```
 
 ### OpenCode 安装
 
@@ -85,7 +112,17 @@ make opencode-install
 `XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
 安装后重启 OpenCode 即可加载插件。
 
-## npm 安装
+## 安装选项
+
+### curl（推荐人类用户）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+```
+
+安装器会检测平台，优先使用 npm；若未安装 npm，则通过 nvm 安装 Node.js LTS。自动安装适合您平台的预编译二进制文件（`tokenless`、`rtk`、`toon`），支持 Linux 和 macOS 的 x86_64 和 arm64 架构。
+
+### npm
 
 ```bash
 npm install -g anolisa-tokenless
@@ -93,6 +130,17 @@ npm install -g anolisa-tokenless
 
 自动安装适合您平台的预编译二进制文件（`tokenless`、`rtk`、`toon`）。
 支持 Linux 和 macOS 的 x86_64 和 arm64 架构。
+
+### Skill 安装（面向 Agent）
+
+将 Token-Less 作为 skill 安装，供 Agent 发现并执行：
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/alibaba/anolisa.git /tmp/anolisa-tokenless
+cd /tmp/anolisa-tokenless && git sparse-checkout set src/tokenless/skills/install-tokenless
+bash src/tokenless/skills/install-tokenless/scripts/install.sh
+rm -rf /tmp/anolisa-tokenless
+```
 
 ## 查看 Token 节省明细
 
@@ -133,6 +181,8 @@ export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 - `crates/tokenless-cli/` — CLI 二进制
 - `adapters/tokenless/` — 适配器包（OpenClaw / Hermes / Qoder / Claude Code / Codex / OpenCode）
 - `third_party/rtk/` — RTK 命令重写引擎（vendored）
+- `install.sh` — 面向人类用户的一键 curl 安装脚本
+- `skills/install-tokenless/` — 面向 Agent 的 Copilot Shell skill
 
 ## 许可证
 

--- a/src/tokenless/install.sh
+++ b/src/tokenless/install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# install.sh — one-line installer for Token-Less.
+#
+# Usage (human users):
+#   curl -fsSL https://raw.githubusercontent.com/alibaba/anolisa/main/src/tokenless/install.sh | bash
+#
+# Environment overrides:
+#   TOKENLESS_VERSION    npm version tag to install (default: latest)
+#   TOKENLESS_NPM_REGISTRY  npm registry override (default: https://registry.npmjs.org/)
+#   TOKENLESS_INSTALL_PREFIX  npm prefix for global install (default: none)
+
+set -euo pipefail
+
+VERSION="${TOKENLESS_VERSION:-latest}"
+NPM_REGISTRY="${TOKENLESS_NPM_REGISTRY:-https://registry.npmjs.org/}"
+INSTALL_PREFIX="${TOKENLESS_INSTALL_PREFIX:-}"
+
+log()  { printf '\033[1;32m%s\033[0m %s\n' "==>" "$*"; }
+warn() { printf '\033[1;33m%s\033[0m %s\n' "warn:" "$*" >&2; }
+err()  { printf '\033[1;31m%s\033[0m %s\n' "error:" "$*" >&2; exit 1; }
+
+detect_platform() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="darwin" ;;
+    *)      err "unsupported OS: $os (only Linux and macOS are supported)" ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64)   ARCH="x64" ;;
+    aarch64|arm64)  ARCH="arm64" ;;
+    *)              err "unsupported architecture: $arch" ;;
+  esac
+}
+
+check_musl() {
+  [ "$OS" != "linux" ] && return 0
+  # Detect musl by absence of glibc loader and presence of musl loader,
+  # avoiding ldd which may be missing or unreliable on minimal distros.
+  if [ ! -f /lib/x86_64-linux-gnu/libc.so.6 ] && \
+     [ ! -f /lib/aarch64-linux-gnu/libc.so.6 ] && \
+     [ ! -f /lib64/libc.so.6 ] && \
+     [ ! -f /lib/libc.so.6 ]; then
+    if ls /lib/ld-musl-*.so* >/dev/null 2>&1; then
+      err "musl-based Linux distributions (e.g. Alpine) are not supported by the prebuilt binaries; build from source instead"
+    fi
+  fi
+}
+
+ensure_npm() {
+  if command -v npm >/dev/null 2>&1; then
+    return 0
+  fi
+
+  warn "npm not found; attempting to install Node.js via nvm..."
+
+  if [ -z "${NVM_DIR:-}" ] && [ -d "$HOME/.nvm" ]; then
+    export NVM_DIR="$HOME/.nvm"
+  fi
+
+  if [ -s "${NVM_DIR:-}/nvm.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$NVM_DIR/nvm.sh"
+    if command -v npm >/dev/null 2>&1; then
+      return 0
+    fi
+    nvm install --lts
+    return 0
+  fi
+
+  warn "nvm not found; installing nvm and Node.js LTS..."
+  if ! command -v curl >/dev/null 2>&1; then
+    err "curl is required to install Node.js automatically"
+  fi
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+  export NVM_DIR="$HOME/.nvm"
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+  nvm install --lts
+}
+
+install_with_npm() {
+  local npm_args=("install" "-g" "anolisa-tokenless@${VERSION}" "--registry=${NPM_REGISTRY}")
+  if [ -n "$INSTALL_PREFIX" ]; then
+    npm_args+=("--prefix=${INSTALL_PREFIX}")
+  fi
+
+  log "installing anolisa-tokenless@${VERSION} via npm..."
+  if ! npm "${npm_args[@]}"; then
+    err "npm install failed"
+  fi
+}
+
+verify_installation() {
+  local bin_dir
+  if [ -n "$INSTALL_PREFIX" ]; then
+    bin_dir="${INSTALL_PREFIX}/bin"
+  else
+    bin_dir="$(npm prefix -g)/bin"
+  fi
+
+  if command -v tokenless >/dev/null 2>&1; then
+    log "tokenless installed: $(tokenless --version)"
+  elif [ -x "${bin_dir}/tokenless" ]; then
+    log "tokenless installed to ${bin_dir}/tokenless"
+    warn "${bin_dir} is not in your PATH; add it with: export PATH=\"${bin_dir}:\$PATH\""
+  else
+    warn "tokenless binary not found in PATH; you may need to add ${bin_dir} to PATH"
+  fi
+
+  log "done"
+}
+
+main() {
+  detect_platform
+  check_musl
+  command -v curl >/dev/null 2>&1 || err "curl is required but not found"
+
+  ensure_npm
+  install_with_npm
+  verify_installation
+}
+
+main

--- a/src/tokenless/skills/install-tokenless/SKILL.md
+++ b/src/tokenless/skills/install-tokenless/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: install-tokenless
+version: 1.0.0
+description: Install the Token-Less toolkit (tokenless, rtk, toon) and its framework adapters on Linux or macOS. Use when the user asks to install Token-Less, set up tokenless, install the anolisa tokenless toolkit, or enable token-saving hooks.
+layer: application
+lifecycle: usage
+platforms: [cosh, qoder]
+---
+
+# Install Token-Less
+
+Installs the Token-Less CLI toolkit and framework adapters.
+
+## Supported platforms
+
+- Linux (glibc) x86_64 / aarch64
+- macOS x86_64 (Intel) / aarch64 (Apple Silicon)
+
+> musl-based Linux (e.g. Alpine) is not supported by the prebuilt binaries; build from source instead.
+
+## Installation workflow
+
+```
+Task Progress:
+- [ ] Step 1: Detect platform and prerequisites
+- [ ] Step 2: Install Token-Less
+- [ ] Step 3: Verify installation
+- [ ] Step 4: Register framework adapters (optional)
+```
+
+### Step 1: Check prerequisites
+
+Ensure the machine is running a supported Linux/macOS platform and has `curl` available.
+
+```bash
+curl --version
+```
+
+### Step 2: Install Token-Less
+
+Run the installer script. It uses npm when available and falls back to installing Node.js LTS via nvm if npm is missing.
+
+```bash
+bash scripts/install.sh
+```
+
+Override behavior with environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `TOKENLESS_VERSION` | `latest` | npm version tag to install |
+| `TOKENLESS_NPM_REGISTRY` | `https://registry.npmjs.org/` | npm registry override |
+| `TOKENLESS_INSTALL_PREFIX` | none | npm global prefix override |
+| `TOKENLESS_INSTALL_REF` | `main` | Git ref for remote installer (set to a version tag to pin) |
+
+### Step 3: Verify installation
+
+```bash
+tokenless --version
+rtk --version
+toon --version
+```
+
+### Step 4: Register adapters (optional)
+
+After installation, register Token-Less with the active agent framework.
+The adapter paths below assume the default install location
+(`~/.local/share/anolisa/adapters/tokenless/`). If you use a custom
+`XDG_DATA_HOME`, replace `~/.local/share` with your value.
+Alternatively, use the corresponding `make` targets (e.g. `make claude-code-install`,
+`make qoder-install`) from the repository root which handle path resolution automatically.
+
+```bash
+# Claude Code
+bash ~/.local/share/anolisa/adapters/tokenless/claude-code/scripts/install.sh
+
+# Codex
+bash ~/.local/share/anolisa/adapters/tokenless/codex/scripts/install.sh
+
+# OpenCode
+bash ~/.local/share/anolisa/adapters/tokenless/opencode/scripts/install.sh
+
+# Qoder CLI
+bash ~/.local/share/anolisa/adapters/tokenless/qoder/scripts/install.sh
+
+# Hermes Agent
+bash ~/.local/share/anolisa/adapters/tokenless/hermes/scripts/install.sh
+```
+
+## Uninstall
+
+```bash
+npm uninstall -g anolisa-tokenless
+rm -rf ~/.local/share/anolisa/adapters/tokenless
+```

--- a/src/tokenless/skills/install-tokenless/scripts/install.sh
+++ b/src/tokenless/skills/install-tokenless/scripts/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# install.sh — Agent-facing installer entry point for the install-tokenless skill.
+#
+# This script delegates to the canonical Token-Less installer. When run from a
+# local checkout it uses the bundled install.sh; otherwise it downloads the
+# installer from the alibaba/anolisa repository.
+#
+# Environment overrides:
+#   TOKENLESS_INSTALL_REF  Git ref for remote installer download (default: main)
+#                           Set to a version tag (e.g. v0.7.0) to pin the installer.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_INSTALLER="${SKILL_DIR}/../../install.sh"
+INSTALL_REF="${TOKENLESS_INSTALL_REF:-main}"
+REMOTE_INSTALLER="https://raw.githubusercontent.com/alibaba/anolisa/${INSTALL_REF}/src/tokenless/install.sh"
+
+if [ -f "$REPO_INSTALLER" ]; then
+  bash "$REPO_INSTALLER" "$@"
+else
+  command -v curl >/dev/null 2>&1 || {
+    echo "error: curl is required but not found" >&2
+    exit 1
+  }
+  curl -fsSL "$REMOTE_INSTALLER" | bash -s -- "$@"
+fi


### PR DESCRIPTION
## Summary

This PR adds two new installation paths for the Token-Less toolkit:

1. **curl installer** (`src/tokenless/install.sh`) — one-line install for human users. It detects the platform, uses npm when available, and falls back to installing Node.js LTS via nvm if npm is missing.
2. **Copilot Shell skill** (`src/tokenless/skills/install-tokenless/`) — agent-driven install. The skill bundles a `SKILL.md` guide and a wrapper script that delegates to the canonical curl installer.

README, README_zh, and the tokenless user-guide quickstarts (EN/ZH) are updated to document all install options.

## Test plan

- [x] `bash -n src/tokenless/install.sh` passes
- [x] `bash -n src/tokenless/skills/install-tokenless/scripts/install.sh` passes
- [ ] Manual install smoke test on Linux x86_64 (requires npm/network)
- [ ] Manual install smoke test on macOS arm64 (requires npm/network)

## Scope

Only tokenless-related files are changed:
- `src/tokenless/install.sh`
- `src/tokenless/skills/install-tokenless/SKILL.md`
- `src/tokenless/skills/install-tokenless/scripts/install.sh`
- `src/tokenless/README.md`
- `src/tokenless/README_zh.md`
- `docs/user-guide/en/token-saving/tokenless/QUICKSTART.md`
- `docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md`