### PR TITLE
fix(cosh-ng): [shell] send raw-mode disable to stdout on drop

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -1,4 +1,4 @@
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
 use std::sync::mpsc::{self, Sender};
@@ -20,6 +20,10 @@ use super::io_loop::{read_until_streaming, wait_child_preserving_signal};
 use super::lifecycle::{build_shell_host_output, push_shell_exited_event};
 use super::model::{ShellHostConfig, ShellHostOutput};
 use super::raw_relay::{read_raw_until_exit, DriverCompletion, RawActionWatchdog};
+
+mod raw_mode_guard;
+
+use raw_mode_guard::{reopen_stdout_blocking, RawModeGuard};
 
 pub fn run_raw_relay_bash<R, W>(
     config: &ShellHostConfig,
@@ -421,164 +425,6 @@ where
     )
 }
 
-/// Re-open stdout on a fresh, blocking file description when needed.
-///
-/// On Linux terminals (and SSH sessions), stdin and stdout often share the
-/// same underlying open file description. `RawModeGuard` sets `O_NONBLOCK` on
-/// stdin (fd 0), which therefore also makes stdout (fd 1) non-blocking.
-/// Subsequent writes to stdout can then return `EAGAIN` / `EWOULDBLOCK`.
-///
-/// This function opens `/dev/tty` to obtain a new, independent file
-/// description that is not marked `O_NONBLOCK`, and uses `dup2` to replace
-/// fd 1 with it. The termios configuration is per-device, so the new fd
-/// inherits the raw-mode settings already applied by `RawModeGuard`.
-///
-/// If stdout is not a terminal, or if `/dev/tty` cannot be opened, the
-/// function logs a warning and returns success so that the shell can still
-/// start. In that case the caller retains the original (possibly
-/// non-blocking) stdout behavior.
-fn reopen_stdout_blocking() -> io::Result<()> {
-    if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 0 {
-        // stdout is not a terminal, so the stdin/stdout shared file
-        // description problem does not apply here.
-        return Ok(());
-    }
-    let tty = match OpenOptions::new().write(true).open("/dev/tty") {
-        Ok(tty) => tty,
-        Err(err) => {
-            eprintln!(
-                "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
-                 EAGAIN risk remains"
-            );
-            return Ok(());
-        }
-    };
-    let tty_fd = tty.as_raw_fd();
-    if unsafe { libc::dup2(tty_fd, libc::STDOUT_FILENO) } < 0 {
-        let err = io::Error::last_os_error();
-        eprintln!(
-            "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
-             EAGAIN risk remains"
-        );
-    }
-    // `tty` is dropped here, but the duplicated fd remains alive because fd 1
-    // now refers to the same open file description.
-    Ok(())
-}
-
-struct RawModeGuard {
-    fd: i32,
-    original_termios: Option<libc::termios>,
-    original_flags: i32,
-    active: bool,
-}
-
-impl RawModeGuard {
-    #[cfg(test)]
-    fn for_test(fd: i32, original_termios: Option<libc::termios>, original_flags: i32) -> Self {
-        Self {
-            fd,
-            original_termios,
-            original_flags,
-            active: true,
-        }
-    }
-
-    /// #1932 F4: modifyOtherKeys level 1 makes the terminal report
-    /// modifier-carrying editing keys (Shift+Enter -> `CSI 27;2;13~`)
-    /// that already sit on the soft-newline whitelist, with zero terminal
-    /// configuration. Level 1 leaves every conventionally-encoded key
-    /// (Esc, Alt+letter, Ctrl+letter) untouched, and terminals without
-    /// the feature ignore the sequence entirely. The enable is written on
-    /// the relay's ordered stdout path; this guard only owns the
-    /// withdrawal so the tty never keeps the mode after exit.
-    const MODIFY_OTHER_KEYS_DISABLE: &'static [u8] = b"\x1b[>4;0m";
-
-    fn activate_stdin() -> io::Result<Option<Self>> {
-        Self::activate_fd(0)
-    }
-
-    fn activate_fd(fd: i32) -> io::Result<Option<Self>> {
-        let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-        if original_flags < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        if unsafe { libc::fcntl(fd, libc::F_SETFL, original_flags | libc::O_NONBLOCK) } < 0 {
-            return Err(io::Error::last_os_error());
-        }
-
-        let original_termios = if unsafe { libc::isatty(fd) } == 1 {
-            let mut original = unsafe { std::mem::zeroed::<libc::termios>() };
-            if unsafe { libc::tcgetattr(fd, &mut original) } < 0 {
-                let error = io::Error::last_os_error();
-                unsafe {
-                    libc::fcntl(fd, libc::F_SETFL, original_flags);
-                }
-                return Err(error);
-            }
-
-            let mut raw = original;
-            unsafe {
-                libc::cfmakeraw(&mut raw);
-            }
-            if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } < 0 {
-                let error = io::Error::last_os_error();
-                unsafe {
-                    libc::fcntl(fd, libc::F_SETFL, original_flags);
-                }
-                return Err(error);
-            }
-            Some(original)
-        } else {
-            None
-        };
-
-        Ok(Some(Self {
-            fd,
-            original_termios,
-            original_flags,
-            active: true,
-        }))
-    }
-}
-
-impl Drop for RawModeGuard {
-    fn drop(&mut self) {
-        if self.active {
-            // Clear O_NONBLOCK temporarily so the cleanup write and termios
-            // restore cannot be lost to EAGAIN. This is necessary even if the
-            // descriptor inherited O_NONBLOCK from the parent process, because
-            // original_flags would then still contain that bit and a plain
-            // restore would leave the fd non-blocking during the write.
-            // The actual original flags are restored after the cleanup.
-            unsafe {
-                libc::fcntl(
-                    self.fd,
-                    libc::F_SETFL,
-                    self.original_flags & !libc::O_NONBLOCK,
-                );
-            }
-            if let Some(original) = &self.original_termios {
-                // Withdraw the keyboard negotiation before handing the tty
-                // back (#1932 F4); paired with the enable in activate_fd.
-                unsafe {
-                    libc::write(
-                        self.fd,
-                        Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
-                        Self::MODIFY_OTHER_KEYS_DISABLE.len(),
-                    );
-                    libc::tcsetattr(self.fd, libc::TCSANOW, original);
-                }
-            }
-            // Restore the exact flags we inherited, even if they included
-            // O_NONBLOCK.
-            unsafe {
-                libc::fcntl(self.fd, libc::F_SETFL, self.original_flags);
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -652,8 +498,12 @@ mod tests {
         );
 
         let fake_termios = unsafe { std::mem::zeroed::<libc::termios>() };
-        let guard =
-            RawModeGuard::for_test(write_fd, Some(fake_termios), original | libc::O_NONBLOCK);
+        let guard = RawModeGuard::for_test(
+            write_fd,
+            write_fd,
+            Some(fake_termios),
+            original | libc::O_NONBLOCK,
+        );
 
         let drain_handle = thread::spawn(move || {
             thread::sleep(Duration::from_millis(50));
@@ -677,6 +527,88 @@ mod tests {
             output.contains("\x1b[>4;0m"),
             "disable sequence not found in pipe output: {output:?}"
         );
+    }
+
+    #[test]
+    fn raw_mode_guard_disable_write_targets_output_fd() {
+        // The withdrawal must travel on the output path that carried the
+        // enable, not on the input fd: a read-only or separately opened
+        // stdin never delivers bytes to the terminal. Input and output are
+        // separate pipes standing in for stdin and stdout; the guard is
+        // built with a fake termios so the cleanup write path runs. The
+        // disable sequence must land on the output pipe and nothing may be
+        // written to the input pipe.
+        let (input_read_owned, input_write_owned) = nix::unistd::pipe().expect("open input pipe");
+        let (output_read_owned, output_write_owned) =
+            nix::unistd::pipe().expect("open output pipe");
+        let input_read = input_read_owned.as_raw_fd();
+        let input_write = input_write_owned.as_raw_fd();
+        let output_read = output_read_owned.as_raw_fd();
+        let output_write = output_write_owned.as_raw_fd();
+
+        let original = unsafe { libc::fcntl(input_write, libc::F_GETFL) };
+        let fake_termios = unsafe { std::mem::zeroed::<libc::termios>() };
+        let guard = RawModeGuard::for_test(input_write, output_write, Some(fake_termios), original);
+        drop(guard);
+
+        // The drop above already wrote synchronously, so a non-blocking read
+        // either sees the sequence or fails immediately instead of hanging
+        // when the write went to the wrong fd.
+        let output_flags = unsafe { libc::fcntl(output_read, libc::F_GETFL) };
+        unsafe { libc::fcntl(output_read, libc::F_SETFL, output_flags | libc::O_NONBLOCK) };
+        let mut buf = [0_u8; 64];
+        let n = unsafe { libc::read(output_read, buf.as_mut_ptr().cast(), buf.len()) };
+        assert!(n > 0, "expected disable sequence on the output fd");
+        assert_eq!(&buf[..n as usize], b"\x1b[>4;0m");
+
+        let input_flags = unsafe { libc::fcntl(input_read, libc::F_GETFL) };
+        unsafe { libc::fcntl(input_read, libc::F_SETFL, input_flags | libc::O_NONBLOCK) };
+        let n = unsafe { libc::read(input_read, buf.as_mut_ptr().cast(), buf.len()) };
+        assert!(
+            n < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EAGAIN),
+            "expected no bytes written to the input fd, got {:?}",
+            &buf[..n.max(0) as usize]
+        );
+    }
+
+    #[test]
+    fn raw_mode_guard_full_non_tty_output_does_not_block_exit() {
+        // With stdout on a pipe the enable never reached a terminal, so the
+        // withdrawal must not block shell exit when that pipe is full and
+        // its reader never drains: the write is best-effort non-blocking on
+        // non-tty outputs. The guard drops on a worker thread so a
+        // regression to a blocking write surfaces as a fast timeout here
+        // instead of a hang.
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let (_input_read_owned, input_write_owned) = nix::unistd::pipe().expect("open input pipe");
+        let (output_read_owned, output_write_owned) =
+            nix::unistd::pipe().expect("open output pipe");
+        let input_write = input_write_owned.as_raw_fd();
+        let output_write = output_write_owned.as_raw_fd();
+
+        let output_flags = unsafe { libc::fcntl(output_write, libc::F_GETFL) };
+        unsafe { libc::fcntl(output_write, libc::F_SETFL, output_flags | libc::O_NONBLOCK) };
+        let chunk = [0_u8; 8192];
+        while unsafe { libc::write(output_write, chunk.as_ptr().cast(), chunk.len()) } >= 0 {}
+        unsafe { libc::fcntl(output_write, libc::F_SETFL, output_flags) };
+
+        let original = unsafe { libc::fcntl(input_write, libc::F_GETFL) };
+        let fake_termios = unsafe { std::mem::zeroed::<libc::termios>() };
+        let guard = RawModeGuard::for_test(input_write, output_write, Some(fake_termios), original);
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let dropper = thread::spawn(move || {
+            drop(guard);
+            done_tx.send(()).expect("send drop completion");
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("guard drop must not block on a full non-tty output");
+        dropper.join().expect("join dropper thread");
+        drop(output_read_owned);
     }
 
     fn termios_for_fd(fd: i32) -> libc::termios {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
@@ -1,0 +1,223 @@
+use std::fs::OpenOptions;
+use std::io;
+use std::os::fd::AsRawFd;
+
+use nix::libc;
+
+/// Re-open stdout on a fresh, blocking file description when needed.
+///
+/// On Linux terminals (and SSH sessions), stdin and stdout often share the
+/// same underlying open file description. `RawModeGuard` sets `O_NONBLOCK` on
+/// stdin (fd 0), which therefore also makes stdout (fd 1) non-blocking.
+/// Subsequent writes to stdout can then return `EAGAIN` / `EWOULDBLOCK`.
+///
+/// This function opens `/dev/tty` to obtain a new, independent file
+/// description that is not marked `O_NONBLOCK`, and uses `dup2` to replace
+/// fd 1 with it. The termios configuration is per-device, so the new fd
+/// inherits the raw-mode settings already applied by `RawModeGuard`.
+///
+/// If stdout is not a terminal, or if `/dev/tty` cannot be opened, the
+/// function logs a warning and returns success so that the shell can still
+/// start. In that case the caller retains the original (possibly
+/// non-blocking) stdout behavior.
+pub(super) fn reopen_stdout_blocking() -> io::Result<()> {
+    if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 0 {
+        // stdout is not a terminal, so the stdin/stdout shared file
+        // description problem does not apply here.
+        return Ok(());
+    }
+    let tty = match OpenOptions::new().write(true).open("/dev/tty") {
+        Ok(tty) => tty,
+        Err(err) => {
+            eprintln!(
+                "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
+                 EAGAIN risk remains"
+            );
+            return Ok(());
+        }
+    };
+    let tty_fd = tty.as_raw_fd();
+    if unsafe { libc::dup2(tty_fd, libc::STDOUT_FILENO) } < 0 {
+        let err = io::Error::last_os_error();
+        eprintln!(
+            "cosh-shell: warning: cannot reopen stdout as blocking: {err}; \
+             EAGAIN risk remains"
+        );
+    }
+    // `tty` is dropped here, but the duplicated fd remains alive because fd 1
+    // now refers to the same open file description.
+    Ok(())
+}
+
+pub(super) struct RawModeGuard {
+    fd: i32,
+    /// Where the modifyOtherKeys withdrawal is written. The enable travels
+    /// on the relay's stdout path, so the withdrawal must reach the same
+    /// terminal path; stdin may be a read-only or separately opened
+    /// descriptor that never carries bytes to the terminal.
+    output_fd: i32,
+    original_termios: Option<libc::termios>,
+    original_flags: i32,
+    active: bool,
+}
+
+impl RawModeGuard {
+    /// Field order mirrors the struct: `(fd, output_fd, original_termios,
+    /// original_flags)`; unlike `activate_fd_with_output` the termios and
+    /// flags are injected instead of being probed from the fd.
+    #[cfg(test)]
+    pub(super) fn for_test(
+        fd: i32,
+        output_fd: i32,
+        original_termios: Option<libc::termios>,
+        original_flags: i32,
+    ) -> Self {
+        Self {
+            fd,
+            output_fd,
+            original_termios,
+            original_flags,
+            active: true,
+        }
+    }
+
+    /// #1932 F4: modifyOtherKeys level 1 makes the terminal report
+    /// modifier-carrying editing keys (Shift+Enter -> `CSI 27;2;13~`)
+    /// that already sit on the soft-newline whitelist, with zero terminal
+    /// configuration. Level 1 leaves every conventionally-encoded key
+    /// (Esc, Alt+letter, Ctrl+letter) untouched, and terminals without
+    /// the feature ignore the sequence entirely. The enable is written on
+    /// the relay's ordered stdout path; this guard owns the withdrawal and
+    /// writes it to the same stdout path so the tty never keeps the mode
+    /// after exit.
+    const MODIFY_OTHER_KEYS_DISABLE: &'static [u8] = b"\x1b[>4;0m";
+
+    pub(super) fn activate_stdin() -> io::Result<Option<Self>> {
+        Self::activate_fd_with_output(0, libc::STDOUT_FILENO)
+    }
+
+    #[cfg(test)]
+    pub(super) fn activate_fd(fd: i32) -> io::Result<Option<Self>> {
+        Self::activate_fd_with_output(fd, fd)
+    }
+
+    fn activate_fd_with_output(fd: i32, output_fd: i32) -> io::Result<Option<Self>> {
+        let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if original_flags < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if unsafe { libc::fcntl(fd, libc::F_SETFL, original_flags | libc::O_NONBLOCK) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let original_termios = if unsafe { libc::isatty(fd) } == 1 {
+            let mut original = unsafe { std::mem::zeroed::<libc::termios>() };
+            if unsafe { libc::tcgetattr(fd, &mut original) } < 0 {
+                let error = io::Error::last_os_error();
+                unsafe {
+                    libc::fcntl(fd, libc::F_SETFL, original_flags);
+                }
+                return Err(error);
+            }
+
+            let mut raw = original;
+            unsafe {
+                libc::cfmakeraw(&mut raw);
+            }
+            if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } < 0 {
+                let error = io::Error::last_os_error();
+                unsafe {
+                    libc::fcntl(fd, libc::F_SETFL, original_flags);
+                }
+                return Err(error);
+            }
+            Some(original)
+        } else {
+            None
+        };
+
+        Ok(Some(Self {
+            fd,
+            output_fd,
+            original_termios,
+            original_flags,
+            active: true,
+        }))
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if self.active {
+            // Clear O_NONBLOCK temporarily so the cleanup write and termios
+            // restore cannot be lost to EAGAIN. This is necessary even if the
+            // descriptor inherited O_NONBLOCK from the parent process, because
+            // original_flags would then still contain that bit and a plain
+            // restore would leave the fd non-blocking during the write.
+            // The actual original flags are restored after the cleanup.
+            unsafe {
+                libc::fcntl(
+                    self.fd,
+                    libc::F_SETFL,
+                    self.original_flags & !libc::O_NONBLOCK,
+                );
+            }
+            if let Some(original) = &self.original_termios {
+                // Withdraw the keyboard negotiation before handing the tty
+                // back (#1932 F4); paired with the enable the relay writes on
+                // the stdout path, so the withdrawal targets the same path.
+                if self.output_fd == self.fd {
+                    unsafe {
+                        libc::write(
+                            self.fd,
+                            Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                            Self::MODIFY_OTHER_KEYS_DISABLE.len(),
+                        );
+                    }
+                } else {
+                    // Mirroring the input-fd handling above, O_NONBLOCK is
+                    // cleared around the write so the disable sequence
+                    // cannot be lost to EAGAIN on an inherited non-blocking
+                    // stdout — but only when the output fd is a terminal.
+                    // With stdout on a pipe the enable never reached the
+                    // terminal either, so the withdrawal flips to a
+                    // non-blocking best-effort write instead: a blocking
+                    // write into a full pipe would stall exit before the
+                    // termios restore below.
+                    //
+                    // The flags are snapshotted now, not at activation:
+                    // fd 1 may have been replaced afterwards (see
+                    // reopen_stdout_blocking) and would otherwise get flags
+                    // belonging to the old file description. A failed
+                    // F_GETFL means the fd is no longer usable, so the
+                    // write is skipped instead of running unguarded.
+                    let flags = unsafe { libc::fcntl(self.output_fd, libc::F_GETFL) };
+                    if flags >= 0 {
+                        let write_flags = if unsafe { libc::isatty(self.output_fd) } == 1 {
+                            flags & !libc::O_NONBLOCK
+                        } else {
+                            flags | libc::O_NONBLOCK
+                        };
+                        unsafe {
+                            libc::fcntl(self.output_fd, libc::F_SETFL, write_flags);
+                            libc::write(
+                                self.output_fd,
+                                Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                                Self::MODIFY_OTHER_KEYS_DISABLE.len(),
+                            );
+                            libc::fcntl(self.output_fd, libc::F_SETFL, flags);
+                        }
+                    }
+                }
+                unsafe {
+                    libc::tcsetattr(self.fd, libc::TCSANOW, original);
+                }
+            }
+            // Restore the exact flags we inherited, even if they included
+            // O_NONBLOCK.
+            unsafe {
+                libc::fcntl(self.fd, libc::F_SETFL, self.original_flags);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`RawModeGuard::drop` wrote the modifyOtherKeys withdrawal (`ESC[>4;0m`) to the guarded stdin fd, while the enable sequence (`ESC[>4;1m`) travels on the relay's ordered stdout path (`raw_relay.rs`). When fd 0 does not share a writable file description with fd 1 — e.g. `cosh-shell 0</dev/tty` gives a read-only tty that still passes the startup `stdin.is_terminal()` check — the disable never reaches the terminal and the keyboard negotiation leaks past exit, corrupting modifier-carrying keys (Shift+Enter -> `CSI 27;2;13~` garbage) in the outer shell until a `reset`.

Closes #2091

## Changes

- `RawModeGuard` carries an explicit `output_fd` for the withdrawal: `activate_stdin()` targets `STDOUT_FILENO` (matching the enable path); the single-fd `activate_fd(fd)` form keeps its same-fd behavior for tests/embedded use.
- The drop-time write snapshots the output fd's flags **at withdrawal, not activation** — `reopen_stdout_blocking` may have replaced fd 1 after the guard was armed. On terminal outputs `O_NONBLOCK` is cleared around the write (EAGAIN protection preserved on the new target); on non-tty outputs the write flips to a non-blocking best-effort instead, so a full pipe cannot stall exit before the termios restore, and a failed flags probe skips the write entirely (review round 1).
- `RawModeGuard` + `reopen_stdout_blocking` move verbatim to a `raw_runner/raw_mode_guard.rs` submodule (follows the `raw_relay/` submodule pattern) to keep `raw_runner.rs` under the 700-line layout bar; no behavior change from the move.
- New regression tests: `raw_mode_guard_disable_write_targets_output_fd` pins the disable sequence to the output fd and asserts nothing is written back to the input fd; `raw_mode_guard_full_non_tty_output_does_not_block_exit` proves a full non-tty output cannot block the guard drop. The existing full-buffer EAGAIN test is re-anchored via the widened `for_test` constructor.

## Tests

- `cargo test -p cosh-shell --lib raw_mode_guard`: 5/5 pass (2 pre-existing, 1 re-anchored, 2 new).
- Mutation check: reverting the drop write target back to `self.fd` makes the new test fail immediately (`expected disable sequence on the output fd`, 0.00s — non-blocking read, no hang); restoring the fix returns 4/4 green.
- Coverage boundary: the unit test anchors the drop mechanism via `for_test`; the `activate_stdin() -> STDOUT_FILENO` production wiring is exercised by the real-PTY FAIL->PASS evidence below.

## Verification

- Focused green: `cargo test -p cosh-shell --lib raw_mode_guard` (lib target carries the guard tests).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `check-layout.sh`, `check-test-inventory.sh`: all pass locally after rebase onto latest `main`.
- Not run locally: full workspace test suite and other integration targets (covered by CI).

## Evidence

Real-binary, real-PTY reproduction (scripted PTY drives `cosh-shell`; byte-level assertion on the PTY master for `ESC[>4;1m` / `ESC[>4;0m`):

| Scenario | Before fix | After fix |
|---|---|---|
| issue shape `cosh-shell 0</dev/tty` (separate read-only stdin description) | enable seen, **disable never arrives** (exit 1) | enable + disable both observed (exit 0) |
| control (fd 0 = rw pty slave) | enable + disable observed (exit 0) | enable + disable observed (exit 0) |

Assets (fork orphan branch `pr-2357-assets`, SHA-pinned):

| Run | Cast replay (gif) | Byte-level result |
|---|---|---|
| FAIL baseline, issue shape, pre-fix @ 6ece763e | ![fail-baseline](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/fail-baseline.gif) | [`fail-baseline-result.json`](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/fail-baseline-result.json) — `disable_seen: false` |
| PASS, issue shape, post-fix | ![pass-after-fix](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/pass-after-fix.gif) | [`pass-after-fix-result.json`](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/pass-after-fix-result.json) — `disable_seen: true` |
| Control (rw stdin), post-fix | ![pass-control](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/pass-control.gif) | pre-fix control: [`control-before-fix-result.json`](https://raw.githubusercontent.com/SunnyQjm/anolisa/a970d3ac4fc6d636044dac582e7d5e21ecc61977/control-before-fix-result.json) — `disable_seen: true` |

Note: the enable/disable sequences are invisible in rendered frames by design; the byte-level `result.json` assertions (captured on the PTY master) are the authoritative evidence, the gifs document the real-binary session shape.
