### PR TITLE
fix(cosh-ng): [shell] pair finish after correlated intercept in ledger

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/ledger/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ledger/mod.rs
@@ -12,6 +12,17 @@ pub struct LedgerOutput {
 
 pub fn build_command_blocks(events: &[ShellEvent]) -> LedgerOutput {
     let mut starts = BTreeMap::new();
+    // Starts closed by a correlated intercept (#2106). Ledger contract for a
+    // started command: it yields a block (finish pairs a live or intercepted
+    // start), or an explicit command_started_without_finish error (start
+    // neither intercepted nor finished), or a by-design silent close (start
+    // intercepted and never finished — the NL interception path from #1742,
+    // which must stay free of block and error output). This map holds the
+    // third state: excluded from the started-without-finish sweep, yet still
+    // able to pair a later finish so an intercepted command that ran to
+    // completion keeps its block instead of degrading into
+    // command_finished_without_start.
+    let mut intercepted = BTreeMap::new();
     let mut blocks = Vec::new();
     let mut errors = Vec::new();
 
@@ -30,7 +41,10 @@ pub fn build_command_blocks(events: &[ShellEvent]) -> LedgerOutput {
                     continue;
                 };
 
-                let Some(start) = starts.remove(command_id) else {
+                let Some(start) = starts
+                    .remove(command_id)
+                    .or_else(|| intercepted.remove(command_id))
+                else {
                     errors.push(format!("command_finished_without_start:{command_id}"));
                     continue;
                 };
@@ -75,7 +89,9 @@ pub fn build_command_blocks(events: &[ShellEvent]) -> LedgerOutput {
             }
             ShellEventKind::UserInputIntercepted => {
                 if let Some(command_id) = &event.command_id {
-                    starts.remove(command_id);
+                    if let Some(start) = starts.remove(command_id) {
+                        intercepted.insert(command_id.clone(), start);
+                    }
                 }
             }
             _ => {}
@@ -125,5 +141,54 @@ mod tests {
 
         assert!(output.errors.is_empty());
         assert!(output.blocks.is_empty());
+    }
+
+    #[test]
+    fn user_input_intercepted_does_not_drop_subsequent_finish() {
+        let start = ShellEvent::command_started("session", "command", "echo ok", "/tmp", 1);
+        let mut intercept = ShellEvent::user_input_intercepted("session", "echo ok");
+        intercept.command_id = Some("command".to_string());
+        intercept.component = Some("natural_language".to_string());
+        let finish = ShellEvent::command_finished(
+            ShellEventKind::CommandCompleted,
+            "session",
+            "command",
+            0,
+            2,
+            "/tmp/output",
+        );
+
+        let output = build_command_blocks(&[start, intercept, finish]);
+
+        assert_eq!(output.blocks.len(), 1, "errors: {:?}", output.errors);
+        assert!(
+            !output
+                .errors
+                .iter()
+                .any(|error| error.starts_with("command_finished_without_start")),
+            "errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn user_input_intercepted_does_not_drop_subsequent_failed_finish() {
+        let start = ShellEvent::command_started("session", "command", "echo ok", "/tmp", 1);
+        let mut intercept = ShellEvent::user_input_intercepted("session", "echo ok");
+        intercept.command_id = Some("command".to_string());
+        intercept.component = Some("natural_language".to_string());
+        let finish = ShellEvent::command_finished(
+            ShellEventKind::CommandFailed,
+            "session",
+            "command",
+            1,
+            2,
+            "/tmp/output",
+        );
+
+        let output = build_command_blocks(&[start, intercept, finish]);
+
+        assert_eq!(output.blocks.len(), 1, "errors: {:?}", output.errors);
+        assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
     }
 }


### PR DESCRIPTION
## Summary

`ledger::build_command_blocks` dropped an entire command block when a correlated `UserInputIntercepted` carried the same `command_id` as an in-flight `CommandStarted` and a `CommandCompleted`/`CommandFailed` followed: the intercept branch removed the start outright, so the finish fell into the `command_finished_without_start` error branch and the block was silently discarded, violating the ledger integrity contract (every started command yields either a block or an explicit error).

Fixes #2106

## Changes

- `crates/cosh-shell/src/ledger/mod.rs`: intercept-closed starts now move into an `intercepted` side map instead of being discarded. A later finish restores the pairing from the side map and emits the block; intercepts without a finish keep the existing by-design silent close (no `command_started_without_finish` noise for NL interception, introduced with #1742 and anchored by `correlated_intercept_closes_start_without_creating_command_block`).

## Scope notes (deviations from the issue text)

- The ambiguous sequence is **not reachable from the current osc parser**: a correlated intercept clears the in-flight command (`shell_host/osc/routing.rs`), so no finish is emitted for that `command_id` afterwards. This change hardens the pure function against out-of-contract event streams, matching the maintainer triage (robustness defect, P2).
- The issue's repro step `cosh-ng ledger build --session <sid>` does not exist in the tree (no ledger subcommand in any crate); the reproducible surface is the unit level, which this PR anchors.
- Non-goals (kept out per triage): attaching `intercepted_at_ms` metadata to `CommandBlock`, a new `CommandCancelled` event kind, and an explicit `command_intercepted_without_finish` warning (the last one would regress the by-design silent close).

## Tests

- New: `ledger::tests::user_input_intercepted_does_not_drop_subsequent_finish` — FAILED on the unpatched base with exactly the reported `command_finished_without_start:command` error, PASSES with the fix.
- New: `ledger::tests::user_input_intercepted_does_not_drop_subsequent_failed_finish` — same sequence with `CommandFailed`, asserts a block and zero errors.
- Anchored regression kept green: `correlated_intercept_closes_start_without_creating_command_block` (intercept without finish stays silent, no block).

## Verification

- Focused green: `cargo test -p cosh-shell --bin cosh-shell` — 2360 passed, 0 failed (after rebase onto latest main).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- Gates green locally: `crates/cosh-shell/scripts/check-layout.sh`, `scripts/check-test-inventory.sh`.
- Excluded scope (not run / not attributable): `tests/protocol` suite fails on the macOS dev host in both baseline and patched runs with cosh-core spawn/timeout signatures (pre-existing host environment limitation); Linux CI is the arbiter. No real-PTY acceptance run: the defective sequence is unreachable end-to-end from the current emitter (see scope notes), so the unit-level FAIL→PASS contrast is the acceptance evidence.

## Evidence

- FAIL baseline and PASS logs archived locally (`cosh-2106-fail-baseline-20260804/{fail-baseline,pass-after-fix}-cargo-test.log`); key excerpts quoted above. No screenshots apply (pure-function defect, no TUI surface).
