### PR TITLE
feat(sight): bootstrap dashboard i18n

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -644,6 +644,20 @@ jobs:
         with:
           python-version: '3.11.6'
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: src/agentsight/dashboard/package-lock.json
+
+      - name: Install dashboard dependencies
+        working-directory: src/agentsight/dashboard
+        run: npm ci --no-audit --no-fund
+
+      - name: Run dashboard i18n regression
+        working-directory: src/agentsight/dashboard
+        run: npm run test:i18n
+
       - name: Install eBPF build dependencies
         run: |
           sudo apt-get update

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -160,7 +160,7 @@ agentsight discover --verbose
 
 ## Dashboard
 
-The Dashboard is a React-based web UI for visualizing conversation history, trace details, and token statistics. It is embedded into the `agentsight serve` binary at compile time.
+The Dashboard is a React-based web UI for visualizing conversation history, trace details, and token statistics. It is embedded into the `agentsight serve` binary at compile time. By default, the Dashboard follows the browser language; you can switch languages manually, and the choice is persisted across refreshes.
 
 ### Build the Dashboard
 

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -160,7 +160,7 @@ agentsight discover --verbose
 
 ## Dashboard
 
-Dashboard 是基于 React 的 Web 可视化界面，用于查看对话历史、Trace 详情和 Token 统计数据。它在编译时嵌入到 `agentsight serve` 二进制文件中。
+Dashboard 是基于 React 的 Web 可视化界面，用于查看对话历史、Trace 详情和 Token 统计数据。它在编译时嵌入到 `agentsight serve` 二进制文件中。Dashboard 默认根据浏览器语言选择 UI 语言；你可以手动切换语言，选择会被持久化并在刷新后保持。
 
 ### 构建 Dashboard
 

--- a/src/agentsight/dashboard/index.html
+++ b/src/agentsight/dashboard/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en-US">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent可观测</title>
+  <title>Agent Observability</title>
 </head>
 <body>
   <div id="root"></div>

--- a/src/agentsight/dashboard/package.json
+++ b/src/agentsight/dashboard/package.json
@@ -6,7 +6,8 @@
     "build": "webpack --mode production",
     "build:embed": "AGENTSIGHT_EMBED=1 webpack --mode production",
     "typecheck": "tsc --noEmit",
-    "test:api-client": "node tests/run-api-client-regression.cjs"
+    "test:api-client": "node tests/run-api-client-regression.cjs",
+    "test:i18n": "node tests/run-i18n-regression.cjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/agentsight/dashboard/src/App.tsx
+++ b/src/agentsight/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import { SettingsPage } from './pages/SettingsPage';
 import { RiskEnforcementPage } from './pages/RiskEnforcementPage';
 import { SystemAuditPage } from './pages/SystemAuditPage';
 import { LoginPage } from './pages/LoginPage';
+import { useI18n } from './i18n';
 import { fetchAuthStatus, fetchAuthVerify, login } from './utils/apiClient';
 import type { AppCapability, AuthStatusResponse } from './utils/apiClient';
 
@@ -61,6 +62,7 @@ const AuthGate: React.FC<{ children: (status: AuthStatusResponse | null) => Reac
   const [status, setStatus] = useState<AuthStatusResponse | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
+  const { t } = useI18n();
 
   useEffect(() => {
     // Check for token in URL query parameter (e.g. ?token=xxx from CLI link)
@@ -126,7 +128,7 @@ const AuthGate: React.FC<{ children: (status: AuthStatusResponse | null) => Reac
   if (authState === 'loading') {
     return (
       <div className="min-h-screen flex items-center justify-center text-gray-400">
-        Loading...
+        {t('app.loading')}
       </div>
     );
   }

--- a/src/agentsight/dashboard/src/components/NavBar.tsx
+++ b/src/agentsight/dashboard/src/components/NavBar.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
+import { LanguageSwitcher, useI18n } from '../i18n';
+import type { MessageKey } from '../i18n';
 import type { AppCapability } from '../utils/apiClient';
 
 type NavItem = {
   path: string;
-  label: string;
+  labelKey: MessageKey;
   icon: string;
   capability: AppCapability;
 };
 
 const navItems: NavItem[] = [
-  { path: '/health', label: 'Agent 看板', icon: '🩺', capability: 'agent_health' },
-  { path: '/', label: 'Agent 可观测', icon: '📊', capability: 'agent_observability' },
-  { path: '/sessions', label: '会话列表', icon: '🗂️', capability: 'sessions' },
-  { path: '/savings', label: 'Token 节省', icon: '⚡', capability: 'token_savings' },
-  { path: '/optimization', label: '优化分析', icon: '🔬', capability: 'optimization' },
-  { path: '/skills', label: 'Skill 指标', icon: '🧩', capability: 'skills' },
-  { path: '/security', label: '安全可观测', icon: '🛡️', capability: 'security' },
-  { path: '/audit', label: '系统审计', icon: '📋', capability: 'security' },
-  { path: '/enforcement', label: '风险拦截', icon: '⛔', capability: 'enforcement' },
-  { path: '/atif', label: '轨迹查看', icon: '🔍', capability: 'atif' },
-  { path: '/settings', label: '设置', icon: '⚙️', capability: 'settings' },
+  { path: '/health', labelKey: 'nav.agentHealth', icon: '🩺', capability: 'agent_health' },
+  { path: '/', labelKey: 'nav.agentObservability', icon: '📊', capability: 'agent_observability' },
+  { path: '/sessions', labelKey: 'nav.sessions', icon: '🗂️', capability: 'sessions' },
+  { path: '/savings', labelKey: 'nav.tokenSavings', icon: '⚡', capability: 'token_savings' },
+  { path: '/optimization', labelKey: 'nav.optimization', icon: '🔬', capability: 'optimization' },
+  { path: '/skills', labelKey: 'nav.skillMetrics', icon: '🧩', capability: 'skills' },
+  { path: '/security', labelKey: 'nav.securityObservability', icon: '🛡️', capability: 'security' },
+  { path: '/audit', labelKey: 'nav.systemAudit', icon: '📋', capability: 'security' },
+  { path: '/enforcement', labelKey: 'nav.riskEnforcement', icon: '⛔', capability: 'enforcement' },
+  { path: '/atif', labelKey: 'nav.trajectoryViewer', icon: '🔍', capability: 'atif' },
+  { path: '/settings', labelKey: 'nav.settings', icon: '⚙️', capability: 'settings' },
 ];
 
 interface NavBarProps {
@@ -29,13 +31,14 @@ interface NavBarProps {
 
 export const NavBar: React.FC<NavBarProps> = ({ capabilities }) => {
   const location = useLocation();
+  const { t } = useI18n();
   const visibleItems = Array.isArray(capabilities)
     ? navItems.filter((item) => capabilities.includes(item.capability))
     : navItems;
 
   return (
     <nav className="bg-white border-b border-gray-200 px-6 py-3">
-      <div className="max-w-screen-xl mx-auto flex items-center justify-between">
+      <div className="max-w-screen-2xl mx-auto flex flex-wrap items-center gap-3">
         {/* Logo / Brand */}
         <div className="flex items-center gap-2">
           <span className="text-xl font-bold text-gray-900">AgentSight</span>
@@ -43,7 +46,7 @@ export const NavBar: React.FC<NavBarProps> = ({ capabilities }) => {
         </div>
 
         {/* Navigation Links */}
-        <div className="flex items-center gap-1">
+        <div className="flex flex-1 flex-wrap items-center justify-end gap-1">
           {visibleItems.map((item) => {
             const isActive = item.path === '/' 
               ? location.pathname === '/' 
@@ -60,10 +63,11 @@ export const NavBar: React.FC<NavBarProps> = ({ capabilities }) => {
                 }`}
               >
                 <span className="mr-1.5">{item.icon}</span>
-                {item.label}
+                {t(item.labelKey)}
               </NavLink>
             );
           })}
+          <LanguageSwitcher id="navbar-language" className="ml-2 shrink-0" />
         </div>
       </div>
     </nav>

--- a/src/agentsight/dashboard/src/i18n.tsx
+++ b/src/agentsight/dashboard/src/i18n.tsx
@@ -2,7 +2,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react';
@@ -136,13 +136,12 @@ function syncDocumentMetadata(locale: Locale): void {
 export const I18nProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [locale, setLocaleState] = useState<Locale>(resolveInitialLocale);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     syncDocumentMetadata(locale);
   }, [locale]);
 
   const setLocale = useCallback((nextLocale: Locale) => {
     setLocaleState(nextLocale);
-    syncDocumentMetadata(nextLocale);
 
     try {
       window.localStorage.setItem(LOCALE_STORAGE_KEY, nextLocale);

--- a/src/agentsight/dashboard/src/i18n.tsx
+++ b/src/agentsight/dashboard/src/i18n.tsx
@@ -106,6 +106,7 @@ export function resolveLocale(
   if (isSupportedLocale(persistedLocale)) return persistedLocale;
 
   for (const browserLanguage of browserLanguages) {
+    if (!browserLanguage) continue;
     const normalizedLanguage = browserLanguage.toLowerCase();
     if (normalizedLanguage.startsWith('zh')) return 'zh-CN';
     if (normalizedLanguage.startsWith('en')) return 'en-US';

--- a/src/agentsight/dashboard/src/i18n.tsx
+++ b/src/agentsight/dashboard/src/i18n.tsx
@@ -1,0 +1,209 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export const SUPPORTED_LOCALES = ['en-US', 'zh-CN'] as const;
+
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+const DEFAULT_LOCALE: Locale = 'en-US';
+const LOCALE_STORAGE_KEY = 'agentsight.locale';
+
+const enUSMessages = {
+  'app.title': 'Agent Observability',
+  'app.loading': 'Loading...',
+  'language.label': 'Language',
+  'nav.agentHealth': 'Agent Dashboard',
+  'nav.agentObservability': 'Agent Observability',
+  'nav.sessions': 'Sessions',
+  'nav.tokenSavings': 'Token Savings',
+  'nav.optimization': 'Optimization',
+  'nav.skillMetrics': 'Skill Metrics',
+  'nav.securityObservability': 'Security Observability',
+  'nav.systemAudit': 'System Audit',
+  'nav.riskEnforcement': 'Risk Enforcement',
+  'nav.trajectoryViewer': 'Trajectory Viewer',
+  'nav.settings': 'Settings',
+  'login.subtitle': 'Enter your dashboard token to continue',
+  'login.tokenLabel': 'Dashboard Token',
+  'login.tokenPlaceholder': 'Paste your token here',
+  'login.error.required': 'Please enter a token',
+  'login.error.invalid': 'Invalid token. Check the token with `agentsight dashboard`.',
+  'login.error.connection': 'Connection error. Is the AgentSight server running?',
+  'login.verifying': 'Verifying...',
+  'login.signIn': 'Sign In',
+  'login.tokenHintPrefix': 'Run ',
+  'login.tokenHintSuffix': ' to view your token.',
+  'login.fullTokenHintPrefix': 'Or use ',
+  'login.fullTokenHintSuffix': ' to show the complete value.',
+} as const;
+
+export type MessageKey = keyof typeof enUSMessages;
+
+const messages: Record<Locale, Record<MessageKey, string>> = {
+  'en-US': enUSMessages,
+  'zh-CN': {
+    'app.title': 'Agent可观测',
+    'app.loading': '加载中...',
+    'language.label': '语言',
+    'nav.agentHealth': 'Agent 看板',
+    'nav.agentObservability': 'Agent 可观测',
+    'nav.sessions': '会话列表',
+    'nav.tokenSavings': 'Token 节省',
+    'nav.optimization': '优化分析',
+    'nav.skillMetrics': 'Skill 指标',
+    'nav.securityObservability': '安全可观测',
+    'nav.systemAudit': '系统审计',
+    'nav.riskEnforcement': '风险拦截',
+    'nav.trajectoryViewer': '轨迹查看',
+    'nav.settings': '设置',
+    'login.subtitle': '请输入 Dashboard 令牌以继续',
+    'login.tokenLabel': 'Dashboard 令牌',
+    'login.tokenPlaceholder': '在此粘贴令牌',
+    'login.error.required': '请输入令牌',
+    'login.error.invalid': '令牌无效。请运行 `agentsight dashboard` 检查令牌。',
+    'login.error.connection': '连接失败。请确认 AgentSight 服务正在运行。',
+    'login.verifying': '验证中...',
+    'login.signIn': '登录',
+    'login.tokenHintPrefix': '运行 ',
+    'login.tokenHintSuffix': ' 查看令牌。',
+    'login.fullTokenHintPrefix': '或使用 ',
+    'login.fullTokenHintSuffix': ' 显示完整令牌。',
+  },
+};
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: MessageKey) => string;
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function isSupportedLocale(value: string | null): value is Locale {
+  return value === 'en-US' || value === 'zh-CN';
+}
+
+function readPersistedLocale(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function resolveLocale(
+  persistedLocale: string | null,
+  browserLanguages: readonly string[],
+): Locale {
+  if (isSupportedLocale(persistedLocale)) return persistedLocale;
+
+  const preferredLanguage = browserLanguages.find(Boolean);
+  return preferredLanguage?.toLowerCase().startsWith('zh')
+    ? 'zh-CN'
+    : DEFAULT_LOCALE;
+}
+
+function resolveInitialLocale(): Locale {
+  let browserLanguages: readonly string[] = [];
+  if (typeof navigator !== 'undefined') {
+    browserLanguages = navigator.languages?.length > 0
+      ? navigator.languages
+      : [navigator.language];
+  }
+
+  return resolveLocale(readPersistedLocale(), browserLanguages);
+}
+
+function syncDocumentMetadata(locale: Locale): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = locale;
+    document.title = messages[locale]['app.title'];
+  }
+}
+
+export const I18nProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [locale, setLocaleState] = useState<Locale>(resolveInitialLocale);
+
+  useEffect(() => {
+    syncDocumentMetadata(locale);
+  }, [locale]);
+
+  const setLocale = useCallback((nextLocale: Locale) => {
+    setLocaleState(nextLocale);
+    syncDocumentMetadata(nextLocale);
+
+    try {
+      window.localStorage.setItem(LOCALE_STORAGE_KEY, nextLocale);
+    } catch {
+      // Keep the in-memory selection when storage is unavailable.
+    }
+  }, []);
+
+  const t = useCallback(
+    (key: MessageKey) => messages[locale][key],
+    [locale],
+  );
+
+  const value = useMemo(
+    () => ({ locale, setLocale, t }),
+    [locale, setLocale, t],
+  );
+
+  return (
+    <I18nContext.Provider value={value}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export function useI18n(): I18nContextValue {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error('useI18n must be used within an I18nProvider');
+  }
+  return context;
+}
+
+interface LanguageSwitcherProps {
+  id: string;
+  className?: string;
+}
+
+export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({
+  id,
+  className = '',
+}) => {
+  const { locale, setLocale, t } = useI18n();
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextLocale = event.target.value;
+    if (isSupportedLocale(nextLocale)) {
+      setLocale(nextLocale);
+    }
+  };
+
+  return (
+    <label className={`inline-flex items-center gap-1.5 ${className}`} htmlFor={id}>
+      <span aria-hidden="true">🌐</span>
+      <span className="sr-only">{t('language.label')}</span>
+      <select
+        id={id}
+        aria-label={t('language.label')}
+        value={locale}
+        onChange={handleChange}
+        className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        <option value="en-US">English</option>
+        <option value="zh-CN">简体中文</option>
+      </select>
+    </label>
+  );
+};

--- a/src/agentsight/dashboard/src/i18n.tsx
+++ b/src/agentsight/dashboard/src/i18n.tsx
@@ -105,10 +105,13 @@ export function resolveLocale(
 ): Locale {
   if (isSupportedLocale(persistedLocale)) return persistedLocale;
 
-  const preferredLanguage = browserLanguages.find(Boolean);
-  return preferredLanguage?.toLowerCase().startsWith('zh')
-    ? 'zh-CN'
-    : DEFAULT_LOCALE;
+  for (const browserLanguage of browserLanguages) {
+    const normalizedLanguage = browserLanguage.toLowerCase();
+    if (normalizedLanguage.startsWith('zh')) return 'zh-CN';
+    if (normalizedLanguage.startsWith('en')) return 'en-US';
+  }
+
+  return DEFAULT_LOCALE;
 }
 
 function resolveInitialLocale(): Locale {

--- a/src/agentsight/dashboard/src/index.tsx
+++ b/src/agentsight/dashboard/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { I18nProvider } from './i18n';
 import './styles/index.css';
 
 const root = ReactDOM.createRoot(
@@ -9,6 +10,8 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <App />
+    <I18nProvider>
+      <App />
+    </I18nProvider>
   </React.StrictMode>
 );

--- a/src/agentsight/dashboard/src/pages/LoginPage.tsx
+++ b/src/agentsight/dashboard/src/pages/LoginPage.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { LanguageSwitcher, useI18n } from '../i18n';
+import type { MessageKey } from '../i18n';
 import { login } from '../utils/apiClient';
 
 interface LoginPageProps {
@@ -7,26 +9,27 @@ interface LoginPageProps {
 
 export const LoginPage: React.FC<LoginPageProps> = ({ onAuthenticated }) => {
   const [token, setToken] = useState('');
-  const [error, setError] = useState('');
+  const [errorKey, setErrorKey] = useState<MessageKey | null>(null);
   const [loading, setLoading] = useState(false);
+  const { t } = useI18n();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!token.trim()) {
-      setError('Please enter a token');
+      setErrorKey('login.error.required');
       return;
     }
     setLoading(true);
-    setError('');
+    setErrorKey(null);
     try {
       const ok = await login(token.trim());
       if (ok) {
         onAuthenticated();
       } else {
-        setError('Invalid token. Check the token with `agentsight dashboard`.');
+        setErrorKey('login.error.invalid');
       }
-    } catch (err) {
-      setError('Connection error. Is the AgentSight server running?');
+    } catch {
+      setErrorKey('login.error.connection');
     } finally {
       setLoading(false);
     }
@@ -35,9 +38,13 @@ export const LoginPage: React.FC<LoginPageProps> = ({ onAuthenticated }) => {
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="bg-white p-8 rounded-lg shadow-md w-full max-w-md">
+        <div className="flex justify-end mb-4">
+          <LanguageSwitcher id="login-language" />
+        </div>
+
         <div className="text-center mb-8">
           <h1 className="text-2xl font-bold text-gray-900">AgentSight</h1>
-          <p className="text-gray-500 mt-2">Enter your dashboard token to continue</p>
+          <p className="text-gray-500 mt-2">{t('login.subtitle')}</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -46,22 +53,22 @@ export const LoginPage: React.FC<LoginPageProps> = ({ onAuthenticated }) => {
               htmlFor="token"
               className="block text-sm font-medium text-gray-700 mb-1"
             >
-              Dashboard Token
+              {t('login.tokenLabel')}
             </label>
             <input
               id="token"
               type="password"
               value={token}
               onChange={(e) => setToken(e.target.value)}
-              placeholder="Paste your token here"
+              placeholder={t('login.tokenPlaceholder')}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               autoFocus
             />
           </div>
 
-          {error && (
+          {errorKey && (
             <div className="text-red-600 text-sm bg-red-50 p-2 rounded">
-              {error}
+              {t(errorKey)}
             </div>
           )}
 
@@ -70,14 +77,20 @@ export const LoginPage: React.FC<LoginPageProps> = ({ onAuthenticated }) => {
             disabled={loading}
             className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            {loading ? 'Verifying...' : 'Sign In'}
+            {loading ? t('login.verifying') : t('login.signIn')}
           </button>
         </form>
 
         <div className="mt-6 text-xs text-gray-400 text-center">
-          <p>Run <code className="bg-gray-100 px-1 rounded">agentsight dashboard</code> to view your token.</p>
+          <p>
+            {t('login.tokenHintPrefix')}
+            <code className="bg-gray-100 px-1 rounded">agentsight dashboard</code>
+            {t('login.tokenHintSuffix')}
+          </p>
           <p className="mt-1">
-            Or use <code className="bg-gray-100 px-1 rounded">--full-token</code> to show the complete value.
+            {t('login.fullTokenHintPrefix')}
+            <code className="bg-gray-100 px-1 rounded">--full-token</code>
+            {t('login.fullTokenHintSuffix')}
           </p>
         </div>
       </div>

--- a/src/agentsight/dashboard/tests/i18n-regression.test.cjs
+++ b/src/agentsight/dashboard/tests/i18n-regression.test.cjs
@@ -1,0 +1,16 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { resolveLocale } = require(process.env.AGENTSIGHT_I18N_BUILD);
+
+test('resolveLocale selects the first supported browser locale', () => {
+  assert.equal(resolveLocale(null, ['fr-FR', 'zh-CN']), 'zh-CN');
+  assert.equal(resolveLocale(null, ['fr-FR', 'en-GB']), 'en-US');
+  assert.equal(resolveLocale(null, ['zh-HK', 'en-US']), 'zh-CN');
+  assert.equal(resolveLocale(null, ['de-DE', 'fr-FR']), 'en-US');
+});
+
+test('resolveLocale keeps a supported persisted locale as the highest priority', () => {
+  assert.equal(resolveLocale('zh-CN', ['en-US']), 'zh-CN');
+  assert.equal(resolveLocale('en-US', ['zh-CN']), 'en-US');
+});

--- a/src/agentsight/dashboard/tests/i18n-regression.test.cjs
+++ b/src/agentsight/dashboard/tests/i18n-regression.test.cjs
@@ -14,3 +14,12 @@ test('resolveLocale keeps a supported persisted locale as the highest priority',
   assert.equal(resolveLocale('zh-CN', ['en-US']), 'zh-CN');
   assert.equal(resolveLocale('en-US', ['zh-CN']), 'en-US');
 });
+
+test('resolveLocale rejects an unsupported persisted locale', () => {
+  assert.equal(resolveLocale('fr-FR', ['en-US']), 'en-US');
+});
+
+test('resolveLocale skips falsy browser languages', () => {
+  assert.equal(resolveLocale(null, [undefined, 'zh-CN']), 'zh-CN');
+  assert.equal(resolveLocale(null, [undefined]), 'en-US');
+});

--- a/src/agentsight/dashboard/tests/run-i18n-regression.cjs
+++ b/src/agentsight/dashboard/tests/run-i18n-regression.cjs
@@ -1,0 +1,38 @@
+const { execFileSync } = require('node:child_process');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+
+const outputDir = mkdtempSync(join(tmpdir(), 'agentsight-i18n-regression-'));
+
+try {
+  execFileSync(
+    'tsc',
+    [
+      '--outDir',
+      outputDir,
+      '--module',
+      'commonjs',
+      '--target',
+      'es2020',
+      '--lib',
+      'es2020,dom',
+      '--jsx',
+      'react-jsx',
+      '--esModuleInterop',
+      '--skipLibCheck',
+      'src/i18n.tsx',
+    ],
+    { stdio: 'inherit' },
+  );
+  execFileSync('node', ['--test', 'tests/i18n-regression.test.cjs'], {
+    env: {
+      ...process.env,
+      AGENTSIGHT_I18N_BUILD: join(outputDir, 'i18n.js'),
+      NODE_PATH: join(process.cwd(), 'node_modules'),
+    },
+    stdio: 'inherit',
+  });
+} finally {
+  rmSync(outputDir, { force: true, recursive: true });
+}


### PR DESCRIPTION
## Why

The AgentSight Dashboard currently mixes hard-coded Chinese and English UI strings and previously had no shared locale infrastructure, persisted language preference, or user-facing language switcher.

This change bootstraps Dashboard internationalization for `en-US` and `zh-CN`, while keeping the initial scope limited to the application shell, navigation, login flow, and document metadata.

It also makes locale detection robust when browser language entries are unsupported or falsy.

## What changed

- Added typed Dashboard i18n resources for `en-US` and `zh-CN`.
- Added a React i18n provider and `t()` API.
- Added language switchers to the login page and authenticated navigation bar.
- Added persisted locale selection through `localStorage`.
- Added ordered browser-language matching with safe `en-US` fallback.
- Skip falsy browser-language values instead of calling `toLowerCase()` on them.
- Internationalized:
  - navigation labels
  - login UI and errors
  - loading text
  - document title
  - `html lang`
- Synchronize document metadata with `useLayoutEffect` so the selected locale is applied before paint.
- Keep metadata synchronization on a single state-driven path.
- Added i18n regression tests.
- Wired `npm run test:i18n` into the existing AgentSight CI job.
- Added Dashboard language behavior documentation in both English and Chinese user guides.
- Preserve the 1024px navigation layout by allowing the navigation content to wrap naturally.

## Related issue

closes #2331

## User / Agent impact

Dashboard users now get an initial UI language based on a supported persisted preference first, then their ordered browser language preferences.

Users can switch between English and Simplified Chinese from both the login page and authenticated navigation bar. The selected language is persisted across refreshes.

Unsupported or falsy browser language values are handled safely and fall back to the next supported preference or `en-US`.

No Agent API, authentication protocol, backend behavior, or Rust interface changes are introduced.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk.

The functional changes are limited to the AgentSight Dashboard frontend, locale resolution, document metadata synchronization, regression tests, CI validation, and Dashboard documentation.

No new runtime dependency is introduced.

## Validation

Validated on the latest working tree:

- `npm run typecheck`
- `npm run test:i18n` — 4/4 passed
- `npm run test:api-client` — 10/10 passed
- `npm run build`
- `npm run build:embed`
- `git diff --check`

Earlier validation performed for this PR also included:

- `cargo fmt --all --check` with Rust 1.89
- `cargo clippy --all-targets -- -D warnings` with Rust 1.89
- Full Cargo test run: 1,403 passed, 21 failed, 1 ignored
- AgentSight serve smoke checks for:
  - `/health`
  - embedded Dashboard root
  - authentication status
  - session API
  - timeseries API
  - Agent API routes
- Browser verification for:
  - language detection
  - invalid persisted locale handling
  - refresh persistence
  - translated login errors
  - `document.title`
  - `html lang`
  - 1024px layout
- Visual checks for English and Chinese login/navigation screenshots

The previously observed Cargo test failures were limited to the Work environment's process visibility, PID lookup, and local socket permission constraints; no i18n-specific assertion failure was observed.

## Documentation and rollback

Updated:

- `src/agentsight/README.md`
- `src/agentsight/README_zh.md`

The documentation now notes that the Dashboard follows the browser language by default, supports manual language switching, and persists the user's selection.

Rollback requires only reverting the Dashboard i18n changes, tests, CI step, and documentation updates. No data migration or backend rollback is required.

## Screenshots

### Login page

<img alt="login-en-US" src="https://github.com/user-attachments/assets/c61a3652-130d-4074-8307-47071ba58c49" />

<img alt="login-zh-CN" src="https://github.com/user-attachments/assets/e01e90d7-cb0d-48ec-8267-e6c94f8bf3f2" />

### Navigation bar

<img alt="navbar-en-US" src="https://github.com/user-attachments/assets/8bca265f-3f51-4e80-85bc-b8fa8ba72939" />

<img alt="navbar-zh-CN" src="https://github.com/user-attachments/assets/1e070f8b-0e9d-4300-9a02-0599711fdb21" />