### PR TITLE
fix(skillfs): close security integration gaps

### DIFF
--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -1977,10 +1977,8 @@ async fn cmd_mount(
 
     // Build ControlSocketConfig when the control plane is enabled.
     //
-    // Hermes layout is compatible: the read-only resolver derives full
-    // nested skill ids from the canonical path. Nested activation *writes*
-    // still return an invalid-skill-name error inside the write methods —
-    // enabling the resolver does not widen the write protocol.
+    // Hermes layout is compatible: the resolver and activation write methods
+    // use full layout-relative skill ids such as `category/skill`.
     let control_socket_config: Option<ControlSocketConfig> =
         match (&effective_socket_path, &trusted_peer_exe) {
             (Some(socket_path), Some(exe_path)) => {

--- a/src/skillfs/crates/skillfs-fuse/src/path.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/path.rs
@@ -28,9 +28,8 @@ pub enum SkillLayout {
     /// hidden), `--notify-socket` mutation events, and installer
     /// transactions (staging rename, pending install, quiet timeout,
     /// post-publish grace). Incompatible with `--decision-command`
-    /// (rejected at startup). The read-only `skill.resolveLiveSource`
-    /// control socket query is supported: it derives full nested skill
-    /// ids from the canonical path.
+    /// (rejected at startup). Control socket resolver and activation write
+    /// methods support full nested Skill ids.
     ///
     /// **Parser model:** purely lexical. Every non-management
     /// top-level entry is classified as `CategoryDir`; every second-

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -114,6 +114,7 @@ pub mod resolver;
 pub mod runtime_metrics;
 pub mod session_stats;
 pub mod session_stats_writer;
+mod skill_dir;
 pub mod telemetry_gate;
 pub mod trusted_writer;
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/backing_root.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/backing_root.rs
@@ -250,7 +250,7 @@ impl LedgerBackingRoot {
         source_canon: &Path,
         backing_root_path: &Path,
         mount_canon: &Path,
-        _in_place: bool,
+        in_place: bool,
     ) -> Result<Self, BackingRootError> {
         if backing_root_path.as_os_str().is_empty() {
             return Err(BackingRootError::EmptyPath);
@@ -349,6 +349,44 @@ impl LedgerBackingRoot {
             }
         })?;
 
+        // Repeat the shape checks after following the leaf. An external
+        // symlink can otherwise resolve back into the mount or source tree.
+        if path_is_inside(&backing_canon, mount_canon) {
+            if let Some(ref dir) = created_temp_dir {
+                let _ = std::fs::remove_dir(dir);
+            }
+            return Err(BackingRootError::InsideMountPath {
+                path: backing_canon,
+                mount: mount_canon.to_path_buf(),
+            });
+        }
+
+        // A source alias is safe only when no in-place over-mount can hide
+        // it. Return it directly instead of attempting a self-bind.
+        if backing_canon == source_canon {
+            if in_place {
+                return Err(BackingRootError::InsideMountPath {
+                    path: backing_canon,
+                    mount: mount_canon.to_path_buf(),
+                });
+            }
+            return Ok(Self {
+                path: source_canon.to_path_buf(),
+                created_bind_mount: false,
+                created_temp_dir: None,
+            });
+        }
+
+        if path_is_inside(&backing_canon, source_canon) {
+            if let Some(ref dir) = created_temp_dir {
+                let _ = std::fs::remove_dir(dir);
+            }
+            return Err(BackingRootError::InsideSourceTree {
+                path: backing_canon,
+                source: source_canon.to_path_buf(),
+            });
+        }
+
         // Validate permissions on the backing root's parent directory.
         // After bind mount, the backing root itself shows the source's
         // permissions. The real security boundary is the parent directory
@@ -400,6 +438,19 @@ impl LedgerBackingRoot {
                 })
             }
             Err(e) => {
+                // In-place mounts require a bind created and made private by
+                // this setup. Identity alone cannot prove propagation mode.
+                if in_place {
+                    if let Some(ref dir) = created_temp_dir {
+                        let _ = std::fs::remove_dir(dir);
+                    }
+                    return Err(BackingRootError::BindMountFailed {
+                        source: source_canon.to_path_buf(),
+                        target: backing_canon,
+                        error: e,
+                    });
+                }
+
                 // P1-1: Bind mount failed. Check if the backing root is a
                 // pre-existing alias (e.g. operator-created bind mount or
                 // symlink to source). Verify via stat dev/ino identity.
@@ -810,6 +861,118 @@ mod tests {
         let mount_canon = mount.path().canonicalize().unwrap();
 
         let result = LedgerBackingRoot::setup(&source_canon, &mount_canon, &mount_canon, false);
+        assert!(matches!(
+            result,
+            Err(BackingRootError::InsideMountPath { .. })
+        ));
+    }
+
+    #[test]
+    fn in_place_backing_root_same_as_source_rejected() {
+        let source = tempfile::tempdir().unwrap();
+        let source_canon = source.path().canonicalize().unwrap();
+
+        let result = LedgerBackingRoot::setup(&source_canon, &source_canon, &source_canon, true);
+
+        assert!(matches!(
+            result,
+            Err(BackingRootError::InsideMountPath { .. })
+        ));
+    }
+
+    #[test]
+    fn non_in_place_symlink_to_source_uses_source_without_bind() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = tempfile::tempdir().unwrap();
+        let source_canon = source.path().canonicalize().unwrap();
+        let private_parent = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(
+            private_parent.path(),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let backing_link = private_parent.path().join("backing");
+        std::os::unix::fs::symlink(&source_canon, &backing_link).unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let mount_canon = mount.path().canonicalize().unwrap();
+
+        let backing = LedgerBackingRoot::setup(&source_canon, &backing_link, &mount_canon, false)
+            .expect("non-in-place source alias should remain compatible");
+
+        assert_eq!(backing.path(), source_canon);
+        assert!(!backing.created_bind_mount());
+    }
+
+    #[test]
+    fn symlink_into_mount_rejected_after_canonicalization() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = tempfile::tempdir().unwrap();
+        let source_canon = source.path().canonicalize().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let mount_canon = mount.path().canonicalize().unwrap();
+        let private_parent = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(
+            private_parent.path(),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let backing_link = private_parent.path().join("backing");
+        std::os::unix::fs::symlink(&mount_canon, &backing_link).unwrap();
+
+        let result = LedgerBackingRoot::setup(&source_canon, &backing_link, &mount_canon, false);
+
+        assert!(matches!(
+            result,
+            Err(BackingRootError::InsideMountPath { .. })
+        ));
+    }
+
+    #[test]
+    fn symlink_into_source_subtree_rejected_after_canonicalization() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = tempfile::tempdir().unwrap();
+        let source_canon = source.path().canonicalize().unwrap();
+        let source_child = source_canon.join("child");
+        std::fs::create_dir(&source_child).unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let mount_canon = mount.path().canonicalize().unwrap();
+        let private_parent = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(
+            private_parent.path(),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let backing_link = private_parent.path().join("backing");
+        std::os::unix::fs::symlink(&source_child, &backing_link).unwrap();
+
+        let result = LedgerBackingRoot::setup(&source_canon, &backing_link, &mount_canon, false);
+
+        assert!(matches!(
+            result,
+            Err(BackingRootError::InsideSourceTree { .. })
+        ));
+    }
+
+    #[test]
+    fn in_place_symlink_to_source_rejected() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = tempfile::tempdir().unwrap();
+        let source_canon = source.path().canonicalize().unwrap();
+        let private_parent = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(
+            private_parent.path(),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let backing_link = private_parent.path().join("backing");
+        std::os::unix::fs::symlink(&source_canon, &backing_link).unwrap();
+
+        let result = LedgerBackingRoot::setup(&source_canon, &backing_link, &source_canon, true);
+
         assert!(matches!(
             result,
             Err(BackingRootError::InsideMountPath { .. })

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -720,7 +720,7 @@ fn atomic_write_activation_fd(
 
     // 3. Ensure .skill-meta exists via mkdirat. EEXIST is fine.
     let c_meta = CString::new(".skill-meta").unwrap();
-    let rc = unsafe { libc::mkdirat(skill_fd, c_meta.as_ptr(), 0o755) };
+    let rc = unsafe { libc::mkdirat(skill_fd, c_meta.as_ptr(), 0o700) };
     if rc != 0 {
         let e = std::io::Error::last_os_error();
         if e.raw_os_error() != Some(libc::EEXIST) {
@@ -747,6 +747,14 @@ fn atomic_write_activation_fd(
         ));
     }
     let meta_dir_file = unsafe { std::fs::File::from_raw_fd(meta_fd) };
+    let rc = unsafe { libc::fchmod(meta_fd, 0o700) };
+    if rc != 0 {
+        let e = std::io::Error::last_os_error();
+        return Err(ControlResponse::err(
+            "write_failed",
+            format!("failed to secure .skill-meta permissions: {e}"),
+        ));
+    }
 
     // 5. Create temp file via openat on meta_fd.
     let tmp_name = format!(
@@ -766,7 +774,7 @@ fn atomic_write_activation_fd(
             meta_fd,
             c_tmp.as_ptr(),
             libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC,
-            0o644,
+            0o600,
         )
     };
     if tmp_fd < 0 {
@@ -2701,10 +2709,17 @@ mod tests {
 
     #[test]
     fn meta_write_activation_success_writes_file() {
+        use std::os::unix::fs::PermissionsExt;
+
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path().join("alpha");
-        std::fs::create_dir(&skill_dir).unwrap();
+        let meta_dir = skill_dir.join(".skill-meta");
+        let activation_path = meta_dir.join("activation.json");
+        std::fs::create_dir_all(&meta_dir).unwrap();
         std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
+        std::fs::write(&activation_path, "old").unwrap();
+        std::fs::set_permissions(&meta_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&activation_path, std::fs::Permissions::from_mode(0o644)).unwrap();
 
         let raw = serde_json::json!({
             "schemaVersion": "1",
@@ -2720,11 +2735,18 @@ mod tests {
         let resp = dispatch_request(&req, &raw, Some(&ctx));
         assert!(resp.ok, "expected ok, got: {resp:?}");
 
-        let written =
-            std::fs::read_to_string(skill_dir.join(".skill-meta/activation.json")).unwrap();
+        let written = std::fs::read_to_string(&activation_path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
         assert_eq!(parsed["schemaVersion"], 1);
         assert!(parsed["target"].is_null());
+        let meta_mode = std::fs::metadata(&meta_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(meta_mode, 0o700, ".skill-meta must be owner-only");
+        let mode = std::fs::metadata(&activation_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "activation.json must be owner-only");
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -66,6 +66,7 @@ use super::activation_reload::ReloadOutcome;
 use super::active::{ActiveSkillResolver, ActiveTarget};
 use super::ledger::validate_skill_name_component;
 use super::protocol_events::{ProtocolEvent, ProtocolEventWriter};
+use super::skill_dir::{SkillDirError, VerifiedSkillDir, open_verified_skill_dir};
 use super::trusted_writer::FileId;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -522,8 +523,7 @@ fn extract_and_validate_meta_request<'a>(
             ControlResponse::err("invalid_request", "missing or non-string 'skillName' field")
         })?;
 
-    validate_skill_name_component(skill_name)
-        .map_err(|e| ControlResponse::err("invalid_skill_name", e.to_string()))?;
+    validate_skill_id(skill_name, ctx.layout)?;
 
     let activation_value = raw
         .get("activation")
@@ -542,6 +542,39 @@ fn extract_and_validate_meta_request<'a>(
     let skill_dir = ctx.source_root.join(skill_name);
 
     Ok((skill_name, activation_json, skill_dir))
+}
+
+/// Validate a relative Skill id without weakening the ledger's
+/// single-component name contract.
+fn validate_skill_id(skill_id: &str, layout: SkillLayout) -> Result<(), ControlResponse> {
+    let components: Vec<&str> = skill_id.split('/').collect();
+    let valid_depth = match layout {
+        SkillLayout::Flat => components.len() == 1,
+        SkillLayout::Hermes => matches!(components.len(), 1 | 2),
+    };
+    if !valid_depth {
+        return Err(ControlResponse::err(
+            "invalid_skill_name",
+            format!("skill id '{skill_id}' is incompatible with {layout:?} layout"),
+        ));
+    }
+
+    if components
+        .iter()
+        .any(|component| component.starts_with('.'))
+        || components.first() == Some(&"skill-discover")
+    {
+        return Err(ControlResponse::err(
+            "invalid_skill_name",
+            format!("skill id '{skill_id}' refers to a managed/reserved path"),
+        ));
+    }
+
+    for component in components {
+        validate_skill_name_component(component)
+            .map_err(|e| ControlResponse::err("invalid_skill_name", e.to_string()))?;
+    }
+    Ok(())
 }
 
 fn reload_and_emit(
@@ -643,10 +676,13 @@ fn dispatch_meta_write_activation(
         Err(resp) => return resp,
     };
 
-    let source_root = &ctx.as_ref().unwrap().source_root;
-    if let Err(resp) =
-        atomic_write_activation_fd(source_root, skill_name, activation_json.as_bytes())
-    {
+    let context = ctx.as_ref().unwrap();
+    if let Err(resp) = atomic_write_activation_fd(
+        &context.source_root,
+        skill_name,
+        context.layout,
+        activation_json.as_bytes(),
+    ) {
         return resp;
     }
 
@@ -661,7 +697,8 @@ fn dispatch_meta_write_activation(
 
 /// Fully fd-anchored atomic activation write.
 ///
-/// Opens `source_root` → `openat(skill_name, O_NOFOLLOW|O_DIRECTORY)` →
+/// Opens `source_root` → each Skill-id component with
+/// `openat(O_NOFOLLOW|O_DIRECTORY)` →
 /// `mkdirat(.skill-meta)` → `openat(.skill-meta, O_NOFOLLOW|O_DIRECTORY)` →
 /// `openat(tmp, O_CREAT|O_EXCL)` → write+fsync → `renameat(tmp, activation.json)` →
 /// fsync dir.
@@ -672,13 +709,14 @@ fn dispatch_meta_write_activation(
 fn atomic_write_activation_fd(
     source_root: &Path,
     skill_name: &str,
+    layout: SkillLayout,
     json_bytes: &[u8],
 ) -> Result<(), ControlResponse> {
     use std::ffi::CString;
     use std::os::unix::io::FromRawFd;
 
-    let (_source_guard, skill_guard) = open_skill_dir_nofollow(source_root, skill_name)?;
-    let skill_fd = skill_guard.0;
+    let skill_guard = open_skill_dir_for_write(source_root, skill_name, layout)?;
+    let skill_fd = skill_guard.as_raw_fd();
 
     // 3. Ensure .skill-meta exists via mkdirat. EEXIST is fine.
     let c_meta = CString::new(".skill-meta").unwrap();
@@ -771,104 +809,76 @@ fn atomic_write_activation_fd(
     Ok(())
 }
 
-/// RAII guard that closes a raw fd on drop.
-struct FdGuard(libc::c_int);
-
-impl Drop for FdGuard {
-    fn drop(&mut self) {
-        if self.0 >= 0 {
-            unsafe { libc::close(self.0) };
-        }
-    }
-}
-
-/// Open the source root as a directory fd, then open the skill
-/// directory relative to it with `O_NOFOLLOW|O_DIRECTORY`.
-///
-/// Returns (source_guard, skill_guard) on success. On error, returns
-/// a structured `ControlResponse` distinguishing symlinks, missing
-/// directories, and other failures.
-fn open_skill_dir_nofollow(
+/// Resolve the write target through the shared fd-anchored Skill boundary.
+fn open_skill_dir_for_write(
     source_root: &Path,
     skill_name: &str,
-) -> Result<(FdGuard, FdGuard), ControlResponse> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
+    layout: SkillLayout,
+) -> Result<VerifiedSkillDir, ControlResponse> {
+    let components: Vec<_> = skill_name.split('/').collect();
+    open_verified_skill_dir(source_root, layout, &components)
+        .map_err(|error| map_skill_dir_error_for_write(error, skill_name, layout))
+}
 
-    let c_source = CString::new(source_root.as_os_str().as_bytes())
-        .map_err(|_| ControlResponse::err("write_failed", "source root path contains NUL"))?;
-    let source_fd = unsafe {
-        libc::open(
-            c_source.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-        )
-    };
-    if source_fd < 0 {
-        let e = std::io::Error::last_os_error();
-        return Err(ControlResponse::err(
+fn map_skill_dir_error_for_write(
+    error: SkillDirError,
+    skill_name: &str,
+    layout: SkillLayout,
+) -> ControlResponse {
+    match error {
+        SkillDirError::InvalidDepth => ControlResponse::err(
+            "invalid_skill_name",
+            format!("skill id '{skill_name}' is incompatible with {layout:?} layout"),
+        ),
+        SkillDirError::RootPathContainsNul => {
+            ControlResponse::err("write_failed", "source root path contains NUL")
+        }
+        SkillDirError::RootOpen(error) => ControlResponse::err(
             "write_failed",
-            format!("failed to open source root: {e}"),
-        ));
-    }
-    let source_guard = FdGuard(source_fd);
-
-    let c_skill = CString::new(skill_name.as_bytes())
-        .map_err(|_| ControlResponse::err("write_failed", "skill name contains NUL"))?;
-    let skill_fd = unsafe {
-        libc::openat(
-            source_fd,
-            c_skill.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-        )
-    };
-    if skill_fd < 0 {
-        let e = std::io::Error::last_os_error();
-        let errno = e.raw_os_error().unwrap_or(0);
-
-        // O_NOFOLLOW on a symlink returns ELOOP on some kernels,
-        // ENOTDIR on others (when combined with O_DIRECTORY). Use
-        // fstatat to distinguish "is a symlink" from "truly not a
-        // directory" so we return the right error code.
-        if errno == libc::ELOOP {
-            return Err(ControlResponse::err(
-                "invalid_skill_name",
-                format!("skill directory '{skill_name}' is a symlink; refusing to follow"),
-            ));
+            format!("failed to open source root: {error}"),
+        ),
+        SkillDirError::ComponentContainsNul => {
+            ControlResponse::err("write_failed", "skill name contains NUL")
         }
-        if errno == libc::ENOTDIR {
-            let mut st: libc::stat = unsafe { std::mem::zeroed() };
-            let rc = unsafe {
-                libc::fstatat(
-                    source_fd,
-                    c_skill.as_ptr(),
-                    &mut st,
-                    libc::AT_SYMLINK_NOFOLLOW,
-                )
-            };
-            if rc == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFLNK {
-                return Err(ControlResponse::err(
-                    "invalid_skill_name",
-                    format!("skill directory '{skill_name}' is a symlink; refusing to follow"),
-                ));
-            }
-            return Err(ControlResponse::err(
-                "skill_not_found",
-                format!("skill directory '{skill_name}' is not a directory"),
-            ));
-        }
-        if errno == libc::ENOENT {
-            return Err(ControlResponse::err(
-                "skill_not_found",
-                format!("skill directory '{skill_name}' does not exist"),
-            ));
-        }
-        return Err(ControlResponse::err(
+        SkillDirError::ComponentSymlink { component } => ControlResponse::err(
+            "invalid_skill_name",
+            format!(
+                "skill path component '{component}' in '{skill_name}' is a symlink; refusing to follow"
+            ),
+        ),
+        SkillDirError::ComponentMissing { component } => ControlResponse::err(
+            "skill_not_found",
+            format!("skill path component '{component}' in '{skill_name}' does not exist"),
+        ),
+        SkillDirError::ComponentNotDirectory { component } => ControlResponse::err(
+            "skill_not_found",
+            format!("skill path component '{component}' in '{skill_name}' is not a directory"),
+        ),
+        SkillDirError::ComponentOpen { component, source } => ControlResponse::err(
             "write_failed",
-            format!("failed to open skill directory '{skill_name}': {e}"),
-        ));
+            format!(
+                "failed to open skill path component '{component}' in '{skill_name}': {source}"
+            ),
+        ),
+        SkillDirError::NestedBelowTopLevelSkill { parent, child } => ControlResponse::err(
+            "invalid_skill_layout",
+            format!(
+                "'{parent}' is a top-level skill, not a category; '{child}' is a subdirectory, not a nested Skill"
+            ),
+        ),
+        SkillDirError::MarkerInspect(error) => ControlResponse::err(
+            "write_failed",
+            format!("failed to inspect SKILL.md: {error}"),
+        ),
+        SkillDirError::MissingMarker => ControlResponse::err(
+            "invalid_skill_layout",
+            format!("'{skill_name}' has no regular SKILL.md and is not a Skill"),
+        ),
+        SkillDirError::Identity(error) => ControlResponse::err(
+            "write_failed",
+            format!("failed to stat skill directory: {error}"),
+        ),
     }
-
-    Ok((source_guard, FdGuard(skill_fd)))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -885,8 +895,13 @@ fn dispatch_meta_set_activation_xattr(
         Err(resp) => return resp,
     };
 
-    let source_root = &ctx.as_ref().unwrap().source_root;
-    if let Err(resp) = set_activation_xattr_fd(source_root, skill_name, &activation_json) {
+    let context = ctx.as_ref().unwrap();
+    if let Err(resp) = set_activation_xattr_fd(
+        &context.source_root,
+        skill_name,
+        context.layout,
+        &activation_json,
+    ) {
         return resp;
     }
 
@@ -894,17 +909,18 @@ fn dispatch_meta_set_activation_xattr(
     ControlResponse::ok(result)
 }
 
-/// Fd-anchored xattr write: open source_root → openat(skill_name,
-/// O_NOFOLLOW|O_DIRECTORY) → fsetxattr on the verified fd.
+/// Fd-anchored xattr write: open source_root → each Skill-id component
+/// with `openat(O_NOFOLLOW|O_DIRECTORY)` → fsetxattr on the verified fd.
 fn set_activation_xattr_fd(
     source_root: &Path,
     skill_name: &str,
+    layout: SkillLayout,
     json_str: &str,
 ) -> Result<(), ControlResponse> {
     use std::ffi::CString;
 
-    let (_source_guard, skill_guard) = open_skill_dir_nofollow(source_root, skill_name)?;
-    let skill_fd = skill_guard.0;
+    let skill_guard = open_skill_dir_for_write(source_root, skill_name, layout)?;
+    let skill_fd = skill_guard.as_raw_fd();
 
     let c_name = CString::new(ACTIVATION_XATTR)
         .map_err(|_| ControlResponse::err("write_failed", "xattr name contains NUL"))?;
@@ -1229,6 +1245,7 @@ fn resolve_socket_liveness(
 
 /// One non-blocking `connect(2)` attempt; see [`probe_socket_liveness`].
 fn probe_socket_liveness_once(path: &Path) -> ProbeOnce {
+    use std::os::fd::{FromRawFd, OwnedFd};
     use std::os::unix::ffi::OsStrExt;
 
     let bytes = path.as_os_str().as_bytes();
@@ -1255,7 +1272,8 @@ fn probe_socket_liveness_once(path: &Path) -> ProbeOnce {
     if fd < 0 {
         return ProbeOnce::Ambiguous(std::io::Error::last_os_error());
     }
-    let _guard = FdGuard(fd);
+    // SAFETY: `socket` returned a new fd and ownership is transferred once.
+    let _guard = unsafe { OwnedFd::from_raw_fd(fd) };
 
     let rc = unsafe {
         libc::connect(
@@ -2000,13 +2018,53 @@ mod tests {
     // ── Meta write dispatch (unit) ─────────────────────────────────────
 
     fn test_ctx(source_root: &Path) -> ControlSocketContext {
+        test_ctx_with_layout(source_root, SkillLayout::Flat)
+    }
+
+    fn test_ctx_with_layout(source_root: &Path, layout: SkillLayout) -> ControlSocketContext {
         ControlSocketContext {
             canonical_root: source_root.to_path_buf(),
             source_root: source_root.to_path_buf(),
-            layout: SkillLayout::Flat,
+            layout,
             resolver: Some(Arc::new(ActiveSkillResolver::new(source_root))),
             protocol_event_writer: None,
         }
+    }
+
+    fn seed_activation_skill(source_root: &Path, skill_id: &str) -> PathBuf {
+        let skill_dir = source_root.join(skill_id);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
+        skill_dir
+    }
+
+    fn assert_flat_write_resolve_reject(source_root: &Path, skill_name: &str) {
+        let skill_dir = source_root.join(skill_name);
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": skill_name,
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx(source_root);
+
+        let write_resp = dispatch_request(&req, &raw, Some(&ctx));
+        let resolve_error = super::super::resolver::resolve_live_source(
+            source_root,
+            source_root,
+            SkillLayout::Flat,
+            skill_dir.to_str().unwrap(),
+        )
+        .unwrap_err();
+
+        assert!(!write_resp.ok);
+        assert_eq!(write_resp.error.as_ref().unwrap().code, resolve_error.code);
+        assert_eq!(resolve_error.code, "invalid_skill_layout");
+        assert!(!skill_dir.join(".skill-meta").exists());
     }
 
     #[test]
@@ -2082,6 +2140,339 @@ mod tests {
         let resp = dispatch_request(&req, &raw, Some(&ctx));
         assert!(!resp.ok);
         assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_name");
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_nested_skill_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("category/skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
+
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "category/skill",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(
+            resp.ok,
+            "expected nested activation write to succeed: {resp:?}"
+        );
+        assert_eq!(
+            resp.result
+                .as_ref()
+                .and_then(|result| result["outcome"].as_str()),
+            Some("updated")
+        );
+        assert!(skill_dir.join(".skill-meta/activation.json").is_file());
+        assert!(matches!(
+            ctx.resolver
+                .as_ref()
+                .and_then(|resolver| resolver.get("category/skill")),
+            Some(ActiveTarget::Hidden { .. })
+        ));
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_third_level_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("a/b/c")).unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "a/b/c",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_name");
+        assert!(!dir.path().join("a/b/c/.skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_category_symlink_rejected() {
+        let source = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_skill = outside.path().join("skill");
+        std::fs::create_dir(&outside_skill).unwrap();
+        std::os::unix::fs::symlink(outside.path(), source.path().join("category")).unwrap();
+
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "category/skill",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(source.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_name");
+        assert!(!outside_skill.join(".skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_set_xattr_hermes_nested_skill_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("category/skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.setActivationXattr",
+            "skillName": "category/skill",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.setActivationXattr".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+        if resp.error.as_ref().map(|error| error.code.as_str()) == Some("xattr_not_supported") {
+            eprintln!("SKIP: temp filesystem does not support user xattrs");
+            return;
+        }
+
+        assert!(resp.ok, "expected nested xattr write to succeed: {resp:?}");
+        match super::super::activation::read_activation_xattr(&skill_dir) {
+            super::super::activation::XattrReadOutcome::Present(value) => {
+                let parsed: serde_json::Value = serde_json::from_str(&value).unwrap();
+                assert_eq!(parsed["schemaVersion"], 1);
+                assert!(parsed["target"].is_null());
+            }
+            other => panic!("expected activation xattr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_missing_marker_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("category/ordinary");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "category/ordinary",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_layout");
+        assert!(!skill_dir.join(".skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_top_skill_subdir_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let top_skill = dir.path().join("top");
+        let nested_dir = top_skill.join("subdir");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        std::fs::write(top_skill.join("SKILL.md"), "# Top Skill\n").unwrap();
+        std::fs::write(nested_dir.join("SKILL.md"), "# Nested marker\n").unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "top/subdir",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_layout");
+        assert!(!nested_dir.join(".skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_symlink_marker_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let external = tempfile::NamedTempFile::new().unwrap();
+        let skill_dir = dir.path().join("category/skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::os::unix::fs::symlink(external.path(), skill_dir.join("SKILL.md")).unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "category/skill",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_layout");
+        assert!(!skill_dir.join(".skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_set_xattr_hermes_missing_marker_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("category/ordinary");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.setActivationXattr",
+            "skillName": "category/ordinary",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.setActivationXattr".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_layout");
+    }
+
+    #[test]
+    fn meta_write_activation_hermes_reserved_path_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".hub/skill")).unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": ".hub/skill",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx_with_layout(dir.path(), SkillLayout::Hermes);
+
+        let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+        assert!(!resp.ok);
+        assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_name");
+        assert!(!dir.path().join(".hub/skill/.skill-meta").exists());
+    }
+
+    #[test]
+    fn meta_write_activation_flat_reserved_paths_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        for skill_name in [".hub", "skill-discover"] {
+            let skill_dir = seed_activation_skill(dir.path(), skill_name);
+            let raw = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "meta.writeActivation",
+                "skillName": skill_name,
+                "activation": {"schemaVersion": 1, "target": null}
+            });
+            let req = ControlRequest {
+                schema_version: "1".to_string(),
+                method: "meta.writeActivation".to_string(),
+            };
+            let ctx = test_ctx(dir.path());
+
+            let resp = dispatch_request(&req, &raw, Some(&ctx));
+
+            assert!(!resp.ok, "{skill_name} must remain reserved");
+            assert_eq!(resp.error.as_ref().unwrap().code, "invalid_skill_name");
+            assert!(!skill_dir.join(".skill-meta").exists());
+        }
+    }
+
+    #[test]
+    fn meta_write_activation_flat_missing_marker_matches_resolver() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("ordinary-directory");
+        std::fs::create_dir(&skill_dir).unwrap();
+
+        assert_flat_write_resolve_reject(dir.path(), "ordinary-directory");
+    }
+
+    #[test]
+    fn meta_write_activation_flat_symlink_marker_matches_resolver() {
+        let dir = tempfile::tempdir().unwrap();
+        let external = tempfile::NamedTempFile::new().unwrap();
+        let skill_dir = dir.path().join("symlink-marker");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::os::unix::fs::symlink(external.path(), skill_dir.join("SKILL.md")).unwrap();
+
+        assert_flat_write_resolve_reject(dir.path(), "symlink-marker");
+    }
+
+    #[test]
+    fn shared_fd_resolution_preserves_protocol_error_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_path = dir.path().join("not-a-directory");
+        std::fs::write(&skill_path, "ordinary file").unwrap();
+        let raw = serde_json::json!({
+            "schemaVersion": "1",
+            "method": "meta.writeActivation",
+            "skillName": "not-a-directory",
+            "activation": {"schemaVersion": 1, "target": null}
+        });
+        let req = ControlRequest {
+            schema_version: "1".to_string(),
+            method: "meta.writeActivation".to_string(),
+        };
+        let ctx = test_ctx(dir.path());
+
+        let write_error = dispatch_request(&req, &raw, Some(&ctx))
+            .error
+            .expect("write must reject a non-directory Skill path");
+        let resolve_error = super::super::resolver::resolve_live_source(
+            dir.path(),
+            dir.path(),
+            SkillLayout::Flat,
+            skill_path.to_str().unwrap(),
+        )
+        .unwrap_err();
+
+        assert_eq!(write_error.code, "skill_not_found");
+        assert_eq!(
+            write_error.message,
+            "skill path component 'not-a-directory' in 'not-a-directory' is not a directory"
+        );
+        assert_eq!(resolve_error.code, "invalid_skill_layout");
+        assert_eq!(
+            resolve_error.message,
+            "skill path component 'not-a-directory' is not a directory"
+        );
     }
 
     #[test]
@@ -2313,6 +2704,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path().join("alpha");
         std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
 
         let raw = serde_json::json!({
             "schemaVersion": "1",
@@ -2338,8 +2730,7 @@ mod tests {
     #[test]
     fn meta_write_activation_success_updates_resolver() {
         let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path().join("alpha");
-        std::fs::create_dir(&skill_dir).unwrap();
+        seed_activation_skill(dir.path(), "alpha");
 
         let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
         let ctx = ControlSocketContext {
@@ -2374,6 +2765,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let skill_dir = dir.path().join("alpha");
         std::fs::create_dir_all(skill_dir.join(".skill-meta/versions/v000001.snapshot")).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
 
         let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
         let ctx = ControlSocketContext {
@@ -3518,6 +3910,14 @@ mod tests {
             dir: &Path,
             source_root: &Path,
         ) -> (PathBuf, ControlSocketHandle) {
+            start_server_with_context_and_layout(dir, source_root, SkillLayout::Flat)
+        }
+
+        fn start_server_with_context_and_layout(
+            dir: &Path,
+            source_root: &Path,
+            layout: SkillLayout,
+        ) -> (PathBuf, ControlSocketHandle) {
             let socket_path = dir.join("test.sock");
             let resolver = Arc::new(ActiveSkillResolver::new(source_root));
             let writer =
@@ -3525,7 +3925,7 @@ mod tests {
             let ctx = ControlSocketContext {
                 canonical_root: source_root.to_path_buf(),
                 source_root: source_root.to_path_buf(),
-                layout: SkillLayout::Flat,
+                layout,
                 resolver: Some(resolver),
                 protocol_event_writer: Some(writer),
             };
@@ -3539,11 +3939,45 @@ mod tests {
         }
 
         #[test]
+        fn server_writes_hermes_nested_activation() {
+            let dir = tempfile::tempdir().unwrap();
+            let source = tempfile::tempdir().unwrap();
+            let skill_dir = source.path().join("apple/apple-notes");
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            std::fs::write(skill_dir.join("SKILL.md"), "# Apple Notes\n").unwrap();
+            let (socket_path, handle) = start_server_with_context_and_layout(
+                dir.path(),
+                source.path(),
+                SkillLayout::Hermes,
+            );
+            let req = serde_json::json!({
+                "schemaVersion": "1",
+                "method": "meta.writeActivation",
+                "skillName": "apple/apple-notes",
+                "activation": {"schemaVersion": 1, "target": null}
+            });
+
+            let response = connect_and_send(&socket_path, &req.to_string());
+            let response: ControlResponse = serde_json::from_str(&response).unwrap();
+
+            assert!(response.ok, "expected ok, got: {response:?}");
+            assert_eq!(
+                response
+                    .result
+                    .as_ref()
+                    .and_then(|result| result["outcome"].as_str()),
+                Some("updated")
+            );
+            assert!(skill_dir.join(".skill-meta/activation.json").is_file());
+            handle.shutdown();
+        }
+
+        #[test]
         fn server_meta_write_activation_writes_file() {
             let dir = tempfile::tempdir().unwrap();
             let source = tempfile::tempdir().unwrap();
+            seed_skill_dir(source.path(), "demo-weather");
             let skill_dir = source.path().join("demo-weather");
-            std::fs::create_dir(&skill_dir).unwrap();
 
             let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
 
@@ -3573,6 +4007,7 @@ mod tests {
             let skill_dir = source.path().join("demo-weather");
             std::fs::create_dir_all(skill_dir.join(".skill-meta/versions/v000001.snapshot"))
                 .unwrap();
+            std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
 
             let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
 
@@ -3736,8 +4171,8 @@ mod tests {
         fn server_meta_write_activation_no_partial_json() {
             let dir = tempfile::tempdir().unwrap();
             let source = tempfile::tempdir().unwrap();
+            seed_skill_dir(source.path(), "alpha");
             let skill_dir = source.path().join("alpha");
-            std::fs::create_dir(&skill_dir).unwrap();
 
             let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
 
@@ -3777,8 +4212,7 @@ mod tests {
         fn server_meta_write_without_trusted_writer_exe_works() {
             let dir = tempfile::tempdir().unwrap();
             let source = tempfile::tempdir().unwrap();
-            let skill_dir = source.path().join("alpha");
-            std::fs::create_dir(&skill_dir).unwrap();
+            seed_skill_dir(source.path(), "alpha");
 
             let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
 
@@ -3812,6 +4246,7 @@ mod tests {
             };
             let skill_dir = source.path().join("alpha");
             std::fs::create_dir(&skill_dir).unwrap();
+            std::fs::write(skill_dir.join("SKILL.md"), "# Skill\n").unwrap();
 
             let (socket_path, handle) = start_server_with_context(dir.path(), source.path());
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -1556,6 +1556,44 @@ fn socket_identity(path: &Path) -> Option<FileId> {
     })
 }
 
+fn remove_socket_if_identity_matches(path: &Path, identity: Option<FileId>) {
+    if identity.is_some() && identity == socket_identity(path) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Removes a newly bound socket if startup exits before ownership transfers
+/// to [`ControlSocketHandle`]. Identity matching protects replacements.
+struct BoundSocketGuard {
+    socket_path: PathBuf,
+    bound_identity: Option<FileId>,
+    armed: bool,
+}
+
+impl BoundSocketGuard {
+    fn new(socket_path: PathBuf) -> Self {
+        let bound_identity = socket_identity(&socket_path);
+        Self {
+            socket_path,
+            bound_identity,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) -> Option<FileId> {
+        self.armed = false;
+        self.bound_identity
+    }
+}
+
+impl Drop for BoundSocketGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            remove_socket_if_identity_matches(&self.socket_path, self.bound_identity);
+        }
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Server
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1602,12 +1640,7 @@ impl ControlSocketHandle {
 
         // Only remove the socket if it is still the exact object we bound.
         // If the path was replaced by another socket or object, leave it.
-        match (self.bound_identity, socket_identity(&self.socket_path)) {
-            (Some(bound), Some(current)) if bound == current => {
-                let _ = std::fs::remove_file(&self.socket_path);
-            }
-            _ => {}
-        }
+        remove_socket_if_identity_matches(&self.socket_path, self.bound_identity);
     }
 }
 
@@ -1638,6 +1671,16 @@ impl ControlSocketServer {
     /// Start the server on a dedicated thread. Returns a handle for
     /// shutdown coordination.
     pub fn start(self) -> Result<ControlSocketHandle, Box<dyn std::error::Error>> {
+        self.start_with_listener_setup(|listener| listener.set_nonblocking(true))
+    }
+
+    fn start_with_listener_setup<F>(
+        self,
+        setup_listener: F,
+    ) -> Result<ControlSocketHandle, Box<dyn std::error::Error>>
+    where
+        F: FnOnce(&UnixListener) -> std::io::Result<()>,
+    {
         // Secure socket parent directory to 0o700 before bind to
         // eliminate the bind-to-chmod permission window. Runs before
         // the lifecycle lock so that create_dir_all provides the parent
@@ -1655,6 +1698,8 @@ impl ControlSocketServer {
         preflight_socket_path(&self.config.socket_path)?;
 
         let listener = UnixListener::bind(&self.config.socket_path)?;
+        let bound_socket_guard = BoundSocketGuard::new(self.config.socket_path.clone());
+        setup_listener(&listener)?;
 
         // Set socket file permissions to 0o600.
         #[cfg(target_os = "linux")]
@@ -1663,10 +1708,6 @@ impl ControlSocketServer {
             let perms = std::fs::Permissions::from_mode(0o600);
             std::fs::set_permissions(&self.config.socket_path, perms)?;
         }
-
-        // Record the bound socket identity so shutdown only removes the
-        // exact object we created, never a replacement at the same path.
-        let bound_identity = socket_identity(&self.config.socket_path);
 
         let shutdown = self.shutdown.clone();
         let config = self.config.clone();
@@ -1686,6 +1727,10 @@ impl ControlSocketServer {
             .spawn(move || {
                 run_server_loop(&listener, &config, context.as_deref(), &shutdown_for_thread);
             })?;
+
+        // Ownership transfers to the handle only after every fallible
+        // startup step has completed.
+        let bound_identity = bound_socket_guard.disarm();
 
         Ok(ControlSocketHandle {
             socket_path,
@@ -1712,10 +1757,6 @@ fn run_server_loop(
     // another object (connecting to the path to unblock a blocking
     // accept would not work in that case). Connections are still handled
     // one at a time on this single thread — no thread-per-request.
-    listener
-        .set_nonblocking(true)
-        .unwrap_or_else(|e| warn!("failed to set listener non-blocking: {e}"));
-
     while !shutdown.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((stream, _addr)) => {
@@ -4747,6 +4788,33 @@ mod tests {
                 connect_and_send(&socket_path, r#"{"schemaVersion":"1","method":"ping"}"#);
             assert!(resp_str.contains("\"ok\":true"));
 
+            handle.shutdown();
+        }
+
+        #[test]
+        fn listener_setup_failure_cleans_socket_and_releases_lock() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let result = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start_with_listener_setup(|_| {
+                Err(std::io::Error::other("injected listener setup failure"))
+            });
+
+            assert!(result.is_err());
+            assert!(
+                !socket_path.exists(),
+                "failed startup must remove its socket"
+            );
+
+            let handle = ControlSocketServer::new(ControlSocketConfig {
+                socket_path: socket_path.clone(),
+                trusted_peer: self_exe_config(),
+            })
+            .start()
+            .expect("failed startup must release the lifecycle lock");
             handle.shutdown();
         }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/resolver.rs
@@ -12,13 +12,11 @@
 //! Skill boundaries as the FUSE layer, so it never reports a phantom Skill
 //! at the wrong directory depth.
 
-use std::ffi::{CStr, CString};
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path};
 
 use crate::path::SkillLayout;
 
-use super::trusted_writer::FileId;
+use super::skill_dir::{SkillDirError, open_verified_skill_dir};
 
 /// Reserved top-level skill name for the synthesized discovery view; it has
 /// no physical backing directory.
@@ -38,17 +36,6 @@ impl ResolveError {
         Self {
             code,
             message: message.into(),
-        }
-    }
-}
-
-/// RAII guard that closes a raw fd on drop.
-struct FdGuard(libc::c_int);
-
-impl Drop for FdGuard {
-    fn drop(&mut self) {
-        if self.0 >= 0 {
-            unsafe { libc::close(self.0) };
         }
     }
 }
@@ -146,7 +133,11 @@ pub fn resolve_live_source(
     }
 
     // 5. Enforce the layout boundary and safely resolve the live directory.
-    let (_leaf, identity) = resolve_leaf(live_root, layout, &components)?;
+    let leaf = open_verified_skill_dir(live_root, layout, &components)
+        .map_err(|error| map_skill_dir_error(error, layout))?;
+    let identity = leaf
+        .identity()
+        .map_err(|error| map_skill_dir_error(error, layout))?;
 
     let relative_skill_dir = components.join("/");
     let live_skill_dir = live_root.join(&relative_skill_dir);
@@ -203,226 +194,65 @@ fn validate_canonical_syntax(raw: &str) -> Result<(), ResolveError> {
     Ok(())
 }
 
-/// Enforce the layout Skill boundary and resolve the leaf directory,
-/// descending one component at a time with `O_NOFOLLOW`.
-///
-/// Boundaries mirror the FUSE layer and the Hermes id enumeration:
-///
-/// * Flat — a Skill is exactly one directory level (`<root>/<skill>`); a
-///   deeper path is a subdirectory, not a Skill.
-/// * Hermes — a Skill is a top-level directory (`<root>/<skill>`) or a
-///   `<root>/<category>/<skill>` leaf whose category is not itself a
-///   top-level skill (has no own `SKILL.md`); anything deeper, or a
-///   subdirectory of a top-level skill, is not a Skill.
-fn resolve_leaf(
-    live_root: &Path,
-    layout: SkillLayout,
-    components: &[&str],
-) -> Result<(FdGuard, FileId), ResolveError> {
-    match layout {
-        SkillLayout::Flat => {
-            if components.len() != 1 {
-                return Err(ResolveError::new(
-                    "invalid_skill_layout",
-                    "flat layout Skills occupy a single directory level",
-                ));
-            }
-        }
-        SkillLayout::Hermes => {
-            if components.len() > 2 {
-                return Err(ResolveError::new(
-                    "invalid_skill_layout",
-                    "hermes layout Skills occupy at most two directory levels",
-                ));
-            }
-        }
-    }
-
-    // The live root is trusted; open it without O_NOFOLLOW.
-    let mut current = open_live_root(live_root)?;
-
-    for (idx, name) in components.iter().enumerate() {
-        let dir = openat_dir_nofollow(&current, name)?;
-
-        // Hermes two-level path: the first component must be a category,
-        // i.e. must NOT be a top-level skill. If it carries its own
-        // SKILL.md the deeper path is a subdirectory of a top-level skill,
-        // not a nested Skill. `?` fails closed on an inconclusive stat so a
-        // permission error never masquerades as "no SKILL.md → category".
-        if layout == SkillLayout::Hermes
-            && components.len() == 2
-            && idx == 0
-            && dir_has_skill_md(&dir)?
-        {
-            return Err(ResolveError::new(
+fn map_skill_dir_error(error: SkillDirError, layout: SkillLayout) -> ResolveError {
+    match error {
+        SkillDirError::InvalidDepth => match layout {
+            SkillLayout::Flat => ResolveError::new(
                 "invalid_skill_layout",
-                format!(
-                    "'{name}' is a top-level skill, not a category; '{}' is a \
-                     subdirectory, not a nested Skill",
-                    components[1]
-                ),
-            ));
+                "flat layout Skills occupy a single directory level",
+            ),
+            SkillLayout::Hermes => ResolveError::new(
+                "invalid_skill_layout",
+                "hermes layout Skills occupy at most two directory levels",
+            ),
+        },
+        SkillDirError::RootPathContainsNul => {
+            ResolveError::new("live_source_unavailable", "live root path contains NUL")
         }
-
-        current = dir;
-    }
-
-    verify_skill_md(&current)?;
-    let identity = fstat_identity(&current)?;
-    Ok((current, identity))
-}
-
-/// Open the (trusted) live root directory.
-fn open_live_root(live_root: &Path) -> Result<FdGuard, ResolveError> {
-    let c_root = CString::new(live_root.as_os_str().as_bytes())
-        .map_err(|_| ResolveError::new("live_source_unavailable", "live root path contains NUL"))?;
-    let fd = unsafe {
-        libc::open(
-            c_root.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-        )
-    };
-    if fd < 0 {
-        let e = std::io::Error::last_os_error();
-        return Err(ResolveError::new(
+        SkillDirError::RootOpen(error) => ResolveError::new(
             "live_source_unavailable",
-            format!("failed to open live root: {e}"),
-        ));
-    }
-    Ok(FdGuard(fd))
-}
-
-/// Open a child directory under `parent` with `O_NOFOLLOW | O_DIRECTORY`,
-/// classifying failures into structured errors.
-fn openat_dir_nofollow(parent: &FdGuard, name: &str) -> Result<FdGuard, ResolveError> {
-    let c_name = CString::new(name.as_bytes()).map_err(|_| {
-        ResolveError::new(
+            format!("failed to open live root: {error}"),
+        ),
+        SkillDirError::ComponentContainsNul => ResolveError::new(
             "invalid_canonical_path",
             "skill path component contains NUL",
-        )
-    })?;
-    let fd = unsafe {
-        libc::openat(
-            parent.0,
-            c_name.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-        )
-    };
-    if fd < 0 {
-        let e = std::io::Error::last_os_error();
-        let errno = e.raw_os_error().unwrap_or(0);
-        if errno == libc::ELOOP {
-            return Err(ResolveError::new(
-                "invalid_canonical_path",
-                format!("skill path component '{name}' is a symlink; refusing to follow"),
-            ));
-        }
-        if errno == libc::ENOENT {
-            return Err(ResolveError::new(
-                "skill_not_found",
-                format!("skill path component '{name}' does not exist under the managed root"),
-            ));
-        }
-        if errno == libc::ENOTDIR {
-            if entry_is_symlink(parent, &c_name) {
-                return Err(ResolveError::new(
-                    "invalid_canonical_path",
-                    format!("skill path component '{name}' is a symlink; refusing to follow"),
-                ));
-            }
-            return Err(ResolveError::new(
-                "invalid_skill_layout",
-                format!("skill path component '{name}' is not a directory"),
-            ));
-        }
-        return Err(ResolveError::new(
+        ),
+        SkillDirError::ComponentSymlink { component } => ResolveError::new(
+            "invalid_canonical_path",
+            format!("skill path component '{component}' is a symlink; refusing to follow"),
+        ),
+        SkillDirError::ComponentMissing { component } => ResolveError::new(
+            "skill_not_found",
+            format!("skill path component '{component}' does not exist under the managed root"),
+        ),
+        SkillDirError::ComponentNotDirectory { component } => ResolveError::new(
+            "invalid_skill_layout",
+            format!("skill path component '{component}' is not a directory"),
+        ),
+        SkillDirError::ComponentOpen { component, source } => ResolveError::new(
             "live_source_unavailable",
-            format!("failed to open skill path component '{name}': {e}"),
-        ));
-    }
-    Ok(FdGuard(fd))
-}
-
-/// Return `true` when the entry named `c_name` under `dir` is a symlink,
-/// probed with `AT_SYMLINK_NOFOLLOW`.
-fn entry_is_symlink(dir: &FdGuard, c_name: &CStr) -> bool {
-    let mut st: libc::stat = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::fstatat(dir.0, c_name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW) };
-    rc == 0 && (st.st_mode & libc::S_IFMT) == libc::S_IFLNK
-}
-
-/// Classify the `SKILL.md` marker in `dir` using the same "no-follow
-/// regular file" rule as [`skillfs_core::store::has_regular_skill_md`], so
-/// the resolver never disagrees with store discovery, the FUSE layer, or
-/// Hermes activation enumeration about what a Skill is:
-///
-/// * `Ok(true)` — a regular-file `SKILL.md` is present (a valid marker),
-///   even when it is unreadable (mode `000`).
-/// * `Ok(false)` — no valid marker: the entry is absent (`ENOENT`/`ENOTDIR`)
-///   **or** exists but is not a regular file (a symlink — never followed —,
-///   directory, FIFO, …). A non-regular `SKILL.md` is treated as absent, so
-///   a symlinked top-level marker makes the directory a category (its real
-///   nested Skills still resolve) exactly as store discovery treats it.
-/// * `Err(live_source_unavailable)` — the entry cannot be classified (e.g.
-///   an I/O or permission error while stat-ing). Only a genuinely
-///   inconclusive result fails closed.
-///
-/// Existence and type are decided with `fstatat(AT_SYMLINK_NOFOLLOW)` on the
-/// already-opened directory fd rather than a path-based `symlink_metadata`,
-/// which keeps the resolver's symlink-escape-safe fd descent while yielding
-/// the identical marker classification.
-fn dir_has_skill_md(dir: &FdGuard) -> Result<bool, ResolveError> {
-    let c_name = CString::new("SKILL.md")
-        .map_err(|_| ResolveError::new("live_source_unavailable", "SKILL.md name contains NUL"))?;
-    let mut st: libc::stat = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::fstatat(dir.0, c_name.as_ptr(), &mut st, libc::AT_SYMLINK_NOFOLLOW) };
-    if rc == 0 {
-        // Present: a valid marker only when it is a regular file. A symlink
-        // (never followed), directory, or other object is not a marker and
-        // is treated as absent — matching store/FUSE discovery.
-        return Ok((st.st_mode & libc::S_IFMT) == libc::S_IFREG);
-    }
-    let e = std::io::Error::last_os_error();
-    match e.raw_os_error() {
-        // Definitively absent.
-        Some(libc::ENOENT) | Some(libc::ENOTDIR) => Ok(false),
-        // Anything else (EACCES, EIO, …) is inconclusive — fail closed
-        // rather than assume the marker is absent.
-        _ => Err(ResolveError::new(
+            format!("failed to open skill path component '{component}': {source}"),
+        ),
+        SkillDirError::NestedBelowTopLevelSkill { parent, child } => ResolveError::new(
+            "invalid_skill_layout",
+            format!(
+                "'{parent}' is a top-level skill, not a category; '{child}' is a \
+                 subdirectory, not a nested Skill"
+            ),
+        ),
+        SkillDirError::MarkerInspect(error) => ResolveError::new(
             "live_source_unavailable",
-            format!("cannot determine SKILL.md presence: {e}"),
-        )),
-    }
-}
-
-/// Verify that `dir` contains a regular-file `SKILL.md`, failing closed on
-/// an inconclusive stat.
-fn verify_skill_md(dir: &FdGuard) -> Result<(), ResolveError> {
-    if dir_has_skill_md(dir)? {
-        Ok(())
-    } else {
-        Err(ResolveError::new(
+            format!("cannot determine SKILL.md presence: {error}"),
+        ),
+        SkillDirError::MissingMarker => ResolveError::new(
             "invalid_skill_layout",
             "skill directory is missing a regular SKILL.md",
-        ))
-    }
-}
-
-/// Read the `(dev, ino)` identity of an open directory fd via `fstat`.
-fn fstat_identity(dir: &FdGuard) -> Result<FileId, ResolveError> {
-    let mut st: libc::stat = unsafe { std::mem::zeroed() };
-    let rc = unsafe { libc::fstat(dir.0, &mut st) };
-    if rc != 0 {
-        let e = std::io::Error::last_os_error();
-        return Err(ResolveError::new(
+        ),
+        SkillDirError::Identity(error) => ResolveError::new(
             "live_source_unavailable",
-            format!("failed to stat live skill directory: {e}"),
-        ));
+            format!("failed to stat live skill directory: {error}"),
+        ),
     }
-    Ok(FileId {
-        dev: st.st_dev,
-        ino: st.st_ino,
-    })
 }
 
 #[cfg(test)]

--- a/src/skillfs/crates/skillfs-fuse/src/security/skill_dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/skill_dir.rs
@@ -1,0 +1,195 @@
+//! FD-anchored Skill directory resolution shared by control-plane readers and writers.
+
+use std::ffi::{CStr, CString};
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+use crate::path::SkillLayout;
+
+/// Failure classes from protocol-neutral Skill directory resolution.
+#[derive(Debug)]
+pub(crate) enum SkillDirError {
+    InvalidDepth,
+    RootPathContainsNul,
+    RootOpen(io::Error),
+    ComponentContainsNul,
+    ComponentSymlink {
+        component: String,
+    },
+    ComponentMissing {
+        component: String,
+    },
+    ComponentNotDirectory {
+        component: String,
+    },
+    ComponentOpen {
+        component: String,
+        source: io::Error,
+    },
+    NestedBelowTopLevelSkill {
+        parent: String,
+        child: String,
+    },
+    MarkerInspect(io::Error),
+    MissingMarker,
+    Identity(io::Error),
+}
+
+/// Identity read from an already-verified Skill directory fd.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SkillDirIdentity {
+    pub(crate) dev: u64,
+    pub(crate) ino: u64,
+}
+
+/// Owned fd for a directory that satisfies the configured Skill boundary.
+#[derive(Debug)]
+pub(crate) struct VerifiedSkillDir(OwnedFd);
+
+impl VerifiedSkillDir {
+    /// Returns the raw fd for fd-relative metadata mutations.
+    pub(crate) fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+
+    /// Reads the stable filesystem identity from the verified directory fd.
+    pub(crate) fn identity(&self) -> Result<SkillDirIdentity, SkillDirError> {
+        let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::fstat(self.as_raw_fd(), &mut stat) };
+        if rc != 0 {
+            return Err(SkillDirError::Identity(io::Error::last_os_error()));
+        }
+        Ok(SkillDirIdentity {
+            dev: stat.st_dev,
+            ino: stat.st_ino,
+        })
+    }
+}
+
+/// Open and verify a layout-relative Skill directory without following links.
+///
+/// The returned fd is the capability used by both read-side identity queries
+/// and write-side metadata mutations. Protocol-specific validation and error
+/// vocabulary remain with the caller.
+pub(crate) fn open_verified_skill_dir(
+    root: &Path,
+    layout: SkillLayout,
+    components: &[&str],
+) -> Result<VerifiedSkillDir, SkillDirError> {
+    let valid_depth = match layout {
+        SkillLayout::Flat => components.len() == 1,
+        SkillLayout::Hermes => matches!(components.len(), 1 | 2),
+    };
+    if !valid_depth {
+        return Err(SkillDirError::InvalidDepth);
+    }
+
+    let root_name = CString::new(root.as_os_str().as_bytes())
+        .map_err(|_| SkillDirError::RootPathContainsNul)?;
+    let root_fd = unsafe {
+        libc::open(
+            root_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if root_fd < 0 {
+        return Err(SkillDirError::RootOpen(io::Error::last_os_error()));
+    }
+    // SAFETY: `open` returned a new fd and ownership is transferred once.
+    let mut current = unsafe { OwnedFd::from_raw_fd(root_fd) };
+
+    for (index, component) in components.iter().enumerate() {
+        let child = open_child_dir(current.as_raw_fd(), component)?;
+        if layout == SkillLayout::Hermes
+            && components.len() == 2
+            && index == 0
+            && dir_has_regular_skill_md(child.as_raw_fd())?
+        {
+            return Err(SkillDirError::NestedBelowTopLevelSkill {
+                parent: (*component).to_string(),
+                child: components[1].to_string(),
+            });
+        }
+        current = child;
+    }
+
+    if !dir_has_regular_skill_md(current.as_raw_fd())? {
+        return Err(SkillDirError::MissingMarker);
+    }
+    Ok(VerifiedSkillDir(current))
+}
+
+fn open_child_dir(parent_fd: RawFd, component: &str) -> Result<OwnedFd, SkillDirError> {
+    let child_name =
+        CString::new(component.as_bytes()).map_err(|_| SkillDirError::ComponentContainsNul)?;
+    let child_fd = unsafe {
+        libc::openat(
+            parent_fd,
+            child_name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if child_fd >= 0 {
+        // SAFETY: `openat` returned a new fd and ownership is transferred once.
+        return Ok(unsafe { OwnedFd::from_raw_fd(child_fd) });
+    }
+
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ELOOP) => Err(SkillDirError::ComponentSymlink {
+            component: component.to_string(),
+        }),
+        Some(libc::ENOENT) => Err(SkillDirError::ComponentMissing {
+            component: component.to_string(),
+        }),
+        Some(libc::ENOTDIR) if entry_is_symlink(parent_fd, &child_name) => {
+            Err(SkillDirError::ComponentSymlink {
+                component: component.to_string(),
+            })
+        }
+        Some(libc::ENOTDIR) => Err(SkillDirError::ComponentNotDirectory {
+            component: component.to_string(),
+        }),
+        _ => Err(SkillDirError::ComponentOpen {
+            component: component.to_string(),
+            source: error,
+        }),
+    }
+}
+
+fn entry_is_symlink(parent_fd: RawFd, name: &CStr) -> bool {
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::fstatat(
+            parent_fd,
+            name.as_ptr(),
+            &mut stat,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    rc == 0 && (stat.st_mode & libc::S_IFMT) == libc::S_IFLNK
+}
+
+fn dir_has_regular_skill_md(dir_fd: RawFd) -> Result<bool, SkillDirError> {
+    let marker = c"SKILL.md";
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::fstatat(
+            dir_fd,
+            marker.as_ptr(),
+            &mut stat,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if rc == 0 {
+        return Ok((stat.st_mode & libc::S_IFMT) == libc::S_IFREG);
+    }
+
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ENOENT) | Some(libc::ENOTDIR) => Ok(false),
+        _ => Err(SkillDirError::MarkerInspect(error)),
+    }
+}

--- a/src/skillfs/docs/design/control-socket-resolver.md
+++ b/src/skillfs/docs/design/control-socket-resolver.md
@@ -208,10 +208,11 @@ Resolution is O(path depth) and never scans the whole Skill root:
    `invalid_skill_layout`, and a symlinked *top-level* marker means the
    directory is a category whose real nested Skills still resolve. Only a
    genuinely inconclusive `stat` (e.g. an I/O error) fails closed as
-   `live_source_unavailable`. This is the same predicate — a shared
-   `has_regular_skill_md` — that store discovery, the FUSE readdir/read
-   gating, and Hermes activation enumeration apply, so no layer disagrees
-   about what a Skill is (see [Skill layout](#skill-layout-and-skill-id)).
+   `live_source_unavailable`. The fd-based resolver and mutation paths share
+   one classifier. Store discovery and FUSE layout code apply the same
+   no-follow regular-file rule through their path-based helper, so no layer
+   disagrees about what a Skill is (see
+   [Skill layout](#skill-layout-and-skill-id)).
 
 The backing path is never produced by naively joining unvalidated user
 input; each component is validated and opened without following symlinks.
@@ -234,25 +235,82 @@ phantom Skill, keeping the resolver's identities consistent with the FUSE
 layer and the notify id enumeration.
 
 Whether a directory "has a `SKILL.md`" — used for the top-level-vs-category
-decision and the leaf check — is the single shared `has_regular_skill_md`
-predicate: a **no-follow regular file**. A `SKILL.md` that is a symlink or
-other non-regular object is not a marker, so such a top-level directory is a
-category (its real nested Skills resolve) and such a leaf is
-`invalid_skill_layout`. Store discovery, FUSE readdir/read gating, and Hermes
-activation enumeration all use the same predicate, so a directory is a Skill
-in every layer or in none — the resolver cannot report a Skill the store
-never loaded, or reject one it did.
+decision and the leaf check — follows one semantic predicate: a **no-follow
+regular file**. A `SKILL.md` that is a symlink or other non-regular object is
+not a marker, so such a top-level directory is a category (its real nested
+Skills resolve) and such a leaf is `invalid_skill_layout`. The fd-based
+control-plane paths share one implementation; store discovery and FUSE layout
+code retain their crate-local path helper but apply the same rule. A directory
+is therefore a Skill in every layer or in none — the resolver cannot report a
+Skill the store never loaded, or reject one it did.
 
 ### Relationship to activation writes
 
-The read-only resolver is layout-agnostic and supports nested ids. The
-existing activation *write* methods (`meta.writeActivation`,
-`meta.setActivationXattr`) still validate a single skill-name component and
-reject nested ids with a clear invalid-skill-name error — they are not
-widened, and a nested write is never truncated to a basename and applied
-to the wrong target. Enabling the resolver under Hermes layout only lifts
-the blanket startup gate that previously refused to start the control
-socket in Hermes mode; it does not extend the write protocol.
+The read-only resolver and activation write methods (`meta.writeActivation`,
+`meta.setActivationXattr`) use layout-relative Skill ids. Flat layout accepts
+one component, while Hermes accepts either a top-level Skill or
+`category/skill`. Each component is validated independently and opened with
+`O_NOFOLLOW|O_DIRECTORY`; nested ids are never truncated to a basename, and
+managed or reserved paths remain invalid write targets. Writes in both layouts
+require a no-follow regular `SKILL.md` at the leaf. Hermes nested writes also
+require the first component to be a category rather than a top-level Skill.
+
+## Shared fd boundary and container follow-up
+
+### Decision for S1
+
+Read-side resolution and activation writes use one internal fd-anchored Skill
+directory capability. That shared layer owns:
+
+- opening the trusted live root and descending each component with
+  `O_NOFOLLOW | O_DIRECTORY`;
+- classifying symlink, missing, and non-directory components;
+- enforcing Flat and Hermes depth and category boundaries;
+- requiring a no-follow regular `SKILL.md` at the leaf; and
+- retaining the verified leaf fd for identity reads or metadata mutations.
+
+Request syntax, reserved-name checks, response construction, and protocol
+error mapping stay with each caller. This is intentional: for example, the
+resolver reports a non-directory component as `invalid_skill_layout`, while
+the existing activation-write protocol reports it as `skill_not_found`.
+Sharing the syscall and boundary layer must not silently change either public
+contract.
+
+The capability is rooted at a directory fd internally rather than at a joined
+user-controlled path. S1 still opens that root from the configured shared path
+and still returns `transport = shared_path`; it does not add an unused wire
+protocol or expose a new public API.
+
+### Container and security-integration plan
+
+The shared fd boundary is a prerequisite, not the complete container design.
+Follow-up container work is split into these independently testable steps:
+
+1. **SkillFS sidecar only** — keep the current shared-volume FUSE topology.
+   OpenClaw flat/staging paths and Hermes nested paths continue using their
+   existing layout semantics; replacing the example workload with either real
+   runtime does not itself require a new resolver protocol.
+2. **Ledger colocated with SkillFS** — when security integration is required
+   before a cross-container trust design is approved, run the trusted Ledger
+   worker in the SkillFS container. Existing `SO_PEERCRED`, `/proc/<pid>/exe`,
+   socket, and ledger-backing-root assumptions remain locally verifiable.
+3. **Ledger in a separate container** — define a shared runtime volume for
+   sockets and an explicit source capability transport. Evaluate a shared PID
+   namespace against a container-aware authenticated identity; any identity or
+   executable lookup ambiguity must fail closed.
+4. **General multi-container/Kubernetes support** — add `dir-fd` /
+   `SCM_RIGHTS` only with a versioned transport contract, namespace-aware
+   identity tests, and lifecycle tests for sidecar restart and fd revocation.
+   The same verified-directory primitive then consumes the received root fd,
+   so Flat/Hermes Skill boundaries do not fork again.
+
+The complex part of containerizing Skill Ledger is therefore not OpenClaw or
+Hermes parsing. It is preserving four cross-container security invariants:
+authenticated peer identity, visibility of the runtime socket, access to the
+physical live/backing source rather than the FUSE view, and consistent fd/path
+identity across PID and mount namespaces. Until those invariants have an
+accepted threat model and black-box Kubernetes tests, the separate-Ledger
+profile is not advertised as supported.
 
 ## Socket lifecycle hardening
 


### PR DESCRIPTION
## Why

SkillFS security integration had four boundary gaps affecting Hermes activation
updates, activation metadata confidentiality, control socket shutdown, and
in-place backing-root isolation. Issue #2404 now includes a black-box
reproduction for the nested Hermes activation failure.

## What changed

- Validate layout-relative Skill IDs component by component and descend with
  `O_NOFOLLOW|O_DIRECTORY` for both activation write methods.
- Enforce `0700` on `.skill-meta` and `0600` on `activation.json`, including
  tightening pre-existing metadata.
- Configure the listener as non-blocking before spawning the server and clean
  failed startup by exact socket identity.
- Revalidate canonical backing aliases and require an owned private bind for
  accepted in-place configurations.

## Related issue

Closes #2404

## User / Agent impact

Hermes nested Skills can update activation through the control socket and
receive the documented `updated` outcome. Unsafe in-place backing aliases now
fail closed, while Flat layout and non-in-place source aliases retain their
existing behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The control-socket `skillName` field now accepts a layout-relative Hermes Skill
ID such as `category/skill`. Validation remains depth-bounded, rejects reserved
paths, and opens every path component without following symlinks. The four
fixes are split into independent commits for focused review and rollback.

## Validation

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 doc --workspace --no-deps`
- `scripts/test.sh`
- Focused listener-failure, permissions, Hermes nested write/xattr, and
  backing-alias regression tests

## Documentation and rollback

Updated the Hermes control-socket behavior in the layout rustdoc, CLI wiring
comment, and control-socket resolver design document. Roll back by reverting
the corresponding independent fix commit for the affected boundary.
