### PR TITLE
feat(cosh-ng): [packaging] add raw packer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1191,6 +1191,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: 'rustfmt, clippy'
@@ -1202,7 +1206,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config ripgrep
+          sudo apt-get install -y libssl-dev pkg-config ripgrep shellcheck
 
       - name: Check formatting
         run: |

--- a/scripts/check-component-versions.py
+++ b/scripts/check-component-versions.py
@@ -23,6 +23,8 @@ TOML_CONTRACTS = (
     ("src/agentsight/Cargo.toml", "src/agentsight/component.toml"),
     ("src/copilot-shell/package.json", "src/copilot-shell/component.toml"),
     ("src/cosh-ng/Cargo.toml", "src/cosh-ng/component.toml"),
+    ("src/cosh-ng/Cargo.toml", "src/cosh-ng/.anolisa/component.toml"),
+    ("src/cosh-ng/Cargo.toml", "src/cosh-ng/.anolisa/component.macos.toml"),
     ("src/skillfs/Cargo.toml", "src/skillfs/component.toml"),
     ("src/tokenless/Cargo.toml", "src/anolisa/manifests/components/tokenless/component.toml"),
     ("src/ws-ckpt/src/Cargo.toml", "src/ws-ckpt/component.toml"),

--- a/src/cosh-ng/.anolisa/component.macos.toml
+++ b/src/cosh-ng/.anolisa/component.macos.toml
@@ -1,0 +1,80 @@
+[component]
+name = "cosh-ng"
+version = "0.15.0"
+layer = "runtime"
+domain = "tools"
+display_name = "cosh-ng"
+description = "Computable Operating System Harness (cosh-ng) - a deterministic Agent-OS interface"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/anolisa"
+conflicts = ["cosh"]
+
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.2.17"
+
+[backends.rpm]
+package = "cosh-ng"
+
+[component.platform]
+os = ["macos"]
+arch = ["aarch64"]
+
+[[component.dependencies]]
+name = "bash"
+kind = "system-package"
+probe = "bash --version"
+packages = { rpm = "bash", deb = "bash" }
+
+[component.layout]
+modes = ["user", "system"]
+
+[[component.layout.files]]
+source = ".anolisa/component.toml"
+target = "{datadir}/components/cosh-ng/component.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/cosh-cli"
+target = "{bindir}/cosh-cli"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/cosh"
+target = "{bindir}/cosh"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/cosh-switch"
+target = "{bindir}/cosh-switch"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/cosh-ng/cosh-core"
+target = "{libexecdir}/cosh-ng/cosh-core"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/cosh-ng/cosh-shell"
+target = "{libexecdir}/cosh-ng/cosh-shell"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "share/doc/cosh-ng/LICENSE"
+target = "{datadir}/doc/cosh-ng/LICENSE"
+mode = "0644"
+
+[[component.layout.files]]
+source = "share/doc/cosh-ng/README.md"
+target = "{datadir}/doc/cosh-ng/README.md"
+mode = "0644"
+
+[component.health_check]
+type = "binary_version"
+binary = "{bindir}/cosh-cli"
+timeout_secs = 5

--- a/src/cosh-ng/.anolisa/component.toml
+++ b/src/cosh-ng/.anolisa/component.toml
@@ -1,0 +1,85 @@
+[component]
+name = "cosh-ng"
+version = "0.15.0"
+layer = "runtime"
+domain = "tools"
+display_name = "cosh-ng"
+description = "Computable Operating System Harness (cosh-ng) - a deterministic Agent-OS interface"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/anolisa"
+conflicts = ["cosh"]
+
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.2.17"
+
+[backends.rpm]
+package = "cosh-ng"
+
+[component.platform]
+os = ["linux"]
+arch = ["x86_64", "aarch64"]
+
+[[component.dependencies]]
+name = "openssl1.1"
+kind = "system-package"
+packages = { rpm = "openssl1.1", deb = "libssl1.1" }
+
+[[component.dependencies]]
+name = "bash"
+kind = "system-package"
+probe = "bash --version"
+packages = { rpm = "bash", deb = "bash" }
+
+[component.layout]
+modes = ["user", "system"]
+
+[[component.layout.files]]
+source = ".anolisa/component.toml"
+target = "{datadir}/components/cosh-ng/component.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/cosh-cli"
+target = "{bindir}/cosh-cli"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/cosh"
+target = "{bindir}/cosh"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/cosh-switch"
+target = "{bindir}/cosh-switch"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/cosh-ng/cosh-core"
+target = "{libexecdir}/cosh-ng/cosh-core"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "libexec/anolisa/cosh-ng/cosh-shell"
+target = "{libexecdir}/cosh-ng/cosh-shell"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "share/doc/cosh-ng/LICENSE"
+target = "{datadir}/doc/cosh-ng/LICENSE"
+mode = "0644"
+
+[[component.layout.files]]
+source = "share/doc/cosh-ng/README.md"
+target = "{datadir}/doc/cosh-ng/README.md"
+mode = "0644"
+
+[component.health_check]
+type = "binary_version"
+binary = "{bindir}/cosh-cli"
+timeout_secs = 5

--- a/src/cosh-ng/packaging/raw/assets/bin/cosh
+++ b/src/cosh-ng/packaging/raw/assets/bin/cosh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Resolve cosh-ng's private runtime in both ANOLISA install modes.
+set -e
+
+resolve_script_path() {
+    local source_path="${BASH_SOURCE[0]}"
+    local source_dir link_target depth=0
+
+    while [ -L "$source_path" ]; do
+        depth=$((depth + 1))
+        [ "$depth" -le 40 ] || return
+        source_dir="$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P)" || return
+        link_target="$(readlink "$source_path")" || return
+        case "$link_target" in
+            /*) source_path="$link_target" ;;
+            *) source_path="$source_dir/$link_target" ;;
+        esac
+    done
+
+    source_dir="$(cd "$(dirname "$source_path")" 2>/dev/null && pwd -P)" || return
+    printf '%s/%s\n' "$source_dir" "$(basename "$source_path")"
+}
+
+script_path="$(resolve_script_path || true)"
+
+prefix=""
+if [ -n "$script_path" ]; then
+    bindir="$(dirname "$script_path")"
+    if ! prefix="$(cd "$bindir/.." 2>/dev/null && pwd -P)"; then
+        prefix=""
+    fi
+fi
+
+for runtime_dir in \
+    "${prefix:+$prefix/libexec/anolisa/cosh-ng}" \
+    "${prefix:+$prefix/lib/anolisa/libexec/cosh-ng}" \
+    "${HOME:-}/.local/lib/anolisa/libexec/cosh-ng" \
+    "/usr/local/libexec/anolisa/cosh-ng" \
+    "/usr/libexec/anolisa/cosh-ng"; do
+    if [ -n "$runtime_dir" ] && \
+        [ -x "$runtime_dir/cosh-shell" ] && \
+        [ -x "$runtime_dir/cosh-core" ]; then
+        export PATH="$runtime_dir:$PATH"
+        case "${1:-}" in
+            -c | -- | --help | --version)
+                exec "$runtime_dir/cosh-shell" "$@"
+                ;;
+        esac
+        if [ "$#" -eq 0 ] && [ ! -t 0 ]; then
+            exec "$runtime_dir/cosh-shell"
+        fi
+        exec "$runtime_dir/cosh-shell" raw cosh-core "$@"
+    fi
+done
+
+echo "Error: cosh-ng runtime not found under ANOLISA libexec directories." >&2
+exit 127

--- a/src/cosh-ng/packaging/raw/assets/bin/cosh-switch
+++ b/src/cosh-ng/packaging/raw/assets/bin/cosh-switch
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# RPM owns package switching; raw installs use anolisa install/uninstall.
+set -e
+
+if command -v rpm >/dev/null 2>&1; then
+    current="$(rpm -q --qf '%{NAME}' -f /usr/bin/cosh 2>/dev/null || echo none)"
+    case "$current" in
+        cosh-ng)
+            echo "Current: cosh-ng -> switching to copilot-shell"
+            exec sudo yum swap cosh-ng copilot-shell
+            ;;
+        copilot-shell)
+            echo "Current: copilot-shell -> switching to cosh-ng"
+            exec sudo yum swap copilot-shell cosh-ng
+            ;;
+    esac
+fi
+
+printf '%s\n' \
+    'Error: cosh-switch is only supported for RPM-managed cosh-ng/copilot-shell.' \
+    'For ANOLISA raw installs, switch components with anolisa install/uninstall.' >&2
+exit 1

--- a/src/cosh-ng/packaging/raw/package.sh
+++ b/src/cosh-ng/packaging/raw/package.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Assemble prebuilt cosh-ng binaries into the ANOLISA raw-package layout.
+set -euo pipefail
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux) printf 'linux\n' ;;
+        Darwin) printf 'macos\n' ;;
+        *) die "unsupported host OS; set TARGET_OS explicitly" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported host architecture; set TARGET_ARCH explicitly" ;;
+    esac
+}
+
+normalize_os() {
+    case "$1" in
+        linux) printf 'linux\n' ;;
+        macos | darwin) printf 'macos\n' ;;
+        *) die "unsupported cosh-ng target OS: $1" ;;
+    esac
+}
+
+normalize_arch() {
+    case "$1" in
+        x86_64 | amd64 | x64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported cosh-ng target architecture: $1" ;;
+    esac
+}
+
+validate_target() {
+    case "$TARGET_OS-$TARGET_ARCH" in
+        linux-x86_64 | linux-aarch64 | macos-aarch64) ;;
+        macos-x86_64) die "cosh-ng raw packages do not support macOS x86_64" ;;
+        *) die "unsupported cosh-ng raw target: $TARGET_OS-$TARGET_ARCH" ;;
+    esac
+}
+
+require_file() {
+    [ -f "$1" ] || die "missing packaging input: $1"
+}
+
+default_contract_path() {
+    case "$TARGET_OS" in
+        linux) printf '%s/.anolisa/component.toml\n' "$SOURCE_ROOT" ;;
+        macos) printf '%s/.anolisa/component.macos.toml\n' "$SOURCE_ROOT" ;;
+    esac
+}
+
+verify_native_binary_version() {
+    local output reported
+
+    if [ "$HAS_BUILD_METADATA" -eq 1 ]; then
+        return
+    fi
+    if ! output="$("$BIN_DIR/cosh-cli" --version 2>&1)"; then
+        die "cosh-cli --version failed: $output"
+    fi
+    reported="$(printf '%s\n' "$output" | awk 'NR == 1 { print $NF; exit }')"
+    [ "$reported" = "$VERSION" ] || \
+        die "cosh-cli reports $reported but contract says $VERSION"
+}
+
+normalize_modes() {
+    local stage="$1"
+
+    find "$stage" -type d -exec chmod 0755 {} +
+    find "$stage" -type f -exec chmod 0644 {} +
+    chmod 0755 \
+        "$stage/bin/cosh-cli" \
+        "$stage/bin/cosh" \
+        "$stage/bin/cosh-switch" \
+        "$stage/libexec/anolisa/cosh-ng/cosh-core" \
+        "$stage/libexec/anolisa/cosh-ng/cosh-shell"
+}
+
+stage_payload() {
+    local stage="$1"
+
+    if [ -e "$stage" ] && [ -n "$(find "$stage" -mindepth 1 -print -quit)" ]; then
+        die "DESTDIR must be empty: $stage"
+    fi
+
+    install -d -m 0755 \
+        "$stage/.anolisa" \
+        "$stage/bin" \
+        "$stage/libexec/anolisa/cosh-ng" \
+        "$stage/share/doc/cosh-ng"
+    install -p -m 0644 "$CONTRACT" "$stage/.anolisa/component.toml"
+    install -p -m 0755 "$BIN_DIR/cosh-cli" "$stage/bin/cosh-cli"
+    install -p -m 0755 "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell" \
+        "$stage/libexec/anolisa/cosh-ng/"
+    install -p -m 0755 \
+        "$SCRIPT_DIR/assets/bin/cosh" \
+        "$SCRIPT_DIR/assets/bin/cosh-switch" \
+        "$stage/bin/"
+    install -p -m 0644 "$SOURCE_ROOT/LICENSE" "$stage/share/doc/cosh-ng/LICENSE"
+    install -p -m 0644 "$SOURCE_ROOT/README.md" "$stage/share/doc/cosh-ng/README.md"
+    normalize_modes "$stage"
+
+    if [ -n "$(find "$stage" -type l -print -quit)" ]; then
+        die "raw payload contains a symbolic link"
+    fi
+}
+
+resolve_epoch() {
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        printf '%s\n' "$SOURCE_DATE_EPOCH"
+        return
+    fi
+    git -C "$SOURCE_ROOT" log -1 --format=%ct -- . 2>/dev/null || \
+        die "SOURCE_DATE_EPOCH is unset and the source commit time is unavailable"
+}
+
+COMMAND="${1:-}"
+[ "$COMMAND" = "stage" ] || [ "$COMMAND" = "package" ] || \
+    die "usage: $0 {stage|package}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_ROOT="${COSH_NG_SOURCE_DIR:-$DEFAULT_ROOT}"
+BIN_DIR="${BIN_DIR:-$SOURCE_ROOT/target/release}"
+TARGET_OS="$(normalize_os "${TARGET_OS:-$(detect_os)}")"
+TARGET_ARCH="$(normalize_arch "${TARGET_ARCH:-$(detect_arch)}")"
+CONTRACT="${RAW_CONTRACT:-$(default_contract_path)}"
+BUILD_METADATA="${COSH_NG_BUILD_METADATA:-$BIN_DIR/cosh-ng-build.toml}"
+
+validate_target
+for input in \
+    "$CONTRACT" \
+    "$SOURCE_ROOT/Cargo.toml" \
+    "$SOURCE_ROOT/LICENSE" \
+    "$SOURCE_ROOT/README.md" \
+    "$SCRIPT_DIR/assets/bin/cosh" \
+    "$SCRIPT_DIR/assets/bin/cosh-switch"; do
+    require_file "$input"
+done
+for binary in cosh-cli cosh-core cosh-shell; do
+    [ -x "$BIN_DIR/$binary" ] || die "missing executable: $BIN_DIR/$binary"
+done
+
+VERSION="$(
+    python3 "$SCRIPT_DIR/verify-release.py" \
+        "$SOURCE_ROOT" "$CONTRACT" \
+        --os "$TARGET_OS" --arch "$TARGET_ARCH"
+)"
+HAS_BUILD_METADATA=0
+if [ -n "${COSH_NG_BUILD_METADATA:-}" ]; then
+    require_file "$BUILD_METADATA"
+fi
+if [ -f "$BUILD_METADATA" ]; then
+    HAS_BUILD_METADATA=1
+    python3 "$SCRIPT_DIR/verify-binaries.py" \
+        --os "$TARGET_OS" \
+        --arch "$TARGET_ARCH" \
+        --metadata "$BUILD_METADATA" \
+        --component-version "$VERSION" \
+        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell"
+elif [ "$(detect_os)-$(detect_arch)" != "$TARGET_OS-$TARGET_ARCH" ]; then
+    die "cross-target packaging requires build metadata: $BUILD_METADATA"
+else
+    python3 "$SCRIPT_DIR/verify-binaries.py" \
+        --os "$TARGET_OS" \
+        --arch "$TARGET_ARCH" \
+        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell"
+fi
+verify_native_binary_version
+
+if [ "$COMMAND" = "stage" ]; then
+    [ -n "${DESTDIR:-}" ] || die "DESTDIR is required by stage"
+    stage_payload "$DESTDIR"
+    printf 'Staged cosh-ng %s for %s-%s at %s\n' \
+        "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$DESTDIR"
+    exit 0
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$SOURCE_ROOT/target/raw}"
+EPOCH="$(resolve_epoch)"
+case "$EPOCH" in
+    '' | *[!0-9]*) die "SOURCE_DATE_EPOCH must be a non-negative integer" ;;
+esac
+tar --version 2>/dev/null | grep -q 'GNU tar' || \
+    die "GNU tar is required for reproducible raw packages"
+
+WORK="$(mktemp -d)"
+TEMP_ARTIFACT=""
+cleanup() {
+    rm -rf "$WORK"
+    if [ -n "$TEMP_ARTIFACT" ]; then
+        rm -f "$TEMP_ARTIFACT"
+    fi
+}
+trap cleanup EXIT
+
+STAGE="$WORK/stage"
+stage_payload "$STAGE"
+install -d -m 0755 "$OUTPUT_DIR"
+ARTIFACT="cosh-ng-${VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+TEMP_ARTIFACT="$OUTPUT_DIR/.${ARTIFACT}.tmp.$$"
+LC_ALL=C tar \
+    --sort=name \
+    --mtime="@$EPOCH" \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    --hard-dereference \
+    --format=gnu \
+    -C "$STAGE" \
+    -cf - . | gzip -n -9 > "$TEMP_ARTIFACT"
+mv -f "$TEMP_ARTIFACT" "$OUTPUT_DIR/$ARTIFACT"
+TEMP_ARTIFACT=""
+printf '%s\n' "$OUTPUT_DIR/$ARTIFACT"

--- a/src/cosh-ng/packaging/raw/verify-binaries.py
+++ b/src/cosh-ng/packaging/raw/verify-binaries.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify that prebuilt cosh-ng binaries match the requested target."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import struct
+import tomllib
+from pathlib import Path
+
+
+ELF_MACHINES = {
+    "x86_64": 62,
+    "aarch64": 183,
+}
+MACHO_CPUS = {
+    "x86_64": 0x01000007,
+    "aarch64": 0x0100000C,
+}
+
+
+def verify_build_metadata(
+    path: Path,
+    version: str,
+    os_name: str,
+    arch: str,
+    binaries: list[Path],
+) -> None:
+    """Verify build identity and bind it to the supplied binary bytes."""
+    try:
+        with path.open("rb") as stream:
+            metadata = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"cannot read build metadata: {error}") from error
+
+    expected_identity = {
+        "version": version,
+        "target_os": os_name,
+        "target_arch": arch,
+    }
+    for key, expected in expected_identity.items():
+        actual = metadata.get(key)
+        if actual != expected:
+            raise ValueError(f"{key} {actual!r} does not match {expected!r}")
+
+    hashes = metadata.get("binaries")
+    if not isinstance(hashes, dict):
+        raise ValueError("missing [binaries] SHA-256 table")
+    expected_names = {binary.name for binary in binaries}
+    unexpected = sorted(set(hashes) - expected_names)
+    if unexpected:
+        raise ValueError(f"unexpected binaries in metadata: {', '.join(unexpected)}")
+    for binary in binaries:
+        expected_hash = hashes.get(binary.name)
+        if not isinstance(expected_hash, str):
+            raise ValueError(f"missing SHA-256 for {binary.name}")
+        try:
+            actual_hash = hashlib.sha256(binary.read_bytes()).hexdigest()
+        except OSError as error:
+            raise ValueError(f"cannot hash {binary.name}: {error}") from error
+        if expected_hash.lower() != actual_hash:
+            raise ValueError(f"SHA-256 for {binary.name} does not match build metadata")
+
+
+def verify_elf(path: Path, arch: str) -> None:
+    """Verify one 64-bit little-endian ELF binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(64)
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        raise ValueError("not an ELF binary")
+    if header[4] != 2:
+        raise ValueError("not a 64-bit ELF binary")
+    if header[5] != 1:
+        raise ValueError("not a little-endian ELF binary")
+    machine = struct.unpack_from("<H", header, 18)[0]
+    if machine != ELF_MACHINES[arch]:
+        raise ValueError(f"ELF machine {machine} does not match {arch}")
+
+
+def verify_macho(path: Path, arch: str) -> None:
+    """Verify one thin 64-bit Mach-O binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(32)
+    if len(header) < 8:
+        raise ValueError("Mach-O header is truncated")
+    if header[:4] == b"\xcf\xfa\xed\xfe":
+        byte_order = "<"
+    elif header[:4] == b"\xfe\xed\xfa\xcf":
+        byte_order = ">"
+    else:
+        raise ValueError("not a thin 64-bit Mach-O binary")
+    cpu = struct.unpack_from(f"{byte_order}I", header, 4)[0]
+    if cpu != MACHO_CPUS[arch]:
+        raise ValueError(f"Mach-O CPU {cpu:#x} does not match {arch}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse target identity and binary paths."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=tuple(ELF_MACHINES), required=True)
+    parser.add_argument("--metadata", type=Path)
+    parser.add_argument("--component-version")
+    parser.add_argument("binaries", nargs="+", type=Path)
+    args = parser.parse_args()
+    if (args.metadata is None) != (args.component_version is None):
+        parser.error("--metadata and --component-version must be supplied together")
+    return args
+
+
+def main() -> int:
+    """Validate all supplied binaries without executing cross-target code."""
+    args = parse_args()
+    verifier = verify_elf if args.os == "linux" else verify_macho
+    for path in args.binaries:
+        if not path.is_file():
+            raise SystemExit(f"ERROR: missing binary: {path}")
+        try:
+            verifier(path, args.arch)
+        except (OSError, ValueError) as error:
+            raise SystemExit(f"ERROR: {path}: {error}") from error
+    if args.metadata is not None:
+        try:
+            verify_build_metadata(
+                args.metadata,
+                args.component_version,
+                args.os,
+                args.arch,
+                args.binaries,
+            )
+        except ValueError as error:
+            raise SystemExit(f"ERROR: {args.metadata}: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cosh-ng/packaging/raw/verify-release.py
+++ b/src/cosh-ng/packaging/raw/verify-release.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate cosh-ng release metadata before raw packaging."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from pathlib import Path
+
+
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+REQUIRED_SOURCES = {
+    ".anolisa/component.toml",
+    "bin/cosh-cli",
+    "bin/cosh",
+    "bin/cosh-switch",
+    "libexec/anolisa/cosh-ng/cosh-core",
+    "libexec/anolisa/cosh-ng/cosh-shell",
+    "share/doc/cosh-ng/LICENSE",
+    "share/doc/cosh-ng/README.md",
+}
+CONFLICT_AWARE_ANOLISA_VERSION = "0.2.17"
+
+
+def read_toml(path: Path) -> dict[str, object]:
+    """Read one TOML document with path-aware errors."""
+    try:
+        with path.open("rb") as stream:
+            return tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+
+
+def release_key(version: str) -> tuple[int, int, int, bool]:
+    """Order SemVer releases against a stable minimum version."""
+    core = version.split("+", 1)[0]
+    numbers, separator, _prerelease = core.partition("-")
+    major, minor, patch = (int(part) for part in numbers.split("."))
+    return major, minor, patch, not separator
+
+
+def verify_release(root: Path, contract_path: Path, os_name: str, arch: str) -> str:
+    """Return the synchronized version after validating the raw contract."""
+    cargo = read_toml(root / "Cargo.toml")
+    workspace = cargo.get("workspace")
+    package = workspace.get("package") if isinstance(workspace, dict) else None
+    source_version = package.get("version") if isinstance(package, dict) else None
+    if not isinstance(source_version, str) or SEMVER.fullmatch(source_version) is None:
+        raise SystemExit(f"ERROR: {root / 'Cargo.toml'} has no valid workspace version")
+
+    contract = read_toml(contract_path)
+    component = contract.get("component")
+    if not isinstance(component, dict):
+        raise SystemExit(f"ERROR: {contract_path} has no [component] table")
+    if component.get("name") != "cosh-ng":
+        raise SystemExit(f"ERROR: {contract_path} is not a cosh-ng contract")
+    contract_version = component.get("version")
+    if contract_version != source_version:
+        raise SystemExit(
+            f"ERROR: {contract_path} version {contract_version!r} does not match "
+            f"Cargo.toml version {source_version}"
+        )
+
+    contract_spec = component.get("contract")
+    minimum_version = (
+        contract_spec.get("min_anolisa_version")
+        if isinstance(contract_spec, dict)
+        else None
+    )
+    if not isinstance(minimum_version, str) or SEMVER.fullmatch(minimum_version) is None:
+        raise SystemExit(
+            f"ERROR: {contract_path} has no valid component.contract.min_anolisa_version"
+        )
+    conflicts = component.get("conflicts")
+    if (
+        isinstance(conflicts, list)
+        and conflicts
+        and release_key(minimum_version)
+        < release_key(CONFLICT_AWARE_ANOLISA_VERSION)
+    ):
+        raise SystemExit(
+            f"ERROR: {contract_path} uses component conflicts but allows ANOLISA "
+            f"{minimum_version}; require {CONFLICT_AWARE_ANOLISA_VERSION} or newer"
+        )
+
+    platform = component.get("platform")
+    operating_systems = platform.get("os") if isinstance(platform, dict) else None
+    architectures = platform.get("arch") if isinstance(platform, dict) else None
+    if not isinstance(operating_systems, list) or os_name not in operating_systems:
+        raise SystemExit(f"ERROR: {contract_path} does not support target OS {os_name}")
+    if not isinstance(architectures, list) or arch not in architectures:
+        raise SystemExit(f"ERROR: {contract_path} does not support target architecture {arch}")
+
+    layout = component.get("layout")
+    files = layout.get("files") if isinstance(layout, dict) else None
+    if not isinstance(files, list):
+        raise SystemExit(f"ERROR: {contract_path} has no component layout files")
+    sources = {
+        row.get("source")
+        for row in files
+        if isinstance(row, dict) and isinstance(row.get("source"), str)
+    }
+    missing_sources = sorted(REQUIRED_SOURCES - sources)
+    if missing_sources:
+        raise SystemExit(
+            f"ERROR: {contract_path} is missing packaged layout sources: "
+            + ", ".join(missing_sources)
+        )
+
+    return source_version
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse source, contract, and target identity arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("contract", type=Path)
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=("x86_64", "aarch64"), required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Print the verified cosh-ng release version."""
+    args = parse_args()
+    print(
+        verify_release(
+            args.source_root.resolve(),
+            args.contract.resolve(),
+            args.os,
+            args.arch,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cosh-ng/scripts/run-test-gates.sh
+++ b/src/cosh-ng/scripts/run-test-gates.sh
@@ -106,10 +106,24 @@ run_heavy() {
     -- --exact --ignored --test-threads=1
 }
 
+run_raw_packaging() {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck is required by the raw packaging gate" >&2
+    return 1
+  fi
+  shellcheck \
+    packaging/raw/package.sh \
+    packaging/raw/assets/bin/cosh \
+    packaging/raw/assets/bin/cosh-switch \
+    tests/test-package-raw.sh
+  bash tests/test-package-raw.sh
+}
+
 case "${1:-all}" in
   fast)
     scripts/check-test-inventory.sh
     crates/cosh-shell/scripts/check-layout.sh
+    run_raw_packaging
     cargo test --locked --workspace --exclude cosh-core --exclude cosh-shell
     run_canonical_units cosh-core cosh-core
     run_canonical_units cosh-shell cosh-shell 1
@@ -126,6 +140,7 @@ case "${1:-all}" in
   all)
     scripts/check-test-inventory.sh
     crates/cosh-shell/scripts/check-layout.sh
+    run_raw_packaging
     cargo test --locked --workspace --exclude cosh-core --exclude cosh-shell
     run_canonical_units cosh-core cosh-core
     run_core_integrations

--- a/src/cosh-ng/tests/test-package-raw.sh
+++ b/src/cosh-ng/tests/test-package-raw.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# Exercise the component-owned raw packer without compiling native binaries.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d /tmp/cosh-ng-raw-package-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+SOURCE="$TMP/cosh-ng"
+LINUX_CONTRACT="$SOURCE/.anolisa/component.toml"
+MACOS_CONTRACT="$SOURCE/.anolisa/component.macos.toml"
+VERSION="$(awk -F'"' '/^version = / { print $2; exit }' "$ROOT/Cargo.toml")"
+
+install -d -m 0755 "$SOURCE/.anolisa"
+install -p -m 0644 "$ROOT/.anolisa/component.toml" "$LINUX_CONTRACT"
+install -p -m 0644 "$ROOT/.anolisa/component.macos.toml" "$MACOS_CONTRACT"
+install -p -m 0644 "$ROOT/Cargo.toml" "$SOURCE/Cargo.toml"
+install -p -m 0644 "$ROOT/LICENSE" "$SOURCE/LICENSE"
+install -p -m 0644 "$ROOT/README.md" "$SOURCE/README.md"
+
+make_binaries() {
+    local os="$1"
+    local arch="$2"
+    local destination="$3"
+
+    install -d -m 0755 "$destination"
+    python3 - "$os" "$arch" "$destination" "$VERSION" <<'PY'
+import hashlib
+import json
+import pathlib
+import struct
+import sys
+
+os_name, arch, destination, version = sys.argv[1:]
+if os_name == "linux":
+    machine = {"x86_64": 62, "aarch64": 183}[arch]
+    header = bytearray(64)
+    header[:6] = b"\x7fELF\x02\x01"
+    struct.pack_into("<H", header, 16, 2)
+    struct.pack_into("<H", header, 18, machine)
+    struct.pack_into("<I", header, 20, 1)
+    content = bytes(header)
+else:
+    cpu = {"aarch64": 0x0100000C}[arch]
+    content = struct.pack("<IiiIIIII", 0xFEEDFACF, cpu, 0, 2, 0, 0, 0, 0)
+for name in ("cosh-cli", "cosh-core", "cosh-shell"):
+    (pathlib.Path(destination) / name).write_bytes(content)
+digest = hashlib.sha256(content).hexdigest()
+metadata = [
+    f"version = {json.dumps(version)}",
+    f"target_os = {json.dumps(os_name)}",
+    f"target_arch = {json.dumps(arch)}",
+    "",
+    "[binaries]",
+]
+metadata.extend(
+    f'{name} = "{digest}"' for name in ("cosh-cli", "cosh-core", "cosh-shell")
+)
+(pathlib.Path(destination) / "cosh-ng-build.toml").write_text(
+    "\n".join(metadata) + "\n",
+    encoding="utf-8",
+)
+PY
+    chmod 0755 \
+        "$destination/cosh-cli" \
+        "$destination/cosh-core" \
+        "$destination/cosh-shell"
+}
+
+LINUX_X64="$TMP/bin-linux-x86_64"
+LINUX_ARM64="$TMP/bin-linux-aarch64"
+MACOS_ARM64="$TMP/bin-macos-aarch64"
+make_binaries linux x86_64 "$LINUX_X64"
+make_binaries linux aarch64 "$LINUX_ARM64"
+make_binaries macos aarch64 "$MACOS_ARM64"
+
+run_pack() {
+    local os="$1"
+    local arch="$2"
+    local binaries="$3"
+    local output="$4"
+
+    COSH_NG_SOURCE_DIR="$SOURCE" \
+    BIN_DIR="$binaries" \
+    TARGET_OS="$os" \
+    TARGET_ARCH="$arch" \
+    OUTPUT_DIR="$output" \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$ROOT/packaging/raw/package.sh" package >/dev/null
+}
+
+OUT_ONE="$TMP/out-one"
+OUT_TWO="$TMP/out-two"
+run_pack linux x64 "$LINUX_X64" "$OUT_ONE"
+run_pack linux x86_64 "$LINUX_X64" "$OUT_TWO"
+X64_ARTIFACT="cosh-ng-$VERSION-linux-x86_64.tar.gz"
+cmp "$OUT_ONE/$X64_ARTIFACT" "$OUT_TWO/$X64_ARTIFACT"
+
+run_pack linux arm64 "$LINUX_ARM64" "$TMP/out-linux-arm64"
+test -f "$TMP/out-linux-arm64/cosh-ng-$VERSION-linux-aarch64.tar.gz"
+run_pack darwin arm64 "$MACOS_ARM64" "$TMP/out-macos-arm64"
+MACOS_ARTIFACT="cosh-ng-$VERSION-macos-aarch64.tar.gz"
+test -f "$TMP/out-macos-arm64/$MACOS_ARTIFACT"
+
+if run_pack macos x64 "$LINUX_X64" "$TMP/unsupported-macos-x64" 2>/dev/null; then
+    echo "ERROR: macOS x86_64 raw packaging unexpectedly succeeded" >&2
+    exit 1
+fi
+python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os linux --arch aarch64 "$LINUX_ARM64/cosh-cli" >/dev/null
+python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os macos --arch aarch64 "$MACOS_ARM64/cosh-cli" >/dev/null
+if python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os linux --arch aarch64 "$LINUX_X64/cosh-cli" >/dev/null 2>&1; then
+    echo "ERROR: mislabeled x86_64 binary unexpectedly passed as aarch64" >&2
+    exit 1
+fi
+if python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os macos --arch aarch64 "$LINUX_ARM64/cosh-cli" >/dev/null 2>&1; then
+    echo "ERROR: ELF binary unexpectedly passed as Mach-O" >&2
+    exit 1
+fi
+
+EXTRA_BUILD="$TMP/extra-build.toml"
+install -p -m 0644 "$LINUX_ARM64/cosh-ng-build.toml" "$EXTRA_BUILD"
+printf 'unexpected-tool = "%064d"\n' 0 >> "$EXTRA_BUILD"
+if python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os linux \
+    --arch aarch64 \
+    --metadata "$EXTRA_BUILD" \
+    --component-version "$VERSION" \
+    "$LINUX_ARM64/cosh-cli" \
+    "$LINUX_ARM64/cosh-core" \
+    "$LINUX_ARM64/cosh-shell" >/dev/null 2>&1; then
+    echo "ERROR: unexpected build metadata entry was accepted" >&2
+    exit 1
+fi
+
+test_native_without_metadata() {
+    local host_arch native_version native_source native_bins native_stage python_bin
+
+    [ "$(uname -s)" = Linux ] || return
+    case "$(uname -m)" in
+        x86_64 | amd64) host_arch=x86_64 ;;
+        aarch64 | arm64) host_arch=aarch64 ;;
+        *) return ;;
+    esac
+
+    python_bin="$(command -v python3)"
+    native_version="$("$python_bin" --version 2>&1 | awk 'NR == 1 { print $NF; exit }')"
+    native_source="$TMP/native-source"
+    native_bins="$TMP/native-bins"
+    native_stage="$TMP/native-stage"
+    install -d -m 0755 "$native_source/.anolisa" "$native_bins"
+    sed "0,/version = \"$VERSION\"/s//version = \"$native_version\"/" \
+        "$ROOT/Cargo.toml" > "$native_source/Cargo.toml"
+    sed "0,/version = \"$VERSION\"/s//version = \"$native_version\"/" \
+        "$ROOT/.anolisa/component.toml" > "$native_source/.anolisa/component.toml"
+    install -p -m 0644 "$ROOT/LICENSE" "$native_source/LICENSE"
+    install -p -m 0644 "$ROOT/README.md" "$native_source/README.md"
+    for binary in cosh-cli cosh-core cosh-shell; do
+        install -p -m 0755 "$python_bin" "$native_bins/$binary"
+    done
+
+    COSH_NG_SOURCE_DIR="$native_source" \
+    BIN_DIR="$native_bins" \
+    TARGET_OS=linux \
+    TARGET_ARCH="$host_arch" \
+    DESTDIR="$native_stage" \
+        "$ROOT/packaging/raw/package.sh" stage >/dev/null
+}
+
+test_native_without_metadata
+
+STAGED="$TMP/staged"
+COSH_NG_SOURCE_DIR="$SOURCE" \
+BIN_DIR="$LINUX_X64" \
+TARGET_OS=linux \
+TARGET_ARCH=x86_64 \
+DESTDIR="$STAGED" \
+    "$ROOT/packaging/raw/package.sh" stage >/dev/null
+
+install -d -m 0755 "$TMP/not-empty"
+printf 'occupied\n' > "$TMP/not-empty/file"
+if COSH_NG_SOURCE_DIR="$SOURCE" \
+    RAW_CONTRACT="$LINUX_CONTRACT" \
+    BIN_DIR="$LINUX_X64" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    DESTDIR="$TMP/not-empty" \
+        "$ROOT/packaging/raw/package.sh" stage >/dev/null 2>&1; then
+    echo "ERROR: non-empty DESTDIR unexpectedly succeeded" >&2
+    exit 1
+fi
+
+MISMATCH="$TMP/mismatched-component.toml"
+sed "0,/version = \"$VERSION\"/s//version = \"9.8.7\"/" \
+    "$LINUX_CONTRACT" > "$MISMATCH"
+if COSH_NG_SOURCE_DIR="$SOURCE" \
+    RAW_CONTRACT="$MISMATCH" \
+    BIN_DIR="$LINUX_X64" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    DESTDIR="$TMP/mismatch-stage" \
+        "$ROOT/packaging/raw/package.sh" stage >/dev/null 2>&1; then
+    echo "ERROR: mismatched contract version unexpectedly succeeded" >&2
+    exit 1
+fi
+
+MISMATCHED_BUILD="$TMP/mismatched-build.toml"
+sed "0,/version = \"$VERSION\"/s//version = \"9.8.7\"/" \
+    "$LINUX_ARM64/cosh-ng-build.toml" > "$MISMATCHED_BUILD"
+if COSH_NG_SOURCE_DIR="$SOURCE" \
+    COSH_NG_BUILD_METADATA="$MISMATCHED_BUILD" \
+    BIN_DIR="$LINUX_ARM64" \
+    TARGET_OS=linux \
+    TARGET_ARCH=aarch64 \
+    DESTDIR="$TMP/mismatched-build-stage" \
+        "$ROOT/packaging/raw/package.sh" stage >/dev/null 2>&1; then
+    echo "ERROR: mismatched cross-target build version unexpectedly succeeded" >&2
+    exit 1
+fi
+
+EXTRACTED="$TMP/extracted"
+install -d -m 0755 "$EXTRACTED"
+tar -xzf "$OUT_ONE/$X64_ARTIFACT" -C "$EXTRACTED"
+cmp "$LINUX_CONTRACT" "$EXTRACTED/.anolisa/component.toml"
+cmp "$LINUX_X64/cosh-cli" "$EXTRACTED/bin/cosh-cli"
+cmp "$LINUX_X64/cosh-core" "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-core"
+cmp "$LINUX_X64/cosh-shell" "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell"
+cmp "$ROOT/LICENSE" "$EXTRACTED/share/doc/cosh-ng/LICENSE"
+cmp "$ROOT/README.md" "$EXTRACTED/share/doc/cosh-ng/README.md"
+test -z "$(find "$EXTRACTED" -type l -print -quit)"
+file_mode() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+test "$(file_mode "$EXTRACTED/bin/cosh")" = 755
+test "$(file_mode "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell")" = 755
+test "$(file_mode "$EXTRACTED/share/doc/cosh-ng/README.md")" = 644
+test ! -e "$EXTRACTED/share/anolisa/hooks"
+cmp "$STAGED/bin/cosh" "$EXTRACTED/bin/cosh"
+
+cat > "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$#" "$@"
+EOF
+chmod 0755 "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell"
+test "$("$EXTRACTED/bin/cosh" --version)" = $'1\n--version'
+READLINK_STUB="$TMP/readlink-without-f"
+install -d -m 0755 "$READLINK_STUB"
+install -p -m 0755 /bin/false "$READLINK_STUB/readlink"
+test "$(PATH="$READLINK_STUB:/usr/bin:/bin" \
+    "$EXTRACTED/bin/cosh" --version)" = $'1\n--version'
+LINKED_BIN="$TMP/linked-bin"
+install -d -m 0755 "$LINKED_BIN"
+ln -s "$EXTRACTED/bin/cosh" "$LINKED_BIN/cosh"
+test "$(bash "$LINKED_BIN/cosh" --version)" = $'1\n--version'
+test "$("$EXTRACTED/bin/cosh" prompt)" = $'3\nraw\ncosh-core\nprompt'
+test "$(printf '' | "$EXTRACTED/bin/cosh")" = "0"
+
+NO_RPM_OUTPUT="$TMP/cosh-switch-no-rpm.out"
+if PATH="$TMP/no-rpm-path" "$BASH" \
+    "$EXTRACTED/bin/cosh-switch" >"$NO_RPM_OUTPUT" 2>&1; then
+    echo "ERROR: cosh-switch unexpectedly succeeded without RPM ownership" >&2
+    exit 1
+else
+    test "$?" -eq 1
+fi
+grep -Fq 'only supported for RPM-managed cosh-ng/copilot-shell' "$NO_RPM_OUTPUT"
+grep -Fq 'switch components with anolisa install/uninstall' "$NO_RPM_OUTPUT"
+
+python3 "$ROOT/packaging/raw/verify-release.py" \
+    "$SOURCE" "$LINUX_CONTRACT" --os linux --arch x86_64 >/dev/null
+python3 "$ROOT/packaging/raw/verify-release.py" \
+    "$SOURCE" "$MACOS_CONTRACT" --os macos --arch aarch64 >/dev/null
+python3 - "$LINUX_CONTRACT" "$MACOS_CONTRACT" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+linux_path, macos_path = (pathlib.Path(value) for value in sys.argv[1:])
+with linux_path.open("rb") as stream:
+    linux = tomllib.load(stream)
+with macos_path.open("rb") as stream:
+    macos = tomllib.load(stream)
+
+assert linux["component"]["platform"]["os"] == ["linux"]
+assert macos["component"]["platform"]["os"] == ["macos"]
+assert linux["component"]["contract"]["min_anolisa_version"] == "0.2.17"
+assert macos["component"]["contract"]["min_anolisa_version"] == "0.2.17"
+assert linux["component"]["conflicts"] == ["cosh"]
+assert macos["component"]["conflicts"] == ["cosh"]
+linux_dependencies = {
+    dependency["name"]: dependency for dependency in linux["component"]["dependencies"]
+}
+macos_dependencies = {
+    dependency["name"]: dependency for dependency in macos["component"]["dependencies"]
+}
+assert "probe" not in linux_dependencies["openssl1.1"]
+assert "openssl1.1" not in macos_dependencies
+linux_common = dict(linux["component"])
+macos_common = dict(macos["component"])
+for component in (linux_common, macos_common):
+    component.pop("platform")
+    component.pop("dependencies")
+assert linux_common == macos_common
+assert linux.get("backends") == macos.get("backends")
+PY
+
+LEGACY_CONFLICT_CONTRACT="$TMP/legacy-conflict-component.toml"
+sed 's/min_anolisa_version = "0.2.17"/min_anolisa_version = "0.2.16"/' \
+    "$LINUX_CONTRACT" > "$LEGACY_CONFLICT_CONTRACT"
+if python3 "$ROOT/packaging/raw/verify-release.py" \
+    "$SOURCE" "$LEGACY_CONFLICT_CONTRACT" \
+    --os linux --arch x86_64 >/dev/null 2>&1; then
+    echo "ERROR: conflict contract accepted an ANOLISA version before 0.2.17" >&2
+    exit 1
+fi
+MACOS_EXTRACTED="$TMP/extracted-macos"
+install -d -m 0755 "$MACOS_EXTRACTED"
+tar -xzf "$TMP/out-macos-arm64/$MACOS_ARTIFACT" -C "$MACOS_EXTRACTED"
+cmp "$MACOS_CONTRACT" "$MACOS_EXTRACTED/.anolisa/component.toml"
+grep -Fq 'name = "openssl1.1"' "$ROOT/.anolisa/component.toml"
+test -z "$(grep -F 'name = "openssl1.1"' \
+    "$ROOT/.anolisa/component.macos.toml" || true)"
+grep -Fq 'source = "bin/cosh"' "$ROOT/.anolisa/component.toml"
+grep -Fq 'source = "libexec/anolisa/cosh-ng/cosh-shell"' \
+    "$ROOT/.anolisa/component.toml"
+
+echo "cosh-ng component-owned raw package tests passed"


### PR DESCRIPTION
## Why

cosh-ng needs a component-owned raw packaging interface so release tooling can consume immutable artifacts without duplicating payload assembly. Keeping the contracts, launchers, and validation beside the component makes the shipped layout independently testable and reviewable across supported targets.

## What changed

- Add a `stage`/`package` entrypoint for deterministic cosh-ng raw archives.
- Support Linux x86_64, Linux aarch64, and macOS aarch64; explicitly reject macOS x86_64.
- Select target-specific Linux/macOS contracts so Linux keeps its OpenSSL runtime dependency without imposing it on macOS.
- Validate contract metadata, prebuilt ELF/Mach-O architecture, and cross-target build provenance before packaging.
- Add static launcher assets without lifecycle hooks, including portable macOS path resolution.
- Add fixture coverage for reproducibility, platform normalization, layout, permissions, wrapper routing, and failure cases.
- Register the raw packaging suite and ShellCheck in the cosh-ng fast CI gate.
- Extend the repository version check to keep both raw contracts synchronized with the cosh-ng workspace version.

## Related issue

no-issue: move raw packaging ownership into the cosh-ng component

## User / Agent impact

There is no change to the existing source or RPM installation path. Release tooling can invoke `src/cosh-ng/packaging/raw/package.sh` for these artifacts:

- `cosh-ng-<version>-linux-x86_64.tar.gz`
- `cosh-ng-<version>-linux-aarch64.tar.gz`
- `cosh-ng-<version>-macos-aarch64.tar.gz`

Cross-target `BIN_DIR` inputs must include `cosh-ng-build.toml` with the version, target OS/architecture, and SHA-256 of all three binaries. Release-pipeline integration is intentionally outside this PR.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The packer embeds a Linux contract that lets ANOLISA query the native `openssl1.1`/`libssl1.1` package, or a macOS contract without that Linux-only dependency because native-tls uses Security.framework there. The raw package has no lifecycle hooks and does not modify `/etc/shells`. Both contracts require ANOLISA 0.2.17 or newer and do not replace the existing RPM contract.

## Validation

- `shellcheck src/cosh-ng/packaging/raw/package.sh src/cosh-ng/packaging/raw/assets/bin/cosh src/cosh-ng/packaging/raw/assets/bin/cosh-switch src/cosh-ng/tests/test-package-raw.sh`
- `bash src/cosh-ng/tests/test-package-raw.sh`
- `python3 scripts/check-component-versions.py`
- `cargo fmt --all -- --check`
- `git diff origin/main...HEAD --check`

The packaging test creates synthetic Linux x86_64/aarch64 ELF and macOS aarch64 Mach-O inputs with hash-bound build metadata. It verifies all three artifact names and target contracts, rejects unsupported, mislabeled, or version-mismatched inputs, checks deterministic output and layout, exercises the launcher without GNU `readlink -f`, uses portable permission checks, and confirms that no lifecycle hook is shipped.

`cargo clippy --workspace --all-targets -- -D warnings` could not complete in the local environment because the host lacks the OpenSSL development package and `openssl.pc`; the PR CI build and cosh-ng checks remain the authoritative Rust gates.

## Documentation and rollback

No user documentation changed. Revert commit `89541c31` to remove the component-owned raw packaging interface and contracts.