### PR TITLE
fix(tokenless): scan past malformed markers

### DIFF
--- a/src/tokenless/crates/tokenless-ccr/src/marker.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/marker.rs
@@ -11,6 +11,9 @@ pub const MARKER_PREFIX: &str = "<<tokenless:";
 /// Marker suffix.
 pub const MARKER_SUFFIX: &str = ">>";
 
+/// Length of a stash hash in hex characters (see `key.rs`).
+const HASH_LEN: usize = 24;
+
 /// Build a marker string for `hash`.
 pub fn marker_for(hash: &str) -> String {
     format!("{MARKER_PREFIX}{hash}{MARKER_SUFFIX}")
@@ -26,16 +29,36 @@ pub fn parse_marker(s: &str) -> Option<&str> {
     Some(inner)
 }
 
-/// Extract the first marker's hash from arbitrary text. Useful when the LLM
-/// quotes a whole truncation line such as
+/// Extract the first **valid** marker's hash from arbitrary text. Useful
+/// when the LLM quotes a whole truncation line such as
 /// `<... 12 items truncated, retrieve with <<tokenless:abcd…>>`.
+///
+/// Scans past malformed markers (wrong-length or non-hex content between a
+/// prefix/suffix pair) so a hallucinated or partial marker earlier in the
+/// text does not prevent retrieval of a valid marker that follows it.
+///
+/// The scan stays linear on untrusted input: at each prefix the fixed
+/// `24-hex + suffix` window directly after it is validated in place instead
+/// of searching the rest of the text for the next suffix, so a rejected
+/// prefix costs O(1) and no tail is ever rescanned.
 pub fn extract_hash(text: &str) -> Option<&str> {
-    let start = text.find(MARKER_PREFIX)?;
-    let rest = &text[start + MARKER_PREFIX.len()..];
-    let end = rest.find(MARKER_SUFFIX)?;
-    let hash = &rest[..end];
-    validate_hash(hash)?;
-    Some(hash)
+    let mut search_from = 0;
+    while let Some(start) = text[search_from..].find(MARKER_PREFIX) {
+        let hash_start = search_from + start + MARKER_PREFIX.len();
+        // A valid marker is exactly prefix + 24 hex chars + suffix, so only
+        // the fixed window right after the prefix can complete it. When too
+        // few bytes remain, `get` yields None and this prefix is rejected.
+        if let Some(hash) = text.get(hash_start..hash_start + HASH_LEN)
+            && validate_hash(hash).is_some()
+            && text[hash_start + HASH_LEN..].starts_with(MARKER_SUFFIX)
+        {
+            return Some(hash);
+        }
+        // MARKER_PREFIX cannot overlap itself, so no marker can start inside
+        // the prefix just rejected; resume right after it.
+        search_from = hash_start;
+    }
+    None
 }
 
 /// Whether `hash` is a valid stash key: exactly 24 ASCII hex characters
@@ -43,7 +66,7 @@ pub fn extract_hash(text: &str) -> Option<&str> {
 /// so callers can validate a bare hash before a DB round-trip and surface a
 /// clear format error to the user.
 pub fn is_valid_hash(hash: &str) -> bool {
-    hash.len() == 24 && hash.bytes().all(|b| b.is_ascii_hexdigit())
+    hash.len() == HASH_LEN && hash.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 /// A valid stash key is exactly 24 ASCII hex characters.
@@ -120,5 +143,56 @@ mod tests {
         let text =
             "<<tokenless:000000000000000000000000>> then <<tokenless:111111111111111111111111>>";
         assert_eq!(extract_hash(text), Some("000000000000000000000000"));
+    }
+
+    #[test]
+    fn extract_hash_skips_malformed_marker_before_valid() {
+        // A partial/hallucinated marker (3 hex chars) precedes a valid one.
+        let text = "see <<tokenless:abc>> then <<tokenless:0123456789abcdef01234567>>";
+        assert_eq!(extract_hash(text), Some("0123456789abcdef01234567"));
+    }
+
+    #[test]
+    fn extract_hash_skips_non_hex_marker_before_valid() {
+        let text =
+            "<<tokenless:ZZZZZZZZZZZZZZZZZZZZZZZZ>> and <<tokenless:abcdef0123456789abcdef01>>";
+        assert_eq!(extract_hash(text), Some("abcdef0123456789abcdef01"));
+    }
+
+    #[test]
+    fn extract_hash_all_malformed_returns_none() {
+        assert_eq!(
+            extract_hash("<<tokenless:abc>> and <<tokenless:def>>"),
+            None,
+        );
+    }
+
+    #[test]
+    fn extract_hash_skips_nested_malformed_prefix_before_valid() {
+        // An unclosed/partial prefix is followed immediately by a valid marker.
+        // The first prefix pairs with the valid marker's suffix and produces
+        // an invalid hash; scanning must resume inside that rejected span to
+        // find the real marker.
+        let text = "<<tokenless:abc <<tokenless:0123456789abcdef01234567>>";
+        assert_eq!(extract_hash(text), Some("0123456789abcdef01234567"));
+    }
+
+    #[test]
+    fn extract_hash_many_malformed_prefixes_returns_none() {
+        // Pathological untrusted input for the old rescanning scanner: N
+        // repeated prefixes sharing one trailing suffix. The fixed-window
+        // scan rejects each prefix in O(1), keeping this linear.
+        let text = format!("{}>>", "<<tokenless:".repeat(20_000));
+        assert_eq!(extract_hash(&text), None);
+    }
+
+    #[test]
+    fn extract_hash_finds_valid_marker_after_many_malformed_prefixes() {
+        let mut text = String::new();
+        for _ in 0..1_000 {
+            text.push_str("<<tokenless:not-a-hash ");
+        }
+        text.push_str("<<tokenless:0123456789abcdef01234567>>");
+        assert_eq!(extract_hash(&text), Some("0123456789abcdef01234567"));
     }
 }


### PR DESCRIPTION
## Summary

`tokenless retrieve` failed when text contained a malformed marker (e.g. `<<tokenless:abc>>`, hash too short) before a valid one. `extract_hash` found the first `<<tokenless:` prefix, took the first `>>` suffix, validated the sandwiched hash, and returned `None` on failure — without scanning for a subsequent valid marker. The CLI then fell back to `is_valid_hash` on the whole string, which also failed, producing "invalid stash hash".

This rewrites `extract_hash` to loop: on validation failure, advance past the current suffix and search for the next prefix, returning the first valid hash. This handles the case where an LLM emits a partial or hallucinated marker before quoting the real one.

## Changes

- Rewrote `extract_hash` in `marker.rs` to scan past malformed prefix-suffix pairs
- Updated doc comment to reflect the scanning behavior
- Added 3 tests: malformed-then-valid, non-hex-then-valid, all-malformed-returns-none

## Risk and compatibility

- No change to `parse_marker` (whole-string marker parsing)
- Existing `extract_hash` callers benefit transparently — no API change
- Preserved existing behavior for no-prefix, no-suffix, and all-malformed cases

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p tokenless-ccr --all-targets -- -D warnings`
- `cargo test -p tokenless-ccr` (39 passed, 0 failed)
- `cargo test -p tokenless-cli` (25 passed, 0 failed — no CLI regressions)
