### PR TITLE
fix(cosh-ng): [shell] map missing failed exit code to -1 sentinel

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/ledger/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/ledger/mod.rs
@@ -54,7 +54,28 @@ pub fn build_command_blocks(events: &[ShellEvent]) -> LedgerOutput {
                 let duration_ms = event
                     .duration_ms
                     .unwrap_or_else(|| ended_at_ms.saturating_sub(started_at_ms));
-                let exit_code = event.exit_code.unwrap_or(0);
+                // Exit-code narrowing contract (Option<i32> -> i32):
+                //   Some(c)                 -> c verbatim; the aggregator never
+                //                              rewrites explicit exit codes.
+                //   None + CommandFailed    -> -1 sentinel; a failed finish
+                //                              without an exit code (replayed
+                //                              journals from older or external
+                //                              producers) must fall toward
+                //                              failure, never toward success 0.
+                //                              -1 sits outside the shell's
+                //                              0..=255 exit domain and matches
+                //                              the missing-exit-code sentinel
+                //                              the agent host-executed chain
+                //                              already uses (#2105).
+                //   None + other kinds      -> 0; the finish is logically
+                //                              successful and only the actual
+                //                              exit code went unrecorded.
+                // Invariant: missing data never fabricates success for a
+                // failed command.
+                let exit_code = event.exit_code.unwrap_or(match &event.kind {
+                    ShellEventKind::CommandFailed => -1,
+                    _ => 0,
+                });
                 let status =
                     if matches!(&event.kind, ShellEventKind::CommandFailed) || exit_code != 0 {
                         CommandStatus::Failed
@@ -128,6 +149,77 @@ mod tests {
 
         assert!(output.errors.is_empty());
         assert_eq!(output.blocks[0].shell_environment_generation, Some(7));
+    }
+
+    #[test]
+    fn command_failed_no_exit_code_does_not_default_to_zero() {
+        let start = ShellEvent::command_started("session", "command", "sleep 60", "/tmp", 1);
+        let mut finish = ShellEvent::command_finished(
+            ShellEventKind::CommandFailed,
+            "session",
+            "command",
+            0,
+            2,
+            "/tmp/output",
+        );
+        finish.exit_code = None;
+
+        let output = build_command_blocks(&[start, finish]);
+
+        assert!(output.errors.is_empty());
+        assert_eq!(output.blocks.len(), 1);
+        let block = &output.blocks[0];
+        assert_eq!(block.status, crate::types::CommandStatus::Failed);
+        assert_eq!(
+            block.exit_code, -1,
+            "CommandFailed without an exit code must surface the missing-exit sentinel, not success 0"
+        );
+    }
+
+    #[test]
+    fn command_completed_no_exit_code_keeps_success_zero() {
+        let start = ShellEvent::command_started("session", "command", "echo ok", "/tmp", 1);
+        let mut finish = ShellEvent::command_finished(
+            ShellEventKind::CommandCompleted,
+            "session",
+            "command",
+            0,
+            2,
+            "/tmp/output",
+        );
+        finish.exit_code = None;
+
+        let output = build_command_blocks(&[start, finish]);
+
+        assert!(output.errors.is_empty());
+        assert_eq!(output.blocks.len(), 1);
+        let block = &output.blocks[0];
+        assert_eq!(block.status, crate::types::CommandStatus::Completed);
+        assert_eq!(block.exit_code, 0);
+    }
+
+    #[test]
+    fn explicit_exit_code_passes_through_verbatim() {
+        let start = ShellEvent::command_started("session", "command", "grep x y", "/tmp", 1);
+        let finish = ShellEvent::command_finished(
+            ShellEventKind::CommandFailed,
+            "session",
+            "command",
+            2,
+            2,
+            "/tmp/output",
+        );
+
+        let output = build_command_blocks(&[start, finish]);
+
+        assert!(output.errors.is_empty());
+        assert_eq!(output.blocks.len(), 1);
+        let block = &output.blocks[0];
+        assert_eq!(block.status, crate::types::CommandStatus::Failed);
+        assert_eq!(
+            block.exit_code, 2,
+            "the aggregator must never rewrite an explicit exit code"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Summary

`ledger::build_command_blocks` narrows `ShellEvent.exit_code` (`Option<i32>`) into `CommandBlock.exit_code` (`i32`) with `unwrap_or(0)`. A `CommandFailed` event without an exit code therefore produced the self-contradictory pair `exit_code=0` (success) + `status=Failed`, breaking the `exit_code == 0 ⟺ status == Completed` consistency contract for every consumer that reads `exit_code` without checking `status`.

This PR makes the fallback kind-aware: a `CommandFailed` finish without an exit code now yields the sentinel `-1`; `CommandCompleted` keeps the `0` default (its success contract is unchanged).

Closes #2105

## Scope note (issue description vs code facts)

Two claims in the issue do not match the code and were treated as out of scope:

- **The live path cannot reach this defect.** Both `CommandFailed` emitters (`shell_host/osc.rs` precmd marker handling and `finish_current_on_exit`) construct the event via `command_finished_event(status: i32)`, which always attaches `Some(status)`, and the event kind itself is derived from `status != 0`. A SIGKILL scenario yields `CommandFailed + Some(137)`, not `None`. The reachable input surface is journal replay (`events.jsonl` from older or external producers may carry `"exit_code": null`) plus any future producer of this public aggregation API.
- **The reproduction steps in the issue do not exist.** There is no `cosh-ng ledger build` subcommand in the tree; the defect is instead reproduced deterministically by the new regression test.

Of the suggested fixes, the sentinel direction was chosen over `Option<i32>` propagation: `CommandBlock` is a serde contract type with ~40 non-test `exit_code` consumers; `Option`-izing it rewrites every `!= 0` / `== 127` branch (any missed spot silently routes `None` into the success path), while `-1` sits outside the shell's `0..=255` exit domain, hits no code-specific consumer branch (`127`/`126`/`137`/`>128`), and matches the missing-exit-code sentinel already used by the agent host-executed chain (`runtime/evidence_delivery.rs`, `agent/approval_bridge.rs`, `cosh-core/src/tool/shell.rs` — the last one being exactly the signal-killed case). `128+signal` is not constructible: `ShellEvent` carries no signal information.

The sibling "missing maps to success" defect on the live path (`shell_host/osc.rs` `marker.status.unwrap_or(0)`) is intentionally not part of this PR — it sits in the marker-parsing layer, changes the Completed/Failed decision source, and needs live-PTY verification; it will be tracked separately (this PR is its prerequisite, since `unwrap_or(-1)` there would flow into the path fixed here).

# Changes

- `crates/cosh-shell/src/ledger/mod.rs`: kind-aware exit-code fallback (`CommandFailed → -1`, otherwise `0`) with an invariant comment; the status derivation is untouched (`-1 != 0` and the `CommandFailed` match both land on `Failed`).
- Regression tests `command_failed_no_exit_code_does_not_default_to_zero` (asserts `(-1, Failed)`) and `command_completed_no_exit_code_keeps_success_zero` (asserts `(0, Completed)`), both driven through the production `build_command_blocks` entry point.

# Tests

- FAIL→PASS on the original reproduction path: `cargo test -p cosh-shell --bin cosh-shell ledger::tests::command_failed_no_exit_code_does_not_default_to_zero` fails on `origin/main` (exit 101, `left: 0`) and passes with this change.
- `cargo test -p cosh-shell` (lib + bin ledger scope), `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` (also re-run under latest stable), `check-layout.sh`, `check-test-inventory.sh`: green.

# Verification

- **Focused green:** ledger test scope, workspace clippy/fmt, both CI gate scripts locally.
- **Live-path smoke (real PTY, real `cosh-shell` + `cosh-core` binaries):** ran a failing command (`ls /nonexistent-cosh-2105`) and a succeeding one in a real PTY session; the journal records `command_failed` with `exit_code=1` (live path always carries `Some`, as analyzed), no `-1` appears in the live journal, and the UI transcript never renders `-1` — confirming the sentinel is unreachable live and display consumers are unaffected.
- **Excluded scope (not run):** full workspace test suite beyond `cosh-shell`; the full local `--bins --tests` run on this macOS host carries pre-existing PTY-environment failures that reproduce identically on unmodified `origin/main` (base-control compared); all fix-branch-unique first-run failures pass on serial rerun.

# Evidence

| Item | Evidence |
| --- | --- |
| FAIL baseline on `origin/main` `7e971b13` (probe test, exit 101, `left: 0`) | [fail-rebaseline-7e971b13.log](https://raw.githubusercontent.com/SunnyQjm/anolisa/370dafbcf4248f9c6358cb819bac18bf829f7d32/fail-rebaseline-7e971b13.log) |
| Live-path smoke final frame (real PTY, failing + succeeding command, no `-1` rendered) | ![smoke final](https://raw.githubusercontent.com/SunnyQjm/anolisa/370dafbcf4248f9c6358cb819bac18bf829f7d32/smoke-2105-final.png) |
| Smoke session replay (GIF) | ![smoke gif](https://raw.githubusercontent.com/SunnyQjm/anolisa/370dafbcf4248f9c6358cb819bac18bf829f7d32/smoke-2105.gif) |
| Smoke asciinema cast | [smoke-2105.cast](https://raw.githubusercontent.com/SunnyQjm/anolisa/370dafbcf4248f9c6358cb819bac18bf829f7d32/smoke-2105.cast) |

Smoke journal facts (captured `events.jsonl`): `command_failed exit_code=1` for `ls /nonexistent-cosh-2105`, `command_completed exit_code=0` for `echo smoke-ok`, no event with `exit_code=-1`.
