### PR TITLE
feat(anolisa): show platform availability

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list.rs
@@ -44,6 +44,10 @@ pub struct Row {
     pub display_name: String,
     pub summary: String,
     pub backends: Vec<String>,
+    /// Platforms declared by the component index.
+    pub platforms: Vec<String>,
+    /// Whether the component declares support for the current platform.
+    pub platform_available: bool,
     pub status: String,
     pub local_state: String,
     pub ownership: String,
@@ -96,6 +100,7 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
         &args,
         &view,
         rpm_query.as_ref().map(|query| query as &dyn PackageQuery),
+        &env.os,
     );
 
     if ctx.json {
@@ -110,7 +115,7 @@ pub fn handle(args: ListArgs, ctx: &CliContext) -> Result<(), CliError> {
 
     if !ctx.quiet {
         render_warnings(&view.warnings);
-        render_human(&rows, ctx.no_color);
+        render_human(&rows, ctx.no_color, &env.os);
     }
     Ok(())
 }
@@ -121,6 +126,17 @@ fn build_rows(
     args: &ListArgs,
     state: &StateStore,
     rpm_query: Option<&dyn PackageQuery>,
+) -> Vec<Row> {
+    build_rows_for_platform(index, args, state, rpm_query, "linux")
+}
+
+#[cfg(test)]
+fn build_rows_for_platform(
+    index: &ComponentIndex,
+    args: &ListArgs,
+    state: &StateStore,
+    rpm_query: Option<&dyn PackageQuery>,
+    platform: &str,
 ) -> Vec<Row> {
     index
         .components
@@ -133,6 +149,7 @@ fn build_rows(
             Some(entry_to_row(
                 entry,
                 projection,
+                platform,
                 RowScope {
                     scope: "none".to_string(),
                     active: false,
@@ -150,6 +167,7 @@ fn build_rows_from_view(
     args: &ListArgs,
     view: &StateView,
     rpm_query: Option<&dyn PackageQuery>,
+    platform: &str,
 ) -> Vec<Row> {
     let visible_components = view.visible_components();
     index
@@ -178,7 +196,7 @@ fn build_rows_from_view(
                                 .map(str::to_string),
                             state_path: Some(record.root.state_path.display().to_string()),
                         };
-                        Some(entry_to_row(entry, projection, row_scope))
+                        Some(entry_to_row(entry, projection, platform, row_scope))
                     })
                     .collect::<Vec<_>>();
             }
@@ -201,6 +219,7 @@ fn build_rows_from_view(
             vec![entry_to_row(
                 entry,
                 projection,
+                platform,
                 RowScope {
                     scope: scope.to_string(),
                     active: false,
@@ -224,12 +243,19 @@ struct RowScope {
 fn entry_to_row(
     entry: &ComponentIndexEntry,
     projection: LocalProjection,
+    platform: &str,
     row_scope: RowScope,
 ) -> Row {
     let backends: Vec<String> = entry.backends.iter().map(|b| b.kind.clone()).collect();
     let local_state = projection.local_state.label().to_string();
     let ownership = projection.ownership_label().to_string();
-    let action = projection.action_label().to_string();
+    let platform_available = entry.supports_platform(platform);
+    let install_available = platform_available && !backends.is_empty();
+    let action = if install_available || projection.action_label() != "install" {
+        projection.action_label().to_string()
+    } else {
+        "unavailable".to_string()
+    };
     Row {
         name: entry.name.clone(),
         display_name: entry
@@ -238,6 +264,8 @@ fn entry_to_row(
             .unwrap_or_else(|| entry.name.clone()),
         summary: entry.summary.clone().unwrap_or_default(),
         backends,
+        platforms: entry.platforms.clone(),
+        platform_available,
         status: projection.status,
         local_state,
         ownership,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/render.rs
@@ -4,45 +4,36 @@ use crate::commands::tier1::list::Row;
 pub(super) fn human_header(rows: &[Row]) -> String {
     let widths = HumanWidths::for_rows(rows);
     format!(
-        "{:<name_width$}{:<backends_width$}{:<scope_width$}{:<local_state_width$}{:<ownership_width$}{}",
+        "{:<name_width$}{:<availability_width$}{:<scope_width$}{:<local_state_width$}{}",
         "NAME",
-        "BACKENDS",
+        "AVAILABILITY",
         "SCOPE",
         "LOCAL STATE",
-        "OWNERSHIP",
         "ACTION",
         name_width = widths.name,
-        backends_width = widths.backends,
+        availability_width = widths.availability,
         scope_width = widths.scope,
         local_state_width = widths.local_state,
-        ownership_width = widths.ownership,
     )
 }
 
 struct HumanWidths {
     name: usize,
-    backends: usize,
+    availability: usize,
     scope: usize,
     local_state: usize,
-    ownership: usize,
 }
 
 impl HumanWidths {
     fn for_rows(rows: &[Row]) -> Self {
         Self {
             name: rows.iter().map(|r| r.name.len()).max().unwrap_or(4).max(4) + 4,
-            backends: rows
+            availability: rows
                 .iter()
-                .map(|r| {
-                    if r.backends.is_empty() {
-                        1
-                    } else {
-                        r.backends.join(",").len()
-                    }
-                })
+                .map(|r| availability_label(r).len())
                 .max()
-                .unwrap_or(8)
-                .max(8)
+                .unwrap_or(12)
+                .max(12)
                 + 4,
             scope: rows.iter().map(|r| r.scope.len()).max().unwrap_or(5).max(5) + 4,
             local_state: rows
@@ -52,19 +43,17 @@ impl HumanWidths {
                 .unwrap_or(11)
                 .max(11)
                 + 4,
-            ownership: rows
-                .iter()
-                .map(|r| r.ownership.len())
-                .max()
-                .unwrap_or(9)
-                .max(9)
-                + 4,
         }
     }
 }
 
-pub(super) fn render_human(rows: &[Row], no_color: bool) {
+pub(super) fn render_human(rows: &[Row], no_color: bool, platform: &str) {
     let color = Palette::new(no_color);
+    println!(
+        "{}",
+        color.header(format!("Components for {}", display_platform(platform)))
+    );
+    println!();
     if rows.is_empty() {
         println!("{}", color.muted("no components found"));
         return;
@@ -74,23 +63,47 @@ pub(super) fn render_human(rows: &[Row], no_color: bool) {
 
     println!("{}", color.header(human_header(rows)));
     for row in rows {
-        let backend_str = if row.backends.is_empty() {
-            "-".to_string()
+        let availability = availability_label(row);
+        let availability = if row.platform_available {
+            color.ok(availability)
         } else {
-            row.backends.join(",")
+            color.err(availability)
+        };
+        let action = if row.action == "unavailable" {
+            "-"
+        } else {
+            &row.action
         };
         println!(
-            "{:<name_width$}{:<backends_width$}{:<scope_width$}{}{:<ownership_width$}{}",
+            "{:<name_width$}{}{:<scope_width$}{}{}",
             row.name,
-            backend_str,
+            pad_right(availability, widths.availability),
             row.scope,
             pad_right(color.status(&row.local_state), widths.local_state),
-            row.ownership,
-            row.action,
+            action,
             name_width = widths.name,
-            backends_width = widths.backends,
             scope_width = widths.scope,
-            ownership_width = widths.ownership,
         );
+    }
+}
+
+pub(super) fn availability_label(row: &Row) -> String {
+    if row.platform_available {
+        return "available".to_string();
+    }
+    let supported = row
+        .platforms
+        .iter()
+        .map(|platform| display_platform(platform))
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("{supported} only")
+}
+
+fn display_platform(platform: &str) -> String {
+    match platform {
+        "linux" => "Linux".to_string(),
+        "macos" => "macOS".to_string(),
+        other => other.to_string(),
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/compatibility.rs
@@ -1,7 +1,7 @@
 use anolisa_core::domain::LifecycleStatus;
 use anolisa_core::state::ObjectKind;
 
-use crate::commands::tier1::list::{ListArgs, ListPayload, build_rows};
+use crate::commands::tier1::list::{ListArgs, ListPayload, build_rows, build_rows_for_platform};
 use crate::resolution::{ComponentBackendEntry, ComponentIndex, ComponentIndexEntry};
 
 use super::support::{
@@ -21,11 +21,32 @@ fn index_builds_rows() {
     assert_eq!(sight.display_name, "AgentSight");
     assert_eq!(sight.summary, "eBPF-based AI agent observability tool");
     assert_eq!(sight.backends, vec!["raw", "rpm"]);
+    assert_eq!(sight.platforms, vec!["linux"]);
+    assert!(sight.platform_available);
     assert_eq!(sight.status, "not_installed");
 
     let token = &rows[1];
     assert_eq!(token.name, "tokenless");
     assert_eq!(token.backends, vec!["raw"]);
+    assert_eq!(token.platforms, vec!["linux", "macos"]);
+    assert!(token.platform_available);
+}
+
+#[test]
+fn macos_rows_remain_complete_and_report_platform_availability() {
+    let index = sample_index();
+    let args = ListArgs { installed: false };
+    let state = empty_state();
+
+    let rows = build_rows_for_platform(&index, &args, &state, None, "macos");
+
+    assert_eq!(rows.len(), 2);
+    let sight = rows.iter().find(|row| row.name == "agentsight").unwrap();
+    assert!(!sight.platform_available);
+    assert_eq!(sight.action, "unavailable");
+    let token = rows.iter().find(|row| row.name == "tokenless").unwrap();
+    assert!(token.platform_available);
+    assert_eq!(token.action, "install");
 }
 
 #[test]
@@ -208,6 +229,7 @@ fn missing_optional_fields_use_defaults() {
             name: "minimal".to_string(),
             display_name: None,
             summary: None,
+            platforms: vec!["linux".to_string()],
             backends: Vec::new(),
             aliases: Vec::new(),
         }],
@@ -221,7 +243,10 @@ fn missing_optional_fields_use_defaults() {
     assert_eq!(row.display_name, "minimal");
     assert!(row.summary.is_empty());
     assert!(row.backends.is_empty());
+    assert_eq!(row.platforms, ["linux"]);
+    assert!(row.platform_available);
     assert_eq!(row.status, "not_installed");
+    assert_eq!(row.action, "unavailable");
 }
 
 #[test]
@@ -234,6 +259,7 @@ fn unknown_backend_kind_preserved() {
             name: "test".to_string(),
             display_name: None,
             summary: None,
+            platforms: vec!["linux".to_string()],
             backends: vec![ComponentBackendEntry {
                 kind: "custom-repo".to_string(),
                 package: "test".to_string(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/output.rs
@@ -1,4 +1,4 @@
-use crate::commands::tier1::list::render::human_header;
+use crate::commands::tier1::list::render::{availability_label, human_header};
 use crate::commands::tier1::list::{ListArgs, ListPayload, Row, build_rows};
 
 use super::support::{FakeRpmQuery, empty_state, pkg_info, sample_index};
@@ -32,12 +32,15 @@ fn row_json_retains_status_and_adds_local_fields() {
         .unwrap();
 
     assert_eq!(sight["status"], "not_installed");
+    assert_eq!(sight["backends"], serde_json::json!(["raw", "rpm"]));
     assert_eq!(sight["local_state"], "observed");
     assert_eq!(sight["ownership"], "rpm");
     assert_eq!(sight["scope"], "none");
     assert_eq!(sight["active"], false);
     assert_eq!(sight["mutable_by_current_invocation"], false);
     assert_eq!(sight["action"], "install");
+    assert_eq!(sight["platforms"], serde_json::json!(["linux"]));
+    assert_eq!(sight["platform_available"], true);
 }
 
 #[test]
@@ -47,6 +50,8 @@ fn human_header_contains_local_state() {
         display_name: "AgentSight".to_string(),
         summary: "observability".to_string(),
         backends: vec!["rpm".to_string()],
+        platforms: vec!["linux".to_string()],
+        platform_available: true,
         status: "not_installed".to_string(),
         local_state: "observed".to_string(),
         ownership: "none".to_string(),
@@ -64,7 +69,27 @@ fn human_header_contains_local_state() {
 
     let header = human_header(&rows);
     assert!(header.contains("SCOPE"));
+    assert!(header.contains("AVAILABILITY"));
     assert!(header.contains("LOCAL STATE"));
+    assert!(!header.contains("BACKENDS"));
+    assert!(!header.contains("OWNERSHIP"));
+}
+
+#[test]
+fn human_availability_explains_the_supported_platform() {
+    let mut rows = build_rows(
+        &sample_index(),
+        &ListArgs { installed: false },
+        &empty_state(),
+        None,
+    );
+    let sight = rows
+        .iter_mut()
+        .find(|row| row.name == "agentsight")
+        .unwrap();
+    sight.platform_available = false;
+
+    assert_eq!(availability_label(sight), "Linux only");
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/scoped_rows.rs
@@ -20,7 +20,7 @@ fn user_view_installed_filter_keeps_system_provided_component() {
         state_with_component_object(owned_component("agentsight", LifecycleStatus::Installed)),
     );
 
-    let rows = build_rows_from_view(&index, &args, &view, None);
+    let rows = build_rows_from_view(&index, &args, &view, None, "linux");
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].name, "agentsight");
@@ -47,7 +47,7 @@ fn user_record_shadows_system_record_in_list_rows() {
         )),
     );
 
-    let rows = build_rows_from_view(&index, &args, &view, None);
+    let rows = build_rows_from_view(&index, &args, &view, None, "linux");
 
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0].name, "agentsight");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/list/tests/support.rs
@@ -21,6 +21,7 @@ pub(super) fn sample_index() -> ComponentIndex {
                 name: "agentsight".to_string(),
                 display_name: Some("AgentSight".to_string()),
                 summary: Some("eBPF-based AI agent observability tool".to_string()),
+                platforms: vec!["linux".to_string()],
                 backends: vec![
                     ComponentBackendEntry {
                         kind: "raw".to_string(),
@@ -41,6 +42,7 @@ pub(super) fn sample_index() -> ComponentIndex {
                 name: "tokenless".to_string(),
                 display_name: Some("Tokenless".to_string()),
                 summary: Some("LLM token optimization toolkit".to_string()),
+                platforms: vec!["linux".to_string(), "macos".to_string()],
                 backends: vec![ComponentBackendEntry {
                     kind: "raw".to_string(),
                     package: "tokenless".to_string(),
@@ -291,6 +293,7 @@ pub(super) fn sample_index_with_aliases() -> ComponentIndex {
             name: "cosh".to_string(),
             display_name: Some("Copilot Shell".to_string()),
             summary: Some("shell".to_string()),
+            platforms: vec!["linux".to_string()],
             backends: vec![
                 ComponentBackendEntry {
                     kind: "raw".to_string(),

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -54,6 +54,13 @@ pub(crate) struct ComponentIndexEntry {
     /// Optional one-line summary; not used by resolution v1.
     #[serde(default)]
     pub(crate) summary: Option<String>,
+    /// Operating systems supported by this component.
+    ///
+    /// The field is optional on the wire so existing v1 indexes remain valid;
+    /// indexes that omit it inherit the original Linux-only behavior. A
+    /// published backend is still required before installation is actionable.
+    #[serde(default = "default_component_platforms")]
+    pub(crate) platforms: Vec<String>,
     /// Backend-native package names for this component.
     ///
     /// Components may initially ship on only one backend, so the list defaults
@@ -96,6 +103,21 @@ pub(crate) struct ComponentAliasEntry {
     pub(crate) kind: String,
     /// Alias value.
     pub(crate) name: String,
+}
+
+fn default_component_platforms() -> Vec<String> {
+    vec!["linux".to_string()]
+}
+
+fn is_canonical_platform(platform: &str) -> bool {
+    let bytes = platform.as_bytes();
+    bytes.first().is_some_and(u8::is_ascii_lowercase)
+        && bytes
+            .last()
+            .is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
 }
 
 /// Parse or validation failures for `components.toml`.
@@ -462,6 +484,34 @@ impl ComponentIndex {
                     reason: format!("duplicate component '{name}'"),
                 });
             }
+            if entry.platforms.is_empty() {
+                return Err(ComponentIndexError::Invalid {
+                    reason: format!("component '{name}' must declare at least one platform"),
+                });
+            }
+            let mut platforms = BTreeSet::new();
+            for platform in &entry.platforms {
+                if platform.trim().is_empty() {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!("component '{name}' has an empty platform"),
+                    });
+                }
+                if !is_canonical_platform(platform) {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!(
+                            "component '{name}' platform '{platform}' must be a lowercase ASCII \
+                             identifier with optional internal digits or hyphens"
+                        ),
+                    });
+                }
+                if !platforms.insert(platform) {
+                    return Err(ComponentIndexError::Invalid {
+                        reason: format!(
+                            "component '{name}' declares duplicate platform '{platform}'"
+                        ),
+                    });
+                }
+            }
             for backend in &entry.backends {
                 if backend.kind.trim().is_empty() {
                     return Err(ComponentIndexError::Invalid {
@@ -541,6 +591,11 @@ impl ComponentIndex {
 }
 
 impl ComponentIndexEntry {
+    /// Whether the component index permits installation on `platform`.
+    pub(crate) fn supports_platform(&self, platform: &str) -> bool {
+        self.platforms.iter().any(|candidate| candidate == platform)
+    }
+
     fn backends_for(&self, backend: BackendKind) -> impl Iterator<Item = &ComponentBackendEntry> {
         self.backends
             .iter()
@@ -827,6 +882,63 @@ name = "copilot-shell"
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let index_path = manifest_dir.join("../../manifests/components.toml");
         ComponentIndex::load(&index_path).expect("component index template must parse");
+    }
+
+    #[test]
+    fn component_index_without_platforms_keeps_legacy_linux_default() {
+        let index = index();
+
+        assert_eq!(index.components[0].platforms, ["linux"]);
+        assert!(index.components[0].supports_platform("linux"));
+        assert!(!index.components[0].supports_platform("macos"));
+    }
+
+    #[test]
+    fn non_canonical_platform_identifiers_are_rejected() {
+        for platform in ["Linux", " linux "] {
+            let source = format!(
+                r#"
+schema_version = 1
+
+[[components]]
+name = "test"
+platforms = ["{platform}"]
+"#
+            );
+
+            let err = ComponentIndex::from_toml_str(&source, "components.toml")
+                .expect_err("non-canonical platform must be rejected");
+            assert!(
+                matches!(
+                    err,
+                    ComponentIndexError::Invalid { ref reason }
+                        if reason.contains("lowercase ASCII identifier")
+                ),
+                "unexpected error for {platform:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn repository_component_index_declares_current_platform_matrix() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let index_path = manifest_dir.join("../../manifests/components.toml");
+        let index = ComponentIndex::load(&index_path).expect("component index template must parse");
+
+        assert!(
+            index
+                .components
+                .iter()
+                .all(|component| component.supports_platform("linux")),
+            "every published component must remain visible as available on Linux"
+        );
+        let macos_components = index
+            .components
+            .iter()
+            .filter(|component| component.supports_platform("macos"))
+            .map(|component| component.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(macos_components, ["tokenless"]);
     }
 
     #[test]

--- a/src/anolisa/manifests/components.toml
+++ b/src/anolisa/manifests/components.toml
@@ -14,6 +14,7 @@ publisher = "anolisa"
 name = "cosh"
 display_name = "Copilot Shell"
 summary = "Copilot shell launcher and deterministic CLI gateway"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -37,6 +38,7 @@ name = "copilot-shell"
 name = "cosh-ng"
 display_name = "cosh-ng"
 summary = "Computable Operating System Harness (cosh-ng) - a deterministic Agent-OS interface"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -52,6 +54,7 @@ legacy_adopt = true
 name = "agentsight"
 display_name = "AgentSight"
 summary = "eBPF-based AI agent observability tool"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -67,6 +70,7 @@ legacy_adopt = true
 name = "agent-memory"
 display_name = "Agent Memory"
 summary = "Agent persistent memory and context"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -82,6 +86,7 @@ legacy_adopt = true
 name = "os-skills"
 display_name = "OS Skills"
 summary = "Curated OS Skill library for agent runtimes"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -97,6 +102,7 @@ legacy_adopt = true
 name = "tokenless"
 display_name = "Tokenless"
 summary = "LLM token optimization toolkit"
+platforms = ["linux", "macos"]
 
 [[components.backends]]
 kind = "raw"
@@ -112,6 +118,7 @@ legacy_adopt = true
 name = "ws-ckpt"
 display_name = "Workspace Checkpoint"
 summary = "Workspace checkpoint and rollback service"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"
@@ -127,6 +134,7 @@ legacy_adopt = true
 name = "sec-core"
 display_name = "Agent Security Core"
 summary = "Agent security core adapters and runtime"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "rpm"
@@ -138,6 +146,7 @@ legacy_adopt = true
 name = "skillfs"
 display_name = "SkillFS"
 summary = "AI agent skill management via virtual filesystem"
+platforms = ["linux"]
 
 [[components.backends]]
 kind = "raw"


### PR DESCRIPTION
## Why

`anolisa list` did not distinguish components that are installable on the current operating system. On macOS this made Linux-only components look actionable, while filtering by the default user install mode would incorrectly hide valid system-mode and RPM components on Linux.

## What changed

- Add component-level `platforms` metadata to the v1 component index, with a conservative Linux default for older indexes.
- Keep the default list complete, but render host-aware availability and suppress install actions for unsupported components.
- Simplify human output to name, availability, scope, local state, and action; retain backend, ownership, and platform metadata in JSON.

## Related issue

closes #2189

## User / Agent impact

Users now see the current host at the top of `anolisa list`, `available` for supported components, and an explicit label such as `Linux only` otherwise. Unsupported rows remain visible but no longer suggest an install action. Machine consumers receive additive `platforms` and `platform_available` fields.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The human table intentionally removes backend and ownership columns; those details remain in `--json`. The component-index field is optional, and older v1 indexes default to Linux, so no schema-version bump or migration is required.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --locked -p anolisa-cli commands::tier1::list` (39 passed)
- `cargo test --locked -p anolisa-cli component_index_without_platforms_keeps_legacy_linux_default`
- `cargo test --locked -p anolisa-cli repository_component_index_declares_current_platform_matrix`
- `cargo doc --workspace --no-deps`
- `cargo test --workspace --locked` was also attempted; the existing host-sensitive `anolisa-platform::systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking` test fails because this machine has a loaded `agentsight.service`. The failure reproduces independently of this change.

## Documentation and rollback

No documentation files changed; the CLI labels are self-describing and the JSON additions are covered by tests. Reverting commit `7c4c642b` restores the previous index and output behavior.

