### PR TITLE
docs(docs): sync agentsight guide with v0.9.1 CLI

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight.md
+++ b/docs/user-guide/en/agent-observability/agentsight.md
@@ -24,6 +24,8 @@ AgentSight provides full-stack observability for AI Agents running on Linux:
 | Privileges | root or CAP_BPF (for eBPF probes) |
 | Architecture | x86_64 / aarch64 |
 
+> **macOS**: On macOS, AgentSight provides two commands — `trace` (trajectory collector that scans local JSONL session files, no eBPF) and `serve` (Dashboard viewer). All other eBPF-dependent commands are Linux-only.
+
 ## Installation
 
 ```bash
@@ -34,8 +36,10 @@ sudo anolisa install agentsight
 sudo yum install agentsight
 
 # Source build (developers only)
-cd src/agentsight && make build
+cd src/agentsight && make build-all
 ```
+
+> Use `make build-all` for source builds: it builds the Dashboard frontend, the main binary, and `agentsight-enforcer` in sequence. Running only `make build` skips the enforcer, and `serve` will keep logging `AgentSight enforcement unavailable`.
 
 ## Quick Start
 
@@ -46,7 +50,12 @@ sudo agentsight trace
 # Terminal 2: Start Dashboard
 agentsight serve
 # Open http://localhost:7396 in browser
+
+# Show the Dashboard URL and auth token
+agentsight dashboard
 ```
+
+> Localhost access is authentication-free; remote access requires a token, see [Dashboard Access & Authentication](#dashboard-access--authentication).
 
 ## Usage
 
@@ -71,6 +80,49 @@ agentsight serve --host 0.0.0.0 --port 7396
 ```
 
 > Ensure your firewall allows access to port 7396 if accessing remotely.
+
+#### Dashboard Access & Authentication
+
+Dashboard token authentication is enabled by default:
+
+- **Localhost access** (loopback) bypasses authentication — just open `http://127.0.0.1:7396`.
+- **Remote access** requires a token: append `?token=<TOKEN>` to the browser URL, or set the `Authorization: Bearer <TOKEN>` HTTP header.
+- The token is auto-generated on the first `serve` startup (64 hex characters) and persisted to the `.dashboard_token` file next to the database (default `/var/log/sysak/.agentsight/.dashboard_token`); it is reused across restarts.
+- Run `agentsight dashboard` to view the access URL and token directly.
+
+To disable authentication (only recommended on trusted internal networks), set in the config file:
+
+```json
+{
+  "server": { "auth": { "enabled": false } }
+}
+```
+
+### agentsight dashboard — Show Dashboard Access Info
+
+Displays the Dashboard URL and auth token, then tries to open a browser. On ECS instances it also prints a security-group configuration guide.
+
+```bash
+# Show URL and token (requires serve to be running)
+agentsight dashboard
+
+# Show info only, do not open a browser
+agentsight dashboard --no-open
+```
+
+### agentsight summary — Unified Overview
+
+Rolls up sessions and Token usage, interruption events grouped by severity, and Tokenless savings for a recent time window — one command for the overall health picture.
+
+```bash
+# Last 24 hours (default)
+agentsight summary
+
+# Last 7 days, JSON output
+agentsight summary --last 168 --json
+```
+
+> Data sources degrade independently: a missing database contributes zeros without affecting the rest of the report.
 
 ### agentsight token — Query Token Usage
 
@@ -132,6 +184,13 @@ agentsight interruption stats
 
 # Count by severity
 agentsight interruption count
+
+# Get a single event by ID
+agentsight interruption get <ID>
+
+# List all interruption events of a session / conversation
+agentsight interruption session <SESSION_ID>
+agentsight interruption conversation <CONVERSATION_ID>
 
 # Mark as resolved
 agentsight interruption resolve <ID>

--- a/docs/user-guide/zh/agent-observability/agentsight.md
+++ b/docs/user-guide/zh/agent-observability/agentsight.md
@@ -24,6 +24,8 @@ AgentSight 为运行在 Linux 上的 AI Agent 提供全栈可观测能力：
 | 权限 | root 或 CAP_BPF（eBPF 探针） |
 | 架构 | x86_64 / aarch64 |
 
+> **macOS**：AgentSight 在 macOS 上提供 `trace`（轨迹采集器，扫描本地 JSONL 会话文件，无 eBPF）和 `serve`（Dashboard 查看器）两个命令；其余依赖 eBPF 的命令仅 Linux 可用。
+
 ## 安装
 
 ```bash
@@ -34,8 +36,10 @@ sudo anolisa install agentsight
 sudo yum install agentsight
 
 # 源码编译（仅开发者）
-cd src/agentsight && make build
+cd src/agentsight && make build-all
 ```
+
+> 源码编译请使用 `make build-all`：它会依次构建 Dashboard 前端、主二进制和 `agentsight-enforcer`。仅执行 `make build` 不会构建 enforcer，`serve` 运行时会持续输出 `AgentSight enforcement unavailable` 日志。
 
 ## 快速开始
 
@@ -46,7 +50,12 @@ sudo agentsight trace
 # 终端 2: 启动 Dashboard
 agentsight serve
 # 浏览器访问 http://localhost:7396
+
+# 查看 Dashboard 访问地址与认证 Token
+agentsight dashboard
 ```
+
+> 本机（localhost）访问免认证；远程访问需要携带 Token，见[Dashboard 访问与认证](#dashboard-访问与认证)。
 
 ## 使用详解
 
@@ -71,6 +80,49 @@ agentsight serve --host 0.0.0.0 --port 7396
 ```
 
 > 远程访问时请确保防火墙已放行对应端口。
+
+#### Dashboard 访问与认证
+
+Dashboard Token 认证默认开启：
+
+- **本机访问**（loopback）自动免认证，直接打开 `http://127.0.0.1:7396` 即可。
+- **远程访问**需携带 Token：浏览器 URL 追加 `?token=<TOKEN>`，或 HTTP 请求头设置 `Authorization: Bearer <TOKEN>`。
+- Token 在首次启动 `serve` 时自动生成（64 位十六进制），持久化于数据库同目录的 `.dashboard_token` 文件（默认 `/var/log/sysak/.agentsight/.dashboard_token`），重启后复用。
+- 使用 `agentsight dashboard` 命令可直接查看访问地址与 Token。
+
+如需关闭认证（仅建议在可信内网使用），在配置文件中设置：
+
+```json
+{
+  "server": { "auth": { "enabled": false } }
+}
+```
+
+### agentsight dashboard — 查看 Dashboard 访问信息
+
+显示 Dashboard 访问地址、认证 Token，并尝试打开浏览器。在 ECS 实例上还会输出安全组放行指引。
+
+```bash
+# 查看访问地址与 Token（需要 serve 已启动）
+agentsight dashboard
+
+# 仅显示信息，不打开浏览器
+agentsight dashboard --no-open
+```
+
+### agentsight summary — 统一概览
+
+汇总最近时间窗口内的会话与 Token 用量、按严重级别统计的中断事件，以及 Tokenless 节省数据，一条命令查看整体运行状况。
+
+```bash
+# 最近 24 小时概览（默认）
+agentsight summary
+
+# 最近 7 天，JSON 格式输出
+agentsight summary --last 168 --json
+```
+
+> 各数据源相互独立：某个数据库缺失时对应部分显示为 0，不影响其余输出。
 
 ### agentsight token — 查询 Token 用量
 
@@ -132,6 +184,13 @@ agentsight interruption stats
 
 # 按严重级别统计
 agentsight interruption count
+
+# 按 ID 查看单个事件详情
+agentsight interruption get <ID>
+
+# 查看指定会话 / 对话的全部中断事件
+agentsight interruption session <SESSION_ID>
+agentsight interruption conversation <CONVERSATION_ID>
 
 # 标记为已解决
 agentsight interruption resolve <ID>


### PR DESCRIPTION
## Description

Syncs the AgentSight user guide (en/zh) with the v0.9.1 CLI. Adds a Dashboard access & authentication section (token auth is on by default; remote access needs `?token=` or a Bearer header, token persisted at `/var/log/sysak/.agentsight/.dashboard_token`), documents the missing `agentsight dashboard` / `agentsight summary` commands and `interruption get/session/conversation` subcommands, notes macOS trace/serve support, and switches the source-build instruction to `make build-all` so the enforcer is built and `serve` stops logging enforcement errors.

## Related Issue

closes #2323

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `docs` (documentation)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] `scripts/docs-lint.sh` and `scripts/docs-link-check.py` pass
- [x] en/zh guides stay semantically equivalent per `specs/documentation-standard.md`

## Testing

Docs-only change. Verified by:
- `bash scripts/docs-lint.sh` — naming convention and en/zh tree parity pass
- `python3.11 scripts/docs-link-check.py` — all relative links resolve
- Every documented command/flag checked against the v0.9.1 structopt definitions
- End-to-end run on Linux (kernel 5.10, x86_64): `make build` vs `make build-all` behavior, `serve` (UI 200, APIs 200, token generated), `sudo trace` (probes attached, SQLite written)

## Additional Notes

`metrics` / `skill-metrics` are intentionally left undocumented (internal diagnostics, also absent from the component README).