### PR TITLE
chore(anolisa): bump version to 0.2.20

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.20] - 2026-08-11
+
+### Changed
+
+- `anolisa list` now announces the detected host platform and reports component
+  availability instead of backend and ownership columns in human-readable
+  output. Components unsupported on the host remain visible with their
+  supported platform and no install action, while JSON adds `platforms` and
+  `platform_available` without removing backend or ownership metadata
+  ([#2367](https://github.com/alibaba/anolisa/pull/2367)).
+
+### Fixed
+
+- npm installs now keep `@anolisa/cli` as the sole owner of the public
+  `anolisa` executable. With npm 10, local installs reliably create
+  `node_modules/.bin/anolisa` instead of losing the command when platform
+  packages are linked
+  ([#2345](https://github.com/alibaba/anolisa/pull/2345)).
+
 ## [0.2.19] - 2026-08-10
 
 ### Fixed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,23 @@
 
 ## [未发布]
 
+## [0.2.20] - 2026-08-11
+
+### 变更
+
+- `anolisa list` 现显示检测到的 host platform，并在 human-readable output 中以
+  component availability 取代 backend 和 ownership column。不支持当前 host 的
+  component 仍会显示其支持的 platform，且不提供 install action；JSON 新增
+  `platforms` 和 `platform_available`，同时保留 backend 与 ownership metadata
+  ([#2367](https://github.com/alibaba/anolisa/pull/2367))。
+
+### 修复
+
+- npm 安装现由 `@anolisa/cli` 独占公开的 `anolisa` executable。在 npm 10 下，
+  本地安装可稳定创建 `node_modules/.bin/anolisa`，不再因 platform package 参与
+  链接而丢失该 command
+  ([#2345](https://github.com/alibaba/anolisa/pull/2345))。
+
 ## [0.2.19] - 2026-08-10
 
 ### 修复

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Mon Aug 10 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Tue Aug 11 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Component listing now reports host-aware availability in human and JSON output.
+- npm installs now keep the public command link under the root package.
+
+* Mon Aug 10 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.19-1
 - Raw dependency provisioning now recognizes RPM and DEB family hints without `which`.
 - Sandbox-list and registration-status JSON now use the standard response envelope.
 - OpenClaw adapters now honor configured state directories and migrate legacy installs safely.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.19",
-    "@anolisa/cli-linux-arm64": "0.2.19",
-    "@anolisa/cli-darwin-arm64": "0.2.19"
+    "@anolisa/cli-linux-x64": "0.2.20",
+    "@anolisa/cli-linux-arm64": "0.2.20",
+    "@anolisa/cli-darwin-arm64": "0.2.20"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA CLI needs a 0.2.20 release boundary for the user-visible component availability and npm command-link fixes merged after 0.2.19. Keeping Cargo, npm, and RPM metadata synchronized prevents the published distributions from drifting.

## What changed

- Bumped the Cargo workspace and lockfile package versions to 0.2.20.
- Synchronized the npm root package, native optional dependencies, and all platform package manifests.
- Curated matching English and Chinese changelog entries from the actual post-0.2.19 range.
- Froze the previous RPM changelog row at 0.2.19 and opened the 0.2.20 `@VERSION@` row.

The version-bump commit itself adds no runtime behavior.

## Related issue

no-issue: routine ANOLISA CLI 0.2.20 release synchronization

## User / Agent impact

Users receive consistent 0.2.20 version metadata across Cargo, npm, and RPM distributions. The release notes document platform-aware `anolisa list` output and reliable creation of the npm `anolisa` command link.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this PR synchronizes release metadata for behavior already merged on `main`; it introduces no additional runtime changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked --quiet` — 2,103 passed, 1 ignored with `systemctl` isolated from the host service state
- `cargo doc --workspace --no-deps --locked`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `target/debug/anolisa --version` — `anolisa 0.2.20`
- `git diff --check`
- Release metadata audit against the repository's separate English and Chinese changelog files

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog. Revert commit `e3d31192` to roll back the release metadata; no runtime migration or disablement is required.