### PR TITLE
fix(anolisa): honor OpenClaw state dir

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -631,6 +631,7 @@ fn map_err(command: &str, err: AdapterError) -> CliError {
         AdapterError::AdapterManifest { .. }
         | AdapterError::MissingAdapterManifest { .. }
         | AdapterError::FrameworkCli { .. }
+        | AdapterError::ReenableCleanupIncomplete { .. }
         | AdapterError::Lock(_)
         | AdapterError::State(_)
         | AdapterError::Log(_)
@@ -780,6 +781,19 @@ mod tests {
             AdapterError::FrameworkCli {
                 program: "openclaw".to_string(),
                 reason: "boom".to_string(),
+            },
+        );
+        assert!(matches!(err, CliError::Runtime { .. }));
+    }
+
+    #[test]
+    fn reenable_cleanup_failure_maps_to_runtime() {
+        let err = map_err(
+            "adapter enable",
+            AdapterError::ReenableCleanupIncomplete {
+                component: "tokenless".to_string(),
+                framework: "openclaw".to_string(),
+                reason: "uninstall failed".to_string(),
             },
         );
         assert!(matches!(err, CliError::Runtime { .. }));

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -215,6 +215,20 @@ pub enum AdapterError {
         reason: String,
     },
 
+    /// Re-enable could not release resources owned by the prior receipt, so
+    /// replacing it would discard the only durable cleanup record.
+    #[error(
+        "cannot re-enable {component}/{framework} because prior cleanup was incomplete: {reason}"
+    )]
+    ReenableCleanupIncomplete {
+        /// Component whose prior adapter installation remains active.
+        component: String,
+        /// Framework whose prior adapter installation remains active.
+        framework: String,
+        /// Driver-provided cleanup failure details.
+        reason: String,
+    },
+
     /// A receipt's claim resources failed re-validation.
     #[error("adapter claim validation failed: {0}")]
     ClaimValidation(#[from] claim::ClaimValidationError),

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -569,6 +569,25 @@ pub trait FrameworkDriver: Send + Sync {
         ctx: &DriverCtx,
     ) -> Result<DriverPlan, AdapterError>;
 
+    /// Describe cleanup that will run before a validated prior receipt is
+    /// replaced during re-enable.
+    ///
+    /// The Manager prepends these descriptions to the ordinary enable plan,
+    /// preserving the real execution order. Implementations must remain
+    /// read-only; the default represents drivers whose replacement happens in
+    /// place and requires no separate cleanup.
+    ///
+    /// # Errors
+    ///
+    /// Returns a driver-specific receipt consistency error.
+    fn plan_reenable_cleanup(
+        &self,
+        _prior: &AdapterClaim,
+        _ctx: &DriverCtx,
+    ) -> Result<Vec<String>, AdapterError> {
+        Ok(Vec::new())
+    }
+
     /// Build the pure-data receipt for a future enable operation without
     /// mutating framework state, together with any driver-private
     /// [`PreparedEnable`] state (host capabilities resolved by read-only
@@ -607,6 +626,31 @@ pub trait FrameworkDriver: Send + Sync {
         _next: &mut AdapterClaim,
     ) -> Result<(), AdapterError> {
         Ok(())
+    }
+
+    /// Release prior resources that the replacement receipt cannot continue
+    /// to own.
+    ///
+    /// The Manager calls this only after validating both receipts and keeps
+    /// the prior receipt durable until cleanup completes. Drivers should make
+    /// the operation idempotent and return `cleanup_complete = false` rather
+    /// than abandon any resource still requiring a later disable retry. The
+    /// default keeps existing re-enable behavior for drivers whose new receipt
+    /// fully supersedes the old one in place.
+    ///
+    /// # Errors
+    ///
+    /// Returns a driver-specific cleanup error.
+    fn cleanup_replaced_claim(
+        &self,
+        _prior: &AdapterClaim,
+        _next: &AdapterClaim,
+        _ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        Ok(DisableReport {
+            cleanup_complete: true,
+            messages: Vec::new(),
+        })
     }
 
     /// Validate the final prepared receipt after re-enable facts have been

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -740,8 +740,8 @@ impl AdapterManager {
     /// [`AdapterError::AmbiguousFramework`], [`AdapterError::UnsupportedAdapterType`],
     /// [`AdapterError::ResourceRootNotFound`],
     /// [`AdapterError::FrameworkNotDetected`], [`AdapterError::BundleInvalid`],
-    /// [`AdapterError::FrameworkCli`], [`AdapterError::ClaimValidation`], or
-    /// state/lock/log errors.
+    /// [`AdapterError::FrameworkCli`], [`AdapterError::ClaimValidation`],
+    /// [`AdapterError::ReenableCleanupIncomplete`], or state/lock/log errors.
     pub fn enable(
         &self,
         component: &str,
@@ -956,7 +956,18 @@ impl AdapterManager {
         let bundle = driver.read_bundle(&ctx)?;
 
         if dry_run {
-            let plan = driver.plan_enable(&bundle, &ctx)?;
+            let mut plan = driver.plan_enable(&bundle, &ctx)?;
+            if let Some(prior) = state.find_adapter_claim(component, &framework) {
+                let claim_allowed_roots = driver.allowed_external_roots(&ctx);
+                prior.validate_with_trust(
+                    &self.layout,
+                    &claim_allowed_roots,
+                    &trust.target_roots,
+                    trust.exact_targets(),
+                )?;
+                let cleanup_actions = driver.plan_reenable_cleanup(prior, &ctx)?;
+                plan.actions.splice(0..0, cleanup_actions);
+            }
             let notices = declared_notices(
                 &manifest,
                 &framework,
@@ -982,7 +993,8 @@ impl AdapterManager {
         // Inert text — never expanded or executed.
         claim.notices = all_notices;
         let claim_allowed_roots = driver.allowed_external_roots(&ctx);
-        if let Some(prior) = state.find_adapter_claim(component, &framework).cloned() {
+        let prior = state.find_adapter_claim(component, &framework).cloned();
+        if let Some(prior) = &prior {
             // A forged prior receipt must not gain authority merely because a
             // driver preserves facts from it during re-enable.
             prior.validate_with_trust(
@@ -991,7 +1003,7 @@ impl AdapterManager {
                 &trust.target_roots,
                 trust.exact_targets(),
             )?;
-            driver.preserve_reenable_facts(&prior, &mut claim)?;
+            driver.preserve_reenable_facts(prior, &mut claim)?;
         }
         // Defense in depth: the driver must not emit a claim that points
         // outside its own declared roots. Reject before persisting.
@@ -1002,6 +1014,26 @@ impl AdapterManager {
             trust.exact_targets(),
         )?;
         driver.validate_prepared_enable(&claim)?;
+
+        if let Some(prior) = &prior {
+            // Do not overwrite the only durable ownership record until the
+            // driver has released resources the replacement cannot describe.
+            // A failed cleanup leaves the validated prior receipt untouched,
+            // so disable or a later re-enable can retry safely.
+            let report = driver.cleanup_replaced_claim(prior, &claim, &ctx)?;
+            if !report.cleanup_complete {
+                let reason = if report.messages.is_empty() {
+                    "driver reported incomplete cleanup without details".to_string()
+                } else {
+                    report.messages.join("; ")
+                };
+                return Err(AdapterError::ReenableCleanupIncomplete {
+                    component: component.to_string(),
+                    framework: framework.clone(),
+                    reason,
+                });
+            }
+        }
 
         state.upsert_adapter_claim(claim.clone());
         // Anchor lifecycle shares the trust decision above: it is recorded

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -10,9 +10,9 @@
 //! only builds argv arrays from validated data.
 //!
 //! The CLI env contract mirrors `openclaw/scripts/install.sh`: unset
-//! `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the resolved home, and
-//! prepend the standard bin dirs to `PATH`. `OPENCLAW_BIN` overrides the
-//! executable (used by tests to point at a fake CLI).
+//! `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the resolved state directory,
+//! and prepend the standard bin dirs to `PATH`. `OPENCLAW_BIN` overrides
+//! the executable (used by tests to point at a fake CLI).
 //!
 //! Before the first framework mutation — during `prepare_enable` (and, for
 //! `--dry-run`, `plan_enable`) — `enable` builds a read-only
@@ -30,7 +30,8 @@
 
 use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use sha2::{Digest, Sha256};
@@ -101,10 +102,7 @@ impl FrameworkDriver for OpenClawDriver {
     }
 
     fn allowed_external_roots(&self, ctx: &DriverCtx) -> Vec<PathBuf> {
-        // The only external root OpenClaw writes is its own home/state dir.
-        openclaw_home(ctx.user_home.as_deref())
-            .into_iter()
-            .collect()
+        openclaw_allowed_roots(ctx.user_home.as_deref())
     }
 
     fn read_bundle(&self, ctx: &DriverCtx) -> Result<AdapterBundle, AdapterError> {
@@ -205,6 +203,33 @@ impl FrameworkDriver for OpenClawDriver {
             actions,
             register_command,
         })
+    }
+
+    fn plan_reenable_cleanup(
+        &self,
+        prior: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<Vec<String>, AdapterError> {
+        let prior_home = claim_state_dir(prior)?;
+        if prior_home == require_home(ctx)? {
+            return Ok(Vec::new());
+        }
+
+        let mut actions = Vec::new();
+        if let Some(plugin_id) = claim_plugin_id(prior) {
+            validate_plugin_id(&plugin_id)?;
+            actions.push(format!(
+                "unregister prior openclaw plugin '{plugin_id}' from {}",
+                prior_home.display()
+            ));
+        }
+        for skill_name in claim_skill_resources(prior) {
+            actions.push(format!(
+                "remove prior openclaw skill '{skill_name}' from {}",
+                prior_home.join("skills").join(&skill_name).display()
+            ));
+        }
+        Ok(actions)
     }
 
     fn prepare_enable(
@@ -313,6 +338,25 @@ impl FrameworkDriver for OpenClawDriver {
         next: &mut AdapterClaim,
     ) -> Result<(), AdapterError> {
         preserve_openclaw_config_facts(prior, next)
+    }
+
+    fn cleanup_replaced_claim(
+        &self,
+        prior: &AdapterClaim,
+        next: &AdapterClaim,
+        ctx: &DriverCtx,
+    ) -> Result<DisableReport, AdapterError> {
+        if claim_state_dir(prior)? == claim_state_dir(next)? {
+            return Ok(DisableReport {
+                cleanup_complete: true,
+                messages: Vec::new(),
+            });
+        }
+
+        // A state-directory migration creates a separate OpenClaw registry
+        // and skills tree. Release the prior installation while its validated
+        // receipt is still durable, before the Manager replaces ownership.
+        self.disable(prior, ctx)
     }
 
     fn apply_enable(
@@ -566,7 +610,11 @@ impl FrameworkDriver for OpenClawDriver {
         claim: &AdapterClaim,
         ctx: &DriverCtx,
     ) -> Result<DisableReport, AdapterError> {
-        let home = require_home(ctx)?;
+        // Disable must clean the state directory recorded at enable time. In
+        // particular, pre-fix receipts can point at the legacy resolver's
+        // directory while the caller's active OPENCLAW_STATE_DIR points
+        // elsewhere.
+        let home = claim_state_dir(claim)?;
         let mut messages = Vec::new();
         let mut cleanup_complete = true;
 
@@ -586,6 +634,10 @@ impl FrameworkDriver for OpenClawDriver {
             let output = ctx.ops.run_framework_cli(cmd)?;
             if output.success() {
                 messages.push(format!("unregistered openclaw plugin '{plugin_id}'"));
+            } else if uninstall_reports_missing_plugin(&output, &plugin_id) {
+                messages.push(format!(
+                    "openclaw plugin '{plugin_id}' was already unregistered"
+                ));
             } else {
                 return Ok(DisableReport {
                     cleanup_complete: false,
@@ -1988,18 +2040,101 @@ fn openclaw_bin() -> String {
         .unwrap_or_else(|| "openclaw".to_string())
 }
 
-/// Resolve the OpenClaw home (also the state dir): `OPENCLAW_HOME`, else
-/// `<user_home>/.openclaw`. Trailing slashes are trimmed to match the
-/// official script.
+/// Resolve the OpenClaw state directory using the runtime's whitespace,
+/// tilde-expansion, and absolute-path semantics. `OPENCLAW_HOME` remains a
+/// direct state-directory fallback for compatibility with earlier releases.
 fn openclaw_home(user_home: Option<&Path>) -> Option<PathBuf> {
-    if let Some(h) = std::env::var_os("OPENCLAW_HOME") {
-        let s = h.to_string_lossy();
-        let trimmed = s.trim_end_matches('/');
+    let home_override = std::env::var_os("OPENCLAW_HOME")
+        .and_then(|value| resolve_openclaw_path(&value, user_home));
+    let tilde_home = home_override.as_deref().or(user_home);
+
+    if let Some(state_dir) = std::env::var_os("OPENCLAW_STATE_DIR")
+        && let Some(state_dir) = resolve_openclaw_path(&state_dir, tilde_home)
+    {
+        return Some(state_dir);
+    }
+
+    home_override
+        .or_else(|| user_home.and_then(|home| absolute_normalized_path(home.join(".openclaw"))))
+}
+
+/// External roots accepted for current receipts plus the exact root the
+/// pre-fix resolver could have persisted. The compatibility root is rebuilt
+/// from trusted process/user context, never from receipt contents.
+fn openclaw_allowed_roots(user_home: Option<&Path>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(current) = openclaw_home(user_home) {
+        roots.push(current);
+    }
+    if let Some(legacy) = legacy_openclaw_home(user_home)
+        && !roots.contains(&legacy)
+    {
+        roots.push(legacy);
+    }
+    roots
+}
+
+/// Reproduce the old resolver only to validate receipts it created. New CLI
+/// operations and receipts always use [`openclaw_home`].
+fn legacy_openclaw_home(user_home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("OPENCLAW_HOME") {
+        let home = home.to_string_lossy();
+        let trimmed = home.trim_end_matches('/');
         if !trimmed.is_empty() {
             return Some(PathBuf::from(trimmed));
         }
     }
     user_home.map(|h| h.join(".openclaw"))
+}
+
+/// Match OpenClaw's `resolveUserPath`: trim, expand a leading `~`, resolve
+/// relative paths from the current directory, and normalize lexically.
+fn resolve_openclaw_path(value: &OsStr, tilde_home: Option<&Path>) -> Option<PathBuf> {
+    let value = value.to_string_lossy();
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let path = if value == "~" {
+        tilde_home
+            .map(Path::to_path_buf)
+            .or_else(|| std::env::current_dir().ok())?
+    } else if let Some(rest) = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
+        tilde_home
+            .map(Path::to_path_buf)
+            .or_else(|| std::env::current_dir().ok())?
+            .join(rest)
+    } else {
+        PathBuf::from(value)
+    };
+    absolute_normalized_path(path)
+}
+
+fn absolute_normalized_path(path: PathBuf) -> Option<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    Some(normalize_lexically(&absolute))
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// PATH prefix dirs, mirroring `install.sh`:
@@ -2014,8 +2149,8 @@ fn path_prepend(home: &Path, user_home: Option<&Path>) -> Vec<PathBuf> {
     v
 }
 
-/// Shared env contract for every OpenClaw invocation: unset
-/// `OPENCLAW_HOME`, set `OPENCLAW_STATE_DIR` to the home, prepend PATH.
+/// Keep every OpenClaw invocation on the resolved state directory while
+/// suppressing the legacy home override.
 fn base_cmd(args: Vec<String>, home: &Path, user_home: Option<&Path>) -> FrameworkCommand {
     FrameworkCommand {
         program: openclaw_bin(),
@@ -2474,12 +2609,13 @@ fn require_plugin_id(bundle: &AdapterBundle) -> Result<String, AdapterError> {
         })
 }
 
-/// OpenClaw home, or [`AdapterError::FrameworkCli`] when `$HOME` is
-/// unresolvable (no `user_home`, no `OPENCLAW_HOME`).
+/// OpenClaw state directory, or [`AdapterError::FrameworkCli`] when no
+/// explicit state/home override or user home is available.
 fn require_home(ctx: &DriverCtx) -> Result<PathBuf, AdapterError> {
     openclaw_home(ctx.user_home.as_deref()).ok_or_else(|| AdapterError::FrameworkCli {
         program: openclaw_bin(),
-        reason: "cannot resolve OpenClaw home (no $HOME and no OPENCLAW_HOME)".to_string(),
+        reason: "cannot resolve OpenClaw state directory (no OPENCLAW_STATE_DIR, OPENCLAW_HOME, or $HOME)"
+            .to_string(),
     })
 }
 
@@ -2647,6 +2783,62 @@ fn config_value_display(value: &toml::Value) -> String {
     }
 }
 
+/// Resolve the state directory from a manager-validated OpenClaw receipt.
+fn claim_state_dir(claim: &AdapterClaim) -> Result<PathBuf, AdapterError> {
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        return Err(invalid_state_dir_claim(
+            claim,
+            "receipt payload is not OpenClaw",
+        ));
+    };
+    let resource = claim.resource(&payload.state_dir_resource).ok_or_else(|| {
+        invalid_state_dir_claim(
+            claim,
+            &format!(
+                "state directory resource '{}' is missing",
+                payload.state_dir_resource
+            ),
+        )
+    })?;
+    match &resource.kind {
+        ClaimResourceKind::ExternalPath { path } => Ok(path.clone()),
+        _ => Err(invalid_state_dir_claim(
+            claim,
+            &format!(
+                "state directory resource '{}' is not an external path",
+                payload.state_dir_resource
+            ),
+        )),
+    }
+}
+
+fn invalid_state_dir_claim(claim: &AdapterClaim, reason: &str) -> AdapterError {
+    AdapterError::BundleInvalid {
+        root: claim.resource_root.clone(),
+        reason: format!("invalid OpenClaw state directory receipt: {reason}"),
+    }
+}
+
+/// True only for OpenClaw's exact idempotent-uninstall failure. Other
+/// non-zero exits must keep the receipt so cleanup can be retried.
+fn uninstall_reports_missing_plugin(output: &CliOutput, plugin_id: &str) -> bool {
+    if output.timed_out {
+        return false;
+    }
+    let expected = format!("plugin not found: {}", plugin_id.to_ascii_lowercase());
+    let combined = format!(
+        "{}\n{}",
+        strip_ansi(&output.stdout),
+        strip_ansi(&output.stderr)
+    );
+    let mut lines = combined
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_ascii_lowercase);
+    matches!(lines.next(), Some(line) if line == expected) && lines.next().is_none()
+}
+
 /// Extract skill names from a claim's `skill_resources` by parsing the
 /// resource ids. Each id has the form `openclaw_skill_<name>`, and we
 /// extract `<name>` as the directory name under `<home>/skills/`.
@@ -2812,6 +3004,41 @@ mod tests {
         assert_eq!(strip_ansi("\x1b[1mbold\x1b[0m"), "bold");
         assert_eq!(strip_ansi("\x1b[32mgreen\x1b[0m text"), "green text");
         assert_eq!(strip_ansi("no escapes here"), "no escapes here");
+    }
+
+    #[test]
+    fn missing_plugin_uninstall_is_idempotent_only_for_exact_error() {
+        let missing = CliOutput {
+            status: Some(1),
+            timed_out: false,
+            stdout: String::new(),
+            stderr: "\x1b[31mPlugin not found: tokenless\x1b[0m\n".to_string(),
+        };
+        assert!(uninstall_reports_missing_plugin(&missing, "tokenless"));
+
+        let additional_error = CliOutput {
+            stderr: "Plugin not found: tokenless\nUnable to update registry\n".to_string(),
+            ..missing.clone()
+        };
+        assert!(!uninstall_reports_missing_plugin(
+            &additional_error,
+            "tokenless"
+        ));
+
+        let wrong_plugin = CliOutput {
+            stderr: "Plugin not found: other-plugin\n".to_string(),
+            ..missing.clone()
+        };
+        assert!(!uninstall_reports_missing_plugin(
+            &wrong_plugin,
+            "tokenless"
+        ));
+
+        let timed_out = CliOutput {
+            timed_out: true,
+            ..missing
+        };
+        assert!(!uninstall_reports_missing_plugin(&timed_out, "tokenless"));
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -7,10 +7,10 @@
 //! not clean up arbitrary paths", and forged-receipt rejection.
 //!
 //! The fake CLI is controlled entirely through the same env contract the
-//! real driver uses (`OPENCLAW_BIN`, `OPENCLAW_HOME`, plus a test-only
-//! `FAKE_OPENCLAW_FAIL` knob). Because those are process-global, every test
-//! serializes on [`ENV_LOCK`], starts from a clean env contract, and
-//! restores the prior environment on exit.
+//! real driver uses (`OPENCLAW_BIN`, `OPENCLAW_STATE_DIR`, `OPENCLAW_HOME`,
+//! plus a test-only `FAKE_OPENCLAW_FAIL` knob). Because those are
+//! process-global, every test serializes on [`ENV_LOCK`], starts from a clean
+//! env contract, and restores the prior environment on exit.
 #![cfg(unix)]
 
 use std::ffi::OsString;
@@ -20,7 +20,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{
-    ClaimResourceKind, ClaimStatus, ConfigApplyState, DriverPayload,
+    AdapterClaim, ClaimResourceKind, ClaimStatus, ConfigApplyState, DriverPayload,
 };
 use anolisa_core::adapter::driver::{AdapterSummary, ConditionStatus};
 use anolisa_core::adapter::manager::{AdapterManager, EnableOptions, EnableOutcome};
@@ -88,6 +88,19 @@ impl World {
     }
 }
 
+fn recorded_openclaw_state_dir(claim: &AdapterClaim) -> &Path {
+    let DriverPayload::OpenClaw(payload) = &claim.driver_payload else {
+        panic!("expected OpenClaw receipt");
+    };
+    let resource = claim
+        .resource(&payload.state_dir_resource)
+        .expect("state directory resource");
+    match &resource.kind {
+        ClaimResourceKind::ExternalPath { path } => path,
+        other => panic!("expected external state directory, got {other:?}"),
+    }
+}
+
 /// Lines the fake CLI recorded, in invocation order (empty when unset/absent).
 fn argv_lines(path: &Path) -> Vec<String> {
     std::fs::read_to_string(path)
@@ -149,11 +162,29 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
     )
 }
 
+fn configure_plugin_with_skill(world: &World, skill_name: &str) {
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[adapters.openclaw]
+skills = ["{skill_name}"]
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    let skill_source = world.resource_root.join("skills").join(skill_name);
+    std::fs::create_dir_all(&skill_source).expect("skill source");
+    std::fs::write(skill_source.join("marker.txt"), b"skill").expect("skill marker");
+}
+
 /// Every environment variable this test binary's fake OpenClaw contract
 /// owns. The guard saves and restores exactly these so no test leaks state
 /// into another. `FAKE_OC_*` are the capability knobs the fake CLI reads.
 const OWNED_ENV: &[&str] = &[
     "OPENCLAW_BIN",
+    "OPENCLAW_STATE_DIR",
     "OPENCLAW_HOME",
     "FAKE_OPENCLAW_FAIL",
     "FAKE_OC_VERSION",
@@ -227,6 +258,17 @@ impl OpenClawEnvGuard {
         // SAFETY: this guard holds ENV_LOCK.
         unsafe {
             std::env::set_var(key, value);
+        }
+    }
+
+    fn unset(&self, key: &str) {
+        assert!(
+            OWNED_ENV.contains(&key),
+            "env key {key} must be guard-owned"
+        );
+        // SAFETY: this guard holds ENV_LOCK.
+        unsafe {
+            std::env::remove_var(key);
         }
     }
 }
@@ -393,6 +435,7 @@ case "$action" in
   uninstall)
     reg="$OPENCLAW_STATE_DIR/registry"; mkdir -p "$reg" 2>/dev/null
     if [ "${FAKE_OPENCLAW_FAIL:-}" = "uninstall" ]; then echo "boom-uninstall" >&2; exit 8; fi
+    if [ ! -e "$reg/$arg3" ]; then echo "Plugin not found: $arg3" >&2; exit 1; fi
     rm -f "$reg/$arg3"
     echo "uninstalled $arg3"
     ;;
@@ -531,6 +574,394 @@ fn enable_status_disable_happy_path() {
             .is_none(),
         "receipt must be gone after successful disable"
     );
+}
+
+#[test]
+fn enable_honors_explicit_openclaw_state_dir() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let state_dir = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &state_dir);
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable in configured state directory");
+    let claim = match outcome {
+        EnableOutcome::Enabled(claim) => claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
+    };
+
+    assert!(state_dir.join("registry").join(COMPONENT).exists());
+    assert!(
+        !world.registry_marker_exists(),
+        "OPENCLAW_HOME must not override an explicit OPENCLAW_STATE_DIR"
+    );
+    assert!(claim.resources.iter().any(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::ExternalPath { path } if path == &state_dir
+    )));
+
+    let status = manager.status(Some(COMPONENT)).expect("status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+}
+
+#[test]
+fn blank_openclaw_state_dir_falls_back_to_openclaw_home() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    guard.set("OPENCLAW_STATE_DIR", "  \t  ");
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable with a blank state override");
+    let claim = match outcome {
+        EnableOutcome::Enabled(claim) => claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
+    };
+
+    assert!(world.registry_marker_exists());
+    assert!(claim.resources.iter().any(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::ExternalPath { path } if path == &world.openclaw_home
+    )));
+}
+
+#[test]
+fn skill_bundle_expands_tilde_in_openclaw_state_dir() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let block = format!(
+        r#"[[adapters]]
+framework = "openclaw"
+adapter_type = "skill_bundle"
+source = "adapters/{COMPONENT}/openclaw"
+dest = "{{datadir}}/adapters/{{component}}/openclaw/"
+
+[adapters.openclaw]
+skills = ["sec-audit"]
+"#
+    );
+    write_openclaw_manifest(&world.layout, &block);
+    let skill_source = world.resource_root.join("skills/sec-audit");
+    std::fs::create_dir_all(&skill_source).expect("skill source");
+    std::fs::write(skill_source.join("marker.txt"), b"skill").expect("skill marker");
+
+    world.apply_env(&guard, None);
+    guard.unset("OPENCLAW_HOME");
+    guard.set("OPENCLAW_STATE_DIR", "~/.openclaw-work");
+    let manager = world.manager();
+
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable skill bundle with a tilde state directory");
+    let claim = match outcome {
+        EnableOutcome::Enabled(claim) => claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
+    };
+    let expected = world.user_home.join(".openclaw-work");
+
+    assert!(expected.join("skills/sec-audit/marker.txt").is_file());
+    assert!(claim.resources.iter().any(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::ExternalPath { path } if path == &expected
+    )));
+}
+
+#[test]
+fn pre_fix_receipt_remains_visible_and_disable_cleans_recorded_state() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed a receipt using the pre-fix state directory");
+    assert!(world.registry_marker_exists());
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+
+    let status = manager.status(Some(COMPONENT)).expect("status old receipt");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable old receipt");
+    assert!(disabled.claim_removed);
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
+}
+
+#[test]
+fn reenable_migrates_pre_fix_receipt_to_configured_state_dir() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed a receipt using the pre-fix state directory");
+    assert!(world.registry_marker_exists());
+    assert!(
+        world
+            .openclaw_home
+            .join("skills/sec-audit/marker.txt")
+            .is_file()
+    );
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("re-enable old receipt in configured state directory");
+    let claim = match outcome {
+        EnableOutcome::Enabled(claim) => claim,
+        EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
+    };
+
+    assert!(configured_state.join("registry").join(COMPONENT).exists());
+    assert!(
+        configured_state
+            .join("skills/sec-audit/marker.txt")
+            .is_file()
+    );
+    assert!(!world.registry_marker_exists());
+    assert!(
+        !world
+            .openclaw_home
+            .join("skills/sec-audit/marker.txt")
+            .exists()
+    );
+    assert!(claim.resources.iter().any(|resource| matches!(
+        &resource.kind,
+        ClaimResourceKind::ExternalPath { path } if path == &configured_state
+    )));
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status migrated receipt");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("disable migrated receipt");
+    assert!(disabled.claim_removed);
+    assert!(!world.registry_marker_exists());
+    assert!(!configured_state.join("registry").join(COMPONENT).exists());
+    assert!(
+        !configured_state
+            .join("skills/sec-audit/marker.txt")
+            .exists()
+    );
+    assert!(!world.has_claim());
+}
+
+#[test]
+fn migration_cleanup_retry_tolerates_already_missing_plugin() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed old registry and skill");
+
+    let old_skill = world.openclaw_home.join("skills/sec-audit");
+    let mut blocked = std::fs::metadata(&old_skill)
+        .expect("old skill metadata")
+        .permissions();
+    blocked.set_mode(0o000);
+    std::fs::set_permissions(&old_skill, blocked).expect("block old skill cleanup");
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("skill cleanup failure must keep the prior receipt");
+    assert!(matches!(
+        err,
+        AdapterError::ReenableCleanupIncomplete { .. }
+    ));
+    assert!(
+        !world.registry_marker_exists(),
+        "the first cleanup already unregistered the old plugin"
+    );
+    assert!(old_skill.exists());
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("prior receipt retained for retry");
+    assert_eq!(recorded_openclaw_state_dir(claim), world.openclaw_home);
+
+    let mut retryable = std::fs::metadata(&old_skill)
+        .expect("blocked skill metadata")
+        .permissions();
+    retryable.set_mode(0o755);
+    std::fs::set_permissions(&old_skill, retryable).expect("allow cleanup retry");
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("retry treats the missing old plugin as already clean");
+    assert!(!old_skill.exists());
+    assert!(configured_state.join("registry").join(COMPONENT).exists());
+    assert!(
+        configured_state
+            .join("skills/sec-audit/marker.txt")
+            .is_file()
+    );
+}
+
+#[test]
+fn migration_dry_run_previews_cleanup_without_mutation() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed old registry and skill");
+    let state_path = world.layout.state_dir.join("installed.toml");
+    let state_before = std::fs::read(&state_path).expect("state before dry-run");
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    guard.set("FAKE_OC_ARGV_LOG", world.argv_log());
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("plan state-directory migration");
+    let plan = match outcome {
+        EnableOutcome::Planned { plan, .. } => plan,
+        EnableOutcome::Enabled(_) => panic!("dry-run must return a plan"),
+    };
+
+    let action_index = |needle: &str| {
+        plan.actions
+            .iter()
+            .position(|action| action.contains(needle))
+            .unwrap_or_else(|| panic!("missing '{needle}' in plan: {:?}", plan.actions))
+    };
+    assert!(
+        action_index("unregister prior openclaw plugin") < action_index("register openclaw plugin")
+    );
+    assert!(action_index("remove prior openclaw skill") < action_index("deliver openclaw skill"));
+
+    assert_eq!(
+        std::fs::read(&state_path).expect("state after dry-run"),
+        state_before
+    );
+    assert!(world.registry_marker_exists());
+    assert!(
+        world
+            .openclaw_home
+            .join("skills/sec-audit/marker.txt")
+            .is_file()
+    );
+    assert!(!configured_state.join("registry").join(COMPONENT).exists());
+    assert!(
+        argv_lines(&world.argv_log())
+            .iter()
+            .all(|line| !line.starts_with("plugins uninstall "))
+    );
+}
+
+#[test]
+fn reenable_cleanup_failure_keeps_prior_receipt_and_installation() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed a receipt using the pre-fix state directory");
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    guard.set("FAKE_OPENCLAW_FAIL", "uninstall");
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("failed prior cleanup must block receipt replacement");
+
+    assert!(matches!(
+        err,
+        AdapterError::ReenableCleanupIncomplete { .. }
+    ));
+    assert!(world.registry_marker_exists());
+    assert!(!configured_state.join("registry").join(COMPONENT).exists());
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("prior receipt must remain durable");
+    assert_eq!(recorded_openclaw_state_dir(claim), world.openclaw_home);
+    assert_eq!(claim.status, ClaimStatus::Enabled);
+}
+
+#[test]
+fn failed_install_after_state_migration_tracks_only_new_state() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed a receipt using the pre-fix state directory");
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    guard.set("FAKE_OPENCLAW_FAIL", "install");
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("new-state install must fail");
+    assert!(matches!(err, AdapterError::FrameworkCli { .. }));
+
+    assert!(!world.registry_marker_exists());
+    assert!(!configured_state.join("registry").join(COMPONENT).exists());
+    let state = world.load_state();
+    let claim = state
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .expect("new-state cleanup receipt");
+    assert_eq!(recorded_openclaw_state_dir(claim), configured_state);
+    assert_eq!(claim.status, ClaimStatus::CleanupFailed);
+
+    guard.unset("FAKE_OPENCLAW_FAIL");
+    let disabled = manager
+        .disable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("clean failed new-state install");
+    assert!(disabled.claim_removed);
+    assert!(!world.registry_marker_exists());
+    assert!(!configured_state.join("registry").join(COMPONENT).exists());
+    assert!(!world.has_claim());
+}
+
+#[test]
+fn legacy_home_must_be_restored_when_it_cannot_be_reconstructed() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("seed a receipt using the pre-fix state directory");
+
+    let configured_state = world._root.path().join("configured-openclaw-state");
+    guard.set("OPENCLAW_STATE_DIR", &configured_state);
+    guard.unset("OPENCLAW_HOME");
+    let err = manager
+        .status(Some(COMPONENT))
+        .expect_err("unknown legacy root must not self-authorize from receipt data");
+    assert!(matches!(err, AdapterError::ClaimValidation(_)));
+
+    guard.set("OPENCLAW_HOME", &world.openclaw_home);
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("restored legacy home validates the old receipt");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
 }
 
 #[test]


### PR DESCRIPTION
## Why

`anolisa adapter enable` ignored the caller's `OPENCLAW_STATE_DIR` and derived a different state directory from `OPENCLAW_HOME` or `$HOME`. This could leave the adapter receipt enabled while the OpenClaw runtime could not find or load the installed plugin.

## What changed

- Resolve `OPENCLAW_STATE_DIR` before the legacy fallbacks and normalize it with OpenClaw-compatible trim, tilde expansion, and absolute-path semantics.
- Use the resolved directory consistently for CLI invocations, plugin and skill installation, receipts, and runtime inspection.
- Preserve status, disable, and re-enable access to pre-fix receipts when the legacy root is still derivable from trusted process and user context.
- Before a state-directory migration replaces the receipt, remove the prior registry entry and skills; an incomplete cleanup keeps the prior receipt for retry.
- Treat OpenClaw's exact missing-plugin uninstall result as idempotent so a partially completed migration can continue cleaning skills, while all other uninstall failures still fail closed.
- Include the prior plugin and skill removals in dry-run plans before replacement actions without mutating framework or receipt state.
- Add end-to-end regressions for explicit and blank overrides, tilde-expanded skill delivery, successful and failed migration, partial-cleanup retry, dry-run migration, and old-receipt lifecycle operations.

## Related issue

closes #2280

## User / Agent impact

OpenClaw adapters now install and inspect plugins and skills in the caller's explicitly configured state directory. Re-enable migrates a validated prior installation without abandoning cleanup ownership, and dry-run exposes the destructive migration steps before execution.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The compatibility validation root is deterministic and rebuilt from trusted environment/user context; receipt contents cannot widen it. `OPENCLAW_HOME` and `$HOME/.openclaw` remain compatible fallbacks.

If a pre-fix receipt was created with an `OPENCLAW_HOME` value that is no longer present and cannot otherwise be reconstructed, temporarily restore `OPENCLAW_HOME=<old-state-dir>`. Keep `OPENCLAW_STATE_DIR=<new-state-dir>` set while re-enabling to migrate, or run disable with the restored legacy home to clean up the old installation. The CLI intentionally fails closed until that trusted legacy root is supplied.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-core --test adapter_manager --locked` (74 passed)
- `cargo test -p anolisa-core --lib openclaw --locked` (41 passed)
- `cargo doc --workspace --no-deps --locked`

A local full-workspace test run reached all changed-component tests successfully; the unrelated `anolisa-platform` systemd test failed because this host has `agentsight.service` installed while that test expects the query to fail.

## Documentation and rollback

The migration boundary and recovery environment are documented above. Revert commit `98b333ed` to roll back.