### PR TITLE
docs(docs): document ANOLISA 1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1] - 2026-08-08
+
+### Component Versions
+
+| Component | Version |
+|-----------|--------|
+| copilot-shell | 2.8.0 |
+| agent-sec-core | 0.9.0 |
+| agentsight | 0.9.1 |
+| tokenless | 0.7.3 |
+| agent-memory | 0.2.6 |
+| os-skills | 0.6.1 |
+| anolisa | 0.2.15 |
+| skillfs | 0.4.0 |
+| ws-ckpt | 0.4.2 |
+| cosh-ng | 0.14.0 |
+
+> **Note:** os-skills remains at v0.6.1; it did not change in this release and
+> is listed to show the complete stack composition.
+
+### Highlights
+
+- **cosh-ng**: Updated to v0.14.0, added resumable workspace sessions, MCP management, runtime introspection, and DashScope prompt caching, agents can recover long-running work and extend capabilities while reducing repeated prompt cost (#1546, #1592, #1778, #1949, #2046)
+- **agentsight**: Updated to v0.9.1, added optimization and trajectory analysis together with case containment, system audit, and ActPlane risk enforcement, users can diagnose agent quality and cost while investigating and containing risky behavior (#1728, #1789, #2051)
+- **agent-sec-core**: Updated to v0.9.0, expanded prompt, PII, code, and observability hooks across Qoder CLI, Qwen Code, and Codex, users can apply consistent security policies across supported agent runtimes (#1473, #1480, #1495, #1501, #1529, #1535)
+- **tokenless**: Updated to v0.7.3, added reversible compression with MCP retrieval plus Cosh-NG response and command compression, agents can reduce model context while recovering truncated payloads on demand (#1285, #1376, #1669)
+- **anolisa**: Updated to v0.2.15, added exact-version RPM and raw installs, file-metadata repair, and interactive progress, administrators can select published versions and recover installation drift with visible operation phases (#1700, #1740, #1987, #2036)
+
+### Updated
+
+- **copilot-shell**: Updated to v2.8.0, added the consent-gated `/ktuner` command, exported `COSH_SESSION_ID`, and reused compatible cosh-ng authentication during switching, users can tune hosts, correlate subprocess activity, and move between shells with less setup (#1279, #1491, #1951)
+- **agent-sec-core**: Updated to v0.9.0, added Qoder CLI and Qwen Code hook coverage, Codex PII and observability hooks, custom PII rules, and Chinese prompt-injection detection, users receive broader protection across prompts, tool calls, skills, and agent output (#1473, #1495, #1501, #1522, #1554)
+- **agentsight**: Updated to v0.9.1, added ATIF v1.7 trajectory analysis, accuracy/performance/cost workspaces, case containment, system audit, and risk dashboards, users can trace multi-agent behavior and act on optimization or security findings (#1728, #1789, #1828, #2051)
+- **tokenless**: Updated to v0.7.3, added stash-backed reversible compression, an MCP retrieval server, Cosh-NG compression, and macOS/Qwencode adapter support, agents can save tokens across more runtimes without permanently losing compressed content (#1285, #1376, #1669, #1894, #1964)
+- **agent-memory**: Updated to v0.2.6, added synchronous indexing plus focused-query and OR-ranked recall fallbacks, agents can retrieve newly captured memories from verbose or stopword-heavy prompts (#1520, #1574, #2047)
+- **anolisa**: Updated to v0.2.15, added exact-version RPM and raw installs, telemetry controls, macOS arm64 npm delivery, file-metadata repair, and phase-based progress, users can select published versions across Linux and macOS, control reporting, and repair Linux installation drift (#1619, #1700, #1740, #1962, #1987, #2036)
+- **skillfs**: Updated to v0.4.0, added Hermes nested-skill compatibility, configurable read-time transforms, authenticated live-source resolution, and hardened permission boundaries, agents can consume adapted skill views while source mutations remain safely controlled (#1146, #1484, #1517)
+- **ws-ckpt**: Updated to v0.4.2, added telemetry gating and automatic recovery of orphaned pre-init backups, users can recover workspaces after interrupted initialization without stale backup state (#1509, #1601)
+- **cosh-ng**: Updated to v0.14.0, added session recovery, MCP tools, slash-command introspection, and prompt-cache observability, agents can resume complex work, extend capabilities, and diagnose cache savings (#1530, #1546, #1592, #1778, #1949, #2046, #2075)
+
 ## [1.0] - 2026-07-06
 
 ### Component Versions

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -6,6 +6,45 @@
 
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，项目遵循[语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [1.1] - 2026-08-08
+
+### 组件版本
+
+| 组件 | 版本 |
+|------|------|
+| copilot-shell | 2.8.0 |
+| agent-sec-core | 0.9.0 |
+| agentsight | 0.9.1 |
+| tokenless | 0.7.3 |
+| agent-memory | 0.2.6 |
+| os-skills | 0.6.1 |
+| anolisa | 0.2.15 |
+| skillfs | 0.4.0 |
+| ws-ckpt | 0.4.2 |
+| cosh-ng | 0.14.0 |
+
+> **说明：** os-skills 保持 v0.6.1，本次发布未更新；版本表保留该组件以展示完整组件组合。
+
+### 重点特性
+
+- **cosh-ng**：更新到 v0.14.0，新增可恢复的 Workspace Session、MCP 管理、运行时状态查询和 DashScope Prompt Cache，Agent 可恢复长时间任务、扩展能力并降低重复 Prompt 成本（#1546、#1592、#1778、#1949、#2046）
+- **agentsight**：更新到 v0.9.1，新增优化与 Trajectory 分析以及 Case Containment、System Audit 和 ActPlane 风险执行，用户可诊断 Agent 质量与成本并调查、遏制风险行为（#1728、#1789、#2051）
+- **agent-sec-core**：更新到 v0.9.0，将 Prompt、PII、Code 和 Observability Hook 扩展到 Qoder CLI、Qwen Code 和 Codex，用户可在受支持的 Agent Runtime 间应用一致的安全策略（#1473、#1480、#1495、#1501、#1529、#1535）
+- **tokenless**：更新到 v0.7.3，新增带 MCP 检索的可逆压缩以及 Cosh-NG 响应与命令压缩，Agent 可减少 Model Context 并按需恢复被截断的内容（#1285、#1376、#1669）
+- **anolisa**：更新到 v0.2.15，新增精确版本 RPM/Raw 安装、文件元数据修复和交互式进度，管理员可选择已发布版本、修复安装漂移并查看操作阶段（#1700、#1740、#1987、#2036）
+
+### 组件更新
+
+- **copilot-shell**：更新到 v2.8.0，新增需用户同意的 `/ktuner` 命令、导出 `COSH_SESSION_ID` 并在切换时复用兼容的 cosh-ng 认证，用户可调优主机、关联子进程活动并以更少配置在 Shell 间切换（#1279、#1491、#1951）
+- **agent-sec-core**：更新到 v0.9.0，新增 Qoder CLI 与 Qwen Code Hook 覆盖、Codex PII 与 Observability Hook、自定义 PII 规则及中文 Prompt Injection 检测，用户在 Prompt、Tool Call、Skill 和 Agent 输出上获得更广泛的保护（#1473、#1495、#1501、#1522、#1554）
+- **agentsight**：更新到 v0.9.1，新增 ATIF v1.7 Trajectory 分析、准确性/性能/成本 Workspace、Case Containment、System Audit 和风险 Dashboard，用户可追踪多 Agent 行为并处理优化或安全发现（#1728、#1789、#1828、#2051）
+- **tokenless**：更新到 v0.7.3，新增基于 Stash 的可逆压缩、MCP 检索服务器、Cosh-NG 压缩和 macOS/Qwencode Adapter 支持，Agent 可在更多 Runtime 中节省 Token 而不永久丢失压缩内容（#1285、#1376、#1669、#1894、#1964）
+- **agent-memory**：更新到 v0.2.6，新增同步索引以及聚焦 Query 和 OR 排序 Recall Fallback，Agent 可从冗长或包含较多停用词的 Prompt 中检索刚捕获的记忆（#1520、#1574、#2047）
+- **anolisa**：更新到 v0.2.15，新增精确版本 RPM/Raw 安装、Telemetry 控制、macOS arm64 npm 交付、文件元数据修复和分阶段进度，用户可跨 Linux 与 macOS 选择已发布版本、控制上报并修复 Linux 安装漂移（#1619、#1700、#1740、#1962、#1987、#2036）
+- **skillfs**：更新到 v0.4.0，新增 Hermes 嵌套 Skill 兼容、可配置读取时转换、认证的 Live Source 解析和强化的权限边界，Agent 可使用适配后的 Skill View，同时 Source Mutation 仍受安全控制（#1146、#1484、#1517）
+- **ws-ckpt**：更新到 v0.4.2，新增 Telemetry Gate 和孤立 Pre-init Backup 自动恢复，用户可在初始化中断后恢复 Workspace 而不受陈旧备份状态影响（#1509、#1601）
+- **cosh-ng**：更新到 v0.14.0，新增 Session 恢复、MCP Tool、Slash Command 状态查询和 Prompt Cache 可观测，Agent 可恢复复杂任务、扩展能力并诊断 Cache 节省效果（#1530、#1546、#1592、#1778、#1949、#2046、#2075）
+
 ## [1.0] - 2026-07-06
 
 ### 组件版本


### PR DESCRIPTION
## Why

ANOLISA 1.1 has been released with nine component version updates.
The root changelogs need to record the complete release composition and
user-visible changes in both supported languages.

## What changed

- Add the ANOLISA 1.1 component version table to both root changelogs.
- Summarize release highlights and per-component user-visible updates.
- Keep os-skills at v0.6.1 so the table describes the complete stack.

## Related issue

no-issue: synchronize the published ANOLISA 1.1 release changelog

## User / Agent impact

Users and agents can identify the exact component versions in ANOLISA 1.1
and review the release highlights from the root changelog.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This PR changes release documentation only.

## Validation

- `git diff --check origin/main...HEAD`
- `bash scripts/docs-lint.sh`
- `npm run validate:locales --prefix website`
- `npm run build --prefix website`
- `npm run validate:agent-index --prefix website`
- `npm run check:links --prefix website`

## Documentation and rollback

This PR updates `CHANGELOG.md` and `CHANGELOG_zh.md`.
Revert commit `cc3ffef4` to remove the 1.1 release entry.