### PR TITLE
fix(cosh-ng): [core] guard sensitive writes

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -37,6 +37,14 @@ mod auth;
 mod extensions;
 mod tool_execution;
 
+fn is_sensitive_write(tool_name: &str, params: &serde_json::Value) -> bool {
+    tool_name == "write_file"
+        && params
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(crate::redaction::contains_sensitive_text)
+}
+
 /// Typed terminal state for one user-request loop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AgentTurnOutcome {
@@ -221,7 +229,7 @@ impl CoshCore {
             .effective_history_tokens(&self.messages, prefix_tokens)
     }
 
-    fn classify_tool(&self, tool_name: &str, _params: &serde_json::Value) -> Outcome {
+    fn classify_tool(&self, tool_name: &str, params: &serde_json::Value) -> Outcome {
         let mode = self.config.agent.approval_mode.as_str();
 
         if mode == "trust" {
@@ -235,6 +243,10 @@ impl CoshCore {
 
         if self.config.agent.allowed_tools.contains(tool_name) {
             return Outcome::Allow;
+        }
+
+        if is_sensitive_write(tool_name, params) && mode == "auto" {
+            return Outcome::RequireApproval;
         }
 
         let kind = tool.kind();
@@ -1069,6 +1081,11 @@ impl CoshCore {
                         Ok(params) => hash_json(params),
                         Err(_) => hash_bytes(tc.arguments.as_bytes()),
                     }),
+                    execution_path: parsed_params
+                        .as_ref()
+                        .ok()
+                        .filter(|params| is_sensitive_write(&tc.name, params))
+                        .map(|_| "sensitive_write".to_string()),
                     ..AuditToolData::default()
                 };
                 self.audit

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -182,6 +182,120 @@ fn allowlisted_tools_bypass_strict_approval() {
 }
 
 #[test]
+fn sensitive_write_requires_auto_approval_but_preserves_bypass_modes() {
+    let sensitive = serde_json::json!({
+        "path": "settings.env",
+        "content": "AWS_ACCESS_KEY_ID=AKIA1234567890ABCDEF"
+    });
+    let ordinary = serde_json::json!({"path": "settings.env", "content": "safe=true"});
+
+    for (mode, expected) in [
+        ("trust", Outcome::Allow),
+        ("auto", Outcome::RequireApproval),
+        ("balanced", Outcome::RequireApproval),
+        ("suggest", Outcome::RequireApproval),
+        ("strict", Outcome::RequireApproval),
+    ] {
+        let mut config = CoreConfig::default();
+        config.agent.approval_mode = mode.to_string();
+        let core = CoshCore::new(
+            config,
+            Box::new(MockProvider::new(Vec::new())),
+            ToolRegistry::with_defaults_for_test(),
+        );
+
+        assert_eq!(
+            core.classify_tool("write_file", &sensitive),
+            expected,
+            "unexpected sensitive write policy in {mode} mode"
+        );
+    }
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "auto".to_string();
+    let core = CoshCore::new(
+        config,
+        Box::new(MockProvider::new(Vec::new())),
+        ToolRegistry::with_defaults_for_test(),
+    );
+    assert_eq!(
+        core.classify_tool("write_file", &ordinary),
+        Outcome::Allow,
+        "ordinary auto-mode writes remain allowed"
+    );
+
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "strict".to_string();
+    config.agent.allowed_tools.insert("write_file".to_string());
+    let core = CoshCore::new(
+        config,
+        Box::new(MockProvider::new(Vec::new())),
+        ToolRegistry::with_defaults_for_test(),
+    );
+    assert_eq!(
+        core.classify_tool("write_file", &sensitive),
+        Outcome::Allow,
+        "explicit allowlist entries remain authoritative"
+    );
+}
+
+#[tokio::test]
+async fn sensitive_write_audit_uses_generic_execution_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let secret = "AKIA1234567890ABCDEF";
+    let provider = MockProvider::new(vec![
+        vec![
+            GenerateEvent::ToolCallStart {
+                index: 0,
+                id: "call-sensitive-write".to_string(),
+                name: "write_file".to_string(),
+            },
+            GenerateEvent::ToolCallDelta {
+                index: 0,
+                arguments_delta: format!(
+                    r#"{{"path":"settings.env","content":"AWS_ACCESS_KEY_ID={secret}"}}"#
+                ),
+            },
+            GenerateEvent::ToolCallEnd { index: 0 },
+            GenerateEvent::MessageEnd,
+        ],
+        vec![
+            GenerateEvent::TextDelta("done".to_string()),
+            GenerateEvent::MessageEnd,
+        ],
+    ]);
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = "trust".to_string();
+    let mut core = CoshCore::new(
+        config,
+        Box::new(provider),
+        ToolRegistry::with_defaults_for_test(),
+    );
+    core.project_root = dir.path().to_path_buf();
+    core.workspace = crate::tool::SessionWorkspace::new(dir.path());
+    core.audit = CoreAuditRecorder::test_capture(&core.session_id);
+
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+    core.handle_user_message("write the file", &mut reader, &mut output)
+        .await
+        .expect("sensitive write turn");
+
+    let event = core
+        .audit
+        .captured_events()
+        .iter()
+        .find(|event| {
+            event.event_type.as_str() == "tool.requested"
+                && event.identity.tool_use_id.as_deref() == Some("call-sensitive-write")
+        })
+        .expect("sensitive write audit event");
+    let serialized = serde_json::to_value(event).unwrap();
+    assert_eq!(serialized["data"]["execution_path"], "sensitive_write");
+    assert!(!serialized.to_string().contains(secret));
+}
+
+#[test]
 fn mcp_tools_require_approval_outside_trust_mode() {
     for mode in ["auto", "balanced", "suggest", "strict"] {
         let mut config = CoreConfig::default();

--- a/src/cosh-ng/crates/cosh-core/src/redaction.rs
+++ b/src/cosh-ng/crates/cosh-core/src/redaction.rs
@@ -28,6 +28,13 @@ pub(crate) fn redact_text(text: &str) -> String {
     redacted
 }
 
+/// Returns whether text matches a redaction rule or private-key end marker.
+pub(crate) fn contains_sensitive_text(text: &str) -> bool {
+    text.lines()
+        .any(|line| private_key_marker_range(line, "-----END ").is_some())
+        || redact_text(text) != text
+}
+
 pub(crate) fn redact_value(value: &mut Value) {
     match value {
         Value::Object(values) => {

--- a/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/write_file.rs
@@ -54,6 +54,7 @@ impl Tool for WriteFileTool {
                 placeholders.join(", "),
             )));
         }
+        let contains_sensitive = crate::redaction::contains_sensitive_text(content);
 
         let workspace = match ctx.workspace() {
             Ok(workspace) => workspace,
@@ -82,9 +83,14 @@ impl Tool for WriteFileTool {
 
         let lines = content.lines().count();
         let bytes = content.len();
+        let warning = if contains_sensitive {
+            "\nWarning: content appears to contain sensitive material; verify the destination and access permissions."
+        } else {
+            ""
+        };
         Ok(ToolResult::success(format!(
-            "Wrote {bytes} bytes ({lines} lines) to {}",
-            display_path.display()
+            "Wrote {bytes} bytes ({lines} lines) to {}{warning}",
+            display_path.display(),
         )))
     }
 }
@@ -95,6 +101,9 @@ fn placeholder_markers(content: &str) -> Vec<&'static str> {
 
     if upper.contains("<REDACTED") {
         markers.push("<redacted>");
+    }
+    if upper.contains("<SECRET>") {
+        markers.push("<secret>");
     }
     if upper.contains("[REDACTED:") {
         markers.push("[REDACTED:...]");
@@ -107,6 +116,18 @@ fn placeholder_markers(content: &str) -> Vec<&'static str> {
         })
     {
         markers.push("YOUR_*_KEY/TOKEN/SECRET");
+    }
+    if upper
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .any(|word| {
+            word.starts_with("XXX_")
+                && word.ends_with("_XXX")
+                && ["_KEY_", "_TOKEN_", "_SECRET_"]
+                    .iter()
+                    .any(|marker| word.contains(marker))
+        })
+    {
+        markers.push("XXX_*_(KEY|TOKEN|SECRET)_XXX");
     }
 
     markers
@@ -573,6 +594,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_new_placeholders_is_refused_before_fs_side_effects() {
+        for (name, content) in [
+            ("secret.txt", "value=<SeCrEt>"),
+            ("token.txt", "value=XXX_SERVICE_TOKEN_XXX"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let parent = dir.path().join("new");
+            let path = parent.join(name);
+
+            let result = WriteFileTool
+                .invoke(
+                    serde_json::json!({"path": path, "content": content}),
+                    &test_ctx_in(dir.path()),
+                )
+                .await
+                .unwrap();
+
+            assert!(result.is_error, "{content} should be refused");
+            assert!(result.output.starts_with("Write refused:"));
+            assert!(!path.exists());
+            assert!(!parent.exists());
+        }
+    }
+
+    #[tokio::test]
+    async fn write_sensitive_content_warns_without_echoing_it() {
+        for (name, content) in [
+            ("aws.env", "AWS_ACCESS_KEY_ID=AKIA1234567890ABCDEF"),
+            ("sts.env", "AWS_ACCESS_KEY_ID=ASIA1234567890ABCDEF"),
+            (
+                "key.pem",
+                "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----",
+            ),
+            (
+                "orphan-key-end.pem",
+                "MII...\n-----END RSA PRIVATE KEY-----",
+            ),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(name);
+
+            let result = WriteFileTool
+                .invoke(
+                    serde_json::json!({"path": path, "content": content}),
+                    &test_ctx_in(dir.path()),
+                )
+                .await
+                .unwrap();
+
+            assert!(!result.is_error, "{content}");
+            assert!(result.output.contains("sensitive material"));
+            assert!(!result.output.contains(content));
+            assert_eq!(std::fs::read_to_string(path).unwrap(), content);
+        }
+    }
+
+    #[tokio::test]
     async fn refused_write_does_not_overwrite_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         let tool = WriteFileTool;
@@ -598,13 +676,20 @@ mod tests {
     #[test]
     fn detects_supported_placeholder_markers() {
         let markers = placeholder_markers(
-            "<REDACTED private key block> [redacted: token] YOUR_API_KEY YOUR_ACCESS_TOKEN \
-             YOUR_DB_SECRET",
+            "<REDACTED private key block> [redacted: token] <secret> YOUR_API_KEY \
+             YOUR_ACCESS_TOKEN YOUR_DB_SECRET XXX_API_KEY_XXX XXX_SERVICE_TOKEN_XXX \
+             XXX_CLIENT_SECRET_XXX",
         );
 
         assert_eq!(
             markers,
-            vec!["<redacted>", "[REDACTED:...]", "YOUR_*_KEY/TOKEN/SECRET"]
+            vec![
+                "<redacted>",
+                "<secret>",
+                "[REDACTED:...]",
+                "YOUR_*_KEY/TOKEN/SECRET",
+                "XXX_*_(KEY|TOKEN|SECRET)_XXX"
+            ]
         );
     }
 


### PR DESCRIPTION
## Why

`write_file` rejected explicit placeholders but did not surface content that
matched existing credential redaction rules. This could silently persist
credential-shaped material without an approval upgrade or audit category.

## What changed

Reused the central redaction rules to classify sensitive writes, upgraded them
to approval in auto mode, and recorded a generic `sensitive_write` audit path.
Trust and explicit allowlists remain authoritative, while successful sensitive
writes return a warning without echoing or changing the content. Added hard
refusals for the genuine `<secret>` and `XXX_*_(KEY|TOKEN|SECRET)_XXX`
placeholder forms.

## Related issue

closes #2302

## User / Agent impact

Auto mode now asks before writing credential-shaped content. Trust mode and
explicitly allowlisted writes still proceed, but return a generic warning.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The shared detector can conservatively flag documentation or test fixtures.
Those writes remain possible through approval, trust mode, or an explicit
allowlist.

## Validation

- `cargo fmt --all -- --check`
- `scripts/check-test-inventory.sh`
- `cargo test -p cosh-core --bin cosh-core` — 832 passed
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `git diff --check`

Validated locally on Linux; no ECS or live-provider testing was requested.

## Documentation and rollback

No documentation changes were required. Roll back by reverting commit
`6a861409effa25a3036f9acfd322b673e40f649e`.