### PR TITLE
fix(cosh-ng): [shell] narrow interactive-cancel needles

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/failed_command_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/failed_command_tests.rs
@@ -1207,3 +1207,73 @@ fn manual_mode_skips_user_interrupted_failed_command_card() {
 
     assert!(output.is_empty());
 }
+
+#[test]
+fn interrupted_substring_failure_is_not_cancel_classified_end_to_end() {
+    let mut block = failed_block(1, "curl https://example.com/api");
+    let output = "curl: (18) transfer was interrupted by peer\n";
+    block.output.terminal_output_ref = Some(write_output(output.as_bytes()));
+
+    // The skip gate must not swallow the block before classification.
+    assert!(!command_should_skip_failure_analysis(&[], &block));
+    let semantics = classify_failure(&block, &[], Some(output));
+    assert_ne!(semantics.class, FailureClass::InteractiveCancel);
+    assert!(!format!("{:?}", semantics.reasons).contains("InteractiveCancelOutput"));
+}
+
+#[test]
+fn access_key_error_failure_is_not_cancel_classified_end_to_end() {
+    let mut block = failed_block(1, "ossutil cp local oss://bucket/key");
+    let output = "Error: InvalidAccessKeyId, the access key id you provided does not exist\n";
+    block.output.terminal_output_ref = Some(write_output(output.as_bytes()));
+
+    assert!(!command_should_skip_failure_analysis(&[], &block));
+    let semantics = classify_failure(&block, &[], Some(output));
+    assert_ne!(semantics.class, FailureClass::InteractiveCancel);
+    assert!(!format!("{:?}", semantics.reasons).contains("InteractiveCancelOutput"));
+}
+
+#[test]
+fn credential_error_header_stays_analyzable_end_to_end() {
+    let mut block = failed_block(1, "ossutil ls oss://bucket");
+    let output =
+        "Error: failed to validate access key id:\n  the key contains invalid characters\n";
+    block.output.terminal_output_ref = Some(write_output(output.as_bytes()));
+
+    assert!(!command_should_skip_failure_analysis(&[], &block));
+    let semantics = classify_failure(&block, &[], Some(output));
+    assert_ne!(semantics.class, FailureClass::InteractiveCancel);
+    assert!(!format!("{:?}", semantics.reasons).contains("InteractiveCancelOutput"));
+}
+
+#[test]
+fn bare_interrupted_line_stays_silent_end_to_end() {
+    let mut block = failed_block(1, "pip install requests");
+    let output = "Collecting requests\nInterrupted\n";
+    block.output.terminal_output_ref = Some(write_output(output.as_bytes()));
+
+    assert_eq!(
+        classify_failure(&block, &[], Some(output)).class,
+        FailureClass::InteractiveCancel
+    );
+    assert_eq!(
+        failure_analysis_disposition(&[], &block, AnalysisMode::Smart, Some(output)),
+        FailureAnalysisDisposition::SilentRecord
+    );
+}
+
+#[test]
+fn credential_prompt_output_stays_silent_end_to_end() {
+    let mut block = failed_block(1, "aliyun configure");
+    let output = "Access Key Id []:";
+    block.output.terminal_output_ref = Some(write_output(output.as_bytes()));
+
+    assert_eq!(
+        classify_failure(&block, &[], Some(output)).class,
+        FailureClass::InteractiveCancel
+    );
+    assert_eq!(
+        failure_analysis_disposition(&[], &block, AnalysisMode::Smart, Some(output)),
+        FailureAnalysisDisposition::SilentRecord
+    );
+}

--- a/src/cosh-ng/crates/cosh-shell/src/command/failure_semantics.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/command/failure_semantics.rs
@@ -505,21 +505,50 @@ use failure_signatures::{
     BoundedOutput,
 };
 
-fn interactive_cancel_output(output: &str) -> bool {
-    [
+/// Shared cancel-output matcher for failure classification and the
+/// failure-analysis skip gate (`hooks::interrupt`). Needles are tiered by
+/// specificity so real failures whose output merely mentions these words
+/// stay analyzable (issue #2090). Input is normalized here (ANSI stripped,
+/// lowercased) because raw callers pass terminal output with control
+/// sequences; the pass is idempotent for pre-normalized callers.
+pub(crate) fn interactive_cancel_output(output: &str) -> bool {
+    let normalized = normalize_output(output);
+    let phrase_hit = [
         "sudo: a password is required",
         "a password is required",
         "a terminal is required",
         "operation cancelled",
         "operation canceled",
         "keyboardinterrupt",
-        "interrupted",
-        "access key id",
-        "access key secret",
-        "default region id",
     ]
     .iter()
-    .any(|needle| output.contains(needle))
+    .any(|needle| normalized.contains(needle));
+    if phrase_hit {
+        return true;
+    }
+
+    normalized.lines().any(|line| {
+        let line = line.trim();
+        // Single-word cancel markers must stand alone on their own line so
+        // failures like "transfer was interrupted by peer" stay analyzable.
+        if line == "interrupted" {
+            return true;
+        }
+        // Credential needles only signal a cancel when the line itself is the
+        // prompt label, optionally with a bracketed default, ending with ':'
+        // (e.g. "access key id []:"); error headers that merely mention the
+        // needle and end with ':' stay analyzable.
+        ["access key id", "access key secret", "default region id"]
+            .iter()
+            .any(|needle| {
+                line.strip_prefix(needle)
+                    .and_then(|rest| rest.strip_suffix(':'))
+                    .is_some_and(|middle| {
+                        let middle = middle.trim();
+                        middle.is_empty() || (middle.starts_with('[') && middle.ends_with(']'))
+                    })
+            })
+    })
 }
 
 fn push_reason_once(reasons: &mut Vec<FailureReason>, reason: FailureReason) {

--- a/src/cosh-ng/crates/cosh-shell/src/command/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/command/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use exit_classify::{
 };
 #[allow(unused_imports)]
 pub(crate) use failure_semantics::{
-    classify_failure, BuildOrTestFamily, FailureAutoEligibility, FailureClass, FailureConfidence,
-    FailureExcerptDirection, FailureReason, FailureSemantics, FailureTerminalSignature,
+    classify_failure, interactive_cancel_output, BuildOrTestFamily, FailureAutoEligibility,
+    FailureClass, FailureConfidence, FailureExcerptDirection, FailureReason, FailureSemantics,
+    FailureTerminalSignature,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/interrupt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/interrupt.rs
@@ -1,7 +1,8 @@
 use std::fs;
 
 use super::prelude::{
-    classify_command_interaction, CommandBlock, PtyRequirement, ShellEvent, ShellEventKind,
+    classify_command_interaction, interactive_cancel_output, CommandBlock, PtyRequirement,
+    ShellEvent, ShellEventKind,
 };
 
 pub(crate) fn command_should_skip_failure_analysis(
@@ -47,24 +48,6 @@ fn output_preview(block: &CommandBlock) -> String {
         return String::new();
     };
     content.chars().take(4096).collect()
-}
-
-fn interactive_cancel_output(output: &str) -> bool {
-    let normalized = output.to_ascii_lowercase();
-    [
-        "sudo: a password is required",
-        "a password is required",
-        "a terminal is required",
-        "operation cancelled",
-        "operation canceled",
-        "keyboardinterrupt",
-        "interrupted",
-        "access key id",
-        "access key secret",
-        "default region id",
-    ]
-    .iter()
-    .any(|needle| normalized.contains(needle))
 }
 
 fn prompt_like_output(output: &str) -> bool {
@@ -156,6 +139,68 @@ mod tests {
         block.output.terminal_output_ref = Some(write_output("Access Key Id []:"));
 
         assert!(command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn detects_bare_interrupted_line_as_cancel() {
+        let mut block = block();
+        block.command = "pip install requests".to_string();
+        block.output.terminal_output_ref = Some(write_output("Collecting requests\nInterrupted\n"));
+
+        assert!(command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn detects_ansi_colored_interrupted_line_as_cancel() {
+        let mut block = block();
+        block.command = "pip install requests".to_string();
+        block.output.terminal_output_ref = Some(write_output(
+            "Collecting requests\n\x1b[31mInterrupted\x1b[0m\n",
+        ));
+
+        assert!(command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn detects_ansi_colored_credential_prompt_as_cancel() {
+        let mut block = block();
+        block.command = "aliyun configure".to_string();
+        block.output.terminal_output_ref = Some(write_output("\x1b[36mAccess Key Id []:\x1b[0m"));
+
+        assert!(command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn keeps_credential_error_header_analyzable() {
+        let mut block = block();
+        block.command = "ossutil ls oss://bucket".to_string();
+        block.output.terminal_output_ref = Some(write_output(
+            "Error: failed to validate access key id:\n  the key contains invalid characters\n",
+        ));
+
+        assert!(!command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn keeps_failures_with_interrupted_substring_analyzable() {
+        let mut block = block();
+        block.command = "curl https://example.com/api".to_string();
+        block.output.terminal_output_ref = Some(write_output(
+            "curl: (18) transfer was interrupted by peer\n",
+        ));
+
+        assert!(!command_should_skip_failure_analysis(&[], &block));
+    }
+
+    #[test]
+    fn keeps_failures_mentioning_access_key_analyzable() {
+        let mut block = block();
+        block.command = "ossutil cp local oss://bucket/key".to_string();
+        block.output.terminal_output_ref = Some(write_output(
+            "Error: InvalidAccessKeyId, the access key id you provided does not exist\n",
+        ));
+
+        assert!(!command_should_skip_failure_analysis(&[], &block));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/prelude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/prelude.rs
@@ -2,7 +2,7 @@
 pub(super) use crate::adapter::AdapterInstance;
 #[cfg(test)]
 pub(super) use crate::adapter::{prompt_from_request, FakeAgentAdapter};
-pub(super) use crate::command::first_program_token;
+pub(super) use crate::command::{first_program_token, interactive_cancel_output};
 pub(super) use crate::config::Language;
 pub(super) use crate::config::{load_hook_feedback_preference_details, HookFeedbackPreference};
 pub(super) use crate::evidence::{


### PR DESCRIPTION
## Summary

`interactive_cancel_output` in `crates/cosh-shell/src/hooks/interrupt.rs` matched a set of overly broad needles with plain substring `contains`: any `exit_code=1` command whose output merely contained `"interrupted"`, `"access key id"`, `"access key secret"` or `"default region id"` was misclassified as a user-interactive cancel, so failure analysis was silently skipped for real failures (e.g. `curl: (18) transfer was interrupted by peer`, `InvalidAccessKeyId` errors).

This PR tiers the needles by specificity instead of removing them, preserving every existing by-design detection.

Closes #2090

## Changes

- The cancel matcher is converged into a single shared `pub(crate) fn interactive_cancel_output` in `command/failure_semantics.rs` (review round 1: `classify_failure` had a second wide-substring copy which still classified these outputs as `InteractiveCancel`); `hooks/interrupt.rs` now reuses it via the hooks prelude.
- The shared matcher normalizes its input itself (review round 2: ANSI strip + lowercase via the module's `normalize_output`, idempotent for the pre-normalized `classify_failure` path) — `hooks/interrupt.rs` passes raw `output_preview` text, so colored cancels like `\x1b[31mInterrupted\x1b[0m` must not slip past the line-shape checks.
- The shared matcher applies three tiers:
  - multi-word cancel phrases (`sudo: a password is required`, `operation cancelled/canceled`, `keyboardinterrupt`, …) keep substring matching — they are specific enough that false hits are negligible;
  - the bare `interrupted` marker only counts when a line, after trim, is exactly `interrupted`;
  - credential needles (`access key id`, `access key secret`, `default region id`) only count when the line itself is the prompt label — it must start with the needle and carry at most a bracketed default before the trailing `:` (review round 3: colon-ended error headers like `Error: failed to validate access key id:` previously matched the looser contains + `ends_with(':')` shape). `Access Key Id []:` prompts from `aliyun configure` stay detected; `InvalidAccessKeyId …` errors and credential error headers stay analyzable.
- No change to the `exit_code == 1` gate, the ctrl-c event window (`command_has_user_interrupt_event`), the 4096-char `output_preview` truncation, or the `prompt_like_output` fallback.
- All production paths are covered by the one shared predicate: the skip gate (`agent/failed_command.rs::failure_analysis_disposition`, `runtime/hooks.rs::record_command_hook_findings`) and the classifier (`command/failure_semantics.rs::classify_failure`). A repo-wide grep confirms no further copies.

## Tests

Added in `hooks::interrupt::tests` (production entry `command_should_skip_failure_analysis` through the real `output_preview` file path):

- `keeps_failures_with_interrupted_substring_analyzable` — `curl: (18) transfer was interrupted by peer` must not be skipped (FAIL before this fix);
- `keeps_failures_mentioning_access_key_analyzable` — `Error: InvalidAccessKeyId, the access key id you provided does not exist` must not be skipped (FAIL before this fix);
- `detects_bare_interrupted_line_as_cancel` — a standalone `Interrupted` line is still treated as a user cancel;
- `detects_ansi_colored_interrupted_line_as_cancel` / `detects_ansi_colored_credential_prompt_as_cancel` (review round 2) — ANSI-colored cancel lines still match after in-matcher normalization (both FAIL without it);
- `keeps_credential_error_header_analyzable` (hook gate) and `credential_error_header_stays_analyzable_end_to_end` (skip gate + `classify_failure`, review round 3) — colon-ended credential error headers are not treated as prompts (both FAIL against the previous prompt-shape check).

Added in `agent::failed_command::tests` (review round 1, end-to-end through `classify_failure` + the skip gate; placed in this bin-only module so the `check-test-inventory.sh` lib/bin overlap ceiling stays at 688):

- `interrupted_substring_failure_is_not_cancel_classified_end_to_end` / `access_key_error_failure_is_not_cancel_classified_end_to_end` — skip gate stays open and `classify_failure` no longer yields `InteractiveCancel` nor an `InteractiveCancelOutput` reason (both FAIL against the wide matcher). Honest scope note: these outputs classify as `GenericRuntimeFailure`/`UnknownFailure`, which stay `SilentRecord` by the existing disposition table — the fix removes the false *cancel* attribution; it does not promise an action card for them;
- `bare_interrupted_line_stays_silent_end_to_end` / `credential_prompt_output_stays_silent_end_to_end` — true cancels still classify `InteractiveCancel` and stay `SilentRecord`.

Existing contract tests remain untouched and green: sudo password prompt, `aliyun configure` credential prompt, ctrl-c window boundaries, plain `exit 1` stays analyzable.

## Verification

- FAIL→PASS control: `cargo test -p cosh-shell --bin cosh-shell hooks::interrupt` — on the unfixed base the two regression tests fail (`5 passed; 2 failed`); with the fix all pass (`8 passed; 0 failed`). Note the module is compiled into the **bin** target only (the lib target maps `hooks` via `hooks/public.rs` to model+engine), hence `--bin cosh-shell`.
- Round-1 FAIL→PASS control: with the wide matcher temporarily restored, the two new end-to-end regressions fail; with the shared tiered matcher they pass (`end_to_end` filter: `4 passed; 0 failed`; `--lib failure_semantics`: `16 passed; 0 failed`).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `crates/cosh-shell/scripts/check-layout.sh`, `scripts/check-test-inventory.sh` all green locally; no upstream drift at submission time.
- Not run locally (excluded scope, delegated to CI): full workspace test suite, release build.

## Evidence

Pure classification-logic fix with no UI rendering path; evidence is anchored in-repo by the regression test names above and the FAIL→PASS control command. No screenshot/cast assets apply.
