### PR TITLE
fix(blaze): keep lifecycle state bound to opened directories

### DIFF
--- a/src/blaze/crates/blaze-core/src/backend.rs
+++ b/src/blaze/crates/blaze-core/src/backend.rs
@@ -84,13 +84,11 @@ impl FromStr for BackendKind {
     }
 }
 
-/// Complete input for starting a backend instance.
+/// Portable parameters for starting a backend instance.
 #[derive(Debug, Clone)]
 pub struct SpawnRequest {
     /// Stable sandbox identifier.
     pub instance_id: Uuid,
-    /// Provider-owned runtime directory.
-    pub run_dir: PathBuf,
     /// Backend executable selected during daemon startup.
     pub binary_path: PathBuf,
     /// Storage resources owned by this sandbox.

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -354,7 +354,7 @@ async fn checkpoint(state: &Arc<ServerState>, id: &str) -> Result<Response<Full<
         inst.transition(SandboxState::Paused)?;
     }
     inst.transition(SandboxState::Checkpointed)?;
-    inst.persist(&state.state_dir)?;
+    state.state_store.persist(inst)?;
 
     let checkpoint_id = format!("ckpt-{}-{}", inst.id, chrono::Utc::now().timestamp());
     json_ok(&json!({
@@ -379,7 +379,7 @@ async fn reset_instance(state: &Arc<ServerState>, id: &str) -> Result<Response<F
     // pool. Current implementation is control-plane state only.
     inst.transition(SandboxState::Reset)?;
     inst.transition(SandboxState::Warm)?;
-    inst.persist(&state.state_dir)?;
+    state.state_store.persist(inst)?;
 
     // return to pool keyed on (backend, class, image_digest)
     let key = PoolKey::new(inst.backend, inst.workload_class, inst.image_digest.clone());
@@ -2629,8 +2629,7 @@ mod tests {
         let restored = state.instances.lock().expect("instances")[&uuid].clone();
         assert_eq!(restored.state, SandboxState::Warm);
         assert!(restored.operation.is_none());
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted warm state");
+        let persisted = state.state_store.load(uuid).expect("persisted warm state");
         assert_eq!(persisted.state, SandboxState::Warm);
         assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
         assert!(persisted.operation.is_none());
@@ -2642,8 +2641,10 @@ mod tests {
         let retried = created_json(&state, &request).await;
         assert_eq!(retried["instance"]["id"], id);
         assert_eq!(retried["start_path"], "warm");
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted running state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted running state");
         assert_eq!(persisted.state, SandboxState::Running);
         assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
         assert!(persisted.operation.is_none());
@@ -2809,8 +2810,10 @@ mod tests {
         let retained = state.instances.lock().expect("instances")[&uuid].clone();
         assert_eq!(retained.state, SandboxState::RecoveryRequired);
         assert!(retained.operation.is_none());
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted recovery state");
         assert_eq!(persisted.state, SandboxState::RecoveryRequired);
         assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
         assert!(persisted.operation.is_none());
@@ -2823,8 +2826,10 @@ mod tests {
             state.instances.lock().expect("instances")[&uuid].state,
             SandboxState::Destroyed
         );
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
     }
@@ -2855,8 +2860,10 @@ mod tests {
             retained.operation.as_ref().map(|operation| operation.kind),
             Some(OperationKind::Destroy)
         );
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted recovery state");
         assert_eq!(persisted.state, SandboxState::RecoveryRequired);
         assert_eq!(persisted.backend_ownership, BackendOwnership::Stopped);
         assert_eq!(
@@ -2868,8 +2875,10 @@ mod tests {
         destroy_instance(&state, &id).await.expect("destroy retry");
         assert_eq!(kill_count.load(Ordering::Acquire), 1);
         assert_eq!(release_count.load(Ordering::Acquire), 1);
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
     }
@@ -2901,8 +2910,10 @@ mod tests {
             retained.operation.as_ref().map(|operation| operation.kind),
             Some(OperationKind::Destroy)
         );
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted recovery state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted recovery state");
         assert_eq!(persisted.state, SandboxState::RecoveryRequired);
         assert_eq!(persisted.backend_ownership, BackendOwnership::Stopped);
         assert_eq!(
@@ -2916,8 +2927,10 @@ mod tests {
         let destroyed = state.instances.lock().expect("instances")[&uuid].clone();
         assert_eq!(destroyed.state, SandboxState::Destroyed);
         assert!(destroyed.operation.is_none());
-        let persisted =
-            SandboxInstance::load(&state.state_dir, uuid).expect("persisted destroyed state");
+        let persisted = state
+            .state_store
+            .load(uuid)
+            .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
     }

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -778,7 +778,7 @@ mod tests {
 
     use async_trait::async_trait;
     use blaze_core::BlazeError;
-    use blaze_core::backend::{BackendKind, SpawnRequest};
+    use blaze_core::backend::BackendKind;
     use blaze_core::config::DaemonConfig;
     use blaze_core::kernel::HookRegistry;
     use blaze_core::lifecycle::{BackendOwnership, OperationKind};
@@ -795,10 +795,11 @@ mod tests {
     #[cfg(target_os = "linux")]
     use crate::spawner::BubblewrapSpawner;
     use crate::spawner::{
-        BackendInstance, BackendSpawner, DynBackendInstance, DynSpawner, GuestMockSpawner,
-        MockSpawner, SpawnFailure, SpawnResult, SpawnerRegistry,
+        BackendInstance, BackendSpawnRequest, BackendSpawner, DynBackendInstance, DynSpawner,
+        GuestMockSpawner, MockSpawner, SpawnFailure, SpawnResult, SpawnerRegistry,
     };
     use crate::state::ServerState;
+    use crate::state_store::OwnedRunDir;
     #[cfg(target_os = "linux")]
     use tokio::sync::Notify;
 
@@ -1114,7 +1115,7 @@ mod tests {
     impl BackendSpawner for PartialSpawnSpawner {
         async fn spawn(
             &self,
-            request: SpawnRequest,
+            request: BackendSpawnRequest,
         ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
             let owner: DynBackendInstance = Arc::new(FailOnceOwner {
                 instance_id: request.instance_id,
@@ -1135,7 +1136,7 @@ mod tests {
         async fn cleanup_orphan(
             &self,
             _instance_id: Uuid,
-            _run_dir: &Path,
+            _run_dir: &OwnedRunDir,
         ) -> blaze_core::Result<()> {
             Err(BlazeError::BackendError {
                 msg: "partial owner must remain registered".into(),
@@ -1151,13 +1152,13 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[async_trait]
     impl BackendSpawner for PreSpawnBoundarySpawner {
-        async fn prepare_spawn(&self, run_dir: &Path) -> blaze_core::Result<()> {
+        async fn prepare_spawn(&self, run_dir: &OwnedRunDir) -> blaze_core::Result<()> {
             BubblewrapSpawner.prepare_spawn(run_dir).await
         }
 
         async fn spawn(
             &self,
-            _request: SpawnRequest,
+            _request: BackendSpawnRequest,
         ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
             self.reached.notify_one();
             std::future::pending().await
@@ -1170,7 +1171,7 @@ mod tests {
         async fn cleanup_orphan(
             &self,
             instance_id: Uuid,
-            run_dir: &Path,
+            run_dir: &OwnedRunDir,
         ) -> blaze_core::Result<()> {
             BubblewrapSpawner.cleanup_orphan(instance_id, run_dir).await
         }
@@ -1184,7 +1185,7 @@ mod tests {
     impl BackendSpawner for RecordingSpawner {
         async fn spawn(
             &self,
-            _request: SpawnRequest,
+            _request: BackendSpawnRequest,
         ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
             Err(SpawnFailure::clean(BlazeError::BackendError {
                 msg: "spawn not used".into(),
@@ -1198,7 +1199,7 @@ mod tests {
         async fn cleanup_orphan(
             &self,
             _instance_id: Uuid,
-            _run_dir: &Path,
+            _run_dir: &OwnedRunDir,
         ) -> blaze_core::Result<()> {
             self.cleanup_count.fetch_add(1, Ordering::AcqRel);
             Ok(())
@@ -1214,7 +1215,7 @@ mod tests {
     impl BackendSpawner for SelectiveCleanupSpawner {
         async fn spawn(
             &self,
-            request: SpawnRequest,
+            request: BackendSpawnRequest,
         ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
             MockSpawner.spawn(request).await
         }
@@ -1226,7 +1227,7 @@ mod tests {
         async fn cleanup_orphan(
             &self,
             instance_id: Uuid,
-            _run_dir: &Path,
+            _run_dir: &OwnedRunDir,
         ) -> blaze_core::Result<()> {
             self.cleanup_count.fetch_add(1, Ordering::AcqRel);
             if instance_id == self.failed_id {
@@ -1275,7 +1276,7 @@ mod tests {
     impl BackendSpawner for CountingSpawner {
         async fn spawn(
             &self,
-            request: SpawnRequest,
+            request: BackendSpawnRequest,
         ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
             Ok(Arc::new(CountingOwner {
                 instance_id: request.instance_id,
@@ -1291,7 +1292,7 @@ mod tests {
         async fn cleanup_orphan(
             &self,
             _instance_id: Uuid,
-            _run_dir: &Path,
+            _run_dir: &OwnedRunDir,
         ) -> blaze_core::Result<()> {
             self.orphan_cleanup_count.fetch_add(1, Ordering::AcqRel);
             Ok(())
@@ -2206,10 +2207,12 @@ mod tests {
             .expect("creating");
         instance.begin_operation(OperationKind::Create);
         let run_dir = config.daemon.state_dir.join(instance.id.to_string());
+        let run_dir_owner = OwnedRunDir::for_test(instance.id, run_dir.clone());
         BubblewrapSpawner
-            .prepare_spawn(&run_dir)
+            .prepare_spawn(&run_dir_owner)
             .await
             .expect("prepare PID handoff");
+        drop(run_dir_owner);
         instance.backend_ownership = BackendOwnership::Starting;
         instance
             .persist(&config.daemon.state_dir)
@@ -2363,11 +2366,17 @@ mod tests {
         );
         assert!(instances_dir.join(instance.id.to_string()).is_dir());
         assert!(state.manager.backend_owner(instance.id).is_some());
+        assert!(state.state_store.run_dir(instance.id).is_ok());
 
         destroy_instance(&state, &instance.id.to_string())
             .await
             .expect("retry destroy");
         assert!(!instances_dir.join(instance.id.to_string()).exists());
+        assert!(state.manager.backend_owner(instance.id).is_none());
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
         assert_eq!(
             state.instances.lock().expect("instances")[&instance.id].state,
             SandboxState::Destroyed
@@ -2610,10 +2619,84 @@ mod tests {
         assert_ne!(replacement["instance"]["id"], id);
         assert_eq!(replacement["start_path"], "cold");
         let uuid = Uuid::parse_str(&id).expect("uuid");
+        let replacement_id = Uuid::parse_str(
+            replacement["instance"]["id"]
+                .as_str()
+                .expect("replacement id"),
+        )
+        .expect("replacement uuid");
         assert_eq!(
             state.instances.lock().expect("instances")[&uuid].state,
             SandboxState::Destroyed
         );
+        assert!(matches!(
+            state.state_store.run_dir(uuid),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+        assert!(state.state_store.run_dir(replacement_id).is_ok());
+    }
+
+    #[tokio::test]
+    async fn warm_quarantine_cleanup_failure_retains_resources_for_destroy_retry() {
+        let temp = tempfile::tempdir().expect("temp");
+        let config = test_config(&temp);
+        let instances_dir = config.storage.instances_dir.clone();
+        let storage: Arc<dyn StorageProvider> = Arc::new(FileStorageProvider::with_images(
+            config.storage.images_dir.clone(),
+            instances_dir.clone(),
+        ));
+        let state = build_test_state(
+            config,
+            test_policy(BackendKind::Mock, true),
+            spawners(BackendKind::Mock, Arc::new(MockSpawner)),
+            BackendKind::Mock,
+            storage,
+        );
+        let request = test_request();
+        let cold = created_json(&state, &request).await;
+        let id = cold["instance"]["id"].as_str().expect("id").to_string();
+        let uuid = Uuid::parse_str(&id).expect("uuid");
+        reset_instance(&state, &id).await.expect("warm");
+        state
+            .manager
+            .insert_backend_owner(
+                uuid,
+                Arc::new(FailOnceOwner {
+                    instance_id: uuid,
+                    attempts: AtomicUsize::new(0),
+                }),
+            )
+            .expect("replace backend owner");
+        std::fs::remove_file(instances_dir.join(&id).join("mem.bin")).expect("remove artifact");
+
+        let replacement = created_json(&state, &request).await;
+
+        assert_ne!(replacement["instance"]["id"], id);
+        let retained = state.instances.lock().expect("instances")[&uuid].clone();
+        assert_eq!(retained.state, SandboxState::RecoveryRequired);
+        assert_eq!(retained.backend_ownership, BackendOwnership::Running);
+        assert_eq!(
+            retained.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Destroy)
+        );
+        assert!(state.manager.backend_owner(uuid).is_some());
+        assert!(state.state_store.run_dir(uuid).is_ok());
+        assert!(instances_dir.join(&id).is_dir());
+
+        destroy_instance(&state, &id)
+            .await
+            .expect("retry quarantined destroy");
+
+        assert_eq!(
+            state.instances.lock().expect("instances")[&uuid].state,
+            SandboxState::Destroyed
+        );
+        assert!(state.manager.backend_owner(uuid).is_none());
+        assert!(matches!(
+            state.state_store.run_dir(uuid),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+        assert!(!instances_dir.join(&id).exists());
     }
 
     #[cfg(feature = "test-failpoints")]
@@ -3113,6 +3196,7 @@ mod tests {
         assert_eq!(persisted.backend_ownership, BackendOwnership::Running);
         assert!(persisted.operation.is_none());
         assert!(temp.path().join("instances").join(&id).is_dir());
+        assert!(state.state_store.run_dir(uuid).is_ok());
 
         destroy_instance(&state, &id).await.expect("destroy retry");
         assert_eq!(kill_count.load(Ordering::Acquire), 1);
@@ -3127,6 +3211,10 @@ mod tests {
             .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
+        assert!(matches!(
+            state.state_store.run_dir(uuid),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
     }
 
     #[cfg(feature = "test-failpoints")]
@@ -3166,6 +3254,7 @@ mod tests {
             Some(OperationKind::Destroy)
         );
         assert!(temp.path().join("instances").join(&id).is_dir());
+        assert!(state.state_store.run_dir(uuid).is_ok());
 
         destroy_instance(&state, &id).await.expect("destroy retry");
         assert_eq!(kill_count.load(Ordering::Acquire), 1);
@@ -3176,6 +3265,10 @@ mod tests {
             .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
+        assert!(matches!(
+            state.state_store.run_dir(uuid),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
     }
 
     #[cfg(feature = "test-failpoints")]
@@ -3215,6 +3308,7 @@ mod tests {
             persisted.operation.as_ref().map(|operation| operation.kind),
             Some(OperationKind::Destroy)
         );
+        assert!(state.state_store.run_dir(uuid).is_ok());
 
         destroy_instance(&state, &id).await.expect("destroy retry");
         assert_eq!(kill_count.load(Ordering::Acquire), 1);
@@ -3228,6 +3322,10 @@ mod tests {
             .expect("persisted destroyed state");
         assert_eq!(persisted.state, SandboxState::Destroyed);
         assert!(persisted.operation.is_none());
+        assert!(matches!(
+            state.state_store.run_dir(uuid),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
     }
 
     #[cfg(feature = "test-failpoints")]

--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -1500,6 +1500,10 @@ mod tests {
                 state.manager.get(id).expect("destroyed state").state,
                 SandboxState::Destroyed
             );
+            assert!(matches!(
+                state.state_store.run_dir(id),
+                Err(BlazeDaemonError::NotFound(_))
+            ));
         }
     }
 
@@ -2171,6 +2175,10 @@ mod tests {
                 .is_file()
         );
         assert!(!pid_file.exists());
+        assert!(matches!(
+            recovered.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
     }
 
     #[cfg(target_os = "linux")]
@@ -2255,6 +2263,7 @@ mod tests {
                 .is_dir()
         );
         assert!(!run_dir.join("backend.stopped").exists());
+        assert!(state.state_store.run_dir(instance.id).is_ok());
 
         drop(handoff);
         let retry = state.manager.reconcile_startup().await;
@@ -2279,6 +2288,10 @@ mod tests {
         );
         assert!(run_dir.join("backend.stopped").is_file());
         assert!(!pid_file.exists());
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
     }
 
     #[tokio::test]
@@ -2789,6 +2802,288 @@ mod tests {
     }
 
     #[cfg(feature = "test-failpoints")]
+    async fn assert_create_rollback_commit_failure_is_retryable(
+        failpoints: &'static [&'static str],
+    ) {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(failpoints);
+
+        let error = hook
+            .run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("rollback terminal commit failure");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("recovery record");
+        assert_eq!(instance.state, SandboxState::RecoveryRequired);
+        assert_eq!(instance.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            instance.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
+        assert_eq!(
+            state
+                .state_store
+                .load(instance.id)
+                .expect("persisted recovery record")
+                .state,
+            SandboxState::RecoveryRequired
+        );
+        assert!(state.state_store.run_dir(instance.id).is_ok());
+        assert!(
+            !temp
+                .path()
+                .join("instances")
+                .join(instance.id.to_string())
+                .exists()
+        );
+
+        destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect("destroy retry");
+
+        assert_eq!(
+            state.instances.lock().expect("instances")[&instance.id].state,
+            SandboxState::Destroyed
+        );
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn initial_publication_failure_before_publish_touches_no_resources() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(&["state-before-first-publication"]);
+
+        hook.run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("pre-publication failure");
+
+        assert!(state.instances.lock().expect("instances").is_empty());
+        assert_eq!(state.state_store.retained_run_dir_count(), 0);
+        assert!(
+            std::fs::read_dir(temp.path().join("state"))
+                .expect("state directory")
+                .next()
+                .is_none()
+        );
+        assert!(
+            std::fs::read_dir(temp.path().join("instances"))
+                .expect("instance directory")
+                .next()
+                .is_none()
+        );
+
+        let created = created_json(&state, &test_request()).await;
+        assert_eq!(created["instance"]["state"], "running");
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn initial_publication_sync_failure_is_rolled_back_terminally() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(&["state-first-publication-root-sync"]);
+
+        hook.run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("initial state publication sync failure");
+
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("terminal rollback record");
+        assert_eq!(instance.state, SandboxState::Destroyed);
+        assert_eq!(instance.backend_ownership, BackendOwnership::Stopped);
+        assert!(instance.operation.is_none());
+        assert_eq!(
+            state
+                .state_store
+                .load(instance.id)
+                .expect("persisted terminal record")
+                .state,
+            SandboxState::Destroyed
+        );
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+        assert!(
+            !temp
+                .path()
+                .join("instances")
+                .join(instance.id.to_string())
+                .exists()
+        );
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn unconfirmed_initial_publication_is_retained_for_recovery() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(&["state-post-publication-identity"]);
+
+        let error = hook
+            .run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("unconfirmed publication");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("recovery record");
+        assert_eq!(instance.state, SandboxState::RecoveryRequired);
+        assert_eq!(instance.backend_ownership, BackendOwnership::Stopped);
+        assert_eq!(
+            instance.operation.as_ref().map(|operation| operation.kind),
+            Some(OperationKind::Create)
+        );
+        assert!(
+            state
+                .state_store
+                .has_run_dir_residual(instance.id)
+                .expect("publication residual")
+        );
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::RecoveryRequired(_))
+        ));
+        assert!(
+            !temp
+                .path()
+                .join("instances")
+                .join(instance.id.to_string())
+                .exists()
+        );
+
+        destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect("destroy revalidates the publication");
+        assert_eq!(
+            state.instances.lock().expect("instances")[&instance.id].state,
+            SandboxState::Destroyed
+        );
+        assert_eq!(
+            state
+                .state_store
+                .load(instance.id)
+                .expect("persisted terminal record")
+                .state,
+            SandboxState::Destroyed
+        );
+        assert!(
+            !state
+                .state_store
+                .has_run_dir_residual(instance.id)
+                .expect("released publication residual")
+        );
+        assert!(matches!(
+            state.state_store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn unconfirmed_publication_rejects_a_replaced_directory_on_retry() {
+        let temp = tempfile::tempdir().expect("temp");
+        let state = mock_state(&temp, false);
+        let hook = crate::failpoint::TestFailpoint::new(&["state-post-publication-identity"]);
+
+        hook.run(create_instance(&state, &test_request()))
+            .await
+            .expect_err("unconfirmed publication");
+        let instance = state
+            .instances
+            .lock()
+            .expect("instances")
+            .values()
+            .next()
+            .cloned()
+            .expect("recovery record");
+        let configured = temp.path().join("state").join(instance.id.to_string());
+        let retained = temp.path().join("retained-state-directory");
+        std::fs::rename(&configured, &retained).expect("move retained state directory");
+        std::fs::create_dir(&configured).expect("replacement state directory");
+
+        let error = destroy_instance(&state, &instance.id.to_string())
+            .await
+            .expect_err("replacement must keep recovery fail-closed");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        assert_eq!(
+            state.instances.lock().expect("instances")[&instance.id].state,
+            SandboxState::RecoveryRequired
+        );
+        assert!(
+            state
+                .state_store
+                .has_run_dir_residual(instance.id)
+                .expect("publication residual")
+        );
+        assert!(
+            configured
+                .read_dir()
+                .expect("replacement directory")
+                .next()
+                .is_none()
+        );
+        assert!(retained.join("state.json").is_file());
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn spawn_failure_rollback_commit_failure_remains_retryable() {
+        assert_create_rollback_commit_failure_is_retryable(&[
+            "create-spawn",
+            "create-rollback-final-state-commit",
+        ])
+        .await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn clean_acquire_failure_rollback_commit_failure_remains_retryable() {
+        assert_create_rollback_commit_failure_is_retryable(&[
+            "storage-acquire",
+            "create-rollback-final-state-commit",
+        ])
+        .await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn initial_publication_and_rollback_failures_remain_retryable() {
+        assert_create_rollback_commit_failure_is_retryable(&[
+            "state-first-publication-root-sync",
+            "create-rollback-final-state-commit",
+        ])
+        .await;
+    }
+
+    #[cfg(feature = "test-failpoints")]
     #[tokio::test]
     async fn destroy_intent_failure_does_not_touch_owned_resources() {
         let temp = tempfile::tempdir().expect("temp");
@@ -3199,6 +3494,11 @@ mod tests {
                 .join(completed_id.to_string())
                 .exists()
         );
+        assert!(state.state_store.run_dir(failed_id).is_ok());
+        assert!(matches!(
+            state.state_store.run_dir(completed_id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
         let created = created_json(&state, &test_request()).await;
         assert_eq!(created["instance"]["state"], "running");
     }

--- a/src/blaze/crates/blazed/src/daemon.rs
+++ b/src/blaze/crates/blazed/src/daemon.rs
@@ -30,6 +30,7 @@ use crate::spawner::{
     BubblewrapSpawner, DynSpawner, FirecrackerSpawner, MockSpawner, SpawnerRegistry,
 };
 use crate::state::ServerState;
+use crate::state_store::StateStore;
 
 /// Boot the daemon: load config + policies, prepare state directories,
 /// bind the API socket, and run the accept loop until SIGTERM/SIGINT.
@@ -82,6 +83,9 @@ async fn run_loaded_config(loaded: LoadedDaemonConfig) -> Result<()> {
     let policy_load = template_roots.policy_load_disposition();
     let template_catalog = TemplateCatalog::open_validated(&config.template, template_roots)?;
     ensure_dirs(&config)?;
+    // Retain the accepted state-root object before policy, backend, and
+    // storage initialization so later code cannot reopen a replacement path.
+    let state_store = StateStore::open(config.daemon.state_dir.clone())?;
     let policy = load_policy_engine(&config, policy_load)?;
     let pool = PoolManager::new();
     let hook = HookRegistry::new();
@@ -127,7 +131,7 @@ async fn run_loaded_config(loaded: LoadedDaemonConfig) -> Result<()> {
 
     let socket_path = config.daemon.socket.clone();
     let http_addr = config.listen.http_addr.clone();
-    let state = Arc::new(ServerState::build_with_template_catalog(
+    let state = Arc::new(ServerState::build_with_store(
         config,
         policy,
         pool,
@@ -136,6 +140,7 @@ async fn run_loaded_config(loaded: LoadedDaemonConfig) -> Result<()> {
         active_backend,
         storage,
         template_catalog,
+        state_store,
     )?);
     let reconciliation = state.manager.reconcile_startup().await;
     tracing::info!(

--- a/src/blaze/crates/blazed/src/main.rs
+++ b/src/blaze/crates/blazed/src/main.rs
@@ -19,6 +19,7 @@ mod metrics;
 mod sandbox;
 mod spawner;
 mod state;
+mod state_store;
 
 use std::process::ExitCode;
 

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -22,7 +22,9 @@ use crate::error::{BlazeDaemonError, Result};
 use crate::guest::{GuestClient, GuestExecResult, MAX_GUEST_FILE_BYTES};
 use crate::metrics::Metrics;
 use crate::sandbox::template::TemplateCatalog;
-use crate::spawner::{DynBackendInstance, SpawnerRegistry};
+use crate::spawner::{
+    BackendSpawnRequest, DynBackendInstance, SpawnerRegistry, spawn_with_runtime_directory,
+};
 use crate::state_store::StateStore;
 
 const GUEST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -359,7 +361,7 @@ impl SandboxManager {
                     .await);
             }
         };
-        if let Err(error) = spawner.prepare_spawn(work_dir.path()).await {
+        if let Err(error) = spawner.prepare_spawn(&work_dir).await {
             return Err(self
                 .cleanup_failed_create(&mut instance, storage, None, false, error.into())
                 .await);
@@ -385,22 +387,28 @@ impl SandboxManager {
                 .await);
         }
 
-        let spawn = match crate::failpoint::backend("create-spawn") {
-            Ok(()) => {
-                spawner
-                    .spawn(SpawnRequest {
-                        instance_id: instance.id,
-                        run_dir: work_dir.path().to_path_buf(),
-                        binary_path: request.binary_path,
-                        storage: storage.clone(),
-                        backend: request.decision.backend,
-                        vm: request.decision.vm,
-                    })
-                    .await
+        let backend_request = match BackendSpawnRequest::new(
+            SpawnRequest {
+                instance_id: instance.id,
+                binary_path: request.binary_path,
+                storage: storage.clone(),
+                backend: request.decision.backend,
+                vm: request.decision.vm,
+            },
+            work_dir.clone(),
+        ) {
+            Ok(request) => request,
+            Err(error) => {
+                instance.backend_ownership = BackendOwnership::NotStarted;
+                return Err(self
+                    .cleanup_failed_create(&mut instance, storage, None, false, error.into())
+                    .await);
             }
+        };
+        let spawn = match crate::failpoint::backend("create-spawn") {
+            Ok(()) => spawn_with_runtime_directory(spawner.as_ref(), backend_request).await,
             Err(error) => Err(crate::spawner::SpawnFailure::clean(error)),
         };
-        drop(work_dir);
         let actual_backend = match spawn {
             Ok(backend_instance) => {
                 instance.backend_ownership = BackendOwnership::Running;
@@ -678,7 +686,7 @@ impl SandboxManager {
             }
             None => match self.spawners.get(metadata.backend) {
                 Some(spawner) => match self.state_store.run_dir(id) {
-                    Ok(run_dir) => match spawner.cleanup_orphan(id, run_dir.path()).await {
+                    Ok(run_dir) => match spawner.cleanup_orphan(id, &run_dir).await {
                         Ok(()) => true,
                         Err(error) => {
                             tracing::error!(
@@ -805,7 +813,7 @@ impl SandboxManager {
                 } else {
                     match self.spawners.get(original.backend) {
                         Some(spawner) => match self.state_store.run_dir(id) {
-                            Ok(run_dir) => spawner.cleanup_orphan(id, run_dir.path()).await,
+                            Ok(run_dir) => spawner.cleanup_orphan(id, &run_dir).await,
                             Err(error) => Err(BlazeError::BackendError {
                                 msg: format!(
                                     "open owned run directory for persisted instance {id}: {error}"
@@ -881,11 +889,7 @@ impl SandboxManager {
                     .unwrap_or_default()
             )));
         }
-        if let Some(error) = self.retain_instance(destroyed) {
-            return Err(BlazeDaemonError::RecoveryRequired(format!(
-                "destroy {id}: resources released but {error}"
-            )));
-        }
+        let retention_error = self.retain_instance(destroyed);
         match self.backend_instances.lock() {
             Ok(mut instances) => {
                 instances.remove(&id);
@@ -893,6 +897,11 @@ impl SandboxManager {
             Err(poisoned) => {
                 poisoned.into_inner().remove(&id);
             }
+        }
+        if let Some(error) = retention_error {
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "destroy {id}: resources released but {error}"
+            )));
         }
         self.metrics.inc(&self.metrics.instances_destroyed);
         Ok(true)

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -288,7 +288,28 @@ impl SandboxManager {
         instance.begin_operation(OperationKind::Create);
 
         // Publish the stable identity and create intent before allocation.
-        self.state_store.persist(&instance)?;
+        if let Err(error) = self.state_store.persist(&instance) {
+            match self.state_store.has_run_dir_residual(instance.id) {
+                Ok(true) => {}
+                Ok(false) => return Err(error),
+                Err(residual_error) => {
+                    return Err(BlazeDaemonError::RecoveryRequired(format!(
+                        "create {}: initial state publication failed: {error}; could not inspect \
+                         publication residual: {residual_error}",
+                        instance.id
+                    )));
+                }
+            }
+            let rollback_errors = self.commit_create_rollback(&mut instance);
+            if rollback_errors.is_empty() {
+                return Err(error);
+            }
+            return Err(BlazeDaemonError::RecoveryRequired(format!(
+                "create {}: initial state publication failed: {error}; {}",
+                instance.id,
+                rollback_errors.join("; ")
+            )));
+        }
         if let Some(error) = self.retain_instance(instance.clone()) {
             return Err(BlazeDaemonError::RecoveryRequired(format!(
                 "create {}: {error}",
@@ -313,7 +334,14 @@ impl SandboxManager {
         };
         crate::failpoint::pause("create-after-storage-acquire").await;
 
-        let work_dir = self.state_store.run_dir(instance.id);
+        let work_dir = match self.state_store.run_dir(instance.id) {
+            Ok(work_dir) => work_dir,
+            Err(error) => {
+                return Err(self
+                    .cleanup_failed_create(&mut instance, storage, None, false, error)
+                    .await);
+            }
+        };
         let spawner = match self.spawners.get(self.active_backend) {
             Some(spawner) => spawner,
             None => {
@@ -331,7 +359,7 @@ impl SandboxManager {
                     .await);
             }
         };
-        if let Err(error) = spawner.prepare_spawn(&work_dir).await {
+        if let Err(error) = spawner.prepare_spawn(work_dir.path()).await {
             return Err(self
                 .cleanup_failed_create(&mut instance, storage, None, false, error.into())
                 .await);
@@ -362,7 +390,7 @@ impl SandboxManager {
                 spawner
                     .spawn(SpawnRequest {
                         instance_id: instance.id,
-                        run_dir: work_dir,
+                        run_dir: work_dir.path().to_path_buf(),
                         binary_path: request.binary_path,
                         storage: storage.clone(),
                         backend: request.decision.backend,
@@ -372,6 +400,7 @@ impl SandboxManager {
             }
             Err(error) => Err(crate::spawner::SpawnFailure::clean(error)),
         };
+        drop(work_dir);
         let actual_backend = match spawn {
             Ok(backend_instance) => {
                 instance.backend_ownership = BackendOwnership::Running;
@@ -648,16 +677,23 @@ impl SandboxManager {
                 true
             }
             None => match self.spawners.get(metadata.backend) {
-                Some(spawner) => match spawner
-                    .cleanup_orphan(id, &self.state_store.run_dir(id))
-                    .await
-                {
-                    Ok(()) => true,
+                Some(spawner) => match self.state_store.run_dir(id) {
+                    Ok(run_dir) => match spawner.cleanup_orphan(id, run_dir.path()).await {
+                        Ok(()) => true,
+                        Err(error) => {
+                            tracing::error!(
+                                instance = %id,
+                                %error,
+                                "quarantined orphan cleanup failed"
+                            );
+                            false
+                        }
+                    },
                     Err(error) => {
                         tracing::error!(
                             instance = %id,
                             %error,
-                            "quarantined orphan cleanup failed"
+                            "quarantined run-directory ownership failed"
                         );
                         false
                     }
@@ -768,11 +804,14 @@ impl SandboxManager {
                     Ok(())
                 } else {
                     match self.spawners.get(original.backend) {
-                        Some(spawner) => {
-                            spawner
-                                .cleanup_orphan(id, &self.state_store.run_dir(id))
-                                .await
-                        }
+                        Some(spawner) => match self.state_store.run_dir(id) {
+                            Ok(run_dir) => spawner.cleanup_orphan(id, run_dir.path()).await,
+                            Err(error) => Err(BlazeError::BackendError {
+                                msg: format!(
+                                    "open owned run directory for persisted instance {id}: {error}"
+                                ),
+                            }),
+                        },
                         None => Err(BlazeError::BackendError {
                             msg: format!(
                                 "no recovery spawner registered for persisted backend {}",
@@ -1005,18 +1044,7 @@ impl SandboxManager {
         }
 
         if backend_stopped && storage_released {
-            instance.backend_ownership = BackendOwnership::Stopped;
-            if let Err(error) = instance.transition(SandboxState::Destroyed) {
-                cleanup_errors.push(format!("lifecycle update failed: {error}"));
-            } else {
-                instance.finish_operation();
-            }
-            if let Err(error) = self.state_store.persist(instance) {
-                cleanup_errors.push(format!("state persistence failed: {error}"));
-            }
-            if let Some(error) = self.retain_instance(instance.clone()) {
-                cleanup_errors.push(error);
-            }
+            cleanup_errors.extend(self.commit_create_rollback(instance));
             if cleanup_errors.is_empty() {
                 self.metrics.inc(&self.metrics.instances_destroyed);
                 return original;
@@ -1082,19 +1110,7 @@ impl SandboxManager {
             ));
         }
 
-        let mut errors = Vec::new();
-        instance.backend_ownership = BackendOwnership::Stopped;
-        if let Err(error) = instance.transition(SandboxState::Destroyed) {
-            errors.push(format!("lifecycle update failed: {error}"));
-        } else {
-            instance.finish_operation();
-        }
-        if let Err(error) = self.state_store.persist(instance) {
-            errors.push(format!("state persistence failed: {error}"));
-        }
-        if let Some(error) = self.retain_instance(instance.clone()) {
-            errors.push(error);
-        }
+        let errors = self.commit_create_rollback(instance);
         if errors.is_empty() {
             original
         } else {
@@ -1102,6 +1118,47 @@ impl SandboxManager {
                 "{original}; acquire rollback completed but {}",
                 errors.join("; ")
             ))
+        }
+    }
+
+    /// Commit a fully compensated create as terminal without losing the
+    /// operation record when that terminal commit itself fails.
+    fn commit_create_rollback(&self, instance: &mut SandboxInstance) -> Vec<String> {
+        let recoverable = instance.clone();
+        let mut terminal = recoverable.clone();
+        terminal.backend_ownership = BackendOwnership::Stopped;
+        let terminal_result = (|| -> Result<()> {
+            if terminal.state != SandboxState::Destroyed {
+                terminal.transition(SandboxState::Destroyed)?;
+            }
+            terminal.finish_operation();
+            crate::failpoint::state("create-rollback-final-state-commit")?;
+            self.state_store.persist(&terminal)
+        })();
+
+        match terminal_result {
+            Ok(()) => {
+                *instance = terminal.clone();
+                self.retain_instance(terminal).into_iter().collect()
+            }
+            Err(error) => {
+                let mut errors = vec![format!("final state persistence failed: {error}")];
+                let mut recovery = recoverable;
+                recovery.backend_ownership = BackendOwnership::Stopped;
+                if recovery.state != SandboxState::RecoveryRequired
+                    && let Err(error) = recovery.transition(SandboxState::RecoveryRequired)
+                {
+                    errors.push(format!("recovery state update failed: {error}"));
+                }
+                if let Err(error) = self.state_store.persist(&recovery) {
+                    errors.push(format!("recovery state persistence failed: {error}"));
+                }
+                if let Some(error) = self.retain_instance(recovery.clone()) {
+                    errors.push(error);
+                }
+                *instance = recovery;
+                errors
+            }
         }
     }
 

--- a/src/blaze/crates/blazed/src/sandbox/manager.rs
+++ b/src/blaze/crates/blazed/src/sandbox/manager.rs
@@ -23,6 +23,7 @@ use crate::guest::{GuestClient, GuestExecResult, MAX_GUEST_FILE_BYTES};
 use crate::metrics::Metrics;
 use crate::sandbox::template::TemplateCatalog;
 use crate::spawner::{DynBackendInstance, SpawnerRegistry};
+use crate::state_store::StateStore;
 
 const GUEST_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -83,7 +84,7 @@ pub struct SandboxManager {
     spawners: Arc<SpawnerRegistry>,
     active_backend: BackendKind,
     storage: Arc<dyn StorageProvider>,
-    state_dir: PathBuf,
+    state_store: StateStore,
     rootfs_size: u64,
     mem_size: u64,
     metrics: Arc<Metrics>,
@@ -97,7 +98,7 @@ pub struct SandboxManagerInit {
     pub spawners: SpawnerRegistry,
     pub active_backend: BackendKind,
     pub storage: Arc<dyn StorageProvider>,
-    pub state_dir: PathBuf,
+    pub state_store: StateStore,
     pub rootfs_size: u64,
     pub mem_size: u64,
     pub template_catalog: TemplateCatalog,
@@ -120,7 +121,7 @@ impl SandboxManager {
             spawners,
             active_backend,
             storage,
-            state_dir,
+            state_store,
             rootfs_size,
             mem_size,
             template_catalog,
@@ -152,7 +153,7 @@ impl SandboxManager {
                 spawners: Arc::new(spawners),
                 active_backend,
                 storage,
-                state_dir,
+                state_store,
                 rootfs_size,
                 mem_size,
                 metrics,
@@ -287,7 +288,7 @@ impl SandboxManager {
         instance.begin_operation(OperationKind::Create);
 
         // Publish the stable identity and create intent before allocation.
-        instance.persist(&self.state_dir)?;
+        self.state_store.persist(&instance)?;
         if let Some(error) = self.retain_instance(instance.clone()) {
             return Err(BlazeDaemonError::RecoveryRequired(format!(
                 "create {}: {error}",
@@ -312,7 +313,7 @@ impl SandboxManager {
         };
         crate::failpoint::pause("create-after-storage-acquire").await;
 
-        let work_dir = self.state_dir.join(instance.id.to_string());
+        let work_dir = self.state_store.run_dir(instance.id);
         let spawner = match self.spawners.get(self.active_backend) {
             Some(spawner) => spawner,
             None => {
@@ -337,10 +338,10 @@ impl SandboxManager {
         }
 
         instance.backend_ownership = BackendOwnership::Starting;
-        if let Err(error) = instance.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(&instance) {
             instance.backend_ownership = BackendOwnership::NotStarted;
             return Err(self
-                .cleanup_failed_create(&mut instance, storage, None, false, error.into())
+                .cleanup_failed_create(&mut instance, storage, None, false, error)
                 .await);
         }
         if let Some(error) = self.retain_instance(instance.clone()) {
@@ -437,7 +438,7 @@ impl SandboxManager {
         }
         instance.finish_operation();
         if let Err(error) = crate::failpoint::state("create-state-commit")
-            .and_then(|_| instance.persist(&self.state_dir).map_err(Into::into))
+            .and_then(|_| self.state_store.persist(&instance))
         {
             return Err(self
                 .cleanup_failed_create(&mut instance, storage, None, true, error)
@@ -530,11 +531,9 @@ impl SandboxManager {
 
         let mut activating = original.clone();
         activating.begin_operation(OperationKind::Create);
-        if let Err(error) = crate::failpoint::state("warm-intent-state-commit").and_then(|_| {
-            activating
-                .persist(&self.state_dir)
-                .map_err(BlazeDaemonError::from)
-        }) {
+        if let Err(error) = crate::failpoint::state("warm-intent-state-commit")
+            .and_then(|_| self.state_store.persist(&activating))
+        {
             return Err(self.restore_warm_claim(key, original, error));
         }
         if let Some(error) = self.retain_instance(activating.clone()) {
@@ -550,11 +549,9 @@ impl SandboxManager {
             return Err(self.restore_warm_claim(key, original, error.into()));
         }
         activating.finish_operation();
-        if let Err(error) = crate::failpoint::state("warm-final-state-commit").and_then(|_| {
-            activating
-                .persist(&self.state_dir)
-                .map_err(BlazeDaemonError::from)
-        }) {
+        if let Err(error) = crate::failpoint::state("warm-final-state-commit")
+            .and_then(|_| self.state_store.persist(&activating))
+        {
             return Err(self.restore_warm_claim(key, original, error));
         }
         if let Some(error) = self.retain_instance(activating.clone()) {
@@ -574,7 +571,7 @@ impl SandboxManager {
     ) -> BlazeDaemonError {
         let id = instance.id;
         let mut errors = Vec::new();
-        if let Err(error) = instance.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(&instance) {
             errors.push(format!("restore warm state persistence failed: {error}"));
         }
         if let Some(error) = self.retain_instance(instance) {
@@ -626,7 +623,7 @@ impl SandboxManager {
             return;
         };
         metadata.begin_operation(OperationKind::Destroy);
-        if let Err(error) = metadata.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(metadata) {
             tracing::error!(instance = %id, %error, "quarantine intent commit failed");
             return;
         }
@@ -652,7 +649,7 @@ impl SandboxManager {
             }
             None => match self.spawners.get(metadata.backend) {
                 Some(spawner) => match spawner
-                    .cleanup_orphan(id, &self.state_dir.join(id.to_string()))
+                    .cleanup_orphan(id, &self.state_store.run_dir(id))
                     .await
                 {
                     Ok(()) => true,
@@ -681,7 +678,7 @@ impl SandboxManager {
         }
 
         metadata.backend_ownership = BackendOwnership::Stopped;
-        if let Err(error) = metadata.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(metadata) {
             tracing::error!(instance = %id, %error, "quarantined stop state commit failed");
             let _ = self.mark_recovery(id);
             return;
@@ -705,7 +702,7 @@ impl SandboxManager {
             return;
         }
         metadata.finish_operation();
-        if let Err(error) = metadata.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(metadata) {
             tracing::error!(instance = %id, %error, "quarantined state commit failed");
             let _ = self.mark_recovery(id);
             return;
@@ -739,11 +736,9 @@ impl SandboxManager {
         {
             original.begin_operation(OperationKind::Destroy);
         }
-        if let Err(error) = crate::failpoint::state("destroy-intent-state-commit").and_then(|_| {
-            original
-                .persist(&self.state_dir)
-                .map_err(BlazeDaemonError::from)
-        }) {
+        if let Err(error) = crate::failpoint::state("destroy-intent-state-commit")
+            .and_then(|_| self.state_store.persist(&original))
+        {
             let _ = self.mark_recovery(id);
             return Err(BlazeDaemonError::RecoveryRequired(format!(
                 "destroy {id}: intent persistence failed: {error}; resources retained"
@@ -775,7 +770,7 @@ impl SandboxManager {
                     match self.spawners.get(original.backend) {
                         Some(spawner) => {
                             spawner
-                                .cleanup_orphan(id, &self.state_dir.join(id.to_string()))
+                                .cleanup_orphan(id, &self.state_store.run_dir(id))
                                 .await
                         }
                         None => Err(BlazeError::BackendError {
@@ -800,11 +795,9 @@ impl SandboxManager {
         }
 
         original.backend_ownership = BackendOwnership::Stopped;
-        if let Err(error) = crate::failpoint::state("destroy-stop-state-commit").and_then(|_| {
-            original
-                .persist(&self.state_dir)
-                .map_err(BlazeDaemonError::from)
-        }) {
+        if let Err(error) = crate::failpoint::state("destroy-stop-state-commit")
+            .and_then(|_| self.state_store.persist(&original))
+        {
             let recovery = self.mark_instance_recovery(original.clone()).err();
             return Err(BlazeDaemonError::RecoveryRequired(format!(
                 "destroy {id}: backend stopped but stop state persistence failed: {error}; \
@@ -838,11 +831,9 @@ impl SandboxManager {
             destroyed.transition(SandboxState::Destroyed)?;
         }
         destroyed.finish_operation();
-        if let Err(error) = crate::failpoint::state("destroy-final-state-commit").and_then(|_| {
-            destroyed
-                .persist(&self.state_dir)
-                .map_err(BlazeDaemonError::from)
-        }) {
+        if let Err(error) = crate::failpoint::state("destroy-final-state-commit")
+            .and_then(|_| self.state_store.persist(&destroyed))
+        {
             let recovery = self.mark_recovery(id).err();
             return Err(BlazeDaemonError::RecoveryRequired(format!(
                 "destroy {id}: resources released but final state persistence failed: {error}{}",
@@ -1020,7 +1011,7 @@ impl SandboxManager {
             } else {
                 instance.finish_operation();
             }
-            if let Err(error) = instance.persist(&self.state_dir) {
+            if let Err(error) = self.state_store.persist(instance) {
                 cleanup_errors.push(format!("state persistence failed: {error}"));
             }
             if let Some(error) = self.retain_instance(instance.clone()) {
@@ -1046,7 +1037,7 @@ impl SandboxManager {
         {
             cleanup_errors.push(format!("recovery state update failed: {error}"));
         }
-        if let Err(error) = instance.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(instance) {
             cleanup_errors.push(format!("state persistence failed: {error}"));
         }
         if let Some(error) = self.retain_instance(instance.clone()) {
@@ -1071,7 +1062,7 @@ impl SandboxManager {
             {
                 errors.push(format!("recovery state update failed: {error}"));
             }
-            if let Err(error) = instance.persist(&self.state_dir) {
+            if let Err(error) = self.state_store.persist(instance) {
                 errors.push(format!("state persistence failed: {error}"));
             }
             if let Some(error) = self.retain_instance(instance.clone()) {
@@ -1098,7 +1089,7 @@ impl SandboxManager {
         } else {
             instance.finish_operation();
         }
-        if let Err(error) = instance.persist(&self.state_dir) {
+        if let Err(error) = self.state_store.persist(instance) {
             errors.push(format!("state persistence failed: {error}"));
         }
         if let Some(error) = self.retain_instance(instance.clone()) {
@@ -1122,11 +1113,11 @@ impl SandboxManager {
         if instance.state != SandboxState::RecoveryRequired {
             instance.transition(SandboxState::RecoveryRequired)?;
         }
-        let persist = instance.persist(&self.state_dir);
+        let persist = self.state_store.persist(&instance);
         let retained = self.retain_instance(instance);
         match (persist, retained) {
             (Ok(()), None) => Ok(()),
-            (Err(error), None) => Err(error.into()),
+            (Err(error), None) => Err(error),
             (Ok(()), Some(error)) => Err(BlazeDaemonError::Internal(error)),
             (Err(persist), Some(retain)) => Err(BlazeDaemonError::RecoveryRequired(format!(
                 "recovery state persistence failed: {persist}; {retain}"

--- a/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
+++ b/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
@@ -464,9 +464,10 @@ mod tests {
     use crate::sandbox::manager::{SandboxManagerInit, SandboxManagerResources};
     use crate::sandbox::template::TemplateCatalog;
     use crate::spawner::{
-        BackendInstance, BackendSpawner, MockSpawner, SpawnResult, SpawnerRegistry,
+        BackendInstance, BackendSpawnRequest, MockSpawner, SpawnResult, SpawnerRegistry,
+        spawn_with_runtime_directory,
     };
-    use crate::state_store::StateStore;
+    use crate::state_store::{OwnedRunDir, StateStore};
 
     use super::*;
 
@@ -752,17 +753,24 @@ mod tests {
                 rootfs_diff_path: PathBuf::new(),
                 instance_dir: PathBuf::new(),
             });
-            let owner = MockSpawner
-                .spawn(SpawnRequest {
-                    instance_id: id,
-                    run_dir,
-                    binary_path: PathBuf::new(),
-                    storage: slot,
-                    backend: BackendConfigs::default(),
-                    vm: None,
-                })
-                .await
-                .expect("mock owner");
+            let run_dir = OwnedRunDir::for_test(id, run_dir);
+            let owner = spawn_with_runtime_directory(
+                &MockSpawner,
+                BackendSpawnRequest::new(
+                    SpawnRequest {
+                        instance_id: id,
+                        binary_path: PathBuf::new(),
+                        storage: slot,
+                        backend: BackendConfigs::default(),
+                        vm: None,
+                    },
+                    run_dir.clone(),
+                )
+                .expect("matching backend request"),
+            )
+            .await
+            .expect("mock owner");
+            drop(run_dir);
             manager
                 .insert_backend_owner(id, owner)
                 .expect("register owner");

--- a/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
+++ b/src/blaze/crates/blazed/src/sandbox/storage_sync.rs
@@ -466,6 +466,7 @@ mod tests {
     use crate::spawner::{
         BackendInstance, BackendSpawner, MockSpawner, SpawnResult, SpawnerRegistry,
     };
+    use crate::state_store::StateStore;
 
     use super::*;
 
@@ -667,7 +668,7 @@ mod tests {
             spawners,
             active_backend: BackendKind::Mock,
             storage,
-            state_dir,
+            state_store: StateStore::new(state_dir),
             rootfs_size: 64,
             mem_size: 32,
             template_catalog,

--- a/src/blaze/crates/blazed/src/spawner.rs
+++ b/src/blaze/crates/blazed/src/spawner.rs
@@ -6,6 +6,7 @@ mod netns;
 
 use std::collections::HashMap;
 use std::fmt;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -28,6 +29,8 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+
+use crate::state_store::OwnedRunDir;
 
 pub use firecracker::FirecrackerSpawner;
 
@@ -75,6 +78,100 @@ pub trait BackendInstance: Send + Sync {
 
 /// Shared backend instance handle stored in the daemon runtime map.
 pub type DynBackendInstance = Arc<dyn BackendInstance>;
+
+/// Backend launch inputs paired with the opened runtime-directory owner.
+///
+/// The portable request remains in `blaze-core`; this daemon-local wrapper
+/// prevents backend implementations from reconstructing the runtime directory
+/// from a configured pathname.
+#[derive(Debug, Clone)]
+pub struct BackendSpawnRequest {
+    request: SpawnRequest,
+    /// Opened directory used for all backend runtime artifacts.
+    pub run_dir: OwnedRunDir,
+}
+
+impl BackendSpawnRequest {
+    pub(crate) fn new(request: SpawnRequest, run_dir: OwnedRunDir) -> Result<Self> {
+        if request.instance_id != run_dir.instance_id() {
+            return Err(BlazeError::BackendError {
+                msg: format!(
+                    "backend request for {} does not match runtime-directory owner for {}",
+                    request.instance_id,
+                    run_dir.instance_id()
+                ),
+            });
+        }
+        Ok(Self { request, run_dir })
+    }
+}
+
+impl Deref for BackendSpawnRequest {
+    type Target = SpawnRequest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.request
+    }
+}
+
+/// Runtime owner that keeps the opened sandbox directory alive for as long as
+/// any backend handle can still use paths derived from it.
+struct RuntimeOwnedBackend {
+    inner: DynBackendInstance,
+    _run_dir: OwnedRunDir,
+}
+
+#[async_trait]
+impl BackendInstance for RuntimeOwnedBackend {
+    fn backend(&self) -> BackendKind {
+        self.inner.backend()
+    }
+
+    fn guest_socket_path(&self) -> &Path {
+        self.inner.guest_socket_path()
+    }
+
+    async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+        self.inner.try_wait().await
+    }
+
+    async fn kill(&self) -> Result<()> {
+        self.inner.kill().await
+    }
+}
+
+/// Attach runtime-directory ownership to a successful or partially started
+/// backend handle before it enters lifecycle management.
+pub(crate) fn bind_runtime_directory(
+    inner: DynBackendInstance,
+    run_dir: OwnedRunDir,
+) -> DynBackendInstance {
+    Arc::new(RuntimeOwnedBackend {
+        inner,
+        _run_dir: run_dir,
+    })
+}
+
+/// Start one backend while attaching the runtime-directory owner to every
+/// returned process owner, including a partial owner carried by a failure.
+pub(crate) async fn spawn_with_runtime_directory(
+    spawner: &dyn BackendSpawner,
+    request: BackendSpawnRequest,
+) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+    let run_dir = request.run_dir.clone();
+    match spawner.spawn(request).await {
+        Ok(owner) => Ok(bind_runtime_directory(owner, run_dir)),
+        Err(error) => {
+            let (source, owner) = error.into_parts();
+            Err(match owner {
+                Some(owner) => {
+                    SpawnFailure::with_owner(source, bind_runtime_directory(owner, run_dir))
+                }
+                None => SpawnFailure::clean(source),
+            })
+        }
+    }
+}
 
 /// Backend start failure that may retain ownership of a started process.
 pub struct SpawnFailure {
@@ -156,14 +253,14 @@ impl From<std::io::Error> for SpawnFailure {
 #[async_trait]
 pub trait BackendSpawner: Send + Sync {
     /// Persist backend-specific pre-spawn ownership metadata.
-    async fn prepare_spawn(&self, _run_dir: &Path) -> Result<()> {
+    async fn prepare_spawn(&self, _run_dir: &OwnedRunDir) -> Result<()> {
         Ok(())
     }
 
     /// Start a new sandbox.
     async fn spawn(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure>;
 
     /// Probe whether the configured backend executable is usable.
@@ -171,7 +268,7 @@ pub trait BackendSpawner: Send + Sync {
 
     /// Clean up a backend process and resources whose in-memory handle was
     /// lost across daemon restart.
-    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()>;
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &OwnedRunDir) -> Result<()>;
 }
 
 /// Shared backend spawner selected during daemon startup.
@@ -205,18 +302,16 @@ pub struct BubblewrapSpawner;
 
 #[async_trait]
 impl BackendSpawner for BubblewrapSpawner {
-    async fn prepare_spawn(&self, run_dir: &Path) -> Result<()> {
-        tokio::fs::create_dir_all(run_dir).await?;
-        prepare_pid_handoff(&run_dir.join("backend.pid"))
+    async fn prepare_spawn(&self, run_dir: &OwnedRunDir) -> Result<()> {
+        prepare_pid_handoff(&run_dir.path().join("backend.pid"))
     }
 
     async fn spawn(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
-        tokio::fs::create_dir_all(&request.run_dir).await?;
-        remove_file_if_exists(&request.run_dir.join(STOPPED_MARKER)).await?;
-        let pid_file = request.run_dir.join("backend.pid");
+        remove_file_if_exists(&request.run_dir.path().join(STOPPED_MARKER)).await?;
+        let pid_file = request.run_dir.path().join("backend.pid");
         let mut command = Command::new(&request.binary_path);
         command
             .args([
@@ -243,7 +338,7 @@ impl BackendSpawner for BubblewrapSpawner {
         let child = command.spawn();
         drop(pid_handoff);
         let child = child?;
-        let stopped_marker = request.run_dir.join(STOPPED_MARKER);
+        let stopped_marker = request.run_dir.path().join(STOPPED_MARKER);
         let instance = ProcessInstance::new(
             request.instance_id,
             BackendKind::Bubblewrap,
@@ -258,8 +353,8 @@ impl BackendSpawner for BubblewrapSpawner {
         Ok(binary_path.is_file())
     }
 
-    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()> {
-        cleanup_process_run_dir(instance_id, run_dir, "bubblewrap").await
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &OwnedRunDir) -> Result<()> {
+        cleanup_process_run_dir(instance_id, run_dir.path(), "bubblewrap").await
     }
 }
 
@@ -340,9 +435,9 @@ pub struct MockSpawner;
 impl BackendSpawner for MockSpawner {
     async fn spawn(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
-        spawn_mock_instance(request.instance_id, request.run_dir)
+        spawn_mock_instance(request.instance_id)
             .await
             .map_err(SpawnFailure::from)
     }
@@ -351,7 +446,7 @@ impl BackendSpawner for MockSpawner {
         Ok(true)
     }
 
-    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &Path) -> Result<()> {
+    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &OwnedRunDir) -> Result<()> {
         // Mock owners are in-process tasks and cannot survive daemon exit.
         Ok(())
     }
@@ -364,8 +459,7 @@ struct MockInstance {
     killed: AtomicBool,
 }
 
-async fn spawn_mock_instance(instance_id: Uuid, run_dir: PathBuf) -> Result<DynBackendInstance> {
-    tokio::fs::create_dir_all(&run_dir).await?;
+async fn spawn_mock_instance(instance_id: Uuid) -> Result<DynBackendInstance> {
     let cancellation = CancellationToken::new();
     let task_token = cancellation.clone();
     let task = tokio::spawn(async move { task_token.cancelled().await });
@@ -434,9 +528,9 @@ pub(crate) struct GuestMockSpawner;
 impl BackendSpawner for GuestMockSpawner {
     async fn spawn(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
-        spawn_guest_mock_instance(request.instance_id, request.run_dir)
+        spawn_guest_mock_instance(request.instance_id, &request.run_dir)
             .await
             .map_err(SpawnFailure::from)
     }
@@ -445,7 +539,7 @@ impl BackendSpawner for GuestMockSpawner {
         Ok(true)
     }
 
-    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &Path) -> Result<()> {
+    async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &OwnedRunDir) -> Result<()> {
         Ok(())
     }
 }
@@ -462,10 +556,9 @@ struct GuestMockInstance {
 #[cfg(test)]
 async fn spawn_guest_mock_instance(
     instance_id: Uuid,
-    run_dir: PathBuf,
+    run_dir: &OwnedRunDir,
 ) -> Result<DynBackendInstance> {
-    tokio::fs::create_dir_all(&run_dir).await?;
-    let socket = run_dir.join("vsock.uds");
+    let socket = run_dir.path().join("vsock.uds");
     if socket.exists() {
         tokio::fs::remove_file(&socket).await?;
     }
@@ -1056,24 +1149,116 @@ mod tests {
 
     use super::*;
 
-    fn request(root: &Path) -> SpawnRequest {
+    fn request(root: &Path) -> BackendSpawnRequest {
         let id = Uuid::new_v4();
         let slot_dir = root.join("slot");
-        SpawnRequest {
-            instance_id: id,
-            run_dir: root.join("run"),
-            binary_path: PathBuf::new(),
-            storage: StorageSlot {
-                id: id.to_string(),
-                rootfs_path: slot_dir.join("rootfs.ext4"),
-                mem_path: slot_dir.join("mem.bin"),
-                mem_diff_path: slot_dir.join("mem.diff"),
-                rootfs_diff_path: slot_dir.join("rootfs.diff"),
-                instance_dir: slot_dir,
+        BackendSpawnRequest::new(
+            SpawnRequest {
+                instance_id: id,
+                binary_path: PathBuf::new(),
+                storage: StorageSlot {
+                    id: id.to_string(),
+                    rootfs_path: slot_dir.join("rootfs.ext4"),
+                    mem_path: slot_dir.join("mem.bin"),
+                    mem_diff_path: slot_dir.join("mem.diff"),
+                    rootfs_diff_path: slot_dir.join("rootfs.diff"),
+                    instance_dir: slot_dir,
+                },
+                backend: BackendConfigs::default(),
+                vm: None,
             },
-            backend: BackendConfigs::default(),
-            vm: None,
+            OwnedRunDir::for_test(id, root.join("run")),
+        )
+        .expect("matching backend request")
+    }
+
+    #[test]
+    fn backend_request_rejects_a_mismatched_runtime_owner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let mut request = request(temp.path());
+        request.request.instance_id = Uuid::new_v4();
+        assert!(
+            BackendSpawnRequest::new(request.request.clone(), request.run_dir.clone()).is_err()
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    struct PartialPathOwner {
+        marker: PathBuf,
+    }
+
+    #[cfg(target_os = "linux")]
+    #[async_trait]
+    impl BackendInstance for PartialPathOwner {
+        fn backend(&self) -> BackendKind {
+            BackendKind::Mock
         }
+
+        async fn try_wait(&self) -> Result<Option<SpawnResult>> {
+            Ok(None)
+        }
+
+        async fn kill(&self) -> Result<()> {
+            std::fs::write(&self.marker, b"partial owner")?;
+            Ok(())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    struct PartialPathSpawner;
+
+    #[cfg(target_os = "linux")]
+    #[async_trait]
+    impl BackendSpawner for PartialPathSpawner {
+        async fn spawn(
+            &self,
+            request: BackendSpawnRequest,
+        ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
+            let owner: DynBackendInstance = Arc::new(PartialPathOwner {
+                marker: request.run_dir.path().join("partial-owner-marker"),
+            });
+            Err(SpawnFailure::with_owner(
+                BlazeError::BackendError {
+                    msg: "injected partial start".into(),
+                },
+                owner,
+            ))
+        }
+
+        async fn probe(&self, _binary_path: &Path) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn cleanup_orphan(&self, _instance_id: Uuid, _run_dir: &OwnedRunDir) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn partial_spawn_failure_retains_the_runtime_directory_owner() {
+        let temp = tempfile::tempdir().expect("temp");
+        let request = request(temp.path());
+        let failure = match spawn_with_runtime_directory(&PartialPathSpawner, request).await {
+            Ok(_) => panic!("partial spawn must fail"),
+            Err(failure) => failure,
+        };
+        let (source, owner) = failure.into_parts();
+        assert!(source.to_string().contains("injected partial start"));
+        let owner = owner.expect("partial backend owner");
+
+        let configured_run_dir = temp.path().join("run");
+        let owned_run_dir = temp.path().join("owned-partial-run");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move owned runtime directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement runtime directory");
+
+        owner.kill().await.expect("use retained runtime owner");
+
+        assert_eq!(
+            std::fs::read(owned_run_dir.join("partial-owner-marker")).expect("owned marker"),
+            b"partial owner"
+        );
+        assert!(!configured_run_dir.join("partial-owner-marker").exists());
     }
 
     #[cfg(target_os = "linux")]
@@ -1114,12 +1299,19 @@ mod tests {
     #[tokio::test]
     async fn test_guest_instance_supports_io_and_idempotent_kill() {
         let temp = tempfile::tempdir().expect("temp");
-        let instance = GuestMockSpawner
-            .spawn(request(temp.path()))
+        let request = request(temp.path());
+        let run_dir = request.run_dir.clone();
+        let instance = spawn_with_runtime_directory(&GuestMockSpawner, request)
             .await
             .expect("spawn");
+        drop(run_dir);
+        let configured_run_dir = temp.path().join("run");
+        let owned_run_dir = temp.path().join("owned-run");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move owned runtime directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement runtime directory");
+        assert_eq!(instance.backend(), BackendKind::Mock);
         let client = GuestClient::new(
-            temp.path().join("run/vsock.uds"),
+            instance.guest_socket_path().to_path_buf(),
             Duration::from_secs(1),
             1024,
         );
@@ -1131,6 +1323,8 @@ mod tests {
             client.read_file("/tmp/value".into()).await.expect("read"),
             b"hello"
         );
+        assert!(owned_run_dir.join("vsock.uds").exists());
+        assert!(!configured_run_dir.join("vsock.uds").exists());
         assert_eq!(instance.try_wait().await.expect("try wait"), None);
         instance.kill().await.expect("kill");
         assert!(instance.try_wait().await.expect("try wait").is_some());

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -195,7 +195,12 @@ impl FirecrackerSpawner {
             None
         };
 
-        let mut command = build_launch_command(&request.binary_path, network.as_ref(), &api_socket);
+        let mut command = build_launch_command(
+            &request.binary_path,
+            network.as_ref(),
+            &api_socket,
+            request.instance_id,
+        );
         let config_path = match write_vm_config(
             &self.images_dir,
             &request,
@@ -629,6 +634,7 @@ fn build_launch_command(
     binary: &Path,
     network: Option<&NetworkSlot>,
     api_socket: &Path,
+    instance_id: Uuid,
 ) -> Command {
     #[cfg(target_os = "linux")]
     let mut command = if let Some(network) = network {
@@ -660,14 +666,7 @@ fn build_launch_command(
         Command::new(binary)
     };
     command.arg("--api-sock").arg(api_socket);
-    command.arg("--id").arg(format!(
-        "fc-{}",
-        api_socket
-            .parent()
-            .and_then(Path::file_name)
-            .and_then(std::ffi::OsStr::to_str)
-            .unwrap_or("blaze")
-    ));
+    command.arg("--id").arg(format!("fc-{instance_id}"));
     command
 }
 
@@ -986,6 +985,25 @@ mod tests {
     fn version_parser_rejects_missing_or_ambiguous_version() {
         assert!(parse_backend_version(b"Firecracker exiting successfully\n").is_err());
         assert!(parse_backend_version(b"Firecracker v1.15.0\nFirecracker v1.16.0\n").is_err());
+    }
+
+    #[test]
+    fn launch_command_uses_the_sandbox_uuid_as_the_backend_id() {
+        let instance_id = Uuid::new_v4();
+        let command = build_launch_command(
+            Path::new("/usr/bin/firecracker"),
+            None,
+            Path::new("/proc/self/fd/17/api.sock"),
+            instance_id,
+        );
+        let arguments = command.as_std().get_args().collect::<Vec<_>>();
+        let id_index = arguments
+            .iter()
+            .position(|argument| *argument == "--id")
+            .expect("--id argument");
+        let expected = format!("fc-{instance_id}");
+
+        assert_eq!(arguments.get(id_index + 1), Some(&expected.as_ref()));
     }
 
     #[test]

--- a/src/blaze/crates/blazed/src/spawner/firecracker.rs
+++ b/src/blaze/crates/blazed/src/spawner/firecracker.rs
@@ -9,7 +9,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use blaze_core::backend::{BackendKind, SpawnRequest};
+use blaze_core::backend::BackendKind;
+#[cfg(test)]
+use blaze_core::backend::SpawnRequest;
 use blaze_core::policy::{FirecrackerConfig, VmConfig, parse_memory_value, to_mib_ceil};
 use blaze_core::{BlazeError, Result};
 use tokio::net::UnixStream;
@@ -21,9 +23,9 @@ use super::netns::{NetworkManager, NetworkSlot};
 #[cfg(target_os = "linux")]
 use super::terminate_recorded_process;
 use super::{
-    BackendInstance, BackendSpawner, DynBackendInstance, SpawnFailure, SpawnResult,
-    configure_pid_handoff, prepare_pid_handoff, record_backend_stopped, remove_file_if_exists,
-    spawn_result, stopped_marker, terminate_child,
+    BackendInstance, BackendSpawnRequest, BackendSpawner, DynBackendInstance, OwnedRunDir,
+    SpawnFailure, SpawnResult, configure_pid_handoff, prepare_pid_handoff, record_backend_stopped,
+    remove_file_if_exists, spawn_result, stopped_marker, terminate_child,
 };
 
 const NETWORK_BOOT_IP: &str = "ip=169.254.0.2::169.254.0.1:255.255.255.252::eth0:off";
@@ -84,17 +86,16 @@ impl FirecrackerSpawner {
 
     async fn start(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
         validate_regular_file(&request.binary_path, "firecracker binary")?;
         validate_regular_file(&request.storage.rootfs_path, "rootfs")?;
         validate_regular_file(&self.images_dir.join("vmlinux"), "vmlinux")?;
-        tokio::fs::create_dir_all(&request.run_dir).await?;
-        let api_socket = request.run_dir.join("api.sock");
-        let guest_socket = request.run_dir.join("vsock.uds");
-        let pid_file = request.run_dir.join("firecracker.pid");
-        let stopped_marker = stopped_marker(&request.run_dir);
-        let network_file = request.run_dir.join("network.json");
+        let api_socket = request.run_dir.path().join("api.sock");
+        let guest_socket = request.run_dir.path().join("vsock.uds");
+        let pid_file = request.run_dir.path().join("firecracker.pid");
+        let stopped_marker = stopped_marker(request.run_dir.path());
+        let network_file = request.run_dir.path().join("network.json");
         let network_temp_file = network_metadata_temp(&network_file);
         remove_if_exists(&api_socket).await?;
         remove_if_exists(&guest_socket).await?;
@@ -201,6 +202,7 @@ impl FirecrackerSpawner {
             &api_socket,
             request.instance_id,
         );
+        request.run_dir.inherit_into(&mut command);
         let config_path = match write_vm_config(
             &self.images_dir,
             &request,
@@ -227,7 +229,9 @@ impl FirecrackerSpawner {
             }
         };
         command.arg("--config-file").arg(config_path);
-        if let Err(error) = configure_logs(&mut command, &request.run_dir, fc_config.serial_log) {
+        if let Err(error) =
+            configure_logs(&mut command, request.run_dir.path(), fc_config.serial_log)
+        {
             return Err(self
                 .compensate_before_spawn(
                     request.instance_id,
@@ -362,14 +366,13 @@ impl FirecrackerSpawner {
 
 #[async_trait]
 impl BackendSpawner for FirecrackerSpawner {
-    async fn prepare_spawn(&self, run_dir: &Path) -> Result<()> {
-        tokio::fs::create_dir_all(run_dir).await?;
-        prepare_pid_handoff(&run_dir.join("firecracker.pid"))
+    async fn prepare_spawn(&self, run_dir: &OwnedRunDir) -> Result<()> {
+        prepare_pid_handoff(&run_dir.path().join("firecracker.pid"))
     }
 
     async fn spawn(
         &self,
-        request: SpawnRequest,
+        request: BackendSpawnRequest,
     ) -> std::result::Result<DynBackendInstance, SpawnFailure> {
         self.start(request).await
     }
@@ -393,8 +396,8 @@ impl BackendSpawner for FirecrackerSpawner {
         }
     }
 
-    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &Path) -> Result<()> {
-        cleanup_orphan_run_dir_with(instance_id, run_dir, &self.network).await
+    async fn cleanup_orphan(&self, instance_id: Uuid, run_dir: &OwnedRunDir) -> Result<()> {
+        cleanup_orphan_run_dir_with(instance_id, run_dir.path(), &self.network).await
     }
 }
 
@@ -542,7 +545,7 @@ impl FirecrackerInstance {
 
 fn write_vm_config(
     images_dir: &Path,
-    request: &SpawnRequest,
+    request: &BackendSpawnRequest,
     config: &FirecrackerConfig,
     guest_socket: &Path,
     network: Option<&NetworkSlot>,
@@ -607,7 +610,7 @@ fn write_vm_config(
             "host_dev_name": network.tap_name()
         }]);
     }
-    let path = request.run_dir.join("vmconfig.json");
+    let path = request.run_dir.path().join("vmconfig.json");
     std::fs::write(
         &path,
         serde_json::to_vec_pretty(&value).map_err(|error| BlazeError::BackendError {
@@ -1684,26 +1687,28 @@ mod tests {
         assert!(!pid_file.exists());
     }
 
-    fn spawn_request(root: &Path) -> SpawnRequest {
+    fn spawn_request(root: &Path) -> BackendSpawnRequest {
         let instance_id = Uuid::new_v4();
         let run_dir = root.join("run");
-        std::fs::create_dir_all(&run_dir).expect("run dir");
         let slot_dir = root.join("slot");
-        SpawnRequest {
-            instance_id,
-            run_dir,
-            binary_path: root.join("firecracker"),
-            storage: StorageSlot {
-                id: instance_id.to_string(),
-                rootfs_path: slot_dir.join("rootfs.ext4"),
-                mem_path: slot_dir.join("mem.bin"),
-                mem_diff_path: slot_dir.join("mem.diff"),
-                rootfs_diff_path: slot_dir.join("rootfs.diff"),
-                instance_dir: slot_dir,
+        BackendSpawnRequest::new(
+            SpawnRequest {
+                instance_id,
+                binary_path: root.join("firecracker"),
+                storage: StorageSlot {
+                    id: instance_id.to_string(),
+                    rootfs_path: slot_dir.join("rootfs.ext4"),
+                    mem_path: slot_dir.join("mem.bin"),
+                    mem_diff_path: slot_dir.join("mem.diff"),
+                    rootfs_diff_path: slot_dir.join("rootfs.diff"),
+                    instance_dir: slot_dir,
+                },
+                backend: blaze_core::policy::BackendConfigs::default(),
+                vm: None,
             },
-            backend: blaze_core::policy::BackendConfigs::default(),
-            vm: None,
-        }
+            OwnedRunDir::for_test(instance_id, run_dir),
+        )
+        .expect("matching backend request")
     }
 
     #[derive(Default)]

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -6,7 +6,6 @@
 //! are never held across `.await` boundaries.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use blaze_core::backend::BackendKind;
@@ -25,6 +24,7 @@ use crate::sandbox::template::TemplateCatalog;
 use crate::sandbox::template::validate_template_roots;
 use crate::sandbox::{SandboxManager, SandboxManagerInit};
 use crate::spawner::SpawnerRegistry;
+use crate::state_store::StateStore;
 
 /// All daemon mutable state. Cloning is via `Arc` (see the `state.clone()`
 /// idiom in `daemon.rs`); the struct itself is never `Clone`.
@@ -40,7 +40,7 @@ pub struct ServerState {
     /// backend rather than reporting all configured binaries.
     pub active_backend: BackendKind,
     pub storage: Arc<dyn StorageProvider>,
-    pub state_dir: PathBuf,
+    pub state_store: StateStore,
     pub metrics: Arc<Metrics>,
 }
 
@@ -93,8 +93,8 @@ impl ServerState {
         storage: Arc<dyn StorageProvider>,
         template_catalog: TemplateCatalog,
     ) -> Result<Self> {
-        let state_dir = config.daemon.state_dir.clone();
-        let instances = scan_state_dir(&state_dir).unwrap_or_else(|err| {
+        let state_store = StateStore::new(config.daemon.state_dir.clone());
+        let instances = state_store.scan().unwrap_or_else(|err| {
             tracing::warn!(error = %err, "failed to scan state_dir, starting empty");
             HashMap::new()
         });
@@ -104,7 +104,7 @@ impl ServerState {
             spawners,
             active_backend,
             storage: storage.clone(),
-            state_dir: state_dir.clone(),
+            state_store: state_store.clone(),
             rootfs_size: config.storage.rootfs_size,
             mem_size: config.storage.mem_size,
             template_catalog,
@@ -119,7 +119,7 @@ impl ServerState {
             manager: Arc::new(manager),
             active_backend,
             storage,
-            state_dir,
+            state_store,
             metrics: resources.metrics,
         })
     }
@@ -128,36 +128,4 @@ impl ServerState {
     pub fn operation_lock(&self, id: Uuid) -> Arc<tokio::sync::Mutex<()>> {
         self.manager.operation_lock(id)
     }
-}
-
-/// Best-effort: walk `{state_dir}/<uuid>/state.json` and rebuild the
-/// instance map. Used both at boot and (in the future) by `daemon doctor`.
-fn scan_state_dir(state_dir: &Path) -> Result<HashMap<Uuid, SandboxInstance>> {
-    let mut out = HashMap::new();
-    if !state_dir.exists() {
-        return Ok(out);
-    }
-    for entry in std::fs::read_dir(state_dir)? {
-        let entry = entry?;
-        if !entry.file_type()?.is_dir() {
-            continue;
-        }
-        let name = entry.file_name();
-        let Some(name_str) = name.to_str() else {
-            continue;
-        };
-        let Ok(id) = Uuid::parse_str(name_str) else {
-            continue;
-        };
-        match SandboxInstance::load(state_dir, id) {
-            Ok(inst) => {
-                out.insert(id, inst);
-            }
-            Err(err) => {
-                tracing::warn!(instance = %id, error = %err, "skipping corrupt instance state");
-            }
-        }
-    }
-    tracing::info!(instances = out.len(), "rehydrated instances from state_dir");
-    Ok(out)
 }

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -49,7 +49,32 @@ impl ServerState {
     /// `instances` map from previous runs (best-effort; corrupt entries
     /// are skipped with a warning).
     #[allow(clippy::too_many_arguments)]
+    pub fn build_with_store(
+        config: DaemonConfig,
+        policy: PolicyEngine,
+        pool: PoolManager,
+        hook: HookRegistry,
+        spawners: SpawnerRegistry,
+        active_backend: BackendKind,
+        storage: Arc<dyn StorageProvider>,
+        template_catalog: TemplateCatalog,
+        state_store: StateStore,
+    ) -> Result<Self> {
+        Self::assemble(
+            config,
+            policy,
+            pool,
+            hook,
+            spawners,
+            active_backend,
+            storage,
+            template_catalog,
+            state_store,
+        )
+    }
+
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     pub fn build(
         config: DaemonConfig,
         policy: PolicyEngine,
@@ -70,7 +95,8 @@ impl ServerState {
             None,
         )?;
         let template_catalog = TemplateCatalog::open_validated(&config.template, template_roots)?;
-        Self::build_with_template_catalog(
+        let state_store = StateStore::new(config.daemon.state_dir.clone());
+        Self::assemble(
             config,
             policy,
             pool,
@@ -79,11 +105,12 @@ impl ServerState {
             active_backend,
             storage,
             template_catalog,
+            state_store,
         )
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn build_with_template_catalog(
+    fn assemble(
         config: DaemonConfig,
         policy: PolicyEngine,
         pool: PoolManager,
@@ -92,8 +119,8 @@ impl ServerState {
         active_backend: BackendKind,
         storage: Arc<dyn StorageProvider>,
         template_catalog: TemplateCatalog,
+        state_store: StateStore,
     ) -> Result<Self> {
-        let state_store = StateStore::new(config.daemon.state_dir.clone());
         let instances = state_store.scan().unwrap_or_else(|err| {
             tracing::warn!(error = %err, "failed to scan state_dir, starting empty");
             HashMap::new()
@@ -127,5 +154,102 @@ impl ServerState {
     /// Return the async operation lock that serializes one sandbox mutation.
     pub fn operation_lock(&self, id: Uuid) -> Arc<tokio::sync::Mutex<()>> {
         self.manager.operation_lock(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use blaze_core::lifecycle::StartPath;
+    use blaze_core::policy::WorkloadClass;
+
+    use crate::file_provider::FileStorageProvider;
+    use crate::spawner::{MockSpawner, SpawnerRegistry};
+
+    use super::*;
+
+    #[test]
+    fn builder_uses_the_preopened_state_store_after_path_replacement() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let configured_root = temporary.path().join("state");
+        let retained_root = temporary.path().join("retained-state");
+        let images = temporary.path().join("images");
+        let instances = temporary.path().join("instances");
+        for directory in [&configured_root, &images, &instances] {
+            std::fs::create_dir(directory).expect("test directory");
+        }
+
+        let mut config = DaemonConfig::default();
+        config.daemon.state_dir = configured_root.clone();
+        config.storage.images_dir = images.clone();
+        config.storage.instances_dir = instances.clone();
+        config.template.dir = temporary.path().join("templates");
+        config.template.import_root = Some(temporary.path().join("template-imports"));
+        std::fs::create_dir(
+            config
+                .template
+                .import_root
+                .as_ref()
+                .expect("template import root"),
+        )
+        .expect("template import directory");
+        let template_catalog = TemplateCatalog::open(&config.template).expect("template catalog");
+        let existing = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:existing".into(),
+            StartPath::Cold,
+            "default".into(),
+        );
+        existing
+            .persist(&configured_root)
+            .expect("persist existing fixture");
+        let state_store = StateStore::new(configured_root.clone());
+
+        std::fs::rename(&configured_root, &retained_root).expect("move opened state root");
+        std::fs::create_dir(&configured_root).expect("replacement state root");
+
+        let mut spawners = SpawnerRegistry::new();
+        spawners.insert(BackendKind::Mock, Arc::new(MockSpawner));
+        let storage: Arc<dyn StorageProvider> =
+            Arc::new(FileStorageProvider::with_images(images, instances));
+        let state = ServerState::build_with_store(
+            config,
+            PolicyEngine::new(),
+            PoolManager::new(),
+            HookRegistry::new(),
+            spawners,
+            BackendKind::Mock,
+            storage,
+            template_catalog,
+            state_store,
+        )
+        .expect("server state");
+
+        assert!(
+            state
+                .instances
+                .lock()
+                .expect("instances")
+                .contains_key(&existing.id)
+        );
+        let new_instance = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:new".into(),
+            StartPath::Cold,
+            "default".into(),
+        );
+        state
+            .state_store
+            .persist(&new_instance)
+            .expect("persist through retained store");
+
+        assert!(
+            retained_root
+                .join(new_instance.id.to_string())
+                .join("state.json")
+                .is_file()
+        );
+        assert!(!configured_root.join(new_instance.id.to_string()).exists());
     }
 }

--- a/src/blaze/crates/blazed/src/state_store.rs
+++ b/src/blaze/crates/blazed/src/state_store.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Daemon-owned access to persisted sandbox state and runtime directories.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use blaze_core::lifecycle::SandboxInstance;
+use uuid::Uuid;
+
+use crate::error::Result;
+
+/// Central access point for the daemon state directory.
+///
+/// Keeping path derivation and lifecycle-record I/O behind this type lets the
+/// daemon strengthen object ownership without changing every caller again.
+#[derive(Clone, Debug)]
+pub struct StateStore {
+    root: Arc<PathBuf>,
+}
+
+impl StateStore {
+    /// Create a state-store view rooted at the configured daemon directory.
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root: Arc::new(root),
+        }
+    }
+
+    /// Return the configured state directory.
+    pub fn root(&self) -> &Path {
+        self.root.as_path()
+    }
+
+    /// Return the directory assigned to one sandbox.
+    pub fn run_dir(&self, id: Uuid) -> PathBuf {
+        self.root.join(id.to_string())
+    }
+
+    /// Persist one lifecycle record below this store.
+    pub fn persist(&self, instance: &SandboxInstance) -> Result<()> {
+        instance.persist(self.root())?;
+        Ok(())
+    }
+
+    /// Load one lifecycle record from this store.
+    pub fn load(&self, id: Uuid) -> Result<SandboxInstance> {
+        Ok(SandboxInstance::load(self.root(), id)?)
+    }
+
+    /// Best-effort scan of persisted lifecycle records.
+    pub fn scan(&self) -> Result<HashMap<Uuid, SandboxInstance>> {
+        let mut instances = HashMap::new();
+        if !self.root().exists() {
+            return Ok(instances);
+        }
+
+        for entry in std::fs::read_dir(self.root())? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            let Ok(id) = Uuid::parse_str(name) else {
+                continue;
+            };
+            match self.load(id) {
+                Ok(instance) => {
+                    instances.insert(id, instance);
+                }
+                Err(error) => {
+                    tracing::warn!(instance = %id, error = %error, "skipping corrupt instance state");
+                }
+            }
+        }
+        tracing::info!(
+            instances = instances.len(),
+            "rehydrated instances from state_dir"
+        );
+        Ok(instances)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use blaze_core::backend::BackendKind;
+    use blaze_core::lifecycle::StartPath;
+    use blaze_core::policy::WorkloadClass;
+
+    use super::*;
+
+    #[test]
+    fn store_centralizes_record_io_scan_and_run_directory_derivation() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let instance = SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:test".into(),
+            StartPath::Cold,
+            "default".into(),
+        );
+
+        store.persist(&instance).expect("persist instance");
+
+        let loaded = store.load(instance.id).expect("load instance");
+        assert_eq!(loaded.id, instance.id);
+        assert_eq!(
+            store.run_dir(instance.id),
+            root.join(instance.id.to_string())
+        );
+        let scanned = store.scan().expect("scan state store");
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[&instance.id].id, instance.id);
+    }
+}

--- a/src/blaze/crates/blazed/src/state_store.rs
+++ b/src/blaze/crates/blazed/src/state_store.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Daemon-owned access to persisted sandbox lifecycle state.
+//! Daemon-owned access to persisted sandbox state and runtime directories.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -27,7 +27,7 @@ const TEMP_STATE_FILE: &str = "state.json.tmp";
 /// Central access point for the daemon state directory.
 ///
 /// The store holds the opened state-root object for its complete lifetime.
-/// Record I/O and stable per-sandbox paths are derived from that object rather
+/// Record I/O and runtime-directory paths are derived from that object rather
 /// than reopening the configured pathname.
 #[derive(Clone)]
 pub struct StateStore {
@@ -46,11 +46,11 @@ enum RunDirEntry {
     Released,
 }
 
-/// A cloneable owner of one sandbox lifecycle-record directory.
+/// A cloneable owner of one sandbox runtime directory.
 ///
-/// The handle keeps the opened directory object alive while lifecycle records
-/// are read or replaced. Existing path-based backend callers receive an alias
-/// that resolves through the retained descriptor.
+/// The handle keeps the opened directory object alive while lifecycle and
+/// backend work use it. Its stable path resolves through that descriptor on
+/// Linux, so replacing the configured pathname cannot redirect later work.
 #[derive(Clone)]
 pub(crate) struct OwnedRunDir {
     inner: Arc<OwnedRunDirInner>,
@@ -675,11 +675,7 @@ fn is_state_staging_name(name: &str) -> bool {
 impl OwnedRunDir {
     fn new(instance_id: Uuid, configured_path: PathBuf, directory: OwnedFd) -> Self {
         #[cfg(target_os = "linux")]
-        let stable_path = PathBuf::from(format!(
-            "/proc/{}/fd/{}",
-            std::process::id(),
-            directory.as_raw_fd()
-        ));
+        let stable_path = PathBuf::from(format!("/proc/self/fd/{}", directory.as_raw_fd()));
         #[cfg(not(target_os = "linux"))]
         let stable_path = configured_path.clone();
         Self {
@@ -693,12 +689,50 @@ impl OwnedRunDir {
         }
     }
 
+    pub(crate) fn path(&self) -> &Path {
+        &self.inner.stable_path
+    }
+
+    pub(crate) fn instance_id(&self) -> Uuid {
+        self.inner.instance_id
+    }
+
     fn same_object(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 
-    pub(crate) fn path(&self) -> &Path {
-        &self.inner.stable_path
+    #[cfg(target_os = "linux")]
+    pub(crate) fn inherit_into(&self, command: &mut tokio::process::Command) {
+        use std::os::unix::process::CommandExt;
+
+        let owner = self.clone();
+        // SAFETY: `fcntl` is async-signal-safe. The closure only changes the
+        // child-side copy of a descriptor retained through the spawn call.
+        unsafe {
+            command.as_std_mut().pre_exec(move || {
+                let descriptor = owner.inner.directory.as_raw_fd();
+                if libc::fcntl(descriptor, libc::F_SETFD, 0) == -1 {
+                    Err(std::io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn inherit_into(&self, _command: &mut tokio::process::Command) {}
+
+    #[cfg(test)]
+    pub(crate) fn for_test(instance_id: Uuid, path: PathBuf) -> Self {
+        std::fs::create_dir_all(&path).expect("test runtime directory");
+        let directory = open(
+            &path,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .expect("open test runtime directory");
+        Self::new(instance_id, path, directory)
     }
 }
 
@@ -1057,7 +1091,13 @@ mod tests {
         store.persist(&instance).expect("persist recovery record");
 
         assert_eq!(store.retained_run_dir_count(), 1);
-        assert!(store.run_dir(instance.id).is_ok());
+        assert_eq!(
+            store
+                .run_dir(instance.id)
+                .expect("recovery runtime owner")
+                .instance_id(),
+            instance.id
+        );
     }
 
     #[test]
@@ -1136,6 +1176,42 @@ mod tests {
                 Err(BlazeDaemonError::NotFound(_))
             ));
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn child_inherits_the_owned_runtime_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let instance = instance();
+        store.persist(&instance).expect("initial persist");
+        let runtime_owner = store.run_dir(instance.id).expect("runtime owner");
+
+        let configured_run_dir = root.join(instance.id.to_string());
+        let owned_run_dir = root.join("owned-child-run-dir");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move owned run directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement run directory");
+
+        let marker = runtime_owner.path().join("child-marker");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("printf child > \"$1\"")
+            .arg("sh")
+            .arg(marker);
+        runtime_owner.inherit_into(&mut command);
+        drop(runtime_owner);
+        drop(store);
+        let status = command.status().await.expect("run child");
+
+        assert!(status.success());
+        assert_eq!(
+            std::fs::read(owned_run_dir.join("child-marker")).expect("owned child marker"),
+            b"child"
+        );
+        assert!(!configured_run_dir.join("child-marker").exists());
     }
 
     #[test]

--- a/src/blaze/crates/blazed/src/state_store.rs
+++ b/src/blaze/crates/blazed/src/state_store.rs
@@ -1,78 +1,289 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Daemon-owned access to persisted sandbox state and runtime directories.
+//! Daemon-owned access to persisted sandbox lifecycle state.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Write};
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use blaze_core::lifecycle::SandboxInstance;
+use rustix::fs::{
+    AtFlags, Dir, FlockOperation, Mode, OFlags, RenameFlags, flock, fstat, fsync, mkdirat, open,
+    openat, renameat, renameat_with, unlinkat,
+};
+use rustix::io::Errno;
 use uuid::Uuid;
 
-use crate::error::Result;
+use crate::error::{BlazeDaemonError, Result};
+
+const STATE_FILE: &str = "state.json";
+const TEMP_STATE_FILE: &str = "state.json.tmp";
 
 /// Central access point for the daemon state directory.
 ///
-/// Keeping path derivation and lifecycle-record I/O behind this type lets the
-/// daemon strengthen object ownership without changing every caller again.
-#[derive(Clone, Debug)]
+/// The store holds the opened state-root object for its complete lifetime.
+/// Record I/O and stable per-sandbox paths are derived from that object rather
+/// than reopening the configured pathname.
+#[derive(Clone)]
 pub struct StateStore {
-    root: Arc<PathBuf>,
+    inner: Arc<StateStoreInner>,
+}
+
+struct StateStoreInner {
+    configured_root: PathBuf,
+    root: OwnedFd,
+    run_dirs: Mutex<HashMap<Uuid, RunDirEntry>>,
+}
+
+enum RunDirEntry {
+    Owned(OwnedRunDir),
+    Uncertain(OwnedRunDir),
+    Released,
+}
+
+/// A cloneable owner of one sandbox lifecycle-record directory.
+///
+/// The handle keeps the opened directory object alive while lifecycle records
+/// are read or replaced. Existing path-based backend callers receive an alias
+/// that resolves through the retained descriptor.
+#[derive(Clone)]
+pub(crate) struct OwnedRunDir {
+    inner: Arc<OwnedRunDirInner>,
+}
+
+struct OwnedRunDirInner {
+    instance_id: Uuid,
+    configured_path: PathBuf,
+    stable_path: PathBuf,
+    directory: OwnedFd,
+    writer: Mutex<()>,
+}
+
+impl fmt::Debug for StateStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StateStore")
+            .field("configured_root", &self.inner.configured_root)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for OwnedRunDir {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OwnedRunDir")
+            .field("instance_id", &self.inner.instance_id)
+            .field("configured_path", &self.inner.configured_path)
+            .finish_non_exhaustive()
+    }
 }
 
 impl StateStore {
-    /// Create a state-store view rooted at the configured daemon directory.
-    pub fn new(root: PathBuf) -> Self {
-        Self {
-            root: Arc::new(root),
+    /// Open and exclusively own the configured state directory.
+    pub fn open(root: PathBuf) -> Result<Self> {
+        Self::open_with_lock(root, true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(root: PathBuf) -> Self {
+        Self::open_with_lock(root, false).expect("open test state store")
+    }
+
+    fn open_with_lock(root: PathBuf, lock: bool) -> Result<Self> {
+        let directory = open(
+            &root,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(std::io::Error::from)?;
+        if lock && let Err(error) = flock(&directory, FlockOperation::NonBlockingLockExclusive) {
+            return if error == Errno::WOULDBLOCK {
+                Err(BlazeDaemonError::Conflict(format!(
+                    "state directory {} is already owned by another daemon",
+                    root.display()
+                )))
+            } else {
+                Err(std::io::Error::from(error).into())
+            };
         }
+        Ok(Self {
+            inner: Arc::new(StateStoreInner {
+                configured_root: root,
+                root: directory,
+                run_dirs: Mutex::new(HashMap::new()),
+            }),
+        })
     }
 
-    /// Return the configured state directory.
-    pub fn root(&self) -> &Path {
-        self.root.as_path()
+    /// Return the retained owner for one known sandbox directory.
+    pub(crate) fn run_dir(&self, id: Uuid) -> Result<OwnedRunDir> {
+        self.cached_run_dir(id)?.ok_or_else(|| {
+            BlazeDaemonError::NotFound(format!(
+                "owned runtime directory for instance {id} is unavailable"
+            ))
+        })
     }
 
-    /// Return the directory assigned to one sandbox.
-    pub fn run_dir(&self, id: Uuid) -> PathBuf {
-        self.root.join(id.to_string())
+    /// Report whether a failed first publication left an object that must be
+    /// completed or released through lifecycle recovery.
+    pub(crate) fn has_run_dir_residual(&self, id: Uuid) -> Result<bool> {
+        Ok(matches!(
+            self.inner
+                .run_dirs
+                .lock()
+                .map_err(|_| BlazeDaemonError::Internal(
+                    "state run-directory lock poisoned".into()
+                ))?
+                .get(&id),
+            Some(RunDirEntry::Owned(_) | RunDirEntry::Uncertain(_))
+        ))
     }
 
-    /// Persist one lifecycle record below this store.
+    /// Persist one lifecycle record below the owned state root.
     pub fn persist(&self, instance: &SandboxInstance) -> Result<()> {
-        instance.persist(self.root())?;
+        let json = serde_json::to_vec_pretty(instance)?;
+        let run_dir = {
+            let mut run_dirs = self.inner.run_dirs.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state run-directory lock poisoned".into())
+            })?;
+            match run_dirs.get(&instance.id) {
+                Some(RunDirEntry::Owned(run_dir)) => run_dir.clone(),
+                Some(RunDirEntry::Uncertain(run_dir)) => {
+                    let run_dir = run_dir.clone();
+                    self.revalidate_uncertain(instance.id, &run_dir)?;
+                    run_dirs.insert(instance.id, RunDirEntry::Owned(run_dir.clone()));
+                    run_dir
+                }
+                Some(RunDirEntry::Released) => {
+                    return Err(BlazeDaemonError::Conflict(format!(
+                        "terminal lifecycle record for instance {} cannot be rewritten",
+                        instance.id
+                    )));
+                }
+                None => {
+                    return self.publish_new_record(&mut run_dirs, instance, &json);
+                }
+            }
+        };
+        let _writer =
+            run_dir.inner.writer.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state record writer lock poisoned".into())
+            })?;
+        {
+            let run_dirs = self.inner.run_dirs.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state run-directory lock poisoned".into())
+            })?;
+            match run_dirs.get(&instance.id) {
+                Some(RunDirEntry::Owned(retained)) if retained.same_object(&run_dir) => {}
+                Some(RunDirEntry::Uncertain(_)) => {
+                    return Err(BlazeDaemonError::RecoveryRequired(format!(
+                        "runtime-directory publication for instance {} is unconfirmed",
+                        instance.id
+                    )));
+                }
+                Some(RunDirEntry::Released) => {
+                    return Err(BlazeDaemonError::Conflict(format!(
+                        "terminal lifecycle record for instance {} cannot be rewritten",
+                        instance.id
+                    )));
+                }
+                Some(RunDirEntry::Owned(_)) => {
+                    return Err(BlazeDaemonError::Conflict(format!(
+                        "runtime-directory ownership changed for instance {}",
+                        instance.id
+                    )));
+                }
+                None => {
+                    return Err(BlazeDaemonError::Internal(format!(
+                        "runtime-directory ownership disappeared for instance {}",
+                        instance.id
+                    )));
+                }
+            }
+        }
+        self.write_record_locked(&run_dir, &json)?;
+        // Retrying a publication whose parent-directory sync previously
+        // failed must cross that durability boundary before the owner can be
+        // released. Syncing the root on every commit keeps that retry path
+        // explicit without maintaining a second publication journal.
+        fsync(&self.inner.root).map_err(std::io::Error::from)?;
+        self.update_retention(instance, &run_dir)?;
         Ok(())
     }
 
-    /// Load one lifecycle record from this store.
+    /// Load one lifecycle record from the owned sandbox directory.
+    #[cfg(test)]
     pub fn load(&self, id: Uuid) -> Result<SandboxInstance> {
-        Ok(SandboxInstance::load(self.root(), id)?)
+        let run_dir = match self.cached_run_dir(id)? {
+            Some(run_dir) => run_dir,
+            None => self.open_run_dir_object(id)?,
+        };
+        Self::load_from(&run_dir)
     }
 
-    /// Best-effort scan of persisted lifecycle records.
+    /// Best-effort startup scan of persisted lifecycle records.
+    ///
+    /// The scan owns the run-directory map for its complete duration and must
+    /// run before request handling starts. This prevents a stale scan result
+    /// from restoring ownership after a concurrent terminal commit.
     pub fn scan(&self) -> Result<HashMap<Uuid, SandboxInstance>> {
         let mut instances = HashMap::new();
-        if !self.root().exists() {
-            return Ok(instances);
+        let mut run_dirs =
+            self.inner.run_dirs.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state run-directory lock poisoned".into())
+            })?;
+        if !run_dirs.is_empty() {
+            return Err(BlazeDaemonError::Internal(
+                "state scan must complete before lifecycle persistence starts".into(),
+            ));
         }
-
-        for entry in std::fs::read_dir(self.root())? {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
-                continue;
-            }
-            let name = entry.file_name();
-            let Some(name) = name.to_str() else {
+        let entries = Dir::read_from(&self.inner.root).map_err(std::io::Error::from)?;
+        for entry in entries {
+            let entry = entry.map_err(std::io::Error::from)?;
+            let Ok(name) = entry.file_name().to_str() else {
                 continue;
             };
+            if is_state_staging_name(name) {
+                if let Err(error) = self.remove_stale_staging(name) {
+                    tracing::warn!(entry = name, %error, "failed to remove stale state staging");
+                }
+                continue;
+            }
             let Ok(id) = Uuid::parse_str(name) else {
                 continue;
             };
-            match self.load(id) {
+            let run_dir = match self.open_run_dir_object(id) {
+                Ok(run_dir) => run_dir,
+                Err(error) => {
+                    tracing::warn!(instance = %id, %error, "skipping invalid instance directory");
+                    continue;
+                }
+            };
+            if let Err(error) = remove_file_if_exists(&run_dir.inner.directory, TEMP_STATE_FILE) {
+                tracing::warn!(
+                    instance = %id,
+                    %error,
+                    "failed to remove stale state record temporary file"
+                );
+            }
+            match Self::load_from(&run_dir) {
                 Ok(instance) => {
+                    let ownership =
+                        if instance.state == blaze_core::lifecycle::SandboxState::Destroyed {
+                            RunDirEntry::Released
+                        } else {
+                            RunDirEntry::Owned(run_dir)
+                        };
+                    run_dirs.insert(id, ownership);
                     instances.insert(id, instance);
                 }
                 Err(error) => {
-                    tracing::warn!(instance = %id, error = %error, "skipping corrupt instance state");
+                    tracing::warn!(instance = %id, %error, "skipping corrupt instance state");
                 }
             }
         }
@@ -81,6 +292,413 @@ impl StateStore {
             "rehydrated instances from state_dir"
         );
         Ok(instances)
+    }
+
+    fn cached_run_dir(&self, id: Uuid) -> Result<Option<OwnedRunDir>> {
+        let run_dirs =
+            self.inner.run_dirs.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state run-directory lock poisoned".into())
+            })?;
+        match run_dirs.get(&id) {
+            Some(RunDirEntry::Owned(run_dir)) => Ok(Some(run_dir.clone())),
+            Some(RunDirEntry::Uncertain(_)) => Err(BlazeDaemonError::RecoveryRequired(format!(
+                "runtime-directory publication for instance {id} is unconfirmed"
+            ))),
+            Some(RunDirEntry::Released) | None => Ok(None),
+        }
+    }
+
+    fn open_run_dir_object(&self, id: Uuid) -> Result<OwnedRunDir> {
+        let name = id.to_string();
+        let directory = openat(
+            &self.inner.root,
+            name.as_str(),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(std::io::Error::from)?;
+        Ok(OwnedRunDir::new(
+            id,
+            self.inner.configured_root.join(&name),
+            directory,
+        ))
+    }
+
+    fn publish_new_record(
+        &self,
+        run_dirs: &mut HashMap<Uuid, RunDirEntry>,
+        instance: &SandboxInstance,
+        json: &[u8],
+    ) -> Result<()> {
+        crate::failpoint::state("state-before-first-publication")?;
+        let id = instance.id;
+        let final_name = id.to_string();
+        let staging_name = loop {
+            let candidate = format!(".state-{id}-{}.tmp", Uuid::new_v4());
+            match mkdirat(
+                &self.inner.root,
+                candidate.as_str(),
+                Mode::from_bits_truncate(0o777),
+            ) {
+                Ok(()) => break candidate,
+                Err(Errno::EXIST) => continue,
+                Err(error) => return Err(std::io::Error::from(error).into()),
+            }
+        };
+        let directory = match openat(
+            &self.inner.root,
+            staging_name.as_str(),
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        ) {
+            Ok(directory) => directory,
+            Err(error) => {
+                let original = BlazeDaemonError::from(std::io::Error::from(error));
+                let cleanup = remove_directory_if_exists(&self.inner.root, &staging_name);
+                return Err(combine_publication_cleanup(original, cleanup));
+            }
+        };
+        let run_dir = OwnedRunDir::new(id, self.inner.configured_root.join(&final_name), directory);
+        let writer =
+            run_dir.inner.writer.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state record writer lock poisoned".into())
+            })?;
+        if let Err(error) = self.write_record_locked(&run_dir, json) {
+            let cleanup = self.discard_staging(&run_dir, &staging_name);
+            return Err(retain_failed_publication(
+                run_dirs, id, &run_dir, error, cleanup,
+            ));
+        }
+        if let Err(error) = renameat_with(
+            &self.inner.root,
+            staging_name.as_str(),
+            &self.inner.root,
+            final_name.as_str(),
+            RenameFlags::NOREPLACE,
+        ) {
+            let original = if error == Errno::EXIST {
+                BlazeDaemonError::Conflict(format!(
+                    "runtime directory for new instance {id} already exists"
+                ))
+            } else {
+                BlazeDaemonError::from(std::io::Error::from(error))
+            };
+            let cleanup = self.discard_staging(&run_dir, &staging_name);
+            return Err(retain_failed_publication(
+                run_dirs, id, &run_dir, original, cleanup,
+            ));
+        }
+        let linkage = crate::failpoint::state("state-post-publication-identity")
+            .and_then(|_| self.linked_directory_matches(&final_name, &run_dir));
+        match linkage {
+            Ok(Some(true)) => {}
+            Ok(Some(false)) => {
+                run_dirs.insert(id, RunDirEntry::Uncertain(run_dir.clone()));
+                return Err(BlazeDaemonError::Conflict(format!(
+                    "published runtime directory for new instance {id} changed identity"
+                )));
+            }
+            Ok(None) => {
+                run_dirs.insert(id, RunDirEntry::Uncertain(run_dir.clone()));
+                return Err(BlazeDaemonError::Conflict(format!(
+                    "published runtime directory for new instance {id} disappeared"
+                )));
+            }
+            Err(error) => {
+                run_dirs.insert(id, RunDirEntry::Uncertain(run_dir.clone()));
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "published runtime directory for new instance {id} could not be verified: \
+                     {error}"
+                )));
+            }
+        }
+        run_dirs.insert(id, RunDirEntry::Owned(run_dir.clone()));
+        crate::failpoint::state("state-first-publication-root-sync")?;
+        if let Err(error) = fsync(&self.inner.root) {
+            return Err(std::io::Error::from(error).into());
+        }
+        if instance.state == blaze_core::lifecycle::SandboxState::Destroyed {
+            run_dirs.insert(id, RunDirEntry::Released);
+        }
+        drop(writer);
+        Ok(())
+    }
+
+    fn write_record_locked(&self, run_dir: &OwnedRunDir, json: &[u8]) -> Result<()> {
+        match unlinkat(&run_dir.inner.directory, TEMP_STATE_FILE, AtFlags::empty()) {
+            Ok(()) | Err(Errno::NOENT) => {}
+            Err(error) => return Err(std::io::Error::from(error).into()),
+        }
+        let temporary = openat(
+            &run_dir.inner.directory,
+            TEMP_STATE_FILE,
+            OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::from_bits_truncate(0o666),
+        )
+        .map_err(std::io::Error::from)?;
+        let result = (|| -> Result<()> {
+            let mut temporary = File::from(temporary);
+            temporary.write_all(json)?;
+            temporary.write_all(b"\n")?;
+            temporary.sync_all()?;
+            renameat(
+                &run_dir.inner.directory,
+                TEMP_STATE_FILE,
+                &run_dir.inner.directory,
+                STATE_FILE,
+            )
+            .map_err(std::io::Error::from)?;
+            fsync(&run_dir.inner.directory).map_err(std::io::Error::from)?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => Ok(()),
+            Err(original) => {
+                let cleanup = remove_file_if_exists(&run_dir.inner.directory, TEMP_STATE_FILE);
+                Err(combine_record_cleanup(original, cleanup))
+            }
+        }
+    }
+
+    fn update_retention(&self, instance: &SandboxInstance, run_dir: &OwnedRunDir) -> Result<()> {
+        let mut run_dirs =
+            self.inner.run_dirs.lock().map_err(|_| {
+                BlazeDaemonError::Internal("state run-directory lock poisoned".into())
+            })?;
+        if instance.state == blaze_core::lifecycle::SandboxState::Destroyed {
+            if matches!(
+                run_dirs.get(&instance.id),
+                Some(RunDirEntry::Owned(retained)) if retained.same_object(run_dir)
+            ) {
+                run_dirs.insert(instance.id, RunDirEntry::Released);
+            }
+        } else {
+            run_dirs.insert(instance.id, RunDirEntry::Owned(run_dir.clone()));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retained_run_dir_count(&self) -> usize {
+        self.inner
+            .run_dirs
+            .lock()
+            .expect("state run-directory lock")
+            .values()
+            .filter(|entry| matches!(entry, RunDirEntry::Owned(_) | RunDirEntry::Uncertain(_)))
+            .count()
+    }
+
+    fn discard_staging(&self, run_dir: &OwnedRunDir, staging_name: &str) -> Result<()> {
+        crate::failpoint::state("state-before-staging-discard")?;
+        match self.linked_directory_matches(staging_name, run_dir)? {
+            Some(true) => {}
+            Some(false) => {
+                return Err(BlazeDaemonError::Conflict(format!(
+                    "state staging entry {staging_name} changed identity before cleanup"
+                )));
+            }
+            None => {
+                return Err(BlazeDaemonError::RecoveryRequired(format!(
+                    "state staging entry {staging_name} disappeared before cleanup"
+                )));
+            }
+        }
+        let mut errors = Vec::new();
+        for name in [STATE_FILE, TEMP_STATE_FILE] {
+            if let Err(error) = remove_file_if_exists(&run_dir.inner.directory, name) {
+                errors.push(format!("remove {name}: {error}"));
+            }
+        }
+        if let Err(error) = remove_directory_if_exists(&self.inner.root, staging_name) {
+            errors.push(format!("remove {staging_name}: {error}"));
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(BlazeDaemonError::Internal(errors.join("; ")))
+        }
+    }
+
+    fn linked_directory_matches(&self, name: &str, run_dir: &OwnedRunDir) -> Result<Option<bool>> {
+        let linked = match openat(
+            &self.inner.root,
+            name,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        ) {
+            Ok(linked) => linked,
+            Err(Errno::NOENT) => return Ok(None),
+            Err(error) => return Err(std::io::Error::from(error).into()),
+        };
+        Ok(Some(same_opened_object(&linked, &run_dir.inner.directory)?))
+    }
+
+    fn revalidate_uncertain(&self, id: Uuid, run_dir: &OwnedRunDir) -> Result<()> {
+        let name = id.to_string();
+        let linkage = crate::failpoint::state("state-post-publication-identity")
+            .and_then(|_| self.linked_directory_matches(&name, run_dir));
+        match linkage {
+            Ok(Some(true)) => Ok(()),
+            Ok(Some(false)) => Err(BlazeDaemonError::RecoveryRequired(format!(
+                "published runtime directory for instance {id} has a different identity"
+            ))),
+            Ok(None) => Err(BlazeDaemonError::RecoveryRequired(format!(
+                "published runtime directory for instance {id} is missing"
+            ))),
+            Err(error) => Err(BlazeDaemonError::RecoveryRequired(format!(
+                "published runtime directory for instance {id} still cannot be verified: {error}"
+            ))),
+        }
+    }
+
+    fn remove_stale_staging(&self, staging_name: &str) -> Result<()> {
+        let directory = openat(
+            &self.inner.root,
+            staging_name,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(std::io::Error::from)?;
+        let run_dir = OwnedRunDir::new(
+            Uuid::nil(),
+            self.inner.configured_root.join(staging_name),
+            directory,
+        );
+        self.discard_staging(&run_dir, staging_name)
+    }
+
+    fn load_from(run_dir: &OwnedRunDir) -> Result<SandboxInstance> {
+        let state = openat(
+            &run_dir.inner.directory,
+            STATE_FILE,
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+            Mode::empty(),
+        )
+        .map_err(std::io::Error::from)?;
+        let mut state = File::from(state);
+        if !state.metadata()?.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "{} must be a regular file",
+                    run_dir.inner.configured_path.join(STATE_FILE).display()
+                ),
+            )
+            .into());
+        }
+        let mut raw = Vec::new();
+        state.read_to_end(&mut raw)?;
+        Ok(serde_json::from_slice(&raw)?)
+    }
+}
+
+fn remove_file_if_exists(directory: &OwnedFd, name: &str) -> Result<()> {
+    match unlinkat(directory, name, AtFlags::empty()) {
+        Ok(()) | Err(Errno::NOENT) => Ok(()),
+        Err(error) => Err(std::io::Error::from(error).into()),
+    }
+}
+
+fn same_opened_object(left: &OwnedFd, right: &OwnedFd) -> Result<bool> {
+    let left = fstat(left).map_err(std::io::Error::from)?;
+    let right = fstat(right).map_err(std::io::Error::from)?;
+    Ok(left.st_dev == right.st_dev && left.st_ino == right.st_ino)
+}
+
+fn remove_directory_if_exists(directory: &OwnedFd, name: &str) -> Result<()> {
+    match unlinkat(directory, name, AtFlags::REMOVEDIR) {
+        Ok(()) | Err(Errno::NOENT) => Ok(()),
+        Err(error) => Err(std::io::Error::from(error).into()),
+    }
+}
+
+fn combine_publication_cleanup(
+    original: BlazeDaemonError,
+    cleanup: Result<()>,
+) -> BlazeDaemonError {
+    match cleanup {
+        Ok(()) => original,
+        Err(cleanup) => BlazeDaemonError::Internal(format!(
+            "{original}; unpublished state staging cleanup failed: {cleanup}"
+        )),
+    }
+}
+
+fn retain_failed_publication(
+    run_dirs: &mut HashMap<Uuid, RunDirEntry>,
+    id: Uuid,
+    run_dir: &OwnedRunDir,
+    original: BlazeDaemonError,
+    cleanup: Result<()>,
+) -> BlazeDaemonError {
+    match cleanup {
+        Ok(()) => original,
+        Err(cleanup) => {
+            run_dirs.insert(id, RunDirEntry::Uncertain(run_dir.clone()));
+            BlazeDaemonError::RecoveryRequired(format!(
+                "{original}; unpublished state staging cleanup failed: {cleanup}; \
+                 runtime-directory owner retained for recovery"
+            ))
+        }
+    }
+}
+
+fn combine_record_cleanup(original: BlazeDaemonError, cleanup: Result<()>) -> BlazeDaemonError {
+    match cleanup {
+        Ok(()) => original,
+        Err(cleanup) => BlazeDaemonError::Internal(format!(
+            "{original}; state record temporary-file cleanup failed: {cleanup}"
+        )),
+    }
+}
+
+fn is_state_staging_name(name: &str) -> bool {
+    let Some(body) = name
+        .strip_prefix(".state-")
+        .and_then(|body| body.strip_suffix(".tmp"))
+    else {
+        return false;
+    };
+    if body.len() != 73 || body.as_bytes().get(36) != Some(&b'-') {
+        return false;
+    }
+    let Some(instance_id) = body.get(..36) else {
+        return false;
+    };
+    let Some(nonce) = body.get(37..) else {
+        return false;
+    };
+    Uuid::parse_str(instance_id).is_ok() && Uuid::parse_str(nonce).is_ok()
+}
+
+impl OwnedRunDir {
+    fn new(instance_id: Uuid, configured_path: PathBuf, directory: OwnedFd) -> Self {
+        #[cfg(target_os = "linux")]
+        let stable_path = PathBuf::from(format!(
+            "/proc/{}/fd/{}",
+            std::process::id(),
+            directory.as_raw_fd()
+        ));
+        #[cfg(not(target_os = "linux"))]
+        let stable_path = configured_path.clone();
+        Self {
+            inner: Arc::new(OwnedRunDirInner {
+                instance_id,
+                configured_path,
+                stable_path,
+                directory,
+                writer: Mutex::new(()),
+            }),
+        }
+    }
+
+    fn same_object(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.inner.stable_path
     }
 }
 
@@ -92,30 +710,444 @@ mod tests {
 
     use super::*;
 
+    fn instance() -> SandboxInstance {
+        SandboxInstance::new(
+            BackendKind::Mock,
+            WorkloadClass::AgentTool,
+            "sha256:test".into(),
+            StartPath::Cold,
+            "default".into(),
+        )
+    }
+
     #[test]
     fn store_centralizes_record_io_scan_and_run_directory_derivation() {
         let temporary = tempfile::tempdir().expect("temporary directory");
         let root = temporary.path().join("state");
         std::fs::create_dir(&root).expect("state directory");
         let store = StateStore::new(root.clone());
-        let instance = SandboxInstance::new(
-            BackendKind::Mock,
-            WorkloadClass::AgentTool,
-            "sha256:test".into(),
-            StartPath::Cold,
-            "default".into(),
-        );
+        let instance = instance();
 
         store.persist(&instance).expect("persist instance");
 
         let loaded = store.load(instance.id).expect("load instance");
         assert_eq!(loaded.id, instance.id);
+        let run_dir = store.run_dir(instance.id).expect("owned run directory");
         assert_eq!(
-            store.run_dir(instance.id),
-            root.join(instance.id.to_string())
+            std::fs::canonicalize(run_dir.path()).expect("resolve owned run directory"),
+            std::fs::canonicalize(root.join(instance.id.to_string())).expect("resolve configured")
         );
-        let scanned = store.scan().expect("scan state store");
+        let scanned = StateStore::new(root).scan().expect("scan state store");
         assert_eq!(scanned.len(), 1);
         assert_eq!(scanned[&instance.id].id, instance.id);
+    }
+
+    #[test]
+    fn configured_root_replacement_does_not_redirect_record_io() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let configured = temporary.path().join("state");
+        let owned = temporary.path().join("owned");
+        std::fs::create_dir(&configured).expect("state directory");
+        let store = StateStore::new(configured.clone());
+
+        std::fs::rename(&configured, &owned).expect("move owned root");
+        std::fs::create_dir(&configured).expect("replacement root");
+        let instance = instance();
+        store
+            .persist(&instance)
+            .expect("persist through owned root");
+
+        assert!(
+            owned
+                .join(instance.id.to_string())
+                .join(STATE_FILE)
+                .is_file()
+        );
+        assert!(!configured.join(instance.id.to_string()).exists());
+        assert_eq!(
+            store.load(instance.id).expect("load owned record").id,
+            instance.id
+        );
+    }
+
+    #[test]
+    fn opened_run_directory_replacement_does_not_redirect_record_io() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let mut instance = instance();
+        store.persist(&instance).expect("initial persist");
+
+        let configured_run_dir = root.join(instance.id.to_string());
+        let owned_run_dir = root.join("owned-run-dir");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move owned run directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement run directory");
+        instance.policy_name = "updated".into();
+        store
+            .persist(&instance)
+            .expect("persist through owned run directory");
+
+        let owned: SandboxInstance = serde_json::from_slice(
+            &std::fs::read(owned_run_dir.join(STATE_FILE)).expect("owned record"),
+        )
+        .expect("decode owned record");
+        assert_eq!(owned.policy_name, "updated");
+        assert!(!configured_run_dir.join(STATE_FILE).exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn runtime_path_remains_attached_to_the_opened_run_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let instance = instance();
+        store.persist(&instance).expect("initial persist");
+        let runtime_owner = store.run_dir(instance.id).expect("runtime owner");
+
+        let configured_run_dir = root.join(instance.id.to_string());
+        let owned_run_dir = root.join("owned-run-dir");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move owned run directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement run directory");
+        std::fs::write(runtime_owner.path().join("backend.pid"), b"42\n")
+            .expect("write through owned runtime path");
+
+        assert_eq!(
+            std::fs::read(owned_run_dir.join("backend.pid")).expect("owned backend marker"),
+            b"42\n"
+        );
+        assert!(!configured_run_dir.join("backend.pid").exists());
+    }
+
+    #[test]
+    fn first_publication_does_not_adopt_a_preexisting_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let instance = instance();
+        let preexisting = root.join(instance.id.to_string());
+        std::fs::create_dir(&preexisting).expect("preexisting directory");
+        std::fs::write(preexisting.join("owner-marker"), b"external\n")
+            .expect("preexisting marker");
+
+        let error = store
+            .persist(&instance)
+            .expect_err("preexisting directory must not be adopted");
+
+        assert!(matches!(error, BlazeDaemonError::Conflict(_)));
+        assert_eq!(
+            std::fs::read(preexisting.join("owner-marker")).expect("unchanged marker"),
+            b"external\n"
+        );
+        assert!(!preexisting.join(STATE_FILE).exists());
+        assert!(
+            std::fs::read_dir(&root)
+                .expect("state entries")
+                .all(|entry| !entry
+                    .expect("state entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".state-"))
+        );
+    }
+
+    #[cfg(feature = "test-failpoints")]
+    #[tokio::test]
+    async fn failed_staging_cleanup_retains_an_uncertain_owner() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let instance = instance();
+        let preexisting = root.join(instance.id.to_string());
+        std::fs::create_dir(&preexisting).expect("preexisting directory");
+        std::fs::write(preexisting.join("owner-marker"), b"external\n")
+            .expect("preexisting marker");
+        let hook = crate::failpoint::TestFailpoint::new(&["state-before-staging-discard"]);
+
+        let error = hook
+            .run(async { store.persist(&instance) })
+            .await
+            .expect_err("failed staging cleanup must retain recovery ownership");
+
+        assert!(matches!(error, BlazeDaemonError::RecoveryRequired(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("runtime-directory owner retained for recovery")
+        );
+        assert!(
+            store
+                .has_run_dir_residual(instance.id)
+                .expect("publication residual")
+        );
+        assert_eq!(store.retained_run_dir_count(), 1);
+        assert!(matches!(
+            store.run_dir(instance.id),
+            Err(BlazeDaemonError::RecoveryRequired(_))
+        ));
+        assert_eq!(
+            std::fs::read(preexisting.join("owner-marker")).expect("unchanged marker"),
+            b"external\n"
+        );
+        assert!(!preexisting.join(STATE_FILE).exists());
+
+        let staging = std::fs::read_dir(&root)
+            .expect("state entries")
+            .filter_map(|entry| entry.ok())
+            .find(|entry| is_state_staging_name(&entry.file_name().to_string_lossy()))
+            .expect("retained staging entry");
+        assert!(staging.path().join(STATE_FILE).is_file());
+    }
+
+    #[test]
+    fn linked_directory_identity_check_detects_replacement() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let id = Uuid::new_v4();
+        let name = format!(".state-{id}-{}.tmp", Uuid::new_v4());
+        let configured = root.join(&name);
+        std::fs::create_dir(&configured).expect("staging directory");
+        let directory = open(
+            &configured,
+            OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .expect("open staging directory");
+        let owner = OwnedRunDir::new(id, configured.clone(), directory);
+
+        assert_eq!(
+            store
+                .linked_directory_matches(&name, &owner)
+                .expect("identity check"),
+            Some(true)
+        );
+
+        std::fs::rename(&configured, root.join("moved-staging")).expect("move staging directory");
+        std::fs::create_dir(&configured).expect("replacement staging directory");
+
+        assert_eq!(
+            store
+                .linked_directory_matches(&name, &owner)
+                .expect("replacement identity check"),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn destroyed_commit_releases_cache_but_preserves_external_owner() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root.clone());
+        let mut instance = instance();
+        store.persist(&instance).expect("initial persist");
+        let runtime_owner = store.run_dir(instance.id).expect("runtime owner");
+
+        instance
+            .transition(blaze_core::lifecycle::SandboxState::Destroyed)
+            .expect("destroy transition");
+        store.persist(&instance).expect("terminal persist");
+
+        assert_eq!(store.retained_run_dir_count(), 0);
+        assert!(matches!(
+            store.run_dir(instance.id),
+            Err(BlazeDaemonError::NotFound(_))
+        ));
+        assert_eq!(
+            store.load(instance.id).expect("load terminal record").state,
+            blaze_core::lifecycle::SandboxState::Destroyed
+        );
+        assert_eq!(store.retained_run_dir_count(), 0);
+
+        assert!(matches!(
+            store.persist(&instance),
+            Err(BlazeDaemonError::Conflict(_))
+        ));
+        assert_eq!(store.retained_run_dir_count(), 0);
+
+        let configured_run_dir = root.join(instance.id.to_string());
+        let owned_run_dir = root.join("owned-terminal-run-dir");
+        std::fs::rename(&configured_run_dir, &owned_run_dir).expect("move terminal directory");
+        std::fs::create_dir(&configured_run_dir).expect("replacement directory");
+        std::fs::write(runtime_owner.path().join("runtime-marker"), b"owned\n")
+            .expect("write through external owner");
+
+        assert_eq!(
+            std::fs::read(owned_run_dir.join("runtime-marker")).expect("owned marker"),
+            b"owned\n"
+        );
+        assert!(!configured_run_dir.join("runtime-marker").exists());
+    }
+
+    #[test]
+    fn scan_does_not_retain_terminal_run_directories() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let writer = StateStore::new(root.clone());
+        let mut instance = instance();
+        instance
+            .transition(blaze_core::lifecycle::SandboxState::Destroyed)
+            .expect("destroy transition");
+        writer.persist(&instance).expect("persist terminal record");
+
+        let reader = StateStore::new(root);
+        let scanned = reader.scan().expect("scan state store");
+
+        assert_eq!(
+            scanned[&instance.id].state,
+            blaze_core::lifecycle::SandboxState::Destroyed
+        );
+        assert_eq!(reader.retained_run_dir_count(), 0);
+        assert!(matches!(
+            reader.persist(&instance),
+            Err(BlazeDaemonError::Conflict(_))
+        ));
+        assert_eq!(reader.retained_run_dir_count(), 0);
+        assert_eq!(
+            reader
+                .load(instance.id)
+                .expect("reload repeated terminal record")
+                .state,
+            blaze_core::lifecycle::SandboxState::Destroyed
+        );
+    }
+
+    #[test]
+    fn scan_retains_nonterminal_run_directories() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let writer = StateStore::new(root.clone());
+        let mut instance = instance();
+        instance
+            .transition(blaze_core::lifecycle::SandboxState::RecoveryRequired)
+            .expect("recovery transition");
+        writer.persist(&instance).expect("persist recovery record");
+        drop(writer);
+
+        let reader = StateStore::new(root);
+        let scanned = reader.scan().expect("scan state store");
+
+        assert_eq!(
+            scanned[&instance.id].state,
+            blaze_core::lifecycle::SandboxState::RecoveryRequired
+        );
+        assert_eq!(reader.retained_run_dir_count(), 1);
+        assert!(reader.run_dir(instance.id).is_ok());
+    }
+
+    #[test]
+    fn recovery_required_record_retains_its_runtime_directory() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root);
+        let mut instance = instance();
+        instance
+            .transition(blaze_core::lifecycle::SandboxState::RecoveryRequired)
+            .expect("recovery transition");
+
+        store.persist(&instance).expect("persist recovery record");
+
+        assert_eq!(store.retained_run_dir_count(), 1);
+        assert!(store.run_dir(instance.id).is_ok());
+    }
+
+    #[test]
+    fn startup_scan_removes_known_stale_state_temporaries() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let instance = instance();
+        instance.persist(&root).expect("write lifecycle fixture");
+        let record_temp = root.join(instance.id.to_string()).join(TEMP_STATE_FILE);
+        std::fs::write(&record_temp, b"stale\n").expect("stale record temp");
+
+        let staging_name = format!(".state-{}-{}.tmp", instance.id, Uuid::new_v4());
+        let staging = root.join(&staging_name);
+        std::fs::create_dir(&staging).expect("stale staging directory");
+        std::fs::write(staging.join(STATE_FILE), b"stale\n").expect("stale staged state");
+        std::fs::write(staging.join(TEMP_STATE_FILE), b"stale\n").expect("stale staged temp");
+
+        let store = StateStore::new(root);
+        let scanned = store.scan().expect("startup scan");
+
+        assert_eq!(scanned[&instance.id].id, instance.id);
+        assert!(!record_temp.exists());
+        assert!(!staging.exists());
+    }
+
+    #[test]
+    fn concurrent_commits_keep_record_and_retention_consistent() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let store = StateStore::new(root);
+
+        for iteration in 0..16 {
+            let mut active = instance();
+            active.policy_name = format!("active-{iteration}");
+            store.persist(&active).expect("initial active record");
+            let id = active.id;
+
+            let mut terminal = active.clone();
+            terminal
+                .transition(blaze_core::lifecycle::SandboxState::Destroyed)
+                .expect("destroy transition");
+            terminal.policy_name = format!("terminal-{iteration}");
+
+            let barrier = Arc::new(std::sync::Barrier::new(3));
+            let active_store = store.clone();
+            let active_barrier = Arc::clone(&barrier);
+            let active_thread = std::thread::spawn(move || {
+                active_barrier.wait();
+                active_store.persist(&active)
+            });
+            let terminal_store = store.clone();
+            let terminal_barrier = Arc::clone(&barrier);
+            let terminal_thread = std::thread::spawn(move || {
+                terminal_barrier.wait();
+                terminal_store.persist(&terminal)
+            });
+            barrier.wait();
+
+            let active_result = active_thread.join().expect("active writer thread");
+            terminal_thread
+                .join()
+                .expect("terminal writer thread")
+                .expect("terminal persist");
+
+            if let Err(error) = active_result {
+                assert!(matches!(error, BlazeDaemonError::Conflict(_)));
+            }
+            assert_eq!(
+                store.load(id).expect("load final record").state,
+                blaze_core::lifecycle::SandboxState::Destroyed
+            );
+            assert!(matches!(
+                store.run_dir(id),
+                Err(BlazeDaemonError::NotFound(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn state_root_allows_only_one_production_owner() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("state");
+        std::fs::create_dir(&root).expect("state directory");
+        let owner = StateStore::open(root.clone()).expect("first owner");
+
+        let error = StateStore::open(root).expect_err("second owner must fail");
+
+        assert!(matches!(error, BlazeDaemonError::Conflict(_)));
+        drop(owner);
     }
 }


### PR DESCRIPTION
## Why

Lifecycle records and sandbox work directories were addressed by rebuilding
`daemon.state_dir/<uuid>` paths for later operations. A path says where to
look, but it does not keep later persistence, startup compensation, or backend
cleanup attached to the directory object the daemon accepted.

Replacing the configured root or a UUID entry during the daemon lifetime could
therefore redirect later work to another object. A failed first publication
could also leave creation without a trustworthy ownership result.

## What changed

**Before:** production scan, load, persistence, sandbox-directory lookup, and
backend startup each carried or reconstructed paths. The daemon did not have
one ownership boundary spanning the accepted state root, a sandbox directory,
and the backend handle that continued using it.

**After:** the daemon opens and locks the lifecycle-state root before inventory.
Record operations are relative to retained directories, new sandbox directories
are published without replacing an existing entry, and nonterminal directories
remain owned until their terminal record is committed. The accepted
`OwnedRunDir` is passed into backend startup; both successful and partially
started backend handles retain it. Firecracker inherits the required directory
descriptor into the child before exec.

The resulting flow is:

```text
open and lock lifecycle-state root
        |
scan and retain nonterminal UUID directories
        |
perform descriptor-relative lifecycle-record updates
        |
pass OwnedRunDir into backend startup
        |
successful or partial backend handle retains the same object
        |
terminal commit permits StateStore to release its owner
        |
manager removes the backend handle after terminal bookkeeping
```

### Commits

1. `9f29c36c71a9 refactor(blaze): centralize daemon state access`
   - **Intent:** establish one production access boundary before changing
     object-lifetime behavior.
   - **Implementation:** route scan, load, persist, and per-sandbox directory
     lookup through `StateStore`.
   - **Result:** a mechanical foundation with unchanged disk layout and runtime
     behavior.

2. `2adc3f4cf7a4 fix(blaze): own persisted state directories`
   - **Intent:** keep inventory, lifecycle updates, and failure compensation
     attached to the accepted state-root and UUID directory objects.
   - **Implementation:** retain and lock the state root, use descriptor-relative
     record I/O, publish through unique staging with no-replace and durability
     checks, retain nonterminal and unconfirmed staging owners, and report
     `RecoveryRequired` when publication, cleanup, or rollback remains uncertain.
   - **Result:** lifecycle-state ownership and recovery remain attached to the
     accepted objects; path-based spawners receive a descriptor-backed alias.

3. `dc6f4a64d7e7 fix(blaze): retain runtime directory owners`
   - **Intent:** prevent backend startup from reducing an accepted directory
     object back to a path that can be resolved again.
   - **Implementation:** pair portable launch parameters with `OwnedRunDir`,
     validate sandbox identity, retain the owner in success and partial-failure
     handles, and let Firecracker inherit the descriptor it uses for runtime
     artifacts.
   - **Result:** completes the daemon-to-backend ownership handoff without
     adding a daemon HTTP or wire operation.

These commits form one PR because they establish one `state_dir/<uuid>`
continuity invariant. The first commit creates the access boundary, the second
binds lifecycle records to opened directories, and the third carries that same
directory owner into backend lifetime. Splitting the final two into separate
PRs would leave records and runtime artifacts with different ownership
contracts.

## Related issue

closes #2327

Relates to #2254.

## User / Agent impact

No new daemon operation, configuration key, or persisted format is introduced.
Existing create, restart reconciliation, destroy, and warm paths keep their
lifecycle-state and backend-runtime work attached to the directory objects
accepted by the daemon. Uncertain publication or cleanup retains recovery
responsibility instead of silently dropping ownership.

This PR covers lifecycle-state and backend runtime directories only.
Independent storage roots, the earlier startup handoff between peer-root
validation and lifecycle-state opening, and checkpoint namespaces remain
tracked by #2254. Complete startup-inventory validation is tracked by #2369
and implemented by the dependent #2113. Broader staging-entry classification
and cleanup identity remain tracked by #2328; this PR retains the opened owner
whenever its own publication cleanup cannot be confirmed.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged runtime behavior changed
- [x] Cross-component contract changed
- [ ] Data conversion or rollback guidance is needed

The daemon now retains one state-root descriptor plus one directory descriptor
per nonterminal sandbox. Backend handles extend the lifetime of the existing
per-sandbox descriptor; Firecracker also inherits it into the child.

The workspace-only Rust contract is intentionally tightened: `SpawnRequest` no
longer carries a duplicate raw `run_dir`, and `blazed` uses a daemon-local typed
request. The workspace crates are not published. Daemon HTTP and wire
operations, configuration, persisted lifecycle records, and the
restart-reconciliation protocol are unchanged.

## Validation

Validation ran on Linux x86_64, kernel 6.6.102, with rustc/cargo 1.93.1. Each
exact commit was exported with `git archive` and tested from a fresh source tree.
Every commit used its own initially empty default and all-features Cargo targets.

| Commit | Parent | Tree | Archive SHA-256 |
|---|---|---|---|
| `9f29c36c71a9` | `61b825bbddd5` | `76a55633579c` | `2f0c6da5bce3633375ff9d50c73636937aae06543d4ad3d9eb77eebe30190b9b` |
| `2adc3f4cf7a4` | `9f29c36c71a9` | `91e046bcc5ac` | `8dfcceabe808cc651e53d0ef249a8508cda2db0b154f14a8ddfb83c0ed313af9` |
| `dc6f4a64d7e7` | `2adc3f4cf7a4` | `504df6f3a6bd` | `8a3a3be08492f66c88fb08599662900eb92c372daf750ce30a302f89fb619f51` |

The following passed for every commit with locked dependencies:

- `cargo fmt --all -- --check`
- default and all-features `cargo metadata --locked --no-deps`
- default and all-features workspace all-target builds
- default and all-features strict workspace Clippy with `-D warnings`
- default and all-features workspace tests
- default and all-features strict rustdoc with `RUSTDOCFLAGS="-D warnings"`

| Commit | Default tests | All-features tests | Focused evidence | Result |
|---|---:|---:|---|---|
| `9f29c36c71a9` | 52 core + 204 daemon | 52 core + 214 daemon | State-store access boundary 1/1 | PASS |
| `2adc3f4cf7a4` | 52 core + 218 daemon | 52 core + 236 daemon | State-store 14/14; staging residual 1/1; manager recovery 1/1 | PASS |
| `dc6f4a64d7e7` | 52 core + 222 daemon | 52 core + 240 daemon | State-store 15/15; staging residual 1/1; manager recovery 1/1; runtime-owner handoff 1/1 | PASS |

At the exact final commit `dc6f4a64d7e7`, a real Firecracker create/destroy
run replaced the configured UUID pathname with a different directory object
while the sandbox was running. Status and destroy continued through the accepted object; the
terminal record and backend stop marker appeared only there, the replacement
directory remained empty, the backend process exited, and the daemon remained
healthy.

Commitlint 19.8.1, DCO trailer checks, `git diff --check`, fixup scans, and the
public-boundary scan passed. In a disposable copy of commit 2, removing the
`Uncertain` owner insertion made the new staging-cleanup test fail at the
residual-ownership assertion. Hosted PR Lint, Components, and CLA checks passed
for this rewritten head. A new complete-PR review is still pending; results for earlier heads are treated
as historical.

## Documentation and rollback

No operator documentation changes are required because the daemon API,
configuration, and persisted layout are unchanged. Reverting these three
commits restores path-based lifecycle-state and backend-runtime handling;
existing lifecycle records remain readable.
