### PR TITLE
feat(tokenless): add component-owned raw packaging

### DIFF
--- a/src/tokenless/.anolisa/component.toml.in
+++ b/src/tokenless/.anolisa/component.toml.in
@@ -1,12 +1,81 @@
-# Tokenless RPM component contract (source template).
-# The version field below is substituted from Cargo.toml by `make` (sed).
-# This is publishing/plugin metadata only — framework execution (config
-# writes, skill delivery, CLI argv, scripts) belongs to built-in framework
-# drivers, not generic manifest keys.
-# Installed to: %{_datadir}/anolisa/components/tokenless/component.toml
 [component]
 name = "tokenless"
 version = "@VERSION@"
+domain = "optimization"
+display_name = "Tokenless"
+description = "LLM token optimization toolkit - schema/response compression, command rewriting"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/anolisa"
+
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.1.16"
+
+[component.platform]
+# min_kernel is intentionally omitted: tokenless has no kernel capability
+# dependency, and the schema would apply the constraint to Linux and macOS.
+os = ["linux", "macos"]
+arch = ["x86_64", "aarch64"]
+
+[[component.dependencies]]
+name = "python3"
+kind = "system-package"
+probe = "python3 --version"
+packages = { rpm = "python3", deb = "python3" }
+
+[[component.dependencies]]
+name = "bash"
+kind = "system-package"
+probe = "bash --version"
+packages = { rpm = "bash", deb = "bash" }
+
+[component.layout]
+modes = ["user", "system"]
+
+[[component.layout.files]]
+source = ".anolisa/component.toml"
+target = "{datadir}/components/tokenless/component.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/tokenless"
+target = "{bindir}/tokenless"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/tokenless/rtk"
+target = "{libexecdir}/tokenless/rtk"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/tokenless/toon"
+target = "{libexecdir}/tokenless/toon"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "{libexecdir}/tokenless/rtk"
+target = "{bindir}/rtk"
+type = "symlink"
+
+[[component.layout.files]]
+source = "{libexecdir}/tokenless/toon"
+target = "{bindir}/toon"
+type = "symlink"
+
+# Shared hooks are interpreter-loaded resources, so the common tree stays
+# non-executable. Cosh uses its separately staged extension bundle.
+[[component.layout.files]]
+source = "adapters/common/"
+target = "{datadir}/adapters/{component}/common/"
+mode = "0644"
+
+[component.health_check]
+type = "binary_version"
+binary = "{bindir}/tokenless"
+timeout_secs = 5
 
 [[adapters]]
 framework = "openclaw"
@@ -14,12 +83,9 @@ adapter_type = "plugin"
 plugin_id = "tokenless"
 source = "adapters/openclaw"
 dest = "{datadir}/adapters/{component}/openclaw/"
+detect = { binary = "openclaw" }
 
 [adapters.bundle]
-# Entry-point manifest inside the bundle directory (the file the OpenClaw
-# driver reads to identify the plugin). Declared explicitly rather than
-# relying on the driver's "openclaw.plugin.json" default, so the contract is
-# self-describing and survives driver default changes.
 entry = "openclaw.plugin.json"
 
 [[adapters]]
@@ -28,13 +94,9 @@ adapter_type = "plugin"
 plugin_id = "tokenless"
 source = "adapters/hermes"
 dest = "{datadir}/adapters/{component}/hermes/"
+detect = { binary = "hermes" }
 
 [adapters.bundle]
-# Hermes-native plugin manifest at the bundle root. The driver scans this
-# file for the plugin id when plugin_id is not declared; we declare
-# plugin_id above so the driver need not parse it, but keep entry explicit
-# so the contract names the platform entry manifest (matches the file
-# shipped at the dest root: adapters/<component>/hermes/plugin.yaml).
 entry = "plugin.yaml"
 
 [[adapters]]
@@ -47,9 +109,9 @@ dest = "{datadir}/adapters/{component}/qoder/"
 [adapters.bundle]
 # Qoder-native plugin manifest inside the bundle directory. The built-in
 # qoder driver reads this to confirm the bundle is a valid Qoder plugin and
-# requires hooks/hooks.json. The scripts/install.sh and uninstall.sh ship in
-# the same bundle for direct Makefile installs, but the ANOLISA driver never
-# invokes them — enable/disable behavior is built into Rust.
+# requires hooks.json beside it. The legacy scripts/install.sh and
+# uninstall.sh ship in the same bundle as publishing assets, but the ANOLISA
+# driver never invokes them — enable/disable behavior is built into Rust.
 entry = ".qoder-plugin/plugin.json"
 
 [[adapters]]
@@ -76,7 +138,7 @@ entry = ".codex-plugin/plugin.json"
 framework = "cosh"
 adapter_type = "extension"
 plugin_id = "tokenless"
-source = "adapters/common"
+source = "extensions/tokenless"
 dest = "{datadir}/extensions/{component}/"
 
 [adapters.bundle]

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -29,17 +29,20 @@ ADAPTER_TEMPLATES := \
     $(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/codex/.codex-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json
-# Component contract (publishing/plugin metadata) — kept separate from the
-# adapter payload tree so the contract is not mixed with adapter resources.
-# Shipped to %{_datadir}/anolisa/components/tokenless/component.toml.
+# Canonical RPM/raw component contract — kept separate from the adapter
+# payload tree and stamped from the workspace version before packaging.
+# Shipped to %{_datadir}/anolisa/components/tokenless/component.toml and
+# embedded in raw archives as .anolisa/component.toml.
 COMPONENT_CONTRACT := .anolisa/component.toml
-ANOLISA_COMPONENT_MANIFEST := ../anolisa/manifests/components/tokenless/component.toml
 TOON_VER := 0.5.0
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+NATIVE_NPM_TARGET := $(shell node -p 'process.platform + "-" + process.arch')
+NATIVE_NPM_INPUT_DIR := $(CURDIR)/target/npm-prebuilt/$(NATIVE_NPM_TARGET)
 
 .PHONY: build build-tokenless build-toon build-openclaw-plugin \
         stamp-adapter-templates generate-component-contract \
-        install uninstall test lint clean \
+        install uninstall test lint clean package-raw stage-raw \
+        test-raw-package test-npm-package \
         install-binaries install-helpers install-adapter-resources install-cosh-extension \
         adapter-install adapter-uninstall adapter-scan \
         cosh-extension-install cosh-extension-uninstall \
@@ -51,7 +54,7 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1
         opencode-install opencode-uninstall \
         qwencode-install qwencode-uninstall \
         setup help \
-        npm-package npm-package-all npm-publish \
+        npm-package npm-package-all npm-publish prepare-npm-native-binaries \
         test-hooks
 
 # Default target
@@ -172,7 +175,8 @@ uninstall:
 	rm -rf $(DESTDIR)$(COSH_EXTENSION_DIR)
 
 # Run tests
-test: test-tokenless test-hooks test-integration test-adapters
+test: test-tokenless test-hooks test-integration test-adapters \
+      test-raw-package test-npm-package
 
 test-tokenless:
 	@echo "==> Testing tokenless..."
@@ -200,6 +204,24 @@ test-adapters: build-openclaw-plugin
 	@echo "==> Testing OpenCode adapter..."
 	bash tests/test-opencode-adapter-install.sh
 	node tests/test-opencode-plugin.mjs
+
+# These targets only assemble the prebuilt BIN_DIR/{tokenless,rtk,toon} files
+# into the portable raw-package contract maintained by this component.
+package-raw:
+	@$(MAKE) -B stamp-adapter-templates
+	@$(MAKE) build-openclaw-plugin
+	@./packaging/raw/package.sh package
+
+stage-raw:
+	@$(MAKE) -B stamp-adapter-templates
+	@$(MAKE) build-openclaw-plugin
+	@./packaging/raw/package.sh stage
+
+test-raw-package:
+	@bash tests/test-package-raw.sh
+
+test-npm-package:
+	@bash tests/test-package-npm-prebuilt.sh
 
 # Lint (rtk excluded — vendored third-party source)
 lint:
@@ -391,12 +413,22 @@ setup: install adapter-install
 	@echo "  make adapter-scan"
 
 # --- npm Packaging ---
-# Package for current platform only
-npm-package:
+# Preserve the convenient native entry point while keeping package-npm.js a
+# pure validator/assembler.
+prepare-npm-native-binaries: build-tokenless build-toon
+	@install -d -m 0755 "$(NATIVE_NPM_INPUT_DIR)"
+	@install -p -m 0755 \
+		target/release/tokenless \
+		third_party/rtk/target/release/rtk \
+		"$(HOME)/.cargo/bin/toon" \
+		"$(NATIVE_NPM_INPUT_DIR)/"
+
+# Build and package the current host.
+npm-package: prepare-npm-native-binaries
 	@echo "==> Packaging anolisa-tokenless for npm (current platform)..."
 	node npm/scripts/package-npm.js
 
-# Package for all supported targets (requires cross-compilation toolchain)
+# Package all four prebuilt target directories from target/npm-prebuilt.
 npm-package-all:
 	@echo "==> Packaging anolisa-tokenless for npm (all platforms)..."
 	node npm/scripts/package-npm.js --all
@@ -464,9 +496,11 @@ help:
 	@echo "  qwencode-install  Register Qwen Code plugin via qwen CLI"
 	@echo "  qwencode-uninstall Unregister Qwen Code plugin"
 	@echo "  setup             Full setup: build + install + register adapters"
-	@echo "  npm-package       Package for npm (current platform)"
-	@echo "  npm-package-all   Package for npm (all platforms)"
+	@echo "  npm-package       Build and package the current host"
+	@echo "  npm-package-all   Package target/npm-prebuilt target directories"
 	@echo "  npm-publish       Build and publish all npm packages"
+	@echo "  package-raw       Package prebuilt BIN_DIR binaries for one raw target"
+	@echo "  stage-raw         Stage one raw payload into DESTDIR"
 	@echo "  help              Show this help"
 	@echo ""
 	@echo "Variables:"
@@ -477,3 +511,7 @@ help:
 	@echo "  LIBEXECDIR       Helper binary install path"
 	@echo "  SHARE_DIR        Adapter resources path"
 	@echo "  COSH_EXTENSION_DIR  Cosh extension path"
+	@echo "  BIN_DIR          Directory containing prebuilt tokenless, rtk, and toon"
+	@echo "  TARGET_OS        Raw target OS: linux or macos"
+	@echo "  TARGET_ARCH      Raw target arch: x86_64 or aarch64"
+	@echo "  OUTPUT_DIR       Raw artifact output directory (default: target/raw)"

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -485,6 +485,7 @@ The installer creates a `tokenless.js` symbolic link in OpenCode's global
 | `make lint` | Run clippy checks |
 | `make fmt` | Format code |
 | `make clean` | Clean build artifacts |
+| `make package-raw` | Package prebuilt target binaries as an ANOLISA raw archive |
 | `make adapter-install` | Install all available framework adapters |
 | `make adapter-uninstall` | Remove all adapters |
 | `make cosh-extension-install` | Install Copilot Shell extension |
@@ -509,6 +510,39 @@ Override install paths:
 make install BIN_DIR=/usr/local/bin
 ```
 
+## Raw Packaging
+
+Raw packaging accepts already-built `tokenless`, `rtk`, and `toon`
+executables in one directory and applies the stable component payload layout:
+
+```bash
+make package-raw \
+  BIN_DIR="$PWD/target/release-bins" \
+  TARGET_OS=linux \
+  TARGET_ARCH=aarch64 \
+  OUTPUT_DIR="$PWD/dist"
+```
+
+Supported raw targets are `linux-x86_64`, `linux-aarch64`, and
+`macos-aarch64`. `darwin`/`arm64` and `amd64`/`x64` are accepted as input
+aliases, while artifact names always use the canonical ANOLISA labels. The
+packer verifies the ELF or Mach-O architecture without executing cross-target
+binaries, embeds the component-owned `.anolisa/component.toml`, materializes
+adapter hook symlinks, and emits a reproducible
+`tokenless-<version>-<os>-<arch>.tar.gz` archive. Set `SOURCE_DATE_EPOCH` when
+the caller needs an epoch other than the source commit time.
+
+npm packaging also accepts prebuilt `linux-x64`, `linux-arm64`, `darwin-x64`,
+and `darwin-arm64` binary directories under `target/npm-prebuilt`. The packer
+validates and assembles them:
+
+```bash
+node npm/scripts/package-npm.js --all
+```
+
+See [npm/README.md](npm/README.md#packaging-for-npm) for the fixed directory
+layout and single-target interface.
+
 ## Project Structure
 
 | Path | Description |
@@ -523,6 +557,7 @@ make install BIN_DIR=/usr/local/bin
 | `adapters/tokenless/opencode/` | OpenCode adapter — local JavaScript plugin + lifecycle scripts |
 | `third_party/rtk/` | RTK vendored source — command rewriting engine (justfile clone+patch) |
 | `third_party/patches/` | Patches for vendored third_party sources |
+| `packaging/raw/` | Component-owned ANOLISA raw packer and target validation |
 | `Makefile` | Unified build system for the entire workspace |
 
 ## Prerequisites

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -133,6 +133,36 @@ make opencode-install
 `XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
 安装后重启 OpenCode 即可加载插件。
 
+## Raw 打包
+
+Raw 打包接收同一目录中已经构建好的 `tokenless`、`rtk`、`toon`，并按照
+组件维护的稳定目录结构生成制品：
+
+```bash
+make package-raw \
+  BIN_DIR="$PWD/target/release-bins" \
+  TARGET_OS=linux \
+  TARGET_ARCH=aarch64 \
+  OUTPUT_DIR="$PWD/dist"
+```
+
+Raw 支持矩阵为 `linux-x86_64`、`linux-aarch64` 和 `macos-aarch64`。
+输入可使用 `darwin`/`arm64`、`amd64`/`x64` 别名，产物名始终采用 ANOLISA
+规范名称。脚本不会执行跨平台二进制，而是直接检查 ELF 或 Mach-O 架构，
+并负责嵌入组件自维护的 `.anolisa/component.toml`、展开适配器 Hook 符号链接、
+统一权限以及生成可复现的
+`tokenless-<version>-<os>-<arch>.tar.gz`。需要固定其他时间戳时可传入
+`SOURCE_DATE_EPOCH`。
+
+npm 打包同样从 `target/npm-prebuilt` 下读取预构建的 `linux-x64`、
+`linux-arm64`、`darwin-x64`、`darwin-arm64` 四个二进制目录，并负责校验和组装：
+
+```bash
+node npm/scripts/package-npm.js --all
+```
+
+固定目录结构和单目标接口见 [npm/README.md](npm/README.md#packaging-for-npm)。
+
 ## 查看 Token 节省明细
 
 `show` 用于原样打印完整的压缩前后内容；`diff` 用于解释估算 Token
@@ -172,6 +202,7 @@ export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 - `crates/tokenless-cli/` — CLI 二进制
 - `adapters/tokenless/` — 适配器包（OpenClaw / Hermes / Qoder / Claude Code / Codex / OpenCode）
 - `third_party/rtk/` — RTK 命令重写引擎（vendored）
+- `packaging/raw/` — Tokenless 自维护的 ANOLISA Raw 打包与目标校验
 
 ## 许可证
 

--- a/src/tokenless/npm/README.md
+++ b/src/tokenless/npm/README.md
@@ -109,81 +109,45 @@ make install
 
 ## Packaging for npm
 
-```bash
-# Build for current platform
-node scripts/package-npm.js
+The npm packer reads prebuilt native executables from this fixed layout:
 
-# Build for all supported targets
-node scripts/package-npm.js --all
-
-# Build for a specific target
-node scripts/package-npm.js --target darwin-arm64
+```text
+target/npm-prebuilt/
+├── linux-x64/{tokenless,rtk,toon}
+├── linux-arm64/{tokenless,rtk,toon}
+├── darwin-x64/{tokenless,rtk,toon}
+└── darwin-arm64/{tokenless,rtk,toon}
 ```
 
-### Cross-Compilation (Linux → All Platforms)
+Validating Linux packages requires GNU `readelf` from binutils. The packer
+rejects binaries that require GLIBC symbols newer than the supported 2.17
+baseline.
 
-On a Linux machine, you can cross-compile to **all 4 targets** (including macOS) using `cargo-zigbuild`.
-
-#### 1. Install the toolchain
+Package one target:
 
 ```bash
-# Install cargo-zigbuild and zig
-cargo install cargo-zigbuild
-pip install ziglang   # or: apt install zig / brew install zig
-
-# Add Rust targets
-rustup target add aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
+node npm/scripts/package-npm.js --target linux-arm64
 ```
 
-#### 2. Prepare a macOS SDK (required for Apple targets)
-
-Zig only provides the C toolchain — linking Apple targets additionally
-requires macOS SDK headers and libraries. Download and extract an SDK, then
-point `SDKROOT` at it (the packaging script fails fast if `SDKROOT` is not
-set for a Linux → macOS build):
+For the current host, the Make entry point can build the native executables
+before invoking the same packer:
 
 ```bash
-# Download an extracted macOS SDK (e.g. 13.3)
-curl -LO https://github.com/joseluisq/macosx-sdks/releases/download/13.3/MacOSX13.3.sdk.tar.xz
-sudo tar -xf MacOSX13.3.sdk.tar.xz -C /opt
-export SDKROOT=/opt/MacOSX13.3.sdk
+make npm-package
 ```
 
-> Note: make sure your use of the macOS SDK complies with the
-> [Xcode SDK license agreement](https://www.apple.com/legal/sla/docs/xcode.pdf).
-
-An alternative that avoids manual SDK setup:
-
-- **Official cargo-zigbuild Docker image** (ships with a macOS SDK preinstalled):
-
-  ```bash
-  docker run --rm -it -v $(pwd):/io -w /io messense/cargo-zigbuild \
-    cargo zigbuild --release --target aarch64-apple-darwin
-  ```
-
-#### 3. Build all platforms
+Package the complete matrix:
 
 ```bash
-make npm-package-all
-# or directly:
 node npm/scripts/package-npm.js --all
+# or
+make npm-package-all
 ```
 
-The script auto-detects available cross-compilation tools in this order:
-
-| Tool | Command | macOS from Linux? | Notes |
-|------|---------|-------------------|-------|
-| `cargo-zigbuild` | `cargo install cargo-zigbuild && pip install ziglang` | ✅ Yes | Recommended. Uses Zig's C toolchain as linker |
-| `cross` | `cargo install cross` + Docker | ❌ No | Linux targets only from Linux |
-| `cargo` (native) | Built-in | ❌ No | Host target only |
-
-If no cross-compilation tool is available, the script will warn you and suggest installing `cargo-zigbuild`.
-
-> Linux targets are always routed through `cargo-zigbuild` when it is
-> available — even on a matching host — so the minimum GLIBC baseline is
-> pinned to 2.17 instead of inherited from the build machine. The script
-> verifies the resulting binaries with `readelf` and fails if any symbol
-> requires a newer GLIBC.
+Before copying anything, the packer checks that all three files exist and that
+their ELF or Mach-O architecture matches the selected npm target; it never
+executes cross-target binaries. Prebuilt Linux inputs must retain the documented
+GLIBC 2.17 compatibility baseline.
 
 ### Publishing
 

--- a/src/tokenless/npm/scripts/package-npm.js
+++ b/src/tokenless/npm/scripts/package-npm.js
@@ -9,35 +9,29 @@
 /**
  * npm packaging script for anolisa-tokenless
  *
- * Builds the Rust binaries for the current (or specified) target and packages
- * them into platform-specific npm tarballs ready for `npm publish`.
- *
- * Cross-compilation from Linux to all targets (including macOS) is supported
- * via cargo-zigbuild (recommended) or cross.
+ * Packages prebuilt binaries into platform-specific npm tarballs ready for
+ * `npm publish`. This script validates and assembles binaries but never
+ * compiles native executables.
  *
  * Usage:
- *   node scripts/package-npm.js                     # current platform only
- *   node scripts/package-npm.js --all               # all supported targets
- *   node scripts/package-npm.js --target x86_64     # specific arch
- *   node scripts/package-npm.js --target darwin-arm64  # specific platform-arch
+ *   node npm/scripts/package-npm.js                     # current platform only
+ *   node npm/scripts/package-npm.js --target linux-x64  # one target
+ *   node npm/scripts/package-npm.js --all               # all supported targets
  *
  * Prerequisites:
- *   - Rust toolchain with the target installed (rustup target add ...)
- *   - cargo available on PATH
- *   - just (for rtk build setup)
- *   - For cross-compilation: cargo-zigbuild (recommended) or cross
- *     Install: cargo install cargo-zigbuild && pip install ziglang
+ *   - Prebuilt tokenless, rtk, and toon binaries for each selected target
+ *   - npm (the architecture-independent OpenClaw adapter is built here)
  *
  * Output:
  *   npm/dist/
- *   ├── anolisa-tokenless-<version>.tgz                    (root package)
- *   ├── anolisa-tokenless-linux-x64-<version>.tgz          (platform package)
- *   ├── anolisa-tokenless-linux-arm64-<version>.tgz        (platform package)
- *   ├── anolisa-tokenless-darwin-x64-<version>.tgz         (platform package)
- *   └── anolisa-tokenless-darwin-arm64-<version>.tgz       (platform package)
+ *   ├── tokenless/anolisa-tokenless-<version>.tgz
+ *   ├── tokenless-linux-x64/anolisa-tokenless-linux-x64-<version>.tgz
+ *   ├── tokenless-linux-arm64/anolisa-tokenless-linux-arm64-<version>.tgz
+ *   ├── tokenless-darwin-x64/anolisa-tokenless-darwin-x64-<version>.tgz
+ *   └── tokenless-darwin-arm64/anolisa-tokenless-darwin-arm64-<version>.tgz
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
@@ -48,6 +42,10 @@ import {
   cpSync,
   readdirSync,
   chmodSync,
+  closeSync,
+  openSync,
+  readSync,
+  statSync,
 } from 'node:fs';
 import { join, dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -57,6 +55,7 @@ const __dirname = dirname(__filename);
 const npmDir = join(__dirname, '..');
 const tokenlessRoot = join(npmDir, '..');
 const distDir = join(npmDir, 'dist');
+const prebuiltRoot = join(tokenlessRoot, 'target', 'npm-prebuilt');
 
 // Read version from workspace Cargo.toml
 const cargoToml = readFileSync(join(tokenlessRoot, 'Cargo.toml'), 'utf-8');
@@ -67,16 +66,6 @@ if (!version) {
   process.exit(1);
 }
 
-// Read TOON_VER from Makefile to avoid version drift
-let toonVer = "0.5.0";
-try {
-  const makefileContent = readFileSync(join(tokenlessRoot, "Makefile"), "utf-8");
-  const toonMatch = makefileContent.match(/^TOON_VER\s*[:?]?=\s*(.+)/m);
-  if (toonMatch) toonVer = toonMatch[1].trim();
-} catch {
-  console.warn("Could not read TOON_VER from Makefile, using default 0.5.0");
-}
-
 const BINARIES = ['tokenless', 'rtk', 'toon'];
 
 // npm registry every generated manifest and publish command is pinned to.
@@ -84,416 +73,221 @@ const BINARIES = ['tokenless', 'rtk', 'toon'];
 // explicit publishConfig a maintainer's user-level registry would win.
 const NPM_REGISTRY = 'https://registry.npmjs.org/';
 const PUBLISH_CONFIG = { registry: NPM_REGISTRY, access: 'public' };
-
-// Minimum GLIBC baseline for the *-unknown-linux-gnu targets. Zig links
-// against a specific glibc version, so builds routed through cargo-zigbuild
-// are portable down to this version regardless of the build host. Linux
-// platform packages are glibc-only (declared via "libc": ["glibc"]).
 const GLIBC_MIN = '2.17';
 
 const TARGETS = [
   {
     rust_target: 'x86_64-unknown-linux-gnu',
-    zig_target: 'x86_64-linux-gnu',
     npm_os: 'linux',
     npm_cpu: 'x64',
     pkg_suffix: 'linux-x64',
+    binary_os: 'linux',
+    binary_arch: 'x86_64',
   },
   {
     rust_target: 'aarch64-unknown-linux-gnu',
-    zig_target: 'aarch64-linux-gnu',
     npm_os: 'linux',
     npm_cpu: 'arm64',
     pkg_suffix: 'linux-arm64',
+    binary_os: 'linux',
+    binary_arch: 'aarch64',
   },
   {
     rust_target: 'x86_64-apple-darwin',
-    zig_target: 'x86_64-macos',
     npm_os: 'darwin',
     npm_cpu: 'x64',
     pkg_suffix: 'darwin-x64',
+    binary_os: 'macos',
+    binary_arch: 'x86_64',
   },
   {
     rust_target: 'aarch64-apple-darwin',
-    zig_target: 'aarch64-macos',
     npm_os: 'darwin',
     npm_cpu: 'arm64',
     pkg_suffix: 'darwin-arm64',
+    binary_os: 'macos',
+    binary_arch: 'aarch64',
   },
 ];
 
-async function parseArgs() {
+function printUsage() {
+  console.log(`Usage:
+  node npm/scripts/package-npm.js
+  node npm/scripts/package-npm.js --target <target>
+  node npm/scripts/package-npm.js --all
+
+Targets: ${TARGETS.map((target) => target.pkg_suffix).join(', ')}
+
+Target selectors also accept an OS, npm CPU, architecture, or Rust target
+triple and may select more than one matching target.
+
+Prebuilt binaries are read from:
+  target/npm-prebuilt/<target>/{tokenless,rtk,toon}`);
+}
+
+function optionValue(args, index, option) {
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function parseArgs() {
   const args = process.argv.slice(2);
-  if (args.includes('--all')) return TARGETS;
-  const targetIdx = args.indexOf('--target');
-  if (targetIdx !== -1 && args[targetIdx + 1]) {
-    const targetArg = args[targetIdx + 1];
-    const matched = TARGETS.filter(
-      (t) =>
-        t.rust_target.includes(targetArg) ||
-        t.npm_cpu === targetArg ||
-        t.pkg_suffix.includes(targetArg) ||
-        t.npm_os === targetArg,
-    );
-    if (matched.length === 0) {
-      console.error(`Unknown target: ${targetArg}`);
-      console.error(`Available: ${TARGETS.map((t) => t.pkg_suffix).join(', ')}`);
-      process.exit(1);
+  let all = false;
+  let targetName;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case '--all':
+        all = true;
+        break;
+      case '--target':
+        targetName = optionValue(args, index, arg);
+        index += 1;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+      default:
+        throw new Error(`unknown argument: ${arg}`);
     }
-    return matched;
-  }
-  // Default: current platform
-  const { platform, arch } = await import('node:os');
-  const currentKey = `${platform()}-${arch()}`;
-  const current = TARGETS.find((t) => t.pkg_suffix === currentKey);
-  if (!current) {
-    console.error(`Unsupported host platform: ${currentKey}`);
-    process.exit(1);
-  }
-  return [current];
-}
-
-/**
- * Detect the best available cross-compilation tool.
- * Priority: cargo-zigbuild > cross > native cargo
- */
-function detectBuilder() {
-  // Check cargo-zigbuild (recommended — supports all targets from Linux)
-  try {
-    execSync('cargo-zigbuild --version', { stdio: 'pipe' });
-    return 'zigbuild';
-  } catch {
-    // not installed
   }
 
-  // Check cross (Docker-based — Linux targets only from Linux)
-  try {
-    execSync('cross --version', { stdio: 'pipe' });
-    return 'cross';
-  } catch {
-    // not installed
+  if (all && targetName) {
+    throw new Error('--all and --target cannot be used together');
+  }
+  if (all) {
+    return TARGETS;
   }
 
-  // Fallback: native cargo (no cross-compilation)
-  return 'cargo';
-}
-
-/** Rust target triple with the GLIBC baseline appended for Linux gnu targets. */
-function pinnedRustTarget(target) {
-  return target.npm_os === 'linux' ? `${target.rust_target}.${GLIBC_MIN}` : target.rust_target;
-}
-
-/** Zig target triple with the GLIBC baseline appended for Linux gnu targets. */
-function pinnedZigTarget(target) {
-  return target.npm_os === 'linux' ? `${target.zig_target}.${GLIBC_MIN}` : target.zig_target;
-}
-
-function buildCommand(builder, target, isCross) {
-  if (!isCross) {
-    return 'cargo build --release --locked';
-  }
-
-  switch (builder) {
-    case 'zigbuild':
-      return `cargo zigbuild --release --locked --target ${pinnedRustTarget(target)}`;
-    case 'cross':
-      if (target.npm_os === 'darwin') {
-        console.warn(
-          `  ⚠️  cross does not support macOS targets. ` +
-          `Install cargo-zigbuild for Linux→macOS cross-compilation:`,
-        );
-        console.warn(`     cargo install cargo-zigbuild && pip install ziglang`);
-        return null;
-      }
-      return `cross build --release --locked --target ${target.rust_target}`;
-    case 'cargo':
-      console.warn(
-        `  ⚠️  No cross-compilation tool available for ${target.rust_target}.`,
-      );
-      console.warn(`     Install cargo-zigbuild: cargo install cargo-zigbuild && pip install ziglang`);
-      return null;
-  }
-}
-/**
- * Set up cross-compilation environment for cargo install fallback.
- * Uses zig cc as the C cross-compiler and zig as the Rust linker.
- */
-function setupCrossEnv(target) {
-  const env = { ...process.env };
-  const zigTarget = pinnedZigTarget(target);
-
-  // SDKROOT for darwin targets is validated in buildTarget() before any
-  // cross build starts; it is inherited via process.env here.
-
-  // Resolve how to invoke zig: prefer a real `zig` on PATH, otherwise use
-  // cargo-zigbuild's bundled wrappers (covers `pip install ziglang` setups
-  // where no standalone `zig` executable exists).
-  let zigCC, zigAR, zigRANLIB;
-  try {
-    execSync('zig version', { stdio: 'pipe' });
-    zigCC = `zig cc -target ${zigTarget}`;
-    zigAR = 'zig ar';
-    zigRANLIB = 'zig ranlib';
-  } catch {
-    zigCC = `cargo-zigbuild zig cc -- -target ${zigTarget}`;
-    zigAR = 'cargo-zigbuild zig ar';
-    zigRANLIB = 'cargo-zigbuild zig ranlib';
-  }
-
-  // Set CC for cc crate (used by native deps like onig_sys)
-  const ccEnvKey = `CC_${target.rust_target.replace(/-/g, '_')}`;
-  env[ccEnvKey] = zigCC;
-  env.CC = zigCC;
-  env.AR = zigAR;
-  env.RANLIB = zigRANLIB;
-  env.CRATE_CC_NO_DEFAULTS = '1'; // prevent cc crate from adding --target that zig doesn't understand
-
-  // Create temporary CARGO_HOME with linker config using a wrapper script
-  const cargoHomeDir = join(tokenlessRoot, 'target', '.cargo-cross');
-  const cargoConfigDir = join(cargoHomeDir, 'config');
-  const linkerScript = join(cargoHomeDir, 'zig-linker-' + target.pkg_suffix);
-  if (!existsSync(cargoConfigDir)) mkdirSync(cargoConfigDir, { recursive: true });
-
-  // Write linker wrapper script (cargo requires a single executable, not args)
-  let linkerContent;
-  if (target.npm_os === 'darwin') {
-    // Use cargo-zigbuild's zig cc wrapper which handles SDKROOT for framework/system lib resolution
-    linkerContent = '#!/bin/sh\nexec cargo-zigbuild zig cc -- -target ' + zigTarget + ' "$@"\n';
-  } else {
-    linkerContent = '#!/bin/sh\nexec ' + zigCC + ' "$@"\n';
-  }
-  writeFileSync(linkerScript, linkerContent);
-  execSync(`chmod +x "${linkerScript}"`, { stdio: 'pipe' });
-
-  let configContent = `[target.${target.rust_target}]
-linker = "${linkerScript}"
-`;
-
-  // Merge with existing CARGO_HOME config if present
-  const origCargoHome = process.env.CARGO_HOME || join(process.env.HOME || '/root', '.cargo');
-  const origConfig = join(origCargoHome, 'config.toml');
-  if (existsSync(origConfig)) {
-    const origContent = readFileSync(origConfig, 'utf-8');
-    configContent = configContent + '\n' + origContent;
-  }
-  writeFileSync(join(cargoConfigDir, 'config.toml'), configContent);
-  env.CARGO_HOME = cargoConfigDir;
-
-  return env;
-}
-
-function buildTarget(target) {
-  console.log(`\n🔨 Building for ${target.rust_target}...`);
-
-  // Ensure the Rust target is installed
-  try {
-    execSync(`rustup target add ${target.rust_target}`, { stdio: 'pipe' });
-  } catch {
-    // target may already be installed
-  }
-
-  // Detect host target for cross-compile check
-  let hostTarget;
-  try {
-    hostTarget = execSync('rustc -vV', { encoding: 'utf-8' }).match(/host: (.+)/)?.[1]?.trim();
-  } catch {
-    // ignore
-  }
-
-  const builder = detectBuilder();
-
-  // Linux gnu targets are routed through cargo-zigbuild even on a matching
-  // host, so the minimum GLIBC baseline is pinned to GLIBC_MIN instead of
-  // being inherited from whatever glibc the build machine happens to run.
-  const glibcPinned = target.npm_os === 'linux' && builder === 'zigbuild';
-  const isCross = !hostTarget || target.rust_target !== hostTarget || glibcPinned;
-  if (target.npm_os === 'linux' && !glibcPinned) {
-    console.warn(
-      `  ⚠️  cargo-zigbuild not available — GLIBC baseline NOT pinned for ${target.rust_target} ` +
-      `(binaries will require the build host's glibc). Install cargo-zigbuild before publishing.`,
+  const currentName = `${process.platform}-${process.arch}`;
+  const selectedName = targetName || currentName;
+  const targets = targetName
+    ? TARGETS.filter(
+        (candidate) =>
+          candidate.rust_target.includes(selectedName) ||
+          candidate.npm_cpu === selectedName ||
+          candidate.pkg_suffix.includes(selectedName) ||
+          candidate.npm_os === selectedName,
+      )
+    : TARGETS.filter((candidate) => candidate.pkg_suffix === selectedName);
+  if (targets.length === 0) {
+    throw new Error(
+      `unknown target ${selectedName}; available targets: ` +
+      TARGETS.map((candidate) => candidate.pkg_suffix).join(', '),
     );
   }
-
-  // Cross-compiling to macOS requires a macOS SDK (zig only provides the C
-  // toolchain, not Apple headers/libraries). Fail fast with instructions
-  // instead of hitting an obscure linker error later.
-  if (target.npm_os === 'darwin' && isCross) {
-    if (!process.env.SDKROOT) {
-      const sdkPaths = [
-        '/opt/MacOSX13.3.sdk',
-        '/opt/MacOSX14.0.sdk',
-        '/opt/MacOSX15.0.sdk',
-      ];
-      for (const p of sdkPaths) {
-        if (existsSync(p)) {
-          process.env.SDKROOT = p;
-          break;
-        }
-      }
-    }
-    if (!process.env.SDKROOT || !existsSync(process.env.SDKROOT)) {
-      throw new Error(
-        `macOS SDK not found for ${target.rust_target}. ` +
-        `Set SDKROOT to an extracted macOS SDK (see npm/README.md ` +
-        `"Cross-Compilation" for SDK download and setup steps), ` +
-        `or build Apple targets natively on a macOS host.`,
-      );
-    }
-    console.log(`  Using macOS SDK: ${process.env.SDKROOT}`);
-  }
-
-  if (isCross) {
-    console.log(`  Using builder: ${builder} (host: ${hostTarget || 'unknown'})`);
-  }
-
-  const cmd = buildCommand(builder, target, isCross);
-  if (!cmd) {
-    throw new Error(`Cannot cross-compile to ${target.rust_target}`);
-  }
-
-  // Build tokenless CLI
-  console.log(`  Building tokenless... (${cmd.split(' ').slice(0, 2).join(' ')})`);
-  execSync(cmd, { stdio: 'inherit', cwd: tokenlessRoot });
-
-  // Build rtk (third_party/rtk)
-  console.log(`  Building rtk...`);
-  const rtkDir = join(tokenlessRoot, 'third_party', 'rtk');
-  // Ensure rtk source is available (clone + patch via justfile)
-  if (!existsSync(join(rtkDir, 'Cargo.toml'))) {
-    console.log(`  Setting up rtk source (just setup-rtk)...`);
-    try {
-      execSync('just setup-rtk', { stdio: 'inherit', cwd: tokenlessRoot });
-    } catch {
-      console.warn(`  ⚠️  Failed to run 'just setup-rtk'. Ensure 'just' is installed.`);
-    }
-  }
-  if (existsSync(join(rtkDir, 'Cargo.toml'))) {
-    const rtkCmd = buildCommand(builder, target, isCross);
-    if (rtkCmd) {
-      execSync(rtkCmd, { stdio: 'inherit', cwd: rtkDir });
-    } else {
-      console.warn(`  ⚠️  Cannot cross-compile rtk, skipping.`);
-    }
-  } else {
-    console.warn(`  ⚠️  rtk source not available, skipping rtk binary.`);
-  }
-
-  // Build toon (toon-format crate from crates.io)
-  // toon-format is a registry dependency, NOT a workspace member, so
-  // `cargo build -p toon-format` cannot work here — the `toon` bin is
-  // produced via `cargo install`. Each target installs into its own root
-  // (target/npm-toon/<pkg_suffix>) which is wiped before the install, so a
-  // failed install can never pick up a binary left over from another
-  // target or from the host. If the install fails, the whole target fails.
-  console.log(`  Building toon...`);
-  const toonRoot = join(tokenlessRoot, 'target', 'npm-toon', target.pkg_suffix);
-  rmSync(toonRoot, { recursive: true, force: true });
-  let toonInstallCmd = `cargo install toon-format --version ${toonVer} --locked --root ${toonRoot}`;
-  let toonInstallEnv = process.env;
-  if (isCross) {
-    toonInstallCmd += ` --target ${target.rust_target}`;
-    toonInstallEnv = setupCrossEnv(target);
-  }
-  execSync(toonInstallCmd, { stdio: 'inherit', env: toonInstallEnv });
-  const toonBinPath = join(toonRoot, 'bin', 'toon');
-  if (!existsSync(toonBinPath)) {
-    throw new Error(`toon binary missing at ${toonBinPath} after cargo install for ${target.rust_target}`);
-  }
-
-  // Collect binary paths
-  const binaryPaths = {};
-  const releaseDir = isCross
-    ? join(tokenlessRoot, 'target', target.rust_target, 'release')
-    : join(tokenlessRoot, 'target', 'release');
-  // rtk is built in third_party/rtk, so its binary is in a separate target dir
-  const rtkReleaseDir = isCross
-    ? join(tokenlessRoot, 'third_party', 'rtk', 'target', target.rust_target, 'release')
-    : join(tokenlessRoot, 'third_party', 'rtk', 'target', 'release');
-
-  for (const bin of BINARIES) {
-    let binPath;
-    if (bin === 'rtk') {
-      // rtk binary lives in third_party/rtk/target/...
-      binPath = join(rtkReleaseDir, bin);
-      if (!existsSync(binPath)) {
-        // Fallback: some setups copy rtk to main target dir
-        binPath = join(releaseDir, bin);
-      }
-    } else if (bin === 'toon') {
-      // toon comes exclusively from this target's own install root
-      // (verified to exist right after `cargo install` above) — never fall
-      // back to native or other targets' artifacts.
-      binPath = toonBinPath;
-    } else {
-      binPath = join(releaseDir, bin);
-    }
-    if (existsSync(binPath)) {
-      binaryPaths[bin] = binPath;
-    } else {
-      console.warn(`  ⚠️  Binary ${bin} not found at ${binPath}`);
-    }
-  }
-
-  const builtBins = Object.keys(binaryPaths);
-  const missingBins = BINARIES.filter(b => !builtBins.includes(b));
-  if (missingBins.length > 0) {
-    throw new Error(`Missing required binaries for ${target.rust_target}: ${missingBins.join(', ')}`);
-  }
-
-  verifyGlibcBaseline(target, binaryPaths, glibcPinned);
-
-  console.log(`  ✅ Built ${Object.keys(binaryPaths).join(', ')}`);
-  return binaryPaths;
+  return targets;
 }
 
-/**
- * Verify that Linux binaries do not require GLIBC symbols newer than the
- * GLIBC_MIN baseline. When the build was routed through zigbuild with a
- * pinned baseline, exceeding it is a hard error; for unpinned native builds
- * (no zigbuild) the observed requirement is only reported, since it will
- * legitimately reflect the host glibc.
- */
-function verifyGlibcBaseline(target, binaryPaths, pinned) {
-  if (target.npm_os !== 'linux') return;
-
+function readHeader(path) {
+  const descriptor = openSync(path, 'r');
   try {
-    execSync('readelf --version', { stdio: 'pipe' });
-  } catch {
-    if (pinned) {
-      throw new Error(
-        `readelf not found — cannot verify GLIBC baseline for ${target.rust_target}. ` +
-        `Install binutils before packaging Linux targets.`,
-      );
+    const header = Buffer.alloc(64);
+    const length = readSync(descriptor, header, 0, header.length, 0);
+    return header.subarray(0, length);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function verifyBinaryFormat(target, name, path) {
+  const header = readHeader(path);
+  if (target.binary_os === 'linux') {
+    const elfMagic = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+    if (header.length < 20 || !header.subarray(0, 4).equals(elfMagic)) {
+      throw new Error(`${name} is not an ELF binary: ${path}`);
     }
-    console.warn('  ⚠️  readelf not found — skipping GLIBC baseline verification.');
+    if (header[4] !== 2 || header[5] !== 1) {
+      throw new Error(`${name} is not a 64-bit little-endian ELF binary: ${path}`);
+    }
+    const expected = target.binary_arch === 'x86_64' ? 62 : 183;
+    const actual = header.readUInt16LE(18);
+    if (actual !== expected) {
+      throw new Error(`${name} ELF machine ${actual} does not match ${target.pkg_suffix}`);
+    }
     return;
   }
 
-  const [baseMajor, baseMinor] = GLIBC_MIN.split('.').map(Number);
-  for (const [bin, binPath] of Object.entries(binaryPaths)) {
-    const out = execSync(`readelf --dyn-syms --wide "${binPath}"`, {
+  if (header.length < 8) throw new Error(`${name} Mach-O header is truncated: ${path}`);
+  const littleEndian = header.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+  const bigEndian = header.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf]));
+  if (!littleEndian && !bigEndian) {
+    throw new Error(`${name} is not a thin 64-bit Mach-O binary: ${path}`);
+  }
+  const actual = littleEndian ? header.readUInt32LE(4) : header.readUInt32BE(4);
+  const expected = target.binary_arch === 'x86_64' ? 0x01000007 : 0x0100000c;
+  if (actual !== expected) {
+    throw new Error(
+      `${name} Mach-O CPU 0x${actual.toString(16)} does not match ${target.pkg_suffix}`,
+    );
+  }
+}
+
+function compareVersions(left, right) {
+  const width = Math.max(left.length, right.length);
+  for (let index = 0; index < width; index += 1) {
+    const delta = (left[index] || 0) - (right[index] || 0);
+    if (delta !== 0) return delta;
+  }
+  return 0;
+}
+
+/** Report when Linux binaries require a newer GLIBC than the package baseline. */
+function verifyGlibcBaseline(target, name, path) {
+  if (target.binary_os !== 'linux') return;
+
+  let output;
+  try {
+    output = execFileSync('readelf', ['--version-info', '--wide', path], {
       encoding: 'utf-8',
       maxBuffer: 64 * 1024 * 1024,
     });
-    let max = null;
-    for (const m of out.matchAll(/GLIBC_(\d+)\.(\d+)/g)) {
-      const ver = [Number(m[1]), Number(m[2])];
-      if (!max || ver[0] > max[0] || (ver[0] === max[0] && ver[1] > max[1])) max = ver;
-    }
-    const maxLabel = max ? `GLIBC_${max.join('.')}` : 'none';
-    const exceeds = max && (max[0] > baseMajor || (max[0] === baseMajor && max[1] > baseMinor));
-    if (exceeds && pinned) {
-      throw new Error(
-        `${bin} requires ${maxLabel}, which exceeds the pinned baseline GLIBC_${GLIBC_MIN} ` +
-        `for ${target.rust_target}`,
-      );
-    }
-    if (exceeds) {
-      console.warn(`  ⚠️  ${bin}: max required ${maxLabel} > baseline GLIBC_${GLIBC_MIN} (unpinned native build)`);
-    } else {
-      console.log(`  GLIBC check: ${bin} max required ${maxLabel} (baseline ${GLIBC_MIN})`);
-    }
+  } catch (error) {
+    const detail =
+      error.code === 'ENOENT' ? 'readelf is not installed' : 'readelf could not inspect it';
+    console.warn(
+      `  ⚠️  cannot verify the GLIBC ${GLIBC_MIN} baseline for ${name}: ` +
+      `${detail}; skipping verification (${path})`,
+    );
+    return;
   }
+
+  const required = [...output.matchAll(/GLIBC_(\d+)\.(\d+)(?:\.(\d+))?/g)].map((match) =>
+    match.slice(1).filter((part) => part !== undefined).map(Number),
+  );
+  if (required.length === 0) return;
+
+  const maximum = required.reduce((left, right) =>
+    compareVersions(left, right) >= 0 ? left : right,
+  );
+  const baseline = GLIBC_MIN.split('.').map(Number);
+  if (compareVersions(maximum, baseline) > 0) {
+    console.warn(
+      `  ⚠️  ` +
+      `${name} requires GLIBC_${maximum.join('.')}, exceeding the supported ` +
+      `GLIBC_${GLIBC_MIN} baseline (${path})`,
+    );
+  }
+}
+
+function collectPrebuiltBinaries(target, binDir) {
+  const binaryPaths = {};
+  for (const binary of BINARIES) {
+    const path = join(binDir, binary);
+    if (!existsSync(path) || !statSync(path).isFile()) {
+      throw new Error(`missing prebuilt ${binary} for ${target.pkg_suffix}: ${path}`);
+    }
+    verifyBinaryFormat(target, binary, path);
+    verifyGlibcBaseline(target, binary, path);
+    binaryPaths[binary] = path;
+  }
+  console.log(`  ✅ Verified prebuilt ${Object.keys(binaryPaths).join(', ')}`);
+  return binaryPaths;
 }
 
 function packagePlatform(target, binaryPaths) {
@@ -508,8 +302,9 @@ function packagePlatform(target, binaryPaths) {
 
   // Copy binaries
   for (const [bin, binPath] of Object.entries(binaryPaths)) {
-    copyFileSync(binPath, join(pkgDir, 'bin', bin));
-    execSync(`chmod 755 "${join(pkgDir, 'bin', bin)}"`, { stdio: 'pipe' });
+    const destination = join(pkgDir, 'bin', bin);
+    copyFileSync(binPath, destination);
+    chmodSync(destination, 0o755);
   }
 
   // Build bin map for package.json
@@ -634,11 +429,14 @@ function packageRoot(targets) {
   // Write stub bin scripts that postinstall will replace with symlinks
   for (const bin of BINARIES) {
     const stubScript = `#!/usr/bin/env node
-console.error('anolisa-tokenless: postinstall has not run yet. Run "npm rebuild anolisa-tokenless" to fix.');
+console.error(
+  'anolisa-tokenless: postinstall has not run yet. ' +
+  'Run "npm rebuild anolisa-tokenless" to fix.',
+);
 process.exit(1);
 `;
     writeFileSync(join(rootPkgDir, 'bin', bin), stubScript);
-    execSync(`chmod 755 "${join(rootPkgDir, 'bin', bin)}"`, { stdio: 'pipe' });
+    chmodSync(join(rootPkgDir, 'bin', bin), 0o755);
   }
 
   // Copy postinstall script
@@ -683,7 +481,9 @@ process.exit(1);
     name: 'anolisa-tokenless',
     type: 'module',
     version,
-    description: 'Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)',
+    description:
+      'Token-Less — LLM token optimization toolkit ' +
+      '(schema/response compression, command rewriting, tool readiness)',
     license: 'Apache-2.0',
     repository: {
       type: 'git',
@@ -712,57 +512,41 @@ process.exit(1);
 async function main() {
   console.log(`\n🚀 Token-Less npm packaging (v${version})\n`);
 
-  // Clean dist
+  const targets = parseArgs();
+  console.log(`Targets: ${targets.map((target) => target.pkg_suffix).join(', ')}`);
+
+  // Validate the complete input set before replacing an existing dist tree.
+  const verified = targets.map((target) => {
+    const binDir = join(prebuiltRoot, target.pkg_suffix);
+    console.log(`\n🔎 Verifying ${target.pkg_suffix} binaries from ${binDir}...`);
+    return [target, collectPrebuiltBinaries(target, binDir)];
+  });
+
   if (existsSync(distDir)) rmSync(distDir, { recursive: true });
   mkdirSync(distDir, { recursive: true });
 
-  const targets = await parseArgs();
-  console.log(`Targets: ${targets.map((t) => t.pkg_suffix).join(', ')}`);
-
-  // Detect builder once and report
-  const builder = detectBuilder();
-  console.log(`Cross-compilation tool: ${builder}`);
-  if (builder === 'cargo' && targets.some((t) => t.npm_os !== process.platform || t.npm_cpu !== process.arch)) {
-    console.warn('\n⚠️  No cross-compilation tool detected.');
-    console.warn('   For Linux→all targets (including macOS), install cargo-zigbuild:');
-    console.warn('     cargo install cargo-zigbuild');
-    console.warn('     pip install ziglang   # or: apt install zig / brew install zig');
-    console.warn('');
+  for (const [target, binaryPaths] of verified) {
+    packagePlatform(target, binaryPaths);
   }
 
-  // Build and package each platform (skip failed targets in --all mode)
-  const succeeded = [];
-  const failed = [];
-  for (const target of targets) {
-    try {
-      const binaryPaths = buildTarget(target);
-      packagePlatform(target, binaryPaths);
-      succeeded.push(target.pkg_suffix);
-    } catch (err) {
-      console.error(`\n  ❌ Failed to build ${target.pkg_suffix}: ${err.message}`);
-      failed.push(target.pkg_suffix);
-    }
-  }
-  if (failed.length > 0) {
-    console.error(`\n❌ Build failed: ${failed.length} of ${targets.length} target(s) failed: ${failed.join(', ')}`);
-    console.error('   Cannot publish incomplete platform packages.');
-    process.exit(1);
-  }
-
-  // Package root
+  // The root package always advertises every published platform package, even
+  // when only one selected platform package is assembled locally.
   packageRoot(TARGETS);
 
-  console.log(`\n✅ All packages ready in: ${distDir}/`);
+  console.log(`\n✅ Selected packages ready in: ${distDir}/`);
   console.log('\nTo publish (platform packages first, root last; registry pinned to npmjs):');
   console.log('  make npm-publish');
   console.log('or manually:');
-  for (const t of TARGETS) {
-    console.log(`  cd npm/dist/tokenless-${t.pkg_suffix} && npm publish --access public --registry=${NPM_REGISTRY}`);
+  for (const t of targets) {
+    console.log(
+      `  cd npm/dist/tokenless-${t.pkg_suffix} && ` +
+      `npm publish --access public --registry=${NPM_REGISTRY}`,
+    );
   }
   console.log(`  cd npm/dist/tokenless && npm publish --access public --registry=${NPM_REGISTRY}`);
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error(`Error: ${err.message}`);
   process.exit(1);
 });

--- a/src/tokenless/packaging/raw/package.sh
+++ b/src/tokenless/packaging/raw/package.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Assemble prebuilt Tokenless binaries into the ANOLISA raw-package layout.
+set -euo pipefail
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux) printf 'linux\n' ;;
+        Darwin) printf 'macos\n' ;;
+        *) die "unsupported host OS; set TARGET_OS explicitly" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported host architecture; set TARGET_ARCH explicitly" ;;
+    esac
+}
+
+normalize_os() {
+    case "$1" in
+        linux) printf 'linux\n' ;;
+        macos | darwin) printf 'macos\n' ;;
+        *) die "unsupported target OS: $1" ;;
+    esac
+}
+
+normalize_arch() {
+    case "$1" in
+        x86_64 | amd64 | x64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported target architecture: $1" ;;
+    esac
+}
+
+validate_target() {
+    case "$TARGET_OS-$TARGET_ARCH" in
+        linux-x86_64 | linux-aarch64 | macos-aarch64) ;;
+        macos-x86_64) die "Tokenless raw packages do not support macOS x86_64" ;;
+        *) die "unsupported Tokenless raw target: $TARGET_OS-$TARGET_ARCH" ;;
+    esac
+}
+
+require_file() {
+    [ -f "$1" ] || die "missing packaging input: $1"
+}
+
+normalize_modes() {
+    local stage="$1"
+
+    find "$stage" -type d -exec chmod 0755 {} +
+    find "$stage" -type f -exec chmod 0644 {} +
+    chmod 0755 \
+        "$stage/bin/tokenless" \
+        "$stage/libexec/anolisa/tokenless/rtk" \
+        "$stage/libexec/anolisa/tokenless/toon"
+    find "$stage/adapters" "$stage/extensions/tokenless" \
+        -type f \( -name '*.py' -o -name '*.sh' -o \
+        -path '*/codex/scripts/*' \) -exec chmod 0755 {} +
+}
+
+materialize_hook() {
+    local stage="$1"
+    local relative="$2"
+    local path="$stage/adapters/$relative"
+
+    if [ -L "$path" ]; then
+        install -p -m 0755 "$path" "$path.materialized"
+        mv -f "$path.materialized" "$path"
+    fi
+    [ -f "$path" ] || die "missing staged adapter hook: $relative"
+}
+
+stage_payload() {
+    local stage="$1"
+    local adapters="$SOURCE_ROOT/adapters/tokenless"
+    local relative
+
+    if [ -e "$stage" ] && [ -n "$(find "$stage" -mindepth 1 -print -quit)" ]; then
+        die "DESTDIR must be empty: $stage"
+    fi
+
+    for relative in \
+        manifest.json \
+        openclaw/package.json \
+        openclaw/openclaw.plugin.json \
+        openclaw/dist/index.js \
+        hermes/plugin.yaml \
+        qoder/.qoder-plugin/plugin.json \
+        claude-code/.claude-plugin/marketplace.json \
+        claude-code/.claude-plugin/plugin.json \
+        claude-code/hooks/run-hook.sh \
+        codex/.codex-plugin/plugin.json \
+        qwencode/qwen-extension.json \
+        qwencode/hooks/run-hook.sh \
+        common/cosh-extension.json \
+        common/tool-ready-spec.json \
+        common/tokenless-env-fix.sh; do
+        require_file "$adapters/$relative"
+    done
+
+    install -d -m 0755 \
+        "$stage/.anolisa" \
+        "$stage/bin" \
+        "$stage/libexec/anolisa/tokenless" \
+        "$stage/adapters" \
+        "$stage/extensions/tokenless/hooks" \
+        "$stage/extensions/tokenless/commands"
+    install -p -m 0644 "$CONTRACT" "$stage/.anolisa/component.toml"
+    install -p -m 0755 "$BIN_DIR/tokenless" "$stage/bin/tokenless"
+    install -p -m 0755 "$BIN_DIR/rtk" "$BIN_DIR/toon" \
+        "$stage/libexec/anolisa/tokenless/"
+    cp -a "$adapters"/. "$stage/adapters"/
+
+    # ANOLISA intentionally ignores archive symlinks. The source tree shares
+    # these dispatchers by symlink, so raw packages must carry regular files.
+    materialize_hook "$stage" "claude-code/hooks/run-hook.sh"
+    materialize_hook "$stage" "qwencode/hooks/run-hook.sh"
+
+    install -p -m 0644 \
+        "$adapters/common/cosh-extension.json" \
+        "$adapters/common/tool-ready-spec.json" \
+        "$stage/extensions/tokenless/"
+    install -p -m 0755 "$adapters/common/tokenless-env-fix.sh" \
+        "$stage/extensions/tokenless/"
+    cp -a "$adapters/common/hooks"/. "$stage/extensions/tokenless/hooks"/
+    cp -a "$adapters/common/commands"/. "$stage/extensions/tokenless/commands"/
+
+    # Match the installed adapter payload and exclude build-only inputs.
+    rm -rf "$stage/adapters/openclaw/node_modules"
+    rm -f \
+        "$stage/adapters/openclaw/package-lock.json" \
+        "$stage/adapters/openclaw/index.ts" \
+        "$stage/adapters/openclaw/tsconfig.json"
+    find "$stage/adapters" "$stage/extensions/tokenless" \
+        \( -name '*.in' -o -name '.gitignore' \) -delete
+    normalize_modes "$stage"
+
+    if [ -n "$(find "$stage" -type l -print -quit)" ]; then
+        die "raw payload contains a symbolic link"
+    fi
+}
+
+resolve_epoch() {
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        printf '%s\n' "$SOURCE_DATE_EPOCH"
+        return
+    fi
+    git -C "$SOURCE_ROOT" log -1 --format=%ct -- . 2>/dev/null || \
+        die "SOURCE_DATE_EPOCH is unset and the source commit time is unavailable"
+}
+
+COMMAND="${1:-}"
+[ "$COMMAND" = "stage" ] || [ "$COMMAND" = "package" ] || \
+    die "usage: $0 {stage|package}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_ROOT="${TOKENLESS_SOURCE_DIR:-$DEFAULT_ROOT}"
+BIN_DIR="${BIN_DIR:-}"
+CONTRACT="${RAW_CONTRACT:-$SOURCE_ROOT/.anolisa/component.toml}"
+TARGET_OS="$(normalize_os "${TARGET_OS:-$(detect_os)}")"
+TARGET_ARCH="$(normalize_arch "${TARGET_ARCH:-$(detect_arch)}")"
+
+validate_target
+[ -n "$BIN_DIR" ] || die "BIN_DIR must contain prebuilt tokenless, rtk, and toon binaries"
+for binary in tokenless rtk toon; do
+    [ -x "$BIN_DIR/$binary" ] || die "missing executable: $BIN_DIR/$binary"
+done
+require_file "$CONTRACT"
+
+VERSION="$(python3 "$SCRIPT_DIR/verify-release.py" "$SOURCE_ROOT" "$CONTRACT")"
+python3 "$SCRIPT_DIR/verify-binaries.py" \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH" \
+    "$BIN_DIR/tokenless" "$BIN_DIR/rtk" "$BIN_DIR/toon"
+
+if [ "$COMMAND" = "stage" ]; then
+    [ -n "${DESTDIR:-}" ] || die "DESTDIR is required by stage"
+    stage_payload "$DESTDIR"
+    printf 'Staged tokenless %s for %s-%s at %s\n' \
+        "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$DESTDIR"
+    exit 0
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$SOURCE_ROOT/target/raw}"
+EPOCH="$(resolve_epoch)"
+case "$EPOCH" in
+    '' | *[!0-9]*) die "SOURCE_DATE_EPOCH must be a non-negative integer" ;;
+esac
+tar --version 2>/dev/null | grep -q 'GNU tar' || \
+    die "GNU tar is required for reproducible raw packages"
+
+WORK="$(mktemp -d)"
+TEMP_ARTIFACT=""
+cleanup() {
+    rm -rf "$WORK"
+    if [ -n "$TEMP_ARTIFACT" ]; then
+        rm -f "$TEMP_ARTIFACT"
+    fi
+}
+trap cleanup EXIT
+
+STAGE="$WORK/stage"
+stage_payload "$STAGE"
+install -d -m 0755 "$OUTPUT_DIR"
+ARTIFACT="tokenless-${VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+TEMP_ARTIFACT="$OUTPUT_DIR/.${ARTIFACT}.tmp.$$"
+LC_ALL=C tar \
+    --sort=name \
+    --mtime="@$EPOCH" \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    --hard-dereference \
+    --format=gnu \
+    -C "$STAGE" \
+    -cf - . | gzip -n -9 > "$TEMP_ARTIFACT"
+mv -f "$TEMP_ARTIFACT" "$OUTPUT_DIR/$ARTIFACT"
+TEMP_ARTIFACT=""
+printf '%s\n' "$OUTPUT_DIR/$ARTIFACT"

--- a/src/tokenless/packaging/raw/verify-binaries.py
+++ b/src/tokenless/packaging/raw/verify-binaries.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify that prebuilt raw-package binaries match the requested target."""
+
+from __future__ import annotations
+
+import argparse
+import struct
+from pathlib import Path
+
+
+ELF_MACHINES = {
+    "x86_64": 62,
+    "aarch64": 183,
+}
+MACHO_CPUS = {
+    "x86_64": 0x01000007,
+    "aarch64": 0x0100000C,
+}
+
+
+def verify_elf(path: Path, arch: str) -> None:
+    """Verify one 64-bit little-endian ELF binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(64)
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        raise ValueError("not an ELF binary")
+    if header[4] != 2:
+        raise ValueError("not a 64-bit ELF binary")
+    if header[5] != 1:
+        raise ValueError("not a little-endian ELF binary")
+    machine = struct.unpack_from("<H", header, 18)[0]
+    if machine != ELF_MACHINES[arch]:
+        raise ValueError(f"ELF machine {machine} does not match {arch}")
+
+
+def verify_macho(path: Path, arch: str) -> None:
+    """Verify one thin 64-bit Mach-O binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(32)
+    if len(header) < 8:
+        raise ValueError("Mach-O header is truncated")
+    if header[:4] == b"\xcf\xfa\xed\xfe":
+        byte_order = "<"
+    elif header[:4] == b"\xfe\xed\xfa\xcf":
+        byte_order = ">"
+    else:
+        raise ValueError("not a thin 64-bit Mach-O binary")
+    cpu = struct.unpack_from(f"{byte_order}I", header, 4)[0]
+    if cpu != MACHO_CPUS[arch]:
+        raise ValueError(f"Mach-O CPU {cpu:#x} does not match {arch}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse target identity and binary paths."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=tuple(ELF_MACHINES), required=True)
+    parser.add_argument("binaries", nargs="+", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Validate all binaries without executing cross-target code."""
+    args = parse_args()
+    verifier = verify_elf if args.os == "linux" else verify_macho
+    for path in args.binaries:
+        if not path.is_file():
+            raise SystemExit(f"ERROR: missing binary: {path}")
+        try:
+            verifier(path, args.arch)
+        except (OSError, ValueError) as error:
+            raise SystemExit(f"ERROR: {path}: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tokenless/packaging/raw/verify-release.py
+++ b/src/tokenless/packaging/raw/verify-release.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Validate Tokenless source metadata before assembling a raw package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+WORKSPACE_VERSION = re.compile(
+    r"(?ms)^\[workspace\.package\]\s*$.*?^version\s*=\s*\"([^\"]+)\""
+)
+COMPONENT = re.compile(r"(?ms)^\[component\]\s*$.*?(?=^\[|\Z)")
+FIELD = r"(?m)^{}\s*=\s*\"([^\"]+)\""
+
+
+def match_field(text: str, name: str, path: Path) -> str:
+    """Read one string field from a scoped TOML table."""
+    match = re.search(FIELD.format(re.escape(name)), text)
+    if match is None:
+        raise SystemExit(f"ERROR: {path} has no {name} field")
+    return match.group(1)
+
+
+def read_json_version(path: Path) -> str:
+    """Read one generated adapter's top-level JSON version."""
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+    version = document.get("version") if isinstance(document, dict) else None
+    if not isinstance(version, str) or not version:
+        raise SystemExit(f"ERROR: {path} has no string version")
+    return version
+
+
+def read_hermes_version(path: Path) -> str:
+    """Read the generated Hermes manifest's simple version field."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+    match = re.search(r'(?m)^version:\s*["\']?([^"\'\s]+)', text)
+    if match is None:
+        raise SystemExit(f"ERROR: {path} has no version")
+    return match.group(1)
+
+
+def verify_versions(root: Path, contract: Path) -> str:
+    """Return the source version after checking packaged release metadata."""
+    cargo_path = root / "Cargo.toml"
+    try:
+        cargo_text = cargo_path.read_text(encoding="utf-8")
+        contract_text = contract.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"ERROR: cannot read release metadata: {error}") from error
+
+    cargo_match = WORKSPACE_VERSION.search(cargo_text)
+    if cargo_match is None:
+        raise SystemExit(f"ERROR: {cargo_path} has no workspace package version")
+    expected = cargo_match.group(1)
+
+    component_match = COMPONENT.search(contract_text)
+    if component_match is None:
+        raise SystemExit(f"ERROR: {contract} has no [component] table")
+    component_text = component_match.group(0)
+    if match_field(component_text, "name", contract) != "tokenless":
+        raise SystemExit(f"ERROR: {contract} is not a tokenless contract")
+    contract_version = match_field(component_text, "version", contract)
+    if contract_version != expected:
+        raise SystemExit(
+            f"ERROR: {contract} version {contract_version} does not match "
+            f"Cargo.toml version {expected}"
+        )
+
+    adapters = root / "adapters" / "tokenless"
+    json_manifests = (
+        adapters / "manifest.json",
+        adapters / "openclaw" / "package.json",
+        adapters / "openclaw" / "openclaw.plugin.json",
+        adapters / "qoder" / ".qoder-plugin" / "plugin.json",
+        adapters / "claude-code" / ".claude-plugin" / "plugin.json",
+        adapters / "codex" / ".codex-plugin" / "plugin.json",
+        adapters / "qwencode" / "qwen-extension.json",
+    )
+    versions = {str(path.relative_to(root)): read_json_version(path) for path in json_manifests}
+    hermes = adapters / "hermes" / "plugin.yaml"
+    versions[str(hermes.relative_to(root))] = read_hermes_version(hermes)
+    drift = [f"{path}={version}" for path, version in versions.items() if version != expected]
+    if drift:
+        raise SystemExit(
+            f"ERROR: generated adapter versions do not match {expected}: "
+            + ", ".join(drift)
+        )
+    return expected
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse source and contract paths."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("contract", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Print the verified release version for the packaging shell script."""
+    args = parse_args()
+    print(verify_versions(args.source_root.resolve(), args.contract.resolve()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tokenless/tests/test-package-npm-prebuilt.sh
+++ b/src/tokenless/tests/test-package-npm-prebuilt.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Verify npm packaging consumes, validates, and preserves prebuilt binaries.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d /tmp/tokenless-npm-package-test.XXXXXX)"
+PREBUILT="$ROOT/target/npm-prebuilt"
+BACKUP="$TMP/npm-prebuilt.backup"
+TEST_TOOLS="$TMP/tools"
+
+cleanup() {
+    rm -rf "$PREBUILT"
+    if [[ -e "$BACKUP" ]]; then
+        mv "$BACKUP" "$PREBUILT"
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+if [[ -e "$PREBUILT" ]]; then
+    mv "$PREBUILT" "$BACKUP"
+fi
+
+mkdir -p "$TEST_TOOLS"
+cat >"$TEST_TOOLS/readelf" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+input="${@: -1}"
+grep -aoE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' "$input" || true
+SH
+chmod 0755 "$TEST_TOOLS/readelf"
+export PATH="$TEST_TOOLS:$PATH"
+
+make_binaries() {
+    local target="$1"
+    local destination="$PREBUILT/$target"
+
+    mkdir -p "$destination"
+    python3 - "$target" "$destination" <<'PY'
+import pathlib
+import struct
+import sys
+
+target, destination = sys.argv[1:]
+root = pathlib.Path(destination)
+if target.startswith("linux-"):
+    machine = {"linux-x64": 62, "linux-arm64": 183}[target]
+    header = bytearray(64)
+    header[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into("<H", header, 16, 2)
+    struct.pack_into("<H", header, 18, machine)
+    struct.pack_into("<I", header, 20, 1)
+    content = bytes(header) + b"\nGLIBC_2.17\n"
+else:
+    cpu = {"darwin-x64": 0x01000007, "darwin-arm64": 0x0100000C}[target]
+    content = struct.pack("<IiiIIIII", 0xFEEDFACF, cpu, 0, 2, 0, 0, 0, 0)
+for name in ("tokenless", "rtk", "toon"):
+    (root / name).write_bytes(content + f"\n{name}-{target}\n".encode())
+PY
+    chmod 0755 "$destination/tokenless" "$destination/rtk" "$destination/toon"
+}
+
+for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+    make_binaries "$target"
+done
+
+cp "$PREBUILT/linux-x64/"* "$PREBUILT/linux-arm64/"
+if node "$ROOT/npm/scripts/package-npm.js" --target linux-arm64 \
+    >"$TMP/mismatch.out" 2>&1; then
+    echo "ERROR: npm packer accepted mislabeled x86_64 binaries as arm64" >&2
+    exit 1
+fi
+grep -Fq 'does not match linux-arm64' "$TMP/mismatch.out"
+make_binaries linux-arm64
+
+python3 - "$PREBUILT/linux-x64/tokenless" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_bytes(path.read_bytes().replace(b"GLIBC_2.17", b"GLIBC_2.18"))
+PY
+if ! node "$ROOT/npm/scripts/package-npm.js" --target linux-x64 \
+    >"$TMP/glibc.out" 2>&1; then
+    echo "ERROR: npm packer rejected a binary above the GLIBC 2.17 baseline" >&2
+    exit 1
+fi
+grep -Fq 'requires GLIBC_2.18' "$TMP/glibc.out"
+make_binaries linux-x64
+
+check_selector() {
+    local selector="$1"
+    local expected="$2"
+    node "$ROOT/npm/scripts/package-npm.js" --target "$selector" >"$TMP/selector.out"
+    grep -Fq "Targets: $expected" "$TMP/selector.out"
+}
+
+check_selector x86_64 'linux-x64, darwin-x64'
+check_selector arm64 'linux-arm64, darwin-arm64'
+check_selector linux 'linux-x64, linux-arm64'
+check_selector aarch64-apple-darwin 'darwin-arm64'
+
+node "$ROOT/npm/scripts/package-npm.js" --all
+
+for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+    package="$ROOT/npm/dist/tokenless-$target"
+    test -f "$package/package.json"
+    test -f "$package"/*.tgz
+    for binary in tokenless rtk toon; do
+        cmp "$PREBUILT/$target/$binary" "$package/bin/$binary"
+        test "$(stat -c '%a' "$package/bin/$binary")" = 755
+    done
+done
+
+node - "$ROOT/npm/dist/tokenless/package.json" <<'JS'
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const expected = [
+  '@anolisa/tokenless-linux-x64',
+  '@anolisa/tokenless-linux-arm64',
+  '@anolisa/tokenless-darwin-x64',
+  '@anolisa/tokenless-darwin-arm64',
+];
+for (const name of expected) {
+  if (manifest.optionalDependencies?.[name] !== manifest.version) {
+    throw new Error(`missing optional dependency ${name}`);
+  }
+}
+JS
+
+if grep -Eq \
+    'cargo-zigbuild|cargo zigbuild|cross build|rustup target|SDKROOT|detectBuilder' \
+    "$ROOT/npm/scripts/package-npm.js"; then
+    echo "ERROR: npm packer still contains cross-compilation logic" >&2
+    exit 1
+fi
+echo "tokenless prebuilt npm package tests passed"

--- a/src/tokenless/tests/test-package-raw.sh
+++ b/src/tokenless/tests/test-package-raw.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Exercise the component-owned raw packer without compiling native binaries.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d /tmp/tokenless-raw-package-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+SOURCE="$TMP/tokenless"
+ADAPTERS="$SOURCE/adapters/tokenless"
+CONTRACT="$SOURCE/.anolisa/component.toml"
+VERSION="9.8.7"
+
+mkdir -p \
+    "$SOURCE/.anolisa" \
+    "$ADAPTERS/common/hooks" \
+    "$ADAPTERS/common/commands" \
+    "$ADAPTERS/openclaw/dist" \
+    "$ADAPTERS/hermes" \
+    "$ADAPTERS/qoder/.qoder-plugin" \
+    "$ADAPTERS/claude-code/.claude-plugin" \
+    "$ADAPTERS/claude-code/hooks" \
+    "$ADAPTERS/codex/.codex-plugin" \
+    "$ADAPTERS/qwencode/hooks"
+
+cat > "$SOURCE/Cargo.toml" <<EOF
+[workspace]
+[workspace.package]
+version = "$VERSION"
+EOF
+cat > "$CONTRACT" <<EOF
+[component]
+name = "tokenless"
+version = "$VERSION"
+EOF
+
+write_json_version() {
+    mkdir -p "$(dirname "$1")"
+    printf '{"name":"tokenless","version":"%s"}\n' "$VERSION" > "$1"
+}
+
+write_json_version "$ADAPTERS/manifest.json"
+write_json_version "$ADAPTERS/openclaw/package.json"
+write_json_version "$ADAPTERS/openclaw/openclaw.plugin.json"
+write_json_version "$ADAPTERS/qoder/.qoder-plugin/plugin.json"
+write_json_version "$ADAPTERS/claude-code/.claude-plugin/plugin.json"
+write_json_version "$ADAPTERS/codex/.codex-plugin/plugin.json"
+write_json_version "$ADAPTERS/qwencode/qwen-extension.json"
+printf '{"name":"anolisa-tokenless"}\n' \
+    > "$ADAPTERS/claude-code/.claude-plugin/marketplace.json"
+printf 'version: "%s"\n' "$VERSION" > "$ADAPTERS/hermes/plugin.yaml"
+printf 'export default {};\n' > "$ADAPTERS/openclaw/dist/index.js"
+printf '{"name":"tokenless","version":"%s"}\n' "$VERSION" \
+    > "$ADAPTERS/common/cosh-extension.json"
+printf '{}\n' > "$ADAPTERS/common/tool-ready-spec.json"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$ADAPTERS/common/tokenless-env-fix.sh"
+printf '#!/usr/bin/env bash\nprintf "shared hook\\n"\n' \
+    > "$ADAPTERS/common/hooks/run-hook.sh"
+printf 'description = "fixture"\n' \
+    > "$ADAPTERS/common/commands/tokenless-stats.toml"
+chmod 0755 \
+    "$ADAPTERS/common/tokenless-env-fix.sh" \
+    "$ADAPTERS/common/hooks/run-hook.sh"
+ln -s ../../common/hooks/run-hook.sh "$ADAPTERS/claude-code/hooks/run-hook.sh"
+ln -s ../../common/hooks/run-hook.sh "$ADAPTERS/qwencode/hooks/run-hook.sh"
+
+make_binaries() {
+    local os="$1"
+    local arch="$2"
+    local destination="$3"
+
+    mkdir -p "$destination"
+    python3 - "$os" "$arch" "$destination" <<'PY'
+import pathlib
+import struct
+import sys
+
+os_name, arch, destination = sys.argv[1:]
+root = pathlib.Path(destination)
+if os_name == "linux":
+    machine = {"x86_64": 62, "aarch64": 183}[arch]
+    header = bytearray(64)
+    header[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into("<H", header, 16, 2)
+    struct.pack_into("<H", header, 18, machine)
+    struct.pack_into("<I", header, 20, 1)
+    content = bytes(header)
+else:
+    cpu = {"aarch64": 0x0100000C}[arch]
+    content = struct.pack("<IiiIIIII", 0xFEEDFACF, cpu, 0, 2, 0, 0, 0, 0)
+for name in ("tokenless", "rtk", "toon"):
+    (root / name).write_bytes(content)
+PY
+    chmod 0755 "$destination/tokenless" "$destination/rtk" "$destination/toon"
+}
+
+LINUX_X64="$TMP/bin-linux-x64"
+LINUX_ARM64="$TMP/bin-linux-arm64"
+MACOS_ARM64="$TMP/bin-macos-arm64"
+make_binaries linux x86_64 "$LINUX_X64"
+make_binaries linux aarch64 "$LINUX_ARM64"
+make_binaries macos aarch64 "$MACOS_ARM64"
+
+run_pack() {
+    local os="$1"
+    local arch="$2"
+    local bins="$3"
+    local output="$4"
+
+    TOKENLESS_SOURCE_DIR="$SOURCE" \
+    RAW_CONTRACT="$CONTRACT" \
+    BIN_DIR="$bins" \
+    TARGET_OS="$os" \
+    TARGET_ARCH="$arch" \
+    OUTPUT_DIR="$output" \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$ROOT/packaging/raw/package.sh" package >/dev/null
+}
+
+OUT_ONE="$TMP/out-one"
+OUT_TWO="$TMP/out-two"
+run_pack linux x64 "$LINUX_X64" "$OUT_ONE"
+run_pack linux x86_64 "$LINUX_X64" "$OUT_TWO"
+LINUX_ARTIFACT="tokenless-$VERSION-linux-x86_64.tar.gz"
+cmp "$OUT_ONE/$LINUX_ARTIFACT" "$OUT_TWO/$LINUX_ARTIFACT"
+
+run_pack linux arm64 "$LINUX_ARM64" "$TMP/out-linux-arm64"
+test -f "$TMP/out-linux-arm64/tokenless-$VERSION-linux-aarch64.tar.gz"
+run_pack darwin arm64 "$MACOS_ARM64" "$TMP/out-macos-arm64"
+test -f "$TMP/out-macos-arm64/tokenless-$VERSION-macos-aarch64.tar.gz"
+
+if run_pack macos x64 "$LINUX_X64" "$TMP/unsupported" 2>/dev/null; then
+    echo "ERROR: macOS x86_64 raw packaging unexpectedly succeeded" >&2
+    exit 1
+fi
+if run_pack linux aarch64 "$LINUX_X64" "$TMP/mislabeled" 2>/dev/null; then
+    echo "ERROR: mislabeled x86_64 binaries unexpectedly passed as aarch64" >&2
+    exit 1
+fi
+
+EXTRACTED="$TMP/extracted"
+mkdir -p "$EXTRACTED"
+tar -xzf "$OUT_ONE/$LINUX_ARTIFACT" -C "$EXTRACTED"
+cmp "$CONTRACT" "$EXTRACTED/.anolisa/component.toml"
+cmp "$LINUX_X64/tokenless" "$EXTRACTED/bin/tokenless"
+cmp "$LINUX_X64/rtk" "$EXTRACTED/libexec/anolisa/tokenless/rtk"
+cmp "$LINUX_X64/toon" "$EXTRACTED/libexec/anolisa/tokenless/toon"
+
+for relative in \
+    adapters/claude-code/hooks/run-hook.sh \
+    adapters/qwencode/hooks/run-hook.sh; do
+    test -f "$EXTRACTED/$relative"
+    test ! -L "$EXTRACTED/$relative"
+    cmp "$ADAPTERS/common/hooks/run-hook.sh" "$EXTRACTED/$relative"
+done
+test -f "$EXTRACTED/extensions/tokenless/cosh-extension.json"
+test -f "$EXTRACTED/extensions/tokenless/hooks/run-hook.sh"
+test -z "$(find "$EXTRACTED" -type l -print -quit)"
+test -z "$(find "$EXTRACTED" \( -name '*.in' -o -name node_modules \) -print -quit)"
+test "$(stat -c '%a' "$EXTRACTED/bin/tokenless")" = 755
+test "$(stat -c '%a' "$EXTRACTED/adapters/manifest.json")" = 644
+test "$(stat -c '%a' "$EXTRACTED/adapters/common/hooks/run-hook.sh")" = 755
+
+grep -Fq 'source = "bin/tokenless"' "$ROOT/.anolisa/component.toml.in"
+grep -Fq 'source = "extensions/tokenless"' "$ROOT/.anolisa/component.toml.in"
+test "$(grep -o '@VERSION@' "$ROOT/.anolisa/component.toml.in" | wc -l)" = 1
+
+echo "tokenless component-owned raw package tests passed"


### PR DESCRIPTION
## Summary

- add a component-owned Raw packer for prebuilt Linux x86_64, Linux aarch64, and macOS aarch64 `tokenless`, `rtk`, and `toon` binaries
- validate release metadata and ELF/Mach-O architecture without executing non-native binaries
- emit reproducible ANOLISA Raw archives with the component contract, adapter resources, normalized permissions, and stable artifact names
- refactor npm packaging around a validator/assembler for prebuilt binaries while preserving the existing command interface and native `make npm-package` entry point
- add component-level Raw/npm packaging tests and usage documentation

## Motivation

Tokenless package layout and release metadata should be maintained alongside the component. This gives component owners a single, versioned implementation for package contents, permissions, adapter resources, validation, and archive naming.

## User and developer impact

- Raw packaging supports `linux-x86_64`, `linux-aarch64`, and `macos-aarch64`; macOS x86_64 Raw packages are intentionally rejected.
- `make package-raw` consumes `BIN_DIR/{tokenless,rtk,toon}` plus `TARGET_OS` and `TARGET_ARCH`.
- `make stage-raw` exposes the same validated payload as an unpacked directory.
- `make npm-package` builds and packages the current host.
- `package-npm.js`, `package-npm.js --target <target>`, and `package-npm.js --all` read prebuilt binaries from `target/npm-prebuilt/<target>/`.
- Both packers verify target architectures without executing non-native binaries.

## Validation

- `make -s test-raw-package`
- `make -s test-npm-package`
- `make npm-package`
- full Tokenless `make test`, including 107/107 hook scenarios and adapter tests
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace -- -D warnings`
- `cargo doc --workspace --no-deps`
- ShellCheck and Node.js syntax checks
- real Linux x86_64 Raw and npm package smoke tests using `tokenless 0.7.5`, `rtk 0.43.0`, and `toon 0.5.0`

Non-native package tests cover target-header validation, deterministic output, payload layout, permissions, rejection of unsupported or mislabeled targets, and byte-for-byte preservation of packaged binaries.