### PR TITLE
feat(sec-core): add capability view CLI

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -336,7 +336,7 @@ agent-sec-cli capabilities --agent hermes --capability code-scan
 agent-sec-cli capabilities --agent qwen --capability pii-check --output json
 ```
 
-Supported capability names are exactly `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`; plugin-internal IDs such as `scan-code`, `prompt-scan-user-input`, or `pii-scan-user-input` are rejected. Table output is grouped by Agent and includes `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`; `MODE` is the hook interaction mode, while `SCAN_MODE` is the prompt scanner engine mode (`fast`, `standard`, or `strict`). JSON output uses the same user-facing fields and also includes the current CLI process environment values and diagnostics.
+Supported capability names are exactly `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`; plugin-internal IDs such as `scan-code`, `prompt-scan-user-input`, or `pii-scan-user-input` are rejected. Table output is grouped by Agent and includes only `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`; `MODE` is the hook interaction mode, while `SCAN_MODE` is the prompt scanner engine mode (`fast`, `standard`, or `strict`). JSON output uses the same user-facing fields and sanitized `env` entries containing only `effective` and `default` values. Neither format exposes hook matcher lists, source labels, Agent config contents, config paths, or raw environment variable values. Diagnostics name the invalid setting and fallback behavior without echoing the original value.
 
 View source and limits:
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -313,6 +313,37 @@ agent-sec-cli events --offset 50 --limit 20
 agent-sec-cli events --summary
 ```
 
+### Agent Capability View
+
+`agent-sec-cli capabilities` shows the hook capability view for Qoder, Qwen Code, Codex, Cosh, OpenClaw, and Hermes derived from environment variables visible to the current CLI process. It is not a runtime health check and does not prove that hooks are loaded, registered, or currently effective in the target Agent process.
+
+Run the command from the same shell/container/service environment that starts the target Agent when you want the closest approximation. The command does not read OpenClaw, Hermes, or other Agent configuration files, and it does not resolve Agent home directories; Agent config values such as enabled flags, policies, and timeouts can still make runtime behavior differ from this view.
+
+```bash
+# All agents and all capabilities
+agent-sec-cli capabilities
+
+# By agent
+agent-sec-cli capabilities --agent openclaw
+
+# By capability
+agent-sec-cli capabilities --capability prompt-scan
+
+# By agent and capability
+agent-sec-cli capabilities --agent hermes --capability code-scan
+
+# Machine-readable output
+agent-sec-cli capabilities --agent qwen --capability pii-check --output json
+```
+
+Supported capability names are exactly `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`; plugin-internal IDs such as `scan-code`, `prompt-scan-user-input`, or `pii-scan-user-input` are rejected. Table output is grouped by Agent and includes `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`; `MODE` is the hook interaction mode, while `SCAN_MODE` is the prompt scanner engine mode (`fast`, `standard`, or `strict`). JSON output uses the same user-facing fields and also includes the current CLI process environment values and diagnostics.
+
+View source and limits:
+
+- Source: static hook capability metadata plus environment variables visible to the current CLI process.
+- Not included: OpenClaw, Hermes, or other Agent configuration files; Agent home directories; live hook loading or registration state.
+- Known drift: running the command from a different shell/container/service or with different Agent config can produce output that differs from real Agent runtime behavior.
+
 ## Agent Framework Integration
 
 ### OpenClaw

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -307,6 +307,38 @@ agent-sec-cli events --offset 50 --limit 20
 agent-sec-cli events --summary
 ```
 
+### Agent Capability 视图
+
+`agent-sec-cli capabilities` 展示当前 CLI 进程可见环境变量推导出的 Qoder、Qwen Code、Codex、Cosh、OpenClaw 和 Hermes hook capability 视图。它不是运行时健康检查，不能证明 hook 已在目标 Agent 进程中加载、注册或实际生效。
+
+若希望结果尽量接近目标 Agent，请在启动目标 Agent 的同一 shell/container/service 环境中运行该命令。命令不读取 OpenClaw、Hermes 或其他 Agent 的配置文件，也不解析 Agent home 目录；Agent 配置中的 enabled、policy、timeout 等值仍可能让真实运行行为与该视图不同。
+
+```bash
+# 展示所有 agent 的所有 capability
+agent-sec-cli capabilities
+
+# 按 agent 查询
+agent-sec-cli capabilities --agent openclaw
+
+# 按 capability 查询
+agent-sec-cli capabilities --capability prompt-scan
+
+# 同时按 agent 和 capability 查询
+agent-sec-cli capabilities --agent hermes --capability code-scan
+
+# JSON 输出，便于脚本消费
+agent-sec-cli capabilities --agent qwen --capability pii-check --output json
+```
+
+支持的 capability 名称只能是 `code-scan`、`prompt-scan`、`pii-check`、`skill-ledger` 和 `observability`；`scan-code`、`prompt-scan-user-input`、`pii-scan-user-input` 等插件内部 ID 会被拒绝。表格输出按 Agent 分块展示，每个分块包含 `CAPABILITY`、`ENABLED`、`MODE`、`SCAN_MODE`、`TIMEOUT(s)` 和 `DIAGNOSTICS`；`MODE` 表示 hook 交互方式，`SCAN_MODE` 表示 prompt scanner 引擎档位（`fast`、`standard` 或 `strict`）。JSON 输出使用同样的用户可见字段，并额外包含当前 CLI 进程可见的环境变量值和诊断信息。
+
+视图来源和限制：
+
+- 来源：静态 hook capability metadata 加当前 CLI 进程可见的环境变量。
+- 不包含：OpenClaw、Hermes 或其他 Agent 配置文件；Agent home 目录；实时 hook 加载或注册状态。
+- 已知偏移：从不同 shell/container/service 运行命令，或真实 Agent 使用不同配置时，输出可能与真实运行行为不同。
+
+
 ## Agent 框架集成
 
 ### OpenClaw

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -330,7 +330,7 @@ agent-sec-cli capabilities --agent hermes --capability code-scan
 agent-sec-cli capabilities --agent qwen --capability pii-check --output json
 ```
 
-支持的 capability 名称只能是 `code-scan`、`prompt-scan`、`pii-check`、`skill-ledger` 和 `observability`；`scan-code`、`prompt-scan-user-input`、`pii-scan-user-input` 等插件内部 ID 会被拒绝。表格输出按 Agent 分块展示，每个分块包含 `CAPABILITY`、`ENABLED`、`MODE`、`SCAN_MODE`、`TIMEOUT(s)` 和 `DIAGNOSTICS`；`MODE` 表示 hook 交互方式，`SCAN_MODE` 表示 prompt scanner 引擎档位（`fast`、`standard` 或 `strict`）。JSON 输出使用同样的用户可见字段，并额外包含当前 CLI 进程可见的环境变量值和诊断信息。
+支持的 capability 名称只能是 `code-scan`、`prompt-scan`、`pii-check`、`skill-ledger` 和 `observability`；`scan-code`、`prompt-scan-user-input`、`pii-scan-user-input` 等插件内部 ID 会被拒绝。表格输出按 Agent 分块展示，仅包含 `CAPABILITY`、`ENABLED`、`MODE`、`SCAN_MODE`、`TIMEOUT(s)` 和 `DIAGNOSTICS`；`MODE` 表示 hook 交互方式，`SCAN_MODE` 表示 prompt scanner 引擎档位（`fast`、`standard` 或 `strict`）。JSON 输出使用同样的用户可见字段，并包含经过脱敏投影的 `env` 条目，其中只含 `effective` 和 `default`。两种格式都不会暴露 hook matcher 列表、source 标签、Agent config 内容、config 路径或原始环境变量值。诊断信息只说明哪个设置无效及 fallback 行为，不回显原始值。
 
 视图来源和限制：
 

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -263,6 +263,29 @@ include = [
 > Lint 检查仅在 PR 触发时对增量代码检查，不检查历史代码。违规信息显示在 PR 的 Job Summary 区域。
 > 增量覆盖率门禁仅在 PR 触发，要求本次 PR 新增/修改的代码行中被测试覆盖的比例 ≥ 80%。
 
+### 12. Capability View Maintenance
+
+`agent-sec-cli capabilities` is the canonical read-only environment-variable view of agent-sec plugin hook capabilities. Treat it as part of the hook environment contract, but do not treat it as proof of the target Agent's live runtime state.
+
+The view and the hook runtime have an implicit dependency: they must interpret hook environment variables the same way while remaining deployment-decoupled. Hook code must not import `agent_sec_cli` to share parsing logic, because hooks and the CLI are installed and executed in different raw/RPM/plugin layouts.
+
+When changing any Agent plugin hook environment behavior, update the capability view in the same PR. This includes:
+
+- Adding, removing, or renaming a hook or capability in Qoder, Qwen Code, Codex, Cosh, OpenClaw, or Hermes integrations
+- Changing environment variables, defaults, accepted values, timeout behavior, mode/policy semantics, legacy fallback behavior, or enabled/disabled behavior
+- Changing hook matchers or hook names that appear in manifests such as `hooks.json`, `qwen-extension.json`, `cosh-extension.json`, `openclaw.plugin.json`, or `hermes-plugin/src/plugin.yaml`
+
+Required synchronized updates:
+
+1. Update `agent-sec-cli/src/agent_sec_cli/capabilities/` metadata and parsing logic.
+2. Update CLI/user documentation for `agent-sec-cli capabilities`.
+3. Update unit/e2e tests that lock each Agent's capability, hook, and environment-variable mapping.
+4. Add or update tests that verify CLI parsing semantics match existing hook semantics for shared environment variables.
+
+Important scope boundary: `agent-sec-cli capabilities` reads only the current CLI process environment variables. It must not read OpenClaw, Hermes, or other Agent configuration files; it must not resolve Agent home directories; and its output must not be described as actual hook load, registration, or runtime-effective state. Config-driven differences are allowed to exist and must be documented as known drift.
+
+Qwen Code PII currently has a specific compatibility fallback: `PII_CHECKER_HOOK_ENABLED` takes precedence, and legacy `PII_CHECKER_ENABLED` is consulted only when the new variable is absent. Do not generalize that fallback to other Agents unless their hook runtime implements it too.
+
 ---
 
 ## raw packaging

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -333,6 +333,28 @@ check carries Qoder trace identifiers into the security audit log.
 
 Design doc: [`docs/design/SKILL_LEDGER_zh.md`](docs/design/SKILL_LEDGER_zh.md) · User guide: [Skill Ledger User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md)
 
+## Agent Capability View
+
+`agent-sec-cli capabilities` shows the hook capability view derived from environment variables visible to the current CLI process across Qoder, Qwen Code, Codex, Cosh, OpenClaw, and Hermes.
+
+The command does not read OpenClaw, Hermes, or other Agent configuration files, and it does not resolve Agent home directories. Run it from the same shell/container/service environment that starts the target Agent when you want the closest approximation, but treat the output as an environment-variable view only: it does not prove that hooks are loaded, registered, or currently effective in the target Agent process. Agent config values such as enabled flags, policies, and timeouts can still make runtime behavior differ from this view.
+
+```bash
+# All agents and all hook capabilities
+agent-sec-cli capabilities
+
+# Filter by agent
+agent-sec-cli capabilities --agent openclaw
+
+# Filter by capability
+agent-sec-cli capabilities --capability code-scan
+
+# Filter by agent and capability, with machine-readable output
+agent-sec-cli capabilities --agent hermes --capability pii-check --output json
+```
+
+Supported capability names are fixed: `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`. Plugin-specific IDs such as `scan-code` or `pii-scan-user-input` are not accepted as CLI filters.
+
 ## Audit Log
 
 All security events are logged as JSONL to `/var/log/agent-sec/security-events.jsonl` (falls back to `~/.agent-sec-core/security-events.jsonl`):

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -355,6 +355,8 @@ agent-sec-cli capabilities --agent hermes --capability pii-check --output json
 
 Supported capability names are fixed: `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`. Plugin-specific IDs such as `scan-code` or `pii-scan-user-input` are not accepted as CLI filters.
 
+Table output is limited to `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`. JSON output keeps the same user-facing fields and sanitized `env` entries containing only `effective` and `default` values. Neither output format exposes hook matcher lists, source labels, Agent config contents, config paths, or raw environment variable values. Diagnostics identify the invalid setting and fallback behavior without echoing the original value.
+
 ## Audit Log
 
 All security events are logged as JSONL to `/var/log/agent-sec/security-events.jsonl` (falls back to `~/.agent-sec-core/security-events.jsonl`):

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -353,6 +353,8 @@ agent-sec-cli capabilities --agent hermes --capability pii-check --output json
 
 支持的 capability 名称固定为：`code-scan`、`prompt-scan`、`pii-check`、`skill-ledger` 和 `observability`。CLI 过滤参数不接受 `scan-code` 或 `pii-scan-user-input` 等插件内部 ID。
 
+表格输出仅包含稳定的用户可见列：`CAPABILITY`、`ENABLED`、`MODE`、`SCAN_MODE`、`TIMEOUT(s)` 和 `DIAGNOSTICS`。JSON 输出保留同样的用户字段，并额外包含经过脱敏投影的 `env` 条目，其中只含 `effective` 和 `default`。两种格式都不会暴露 hook matcher 列表、source 标签、Agent config 内容、config 路径或原始环境变量值。诊断信息只说明哪个设置无效及 fallback 行为，不回显原始值。
+
 ## 审计日志
 
 所有安全事件以 JSONL 格式记录至 `/var/log/agent-sec/security-events.jsonl`（回退路径：`~/.agent-sec-core/security-events.jsonl`）：

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -331,6 +331,28 @@ Skill，随后执行只读的 `skill-ledger check`，并按
 
 设计文档：[`docs/design/SKILL_LEDGER_zh.md`](docs/design/SKILL_LEDGER_zh.md) · 用户指南：[Skill Ledger 用户手册](../../docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md)
 
+## Agent Capability 视图
+
+`agent-sec-cli capabilities` 用于查看当前 CLI 进程可见环境变量推导出的 Qoder、Qwen Code、Codex、Cosh、OpenClaw 和 Hermes agent-sec hook capability 视图。
+
+该命令不读取 OpenClaw、Hermes 或其他 Agent 的配置文件，也不解析 Agent home 目录。若希望结果尽量接近目标 Agent，请在启动目标 Agent 的同一 shell/container/service 环境中运行；即便如此，输出也只代表当前 CLI 环境变量视图，不能证明 hook 已在目标 Agent 进程中加载、注册或实际生效。Agent 配置中的 enabled、policy、timeout 等值仍可能让真实运行行为与该视图不同。
+
+```bash
+# 展示所有 agent 的所有 hook capability
+agent-sec-cli capabilities
+
+# 按 agent 过滤
+agent-sec-cli capabilities --agent openclaw
+
+# 按 capability 过滤
+agent-sec-cli capabilities --capability code-scan
+
+# 同时按 agent 和 capability 过滤，并输出 JSON
+agent-sec-cli capabilities --agent hermes --capability pii-check --output json
+```
+
+支持的 capability 名称固定为：`code-scan`、`prompt-scan`、`pii-check`、`skill-ledger` 和 `observability`。CLI 过滤参数不接受 `scan-code` 或 `pii-scan-user-input` 等插件内部 ID。
+
 ## 审计日志
 
 所有安全事件以 JSONL 格式记录至 `/var/log/agent-sec/security-events.jsonl`（回退路径：`~/.agent-sec-core/security-events.jsonl`）：

--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -119,6 +119,8 @@ Run it from the same shell/container/service environment that starts the target 
 
 Supported capability filters are fixed to `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`; plugin-internal IDs are not accepted as aliases.
 
+Table output is limited to the stable user-facing columns `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`. JSON output uses the same user-facing fields plus sanitized `env` entries with `effective` and `default` values. Neither format exposes hook matcher lists, source labels, Agent config contents, config paths, or raw environment variable values. Diagnostics name the invalid setting and fallback behavior without echoing the original value.
+
 ### Observability Records
 
 `agent-sec-cli observability record` accepts one JSON object from stdin and writes

--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -105,7 +105,19 @@ agent-sec-cli summary --hours 72 --format json
 # Observability record ingestion
 agent-sec-cli observability record --format json --stdin < record.json
 agent-sec-cli observability schema
+
+# Agent plugin capability configuration view
+agent-sec-cli capabilities
+agent-sec-cli capabilities --agent openclaw --capability code-scan --output json
 ```
+
+### Agent Plugin Capability View
+
+`agent-sec-cli capabilities` prints the hook capability view derived from environment variables visible to the current CLI process. It does not read OpenClaw, Hermes, or other Agent configuration files, and it does not resolve Agent home directories.
+
+Run it from the same shell/container/service environment that starts the target Agent when you want the closest approximation. Even then, the output is not proof that hooks are loaded, registered, or currently effective in the target Agent process; Agent config values such as enabled flags, policies, and timeouts can still make runtime behavior differ from this view.
+
+Supported capability filters are fixed to `code-scan`, `prompt-scan`, `pii-check`, `skill-ledger`, and `observability`; plugin-internal IDs are not accepted as aliases.
 
 ### Observability Records
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/__init__.py
@@ -1,0 +1,21 @@
+"""Agent capability configuration view."""
+
+from agent_sec_cli.capabilities.view import (
+    AGENTS,
+    CANONICAL_CAPABILITIES,
+    CapabilityRecord,
+    CapabilityViewError,
+    query_capabilities,
+    render_json,
+    render_table,
+)
+
+__all__ = [
+    "AGENTS",
+    "CANONICAL_CAPABILITIES",
+    "CapabilityRecord",
+    "CapabilityViewError",
+    "query_capabilities",
+    "render_json",
+    "render_table",
+]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/cli.py
@@ -1,0 +1,64 @@
+"""Typer command for the agent capability configuration view."""
+
+import typer
+
+from agent_sec_cli.capabilities.view import (
+    AGENTS,
+    CANONICAL_CAPABILITIES,
+    CapabilityViewError,
+    query_capabilities,
+    render_json,
+    render_table,
+)
+
+app = typer.Typer(
+    name="capabilities",
+    help="Show agent-sec hook capabilities from the current CLI environment variables.",
+    invoke_without_command=True,
+)
+
+_OUTPUT_FORMATS = {"table", "json"}
+
+
+@app.callback(invoke_without_command=True)
+def capabilities(
+    ctx: typer.Context,
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help=f"Filter by agent. Allowed: {', '.join(AGENTS)}.",
+    ),
+    capability: str | None = typer.Option(
+        None,
+        "--capability",
+        "-c",
+        help=f"Filter by capability. Allowed: {', '.join(CANONICAL_CAPABILITIES)}.",
+    ),
+    output: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table or json.",
+    ),
+) -> None:
+    """Show the capability view using this CLI process environment.
+
+    This command reads only environment variables inherited by the CLI process.
+    It does not read Agent config files, Agent home directories, or prove that
+    hooks are loaded in the target Agent process.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    if output not in _OUTPUT_FORMATS:
+        typer.echo("Error: --output must be one of: json, table.", err=True)
+        raise typer.Exit(code=1)
+    try:
+        records = query_capabilities(agent=agent, capability=capability)
+    except CapabilityViewError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if output == "json":
+        typer.echo(render_json(records))
+    else:
+        typer.echo(render_table(records))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/cli.py
@@ -1,7 +1,6 @@
 """Typer command for the agent capability configuration view."""
 
 import typer
-
 from agent_sec_cli.capabilities.view import (
     AGENTS,
     CANONICAL_CAPABILITIES,

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
@@ -1,0 +1,592 @@
+"""Environment-variable capability view for agent-sec plugin integrations."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+CANONICAL_CAPABILITIES = (
+    "code-scan",
+    "prompt-scan",
+    "pii-check",
+    "skill-ledger",
+    "observability",
+)
+
+AGENTS = ("qoder", "qwen", "codex", "cosh", "openclaw", "hermes")
+_OUTPUT_COLUMNS = (
+    "CAPABILITY",
+    "ENABLED",
+    "MODE",
+    "SCAN_MODE",
+    "TIMEOUT(s)",
+    "DIAGNOSTICS",
+)
+_STRICT_TRUE_FALSE = {"true": True, "false": False}
+_BOOLEAN_TRUE_VALUES = {"1", "true", "yes", "on"}
+_BOOLEAN_FALSE_VALUES = {"0", "false", "no", "off"}
+_HOOK_POLICY_ALIASES = {"debug": "observe", "deny": "block"}
+_HOOK_POLICIES = {"observe", "warn", "ask", "block"}
+_VALID_SCAN_MODES = {"fast", "standard", "strict"}
+
+
+@dataclass(frozen=True)
+class EnvSpec:
+    name: str
+    default: Any
+    valid_values: frozenset[str] | None = None
+    bool_style: str | None = None
+    aliases: Mapping[str, str] = field(default_factory=dict)
+    value_kind: str = "string"
+    max_value: float | None = None
+
+
+@dataclass(frozen=True)
+class CapabilitySpec:
+    hooks: tuple[str, ...]
+    env: tuple[EnvSpec, ...] = ()
+    default_mode: str = "observe"
+
+
+@dataclass
+class CapabilityRecord:
+    agent: str
+    capability: str
+    hooks: list[str]
+    effective: str
+    source: str
+    mode: str = "observe"
+    scan_mode: str = "-"
+    timeout: str = "-"
+    config: dict[str, Any] = field(default_factory=dict)
+    env: dict[str, Any] = field(default_factory=dict)
+    config_path: str | None = None
+    diagnostics: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "capability": self.capability,
+            "enabled": self.effective,
+            "mode": self.mode,
+            "scan_mode": self.scan_mode,
+            "timeout": self.timeout,
+            "config": self.config,
+            "env": self.env,
+            "config_path": self.config_path,
+            "diagnostics": self.diagnostics,
+        }
+
+
+def _hook_enabled(name: str) -> EnvSpec:
+    return EnvSpec(name, True, bool_style="strict")
+
+
+def _timeout(
+    name: str,
+    default: str,
+    value_kind: str = "int",
+    max_value: float | None = None,
+) -> EnvSpec:
+    return EnvSpec(name, default, value_kind=value_kind, max_value=max_value)
+
+
+def _mode(name: str, default: str, valid_values: set[str]) -> EnvSpec:
+    return EnvSpec(
+        name,
+        default,
+        frozenset(valid_values),
+        aliases=_HOOK_POLICY_ALIASES,
+    )
+
+
+def _plain_mode(name: str, default: str, valid_values: set[str]) -> EnvSpec:
+    return EnvSpec(name, default, frozenset(valid_values))
+
+
+def _prompt_scan_mode() -> EnvSpec:
+    return EnvSpec("PROMPT_SCANNER_SCAN_MODE", "standard", frozenset(_VALID_SCAN_MODES))
+
+
+_CODE_MODES_INTERACTIVE = {"observe", "ask", "block"}
+_CODE_MODES_BLOCK_ONLY = {"observe", "block"}
+_PROMPT_MODES = {"observe", "deny"}
+
+_QODER_HOOKS = {
+    "code-scan": ("PreToolUse:Bash",),
+    "prompt-scan": ("UserPromptSubmit",),
+    "pii-check": ("UserPromptSubmit", "PreToolUse", "PostToolUse"),
+    "skill-ledger": ("PreToolUse:Skill",),
+    "observability": (
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    ),
+}
+
+_QWEN_HOOKS = {
+    "code-scan": ("PreToolUse:run_shell_command",),
+    "prompt-scan": ("UserPromptSubmit",),
+    "pii-check": (
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    ),
+    "skill-ledger": ("PreToolUse:skill",),
+    "observability": (
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+        "StopFailure",
+    ),
+}
+
+_CODEX_HOOKS = {
+    "code-scan": ("PreToolUse:Bash",),
+    "prompt-scan": ("UserPromptSubmit",),
+    "pii-check": ("PreToolUse", "UserPromptSubmit", "PostToolUse"),
+    "skill-ledger": ("UserPromptSubmit",),
+    "observability": ("PreToolUse", "UserPromptSubmit", "PostToolUse", "Stop"),
+}
+
+_COSH_HOOKS = {
+    "code-scan": ("PreToolUse:run_shell_command|shell",),
+    "prompt-scan": ("UserPromptSubmit",),
+    "pii-check": (
+        "PreToolUse",
+        "UserPromptSubmit",
+        "AfterModel",
+        "PostToolUse",
+        "PostToolUseFailure",
+    ),
+    "skill-ledger": ("PreToolUse:skill",),
+    "observability": (
+        "PreToolUse",
+        "UserPromptSubmit",
+        "BeforeModel",
+        "AfterModel",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "Stop",
+    ),
+}
+
+_OPENCLAW_HOOKS = {
+    "code-scan": ("before_tool_call",),
+    "prompt-scan": ("before_dispatch",),
+    "pii-check": ("before_dispatch", "before_tool_call", "after_tool_call", "llm_output"),
+    "skill-ledger": ("before_tool_call",),
+    "observability": (
+        "llm_input",
+        "model_call_started",
+        "model_call_ended",
+        "llm_output",
+        "agent_end",
+        "before_tool_call",
+        "after_tool_call",
+    ),
+}
+
+_HERMES_HOOKS = {
+    "code-scan": ("pre_tool_call",),
+    "prompt-scan": ("pre_llm_call", "transform_llm_output", "on_session_end"),
+    "pii-check": (
+        "pre_llm_call",
+        "pre_tool_call",
+        "post_tool_call",
+        "transform_llm_output",
+        "on_session_end",
+    ),
+    "skill-ledger": ("pre_tool_call", "transform_llm_output"),
+    "observability": (
+        "pre_llm_call",
+        "pre_api_request",
+        "post_api_request",
+        "pre_tool_call",
+        "post_tool_call",
+        "post_llm_call",
+    ),
+}
+
+
+def _agent_specs(
+    hooks: Mapping[str, tuple[str, ...]],
+    code_modes: set[str],
+    include_timeouts: bool = True,
+    qwen_legacy_pii_enabled: bool = False,
+    include_prompt_mode: bool = True,
+) -> dict[str, CapabilitySpec]:
+    code_env = [
+        _hook_enabled("CODE_SCANNER_HOOK_ENABLED"),
+        _mode("CODE_SCANNER_MODE", "observe", code_modes),
+    ]
+    prompt_env = [_hook_enabled("PROMPT_SCANNER_HOOK_ENABLED")]
+    if include_prompt_mode:
+        prompt_env.append(_plain_mode("PROMPT_SCANNER_MODE", "observe", _PROMPT_MODES))
+    prompt_env.append(_prompt_scan_mode())
+    pii_env = [
+        _hook_enabled("PII_CHECKER_HOOK_ENABLED"),
+        _mode("PII_CHECKER_MODE", "observe", _HOOK_POLICIES),
+    ]
+    skill_env = [
+        _hook_enabled("SKILL_LEDGER_HOOK_ENABLED"),
+        _mode("SKILL_LEDGER_MODE", "ask", _HOOK_POLICIES),
+    ]
+    if include_timeouts:
+        code_env.append(_timeout("CODE_SCANNER_TIMEOUT", "10"))
+        prompt_env.append(_timeout("PROMPT_SCANNER_TIMEOUT", "10"))
+        pii_env.append(_timeout("PII_CHECKER_TIMEOUT", "5"))
+        skill_env.append(_timeout("SKILL_LEDGER_TIMEOUT", "5"))
+    if qwen_legacy_pii_enabled:
+        pii_env.insert(1, EnvSpec("PII_CHECKER_ENABLED", True, bool_style="broad"))
+    return {
+        "code-scan": CapabilitySpec(hooks["code-scan"], tuple(code_env)),
+        "prompt-scan": CapabilitySpec(hooks["prompt-scan"], tuple(prompt_env)),
+        "pii-check": CapabilitySpec(hooks["pii-check"], tuple(pii_env)),
+        "skill-ledger": CapabilitySpec(hooks["skill-ledger"], tuple(skill_env), "ask"),
+        "observability": CapabilitySpec(
+            hooks["observability"], (_hook_enabled("OBSERVABILITY_HOOK_ENABLED"),)
+        ),
+    }
+
+
+AGENT_SPECS: dict[str, dict[str, CapabilitySpec]] = {
+    "qoder": _agent_specs(_QODER_HOOKS, _CODE_MODES_INTERACTIVE),
+    "qwen": _agent_specs(
+        _QWEN_HOOKS, _CODE_MODES_INTERACTIVE, qwen_legacy_pii_enabled=True
+    ),
+    "codex": _agent_specs(_CODEX_HOOKS, _CODE_MODES_BLOCK_ONLY),
+    "cosh": _agent_specs(
+        _COSH_HOOKS,
+        {"ask"},
+        include_timeouts=False,
+        include_prompt_mode=False,
+    ),
+    "openclaw": _agent_specs(
+        _OPENCLAW_HOOKS,
+        _CODE_MODES_INTERACTIVE,
+        include_timeouts=False,
+        include_prompt_mode=False,
+    ),
+    "hermes": _agent_specs(
+        _HERMES_HOOKS,
+        _CODE_MODES_BLOCK_ONLY,
+        include_timeouts=False,
+        include_prompt_mode=False,
+    ),
+}
+AGENT_SPECS["qoder"]["pii-check"] = CapabilitySpec(
+    _QODER_HOOKS["pii-check"],
+    (
+        _hook_enabled("PII_CHECKER_HOOK_ENABLED"),
+        _mode("PII_CHECKER_MODE", "observe", _HOOK_POLICIES),
+        EnvSpec("PII_CHECKER_INCLUDE_LOW_CONFIDENCE", False, bool_style="broad"),
+        _timeout("PII_CHECKER_TIMEOUT", "5"),
+    ),
+)
+AGENT_SPECS["qoder"]["skill-ledger"] = CapabilitySpec(
+    _QODER_HOOKS["skill-ledger"],
+    (
+        _hook_enabled("SKILL_LEDGER_HOOK_ENABLED"),
+        _mode("SKILL_LEDGER_MODE", "ask", _HOOK_POLICIES),
+        _timeout("SKILL_LEDGER_TIMEOUT", "5", "float"),
+    ),
+    "ask",
+)
+AGENT_SPECS["qwen"]["pii-check"] = CapabilitySpec(
+    _QWEN_HOOKS["pii-check"],
+    (
+        _hook_enabled("PII_CHECKER_HOOK_ENABLED"),
+        EnvSpec("PII_CHECKER_ENABLED", True, bool_style="broad"),
+        _mode("PII_CHECKER_MODE", "observe", _HOOK_POLICIES),
+        EnvSpec("PII_CHECKER_INCLUDE_LOW_CONFIDENCE", False, bool_style="broad"),
+        _timeout("PII_CHECKER_TIMEOUT", "5", "float", 8.0),
+    ),
+)
+AGENT_SPECS["qwen"]["skill-ledger"] = CapabilitySpec(
+    _QWEN_HOOKS["skill-ledger"],
+    (
+        _hook_enabled("SKILL_LEDGER_HOOK_ENABLED"),
+        _mode("SKILL_LEDGER_MODE", "ask", _HOOK_POLICIES),
+    ),
+    "ask",
+)
+AGENT_SPECS["cosh"]["code-scan"] = CapabilitySpec(
+    _COSH_HOOKS["code-scan"],
+    (
+        _hook_enabled("CODE_SCANNER_HOOK_ENABLED"),
+        _mode("CODE_SCANNER_MODE", "ask", {"ask"}),
+    ),
+    "ask",
+)
+AGENT_SPECS["cosh"]["prompt-scan"] = CapabilitySpec(
+    _COSH_HOOKS["prompt-scan"],
+    (
+        _hook_enabled("PROMPT_SCANNER_HOOK_ENABLED"),
+        _prompt_scan_mode(),
+    ),
+    "ask",
+)
+
+STATIC_DEFAULT_TIMEOUTS = {
+    ("qoder", "observability"): "3",
+    ("qwen", "skill-ledger"): "5",
+    ("qwen", "observability"): "3",
+    ("codex", "observability"): "3",
+    ("cosh", "code-scan"): "10",
+    ("cosh", "prompt-scan"): "10",
+    ("cosh", "pii-check"): "10",
+    ("cosh", "skill-ledger"): "5",
+    ("cosh", "observability"): "3",
+    ("openclaw", "code-scan"): "10",
+    ("openclaw", "prompt-scan"): "10",
+    ("openclaw", "pii-check"): "10",
+    ("openclaw", "skill-ledger"): "5",
+    ("openclaw", "observability"): "5",
+    ("hermes", "code-scan"): "10",
+    ("hermes", "prompt-scan"): "15",
+    ("hermes", "pii-check"): "10",
+    ("hermes", "skill-ledger"): "5",
+    ("hermes", "observability"): "5",
+}
+
+
+class CapabilityViewError(ValueError):
+    """Raised for invalid capability view filters."""
+
+
+def query_capabilities(
+    agent: str | None = None,
+    capability: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> list[CapabilityRecord]:
+    effective_env = dict(os.environ if env is None else env)
+    agent_filter = _normalize_filter(agent, AGENTS, "agent")
+    capability_filter = _normalize_filter(
+        capability, CANONICAL_CAPABILITIES, "capability"
+    )
+    records: list[CapabilityRecord] = []
+    for agent_name in AGENTS:
+        if agent_filter is not None and agent_name != agent_filter:
+            continue
+        for record in _agent_records(agent_name, effective_env):
+            if capability_filter is None or record.capability == capability_filter:
+                records.append(record)
+    return sorted(
+        records, key=lambda item: (item.agent, item.capability, ",".join(item.hooks))
+    )
+
+
+def render_json(records: list[CapabilityRecord]) -> str:
+    return json.dumps(
+        [record.to_dict() for record in records], ensure_ascii=False, indent=2
+    )
+
+
+def render_table(records: list[CapabilityRecord]) -> str:
+    lines: list[str] = []
+    for agent_name in _ordered_agents(records):
+        agent_records = [record for record in records if record.agent == agent_name]
+        rows = [
+            (
+                record.capability,
+                record.effective,
+                record.mode,
+                record.scan_mode,
+                record.timeout,
+                ";".join(record.diagnostics) if record.diagnostics else "-",
+            )
+            for record in agent_records
+        ]
+        widths = [len(column) for column in _OUTPUT_COLUMNS]
+        for row in rows:
+            for index, value in enumerate(row):
+                widths[index] = max(widths[index], len(value))
+        if lines:
+            lines.append("")
+        lines.append(f"[{agent_name}]")
+        lines.append(_format_row(_OUTPUT_COLUMNS, widths))
+        lines.append(_format_row(tuple("-" * width for width in widths), widths))
+        lines.extend(_format_row(row, widths) for row in rows)
+    return "\n".join(lines)
+
+
+def _ordered_agents(records: list[CapabilityRecord]) -> list[str]:
+    ordered: list[str] = []
+    for record in records:
+        if record.agent not in ordered:
+            ordered.append(record.agent)
+    return ordered
+
+
+def _normalize_filter(
+    value: str | None, allowed: tuple[str, ...], field_name: str
+) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized not in allowed:
+        raise CapabilityViewError(
+            f"unknown {field_name}: {value}. Allowed values: {', '.join(allowed)}"
+        )
+    return normalized
+
+
+def _agent_records(agent: str, env: Mapping[str, str]) -> list[CapabilityRecord]:
+    records: list[CapabilityRecord] = []
+    for capability in CANONICAL_CAPABILITIES:
+        spec = AGENT_SPECS[agent][capability]
+        env_values, diagnostics, enabled = _resolve_env(spec.env, env)
+        records.append(
+            CapabilityRecord(
+                agent=agent,
+                capability=capability,
+                hooks=list(spec.hooks),
+                effective="enabled" if enabled else "disabled",
+                source="manifest+env",
+                mode=_mode_from_env(env_values, spec.default_mode),
+                scan_mode=_scan_mode(capability, env_values),
+                timeout=_timeout_from_env_or_default(agent, capability, env_values),
+                env=env_values,
+                diagnostics=diagnostics,
+            )
+        )
+    return records
+
+
+def _resolve_env(
+    specs: tuple[EnvSpec, ...], env: Mapping[str, str]
+) -> tuple[dict[str, Any], list[str], bool]:
+    values: dict[str, Any] = {}
+    diagnostics: list[str] = []
+    for spec in specs:
+        raw = env.get(spec.name)
+        if spec.bool_style is not None:
+            effective = _resolve_bool(spec, raw, diagnostics)
+        elif spec.name.endswith("_TIMEOUT"):
+            effective = _resolve_timeout(spec, raw, diagnostics)
+        elif raw is None:
+            effective = spec.default
+        else:
+            effective = raw.strip().lower()
+            effective = spec.aliases.get(effective, effective)
+            if spec.valid_values is not None and effective not in spec.valid_values:
+                diagnostics.append(
+                    f"{spec.name}={raw!r} invalid; using {spec.default!r}"
+                )
+                effective = spec.default
+        values[spec.name] = {
+            "raw": raw,
+            "effective": effective,
+            "default": spec.default,
+        }
+    return values, diagnostics, _enabled_from_values(values)
+
+
+def _resolve_bool(spec: EnvSpec, raw: str | None, diagnostics: list[str]) -> bool:
+    if raw is None:
+        return bool(spec.default)
+    normalized = raw.strip().lower()
+    if spec.bool_style == "strict":
+        if normalized in _STRICT_TRUE_FALSE:
+            return _STRICT_TRUE_FALSE[normalized]
+    else:
+        if normalized in _BOOLEAN_TRUE_VALUES:
+            return True
+        if normalized in _BOOLEAN_FALSE_VALUES:
+            return False
+    diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+    return bool(spec.default)
+
+
+def _resolve_timeout(spec: EnvSpec, raw: str | None, diagnostics: list[str]) -> str:
+    if raw is None:
+        return str(spec.default)
+    text = raw.strip()
+    try:
+        if spec.value_kind == "int":
+            value = int(text)
+            if value <= 0:
+                raise ValueError
+            return str(value)
+        value = float(text)
+    except (TypeError, ValueError):
+        diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+        return str(spec.default)
+    if not math.isfinite(value) or value <= 0:
+        diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+        return str(spec.default)
+    if spec.max_value is not None:
+        value = min(value, spec.max_value)
+    return _format_number(value)
+
+
+def _format_number(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _enabled_from_values(env_values: dict[str, Any]) -> bool:
+    hook_enabled = env_values.get("PII_CHECKER_HOOK_ENABLED")
+    legacy_enabled = env_values.get("PII_CHECKER_ENABLED")
+    if hook_enabled is not None and legacy_enabled is not None:
+        if hook_enabled["raw"] is not None:
+            return bool(hook_enabled["effective"])
+        return bool(legacy_enabled["effective"])
+    for name, value in env_values.items():
+        if name.endswith("_ENABLED") and value["effective"] is False:
+            return False
+    return True
+
+
+def _mode_from_env(env_values: dict[str, Any], default: str = "observe") -> str:
+    for name in (
+        "CODE_SCANNER_MODE",
+        "PROMPT_SCANNER_MODE",
+        "PII_CHECKER_MODE",
+        "SKILL_LEDGER_MODE",
+    ):
+        if name in env_values:
+            return str(env_values[name]["effective"])
+    return default
+
+
+def _scan_mode(capability: str, env_values: dict[str, Any]) -> str:
+    if capability != "prompt-scan":
+        return "-"
+    value = env_values.get("PROMPT_SCANNER_SCAN_MODE")
+    if value is None:
+        return "standard"
+    return str(value["effective"])
+
+
+def _timeout_from_env_or_default(
+    agent: str, capability: str, env_values: dict[str, Any]
+) -> str:
+    for name, value in env_values.items():
+        if name.endswith("_TIMEOUT"):
+            return _format_timeout(value["effective"])
+    return STATIC_DEFAULT_TIMEOUTS.get((agent, capability), "-")
+
+
+def _format_timeout(value: Any) -> str:
+    if value is None:
+        return "-"
+    text = str(value).strip()
+    return text if text else "-"
+
+
+def _format_row(row: tuple[str, ...], widths: list[int]) -> str:
+    return "  ".join(value.ljust(widths[index]) for index, value in enumerate(row))

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/capabilities/view.py
@@ -74,9 +74,13 @@ class CapabilityRecord:
             "mode": self.mode,
             "scan_mode": self.scan_mode,
             "timeout": self.timeout,
-            "config": self.config,
-            "env": self.env,
-            "config_path": self.config_path,
+            "env": {
+                name: {
+                    "effective": value["effective"],
+                    "default": value["default"],
+                }
+                for name, value in self.env.items()
+            },
             "diagnostics": self.diagnostics,
         }
 
@@ -185,7 +189,12 @@ _COSH_HOOKS = {
 _OPENCLAW_HOOKS = {
     "code-scan": ("before_tool_call",),
     "prompt-scan": ("before_dispatch",),
-    "pii-check": ("before_dispatch", "before_tool_call", "after_tool_call", "llm_output"),
+    "pii-check": (
+        "before_dispatch",
+        "before_tool_call",
+        "after_tool_call",
+        "llm_output",
+    ),
     "skill-ledger": ("before_tool_call",),
     "observability": (
         "llm_input",
@@ -437,10 +446,30 @@ def _normalize_filter(
         return None
     normalized = value.strip().lower()
     if normalized not in allowed:
+        display_value = _safe_cli_value(value)
         raise CapabilityViewError(
-            f"unknown {field_name}: {value}. Allowed values: {', '.join(allowed)}"
+            f"unknown {field_name}: {display_value}. Allowed values: {', '.join(allowed)}"
         )
     return normalized
+
+
+def _safe_cli_value(value: str, limit: int = 80) -> str:
+    escaped: list[str] = []
+    for char in value:
+        if char.isprintable():
+            escaped.append(char)
+        else:
+            code_point = ord(char)
+            if code_point <= 0xFF:
+                escaped.append(f"\\x{code_point:02x}")
+            elif code_point <= 0xFFFF:
+                escaped.append(f"\\u{code_point:04x}")
+            else:
+                escaped.append(f"\\U{code_point:08x}")
+    display_value = "".join(escaped)
+    if len(display_value) > limit:
+        return f"{display_value[: limit - 1]}…"
+    return display_value
 
 
 def _agent_records(agent: str, env: Mapping[str, str]) -> list[CapabilityRecord]:
@@ -482,9 +511,7 @@ def _resolve_env(
             effective = raw.strip().lower()
             effective = spec.aliases.get(effective, effective)
             if spec.valid_values is not None and effective not in spec.valid_values:
-                diagnostics.append(
-                    f"{spec.name}={raw!r} invalid; using {spec.default!r}"
-                )
+                diagnostics.append(_fallback_diagnostic(spec))
                 effective = spec.default
         values[spec.name] = {
             "raw": raw,
@@ -506,7 +533,7 @@ def _resolve_bool(spec: EnvSpec, raw: str | None, diagnostics: list[str]) -> boo
             return True
         if normalized in _BOOLEAN_FALSE_VALUES:
             return False
-    diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+    diagnostics.append(_fallback_diagnostic(spec))
     return bool(spec.default)
 
 
@@ -518,18 +545,24 @@ def _resolve_timeout(spec: EnvSpec, raw: str | None, diagnostics: list[str]) -> 
         if spec.value_kind == "int":
             value = int(text)
             if value <= 0:
-                raise ValueError
+                diagnostics.append(
+                    f"{spec.name} is nonpositive; the hook subprocess may fail open"
+                )
             return str(value)
         value = float(text)
     except (TypeError, ValueError):
-        diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+        diagnostics.append(_fallback_diagnostic(spec))
         return str(spec.default)
     if not math.isfinite(value) or value <= 0:
-        diagnostics.append(f"{spec.name}={raw!r} invalid; using {spec.default!r}")
+        diagnostics.append(_fallback_diagnostic(spec))
         return str(spec.default)
     if spec.max_value is not None:
         value = min(value, spec.max_value)
     return _format_number(value)
+
+
+def _fallback_diagnostic(spec: EnvSpec) -> str:
+    return f"{spec.name} has an invalid value; using {spec.default!r}"
 
 
 def _format_number(value: float) -> str:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import typer
+from agent_sec_cli.capabilities.cli import app as capabilities_app
 from agent_sec_cli.cli_logging import setup_cli_logging
 from agent_sec_cli.correlation_context import (
     init_invocation_context,
@@ -132,6 +133,7 @@ def main_callback(
 # Mount skill-ledger as a subcommand group: agent-sec-cli skill-ledger <cmd>
 app.add_typer(skill_ledger_app, name="skill-ledger")
 app.add_typer(observability_app, name="observability")
+app.add_typer(capabilities_app, name="capabilities")
 
 # ---------------------------------------------------------------------------
 # Command: harden

--- a/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
@@ -44,7 +44,8 @@ def test_capabilities_json_uses_cli_process_environment() -> None:
     assert payload[0]["timeout"] == "10"
     assert "hooks" not in payload[0]
     assert "source" not in payload[0]
-    assert payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]["raw"] == "false"
+    assert "raw" not in payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]
+    assert payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]["effective"] is False
 
 
 def test_capabilities_json_reads_new_hook_enabled_environment() -> None:
@@ -64,9 +65,10 @@ def test_capabilities_json_reads_new_hook_enabled_environment() -> None:
     assert payload[0]["enabled"] == "disabled"
     assert payload[0]["mode"] == "observe"
     assert payload[0]["scan_mode"] == "standard"
-    assert payload[0]["config"] == {}
-    assert payload[0]["config_path"] is None
-    assert payload[0]["env"]["PROMPT_SCANNER_HOOK_ENABLED"]["raw"] == "false"
+    assert "config" not in payload[0]
+    assert "config_path" not in payload[0]
+    assert "raw" not in payload[0]["env"]["PROMPT_SCANNER_HOOK_ENABLED"]
+    assert payload[0]["env"]["PROMPT_SCANNER_HOOK_ENABLED"]["effective"] is False
 
 
 def test_capabilities_rejects_noncanonical_capability_name() -> None:

--- a/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
@@ -1,0 +1,76 @@
+"""E2E tests for ``agent-sec-cli capabilities``."""
+
+import json
+import os
+
+from cli.conftest import run_cli
+
+
+class _EnvPatch:
+    def __init__(self, **values: str) -> None:
+        self.values = values
+        self.previous: dict[str, str | None] = {}
+
+    def __enter__(self) -> None:
+        for name, value in self.values.items():
+            self.previous[name] = os.environ.get(name)
+            os.environ[name] = value
+
+    def __exit__(self, *_args: object) -> None:
+        for name, value in self.previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def test_capabilities_json_uses_cli_process_environment() -> None:
+    with _EnvPatch(CODE_SCANNER_HOOK_ENABLED="false"):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            "qoder",
+            "--capability",
+            "code-scan",
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload[0]["enabled"] == "disabled"
+    assert payload[0]["mode"] == "observe"
+    assert payload[0]["scan_mode"] == "-"
+    assert payload[0]["timeout"] == "10"
+    assert "hooks" not in payload[0]
+    assert "source" not in payload[0]
+    assert payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]["raw"] == "false"
+
+
+def test_capabilities_json_reads_new_hook_enabled_environment() -> None:
+    with _EnvPatch(PROMPT_SCANNER_HOOK_ENABLED="false"):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            "codex",
+            "--capability",
+            "prompt-scan",
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload[0]["enabled"] == "disabled"
+    assert payload[0]["mode"] == "observe"
+    assert payload[0]["scan_mode"] == "standard"
+    assert payload[0]["config"] == {}
+    assert payload[0]["config_path"] is None
+    assert payload[0]["env"]["PROMPT_SCANNER_HOOK_ENABLED"]["raw"] == "false"
+
+
+def test_capabilities_rejects_noncanonical_capability_name() -> None:
+    result = run_cli("capabilities", "--capability", "scan-code")
+
+    assert result.returncode == 1
+    assert "unknown capability" in result.stderr

--- a/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
+++ b/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
-
 from agent_sec_cli.capabilities.view import (
     CapabilityViewError,
     query_capabilities,

--- a/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
+++ b/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
@@ -1,0 +1,446 @@
+"""Tests for the agent capability environment view."""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from agent_sec_cli.capabilities.view import (
+    CapabilityViewError,
+    query_capabilities,
+    render_json,
+    render_table,
+)
+
+_SEC_CORE_ROOT = Path(__file__).resolve().parents[3]
+
+
+_PYTHON_HOOK_HELPERS = [
+    ("qoder", _SEC_CORE_ROOT / "qoder-plugin" / "hooks" / "qoder_hook_common.py"),
+    ("qwen", _SEC_CORE_ROOT / "qwen-code-extension" / "hooks" / "hook_config.py"),
+    (
+        "codex",
+        _SEC_CORE_ROOT / "codex-plugin" / "hooks-plugin" / "hooks" / "hook_config.py",
+    ),
+    ("cosh", _SEC_CORE_ROOT / "cosh-extension" / "hooks" / "hook_config.py"),
+    ("hermes", _SEC_CORE_ROOT / "hermes-plugin" / "src" / "hook_config.py"),
+]
+
+
+def _load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def _load_qwen_pii_module() -> ModuleType:
+    hook_dir = _SEC_CORE_ROOT / "qwen-code-extension" / "hooks"
+    for name in ("hook_config", "pii_text", "trace_context"):
+        sys.modules.pop(name, None)
+    return _load_module(hook_dir / "pii_checker_hook.py", "qwen_pii_checker_hook_for_caps")
+
+
+def _table_section(table: str, agent: str) -> list[str]:
+    lines = table.splitlines()
+    start = lines.index(f"[{agent}]")
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index] == "":
+            end = index
+            break
+    return lines[start:end]
+
+
+def _section_row(table: str, agent: str, capability: str) -> str:
+    for line in _table_section(table, agent):
+        if line.startswith(capability):
+            return line
+    raise AssertionError(f"missing row for {agent}/{capability}")
+
+
+def _single_record(agent: str, capability: str, env: dict[str, str] | None = None):
+    records = query_capabilities(agent=agent, capability=capability, env=env or {})
+    assert len(records) == 1
+    return records[0]
+
+
+def test_query_all_returns_six_agents_and_five_capabilities() -> None:
+    records = query_capabilities(env={})
+
+    assert len(records) == 30
+    assert {record.agent for record in records} == {
+        "qoder",
+        "qwen",
+        "codex",
+        "cosh",
+        "openclaw",
+        "hermes",
+    }
+    assert {record.capability for record in records} == {
+        "code-scan",
+        "prompt-scan",
+        "pii-check",
+        "skill-ledger",
+        "observability",
+    }
+
+
+@pytest.mark.parametrize(
+    "capability",
+    ["scan-code", "prompt-scan-user-input", "pii-scan-user-input", "code_scanner"],
+)
+def test_capability_filter_rejects_aliases(capability: str) -> None:
+    with pytest.raises(CapabilityViewError, match="unknown capability"):
+        query_capabilities(capability=capability, env={})
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, True),
+        ("true", True),
+        ("TRUE", True),
+        (" true ", True),
+        ("false", False),
+        ("FALSE", False),
+        (" false ", False),
+        ("0", True),
+        ("no", True),
+        ("off", True),
+        ("invalid", True),
+    ],
+)
+@pytest.mark.parametrize(("agent", "helper_path"), _PYTHON_HOOK_HELPERS)
+def test_cli_strict_enabled_matches_python_hook_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+    agent: str,
+    helper_path: Path,
+    raw: str | None,
+    expected: bool,
+) -> None:
+    env_name = "OBSERVABILITY_HOOK_ENABLED"
+    helper = _load_module(helper_path, f"{agent}_hook_config_for_caps")
+    if raw is None:
+        monkeypatch.delenv(env_name, raising=False)
+        env = {}
+    else:
+        monkeypatch.setenv(env_name, raw)
+        env = {env_name: raw}
+
+    hook_enabled = helper.env_flag_enabled(env_name, True)
+    record = _single_record(agent, "observability", env)
+
+    assert hook_enabled is expected
+    assert record.env[env_name]["effective"] is expected
+    assert record.effective == ("enabled" if expected else "disabled")
+    has_diagnostic = any(env_name in item for item in record.diagnostics)
+    assert has_diagnostic is (raw not in {None, "true", "TRUE", " true ", "false", "FALSE", " false "})
+
+
+def test_static_agent_code_scanner_enabled_env_controls_effective() -> None:
+    record = _single_record(
+        "qoder",
+        "code-scan",
+        {"CODE_SCANNER_HOOK_ENABLED": "false"},
+    )
+
+    assert record.effective == "disabled"
+    assert record.mode == "observe"
+    assert record.scan_mode == "-"
+    assert record.timeout == "10"
+    assert record.env["CODE_SCANNER_HOOK_ENABLED"]["effective"] is False
+
+
+def test_invalid_env_values_fall_back_with_diagnostic() -> None:
+    record = _single_record(
+        "qwen",
+        "prompt-scan",
+        {"PROMPT_SCANNER_MODE": "block", "PROMPT_SCANNER_SCAN_MODE": "fast"},
+    )
+
+    assert record.effective == "enabled"
+    assert record.mode == "observe"
+    assert record.scan_mode == "fast"
+    assert record.timeout == "10"
+    assert record.env["PROMPT_SCANNER_MODE"]["effective"] == "observe"
+    assert record.env["PROMPT_SCANNER_SCAN_MODE"]["effective"] == "fast"
+    assert any("PROMPT_SCANNER_MODE" in item for item in record.diagnostics)
+
+
+def test_invalid_timeout_values_fall_back_with_diagnostic() -> None:
+    record = _single_record(
+        "qwen",
+        "pii-check",
+        {"PII_CHECKER_TIMEOUT": "nan"},
+    )
+
+    assert record.timeout == "5"
+    assert record.env["PII_CHECKER_TIMEOUT"]["effective"] == "5"
+    assert any("PII_CHECKER_TIMEOUT" in item for item in record.diagnostics)
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "inf", "bad"])
+def test_non_positive_or_non_numeric_timeout_values_fall_back(value: str) -> None:
+    record = _single_record(
+        "qoder",
+        "code-scan",
+        {"CODE_SCANNER_TIMEOUT": value},
+    )
+
+    assert record.timeout == "10"
+    assert any("CODE_SCANNER_TIMEOUT" in item for item in record.diagnostics)
+
+
+def test_timeout_parsing_matches_agent_specific_runtime_rules() -> None:
+    qoder_skill = _single_record(
+        "qoder",
+        "skill-ledger",
+        {"SKILL_LEDGER_TIMEOUT": "0.05"},
+    )
+    qwen_pii = _single_record(
+        "qwen",
+        "pii-check",
+        {"PII_CHECKER_TIMEOUT": "99"},
+    )
+    qoder_code = _single_record(
+        "qoder",
+        "code-scan",
+        {"CODE_SCANNER_TIMEOUT": "1.5"},
+    )
+    qwen_skill = _single_record(
+        "qwen",
+        "skill-ledger",
+        {"SKILL_LEDGER_TIMEOUT": "99"},
+    )
+
+    assert qoder_skill.timeout == "0.05"
+    assert qwen_pii.timeout == "8"
+    assert qwen_pii.env["PII_CHECKER_TIMEOUT"]["effective"] == "8"
+    assert qoder_code.timeout == "10"
+    assert any("CODE_SCANNER_TIMEOUT" in item for item in qoder_code.diagnostics)
+    assert qwen_skill.timeout == "5"
+    assert "SKILL_LEDGER_TIMEOUT" not in qwen_skill.env
+
+
+def test_static_timeout_defaults_match_runtime_constants() -> None:
+    assert _single_record("qoder", "observability").timeout == "3"
+    assert _single_record("qwen", "observability").timeout == "3"
+    assert _single_record("codex", "observability").timeout == "3"
+    assert _single_record("cosh", "code-scan").timeout == "10"
+    assert _single_record("cosh", "observability").timeout == "3"
+    assert _single_record("openclaw", "observability").timeout == "5"
+    assert _single_record("hermes", "prompt-scan").timeout == "15"
+    assert _single_record("hermes", "observability").timeout == "5"
+
+
+def test_pii_include_low_confidence_is_only_exposed_for_supported_hooks() -> None:
+    env = {"PII_CHECKER_INCLUDE_LOW_CONFIDENCE": "true"}
+    qoder = _single_record("qoder", "pii-check", env)
+    qwen = _single_record("qwen", "pii-check", env)
+    codex = _single_record("codex", "pii-check", env)
+    openclaw = _single_record("openclaw", "pii-check", env)
+    hermes = _single_record("hermes", "pii-check", env)
+
+    assert qoder.env["PII_CHECKER_INCLUDE_LOW_CONFIDENCE"]["effective"] is True
+    assert qwen.env["PII_CHECKER_INCLUDE_LOW_CONFIDENCE"]["effective"] is True
+    assert "PII_CHECKER_INCLUDE_LOW_CONFIDENCE" not in codex.env
+    assert "PII_CHECKER_INCLUDE_LOW_CONFIDENCE" not in openclaw.env
+    assert "PII_CHECKER_INCLUDE_LOW_CONFIDENCE" not in hermes.env
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({"PII_CHECKER_ENABLED": "false"}, False),
+        ({"PII_CHECKER_HOOK_ENABLED": "true", "PII_CHECKER_ENABLED": "false"}, True),
+        ({"PII_CHECKER_HOOK_ENABLED": "invalid", "PII_CHECKER_ENABLED": "false"}, True),
+        ({"PII_CHECKER_HOOK_ENABLED": "false", "PII_CHECKER_ENABLED": "true"}, False),
+    ],
+)
+def test_qwen_pii_legacy_enabled_fallback_matches_hook_runtime(
+    monkeypatch: pytest.MonkeyPatch, env: dict[str, str], expected: bool
+) -> None:
+    module = _load_qwen_pii_module()
+    for name in ("PII_CHECKER_HOOK_ENABLED", "PII_CHECKER_ENABLED"):
+        if name in env:
+            monkeypatch.setenv(name, env[name])
+        else:
+            monkeypatch.delenv(name, raising=False)
+
+    if "PII_CHECKER_HOOK_ENABLED" in os.environ:
+        hook_enabled = module.env_flag_enabled("PII_CHECKER_HOOK_ENABLED", True)
+    else:
+        hook_enabled = module._environment_bool("PII_CHECKER_ENABLED", True)
+    record = _single_record("qwen", "pii-check", env)
+
+    assert hook_enabled is expected
+    assert record.effective == ("enabled" if expected else "disabled")
+
+
+def test_cosh_prompt_scan_scan_mode_does_not_change_interaction_mode() -> None:
+    record = _single_record(
+        "cosh",
+        "prompt-scan",
+        {"PROMPT_SCANNER_MODE": "deny", "PROMPT_SCANNER_SCAN_MODE": "strict"},
+    )
+
+    assert record.effective == "enabled"
+    assert record.mode == "ask"
+    assert record.scan_mode == "strict"
+    assert record.timeout == "10"
+    assert "PROMPT_SCANNER_MODE" not in record.env
+    assert record.env["PROMPT_SCANNER_SCAN_MODE"]["effective"] == "strict"
+
+
+def test_agent_home_and_config_files_do_not_affect_environment_view(tmp_path: Path) -> None:
+    openclaw_config = tmp_path / "openclaw.json"
+    hermes_config = tmp_path / "hermes" / "plugins" / "agent-sec-core-hermes-plugin" / "config.toml"
+    openclaw_config.write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "entries": {
+                        "agent-sec": {
+                            "enabled": False,
+                            "config": {"capabilities": {"prompt-scan": {"enabled": False}}},
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    hermes_config.parent.mkdir(parents=True)
+    hermes_config.write_text("[capabilities.prompt-scan-user-input]\nenabled = false\n", encoding="utf-8")
+
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "OPENCLAW_CONFIG_PATH": str(openclaw_config),
+        "OPENCLAW_STATE_DIR": str(tmp_path / "state"),
+        "HERMES_HOME": str(tmp_path / "hermes"),
+        "PROMPT_SCANNER_HOOK_ENABLED": "true",
+        "PROMPT_SCANNER_SCAN_MODE": "strict",
+    }
+
+    openclaw_record = _single_record("openclaw", "prompt-scan", env)
+    hermes_record = _single_record("hermes", "prompt-scan", env)
+
+    assert openclaw_record.effective == "enabled"
+    assert hermes_record.effective == "enabled"
+    assert openclaw_record.config == {}
+    assert hermes_record.config == {}
+    assert openclaw_record.config_path is None
+    assert hermes_record.config_path is None
+    assert openclaw_record.scan_mode == "strict"
+    assert hermes_record.scan_mode == "strict"
+
+
+def test_render_table_groups_prompt_scan_by_agent_with_env_only() -> None:
+    records = query_capabilities(
+        capability="prompt-scan",
+        env={"PROMPT_SCANNER_MODE": "deny", "PROMPT_SCANNER_SCAN_MODE": "strict"},
+    )
+    table = render_table(records)
+
+    assert "AGENT" not in _table_section(table, "codex")[1]
+    assert _section_row(table, "codex", "prompt-scan").split() == [
+        "prompt-scan",
+        "enabled",
+        "deny",
+        "strict",
+        "10",
+        "-",
+    ]
+    assert _section_row(table, "qoder", "prompt-scan").split() == [
+        "prompt-scan",
+        "enabled",
+        "deny",
+        "strict",
+        "10",
+        "-",
+    ]
+    assert _section_row(table, "qwen", "prompt-scan").split() == [
+        "prompt-scan",
+        "enabled",
+        "deny",
+        "strict",
+        "10",
+        "-",
+    ]
+    for agent in ("cosh", "openclaw", "hermes"):
+        expected_mode = "ask" if agent == "cosh" else "observe"
+        expected_timeout = "15" if agent == "hermes" else "10"
+        assert _section_row(table, agent, "prompt-scan").split() == [
+            "prompt-scan",
+            "enabled",
+            expected_mode,
+            "strict",
+            expected_timeout,
+            "-",
+        ]
+
+
+def test_render_table_shows_code_scan_env_disable_per_agent() -> None:
+    records = query_capabilities(
+        capability="code-scan",
+        env={"CODE_SCANNER_HOOK_ENABLED": "false", "CODE_SCANNER_TIMEOUT": "21"},
+    )
+    table = render_table(records)
+
+    for agent in ("codex", "qoder", "qwen"):
+        assert _section_row(table, agent, "code-scan").split() == [
+            "code-scan",
+            "disabled",
+            "observe",
+            "-",
+            "21",
+            "-",
+        ]
+    for agent in ("cosh", "openclaw", "hermes"):
+        expected_mode = "ask" if agent == "cosh" else "observe"
+        assert _section_row(table, agent, "code-scan").split() == [
+            "code-scan",
+            "disabled",
+            expected_mode,
+            "-",
+            "10",
+            "-",
+        ]
+
+
+def test_renderers_emit_stable_shapes() -> None:
+    records = query_capabilities(agent="cosh", capability="code-scan", env={})
+
+    payload = json.loads(render_json(records))
+    table = render_table(records)
+
+    assert payload[0]["agent"] == "cosh"
+    assert payload[0]["capability"] == "code-scan"
+    assert payload[0]["enabled"] == "enabled"
+    assert payload[0]["mode"] == "ask"
+    assert payload[0]["scan_mode"] == "-"
+    assert payload[0]["timeout"] == "10"
+    assert payload[0]["config"] == {}
+    assert payload[0]["config_path"] is None
+    assert "hooks" not in payload[0]
+    assert "source" not in payload[0]
+    lines = table.splitlines()
+    assert lines[0] == "[cosh]"
+    assert lines[1].startswith("CAPABILITY")
+    assert "AGENT" not in lines[1]
+    assert "SCAN_MODE" in lines[1]
+    assert "TIMEOUT(s)" in lines[1]
+    assert "HOOKS" not in lines[1]
+    assert "SOURCE" not in lines[1]
+    assert "code-scan" in table

--- a/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
+++ b/src/agent-sec-core/tests/unit-test/capabilities/test_view.py
@@ -48,7 +48,9 @@ def _load_qwen_pii_module() -> ModuleType:
     hook_dir = _SEC_CORE_ROOT / "qwen-code-extension" / "hooks"
     for name in ("hook_config", "pii_text", "trace_context"):
         sys.modules.pop(name, None)
-    return _load_module(hook_dir / "pii_checker_hook.py", "qwen_pii_checker_hook_for_caps")
+    return _load_module(
+        hook_dir / "pii_checker_hook.py", "qwen_pii_checker_hook_for_caps"
+    )
 
 
 def _table_section(table: str, agent: str) -> list[str]:
@@ -145,7 +147,9 @@ def test_cli_strict_enabled_matches_python_hook_helpers(
     assert record.env[env_name]["effective"] is expected
     assert record.effective == ("enabled" if expected else "disabled")
     has_diagnostic = any(env_name in item for item in record.diagnostics)
-    assert has_diagnostic is (raw not in {None, "true", "TRUE", " true ", "false", "FALSE", " false "})
+    assert has_diagnostic is (
+        raw not in {None, "true", "TRUE", " true ", "false", "FALSE", " false "}
+    )
 
 
 def test_static_agent_code_scanner_enabled_env_controls_effective() -> None:
@@ -190,8 +194,22 @@ def test_invalid_timeout_values_fall_back_with_diagnostic() -> None:
     assert any("PII_CHECKER_TIMEOUT" in item for item in record.diagnostics)
 
 
-@pytest.mark.parametrize("value", ["0", "-1", "inf", "bad"])
-def test_non_positive_or_non_numeric_timeout_values_fall_back(value: str) -> None:
+@pytest.mark.parametrize(("value", "expected"), [("0", "0"), ("-1", "-1")])
+def test_non_positive_int_timeout_matches_hook_runtime(
+    value: str, expected: str
+) -> None:
+    record = _single_record(
+        "qoder",
+        "code-scan",
+        {"CODE_SCANNER_TIMEOUT": value},
+    )
+
+    assert record.timeout == expected
+    assert any("may fail open" in item for item in record.diagnostics)
+
+
+@pytest.mark.parametrize("value", ["inf", "bad", "1.5"])
+def test_invalid_int_timeout_values_fall_back(value: str) -> None:
     record = _single_record(
         "qoder",
         "code-scan",
@@ -303,9 +321,13 @@ def test_cosh_prompt_scan_scan_mode_does_not_change_interaction_mode() -> None:
     assert record.env["PROMPT_SCANNER_SCAN_MODE"]["effective"] == "strict"
 
 
-def test_agent_home_and_config_files_do_not_affect_environment_view(tmp_path: Path) -> None:
+def test_agent_home_and_config_files_do_not_affect_environment_view(
+    tmp_path: Path,
+) -> None:
     openclaw_config = tmp_path / "openclaw.json"
-    hermes_config = tmp_path / "hermes" / "plugins" / "agent-sec-core-hermes-plugin" / "config.toml"
+    hermes_config = (
+        tmp_path / "hermes" / "plugins" / "agent-sec-core-hermes-plugin" / "config.toml"
+    )
     openclaw_config.write_text(
         json.dumps(
             {
@@ -313,7 +335,9 @@ def test_agent_home_and_config_files_do_not_affect_environment_view(tmp_path: Pa
                     "entries": {
                         "agent-sec": {
                             "enabled": False,
-                            "config": {"capabilities": {"prompt-scan": {"enabled": False}}},
+                            "config": {
+                                "capabilities": {"prompt-scan": {"enabled": False}}
+                            },
                         }
                     }
                 }
@@ -322,7 +346,9 @@ def test_agent_home_and_config_files_do_not_affect_environment_view(tmp_path: Pa
         encoding="utf-8",
     )
     hermes_config.parent.mkdir(parents=True)
-    hermes_config.write_text("[capabilities.prompt-scan-user-input]\nenabled = false\n", encoding="utf-8")
+    hermes_config.write_text(
+        "[capabilities.prompt-scan-user-input]\nenabled = false\n", encoding="utf-8"
+    )
 
     env = {
         "HOME": str(tmp_path / "home"),
@@ -419,22 +445,56 @@ def test_render_table_shows_code_scan_env_disable_per_agent() -> None:
         ]
 
 
+def test_public_outputs_do_not_expose_raw_environment_values() -> None:
+    sensitive_value = "token-like-sensitive-value"
+    records = query_capabilities(
+        agent="qwen",
+        capability="prompt-scan",
+        env={"PROMPT_SCANNER_MODE": sensitive_value},
+    )
+
+    payload = json.loads(render_json(records))
+    table = render_table(records)
+
+    assert sensitive_value not in json.dumps(payload)
+    assert sensitive_value not in table
+    assert "raw" not in payload[0]["env"]["PROMPT_SCANNER_MODE"]
+    assert payload[0]["env"]["PROMPT_SCANNER_MODE"] == {
+        "effective": "observe",
+        "default": "observe",
+    }
+    assert payload[0]["diagnostics"] == [
+        "PROMPT_SCANNER_MODE has an invalid value; using 'observe'"
+    ]
+
+
 def test_renderers_emit_stable_shapes() -> None:
     records = query_capabilities(agent="cosh", capability="code-scan", env={})
 
     payload = json.loads(render_json(records))
     table = render_table(records)
 
+    assert set(payload[0]) == {
+        "agent",
+        "capability",
+        "enabled",
+        "mode",
+        "scan_mode",
+        "timeout",
+        "env",
+        "diagnostics",
+    }
     assert payload[0]["agent"] == "cosh"
     assert payload[0]["capability"] == "code-scan"
     assert payload[0]["enabled"] == "enabled"
     assert payload[0]["mode"] == "ask"
     assert payload[0]["scan_mode"] == "-"
     assert payload[0]["timeout"] == "10"
-    assert payload[0]["config"] == {}
-    assert payload[0]["config_path"] is None
+    assert "raw" not in payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]
     assert "hooks" not in payload[0]
     assert "source" not in payload[0]
+    assert "config" not in payload[0]
+    assert "config_path" not in payload[0]
     lines = table.splitlines()
     assert lines[0] == "[cosh]"
     assert lines[1].startswith("CAPABILITY")

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -1,11 +1,15 @@
 """Unit tests for the top-level CLI entry points."""
 
+import json
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from click import unstyle
+from typer.testing import CliRunner
+
 from agent_sec_cli.cli import (
     _extract_trace_context_arg,
     _is_read_only_skill_analyze,
@@ -19,8 +23,6 @@ from agent_sec_cli.correlation_context import (
     get_current_trace_context,
 )
 from agent_sec_cli.security_middleware.result import ActionResult
-from click import unstyle
-from typer.testing import CliRunner
 
 
 @patch("agent_sec_cli.cli.invoke")
@@ -508,6 +510,71 @@ def test_events_help_lists_session_and_run_filters():
     help_text = unstyle(result.output)
     assert "--session-id" in help_text
     assert "--run-id" in help_text
+
+
+def test_capabilities_json_filter_outputs_current_environment(monkeypatch):
+    monkeypatch.setenv("CODE_SCANNER_HOOK_ENABLED", "false")
+    result = CliRunner().invoke(
+        app,
+        [
+            "capabilities",
+            "--agent",
+            "qoder",
+            "--capability",
+            "code-scan",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 1
+    assert payload[0]["agent"] == "qoder"
+    assert payload[0]["capability"] == "code-scan"
+    assert payload[0]["enabled"] == "disabled"
+    assert payload[0]["mode"] == "observe"
+    assert payload[0]["scan_mode"] == "-"
+    assert payload[0]["timeout"] == "10"
+    assert "hooks" not in payload[0]
+    assert "source" not in payload[0]
+    assert payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]["effective"] is False
+
+
+def test_capabilities_default_table_output(monkeypatch):
+    monkeypatch.delenv("OPENCLAW_CONFIG_PATH", raising=False)
+    result = CliRunner().invoke(app, ["capabilities", "--agent", "cosh"])
+
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "[cosh]"
+    assert lines[1].startswith("CAPABILITY")
+    assert "AGENT" not in lines[1]
+    assert "CAPABILITY" in lines[1]
+    assert "ENABLED" in lines[1]
+    assert "MODE" in lines[1]
+    assert "SCAN_MODE" in lines[1]
+    assert "TIMEOUT(s)" in lines[1]
+    assert "HOOKS" not in lines[1]
+    assert "SOURCE" not in lines[1]
+    assert "code-scan" in result.output
+
+
+def test_capabilities_rejects_plugin_capability_alias():
+    result = CliRunner().invoke(
+        app,
+        ["capabilities", "--capability", "scan-code"],
+    )
+
+    assert result.exit_code == 1
+    assert "unknown capability" in result.stderr
+
+
+def test_capabilities_rejects_invalid_output_format():
+    result = CliRunner().invoke(app, ["capabilities", "--output", "yaml"])
+
+    assert result.exit_code == 1
+    assert "--output must be one of" in result.stderr
 
 
 class TestHardenCli(unittest.TestCase):

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -7,9 +7,6 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from click import unstyle
-from typer.testing import CliRunner
-
 from agent_sec_cli.cli import (
     _extract_trace_context_arg,
     _is_read_only_skill_analyze,
@@ -23,6 +20,8 @@ from agent_sec_cli.correlation_context import (
     get_current_trace_context,
 )
 from agent_sec_cli.security_middleware.result import ActionResult
+from click import unstyle
+from typer.testing import CliRunner
 
 
 @patch("agent_sec_cli.cli.invoke")

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -538,7 +538,22 @@ def test_capabilities_json_filter_outputs_current_environment(monkeypatch):
     assert payload[0]["timeout"] == "10"
     assert "hooks" not in payload[0]
     assert "source" not in payload[0]
+    assert "config" not in payload[0]
+    assert "config_path" not in payload[0]
+    assert "raw" not in payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]
     assert payload[0]["env"]["CODE_SCANNER_HOOK_ENABLED"]["effective"] is False
+
+
+def test_capabilities_rejects_control_characters_without_terminal_escape():
+    result = CliRunner().invoke(
+        app,
+        ["capabilities", "--agent", "\x1b[31m" + "x" * 100],
+    )
+
+    assert result.exit_code == 1
+    assert "\x1b" not in result.output
+    assert "\\x1b[31m" in result.output
+    assert "x" * 80 not in result.output
 
 
 def test_capabilities_default_table_output(monkeypatch):


### PR DESCRIPTION
## Why

agent-sec-core 已支持多个 Agent Hook，但用户缺少一个统一入口来查看当前 CLI 环境变量下各 Agent 能力是否启用，以及 mode、scan mode、timeout 等关键配置推导结果。

本次补齐 `agent-sec-cli capabilities`，并明确它是当前 CLI 进程环境变量视图，不读取 OpenClaw、Hermes 或其他 Agent 配置文件，也不证明目标 Agent 运行时已加载 hook。

## What changed

- 新增 `agent-sec-cli capabilities` 子命令，支持按 Agent、capability 过滤，并输出 table 或 JSON。
- 为 Qoder、Qwen Code、Codex、Cosh、OpenClaw、Hermes 六个 Agent 建立 capability metadata，覆盖 code-scan、prompt-scan、pii-check、skill-ledger、observability。
- 对齐各 Agent hook runtime 的环境变量语义，包括 Cosh 默认 ask、Qwen PII legacy fallback、Qwen PII timeout 上限、Hermes 默认 timeout、Observability 静态 timeout 等。
- 明确 OpenClaw 和 Hermes 的部分 hook 行为仍来自插件配置文件而非环境变量，当前 CLI 不解析这些配置，因此 capabilities 输出不能视为完整 runtime-effective 配置。
- 增加单元测试和 CLI E2E，验证 CLI capability view 与 hook runtime 的环境变量解析语义一致。
- 更新 README、QUICKSTART 和 AGENTS.md，说明 environment-only 范围、环境漂移限制，以及 CLI view 与 hook runtime 的隐式维护契约。

## Related issue

no-issue: 新增 agent-sec-core CLI 能力视图，当前没有关联 issue。

## User / Agent impact

用户可以通过 `agent-sec-cli capabilities` 查看当前 CLI 环境变量下六个 Agent Hook 能力的启用状态、MODE、SCAN_MODE、TIMEOUT(s) 和配置解析诊断。

该命令不会改变 hook runtime 行为，也不会读取 Agent home 或宿主 Agent 配置文件。OpenClaw 和 Hermes 的部分配置来源不是环境变量，因此 CLI 输出只代表当前环境变量和静态默认值推导结果，不代表完整 runtime-effective 配置。如果 CLI 进程环境与真实 Agent 运行环境不同，或真实 Agent 依赖配置文件覆盖默认值，输出可能与真实运行时存在偏移，文档已明确说明该限制。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

新增公开 CLI 子命令和用户文档说明，因此属于 public CLI/documented behavior 变化。该命令只读当前环境变量，不修改配置、不启停 hook、不改变安全拦截行为。

CLI capability view 与各 Agent hook runtime 之间存在隐式环境变量语义契约，本次已通过 AGENTS.md 和测试固化维护要求。该契约只覆盖环境变量解析语义；OpenClaw 和 Hermes 中由插件配置文件控制的行为不在当前 CLI 解析范围内，后续如需完整 runtime-effective 视图，需要另行实现配置文件读取与优先级合并。

## Validation

- `uv run --project /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/agent-sec-cli pytest /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/tests/unit-test/capabilities/test_view.py /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/tests/unit-test/test_cli.py -q` — 132 passed, 4 subtests passed
- `uv run --project /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/agent-sec-cli pytest /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py -q` — 3 passed
- `make -C /Users/blank/Workspace/mine_anolisa/mine_anolisa/src/agent-sec-core python-lint-ci` — 100% quality, 0 violations
- CodeReview subagent — PASS，无 must-fix / should-fix，确认六个 Agent 环境变量解析语义无剩余偏差；OpenClaw/Hermes 非环境变量配置不在当前 CLI 解析范围内

## Documentation and rollback

已更新英文和中文 QUICKSTART、agent-sec-core README、agent-sec-core README_zh、agent-sec-cli README，以及 AGENTS.md 的 capability view 维护规则。

如需回滚，移除 `agent-sec-cli capabilities` 注册、capabilities 模块、相关测试和文档段落即可；该变更不涉及数据迁移，也不改变已安装 hook 的运行时拦截逻辑。
