### PR TITLE
fix(anolisa): restore npm bin link

### DIFF
--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -10,9 +10,6 @@
   },
   "os": ["darwin"],
   "cpu": ["arm64"],
-  "bin": {
-    "anolisa": "bin/anolisa"
-  },
   "files": [
     "bin/"
   ],

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -10,9 +10,6 @@
   },
   "os": ["linux"],
   "cpu": ["arm64"],
-  "bin": {
-    "anolisa": "bin/anolisa"
-  },
   "files": [
     "bin/"
   ],

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -10,9 +10,6 @@
   },
   "os": ["linux"],
   "cpu": ["x64"],
-  "bin": {
-    "anolisa": "bin/anolisa"
-  },
   "files": [
     "bin/"
   ],

--- a/src/anolisa/npm/scripts/package-npm.js
+++ b/src/anolisa/npm/scripts/package-npm.js
@@ -84,13 +84,13 @@ function packageTemplate(path, expectedName) {
 function platformPackageTemplate(path, expectedName) {
   const template = packageTemplate(path, expectedName);
   if (
-    template.bin?.anolisa !== 'bin/anolisa' ||
+    template.bin !== undefined ||
     !Array.isArray(template.files) ||
     !template.files.includes('bin/') ||
     template.preferUnplugged !== true
   ) {
     throw new Error(
-      `npm platform template must package the native binary without modification: ${path}`,
+      `npm platform template must be a command-free native payload: ${path}`,
     );
   }
   return template;

--- a/src/anolisa/npm/tests/platforms.test.js
+++ b/src/anolisa/npm/tests/platforms.test.js
@@ -5,9 +5,11 @@
  */
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import {
   buildStrategyForTarget,
   platformPackageName,
+  TARGETS,
   targetForSelector,
   targetsForHost,
 } from '../scripts/platforms.js';
@@ -15,6 +17,23 @@ import {
 const linuxX64 = targetForSelector('linux-x64');
 const linuxArm64 = targetForSelector('linux-arm64');
 const darwinArm64 = targetForSelector('darwin-arm64');
+
+const rootManifest = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+);
+assert.deepEqual(rootManifest.bin, { anolisa: 'bin/anolisa' });
+for (const target of TARGETS) {
+  const platformManifest = JSON.parse(
+    readFileSync(
+      new URL(
+        `../platforms/${target.pkg_suffix}/package.json`,
+        import.meta.url,
+      ),
+      'utf8',
+    ),
+  );
+  assert.equal('bin' in platformManifest, false);
+}
 
 assert.equal(targetForSelector('linux-arm64').pkg_suffix, 'linux-arm64');
 assert.equal(


### PR DESCRIPTION
## Why

Project-local installs of `@anolisa/cli` can leave `node_modules/.bin/anolisa` missing under npm 10 even though the native package and `@anolisa/cli/bin/anolisa` are installed correctly. The root package and every optional native package currently claim the same command name, so npm's initial bin-link pass can resolve the collision without creating the consumer-facing link.

## What changed

The root `@anolisa/cli` package is now the sole owner of the public `anolisa` command. Platform packages remain command-free native payloads, and both package-template validation and the existing Node test enforce that ownership split.

## Related issue

no-issue: reproduced directly against the published npm packages

## User / Agent impact

Local and custom-prefix npm installs reliably create `node_modules/.bin/anolisa`; global installation behavior remains unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Direct installation of a platform package no longer exposes a command, because those packages are implementation-only optional dependencies of `@anolisa/cli`.

## Validation

- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `git diff --check`
- Manual npm 10.9.8 Linux x64 consumer install through a local registry; verified that `node_modules/.bin/anolisa` exists and executes

## Documentation and rollback

No documentation changes are required. Revert commit `85d775b3` to restore the previous package metadata.
