### PR TITLE
fix(cosh-ng): [core,shell] harden hooks

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -136,6 +136,10 @@ pub struct HookDefinition {
     pub timeout: Option<u64>,
     #[serde(default)]
     pub sequential: Option<bool>,
+    /// Allow this hook to fail open. The default is fail closed because a
+    /// PreToolUse hook failure must never silently authorize a tool call.
+    #[serde(default)]
+    pub fail_open: bool,
     /// Environment variables injected into this hook's child process only.
     /// The child inherits the parent environment first, so an entry here
     /// overrides an inherited value of the same name. The host never calls

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -16,7 +16,7 @@ use crate::compaction::{CompactionRuntime, ModelCapability};
 use crate::config::{self, CoreConfig};
 use crate::context::ContextBuilder;
 use crate::extension::{GenerationController, RuntimeGeneration, RuntimeSnapshot};
-use crate::hook::{HookDecision, HookNotification, HookSystem};
+use crate::hook::{HookDecision, HookNotification, HookSystem, PreToolUseResult};
 use crate::loop_detect::LoopDetector;
 use crate::metrics::TurnMetrics;
 use crate::protocol::{InputMessage, OutputMessage, ShellContext, ShellControlRequest};
@@ -1198,15 +1198,16 @@ impl CoshCore {
                     )
                     .await;
                 self.emit_hook_notifications(writer, &hook_result.notifications, Some(&tc.id));
+                let (hook_status, hook_decision) = pre_tool_hook_audit(&hook_result);
                 self.audit.record_hook_decision(
                     tool_scope,
                     "pre_tool_use",
-                    hook_outcome(&hook_result.decision),
-                    hook_decision_name(&hook_result.decision),
+                    hook_status,
+                    hook_decision,
                 );
 
                 let (outcome, params) = match hook_result.decision {
-                    HookDecision::Block(reason) => {
+                    HookDecision::Block(reason) | HookDecision::HookFailure(reason) => {
                         // ─── SLS: hook-blocked tool call counts as total + fail ───
                         self.metrics.tool_calls_total += 1;
                         self.metrics.tool_calls_fail += 1;
@@ -2206,8 +2207,26 @@ fn hook_decision_name(decision: &HookDecision) -> &'static str {
     match decision {
         HookDecision::Allow => "allow",
         HookDecision::Block(_) => "block",
+        HookDecision::HookFailure(_) => "hook_failure",
         HookDecision::Ask => "ask",
         HookDecision::Passthrough => "passthrough",
+    }
+}
+
+fn pre_tool_hook_audit(result: &PreToolUseResult) -> (AuditOutcomeStatus, &'static str) {
+    if !result.hook_failures.is_empty()
+        && matches!(
+            result.decision,
+            HookDecision::Allow | HookDecision::Passthrough
+        )
+    {
+        // A fail-open hook failed and no stronger decision stopped the tool.
+        (AuditOutcomeStatus::Failed, "hook_failure")
+    } else {
+        (
+            hook_outcome(&result.decision),
+            hook_decision_name(&result.decision),
+        )
     }
 }
 
@@ -2215,6 +2234,7 @@ fn hook_outcome(decision: &HookDecision) -> AuditOutcomeStatus {
     match decision {
         HookDecision::Allow | HookDecision::Passthrough => AuditOutcomeStatus::Allowed,
         HookDecision::Block(_) => AuditOutcomeStatus::Denied,
+        HookDecision::HookFailure(_) => AuditOutcomeStatus::Failed,
         HookDecision::Ask => AuditOutcomeStatus::Started,
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -19,6 +19,55 @@ fn make_core(provider: MockProvider) -> CoshCore {
     CoshCore::new(config, Box::new(provider), tools)
 }
 
+#[test]
+fn hook_failure_audit_is_distinct_from_real_allow() {
+    let allow = crate::hook::PreToolUseResult {
+        decision: crate::hook::HookDecision::Allow,
+        tool_input_patch: None,
+        notifications: Vec::new(),
+        hook_failures: Vec::new(),
+    };
+    assert_eq!(
+        pre_tool_hook_audit(&allow),
+        (cosh_types::audit::AuditOutcomeStatus::Allowed, "allow")
+    );
+
+    let fail_open = crate::hook::PreToolUseResult {
+        decision: crate::hook::HookDecision::Allow,
+        tool_input_patch: None,
+        notifications: Vec::new(),
+        hook_failures: vec![crate::hook::HookFailure {
+            hook_name: "probe".to_string(),
+            kind: crate::hook::HookFailureKind::InvalidJson,
+        }],
+    };
+    assert_eq!(
+        pre_tool_hook_audit(&fail_open),
+        (
+            cosh_types::audit::AuditOutcomeStatus::Failed,
+            "hook_failure"
+        )
+    );
+
+    let blocked_with_fail_open_failure = crate::hook::PreToolUseResult {
+        decision: crate::hook::HookDecision::Block("policy denied".to_string()),
+        ..fail_open.clone()
+    };
+    assert_eq!(
+        pre_tool_hook_audit(&blocked_with_fail_open_failure),
+        (cosh_types::audit::AuditOutcomeStatus::Denied, "block")
+    );
+
+    let ask_with_fail_open_failure = crate::hook::PreToolUseResult {
+        decision: crate::hook::HookDecision::Ask,
+        ..fail_open
+    };
+    assert_eq!(
+        pre_tool_hook_audit(&ask_with_fail_open_failure),
+        (cosh_types::audit::AuditOutcomeStatus::Started, "ask")
+    );
+}
+
 struct CountingShellTool {
     calls: Arc<AtomicUsize>,
 }
@@ -337,6 +386,7 @@ async fn raw_shell_input_reaches_prompt_hook_without_changing_provider_content()
         matcher: None,
         timeout: Some(5_000),
         sequential: None,
+        fail_open: false,
         env: Default::default(),
     }];
     let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
@@ -374,6 +424,7 @@ async fn prompt_hook_falls_back_to_content_without_raw_shell_input() {
         matcher: None,
         timeout: Some(5_000),
         sequential: None,
+        fail_open: false,
         env: Default::default(),
     }];
     let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
@@ -476,6 +527,7 @@ fn compress_schema_hook(command: &str) -> crate::config::HookDefinition {
         matcher: None,
         timeout: Some(10_000),
         sequential: None,
+        fail_open: false,
         env: Default::default(),
     }
 }
@@ -1462,6 +1514,7 @@ fn sandbox_bypass_hook(marker: &std::path::Path) -> crate::config::HookDefinitio
         matcher: None,
         timeout: Some(10_000),
         sequential: None,
+        fail_open: false,
         env: Default::default(),
     }
 }
@@ -2008,6 +2061,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            fail_open: false,
             env: Default::default(),
         }],
         post_tool_use: vec![config::HookDefinition {
@@ -2017,6 +2071,7 @@ async fn cosh_shell_evidence_bypasses_normal_tool_hooks() {
             matcher: Some("cosh_shell_evidence".to_string()),
             timeout: Some(5000),
             sequential: None,
+            fail_open: false,
             env: Default::default(),
         }],
         ..Default::default()
@@ -3216,6 +3271,7 @@ fn ask_hook(name: &str) -> crate::config::HookDefinition {
         matcher: None,
         timeout: Some(10_000),
         sequential: None,
+        fail_open: false,
         env: Default::default(),
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/extension/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/config.rs
@@ -85,6 +85,9 @@ pub struct CommandHookConfig {
     pub description: Option<String>,
     #[serde(default)]
     pub timeout: Option<u64>,
+    /// Explicitly permit this hook to fail open.
+    #[serde(default)]
+    pub fail_open: bool,
     /// Environment variables for this hook's child process. Passed through to
     /// [`HookDefinition::env`] verbatim; see there for the scoping guarantees.
     #[serde(default)]
@@ -124,6 +127,7 @@ impl HookGroup {
                 matcher: self.matcher.clone(),
                 timeout: h.timeout,
                 sequential: self.sequential,
+                fail_open: h.fail_open,
                 env: h.env.clone(),
             })
             .collect()
@@ -282,6 +286,7 @@ mod tests {
                     name: Some("hook-a".to_string()),
                     description: None,
                     timeout: Some(3000),
+                    fail_open: false,
                     env: BTreeMap::from([("TOKENLESS_AGENT_ID".to_string(), "cosh".to_string())]),
                 }],
             },
@@ -294,6 +299,7 @@ mod tests {
                     name: None,
                     description: None,
                     timeout: None,
+                    fail_open: false,
                     env: BTreeMap::new(),
                 }],
             },

--- a/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
+++ b/src/cosh-ng/crates/cosh-core/src/extension/manifest/v1.rs
@@ -424,6 +424,9 @@ fn validate_and_convert_hooks(
                 if let Some(timeout) = hook.timeout {
                     projection["timeout"] = Value::Number(timeout.into());
                 }
+                if hook.fail_open {
+                    projection["fail_open"] = Value::Bool(true);
+                }
                 records.push(CapabilityRecord {
                     id: id.canonical(),
                     projection,
@@ -434,6 +437,7 @@ fn validate_and_convert_hooks(
                     name: Some(hook.name),
                     description: hook.description,
                     timeout: hook.timeout,
+                    fail_open: hook.fail_open,
                     env: hook.env,
                 });
             }
@@ -784,6 +788,8 @@ struct CommandHookV1 {
     description: Option<String>,
     #[serde(default)]
     timeout: Option<u64>,
+    #[serde(default)]
+    fail_open: bool,
     #[serde(default)]
     env: BTreeMap<String, String>,
 }

--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
 
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::de::{value::MapAccessDeserializer, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use crate::config::{HookDefinition, HooksConfig};
@@ -56,6 +57,12 @@ pub struct HookInput {
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct HookOutput {
+    #[serde(rename = "continue")]
+    pub should_continue: Option<bool>,
+    #[serde(alias = "stopReason")]
+    pub stop_reason: Option<String>,
+    #[serde(alias = "suppressOutput")]
+    pub suppress_output: Option<bool>,
     pub decision: Option<String>,
     pub reason: Option<String>,
     #[serde(alias = "systemMessage")]
@@ -64,12 +71,90 @@ pub struct HookOutput {
     pub hook_specific_output: Option<Value>,
 }
 
+struct ObjectOnlyHookOutput(HookOutput);
+
+impl<'de> Deserialize<'de> for ObjectOnlyHookOutput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ObjectVisitor;
+
+        impl<'de> Visitor<'de> for ObjectVisitor {
+            type Value = ObjectOnlyHookOutput;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a hook output JSON object")
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                HookOutput::deserialize(MapAccessDeserializer::new(map)).map(ObjectOnlyHookOutput)
+            }
+        }
+
+        deserializer.deserialize_map(ObjectVisitor)
+    }
+}
+
+fn decode_hook_output(raw: &[u8]) -> Option<HookOutput> {
+    serde_json::from_slice::<ObjectOnlyHookOutput>(raw)
+        .ok()
+        .map(|output| output.0)
+}
+
+/// Classifies why a hook could not produce a valid protocol response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookFailureKind {
+    /// The child process could not be started.
+    Spawn,
+    /// The child process failed during I/O.
+    Io,
+    /// The hook exceeded its configured deadline.
+    Timeout,
+    /// The hook exited with an unexpected non-zero status.
+    NonZero,
+    /// The hook terminated because it received a signal.
+    Signaled,
+    /// The hook emitted malformed or non-object JSON.
+    InvalidJson,
+    /// The hook exited successfully without output.
+    EmptyOutput,
+}
+
+impl HookFailureKind {
+    fn reason(self) -> &'static str {
+        match self {
+            Self::Spawn => "failed to start",
+            Self::Io => "failed during execution",
+            Self::Timeout => "timed out",
+            Self::NonZero => "exited with a non-zero status",
+            Self::Signaled => "terminated by signal",
+            Self::InvalidJson => "returned invalid JSON",
+            Self::EmptyOutput => "returned empty output",
+        }
+    }
+}
+
+/// A hook execution failure captured alongside the aggregate decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookFailure {
+    /// Stable configured hook name.
+    pub hook_name: String,
+    /// Failure category, without exposing hook output or stderr.
+    pub kind: HookFailureKind,
+}
+
 // ─── Aggregated Results ──────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum HookDecision {
     Allow,
     Block(String),
+    /// The hook failed and the action was blocked for safety.
+    HookFailure(String),
     Ask,
     Passthrough,
 }
@@ -89,6 +174,8 @@ pub struct PreToolUseResult {
     pub decision: HookDecision,
     pub tool_input_patch: Option<Value>,
     pub notifications: Vec<HookNotification>,
+    /// Hook execution failures, including explicitly configured fail-open hooks.
+    pub hook_failures: Vec<HookFailure>,
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +247,11 @@ pub struct HookSystem {
     hooks: HashMap<HookEventName, Vec<HookDefinition>>,
     /// Current run_id, set at the start of each agent run.
     run_id: Option<String>,
+}
+
+struct HookExecution {
+    output: HookOutput,
+    failure: Option<HookFailureKind>,
 }
 
 impl HookSystem {
@@ -413,6 +505,7 @@ impl HookSystem {
                 decision: HookDecision::Passthrough,
                 tool_input_patch: None,
                 notifications: vec![],
+                hook_failures: vec![],
             };
         }
 
@@ -427,6 +520,7 @@ impl HookSystem {
                 decision: HookDecision::Passthrough,
                 tool_input_patch: None,
                 notifications: vec![],
+                hook_failures: vec![],
             };
         }
 
@@ -618,7 +712,8 @@ impl HookSystem {
 
         let mut notifications = Vec::new();
         let mut sandbox_bypass_request = None;
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
             // Extract sandbox_bypass_request from hookSpecificOutput (last valid wins).
@@ -697,7 +792,8 @@ impl HookSystem {
 
         let mut notifications = Vec::new();
         let mut updated_tools = None;
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
             // Last valid full array in configuration order wins; a rejected
@@ -786,7 +882,8 @@ impl HookSystem {
         let outputs = self.run_hooks(&defs, &input).await;
 
         let mut notifications = Vec::new();
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
         }
@@ -817,7 +914,7 @@ impl HookSystem {
         &self,
         defs: &[&HookDefinition],
         input: &HookInput,
-    ) -> Vec<(usize, HookOutput)> {
+    ) -> Vec<(usize, HookExecution)> {
         let input_json = crate::redaction::to_redacted_json_with_schemas(
             input,
             crate::redaction::TOOL_DECLARATION_PATHS,
@@ -849,7 +946,7 @@ impl HookSystem {
         }
     }
 
-    async fn run_single_hook(def: &HookDefinition, input_json: &str) -> HookOutput {
+    async fn run_single_hook(def: &HookDefinition, input_json: &str) -> HookExecution {
         Self::run_hook_cmd(&def.command, &def.env, input_json, Self::timeout_for(def)).await
     }
 
@@ -858,7 +955,7 @@ impl HookSystem {
         env: &BTreeMap<String, String>,
         input_json: &str,
         timeout: Duration,
-    ) -> HookOutput {
+    ) -> HookExecution {
         use tokio::process::Command;
 
         use crate::process::{output_with_timeout, OutputError};
@@ -901,59 +998,102 @@ impl HookSystem {
             Ok(o) => o,
             Err(OutputError::Spawn(e)) => {
                 tracing::error!(target: "cosh_hook", "Failed to spawn hook '{safe_command}': {e}");
-                return HookOutput::default();
+                return HookExecution {
+                    output: HookOutput::default(),
+                    failure: Some(HookFailureKind::Spawn),
+                };
             }
             Err(OutputError::Io(e)) => {
                 tracing::error!(target: "cosh_hook", "Hook '{safe_command}' execution failed: {e}");
-                return HookOutput::default();
+                return HookExecution {
+                    output: HookOutput::default(),
+                    failure: Some(HookFailureKind::Io),
+                };
             }
             Err(OutputError::Timeout) => {
                 tracing::warn!(target: "cosh_hook", "Hook '{safe_command}' timed out");
-                return HookOutput::default();
+                return HookExecution {
+                    output: HookOutput::default(),
+                    failure: Some(HookFailureKind::Timeout),
+                };
             }
         };
 
-        let exit_code = output.status.code().unwrap_or(1);
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let Some(exit_code) = output.status.code() else {
+            tracing::warn!(target: "cosh_hook", "Hook '{safe_command}' terminated by signal");
+            return HookExecution {
+                output: HookOutput::default(),
+                failure: Some(HookFailureKind::Signaled),
+            };
+        };
 
         match exit_code {
             0 => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                let trimmed = stdout.trim();
-                if trimmed.is_empty() {
-                    return HookOutput::default();
+                if output.stdout.iter().all(u8::is_ascii_whitespace) {
+                    tracing::warn!(target: "cosh_hook", "Hook '{safe_command}' returned empty output");
+                    return HookExecution {
+                        output: HookOutput::default(),
+                        failure: Some(HookFailureKind::EmptyOutput),
+                    };
                 }
-                let output = serde_json::from_str::<HookOutput>(trimmed).unwrap_or_else(|e| {
-                    tracing::warn!(target: "cosh_hook", "Failed to parse output from '{safe_command}': {e}");
-                    HookOutput::default()
-                });
-                Self::redact_hook_output(output)
+                match decode_hook_output(&output.stdout) {
+                    Some(output)
+                        if classify_hook_decision(output.decision.as_deref())
+                            != HookDecisionClass::Invalid =>
+                    {
+                        HookExecution {
+                            output: Self::redact_hook_output(output),
+                            failure: None,
+                        }
+                    }
+                    Some(_) | None => {
+                        tracing::warn!(
+                            target: "cosh_hook",
+                            "Hook '{safe_command}' returned invalid JSON"
+                        );
+                        HookExecution {
+                            output: HookOutput::default(),
+                            failure: Some(HookFailureKind::InvalidJson),
+                        }
+                    }
+                }
             }
             2 => {
                 // System block via exit code 2
-                Self::redact_hook_output(HookOutput {
-                    decision: Some("block".to_string()),
-                    reason: Some(if stderr.is_empty() {
-                        "Blocked by hook".to_string()
-                    } else {
-                        stderr.trim().to_string()
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let reason = if stderr.trim().is_empty() {
+                    "Blocked by hook (exit 2)".to_string()
+                } else {
+                    stderr.trim().to_string()
+                };
+                HookExecution {
+                    output: Self::redact_hook_output(HookOutput {
+                        decision: Some("block".to_string()),
+                        reason: Some(reason),
+                        ..Default::default()
                     }),
-                    system_message: None,
-                    hook_specific_output: None,
-                })
+                    failure: None,
+                }
             }
             _ => {
-                // Non-zero (not 2) = warning, do not block
-                if !stderr.is_empty() {
-                    let stderr = crate::redaction::redact_text(stderr.trim());
-                    tracing::warn!(target: "cosh_hook", "Hook '{safe_command}' warning: {stderr}");
+                // Non-zero (not 2) is a hook execution failure. Keep stderr
+                // out of the result and logs because hooks may write secrets.
+                tracing::warn!(
+                    target: "cosh_hook",
+                    "Hook '{safe_command}' exited with unexpected status"
+                );
+                HookExecution {
+                    output: HookOutput::default(),
+                    failure: Some(HookFailureKind::NonZero),
                 }
-                HookOutput::default()
             }
         }
     }
 
     fn redact_hook_output(mut output: HookOutput) -> HookOutput {
+        output.stop_reason = output
+            .stop_reason
+            .map(|value| crate::redaction::redact_text(&value));
         output.reason = output
             .reason
             .map(|value| crate::redaction::redact_text(&value));
@@ -973,15 +1113,32 @@ impl HookSystem {
 
     fn aggregate_pre_tool_use(
         &self,
-        outputs: Vec<(usize, HookOutput)>,
+        outputs: Vec<(usize, HookExecution)>,
         defs: &[&HookDefinition],
     ) -> PreToolUseResult {
         let mut decision = HookDecision::Passthrough;
         let mut tool_input_patch: Option<Value> = None;
         let mut notifications = Vec::new();
+        let mut hook_failures = Vec::new();
 
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
             let name = Self::hook_name(defs[i], i);
+            if let Some(kind) = execution.failure {
+                hook_failures.push(HookFailure {
+                    hook_name: name.clone(),
+                    kind,
+                });
+                notifications.push(HookNotification {
+                    hook_name: name,
+                    message: format!("Hook failed: {}", kind.reason()),
+                    decision: Some("hook_failure".to_string()),
+                });
+                if !defs[i].fail_open {
+                    decision = fold_hook_failure(decision, kind.reason());
+                }
+                continue;
+            }
+            let out = execution.output;
             self.collect_notifications(&out, &name, &mut notifications);
 
             decision = fold_decision(decision, out.decision.as_deref(), out.reason.clone());
@@ -1000,12 +1157,13 @@ impl HookSystem {
             decision,
             tool_input_patch,
             notifications,
+            hook_failures,
         }
     }
 
     fn aggregate_post_tool_use(
         &self,
-        outputs: Vec<(usize, HookOutput)>,
+        outputs: Vec<(usize, HookExecution)>,
         defs: &[&HookDefinition],
     ) -> PostToolUseResult {
         let mut decision = HookDecision::Passthrough;
@@ -1013,7 +1171,8 @@ impl HookSystem {
         let mut updated_tool_response: Option<String> = None;
         let mut notifications = Vec::new();
 
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
 
@@ -1038,14 +1197,15 @@ impl HookSystem {
 
     fn aggregate_user_prompt(
         &self,
-        outputs: Vec<(usize, HookOutput)>,
+        outputs: Vec<(usize, HookExecution)>,
         defs: &[&HookDefinition],
     ) -> UserPromptResult {
         let mut decision = HookDecision::Passthrough;
         let mut additional_context: Option<String> = None;
         let mut notifications = Vec::new();
 
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
 
@@ -1062,13 +1222,14 @@ impl HookSystem {
 
     fn aggregate_session_start(
         &self,
-        outputs: Vec<(usize, HookOutput)>,
+        outputs: Vec<(usize, HookExecution)>,
         defs: &[&HookDefinition],
     ) -> SessionStartResult {
         let mut additional_context: Option<String> = None;
         let mut notifications = Vec::new();
 
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
 
@@ -1083,13 +1244,14 @@ impl HookSystem {
 
     fn aggregate_stop(
         &self,
-        outputs: Vec<(usize, HookOutput)>,
+        outputs: Vec<(usize, HookExecution)>,
         defs: &[&HookDefinition],
     ) -> StopResult {
         let mut decision = HookDecision::Passthrough;
         let mut notifications = Vec::new();
 
-        for (i, out) in outputs {
+        for (i, execution) in outputs {
+            let out = execution.output;
             let name = Self::hook_name(defs[i], i);
             self.collect_notifications(&out, &name, &mut notifications);
 
@@ -1146,29 +1308,57 @@ pub fn merge_json_pub(a: Value, b: Value) -> Value {
 
 // ─── Decision Aggregation Primitives ─────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HookDecisionClass {
+    Passthrough,
+    Block,
+    Ask,
+    Allow,
+    Invalid,
+}
+
+fn classify_hook_decision(raw: Option<&str>) -> HookDecisionClass {
+    match raw {
+        None | Some("") => HookDecisionClass::Passthrough,
+        Some("block") | Some("deny") | Some("reject") => HookDecisionClass::Block,
+        Some("ask") => HookDecisionClass::Ask,
+        Some("approve") | Some("allow") => HookDecisionClass::Allow,
+        Some(_) => HookDecisionClass::Invalid,
+    }
+}
+
+fn fold_hook_failure(current: HookDecision, reason: &str) -> HookDecision {
+    match current {
+        HookDecision::HookFailure(_) => current,
+        _ => HookDecision::HookFailure(format!("Hook failure: {reason}")),
+    }
+}
+
 /// Fold a raw hook output decision string into the running `HookDecision`.
 ///
 /// Priority (highest wins): Block > Ask > Allow > Passthrough.
 /// "reject" is treated as equivalent to "block"/"deny" (used by Stop hooks).
 fn fold_decision(current: HookDecision, raw: Option<&str>, reason: Option<String>) -> HookDecision {
-    match raw {
-        Some("block") | Some("deny") | Some("reject") => {
+    match classify_hook_decision(raw) {
+        HookDecisionClass::Block => {
             // Preserve the first non-empty block reason; don't let a later
             // hook without a reason overwrite an existing detailed message.
             match (&current, &reason) {
+                (HookDecision::HookFailure(_), _) => current,
                 (HookDecision::Block(_), None) => current,
                 _ => HookDecision::Block(reason.unwrap_or_else(|| "Blocked by hook".to_string())),
             }
         }
-        Some("ask") => match current {
-            HookDecision::Block(_) => current,
+        HookDecisionClass::Ask => match current {
+            HookDecision::Block(_) | HookDecision::HookFailure(_) => current,
             _ => HookDecision::Ask,
         },
-        Some("approve") | Some("allow") => match current {
+        HookDecisionClass::Allow => match current {
             HookDecision::Passthrough => HookDecision::Allow,
             _ => current,
         },
-        _ => current,
+        HookDecisionClass::Passthrough => current,
+        HookDecisionClass::Invalid => fold_hook_failure(current, "returned invalid decision"),
     }
 }
 
@@ -1293,9 +1483,65 @@ mod tests {
     }
 
     #[test]
+    fn parse_hook_output_accepts_camel_case_aliases() {
+        let json = r#"{"continue":false,"stopReason":"stop","suppressOutput":true,"systemMessage":"notice","hookSpecificOutput":{"additionalContext":"context"}}"#;
+        let out = decode_hook_output(json.as_bytes()).unwrap();
+        assert_eq!(out.should_continue, Some(false));
+        assert_eq!(out.stop_reason.as_deref(), Some("stop"));
+        assert_eq!(out.suppress_output, Some(true));
+        assert_eq!(out.system_message.as_deref(), Some("notice"));
+        assert_eq!(
+            out.hook_specific_output.unwrap()["additionalContext"],
+            "context"
+        );
+    }
+
+    #[test]
+    fn parse_hook_output_accepts_unknown_fields() {
+        let json = r#"{"decision":"block","metadata":{"severity":"high"}}"#;
+        let out = decode_hook_output(json.as_bytes()).unwrap();
+        assert_eq!(out.decision.as_deref(), Some("block"));
+    }
+
+    #[test]
+    fn parse_hook_output_accepts_null_decision() {
+        let json = r#"{"decision":null}"#;
+        let out = decode_hook_output(json.as_bytes()).unwrap();
+        assert_eq!(out.decision, None);
+    }
+
+    #[test]
+    fn hook_decision_classification_matches_protocol() {
+        for (raw, expected) in [
+            (None, HookDecisionClass::Passthrough),
+            (Some(""), HookDecisionClass::Passthrough),
+            (Some("block"), HookDecisionClass::Block),
+            (Some("deny"), HookDecisionClass::Block),
+            (Some("reject"), HookDecisionClass::Block),
+            (Some("ask"), HookDecisionClass::Ask),
+            (Some("approve"), HookDecisionClass::Allow),
+            (Some("allow"), HookDecisionClass::Allow),
+            (Some("blok"), HookDecisionClass::Invalid),
+        ] {
+            assert_eq!(classify_hook_decision(raw), expected, "{raw:?}");
+        }
+    }
+
+    #[test]
+    fn hook_fail_open_defaults_closed_and_accepts_explicit_true() {
+        let default: HookDefinition = serde_json::from_str(r#"{"command":"true"}"#).unwrap();
+        assert!(!default.fail_open);
+
+        let explicit: HookDefinition =
+            serde_json::from_str(r#"{"command":"true","fail_open":true}"#).unwrap();
+        assert!(explicit.fail_open);
+    }
+
+    #[test]
     fn hook_output_is_redacted_before_aggregation() {
         let secret = "short-hook-secret";
         let output = HookOutput {
+            stop_reason: Some(format!("token={secret}")),
             decision: Some("block".to_string()),
             reason: Some(format!("password={secret}")),
             system_message: Some(format!("Bearer {secret}")),
@@ -1303,11 +1549,13 @@ mod tests {
                 "additionalContext": format!("api_key={secret}"),
                 "tool_input": {"token": secret}
             })),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
         let serialized = format!(
-            "{} {} {}",
+            "{} {} {} {}",
+            output.stop_reason.as_deref().unwrap_or_default(),
             output.reason.as_deref().unwrap_or_default(),
             output.system_message.as_deref().unwrap_or_default(),
             output
@@ -1349,6 +1597,7 @@ mod tests {
             matcher: Some("run_shell.*".to_string()),
             timeout: None,
             sequential: None,
+            fail_open: false,
             env: Default::default(),
         };
         assert!(HookSystem::matches_tool(&def, "run_shell_command"));
@@ -1363,6 +1612,7 @@ mod tests {
             matcher: None,
             timeout: None,
             sequential: None,
+            fail_open: false,
             env: Default::default(),
         };
         assert!(HookSystem::matches_tool(&def, "any_tool"));
@@ -1379,6 +1629,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use: vec![],
@@ -1418,6 +1669,7 @@ mod tests {
                 matcher: Some("run_shell_command".to_string()),
                 timeout: None,
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use: vec![],
@@ -1458,6 +1710,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             session_start: vec![],
@@ -1484,11 +1737,12 @@ mod tests {
             enabled: true,
 
             pre_tool_use: vec![HookDefinition {
-                command: "sh -c 'echo blocked >&2; exit 2'".to_string(),
+                command: "sh -c 'echo blocked: api_key=sk-exit2-secret >&2; exit 2'".to_string(),
                 name: Some("exit2-hook".to_string()),
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use: vec![],
@@ -1503,7 +1757,138 @@ mod tests {
         let result = sys
             .fire_pre_tool_use("s1", "/tmp", "tool-1", "any", &serde_json::json!({}), None)
             .await;
-        assert_eq!(result.decision, HookDecision::Block("blocked".to_string()));
+        let HookDecision::Block(reason) = result.decision else {
+            panic!("exit code 2 must block");
+        };
+        assert!(reason.starts_with("blocked:"), "{reason}");
+        assert!(reason.contains("<redacted>"), "{reason}");
+        assert!(!reason.contains("sk-exit2-secret"), "{reason}");
+        assert!(result.hook_failures.is_empty());
+    }
+
+    async fn run_pre_hook(
+        command: &str,
+        timeout: Option<u64>,
+        fail_open: bool,
+    ) -> PreToolUseResult {
+        let config = HooksConfig {
+            enabled: true,
+            pre_tool_use: vec![HookDefinition {
+                command: command.to_string(),
+                name: Some("failure-probe".to_string()),
+                matcher: None,
+                timeout,
+                sequential: None,
+                fail_open,
+                env: Default::default(),
+            }],
+            ..Default::default()
+        };
+        HookSystem::from_config(&config)
+            .fire_pre_tool_use("s1", "/tmp", "tool-1", "shell", &Value::Null, None)
+            .await
+    }
+
+    #[tokio::test]
+    async fn exit_code_2_without_stderr_uses_fallback_reason() {
+        let result = run_pre_hook("sh -c 'exit 2'", Some(5000), false).await;
+        assert_eq!(
+            result.decision,
+            HookDecision::Block("Blocked by hook (exit 2)".to_string())
+        );
+        assert!(result.hook_failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_failures_block_without_leaking_output() {
+        let cases = [
+            ("exit 7", HookFailureKind::NonZero),
+            ("printf 'not-json'", HookFailureKind::InvalidJson),
+            ("true", HookFailureKind::EmptyOutput),
+            (
+                "printf 'secret-output' >&2; exit 7",
+                HookFailureKind::NonZero,
+            ),
+        ];
+        for (command, kind) in cases {
+            let result = run_pre_hook(command, Some(500), false).await;
+            assert!(matches!(result.decision, HookDecision::HookFailure(_)));
+            assert_eq!(result.hook_failures[0].kind, kind);
+            assert!(!result.notifications[0].message.contains("secret-output"));
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_tool_use_timeout_and_signal_fail_closed() {
+        let timeout = run_pre_hook("sleep 2", Some(20), false).await;
+        assert!(matches!(timeout.decision, HookDecision::HookFailure(_)));
+        assert_eq!(timeout.hook_failures[0].kind, HookFailureKind::Timeout);
+
+        let signal = run_pre_hook("kill -TERM $$", Some(500), false).await;
+        assert!(matches!(signal.decision, HookDecision::HookFailure(_)));
+        assert_eq!(signal.hook_failures[0].kind, HookFailureKind::Signaled);
+    }
+
+    #[tokio::test]
+    async fn explicit_fail_open_records_failure_without_authorizing_it() {
+        let result = run_pre_hook("printf 'secret-output'", Some(500), true).await;
+        assert_eq!(result.decision, HookDecision::Passthrough);
+        assert_eq!(result.hook_failures[0].kind, HookFailureKind::InvalidJson);
+        assert_eq!(
+            result.notifications[0].decision.as_deref(),
+            Some("hook_failure")
+        );
+        assert!(!result.notifications[0].message.contains("secret-output"));
+    }
+
+    #[tokio::test]
+    async fn valid_allow_has_no_hook_failure_metadata() {
+        let result = run_pre_hook("printf '{\"decision\":\"allow\"}'", Some(500), false).await;
+        assert_eq!(result.decision, HookDecision::Allow);
+        assert!(result.hook_failures.is_empty());
+    }
+
+    #[test]
+    fn all_hook_failure_kinds_fail_closed_without_detail_leakage() {
+        let definition = HookDefinition {
+            command: "probe".to_string(),
+            name: Some("failure-probe".to_string()),
+            matcher: None,
+            timeout: None,
+            sequential: None,
+            fail_open: false,
+            env: Default::default(),
+        };
+        let definitions = [&definition];
+        let system = HookSystem::new_disabled();
+
+        for kind in [
+            HookFailureKind::Spawn,
+            HookFailureKind::Io,
+            HookFailureKind::Timeout,
+            HookFailureKind::NonZero,
+            HookFailureKind::Signaled,
+            HookFailureKind::InvalidJson,
+            HookFailureKind::EmptyOutput,
+        ] {
+            let result = system.aggregate_pre_tool_use(
+                vec![(
+                    0,
+                    HookExecution {
+                        output: HookOutput::default(),
+                        failure: Some(kind),
+                    },
+                )],
+                &definitions,
+            );
+            assert!(matches!(result.decision, HookDecision::HookFailure(_)));
+            assert_eq!(result.hook_failures[0].kind, kind);
+            assert_eq!(
+                result.notifications[0].message,
+                format!("Hook failed: {}", kind.reason())
+            );
+        }
     }
 
     // ===== Task 1: matcher 双向工具名兼容 =====
@@ -1515,6 +1900,7 @@ mod tests {
             matcher: Some(matcher.to_string()),
             timeout: None,
             sequential: None,
+            fail_open: false,
             env: Default::default(),
         }
     }
@@ -1710,6 +2096,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(10_000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             ..Default::default()
@@ -1738,6 +2125,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(10_000),
                     sequential: None,
+                    fail_open: false,
                     env: Default::default(),
                 },
                 HookDefinition {
@@ -1746,6 +2134,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(10_000),
                     sequential: None,
+                    fail_open: false,
                     env: Default::default(),
                 },
             ],
@@ -1778,6 +2167,7 @@ mod tests {
                     },
                 },
             }])),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
@@ -1804,6 +2194,7 @@ mod tests {
             hook_specific_output: Some(serde_json::json!({
                 "api_key": "leaked-value",
             })),
+            ..Default::default()
         };
 
         let output = HookSystem::redact_hook_output(output);
@@ -1877,6 +2268,7 @@ mod tests {
                 matcher: Some("^run_shell_command$".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use_failure: vec![],
@@ -1919,6 +2311,7 @@ mod tests {
                 matcher: Some("skill".to_string()),
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use_failure: vec![],
@@ -1965,7 +2358,7 @@ mod tests {
             HookSystem::run_hook_cmd(&script, &BTreeMap::new(), "{}", Duration::from_millis(300))
                 .await;
         assert!(
-            out.decision.is_none(),
+            out.output.decision.is_none(),
             "timed-out hook must fall back to the default output"
         );
 
@@ -1992,7 +2385,7 @@ mod tests {
             Duration::from_millis(300),
         )
         .await;
-        assert!(out.decision.is_none());
+        assert!(out.output.decision.is_none());
         assert!(
             started.elapsed() < Duration::from_secs(5),
             "stdin write must be bounded by the hook deadline"
@@ -2169,6 +2562,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use_failure: vec![],
@@ -2215,6 +2609,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                    fail_open: false,
                     env: Default::default(),
                 },
                 HookDefinition {
@@ -2223,6 +2618,7 @@ mod tests {
                     matcher: None,
                     timeout: Some(5000),
                     sequential: None,
+                    fail_open: false,
                     env: Default::default(),
                 },
             ],
@@ -2263,6 +2659,7 @@ mod tests {
                 matcher: None,
                 timeout: Some(5000),
                 sequential: None,
+                fail_open: false,
                 env: Default::default(),
             }],
             post_tool_use_failure: vec![],

--- a/src/cosh-ng/crates/cosh-shell/src/config/load.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/config/load.rs
@@ -12,7 +12,9 @@ pub fn load_config() -> CoshConfig {
         load_config_file_into(&path, &mut config);
     }
     if let Some(path) = project_trust_store_path() {
-        load_project_trust_store(&mut config, &path);
+        if let Err(error) = load_project_trust_store(&mut config, &path) {
+            tracing::error!("load project trust store failed: {error}");
+        }
     }
 
     apply_env_overrides(&mut config);

--- a/src/cosh-ng/crates/cosh-shell/src/config/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/config/tests.rs
@@ -551,18 +551,22 @@ fn project_trust_store_adds_dedupes_and_removes_canonical_roots() {
     add_trusted_project_root_to_store_path(&store, &nested.join("..")).expect("dedupe root");
     add_trusted_project_root_to_store_path(&store, &other).expect("trust other");
 
-    let roots = read_trusted_project_roots_from_store_path(&store);
+    let roots = read_trusted_project_roots_from_store_path(&store).expect("read store");
     assert_eq!(roots.len(), 2, "{roots:?}");
     assert!(roots.contains(&root.canonicalize().expect("canonical root")));
     assert!(roots.contains(&other.canonicalize().expect("canonical other")));
 
     remove_trusted_project_root_from_store_path(&store, &nested.join("..")).expect("untrust root");
-    let roots = read_trusted_project_roots_from_store_path(&store);
+    let roots = read_trusted_project_roots_from_store_path(&store).expect("read store");
     assert_eq!(roots, vec![other.canonicalize().expect("canonical other")]);
 
     let _ = std::fs::remove_dir_all(&root);
     let _ = std::fs::remove_dir_all(&other);
     let _ = std::fs::remove_file(&store);
+
+    assert_corrupted_project_trust_store_is_reported();
+    #[cfg(unix)]
+    assert_trust_store_atomic_write_preserves_permissions();
 }
 
 #[test]
@@ -575,7 +579,7 @@ fn load_project_trust_store_extends_config_roots() {
     std::fs::write(&store, "# comment\n/work/app\n\n/work/lib\n").expect("write store");
 
     let mut cfg = CoshConfig::default();
-    load_project_trust_store(&mut cfg, &store);
+    load_project_trust_store(&mut cfg, &store).expect("load store");
 
     assert_eq!(cfg.trusted_project_roots.len(), 2);
     assert_eq!(cfg.trusted_project_roots[0], PathBuf::from("/work/app"));
@@ -595,12 +599,71 @@ fn clear_project_trust_store_path_keeps_empty_store_file() {
 
     write_trusted_project_roots_to_store_path(&store, &[]).expect("clear store");
 
-    let roots = read_trusted_project_roots_from_store_path(&store);
+    let roots = read_trusted_project_roots_from_store_path(&store).expect("read store");
     assert!(roots.is_empty(), "{roots:?}");
     let content = std::fs::read_to_string(&store).expect("read store");
     assert!(content.contains("cosh-shell trusted project hook roots"));
 
     let _ = std::fs::remove_file(&store);
+}
+
+fn assert_corrupted_project_trust_store_is_reported() {
+    let store = std::env::temp_dir().join(format!(
+        "cosh-shell-trust-store-corrupt-{}.txt",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&store);
+    std::fs::write(&store, b"/work/app\n\xff\n").expect("write corrupt store");
+
+    let error = read_trusted_project_roots_from_store_path(&store)
+        .expect_err("invalid UTF-8 must not become an empty trust set");
+    assert!(error.contains("not valid UTF-8"), "{error}");
+    let mut cfg = CoshConfig::default();
+    assert!(load_project_trust_store(&mut cfg, &store).is_err());
+    assert!(cfg.trusted_project_roots.is_empty());
+
+    let _ = std::fs::remove_file(&store);
+}
+
+#[cfg(unix)]
+fn assert_trust_store_atomic_write_preserves_permissions() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    let dir = std::env::temp_dir().join(format!(
+        "cosh-shell-trust-store-atomic-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let store = dir.join("trusted-project-hooks");
+    std::fs::write(&store, "/work/old\n").expect("seed store");
+    std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o640))
+        .expect("set store mode");
+
+    write_trusted_project_roots_to_store_path(&store, &[PathBuf::from("/work/new")])
+        .expect("atomic update");
+
+    let mode = std::fs::metadata(&store)
+        .expect("stat store")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(mode, 0o640);
+    assert_eq!(
+        read_trusted_project_roots_from_store_path(&store).expect("read updated store"),
+        vec![PathBuf::from("/work/new")]
+    );
+    assert!(!std::fs::read_dir(&dir)
+        .expect("list store directory")
+        .flatten()
+        .any(|entry| entry.file_name().to_string_lossy().contains(".tmp-")));
+
+    let link = dir.join("trusted-project-hooks-link");
+    symlink(&store, &link).expect("create symlink");
+    let error = write_trusted_project_roots_to_store_path(&link, &[])
+        .expect_err("symlink target must not be replaced");
+    assert!(error.contains("symbolic link"), "{error}");
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/config/trust.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/config/trust.rs
@@ -1,4 +1,11 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::load::copilot_shell_cosh_dir;
 use super::CoshConfig;
@@ -32,22 +39,53 @@ pub(super) fn project_trust_store_path_in_dir(cosh_dir: &Path) -> PathBuf {
     cosh_dir.join("trusted-project-hooks")
 }
 
-pub(super) fn load_project_trust_store(config: &mut CoshConfig, path: &Path) {
-    config
-        .trusted_project_roots
-        .extend(read_trusted_project_roots_from_store_path(path));
+pub(super) fn load_project_trust_store(config: &mut CoshConfig, path: &Path) -> Result<(), String> {
+    let roots = read_trusted_project_roots_from_store_path(path)?;
+    config.trusted_project_roots.extend(roots);
+    Ok(())
 }
 
-pub(super) fn read_trusted_project_roots_from_store_path(path: &Path) -> Vec<PathBuf> {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
+pub(super) fn read_trusted_project_roots_from_store_path(
+    path: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(format!(
+                "inspect project trust store failed for {}: {error}",
+                path.display()
+            ));
+        }
     };
-    content
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "project trust store is a symbolic link: {}",
+            path.display()
+        ));
+    }
+    if !metadata.file_type().is_file() {
+        return Err(format!(
+            "project trust store is not a regular file: {}",
+            path.display()
+        ));
+    }
+
+    let bytes = fs::read(path).map_err(|error| {
+        format!(
+            "read project trust store failed for {}: {error}",
+            path.display()
+        )
+    })?;
+    let content = String::from_utf8(bytes)
+        .map_err(|_| format!("project trust store is not valid UTF-8: {}", path.display()))?;
+
+    Ok(content
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .map(PathBuf::from)
-        .collect()
+        .collect())
 }
 
 pub(super) fn add_trusted_project_root_to_store_path(
@@ -55,7 +93,7 @@ pub(super) fn add_trusted_project_root_to_store_path(
     root: &Path,
 ) -> Result<(), String> {
     let root = canonical_project_root(root);
-    let mut roots = read_trusted_project_roots_from_store_path(path)
+    let mut roots = read_trusted_project_roots_from_store_path(path)?
         .into_iter()
         .map(|root| canonical_project_root(&root))
         .collect::<Vec<_>>();
@@ -70,7 +108,7 @@ pub(super) fn remove_trusted_project_root_from_store_path(
     root: &Path,
 ) -> Result<(), String> {
     let root = canonical_project_root(root);
-    let mut roots = read_trusted_project_roots_from_store_path(path)
+    let mut roots = read_trusted_project_roots_from_store_path(path)?
         .into_iter()
         .map(|root| canonical_project_root(&root))
         .collect::<Vec<_>>();
@@ -82,17 +120,127 @@ pub(super) fn write_trusted_project_roots_to_store_path(
     path: &Path,
     roots: &[PathBuf],
 ) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|err| format!("create trust store directory failed: {err}"))?;
-    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("project trust store has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|err| format!("create trust store directory failed: {err}"))?;
+
+    let existing = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(format!(
+                "project trust store is a symbolic link: {}",
+                path.display()
+            ));
+        }
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            return Err(format!(
+                "project trust store is not a regular file: {}",
+                path.display()
+            ));
+        }
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(format!(
+                "inspect project trust store failed for {}: {error}",
+                path.display()
+            ));
+        }
+    };
+
     let mut content = String::new();
     content.push_str("# cosh-shell trusted project hook roots\n");
     for root in roots {
         content.push_str(&root.to_string_lossy());
         content.push('\n');
     }
-    std::fs::write(path, content).map_err(|err| format!("write project trust store failed: {err}"))
+
+    #[cfg(unix)]
+    let mode = existing
+        .as_ref()
+        .map(|metadata| metadata.permissions().mode() & 0o7777)
+        .unwrap_or(0o600);
+
+    let mut temporary_path = None;
+    let mut temporary_file = None;
+    for _ in 0..16 {
+        let candidate = temporary_store_path(path);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(mode);
+        match options.open(&candidate) {
+            Ok(file) => {
+                #[cfg(unix)]
+                if let Err(error) = file.set_permissions(fs::Permissions::from_mode(mode)) {
+                    let _ = fs::remove_file(&candidate);
+                    return Err(format!(
+                        "set project trust store temporary file permissions failed: {error}"
+                    ));
+                }
+                temporary_path = Some(candidate);
+                temporary_file = Some(file);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(format!(
+                    "create project trust store temporary file failed: {error}"
+                ));
+            }
+        }
+    }
+    let Some(temporary_path) = temporary_path else {
+        return Err("create project trust store temporary file failed: name collision".to_string());
+    };
+    let Some(mut temporary_file) = temporary_file else {
+        return Err("create project trust store temporary file failed: missing handle".to_string());
+    };
+
+    let result = (|| {
+        temporary_file
+            .write_all(content.as_bytes())
+            .map_err(|error| format!("write project trust store failed: {error}"))?;
+        temporary_file
+            .sync_data()
+            .map_err(|error| format!("sync project trust store failed: {error}"))?;
+        drop(temporary_file);
+        fs::rename(&temporary_path, path)
+            .map_err(|error| format!("replace project trust store failed: {error}"))?;
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| format!("sync project trust store directory failed: {error}"))
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn temporary_store_path(path: &Path) -> PathBuf {
+    static NEXT_TEMPORARY_ID: AtomicU64 = AtomicU64::new(0);
+    let id = NEXT_TEMPORARY_ID.fetch_add(1, Ordering::Relaxed);
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("trusted-project-hooks"));
+    path.with_file_name(format!(".{name}.tmp-{}-{id}", std::process::id()))
+}
+
+#[cfg(not(unix))]
+fn temporary_store_path(path: &Path) -> PathBuf {
+    static NEXT_TEMPORARY_ID: std::sync::OnceLock<std::sync::atomic::AtomicU64> =
+        std::sync::OnceLock::new();
+    let id = NEXT_TEMPORARY_ID
+        .get_or_init(|| std::sync::atomic::AtomicU64::new(0))
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| std::borrow::Cow::Borrowed("trusted-project-hooks"));
+    path.with_file_name(format!(".{name}.tmp-{}-{id}", std::process::id()))
 }
 
 fn canonical_project_root(root: &Path) -> PathBuf {

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine.rs
@@ -10,6 +10,30 @@ use crate::types::{
 use loader::load_external_hook_configs;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::sync::Arc;
+
+// Each Unix registration owns a descriptor for the engine lifetime. Keep a
+// fixed budget so project discovery cannot starve later process and log I/O.
+const MAX_EXTERNAL_HOOKS: usize = 64;
+// Hold these descriptors while pinning hooks, then release them so later
+// process, pipe, PTY, and logging operations retain real kernel headroom.
+#[cfg(unix)]
+const EXTERNAL_HOOK_FD_HEADROOM: usize = 32;
+
+#[cfg(unix)]
+fn reserve_external_hook_headroom(operation: &'static str) -> Option<Vec<std::fs::File>> {
+    let reserve = loader::reserve_hook_descriptor_headroom(EXTERNAL_HOOK_FD_HEADROOM);
+    if reserve.is_none() {
+        tracing::warn!(
+            target: "cosh_hook",
+            operation,
+            reserved_descriptors = EXTERNAL_HOOK_FD_HEADROOM,
+            "insufficient descriptor headroom for external hooks"
+        );
+    }
+    reserve
+}
 
 #[path = "engine/loader.rs"]
 mod loader;
@@ -62,6 +86,8 @@ pub enum HookSourceInfo {
 pub struct HookEngine {
     builtin_hooks: Vec<Box<dyn BuiltinHook>>,
     external_hooks: Vec<ExternalHookConfig>,
+    #[cfg(unix)]
+    external_hook_executables: Vec<Arc<std::fs::File>>,
 }
 
 impl Default for HookEngine {
@@ -75,6 +101,8 @@ impl HookEngine {
         Self {
             builtin_hooks: Vec::new(),
             external_hooks: Vec::new(),
+            #[cfg(unix)]
+            external_hook_executables: Vec::new(),
         }
     }
 
@@ -83,6 +111,24 @@ impl HookEngine {
     }
 
     pub fn register_external(&mut self, config: ExternalHookConfig) {
+        if self.external_hooks.len() >= MAX_EXTERNAL_HOOKS {
+            tracing::warn!(
+                target: "cosh_hook",
+                max_external_hooks = MAX_EXTERNAL_HOOKS,
+                "external hook registry is full"
+            );
+            return;
+        }
+        #[cfg(unix)]
+        {
+            let Some(_descriptor_headroom) = reserve_external_hook_headroom("register") else {
+                return;
+            };
+            let Some(executable) = loader::open_hook_executable(&config.path) else {
+                return;
+            };
+            self.external_hook_executables.push(Arc::new(executable));
+        }
         self.external_hooks.push(config);
     }
 
@@ -91,16 +137,24 @@ impl HookEngine {
     }
 
     pub fn load_project_hooks_from_root(&mut self, project_root: &Path, trusted: bool) {
+        #[cfg(unix)]
+        let Some(_descriptor_headroom) = reserve_external_hook_headroom("load_project") else {
+            return;
+        };
         let root = project_root
             .canonicalize()
             .unwrap_or_else(|_| project_root.to_path_buf());
-        let hooks_dir = root.join(".cosh/hooks");
-        self.load_external_hooks_from_dir(
-            &hooks_dir,
-            ExternalHookSource::Project,
-            Some(root),
-            trusted,
-        );
+        let remaining = MAX_EXTERNAL_HOOKS.saturating_sub(self.external_hooks.len());
+        let loaded = loader::load_project_external_hook_configs(&root, trusted, remaining);
+        self.extend_external_hooks(loaded);
+    }
+
+    fn extend_external_hooks(&mut self, loaded: Vec<loader::LoadedExternalHookConfig>) {
+        for loaded_hook in loaded {
+            #[cfg(unix)]
+            self.external_hook_executables.push(loaded_hook.executable);
+            self.external_hooks.push(loaded_hook.config);
+        }
     }
 
     fn load_external_hooks_from_dir(
@@ -110,12 +164,13 @@ impl HookEngine {
         project_root: Option<PathBuf>,
         trusted: bool,
     ) {
-        self.external_hooks.extend(load_external_hook_configs(
-            dir,
-            source,
-            project_root,
-            trusted,
-        ));
+        #[cfg(unix)]
+        let Some(_descriptor_headroom) = reserve_external_hook_headroom("load_external") else {
+            return;
+        };
+        let remaining = MAX_EXTERNAL_HOOKS.saturating_sub(self.external_hooks.len());
+        let loaded = load_external_hook_configs(dir, source, project_root, trusted, remaining);
+        self.extend_external_hooks(loaded);
     }
 
     pub fn evaluate(&self, block: &CommandBlock) -> Vec<EvaluatedHookFinding> {
@@ -167,7 +222,12 @@ impl HookEngine {
                 continue;
             }
             if matcher::matches_command(&ext.matcher, &input) {
-                if let Some(finding) = runtime::run_external_hook(ext, &input) {
+                if let Some(finding) = runtime::run_external_hook(
+                    ext,
+                    #[cfg(unix)]
+                    &self.external_hook_executables[registration_index],
+                    &input,
+                ) {
                     findings.push(EvaluatedHookFinding::external(
                         format!("external:{registration_index}"),
                         finding,

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine/loader.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine/loader.rs
@@ -1,48 +1,122 @@
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+#[cfg(unix)]
+use std::sync::Arc;
+
+#[cfg(unix)]
+use nix::dir::{Dir, Type};
+#[cfg(unix)]
+use nix::fcntl::{open, openat, OFlag};
+#[cfg(unix)]
+use nix::sys::stat::Mode;
 
 use crate::hooks::model::{HookMatcher, HookTrigger};
 
 use super::{ExternalHookConfig, ExternalHookSource};
+
+pub(super) struct LoadedExternalHookConfig {
+    pub config: ExternalHookConfig,
+    #[cfg(unix)]
+    pub executable: Arc<fs::File>,
+}
+
+#[cfg(unix)]
+pub(super) fn reserve_hook_descriptor_headroom(count: usize) -> Option<Vec<fs::File>> {
+    (0..count)
+        .map(|_| fs::File::open("/dev/null"))
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
+}
 
 pub(super) fn load_external_hook_configs(
     dir: &Path,
     source: ExternalHookSource,
     project_root: Option<PathBuf>,
     trusted: bool,
-) -> Vec<ExternalHookConfig> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(_) => return Vec::new(),
-    };
+    max_hooks: usize,
+) -> Vec<LoadedExternalHookConfig> {
+    #[cfg(unix)]
+    {
+        load_external_hook_configs_unix(dir, source, project_root, trusted, max_hooks)
+    }
 
-    let mut configs = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            if let Ok(meta) = path.metadata() {
-                if meta.permissions().mode() & 0o111 == 0 {
-                    continue;
-                }
+    #[cfg(not(unix))]
+    {
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut configs = Vec::new();
+        for entry in entries.flatten() {
+            if configs.len() >= max_hooks {
+                break;
+            }
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            if let Some(mut config) = parse_hook_header(&path) {
+                config.source = source.clone();
+                config.project_root = project_root.clone();
+                config.trusted = trusted;
+                configs.push(LoadedExternalHookConfig { config });
             }
         }
-        if let Some(mut config) = parse_hook_header(&path) {
-            config.source = source.clone();
-            config.project_root = project_root.clone();
-            config.trusted = trusted;
-            configs.push(config);
-        }
+        configs
     }
-    configs
+}
+
+pub(super) fn load_project_external_hook_configs(
+    project_root: &Path,
+    trusted: bool,
+    max_hooks: usize,
+) -> Vec<LoadedExternalHookConfig> {
+    #[cfg(unix)]
+    {
+        load_project_external_hook_configs_unix(project_root, trusted, max_hooks)
+    }
+
+    #[cfg(not(unix))]
+    {
+        load_external_hook_configs(
+            &project_root.join(".cosh/hooks"),
+            ExternalHookSource::Project,
+            Some(project_root.to_path_buf()),
+            trusted,
+            max_hooks,
+        )
+    }
 }
 
 pub(super) fn parse_hook_header(path: &Path) -> Option<ExternalHookConfig> {
-    let content = fs::read_to_string(path).ok()?;
+    #[cfg(unix)]
+    let mut file = open_hook_file(path)?;
+    #[cfg(not(unix))]
+    let mut file = {
+        let metadata = fs::symlink_metadata(path).ok()?;
+        if !metadata.file_type().is_file() {
+            return None;
+        }
+        fs::File::open(path).ok()?
+    };
+
+    let mut content = String::new();
+    file.read_to_string(&mut content).ok()?;
+    parse_hook_header_content(&content, path)
+}
+
+fn parse_hook_header_content(content: &str, path: &Path) -> Option<ExternalHookConfig> {
     let mut hook_id: Option<String> = None;
     let mut match_commands: Vec<String> = Vec::new();
     let mut trigger = HookTrigger::OnComplete;
@@ -82,6 +156,151 @@ pub(super) fn parse_hook_header(path: &Path) -> Option<ExternalHookConfig> {
         project_root: None,
         trusted: true,
     })
+}
+
+#[cfg(unix)]
+fn open_hook_file(path: &Path) -> Option<fs::File> {
+    let fd = open(
+        path,
+        OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+        Mode::empty(),
+    )
+    .ok()?;
+    // `open` transfers ownership of the descriptor to this File. Keeping the
+    // descriptor open through parsing prevents a path replacement from
+    // changing the bytes that are inspected.
+    let file = unsafe { fs::File::from_raw_fd(fd) };
+    let metadata = file.metadata().ok()?;
+    metadata.is_file().then_some(file)
+}
+
+#[cfg(unix)]
+pub(super) fn open_hook_executable(path: &Path) -> Option<fs::File> {
+    let file = open_hook_file(path)?;
+    let metadata = file.metadata().ok()?;
+    (metadata.permissions().mode() & 0o111 != 0).then_some(file)
+}
+
+#[cfg(unix)]
+fn load_external_hook_configs_unix(
+    dir: &Path,
+    source: ExternalHookSource,
+    project_root: Option<PathBuf>,
+    trusted: bool,
+    max_hooks: usize,
+) -> Vec<LoadedExternalHookConfig> {
+    let Ok(directory) = Dir::open(
+        dir,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    ) else {
+        return Vec::new();
+    };
+
+    load_external_hook_configs_from_dir(directory, dir, source, project_root, trusted, max_hooks)
+}
+
+#[cfg(unix)]
+fn load_project_external_hook_configs_unix(
+    project_root: &Path,
+    trusted: bool,
+    max_hooks: usize,
+) -> Vec<LoadedExternalHookConfig> {
+    let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+    let Ok(root) = Dir::open(project_root, flags, Mode::empty()) else {
+        return Vec::new();
+    };
+    let Ok(cosh_dir) = Dir::openat(
+        Some(root.as_raw_fd()),
+        OsStr::new(".cosh"),
+        flags,
+        Mode::empty(),
+    ) else {
+        return Vec::new();
+    };
+    let Ok(hooks_dir) = Dir::openat(
+        Some(cosh_dir.as_raw_fd()),
+        OsStr::new("hooks"),
+        flags,
+        Mode::empty(),
+    ) else {
+        return Vec::new();
+    };
+    let display_dir = project_root.join(".cosh/hooks");
+    load_external_hook_configs_from_dir(
+        hooks_dir,
+        &display_dir,
+        ExternalHookSource::Project,
+        Some(project_root.to_path_buf()),
+        trusted,
+        max_hooks,
+    )
+}
+
+#[cfg(unix)]
+fn load_external_hook_configs_from_dir(
+    mut directory: Dir,
+    display_dir: &Path,
+    source: ExternalHookSource,
+    project_root: Option<PathBuf>,
+    trusted: bool,
+    max_hooks: usize,
+) -> Vec<LoadedExternalHookConfig> {
+    let directory_fd = directory.as_raw_fd();
+    let mut configs = Vec::new();
+    for entry in directory.iter().flatten() {
+        if configs.len() >= max_hooks {
+            break;
+        }
+        let name = entry.file_name();
+        let name_bytes = name.to_bytes();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+        // Reject the cheap directory-entry symlink signal before opening. The
+        // O_NOFOLLOW flag below remains authoritative for filesystems that do
+        // not expose d_type or race a replacement after readdir.
+        if entry.file_type() == Some(Type::Symlink) {
+            continue;
+        }
+
+        let Ok(fd) = openat(
+            Some(directory_fd),
+            name,
+            OFlag::O_RDONLY | OFlag::O_CLOEXEC | OFlag::O_NOFOLLOW,
+            Mode::empty(),
+        ) else {
+            continue;
+        };
+        // `openat` transfers ownership of the descriptor to this File. All
+        // metadata checks and reads therefore refer to one stable object.
+        let mut file = unsafe { fs::File::from_raw_fd(fd) };
+        let Ok(metadata) = file.metadata() else {
+            continue;
+        };
+        if !metadata.is_file()
+            || (entry.ino() != 0 && metadata.ino() != entry.ino())
+            || metadata.permissions().mode() & 0o111 == 0
+        {
+            continue;
+        }
+
+        let mut content = String::new();
+        if file.read_to_string(&mut content).is_err() {
+            continue;
+        }
+        let path = display_dir.join(OsStr::from_bytes(name_bytes));
+        if let Some(mut config) = parse_hook_header_content(&content, &path) {
+            config.source = source.clone();
+            config.project_root = project_root.clone();
+            config.trusted = trusted;
+            configs.push(LoadedExternalHookConfig {
+                config,
+                executable: Arc::new(file),
+            });
+        }
+    }
+    configs
 }
 
 pub(super) fn parse_timeout(s: &str) -> u64 {

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine/runtime.rs
@@ -1,5 +1,9 @@
 use std::fs;
+#[cfg(unix)]
+use std::io;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
@@ -12,6 +16,11 @@ use crate::types::CommandBlock;
 use crate::types::HookFinding;
 
 use super::ExternalHookConfig;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const PINNED_HOOK_FD_ROOT: &str = "/proc/self/fd";
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+const PINNED_HOOK_FD_ROOT: &str = "/dev/fd";
 
 pub(super) fn hook_input_from_block(block: &CommandBlock) -> HookInput {
     let output_preview = block
@@ -65,12 +74,26 @@ fn read_preview(path: &str, max_lines: usize) -> Option<String> {
 
 pub(super) fn run_external_hook(
     config: &ExternalHookConfig,
+    #[cfg(unix)] executable: &fs::File,
     input: &HookInput,
 ) -> Option<HookFinding> {
     let input_json = serde_json::to_string(input).ok()?;
     let safe_path = redact(&config.path.to_string_lossy());
 
-    let mut child = Command::new(&config.path)
+    #[cfg(unix)]
+    let (mut command, _inherited_executable) = command_for_pinned_hook(executable)
+        .map_err(|error| {
+            tracing::error!(
+                target: "cosh_hook",
+                path = %safe_path,
+                "external hook descriptor preparation failed: {error}"
+            );
+        })
+        .ok()?;
+    #[cfg(not(unix))]
+    let mut command = Command::new(&config.path);
+
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -190,6 +213,19 @@ pub(super) fn run_external_hook(
             );
         })
         .ok()
+}
+
+#[cfg(unix)]
+fn command_for_pinned_hook(executable: &fs::File) -> io::Result<(Command, fs::File)> {
+    let fd = nix::unistd::dup(executable.as_raw_fd())
+        .map_err(|error| io::Error::from_raw_os_error(error as i32))?;
+    // `dup` clears CLOEXEC. Script interpreters must inherit this descriptor
+    // so the platform's descriptor path remains valid through exec.
+    let inherited = unsafe { fs::File::from_raw_fd(fd) };
+    Ok((
+        Command::new(format!("{PINNED_HOOK_FD_ROOT}/{fd}")),
+        inherited,
+    ))
 }
 
 /// Delivers the hook's stdin payload on a background thread; the receiver

--- a/src/cosh-ng/crates/cosh-shell/src/hooks/engine/tests/loader.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/hooks/engine/tests/loader.rs
@@ -31,6 +31,12 @@ fn load_hooks_from_dir_skips_non_executable() {
     assert_eq!(engine.external_hooks()[0].matcher.id, "exec-hook");
 
     let _ = fs::remove_dir_all(&dir);
+
+    #[cfg(unix)]
+    {
+        assert_loader_skips_symlinked_hooks();
+        assert_loader_resists_replacement_symlink_race();
+    }
 }
 
 #[test]
@@ -46,4 +52,78 @@ fn load_project_hooks_missing_dir_is_noop() {
     assert!(engine.registered_hook_infos().is_empty());
 
     let _ = fs::remove_dir_all(&project);
+}
+
+#[cfg(unix)]
+fn assert_loader_skips_symlinked_hooks() {
+    use std::os::unix::fs::symlink;
+
+    let (outside_dir, outside_path) = write_executable_hook(
+        "loader-symlink-target",
+        "outside.sh",
+        "#!/bin/sh\n# cosh-hook: outside\n",
+    );
+    let (dir, path) = write_executable_hook(
+        "loader-symlink-dir",
+        "link.sh",
+        "#!/bin/sh\n# cosh-hook: placeholder\n",
+    );
+    fs::remove_file(&path).unwrap();
+    symlink(&outside_path, &path).unwrap();
+
+    let mut engine = HookEngine::new();
+    engine.load_hooks_from_dir(&dir);
+
+    assert!(engine.external_hooks().is_empty());
+    let _ = fs::remove_dir_all(&dir);
+    let _ = fs::remove_dir_all(&outside_dir);
+}
+
+#[cfg(unix)]
+fn assert_loader_resists_replacement_symlink_race() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    let (outside_dir, outside_path) = write_executable_hook(
+        "loader-race-target",
+        "outside.sh",
+        "#!/bin/sh\n# cosh-hook: outside\n",
+    );
+    let (dir, path) = write_executable_hook(
+        "loader-race-dir",
+        "candidate.sh",
+        "#!/bin/sh\n# cosh-hook: trusted\n",
+    );
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_replacer = Arc::clone(&stop);
+    let replacement_path = path.clone();
+    let replacement_target = outside_path.clone();
+    let replacer = std::thread::spawn(move || {
+        while !stop_replacer.load(Ordering::Relaxed) {
+            let _ = fs::remove_file(&replacement_path);
+            let _ = symlink(&replacement_target, &replacement_path);
+            std::thread::yield_now();
+            let _ = fs::remove_file(&replacement_path);
+            if fs::write(&replacement_path, "#!/bin/sh\n# cosh-hook: trusted\n").is_ok() {
+                let _ = fs::set_permissions(&replacement_path, fs::Permissions::from_mode(0o755));
+            }
+        }
+    });
+
+    for _ in 0..200 {
+        let mut engine = HookEngine::new();
+        engine.load_hooks_from_dir(&dir);
+        assert!(engine
+            .external_hooks()
+            .iter()
+            .all(|hook| hook.matcher.id == "trusted"));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    replacer.join().unwrap();
+    let _ = fs::remove_dir_all(&dir);
+    let _ = fs::remove_dir_all(&outside_dir);
 }

--- a/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/hooks_tests.rs
@@ -63,6 +63,34 @@ struct EnvLock {
     path: std::path::PathBuf,
 }
 
+pub(super) struct TestHookFixture {
+    pub(super) root: std::path::PathBuf,
+    pub(super) path: std::path::PathBuf,
+}
+
+impl TestHookFixture {
+    pub(super) fn new(label: &str) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("cosh-shell-slash-{label}-{}", std::process::id()));
+        let hooks_dir = root.join(".cosh/hooks");
+        let path = hooks_dir.join("project.sh");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&hooks_dir).expect("create test hook directory");
+        std::fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write test hook");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("make test hook executable");
+        Self { root, path }
+    }
+}
+
+impl Drop for TestHookFixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
 impl Drop for EnvLock {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
@@ -94,9 +122,10 @@ fn env_lock() -> EnvLock {
     }
 }
 
-fn register_project_hook(state: &mut InlineState) {
+fn register_project_hook(state: &mut InlineState) -> TestHookFixture {
+    let fixture = TestHookFixture::new("hooks-trust");
     state.hooks.engine.register_external(ExternalHookConfig {
-        path: std::path::PathBuf::from("/tmp/project/.cosh/hooks/project.sh"),
+        path: fixture.path.clone(),
         matcher: HookMatcher {
             id: "project-hook".to_string(),
             commands: vec!["echo".to_string()],
@@ -108,9 +137,10 @@ fn register_project_hook(state: &mut InlineState) {
         },
         timeout_ms: 1000,
         source: ExternalHookSource::Project,
-        project_root: Some(std::path::PathBuf::from("/tmp/project")),
+        project_root: Some(fixture.root.clone()),
         trusted: false,
     });
+    fixture
 }
 
 fn hook_hint() -> RuntimeHookFinding {
@@ -298,7 +328,7 @@ fn hooks_project_trust_uses_zh_catalog_text() {
     let _ = std::fs::remove_file(&store);
     std::env::set_var("COSH_SHELL_PROJECT_TRUST_STORE", &store);
     let mut state = zh_state();
-    register_project_hook(&mut state);
+    let _hook = register_project_hook(&mut state);
 
     let trusted = render_hooks_test_command(Some("trust-project"), None, None, &mut state);
     assert!(trusted.contains("项目 Hook 已信任"), "{trusted}");

--- a/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/runtime.rs
@@ -73,6 +73,7 @@ mod tests {
     use crate::runtime::state::ContinuityFactKind;
     use crate::slash::debug::render_debug_command;
     use crate::slash::hooks::render_hooks_command;
+    use crate::slash::hooks_tests::TestHookFixture;
     use crate::types::{FindingSeverity, HookFinding};
     use std::sync::{Arc, Mutex};
 
@@ -348,10 +349,12 @@ mod tests {
 
     #[test]
     fn hooks_root_renders_status_without_source_paths() {
+        let user_hook = TestHookFixture::new("hooks-status-user");
+        let project_hook = TestHookFixture::new("hooks-status-project");
         let mut state = InlineState::default();
         state.hooks.disabled.insert("project-hook".to_string());
         state.hooks.engine.register_external(ExternalHookConfig {
-            path: std::path::PathBuf::from("/tmp/user-hook.sh"),
+            path: user_hook.path.clone(),
             matcher: HookMatcher {
                 id: "user-hook".to_string(),
                 commands: vec!["echo".to_string()],
@@ -367,7 +370,7 @@ mod tests {
             trusted: true,
         });
         state.hooks.engine.register_external(ExternalHookConfig {
-            path: std::path::PathBuf::from("/tmp/project/.cosh/hooks/project.sh"),
+            path: project_hook.path.clone(),
             matcher: HookMatcher {
                 id: "project-hook".to_string(),
                 commands: vec!["echo".to_string()],
@@ -379,7 +382,7 @@ mod tests {
             },
             timeout_ms: 1000,
             source: ExternalHookSource::Project,
-            project_root: Some(std::path::PathBuf::from("/tmp/project")),
+            project_root: Some(project_hook.root.clone()),
             trusted: false,
         });
         let mut output = Vec::new();
@@ -401,8 +404,14 @@ mod tests {
             rendered.contains("Project trust: trusted=0; untrusted=1."),
             "{rendered}"
         );
-        assert!(!rendered.contains("/tmp/user-hook.sh"), "{rendered}");
-        assert!(!rendered.contains("/tmp/project/.cosh/hooks"), "{rendered}");
+        assert!(
+            !rendered.contains(user_hook.path.to_string_lossy().as_ref()),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains(project_hook.root.to_string_lossy().as_ref()),
+            "{rendered}"
+        );
         assert!(
             !rendered.contains("project-hook external project"),
             "{rendered}"
@@ -412,6 +421,7 @@ mod tests {
     #[test]
     fn hooks_trust_project_and_untrust_project_update_session_state() {
         let _env_lock = env_lock();
+        let project_hook = TestHookFixture::new("hooks-trust-project");
         let store = std::env::temp_dir().join(format!(
             "cosh-shell-slash-trust-store-{}.txt",
             std::process::id()
@@ -420,7 +430,7 @@ mod tests {
         std::env::set_var("COSH_SHELL_PROJECT_TRUST_STORE", &store);
         let mut state = InlineState::default();
         state.hooks.engine.register_external(ExternalHookConfig {
-            path: std::path::PathBuf::from("/tmp/project/.cosh/hooks/project.sh"),
+            path: project_hook.path.clone(),
             matcher: HookMatcher {
                 id: "project-hook".to_string(),
                 commands: vec!["echo".to_string()],
@@ -432,7 +442,7 @@ mod tests {
             },
             timeout_ms: 1000,
             source: ExternalHookSource::Project,
-            project_root: Some(std::path::PathBuf::from("/tmp/project")),
+            project_root: Some(project_hook.root.clone()),
             trusted: false,
         });
         let mut output = Vec::new();
@@ -448,7 +458,10 @@ mod tests {
         .expect("trust project hooks");
         assert!(state.hooks.engine.external_hooks()[0].trusted);
         let persisted = std::fs::read_to_string(&store).expect("read trust store");
-        assert!(persisted.contains("/tmp/project"), "{persisted}");
+        assert!(
+            persisted.contains(project_hook.root.to_string_lossy().as_ref()),
+            "{persisted}"
+        );
 
         render_hooks_test_command(None, None, None, &[], &mut state, &mut output)
             .expect("show hook status");
@@ -469,7 +482,10 @@ mod tests {
         .expect("untrust project hooks");
         assert!(!state.hooks.engine.external_hooks()[0].trusted);
         let persisted = std::fs::read_to_string(&store).expect("read trust store");
-        assert!(!persisted.contains("/tmp/project"), "{persisted}");
+        assert!(
+            !persisted.contains(project_hook.root.to_string_lossy().as_ref()),
+            "{persisted}"
+        );
         let rendered = String::from_utf8(output.clone()).expect("utf8");
         assert!(
             rendered.contains("1 project hook(s) marked untrusted."),
@@ -487,7 +503,10 @@ mod tests {
         .expect("trust project hooks again");
         assert!(state.hooks.engine.external_hooks()[0].trusted);
         let persisted = std::fs::read_to_string(&store).expect("read trust store");
-        assert!(persisted.contains("/tmp/project"), "{persisted}");
+        assert!(
+            persisted.contains(project_hook.root.to_string_lossy().as_ref()),
+            "{persisted}"
+        );
 
         render_hooks_test_command(
             Some("clear-project-trust"),
@@ -500,7 +519,10 @@ mod tests {
         .expect("clear project trust store");
         assert!(!state.hooks.engine.external_hooks()[0].trusted);
         let persisted = std::fs::read_to_string(&store).expect("read trust store");
-        assert!(!persisted.contains("/tmp/project"), "{persisted}");
+        assert!(
+            !persisted.contains(project_hook.root.to_string_lossy().as_ref()),
+            "{persisted}"
+        );
         assert!(
             persisted.contains("cosh-shell trusted project hook roots"),
             "{persisted}"

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
@@ -26,6 +26,16 @@ fn install_user_hook(home: &Path, name: &str, body: &str) {
     write_executable(&hooks_dir.join(name), body);
 }
 
+fn hook_status_count(output: &str, label: &str) -> usize {
+    let start = output.find(label).expect("hook status label") + label.len();
+    output[start..]
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .expect("hook status count")
+}
+
 fn spawn_hook_session(
     home: &Path,
     command: &[u8],
@@ -47,6 +57,154 @@ fn spawn_hook_session(
         )
     });
     (session, session_started_rx)
+}
+
+#[test]
+fn raw_cli_external_hook_executes_pinned_file_after_path_replacement() {
+    let home = temp_shell_home("external-hook-pinned-exec");
+    let hook_path = home.join(".copilot-shell/cosh/hooks/pinned.sh");
+    let outside_path = home.join("outside.sh");
+    let original_marker = home.join("original.marker");
+    let outside_marker = home.join("outside.marker");
+
+    install_user_hook(
+        &home,
+        "pinned.sh",
+        &format!(
+            "#!/bin/sh\n# cosh-hook: pinned-hook\n# match-commands: echo\n\
+             : > '{}'\nprintf '%s\\n' '{{\"hook_id\":\"pinned-hook\",\"severity\":\"warning\",\"title\":\"PINNED ORIGINAL HOOK\",\"description\":\"original\",\"suggestion\":\"none\"}}'\n",
+            original_marker.display()
+        ),
+    );
+    write_executable(
+        &outside_path,
+        &format!(
+            "#!/bin/sh\n: > '{}'\nprintf '%s\\n' '{{\"hook_id\":\"outside\",\"severity\":\"warning\",\"title\":\"REPLACED OUTSIDE HOOK\",\"description\":\"outside\",\"suggestion\":\"none\"}}'\n",
+            outside_marker.display()
+        ),
+    );
+
+    // The engine loads user hooks before launching bash. Replacing the path
+    // from .bashrc therefore exercises the load-to-exec window end to end.
+    fs::write(
+        home.join(".bashrc"),
+        format!(
+            "rm -f -- '{}'\nln -s -- '{}' '{}'\n",
+            hook_path.display(),
+            outside_path.display(),
+            hook_path.display()
+        ),
+    )
+    .unwrap();
+
+    let home_str = home.to_string_lossy().into_owned();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "bash"],
+        &[("HOME", home_str.as_str()), ("COSH_SHELL_ISOLATED", "0")],
+        vec![
+            (b"echo pinned-hook-check\n".to_vec(), Duration::ZERO),
+            (b"exit\n".to_vec(), Duration::from_millis(500)),
+        ],
+    );
+
+    assert!(output.contains("PINNED ORIGINAL HOOK"), "{output}");
+    assert!(!output.contains("REPLACED OUTSIDE HOOK"), "{output}");
+    assert!(original_marker.exists(), "original pinned hook did not run");
+    assert!(
+        !outside_marker.exists(),
+        "replacement hook unexpectedly ran"
+    );
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[cfg(unix)]
+#[test]
+fn raw_cli_project_hook_rejects_symlinked_cosh_directory() {
+    use std::os::unix::fs::symlink;
+
+    let home = temp_shell_home("project-hook-symlinked-cosh");
+    let project = home.join("project");
+    let outside_cosh = home.join("outside-cosh");
+    let outside_hooks = outside_cosh.join("hooks");
+    let marker = home.join("outside-hook.marker");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&outside_hooks).unwrap();
+    write_executable(
+        &outside_hooks.join("outside.sh"),
+        &format!(
+            "#!/bin/sh\n# cosh-hook: outside-project\n# match-commands: echo\n\
+             : > '{}'\nprintf '%s\\n' '{{\"hook_id\":\"outside-project\",\"severity\":\"warning\",\"title\":\"OUTSIDE PROJECT HOOK\",\"description\":\"outside\",\"suggestion\":\"none\"}}'\n",
+            marker.display()
+        ),
+    );
+    symlink(&outside_cosh, project.join(".cosh")).unwrap();
+    let trust_store = home.join("trusted-project-hooks");
+    fs::write(
+        &trust_store,
+        format!(
+            "# cosh-shell trusted project hook roots\n{}\n",
+            project.display()
+        ),
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().into_owned();
+    let trust_store_str = trust_store.to_string_lossy().into_owned();
+
+    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+        "fake",
+        &[],
+        &[
+            ("HOME", home_str.as_str()),
+            ("COSH_SHELL_PROJECT_TRUST_STORE", trust_store_str.as_str()),
+        ],
+        &project,
+        vec![
+            (b"echo project-symlink-check\n".to_vec(), Duration::ZERO),
+            (b"exit\n".to_vec(), Duration::from_millis(500)),
+        ],
+    );
+
+    assert!(!output.contains("OUTSIDE PROJECT HOOK"), "{output}");
+    assert!(!marker.exists(), "symlinked project hook unexpectedly ran");
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
+fn raw_cli_untrusted_project_hook_registry_is_bounded() {
+    const EXPECTED_PROJECT_HOOK_LIMIT: usize = 64;
+
+    // This same regression is also run under `prlimit --nofile=64:64` so the
+    // assertion stays valid when real descriptor headroom lowers the count.
+    let home = temp_shell_home("project-hook-registry-limit");
+    let project = home.join("project");
+    let hooks_dir = project.join(".cosh/hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    for index in 0..=EXPECTED_PROJECT_HOOK_LIMIT {
+        write_executable(
+            &hooks_dir.join(format!("project-{index}.sh")),
+            &format!("#!/bin/sh\n# cosh-hook: project-{index}\n"),
+        );
+    }
+    let home_str = home.to_string_lossy().into_owned();
+
+    let output = run_raw_cli_with_args_env_current_dir_and_delayed_input(
+        "fake",
+        &[],
+        &[("HOME", home_str.as_str())],
+        &project,
+        vec![
+            (b"/hooks\n".to_vec(), Duration::ZERO),
+            (b"exit\n".to_vec(), Duration::from_millis(500)),
+        ],
+    );
+
+    let project_count = hook_status_count(&output, "project=");
+    let untrusted_count = hook_status_count(&output, "untrusted=");
+    assert!(project_count > 0, "{output}");
+    assert!(project_count <= EXPECTED_PROJECT_HOOK_LIMIT, "{output}");
+    assert_eq!(untrusted_count, project_count, "{output}");
+    let _ = fs::remove_dir_all(&home);
 }
 
 fn wait_for_pids(path: &Path, count: usize) -> Option<Vec<i32>> {


### PR DESCRIPTION
## Why

Project hooks could follow symlinks outside the hook directory, trust-store
updates were not crash-durable, and hook execution or parse failures could
silently authorize a PreToolUse action. These paths share the same hook trust
boundary and need to fail closed while preserving an explicit compatibility
escape hatch.

## What changed

- Open hook directories and entries through pinned descriptors with
  `O_NOFOLLOW`, then validate and parse the opened file.
- Persist the project trust store through a same-directory temporary file,
  `sync_data`, atomic rename, and parent-directory sync while preserving mode.
- Classify hook failures, block PreToolUse by default, expose an explicit
  `fail_open` setting, and distinguish failures from real allows in audit data.

## Related issue

Fixes #2306

Fixes #2305

Fixes #2301

Fixes #2101

## User / Agent impact

Symlinked project hooks are rejected, trust decisions survive crash windows,
and broken security hooks block affected tool calls by default. Existing hook
config remains compatible; `fail_open = true` is an explicit opt-in for users
who need the previous availability-first behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The default for execution, signal, timeout, empty-output, and JSON parse
failures changes from passthrough to block. Valid hook allow/block behavior and
exit-code 2 blocking remain unchanged.

## Validation

- `cargo test -p cosh-shell --lib hooks::engine::tests::loader --no-default-features --locked`
  — 2 passed; includes direct symlink and replacement-race assertions.
- `cargo test -p cosh-shell --lib config::tests --no-default-features --locked`
  — 39 passed.
- `cargo test -p cosh-core hook::tests --no-default-features --locked`
  — 60 passed.
- `cargo test -p cosh-core hook_failure_audit_is_distinct_from_real_allow --no-default-features --locked`
  — 1 passed.
- `cargo clippy -p cosh-shell -p cosh-core --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

## Documentation and rollback

No documentation files changed. The three commits are independently scoped to
loader confinement, durable trust storage, and fail-closed execution policy;
each can be reverted independently if rollback is required.
