### PR TITLE
fix(bench): read ssh password from env not argv

### DIFF
--- a/src/tokenless/benchmark/l2-module/README.md
+++ b/src/tokenless/benchmark/l2-module/README.md
@@ -89,8 +89,17 @@ degradation in the report:
 
 ## Security note
 
-> The remote scripts use `sshpass -p "$L2_SSH_PASS"` for non-interactive
-> SSH/rsync against short-lived benchmark hosts. Never hard-code passwords
-> or keys anywhere in the repository (see AGENTS.md §10 sensitive-data
-> gate); prefer key-based auth when wiring these scripts into any
-> longer-lived pipeline.
+> The remote scripts authenticate non-interactive SSH/rsync with
+> `SSHPASS="$L2_SSH_PASS" sshpass -e`. `-e` reads the password from the
+> environment rather than argv: with `-p` the password appears in the process
+> table and any local user can read it out of `ps`. Never hard-code passwords
+> or keys anywhere in the repository (see AGENTS.md §10 sensitive-data gate);
+> prefer key-based auth when wiring these scripts into any longer-lived
+> pipeline.
+>
+> `-e` narrows the exposure but does not remove it. The password still lives in
+> the process environment, so anything running as the same user (or as root) can
+> read it from `/proc/<pid>/environ` for as long as the process exists. On a
+> shared or multi-tenant runner, treat that as unacceptable and use key-based
+> auth instead: `-e` is a fix for the `ps`-visible-to-everyone case, not a way to
+> make password auth safe on a host you do not control.

--- a/src/tokenless/benchmark/l2-module/assets/scripts/remote_run.sh
+++ b/src/tokenless/benchmark/l2-module/assets/scripts/remote_run.sh
@@ -53,7 +53,7 @@ for arg in "$@"; do
 done
 
 echo "[run] executing l2_compare on $L2_SSH_HOST"
-sshpass -p "$L2_SSH_PASS" ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
+SSHPASS="$L2_SSH_PASS" sshpass -e ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
     "DASHSCOPE_API_KEY=$SAFE_DASHSCOPE_API_KEY \
      HEADROOM_PYTHON=$L2_REMOTE_WORK/headroom-venv/bin/python \
      RTK_BIN=$L2_REMOTE_WORK/anolisa/src/tokenless/third_party/rtk/target/release/rtk \
@@ -64,7 +64,7 @@ sshpass -p "$L2_SSH_PASS" ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
 LOCAL_REPORTS="$SCRIPT_DIR/../../reports"
 mkdir -p "$LOCAL_REPORTS"
 echo "[run] pulling reports back to $LOCAL_REPORTS"
-sshpass -p "$L2_SSH_PASS" rsync -az -e "ssh ${SSH_OPTS[*]}" \
+SSHPASS="$L2_SSH_PASS" sshpass -e rsync -az -e "ssh ${SSH_OPTS[*]}" \
     "$L2_SSH_USER@$L2_SSH_HOST:$L2_REMOTE_WORK/anolisa/src/tokenless/benchmark/l2-module/reports/" \
     "$LOCAL_REPORTS/"
 

--- a/src/tokenless/benchmark/l2-module/assets/scripts/remote_setup.sh
+++ b/src/tokenless/benchmark/l2-module/assets/scripts/remote_setup.sh
@@ -32,14 +32,14 @@ L2_REMOTE_WORK="${L2_REMOTE_WORK:-/root/work}"
 SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null)
 
 remote_ssh() {
-    sshpass -p "$L2_SSH_PASS" ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" "$@"
+    SSHPASS="$L2_SSH_PASS" sshpass -e ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" "$@"
 }
 
 # --- 1. Upload the idempotent inner build script ----------------------------
 # The heredoc is quoted so nothing is expanded locally; every $VAR is resolved
 # on the remote when the script actually runs.
 echo "[setup] uploading remote build script"
-sshpass -p "$L2_SSH_PASS" ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
+SSHPASS="$L2_SSH_PASS" sshpass -e ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
     "mkdir -p $L2_REMOTE_WORK/logs && cat > $L2_REMOTE_WORK/remote_build_inner.sh" <<'INNER'
 #!/usr/bin/env bash
 # Heavy, idempotent remote build. Runs under nohup; each step streams to its

--- a/src/tokenless/benchmark/l2-module/assets/scripts/remote_sync.sh
+++ b/src/tokenless/benchmark/l2-module/assets/scripts/remote_sync.sh
@@ -69,16 +69,16 @@ RSYNC_EXCLUDES=(
 # fresh box without the workspace root would fail on the very first transfer.
 # Create the destination root up front (idempotent).
 echo "[sync] ensuring $L2_REMOTE_WORK exists on $L2_SSH_HOST"
-sshpass -p "$L2_SSH_PASS" ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
+SSHPASS="$L2_SSH_PASS" sshpass -e ssh "${SSH_OPTS[@]}" "$L2_SSH_USER@$L2_SSH_HOST" \
     "mkdir -p $L2_REMOTE_WORK"
 
 echo "[sync] anolisa -> $L2_SSH_USER@$L2_SSH_HOST:$L2_REMOTE_WORK/anolisa"
-sshpass -p "$L2_SSH_PASS" rsync -az --delete "${RSYNC_EXCLUDES[@]}" \
+SSHPASS="$L2_SSH_PASS" sshpass -e rsync -az --delete "${RSYNC_EXCLUDES[@]}" \
     -e "ssh ${SSH_OPTS[*]}" \
     "$ANOLISA_SRC/" "$L2_SSH_USER@$L2_SSH_HOST:$L2_REMOTE_WORK/anolisa/"
 
 echo "[sync] headroom -> $L2_SSH_USER@$L2_SSH_HOST:$L2_REMOTE_WORK/headroom"
-sshpass -p "$L2_SSH_PASS" rsync -az --delete "${RSYNC_EXCLUDES[@]}" \
+SSHPASS="$L2_SSH_PASS" sshpass -e rsync -az --delete "${RSYNC_EXCLUDES[@]}" \
     -e "ssh ${SSH_OPTS[*]}" \
     "$HEADROOM_SRC/" "$L2_SSH_USER@$L2_SSH_HOST:$L2_REMOTE_WORK/headroom/"
 


### PR DESCRIPTION
The L2 remote scripts passed the password with `sshpass -p "$L2_SSH_PASS"`, which places it in the process argv where any local user can read it out of the process table. The password was never hard-coded, so this was a disclosure path rather than a leaked credential, but the exposure is real on any shared or multi-user runner.

Switched all seven call sites to `SSHPASS="$L2_SSH_PASS" sshpass -e`, which takes the password from the environment instead. Chose -e over a password file because a file adds a cleanup obligation on abnormal exit, and over key-based auth because these scripts target short-lived benchmark hosts where provisioning keys is out of scope; the README now records key-based auth as the preference for anything longer-lived.

Verified on the benchmark host that `sshpass -e` authenticates, that the nested `sshpass -e rsync -e "ssh ..."` form parses correctly (sshpass consumes its own -e before rsync sees the second one), and that the password no longer appears in the process table.

Assisted-by: Qoder

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
