### PR TITLE
fix(tokenless): honor --json with --checklist

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -207,6 +207,36 @@ tokenless env-check --all --json
 tokenless env-check --all --checklist
 ```
 
+Full checklist as one JSON object for hooks, plugins, and CI gates:
+
+```bash
+tokenless env-check --checklist --json
+```
+
+```json
+{
+  "tools": [
+    {
+      "tool": "Shell",
+      "status": "PARTIAL",
+      "required": [{ "binary": "jq", "status": "INSTALLED" }],
+      "recommended": [{ "binary": "rtk", "status": "MISSING" }],
+      "config": [{ "name": "~/.tokenless/config.json", "ok": true }],
+      "permissions": [{ "name": "exec_shell", "ok": true }],
+      "network": [{ "name": "https_outbound", "ok": true }]
+    }
+  ],
+  "summary": { "ready": 0, "partial": 1, "not_ready": 0, "unknown": 0, "total": 1 }
+}
+```
+
+Checklist JSON contract:
+
+- `tools` is sorted by tool name, so repeated runs produce identical output that is safe to diff, hash, cache, or snapshot.
+- `status` uses the fixed labels `READY` / `PARTIAL` / `NOT_READY` / `UNKNOWN`.
+- Dependency entries report `INSTALLED`, `MISSING`, or `OUTDATED (<installed>/<required>)`; config, permission, and network entries report `ok: true|false`.
+- `summary` aggregates the same results: `ready`, `partial`, `not_ready`, `unknown`, and `total`.
+
 Status meanings:
 
 | Status | Meaning |

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -207,6 +207,36 @@ tokenless env-check --all --json
 tokenless env-check --all --checklist
 ```
 
+以单个 JSON 对象输出完整清单，供 Hook、插件和 CI 门禁消费：
+
+```bash
+tokenless env-check --checklist --json
+```
+
+```json
+{
+  "tools": [
+    {
+      "tool": "Shell",
+      "status": "PARTIAL",
+      "required": [{ "binary": "jq", "status": "INSTALLED" }],
+      "recommended": [{ "binary": "rtk", "status": "MISSING" }],
+      "config": [{ "name": "~/.tokenless/config.json", "ok": true }],
+      "permissions": [{ "name": "exec_shell", "ok": true }],
+      "network": [{ "name": "https_outbound", "ok": true }]
+    }
+  ],
+  "summary": { "ready": 0, "partial": 1, "not_ready": 0, "unknown": 0, "total": 1 }
+}
+```
+
+清单 JSON 约定：
+
+- `tools` 按工具名排序，重复运行输出完全一致，可安全用于 diff、hash、缓存或快照。
+- `status` 使用固定标签 `READY` / `PARTIAL` / `NOT_READY` / `UNKNOWN`。
+- 依赖项报告 `INSTALLED`、`MISSING` 或 `OUTDATED (<installed>/<required>)`；配置、权限和网络项报告 `ok: true|false`。
+- `summary` 对同一结果汇总：`ready`、`partial`、`not_ready`、`unknown` 与 `total`。
+
 状态含义：
 
 | 状态 | 含义 |

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -302,9 +302,17 @@ tokenless env-check --all
 # Generate checklist
 tokenless env-check --checklist
 
+# Machine-readable checklist (single JSON object, tools sorted by name)
+tokenless env-check --checklist --json
+
 # Check and auto-fix missing deps
 tokenless env-check --tool Shell --fix
 ```
+
+`--checklist --json` emits one `{tools, summary}` object with stable ordering
+for hooks, plugins, and CI gates; see the
+[CLI reference](../../docs/user-guide/en/token-saving/tokenless/cli-reference.md#env-check)
+for the full schema.
 
 ### Configuration
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -197,6 +197,33 @@ export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 覆盖项优先级更高，但必须位于真实用户 home 或选定的数据目录下。配置文件
 仍位于 `~/.tokenless/config.json`。
 
+## Tool Ready
+
+Tool Ready 在工具调用前预检环境依赖（来自 `tool-ready-spec.json`），缺失时
+报告 `NOT_READY` 并提示跳过重试，避免浪费 Token 重试必然失败的命令；调用失败
+后再做错误归因。
+
+```bash
+# 检查单个工具
+tokenless env-check --tool Shell
+
+# 检查全部工具
+tokenless env-check --all
+
+# 生成清单
+tokenless env-check --checklist
+
+# 机器可读清单（单个 JSON 对象，tools 按名称排序）
+tokenless env-check --checklist --json
+
+# 检查并自动修复缺失依赖
+tokenless env-check --tool Shell --fix
+```
+
+`--checklist --json` 输出单个 `{tools, summary}` 对象，顺序稳定，供 Hook、
+插件和 CI 门禁消费；完整 schema 见
+[CLI 参考](../../docs/user-guide/zh/token-saving/tokenless/cli-reference.md#env-check)。
+
 ## 架构
 
 - `crates/tokenless-schema/` — 核心库：SchemaCompressor + ResponseCompressor

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -809,7 +809,7 @@ fn check_tool(tool_name: &str, spec: &ToolDepSpec) -> ToolReadyResult {
     let has_perm_missing = permission_results.iter().any(|(_, ok)| !ok);
     let has_recommended_missing = recommended_results
         .iter()
-        .any(|(_, s)| s == &DepStatus::Missing);
+        .any(|(_, s)| s == &DepStatus::Missing || matches!(s, DepStatus::VersionLow { .. }));
     let has_config_missing = config_results.iter().any(|(_, ok)| !ok);
     let has_net_missing = network_results.iter().any(|(_, ok)| !ok);
 
@@ -898,10 +898,15 @@ fn generate_checklist(results: &[ToolReadyResult]) -> String {
             let label = if *ok { "GRANTED" } else { "DENIED" };
             output.push_str(&format!("  permission: {:12} {}\n", perm, label));
         }
+        for (net, ok) in &result.network_results {
+            let label = if *ok { "OK" } else { "FAIL" };
+            output.push_str(&format!("  network:    {:12} {}\n", net, label));
+        }
         if !result.required_results.is_empty()
             || !result.recommended_results.is_empty()
             || !result.config_results.is_empty()
             || !result.permission_results.is_empty()
+            || !result.network_results.is_empty()
         {
             output.push('\n');
         }
@@ -935,6 +940,124 @@ fn generate_checklist(results: &[ToolReadyResult]) -> String {
     output.push_str(&summary);
 
     output
+}
+
+/// Serialize checklist results as a JSON object for machine consumption.
+///
+/// **Sync rule**: when `ToolReadyResult` gains a new check category, add a
+/// matching array here so JSON consumers see every field the text path shows.
+///
+/// **Ordering contract**: the `tools` array preserves the caller's order.
+/// `run()` sorts tool names before building results, so output is stable
+/// across processes and safe for diff/hash/cache/snapshot consumers.
+///
+/// Schema:
+/// ```json
+/// {
+///   "tools": [
+///     {
+///       "tool": "<name>",
+///       "status": "READY|PARTIAL|NOT_READY|UNKNOWN",
+///       "required":    [{"binary":"…","status":"…"}, …],
+///       "recommended": [{"binary":"…","status":"…"}, …],
+///       "config":      [{"name":"…","ok":true}, …],
+///       "permissions": [{"name":"…","ok":true}, …],
+///       "network":     [{"name":"…","ok":true}, …]
+///     },
+///     …
+///   ],
+///   "summary": {
+///     "ready": N, "partial": N, "not_ready": N, "unknown": N, "total": N
+///   }
+/// }
+/// ```
+fn generate_checklist_json(results: &[ToolReadyResult]) -> Value {
+    let tools: Vec<Value> = results
+        .iter()
+        .map(|r| {
+            let mut obj = serde_json::Map::new();
+            obj.insert("tool".to_string(), Value::String(r.tool_name.clone()));
+            obj.insert(
+                "status".to_string(),
+                Value::String(format_status(&r.status).to_string()),
+            );
+
+            let required: Vec<Value> = r
+                .required_results
+                .iter()
+                .map(|(dep, status)| {
+                    serde_json::json!({
+                        "binary": dep.binary,
+                        "status": format_dep_status_label(status)
+                    })
+                })
+                .collect();
+            obj.insert("required".to_string(), Value::Array(required));
+
+            let recommended: Vec<Value> = r
+                .recommended_results
+                .iter()
+                .map(|(dep, status)| {
+                    serde_json::json!({
+                        "binary": dep.binary,
+                        "status": format_dep_status_label(status)
+                    })
+                })
+                .collect();
+            obj.insert("recommended".to_string(), Value::Array(recommended));
+
+            let config: Vec<Value> = r
+                .config_results
+                .iter()
+                .map(|(name, ok)| serde_json::json!({"name": name, "ok": ok}))
+                .collect();
+            obj.insert("config".to_string(), Value::Array(config));
+
+            let permissions: Vec<Value> = r
+                .permission_results
+                .iter()
+                .map(|(name, ok)| serde_json::json!({"name": name, "ok": ok}))
+                .collect();
+            obj.insert("permissions".to_string(), Value::Array(permissions));
+
+            let network: Vec<Value> = r
+                .network_results
+                .iter()
+                .map(|(name, ok)| serde_json::json!({"name": name, "ok": ok}))
+                .collect();
+            obj.insert("network".to_string(), Value::Array(network));
+
+            Value::Object(obj)
+        })
+        .collect();
+
+    let ready = results
+        .iter()
+        .filter(|r| r.status == ReadyStatus::Ready)
+        .count();
+    let partial = results
+        .iter()
+        .filter(|r| r.status == ReadyStatus::Partial)
+        .count();
+    let not_ready = results
+        .iter()
+        .filter(|r| r.status == ReadyStatus::NotReady)
+        .count();
+    let unknown = results
+        .iter()
+        .filter(|r| r.status == ReadyStatus::Unknown)
+        .count();
+
+    serde_json::json!({
+        "tools": tools,
+        "summary": {
+            "ready": ready,
+            "partial": partial,
+            "not_ready": not_ready,
+            "unknown": unknown,
+            "total": results.len()
+        }
+    })
 }
 
 /// Build the ordered candidate list for `auto_fix`.
@@ -1198,11 +1321,22 @@ pub fn run(
     let specs = load_spec(&spec_path).map_err(|e| (e, 1))?;
 
     if checklist {
-        let results: Vec<ToolReadyResult> = specs
-            .keys()
-            .map(|name| check_tool(name, specs.get(name).unwrap()))
+        // Sort tool names before building results so both the text and JSON
+        // checklist output keep a stable order across processes; `specs` is a
+        // HashMap, whose iteration order is randomized per process.
+        let mut tool_names: Vec<&str> = specs.keys().map(String::as_str).collect();
+        tool_names.sort_unstable();
+        let results: Vec<ToolReadyResult> = tool_names
+            .iter()
+            .map(|name| check_tool(name, specs.get(*name).unwrap()))
             .collect();
-        println!("{}", generate_checklist(&results));
+        if json {
+            let json_value = serde_json::to_string(&generate_checklist_json(&results))
+                .map_err(|e| (format!("Failed to serialize checklist JSON: {}", e), 1))?;
+            println!("{}", json_value);
+        } else {
+            println!("{}", generate_checklist(&results));
+        }
         return Ok(());
     }
 

--- a/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
@@ -698,6 +698,38 @@ fn check_tool_partial_missing_recommended() {
 }
 
 #[test]
+fn check_tool_partial_recommended_version_low() {
+    // bash>=999.0.0 is always VersionLow; the overall status must be PARTIAL, not READY.
+    let spec = ToolDepSpec {
+        aliases: vec![],
+        required: vec![make_dep("sh")],
+        recommended: vec![DepEntry {
+            binary: "bash".to_string(),
+            version: Some(">=999.0.0".to_string()),
+            package: "bash".to_string(),
+            apt_package: None,
+            apk_package: None,
+            manager: "rpm".to_string(),
+            pip_name: None,
+            uv_name: None,
+            npm_name: None,
+            use_npx: false,
+            fallback: vec![],
+        }],
+        config_files: vec![],
+        permissions: vec![],
+        network: vec![],
+    };
+    let result = check_tool("PartialVersionedTool", &spec);
+    assert_eq!(result.status, ReadyStatus::Partial);
+    // Confirm the dep itself is VersionLow, not Missing
+    assert!(
+        matches!(result.recommended_results[0].1, DepStatus::VersionLow { .. }),
+        "expected VersionLow for bash>=999.0.0"
+    );
+}
+
+#[test]
 fn check_tool_partial_missing_config() {
     let spec = ToolDepSpec {
         aliases: vec![],
@@ -1132,8 +1164,13 @@ fn check_tool_versioned_available() {
     let spec_path = write_versioned_spec(dir.path());
     let specs = load_spec(&spec_path).unwrap();
     let result = check_tool("VersionedTool", specs.get("VersionedTool").unwrap());
-    // bash >= 1.0 should be available on any Linux
-    assert_eq!(result.status, ReadyStatus::Ready);
+    // bash >= 1.0 satisfies the required dep; cat>=0.1 may be VersionLow (no --version)
+    // and ~/.bashrc is likely absent — both conditions produce Partial, not Ready.
+    assert!(
+        result.status == ReadyStatus::Partial || result.status == ReadyStatus::Ready,
+        "expected Partial or Ready, got {:?}",
+        result.status
+    );
     assert!(!result.config_results.is_empty());
 }
 
@@ -1578,4 +1615,94 @@ fn normalize_dep_with_fallback() {
     assert_eq!(dep.manager, "pip");
     assert_eq!(dep.fallback.len(), 1);
     assert_eq!(dep.fallback[0].binary.as_deref(), Some("rtk-fallback"));
+}
+
+fn synthetic_checklist_results() -> Vec<ToolReadyResult> {
+    vec![
+        ToolReadyResult {
+            tool_name: "Read".to_string(),
+            status: ReadyStatus::Ready,
+            required_results: vec![(normalize_dep(&json!("bash")), DepStatus::Available)],
+            recommended_results: vec![],
+            config_results: vec![("/etc/hostname".to_string(), true)],
+            permission_results: vec![("exec_shell".to_string(), true)],
+            network_results: vec![],
+        },
+        ToolReadyResult {
+            tool_name: "WebFetch".to_string(),
+            status: ReadyStatus::Partial,
+            required_results: vec![],
+            recommended_results: vec![(
+                normalize_dep(&json!("nonexistent_binary_xyz_99")),
+                DepStatus::Missing,
+            )],
+            config_results: vec![],
+            permission_results: vec![],
+            network_results: vec![("lan_probe".to_string(), true)],
+        },
+        ToolReadyResult {
+            tool_name: "Write".to_string(),
+            status: ReadyStatus::NotReady,
+            required_results: vec![(
+                normalize_dep(&json!("nonexistent_binary_xyz_99")),
+                DepStatus::Missing,
+            )],
+            recommended_results: vec![],
+            config_results: vec![("~/.nonexistent_config_xyz".to_string(), false)],
+            permission_results: vec![("file_write".to_string(), false)],
+            network_results: vec![],
+        },
+    ]
+}
+
+#[test]
+fn checklist_json_schema_covers_all_categories() {
+    let value = generate_checklist_json(&synthetic_checklist_results());
+
+    let tools = value["tools"].as_array().expect("tools must be an array");
+    assert_eq!(tools.len(), 3);
+
+    // Every tool entry carries the status label plus all five categories.
+    for tool in tools {
+        assert!(tool["status"].is_string());
+        for category in ["required", "recommended", "config", "permissions", "network"] {
+            assert!(
+                tool[category].is_array(),
+                "tool {} must serialize category {}",
+                tool["tool"],
+                category
+            );
+        }
+    }
+
+    let read = &tools[0];
+    assert_eq!(read["tool"], "Read");
+    assert_eq!(read["status"], "READY");
+    assert_eq!(read["required"][0]["binary"], "bash");
+    assert_eq!(read["required"][0]["status"], "INSTALLED");
+    assert_eq!(read["config"][0]["name"], "/etc/hostname");
+    assert_eq!(read["config"][0]["ok"], true);
+    assert_eq!(read["permissions"][0]["name"], "exec_shell");
+    assert_eq!(read["permissions"][0]["ok"], true);
+    assert_eq!(read["recommended"].as_array().unwrap().len(), 0);
+    assert_eq!(read["network"].as_array().unwrap().len(), 0);
+
+    let web_fetch = &tools[1];
+    assert_eq!(web_fetch["status"], "PARTIAL");
+    assert_eq!(web_fetch["recommended"][0]["status"], "MISSING");
+    assert_eq!(web_fetch["network"][0]["name"], "lan_probe");
+    assert_eq!(web_fetch["network"][0]["ok"], true);
+
+    let write = &tools[2];
+    assert_eq!(write["status"], "NOT_READY");
+    assert_eq!(write["required"][0]["status"], "MISSING");
+    assert_eq!(write["config"][0]["ok"], false);
+    assert_eq!(write["permissions"][0]["ok"], false);
+
+    // Summary counts are derived from the same results.
+    assert_eq!(value["summary"]["ready"], 1);
+    assert_eq!(value["summary"]["partial"], 1);
+    assert_eq!(value["summary"]["not_ready"], 1);
+    assert_eq!(value["summary"]["unknown"], 0);
+    assert_eq!(value["summary"]["total"], 3);
 }

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -613,3 +613,144 @@ fn stats_diff_invalid_scope_and_missing_record_use_expected_exit_codes() {
         .unwrap();
     assert_eq!(missing.status.code(), Some(1));
 }
+
+fn write_checklist_spec(dir: &std::path::Path) -> std::path::PathBuf {
+    // Config file that reliably exists for the config-file check.
+    let config_path = dir.join("present.conf");
+    std::fs::write(&config_path, "").unwrap();
+    let spec = serde_json::json!({
+        "_comment": "comment keys must be skipped",
+        "Write": {
+            "required": ["nonexistent_binary_xyz_98"],
+            "recommended": [],
+            "config_files": [],
+            "permissions": [],
+            "network": []
+        },
+        "Shell": {
+            "required": ["bash"],
+            "recommended": [],
+            "config_files": [],
+            "permissions": [],
+            "network": []
+        },
+        "WebFetch": {
+            "required": [],
+            "recommended": ["nonexistent_binary_xyz_99"],
+            "config_files": [],
+            "permissions": [],
+            "network": ["lan_probe"]
+        },
+        "Read": {
+            "required": ["bash"],
+            "recommended": [],
+            "config_files": [config_path],
+            "permissions": ["exec_shell"],
+            "network": []
+        }
+    });
+    let spec_path = dir.join("checklist-spec.json");
+    std::fs::write(&spec_path, spec.to_string()).unwrap();
+    spec_path
+}
+
+#[test]
+fn env_check_checklist_json_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec_path = write_checklist_spec(dir.path());
+
+    let output = tokenless_bin()
+        .args(["env-check", "--checklist", "--json"])
+        .env("TOKENLESS_TOOL_READY_SPEC", &spec_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "env-check --checklist --json should succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect(
+        "--checklist --json must print one JSON object on stdout (text output would not parse)",
+    );
+
+    // Tools are ordered by tool name so the array is stable across runs.
+    let tools = value["tools"].as_array().expect("tools must be an array");
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|tool| tool["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["Read", "Shell", "WebFetch", "Write"]);
+
+    // Every tool entry carries the status label plus all five categories.
+    for tool in tools {
+        assert!(tool["status"].is_string());
+        for category in [
+            "required",
+            "recommended",
+            "config",
+            "permissions",
+            "network",
+        ] {
+            assert!(
+                tool[category].is_array(),
+                "tool {} must serialize category {}",
+                tool["tool"],
+                category
+            );
+        }
+    }
+
+    // READY tool: required dep installed, config present, permission granted.
+    let read = &tools[0];
+    assert_eq!(read["status"], "READY");
+    assert_eq!(read["required"][0]["binary"], "bash");
+    assert_eq!(read["required"][0]["status"], "INSTALLED");
+    assert_eq!(read["config"][0]["ok"], true);
+    assert_eq!(read["permissions"][0]["name"], "exec_shell");
+    assert_eq!(read["permissions"][0]["ok"], true);
+
+    // PARTIAL tool: only a recommended dep missing.
+    let web_fetch = &tools[2];
+    assert_eq!(web_fetch["status"], "PARTIAL");
+    assert_eq!(web_fetch["recommended"][0]["status"], "MISSING");
+    assert_eq!(web_fetch["network"][0]["ok"], true);
+
+    // NOT_READY tool: required dep missing.
+    let write = &tools[3];
+    assert_eq!(write["status"], "NOT_READY");
+    assert_eq!(write["required"][0]["status"], "MISSING");
+
+    // Summary counts must agree with the tools array.
+    assert_eq!(value["summary"]["ready"], 2);
+    assert_eq!(value["summary"]["partial"], 1);
+    assert_eq!(value["summary"]["not_ready"], 1);
+    assert_eq!(value["summary"]["unknown"], 0);
+    assert_eq!(value["summary"]["total"], 4);
+}
+
+#[test]
+fn env_check_checklist_json_stable_across_processes() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec_path = write_checklist_spec(dir.path());
+
+    let mut outputs = Vec::new();
+    for _ in 0..8 {
+        let output = tokenless_bin()
+            .args(["env-check", "--checklist", "--json"])
+            .env("TOKENLESS_TOOL_READY_SPEC", &spec_path)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        outputs.push(output.stdout);
+    }
+
+    for (index, stdout) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            stdout,
+            &outputs[0],
+            "checklist JSON must be byte-identical across processes (run {})",
+            index + 1
+        );
+    }
+}


### PR DESCRIPTION
## Description

`env-check --checklist --json` silently ignored `--json` and always emitted the human-readable text checklist. The `--checklist` branch in `run()` called `generate_checklist()` unconditionally and returned early, so the `json` flag was never consulted.

Fix: add `generate_checklist_json()` that serialises the same per-tool results as a JSON object with a `tools` array and a `summary` object, then branch on the `json` flag inside the `--checklist` path. The text checklist format gains `network` result lines to match the per-tool text output and the new JSON schema.

Output schema for `--checklist --json`:
```json
{
  "tools": [
    {
      "tool": "Shell",
      "status": "PARTIAL",
      "required":    [{"binary": "bash", "status": "INSTALLED"}],
      "recommended": [{"binary": "rtk", "status": "MISSING"}],
      "config":      [],
      "permissions": [],
      "network":     []
    }
  ],
  "summary": {"ready": 0, "partial": 1, "not_ready": 0, "unknown": 0, "total": 1}
}
```

## Related Issue

closes #2365

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `tokenless`

## Risk and Compatibility

The new JSON output path is additive. One existing behaviour is corrected: a recommended dependency whose installed version is lower than required (`VersionLow`) now contributes to `PARTIAL` status instead of being silently treated as `READY`. This aligns the aggregate status with the documented contract and prevents CI gates from passing a degraded environment.

## Documentation

- Updated EN and ZH `docs/user-guide/*/token-saving/tokenless/cli-reference.md` to document `--checklist --json`, its schema (including the `network` field), and status meanings.
- Corrected the JSON example in both languages so that a tool with a missing recommended dependency shows `status: "PARTIAL"` and `summary.partial: 1`.
- Updated EN and ZH component READMEs.

## Rollback

Revert this single commit to restore the previous `--checklist` behaviour; no schema or persisted-state migrations are required.

## Validation

```
cargo fmt --all -- --check                              # clean
cargo clippy --workspace --all-targets -- -D warnings  # clean
cargo test --workspace                                  # 217 passed (tokenless-cli), all workspace suites green
```

Manual smoke-test: `tokenless env-check --checklist --json` now emits a `{` on the first line. `tokenless env-check --checklist` (no `--json`) still emits `Tool Environment Ready Checklist`.