### PR TITLE
fix(tokenless): keep retrieve stdout byte-exact

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -693,7 +693,17 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             };
             match store.retrieve(&key) {
                 Ok(Some(payload)) => {
-                    println!("{}", payload);
+                    // Byte-exact restore: do not append a trailing newline.
+                    // `println!` would break end-to-end lossless retrieve for
+                    // payloads that do not already end with `\n` (and would
+                    // diverge from MCP `tokenless_retrieve`, which returns the
+                    // stored string unchanged).
+                    use std::io::Write;
+                    let mut out = io::stdout().lock();
+                    out.write_all(payload.as_bytes())
+                        .map_err(|e| (format!("failed to write retrieved payload: {e}"), 1))?;
+                    out.flush()
+                        .map_err(|e| (format!("failed to flush retrieved payload: {e}"), 1))?;
                 }
                 Ok(None) => {
                     return Err((format!("no stashed payload for hash: {}", key), 1));

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -4,7 +4,7 @@ mod mcp;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
-use std::io::{self, IsTerminal as _, Read};
+use std::io::{self, IsTerminal as _, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
@@ -698,7 +698,6 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     // payloads that do not already end with `\n` (and would
                     // diverge from MCP `tokenless_retrieve`, which returns the
                     // stored string unchanged).
-                    use std::io::Write;
                     let mut out = io::stdout().lock();
                     out.write_all(payload.as_bytes())
                         .map_err(|e| (format!("failed to write retrieved payload: {e}"), 1))?;
@@ -831,7 +830,6 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     let recorder = open_recorder()?;
                     if !yes {
                         print!("Are you sure you want to clear all statistics? [y/N] ");
-                        use std::io::Write;
                         let _ = io::stdout().flush();
                         let mut input = String::new();
                         if io::stdin().read_line(&mut input).unwrap_or(0) == 0 {

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -406,6 +406,72 @@ fn retrieve_invalid_hash() {
 }
 
 #[test]
+fn retrieve_stdout_is_byte_exact_without_extra_trailing_newline() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let stash_db = fixture.data_dir.join("stash.db");
+    // Long string forces reversible truncation + stash. The stored payload is
+    // this string value (not the whole JSON document) and has no trailing `\n`.
+    let stashed_string = format!("HELLO_RETRIEVE_EXACT_{}", "X".repeat(200));
+    let original = format!("{{\"s\":\"{stashed_string}\"}}");
+
+    let compressed = fixture
+        .command()
+        .env("TOKENLESS_STATS_ENABLED", "0")
+        .args([
+            "compress-response",
+            "--truncate-strings-at",
+            "80",
+            "--stash-db",
+        ])
+        .arg(&stash_db)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(original.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        compressed.status.success(),
+        "compress-response failed: {}",
+        String::from_utf8_lossy(&compressed.stderr)
+    );
+    let compressed_text = String::from_utf8_lossy(&compressed.stdout);
+    let marker_start = compressed_text
+        .find("<<tokenless:")
+        .expect("compressed output should contain a stash marker");
+    let marker_end = compressed_text[marker_start..]
+        .find(">>")
+        .map(|i| marker_start + i + 2)
+        .expect("stash marker should be closed");
+    let marker = &compressed_text[marker_start..marker_end];
+
+    let retrieved = fixture
+        .command()
+        .args(["retrieve", marker, "--stash-db"])
+        .arg(&stash_db)
+        .output()
+        .unwrap();
+    assert!(
+        retrieved.status.success(),
+        "retrieve failed: {}",
+        String::from_utf8_lossy(&retrieved.stderr)
+    );
+    assert_eq!(
+        retrieved.stdout.as_slice(),
+        stashed_string.as_bytes(),
+        "retrieve must restore the stashed payload byte-for-byte; \
+         an extra trailing newline breaks end-to-end lossless recovery"
+    );
+}
+
+#[test]
 fn no_args_shows_error() {
     let output = tokenless_bin().output().unwrap();
     assert!(!output.status.success());

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -419,6 +419,10 @@ fn retrieve_stdout_is_byte_exact_without_extra_trailing_newline() {
 
     let compressed = fixture
         .command()
+        // Force compression on so a caller/home config with
+        // TOKENLESS_COMPRESSION_ENABLED=0 (or compression_enabled:false)
+        // cannot dry-run this subprocess and skip the stash marker.
+        .env("TOKENLESS_COMPRESSION_ENABLED", "1")
         .env("TOKENLESS_STATS_ENABLED", "0")
         .args([
             "compress-response",


### PR DESCRIPTION
## Why

`tokenless retrieve` 用 `println!` 输出 stash payload，导致 stdout 总是多一个尾部 `\n`。对本身不以换行结尾的截断字符串（常见可逆压缩场景），CLI 取回结果不再等于数据库原文，破坏文档中的 end-to-end lossless，并与 MCP `tokenless_retrieve`（原样返回）不一致。

## What changed

- `Commands::Retrieve` 改为 `write_all` + `flush`，按字节写出 payload，不再追加换行。
- `Write` 提到文件顶部 `std::io` import（review follow-up）。
- 新增集成测试 `retrieve_stdout_is_byte_exact_without_extra_trailing_newline`：compress→retrieve 后断言 stdout 与 stash 字符串值字节相等；子进程强制 `TOKENLESS_COMPRESSION_ENABLED=1`，避免 home/env dry-run 配置跳过 stash（Codex P2）。

## Related issue

fixes #2395

## User / Agent impact

`tokenless retrieve` 现在按字节恢复 stash 原文。依赖精确取回做解析/比对的 agent 与脚本不再被多余换行干扰。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

CLI stdout 去掉额外 `\n`，对齐已文档化的 lossless 契约。若有调用方错误依赖“retrieve 总以换行结尾”，需要自行 `rstrip`/`echo`；正确按原文消费的路径不受影响。MCP 行为不变。

## Validation

```bash
cd src/tokenless
cargo fmt --all --check
cargo clippy --workspace --locked -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test -p tokenless-cli --test cli_integration \
  retrieve_stdout_is_byte_exact --locked -- --test-threads=1
# isolation check (parent dry-run must not break the forced-on child):
TOKENLESS_COMPRESSION_ENABLED=0 cargo test -p tokenless-cli --test cli_integration \
  retrieve_stdout_is_byte_exact --locked -- --test-threads=1
```

环境：Linux。修复前复现：`db_len=221 cli_len=222 exact_match=False`；修复后 `cli_len` 与 db 一致且 `exact_match=True`。

## Documentation and rollback

无需改文档（README / stash 文档已承诺无损）。回滚本 PR 即可恢复旧的 `println!` 行为。
