### PR TITLE
fix(cosh-ng): [shell] list all slash hint matches

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -396,9 +396,28 @@ pub(super) fn candidate_inline_hint(line: &str) -> Option<String> {
             Some("approval [recommend|auto|trust] | analysis [smart|auto|manual]".to_string())
         }
         "/details" if parts.next().is_none() => Some("<id>".to_string()),
-        _ => crate::slash::registry::visible_slash_commands()
-            .find(|spec| spec.name.starts_with(token) && spec.name != token)
-            .map(|spec| spec.usage.to_string()),
+        _ => {
+            // List every matching command: returning only the first prefix
+            // match hides same-prefix siblings (`/sta` hid `/stats`). Names
+            // are deduplicated so multi-spec commands (`/mode`) still count
+            // as a single candidate and keep their usage hint.
+            let mut names: Vec<&'static str> = Vec::new();
+            let mut sole_usage = None;
+            for spec in crate::slash::registry::visible_slash_commands() {
+                if spec.name.starts_with(token) && spec.name != token && !names.contains(&spec.name)
+                {
+                    names.push(spec.name);
+                    if names.len() == 1 {
+                        sole_usage = Some(spec.usage);
+                    }
+                }
+            }
+            match names.len() {
+                0 => None,
+                1 => sole_usage.map(str::to_string),
+                _ => Some(names.join(" · ")),
+            }
+        }
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -540,6 +540,39 @@ mod tests {
     }
 
     #[test]
+    fn ambiguous_prefix_hint_lists_all_matching_candidates() {
+        assert_eq!(
+            candidate_inline_hint("/sta"),
+            Some("/status · /stats".to_string())
+        );
+        assert_eq!(
+            candidate_inline_hint("/st"),
+            Some("/status · /stats".to_string())
+        );
+        assert_eq!(
+            candidate_inline_hint("/s"),
+            Some("/status · /stats · /session · /skills".to_string())
+        );
+        assert_eq!(
+            candidate_inline_hint("/h"),
+            Some("/health · /hooks".to_string())
+        );
+        // `/mode` has two specs but deduplicates to one candidate name.
+        assert_eq!(
+            candidate_inline_hint("/m"),
+            Some("/mode · /mcp".to_string())
+        );
+    }
+
+    #[test]
+    fn exact_command_token_excludes_itself_from_hint() {
+        // `/stats` is complete: no other visible command shares the prefix.
+        assert_eq!(candidate_inline_hint("/stats"), None);
+        // `/status` is complete and no sibling extends it either.
+        assert_eq!(candidate_inline_hint("/status"), None);
+    }
+
+    #[test]
     fn extension_setting_values_are_redacted_from_candidate_echo() {
         let command = b"/extensions settings set fixture token secret-value --scope user";
         let redacted = redact_extension_setting_value(command);

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/input_events.rs
@@ -55,6 +55,19 @@ fn erase_native_columns<W: Write>(output: &mut W, columns: usize) -> io::Result<
     Ok(())
 }
 
+// The inline hint must never trigger terminal auto-wrap: a wrapped tail
+// lands on the next screen line where the erase-to-EOL of the following
+// redraw/commit cannot reach it, leaving residue behind. The native
+// prompt width is unknown here, so clipping by remaining columns is not
+// possible; instead auto-wrap (DECAWM) is disabled around the write and
+// the terminal clips the hint at the right edge itself.
+fn write_inline_hint<W: Write>(output: &mut W, hint: &str) -> io::Result<()> {
+    write!(
+        output,
+        "{SAVE_CURSOR}\x1b[?7l\x1b[2m {hint}\x1b[0m\x1b[?7h{RESTORE_CURSOR}"
+    )
+}
+
 pub(super) fn drain_raw_input_events<W: Write>(
     input_events: &Receiver<RawInputEvent>,
     parser: &mut OscParser,
@@ -139,14 +152,14 @@ pub(super) fn drain_raw_input_events<W: Write>(
                     write!(output, "\x1b[K")?;
                     output.write_all(&input)?;
                     if let Some(hint) = hint {
-                        write!(output, "{SAVE_CURSOR}\x1b[2m {hint}\x1b[0m{RESTORE_CURSOR}")?;
+                        write_inline_hint(output, &hint)?;
                     }
                     *native_candidate_echoed_len = candidate_display_columns(&input);
                 } else {
                     write!(output, "\r\x1b[2K{prompt}")?;
                     output.write_all(&input)?;
                     if let Some(hint) = hint {
-                        write!(output, "{SAVE_CURSOR}\x1b[2m {hint}\x1b[0m{RESTORE_CURSOR}")?;
+                        write_inline_hint(output, &hint)?;
                     }
                 }
                 output.flush()?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -225,11 +225,50 @@ fn candidate_hint_uses_terminfo_cursor_save_restore() {
 
     assert_eq!(
         output,
-        b"\x1b[K/m\x1b7\x1b[2m /mode approval [recommend|auto|trust]\x1b[0m\x1b8"
+        b"\x1b[K/m\x1b7\x1b[?7l\x1b[2m /mode approval [recommend|auto|trust]\x1b[0m\x1b[?7h\x1b8"
     );
     assert_eq!(echoed, 2);
     assert!(!output.windows(3).any(|window| window == b"\x1b[s"));
     assert!(!output.windows(3).any(|window| window == b"\x1b[u"));
+}
+
+// A wrapped hint tail would land below the erase-to-EOL reach of the next
+// redraw/commit, so the hint write must keep auto-wrap disabled in both
+// the native and the prompt-owned branches.
+#[test]
+fn candidate_hint_disables_autowrap_in_both_branches() {
+    for prompt in ["", "prompt> "] {
+        let mut parser = parser_for_test("candidate-hint-autowrap");
+        let (_generation, mut prompt_replay) = tracker_for_test();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut output = Vec::new();
+        let mut echoed = 0usize;
+
+        sender
+            .send(crate::raw_input::RawInputEvent::CandidateRedraw {
+                input: b"/s".to_vec(),
+                hint: Some("/status · /stats · /session · /skills".to_string()),
+            })
+            .expect("queue candidate redraw");
+        drain_raw_input_events(
+            &receiver,
+            &mut parser,
+            &mut output,
+            prompt,
+            &mut echoed,
+            &mut prompt_replay,
+        )
+        .expect("draw candidate hint");
+
+        let rendered = String::from_utf8(output).expect("utf8 output");
+        let disable = rendered.find("\x1b[?7l").expect("auto-wrap disabled");
+        let hint = rendered.find("/status · /stats").expect("hint rendered");
+        let enable = rendered.find("\x1b[?7h").expect("auto-wrap restored");
+        assert!(
+            disable < hint && hint < enable,
+            "hint must render inside the no-wrap window: {rendered:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

In the cosh-shell raw TUI, typing a slash prefix (e.g. `/sta`) rendered
an inline hint with only the **first** prefix match from the registry:
`/status` was hinted while `/stats` never appeared, so users could not
discover sibling commands. Every ambiguous prefix (`/s`, `/h`, `/m`)
hid its later siblings the same way. The submit-time hint panel
(`slash_command_hints`) already lists every candidate, so the inline
hint contradicted the existing discovery contract.

## What changed

`candidate_inline_hint` (raw_input/event_parser.rs) now collects every
matching visible command instead of stopping at the first:

- unique match: unchanged — full usage hint (e.g. `/sk` →
  `/skills [list|detail] [name]`);
- multiple matches: all candidate names in registry order joined by
  " · " (e.g. `/sta` → `/status · /stats`), matching the startup
  banner separator convention;
- names are deduplicated, so multi-spec commands (`/mode`) still count
  as a single candidate and `/mo` keeps its usage hint.

The `/mode` / `/details` dedicated arms, bare `/`, second-`/` and
no-match paths are byte-for-byte unchanged.

Review round 1 (P2, kongche-jbw): the inline hint write in
`shell_host/raw_relay/input_events.rs` now disables terminal auto-wrap
(DECAWM, `ESC[?7l` … `ESC[?7h`) around the dim segment, so a hint
longer than the remaining row width is clipped at the right edge by
the terminal instead of wrapping; the wrapped tail could otherwise
survive the erase-to-EOL of the next redraw/commit as screen residue.
This bounds every hint form (long single-usage hints had the same
pre-existing exposure), works in both the native and prompt-owned
branches, and needs no knowledge of the (unknown) native prompt width.

## Related issue

closes #2304

## User / Agent impact

Inline slash hint now surfaces every command sharing the typed prefix.
No key bindings, submit behavior, or command semantics changed.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: pure string composition in one `pub(super)` helper; the
rendering path (`CandidateRedraw` erase + redraw with `\x1b[K`) is
untouched and already handles long single-usage hints of comparable
length.

## Validation

- `cargo test -p cosh-shell --lib raw_input` — 203 passed (macOS)
- `cargo test -p cosh-shell --bin cosh-shell raw_input` — 205 passed
- new regression tests: `ambiguous_prefix_hint_lists_all_matching_candidates`,
  `exact_command_token_excludes_itself_from_hint`; existing anchor
  `bare_slash_has_no_inline_hint` unchanged and green
- shell_host regression tests: `candidate_hint_disables_autowrap_in_both_branches`
  (new) plus re-anchored `candidate_hint_uses_terminfo_cursor_save_restore`;
  `cargo test -p cosh-shell --lib/--bin raw_relay` — 44/44 passed
- narrow-terminal real-PTY FAIL→PASS (40 cols, real binary): typing `/s`
  then `t` leaves a wrapped-hint residue line on the pre-fix binary and
  no residue with the DECAWM fix (screenshots in Evidence)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets`
  (0 warnings, also clean under latest stable with `-D warnings`)
- gates: `crates/cosh-shell/scripts/check-layout.sh`,
  `scripts/check-test-inventory.sh` — both pass
- full `--lib`/`--bin` suites: only pre-existing failures in
  `hooks::engine`/`runtime::controller::hook_tests` (12 total) which
  reproduce identically on clean origin/main on this macOS host
  (introduced by 5614d471, unrelated to this diff); CI is authoritative
- real-PTY FAIL→PASS: scripted PTY drives the real `cosh-shell raw`
  binary (cosh-core adapter on PATH), types `/sta` without submitting;
  3/3 runs FAIL on base 7e971b13 (hint `/status` only) → 3/3 runs PASS
  with this fix (hint `/status · /stats`)
- excluded scope (not run): integration targets `logic` / `protocol` /
  `shell_host` / `raw_cli`, non-macOS platforms

## Evidence

Screenshots come from the real `cosh-shell raw` binary in a scripted
PTY (100x30, cosh-core adapter on PATH), hosted on a fork orphan
branch (`pr-2410-assets`, commit-pinned raw links; not part of this
repo's history).

Before (base 7e971b13): typing `/sta` hints `/status` only — `/stats`
is hidden:

![before-fix](https://raw.githubusercontent.com/SunnyQjm/anolisa/913059cb9711fb649ee521f76d3c77f38c41029a/before-fix-sta-hint.png)

After (this PR): the same input hints `/status · /stats`:

![after-fix](https://raw.githubusercontent.com/SunnyQjm/anolisa/913059cb9711fb649ee521f76d3c77f38c41029a/after-fix-sta-hint.png)

Review round 1 narrow-terminal check (40 cols, `/s` then `t`) — before:
the wrapped hint tail (`· /skills`) survives the next redraw as residue
and misplaces the draft line; after: the hint is clipped at the right
edge and the screen stays clean:

![narrow-before](https://raw.githubusercontent.com/SunnyQjm/anolisa/913059cb9711fb649ee521f76d3c77f38c41029a/narrow-40col-before-residue.png)

![narrow-after](https://raw.githubusercontent.com/SunnyQjm/anolisa/913059cb9711fb649ee521f76d3c77f38c41029a/narrow-40col-after-clipped.png)

## Documentation and rollback

No documentation changes needed (behavior now matches the documented
discovery expectation). Revert of the single commit restores the old
first-match hint.
