### PR TITLE
feat(docs): refresh contributor workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,9 @@ This file provides context for AI coding assistants (Qoder, Claude, etc.) workin
 | Component | Path | Tech | Platform |
 |-----------|------|------|----------|
 | **copilot-shell** (`cosh`) | `src/copilot-shell/` | TypeScript / Node.js | All |
-| **cosh-ng** | `src/cosh-ng/` | Rust | Linux only |
+| **cosh-ng** | `src/cosh-ng/` | Rust | Linux (full); macOS (limited functionality) |
 | **agent-sec-core** | `src/agent-sec-core/` | Rust + Python | Linux only |
-| **agentsight** | `src/agentsight/` | Rust (eBPF) | Linux only |
+| **agentsight** | `src/agentsight/` | Rust (eBPF) | Linux (full); macOS (trajectory/serve only) |
 | **tokenless** | `src/tokenless/` | Rust | Linux (full); macOS x64/arm64 (CLI binaries + adapters, via npm) |
 | **agent-memory** (`memory`) | `src/agent-memory/` | Rust | Linux only |
 | **os-skills** | `src/os-skills/` | Python / Shell | All |
@@ -21,18 +21,18 @@ This file provides context for AI coding assistants (Qoder, Claude, etc.) workin
 | **ktuner** | `src/ktuner/` | Rust | Linux only |
 | **blaze** | `src/blaze/` | Rust | Linux only |
 
-> `agent-sec-core`, `agentsight`, `tokenless`, `agent-memory`, `skillfs`, `ktuner`, and `blaze` require Linux. Do **not** attempt to build them on macOS or Windows. (tokenless ships macOS CLI binaries and framework adapters via npm, but the binaries are cross-compiled **from Linux** — building tokenless on macOS is still unsupported.)
+> `agent-sec-core`, `agent-memory`, `skillfs`, `ktuner`, and `blaze` require Linux. `agentsight` provides full eBPF tracing on Linux and limited trajectory collection plus the local viewer on macOS. `cosh-ng` is Linux-first and supports limited functionality on macOS. Do **not** attempt to build the Linux-only components on macOS or Windows. (tokenless ships macOS CLI binaries and framework adapters via npm, but the binaries are cross-compiled **from Linux** — building tokenless on macOS is still unsupported.)
 
 ## 2. Development Commands
 
 ```bash
-# Unified build (recommended — handles deps, build, and system install)
-./scripts/build-all.sh                                        # all default components
+# Unified build (recommended — handles deps, build, and user install)
+./scripts/build-all.sh                                        # integrated default components
 ./scripts/build-all.sh --no-install                           # build only, skip install
 ./scripts/build-all.sh --ignore-deps                          # skip dep installation
 ./scripts/build-all.sh --component cosh --component sec-core  # selected components
 
-# Unified test runner
+# Partial convenience test runner (five components; may skip unavailable suites)
 ./tests/run-all-tests.sh
 ./tests/run-all-tests.sh --filter shell   # copilot-shell only
 ./tests/run-all-tests.sh --filter sec     # agent-sec-core only
@@ -45,27 +45,43 @@ make build
 make lint
 make test
 
-# agent-sec-core (Linux only, per-component)
-cd src/agent-sec-core
-make build-sandbox
-pytest tests/integration-test/ tests/unit-test/ -v
+# cosh-ng (Linux full; macOS limited functionality, per-component)
+cd src/cosh-ng
+cargo build --workspace
+cargo fmt --all -- --check
+# Select the closest targeted test from src/cosh-ng/CONTRIBUTING.md.
+# Full gates require a large/cross-cutting change and an explicit request.
 
-# agentsight (Linux only, optional, per-component)
+# agent-sec-core (Linux only; Python 3.11.6 + uv, per-component)
+cd src/agent-sec-core
+make build-all
+uv run --project agent-sec-cli python --version  # must report 3.11.6
+make test         # Python + Rust sandbox + OpenClaw plugin tests
+
+# agentsight (Linux full eBPF; macOS trajectory/serve only, per-component)
 cd src/agentsight
-make build
-cargo test
+# Linux
+make build-all
+make lint
+make test
+
+# macOS
+make build-mac
 
 # os-skills
 cd src/os-skills   # Skill definitions are static assets, no compilation needed
 
 # tokenless (per-component)
 cd src/tokenless
-cargo build --release
-cargo test
+make build       # tokenless + RTK + TOON + OpenClaw plugin
+make lint
+make test        # Rust + hooks + integration + adapters
 
 # agent-memory (Linux only, per-component)
 cd src/agent-memory
 make build       # cargo build --release --locked
+make fmt-check
+make lint
 make test        # cargo test --locked
 make smoke       # end-to-end MCP stdio smoke test
 
@@ -102,7 +118,7 @@ cargo test --workspace
 
 ## 3. Rust Common Conventions
 
-> Applies to all Rust components: `anolisa`, `agentsight`, `tokenless`, `agent-memory`, `skillfs`, `ktuner`, `blaze`.
+> Applies to these Rust components: `anolisa`, `agentsight`, `tokenless`, `agent-memory`, `skillfs`, `ktuner`, `blaze`.
 
 ### 3.1 Comment Guidelines
 
@@ -211,7 +227,7 @@ Summary:
 ### Subject line
 
 Format: `type(scope): imperative description`
-- **50 characters max** (type + scope + colon + space + description)
+- **Repository maximum: 50 characters** (commitlint currently hard-fails above 120)
 - Language: **English only**
 - Imperative mood ("add", "fix", "remove" — not "added", "fixes", "removing")
 - Lowercase first letter, no trailing period
@@ -266,6 +282,7 @@ When generating commits, detect the active tool and fill in the actual version. 
 | Changed path | Scope |
 |---|---|
 | `src/copilot-shell/` | `cosh` |
+| `src/cosh-ng/` | `cosh-ng` |
 | `src/agent-sec-core/` | `sec-core` |
 | `src/os-skills/` | `skill` |
 | `src/agentsight/` | `sight` |
@@ -312,8 +329,9 @@ Use [`.github/pull_request_template.md`](.github/pull_request_template.md) as th
 
 - **Description**: 2–5 sentences — what changed, why, key implementation decision
 - **Related Issue**: `closes #<n>` or `no-issue: <reason>`
-- **Type / Scope**: check all that apply based on the diff
-- **Testing**: command used, scope (unit/integration/manual), edge cases verified
+- **Risk and compatibility**: explain checked public, privileged, contract, or migration risks
+- **Validation**: commands, environment, scope (unit/integration/manual), and edge cases
+- **Documentation and rollback**: record documentation updates and rollback guidance
 - PR title follows commit message format: `type(scope): description`
 
 ## 9. Documentation Rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,113 +2,214 @@
 
 [中文版](CONTRIBUTING_zh.md)
 
-We welcome contributions! This document covers the basics of contributing to the project.
+This guide describes the repository-wide contribution flow. It covers the
+development entry point and the minimum local checks for every component. Keep
+architecture and component-specific rules in each component's own
+`AGENTS.md`, `README.md`, or `CONTRIBUTING.md`.
 
-> **Done coding?** Ask your AI assistant: *"Read AGENTS.md and help me generate a commit message and PR description."*
+> **Done coding?** Ask your AI assistant to read `AGENTS.md` and help draft the
+> commit message and PR description.
 
-## Development Environment
+Before changing documentation, read
+[`specs/documentation-standard.md`](specs/documentation-standard.md). It is the
+source of truth for file placement, bilingual names, and documentation
+updates.
 
-### Prerequisites
+## Repository at a glance
 
-- **Node.js** >= 20.0.0 (for copilot-shell)
-- **Python** >= 3.12.0 (for os-skills)
-- **Rust** stable toolchain (for Rust components, Linux only where noted)
-- **uv** (Python package manager for os-skills)
-- **clang** & **libbpf** (for compiling agentsight eBPF C code)
+ANOLISA is a monorepo. The twelve components and their supported development
+platforms are listed below. Build names are accepted by `build-all.sh`; commit
+scopes are used in commit subjects and PR titles.
 
-### Getting Started
+| Component | Path | Platform | Build name | Scope | Development entry and minimum local gate |
+| --- | --- | --- | --- | --- | --- |
+| copilot-shell | `src/copilot-shell/` | All platforms | `cosh` | `cosh` | `cd src/copilot-shell`; `make deps`, `make build`, `make lint`, `make test` |
+| cosh-ng | `src/cosh-ng/` | Linux full; macOS limited functionality | `cosh-ng` | `cosh-ng` | `cd src/cosh-ng`; `cargo build --workspace`, `cargo fmt --all -- --check`, then run the closest targeted test described in `src/cosh-ng/CONTRIBUTING.md` |
+| agent-sec-core | `src/agent-sec-core/` | Linux only | `sec-core` | `sec-core` | Python 3.11.6 and `uv`; `make build-all`, `make test` |
+| agentsight | `src/agentsight/` | Linux full eBPF; macOS `trace`/`serve` only | `sight` | `sight` | Linux uses `make build-all`; macOS uses `make build-mac`; Linux runs `make lint`, `make test` |
+| tokenless | `src/tokenless/` | Linux for full development; macOS x64/arm64 for shipped CLI binaries and npm adapters | `tokenless` | `tokenless` | `make build`, `make lint`, `make test` |
+| agent-memory | `src/agent-memory/` | Linux only | `memory` | `memory` | `make build`, `make fmt-check`, `make lint`, `make test`; use `make smoke` for MCP changes |
+| os-skills | `src/os-skills/` | Assets are cross-platform; individual scripts declare limits | `skills` | `skill` | Static Markdown skill definitions and shell assets; `make build` confirms that no compilation step is required |
+| anolisa | `src/anolisa/` | Linux and macOS arm64 | n/a | `anolisa` | `cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked` |
+| SkillFS | `src/skillfs/` | Linux only | n/a | `skillfs` | `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`; run `scripts/test.sh` for FUSE changes |
+| ws-ckpt | `src/ws-ckpt/` | Linux only | `ws-ckpt` | `ckpt` | `make build`, `make test` |
+| ktuner | `src/ktuner/` | Linux only | n/a | `ktuner` | `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` |
+| blaze | `src/blaze/` | Linux only | n/a | `blaze` | `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` |
+
+`tokenless` can publish macOS artifacts, but its binaries are cross-compiled
+from Linux. Do not use a macOS checkout as the tokenless build environment.
+The Linux-only components must be built and tested on Linux. `cosh-ng` and
+`agentsight` have limited macOS paths described in the matrix.
+
+### Toolchain prerequisites
+
+- Node.js 20 or newer for `copilot-shell` and TypeScript adapters.
+- The stable Rust toolchain for Rust components. Follow a component's
+  `AGENTS.md` when it pins a toolchain or adds native libraries.
+- Python **3.11.6** and [uv](https://docs.astral.sh/uv/) for
+  `agent-sec-core`. `os-skills` is primarily static Markdown and shell data;
+  it does not own the repository Python environment.
+- `clang` and `libbpf` headers when changing `agentsight` eBPF probes.
+
+## Fork and create a branch
+
+Fork the repository and clone your fork. Before starting a change, update your
+local `main` from the official repository and create a working branch.
 
 ```bash
-# Clone the repository
-git clone https://github.com/alibaba/anolisa.git
+git clone https://github.com/<your-account>/anolisa.git
 cd anolisa
-
-# Quick build: install deps + build + install to system (recommended)
-./scripts/build-all.sh
-
-# Build selected components only
-./scripts/build-all.sh --component cosh --component sec-core
-
-# Run unified tests
-./tests/run-all-tests.sh
+git remote add upstream https://github.com/alibaba/anolisa.git
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+git switch -c feature/<scope>/<short-desc>
 ```
 
-For a full breakdown of build options and dependency installation, see [docs/BUILDING.md](docs/BUILDING.md).
+You only need to add `upstream` once. For later changes, repeat the final four
+commands with a new branch name. Keep each branch focused on one logical change.
 
-### Package-Specific Development
+Use one of the following names for internal branches:
 
-Each component has its own build workflow:
+```text
+feature/<scope>/<short-desc>
+fix/<scope>/<short-desc>
+hotfix/<scope>/<short-desc>
+release/<scope>/vX.Y
+```
 
-- **copilot-shell**:
-  ```bash
-  cd src/copilot-shell
-  make deps   # npm install + husky hooks
-  make build
-  ```
-  > `make deps` sets up [husky](https://typicode.github.io/husky/) pre-commit hooks that run Prettier and ESLint on staged files. Use `make deps-ci` in CI to skip hook installation.
+Fork branch names are accepted even when they do not match this recommendation;
+the branch check reports a non-blocking warning.
 
-- **os-skills**: `cd src/os-skills` — skill definitions are static assets, no compilation needed
+## Issues and contribution scope
 
-- **agent-sec-core** (Linux only): `cd src/agent-sec-core && make build-sandbox`
+Open or find an issue before implementing a non-trivial feature, behavior
+change, or bug fix. Security vulnerabilities must follow
+[`SECURITY.md`](SECURITY.md) rather than a public issue. A genuinely trivial
+change, such as a typo-only documentation fix, may use
+`no-issue: <brief reason>` in the PR description.
 
-- **agentsight** (Linux only, optional): `cd src/agentsight && make build`
+Keep a PR focused on one logical change. If a change crosses component
+boundaries, explain the contract and test impact in the PR.
 
-- **SkillFS** (Linux only): `cd src/skillfs && cargo build --workspace`
+## Build and test entry points
 
-## Build & Test Commands
+### Unified build
+
+`build-all.sh` supports eight components only:
+
+- Default set: `cosh`, `skills`, `sec-core`, `tokenless`, `ws-ckpt`, `memory`.
+- Optional set: `cosh-ng` and `sight`. Add `--all` or name them with
+  `--component`.
+
+It does not build `anolisa`, `skillfs`, `ktuner`, or `blaze`. Use their
+component gates in the matrix above for those four components.
+
+With no install-mode flag, component files install to the user profile under
+`$HOME/.local` without elevated installation privileges. Dependency bootstrap
+may still request `sudo` for system packages. System installation uses
+`--system` or `--usr` and may require `sudo`. For development, prefer a
+targeted build with installation disabled.
 
 ```bash
-# Unified build (recommended — handles deps, build, and install automatically)
-./scripts/build-all.sh                                        # all default components
-./scripts/build-all.sh --no-install                           # build only, skip system install
-./scripts/build-all.sh --ignore-deps                          # skip dep installation
-./scripts/build-all.sh --component cosh --component sec-core  # selected components
-
-# Unified test runner
-./tests/run-all-tests.sh             # all components
-./tests/run-all-tests.sh --filter shell   # copilot-shell only
-./tests/run-all-tests.sh --filter sec     # agent-sec-core only
-
-# Per-component
-cd src/copilot-shell && make lint && make test
-cd src/agent-sec-core && pytest tests/integration-test/ tests/unit-test/
-cd src/agentsight && cargo test
-cd src/skillfs && cargo test --workspace
+./scripts/build-all.sh --help
+./scripts/build-all.sh --no-install --component cosh
+./scripts/build-all.sh --no-install --component sec-core
+./scripts/build-all.sh --no-install --all
 ```
 
-## Contribution Process
+The main options are:
 
-1. **Open an issue first** - Discuss your proposed change before writing code.
-2. **Fork and branch** - Create a feature branch from `main`.
-3. **Make your changes** - Follow existing code style and conventions.
-4. **Write tests** - Ensure adequate test coverage for your changes.
-5. **Run preflight checks** — lint and test the affected component before submitting:
-   ```bash
-   # copilot-shell
-   cd src/copilot-shell && make lint && make test
-   # agent-sec-core
-   cd src/agent-sec-core && pytest tests/
-   # agentsight
-   cd src/agentsight && cargo clippy -- -D warnings && cargo test
-   # SkillFS
-   cd src/skillfs && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace
-   ```
-6. **Submit a PR** - Link it to the issue and provide a clear description.
+| Option | Effect |
+| --- | --- |
+| `--no-install` | Install dependencies and build, then skip installation. |
+| `--install-mode <mode>` | Select `user` or `system`; `user` is the default. |
+| `--usr`, `--system` | Select system installation mode. |
+| `--ignore-deps` | Skip dependency installation. |
+| `--deps-only` | Install dependencies without building. |
+| `--uninstall` | Remove installed files; combine with `--component` to target a component. |
+| `--dry-run` | Print actions without changing files or systemd state. |
+| `--interactive`, `--non-interactive` | Open the guided flow or explicitly select automation mode. |
+| `--all` | Include optional components `cosh-ng` and `sight`. |
+| `--component <name>` | Build or uninstall one supported component; repeat for multiple components. |
 
-### Commit Messages
+Do not treat `build-all.sh --all` as a build of every `src/<component>/`
+directory. Its scope is limited to the eight names printed by
+`./scripts/build-all.sh --help`.
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+The `sight` selection uses the Linux eBPF build. On macOS, build AgentSight
+locally with `make build-mac` instead.
 
+See [`docs/BUILDING.md`](docs/BUILDING.md) and
+[`docs/BUILDING_zh.md`](docs/BUILDING_zh.md) for the longer dependency and
+packaging reference.
+
+### Convenience test runner
+
+`tests/run-all-tests.sh` is a convenience aggregator for five components:
+`copilot-shell`, `agent-sec-core`, `agentsight`, `tokenless`, and
+`agent-memory`. It accepts these filters:
+
+```bash
+./tests/run-all-tests.sh
+./tests/run-all-tests.sh --filter shell
+./tests/run-all-tests.sh --filter sec
+./tests/run-all-tests.sh --filter sight
+./tests/run-all-tests.sh --filter tokenless
+./tests/run-all-tests.sh --filter memory
 ```
-feat(cosh): add --json flag to config command
-fix(sec-core): handle sandbox escape edge case
-docs(docs): update installation guide
+
+The runner may skip a component when `uv`, `cargo`, Linux, or the installed
+`linux-sandbox` binary is unavailable, and it can still print a successful
+summary. A successful run therefore does not prove that the repository or
+even every selected test suite passed. Use the affected-component gate from
+the matrix above as the PR acceptance check.
+
+## Local gates by component
+
+Run the applicable formatter, linter, tests, and any component-specific smoke
+test for every component touched by the PR. The root guide intentionally keeps
+the matrix small; read the scoped `AGENTS.md` before changing component
+architecture, security behavior, FUSE code, or protocol contracts.
+
+The common baseline for Rust code changes is:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 ```
 
-**scope is mandatory** and must be one of the following:
+Public Rust API or rustdoc changes also require
+`cargo doc --workspace --no-deps`. Documentation-only changes use the
+repository documentation checks and do not require Cargo validation unless a
+component guide says otherwise.
 
-| Scope | Covers |
-|-------|--------|
+Apply the component-specific commands in the repository matrix. For
+`agent-sec-core`, use `uv` and Python 3.11.6 for Python tests; the version
+command must report 3.11.6. For
+`agentsight`, include frontend or eBPF smoke checks when those areas change.
+For `agent-memory`, MCP changes require `make smoke`; for `SkillFS`,
+filesystem-layer changes require `scripts/test.sh` when FUSE is available.
+CI adds coverage, packaging, frontend, adapter, and integration jobs according
+to the changed paths. Check [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml)
+when changing generated packages or framework adapters.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) with an
+English, imperative subject in this form:
+
+```text
+type(scope): imperative description
+```
+
+The scope is mandatory. Commitlint rejects an empty scope. The following
+values are the repository's recommended scopes; an unlisted scope produces a
+warning and should be justified or replaced before review.
+
+| Scope | Path or purpose |
+| --- | --- |
 | `cosh` | `src/copilot-shell/` |
 | `cosh-ng` | `src/cosh-ng/` |
 | `sec-core` | `src/agent-sec-core/` |
@@ -121,58 +222,88 @@ docs(docs): update installation guide
 | `skillfs` | `src/skillfs/` |
 | `ktuner` | `src/ktuner/` |
 | `blaze` | `src/blaze/` |
-| `ci` | `.github/workflows/` |
-| `docs` | `docs/` or documentation updates |
-| `deps` | Dependency version bumps (lock files) |
-| `chore` | Other maintenance (config, scripts, tooling) |
+| `deps` | Dependency changes, including lockfiles. |
+| `ci` | `.github/workflows/` and CI configuration. |
+| `docs` | Documentation-only changes. |
+| `chore` | Root scripts, tooling, and other maintenance. |
 
-If **Commit Message Lint** rejects an existing commit, update the message and
-publish the rewritten branch safely:
+Repository convention limits the full subject to 50 characters; commitlint
+currently enforces a hard ceiling of 120 characters. Start the description
+with lowercase, and omit a trailing period. Fold tests and formatting fixes
+into the logical commit when possible. Every commit must carry a
+`Signed-off-by` trailer using the contributor's own Git identity:
 
 ```bash
-# Update the latest commit.
+git commit -s -m 'docs(docs): refresh contribution guide'
+```
+
+If **Commit Message Lint** rejects the latest commit, update its message and
+push the rewritten branch safely.
+
+```bash
 git commit --amend
 git push --force-with-lease
+```
 
-# Update one of the last N commits: select "reword" for the target commit.
+For an older commit, select `reword` in an interactive rebase.
+
+```bash
 git rebase -i HEAD~N
 git push --force-with-lease
 ```
 
-Do not use plain `git push --force`; `--force-with-lease` refuses to overwrite
-remote work that you have not seen.
+Do not use plain `git push --force`. The lease prevents overwriting remote work
+that is not present in your local checkout.
 
-### Branch Naming
+Use `git commit --fixup=<commit>` followed by an autosquash rebase when fixing
+a defect introduced earlier in the same PR. A fix for code already on `main`
+uses a standalone commit with a `Fixes:` reference to the introducing commit.
+An enhancement to a feature already on `main` uses `Supplements:`. Keep a
+component version bump as the final commit in its feature branch and update
+all version-bearing files atomically.
 
-Internal contributors should follow this convention:
+## Pull requests and CI
 
-```
-feature/<scope>/<short-desc>    e.g. feature/cosh/json-output
-fix/<scope>/<short-desc>        e.g. fix/sec-core/sandbox-escape
-hotfix/<scope>/<short-desc>     e.g. hotfix/skill/broken-load
-```
+Start the PR from [`.github/pull_request_template.md`](.github/pull_request_template.md)
+and keep its sections intact. The description should cover the reason for the
+change, what changed, related issue or `no-issue` reason, user or agent impact,
+risk and compatibility, validation commands and environment, and documentation
+or rollback notes.
 
-**Fork contributors**: branch naming is free — CI will only issue a suggestion, not block your PR.
+Use `closes #<number>`, `fixes #<number>`, or `resolves #<number>` when an issue
+exists. The PR title follows `type(scope): description`. The prelint workflow
+reports title, branch, issue-link, and unlisted-scope problems as warnings.
+Commitlint errors, including an empty scope, invalid Conventional Commit
+syntax, or a subject over 120 characters, block the prelint job.
 
-### CI Checks Explained
+Before requesting review, confirm that:
 
-When you open a PR, the following checks run automatically:
+- The affected component gate passes on its supported platform.
+- New or changed behavior has tests, or the PR explains why a test is not
+  applicable.
+- The PR template records risk, compatibility, and rollback considerations.
+- Documentation and bilingual counterparts are updated when required.
 
-| Check | Level | How to fix |
-|-------|-------|------------|
-| Commit scope missing | **Error** (blocks merge) | Add `(scope)` to every commit message, e.g. `fix(cosh): ...` |
-| Commit scope not in allowed list | Warning | Use one of the scopes in the table above |
-| PR title format | Warning | Follow `type(scope): description` — same as commit messages |
-| Branch name convention | Warning | Follow `feature/<scope>/<desc>` — not required for forks |
-| PR not linked to an issue | Warning | Add `closes #<n>` to your PR description, or `no-issue: <reason>` |
-| CI tests fail | **Error** (blocks merge) | Fix the failing tests before requesting review |
+## Documentation synchronization
 
-## Code Style
+Documentation changes must follow
+[`specs/documentation-standard.md`](specs/documentation-standard.md) and keep
+English and Chinese pages semantically equivalent. Command examples remain
+identical in both languages. The root guide stays a cross-component overview;
+long usage and architecture material belongs in the canonical locations below.
 
-- **TypeScript**: ESLint + Prettier (configured in copilot-shell)
-- **Python**: Ruff + Black (configured in os-skills)
-- **Rust**: `cargo fmt` + `cargo clippy`
+| Change | Update in the same PR |
+| --- | --- |
+| CLI command or flag | Component `README.md` and the relevant `docs/user-guide/` page. |
+| Configuration option | Component `README.md` and the relevant `docs/user-guide/` page. |
+| Installation method | `docs/QUICKSTART*.md` and the component README. |
+| Architecture or protocol | `src/<component>/docs/design/`. |
+| New component | Root README and `NOTICE` when applicable. |
+
+Daily feature and fix PRs update README and user-guide pages. Release version
+bump PRs aggregate user-perceivable entries into `CHANGELOG*.md`.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
+By contributing, you agree that your contributions are licensed under the
+Apache License 2.0.

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -1,113 +1,172 @@
-# 贡献指南
+# ANOLISA 贡献指南
 
 [English](CONTRIBUTING.md)
 
-欢迎参与贡献！本文档介绍参与项目的基本流程。
+本文档说明仓库级贡献流程，覆盖各组件的开发入口和最低本地检查要求。架构说明及组件专属规则继续放在组件自己的 `AGENTS.md`、`README.md` 或 `CONTRIBUTING.md` 中。
 
-> **写完代码了？** 让你的 AI 助手帮忙：*「读一下 AGENTS.md，帮我生成 commit message 和 PR 描述。」*
+> **完成修改后？** 可以请 AI assistant 阅读 `AGENTS.md`，并协助起草 commit
+> message 和 PR 描述。
 
-## 开发环境
+修改文档前请先阅读
+[`specs/documentation-standard.md`](specs/documentation-standard.md)。该文件是文件位置、双语命名和文档同步要求的唯一规范来源。
 
-### 前置依赖
+## 仓库概览
 
-- **Node.js** >= 20.0.0（copilot-shell）
-- **Python** >= 3.12.0（os-skills）
-- **Rust** stable 工具链（Rust 组件，部分仅限 Linux）
-- **uv**（os-skills 的 Python 包管理器）
-- **clang** & **libbpf**（编译 agentsight eBPF C 代码）
+ANOLISA 是一个 monorepo。下表列出十二个组件及其支持的开发平台。构建名称供
+`build-all.sh` 使用，scope 用于 commit subject 和 PR title。
 
-### 快速开始
+| 组件 | 路径 | 平台 | 构建名称 | Scope | 开发入口和最低本地门禁 |
+| --- | --- | --- | --- | --- | --- |
+| copilot-shell | `src/copilot-shell/` | 所有平台 | `cosh` | `cosh` | `cd src/copilot-shell`；`make deps`、`make build`、`make lint`、`make test` |
+| cosh-ng | `src/cosh-ng/` | Linux 完整功能；macOS 功能受限 | `cosh-ng` | `cosh-ng` | `cd src/cosh-ng`; `cargo build --workspace`、`cargo fmt --all -- --check`，随后按 `src/cosh-ng/CONTRIBUTING_zh.md` 选择最接近改动的测试 |
+| agent-sec-core | `src/agent-sec-core/` | 仅 Linux | `sec-core` | `sec-core` | Python 3.11.6 和 `uv`; `make build-all`、`make test` |
+| agentsight | `src/agentsight/` | Linux 完整 eBPF；macOS 仅 `trace`/`serve` | `sight` | `sight` | Linux 使用 `make build-all`；macOS 使用 `make build-mac`；Linux 运行 `make lint`、`make test` |
+| tokenless | `src/tokenless/` | 完整开发在 Linux；发布的 CLI 二进制和 npm adapter 支持 macOS x64/arm64 | `tokenless` | `tokenless` | `make build`、`make lint`、`make test` |
+| agent-memory | `src/agent-memory/` | 仅 Linux | `memory` | `memory` | `make build`、`make fmt-check`、`make lint`、`make test`；MCP 改动追加 `make smoke` |
+| os-skills | `src/os-skills/` | 资源跨平台；单个脚本自行声明限制 | `skills` | `skill` | 静态 Markdown skill 定义和 shell 资源；`make build` 用于确认没有编译步骤 |
+| anolisa | `src/anolisa/` | Linux 和 macOS arm64 | 不适用 | `anolisa` | `cargo fmt --all --check`、`cargo clippy --all-targets --locked -- -D warnings`、`cargo test --locked` |
+| SkillFS | `src/skillfs/` | 仅 Linux | 不适用 | `skillfs` | `cargo fmt --all --check`、`cargo clippy --workspace --all-targets -- -D warnings`、`cargo test --workspace`；修改 FUSE 时运行 `scripts/test.sh` |
+| ws-ckpt | `src/ws-ckpt/` | 仅 Linux | `ws-ckpt` | `ckpt` | `make build`、`make test` |
+| ktuner | `src/ktuner/` | 仅 Linux | 不适用 | `ktuner` | `cargo fmt --all --check`、`cargo clippy --all-targets -- -D warnings`、`cargo test` |
+| blaze | `src/blaze/` | 仅 Linux | 不适用 | `blaze` | `cargo fmt --all --check`、`cargo clippy --workspace --all-targets -- -D warnings`、`cargo test --workspace` |
+
+`tokenless` 可以发布 macOS 产物，但其二进制需要从 Linux 交叉编译。不要把 macOS checkout 当作 tokenless 的构建环境。标为 Linux 的组件都必须在 Linux 上构建和测试。`cosh-ng` 和 `agentsight` 的 macOS 受限路径见上表。
+
+### 工具链前置条件
+
+- `copilot-shell` 和 TypeScript adapter 需要 Node.js 20 或更高版本。
+- Rust 组件需要 stable Rust 工具链。若组件固定了工具链版本或增加了原生库，请遵循对应的 `AGENTS.md`。
+- `agent-sec-core` 使用 Python **3.11.6** 和 [uv](https://docs.astral.sh/uv/)。`os-skills` 主要由静态 Markdown 和 shell 资源组成，不负责仓库的 Python 环境。
+- 修改 `agentsight` eBPF probe 时需要 `clang` 和 `libbpf` 头文件。
+
+## Fork 并创建分支
+
+先在 GitHub 上 fork 本仓库，再克隆自己的 fork。开始修改前，从官方仓库更新
+本地 `main`，然后创建一个工作分支。
 
 ```bash
-# 克隆仓库
-git clone https://github.com/alibaba/anolisa.git
+git clone https://github.com/<your-account>/anolisa.git
 cd anolisa
-
-# 一键构建：安装依赖 + 构建 + 安装到系统（推荐）
-./scripts/build-all.sh
-
-# 仅构建选定组件
-./scripts/build-all.sh --component cosh --component sec-core
-
-# 运行统一测试
-./tests/run-all-tests.sh
+git remote add upstream https://github.com/alibaba/anolisa.git
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+git switch -c feature/<scope>/<short-desc>
 ```
 
-完整的构建选项和依赖安装说明，请参阅 [docs/BUILDING_zh.md](docs/BUILDING_zh.md)。
+`upstream` 只需添加一次。后续修改时，换一个新的分支名并重复最后四条命令。
+每个分支只包含一项逻辑变更。
 
-### 组件独立开发
+内部贡献建议使用以下分支名。
 
-每个组件有自己的构建流程：
+```text
+feature/<scope>/<short-desc>
+fix/<scope>/<short-desc>
+hotfix/<scope>/<short-desc>
+release/<scope>/vX.Y
+```
 
-- **copilot-shell**：
-  ```bash
-  cd src/copilot-shell
-  make deps   # npm install + husky hooks
-  make build
-  ```
+Fork 贡献者可以使用其他分支名，分支检查只会给出非阻塞警告。
 
-- **os-skills**：`cd src/os-skills` — Skill 定义是静态资源，无需编译
+## Issue 和贡献范围
 
-- **agent-sec-core**（仅 Linux）：`cd src/agent-sec-core && make build-sandbox`
+实现非简单功能、行为变更或缺陷修复前，请先创建或找到对应 Issue。安全漏洞应按照 [`SECURITY.md`](SECURITY.md) 的流程处理，不要公开创建 Issue。纯拼写修正等确实简单的改动，可以在 PR 描述中写 `no-issue: <brief reason>`。
 
-- **agentsight**（仅 Linux，可选）：`cd src/agentsight && make build`
+每个 PR 聚焦一项逻辑变更。若修改跨越多个组件，请在 PR 中说明契约变化和测试影响。
 
-- **SkillFS**（仅 Linux）：`cd src/skillfs && cargo build --workspace`
+## 构建和测试入口
 
-## 构建与测试命令
+### 统一构建
+
+`build-all.sh` 目前只支持八个组件。
+
+- 默认集合为 `cosh`、`skills`、`sec-core`、`tokenless`、`ws-ckpt`、`memory`。
+- 可选集合为 `cosh-ng` 和 `sight`。使用 `--all` 或通过 `--component` 指定它们。
+
+它不会构建 `anolisa`、`skillfs`、`ktuner` 或 `blaze`。这四个组件请使用上方矩阵中的组件门禁。
+
+不指定安装模式时，组件文件会安装到用户目录 `$HOME/.local`，这一步不需要提权。
+依赖引导仍可能为了安装系统包请求 `sudo`。使用 `--system` 或 `--usr` 会采用系统
+安装模式，通常需要 `sudo`。开发时建议指定组件并关闭安装。
 
 ```bash
-# 统一构建（推荐——自动处理依赖、构建和安装）
-./scripts/build-all.sh                                        # 所有默认组件
-./scripts/build-all.sh --no-install                           # 仅构建，跳过安装
-./scripts/build-all.sh --ignore-deps                          # 跳过依赖安装
-./scripts/build-all.sh --component cosh --component sec-core  # 选定组件
-
-# 统一测试
-./tests/run-all-tests.sh             # 所有组件
-./tests/run-all-tests.sh --filter shell   # 仅 copilot-shell
-./tests/run-all-tests.sh --filter sec     # 仅 agent-sec-core
-
-# 单组件
-cd src/copilot-shell && make lint && make test
-cd src/agent-sec-core && pytest tests/integration-test/ tests/unit-test/
-cd src/agentsight && cargo test
-cd src/skillfs && cargo test --workspace
+./scripts/build-all.sh --help
+./scripts/build-all.sh --no-install --component cosh
+./scripts/build-all.sh --no-install --component sec-core
+./scripts/build-all.sh --no-install --all
 ```
 
-## 贡献流程
+主要选项如下。
 
-1. **先开 Issue** — 在写代码前讨论你的方案。
-2. **Fork 并创建分支** — 基于 `main` 创建功能分支。
-3. **编写代码** — 遵循已有代码风格和规范。
-4. **编写测试** — 确保变更有充分的测试覆盖。
-5. **运行预检** — 提交前对受影响的组件进行 lint 和测试：
-   ```bash
-   # copilot-shell
-   cd src/copilot-shell && make lint && make test
-   # agent-sec-core
-   cd src/agent-sec-core && pytest tests/
-   # agentsight
-   cd src/agentsight && cargo clippy -- -D warnings && cargo test
-   # SkillFS
-   cd src/skillfs && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace
-   ```
-6. **提交 PR** — 关联 Issue 并提供清晰的描述。
+| 选项 | 作用 |
+| --- | --- |
+| `--no-install` | 安装依赖并构建，随后跳过安装。 |
+| `--install-mode <mode>` | 选择 `user` 或 `system`，默认是 `user`。 |
+| `--usr`、`--system` | 选择系统安装模式。 |
+| `--ignore-deps` | 跳过依赖安装。 |
+| `--deps-only` | 只安装依赖，不构建。 |
+| `--uninstall` | 删除已安装文件；与 `--component` 一起使用可限定组件。 |
+| `--dry-run` | 只打印动作，不修改文件或 systemd 状态。 |
+| `--interactive`、`--non-interactive` | 打开引导流程，或明确选择自动化模式。 |
+| `--all` | 纳入可选组件 `cosh-ng` 和 `sight`。 |
+| `--component <name>` | 构建或卸载一个受支持的组件，可以重复指定。 |
 
-### Commit 规范
+不要把 `build-all.sh --all` 理解成构建每个 `src/<component>/` 目录。它的范围只包括 `./scripts/build-all.sh --help` 打印的八个名称。
 
-遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
+`sight` 选项使用 Linux eBPF 构建。macOS 应在组件目录运行 `make build-mac`。
 
+更完整的依赖和打包说明请阅读 [`docs/BUILDING.md`](docs/BUILDING.md) 与 [`docs/BUILDING_zh.md`](docs/BUILDING_zh.md)。
+
+### 便捷测试脚本
+
+`tests/run-all-tests.sh` 是五个组件的便捷聚合入口，覆盖 `copilot-shell`、`agent-sec-core`、`agentsight`、`tokenless` 和 `agent-memory`。它支持以下过滤器。
+
+```bash
+./tests/run-all-tests.sh
+./tests/run-all-tests.sh --filter shell
+./tests/run-all-tests.sh --filter sec
+./tests/run-all-tests.sh --filter sight
+./tests/run-all-tests.sh --filter tokenless
+./tests/run-all-tests.sh --filter memory
 ```
-feat(cosh): add --json flag to config command
-fix(sec-core): handle sandbox escape edge case
-docs(docs): update installation guide
+
+当缺少 `uv`、`cargo`、Linux 环境或已安装的 `linux-sandbox` 二进制时，脚本可能跳过组件，并仍然打印成功汇总。因此脚本成功并不能证明整个仓库，甚至不能证明每个选中的测试套件都通过。PR 验收请使用上方矩阵中的受影响组件门禁。
+
+## 各组件本地门禁
+
+PR 涉及的每个组件都要运行适用的格式检查、lint、测试以及组件专属 smoke test。
+根指南只保留简短矩阵，修改组件架构、安全行为、FUSE 代码或协议契约前请阅读
+对应范围的 `AGENTS.md`。
+
+Rust 代码变更的通用基线如下。
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 ```
 
-**scope 是必填项**，必须为以下之一：
+修改 Rust 公共 API 或 rustdoc 时，再运行 `cargo doc --workspace --no-deps`。纯文档
+变更使用仓库文档检查，组件指南没有额外要求时无需运行 Cargo 验证。
 
-| Scope | 覆盖范围 |
-|-------|---------|
+请按仓库矩阵执行组件专属命令。`agent-sec-core` 的 Python 测试使用 `uv` 和 Python 3.11.6，版本命令必须报告 3.11.6。修改 `agentsight` 前端或 eBPF 时，补充对应的构建或 smoke 检查。`agent-memory` 的 MCP 改动需要 `make smoke`；`SkillFS` 的文件系统层改动在 FUSE 可用时需要 `scripts/test.sh`。
+
+CI 会根据变更路径追加 coverage、打包、前端、adapter 和集成任务。修改生成包或框架
+adapter 时请查看 [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml)。
+
+## Commit 规范
+
+使用 [Conventional Commits](https://www.conventionalcommits.org/)，subject 使用英文祈使句，格式如下。
+
+```text
+type(scope): imperative description
+```
+
+scope 必填。Commitlint 会拒绝空 scope。下表列出仓库推荐使用的 scope。使用表外
+scope 会产生警告，发起 review 前应说明理由或改用推荐值。
+
+| Scope | 路径或用途 |
+| --- | --- |
 | `cosh` | `src/copilot-shell/` |
 | `cosh-ng` | `src/cosh-ng/` |
 | `sec-core` | `src/agent-sec-core/` |
@@ -120,56 +179,74 @@ docs(docs): update installation guide
 | `skillfs` | `src/skillfs/` |
 | `ktuner` | `src/ktuner/` |
 | `blaze` | `src/blaze/` |
-| `ci` | `.github/workflows/` |
-| `docs` | `docs/` 或文档更新 |
-| `deps` | 依赖版本升级（lock 文件） |
-| `chore` | 其他维护（配置、脚本、工具） |
+| `deps` | 依赖变更，包括 lockfile。 |
+| `ci` | `.github/workflows/` 和 CI 配置。 |
+| `docs` | 纯文档变更。 |
+| `chore` | 根目录脚本、工具和其他维护工作。 |
 
-如果 **Commit Message Lint** 拒绝已有提交，请修改 commit message，并安全地
-推送改写后的分支：
+仓库规范要求完整 subject 不超过 50 个字符，commitlint 当前的硬限制是 120 个字符。
+description 以小写开头，不要以句号结尾。测试和格式修正应尽量合并到对应的逻辑
+commit。每个 commit 都必须使用贡献者自己的 Git identity 添加 `Signed-off-by`
+trailer。
 
 ```bash
-# 修改最新提交。
+git commit -s -m 'docs(docs): refresh contribution guide'
+```
+
+如果 **Commit Message Lint** 拒绝最新的 commit，请修改 message，并安全推送改写
+后的分支。
+
+```bash
 git commit --amend
 git push --force-with-lease
+```
 
-# 修改最近 N 个提交中的一个：将目标 commit 标记为 "reword"。
+如果需要修改更早的 commit，请在交互式 rebase 中选择 `reword`。
+
+```bash
 git rebase -i HEAD~N
 git push --force-with-lease
 ```
 
-不要使用普通的 `git push --force`；`--force-with-lease` 会在远端出现本地未知
-提交时拒绝覆盖。
+不要使用普通的 `git push --force`。lease 会防止覆盖本地 checkout 中不存在的
+远端改动。
 
-### 分支命名
+若缺陷由同一 PR 中较早的 commit 引入，请使用 `git commit --fixup=<commit>`，随后
+执行 autosquash rebase。修复已经进入 `main` 的代码时，应创建独立 commit，并用
+`Fixes:` 指向引入缺陷的 commit。补充已经进入 `main` 的功能时使用 `Supplements:`。
+组件版本升级应放在功能分支的最后一个 commit，并在同一 commit 中原子更新所有带
+版本号的文件。
 
-内部贡献者请遵循以下约定：
+## Pull Request 和 CI
 
-```
-feature/<scope>/<short-desc>    例如 feature/cosh/json-output
-fix/<scope>/<short-desc>        例如 fix/sec-core/sandbox-escape
-hotfix/<scope>/<short-desc>     例如 hotfix/skill/broken-load
-```
+请以 [`.github/pull_request_template.md`](.github/pull_request_template.md) 为 PR 描述起点，并保留其中的章节。描述需要说明变更原因、具体内容、关联 Issue 或 `no-issue` 原因、用户或 Agent 影响、风险与兼容性、验证命令和环境，以及文档或回滚说明。
 
-**Fork 贡献者**：分支命名不作限制——CI 只会给出建议，不会阻止你的 PR。
+有关联 Issue 时使用 `closes #<number>`、`fixes #<number>` 或 `resolves #<number>`。
+PR title 使用 `type(scope): description`。prelint workflow 会把标题、分支、Issue
+链接和表外 scope 作为警告。空 scope、不符合 Conventional Commits 语法或超过
+120 个字符等 commitlint 错误会阻止 prelint job。
 
-### CI 检查说明
+发起 review 前确认以下事项。
 
-| 检查项 | 级别 | 修复方法 |
-|--------|------|---------|
-| Commit scope 缺失 | **错误**（阻止合并） | 给每个 commit message 加 `(scope)`，如 `fix(cosh): ...` |
-| Commit scope 不在允许列表 | 警告 | 使用上方列表中的 scope |
-| PR 标题格式 | 警告 | 遵循 `type(scope): description` 格式 |
-| 分支名不符合约定 | 警告 | 遵循 `feature/<scope>/<desc>`——Fork 不要求 |
-| PR 未关联 Issue | 警告 | 在 PR 描述中添加 `closes #<n>` 或 `no-issue: <reason>` |
-| CI 测试失败 | **错误**（阻止合并） | 在请求 review 前修复失败的测试 |
+- 受影响组件在支持的平台上通过了组件门禁。
+- 新行为或变更行为有测试，或者 PR 解释了无法测试的原因。
+- PR 模板记录了风险、兼容性和回滚考虑。
+- 需要同步的文档和双语对应文件都已更新。
 
-## 代码风格
+## 文档同步
 
-- **TypeScript**：ESLint + Prettier（配置在 copilot-shell）
-- **Python**：Ruff + Black（配置在 os-skills）
-- **Rust**：`cargo fmt` + `cargo clippy`
+文档变更必须遵循 [`specs/documentation-standard.md`](specs/documentation-standard.md)，并保持中英文页面语义等价。两种语言中的命令示例必须完全相同。根指南只做跨组件总览，完整用法和架构内容放在以下规范位置。
+
+| 变更 | 同一 PR 中需要更新 |
+| --- | --- |
+| CLI 命令或 flag | 组件 `README.md` 和对应的 `docs/user-guide/` 页面。 |
+| 配置选项 | 组件 `README.md` 和对应的 `docs/user-guide/` 页面。 |
+| 安装方式 | `docs/QUICKSTART*.md` 和组件 README。 |
+| 架构或协议 | `src/<component>/docs/design/`。 |
+| 新增组件 | 根 README，必要时更新 `NOTICE`。 |
+
+日常功能和修复 PR 更新 README 与 user-guide 页面。发布版本 bump PR 再把面向用户的变更汇总到 `CHANGELOG*.md`。
 
 ## 许可证
 
-参与贡献即表示你同意你的贡献将以 Apache License 2.0 进行许可。
+参与贡献即表示你同意贡献内容采用 Apache License 2.0 许可。

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,449 +2,198 @@
 
 [中文版](BUILDING_zh.md)
 
-This guide describes how to prepare the development environment, build each component from source, and run tests.
+This guide is for contributors working from an ANOLISA checkout. It describes
+the repository-wide build entry point, the boundary of the aggregate test
+runner, and the local build and test commands for all twelve components. A
+component README remains the source for component-specific dependencies and
+runtime setup.
 
-Two paths are provided:
-
-1. Quick Start: run one script to check/install dependencies and build selected components.
-2. Component-by-Component: build each module manually.
-
-## 1. Repository Layout
-
-```text
-anolisa/
-├── src/
-│   ├── copilot-shell/       # AI terminal assistant (Node.js / TypeScript)
-│   ├── os-skills/           # Ops skills (Markdown + optional scripts)
-│   ├── agent-sec-core/      # Agent security sandbox (Rust + Python)
-│   ├── agentsight/          # eBPF observability/audit agent (Rust, optional)
-│   └── agent-memory/        # MCP filesystem memory server (Rust, Linux only)
-├── scripts/
-│   ├── build-all.sh         # Unified build entry
-│   └── rpm-build.sh         # Unified RPM build script
-├── tests/
-│   └── run-all-tests.sh     # Unified test entry
-├── Makefile
-└── docs/
-```
-
-## 2. Environment Dependencies
-
-| Component | Required Tools |
-|-----------|----------------|
-| copilot-shell | Node.js >= 20, npm >= 10, make, g++ |
-| os-skills | Python >= 3.12 (only for optional scripts) |
-| agent-sec-core | Rust >= 1.91.0, Python >= 3.12, uv (Linux only) |
-| agentsight *(optional)* | Rust >= 1.80, clang >= 14, libbpf headers, kernel headers (Linux only) |
-| agent-memory | Rust >= 1.85, cargo, cmake, libsystemd headers (Linux only) |
-
-## 3. Quick Start
-
-The unified build script handles dependency installation, building, and system installation automatically.
+## 1. Prepare a checkout
 
 ```bash
 git clone https://github.com/alibaba/anolisa.git
 cd anolisa
 ```
 
-Then run the build script. By default it installs dependencies, builds, and installs to the system:
+The common prerequisites are Git, Bash, `make`, a C compiler for native Rust
+or Python extensions, and a working network connection for package downloads.
+Platform-specific requirements are listed in the component matrix below. The
+repository does not define one global Rust version. Use the `rust-toolchain.toml`
+or `rust-version` declared by the component you are changing.
 
-> **Tip:** Each option below is a standalone command — just pick the one that fits your use case. If you use the unified script, you can skip the [Component-by-Component Build](#4-component-by-component-build) section below entirely.
+## 2. Repository layout
+
+The `src/` tree currently contains these twelve components:
+
+| Component | Directory | Platform and role |
+|-----------|-----------|-------------------|
+| copilot-shell (`cosh`) | [`src/copilot-shell`](../src/copilot-shell/README.md) | TypeScript terminal assistant; Linux, macOS, and Windows |
+| cosh-ng | [`src/cosh-ng`](../src/cosh-ng/README.md) | Rust Agent OS CLI and shell; full Linux build, limited macOS source build |
+| agent-sec-core | [`src/agent-sec-core`](../src/agent-sec-core/README.md) | Rust sandbox plus Python security CLI; Linux |
+| agentsight | [`src/agentsight`](../src/agentsight/README.md) | Rust/eBPF observability; full tracing on Linux, `trace` and `serve` on macOS |
+| tokenless | [`src/tokenless`](../src/tokenless/README.md) | Rust token and command-output optimization; Linux source build, with cross-compiled npm artifacts for macOS |
+| agent-memory (`memory`) | [`src/agent-memory`](../src/agent-memory/README.md) | Rust MCP memory server; Linux |
+| os-skills (`skills`) | [`src/os-skills`](../src/os-skills/README.md) | Static skill definitions and scripts; all platforms supported by each skill |
+| anolisa | [`src/anolisa`](../src/anolisa/README.md) | Rust component lifecycle CLI; Linux and macOS arm64 |
+| SkillFS (`skillfs`) | [`src/skillfs`](../src/skillfs/README.md) | Rust FUSE skill filesystem; Linux |
+| ws-ckpt | [`src/ws-ckpt`](../src/ws-ckpt/README.md) | Rust workspace checkpoint daemon and TypeScript adapters; Linux system service |
+| ktuner | [`src/ktuner`](../src/ktuner/README.md) | Rust kernel-tuning engine; Linux |
+| blaze | [`src/blaze`](../src/blaze/README.md) | Rust per-host sandbox orchestrator; Linux |
+
+The repository-level instructions are in [`AGENTS.md`](../AGENTS.md). Read a
+component's `AGENTS.md` before changing that component and use its README for
+architecture and runtime details.
+
+## 3. Toolchains and native dependencies
+
+The build script can install common dependencies on supported Linux
+distributions, but it cannot make an unsupported platform build a Linux-only
+component.
+
+| Need | Source of truth |
+|------|-----------------|
+| Node.js | `src/copilot-shell/package.json` requires Node.js `>=20.0.0`; npm is also used by the agentsight, agent-sec-core, tokenless, and ws-ckpt plugin builds. |
+| Python and uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` requires Python `==3.11.6`; use `uv` for that project. Do not replace this with a repository-wide Python minimum. |
+| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` pins `1.93.0`; `src/anolisa/rust-toolchain.toml` and `src/blaze/rust-toolchain.toml` pin `1.88.0`; `src/cosh-ng/rust-toolchain.toml` follows `stable`. Other components use the `rust-version` in their `Cargo.toml` when one is declared. |
+| cosh-ng | Linux source builds need `pkg-config` and OpenSSL development files. |
+| agent-sec-core | Linux sandbox runtime and integration checks may need bubblewrap, GnuPG, and `jq`. |
+| agentsight | Linux eBPF builds need clang, LLVM, libbpf and ELF development headers, kernel headers, and a BTF-enabled kernel. `make build-mac` builds the macOS local viewer without eBPF. |
+| tokenless | `just` is used to fetch and patch RTK; npm is needed for the OpenClaw plugin. |
+| agent-memory | Linux builds need CMake and libsystemd development headers. |
+| SkillFS | FUSE 3 and `/dev/fuse` are needed for the smoke test; ordinary Cargo tests do not mount FUSE. |
+| ws-ckpt | Installing the daemon requires Linux systemd and root privileges. Its user-mode Makefile target intentionally does not install the service. |
+
+When a component has a pinned toolchain, run its commands from that component
+directory so rustup can select the pin automatically. For an unpinned
+component, check its `Cargo.toml` and the installed stable toolchain before
+building.
+
+## 4. Unified build script
+
+`scripts/build-all.sh` is a convenience entry point, not a complete monorepo
+builder. It currently knows eight components:
+
+- Default six: `cosh`, `skills`, `sec-core`, `tokenless`, `ws-ckpt`, and
+  `memory`.
+- Optional two: `cosh-ng` and `sight`. Add `--all` or select them with
+  `--component`.
+
+The four components outside this script are `anolisa`, `skillfs`, `ktuner`, and
+`blaze`; build those with their local commands in section 5.
+
+The default install profile is user mode. Component files install under
+`~/.local` and user-scoped Copilot Shell directories without `sudo`. Initial
+system dependency installation may still request `sudo`. Use `--system` (or
+`--install-mode system`) for system paths; the script stages files and may
+invoke `sudo`. `--no-install` builds and stages artifacts without installing
+them.
 
 ```bash
-# Default: install deps + build + install to system (recommended for most users)
+# Default six components, user install
 ./scripts/build-all.sh
 
-# Build only, skip system install
+# Build and stage without installing
 ./scripts/build-all.sh --no-install
 
-# Skip dependency installation (deps already present)
+# Use system paths instead of the default user profile
+./scripts/build-all.sh --system
+
+# Include cosh-ng and agentsight as well
+./scripts/build-all.sh --all
+
+# Select one or more of the eight supported names
+./scripts/build-all.sh --component cosh --component sec-core
+./scripts/build-all.sh --component cosh-ng --component sight
+
+# Reuse already-installed dependencies
 ./scripts/build-all.sh --ignore-deps
 
-# Install dependencies only (useful for CI or manual builds)
+# Install dependencies only, or print the plan without changing the system
 ./scripts/build-all.sh --deps-only
+./scripts/build-all.sh --dry-run
 
-# Build and install selected components only
-./scripts/build-all.sh --component cosh --component sec-core
-
-# Include optional agentsight
-./scripts/build-all.sh --component cosh --component skills --component sec-core --component sight
+# Explicit non-interactive mode and help
+./scripts/build-all.sh --non-interactive
+./scripts/build-all.sh --help
 ```
 
-### 3.1 Script Options
-
-| Flag | Description |
-|------|-------------|
-| --no-install | Skip installing built components to system paths |
-| --ignore-deps | Skip dependency installation |
-| --deps-only | Install dependencies only, do not build |
-| --component <name> | Build selected component(s), repeatable: cosh, skills, sec-core, sight. Default: cosh, skills, sec-core |
-| --help | Show help |
-
-### 3.2 Important Notes
-
-1. The build script tries system packages first and falls back to upstream installers (nvm / rustup) when system versions don't meet requirements.
-2. os-skills are mostly static assets and do not require compilation.
-3. AgentSight is an optional component that provides audit and observability capabilities but is not required for core functionality. It is excluded from default builds; use `--component sight` to include it explicitly.
-4. AgentSight system dependencies (clang/llvm/libbpf/kernel headers) should be installed through your distro package manager.
-5. **Sandbox policy hooks are not enabled automatically.** After installation, run `/hooks install` inside Copilot Shell once to activate the built-in sandbox-guard hooks. See [3.3 Post-Installation: Enable Sandbox Hooks](#33-post-installation-enable-sandbox-hooks) below.
-
-### 3.3 Post-Installation: Enable Sandbox Hooks
-
-The build script installs the components but does not automatically activate the sandbox policy hooks. To prevent unauthorized file system access or dangerous command execution, run the following inside Copilot Shell after installation:
-
-```bash
-cosh
-```
-
-Then inside the session:
-
-```
-/hooks install
-```
-
-This command:
-- Copies the bundled `sandbox-guard.py` and `sandbox-failure-handler.py` scripts to `~/.copilot-shell/hooks/`
-- Registers them as `PreToolUse` and `PostToolUseFailure` hooks in your user settings (`~/.copilot-shell/settings.json`)
-- Activates the hooks immediately in the current session
-
-You only need to run this once — the configuration persists across sessions.
-
-> **Note:** The sandbox hooks require `agent-sec-core` (linux-sandbox) to be installed at `/usr/local/bin/linux-sandbox`. When a dangerous command is detected, `sandbox-guard.py` wraps it inside the `linux-sandbox` binary for execution. If `agent-sec-core` is not built and installed, the hook will be registered but sandboxed execution of dangerous commands will fail. Make sure `agent-sec-core` is built (it is included in the default `build-all.sh` run) before relying on sandbox enforcement.
-
----
-
-## 4. Component-by-Component Build
-
-> **You can skip this section** if you already used the unified build script above. The script handles all dependency installation, building, and system installation automatically.
-
-If you prefer to set up each toolchain and build each component manually, follow the steps below.
-
-### 4.1 Install Dependencies
-
-#### 4.1.1 Node.js (for copilot-shell)
-
-Required: Node.js >= 20, npm >= 10.
-
-- **Alinux 4 (verified)**
-
-```bash
-sudo dnf install -y nodejs npm make gcc-c++
-```
-
-- **Other distros: nvm**
-
-```bash
-# Skip if Node.js >= 20 is already installed
-if command -v node &>/dev/null && node -v | grep -qE '^v(2[0-9]|[3-9][0-9])'; then
-  echo "Node.js $(node -v) already installed, skipping"
-else
-  # Install nvm from Gitee mirror
-  curl -fsSL --connect-timeout 15 --max-time 60 https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh | bash
-  source "$HOME/.$(basename "$SHELL")rc"
-
-  # Configure npmmirror for faster Node.js downloads
-  export NVM_NODEJS_ORG_MIRROR=https://npmmirror.com/mirrors/node/
-  nvm install 20
-  nvm use 20
-fi
-
-# Verify
-node -v   # expected: v20.x.x or higher
-npm -v    # expected: 10.x.x or higher
-```
-
----
-
-#### 4.1.2 Rust (for agent-sec-core and agentsight)
-
-Required: agent-sec-core needs Rust >= 1.91.0; agentsight needs Rust >= 1.80.
-
-- **Alinux 4 (verified)** — the system `rust` package is below 1.91.0; use rustup instead (see below).
-Only install the build tools from dnf:
-
-```bash
-sudo dnf install -y gcc make
-```
-
-- **Ubuntu 24.04 (verified)**
-
-```bash
-sudo apt install -y rustc-1.91 cargo-1.91 gcc make
-sudo update-alternatives --install /usr/bin/cargo cargo /usr/bin/cargo-1.91 100
-```
-
-> The system `rust` package on some distros may be older than 1.91.0. If the build fails due to version mismatch, use rustup below.
-
-- **Other distros / Alinux 4: rustup (recommended)**
-
-```bash
-# Skip if Rust is already installed
-if command -v rustc &>/dev/null && command -v cargo &>/dev/null; then
-  echo "Rust $(rustc --version) already installed, skipping"
-else
-  # Install Rust via rsproxy.cn (China mirror)
-  curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 15 --max-time 120 https://rsproxy.cn/rustup-init.sh | sh -s -- -y
-  source "$HOME/.cargo/env"
-fi
-
-# Verify
-rustc --version   # expected: rustc 1.91.0 or higher
-cargo --version   # expected: cargo 1.91.0 or higher
-```
-
-> The repository uses a pinned toolchain (`rust-toolchain.toml`) for agent-sec-core. If the system Rust version does not match, rustup will automatically download the correct version when building inside the repo.
-
-**Configure Rustup distribution mirror (recommended for China users)**
-
-If building triggers auto-download of a pinned Rust toolchain (via `rust-toolchain.toml`) and it times out, set the Rustup distribution mirror:
-
-```bash
-export RUSTUP_DIST_SERVER="https://rsproxy.cn"
-export RUSTUP_UPDATE_ROOT="https://rsproxy.cn/rustup"
-```
-
-Add these lines to your shell rc file (`~/.bashrc` or `~/.zshrc`) to persist them. The build script (`build-all.sh`) configures this automatically.
-
-**Configure crates.io mirror (recommended for China users)**
-
-If `cargo build` is slow fetching dependencies, configure an Aliyun crates.io mirror.
-The build script (`build-all.sh`) configures this automatically regardless of how Rust is installed.
-For manual setup, add to `~/.cargo/config.toml`:
-
-```toml
-[source.crates-io]
-replace-with = 'aliyun'
-[source.aliyun]
-registry = "sparse+https://mirrors.aliyun.com/crates.io-index/"
-```
-
----
-
-#### 4.1.3 Python and uv (for agent-sec-core and os-skills)
-
-Required: Python >= 3.12.
-
-- **Alinux 4 (verified)**
-
-```bash
-pip3 install uv
-uv python install 3.12
-```
-
-- **Ubuntu 24.04 (verified)**
-
-```bash
-sudo apt install -y pipx
-pipx ensurepath
-source "$HOME/.$(basename "$SHELL")rc"
-pipx install uv
-```
-
-- **Other distros: uv**
-
-```bash
-# Skip if uv is already installed
-if command -v uv &>/dev/null; then
-  echo "uv $(uv --version) already installed, skipping"
-else
-  # Install uv
-  curl -LsSf --connect-timeout 15 --max-time 60 https://astral.sh/uv/install.sh | sh
-  source "$HOME/.$(basename "$SHELL")rc"
-fi
-
-# Install Python 3.12 via uv (skips if already present)
-uv python install 3.12
-```
-
-```bash
-# Verify
-uv --version          # expected: uv 0.x.x or higher
-uv python find 3.12   # expected: path to python3.12 binary
-```
-
----
-
-#### 4.1.4 AgentSight System Dependencies (Optional, Package Manager Required)
-
-AgentSight is an optional component that provides eBPF-based audit and observability capabilities. It is not required for core ANOLISA functionality. If you choose to build it, the following system-level dependencies are needed:
-
-- **dnf (Alinux / Anolis OS / Fedora / RHEL / CentOS / etc.)**
-
-```bash
-sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd
-sudo dnf install -y kernel-devel-$(uname -r)
-```
-
-- **apt (Debian / Ubuntu)**
-
-```bash
-sudo apt-get update -y
-sudo apt-get install -y clang llvm libbpf-dev libelf-dev zlib1g-dev libssl-dev perl linux-headers-$(uname -r)
-```
-
-> Some distributions do not provide a separate perl-core package. That is expected.
-
-- **Kernel Requirement**
-
-AgentSight requires Linux kernel >= 5.10 and BTF enabled (`CONFIG_DEBUG_INFO_BTF=y`).
-
----
-
-#### 4.1.5 Version Check
-
-```bash
-node -v            # v20.x.x
-npm -v             # 10.x.x
-rustc --version    # rustc 1.91.0+
-cargo --version    # cargo 1.91.0+
-python3 --version  # Python 3.12.x
-uv --version       # uv 0.x.x
-clang --version    # clang version 14+
-```
-
----
-
-### 4.2 Build Components
-
-#### 4.2.1 copilot-shell
-
-```bash
-cd src/copilot-shell
-make deps
-make build
-```
-
-> **Note:** `make deps` runs `npm install`, which automatically sets up husky pre-commit hooks. These hooks run Prettier and ESLint on staged files before each commit. In CI environments, use `make deps-ci` instead, which skips hook installation.
-
-Artifact: `dist/cli.js`
-
-```bash
-# Run directly
-node dist/cli.js
-
-# Or install to system PATH (creates cosh/co/copilot commands)
-sudo make install
-cosh
-```
-
-#### 4.2.2 os-skills
-
-**Install**
-
-Skill search paths (Copilot Shell discovers skills in the following priority order):
-
-| Scope | Path |
-|-------|------|
-| Project | `.copilot-shell/skills/` |
-| User | `~/.copilot-shell/skills/` |
-| System | `/usr/share/anolisa/skills/` |
-
-Install options:
-
-- **Using the build script (automatic)**
-
-```bash
-./scripts/build-all.sh --component skills
-```
-
-- **Manual deployment (user-level)**
-
-```bash
-mkdir -p ~/.copilot-shell/skills
-find src/os-skills -name 'SKILL.md' -exec sh -c \
-	'cp -rp "$(dirname "$1")" ~/.copilot-shell/skills/' _ {} \;
-```
-
-**Verify**
-
-```bash
-co /skills
-```
-
-#### 4.2.3 agent-sec-core (Linux only)
-
-```bash
-cd src/agent-sec-core
-make build-sandbox
-```
-
-Artifact: `linux-sandbox/target/release/linux-sandbox`
-
-**Install**
-
-```bash
-sudo make install-sandbox
-```
-
-#### 4.2.4 agentsight (Optional, Linux only)
-
-> Note: AgentSight is an optional component. It provides eBPF-based audit and observability capabilities but is not required for core ANOLISA functionality.
-
-```bash
-cd src/agentsight
-make build
-```
-
-Artifact: `target/release/agentsight`
-
-**Install**
-
-```bash
-sudo make install
-```
-
-### 4.3 Run Tests (Recommended)
-
-#### 4.3.1 Unified Entry
+Valid `--component` names are `cosh`, `skills`, `sec-core`, `tokenless`,
+`ws-ckpt`, `memory`, `cosh-ng`, and `sight`. The script may build a component
+in `target/` before installing it, and a component's own install policy still
+applies. For example, `ws-ckpt` requires `--system` to install its daemon;
+selecting it in the default user profile does not create a user service.
+
+## 5. Component build and test entry points
+
+Run the commands from the repository root unless a `cd` is shown. These are
+the smallest useful local gates; read the linked README and scoped developer
+guide before changing component internals.
+
+| Component | Build | Test and quality gate |
+|-----------|-------|-----------------------|
+| [copilot-shell](../src/copilot-shell/README.md) | `cd src/copilot-shell && make deps && make build` | `cd src/copilot-shell && make lint && make test` |
+| [os-skills](../src/os-skills/README.md) | `cd src/os-skills && make build` | No compilation target. Validate changed `SKILL.md` files and run changed scripts with their documented interpreter. |
+| [agent-sec-core](../src/agent-sec-core/README.md) | `cd src/agent-sec-core && make build-all` | `cd src/agent-sec-core && make test` runs Python, Rust sandbox, and OpenClaw plugin tests. Python uses uv with Python 3.11.6. |
+| [agentsight](../src/agentsight/README.md) | Linux: `cd src/agentsight && make build-all`; macOS local viewer: `cd src/agentsight && make build-mac` | Linux: `cd src/agentsight && make lint && make test`; macOS: run the tests relevant to the local viewer and trajectory collector. |
+| [tokenless](../src/tokenless/README.md) | `cd src/tokenless && make build` | `cd src/tokenless && make lint && make test` |
+| [agent-memory](../src/agent-memory/README.md) | `cd src/agent-memory && make build` | `cd src/agent-memory && make fmt-check && make lint && make test`; `cd src/agent-memory && make smoke` covers the MCP stdio path. Linux only. |
+| [ws-ckpt](../src/ws-ckpt/README.md) | `cd src/ws-ckpt && make build` | `cd src/ws-ckpt && make test`; install and service checks require Linux system mode. |
+| [cosh-ng](../src/cosh-ng/README.md) | `cd src/cosh-ng && cargo build --workspace` | `cd src/cosh-ng && cargo fmt --all -- --check`, then select the closest targeted test from its [contribution guide](../src/cosh-ng/CONTRIBUTING.md). Full local gates are reserved for explicitly requested large or cross-cutting validation. |
+| [anolisa](../src/anolisa/README.md) | `cd src/anolisa && cargo build --release --locked` | `cd src/anolisa && cargo fmt --all --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked` |
+| [SkillFS](../src/skillfs/README.md) | `cd src/skillfs && cargo build --workspace --release` | `cd src/skillfs && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`; on Linux, `cd src/skillfs && scripts/test.sh` adds the FUSE smoke test. |
+| [ktuner](../src/ktuner/README.md) | `cd src/ktuner && cargo build --release` | `cd src/ktuner && cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test` |
+| [blaze](../src/blaze/README.md) | `cd src/blaze && cargo build --workspace --release` | `cd src/blaze && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` |
+
+For a public API or rustdoc change, add `cargo doc --workspace --no-deps` to
+the affected Rust component's gate. `ktuner tune`, Blaze Firecracker paths,
+FUSE mounts, eBPF tracing, and system daemons need host privileges or kernel
+features beyond a normal unit-test run.
+
+The [CI workflow](https://github.com/alibaba/anolisa/blob/main/.github/workflows/ci.yaml) adds coverage, packaging,
+frontend, adapter, and integration checks for selected components. Those jobs
+are stricter than the smallest local commands in the matrix, so consult the
+workflow when a change touches a generated package or a framework adapter.
+
+## 6. Aggregate tests and pull-request gates
+
+`tests/run-all-tests.sh` is a partial convenience runner. With no filter it
+invokes exactly five components: copilot-shell, agent-sec-core, agentsight,
+tokenless, and agent-memory. It does not test cosh-ng, os-skills, ws-ckpt,
+anolisa, SkillFS, ktuner, or blaze.
 
 ```bash
 ./tests/run-all-tests.sh
 ./tests/run-all-tests.sh --filter shell
 ./tests/run-all-tests.sh --filter sec
 ./tests/run-all-tests.sh --filter sight
+./tests/run-all-tests.sh --filter tokenless
+./tests/run-all-tests.sh --filter memory
 ```
 
-#### 4.3.2 Per Component
+The script currently skips work when prerequisites are missing. It skips
+agent-sec-core Python tests without `uv`, skips its sandbox e2e test when
+`/usr/local/bin/linux-sandbox` is absent, skips AgentSight without `cargo`,
+and skips tokenless only when neither `make` nor `cargo` is available. It also
+skips agent-memory outside Linux or when `cargo` is unavailable. It still
+prints a success line after these skips,
+so a zero exit status does not prove that every test ran. The agent-sec-core
+e2e invocation also depends on its current working-directory layout. Use the
+component Makefiles for a reliable local gate.
 
-```bash
-# copilot-shell
-cd src/copilot-shell && make test
+For a pull request, select the rows in the component matrix that correspond to
+the changed files and run their build, lint, and test commands. Add platform,
+integration, smoke, frontend, or documentation checks when the changed files
+require them. Keep the aggregate runner as a quick signal rather than the
+pull-request acceptance criterion.
 
-# agent-sec-core
-cd src/agent-sec-core
-make test-python
+## 7. Further documentation
 
-# agentsight
-cd src/agentsight && cargo test
-```
+- [User installation guide](user-guide/en/installation.md)
+- [Developer guide index](developer-guide/en/README.md)
+- [Component onboarding specification](../specs/component-onboarding.md)
+- [Documentation standard](../specs/documentation-standard.md)
 
----
-
-## 5. Troubleshooting
-
-### 5.1 Node.js version mismatch
-
-Use nvm and re-activate the expected version:
-
-```bash
-source "$HOME/.$(basename "$SHELL")rc"
-```
-
-### 5.2 Rust toolchain mismatch
-
-```bash
-rustup show
-```
-
-### 5.3 AgentSight missing libbpf / headers
-
-Install distro packages from section 4.1.4 above.
-
-### 5.4 AgentSight runtime permission denied
-
-```bash
-sudo ./target/release/agentsight --help
-# or grant minimum capabilities
-sudo setcap cap_bpf,cap_perfmon=ep ./target/release/agentsight
-```
+Component-specific build details, generated artifacts, and runtime setup belong
+in the component README or its linked developer guide. Keep this page focused
+on repository-wide entry points and update it when the component list or script
+interfaces change.

--- a/docs/BUILDING_zh.md
+++ b/docs/BUILDING_zh.md
@@ -2,448 +2,176 @@
 
 [English](BUILDING.md)
 
-本指南介绍如何准备开发环境、从源码构建各组件并运行测试。
+本指南面向从源码参与 ANOLISA 开发的贡献者，说明仓库级构建入口、聚合测试脚本
+的覆盖范围，以及 12 个组件各自的构建和测试命令。组件特有的依赖和运行方式仍以
+组件 README 为准。
 
-提供两种构建路径：
-
-1. 快速开始：运行一个脚本自动检查/安装依赖并构建选定组件。
-
-2. 分组件构建：手动逐一构建各模块。
-
-## 1. 仓库结构
-
-```text
-anolisa/
-├── src/
-│   ├── copilot-shell/       # AI 终端助手（Node.js / TypeScript）
-│   ├── os-skills/           # 运维技能库（Markdown + 可选脚本）
-│   ├── agent-sec-core/      # Agent 安全沙箱（Rust + Python）
-│   └── agentsight/          # eBPF 可观测/审计引擎（Rust，可选）
-├── scripts/
-│   ├── build-all.sh         # 统一构建入口
-│   └── rpm-build.sh         # 统一 RPM 构建脚本
-├── tests/
-│   └── run-all-tests.sh     # 统一测试入口
-├── Makefile
-└── docs/
-```
-
-## 2. 环境依赖
-
-| 组件 | 所需工具 |
-|------|----------|
-| copilot-shell | Node.js >= 20、npm >= 10、make、g++ |
-| os-skills | Python >= 3.12（仅可选脚本需要） |
-| agent-sec-core | Rust >= 1.91.0、Python >= 3.12、uv（仅 Linux） |
-| agentsight *（可选）* | Rust >= 1.80、clang >= 14、libbpf 头文件、内核头文件（仅 Linux） |
-
-## 3. 快速开始
-
-统一构建脚本可自动完成依赖安装、构建和系统安装。
+## 1. 准备源码目录
 
 ```bash
 git clone https://github.com/alibaba/anolisa.git
 cd anolisa
 ```
 
-克隆完成后，运行构建脚本。默认会安装依赖、构建并安装到系统：
+通用前置条件包括 Git、Bash、`make`、用于编译 Rust 或 Python 原生扩展的 C 编译器，
+以及可下载依赖的网络环境。组件矩阵会列出平台特有的要求。仓库没有统一的 Rust
+版本，构建某个组件时请遵循该组件声明的 `rust-toolchain.toml` 或 `rust-version`。
 
-> **提示：** 以下每个方式都是独立的命令，根据自己的需求选择一个执行即可。如果使用了统一构建脚本，可以跳过下方的[分组件构建](#4-分组件构建)部分。
+## 2. 仓库结构
+
+当前 `src/` 下包含 12 个组件。
+
+| 组件 | 目录 | 平台和职责 |
+|------|------|------------|
+| copilot-shell（`cosh`） | [`src/copilot-shell`](../src/copilot-shell/README_zh.md) | TypeScript 终端助手，支持 Linux、macOS 和 Windows |
+| cosh-ng | [`src/cosh-ng`](../src/cosh-ng/README_zh.md) | Rust Agent OS CLI 和 Shell，Linux 提供完整构建，macOS 提供受限源码构建 |
+| agent-sec-core | [`src/agent-sec-core`](../src/agent-sec-core/README_zh.md) | Rust sandbox 与 Python 安全 CLI，Linux |
+| agentsight | [`src/agentsight`](../src/agentsight/README_zh.md) | Rust/eBPF 可观测组件，Linux 提供完整 tracing，macOS 提供 `trace` 和 `serve` |
+| tokenless | [`src/tokenless`](../src/tokenless/README_zh.md) | Rust Token 与命令输出优化，源码构建面向 Linux，macOS 使用从 Linux 交叉编译的 npm 制品 |
+| agent-memory（`memory`） | [`src/agent-memory`](../src/agent-memory/README_zh.md) | Rust MCP memory server，Linux |
+| os-skills（`skills`） | [`src/os-skills`](../src/os-skills/README_zh.md) | 静态 Skill 定义和脚本，具体平台取决于各 Skill 的声明 |
+| anolisa | [`src/anolisa`](../src/anolisa/README_zh.md) | Rust 组件生命周期 CLI，支持 Linux 和 macOS arm64 |
+| SkillFS（`skillfs`） | [`src/skillfs`](../src/skillfs/README_zh.md) | Rust FUSE Skill 文件系统，Linux |
+| ws-ckpt | [`src/ws-ckpt`](../src/ws-ckpt/README_zh.md) | Rust workspace checkpoint daemon 和 TypeScript adapter，作为 Linux system service 运行 |
+| ktuner | [`src/ktuner`](../src/ktuner/README.md) | Rust kernel tuning engine，Linux |
+| blaze | [`src/blaze`](../src/blaze/README_zh.md) | Rust 单机 sandbox 编排 daemon，Linux |
+
+仓库级规则位于 [`AGENTS.md`](../AGENTS.md)。修改组件前先阅读对应的 `AGENTS.md`，
+架构和运行细节请查看组件 README。
+
+## 3. 工具链和系统依赖
+
+构建脚本可以在受支持的 Linux 发行版上安装常用依赖，但无法让不支持的系统构建
+Linux-only 组件。
+
+| 需求 | 依据 |
+|------|------|
+| Node.js | `src/copilot-shell/package.json` 要求 Node.js `>=20.0.0`。agentsight、agent-sec-core、tokenless 和 ws-ckpt 的插件构建也会使用 npm。 |
+| Python 和 uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` 要求 Python `==3.11.6`，该项目使用 `uv`。不要把它扩展成仓库级 Python 最低版本。 |
+| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` 固定 `1.93.0`；`src/anolisa/rust-toolchain.toml` 和 `src/blaze/rust-toolchain.toml` 固定 `1.88.0`；`src/cosh-ng/rust-toolchain.toml` 跟随 `stable`。其他组件有 `rust-version` 时以各自 `Cargo.toml` 为准。 |
+| cosh-ng | Linux 源码构建需要 `pkg-config` 和 OpenSSL 开发文件。 |
+| agent-sec-core | Linux sandbox 运行和集成检查可能需要 bubblewrap、GnuPG 以及 `jq`。 |
+| agentsight | Linux eBPF 构建需要 clang、LLVM、libbpf 和 ELF 开发头文件、内核头文件，以及启用 BTF 的内核。`make build-mac` 构建不含 eBPF 的 macOS local viewer。 |
+| tokenless | `just` 用于获取并修补 RTK，OpenClaw plugin 构建需要 npm。 |
+| agent-memory | Linux 构建需要 CMake 和 libsystemd 开发头文件。 |
+| SkillFS | FUSE smoke test 需要 FUSE 3 和 `/dev/fuse`，普通 Cargo 测试不会挂载 FUSE。 |
+| ws-ckpt | 安装 daemon 需要 Linux systemd 和 root 权限。组件的 user-mode Makefile 目标会有意跳过 service 安装。 |
+
+组件有固定工具链时，从该组件目录执行命令，rustup 会自动选择对应版本。没有固定
+版本的组件应先查看自己的 `Cargo.toml` 和当前 stable 工具链，再开始构建。
+
+## 4. 统一构建脚本
+
+`scripts/build-all.sh` 是便捷入口，并不负责构建整个 monorepo。当前脚本支持 8 个
+组件。
+
+- 默认 6 个组件包括 `cosh`、`skills`、`sec-core`、`tokenless`、`ws-ckpt` 和
+  `memory`。
+- 可选 2 个组件包括 `cosh-ng` 和 `sight`。可以用 `--all` 或 `--component` 显式加入。
+
+脚本之外的 4 个组件是 `anolisa`、`skillfs`、`ktuner` 和 `blaze`，请按第 5 节的
+组件命令单独构建。
+
+默认安装模式是 user mode，组件文件安装到 `~/.local` 和 Copilot Shell 的用户目录
+时无需 `sudo`，首次安装系统依赖仍可能请求 `sudo`。使用 `--system`（或
+`--install-mode system`）切换到系统路径，脚本会暂存文件并可能调用 `sudo`。
+`--no-install` 只构建并暂存制品，不执行安装。
 
 ```bash
-# 默认：安装依赖 + 构建 + 安装到系统（推荐大多数用户使用）
+# Default six components, user install
 ./scripts/build-all.sh
 
-# 仅构建，不安装到系统
+# Build and stage without installing
 ./scripts/build-all.sh --no-install
 
-# 跳过依赖安装（依赖已就绪时使用）
+# Use system paths instead of the default user profile
+./scripts/build-all.sh --system
+
+# Include cosh-ng and agentsight as well
+./scripts/build-all.sh --all
+
+# Select one or more of the eight supported names
+./scripts/build-all.sh --component cosh --component sec-core
+./scripts/build-all.sh --component cosh-ng --component sight
+
+# Reuse already-installed dependencies
 ./scripts/build-all.sh --ignore-deps
 
-# 仅安装依赖（适用于 CI 或手动构建场景）
+# Install dependencies only, or print the plan without changing the system
 ./scripts/build-all.sh --deps-only
+./scripts/build-all.sh --dry-run
 
-# 仅构建并安装指定组件
-./scripts/build-all.sh --component cosh --component sec-core
-
-# 包含可选的 agentsight
-./scripts/build-all.sh --component cosh --component skills --component sec-core --component sight
+# Explicit non-interactive mode and help
+./scripts/build-all.sh --non-interactive
+./scripts/build-all.sh --help
 ```
 
-### 3.1 脚本选项
-
-| 参数 | 说明 |
-|------|------|
-| --no-install | 跳过将组件安装到系统路径 |
-| --ignore-deps | 跳过依赖安装 |
-| --deps-only | 仅安装依赖，不构建 |
-| --component <名称> | 构建指定组件（可重复使用）：cosh、skills、sec-core、sight。默认：cosh、skills、sec-core |
-| --help | 显示帮助信息 |
-
-### 3.2 注意事项
-
-1. 构建脚本会优先使用系统软件包，当系统版本不满足要求时自动回退到上游安装器（nvm / rustup）。
-2. os-skills 大部分是静态资源，无需编译。
-3. AgentSight 是可选组件，提供审计和可观测性能力，但不是核心功能所必需的。默认构建不包含它，使用 `--component sight` 显式包含。
-4. AgentSight 的系统依赖（clang/llvm/libbpf/内核头文件）需通过发行版包管理器安装。
-5. **沙箱策略 Hooks 不会自动启用。** 安装完成后，需在 Copilot Shell 内执行一次 `/hooks install` 来激活内置的 sandbox-guard hooks。详见 [3.3 安装后：启用沙箱 Hooks](#33-安装后启用沙箱-hooks)。
-
-### 3.3 安装后：启用沙箱 Hooks
-
-构建脚本完成安装后，沙箱策略 hooks 不会自动激活。为防止未经授权的文件系统访问或危险命令执行，请在安装完成后执行以下操作：
-
-```bash
-cosh
-```
-
-进入 Copilot Shell 会话后，执行：
-
-```
-/hooks install
-```
-
-该命令会：
-- 将内置的 `sandbox-guard.py` 和 `sandbox-failure-handler.py` 脚本复制到 `~/.copilot-shell/hooks/`
-- 将其注册为 `PreToolUse` 和 `PostToolUseFailure` hooks，写入用户配置（`~/.copilot-shell/settings.json`）
-- 立即在当前会话中激活这些 hooks
-
-只需执行一次，配置会持久保存，后续会话自动生效。
-
-> **说明：** 沙箱 hooks 依赖 `agent-sec-core`（linux-sandbox）正确构建并安装到 `/usr/local/bin/linux-sandbox`。当 `sandbox-guard.py` 检测到危险命令时，会将其包裹为 `linux-sandbox ... bash -c '...'` 的形式执行。若 `agent-sec-core` 未构建安装，hooks 可以注册成功，但危险命令的沙箱隔离执行将会失败。请确保在依赖沙箱防护前已完成 `agent-sec-core` 的构建（默认 `build-all.sh` 已包含该步骤）。
-
----
-
-## 4. 分组件构建
-
-> **如果已使用上方的统一构建脚本，可以跳过本节。** 脚本会自动完成依赖安装、构建和系统安装的所有步骤。
-
-如果你希望手动设置各工具链并逐个构建组件，请按以下步骤操作。
-
-### 4.1 安装依赖
-
-#### 4.1.1 Node.js（用于 copilot-shell）
-
-要求：Node.js >= 20、npm >= 10。
-
-- **Alinux 4（已验证）**
-
-```bash
-sudo dnf install -y nodejs npm make gcc-c++
-```
-
-- **其他发行版：nvm**
-
-```bash
-# 如果 Node.js >= 20 已安装则跳过
-if command -v node &>/dev/null && node -v | grep -qE '^v(2[0-9]|[3-9][0-9])'; then
-  echo "Node.js $(node -v) 已安装，跳过"
-else
-  # 从 Gitee 镜像安装 nvm
-  curl -fsSL --connect-timeout 15 --max-time 60 https://gitee.com/mirrors/nvm/raw/v0.40.3/install.sh | bash
-  source "$HOME/.$(basename "$SHELL")rc"
-
-  # 配置 npmmirror 加速 Node.js 下载
-  export NVM_NODEJS_ORG_MIRROR=https://npmmirror.com/mirrors/node/
-  nvm install 20
-  nvm use 20
-fi
-
-# 验证
-node -v   # 期望：v20.x.x 或更高
-npm -v    # 期望：10.x.x 或更高
-```
-
----
-
-#### 4.1.2 Rust（用于 agent-sec-core 和 agentsight）
-
-要求：agent-sec-core 需要 Rust >= 1.91.0；agentsight 需要 Rust >= 1.80。
-
-- **Alinux 4（已验证）** — 系统 `rust` 包版本低于 1.91.0，无法直接使用，请用下方 rustup 安装。
-仅需通过 dnf 安装构建工具：
-
-```bash
-sudo dnf install -y gcc make
-```
-
-- **Ubuntu 24.04（已验证）**
-
-```bash
-sudo apt install -y rustc-1.91 cargo-1.91 gcc make
-sudo update-alternatives --install /usr/bin/cargo cargo /usr/bin/cargo-1.91 100
-```
-
-> 部分发行版的系统 `rust` 包版本可能低于 1.91.0。如果构建因版本不匹配而失败，请改用下方的 rustup。
-
-- **其他发行版 / Alinux 4：rustup（推荐）**
-
-```bash
-# 如果 Rust 已安装则跳过
-if command -v rustc &>/dev/null && command -v cargo &>/dev/null; then
-  echo "Rust $(rustc --version) 已安装，跳过"
-else
-  # 通过 rsproxy.cn 镜像安装 Rust
-  curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 15 --max-time 120 https://rsproxy.cn/rustup-init.sh | sh -s -- -y
-  source "$HOME/.cargo/env"
-fi
-
-# 验证
-rustc --version   # 期望：rustc 1.91.0 或更高
-cargo --version   # 期望：cargo 1.91.0 或更高
-```
-
-> 仓库为 agent-sec-core 固定了工具链版本（`rust-toolchain.toml`）。如果系统 Rust 版本不匹配，rustup 会在仓库内构建时自动下载正确版本。
-
-**配置 Rustup 分发镜像（国内用户推荐）**
-
-如果构建时触发了固定工具链的自动下载（通过 `rust-toolchain.toml`）并且超时，请设置 Rustup 分发镜像：
-
-```bash
-export RUSTUP_DIST_SERVER="https://rsproxy.cn"
-export RUSTUP_UPDATE_ROOT="https://rsproxy.cn/rustup"
-```
-
-将以上内容添加到 shell 配置文件（`~/.bashrc` 或 `~/.zshrc`）中以使其永久生效。构建脚本（`build-all.sh`）会自动配置此项。
-
-**配置 crates.io 镜像（国内用户推荐）**
-
-如果 `cargo build` 拉取依赖较慢，可配置阿里云 crates.io 镜像。
-构建脚本（`build-all.sh`）会自动配置，不限于 rustup 安装路径。
-手动设置方法：在 `~/.cargo/config.toml` 中添加：
-
-```toml
-[source.crates-io]
-replace-with = 'aliyun'
-[source.aliyun]
-registry = "sparse+https://mirrors.aliyun.com/crates.io-index/"
-```
-
----
-
-#### 4.1.3 Python 和 uv（用于 agent-sec-core 和 os-skills）
-
-要求：Python >= 3.12。
-
-- **Alinux 4（已验证）**
-
-```bash
-pip3 install uv
-uv python install 3.12
-```
-
-- **Ubuntu 24.04（已验证）**
-
-```bash
-sudo apt install -y pipx
-pipx ensurepath
-source "$HOME/.$(basename "$SHELL")rc"
-pipx install uv
-```
-
-- **其他发行版：uv**
-
-```bash
-# 如果 uv 已安装则跳过
-if command -v uv &>/dev/null; then
-  echo "uv $(uv --version) 已安装，跳过"
-else
-  # 安装 uv
-  curl -LsSf --connect-timeout 15 --max-time 60 https://astral.sh/uv/install.sh | sh
-  source "$HOME/.$(basename "$SHELL")rc"
-fi
-
-# 通过 uv 安装 Python 3.12（已存在则跳过）
-uv python install 3.12
-```
-
-```bash
-# 验证
-uv --version          # 期望：uv 0.x.x 或更高
-uv python find 3.12   # 期望：输出 python3.12 可执行文件路径
-```
-
----
-
-#### 4.1.4 AgentSight 系统依赖（可选，需包管理器）
-
-AgentSight 是可选组件，提供基于 eBPF 的审计和可观测性能力，不是 ANOLISA 核心功能所必需的。如果你选择构建它，需要以下系统级依赖：
-
-- **dnf（Alinux / Anolis OS / Fedora / RHEL / CentOS 等）**
-
-```bash
-sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel zlib-devel openssl-devel perl perl-IPC-Cmd
-sudo dnf install -y kernel-devel-$(uname -r)
-```
-
-- **apt（Debian / Ubuntu）**
-
-```bash
-sudo apt-get update -y
-sudo apt-get install -y clang llvm libbpf-dev libelf-dev zlib1g-dev libssl-dev perl linux-headers-$(uname -r)
-```
-
-> 部分发行版没有单独的 perl-core 包，这是正常的。
-
-- **内核要求**
-
-AgentSight 要求 Linux 内核 >= 5.10 且启用 BTF（`CONFIG_DEBUG_INFO_BTF=y`）。
-
----
-
-#### 4.1.5 版本检查
-
-```bash
-node -v            # v20.x.x
-npm -v             # 10.x.x
-rustc --version    # rustc 1.91.0+
-cargo --version    # cargo 1.91.0+
-python3 --version  # Python 3.12.x
-uv --version       # uv 0.x.x
-clang --version    # clang version 14+
-```
-
----
-
-### 4.2 构建组件
-
-#### 4.2.1 copilot-shell
-
-```bash
-cd src/copilot-shell
-make deps
-make build
-```
-
-> **注意：** `make deps` 执行 `npm install`，会自动初始化 husky pre-commit 钩子。每次提交时，钩子会对暂存文件执行 Prettier 格式化和 ESLint 检查。CI 环境请使用 `make deps-ci`，该命令会跳过钩子安装。
-
-产物：`dist/cli.js`
-
-```bash
-# 直接运行
-node dist/cli.js
-
-# 或安装到系统 PATH（创建 cosh/co/copilot 命令）
-sudo make install
-cosh
-```
-
-#### 4.2.2 os-skills
-
-**安装**
-
-技能搜索路径（Copilot Shell 按以下优先级发现技能）：
-
-| 范围 | 路径 |
-|------|------|
-| 项目级 | `.copilot-shell/skills/` |
-| 用户级 | `~/.copilot-shell/skills/` |
-| 系统级 | `/usr/share/anolisa/skills/` |
-
-安装方式：
-
-- **使用构建脚本自动部署**
-
-```bash
-./scripts/build-all.sh --component skills
-```
-
-- **手动部署（用户级）**
-
-```bash
-mkdir -p ~/.copilot-shell/skills
-find src/os-skills -name 'SKILL.md' -exec sh -c \
-	'cp -rp "$(dirname "$1")" ~/.copilot-shell/skills/' _ {} \;
-```
-
-**验证**
-
-```bash
-co /skills
-```
-
-#### 4.2.3 agent-sec-core（仅 Linux）
-
-```bash
-cd src/agent-sec-core
-make build-sandbox
-```
-
-产物：`linux-sandbox/target/release/linux-sandbox`
-
-**安装**
-
-```bash
-sudo make install-sandbox
-```
-
-#### 4.2.4 agentsight（可选，仅 Linux）
-
-> 注意：AgentSight 是可选组件，提供基于 eBPF 的审计和可观测性能力，不是 ANOLISA 核心功能所必需的。
-
-```bash
-cd src/agentsight
-make build
-```
-
-产物：`target/release/agentsight`
-
-**安装**
-
-```bash
-sudo make install
-```
-
-### 4.3 运行测试（推荐）
-
-#### 4.3.1 统一入口
+`--component` 的合法名称为 `cosh`、`skills`、`sec-core`、`tokenless`、`ws-ckpt`、
+`memory`、`cosh-ng` 和 `sight`。脚本可能先在 `target/` 中生成构建结果，再执行安装，
+最终行为仍由组件自己的安装规则决定。例如 `ws-ckpt` 只有在 `--system` 下才会安装
+daemon，默认 user profile 不会创建 user service。
+
+## 5. 组件构建和测试入口
+
+除非命令中带有 `cd`，否则都从仓库根目录执行。以下命令是最小的本地门禁；修改
+组件内部实现前，请阅读对应 README 和开发指南。
+
+| 组件 | 构建 | 测试和质量门禁 |
+|------|------|----------------|
+| [copilot-shell](../src/copilot-shell/README_zh.md) | `cd src/copilot-shell && make deps && make build` | `cd src/copilot-shell && make lint && make test` |
+| [os-skills](../src/os-skills/README_zh.md) | `cd src/os-skills && make build` | 没有编译目标。检查变更过的 `SKILL.md`，并按文件说明的解释器运行变更脚本。 |
+| [agent-sec-core](../src/agent-sec-core/README_zh.md) | `cd src/agent-sec-core && make build-all` | `cd src/agent-sec-core && make test` 会运行 Python、Rust sandbox 和 OpenClaw plugin 测试。Python 使用 uv 与 Python 3.11.6。 |
+| [agentsight](../src/agentsight/README_zh.md) | Linux 使用 `cd src/agentsight && make build-all`；macOS local viewer 使用 `cd src/agentsight && make build-mac` | Linux 使用 `cd src/agentsight && make lint && make test`；macOS 运行 local viewer 和 trajectory collector 相关测试。 |
+| [tokenless](../src/tokenless/README_zh.md) | `cd src/tokenless && make build` | `cd src/tokenless && make lint && make test` |
+| [agent-memory](../src/agent-memory/README_zh.md) | `cd src/agent-memory && make build` | `cd src/agent-memory && make fmt-check && make lint && make test`；`cd src/agent-memory && make smoke` 覆盖 MCP stdio 路径。仅 Linux。 |
+| [ws-ckpt](../src/ws-ckpt/README_zh.md) | `cd src/ws-ckpt && make build` | `cd src/ws-ckpt && make test`；安装和 service 检查需要 Linux system mode。 |
+| [cosh-ng](../src/cosh-ng/README_zh.md) | `cd src/cosh-ng && cargo build --workspace` | `cd src/cosh-ng && cargo fmt --all -- --check`，随后按[贡献指南](../src/cosh-ng/CONTRIBUTING_zh.md)选择最接近改动的测试。只有明确要求对大型或跨模块改动执行完整验证时，才运行全量本地门禁。 |
+| [anolisa](../src/anolisa/README_zh.md) | `cd src/anolisa && cargo build --release --locked` | `cd src/anolisa && cargo fmt --all --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked` |
+| [SkillFS](../src/skillfs/README_zh.md) | `cd src/skillfs && cargo build --workspace --release` | `cd src/skillfs && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`；Linux 上再运行 `cd src/skillfs && scripts/test.sh` 执行 FUSE smoke test。 |
+| [ktuner](../src/ktuner/README.md) | `cd src/ktuner && cargo build --release` | `cd src/ktuner && cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test` |
+| [blaze](../src/blaze/README_zh.md) | `cd src/blaze && cargo build --workspace --release` | `cd src/blaze && cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` |
+
+修改公共 API 或 rustdoc 时，在受影响的 Rust 组件门禁中追加
+`cargo doc --workspace --no-deps`。`ktuner tune`、Blaze Firecracker 路径、FUSE 挂载、
+eBPF tracing 和系统 daemon 需要普通单元测试之外的主机权限或内核能力。
+
+[CI workflow](https://github.com/alibaba/anolisa/blob/main/.github/workflows/ci.yaml) 还会为部分组件执行 coverage、打包、前端、
+adapter 和集成检查。这些任务比矩阵中的最小本地命令更严格，涉及生成制品或框架
+adapter 时应再查看 workflow。
+
+## 6. 聚合测试与 PR 门禁
+
+`tests/run-all-tests.sh` 只是部分组件的便捷测试脚本。不带过滤条件时，它只会调用
+copilot-shell、agent-sec-core、agentsight、tokenless 和 agent-memory 这 5 个组件，
+不会测试 cosh-ng、os-skills、ws-ckpt、anolisa、SkillFS、ktuner 或 blaze。
 
 ```bash
 ./tests/run-all-tests.sh
 ./tests/run-all-tests.sh --filter shell
 ./tests/run-all-tests.sh --filter sec
 ./tests/run-all-tests.sh --filter sight
+./tests/run-all-tests.sh --filter tokenless
+./tests/run-all-tests.sh --filter memory
 ```
 
-#### 4.3.2 分组件测试
+当前脚本在前置条件缺失时会跳过测试。没有 `uv` 时会跳过 agent-sec-core 的 Python
+测试，没有 `/usr/local/bin/linux-sandbox` 时会跳过其 sandbox e2e，没有 `cargo` 时
+会跳过 AgentSight。只有 `make` 和 `cargo` 都不存在时才会跳过 tokenless。在非 Linux
+系统或没有 `cargo` 时会跳过 agent-memory。即使出现这些跳过，脚本仍会打印成功
+信息，因此退出码为 0 不能证明
+所有测试都已运行。agent-sec-core 的 e2e 调用还依赖当前工作目录布局，可靠的本地
+门禁应使用组件 Makefile。
 
-```bash
-# copilot-shell
-cd src/copilot-shell && make test
+PR 应根据变更文件选择组件矩阵中的对应行，运行相应的构建、lint 和测试命令。变更
+涉及的平台、集成、smoke、前端或文档时，还要补充相应检查。聚合脚本适合作为快速
+信号，不应作为 PR 的唯一验收依据。
 
-# agent-sec-core
-cd src/agent-sec-core
-make test-python
+## 7. 延伸阅读
 
-# agentsight
-cd src/agentsight && cargo test
-```
+- [用户安装指南](user-guide/zh/installation.md)
+- [开发指南索引](developer-guide/zh/README.md)
+- [组件接入规范](../specs/component-onboarding.md)
+- [文档规范](../specs/documentation-standard.md)
 
----
-
-## 5. 常见问题排查
-
-### 5.1 Node.js 版本不匹配
-
-使用 nvm 重新激活期望版本：
-
-```bash
-source "$HOME/.$(basename "$SHELL")rc"
-```
-
-### 5.2 Rust 工具链不匹配
-
-```bash
-rustup show
-```
-
-### 5.3 AgentSight 缺少 libbpf / 头文件
-
-按 4.1.4 节安装对应发行版的系统软件包。
-
-### 5.4 AgentSight 运行时权限被拒绝
-
-```bash
-sudo ./target/release/agentsight --help
-# 或授予最小权限
-sudo setcap cap_bpf,cap_perfmon=ep ./target/release/agentsight
-```
+组件特有的构建细节、生成制品和运行配置应放在组件 README 或对应开发指南中。本页
+只维护仓库级入口，组件清单或脚本接口发生变化时同步更新这里。

--- a/src/cosh-ng/CONTRIBUTING.md
+++ b/src/cosh-ng/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 | Rust toolchain | stable (managed by `rust-toolchain.toml`) |
 | Minimum Rust version | 1.74 |
 | Components | rustfmt + clippy |
+| Supported platforms | Linux (full); macOS (limited functionality) |
 
 ```bash
 cd src/cosh-ng
@@ -53,6 +54,7 @@ depth. Otherwise CI provides broad regression coverage:
 
 ```bash
 scripts/run-test-gates.sh all    # full deterministic gate
+cargo build --workspace --release --locked
 crates/cosh-shell/scripts/check-layout.sh
 ```
 
@@ -135,7 +137,8 @@ git commit -s -m 'feat(cosh-ng): [core] add hook registry list'
 ## PR Process
 
 1. Branch from latest main
-2. Follow branch naming: `feature/cosh/<short-desc>`
-3. Ensure all checks pass before pushing
+2. Follow branch naming: `feature/cosh-ng/<short-desc>`
+3. Ensure all applicable checks pass before pushing
 4. PR title follows commit message format
-5. Fill in PR template (Description / Testing / Related Issue)
+5. Fill in every applicable PR template section, including risk, validation,
+   documentation, and rollback

--- a/src/cosh-ng/CONTRIBUTING_zh.md
+++ b/src/cosh-ng/CONTRIBUTING_zh.md
@@ -9,6 +9,7 @@
 | Rust toolchain | stable（`rust-toolchain.toml` 管理） |
 | Rust 最低版本 | 1.74 |
 | 组件 | rustfmt + clippy |
+| 支持平台 | Linux（完整功能）；macOS（功能受限） |
 
 ```bash
 cd src/cosh-ng
@@ -51,6 +52,7 @@ cargo doc --workspace --no-deps
 
 ```bash
 scripts/run-test-gates.sh all    # 完整确定性门禁
+cargo build --workspace --release --locked
 crates/cosh-shell/scripts/check-layout.sh
 ```
 
@@ -132,7 +134,7 @@ git commit -s -m 'feat(cosh-ng): [core] add hook registry list'
 ## PR 流程
 
 1. 从最新 main 分支切出特性分支
-2. 遵循 `feature/cosh/<short-desc>` 分支命名
-3. 确保所有检查通过后推送
+2. 遵循 `feature/cosh-ng/<short-desc>` 分支命名
+3. 确保所有适用检查通过后推送
 4. PR 标题遵循 commit message 格式
-5. 填写 PR 模板（Description / Testing / Related Issue）
+5. 填写 PR 模板中的适用章节，包括风险、验证、文档和回滚说明


### PR DESCRIPTION
## Why

The repository contribution guide no longer matched the current twelve-component
layout, aggregate build and test boundaries, or contributor checks.

## What changed

- Reworked the English and Chinese contribution and source-build guides around
  the current component matrix, platform limits, toolchains, and local gates.
- Documented the exact scope of `build-all.sh` and `run-all-tests.sh`.
- Synchronized `AGENTS.md` and cosh-ng guidance with component-specific build
  and test gates.

## Related issue

no-issue: contributor workflow documentation refresh

## User / Agent impact

Contributors and coding agents now receive accurate component-specific build,
test, commit, branch, and PR guidance. The documented commands reflect the
artifacts built and tested by each component.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Low risk. Runtime code and component behavior are unchanged; the changes are
limited to contribution and source-build guidance.

## Validation

- `git diff --check`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `npm ci --prefix website`
- `npm run build --prefix website`
- Verified bilingual command blocks and referenced Make targets.
- Verified that agent-sec-core `make build-all` covers the CLI wheel and plugin
  artifacts.
- Rust tests were not run because the change is documentation only.

## Documentation and rollback

Updated the root contribution and build guides and the cosh-ng contribution
guides in both languages. Revert the commit to restore the previous
documentation.