### PR TITLE
fix(sight): report pids in the observer namespace

### DIFF
--- a/src/agentsight/docs/ARCHITECTURE.md
+++ b/src/agentsight/docs/ARCHITECTURE.md
@@ -200,6 +200,8 @@ sequenceDiagram
 
 **实现**: `src/unified.rs:AgentSight::handle_procmon_event()` — 由 ProcMon 事件驱动，调用 `AgentScanner::on_process_create()`。
 
+两条发现路径都用事件里的 pid 去解析 `/proc`，因此该 pid 必须是**用户态所在 pid namespace** 的编号，而不是目标进程最内层 namespace 的编号 —— 二者在容器场景下会不同。约定与实现见 [ebpf-probes.md](design-docs/ebpf-probes.md) 的「PID 命名空间约定」。
+
 ### 3. Dual Export Path: AnalysisResult vs GenAISemanticEvent
 
 `Analyzer` 输出原始 `AnalysisResult`（Token/Audit/Http），`GenAIBuilder` 将其转换为高抽象的 `GenAISemanticEvent`（LLMCall/ToolUse/AgentInteraction）。两条路径独立存储，前者用于本地查询，后者用于远程导出和语义分析。

--- a/src/agentsight/docs/design-docs/ebpf-probes.md
+++ b/src/agentsight/docs/design-docs/ebpf-probes.md
@@ -153,6 +153,25 @@ BPF hash map, key=PID, value=1. Used by:
 
 **Dynamic update**: `Probes::add_traced_pid()` / `Probes::remove_traced_pid()` at runtime.
 
+### PID 命名空间约定
+
+事件里的 pid、以及注册进 `traced_processes` 的 key，**都以"用户态所在的 pid namespace"为基准**。这不是风格问题：用户态拿到 pid 后都要回头解析自己的 `/proc`（cmdline、exe、maps、cgroup，以及 uprobe attach 用的 `/proc/<pid>/root/...`），而 `/proc` 是按**读取者**所在 namespace 编号的。BPF 上报的编号必须落在同一个 namespace，否则解析到的是另一个进程。
+
+`current_observer_pid()`（`src/bpf/common.h`）负责这件事，靠一个 rodata 开关分流：
+
+| 用户态位置 | rodata `observer_pidns_is_init` | 上报的 pid |
+|---|---|---|
+| 初始 pid namespace（宿主机进程，或 DaemonSet + `hostPID: true`） | `true` | host tgid |
+| 某个 pid namespace 内（sidecar + `shareProcessNamespace`） | `false` | 目标最内层 namespace 的 pid |
+
+开关由 `probes::pidns::observer_in_init_pidns()` 在 `open()` 与 `load()` 之间写入每个 skeleton 的 rodata，判定方式是比较 `/proc/self/ns/pid` 的 inode 与内核固定值 `PROC_PID_INIT_INO`。
+
+上表两种情形下，"目标最内层 pid"与"用户态视角 pid"恰好相等，所以历史实现（无条件取最内层）在宿主机和 sidecar 下都是对的；它只在**用户态处于初始 namespace 而目标在容器内**时出错 —— 那时最内层 pid 是个容器内编号，在宿主机上要么不存在，要么属于另一个无关进程。
+
+注意 `bpf_get_ns_current_pid_tgid()` 解决不了这个问题：除非 (dev, ino) 指的就是**当前任务自己**的 namespace，它一律返回 `-EINVAL`，并不会翻译到祖先 namespace。
+
+已知限制：用户态本身在某个 namespace 内、而目标在更深的嵌套 namespace 时，上报的仍是目标最内层 pid，用户态无法解析。此时 `AgentScanner::on_dns_event()` 的空 cmdline 检查会拒绝 attach（fail-closed），不会误挂到别的进程上。
+
 ## Build-Time Code Generation
 
 `build.rs` uses `libbpf-cargo` at compile time to:

--- a/src/agentsight/integration-tests/README.md
+++ b/src/agentsight/integration-tests/README.md
@@ -14,5 +14,6 @@
 | `test_hermes_dns.md` | 通过 DNS 捕获 Hermes agent（dashscope.aliyuncs.com） |
 | `test_http.md` | 明文 HTTP（tcpsniff）流量捕获 |
 | `test_connection_scanner.md` | 连接扫描器：活跃连接发现 |
+| `test_pid_namespace.md` | 容器内目标进程的 pid 解析（DaemonSet + hostPID 形态） |
 | `test_ffi_integration.md` | C FFI API 集成 |
 | `test_claude_code.md` | Claude Code BoringSSL 探针、SSE thinking/tool_use 解析、msg_id 会话关联 |

--- a/src/agentsight/integration-tests/test_pid_namespace.md
+++ b/src/agentsight/integration-tests/test_pid_namespace.md
@@ -1,0 +1,49 @@
+# PID 命名空间（容器内目标进程）集成测试
+
+> 前置条件见 [RULES.md](RULES.md)（环境变量、部署流程、通用规则）
+
+验证 agentsight 从**初始 pid namespace** 观察时，能正确发现并 attach 到**位于其他 pid namespace 内**的目标进程 —— 即 k8s DaemonSet + `hostPID: true` 的部署形态。约定见 [ebpf-probes.md](../docs/design-docs/ebpf-probes.md) 的「PID 命名空间约定」。
+
+不需要 k8s：`unshare --pid --fork --mount-proc` 造出的嵌套 pid namespace 与容器在这一点上同构，目标进程的 host pid 与 ns pid 同样不相等。
+
+## 测试目标
+
+1. 目标进程运行在嵌套 pid namespace 内、agentsight 运行在初始 namespace 时，procmon 的 exec 事件应上报 **host pid**，而不是容器内 pid（判定依据：`RUST_LOG=debug` 下 `Attached to agent: <name> (pid=N)` 里的 N 等于 `/proc/<N>/status` 的 `NSpid:` **第一列**）
+2. 承 1，SSL uprobe 应实际挂载成功，并产出 LLM/HTTPS 事件（判定依据：不出现 `[attach_process] pid=N: no SSL libraries found in maps`；stderr 不出现 `Warning: attach_process pid=`）
+3. 目标进程与 agentsight 同处初始 namespace（不 unshare）时，行为不应有任何变化（回归：host pid 路径本来就正确）
+4. agentsight 自身运行在嵌套 namespace 内、目标进程与其共享该 namespace 时，仍应正常发现并 attach（回归：sidecar + `shareProcessNamespace` 形态，此时上报最内层 pid 才是对的）
+5. rodata 开关判定应与实际所处 namespace 一致（判定依据：`RUST_LOG=debug` 下 `observer pid namespace inode 0x... (init=true|false)`）
+
+## 运行条件
+
+- root 权限
+- Linux kernel >= 5.8 with BTF
+- `unshare` 可用（util-linux）
+- 网络可达：目标进程需真实发起一次 HTTPS 请求以触发 SSL uprobe
+
+## 参考步骤
+
+目标 1 / 2（核心场景，修复前必失败）：
+
+```bash
+# 终端 A：初始 namespace 内启动 agentsight
+RUST_LOG=debug /root/agentsight trace 2>&1 | tee /tmp/agentsight-test-pidns.log
+
+# 终端 B：嵌套 pid namespace 内跑一个匹配 cmdline 规则的目标进程，
+# 让它发起 HTTPS 请求；--mount-proc 使其 /proc 只含该 namespace
+unshare --pid --fork --mount-proc <target-agent-cmd>
+
+# 终端 C：取该进程的 host pid 与 ns pid，确认两者不等
+pgrep -af <target-agent-cmd>
+grep -E '^(Name|Pid|NSpid):' /proc/<host-pid>/status
+```
+
+修复前的失败特征：日志里 `Attached to agent: ... (pid=N)` 的 N 是容器内小编号，
+且 `/proc/N` 对应的是宿主机上另一个无关进程（或不存在），SSL 事件始终为空。
+
+目标 4（sidecar 回归）：把 agentsight 和目标进程放进同一个 unshare 出来的
+namespace，此时 `init=false`，上报最内层 pid 即为正确行为。
+
+## 已知不覆盖
+
+agentsight 自身在某个 namespace 内、目标在**更深**嵌套 namespace 的情形不在本测试范围内 —— 该场景下用户态无法解析目标 pid，预期行为是 fail-closed 不 attach。

--- a/src/agentsight/src/bpf/common.h
+++ b/src/agentsight/src/bpf/common.h
@@ -94,20 +94,64 @@ static inline u32 get_task_ns_pid(struct task_struct *task)
   return BPF_CORE_READ(pid, numbers[level].nr);
 }
 
-/* Convenience wrapper: get the namespace PID of the current task.
+/* Set by user-space when it observes /proc through the initial pid namespace;
+ * see probes::pidns::observer_in_init_pidns() for how that is determined.
+ * Defaults to false so an unconfigured object keeps the historical behaviour. */
+const volatile bool observer_pidns_is_init = false;
+
+/*
+ * current_observer_pid - the current process's PID *as user-space sees it*.
+ *
+ * Every consumer of an event pid resolves it against user-space's own /proc --
+ * cmdline, maps, cgroup, and the /proc/<pid>/root uprobe paths -- and /proc is
+ * rendered in the *reader's* pid namespace. So the number reported here has to
+ * be the one valid in user-space's namespace.
+ *
+ * get_task_ns_pid() returns the target's *innermost* namespace pid. That is the
+ * right answer only when observer and target share a namespace: agentsight on a
+ * host, or a sidecar with shareProcessNamespace, which is why the distinction
+ * went unnoticed. It is the wrong answer when user-space sits in the initial
+ * namespace and the target is inside a container -- a DaemonSet with
+ * hostPID:true -- because a container-local pid either does not exist on the
+ * host or, worse, belongs to an unrelated process that then gets probed in its
+ * place.
+ *
+ * For an initial-namespace observer the correct number is simply the host tgid,
+ * which every task has, so no namespace walking is needed. Note that
+ * bpf_get_ns_current_pid_tgid() cannot serve here: it returns -EINVAL unless the
+ * namespace named by (dev, ino) is the *current task's own*, so it does not
+ * translate into an ancestor namespace.
+ *
+ * We take the tgid rather than the tid for the same reason get_task_ns_pid()
+ * reads the group leader: a syscall may run on a worker thread (e.g.
+ * aiohttp/uvloop doing getaddrinfo in a thread pool), and the event pid must
+ * stay process-level so it correlates with sslsniff and cmdline/DNS discovery.
+ */
+static __always_inline u32 current_observer_pid(void)
+{
+    if (observer_pidns_is_init)
+        return (u32)(bpf_get_current_pid_tgid() >> 32);
+
+    return get_task_ns_pid((struct task_struct *)bpf_get_current_task());
+}
+
+/* Convenience wrapper: get the observer-namespace PID of the current task.
  * In non-container scenarios this equals bpf_get_current_pid_tgid() >> 32. */
 static __always_inline u32 current_ns_pid(void)
 {
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-    return get_task_ns_pid(task);
+    return current_observer_pid();
 }
 
 /*
  * is_pid_traced - check whether the current process should be traced.
  *
- * Returns the namespace PID (to use for event->pid) if the process is traced,
- * or 0 if it should be skipped. Checks both host PID and container ns_pid so
- * that user-space can register either PID and get correct matching.
+ * Returns the PID to use for event->pid if the process is traced, or 0 if it
+ * should be skipped. Checks both the host PID and the observer-namespace PID,
+ * so user-space may register either and still get a match.
+ *
+ * The returned pid is deliberately whichever key hit the map: that keeps
+ * event->pid equal to the pid user-space registered, which is what lets
+ * ConnectionId(pid, ssl_ptr) correlate with the discovery-side caches.
  */
 #ifndef NO_TRACED_PROCESSES_MAP
 static __always_inline u32 is_pid_traced(u32 host_pid)
@@ -116,15 +160,14 @@ static __always_inline u32 is_pid_traced(u32 host_pid)
     if (traced)
         return host_pid;
 
-    /* Container scenario: host PID != namespace PID.
-     * Resolve the current task's ns_pid and retry the lookup. */
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-    u32 ns_pid = get_task_ns_pid(task);
+    /* Container scenario: host PID != observer-namespace PID.
+     * Resolve the pid as user-space sees it and retry the lookup. */
+    u32 observer_pid = current_observer_pid();
 
-    if (ns_pid != host_pid) {
-        traced = bpf_map_lookup_elem(&traced_processes, &ns_pid);
+    if (observer_pid != host_pid) {
+        traced = bpf_map_lookup_elem(&traced_processes, &observer_pid);
         if (traced)
-            return ns_pid;
+            return observer_pid;
     }
 
     return 0;

--- a/src/agentsight/src/bpf/procmon.bpf.c
+++ b/src/agentsight/src/bpf/procmon.bpf.c
@@ -55,7 +55,9 @@ int trace_execve_exit(struct syscall_trace_exit *ctx)
     // Fill event
     event->source = EVENT_SOURCE_PROCMON;
     event->timestamp_ns = ts;
-    event->pid = get_task_ns_pid(task);
+    // Report the pid as user-space's /proc will show it, not the target's
+    // innermost-namespace pid; user-space resolves cmdline/exe from this.
+    event->pid = current_observer_pid();
     event->tid = tid;
     event->ppid = ppid;
     event->uid = uid;

--- a/src/agentsight/src/probes/filewatch.rs
+++ b/src/agentsight/src/probes/filewatch.rs
@@ -11,6 +11,7 @@ use libbpf_rs::{
 };
 use std::mem::MaybeUninit;
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 
 // ─── Generated skeleton ───────────────────────────────────────────────────────
@@ -111,6 +112,9 @@ impl FileWatch {
 
         // Mirror the cgroup-filter rodata flag.
         open_skel.rodata_mut().filter_cgroup_enabled = shared.cgroup_filter_enabled();
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Detect cgroup v2 and pass to BPF via rodata.
         open_skel.rodata_mut().cgroup_v2_mode =

--- a/src/agentsight/src/probes/filewrite.rs
+++ b/src/agentsight/src/probes/filewrite.rs
@@ -11,6 +11,7 @@ use libbpf_rs::{
 };
 use std::mem::MaybeUninit;
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 
 // ─── Generated skeleton ───────────────────────────────────────────────────────
@@ -118,6 +119,9 @@ impl FileWrite {
 
         // Cgroup filter flag
         open_skel.rodata_mut().filter_cgroup_enabled = shared.cgroup_filter_enabled();
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Detect cgroup v2 and pass to BPF via rodata.
         open_skel.rodata_mut().cgroup_v2_mode =

--- a/src/agentsight/src/probes/mod.rs
+++ b/src/agentsight/src/probes/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 pub mod filewatch;
 pub mod filewrite;
+pub mod pidns;
 pub mod probes;
 pub mod procmon;
 pub mod proctrace;
@@ -15,6 +16,7 @@ mod elf_buildid;
 // Re-export commonly used types
 pub use filewatch::{FileWatch, FileWatchEvent};
 pub use filewrite::{FileWrite as FileWriteProbe, FileWriteEvent};
+pub use pidns::observer_in_init_pidns;
 pub use probes::{Probes, ProbesPoller};
 pub use procmon::{Event as ProcMonEventExt, ProcMon, ProcMonEvent};
 pub use proctrace::{ProcPoller, ProcTrace, VariableEvent as ProcEvent};

--- a/src/agentsight/src/probes/pidns.rs
+++ b/src/agentsight/src/probes/pidns.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2025 AgentSight Project
+//
+// Which pid namespace does this process observe `/proc` through?
+//
+// Every pid that comes out of a BPF event is eventually resolved against our
+// own `/proc` -- cmdline, exe, maps, cgroup, and the `/proc/<pid>/root` paths
+// uprobes attach to. `/proc` numbers processes in the *reader's* pid namespace,
+// so BPF has to report the pid in *our* namespace, not the target's innermost
+// one. The BPF side needs one bit to decide that (see `current_observer_pid()`
+// in `src/bpf/common.h`), and this module computes it.
+//
+// The bit is "are we in the initial pid namespace". That is the only case where
+// we can be certain our namespace is an ancestor of every process on the box,
+// and therefore that every task has a pid we can resolve -- its host pid. When
+// we are inside a namespace instead, the only processes we can see are the ones
+// sharing it, whose innermost-namespace pid is already the number our `/proc`
+// shows, which is the historical behaviour.
+
+use std::os::unix::fs::MetadataExt;
+use std::sync::OnceLock;
+
+/// Inode number of the initial pid namespace. Fixed by the kernel as
+/// `PROC_PID_INIT_INO` (`include/linux/proc_ns.h`) and part of the `/proc` ABI,
+/// which is what makes comparing against it a stable check.
+const PROC_PID_INIT_INO: u64 = 0xEFFF_FFFC;
+
+/// Path whose inode identifies our pid namespace.
+const SELF_PIDNS: &str = "/proc/self/ns/pid";
+
+/// Whether this process observes `/proc` through the initial pid namespace.
+///
+/// Cached: a process cannot change its own pid namespace (only children placed
+/// via `setns`/`unshare` get a new one), so this is fixed for our lifetime.
+///
+/// Probes copy this into their BPF `observer_pidns_is_init` rodata flag between
+/// `open()` and `load()`.
+pub fn observer_in_init_pidns() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let ino = match std::fs::metadata(SELF_PIDNS) {
+            Ok(md) => md.ino(),
+            Err(e) => {
+                // Hidden /proc, or a kernel without nsfs. Assume we are not in
+                // the initial namespace: that keeps the historical behaviour
+                // rather than asserting a host-pid view we cannot back up.
+                log::warn!(
+                    "failed to stat {SELF_PIDNS} ({e}); assuming a non-initial pid namespace, \
+                     event pids will use the target's innermost namespace"
+                );
+                return false;
+            }
+        };
+        let is_init = is_init_pidns_ino(ino);
+        log::debug!(
+            "observer pid namespace inode {ino:#x} (init={is_init}); event pids will be {}",
+            if is_init {
+                "host pids"
+            } else {
+                "innermost-namespace pids"
+            }
+        );
+        is_init
+    })
+}
+
+/// Whether a pid-namespace inode number is the initial namespace's.
+///
+/// Split out from [`observer_in_init_pidns`] so the comparison is testable
+/// without depending on which namespace the test runner happens to be in.
+fn is_init_pidns_ino(ino: u64) -> bool {
+    ino == PROC_PID_INIT_INO
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_pidns_inode_is_recognized() {
+        assert!(is_init_pidns_ino(PROC_PID_INIT_INO));
+        // The documented value, spelled out so a typo in the constant fails here.
+        assert!(is_init_pidns_ino(4_026_531_836));
+    }
+
+    #[test]
+    fn other_pidns_inodes_are_rejected() {
+        // Namespaces created after boot get ordinary nsfs inode numbers well
+        // below the initial-namespace magic value.
+        assert!(!is_init_pidns_ino(4_026_532_000));
+        assert!(!is_init_pidns_ino(PROC_PID_INIT_INO - 1));
+        assert!(!is_init_pidns_ino(PROC_PID_INIT_INO + 1));
+        assert!(!is_init_pidns_ino(0));
+    }
+
+    #[test]
+    fn observer_lookup_agrees_with_a_direct_stat() {
+        // Whichever namespace the test runner is in, the cached lookup must
+        // report what stat()ing the namespace link says.
+        let expected = std::fs::metadata(SELF_PIDNS)
+            .map(|md| is_init_pidns_ino(md.ino()))
+            .expect("stat /proc/self/ns/pid");
+        assert_eq!(observer_in_init_pidns(), expected);
+    }
+
+    #[test]
+    fn self_pidns_inode_matches_the_symlink_target() {
+        // Guards the assumption that stat()ing the magic symlink yields the
+        // nsfs inode, i.e. the number inside "pid:[...]" -- that identity is
+        // what makes the init comparison meaningful.
+        let link = std::fs::read_link(SELF_PIDNS).expect("read_link /proc/self/ns/pid");
+        let text = link.to_string_lossy();
+        let digits: String = text.chars().filter(|c| c.is_ascii_digit()).collect();
+        let from_link: u64 = digits.parse().expect("inode digits in pid:[...]");
+        let from_stat = std::fs::metadata(SELF_PIDNS).expect("stat").ino();
+        assert_eq!(from_link, from_stat);
+    }
+}

--- a/src/agentsight/src/probes/procmon.rs
+++ b/src/agentsight/src/probes/procmon.rs
@@ -11,6 +11,7 @@ use libbpf_rs::{
 };
 use std::mem::MaybeUninit;
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 
 // ─── Generated skeleton ───────────────────────────────────────────────────────
@@ -145,6 +146,9 @@ impl ProcMon {
 
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open BPF object")?;
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Reuse the shared ring buffer.
         shared

--- a/src/agentsight/src/probes/proctrace.rs
+++ b/src/agentsight/src/probes/proctrace.rs
@@ -20,6 +20,8 @@ use std::{
     time::Duration,
 };
 
+use super::pidns::observer_in_init_pidns;
+
 // ─── Generated skeleton ───────────────────────────────────────────────────────
 #[allow(
     non_camel_case_types,
@@ -407,6 +409,10 @@ impl ProcTrace {
         // Set cgroup-filter rodata flag before load. Defaults to false so
         // existing behavior is preserved when feature is unused.
         open_skel.rodata_mut().filter_cgroup_enabled = cgroup_filter_enabled;
+
+        // Tell BPF which namespace to report event pids in. proctrace itself
+        // reports host pids, but it shares common.h's is_pid_traced() gate.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Detect cgroup v2 unified hierarchy and pass to BPF via rodata.
         // When true, get_cgroup_id_compat() uses bpf_get_current_cgroup_id() directly.

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -12,6 +12,7 @@ use libbpf_rs::{
 };
 use procfs::process::Process;
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 use std::{
     collections::{HashMap, HashSet},
@@ -266,6 +267,9 @@ impl SslSniff {
         // Keep MaybeUninit on the heap so its address is stable.
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open BPF object")?;
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Reuse shared maps when running under the unified manager.
         if let Some(shared) = shared {

--- a/src/agentsight/src/probes/tcpsniff.rs
+++ b/src/agentsight/src/probes/tcpsniff.rs
@@ -21,6 +21,7 @@ use libbpf_rs::{
 };
 use std::{mem::MaybeUninit, net::Ipv4Addr};
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 
 // --- Generated skeleton ---
@@ -66,6 +67,9 @@ impl TcpSniff {
         let mut open_skel = builder
             .open()
             .context("failed to open tcpsniff BPF object")?;
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Reuse the shared ring buffer.
         shared

--- a/src/agentsight/src/probes/udpdns.rs
+++ b/src/agentsight/src/probes/udpdns.rs
@@ -15,6 +15,7 @@ use libbpf_rs::{
 };
 use std::mem::MaybeUninit;
 
+use super::pidns::observer_in_init_pidns;
 use super::shared_maps::{MapKind, SharedMaps};
 
 // --- Generated skeleton ---
@@ -179,6 +180,9 @@ impl UdpDns {
 
         let open_object = Box::new(MaybeUninit::<libbpf_rs::OpenObject>::uninit());
         let mut open_skel = builder.open().context("failed to open udpdns BPF object")?;
+
+        // Tell BPF which namespace to report event pids in.
+        open_skel.rodata_mut().observer_pidns_is_init = observer_in_init_pidns();
 
         // Reuse shared ring buffer + process filter.
         shared


### PR DESCRIPTION
## Why

BPF 侧上报的 `event->pid` 是**目标进程最内层 pid namespace** 的编号，但用户态拿到这个数字后，一律是去解析**自己的** `/proc` —— cmdline、exe、maps、cgroup，以及 uprobe attach 用的 `/proc/<pid>/root/...`。而 `/proc` 是按**读取者**所在 namespace 编号的。

两者只有在「观察者与目标共处同一个 pid namespace」时才相等。agentsight 直接跑在宿主机上、以及 sidecar 配 `shareProcessNamespace` 时都满足这个前提，所以这个隐含假设一直没被发现。

k8s DaemonSet + `hostPID: true` 打破了它：用户态在初始 namespace，目标进程在容器内，最内层编号是个容器局部值，在宿主机上要么不存在，要么**属于另一个无关进程**。于是 `AgentScanner` 拿错误进程的 cmdline 去匹配、匹配失败、静默不 attach —— 连一条 warning 都没有，因为那个错误的 `/proc` 条目读起来完全正常。

实测：容器内进程 `NSpid: 12345 2415`，用户态读 `/proc/2415/cmdline` 命中宿主机上一个毫不相干的进程。结果是 DaemonSet 形态下容器内的 agent 一个都发现不了，只能采到宿主机上的进程。

现在需要修，是因为 DaemonSet 是 k8s 下的主流部署形态（每节点一个采集器，而不是每 Pod 一个 sidecar），这个 bug 让该形态完全不可用。

## What changed

在 `src/bpf/common.h` 增加 `const volatile bool observer_pidns_is_init` 与 `current_observer_pid()`：该 flag 为真时上报 host tgid，否则回落到原有的 `get_task_ns_pid()`。

新增 `src/probes/pidns.rs` 计算该 flag —— 比较 `/proc/self/ns/pid` 的 inode 与内核固定值 `PROC_PID_INIT_INO`；各 probe 在 `open()` 与 `load()` 之间写入自己 skeleton 的 rodata，沿用仓库既有的 `filter_cgroup_enabled` / `cgroup_v2_mode` 模式。

为什么必须把这个信息传进 BPF，而不是在用户态修：两种 pid 都不是无条件正确的，所以观察者的位置必须传达给内核侧。用户态事后无法换算 —— 反查一个 namespace pid 需要遍历所有 `/proc/*/status` 找 `NSpid` 匹配，每个 exec 事件扫一遍是 O(进程数)，而且**同一个容器局部 pid 可能存在于多个容器**，结果二义。

`bpf_get_ns_current_pid_tgid()` 也帮不上：除非 `(dev, ino)` 指的就是**当前任务自己**的 namespace，它一律返回 `-EINVAL`，并不会翻译到祖先 namespace —— 恰好在本场景失效。（这是实现过程中推翻的第一版方案。）

走 rodata 的好处是 verifier 在 load 时做常量传播，未走的分支直接被剪掉，运行时零开销；且默认 `false` 使未配置的对象逐位保持原行为。

## Related issue

`no-issue: 现场排查 k8s DaemonSet 采集失效时定位到的 bug，未事先建 issue。如需 issue 追踪请告知，我补一个。`

## User / Agent impact

**修复前不可用的场景变为可用**：初始 pid namespace 的观察者（DaemonSet + `hostPID: true`，或宿主机进程）现在能正确发现并 attach 容器内的 agent 进程。

**上报的 pid 取值变化**：对容器内 agent，跨 C FFI 传出的 `AgentsightHttpsData.pid` / `AgentsightLLMData.pid`（下游如 LoongCollector 直接作为 `pid` 日志字段输出）由「容器局部编号」变为「host pid」。旧值本就是错的 —— 它指向宿主机上另一个进程 —— 但下游若做过 pid 关联，取值确实变了。

**无新增配置项**：自动判定，不需要用户配置，YAML / pipeline 配置无需改动。

宿主机与 sidecar 两种形态行为**完全不变**。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

**Privileged**：改动了 BPF 程序。`common.h` 被全部 7 个 BPF 对象引用，因此 7 个对象都需重新过 verifier。未引入任何新的 CO-RE relocation 或 BPF helper —— `current_observer_pid()` 的 true 分支只用 `bpf_get_current_pid_tgid()`，false 分支是原有代码路径。

**Cross-component**：如上，跨 FFI 的 pid 语义对容器内 agent 有变化。FFI 结构体布局**未改动**，无 ABI 影响。

同时明确了一条此前没有文档的契约：**事件 pid 与注册进 `traced_processes` 的 key，都以用户态所在 pid namespace 为基准**。

**已知限制（有意不处理）**：观察者自身在某个 namespace 内、而目标在**更深的嵌套** namespace 时，仍上报最内层 pid，与改动前一致。要修需要在 BPF 里对目标的 upid 链做有界遍历，相对本次支持的两种部署形态而言 verifier 面偏大。该情形下 `AgentScanner::on_dns_event()` 的空 cmdline 检查会 fail-closed 拒绝 attach，不会误挂到别的进程上。

## Validation

**必须如实说明：本改动尚未编译。** 开发环境无 Rust 工具链，因此 `cargo build` / `cargo clippy` / `cargo test` / BPF verifier **均未执行**。

已完成：

- `python3 scripts/check-arch-boundaries.py` → **PASS**（0 violations, 199 files）
- 逐行静态审查，重点核对了几处只有编译才会暴露的问题：
  - `Cargo.lock` 锁定 `libbpf-rs 0.23.3`（pre-0.24），确认 `open_skel.rodata_mut().field` 是正确 API，与既有 `filter_cgroup_enabled` 赋值逐字一致
  - 确认 7 个 BPF 对象**都**引用了新全局（直接经 `current_ns_pid()`，或间接经 `is_pid_traced()` / `traced_pid_cgroup_gate_allow()`），故 clang 不会将其优化掉、skeleton 必然生成 rodata 访问器。特别注意 `procmon` 同时定义 `NO_TRACED_PROCESSES_MAP` + `NO_CGROUP_FILTER`，改动前它没有任何 `const volatile` 全局、也就没有 `.rodata` 段，本次是该 skeleton 上首次 `rodata_mut()` 调用 —— 成立的前提正是 `procmon.bpf.c` 直接读了该 flag
  - 确认 flag 为 `false` 时，三个调用点（`current_ns_pid`、`is_pid_traced`、`procmon.bpf.c` exec 路径）取值与改动前逐位相同
- `src/probes/pidns.rs` 附 4 个单元测试（inode 常量识别、非初始 namespace 拒绝、与直接 stat 结果一致、magic symlink 的 inode 与 `stat` 一致）

**合并前必须补的**（我无法在本机执行）：

```bash
cd src/agentsight
cargo +1.89.0 fmt --all --check
cargo +1.89.0 clippy --workspace --all-targets -- -D warnings
cargo test
sudo cargo test --test bpf_load -- --ignored   # 改了 common.h，7 个 probe 都需过 verifier
```

注意 `tests/bpf_load.rs` 是 `#[ignore]` 的，CI 未必执行，**verifier 回归需人工跑一次**。

**手工端到端验证**：新增 `integration-tests/test_pid_namespace.md`。不需要 k8s —— `unshare --pid --fork --mount-proc` 造出的嵌套 pid namespace 与容器在这一点上同构，目标的 host pid 与 ns pid 同样不相等。核心判定：`Attached to agent: <name> (pid=N)` 里的 N 应等于 `/proc/<N>/status` 中 `NSpid:` 的**第一列**；修复前 N 是容器内小编号。runbook 同时覆盖宿主机与 sidecar 两个回归场景。

## Documentation and rollback

文档改动：

- `docs/design-docs/ebpf-probes.md` —— 新增「PID 命名空间约定」一节，含分流表与已知限制；该文档此前完全未提及 namespace
- `docs/ARCHITECTURE.md` —— ProcMon 自动发现一节补充指引
- `integration-tests/test_pid_namespace.md` + `README.md` 索引

**回滚**：直接 revert 本 commit 即可，无迁移、无状态、无持久化数据。

另有一个更轻的降级手段：由于该 flag 默认 `false` 即为改动前行为，只需移除各 probe 里那行 `open_skel.rodata_mut().observer_pidns_is_init = ...` 赋值，即可在**完全不碰 BPF 代码**的前提下恢复旧行为。
