### PR TITLE
feat(docs): add Token-less README demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Token-less removes redundancy from tool schemas and responses.
 demand so only the relevant ones enter the context, and
 [AgentSight](src/agentsight/README.md) records where Tokens are actually spent.
 
+<table align="center" cellpadding="0" cellspacing="0">
+  <tr>
+    <td>
+      <video
+        controls
+        muted
+        src="https://github.com/user-attachments/assets/1c416b99-2bbb-41c1-b754-fe9af634779c"
+      ></video>
+    </td>
+  </tr>
+</table>
+
+<p align="center">
+  <sub>
+    In one observed coding task, Token-less saved 317K Tokens (40.5%), based
+    on AgentSight measurements.
+    Results vary by workload.
+  </sub>
+</p>
+
 <p align="center">
   <img
     src="docs/images/readme/tokenless-response.png"

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,6 +67,26 @@ Token-less 去掉工具 Schema 和响应中的冗余，[Agent Memory](src/agent-
 Skills，只把用得到的技能放进上下文，[AgentSight](src/agentsight/README_zh.md)
 记录 Token 实际花在哪。
 
+<table align="center" cellpadding="0" cellspacing="0">
+  <tr>
+    <td>
+      <video
+        controls
+        muted
+        src="https://github.com/user-attachments/assets/1c416b99-2bbb-41c1-b754-fe9af634779c"
+      ></video>
+    </td>
+  </tr>
+</table>
+
+<p align="center">
+  <sub>
+    在一次编码任务的单次观测中，Token-less 节省了 317K Tokens（40.5%，
+    基于 AgentSight 观测）。
+    实际效果因工作负载而异。
+  </sub>
+</p>
+
 <p align="center">
   <img
     src="docs/images/readme/tokenless-response.png"


### PR DESCRIPTION
## Why

Give README visitors a concrete view of the Token-less workflow and its
measured effect without requiring them to open the full user guide first.

## What changed

- Embed a centered GitHub-hosted video player in both README locales.
- Start the video with a cover frame highlighting 317K Tokens saved (40.5%),
  then transition into the 17-second terminal workflow.
- Keep the repository free of the previous 5.97 MB GIF and host the 3.7 MB MP4
  in GitHub user-attachments rather than repository history.
- Describe the result as one AgentSight-observed coding task, with a
  workload-dependent-results qualifier.

## Related issue

no-issue: focused README presentation update

## User / Agent impact

Visitors see the measured saving as the player's first frame and can play the
demo directly in the README without navigating away or adding the video asset
to repository clone size.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This changes README presentation only.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`
- Confirmed GitHub renders the attachment as a centered native
  `<video controls>` player
- Inspected the uploaded frame at 0 seconds for the cover and at 2 seconds for
  the terminal transition

## Documentation and rollback

Updated the English and Chinese root README files. Revert the commit to remove
the embedded demo.
