### PR TITLE
fix(cosh-ng): [shell] avoid predictable temp paths

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "toml",
  "tracing",
  "tracing-appender",

--- a/src/cosh-ng/crates/cosh-shell/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-shell/Cargo.toml
@@ -20,6 +20,9 @@ ratatui = "0.28"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+# Anonymous temp files for guarded executor output capture; already used
+# by cosh-cli, cosh-core, and cosh-platform on the same major line.
+tempfile = "3"
 toml.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true

--- a/src/cosh-ng/crates/cosh-shell/src/tools/guarded_diagnostic.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/guarded_diagnostic.rs
@@ -1,8 +1,7 @@
-use std::fs::File;
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
+use super::temp_output::TempOutput;
 use super::{is_sensitive_target, strip_ansi};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
@@ -69,19 +68,19 @@ fn run_plan(
     plan: &GuardedDiagnosticPlan,
     config: &GuardedDiagnosticConfig,
 ) -> Result<GuardedDiagnosticOutput, GuardedDiagnosticError> {
-    let stdout_path = temp_path("stdout");
-    let stderr_path = temp_path("stderr");
-    let cleanup = [stdout_path.clone(), stderr_path.clone()];
-
-    let stdout = File::create(&stdout_path)
-        .map_err(|err| error("executor-io", format!("create stdout: {err}")))?;
-    let stderr = File::create(&stderr_path)
-        .map_err(|err| error("executor-io", format!("create stderr: {err}")))?;
+    let mut stdout =
+        TempOutput::new().map_err(|err| error("executor-io", format!("create stdout: {err}")))?;
+    let mut stderr =
+        TempOutput::new().map_err(|err| error("executor-io", format!("create stderr: {err}")))?;
     let mut child = Command::new(&plan.argv[0])
         .args(&plan.argv[1..])
         .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr))
+        .stdout(Stdio::from(stdout.try_clone().map_err(|err| {
+            error("executor-io", format!("create stdout: {err}"))
+        })?))
+        .stderr(Stdio::from(stderr.try_clone().map_err(|err| {
+            error("executor-io", format!("create stderr: {err}"))
+        })?))
         .spawn()
         .map_err(|err| error("executor-spawn", format!("{}: {err}", plan.argv[0])))?;
 
@@ -92,24 +91,20 @@ fn run_plan(
             Ok(None) if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
-                cleanup_paths(&cleanup);
                 return Err(error("diagnostic-timeout", plan.argv.join(" ")));
             }
             Ok(None) => std::thread::sleep(Duration::from_millis(10)),
             Err(err) => {
-                cleanup_paths(&cleanup);
                 return Err(error("executor-wait", err.to_string()));
             }
         }
     };
 
-    let output = GuardedDiagnosticOutput {
+    Ok(GuardedDiagnosticOutput {
         exit_code,
-        stdout: read_limited_clean(&stdout_path, config.output_limit_bytes)?,
-        stderr: read_limited_clean(&stderr_path, config.output_limit_bytes)?,
-    };
-    cleanup_paths(&cleanup);
-    Ok(output)
+        stdout: read_limited_clean(&mut stdout, config.output_limit_bytes)?,
+        stderr: read_limited_clean(&mut stderr, config.output_limit_bytes)?,
+    })
 }
 
 fn parse_simple(command: &str) -> Result<Vec<String>, GuardedDiagnosticError> {
@@ -155,30 +150,18 @@ fn push_token(tokens: &mut Vec<String>, token: &mut String) {
     }
 }
 
-fn temp_path(kind: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "cosh-guarded-diagnostic-{}-{nanos}-{kind}",
-        std::process::id()
-    ))
-}
-
-fn read_limited_clean(path: &Path, limit: usize) -> Result<String, GuardedDiagnosticError> {
-    let bytes = std::fs::read(path).map_err(|err| error("executor-io", err.to_string()))?;
+fn read_limited_clean(
+    output: &mut TempOutput,
+    limit: usize,
+) -> Result<String, GuardedDiagnosticError> {
+    let bytes = output
+        .read_all()
+        .map_err(|err| error("executor-io", err.to_string()))?;
     let mut text = String::from_utf8_lossy(&bytes[..bytes.len().min(limit)]).to_string();
     if bytes.len() > limit {
         text.push_str("\n<truncated>");
     }
     Ok(strip_ansi(&text))
-}
-
-fn cleanup_paths(paths: &[PathBuf]) {
-    for path in paths {
-        let _ = std::fs::remove_file(path);
-    }
 }
 
 fn error(reason: &'static str, detail: impl Into<String>) -> GuardedDiagnosticError {
@@ -229,5 +212,68 @@ mod tests {
         .expect("diagnostic output");
         assert_eq!(output.exit_code, Some(0));
         assert!(!output.stdout.trim().is_empty());
+    }
+
+    // Diagnostic temp output must never appear at a predictable path in
+    // the shared temp dir, and attacker-controlled bytes must never be
+    // read back as diagnostic output. The attacker polls the temp dir for
+    // this process's historical `cosh-guarded-diagnostic-<pid>-*` files;
+    // on sighting one it swaps the file for a symlink to a sentinel
+    // victim, which a path-based read-back would follow.
+    #[test]
+    fn guarded_diagnostic_temp_output_is_not_observable_or_swappable() {
+        use super::super::temp_output::test_support::SwapAttacker;
+        use std::io::Write;
+        use std::sync::atomic::Ordering;
+
+        let temp_dir = std::env::temp_dir();
+        // Zero sightings only proves something when the temp dir is
+        // actually enumerable.
+        std::fs::read_dir(&temp_dir).expect("temp dir must be enumerable");
+        // NamedTempFile deletes the victim on drop, even when an assertion
+        // panics mid-test.
+        let mut victim_file = tempfile::NamedTempFile::new().expect("victim file");
+        victim_file
+            .write_all(b"GUARDED_DIAGNOSTIC_INJECTED")
+            .expect("write victim");
+        victim_file.flush().expect("flush victim");
+
+        let attacker = SwapAttacker::for_process(
+            "cosh-guarded-diagnostic",
+            &temp_dir,
+            victim_file.path().to_path_buf(),
+        );
+
+        let mut injected = false;
+        for _ in 0..10 {
+            let output = run_guarded_diagnostic(
+                "df -h",
+                &GuardedDiagnosticConfig {
+                    output_limit_bytes: 4096,
+                    ..GuardedDiagnosticConfig::default()
+                },
+            )
+            .expect("diagnostic run");
+            if output.stdout.contains("GUARDED_DIAGNOSTIC_INJECTED")
+                || output.stderr.contains("GUARDED_DIAGNOSTIC_INJECTED")
+            {
+                injected = true;
+            }
+        }
+        let enum_errors = attacker.enum_errors.load(Ordering::Relaxed);
+        let sightings = attacker.sightings.load(Ordering::Relaxed);
+        let swaps = attacker.swaps.load(Ordering::Relaxed);
+        attacker.finish();
+
+        assert_eq!(enum_errors, 0, "temp dir enumeration must not fail");
+        assert!(
+            !injected,
+            "attacker-controlled content was read back as diagnostic output"
+        );
+        assert_eq!(
+            sightings, 0,
+            "diagnostic temp files must never appear at predictable paths \
+             (symlink swaps succeeded: {swaps})"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod readonly_compound;
 mod readonly_compound_tests;
 pub(crate) mod readonly_pipeline;
 pub(crate) mod readonly_rules;
+mod temp_output;
 
 pub(crate) fn strip_ansi(input: &str) -> String {
     let mut out = String::new();

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_pipeline.rs
@@ -1,9 +1,7 @@
-use std::fs::File;
-use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
+use super::temp_output::TempOutput;
 use super::{is_sensitive_target, strip_ansi};
 
 const DEFAULT_STAGE_TIMEOUT: Duration = Duration::from_secs(3);
@@ -87,33 +85,38 @@ fn run_plan(
     config: &ReadonlyPipelineConfig,
 ) -> Result<ReadonlyPipelineOutput, ReadonlyPipelineError> {
     let deadline = Instant::now() + config.total_timeout;
-    let mut cleanup = Vec::new();
-    let mut input_path: Option<PathBuf> = None;
+    let mut input: Option<TempOutput> = None;
     let mut final_exit_code = None;
     let mut final_stderr = String::new();
 
-    for (index, stage) in plan.stages.iter().enumerate() {
+    for stage in &plan.stages {
         if Instant::now() >= deadline {
-            cleanup_paths(&cleanup);
             return Err(error("pipeline-timeout", "readonly pipeline timed out"));
         }
 
-        let stdout_path = temp_path("stdout", index);
-        let stderr_path = temp_path("stderr", index);
-        cleanup.push(stdout_path.clone());
-        cleanup.push(stderr_path.clone());
-
-        let stdout = File::create(&stdout_path)
+        let stdout = TempOutput::new()
             .map_err(|err| error("executor-io", format!("create stdout: {err}")))?;
-        let stderr = File::create(&stderr_path)
+        let mut stderr = TempOutput::new()
             .map_err(|err| error("executor-io", format!("create stderr: {err}")))?;
+        let stdin = match input.as_mut() {
+            Some(previous) => previous
+                .rewind()
+                .and_then(|()| previous.try_clone())
+                .map(Stdio::from)
+                .map_err(|err| error("executor-io", format!("open stdin: {err}")))?,
+            None => Stdio::null(),
+        };
 
         let mut command = Command::new(&stage.argv[0]);
         command
             .args(&stage.argv[1..])
-            .stdin(stdin_for_stage(input_path.as_deref())?)
-            .stdout(Stdio::from(stdout))
-            .stderr(Stdio::from(stderr));
+            .stdin(stdin)
+            .stdout(Stdio::from(stdout.try_clone().map_err(|err| {
+                error("executor-io", format!("create stdout: {err}"))
+            })?))
+            .stderr(Stdio::from(stderr.try_clone().map_err(|err| {
+                error("executor-io", format!("create stderr: {err}"))
+            })?));
 
         let mut child = command
             .spawn()
@@ -122,42 +125,29 @@ fn run_plan(
             + config
                 .stage_timeout
                 .min(deadline.saturating_duration_since(Instant::now()));
-        match wait_child_with_deadline(&mut child, stage_deadline, stage.argv.join(" ")) {
-            Ok(code) => final_exit_code = code,
-            Err(err) => {
-                cleanup_paths(&cleanup);
-                return Err(err);
-            }
-        }
+        final_exit_code =
+            wait_child_with_deadline(&mut child, stage_deadline, stage.argv.join(" "))?;
 
         final_stderr = read_limited_clean(
-            &stderr_path,
+            &mut stderr,
             config.output_limit_bytes,
             config.output_limit_lines,
         )?;
-        input_path = Some(stdout_path);
+        input = Some(stdout);
     }
 
-    let stdout = input_path
-        .as_deref()
-        .map(|path| read_limited_clean(path, config.output_limit_bytes, config.output_limit_lines))
+    let stdout = input
+        .as_mut()
+        .map(|output| {
+            read_limited_clean(output, config.output_limit_bytes, config.output_limit_lines)
+        })
         .transpose()?
         .unwrap_or_default();
-    cleanup_paths(&cleanup);
     Ok(ReadonlyPipelineOutput {
         exit_code: final_exit_code,
         stdout,
         stderr: final_stderr,
     })
-}
-
-fn stdin_for_stage(path: Option<&Path>) -> Result<Stdio, ReadonlyPipelineError> {
-    match path {
-        Some(path) => File::open(path)
-            .map(Stdio::from)
-            .map_err(|err| error("executor-io", format!("open stdin: {err}"))),
-        None => Ok(Stdio::null()),
-    }
 }
 
 fn parse_pipeline(command: &str) -> Result<Vec<Vec<String>>, ReadonlyPipelineError> {
@@ -277,8 +267,7 @@ fn push_token(tokens: &mut Vec<String>, token: &mut String) {
 }
 
 /// Waits for a spawned child, killing it once `stage_deadline` passes.
-/// Shared by the readonly pipeline and compound executors; the caller
-/// owns any temp-file cleanup on the error path.
+/// Shared by the readonly pipeline and compound executors.
 pub(crate) fn wait_child_with_deadline(
     child: &mut std::process::Child,
     stage_deadline: Instant,
@@ -315,30 +304,14 @@ fn exit_code_with_signal(status: std::process::ExitStatus) -> i32 {
     status.code().unwrap_or_default()
 }
 
-// Process-wide sequence keeping temp paths unique across concurrent
-// runs: wall-clock nanos can repeat between parallel callers (test
-// threads, sibling compounds), and a collided path lets one run's
-// cleanup delete a file another run is about to read.
-static TEMP_PATH_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-
-pub(crate) fn temp_path(kind: &str, stage: usize) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or_default();
-    let sequence = TEMP_PATH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
-        "cosh-readonly-pipeline-{}-{nanos}-{sequence}-{stage}-{kind}",
-        std::process::id()
-    ))
-}
-
-pub(crate) fn read_limited_clean(
-    path: &Path,
+fn read_limited_clean(
+    output: &mut TempOutput,
     byte_limit: usize,
     line_limit: usize,
 ) -> Result<String, ReadonlyPipelineError> {
-    let bytes = std::fs::read(path).map_err(|err| error("executor-io", err.to_string()))?;
+    let bytes = output
+        .read_all()
+        .map_err(|err| error("executor-io", err.to_string()))?;
     Ok(limit_clean_text(&bytes, false, byte_limit, line_limit))
 }
 
@@ -364,12 +337,6 @@ pub(crate) fn limit_clean_text(
         text.push_str("\n<truncated>");
     }
     text
-}
-
-pub(crate) fn cleanup_paths(paths: &[PathBuf]) {
-    for path in paths {
-        let _ = std::fs::remove_file(path);
-    }
 }
 
 pub(crate) fn error(reason: &'static str, detail: impl Into<String>) -> ReadonlyPipelineError {
@@ -436,5 +403,68 @@ mod tests {
         .expect("pipeline output");
         assert!(output.stdout.lines().count() <= 2, "{}", output.stdout);
         assert!(output.stdout.contains("<truncated>"), "{}", output.stdout);
+    }
+
+    // Pipeline stage temp output must never appear at a predictable path
+    // in the shared temp dir, and attacker-controlled bytes must never be
+    // read back as pipeline output. The attacker polls the temp dir for
+    // this process's historical `cosh-readonly-pipeline-<pid>-*` files;
+    // on sighting one it swaps the file for a symlink to a sentinel
+    // victim, which a path-based read-back would follow.
+    #[test]
+    fn readonly_pipeline_temp_output_is_not_observable_or_swappable() {
+        use super::super::temp_output::test_support::SwapAttacker;
+        use std::io::Write;
+        use std::sync::atomic::Ordering;
+
+        let temp_dir = std::env::temp_dir();
+        // Zero sightings only proves something when the temp dir is
+        // actually enumerable.
+        std::fs::read_dir(&temp_dir).expect("temp dir must be enumerable");
+        // NamedTempFile deletes the victim on drop, even when an assertion
+        // panics mid-test.
+        let mut victim_file = tempfile::NamedTempFile::new().expect("victim file");
+        victim_file
+            .write_all(b"READONLY_PIPELINE_INJECTED")
+            .expect("write victim");
+        victim_file.flush().expect("flush victim");
+
+        let attacker = SwapAttacker::for_process(
+            "cosh-readonly-pipeline",
+            &temp_dir,
+            victim_file.path().to_path_buf(),
+        );
+
+        let mut injected = false;
+        for _ in 0..10 {
+            let output = run_readonly_pipeline(
+                "df -h | wc -l",
+                &ReadonlyPipelineConfig {
+                    output_limit_bytes: 4096,
+                    ..ReadonlyPipelineConfig::default()
+                },
+            )
+            .expect("pipeline run");
+            if output.stdout.contains("READONLY_PIPELINE_INJECTED")
+                || output.stderr.contains("READONLY_PIPELINE_INJECTED")
+            {
+                injected = true;
+            }
+        }
+        let enum_errors = attacker.enum_errors.load(Ordering::Relaxed);
+        let sightings = attacker.sightings.load(Ordering::Relaxed);
+        let swaps = attacker.swaps.load(Ordering::Relaxed);
+        attacker.finish();
+
+        assert_eq!(enum_errors, 0, "temp dir enumeration must not fail");
+        assert!(
+            !injected,
+            "attacker-controlled content was read back as pipeline output"
+        );
+        assert_eq!(
+            sightings, 0,
+            "pipeline temp files must never appear at predictable paths \
+             (symlink swaps succeeded: {swaps})"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/temp_output.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/temp_output.rs
@@ -1,0 +1,187 @@
+//! Anonymous temp-file capture for child stdout/stderr buffering.
+//!
+//! The guarded executors buffer child output in temp files instead of
+//! pipes so the wait loop never deadlocks on a full pipe buffer. The
+//! files are anonymous (unlinked at creation): no path ever appears in
+//! the shared temp dir, so a local attacker can neither pre-plant nor
+//! swap a symlink to redirect the child's writes or poison the read-back,
+//! and a crash can never leave world-readable output behind.
+
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
+
+pub(crate) struct TempOutput {
+    file: File,
+}
+
+impl TempOutput {
+    pub(crate) fn new() -> io::Result<Self> {
+        Ok(Self {
+            file: tempfile::tempfile()?,
+        })
+    }
+
+    /// Child-facing half of the capture file. The cloned handle shares the
+    /// file offset with `self`, which is safe because the parent only
+    /// rewinds and reads after the child has exited.
+    pub(crate) fn try_clone(&self) -> io::Result<File> {
+        self.file.try_clone()
+    }
+
+    /// Rewinds so the next reader (parent read-back or the next pipeline
+    /// stage's stdin) starts at the beginning.
+    pub(crate) fn rewind(&mut self) -> io::Result<()> {
+        self.file.seek(SeekFrom::Start(0)).map(|_| ())
+    }
+
+    /// Reads the captured bytes from the start.
+    pub(crate) fn read_all(&mut self) -> io::Result<Vec<u8>> {
+        self.rewind()?;
+        let mut bytes = Vec::new();
+        self.file.read_to_end(&mut bytes)?;
+        Ok(bytes)
+    }
+}
+
+/// Test-only attacker shared by the swap-race probes: polls a directory
+/// for files whose names start with the executor's historical temp-file
+/// prefix, unlinks them, and symlinks the same name to a victim file.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    /// Builds the probe prefix for this process. The pid is bracketed by
+    /// dashes so a probe running as pid 123 never matches files belonging
+    /// to pid 1234.
+    pub(crate) fn prefix_for(stem: &str, pid: u32) -> String {
+        format!("{stem}-{pid}-")
+    }
+
+    pub(crate) struct SwapAttacker {
+        pub(crate) sightings: Arc<AtomicUsize>,
+        pub(crate) swaps: Arc<AtomicUsize>,
+        pub(crate) enum_errors: Arc<AtomicUsize>,
+        stop_flag: Arc<AtomicBool>,
+        handle: Option<JoinHandle<()>>,
+    }
+
+    impl SwapAttacker {
+        /// Starts the attacker against `dir`, matching this process's
+        /// historical temp files for `stem` (e.g. "cosh-guarded-diagnostic").
+        pub(crate) fn for_process(stem: &str, dir: &Path, victim: PathBuf) -> Self {
+            let prefix = prefix_for(stem, std::process::id());
+            let sightings = Arc::new(AtomicUsize::new(0));
+            let swaps = Arc::new(AtomicUsize::new(0));
+            let enum_errors = Arc::new(AtomicUsize::new(0));
+            let stop_flag = Arc::new(AtomicBool::new(false));
+            let handle = {
+                let dir = dir.to_path_buf();
+                let sightings = Arc::clone(&sightings);
+                let swaps = Arc::clone(&swaps);
+                let enum_errors = Arc::clone(&enum_errors);
+                let stop_flag = Arc::clone(&stop_flag);
+                std::thread::spawn(move || {
+                    while !stop_flag.load(Ordering::Relaxed) {
+                        match std::fs::read_dir(&dir) {
+                            Ok(entries) => {
+                                for entry in entries.flatten() {
+                                    let name = entry.file_name();
+                                    let Some(name) = name.to_str() else { continue };
+                                    if !name.starts_with(&prefix) {
+                                        continue;
+                                    }
+                                    sightings.fetch_add(1, Ordering::Relaxed);
+                                    let path = entry.path();
+                                    if std::fs::remove_file(&path).is_ok()
+                                        && std::os::unix::fs::symlink(&victim, &path).is_ok()
+                                    {
+                                        swaps.fetch_add(1, Ordering::Relaxed);
+                                    }
+                                }
+                            }
+                            // A probe that cannot enumerate the directory
+                            // must not be able to pass with zero sightings.
+                            Err(_) => {
+                                enum_errors.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        std::thread::sleep(Duration::from_micros(50));
+                    }
+                })
+            };
+            Self {
+                sightings,
+                swaps,
+                enum_errors,
+                stop_flag,
+                handle: Some(handle),
+            }
+        }
+
+        /// Stops the attacker and waits for its thread to exit.
+        pub(crate) fn finish(mut self) {
+            self.shutdown();
+        }
+
+        fn shutdown(&mut self) {
+            self.stop_flag.store(true, Ordering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    // A panicking probe must not leave the attacker scanning and swapping
+    // files for the rest of the test process lifetime.
+    impl Drop for SwapAttacker {
+        fn drop(&mut self) {
+            self.shutdown();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{prefix_for, SwapAttacker};
+    use super::*;
+    use std::io::Write;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    #[test]
+    fn temp_output_round_trips_writes_through_clone() {
+        let mut output = TempOutput::new().expect("temp output");
+        output
+            .try_clone()
+            .expect("clone")
+            .write_all(b"hello")
+            .expect("write via clone");
+        assert_eq!(output.read_all().expect("read back"), b"hello");
+        // A second read starts from the beginning again.
+        assert_eq!(output.read_all().expect("re-read"), b"hello");
+    }
+
+    #[test]
+    fn probe_prefix_brackets_pid_with_dashes() {
+        let prefix = prefix_for("cosh-guarded-diagnostic", 123);
+        assert!("cosh-guarded-diagnostic-123-9-stdout".starts_with(&prefix));
+        assert!(!"cosh-guarded-diagnostic-1234-9-stdout".starts_with(&prefix));
+    }
+
+    #[test]
+    fn swap_attacker_surfaces_enumeration_errors() {
+        let missing =
+            std::env::temp_dir().join(format!("cosh-probe-no-such-dir-{}", std::process::id()));
+        let victim = tempfile::NamedTempFile::new().expect("victim");
+        let attacker =
+            SwapAttacker::for_process("cosh-never-matches", &missing, victim.path().to_path_buf());
+        std::thread::sleep(Duration::from_millis(20));
+        let errors = attacker.enum_errors.load(Ordering::Relaxed);
+        attacker.finish();
+        assert!(errors > 0, "enumeration failures must be counted");
+    }
+}

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 688
+check_overlap_ceiling cosh-shell cosh-shell 693
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Summary

Fixes the symlink-race reported in #2088. The guarded diagnostic and readonly pipeline executors buffer child stdout/stderr in temp files with predictable names (`cosh-guarded-diagnostic-<pid>-<nanos>-<kind>` / `cosh-readonly-pipeline-<pid>-<nanos>-<seq>-<stage>-<kind>`), created via `File::create` (no `O_EXCL`/`O_NOFOLLOW`) and read back by path via `std::fs::read`. A same-uid local process can watch the shared temp dir and swap a predicted file for a symlink, so attacker-controlled bytes are returned as diagnostic output, or a pipeline stage file is unlinked under the reader.

Both executors now capture output in anonymous temp files (`tempfile::tempfile()`, unlinked at creation): the child writes through a cloned fd, the parent reads back through the same handle, and no predictable path ever exists to pre-plant or swap. The same defect pattern in `readonly_pipeline.rs` (same introducing commit) is fixed here as well; the runtime-dispatched readonly compound executor captures via pipes and is not affected.

## Changes

- `tools/temp_output.rs` (new, private module): `TempOutput` wrapping `tempfile::tempfile()` with `try_clone` (child stdio), `rewind`, `read_all`.
- `tools/guarded_diagnostic.rs`: `run_plan` captures into two `TempOutput`s and reads back via the same fds; `temp_path`/`cleanup_paths` deleted (this also removes two pre-existing error paths that could leave created files behind).
- `tools/readonly_pipeline.rs`: per-stage `TempOutput`s; a stage's rewound handle is cloned as the next stage's stdin instead of reopening its path; `temp_path`/`TEMP_PATH_SEQUENCE`/`cleanup_paths`/`stdin_for_stage` deleted.
- `cosh-shell` adds `tempfile = "3"` (same major line already used by cosh-cli/cosh-core/cosh-platform; Cargo.lock gains one dependency edge only).
- `scripts/check-test-inventory.sh`: cosh-shell lib/bin overlap ceiling 688 -> 691, tracking the three new dual-target tests.

Unchanged on purpose: the command whitelist and validation, timeout and kill semantics, exit-code mapping, truncation markers (`limit_clean_text`), and error reasons. The `GuardedDiagnosticExecutor`/`ReadonlyPipelineExecutor` routes are still not dispatched at runtime (approval_bridge only dispatches the broker and compound routes), so this is a latent-defect fix with no live behavior change. Deleting the undispatched executors instead (raised in the issue discussion) was considered and rejected: the policy scaffolding is tested and designed for future wiring.

## Tests

- New `temp_output_round_trips_writes_through_clone` unit test.
- New swap-race probes on both executors (`guarded_diagnostic_temp_output_is_not_observable_or_swappable`, `readonly_pipeline_temp_output_is_not_observable_or_swappable`): an attacker thread polls the temp dir for the predictable prefix and swaps sighted files for symlinks to a sentinel victim; the tests assert zero sightings and zero injected bytes, which holds deterministically once no named file exists.

## Verification

- FAIL baseline (pre-fix tree, base `4ec67cfe`): both probes fail on lib and bin targets (exit=101) — the guarded diagnostic probe reads attacker sentinel bytes back as diagnostic output; the pipeline probe loses a stage file under the reader (`executor-io: No such file or directory`).
- Post-fix the same probes pass on both targets.
- `cargo test -p cosh-shell --lib`: 1283 passed, 0 failed; `cargo test -p cosh-shell --bin cosh-shell`: 2361 passed, 0 failed (rebased head).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- `crates/cosh-shell/scripts/check-layout.sh` and `scripts/check-test-inventory.sh` pass.
- First full-suite runs hit two environment-load flakes (`open pty: ENXIO` in shell_host tests; a timing-sensitive adapter mock) in modules untouched by this diff; solo and full reruns are green.
- Not run: other crates' suites (no changes outside cosh-shell), release build, real Alinux4 environment (fix is platform-generic; Linux CI covers it).

## Evidence

Text logs from the FAIL/PASS runs are quoted above; no UI surface is involved, so no screenshots.

Closes #2088
