### PR TITLE
fix(tokenless): remove extra trailing newline from retrieve output

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -820,7 +820,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             };
             match store.retrieve(&key) {
                 Ok(Some(payload)) => {
-                    println!("{}", payload);
+                    print!("{}", payload);
                 }
                 Ok(None) => {
                     return Err((format!("no stashed payload for hash: {}", key), 1));


### PR DESCRIPTION
## Summary

- `tokenless retrieve` used `println!("{}", payload)` which always appends `\n`, breaking byte-exact lossless retrieval when the stashed payload does not end with a newline.
- Changed to `print!("{}", payload)` so stdout matches the stored payload exactly.
- Consistent with the MCP `tokenless_retrieve` path and the documented end-to-end lossless guarantee.

## Related Issue

closes #2395

## Risk and Compatibility

No API or behavioral contract change for callers that already trim output. Only affects callers relying on exact byte-level output (JSON parse, hash comparison).

## Validation

- `cargo test -p tokenless-cli` — all 215 unit tests + 25 integration tests pass.
- Manually verified: retrieve output length now matches DB payload length exactly.

## Documentation and Rollback

No documentation changes needed. Revert the single-line change to restore prior behavior.