### PR TITLE
fix(agentsight): use absolute path for dashboard check and fail build if frontend embedding is skipped

### DIFF
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -395,14 +395,19 @@ build_agentsight() {
     (
         cd "$SIGHT_DIR"
         # Build frontend (embed into Rust binary via include_dir!)
-        if [ -d "dashboard" ] && command -v npm &>/dev/null; then
+        if [ -d "${SIGHT_DIR}/dashboard" ] && command -v npm &>/dev/null; then
             log "Building frontend..."
-            cd dashboard
+            cd "${SIGHT_DIR}/dashboard"
             npm install
             npm run build:embed
             cd "$SIGHT_DIR"
         else
-            warn "Skipping frontend build (dashboard/ not found or npm unavailable)"
+            local reason=""
+            [ -d "${SIGHT_DIR}/dashboard" ] || reason="${reason}dashboard/ not found at ${SIGHT_DIR}/dashboard; "
+            command -v npm &>/dev/null || reason="${reason}npm not available in PATH; "
+            err "Cannot build agentsight frontend: ${reason}"
+            err "Frontend embedding is required for WebUI/serve tests. Aborting build."
+            exit 1
         fi
         cargo build --release --bin agentsight
         ./scripts/build-enforcer.sh


### PR DESCRIPTION
## Problem

Fixes #2349

The `build_agentsight()` function in `scripts/rpm-build.sh` uses a **relative path** `[ -d "dashboard" ]` to check for the dashboard directory after `cd "$SIGHT_DIR"`. When the working directory resolution fails, the condition silently falls through to the `else` branch which only prints a `warn` and continues. This produces a **broken RPM** where the agentsight binary is compiled without embedded frontend (`frontend-dist/` is empty). All WebUI and serve tests then receive HTTP 404 instead of the dashboard HTML.

The `else` branch should **fail the build** (exit 1), not silently warn — a binary without frontend embedding is broken and should never be packaged as an RPM.

## Fix

1. Use **absolute path** `[ -d "${SIGHT_DIR}/dashboard" ]` instead of relative `[ -d "dashboard" ]`
2. Use **absolute path** `cd "${SIGHT_DIR}/dashboard"` instead of relative `cd dashboard`
3. Replace silent `warn` with `err` + `exit 1` — if dashboard/ or npm is unavailable, the build must fail, not produce a broken RPM
4. Add detailed error message showing which condition failed

```diff
--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -395,14 +395,19 @@ build_agentsight() {
     (
         cd "$SIGHT_DIR"
         # Build frontend (embed into Rust binary via include_dir!)
-        if [ -d "dashboard" ] && command -v npm &>/dev/null; then
+        if [ -d "${SIGHT_DIR}/dashboard" ] && command -v npm &>/dev/null; then
             log "Building frontend..."
-            cd dashboard
+            cd "${SIGHT_DIR}/dashboard"
             npm install
             npm run build:embed
             cd "$SIGHT_DIR"
         else
-            warn "Skipping frontend build (dashboard/ not found or npm unavailable)"
+            local reason=""
+            [ -d "${SIGHT_DIR}/dashboard" ] || reason="${reason}dashboard/ not found at ${SIGHT_DIR}/dashboard; "
+            command -v npm &>/dev/null || reason="${reason}npm not available in PATH; "
+            err "Cannot build agentsight frontend: ${reason}"
+            err "Frontend embedding is required for WebUI/serve tests. Aborting build."
+            exit 1
         fi
         cargo build --release --bin agentsight
         ./scripts/build-enforcer.sh
```

## Verification

```shell
# On ALinux 4 ECS (cn-hongkong):
git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply agentsight.patch
source /root/.cargo/env
bash scripts/rpm-build.sh agentsight
```

Result:
- `[INFO] Building frontend...` (not WARN)
- `npm install` → 592 packages added
- `npm run build:embed` → webpack 5.107.2 compiled successfully
- `frontend-dist/` contains `bundle.0f38ee66.js` (1.1MB) + `index.html`
- `cargo build --release` → Finished in 52.30s
- RPM produced: `agentsight-0.9.1-1.alnx4.x86_64.rpm` (13M)
- **VERIFY_EXIT=0** ✓

Co-Authored-By: Claude <noreply@anthropic.com>
