### PR TITLE
feat(docs): add Tokenless quickstart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ Token-less removes redundancy from tool schemas and responses.
 demand so only the relevant ones enter the context, and
 [AgentSight](src/agentsight/README.md) records where Tokens are actually spent.
 
+### Try Token-less with Claude Code in 3 minutes
+
+Install Token-less and connect it to Claude Code:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+anolisa install tokenless
+anolisa adapter enable tokenless claude-code
+```
+
+Restart Claude Code, run one tool-heavy task, then inspect the result:
+
+```bash
+tokenless stats summary
+tokenless stats list --limit 5
+```
+
+[Open the full Token-less Quick Start →](https://agentic-os.sh/docs/user-guide/token-saving/tokenless/quickstart/)
+· [Read the user manual](https://agentic-os.sh/docs/user-guide/token-saving/tokenless/user-manual/)
+
 <table align="center" cellpadding="0" cellspacing="0">
   <tr>
     <td>
@@ -112,8 +133,6 @@ through a `<<tokenless:KEY>>` marker, which keeps the compression reversible.
 Savings apply to the tool responses entering the context, not to the whole
 session bill — the [Token-less README](src/tokenless/README.md) explains how to
 estimate the effect for a given workload.
-
-[Read the Token-less user manual →](docs/user-guide/en/token-saving/tokenless/user-manual.md)
 
 <p align="center"><strong>03 · EXECUTION RUNTIME</strong></p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,6 +67,27 @@ Token-less 去掉工具 Schema 和响应中的冗余，[Agent Memory](src/agent-
 Skills，只把用得到的技能放进上下文，[AgentSight](src/agentsight/README_zh.md)
 记录 Token 实际花在哪。
 
+### 使用 Claude Code，3 分钟体验 Token-less
+
+安装 Token-less，并将它接入 Claude Code：
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+anolisa install tokenless
+anolisa adapter enable tokenless claude-code
+```
+
+重启 Claude Code，运行一次工具密集型任务，再查看结果：
+
+```bash
+tokenless stats summary
+tokenless stats list --limit 5
+```
+
+[打开完整 Token-less 快速体验 →](https://agentic-os.sh/zh/docs/user-guide/token-saving/tokenless/quickstart/)
+· [阅读完整用户手册](https://agentic-os.sh/zh/docs/user-guide/token-saving/tokenless/user-manual/)
+
 <table align="center" cellpadding="0" cellspacing="0">
   <tr>
     <td>
@@ -105,8 +126,6 @@ Skills，只把用得到的技能放进上下文，[AgentSight](src/agentsight/R
 
 节省比例针对进入上下文的工具响应，不代表整个会话的账单。具体工作负载的估算方法
 见 [Token-less README](src/tokenless/README_zh.md)。
-
-[查看 Token-less 用户手册 →](docs/user-guide/zh/token-saving/tokenless/user-manual.md)
 
 <p align="center"><strong>03 · EXECUTION RUNTIME</strong></p>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,168 +2,70 @@
 
 [中文版](QUICKSTART_zh.md)
 
-ANOLISA is a server-side operating layer for AI Agent workloads. It provides Token optimization, workspace checkpoints, observability, security enforcement, persistent memory, and more — all installable via a unified CLI.
-
----
+ANOLISA is a server-side operating layer for AI Agent workloads. Install the
+CLI once, then enable only the capability that delivers the first result you
+want.
 
 ## Install the CLI
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-> Alinux 4 users can also install via `sudo yum install anolisa`.
+If the anolisa CLI is already installed, skip these commands. Alinux 4 users
+can alternatively install the CLI with `sudo yum install anolisa`.
 
-Verify:
+## Choose your first outcome
+
+### Reduce Agent Token usage
+
+Install Tokenless, connect it to Codex, Claude Code, Qoder, OpenClaw, Hermes,
+Qwen Code, or cosh, then verify a before/after Token record.
+
+[Start the three-minute Tokenless Quick Start →](user-guide/en/token-saving/tokenless/QUICKSTART.md)
+
+### Work with an Agent-native terminal
+
+Choose the terminal that matches your environment:
+
+- [Start with cosh-ng](user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md) — an AI-native Linux terminal
+- [Start with Copilot Shell](user-guide/en/user-entrypoint/copilot-shell/QUICKSTART.md) — an extensible Agent Shell
+
+### Add observability, security, or runtime controls
+
+| Goal | Start here |
+|------|------------|
+| Observe Agent activity and Token usage | [AgentSight](user-guide/en/agent-observability/agentsight.md) |
+| Add security enforcement | [Agent Sec Core](user-guide/en/agent-security/agent-sec-core/QUICKSTART.md) |
+| Create workspace recovery points | [ws-ckpt](user-guide/en/runtime/ws-ckpt.md) |
+| Mount Skills on demand | [SkillFS](user-guide/en/runtime/skillfs.md) |
+| Reuse context across sessions | [Agent Memory](user-guide/en/token-saving/agent-memory.md) |
+
+Each component page starts with its supported platforms and preferred
+installation path. Linux-only components must be installed and run on Linux.
+
+## Explore the installation
+
+Use the CLI to inspect the current machine and installed components:
 
 ```bash
-anolisa --version
-```
-
-AgentSecCore's raw package requires `anolisa` 0.2.17 or later. Updating the
-CLI first lets it read the current component contract and choose the published
-raw package correctly:
-
-```bash
-# CLI installed by get.agentic-os.sh
-anolisa update self
-
-# RPM-owned CLI
-sudo anolisa update self
-```
-
----
-
-## Explore Your Environment
-
-```bash
-# Check platform capabilities
 anolisa env
-
-# List available components
 anolisa list
-```
-
----
-
-## Install Components
-
-Install components on demand. The current `cosh-ng`, `agentsight`, `sec-core`,
-`ws-ckpt`, and `skillfs` artifacts require system mode; the other examples
-below support user mode.
-
-```bash
-# Token optimization (via anolisa CLI)
-anolisa install tokenless
-
-# Workspace checkpoints (btrfs COW)
-sudo anolisa --install-mode system install ws-ckpt
-
-# Observability (Linux system mode)
-sudo anolisa --install-mode system install agentsight
-
-# Security runtime and adapter resources (Linux x86_64 system mode)
-sudo anolisa --install-mode system install sec-core
-
-# Persistent memory (MCP file-based)
-anolisa install agent-memory
-
-# Skill filesystem (FUSE virtual views)
-sudo anolisa --install-mode system install skillfs
-
-# OS skill library
-anolisa install os-skills
-
-# Copilot Shell
-anolisa install cosh
-
-# cosh-ng (AI-native Linux terminal)
-sudo anolisa --install-mode system install cosh-ng
-```
-
-Check health:
-
-```bash
 anolisa status
 ```
 
-System services are placed during installation but are not started or enabled
-automatically. Start AgentSight under systemd when you are ready to collect
-events:
+Adapters connect an installed component to an Agent framework. Scan the
+available integrations after installing a component:
 
 ```bash
-sudo systemctl enable --now agentsight.service
-sudo systemctl status agentsight.service
+anolisa adapter scan
 ```
 
-The main service starts tracing and the Dashboard together and brings up
-`agentsight-enforcer.service` as its dependency.
+## Next steps
 
----
-
-## Use Components
-
-After installation, each component operates independently:
-
-```bash
-# Start the installed terminal
-cosh
-
-# Token optimization — compress tool schemas and command output
-tokenless compress-schema -f tool.json
-tokenless env-check --all
-
-# Workspace checkpoints — instant create/rollback
-ws-ckpt checkpoint -w ~/project -s v1 -m "initial"
-ws-ckpt rollback -w ~/project -s v1
-
-# Observability (the system service stores data as root)
-sudo agentsight token --period week
-# Web Dashboard: http://localhost:7396
-
-# Security — system hardening and skill verification
-agent-sec-cli harden --scan --config agentos_baseline
-agent-sec-cli skill-ledger status
-```
-
----
-
-## Integrate with Agent Frameworks
-
-Bridge installed components to Agent frameworks (cosh / OpenClaw / Hermes):
-
-```bash
-anolisa adapter scan                        # Discover installed frameworks
-anolisa adapter enable tokenless openclaw   # tokenless → OpenClaw
-anolisa adapter enable ws-ckpt hermes       # ws-ckpt → Hermes
-anolisa adapter enable sec-core openclaw    # AgentSecCore → OpenClaw
-```
-
----
-
-## Next Steps
-
-### Global
-
-- [Full User Guide](user-guide/en/README.md) — browse all component docs by category
-- [Installation Guide](user-guide/en/installation.md) — progressive install from CLI to full stack
-- [Troubleshooting](user-guide/en/troubleshooting.md) — common issues and fixes
-
-### User Entry Points
-
-- [anolisa CLI Reference](user-guide/en/user-entrypoint/anolisa-cli.md)
-- [cosh-ng AI-native Terminal](user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md)
-- [Copilot Shell](user-guide/en/user-entrypoint/copilot-shell/QUICKSTART.md)
-- [OS Skills](user-guide/en/user-entrypoint/os-skills.md)
-
-### Runtime & Token Saving
-
-- [Workspace Checkpoints](user-guide/en/runtime/ws-ckpt.md)
-- [Skill Filesystem](user-guide/en/runtime/skillfs.md)
-- [Token Optimization](user-guide/en/token-saving/tokenless/QUICKSTART.md)
-- [Agent Memory](user-guide/en/token-saving/agent-memory.md)
-
-### Observability & Security
-
-- [AgentSight](user-guide/en/agent-observability/agentsight.md)
-- [AgentSecCore](user-guide/en/agent-security/agent-sec-core/QUICKSTART.md)
+- [Installation guide](user-guide/en/installation.md) — platform support, system mode, RPM, and all component install commands
+- [Full user guide](user-guide/en/README.md) — configure, operate, and troubleshoot each capability
+- [anolisa CLI reference](user-guide/en/user-entrypoint/anolisa-cli.md) — lifecycle and adapter commands
+- [Troubleshooting](user-guide/en/troubleshooting.md) — common installation and runtime failures
+- [Build from source](BUILDING.md) — developer builds only

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -2,161 +2,68 @@
 
 [English](QUICKSTART.md)
 
-ANOLISA 是面向 AI Agent 工作负载的服务端操作系统层。通过统一的 `anolisa` CLI 安装和管理所有组件，为 Agent 提供 Token 优化、工作区快照、可观测性、安全策略、持久记忆等能力。
-
----
+ANOLISA 是面向 AI Agent 工作负载的服务端操作系统层。只需安装一次 CLI，再按需
+启用能带来第一个目标结果的能力。
 
 ## 安装 CLI
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-> Alinux 4 用户也可通过 `sudo yum install anolisa` 安装。
+如果已经安装 anolisa CLI，可以跳过这些命令。Alinux 4 用户也可通过
+`sudo yum install anolisa` 安装 CLI。
 
-验证安装。
+## 选择第一个目标
+
+### 减少 Agent Token 开销
+
+安装 Tokenless，将它接入 Codex、Claude Code、Qoder、OpenClaw、Hermes、
+Qwen Code 或 cosh，然后确认一条压缩前后的 Token 记录。
+
+[开始三分钟 Tokenless 快速体验 →](user-guide/zh/token-saving/tokenless/QUICKSTART.md)
+
+### 使用 Agent 原生终端
+
+根据环境选择终端：
+
+- [开始使用 cosh-ng](user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md)——面向 AI 时代重构的 Linux 终端
+- [开始使用 Copilot Shell](user-guide/zh/user-entrypoint/copilot-shell/QUICKSTART.md)——可扩展的 Agent Shell
+
+### 增加可观测性、安全或运行时控制
+
+| 目标 | 开始位置 |
+|------|----------|
+| 观察 Agent 活动与 Token 使用 | [AgentSight](user-guide/zh/agent-observability/agentsight.md) |
+| 增加安全策略 | [Agent Sec Core](user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md) |
+| 创建工作区恢复点 | [ws-ckpt](user-guide/zh/runtime/ws-ckpt.md) |
+| 按需挂载 Skills | [SkillFS](user-guide/zh/runtime/skillfs.md) |
+| 跨 Session 复用上下文 | [Agent Memory](user-guide/zh/token-saving/agent-memory.md) |
+
+每个组件页面都会首先说明支持的平台和首选安装路径。仅支持 Linux 的组件必须在
+Linux 上安装和运行。
+
+## 检查安装状态
+
+通过 CLI 查看当前机器和已经安装的组件：
 
 ```bash
-anolisa --version
-```
-
-AgentSecCore 的 raw 包需要 `anolisa` 0.2.17 或更高版本。先更新 CLI，
-它才能读取当前的组件契约，并正确选中已发布的 raw 包。
-
-```bash
-# 通过 get.agentic-os.sh 安装的 CLI
-anolisa update self
-
-# 由 RPM 管理的 CLI
-sudo anolisa update self
-```
-
----
-
-## 环境探测与组件安装
-
-```bash
-# 查看环境支持情况
 anolisa env
-
-# 列出可用组件
 anolisa list
-```
-
-按需安装组件。当前 `cosh-ng`、`agentsight`、`sec-core`、`ws-ckpt` 和
-`skillfs` 需要以 system 模式安装，其余示例支持 user 模式。
-
-```bash
-# Token 优化
-anolisa install tokenless
-
-# 工作区快照（基于 btrfs COW）
-sudo anolisa --install-mode system install ws-ckpt
-
-# 可观测性（Linux system mode）
-sudo anolisa --install-mode system install agentsight
-
-# 安全运行时和 adapter 资源（Linux x86_64 system mode）
-sudo anolisa --install-mode system install sec-core
-
-# 持久记忆（MCP 文件形态）
-anolisa install agent-memory
-
-# 技能文件系统（FUSE 虚拟视图）
-sudo anolisa --install-mode system install skillfs
-
-# OS 技能库
-anolisa install os-skills
-
-# Copilot Shell
-anolisa install cosh
-
-# cosh-ng（AI 原生 Linux 终端）
-sudo anolisa --install-mode system install cosh-ng
-```
-
-检查健康状态。
-
-```bash
 anolisa status
 ```
 
-安装会放置 systemd 服务文件，不会自动启动或设置开机自启。准备开始
-采集时，再把 AgentSight 交给 systemd 管理。
+Adapter 用于将已安装组件接入 Agent 框架。安装组件后，扫描可用的接入路径：
 
 ```bash
-sudo systemctl enable --now agentsight.service
-sudo systemctl status agentsight.service
+anolisa adapter scan
 ```
-
-主服务会一起启动 trace 和 Dashboard，并带起它依赖的
-`agentsight-enforcer.service`。
-
----
-
-## 使用各组件
-
-安装后，各组件可以独立使用。
-
-```bash
-# 启动已安装的终端
-cosh
-
-# Token 优化，压缩工具定义和命令输出
-tokenless compress-schema -f tool.json
-tokenless env-check --all
-
-# 工作区快照，快速创建和回滚
-ws-ckpt checkpoint -w ~/project -s v1 -m "initial"
-ws-ckpt rollback -w ~/project -s v1
-
-# 可观测性，system 服务以 root 身份保存采集数据
-sudo agentsight token --period week
-# Web Dashboard：http://localhost:7396
-
-# 安全，系统加固与技能验证
-agent-sec-cli harden --scan --config agentos_baseline
-agent-sec-cli skill-ledger status
-```
-
----
-
-## 适配 Agent 框架
-
-将已安装组件接入 Agent 框架，如 cosh、OpenClaw 或 Hermes。
-
-```bash
-anolisa adapter scan                        # 发现已安装框架
-anolisa adapter enable tokenless openclaw   # tokenless → OpenClaw
-anolisa adapter enable ws-ckpt hermes       # ws-ckpt → Hermes
-anolisa adapter enable sec-core openclaw    # AgentSecCore → OpenClaw
-```
-
----
 
 ## 下一步
 
-### 全局入口
-
-- [完整用户指南](user-guide/zh/README.md)，按分类目录浏览所有组件文档
-- [安装指南](user-guide/zh/installation.md)，从 CLI 到全栈的渐进式安装
-- [故障排查](user-guide/zh/troubleshooting.md)，查看常见问题与修复方法
-
-### 用户入口点
-
-- [anolisa CLI 命令参考](user-guide/zh/user-entrypoint/anolisa-cli.md)
-- [cosh-ng AI 原生终端](user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md)
-- [Copilot Shell](user-guide/zh/user-entrypoint/copilot-shell/QUICKSTART.md)
-- [OS 技能库](user-guide/zh/user-entrypoint/os-skills.md)
-
-### 运行时与 Token 节省
-
-- [工作区快照](user-guide/zh/runtime/ws-ckpt.md)
-- [技能文件系统](user-guide/zh/runtime/skillfs.md)
-- [Token 优化](user-guide/zh/token-saving/tokenless/QUICKSTART.md)
-- [Agent 记忆](user-guide/zh/token-saving/agent-memory.md)
-
-### 可观测性与安全
-
-- [AgentSight](user-guide/zh/agent-observability/agentsight.md)
-- [AgentSecCore](user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md)
+- [安装指南](user-guide/zh/installation.md)——平台支持、system mode、RPM 和所有组件安装命令
+- [完整用户指南](user-guide/zh/README.md)——配置、运行和排查各项能力
+- [anolisa CLI 参考](user-guide/zh/user-entrypoint/anolisa-cli.md)——生命周期与 Adapter 命令
+- [故障排查](user-guide/zh/troubleshooting.md)——常见安装和运行问题
+- [从源码构建](BUILDING_zh.md)——仅面向开发者构建

--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -2,117 +2,151 @@
 
 [中文版](../../../zh/token-saving/tokenless/QUICKSTART.md)
 
-## 1. What Tokenless does
+Install Tokenless, connect it to Claude Code, run one real task, and verify a
+before/after Token record in about three minutes. Tokenless works in the
+background, so your prompts and normal Agent workflow do not change.
 
-Tokenless helps an AI agent complete the same work with fewer tokens.
+Savings vary by workload. Tool-heavy tasks usually show the clearest result;
+short or conversation-only tasks may show little change.
 
-After you turn it on, you do not need to change your prompts or the way you use the agent. Tokenless works automatically in the background.
+## 1. Install Tokenless and connect Claude Code
 
-What you may notice:
-
-- Less token usage on lengthy intermediate results.
-- More room for useful information during long tasks.
-- Cleaner information for the agent to use when deciding what to do next.
-
-Savings vary by task. Short tasks or tasks that are mostly conversation may show little change, so check the result with your own workload in [View the result](#4-view-the-result).
-
-## 2. Install Tokenless
-
-Install the anolisa CLI first, then use it to install Tokenless:
+This quick path uses Claude Code as the example Agent:
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
-anolisa --version
 anolisa install tokenless
-tokenless --version
+anolisa adapter enable tokenless claude-code
 ```
 
-If `anolisa --version` succeeds, start with `anolisa install tokenless`. The
-PATH update above makes a fresh default installation available in the current
-shell; new login shells may already include `~/.local/bin`.
+If the anolisa CLI is already installed, start with `anolisa install
+tokenless`. The PATH line is needed only when a fresh installation reports
+that `~/.local/bin` is not available in the current Shell.
 
-## 3. Start using Tokenless
+Using another Agent? Follow the matching setup path in
+[Use another Agent](#use-another-agent); the remaining steps stay the same.
+Most Agents use an `anolisa adapter enable` command, while OpenCode uses its
+linked lifecycle script.
 
-### 3.1 Use Tokenless in your agent
+## 2. Run one real task
 
-Tokenless can work with:
-
-| Agent | Value used in commands |
-|-------|------------------------|
-| cosh / Copilot Shell | `cosh` |
-| OpenClaw | `openclaw` |
-| Hermes | `hermes` |
-| Qoder | `qoder` |
-| Claude Code | `claude-code` |
-| Codex | `codex` |
-| Qwen Code | `qwencode` |
-
-Find your agent and turn on Tokenless:
-
-```bash
-anolisa adapter scan
-anolisa adapter enable tokenless <agent>
-anolisa adapter status tokenless
-```
-
-Restart the agent CLI, IDE, or gateway after Tokenless is enabled.
-
-#### 3.1.1 Example: OpenClaw
-
-Turn on Tokenless and restart the OpenClaw gateway:
-
-```bash
-anolisa adapter enable tokenless openclaw
-anolisa adapter status tokenless
-```
-
-Then ask OpenClaw to perform a normal task:
+Restart Claude Code so it loads the adapter, then start a new session and run a
+tool-heavy task. For example:
 
 > Run the full test suite for this repository and summarize only the failures.
 
 You do not need to mention Tokenless in the prompt.
 
-If OpenClaw rejects the installation during its security check, follow [the OpenClaw instructions](framework-integration.md#openclaw) before retrying.
+## 3. Verify the saving
 
-### 3.2 Use the standalone CLI
-
-You can try response compression directly:
-
-```bash
-printf '%s\n' \
-  '{"status":"ok","data":{"name":"demo","items":[1,2,3]},"debug":{"trace":"verbose"},"metadata":null}' \
-  | tokenless compress-response
-```
-
-The command returns valid JSON with removable fields such as `debug` and `metadata` omitted.
-If the output is unchanged, the input has no compressible content; retry with JSON that contains `debug`, `null`, or a long string.
-
-## 4. View the result
-
-After using a Shell, API, or other supported tool in your agent, run:
+After Claude Code uses a Shell, API, or another supported tool, run:
 
 ```bash
 tokenless stats list --limit 5
 tokenless stats summary
 ```
 
-- `stats list` shows recent results that Tokenless made shorter. Copy a record ID from this list when you want to inspect one result.
-- `stats summary` shows the estimated tokens before and after Tokenless processing and the total saved.
+Example output (values vary by workload):
 
-For the OpenClaw example above, look for a record containing `openclaw` and confirm that its token count decreases from left to right.
+```text
+Showing 1 record(s):
+================================================================================
+[ID:42] 2026-08-12 10:20:30 | claude-code | Session:- | Tool:- | Chars:5120→2880(-2240) | Tokens:1280→720(-44%)
 
-To see what changed in one record:
+Tokenless Statistics Summary
+============================================================
+Total Records: 1
+
+Character Savings:
+  Before: 5120 chars
+  After:  2880 chars
+  Saved:  2240 chars (43.8%)
+
+Token Savings:
+  Before: 1280 tokens
+  After:  720 tokens
+  Saved:  560 tokens (43.8%)
+
+Breakdown by Operation:
+----------------------------------------
+  compress-response: 1 records
+    Chars: 5120 -> 2880 (-43.8%)
+    Tokens: 1280 -> 720 (-43.8%)
+```
+
+You are done when `stats list` contains a record whose estimated Token count
+decreases from before to after. To inspect exactly what changed, copy its ID:
 
 ```bash
 tokenless stats diff <record-id>
 ```
 
-If no record appears, the content may not have passed through Tokenless or may not have become shorter. See [No statistics appear after setup](troubleshooting.md#no-statistics-appear-after-enabling-the-adapter).
+For a visual view of savings over time, follow the
+[AgentSight guide](../../agent-observability/agentsight.md#token-savings-tokenless-integration).
+When Tokenless and AgentSight run as the same user, the Dashboard reads local
+Tokenless statistics without requiring SLS.
 
-Token counts are estimates for content processed by Tokenless, not a direct measurement of the model bill. Statistics and diffs may contain original tool content; avoid sharing their output when it contains sensitive data. See [Measuring savings](measuring-savings.md) and [Configuration and data privacy](configuration-and-privacy.md) for details.
+If no record appears, the content may not have passed through Tokenless or may
+not have become shorter. Check the adapter and component health:
 
-## 5. Platform support
+```bash
+anolisa adapter status tokenless
+anolisa doctor tokenless
+```
+
+Then see
+[No statistics appear after setup](troubleshooting.md#no-statistics-appear-after-enabling-the-adapter).
+
+Token counts are estimates for content processed by Tokenless, not a direct
+measurement of the model bill. Statistics and diffs may contain original tool
+content; avoid sharing their output when it contains sensitive data. See
+[Measuring savings](measuring-savings.md) and
+[Configuration and data privacy](configuration-and-privacy.md) for details.
+
+## Use another Agent
+
+Scan the machine, then enable only the Agent you use:
+
+```bash
+anolisa adapter scan
+```
+
+| Agent | Setup |
+|-------|-------|
+| cosh / Copilot Shell | `anolisa adapter enable tokenless cosh` |
+| OpenClaw | `anolisa adapter enable tokenless openclaw` |
+| Hermes | `anolisa adapter enable tokenless hermes` |
+| Qoder | `anolisa adapter enable tokenless qoder` |
+| Claude Code | `anolisa adapter enable tokenless claude-code` |
+| Codex | `anolisa adapter enable tokenless codex` |
+| OpenCode | Lifecycle script (see below) |
+| Qwen Code | `anolisa adapter enable tokenless qwencode` |
+
+Restart the Agent CLI or IDE after setting it up. OpenClaw also requires
+`openclaw gateway restart`; if its security check rejects the plugin, follow
+the [OpenClaw integration instructions](framework-integration.md#2-enable-one-adapter).
+OpenCode is not registered with `anolisa adapter enable` in this release; use
+the bundled lifecycle script described in the
+[OpenCode integration instructions](framework-integration.md#opencode).
+
+## Optional: test compression without an Agent
+
+Use this deterministic check when you want to confirm the standalone CLI
+before enabling an adapter:
+
+```bash
+printf '%s\n' \
+  '{"status":"ok","data":{"name":"demo","items":[1,2,3]},"debug":{"trace":"verbose"},"metadata":null}' \
+  | tokenless compress-response
+
+tokenless stats list --limit 1
+```
+
+The command returns valid JSON with `debug` and `metadata` omitted. Content
+without removable fields is returned unchanged and is not recorded.
+
+## Platform support
 
 | Platform | anolisa CLI installation |
 |----------|--------------------------|
@@ -121,12 +155,14 @@ Token counts are estimates for content processed by Tokenless, not a direct meas
 | macOS x86_64 | Not currently supported |
 | Windows or Linux with musl, such as Alpine | Not currently supported |
 
-This page covers installation with the anolisa CLI only. To build the standalone CLI from source, see [User manual · Build the standalone CLI from source](user-manual.md#build-the-standalone-cli-from-source).
+This page covers installation with the anolisa CLI only. To build the
+standalone CLI from source, see
+[User manual · Build the standalone CLI from source](user-manual.md#build-the-standalone-cli-from-source).
 
-## 6. Next steps
+## Next steps
 
+- [Framework integration](framework-integration.md): framework-specific activation and behavior
 - [User manual](user-manual.md): behavior boundaries and documentation map
-- [Framework integration](framework-integration.md): enable, verify, and disable each agent
 - [CLI reference](cli-reference.md): all subcommands and options
 - [Measuring savings](measuring-savings.md): statistics, dual runs, and AgentSight/SLS
 - [Configuration and data privacy](configuration-and-privacy.md): toggles, storage, and sensitive data

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -2,117 +2,145 @@
 
 [English](../../../en/token-saving/tokenless/QUICKSTART.md)
 
-## 1. Tokenless 能做什么
+大约三分钟内完成 Tokenless 安装、接入 Claude Code、运行一次真实任务，并确认一条
+压缩前后的 Token 记录。Tokenless 在后台工作，不需要改变 Prompt 或日常使用
+Agent 的方式。
 
-Tokenless 帮助 AI Agent 用更少的 Token 完成原来的工作。
+实际节省效果取决于工作负载。工具调用密集型任务通常最明显；较短或以对话为主的
+任务可能变化不大。
 
-开启后，你不需要改变 Prompt，也不需要改变使用 Agent 的方式，Tokenless 会在后台自动工作。
+## 1. 安装 Tokenless 并接入 Claude Code
 
-你可能会感受到：
-
-- 冗长的中间结果占用更少 Token。
-- 长任务可以为真正有用的信息留出更多空间。
-- Agent 在决定下一步时，面对的信息更加简洁。
-
-不同任务的节省效果不同。较短或以对话为主的任务可能变化不明显，请使用自己的工作负载按[查看效果](#4-查看效果)进行确认。
-
-## 2. 安装 Tokenless
-
-先安装 anolisa CLI，再用它安装 Tokenless：
+下面以 Claude Code 作为示例 Agent：
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
-anolisa --version
 anolisa install tokenless
-tokenless --version
+anolisa adapter enable tokenless claude-code
 ```
 
-如果 `anolisa --version` 能正常返回，可以直接从 `anolisa install tokenless`
-开始。上面的 PATH 设置会让默认安装目录在当前 Shell 中立即生效，新的登录 Shell
-可能已经包含 `~/.local/bin`。
+如果已经安装 anolisa CLI，可以直接从 `anolisa install tokenless` 开始。只有首次
+安装提示当前 Shell 找不到 `~/.local/bin` 时，才需要执行 PATH 设置。
 
-## 3. 开始使用 Tokenless
+使用其他 Agent？按照[使用其他 Agent](#使用其他-agent)中的对应接入方式操作，后续
+步骤保持不变。大多数 Agent 使用 `anolisa adapter enable` 命令，OpenCode 则使用
+链接指向的生命周期脚本。
 
-### 3.1 在 Agent 中使用
+## 2. 运行一次真实任务
 
-Tokenless 可以用于：
-
-| Agent | 命令中使用的值 |
-|-------|----------------|
-| cosh / Copilot Shell | `cosh` |
-| OpenClaw | `openclaw` |
-| Hermes | `hermes` |
-| Qoder | `qoder` |
-| Claude Code | `claude-code` |
-| Codex | `codex` |
-| Qwen Code | `qwencode` |
-
-先查找 Agent，再为它开启 Tokenless：
-
-```bash
-anolisa adapter scan
-anolisa adapter enable tokenless <agent>
-anolisa adapter status tokenless
-```
-
-开启 Tokenless 后，重启对应的 Agent CLI、IDE 或 Gateway。
-
-#### 3.1.1 示例：OpenClaw
-
-为 OpenClaw 开启 Tokenless，然后重启 OpenClaw Gateway：
-
-```bash
-anolisa adapter enable tokenless openclaw
-anolisa adapter status tokenless
-```
-
-接着让 OpenClaw 完成一个正常任务：
+重启 Claude Code，使其加载 Adapter，然后启动新的 Session，并运行一次工具密集型
+任务。例如：
 
 > 运行当前仓库的完整测试，只总结失败项。
 
 Prompt 中不需要提到 Tokenless。
 
-如果 OpenClaw 在安全检查时拒绝安装，请按照 [OpenClaw 说明](framework-integration.md#openclaw)确认后再重试。
+## 3. 查看节省效果
 
-### 3.2 单独使用 CLI
-
-可以直接体验一次响应压缩：
-
-```bash
-printf '%s\n' \
-  '{"status":"ok","data":{"name":"demo","items":[1,2,3]},"debug":{"trace":"verbose"},"metadata":null}' \
-  | tokenless compress-response
-```
-
-命令返回的仍是合法 JSON，其中 `debug`、`metadata` 等可移除字段会被省略。
-如果输出与输入完全相同，说明当前输入没有可压缩内容；请改用包含 `debug`、`null` 或长字符串的 JSON 重试。
-
-## 4. 查看效果
-
-在 Agent 中使用一次 Shell、API 或其他受支持的工具后，运行：
+Claude Code 使用一次 Shell、API 或其他受支持的工具后，运行：
 
 ```bash
 tokenless stats list --limit 5
 tokenless stats summary
 ```
 
-- `stats list` 显示最近被 Tokenless 变短的结果。需要查看某次结果时，从这里复制 record ID。
-- `stats summary` 显示 Tokenless 处理前后的 Token 估算值和总节省量。
+输出示例（实际数值因任务而异）：
 
-对于上面的 OpenClaw 示例，可以找到包含 `openclaw` 的记录，并确认其中的 Token 数从左到右变小。
+```text
+Showing 1 record(s):
+================================================================================
+[ID:42] 2026-08-12 10:20:30 | claude-code | Session:- | Tool:- | Chars:5120→2880(-2240) | Tokens:1280→720(-44%)
 
-查看某条记录具体改变了什么：
+Tokenless Statistics Summary
+============================================================
+Total Records: 1
+
+Character Savings:
+  Before: 5120 chars
+  After:  2880 chars
+  Saved:  2240 chars (43.8%)
+
+Token Savings:
+  Before: 1280 tokens
+  After:  720 tokens
+  Saved:  560 tokens (43.8%)
+
+Breakdown by Operation:
+----------------------------------------
+  compress-response: 1 records
+    Chars: 5120 -> 2880 (-43.8%)
+    Tokens: 1280 -> 720 (-43.8%)
+```
+
+当 `stats list` 中出现 Token 估算值从压缩前到压缩后下降的记录时，首次体验即完成。
+如需检查某条记录具体改变了什么，复制其 ID 后运行：
 
 ```bash
 tokenless stats diff <record-id>
 ```
 
-如果没有记录，可能是内容没有经过 Tokenless，或处理后没有变短。请参阅[开启后没有产生统计记录](troubleshooting.md#启用后没有产生统计记录)。
+需要查看一段时间内的可视化节省趋势时，前往
+[AgentSight 用户指南](../../agent-observability/agentsight.md#token-节省tokenless-集成)。
+Tokenless 与 AgentSight 由同一用户运行时，Dashboard 可以直接读取本地统计，不需要
+配置 SLS。
 
-Token 数只是在 Tokenless 已处理内容范围内的估算值，不等于模型账单的直接变化。统计和 diff 可能包含原始工具内容；涉及敏感数据时不要分享输出。完整说明见[效果度量](measuring-savings.md)和[配置与数据隐私](configuration-and-privacy.md)。
+如果没有记录，可能是内容没有经过 Tokenless，或处理后没有变短。先检查 Adapter
+和组件健康状态：
 
-## 5. 平台适配性
+```bash
+anolisa adapter status tokenless
+anolisa doctor tokenless
+```
+
+再参阅[开启后没有产生统计记录](troubleshooting.md#启用后没有产生统计记录)。
+
+Token 数只是在 Tokenless 已处理内容范围内的估算值，不等于模型账单的直接变化。
+统计和 diff 可能包含原始工具内容；涉及敏感数据时不要分享输出。完整说明见
+[效果度量](measuring-savings.md)和
+[配置与数据隐私](configuration-and-privacy.md)。
+
+## 使用其他 Agent
+
+扫描当前机器，然后只启用正在使用的 Agent：
+
+```bash
+anolisa adapter scan
+```
+
+| Agent | 接入方式 |
+|-------|----------|
+| cosh / Copilot Shell | `anolisa adapter enable tokenless cosh` |
+| OpenClaw | `anolisa adapter enable tokenless openclaw` |
+| Hermes | `anolisa adapter enable tokenless hermes` |
+| Qoder | `anolisa adapter enable tokenless qoder` |
+| Claude Code | `anolisa adapter enable tokenless claude-code` |
+| Codex | `anolisa adapter enable tokenless codex` |
+| OpenCode | 生命周期脚本（见下文） |
+| Qwen Code | `anolisa adapter enable tokenless qwencode` |
+
+接入后重启对应的 Agent CLI 或 IDE。OpenClaw 还需要运行
+`openclaw gateway restart`；如果安全检查拒绝 Plugin，请按照
+[OpenClaw 接入说明](framework-integration.md#2-启用一个-adapter)处理。本版本尚未将
+OpenCode 注册到 `anolisa adapter enable`；请使用
+[OpenCode 接入说明](framework-integration.md#opencode)中的随附生命周期脚本。
+
+## 可选：不接入 Agent 测试压缩
+
+需要在启用 Adapter 前单独确认 CLI 时，运行下面这组结果确定的检查：
+
+```bash
+printf '%s\n' \
+  '{"status":"ok","data":{"name":"demo","items":[1,2,3]},"debug":{"trace":"verbose"},"metadata":null}' \
+  | tokenless compress-response
+
+tokenless stats list --limit 1
+```
+
+命令返回的仍是合法 JSON，其中 `debug` 和 `metadata` 会被省略。不包含可移除字段的
+内容会原样返回且不记录。
+
+## 平台适配性
 
 | 平台 | anolisa CLI 安装 |
 |------|------------------|
@@ -121,12 +149,13 @@ Token 数只是在 Tokenless 已处理内容范围内的估算值，不等于模
 | macOS x86_64 | 暂不支持 |
 | Windows 或使用 musl 的 Linux（例如 Alpine） | 暂不支持 |
 
-本页只提供 anolisa CLI 的安装路径。需要从源码构建独立 CLI 时，请参阅[用户手册 · 从源码构建独立 CLI](user-manual.md#从源码构建独立-cli)。
+本页只提供 anolisa CLI 安装路径。需要从源码构建独立 CLI 时，请参阅
+[用户手册 · 从源码构建独立 CLI](user-manual.md#从源码构建独立-cli)。
 
-## 6. 下一步
+## 下一步
 
+- [框架接入](framework-integration.md)：各框架的激活方法和实际行为
 - [用户手册](user-manual.md)：能力边界和文档导航
-- [框架集成](framework-integration.md)：各 Agent 的启用、验证与禁用
 - [CLI 参考](cli-reference.md)：全部子命令和参数
 - [效果度量](measuring-savings.md)：统计、双跑对比和 AgentSight/SLS
 - [配置与数据隐私](configuration-and-privacy.md)：开关、存储和敏感数据

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -190,7 +190,17 @@ Plugin 在新的 Codex 会话中加载。关闭旧会话并重新启动后验证
 
 ### OpenCode
 
-OpenCode 会在启动时发现全局 Local Plugin。使用上文说明的 Tokenless 生命周期脚本安装或移除后应重启 OpenCode，再执行一次工具调用并检查 `tokenless stats list`。脚本依次从 `TOKENLESS_OPENCODE_CONFIG_DIR`、`OPENCODE_CONFIG_DIR`、`XDG_CONFIG_HOME/opencode`、`~/.config/opencode` 解析配置目录。安装只会创建托管的 `plugins/tokenless.js` 符号链接，若该路径已有无关文件则拒绝覆盖。
+OpenCode 启动时会自动加载配置目录下的 Plugin。使用上述 Tokenless 生命周期脚本
+完成安装或卸载后，请重启 OpenCode。重启后执行一次工具调用，再运行
+`tokenless stats list`，确认已生成统计记录。
+
+脚本会优先使用 `TOKENLESS_OPENCODE_CONFIG_DIR`，其次使用
+`OPENCODE_CONFIG_DIR`。如果两者均未设置，则使用
+`${XDG_CONFIG_HOME}/opencode`；如果 `XDG_CONFIG_HOME` 也未设置，则回退到
+`~/.config/opencode`。
+
+安装过程中，脚本只会创建由 Tokenless 管理的 `plugins/tokenless.js` 符号链接。
+如果目标路径已经存在但不由 Tokenless 管理，安装会停止，原有内容不会被覆盖。
 
 ### Qwen Code
 

--- a/website/agent-index/overrides.json
+++ b/website/agent-index/overrides.json
@@ -12,17 +12,17 @@
       "install_name": "sec-core"
     },
     "tokenless": {
-      "install": "npm install -g anolisa-tokenless",
-      "install_method": "npm",
+      "install": "anolisa install tokenless",
+      "install_method": "cli",
       "install_variants": [
         {
           "method": "cli",
-          "preferred": false,
+          "preferred": true,
           "command": "anolisa install tokenless",
           "platforms": [
             {
               "os": "linux",
-              "architectures": ["x86_64"]
+              "architectures": ["x86_64", "aarch64"]
             },
             {
               "os": "macos",
@@ -39,29 +39,6 @@
             "anolisa --json adapter scan",
             "anolisa --json status tokenless",
             "anolisa --json doctor tokenless"
-          ]
-        },
-        {
-          "method": "npm",
-          "preferred": true,
-          "command": "npm install -g anolisa-tokenless",
-          "platforms": [
-            {
-              "os": "linux",
-              "architectures": ["x86_64", "aarch64"]
-            },
-            {
-              "os": "macos",
-              "architectures": ["x86_64", "aarch64"]
-            }
-          ],
-          "requires": ["node", "npm"],
-          "preflight": [
-            "command -v node",
-            "command -v npm"
-          ],
-          "verify": [
-            "tokenless env-check --all"
           ]
         }
       ]

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1004,6 +1004,52 @@ html:has(.homePage) .footer {
   line-height: 1.6;
 }
 
+.productQuickPath {
+  margin-bottom: 64px;
+}
+
+.productQuickPath > div:first-child {
+  max-width: 720px;
+  margin-bottom: 24px;
+}
+
+.productQuickPath h2 {
+  margin: 0 0 10px;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  letter-spacing: -0.045em;
+}
+
+.productQuickPath > div:first-child p,
+.productQuickSteps p {
+  margin: 0;
+  color: var(--site-muted);
+  line-height: 1.6;
+}
+
+.productQuickSteps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--site-line);
+  border-left: 1px solid var(--site-line);
+}
+
+.productQuickSteps article {
+  padding: 22px;
+  border-right: 1px solid var(--site-line);
+  border-bottom: 1px solid var(--site-line);
+}
+
+.productQuickSteps strong {
+  color: var(--ifm-color-primary);
+  font: 600 0.72rem var(--ifm-font-family-monospace);
+  letter-spacing: 0.08em;
+}
+
+.productQuickSteps p {
+  margin-top: 10px;
+  font-size: 0.88rem;
+}
+
 .codeExample {
   margin: 64px 0 32px;
 }
@@ -1467,6 +1513,10 @@ html[lang='zh-CN'] .agentEntryHero h1 {
 
   .featureList article {
     grid-template-columns: 42px 1fr;
+  }
+
+  .productQuickSteps {
+    grid-template-columns: 1fr;
   }
 
   .changelogNav {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -19,6 +19,8 @@ const content = {
     agentLabel: 'Bring your Agent in',
     agentPrompt:
       'Read https://agentic-os.sh/agents/ to learn how to use ANOLISA, then help me install it for this environment.',
+    startTokenless: 'Start saving with Tokenless',
+    exploreAnolisa: 'Explore ANOLISA',
     copy: 'Copy',
     copied: 'Copied',
     surfaceLabel: 'ANOLISA system surface',
@@ -42,6 +44,8 @@ const content = {
     agentLabel: '让你的 Agent 接入',
     agentPrompt:
       '阅读 https://agentic-os.sh/agents/，了解如何使用 ANOLISA，并根据当前环境帮我完成安装。',
+    startTokenless: '开始使用 Tokenless',
+    exploreAnolisa: '了解 ANOLISA',
     copy: '复制',
     copied: '已复制',
     surfaceLabel: 'ANOLISA 系统能力视图',
@@ -332,6 +336,18 @@ export default function Home() {
                 <p>{t.systemScope}</p>
               </div>
               <p className="heroStatement">{t.statement}</p>
+
+              <div className="buttonRow">
+                <SiteLink
+                  locale={locale}
+                  to="/docs/user-guide/token-saving/tokenless/quickstart"
+                  className="primaryButton">
+                  {t.startTokenless} →
+                </SiteLink>
+                <SiteLink locale={locale} to="/docs/quickstart" className="secondaryButton">
+                  {t.exploreAnolisa}
+                </SiteLink>
+              </div>
 
               <div className="heroCommand">
                 <p>{t.installLabel}</p>

--- a/website/src/pages/products/tokenless.tsx
+++ b/website/src/pages/products/tokenless.tsx
@@ -12,6 +12,15 @@ const copy = {
     intro:
       'Tokenless compresses tool schemas and responses before they enter model context. Its reversible stash lets an agent retrieve dropped payloads by marker when full fidelity is needed.',
     copy: 'Copy', copied: 'Copied', docs: 'Read the Tokenless guide',
+    start: 'Start the 3-minute Quick Start',
+    quickTitle: 'Get your first verified saving',
+    quickIntro:
+      'Install Tokenless, connect one Agent adapter, then confirm a before/after record.',
+    quickSteps: [
+      ['01 · INSTALL', 'Install the published Tokenless component with the ANOLISA CLI.'],
+      ['02 · CONNECT', 'Scan your machine and enable Tokenless for the Agent you use.'],
+      ['03 · VERIFY', 'Run one tool-heavy task, then check tokenless stats list and tokenless stats summary.'],
+    ],
   },
   zh: {
     eyebrow: '产品 / 上下文效率',
@@ -19,6 +28,14 @@ const copy = {
     intro:
       'Tokenless 在工具 Schema 和响应进入模型上下文前完成压缩；需要完整信息时，Agent 可通过标记从可逆 Stash 中取回原始 Payload。',
     copy: '复制', copied: '已复制', docs: '阅读 Tokenless 指南',
+    start: '开始三分钟快速体验',
+    quickTitle: '完成第一次可验证的节省',
+    quickIntro: '安装 Tokenless，接入一个 Agent Adapter，然后确认一条压缩前后的记录。',
+    quickSteps: [
+      ['01 · 安装', '通过 ANOLISA CLI 安装已发布的 Tokenless 组件。'],
+      ['02 · 接入', '扫描当前机器，并为正在使用的 Agent 启用 Tokenless。'],
+      ['03 · 验证', '运行一次工具密集型任务，再查看 tokenless stats list 和 tokenless stats summary。'],
+    ],
   },
 } as const;
 
@@ -49,9 +66,11 @@ export default function TokenlessProduct() {
   const t = copy[locale];
   const component = repoIndex.components.find((item) => item.id === 'tokenless');
   const version = component?.version;
-  const platforms = component?.platform_support.macos
-    ? `Linux · macOS (${component.platform_support.architectures.join(' / ')})`
-    : 'Linux';
+  const installVariants = component?.install_variants ?? [];
+  const preferredInstall = installVariants.find((variant) => variant.preferred);
+  const platforms = preferredInstall
+    ? formatInstallTargets(preferredInstall.platforms as InstallTarget[])
+    : 'Unavailable';
   const features = locale === 'zh'
     ? [
         ['Schema 压缩', '减少 Function Calling 工具定义中的结构与描述开销。'],
@@ -79,7 +98,7 @@ export default function TokenlessProduct() {
             <h1>{t.title}</h1>
             <p className="productIntro">{t.intro}</p>
             <div className="installVariants">
-              {component?.install_variants.map((variant) => (
+              {installVariants.map((variant) => (
                 <div className="installVariant" key={`${variant.method}:${variant.command}`}>
                   <div className="installVariantHeader">
                     <strong>{variant.method === 'cli' ? 'ANOLISA CLI' : variant.method}</strong>
@@ -93,9 +112,31 @@ export default function TokenlessProduct() {
                 </div>
               ))}
             </div>
+            <div className="buttonRow">
+              <SiteLink
+                locale={locale}
+                to="/docs/user-guide/token-saving/tokenless/quickstart"
+                className="primaryButton">
+                {t.start} →
+              </SiteLink>
+            </div>
           </div>
         </header>
         <section className="section siteContainer narrowContainer">
+          <div className="productQuickPath">
+            <div>
+              <h2>{t.quickTitle}</h2>
+              <p>{t.quickIntro}</p>
+            </div>
+            <div className="productQuickSteps">
+              {t.quickSteps.map(([title, body]) => (
+                <article key={title}>
+                  <strong>{title}</strong>
+                  <p>{body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
           <div className="factStrip">
             <div><span>PLATFORM</span><strong>{platforms}</strong></div>
             <div><span>CLI VERSION</span><strong>{version ? `v${version}` : 'unversioned'}</strong></div>
@@ -121,7 +162,10 @@ cat response.json | tokenless compress-response
 # 按标记取回被截断的内容
 tokenless retrieve <HASH>
 
-# 查看节省统计
+# 查看压缩前后记录
+tokenless stats list --limit 5
+
+# 查看汇总节省效果
 tokenless stats summary
 
 # 检查工具运行环境
@@ -135,13 +179,16 @@ cat response.json | tokenless compress-response
 # Recover stashed content by marker
 tokenless retrieve <HASH>
 
-# Review savings
+# Inspect before/after records
+tokenless stats list --limit 5
+
+# Review aggregate savings
 tokenless stats summary
 
 # Check tool environments
 tokenless env-check --all`}</code></pre>
           </div>
-          <SiteLink locale={locale} to="/docs/user-guide/token-saving/tokenless/quickstart" className="primaryButton">
+          <SiteLink locale={locale} to="/docs/user-guide/token-saving/tokenless/user-manual" className="primaryButton">
             {t.docs}
           </SiteLink>
         </section>


### PR DESCRIPTION
## Why

The Tokenless demo shows the result, but the README and website do not give
viewers a direct path to reproduce it. The existing quickstart is also closer
to a command catalog than a short first-success journey.

## What changed

- Route README and homepage CTAs directly to the Tokenless quickstart.
- Reshape the bilingual quickstarts around install, connect, and verify.
- Add a three-step path to the Tokenless product page with copyable commands.
- Remove the unpublished npm route and derive platform labels from the
  preferred install variant.

Fork Pages preview:
https://kongche-jbw.github.io/anolisa/

## Related issue

no-issue: documentation onboarding improvement

## User / Agent impact

New users can move from the demo to a verified Tokenless run without searching
across the documentation. Existing commands and product behavior are unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This changes documentation and website navigation only; the commands
are existing supported interfaces.

## Validation

- `bash scripts/docs-lint.sh`
- `cd website && npm run typecheck`
- `cd website && npm run build`
- `cd website && npm run check:links`
- Fork Pages build and deployment:
  https://github.com/kongche-jbw/anolisa/actions/runs/31457910274
- Manual desktop and 390x844 mobile checks for the homepage and Tokenless page

## Documentation and rollback

Updated the root README files, cross-component quickstarts, Tokenless
quickstarts, homepage, and product page. Roll back by reverting the single
documentation commit.
