### PR TITLE
fix(sight): classify store errors by variant

### DIFF
--- a/src/agentsight/src/server/containment.rs
+++ b/src/agentsight/src/server/containment.rs
@@ -429,8 +429,9 @@ fn containment_error(error: ContainmentError) -> HttpResponse {
             true,
         ),
         Store(error) => {
-            log::error!("containment security store failed: {error}");
-            return system_audit::store_unavailable();
+            // Same classification as the audit handlers: data corruption
+            // must not be reported as store unavailability.
+            return system_audit::store_error(error);
         }
         AlreadyRunning => (
             StatusCode::CONFLICT,

--- a/src/agentsight/src/server/containment_error_tests.rs
+++ b/src/agentsight/src/server/containment_error_tests.rs
@@ -70,6 +70,11 @@ async fn typed_errors_have_stable_sanitized_mappings() {
                 "database /private/db".into(),
             )),
             S::INTERNAL_SERVER_ERROR,
+            "invalid_stored_data",
+        ),
+        (
+            E::Store(SecurityStoreError::Poisoned),
+            S::INTERNAL_SERVER_ERROR,
             "security_store_unavailable",
         ),
         (E::AlreadyRunning, S::CONFLICT, "reconciler_already_running"),

--- a/src/agentsight/src/server/system_audit.rs
+++ b/src/agentsight/src/server/system_audit.rs
@@ -297,12 +297,40 @@ pub(super) fn response(status: StatusCode, state: &str, data: Value) -> HttpResp
     }))
 }
 
+/// Maps a store failure to a sanitized API error by failure class.
+///
+/// Data-corruption errors must not be reported as store unavailability:
+/// the store is reachable and retrying cannot succeed, so misclassifying
+/// them sends operators down the wrong troubleshooting path.
 pub(super) fn store_error(error: SecurityStoreError) -> HttpResponse {
     log::error!("system audit security store failed: {error}");
-    store_unavailable()
+    match error {
+        SecurityStoreError::Serialization(_) | SecurityStoreError::InvalidData(_) => {
+            invalid_stored_data()
+        }
+        SecurityStoreError::Open(_)
+        | SecurityStoreError::Sqlite(_)
+        | SecurityStoreError::InvalidFilter(_)
+        | SecurityStoreError::MissingCase(_)
+        | SecurityStoreError::TimestampOutOfRange(_)
+        | SecurityStoreError::Poisoned
+        | SecurityStoreError::PolicyRevisionConflict { .. } => store_unavailable(),
+    }
 }
 
-pub(super) fn store_unavailable() -> HttpResponse {
+// Details stay in the log above; the response must not leak paths or
+// raw serde output.
+fn invalid_stored_data() -> HttpResponse {
+    error_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "invalid_stored_data",
+        "stored security event data is invalid",
+        false,
+    )
+}
+
+// Private so handlers cannot bypass the classification in store_error().
+fn store_unavailable() -> HttpResponse {
     error_response(
         StatusCode::INTERNAL_SERVER_ERROR,
         "security_store_unavailable",
@@ -347,18 +375,42 @@ mod tests {
 
     use super::{session_page_view, store_error};
 
-    #[actix_web::test]
-    async fn store_errors_do_not_expose_internal_paths() {
-        let response = store_error(SecurityStoreError::InvalidData(
-            "database /private/db is corrupt".into(),
-        ));
+    async fn error_body(response: actix_web::HttpResponse) -> serde_json::Value {
         let body = to_bytes(response.into_body())
             .await
             .expect("error body should render");
-        let rendered = String::from_utf8_lossy(&body);
-        assert!(rendered.contains("security_store_unavailable"));
-        assert!(rendered.contains("security data store is unavailable"));
-        assert!(!rendered.contains("/private/db"));
+        serde_json::from_slice(&body).expect("error body should be JSON")
+    }
+
+    #[actix_web::test]
+    async fn store_errors_do_not_expose_internal_paths() {
+        let value = error_body(store_error(SecurityStoreError::InvalidData(
+            "database /private/db is corrupt".into(),
+        )))
+        .await;
+        assert_eq!(value["error"]["code"], "invalid_stored_data");
+        assert_eq!(
+            value["error"]["message"],
+            "stored security event data is invalid"
+        );
+        assert_eq!(value["error"]["retryable"], false);
+        assert!(!value.to_string().contains("/private/db"));
+    }
+
+    #[actix_web::test]
+    async fn persistence_errors_stay_store_unavailable() {
+        let value = error_body(store_error(SecurityStoreError::Poisoned)).await;
+        assert_eq!(value["error"]["code"], "security_store_unavailable");
+        assert_eq!(value["error"]["retryable"], true);
+    }
+
+    #[actix_web::test]
+    async fn serialization_errors_map_to_invalid_stored_data() {
+        let serde_error = serde_json::from_str::<serde_json::Value>("not json")
+            .expect_err("parsing garbage should fail");
+        let value = error_body(store_error(SecurityStoreError::Serialization(serde_error))).await;
+        assert_eq!(value["error"]["code"], "invalid_stored_data");
+        assert_eq!(value["error"]["retryable"], false);
     }
 
     #[test]


### PR DESCRIPTION
## Why

`store_error()` collapsed all 9 `SecurityStoreError` variants into a single `security_store_unavailable` error code. Data-corruption failures (`Serialization`, `InvalidData`) were therefore misreported as "storage unavailable" with `retryable=true`, misleading operators into retrying requests that can never succeed and pointing troubleshooting at the wrong subsystem.

## What changed

- `store_error()` now exhaustively matches on the error variant:
  - `Serialization` / `InvalidData` -> HTTP 500 + `invalid_stored_data` + `retryable=false`, with a constant message that leaks no internal details (no paths, no serde output).
  - The remaining 7 variants keep `security_store_unavailable` + `retryable=true`.
- The containment endpoint's `Store` error branch (same error type, same root cause) now delegates to `store_error()` instead of duplicating the mapping.
- `store_unavailable()` is narrowed to private so future call sites cannot bypass the variant classification.

## Related issue

closes #2393

## User / Agent impact

On data corruption, audit/containment endpoints now return `invalid_stored_data` (`retryable=false`) instead of `security_store_unavailable` (`retryable=true`). Availability-class failures are unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

- **Error-code contract change**: for data-corruption scenarios the audit/containment endpoints' error code changes from `security_store_unavailable` (`retryable=true`) to `invalid_stored_data` (`retryable=false`). This is a corrective change: it stops pointless retries against corrupted data. The dashboard frontend renders both codes through the same generic fallback path (pre-existing pattern), so there is no UI breakage. No consumer was found that automates retries based on the `retryable` flag.
- **Known pre-existing limitation (not introduced by this PR)**: a single corrupted record still causes the audit endpoints that read it (summary, case detail) to fail with 500 as a whole. Before this fix they also returned 500 -- only the error code differs. Partial success by isolating corrupted rows is a possible follow-up.

## Validation

- ECS (kernel 6.6, toolchain 1.89.0, matching CI): `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass (1541 tests). The only failure is a pre-existing doctest in `src/genai/helpers.rs`, which is untouched by this branch.
- Real-binary end-to-end: injected an `event_json` record missing the identity field, linked to a case via `risk_evidence_links`; `GET /api/audit/cases/{id}` returns 500 + `invalid_stored_data` + `retryable=false` with no path or serde detail leakage, while the cases list still returns 200.
- Discriminating unit tests cover both sides: data-class errors (`InvalidData` and a real serde error) and persistence-class errors (`Poisoned`), plus both mappings through the containment endpoint after delegation.

## Documentation and rollback

- No documentation must be updated. The design docs lack an API error-code catalog, which is a pre-existing gap -- suggested as a follow-up.
- Rollback: revert this single commit.
