### PR TITLE
fix(sight): restore packaged enforcement

### DIFF
--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -202,17 +202,9 @@ jobs:
             )
 
             PACKAGE_DIR=$(mktemp -d)
-            mkdir -p "$PACKAGE_DIR/${COMPONENT}-${VERSION}"
-            cp -p "$SOURCE_ROOT/target/release/agentsight" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/target/release/agentsight-enforcer" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/scripts/agentsight-start.sh" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/agentsight-start"
-            cp -p "$SOURCE_ROOT/scripts/agentsight.service" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/scripts/agentsight-enforcer.service" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/component.toml" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/README.md" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/README_zh.md" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
-            cp -p "$SOURCE_ROOT/LICENSE" "$PACKAGE_DIR/${COMPONENT}-${VERSION}/"
+            "$SOURCE_ROOT/scripts/stage-rpm-payload.sh" "$PACKAGE_DIR/${COMPONENT}-${VERSION}"
             tar -czf ~/rpmbuild/SOURCES/"${EXPECTED_TAR}" -C "$PACKAGE_DIR" "${COMPONENT}-${VERSION}"
+            echo "AGENTSIGHT_VERIFY_RPM=$SOURCE_ROOT/scripts/verify-rpm-package.sh" >> "$GITHUB_ENV"
           fi
 
           # The anolisa spec intentionally unpacks Source0 into `anolisa/`
@@ -271,6 +263,12 @@ jobs:
 
           echo "Built RPMs:"
           ls -la /tmp/rpm-output/
+
+          if [ "${{ inputs.component }}" = "agentsight" ]; then
+            while IFS= read -r rpm_path; do
+              "$AGENTSIGHT_VERIFY_RPM" "$rpm_path"
+            done < <(find /tmp/rpm-output/ -maxdepth 1 -type f -name "*.rpm" -print)
+          fi
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -421,23 +421,7 @@ build_agentsight() {
     local tmp_dir
     tmp_dir=$(mktemp -d)
     local pkg_dir="${tmp_dir}/${pkg_name}-${version}"
-    mkdir -p "$pkg_dir"
-
-    # Copy relevant files
-    cp -p "${SIGHT_DIR}/target/release/agentsight" "$pkg_dir/"
-    cp -p "${SIGHT_DIR}/target/release/agentsight-enforcer" "$pkg_dir/"
-    cp -p "${SIGHT_DIR}/scripts/agentsight.service" "$pkg_dir/"
-    cp -p "${SIGHT_DIR}/scripts/agentsight-enforcer.service" "$pkg_dir/"
-    cp -p "${SIGHT_DIR}/scripts/agentsight-start.sh" "$pkg_dir/agentsight-start"
-    [ -f "${SIGHT_DIR}/README.md" ] && cp "${SIGHT_DIR}/README.md" "$pkg_dir/"
-    [ -f "${SIGHT_DIR}/README_zh.md" ] && cp "${SIGHT_DIR}/README_zh.md" "$pkg_dir/"
-    [ -f "${SIGHT_DIR}/LICENSE" ] && cp "${SIGHT_DIR}/LICENSE" "$pkg_dir/"
-
-    # component.toml — spec %install installs it to %{_datadir}/anolisa/components/agentsight/
-    [ -f "${SIGHT_DIR}/component.toml" ] && cp "${SIGHT_DIR}/component.toml" "$pkg_dir/"
-
-    # agentsight.json — spec %install installs it to %{_sysconfdir}/agentsight/config.json
-    [ -f "${SIGHT_DIR}/agentsight.json" ] && cp "${SIGHT_DIR}/agentsight.json" "$pkg_dir/"
+    "${SIGHT_DIR}/scripts/stage-rpm-payload.sh" "$pkg_dir"
 
     tar -czf "${BUILD_DIR}/SOURCES/${tarball_name}" -C "$tmp_dir" "${pkg_name}-${version}"
     rm -rf "$tmp_dir"

--- a/src/agentsight/scripts/rpm-build.sh
+++ b/src/agentsight/scripts/rpm-build.sh
@@ -157,19 +157,7 @@ TARBALL_NAME="agentsight-${VERSION}"
 TARBALL_DIR="${OUTPUT_DIR}/${TARBALL_NAME}"
 
 log_info "Preparing tarball contents..."
-mkdir -p "$TARBALL_DIR"
-
-# Copy required files
-cp "target/release/agentsight" "$TARBALL_DIR/"
-cp "target/release/agentsight-enforcer" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/scripts/agentsight-start.sh" "$TARBALL_DIR/agentsight-start"
-cp "$PROJECT_ROOT/scripts/agentsight.service" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/scripts/agentsight-enforcer.service" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/component.toml" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/agentsight.json" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/README.md" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/README_zh.md" "$TARBALL_DIR/"
-cp "$PROJECT_ROOT/LICENSE" "$TARBALL_DIR/"
+./scripts/stage-rpm-payload.sh "$TARBALL_DIR"
 
 log_info "Files prepared in: $TARBALL_DIR"
 

--- a/src/agentsight/scripts/stage-rpm-payload.sh
+++ b/src/agentsight/scripts/stage-rpm-payload.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Stages the complete prebuilt payload consumed by agentsight.spec.in.
+set -euo pipefail
+
+if [[ $# -ne 1 || -z "$1" ]]; then
+    echo "usage: $0 <destination>" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="${AGENTSIGHT_PROJECT_ROOT:-$(cd "$script_dir/.." && pwd)}"
+destination="$1"
+
+sources=(
+    "target/release/agentsight"
+    "target/release/agentsight-enforcer"
+    "scripts/agentsight-start.sh"
+    "scripts/agentsight.service"
+    "scripts/agentsight-enforcer.service"
+    "agentsight.json"
+    "component.toml"
+    "README.md"
+    "README_zh.md"
+    "LICENSE"
+)
+targets=(
+    "agentsight"
+    "agentsight-enforcer"
+    "agentsight-start"
+    "agentsight.service"
+    "agentsight-enforcer.service"
+    "agentsight.json"
+    "component.toml"
+    "README.md"
+    "README_zh.md"
+    "LICENSE"
+)
+
+missing=0
+for source in "${sources[@]}"; do
+    if [[ ! -f "$project_root/$source" ]]; then
+        echo "missing AgentSight RPM payload source: $project_root/$source" >&2
+        missing=1
+    fi
+done
+if (( missing != 0 )); then
+    exit 1
+fi
+
+rm -rf -- "$destination"
+install -d -m 0755 "$destination"
+for index in "${!sources[@]}"; do
+    mode=0644
+    case "${targets[$index]}" in
+        agentsight|agentsight-enforcer|agentsight-start)
+            mode=0755
+            ;;
+    esac
+    install -p -m "$mode" \
+        "$project_root/${sources[$index]}" "$destination/${targets[$index]}"
+done

--- a/src/agentsight/scripts/stage-rpm-payload.sh
+++ b/src/agentsight/scripts/stage-rpm-payload.sh
@@ -47,7 +47,11 @@ if (( missing != 0 )); then
     exit 1
 fi
 
-rm -rf -- "$destination"
+if [[ -e "$destination" ]]; then
+    echo "AgentSight RPM payload destination already exists: $destination" >&2
+    exit 1
+fi
+
 install -d -m 0755 "$destination"
 for index in "${!sources[@]}"; do
     mode=0644

--- a/src/agentsight/scripts/test-rpm-packaging.sh
+++ b/src/agentsight/scripts/test-rpm-packaging.sh
@@ -92,6 +92,21 @@ for file in \
     require_file "$fixture_payload/$file"
 done
 
+existing_payload="$tmp_dir/existing-payload"
+mkdir -p "$existing_payload"
+printf 'preserve me\n' > "$existing_payload/sentinel"
+if AGENTSIGHT_PROJECT_ROOT="$fixture_root" \
+    bash "$repo_root/src/agentsight/scripts/stage-rpm-payload.sh" \
+    "$existing_payload" >"$tmp_dir/existing.out" 2>"$tmp_dir/existing.err"; then
+    printf 'existing RPM payload destination unexpectedly replaced\n' >&2
+    failures=$((failures + 1))
+fi
+if [[ ! -f "$existing_payload/sentinel" ]] \
+    || [[ "$(cat "$existing_payload/sentinel")" != "preserve me" ]]; then
+    printf 'existing RPM payload destination was modified\n' >&2
+    failures=$((failures + 1))
+fi
+
 complete_list="$tmp_dir/complete-rpm-files.txt"
 cat > "$complete_list" <<'EOF'
 /usr/local/bin/agentsight

--- a/src/agentsight/scripts/test-rpm-packaging.sh
+++ b/src/agentsight/scripts/test-rpm-packaging.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 failures=0
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
 
 require_literal() {
     local file="$1"
@@ -47,11 +49,91 @@ require_in_order() {
     fi
 }
 
-for builder in src/agentsight/scripts/rpm-build.sh scripts/rpm-build.sh .github/workflows/_rpm-build.yaml; do
-    require_literal "$builder" "./scripts/build-enforcer.sh"
-    require_literal "$builder" "target/release/agentsight-enforcer"
-    require_literal "$builder" "agentsight-enforcer.service"
+require_file() {
+    local file="$1"
+
+    if [[ ! -f "$file" ]]; then
+        printf 'missing staged file %s\n' "$file" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+fixture_root="$tmp_dir/source"
+fixture_payload="$tmp_dir/payload"
+mkdir -p "$fixture_root/target/release" "$fixture_root/scripts"
+for file in \
+    target/release/agentsight \
+    target/release/agentsight-enforcer \
+    scripts/agentsight-start.sh \
+    scripts/agentsight.service \
+    scripts/agentsight-enforcer.service \
+    agentsight.json \
+    component.toml \
+    README.md \
+    README_zh.md \
+    LICENSE; do
+    printf 'fixture: %s\n' "$file" > "$fixture_root/$file"
 done
+
+AGENTSIGHT_PROJECT_ROOT="$fixture_root" \
+    bash "$repo_root/src/agentsight/scripts/stage-rpm-payload.sh" "$fixture_payload"
+
+for file in \
+    agentsight \
+    agentsight-enforcer \
+    agentsight-start \
+    agentsight.service \
+    agentsight-enforcer.service \
+    agentsight.json \
+    component.toml \
+    README.md \
+    README_zh.md \
+    LICENSE; do
+    require_file "$fixture_payload/$file"
+done
+
+complete_list="$tmp_dir/complete-rpm-files.txt"
+cat > "$complete_list" <<'EOF'
+/usr/local/bin/agentsight
+/usr/local/bin/agentsight-enforcer
+/usr/local/bin/agentsight-start
+/usr/lib/systemd/system/agentsight.service
+/usr/lib/systemd/system/agentsight-enforcer.service
+/etc/agentsight/config.json
+/usr/share/anolisa/components/agentsight/component.toml
+EOF
+
+bash "$repo_root/src/agentsight/scripts/verify-rpm-package.sh" \
+    --file-list "$complete_list"
+
+incomplete_list="$tmp_dir/incomplete-rpm-files.txt"
+grep -v -E 'agentsight-enforcer($|\.service$)' "$complete_list" > "$incomplete_list"
+if bash "$repo_root/src/agentsight/scripts/verify-rpm-package.sh" \
+    --file-list "$incomplete_list" >"$tmp_dir/incomplete.out" 2>"$tmp_dir/incomplete.err"; then
+    printf 'incomplete RPM file list unexpectedly passed\n' >&2
+    failures=$((failures + 1))
+else
+    require_literal_from_path() {
+        local file="$1"
+        local expected="$2"
+        if ! grep -Fq -- "$expected" "$file"; then
+            printf 'missing verifier diagnostic %s\n' "$expected" >&2
+            failures=$((failures + 1))
+        fi
+    }
+    require_literal_from_path "$tmp_dir/incomplete.err" "/usr/local/bin/agentsight-enforcer"
+    require_literal_from_path "$tmp_dir/incomplete.err" \
+        "/usr/lib/systemd/system/agentsight-enforcer.service"
+fi
+
+require_literal src/agentsight/scripts/rpm-build.sh \
+    './scripts/stage-rpm-payload.sh "$TARBALL_DIR"'
+require_literal scripts/rpm-build.sh \
+    '"${SIGHT_DIR}/scripts/stage-rpm-payload.sh" "$pkg_dir"'
+require_literal .github/workflows/_rpm-build.yaml \
+    '"$SOURCE_ROOT/scripts/stage-rpm-payload.sh" "$PACKAGE_DIR/${COMPONENT}-${VERSION}"'
+require_literal .github/workflows/_rpm-build.yaml \
+    '"$AGENTSIGHT_VERIFY_RPM" "$rpm_path"'
 
 require_literal src/agentsight/agentsight.spec.in \
     "install -p -m 0755 agentsight-enforcer %{buildroot}/usr/local/bin/"

--- a/src/agentsight/scripts/verify-rpm-package.sh
+++ b/src/agentsight/scripts/verify-rpm-package.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Verifies the deployable AgentSight RPM rather than its source declarations.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <rpm-path> | --file-list <path>" >&2
+}
+
+if [[ $# -eq 1 ]]; then
+    if ! command -v rpm >/dev/null 2>&1; then
+        echo "rpm is required to inspect an AgentSight package" >&2
+        exit 2
+    fi
+    file_list="$(mktemp)"
+    trap 'rm -f "$file_list"' EXIT
+    rpm -qlp "$1" > "$file_list"
+elif [[ $# -eq 2 && "$1" == "--file-list" ]]; then
+    file_list="$2"
+else
+    usage
+    exit 2
+fi
+
+if [[ ! -f "$file_list" ]]; then
+    echo "RPM file list not found: $file_list" >&2
+    exit 2
+fi
+
+required_paths=(
+    "/usr/local/bin/agentsight"
+    "/usr/local/bin/agentsight-enforcer"
+    "/usr/local/bin/agentsight-start"
+    "/usr/lib/systemd/system/agentsight.service"
+    "/usr/lib/systemd/system/agentsight-enforcer.service"
+    "/etc/agentsight/config.json"
+    "/usr/share/anolisa/components/agentsight/component.toml"
+)
+
+missing=0
+for path in "${required_paths[@]}"; do
+    if ! grep -Fxq -- "$path" "$file_list"; then
+        echo "AgentSight RPM is missing required path: $path" >&2
+        missing=1
+    fi
+done
+if (( missing != 0 )); then
+    exit 1
+fi
+
+echo "AgentSight RPM artifact contract passed."

--- a/src/agentsight/src/enforcement/coordinator.rs
+++ b/src/agentsight/src/enforcement/coordinator.rs
@@ -39,6 +39,27 @@ struct IngestionState {
     generation: u64,
 }
 
+#[derive(Default)]
+struct AvailabilityLogTransitions {
+    unavailable_detail: Option<String>,
+}
+
+impl AvailabilityLogTransitions {
+    fn unavailable(&mut self, detail: &str) -> Option<String> {
+        if self.unavailable_detail.as_deref() == Some(detail) {
+            return None;
+        }
+        self.unavailable_detail = Some(detail.into());
+        Some(format!("AgentSight enforcement unavailable: {detail}"))
+    }
+
+    fn recovered(&mut self) -> Option<String> {
+        self.unavailable_detail
+            .take()
+            .map(|_| "AgentSight enforcement recovered".into())
+    }
+}
+
 #[derive(Clone)]
 struct IngestionReadiness {
     state: Arc<Mutex<IngestionState>>,
@@ -839,6 +860,7 @@ fn ingest_loop(
     worker: Arc<WorkerToken>,
 ) {
     let mut backoff = Duration::from_millis(100);
+    let mut availability_log = AvailabilityLogTransitions::default();
     while ingestion_readiness.is_current(&worker) {
         ingestion_readiness.mark_not_ready(&worker);
         match client.subscribe_required() {
@@ -879,7 +901,10 @@ fn ingest_loop(
                 };
                 if let Err(error) = reconciliation {
                     if ingestion_readiness.is_current(&worker) {
-                        eprintln!("AgentSight enforcement reconciliation failed: {error}");
+                        let detail = format!("reconciliation failed: {error}");
+                        if let Some(message) = availability_log.unavailable(&detail) {
+                            eprintln!("{message}");
+                        }
                         if let Err(store_error) =
                             store.mark_active_degraded(DEGRADED_BINDING_MESSAGE)
                         {
@@ -891,6 +916,9 @@ fn ingest_loop(
                     sleep_until_superseded(&ingestion_readiness, &worker, backoff);
                     backoff = backoff.saturating_mul(2).min(Duration::from_secs(5));
                     continue;
+                }
+                if let Some(message) = availability_log.recovered() {
+                    eprintln!("{message}");
                 }
                 backoff = Duration::from_millis(100);
                 while ingestion_readiness.is_subscription_current(&worker, subscription_id) {
@@ -917,7 +945,10 @@ fn ingest_loop(
                             if !ingestion_readiness.is_current(&worker) {
                                 break;
                             }
-                            eprintln!("AgentSight enforcement subscription lost: {error}");
+                            let detail = format!("subscription lost: {error}");
+                            if let Some(message) = availability_log.unavailable(&detail) {
+                                eprintln!("{message}");
+                            }
                             if let Err(store_error) =
                                 store.mark_active_degraded(DEGRADED_BINDING_MESSAGE)
                             {
@@ -933,7 +964,9 @@ fn ingest_loop(
             Err(error) => {
                 ingestion_readiness.mark_not_ready(&worker);
                 if ingestion_readiness.is_current(&worker) {
-                    eprintln!("AgentSight enforcement unavailable: {error}");
+                    if let Some(message) = availability_log.unavailable(&error.to_string()) {
+                        eprintln!("{message}");
+                    }
                     if let Err(store_error) = store.mark_active_degraded(DEGRADED_BINDING_MESSAGE) {
                         eprintln!(
                             "AgentSight could not persist enforcement unavailability: {store_error}"
@@ -991,6 +1024,26 @@ fn sleep_until_superseded(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn availability_log_reports_only_state_transitions() {
+        let mut transitions = AvailabilityLogTransitions::default();
+
+        assert_eq!(
+            transitions.unavailable("socket missing"),
+            Some("AgentSight enforcement unavailable: socket missing".into())
+        );
+        assert_eq!(transitions.unavailable("socket missing"), None);
+        assert_eq!(
+            transitions.unavailable("connection refused"),
+            Some("AgentSight enforcement unavailable: connection refused".into())
+        );
+        assert_eq!(
+            transitions.recovered(),
+            Some("AgentSight enforcement recovered".into())
+        );
+        assert_eq!(transitions.recovered(), None);
+    }
 
     fn make_ready(readiness: &IngestionReadiness, worker: &Arc<WorkerToken>) -> Uuid {
         let subscription_id = Uuid::new_v4();

--- a/src/agentsight/src/enforcement/coordinator.rs
+++ b/src/agentsight/src/enforcement/coordinator.rs
@@ -41,22 +41,24 @@ struct IngestionState {
 
 #[derive(Default)]
 struct AvailabilityLogTransitions {
-    unavailable_detail: Option<String>,
+    unavailable: bool,
 }
 
 impl AvailabilityLogTransitions {
     fn unavailable(&mut self, detail: &str) -> Option<String> {
-        if self.unavailable_detail.as_deref() == Some(detail) {
+        if self.unavailable {
             return None;
         }
-        self.unavailable_detail = Some(detail.into());
+        self.unavailable = true;
         Some(format!("AgentSight enforcement unavailable: {detail}"))
     }
 
     fn recovered(&mut self) -> Option<String> {
-        self.unavailable_detail
-            .take()
-            .map(|_| "AgentSight enforcement recovered".into())
+        if std::mem::take(&mut self.unavailable) {
+            Some("AgentSight enforcement recovered".into())
+        } else {
+            None
+        }
     }
 }
 
@@ -1034,15 +1036,16 @@ mod tests {
             Some("AgentSight enforcement unavailable: socket missing".into())
         );
         assert_eq!(transitions.unavailable("socket missing"), None);
-        assert_eq!(
-            transitions.unavailable("connection refused"),
-            Some("AgentSight enforcement unavailable: connection refused".into())
-        );
+        assert_eq!(transitions.unavailable("connection refused"), None);
         assert_eq!(
             transitions.recovered(),
             Some("AgentSight enforcement recovered".into())
         );
         assert_eq!(transitions.recovered(), None);
+        assert_eq!(
+            transitions.unavailable("socket missing"),
+            Some("AgentSight enforcement unavailable: socket missing".into())
+        );
     }
 
     fn make_ready(readiness: &IngestionReadiness, worker: &Arc<WorkerToken>) -> Uuid {


### PR DESCRIPTION
## Why

AgentSight 0.10.0 can start without a deployable enforcer because the RPM build paths duplicate and drift in their payload lists. The server then retries the missing UDS endpoint and repeats the same availability error.

## What changed

- Stage all AgentSight RPM payloads through one fail-closed script.
- Verify the final RPM contains both binaries, both systemd units, configuration, and component metadata before upload.
- Keep bounded reconnect/recovery while logging only availability transitions.

## Related issue

Closes #2371

## User / Agent impact

RPM installations include the enforcer service required by the existing systemd relationship. A temporarily unavailable enforcer produces one actionable message and one recovery message instead of repeated identical errors.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The enforcement protocol and service ownership are unchanged; the RPM artifact now enforces the already-declared deployment contract.

## Validation

- `bash src/agentsight/scripts/test-rpm-packaging.sh`
- `bash -n src/agentsight/scripts/stage-rpm-payload.sh src/agentsight/scripts/verify-rpm-package.sh src/agentsight/scripts/rpm-build.sh scripts/rpm-build.sh`
- `rustfmt --edition 2024 --check src/agentsight/src/enforcement/coordinator.rs`
- `git diff --check origin/main...HEAD`
- Linux and RPM CI pending on this draft PR.

## Documentation and rollback

No user-facing documentation change. Revert the two commits to restore the previous packaging and logging behavior.