### PR TITLE
fix(tokenless): drop trailing newline in retrieve

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -820,7 +820,15 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             };
             match store.retrieve(&key) {
                 Ok(Some(payload)) => {
-                    println!("{}", payload);
+                    // Verbatim write — no trailing newline, to stay byte-identical to the stashed original.
+                    use std::io::Write;
+                    let mut stdout = io::stdout().lock();
+                    stdout
+                        .write_all(payload.as_bytes())
+                        .map_err(|e| (format!("failed to write payload to stdout: {}", e), 1))?;
+                    stdout
+                        .flush()
+                        .map_err(|e| (format!("failed to flush stdout: {}", e), 1))?;
                 }
                 Ok(None) => {
                     return Err((format!("no stashed payload for hash: {}", key), 1));

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -326,6 +326,67 @@ fn retrieve_invalid_hash() {
 }
 
 #[test]
+fn retrieve_stdout_is_byte_identical_to_stashed_payload() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let stash_db = fixture.root.join("retrieve-exact.db");
+    // Payload deliberately does NOT end with '\n' so a trailing newline is detectable.
+    let long_value = "HELLO_UNIQUE_".to_string() + &"X".repeat(200);
+    let input = serde_json::json!({"s": long_value.clone()}).to_string();
+
+    let compress = fixture
+        .command()
+        .args([
+            "compress-response",
+            "--truncate-strings-at",
+            "80",
+            "--stash-db",
+            stash_db.to_str().unwrap(),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        compress.status.success(),
+        "compress-response failed: {}",
+        String::from_utf8_lossy(&compress.stderr)
+    );
+
+    let compressed = String::from_utf8_lossy(&compress.stdout);
+    let start = compressed
+        .find("<<tokenless:")
+        .expect("compressed output should contain a stash marker");
+    let end = compressed[start..].find(">>").expect("marker end") + start + 2;
+    let marker = &compressed[start..end];
+
+    let retrieve = fixture
+        .command()
+        .args(["retrieve", marker, "--stash-db", stash_db.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        retrieve.status.success(),
+        "retrieve failed: {}",
+        String::from_utf8_lossy(&retrieve.stderr)
+    );
+    // stdout must equal the stashed payload byte-for-byte — no appended newline.
+    assert_eq!(
+        retrieve.stdout,
+        long_value.as_bytes(),
+        "retrieve stdout should be byte-identical to the stashed payload"
+    );
+}
+
+#[test]
 fn no_args_shows_error() {
     let output = tokenless_bin().output().unwrap();
     assert!(!output.status.success());


### PR DESCRIPTION
## Summary

`tokenless retrieve` wrote the stashed payload with `println!`, which always appends a trailing `\n`. When the payload itself did not end in a newline (the common case for truncated JSON string values), CLI stdout was no longer byte-identical to the stash content — breaking the end-to-end lossless contract and diverging from the MCP `tokenless_retrieve` path (which returns the payload unchanged).

The `Retrieve` branch now writes the payload verbatim via `stdout.write_all` + `flush`, so output is byte-for-byte equal to the stashed original.

## Risk and compatibility

- Behavior change: `retrieve` stdout no longer ends with an extra `\n`. Consumers that relied on the trailing newline (e.g. shell `read` loops expecting line-terminated output) need to handle payloads that may or may not end in a newline. This aligns CLI behavior with the documented lossless contract and the MCP path.
- No change to the stash DB schema, marker format, or compression logic.

## Validation

- `cargo build -p tokenless-cli`
- `cargo test -p tokenless-cli` (215 unit + 26 integration tests, including new `retrieve_stdout_is_byte_identical_to_stashed_payload`)
- `cargo fmt --all -- --check`
- `cargo clippy -p tokenless-cli --all-targets -- -D warnings`

The new integration test compresses a non-newline-terminated string via `compress-response`, retrieves its marker, and asserts `stdout == original_payload` byte-for-byte (which fails against the old `println!` code).

Closes #2395