### PR TITLE
fix(tokenless): anchor rtk prefix in Hermes and OpenClaw adapters

### DIFF
--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -582,3 +583,59 @@ def parse_version(version_str: str) -> tuple | None:
     if m:
         return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
     return None
+
+
+# -- RTK command anchoring ----------------------------------------------------
+#
+# Shell connectives that terminate a command-list / pipeline segment.
+# A bare `rtk` wrapper can appear at command start or right after one.
+_RTK_SEGMENT_OPS: frozenset[str] = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _is_rtk_env_assignment(token: str) -> bool:
+    """Return True for a leading shell variable assignment (NAME=value)."""
+    name, sep, _ = token.partition("=")
+    if not sep or not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def anchor_rtk_prefix(rewritten: str, rtk_bin: str) -> str:
+    """Replace bare ``rtk`` wrapper tokens with the resolved binary path.
+
+    rtk prints rewrites with a literal ``rtk`` prefix, which only resolves
+    when the shell executing the tool call has the rtk location on its
+    PATH. Agent runtimes with a trimmed PATH (e.g. IDE tool environments
+    without ``~/.local/bin``) would fail every rewritten command with exit
+    127 even though the hook resolved rtk successfully. Anchoring makes
+    the rewritten command self-contained.
+
+    The pass swaps the first unquoted ``rtk`` token of each segment — at
+    command start or right after ``&&`` / ``||`` / ``;`` / ``|`` / ``&``,
+    optionally behind leading environment assignments or wrappers such
+    as ``sudo``. Unparseable input is returned untouched.
+    """
+    lexer = shlex.shlex(rewritten, posix=False)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return rewritten
+
+    quoted = shlex.quote(rtk_bin)
+    result = list(tokens)
+    wrapped = False
+    for i, token in enumerate(tokens):
+        if token in _RTK_SEGMENT_OPS:
+            wrapped = False
+            continue
+        if _is_rtk_env_assignment(token):
+            continue
+        if not wrapped and token == "rtk":
+            result[i] = quoted
+            wrapped = True
+
+    return " ".join(result)

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -14,7 +14,6 @@ FHS spec: /usr/libexec/anolisa/tokenless/rtk.
 
 import json
 import os
-import shlex
 import subprocess
 import sys
 
@@ -27,6 +26,7 @@ from hook_utils import (
     _TOKENLESS_FALLBACK,
     _TOKENLESS_LOCAL_LIB,
     _TOKENLESS_LOCAL_SHARE,
+    anchor_rtk_prefix,
     forward_stderr,
     parse_version,
     resolve_agent_id,
@@ -41,73 +41,6 @@ from hook_utils import (
 
 _MIN_RTK_VERSION = (0, 35, 0)
 _AGENT_ID = resolve_agent_id()
-
-# Shell connectives that terminate a command-list / pipeline segment.
-# A bare `rtk` wrapper can appear at command start or right after one.
-_SEGMENT_OPS = frozenset({"&&", "||", ";", "|", "&"})
-
-
-def _is_env_assignment(token: str) -> bool:
-    """Return True for a leading shell variable assignment (NAME=value)."""
-    name, sep, _ = token.partition("=")
-    if not sep or not name:
-        return False
-    if not (name[0].isalpha() or name[0] == "_"):
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
-
-
-def _anchor_rtk_prefix(rewritten: str, rtk_bin: str) -> str:
-    """Replace bare `rtk` wrapper tokens with the resolved binary path.
-
-    rtk prints rewrites with a literal `rtk` prefix, which only resolves
-    when the shell executing the tool call has the rtk location on its
-    PATH. Agent runtimes with a trimmed PATH (e.g. IDE tool environments
-    without ~/.local/bin) would fail every rewritten command with exit
-    127 even though the hook resolved rtk successfully. Anchoring makes
-    the rewritten command self-contained.
-
-    The pass swaps the first unquoted `rtk` token of each segment — at
-    command start or right after `&&` / `||` / `;` / `|` / `&`,
-    optionally behind leading environment assignments or wrappers such
-    as `sudo`. It lexes with `posix=False` and no punctuation splitting,
-    so every token keeps its original surface: quoted patterns like
-    `grep -E 'foo|rtk bar'` are never modified, unquoted globs like
-    `*.txt` are not re-quoted into literals, fd redirections (`2>&1`,
-    `2>/dev/null`) and command substitutions (`$(date)`) stay intact,
-    and comment stripping is disabled so a `#` argument cannot truncate
-    the command. Connectives are recognized as whitespace-delimited
-    tokens; an unspaced `cmd1;cmd2` is not split, which only leaves
-    that segment's `rtk` unanchored (conservative, never corrupts).
-    Unparseable input is returned untouched.
-
-    Known limitation: a bare `rtk` token that is another command's
-    argument (e.g. `echo rtk done`) is indistinguishable from a wrapper
-    position inside the rtk-rewrite output domain and gets anchored.
-    Real rtk rewrites do not produce that shape, so this is accepted.
-    """
-    lexer = shlex.shlex(rewritten, posix=False)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    try:
-        tokens = list(lexer)
-    except ValueError:
-        return rewritten
-
-    quoted = shlex.quote(rtk_bin)
-    result = list(tokens)
-    wrapped = False
-    for i, token in enumerate(tokens):
-        if token in _SEGMENT_OPS:
-            wrapped = False
-            continue
-        if _is_env_assignment(token):
-            continue
-        if not wrapped and token == "rtk":
-            result[i] = quoted
-            wrapped = True
-
-    return " ".join(result)
 
 
 # -- main --------------------------------------------------------------------
@@ -200,7 +133,7 @@ def main() -> None:
     if not rewritten or rewritten == cmd:
         skip()
 
-    rewritten = _anchor_rtk_prefix(rewritten, rtk_bin)
+    rewritten = anchor_rtk_prefix(rewritten, rtk_bin)
 
     # 7. Build response
     # Emit both formats for runtime compatibility:

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -159,6 +159,7 @@ from hook_utils import (
     _RTK_FALLBACK,
     _RTK_LOCAL_SHARE,
     _RTK_LOCAL_LIB,
+    anchor_rtk_prefix as _anchor_rtk_prefix,
     resolve_binary,
     warn as _warn_shared,
     try_parse_json as _try_parse_json,
@@ -410,6 +411,7 @@ def _try_rewrite(
     if not rewritten or rewritten == command:
         return None
 
+    rewritten = _anchor_rtk_prefix(rewritten, rtk_bin)
     logger.info("tokenless: rtk rewrite %s → %s", command, rewritten)
     return {
         "action": "block",

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -222,6 +222,79 @@ function checkTokenless(): boolean {
 
 // ---- Subprocess helpers -------------------------------------------------------
 
+// Shell connectives that delimit command-list segments.
+const _RTK_SEGMENT_OPS = new Set(["&&", "||", ";", "|", "&"]);
+
+function _isEnvAssignment(token: string): boolean {
+  const eq = token.indexOf("=");
+  if (eq <= 0) return false;
+  const name = token.slice(0, eq);
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
+ * Tokenize a shell command string into words, treating quoted spans as atomic
+ * tokens (non-POSIX mode — quotes are preserved in the output, matching
+ * Python shlex(posix=False) with whitespace_split=True).  Returns null when
+ * an unterminated quote is detected so callers can bail out safely.
+ */
+function _shellTokenize(s: string): string[] | null {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < s.length) {
+    // skip inter-token whitespace
+    while (i < s.length && /\s/.test(s[i])) i++;
+    if (i >= s.length) break;
+    let tok = "";
+    while (i < s.length && !/\s/.test(s[i])) {
+      const ch = s[i];
+      if (ch === "'" || ch === '"') {
+        const close = s.indexOf(ch, i + 1);
+        if (close === -1) return null; // unterminated quote
+        tok += s.slice(i, close + 1);
+        i = close + 1;
+      } else {
+        tok += ch;
+        i++;
+      }
+    }
+    if (tok.length > 0) tokens.push(tok);
+  }
+  return tokens;
+}
+
+/** Replace bare ``rtk`` prefix tokens with the resolved binary path.
+ *
+ * Mirrors Python ``anchor_rtk_prefix`` in hook_utils.py. Prevents exit-127
+ * failures when the agent tool shell PATH lacks the rtk install location.
+ * Uses shell-aware tokenization so quoted arguments containing connectives or
+ * the word ``rtk`` are never modified.
+ */
+function anchorRtkPrefix(rewritten: string, resolvedRtkPath: string): string {
+  const tokens = _shellTokenize(rewritten);
+  if (tokens === null) return rewritten; // unterminated quote — return untouched
+  let wrapped = false;
+  const result: string[] = [];
+  for (const token of tokens) {
+    if (_RTK_SEGMENT_OPS.has(token)) {
+      wrapped = false;
+      result.push(token);
+      continue;
+    }
+    if (_isEnvAssignment(token)) {
+      result.push(token);
+      continue;
+    }
+    if (!wrapped && token === "rtk") {
+      result.push(resolvedRtkPath.includes(" ") ? `'${resolvedRtkPath}'` : resolvedRtkPath);
+      wrapped = true;
+      continue;
+    }
+    result.push(token);
+  }
+  return result.join(" ");
+}
+
 function tryRtkRewrite(command: string, context: TokenlessCallContext): string | null {
   try {
     const result = spawnSync(rtkPath, ["rewrite", command], {
@@ -239,7 +312,7 @@ function tryRtkRewrite(command: string, context: TokenlessCallContext): string |
     //       user confirmation; in non-interactive hook context, treat as valid
     //       rewrite since the intent is token optimization, not permission gating)
     if ((result.status === 0 || result.status === 3) && rewritten && rewritten !== command) {
-      return rewritten;
+      return anchorRtkPrefix(rewritten, rtkPath);
     }
     return null;
   } catch {


### PR DESCRIPTION
## Description

Follow-up to #1975. That PR fixed the bare `rtk` prefix in `rewrite_hook.py` (common hooks), but two adapters shipped independent rewrite paths with the same latent defect:

- **Hermes** (`hermes/__init__.py`, `_try_rewrite`): returned `proc.stdout.strip()` verbatim without anchoring.
- **OpenClaw** (`openclaw/index.ts`, `tryRtkRewrite`): returned `result.stdout?.trim()` verbatim without anchoring.

In agent runtimes with a trimmed PATH (e.g. IDE tool environments without `~/.local/bin`), every rewritten command fails with exit 127 even though the adapter resolved `rtk` successfully.

**Fix:**
1. Extract `anchor_rtk_prefix` and its helpers from `rewrite_hook.py` into `hook_utils.py` (single shared implementation).
2. `rewrite_hook.py` now imports `anchor_rtk_prefix` from `hook_utils` (no behavior change).
3. `hermes/__init__.py`: import and apply `anchor_rtk_prefix` in `_try_rewrite`.
4. `openclaw/index.ts`: add `anchorRtkPrefix` mirroring the Python logic and apply it in `tryRtkRewrite`.

## Related Issue

closes #2123

## Risk and compatibility

Low. The anchoring logic is identical to what has been in production via `rewrite_hook.py` since #1975. No behavior change in environments where `rtk` is already on PATH — `shlex.quote` and the TS equivalent produce the same path string.

## Validation

- Python `anchor_rtk_prefix` unit-tested manually: basic rewrite, env-assignment prefix, chained `&&`, non-rtk passthrough all correct.
- `python3 -m pytest tests/` passes (excluding pre-existing failures in `test_rewrite_hook.py` due to missing rtk binary in test env, and `test_hermes_plugin_import.py` failures caused by outdated system-installed hook_utils in this environment — neither is introduced by this PR).
- TypeScript `anchorRtkPrefix` verified present and applied in `tryRtkRewrite`.

## Documentation and rollback

No documentation change needed. Rollback: revert this commit.