### PR TITLE
fix(tokenless): avoid direct-schema double stash

### DIFF
--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -133,28 +133,17 @@ impl SchemaCompressor {
                 self.compress_json_schema(params, 1);
             }
         } else {
-            // Direct schema (no function wrapper)
-            // Compress top-level description
-            if let Some(desc) = result.get("description").and_then(|d| d.as_str()) {
-                let compressed = self.truncate_description(desc, self.func_desc_max_len);
-                result["description"] = Value::String(compressed);
-            }
-
-            // Optionally remove title
-            #[allow(clippy::collapsible_if)]
-            if self.drop_titles {
-                if let Some(obj) = result.as_object_mut() {
-                    obj.remove("title");
+            // Direct schema (no function wrapper). Let compress_json_schema
+            // handle description, title removal, and nested properties at
+            // depth 0 — doing it here first would stash description as K1,
+            // then compress_json_schema would stash the marker string as K2,
+            // requiring two retrieves to recover the original.
+            if result.is_object() {
+                // Compress parameters if present (not a JSON Schema keyword;
+                // compress_json_schema does not recurse into it).
+                if let Some(params) = result.get_mut("parameters") {
+                    self.compress_json_schema(params, 1);
                 }
-            }
-
-            // Compress parameters if present
-            if let Some(params) = result.get_mut("parameters") {
-                self.compress_json_schema(params, 1);
-            }
-
-            // If this looks like a JSON Schema itself, compress it recursively
-            if result.get("type").is_some() || result.get("properties").is_some() {
                 self.compress_json_schema(&mut result, 0);
             }
         }

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -472,6 +472,49 @@ fn test_description_truncation_with_stash() {
 }
 
 #[test]
+fn direct_schema_stash_single_retrieve() {
+    // Regression test: direct schema with description > func_desc_max_len must
+    // stash exactly once. The retrieved value must be the verbatim original —
+    // no nested <<tokenless:K1>> markers.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+
+    let original_desc = format!("DIRECTORIG_{}", "a".repeat(280));
+    let schema = json!({
+        "type": "object",
+        "description": original_desc,
+        "properties": {
+            "p": {"description": "b".repeat(180)}
+        }
+    });
+
+    let result = compressor.compress(&schema);
+    let desc = result["description"].as_str().unwrap();
+
+    // Output marker must be present and fit within the limit.
+    assert!(desc.contains("tokenless:"), "expected a stash marker in output");
+    assert!(desc.chars().count() <= 100);
+
+    // Retrieve the single stash key — must yield the verbatim original with
+    // no nested markers.
+    let key = extract_hash(desc).expect("marker must carry a valid hash");
+    let retrieved = store.retrieve(key).unwrap().expect("stash entry must exist");
+    assert_eq!(
+        retrieved, original_desc,
+        "retrieved value must equal the original description verbatim"
+    );
+    assert!(
+        !retrieved.contains("tokenless:"),
+        "retrieved value must not contain nested stash markers"
+    );
+}
+
+#[test]
 fn test_compress_parameters_with_nested_schema() {
     let compressor = SchemaCompressor::new();
     let schema = json!({


### PR DESCRIPTION
## Description

In `schema_compressor.rs`, the direct-schema `else` branch called
`truncate_description` on the top-level description before calling
`compress_json_schema(&mut result, 0)`. When the description exceeded
`func_desc_max_len` and a stash store was attached, this caused:

1. `truncate_description` stashes the original as **K1**, sets
   `result["description"]` = `"<truncated> <<tokenless:K1>>"`.
2. `compress_json_schema` at depth 0 processes `result["description"]`
   again — stashes the K1-marker string as **K2**.

Calling `retrieve(K2)` returned `"<truncated> <<tokenless:K1>>"` — a
string still containing a nested marker — violating the "retrieve yields
the verbatim original" contract and forcing a second retrieve.

## Fix

Remove the early `truncate_description` call from the direct-schema
path and let `compress_json_schema` at depth 0 handle description
exclusively (already the case for the function-wrapper path). The
`compress_json_schema` depth-0 branch already uses `func_desc_max_len`,
so behaviour for schemas within the limit is unchanged.

## Changes

- `src/tokenless/crates/tokenless-schema/src/schema_compressor.rs`:
  remove redundant early truncation; simplify else-branch to call
  `compress_json_schema` unconditionally for object schemas.
- `src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs`:
  add `direct_schema_stash_single_retrieve` regression test.

## Validation

```
cd src/tokenless
cargo fmt --all -- --check   # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p tokenless-schema   # 54 unit + 26 integration, all pass
```

Closes #2363