### PR TITLE
feat(docs): use HD Token-less README video

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ demand so only the relevant ones enter the context, and
       <video
         controls
         muted
-        src="https://github.com/user-attachments/assets/1c416b99-2bbb-41c1-b754-fe9af634779c"
+        src="https://github.com/user-attachments/assets/b372ae72-44fa-492f-9feb-e6cd137b631a"
       ></video>
     </td>
   </tr>

--- a/README_zh.md
+++ b/README_zh.md
@@ -73,7 +73,7 @@ Skills，只把用得到的技能放进上下文，[AgentSight](src/agentsight/R
       <video
         controls
         muted
-        src="https://github.com/user-attachments/assets/1c416b99-2bbb-41c1-b754-fe9af634779c"
+        src="https://github.com/user-attachments/assets/b372ae72-44fa-492f-9feb-e6cd137b631a"
       ></video>
     </td>
   </tr>


### PR DESCRIPTION
## Why

The merged README demo uses a lower-resolution attachment that appears soft on
larger screens. This replaces it with a high-resolution source while keeping the
media outside Git history.

## What changed

- Point both root README video players to the new 2162x1440 H.264 attachment.
- Preserve the cover-first playback and the existing bilingual metric wording.
- Keep the repository free of video binaries.

## Related issue

no-issue: focused README media quality update

## User / Agent impact

README visitors see a sharper Token-less cover and terminal recording. Developer
clone and checkout size remain unchanged because the MP4 stays in GitHub
user-attachments.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The native player and documentation structure are unchanged; only the
attachment URL changes.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`
- Confirmed GitHub Markdown renders the new URL as a native video player.
- Verified the 27,544,680-byte upload matches the local SHA-256 checksum.
- Checked the cover, transition, resolution, frame rate, audio, and duration.

## Documentation and rollback

Updated `README.md` and `README_zh.md`. Revert this commit to restore the previous
attachment URL.
