### PR TITLE
fix(cosh-ng): [shell] skip shrunk audit snapshots

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
@@ -21,6 +21,7 @@ pub(crate) struct ShellAuditRecorder {
     mode: AuditMode,
     shell_session_id: String,
     seen_events: usize,
+    truncation_reported: bool,
     hash_salt: String,
     degraded: bool,
     warning_emitted: bool,
@@ -78,6 +79,7 @@ impl ShellAuditRecorder {
             mode: settings.mode,
             shell_session_id,
             seen_events: 0,
+            truncation_reported: false,
             hash_salt: uuid::Uuid::new_v4().to_string(),
             warning_emitted: false,
             owned_approvals: std::collections::HashSet::new(),
@@ -99,6 +101,7 @@ impl ShellAuditRecorder {
             mode: AuditMode::Required,
             shell_session_id: shell_session_id.into(),
             seen_events: 0,
+            truncation_reported: false,
             hash_salt: "test-salt".to_string(),
             degraded: true,
             warning_emitted: false,
@@ -117,6 +120,7 @@ impl ShellAuditRecorder {
             mode: AuditMode::BestEffort,
             shell_session_id: "audit-test-session".to_string(),
             seen_events: 0,
+            truncation_reported: false,
             hash_salt: "salt".to_string(),
             degraded: false,
             warning_emitted: false,
@@ -127,9 +131,29 @@ impl ShellAuditRecorder {
     }
 
     /// Projects newly observed native command events exactly once.
+    ///
+    /// `events` is a cumulative per-session snapshot that callers only ever
+    /// grow. A shorter snapshot means the upstream buffer was truncated or
+    /// rebuilt; replaying it would duplicate persisted records, so the batch
+    /// is skipped while the high-water mark stays put, and the gap is
+    /// persisted as one `audit.truncated` record per shrink episode
+    /// (re-armed once projection advances again) so reconciliation can tell
+    /// an omission from a complete stream.
     pub(crate) fn observe_shell_events(&mut self, events: &[ShellEvent]) {
         if self.seen_events > events.len() {
-            self.seen_events = 0;
+            tracing::warn!(
+                target: "cosh_audit",
+                seen = self.seen_events,
+                len = events.len(),
+                "shell event snapshot shrank; skipping the batch to keep audit records exactly-once"
+            );
+            if !self.truncation_reported {
+                self.truncation_reported = self.record_truncation(events.len());
+            }
+            return;
+        }
+        if events.len() > self.seen_events {
+            self.truncation_reported = false;
         }
         for event in &events[self.seen_events..] {
             if matches!(
@@ -632,6 +656,9 @@ fn approval_identity(request: &ShellApprovalAuditInput<'_>) -> AuditIdentity {
 
 #[path = "audit/host_execution.rs"]
 mod host_execution;
+
+#[path = "audit/truncation.rs"]
+mod truncation;
 
 #[cfg(test)]
 #[path = "audit_tests.rs"]

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit/truncation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit/truncation.rs
@@ -1,0 +1,62 @@
+//! Persisted projection gaps left by shrunken shell event snapshots.
+
+use super::ShellAuditRecorder;
+use crate::types::audit::{
+    AuditEventOutcome, AuditEventV1, AuditIdentity, AuditOutcomeStatus, AuditRedaction,
+    AuditSubject,
+};
+
+impl ShellAuditRecorder {
+    /// Persists the projection gap left by a shrunken event snapshot.
+    ///
+    /// Returns whether the marker's primary write is durable so the caller
+    /// marks the episode as reported only then and otherwise retries on the
+    /// episode's next observation. Like the recovery markers it writes
+    /// directly, keeping the result free of recovery-injection failures;
+    /// only counters are recorded.
+    pub(super) fn record_truncation(&mut self, snapshot_len: usize) -> bool {
+        let event = AuditEventV1::shell(
+            "audit.truncated",
+            AuditIdentity {
+                shell_session_id: Some(self.shell_session_id.clone()),
+                ..AuditIdentity::default()
+            },
+            AuditEventOutcome {
+                status: AuditOutcomeStatus::Failed,
+                code: None,
+                retryable: false,
+            },
+            AuditSubject {
+                kind: "audit".to_string(),
+                name: None,
+            },
+            &serde_json::json!({
+                "operation": "event_snapshot_shrunk",
+                "seen": self.seen_events,
+                "len": snapshot_len,
+            }),
+            AuditRedaction::clean(),
+        );
+        match event {
+            Ok(mut event) => {
+                self.ensure_writer();
+                let result = self
+                    .writer
+                    .as_mut()
+                    .ok_or_else(|| "audit writer is unavailable".to_string())
+                    .and_then(|writer| writer.append(&mut event, true));
+                match result {
+                    Ok(()) => true,
+                    Err(error) => {
+                        self.mark_degraded(&error);
+                        false
+                    }
+                }
+            }
+            Err(error) => {
+                self.mark_degraded(&error);
+                false
+            }
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit_tests.rs
@@ -59,6 +59,7 @@ fn command_projection_contains_no_raw_command_cwd_or_path() {
         mode: AuditMode::BestEffort,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: false,
         warning_emitted: false,
@@ -92,6 +93,7 @@ fn required_owned_approval_resolution_fails_before_execution_boundary() {
         mode: AuditMode::Required,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: true,
         warning_emitted: false,
@@ -162,6 +164,7 @@ fn required_core_host_execution_fails_before_handoff_boundary() {
         mode: AuditMode::Required,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: true,
         warning_emitted: false,
@@ -201,6 +204,7 @@ fn core_host_execution_does_not_duplicate_the_approval_resolution() {
         mode: AuditMode::BestEffort,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: false,
         warning_emitted: false,
@@ -243,6 +247,7 @@ fn shell_owned_approval_does_not_require_a_provider_tool_identity() {
         mode: AuditMode::Required,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: false,
         warning_emitted: false,
@@ -280,6 +285,7 @@ fn successful_write_closes_shell_degraded_episode() {
         mode: AuditMode::BestEffort,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: true,
         warning_emitted: true,
@@ -298,6 +304,161 @@ fn successful_write_closes_shell_degraded_episode() {
     let _ = std::fs::remove_dir_all(root);
 }
 
+/// Serializes the shrink tests: they share the warning callsite, and the
+/// thread-scoped capture subscriber can miss it when a concurrent test
+/// evaluates the same callsite without any subscriber installed.
+fn shrink_guard() -> std::sync::MutexGuard<'static, ()> {
+    static SHRINK_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    SHRINK_LOCK
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
+#[test]
+fn observe_shell_events_shrink_does_not_replay_recorded_commands() {
+    let _guard = shrink_guard();
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let started = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+    let mut completed = started.clone();
+    completed.kind = ShellEventKind::CommandCompleted;
+    completed.exit_code = Some(0);
+    recorder.observe_shell_events(&[started.clone(), completed]);
+    recorder.observe_shell_events(std::slice::from_ref(&started));
+    // A second shrunken batch in the same episode must not add another marker.
+    recorder.observe_shell_events(&[started]);
+    drop(recorder);
+
+    assert_eq!(
+        record_count(&root, "shell.command.started", None),
+        1,
+        "a shrunken event snapshot must not replay already-recorded commands"
+    );
+    assert_eq!(
+        record_count(&root, "audit.truncated", None),
+        1,
+        "the projection gap must be persisted exactly once per shrink episode"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn observe_shell_events_resumes_projection_after_a_shrink() {
+    let _guard = shrink_guard();
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let first = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+    let mut completed = first.clone();
+    completed.kind = ShellEventKind::CommandCompleted;
+    completed.exit_code = Some(0);
+    recorder.observe_shell_events(&[first.clone(), completed.clone()]);
+    // The transient shrunken view is skipped without moving the projected
+    // high-water mark, so the restored snapshot projects only the events
+    // past the mark and never re-records the persisted completion.
+    recorder.observe_shell_events(std::slice::from_ref(&first));
+    let second = ShellEvent::command_started("session-1", "cmd-2", "pwd", "/tmp/work", 2);
+    recorder.observe_shell_events(&[first.clone(), completed.clone(), second.clone()]);
+    // Advancing past the mark closes the episode; a later shrink is a new
+    // one and persists its own gap marker.
+    recorder.observe_shell_events(std::slice::from_ref(&first));
+    drop(recorder);
+
+    assert_eq!(record_count(&root, "shell.command.completed", None), 1);
+    assert_eq!(record_count(&root, "shell.command.started", None), 2);
+    assert_eq!(
+        record_count(&root, "shell.command.started", Some("cmd-2")),
+        1
+    );
+    assert_eq!(
+        record_count(&root, "audit.truncated", None),
+        2,
+        "each shrink episode persists its own gap marker"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn observe_shell_events_retries_the_truncation_marker_until_durable() {
+    let _guard = shrink_guard();
+    let root = private_root();
+    let mut recorder = recording_recorder(&root);
+    let started = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+    let mut completed = started.clone();
+    completed.kind = ShellEventKind::CommandCompleted;
+    completed.exit_code = Some(0);
+    recorder.observe_shell_events(&[started.clone(), completed]);
+    // The first shrunken snapshot hits an unavailable writer: the marker is
+    // not durable, so the episode must stay unreported.
+    recorder.writer = None;
+    let saved_root = recorder.writer_root.take();
+    recorder.observe_shell_events(std::slice::from_ref(&started));
+    // The writer recovers while the same episode keeps shrinking: the next
+    // observation retries and persists the marker exactly once.
+    recorder.writer_root = saved_root;
+    recorder.observe_shell_events(std::slice::from_ref(&started));
+    recorder.observe_shell_events(&[started]);
+    drop(recorder);
+
+    assert_eq!(
+        record_count(&root, "audit.truncated", None),
+        1,
+        "the gap marker must be retried until durable, then stay bounded"
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn observe_shell_events_shrink_emits_a_warning() {
+    struct SharedWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+    impl std::io::Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let writer_handle = captured.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(move || SharedWriter(writer_handle.clone()))
+        .finish();
+    let _guard = shrink_guard();
+    let root = private_root();
+    tracing::subscriber::with_default(subscriber, || {
+        let mut recorder = recording_recorder(&root);
+        let started = ShellEvent::command_started("session-1", "cmd-1", "ls -l", "/tmp/work", 1);
+        let mut completed = started.clone();
+        completed.kind = ShellEventKind::CommandCompleted;
+        completed.exit_code = Some(0);
+        recorder.observe_shell_events(&[started.clone(), completed]);
+        recorder.observe_shell_events(&[started]);
+    });
+
+    let output = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+    assert!(
+        output.contains("shell event snapshot shrank"),
+        "the skipped batch must leave a warning trail: {output}"
+    );
+    assert!(output.contains("cosh_audit"), "{output}");
+    let _ = std::fs::remove_dir_all(root);
+}
+
+/// Counts persisted command records by event type and optional command id.
+fn record_count(root: &Path, event_type: &str, command_id: Option<&str>) -> usize {
+    walk_segment_text(root)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("audit record"))
+        .filter(|record| record["event_type"] == event_type)
+        .filter(|record| {
+            command_id.is_none_or(|command_id| record["identity"]["command_id"] == command_id)
+        })
+        .count()
+}
+
 fn recording_recorder(root: &Path) -> ShellAuditRecorder {
     ShellAuditRecorder {
         writer: Some(AuditSegmentWriter::create(root).unwrap()),
@@ -305,6 +466,7 @@ fn recording_recorder(root: &Path) -> ShellAuditRecorder {
         mode: AuditMode::BestEffort,
         shell_session_id: "session-1".to_string(),
         seen_events: 0,
+        truncation_reported: false,
         hash_salt: "salt".to_string(),
         degraded: false,
         warning_emitted: false,


### PR DESCRIPTION
## Summary

`ShellAuditRecorder::observe_shell_events` reset `seen_events` to zero whenever the incoming cumulative event snapshot was shorter than the projected prefix, then re-walked the slice from the start. Any upstream truncation or rebuild of the event buffer would re-record already persisted `shell.command.started`/`completed`/`failed` records, breaking the exactly-once contract the projection promises to downstream audit consumers (compliance reconciliation, SIEM sync).

This PR keeps the projected high-water mark fixed on a shrink: the batch is skipped with a `tracing::warn` (counters only) and the gap is persisted as one bounded `audit.truncated` record per shrink episode, re-armed once projection advances again. A transient shrink therefore resumes projection only past the mark, and a permanently replaced stream leaves an auditable gap marker instead of duplicated records. The worst case on this path is a missed batch with both a log trace and a persisted marker, never a duplicate. The doc comment states the cumulative-snapshot contract and the shrink policy explicitly.

Closes #2104

## Reality check on the issue's reproduction claim

- The issue's black-box command `cosh-ng audit replay --session <sid> --events-shrink` does not exist in the codebase (`cosh-cli` has no `audit replay` subcommand); the reporter's follow-up comment on the issue also confirms black-box reproduction is infeasible (PRODUCT_BUG_STATIC).
- The shrink branch is unreachable through today's production chain: the only production caller (`runtime/controller.rs::render_raw_inline_events`) passes `&parser.events`, which only ever grows within a relay session, and the recorder is created once per `run_raw` launch. This fix hardens a latent path so that future upstream changes (replay/truncation) cannot silently duplicate audit records.
- Severity stays `priority:p2`: no user-visible damage today; audit-contract latent defect.

## Changes

- `crates/cosh-shell/src/journal/audit.rs`: the shrink branch warns (target `cosh_audit`, counters only — no command text), records the projection gap, and returns without projecting the batch or moving `seen_events`; the doc comment documents the cumulative snapshot contract and the shrink policy.
- `crates/cosh-shell/src/journal/audit/truncation.rs` (new): holds `record_truncation`, which persists one `audit.truncated` marker per shrink episode and reports whether its primary write is durable so the episode retries until the write sticks. Follows the sibling `audit/host_execution.rs` module form.
- `crates/cosh-shell/src/journal/audit_tests.rs`: four regression tests anchor the shrink path (record counting via parsed JSON fields, not raw string matching), serialized behind a shared test mutex because they share the warning callsite:
  - `observe_shell_events_shrink_does_not_replay_recorded_commands` — a shrunken snapshot must not replay persisted commands, and the gap is recorded exactly once per episode.
  - `observe_shell_events_resumes_projection_after_a_shrink` — a transient shrink keeps the high-water mark, so the restored snapshot projects only new events and never re-records the persisted completion.
  - `observe_shell_events_retries_the_truncation_marker_until_durable` — a fail-once writer leaves the episode unreported, so the next shrunken observation retries the marker.
  - `observe_shell_events_shrink_emits_a_warning` — the skipped batch leaves a `cosh_audit` warning trail (tracing capture).

Diff: 3 files changed, 252 insertions(+), 1 deletion(-).

## Tests

- FAIL→PASS anchor against the current base `d226cf4f`: the shrink probe fails `exit 101` with `left: 2, right: 1` (a second `shell.command.started` for the same `cmd-1`) on the unmodified base, and is green with the fix.
- `cargo test -p cosh-shell --lib journal::implementation::audit`: **20 passed / 0 failed**, all four new tests compiled and executed.

## Verification

Verified on head `dfd38380`, base `d226cf4f` (v0.22.0).

- Gates: `crates/cosh-shell/scripts/check-layout.sh` passed, `scripts/check-test-inventory.sh` passed, `cargo fmt --all --check` clean, `cargo clippy -p cosh-shell --all-targets -- -D warnings` clean, e2e contract (`python3 -m unittest discover -s e2e/tests` 7 tests + `python3 e2e/run.py --plan --profile local`) green.
- `cargo test -p cosh-shell`: `--lib` 1377 passed / 5 failed; `--bin cosh-shell` 2525 passed / 7 failed; `--test logic` 9 passed / 0 failed; `--test protocol` 68 passed / 2 failed.
- Layout note: rebasing onto v0.22.0 pushed `journal/audit.rs` to 715 lines (upstream `9a91e5dd` grew it by 16), crossing the 700-line threshold. `large-file-inventory.md` admits only files already over threshold on `main`, so `record_truncation` was split into `journal/audit/truncation.rs` rather than waived; `audit.rs` is now 665 lines.

### Excluded scope

Every failure listed above reproduces identically on unmodified base `d226cf4f`, so none is attributable to this diff:

- 7 hook cases — `hooks::engine::tests::{external,project}` (5, in both lib and bin) and `runtime::controller::hook_tests::*` (2). Pre-existing on macOS hosts.
- 2 `protocol::session_management` cases — `..._reaps_descendant_that_inherits_output_pipes` and `..._timeout_kills_term_ignoring_process`. Pre-existing on macOS, reproduced 2/2 rounds before the base contrast, so not load noise.

Not run locally, left to Linux CI:

- `cargo clippy` on the CI toolchain 1.97.1 — the local `stable` is 1.96.0, so lints introduced in 1.97 are invisible here. Workspace clippy on 1.96 is otherwise clean apart from pre-existing macOS-only dead code in `cosh-gateway`, reproduced identically on unmodified base.
- `scripts/check-source-layout.sh` — requires `declare -A`, unavailable under macOS bash 3.2. It scans only `crates/cosh-gateway{,-contracts}/src`, which this diff does not touch.
- `run_raw_packaging`, `run_rpm_packaging`, and the `--workspace --exclude cosh-core --exclude cosh-shell` leg of `run-test-gates.sh fast`.
- Workspace-wide test suite beyond `cosh-shell`; real-PTY/adapter acceptance is not applicable — the shrink branch has no production trigger surface, so the white-box FAIL→PASS contrast is the acceptance path.

## Evidence

Text-only evidence (library-internal behavior, no UI frames): FAIL/PASS logs archived locally; the FAIL assertion output is quoted in Tests above. No screenshot assets for this PR.
