### PR TITLE
fix(anolisa): verify package-owned adapters

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -1053,6 +1053,8 @@ mod tests {
             enabled_at: "2026-01-01T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/tmp/adapter-resource"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -480,6 +480,8 @@ mod tests {
             enabled_at: "2026-06-01T10:00:00Z".to_string(),
             resource_root: PathBuf::from("/tmp/anolisa-forget-test"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -2105,6 +2105,8 @@ mod tests {
             enabled_at: "2026-06-01T10:00:00Z".to_string(),
             resource_root: PathBuf::from("/tmp/anolisa-uninstall-test"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -43,7 +43,8 @@ use chrono::{SecondsFormat, Utc};
 use clap::{Parser, Subcommand};
 use serde::Serialize;
 
-use anolisa_core::adapter::claim;
+use anolisa_core::adapter::claim::{self, AdapterSourceRevision};
+use anolisa_core::adapter::manager::{AdapterManager, VisibleRoot};
 use anolisa_core::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
 use anolisa_core::domain::{
     InstallationScope, ManagementRelation, NativePm, OwnedArtifact, ProviderBinding,
@@ -258,192 +259,44 @@ pub(crate) struct AdapterAction {
     pub(crate) command: String,
 }
 
-/// Trusted adapter bundle revisions captured from the component contract and
-/// ANOLISA-managed resource roots.
-pub(crate) type AdapterBundleSnapshot = BTreeMap<String, Option<String>>;
+/// Package-manager-owned adapter revisions captured around an update.
+pub(crate) type AdapterRevisionSnapshot = BTreeMap<String, Option<AdapterSourceRevision>>;
 
-const SYSTEM_BUNDLE_CHANGED_REASON: &str = "adapter bundle changed during system update";
+const SYSTEM_REVISION_CHANGED_REASON: &str = "adapter source revision changed during system update";
 
-/// Capture every adapter bundle declared by `component` without consulting
+/// Capture every adapter revision declared by `component` without consulting
 /// receipt state.
 ///
-/// Contract resolution and destination expansion are scoped to the active
-/// layout's trusted state and datadir roots. The resulting paths are
-/// revalidated as ANOLISA-owned before they are read, so a privileged update
-/// never lets user-controlled receipt fields choose filesystem inputs.
-pub(crate) fn adapter_bundle_snapshot(
+/// Contract resolution is scoped to the active layout's state and fixed
+/// package datadir. File metadata comes from the installation's owning package
+/// manager, so runtime-created files never enter the comparison.
+pub(crate) fn adapter_revision_snapshot(
     ctx: &CliContext,
     layout: &FsLayout,
     component: &str,
-) -> AdapterBundleSnapshot {
+) -> AdapterRevisionSnapshot {
     if ctx.install_mode != crate::context::InstallMode::System {
-        return AdapterBundleSnapshot::new();
+        return AdapterRevisionSnapshot::new();
     }
-    // Environment-driven packaged-data overrides are intentionally excluded:
-    // a privileged update may read only its selected system layout and the
-    // fixed package datadir, never a caller-selected source root.
     let mut datadir_roots = vec![layout.datadir.clone()];
     if let Some(package_datadir) = layout.package_datadir()
         && !datadir_roots.contains(&package_datadir)
     {
         datadir_roots.push(package_datadir);
     }
-    let Ok(resolved) = anolisa_core::adapter::contract::resolve_component_contract_with_source(
-        component,
-        std::slice::from_ref(&layout.state_dir),
-        &datadir_roots,
+    let Ok(state) = StateStore::load_for_layout(
+        &layout.state_dir.join("installed.toml"),
+        privilege::effective_uid(),
+        layout,
     ) else {
-        return AdapterBundleSnapshot::new();
+        return AdapterRevisionSnapshot::new();
     };
-    if resolved.manifest.component.name != component {
-        return AdapterBundleSnapshot::new();
-    }
-
-    if let Some(contract_root) = anolisa_core::adapter::contract::infer_contract_datadir_root(
-        component,
-        &resolved.path,
-        &datadir_roots,
-    ) && let Some(index) = datadir_roots.iter().position(|root| root == &contract_root)
-    {
-        let preferred = datadir_roots.remove(index);
-        datadir_roots.insert(0, preferred);
-    }
-
-    let mut snapshot = AdapterBundleSnapshot::new();
-    for adapter in &resolved.manifest.adapters {
-        let Some(framework) = adapter
-            .framework
-            .as_deref()
-            .filter(|value| !value.is_empty())
-        else {
-            continue;
-        };
-        let root = trusted_adapter_root(
-            layout,
-            component,
-            framework,
-            adapter.dest.as_deref(),
-            &datadir_roots,
-        );
-        snapshot.entry(framework.to_string()).or_insert_with(|| {
-            root.as_deref()
-                .and_then(|root| digest_bundle_tree(root, &datadir_roots))
-        });
-    }
-    snapshot
-}
-
-fn trusted_adapter_root(
-    layout: &FsLayout,
-    component: &str,
-    framework: &str,
-    dest: Option<&str>,
-    datadir_roots: &[PathBuf],
-) -> Option<PathBuf> {
-    for datadir in datadir_roots {
-        let mut scoped_layout = layout.clone();
-        scoped_layout.datadir = datadir.clone();
-        let path = match dest {
-            Some(template) => anolisa_core::expand_layout_placeholders(
-                template,
-                &scoped_layout,
-                &[("component", component)],
-            )
-            .ok()?,
-            None => datadir.join("adapters").join(component).join(framework),
-        };
-        if anolisa_core::path_safety::validate_owned_path(&scoped_layout, &path).is_ok()
-            && path.is_dir()
-        {
-            return Some(path);
-        }
-    }
-    None
-}
-
-/// SHA-256 digest of a trusted adapter directory tree.
-///
-/// Symlink targets contribute both their path text and referent bytes, but
-/// only after the referent canonicalizes under a trusted datadir root. Reading
-/// the canonical referent instead of reopening the link keeps a link swap from
-/// redirecting the privileged read after validation.
-fn digest_bundle_tree(root: &Path, trusted_roots: &[PathBuf]) -> Option<String> {
-    use sha2::{Digest, Sha256};
-
-    fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            let file_type = entry.file_type()?;
-            if file_type.is_dir() {
-                collect_files(&path, files)?;
-            } else if file_type.is_file() || file_type.is_symlink() {
-                files.push(path);
-            } else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    format!("unsupported adapter bundle entry '{}'", path.display()),
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    let canonical_trusted_roots: Vec<PathBuf> = trusted_roots
-        .iter()
-        .filter_map(|root| root.canonicalize().ok())
-        .collect();
-    let canonical_bundle_root = root.canonicalize().ok()?;
-    if !canonical_trusted_roots
-        .iter()
-        .any(|trusted_root| canonical_bundle_root.starts_with(trusted_root))
-    {
-        return None;
-    }
-
-    let mut files = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in files {
-        let relative = path.strip_prefix(root).unwrap_or(&path);
-        let metadata = std::fs::symlink_metadata(&path).ok()?;
-        let (entry_type, link_target, bytes) = if metadata.file_type().is_symlink() {
-            let link_target = std::fs::read_link(&path).ok()?;
-            let target_path = if link_target.is_absolute() {
-                link_target.clone()
-            } else {
-                path.parent()?.join(&link_target)
-            };
-            let canonical_target = target_path.canonicalize().ok()?;
-            if !canonical_trusted_roots
-                .iter()
-                .any(|trusted_root| canonical_target.starts_with(trusted_root))
-            {
-                return None;
-            }
-            (
-                b"symlink".as_slice(),
-                Some(link_target.to_string_lossy().into_owned().into_bytes()),
-                std::fs::read(canonical_target).ok()?,
-            )
-        } else {
-            (b"file".as_slice(), None, std::fs::read(&path).ok()?)
-        };
-        hasher.update(relative.to_string_lossy().as_bytes());
-        hasher.update([0]);
-        hasher.update(entry_type);
-        hasher.update([0]);
-        if let Some(link_target) = link_target {
-            hasher.update((link_target.len() as u64).to_le_bytes());
-            hasher.update([0]);
-            hasher.update(link_target);
-        }
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0]);
-        hasher.update(bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
+    let mut manager = AdapterManager::new(layout.clone(), None, "system-update".into());
+    manager.set_visible_roots(vec![VisibleRoot {
+        state_dir: layout.state_dir.clone(),
+        contract_datadir_roots: datadir_roots,
+    }]);
+    manager.source_revision_snapshot(component, &state)
 }
 
 /// Adapter actions a committed update of `component` leaves behind.
@@ -455,51 +308,71 @@ pub(crate) fn adapter_actions_after_update(
     ctx: &CliContext,
     store: &StateStore,
     component: &str,
-    before: &AdapterBundleSnapshot,
+    before: &AdapterRevisionSnapshot,
 ) -> Vec<AdapterAction> {
     if ctx.install_mode == crate::context::InstallMode::System {
         let layout = common::resolve_layout(ctx);
         return system_adapter_actions(
             component,
             before,
-            &adapter_bundle_snapshot(ctx, &layout, component),
+            &adapter_revision_snapshot(ctx, &layout, component),
         );
     }
-    receipt_adapter_actions(store, component)
+    receipt_adapter_actions(ctx, store, component)
 }
 
-fn receipt_adapter_actions(store: &StateStore, component: &str) -> Vec<AdapterAction> {
-    claim::stale_enabled_claims(&store.adapter_claims, component)
-        .into_iter()
-        .map(|receipt| AdapterAction {
-            component: receipt.component.clone(),
-            framework: receipt.framework.clone(),
-            reason: claim::BUNDLE_CHANGED_REASON.to_string(),
-            command: format!(
-                "anolisa adapter enable {} {}",
-                receipt.component, receipt.framework
-            ),
+fn receipt_adapter_actions(
+    ctx: &CliContext,
+    store: &StateStore,
+    component: &str,
+) -> Vec<AdapterAction> {
+    let manager = common::build_adapter_manager(ctx);
+    store
+        .adapter_claims
+        .iter()
+        .filter(|receipt| {
+            receipt.component == component
+                && receipt.status == anolisa_core::adapter::claim::ClaimStatus::Enabled
+        })
+        .filter_map(|receipt| {
+            let reason = match manager.source_revision_match(receipt, store) {
+                anolisa_core::adapter::managed_files::ManagedMatch::Matched => return None,
+                anolisa_core::adapter::managed_files::ManagedMatch::Changed(_) => {
+                    claim::SOURCE_REVISION_CHANGED_REASON.to_string()
+                }
+                anolisa_core::adapter::managed_files::ManagedMatch::Unknown(reason) => reason,
+            };
+            Some(AdapterAction {
+                component: receipt.component.clone(),
+                framework: receipt.framework.clone(),
+                reason,
+                command: format!(
+                    "anolisa adapter enable {} {}",
+                    receipt.component, receipt.framework
+                ),
+            })
         })
         .collect()
 }
 
 fn system_adapter_actions(
     component: &str,
-    before: &AdapterBundleSnapshot,
-    after: &AdapterBundleSnapshot,
+    before: &AdapterRevisionSnapshot,
+    after: &AdapterRevisionSnapshot,
 ) -> Vec<AdapterAction> {
     before
         .iter()
-        .filter_map(|(framework, before_digest)| {
-            let changed = match (before_digest, after.get(framework)) {
+        .filter_map(|(framework, before_revision)| {
+            let changed = match (before_revision, after.get(framework)) {
                 (Some(before), Some(Some(after))) => before != after,
                 (Some(_), _) => true,
-                _ => false,
+                (None, Some(Some(_))) => true,
+                (None, _) => false,
             };
             changed.then(|| AdapterAction {
                 component: component.to_string(),
                 framework: framework.clone(),
-                reason: SYSTEM_BUNDLE_CHANGED_REASON.to_string(),
+                reason: SYSTEM_REVISION_CHANGED_REASON.to_string(),
                 command: format!("anolisa adapter status {component}"),
             })
         })
@@ -970,7 +843,7 @@ fn execute_planned_update(
             ),
         });
     }
-    let prior_adapter_bundles = adapter_bundle_snapshot(ctx, &layout, target);
+    let prior_adapter_revisions = adapter_revision_snapshot(ctx, &layout, target);
 
     let package = native_package.clone().unwrap_or_else(|| target.to_string());
     let evidence = JournalEvidence::new(&journal_dir, &store.operations);
@@ -1077,7 +950,7 @@ fn execute_planned_update(
     // follow-up; a committed one may have replaced adapter resources
     // (issue #1885).
     let adapter_actions = if updated {
-        adapter_actions_after_update(ctx, &store, target, &prior_adapter_bundles)
+        adapter_actions_after_update(ctx, &store, target, &prior_adapter_revisions)
     } else {
         Vec::new()
     };
@@ -1175,7 +1048,7 @@ fn update_owned(
             });
         }
     };
-    let prior_adapter_bundles = adapter_bundle_snapshot(ctx, layout, target);
+    let prior_adapter_revisions = adapter_revision_snapshot(ctx, layout, target);
 
     let evidence = JournalEvidence::new(journal_dir, &store.operations);
     let mut journal_gate = LockedJournalGate::load(&_lock, evidence, command)?;
@@ -1238,7 +1111,8 @@ fn update_owned(
         None,
     );
 
-    let adapter_actions = adapter_actions_after_update(ctx, &store, target, &prior_adapter_bundles);
+    let adapter_actions =
+        adapter_actions_after_update(ctx, &store, target, &prior_adapter_revisions);
 
     render_result(
         ctx,
@@ -2135,89 +2009,6 @@ pub(crate) mod tests {
     use std::path::{Path, PathBuf};
 
     use anolisa_platform::pkg_query::PackageVersion;
-
-    /// Reproduce the persisted receipt digest without exposing the core
-    /// implementation as public API solely for cross-crate test fixtures.
-    pub(crate) fn receipt_digest(root: &Path) -> Option<String> {
-        use sha2::{Digest, Sha256};
-
-        fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
-            for entry in std::fs::read_dir(dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if entry.file_type()?.is_dir() {
-                    collect_files(&path, files)?;
-                } else {
-                    files.push(path);
-                }
-            }
-            Ok(())
-        }
-
-        let mut files = Vec::new();
-        collect_files(root, &mut files).ok()?;
-        files.sort();
-        let mut hasher = Sha256::new();
-        for path in files {
-            let relative = path.strip_prefix(root).unwrap_or(&path);
-            let bytes = std::fs::read(&path).ok()?;
-            hasher.update(relative.to_string_lossy().as_bytes());
-            hasher.update([0]);
-            hasher.update((bytes.len() as u64).to_le_bytes());
-            hasher.update([0]);
-            hasher.update(bytes);
-        }
-        Some(format!("sha256:{:x}", hasher.finalize()))
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn trusted_bundle_digest_tracks_bounded_symlink_contents() {
-        use std::os::unix::fs::symlink;
-
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let trusted_root = tmp.path().join("datadir");
-        let component_root = trusted_root.join("adapters/tokenless");
-        let bundle = component_root.join("claude-code");
-        let shared_hook = component_root.join("common/hooks/run-hook.sh");
-        std::fs::create_dir_all(bundle.join("hooks")).expect("bundle");
-        std::fs::create_dir_all(shared_hook.parent().expect("shared hook parent"))
-            .expect("shared hooks");
-        std::fs::write(&shared_hook, b"v1").expect("shared hook");
-        symlink(
-            "../../common/hooks/run-hook.sh",
-            bundle.join("hooks/run-hook.sh"),
-        )
-        .expect("symlink");
-
-        let first = digest_bundle_tree(&bundle, std::slice::from_ref(&trusted_root))
-            .expect("trusted symlink target is digestible");
-        std::fs::write(&shared_hook, b"v2").expect("updated shared hook");
-        let second = digest_bundle_tree(&bundle, std::slice::from_ref(&trusted_root))
-            .expect("updated trusted symlink target is digestible");
-
-        assert_ne!(first, second);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn trusted_bundle_digest_rejects_symlink_escape() {
-        use std::os::unix::fs::symlink;
-
-        let tmp = tempfile::tempdir().expect("tmpdir");
-        let trusted_root = tmp.path().join("datadir");
-        let bundle = trusted_root.join("adapters/tokenless/claude-code");
-        std::fs::create_dir_all(&bundle).expect("bundle");
-        let outside = tmp.path().join("outside.sh");
-        std::fs::write(&outside, b"sensitive").expect("outside file");
-        symlink(&outside, bundle.join("run-hook.sh")).expect("symlink");
-
-        assert_eq!(
-            digest_bundle_tree(&bundle, std::slice::from_ref(&trusted_root)),
-            None,
-            "a privileged digest must not read a symlink target outside trusted roots"
-        );
-    }
 
     #[test]
     fn json_dry_run_reports_available_but_not_updated() {
@@ -4679,17 +4470,15 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
     // ── adapter receipts left stale by an update (issue #1885) ──
 
     use anolisa_core::adapter::claim::{
-        AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimStatus, CoshClaim, DRIVER_SCHEMA_VERSION,
-        DriverPayload,
+        AdapterClaim, AdapterSourceRevision, CLAIM_SCHEMA_VERSION, ClaimStatus, CoshClaim,
+        DRIVER_SCHEMA_VERSION, DriverPayload, ManagedFileKind, ManagedSourceFile,
     };
 
-    /// An enabled receipt for `(component, framework)` pointing at
-    /// `resource_root`, carrying `bundle_digest` as its enable-time digest.
+    /// An enabled receipt carrying the managed source revision at enable time.
     pub(crate) fn enabled_claim(
         component: &str,
         framework: &str,
         resource_root: &Path,
-        bundle_digest: Option<&str>,
     ) -> AdapterClaim {
         AdapterClaim {
             claim_schema: CLAIM_SCHEMA_VERSION,
@@ -4699,7 +4488,9 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             adapter_type: Some("extension".to_string()),
             enabled_at: "2026-07-01T00:00:00Z".to_string(),
             resource_root: resource_root.to_path_buf(),
-            bundle_digest: bundle_digest.map(str::to_string),
+            bundle_digest: None,
+            source_revision: recorded_source_revision(resource_root),
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -4708,6 +4499,46 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
                 extension_dir_resource: "cosh_extension_dir".to_string(),
             }),
         }
+    }
+
+    fn recorded_source_revision(root: &Path) -> Option<AdapterSourceRevision> {
+        use sha2::{Digest, Sha256};
+
+        fn collect(root: &Path, dir: &Path, files: &mut Vec<ManagedSourceFile>) -> Option<()> {
+            for entry in std::fs::read_dir(dir).ok()? {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                let file_type = entry.file_type().ok()?;
+                if file_type.is_dir() {
+                    collect(root, &path, files)?;
+                } else if file_type.is_symlink() {
+                    files.push(ManagedSourceFile {
+                        relative_path: path.strip_prefix(root).ok()?.to_path_buf(),
+                        kind: ManagedFileKind::Symlink,
+                        sha256: None,
+                        symlink_target: Some(std::fs::read_link(path).ok()?),
+                    });
+                } else if file_type.is_file() {
+                    files.push(ManagedSourceFile {
+                        relative_path: path.strip_prefix(root).ok()?.to_path_buf(),
+                        kind: ManagedFileKind::File,
+                        sha256: Some(format!("{:x}", Sha256::digest(std::fs::read(path).ok()?))),
+                        symlink_target: None,
+                    });
+                }
+            }
+            Some(())
+        }
+
+        let source_root = std::fs::canonicalize(root).ok()?;
+        let mut files = Vec::new();
+        collect(root, root, &mut files)?;
+        files.sort();
+        (!files.is_empty()).then_some(AdapterSourceRevision {
+            source_root,
+            files,
+            materialized_sources: Vec::new(),
+        })
     }
 
     /// Upsert a receipt into `ctx`'s seeded state.
@@ -4724,7 +4555,7 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
         AdapterAction {
             component: component.to_string(),
             framework: framework.to_string(),
-            reason: "resource bundle changed since enable".to_string(),
+            reason: claim::SOURCE_REVISION_CHANGED_REASON.to_string(),
             command: format!("anolisa adapter enable {component} {framework}"),
         }
     }
@@ -4733,7 +4564,7 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
         AdapterAction {
             component: component.to_string(),
             framework: framework.to_string(),
-            reason: SYSTEM_BUNDLE_CHANGED_REASON.to_string(),
+            reason: SYSTEM_REVISION_CHANGED_REASON.to_string(),
             command: format!("anolisa adapter status {component}"),
         }
     }
@@ -4780,7 +4611,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
     }
 
     /// Seed the adapter bundle an earlier version shipped plus an enabled
-    /// receipt whose enable-time digest matches it; returns the bundle root.
+    /// receipt whose managed source revision matches it; returns the root.
     fn seed_bundle_and_claim(ctx: &CliContext, component: &str, content: &[u8]) -> PathBuf {
         let layout = common::resolve_layout(ctx);
         let manifest_path =
@@ -4799,18 +4630,14 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
             .join("openclaw");
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), content).expect("bundle file");
-        let digest = receipt_digest(&bundle_root).expect("enable-time digest");
-        seed_claim(
-            ctx,
-            enabled_claim(component, "openclaw", &bundle_root, Some(&digest)),
-        );
+        seed_claim(ctx, enabled_claim(component, "openclaw", &bundle_root));
         bundle_root
     }
 
     /// Seed a raw-installed component that ships an adapter bundle: the
     /// record owns the bundle file (as a real install with `[[adapters]]`
-    /// would), and an enabled receipt carries the enable-time digest of the
-    /// bundle root. Returns the bundle root.
+    /// would), and an enabled receipt carries its managed source revision.
+    /// Returns the bundle root.
     fn seed_raw_component_with_bundle(
         ctx: &CliContext,
         component: &str,
@@ -4856,11 +4683,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         });
         state.save(&state_path).expect("save state");
 
-        let digest = receipt_digest(&bundle_root).expect("enable-time digest");
-        seed_claim(
-            ctx,
-            enabled_claim(component, "openclaw", &bundle_root, Some(&digest)),
-        );
+        seed_claim(ctx, enabled_claim(component, "openclaw", &bundle_root));
         bundle_root
     }
 
@@ -4872,19 +4695,12 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         let bundle_root = tmp.path().join("receipt-controlled");
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), b"v1").expect("bundle file");
-        let digest = receipt_digest(&bundle_root).expect("enable-time digest");
-
         let mut store = StateStore::empty();
-        store.upsert_adapter_claim(enabled_claim(
-            "tokenless",
-            "openclaw",
-            &bundle_root,
-            Some(&digest),
-        ));
+        store.upsert_adapter_claim(enabled_claim("tokenless", "openclaw", &bundle_root));
         std::fs::write(bundle_root.join("plugin.json"), b"v2").expect("updated bundle");
 
         assert!(
-            adapter_actions_after_update(&c, &store, "tokenless", &AdapterBundleSnapshot::new())
+            adapter_actions_after_update(&c, &store, "tokenless", &AdapterRevisionSnapshot::new())
                 .is_empty(),
             "system mode must ignore receipt-controlled bundle paths"
         );
@@ -4893,7 +4709,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
     /// A privileged source snapshot must not honor the caller-controlled
     /// packaged-data override.
     #[test]
-    fn system_bundle_snapshot_ignores_packaged_data_override() {
+    fn system_revision_snapshot_ignores_packaged_data_override() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let untrusted = tmp.path().join("caller-data");
         let contract = FsLayout::component_contract_path(&untrusted, "tokenless");
@@ -4909,7 +4725,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         let layout = common::resolve_layout(&c);
 
         assert!(
-            adapter_bundle_snapshot(&c, &layout, "tokenless").is_empty(),
+            adapter_revision_snapshot(&c, &layout, "tokenless").is_empty(),
             "system snapshots must ignore environment-selected data roots"
         );
     }
@@ -4917,11 +4733,15 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
     /// A trusted source revision change yields a generic status action without
     /// loading any user's receipt.
     #[test]
-    fn system_bundle_change_reports_status_action() {
-        let before =
-            AdapterBundleSnapshot::from([("openclaw".to_string(), Some("sha256:old".to_string()))]);
-        let after =
-            AdapterBundleSnapshot::from([("openclaw".to_string(), Some("sha256:new".to_string()))]);
+    fn system_revision_change_reports_status_action() {
+        let before = AdapterRevisionSnapshot::from([(
+            "openclaw".to_string(),
+            Some(test_source_revision("0")),
+        )]);
+        let after = AdapterRevisionSnapshot::from([(
+            "openclaw".to_string(),
+            Some(test_source_revision("1")),
+        )]);
 
         assert_eq!(
             system_adapter_actions("tokenless", &before, &after),
@@ -4930,15 +4750,30 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
     }
 
     #[test]
-    fn system_bundle_becoming_unavailable_reports_status_action() {
-        let before =
-            AdapterBundleSnapshot::from([("openclaw".to_string(), Some("sha256:old".to_string()))]);
-        let after = AdapterBundleSnapshot::from([("openclaw".to_string(), None)]);
+    fn system_revision_becoming_unavailable_reports_status_action() {
+        let before = AdapterRevisionSnapshot::from([(
+            "openclaw".to_string(),
+            Some(test_source_revision("0")),
+        )]);
+        let after = AdapterRevisionSnapshot::from([("openclaw".to_string(), None)]);
 
         assert_eq!(
             system_adapter_actions("tokenless", &before, &after),
             vec![expected_system_action("tokenless", "openclaw")]
         );
+    }
+
+    fn test_source_revision(digest_digit: &str) -> AdapterSourceRevision {
+        AdapterSourceRevision {
+            source_root: PathBuf::from("/usr/share/anolisa/adapters/tokenless/openclaw"),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                kind: ManagedFileKind::File,
+                sha256: Some(digest_digit.repeat(64)),
+                symlink_target: None,
+            }],
+            materialized_sources: Vec::new(),
+        }
     }
 
     /// A system raw update reports a trusted adapter source change without
@@ -4988,11 +4823,15 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
             &raw_artifact_with_adapter("foo", "0.2.0", b"new\n", &[("plugin.json", b"v1")]),
         );
         let rpm = FakeRpm::new("unused", None);
+        let layout = common::resolve_layout(&c);
+        let before = adapter_revision_snapshot(&c, &layout, "foo");
 
         let (outcome, actions) =
             update_component_with_deps("foo", &c, &rpm, &rpm, false).expect("update ok");
+        let after = adapter_revision_snapshot(&c, &layout, "foo");
 
         assert_eq!(outcome, UpdateOutcome::Updated);
+        assert_eq!(before, after, "unchanged managed adapter revision");
         assert!(
             actions.is_empty(),
             "an unchanged bundle must not report an action: {actions:?}"
@@ -5012,15 +4851,9 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), b"v2").expect("bundle file");
         // A receipt stale from an earlier drift — not from this update.
-        seed_claim(
-            &c,
-            enabled_claim(
-                "foo",
-                "openclaw",
-                &bundle_root,
-                Some("sha256:stale-enable-time"),
-            ),
-        );
+        seed_claim(&c, enabled_claim("foo", "openclaw", &bundle_root));
+        std::fs::write(bundle_root.join("plugin.json"), b"already stale")
+            .expect("drift bundle file");
         publish_raw_repo(
             &tmp.path().join("repo"),
             &layout,
@@ -5051,12 +4884,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         let bundle_root = layout.datadir.join("adapters/foo/openclaw");
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), b"v1").expect("bundle file");
-        let receipt = enabled_claim(
-            "foo",
-            "openclaw",
-            &bundle_root,
-            Some("sha256:stale-enable-time"),
-        );
+        let receipt = enabled_claim("foo", "openclaw", &bundle_root);
         seed_claim(&c, receipt.clone());
         publish_raw_repo(
             &tmp.path().join("repo"),
@@ -5079,19 +4907,16 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         );
     }
 
-    /// A successful update never rewrites the enable-time digest: the
-    /// framework side was not reapplied, so the receipt must stay stale
-    /// until an explicit `adapter enable`.
+    /// A successful update never rewrites the enable-time source revision:
+    /// the framework side was not reapplied, so the receipt stays stale until
+    /// an explicit `adapter enable`.
     #[test]
     fn successful_update_leaves_the_receipt_untouched() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().join("sys"), InstallMode::System, false);
         let bundle_root =
             seed_raw_component_with_bundle(&c, "foo", "0.1.0", b"old v1 binary\n", b"v1");
-        let receipt = {
-            let digest = receipt_digest(&bundle_root).expect("enable-time digest");
-            enabled_claim("foo", "openclaw", &bundle_root, Some(&digest))
-        };
+        let receipt = enabled_claim("foo", "openclaw", &bundle_root);
         publish_raw_repo(
             &tmp.path().join("repo"),
             &common::resolve_layout(&c),
@@ -5113,11 +4938,10 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         );
     }
 
-    /// A committed delegated (RPM) update whose package replaces the
-    /// adapter resources propagates the adapter action through the shared
-    /// completion.
+    /// A delegated update cannot infer adapter drift from directory bytes
+    /// when its test-only native backend supplies no rpmdb file inventory.
     #[test]
-    fn delegated_update_completion_propagates_adapter_actions() {
+    fn delegated_update_requires_authoritative_inventory_for_adapter_actions() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         seed(
@@ -5148,10 +4972,9 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
 
         assert_eq!(outcome, UpdateOutcome::Updated);
         assert_eq!(rpm.update_calls.get(), 1);
-        assert_eq!(
-            actions,
-            vec![expected_system_action("copilot-shell", "openclaw")],
-            "the delegated completion must surface the changed source bundle"
+        assert!(
+            actions.is_empty(),
+            "unmanaged directory bytes must not stand in for rpmdb metadata: {actions:?}"
         );
         assert_eq!(update_operation_status(&c, "copilot-shell"), "ok");
     }
@@ -5176,15 +4999,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
         let bundle_root = layout.datadir.join("adapters/copilot-shell/openclaw");
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), b"v1").expect("bundle file");
-        seed_claim(
-            &c,
-            enabled_claim(
-                "copilot-shell",
-                "openclaw",
-                &bundle_root,
-                Some("sha256:stale-enable-time"),
-            ),
-        );
+        seed_claim(&c, enabled_claim("copilot-shell", "openclaw", &bundle_root));
         // upgrade_to is None => dnf update is a no-op; EVR stays the same.
         let rpm = FakeRpm::new(
             "copilot-shell",
@@ -5223,7 +5038,7 @@ dest = "{{datadir}}/adapters/{{component}}/openclaw/"
             serde_json::json!([{
                 "component": "foo",
                 "framework": "openclaw",
-                "reason": "resource bundle changed since enable",
+                "reason": "adapter source revision changed since enable",
                 "command": "anolisa adapter enable foo openclaw",
             }]),
             "{json}"

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -41,8 +41,8 @@ use crate::context::CliContext;
 use crate::response::{CliError, render_json, render_json_with_status};
 
 use super::{
-    AdapterAction, AdapterBundleSnapshot, COMMAND, ComponentUpdateResult, PlannedComponentUpdate,
-    PlannedUpdateRoute, UpdateOutcome, adapter_actions_after_update, adapter_bundle_snapshot,
+    AdapterAction, AdapterRevisionSnapshot, COMMAND, ComponentUpdateResult, PlannedComponentUpdate,
+    PlannedUpdateRoute, UpdateOutcome, adapter_actions_after_update, adapter_revision_snapshot,
     append_update_log, complete_delegated_update, native_update_authorized, now_iso8601,
     plan_component_update, render_adapter_action_notices, step_label, update_backends,
     update_component_with_deps,
@@ -487,13 +487,13 @@ fn execute_merged_updates_with_deps(
     if active.is_empty() {
         return items;
     }
-    let prior_adapter_bundles: HashMap<String, AdapterBundleSnapshot> = active
+    let prior_adapter_revisions: HashMap<String, AdapterRevisionSnapshot> = active
         .iter()
         .map(|(item, _)| {
             let target = item.planned.target.clone();
             (
                 target.clone(),
-                adapter_bundle_snapshot(ctx, &layout, &target),
+                adapter_revision_snapshot(ctx, &layout, &target),
             )
         })
         .collect();
@@ -668,7 +668,7 @@ fn execute_merged_updates_with_deps(
                         // A member whose EVR did not move changed nothing,
                         // so it cannot require adapter follow-up (issue #1885).
                         let adapter_actions = if moved {
-                            let before = prior_adapter_bundles
+                            let before = prior_adapter_revisions
                                 .get(&target)
                                 .cloned()
                                 .unwrap_or_default();
@@ -1602,10 +1602,10 @@ mod tests {
         );
     }
 
-    /// A merged batch reports each changed source bundle under its own
-    /// component (issue #1885): only cosh changes during the transaction.
+    /// A merged batch does not infer drift from directory bytes when its fake
+    /// native backend supplies no authoritative file inventory.
     #[test]
-    fn merged_updates_associate_adapter_actions_with_the_right_component() {
+    fn merged_updates_require_authoritative_inventory_for_adapter_actions() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         managed_pair(&c);
@@ -1662,19 +1662,10 @@ mod tests {
 
         assert_eq!(find(&items, "cosh").status, "updated");
         assert_eq!(find(&items, "sec-core").status, "updated");
-        assert_eq!(
-            find(&items, "cosh").adapter_actions,
-            vec![AdapterAction {
-                component: "cosh".to_string(),
-                framework: "openclaw".to_string(),
-                reason: "adapter bundle changed during system update".to_string(),
-                command: "anolisa adapter status cosh".to_string(),
-            }],
-            "the changed source bundle must surface on cosh's own item"
-        );
         assert!(
-            find(&items, "sec-core").adapter_actions.is_empty(),
-            "an unchanged source bundle must not produce an action"
+            find(&items, "cosh").adapter_actions.is_empty()
+                && find(&items, "sec-core").adapter_actions.is_empty(),
+            "unmanaged directory bytes must not be treated as package revisions"
         );
     }
 
@@ -1709,7 +1700,7 @@ mod tests {
             adapter_actions: vec![AdapterAction {
                 component: "cosh".to_string(),
                 framework: "openclaw".to_string(),
-                reason: anolisa_core::adapter::claim::BUNDLE_CHANGED_REASON.to_string(),
+                reason: anolisa_core::adapter::claim::SOURCE_REVISION_CHANGED_REASON.to_string(),
                 command: "anolisa adapter enable cosh openclaw".to_string(),
             }],
         };
@@ -1721,7 +1712,7 @@ mod tests {
             serde_json::json!([{
                 "component": "cosh",
                 "framework": "openclaw",
-                "reason": "resource bundle changed since enable",
+                "reason": "adapter source revision changed since enable",
                 "command": "anolisa adapter enable cosh openclaw",
             }]),
             "each batch item carries its own adapter actions (issue #1885): {json}"

--- a/src/anolisa/crates/anolisa-cli/tests/adapter_notices.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/adapter_notices.rs
@@ -10,10 +10,11 @@ use std::path::PathBuf;
 use std::process::Output;
 
 use anolisa_core::{
-    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
-    Ownership, SubscriptionScope,
+    FileOwner, InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind,
+    ObjectStatus, OwnedFile, OwnedFileKind, Ownership, SubscriptionScope,
 };
 use anolisa_platform::fs_layout::FsLayout;
+use sha2::{Digest, Sha256};
 
 mod common;
 
@@ -85,11 +86,10 @@ impl NoticeFixture {
             .join(COMPONENT)
             .join("cosh");
         std::fs::create_dir_all(&resource_root).expect("resource root");
-        std::fs::write(
-            resource_root.join("cosh-extension.json"),
-            format!(r#"{{"id":"{COMPONENT}","name":"Notice Demo"}}"#),
-        )
-        .expect("cosh extension manifest");
+        let extension_manifest = format!(r#"{{"id":"{COMPONENT}","name":"Notice Demo"}}"#);
+        let extension_manifest_path = resource_root.join("cosh-extension.json");
+        std::fs::write(&extension_manifest_path, extension_manifest.as_bytes())
+            .expect("cosh extension manifest");
 
         // Component contract snapshot carrying the notices.
         let manifest_path = user_layout.snapshot_path(COMPONENT);
@@ -98,11 +98,20 @@ impl NoticeFixture {
         std::fs::write(&manifest_path, MANIFEST).expect("component manifest");
 
         // Component installed in the user scope; empty system scope.
-        write_state(
-            &user_layout,
-            StateInstallMode::User,
-            vec![component(COMPONENT)],
-        );
+        let mut installed = component(COMPONENT);
+        installed.files.push(OwnedFile {
+            path: extension_manifest_path,
+            owner: FileOwner::Anolisa,
+            sha256: Some(format!(
+                "{:x}",
+                Sha256::digest(extension_manifest.as_bytes())
+            )),
+            kind: OwnedFileKind::File,
+            referent: None,
+            mode: None,
+            capabilities: Vec::new(),
+        });
+        write_state(&user_layout, StateInstallMode::User, vec![installed]);
         write_state(&system_layout, StateInstallMode::System, Vec::new());
 
         Self {

--- a/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
@@ -291,6 +291,8 @@ fn adapter_claim(component: &str) -> AdapterClaim {
         enabled_at: "2026-01-01T00:00:00Z".to_string(),
         resource_root: PathBuf::from("/tmp/adapter-resource"),
         bundle_digest: None,
+        source_revision: None,
+        materialized_files: Vec::new(),
         driver_schema: 1,
         status: ClaimStatus::Enabled,
         notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-cli/tests/update_adapter_actions.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/update_adapter_actions.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use std::process::Output;
 
 use anolisa_core::adapter::claim::{
-    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimStatus, CoshClaim, DRIVER_SCHEMA_VERSION,
-    DriverPayload,
+    AdapterClaim, AdapterSourceRevision, CLAIM_SCHEMA_VERSION, ClaimStatus, CoshClaim,
+    DRIVER_SCHEMA_VERSION, DriverPayload, ManagedFileKind, ManagedSourceFile,
 };
 use anolisa_core::state_store::StateStore;
 use anolisa_core::{
@@ -24,38 +24,6 @@ use anolisa_platform::privilege;
 mod common;
 
 const COMPONENT: &str = "stale-demo";
-
-fn receipt_digest(root: &Path) -> Option<String> {
-    use sha2::{Digest, Sha256};
-
-    fn collect_files(dir: &Path, files: &mut Vec<PathBuf>) -> std::io::Result<()> {
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if entry.file_type()?.is_dir() {
-                collect_files(&path, files)?;
-            } else {
-                files.push(path);
-            }
-        }
-        Ok(())
-    }
-
-    let mut files = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in files {
-        let relative = path.strip_prefix(root).unwrap_or(&path);
-        let bytes = std::fs::read(&path).ok()?;
-        hasher.update(relative.to_string_lossy().as_bytes());
-        hasher.update([0]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0]);
-        hasher.update(bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
 
 fn manifest(version: &str, with_adapter: bool) -> String {
     let adapter = if with_adapter {
@@ -119,7 +87,7 @@ struct UpdateFixture {
     runtime_dir: PathBuf,
     user_layout: FsLayout,
     bundle_root: PathBuf,
-    enable_digest: String,
+    enable_revision: AdapterSourceRevision,
 }
 
 impl UpdateFixture {
@@ -151,7 +119,19 @@ impl UpdateFixture {
             .join("openclaw");
         std::fs::create_dir_all(&bundle_root).expect("bundle root");
         std::fs::write(bundle_root.join("plugin.json"), b"v1").expect("v1 bundle");
-        let enable_digest = receipt_digest(&bundle_root).expect("enable-time digest");
+        let enable_revision = AdapterSourceRevision {
+            source_root: std::fs::canonicalize(&bundle_root).expect("canonical bundle root"),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                kind: ManagedFileKind::File,
+                sha256: Some({
+                    use sha2::{Digest, Sha256};
+                    format!("{:x}", Sha256::digest(b"v1"))
+                }),
+                symlink_target: None,
+            }],
+            materialized_sources: Vec::new(),
+        };
 
         // The installed binary and its manifest snapshot.
         std::fs::create_dir_all(&user_layout.bin_dir).expect("bin dir");
@@ -163,7 +143,7 @@ impl UpdateFixture {
         std::fs::write(&snapshot, manifest("0.1.0", false)).expect("write snapshot");
 
         // State: the component owns the binary, the snapshot, and the
-        // bundle file; the receipt carries the enable-time bundle digest.
+        // bundle file; the receipt carries the enable-time managed revision.
         let sha = |path: &Path| {
             use sha2::{Digest, Sha256};
             format!(
@@ -231,7 +211,9 @@ impl UpdateFixture {
             adapter_type: Some("plugin".to_string()),
             enabled_at: "2026-07-01T00:00:00Z".to_string(),
             resource_root: bundle_root.clone(),
-            bundle_digest: Some(enable_digest.clone()),
+            bundle_digest: None,
+            source_revision: Some(enable_revision.clone()),
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -277,7 +259,7 @@ impl UpdateFixture {
             runtime_dir,
             user_layout,
             bundle_root,
-            enable_digest,
+            enable_revision,
         }
     }
 
@@ -314,12 +296,12 @@ impl UpdateFixture {
         .expect("load state")
     }
 
-    /// The persisted receipt's enable-time digest.
-    fn persisted_bundle_digest(&self) -> Option<String> {
+    /// The persisted receipt's enable-time managed revision.
+    fn persisted_source_revision(&self) -> Option<AdapterSourceRevision> {
         self.load_store()
             .find_adapter_claim(COMPONENT, "openclaw")
             .expect("receipt must survive")
-            .bundle_digest
+            .source_revision
             .clone()
     }
 }
@@ -399,7 +381,7 @@ fn update_human_lists_stale_adapter_with_recovery_command() {
     let out = stdout(&output);
     assert!(out.contains("stale-demo/openclaw"), "{out}");
     assert!(
-        out.contains("resource bundle changed since enable"),
+        out.contains("adapter source revision changed since enable"),
         "{out}"
     );
     assert!(
@@ -411,11 +393,11 @@ fn update_human_lists_stale_adapter_with_recovery_command() {
         std::fs::read(fixture.bundle_root.join("plugin.json")).expect("read bundle"),
         b"v2"
     );
-    // ... but the receipt keeps its enable-time digest: only an explicit
+    // ... but the receipt keeps its enable-time revision: only an explicit
     // `adapter enable` may clear the drift.
     assert_eq!(
-        fixture.persisted_bundle_digest().as_deref(),
-        Some(fixture.enable_digest.as_str()),
+        fixture.persisted_source_revision().as_ref(),
+        Some(&fixture.enable_revision),
         "update must report the drift, not erase it"
     );
 }
@@ -427,7 +409,7 @@ fn update_quiet_suppresses_adapter_notices() {
     assert_success(&output);
     let out = stdout(&output);
     assert!(
-        !out.contains("resource bundle changed") && !out.contains("adapter enable"),
+        !out.contains("source revision changed") && !out.contains("adapter enable"),
         "--quiet must not print adapter notices: {out}"
     );
 }
@@ -445,14 +427,14 @@ fn update_json_carries_adapter_actions() {
         serde_json::json!([{
             "component": "stale-demo",
             "framework": "openclaw",
-            "reason": "resource bundle changed since enable",
+            "reason": "adapter source revision changed since enable",
             "command": "anolisa adapter enable stale-demo openclaw",
         }]),
         "{envelope}"
     );
     assert_eq!(
-        fixture.persisted_bundle_digest().as_deref(),
-        Some(fixture.enable_digest.as_str()),
+        fixture.persisted_source_revision().as_ref(),
+        Some(&fixture.enable_revision),
         "the receipt must survive the update unchanged"
     );
 }
@@ -476,7 +458,7 @@ fn update_dry_run_reports_no_adapter_actions_and_changes_nothing() {
         "dry-run must not touch the bundle"
     );
     assert_eq!(
-        fixture.persisted_bundle_digest().as_deref(),
-        Some(fixture.enable_digest.as_str())
+        fixture.persisted_source_revision().as_ref(),
+        Some(&fixture.enable_revision)
     );
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -27,6 +27,7 @@ pub mod contract;
 pub mod cosh;
 pub mod driver;
 pub mod hermes;
+pub mod managed_files;
 pub mod manager;
 pub mod openclaw;
 pub mod qoder;

--- a/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claim.rs
@@ -34,11 +34,9 @@ use serde_json::Value;
 use crate::path_safety::{PathBoundaryError, canonicalize_nearest_existing, validate_owned_path};
 use anolisa_platform::fs_layout::FsLayout;
 
-use super::util::digest_tree;
-
 /// Schema version for the generic claim shape and [`ClaimResource`].
 /// Persisted in every receipt so a future on-disk migration can branch.
-pub const CLAIM_SCHEMA_VERSION: u32 = 1;
+pub const CLAIM_SCHEMA_VERSION: u32 = 2;
 
 /// Schema version for [`DriverPayload`]. Bumped independently of
 /// [`CLAIM_SCHEMA_VERSION`] when a driver's typed payload changes shape.
@@ -82,10 +80,20 @@ pub struct AdapterClaim {
     /// Resource directory read at enable time. Kept for status display and
     /// upgrade detection; `disable` must NOT depend on it still existing.
     pub resource_root: PathBuf,
-    /// Digest of the resource tree at enable time, for drift/upgrade
-    /// detection. Optional: a driver may decline to compute one.
+    /// Legacy whole-tree digest read only to migrate pre-v2 receipts. New
+    /// receipts never write it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bundle_digest: Option<String>,
+    /// Package-manager-owned adapter inputs captured at enable time. The root
+    /// is the resolved source root and every file path is relative to it, so
+    /// a source-root migration changes the revision even when bytes do not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_revision: Option<AdapterSourceRevision>,
+    /// Files ANOLISA explicitly materialized into framework-owned resources.
+    /// Runtime additions under those resources are intentionally absent and
+    /// therefore ignored by status.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub materialized_files: Vec<MaterializedFile>,
     /// [`DriverPayload`] schema version ([`DRIVER_SCHEMA_VERSION`] at write
     /// time).
     pub driver_schema: u32,
@@ -111,21 +119,6 @@ impl AdapterClaim {
     /// Whether this receipt represents a skill-only adapter bundle.
     pub fn is_skill_bundle(&self) -> bool {
         self.adapter_type.as_deref() == Some("skill_bundle")
-    }
-
-    /// Compare the enable-time [`Self::bundle_digest`] against a fresh digest
-    /// of [`Self::resource_root`].
-    ///
-    /// This is the drift/upgrade detection the `bundle_digest` field exists
-    /// for; the drivers' `ResourceBundleMatches` condition and post-update
-    /// adapter actions branch on the same verdict, so the comparison lives
-    /// with the receipt schema instead of being re-derived per caller.
-    pub fn bundle_match(&self) -> BundleMatch {
-        match (&self.bundle_digest, digest_tree(&self.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => BundleMatch::Matched,
-            (Some(_), Some(_)) => BundleMatch::Changed,
-            _ => BundleMatch::Unknown,
-        }
     }
 
     /// Find a resource by its stable `id`.
@@ -239,6 +232,7 @@ impl AdapterClaim {
                 _ => {}
             }
         }
+        validate_integrity_entries(self)?;
         Ok(())
     }
 
@@ -269,47 +263,74 @@ impl AdapterClaim {
     }
 }
 
-/// Reason text for reports about a receipt whose resource bundle changed
-/// after enable. The drivers' `ResourceBundleMatches` status condition and
-/// the post-update adapter actions share this wording so `adapter status`
-/// and `update` name the same problem identically.
-pub const BUNDLE_CHANGED_REASON: &str = "resource bundle changed since enable";
+/// Follow-up reason shared by adapter status and component update actions.
+pub const SOURCE_REVISION_CHANGED_REASON: &str = "adapter source revision changed since enable";
 
-/// How a receipt's enable-time bundle digest compares to the resource tree
-/// currently on disk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BundleMatch {
-    /// The recorded digest matches a fresh digest of the resource root.
-    Matched,
-    /// Both digests exist and differ: the resource bundle changed after
-    /// enable, so the framework-side state no longer corresponds to the
-    /// component's current adapter resources.
-    Changed,
-    /// No digest was recorded at enable time or the resource root cannot be
-    /// digested now; drift cannot be decided either way.
-    Unknown,
+/// Package-managed file type persisted in source and materialized revisions.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum ManagedFileKind {
+    /// Regular file verified by SHA-256.
+    File,
+    /// Symbolic link verified by its literal target.
+    Symlink,
 }
 
-/// Enabled receipts for `component` whose resource bundle changed since
-/// enable — the receipts a component update leaves stale until the adapter
-/// is re-enabled.
-///
-/// Receipts without a recorded digest (or with an unreadable resource root)
-/// are excluded: their drift is unknown, not detected. Receipts kept for a
-/// failed disable (`CleanupFailed`) are not enabled adapters and are
-/// excluded too.
-pub fn stale_enabled_claims<'a>(
-    claims: &'a [AdapterClaim],
-    component: &str,
-) -> Vec<&'a AdapterClaim> {
-    claims
-        .iter()
-        .filter(|claim| {
-            claim.component == component
-                && claim.status == ClaimStatus::Enabled
-                && claim.bundle_match() == BundleMatch::Changed
-        })
-        .collect()
+/// One package-managed input relative to an adapter source root.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ManagedSourceFile {
+    /// Relative path below [`AdapterSourceRevision::source_root`].
+    pub relative_path: PathBuf,
+    /// File or symbolic link.
+    pub kind: ManagedFileKind,
+    /// Lowercase SHA-256 for regular files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Literal link target for symbolic links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symlink_target: Option<PathBuf>,
+}
+
+/// Canonical adapter input revision captured from package-manager ownership.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterSourceRevision {
+    /// Canonical source root selected from the installed component contract.
+    pub source_root: PathBuf,
+    /// Sorted package-managed inputs below the source root.
+    pub files: Vec<ManagedSourceFile>,
+    /// Additional package-managed source roots ANOLISA explicitly copies.
+    /// Resource ids keep multiple declared copies distinct without assigning
+    /// semantic file roles.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub materialized_sources: Vec<MaterializedSourceRevision>,
+}
+
+/// One explicit-copy source included in an adapter input revision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MaterializedSourceRevision {
+    /// Destination [`ClaimResource::id`] used to identify the copy mapping.
+    pub resource_id: String,
+    /// Canonical package-managed source root copied into that resource.
+    pub source_root: PathBuf,
+    /// Sorted package-managed inputs below the source root.
+    pub files: Vec<ManagedSourceFile>,
+}
+
+/// One expected file below a receipt-declared materialized resource.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MaterializedFile {
+    /// [`ClaimResource::id`] of the copied destination root.
+    pub resource_id: String,
+    /// Relative path below that resource.
+    pub relative_path: PathBuf,
+    /// File or symbolic link.
+    pub kind: ManagedFileKind,
+    /// Lowercase SHA-256 for regular files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Literal link target for symbolic links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symlink_target: Option<PathBuf>,
 }
 
 /// Lifecycle status of a receipt.
@@ -769,6 +790,188 @@ pub enum ClaimValidationError {
         /// Framework in the claim.
         claim_framework: String,
     },
+    /// A persisted source/materialized file entry is malformed or references
+    /// a non-path claim resource.
+    #[error("invalid adapter integrity record: {reason}")]
+    IntegrityRecord {
+        /// Validation failure detail.
+        reason: String,
+    },
+}
+
+fn validate_integrity_entries(claim: &AdapterClaim) -> Result<(), ClaimValidationError> {
+    let fail = |reason: String| Err(ClaimValidationError::IntegrityRecord { reason });
+    if let Some(revision) = &claim.source_revision {
+        if !revision.source_root.is_absolute() {
+            return fail("source root is not absolute".into());
+        }
+        if revision.files.is_empty() {
+            return fail("source revision has no managed files".into());
+        }
+        if revision
+            .files
+            .windows(2)
+            .any(|pair| pair[0].relative_path >= pair[1].relative_path)
+        {
+            return fail("source revision files are not strictly sorted".into());
+        }
+        for file in &revision.files {
+            validate_integrity_file(
+                &file.relative_path,
+                file.kind,
+                file.sha256.as_deref(),
+                file.symlink_target.as_deref(),
+            )?;
+        }
+        if revision.materialized_sources.windows(2).any(|pair| {
+            (&pair[0].resource_id, &pair[0].source_root)
+                >= (&pair[1].resource_id, &pair[1].source_root)
+        }) {
+            return fail("materialized source revisions are not strictly sorted".into());
+        }
+        for source in &revision.materialized_sources {
+            if source.resource_id.is_empty() {
+                return fail("materialized source revision has an empty resource id".into());
+            }
+            let Some(resource) = claim.resource(&source.resource_id) else {
+                return fail(format!(
+                    "materialized source references unknown resource '{}'",
+                    source.resource_id
+                ));
+            };
+            if !matches!(
+                resource.kind,
+                ClaimResourceKind::OwnedPath { .. } | ClaimResourceKind::ExternalPath { .. }
+            ) {
+                return fail(format!(
+                    "materialized source resource '{}' is not a filesystem root",
+                    source.resource_id
+                ));
+            }
+            if !source.source_root.is_absolute() {
+                return fail(format!(
+                    "materialized source '{}' root is not absolute",
+                    source.resource_id
+                ));
+            }
+            if source.files.is_empty() {
+                return fail(format!(
+                    "materialized source '{}' has no managed files",
+                    source.resource_id
+                ));
+            }
+            if source
+                .files
+                .windows(2)
+                .any(|pair| pair[0].relative_path >= pair[1].relative_path)
+            {
+                return fail(format!(
+                    "materialized source '{}' files are not strictly sorted",
+                    source.resource_id
+                ));
+            }
+            for file in &source.files {
+                validate_integrity_file(
+                    &file.relative_path,
+                    file.kind,
+                    file.sha256.as_deref(),
+                    file.symlink_target.as_deref(),
+                )?;
+            }
+        }
+    }
+    if claim.materialized_files.windows(2).any(|pair| {
+        (
+            pair[0].resource_id.as_str(),
+            pair[0].relative_path.as_path(),
+        ) >= (
+            pair[1].resource_id.as_str(),
+            pair[1].relative_path.as_path(),
+        )
+    }) {
+        return fail("materialized files are not strictly sorted".into());
+    }
+    for file in &claim.materialized_files {
+        let Some(resource) = claim.resource(&file.resource_id) else {
+            return fail(format!(
+                "materialized file references unknown resource '{}'",
+                file.resource_id
+            ));
+        };
+        if !matches!(
+            resource.kind,
+            ClaimResourceKind::OwnedPath { .. } | ClaimResourceKind::ExternalPath { .. }
+        ) {
+            return fail(format!(
+                "materialized resource '{}' is not a filesystem root",
+                file.resource_id
+            ));
+        }
+        validate_integrity_file(
+            &file.relative_path,
+            file.kind,
+            file.sha256.as_deref(),
+            file.symlink_target.as_deref(),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_integrity_file(
+    path: &Path,
+    kind: ManagedFileKind,
+    sha256: Option<&str>,
+    symlink_target: Option<&Path>,
+) -> Result<(), ClaimValidationError> {
+    use std::path::Component;
+    let fail = |reason: String| Err(ClaimValidationError::IntegrityRecord { reason });
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::CurDir
+                    | Component::ParentDir
+                    | Component::RootDir
+                    | Component::Prefix(_)
+            )
+        })
+    {
+        return fail(format!(
+            "invalid relative managed path '{}'",
+            path.display()
+        ));
+    }
+    match kind {
+        ManagedFileKind::File => {
+            let Some(digest) = sha256 else {
+                return fail(format!("managed file '{}' has no SHA-256", path.display()));
+            };
+            if digest.len() != 64
+                || !digest
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+                || symlink_target.is_some()
+            {
+                return fail(format!(
+                    "managed file '{}' has invalid digest/type metadata",
+                    path.display()
+                ));
+            }
+        }
+        ManagedFileKind::Symlink => {
+            if sha256.is_some()
+                || symlink_target.is_none()
+                || symlink_target.is_some_and(|target| target.as_os_str().is_empty())
+            {
+                return fail(format!(
+                    "managed symlink '{}' has invalid target/type metadata",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Reasons an external path is rejected.
@@ -1035,7 +1238,9 @@ mod tests {
             adapter_type: None,
             enabled_at: "2026-06-12T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/openclaw"),
-            bundle_digest: Some("sha256:abc".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1093,74 +1298,94 @@ mod tests {
         assert_eq!(claim, parsed);
     }
 
-    fn bundle_claim(root: &Path, digest: Option<String>) -> AdapterClaim {
+    #[test]
+    fn managed_integrity_schema_round_trips_through_toml() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            adapter_claims: Vec<AdapterClaim>,
+        }
+
+        let file = ManagedSourceFile {
+            relative_path: PathBuf::from("SKILL.md"),
+            kind: ManagedFileKind::File,
+            sha256: Some("a".repeat(64)),
+            symlink_target: None,
+        };
         let mut claim = sample_claim();
-        claim.resource_root = root.to_path_buf();
-        claim.bundle_digest = digest;
-        claim
+        claim.source_revision = Some(AdapterSourceRevision {
+            source_root: claim.resource_root.clone(),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                ..file.clone()
+            }],
+            materialized_sources: vec![MaterializedSourceRevision {
+                resource_id: "openclaw_state_dir".into(),
+                source_root: PathBuf::from("/usr/local/share/anolisa/skills/sec-audit"),
+                files: vec![file.clone()],
+            }],
+        });
+        claim.materialized_files = vec![MaterializedFile {
+            resource_id: "openclaw_state_dir".into(),
+            relative_path: file.relative_path,
+            kind: file.kind,
+            sha256: file.sha256,
+            symlink_target: file.symlink_target,
+        }];
+        let wrapper = Wrapper {
+            adapter_claims: vec![claim],
+        };
+        let text = toml::to_string_pretty(&wrapper).expect("serialize integrity receipt");
+        let parsed: Wrapper = toml::from_str(&text).expect("parse integrity receipt");
+        assert_eq!(wrapper, parsed, "round-trip mismatch; TOML was:\n{text}");
     }
 
     #[test]
-    fn bundle_match_classifies_matched_changed_and_unknown() {
-        let dir = tempfile::tempdir().expect("tmpdir");
-        std::fs::write(dir.path().join("bundle.json"), b"v1").expect("write bundle");
-        let mut claim = bundle_claim(dir.path(), None);
+    fn legacy_bundle_digest_round_trips_but_new_claim_omits_it() {
+        let new_claim = serde_json::to_value(sample_claim()).expect("new claim JSON");
+        assert!(new_claim.get("bundle_digest").is_none());
 
-        // No digest recorded at enable time: drift cannot be decided.
-        assert_eq!(claim.bundle_match(), BundleMatch::Unknown);
-
-        claim.bundle_digest = digest_tree(dir.path());
-        assert_eq!(claim.bundle_match(), BundleMatch::Matched);
-
-        std::fs::write(dir.path().join("bundle.json"), b"v2").expect("rewrite bundle");
-        assert_eq!(claim.bundle_match(), BundleMatch::Changed);
-
-        // A vanished resource root is Unknown again, not Changed: the
-        // verdict must never rest on a digest that could not be computed.
-        std::fs::remove_dir_all(dir.path()).expect("remove bundle root");
-        assert_eq!(claim.bundle_match(), BundleMatch::Unknown);
-    }
-
-    #[test]
-    fn stale_enabled_claims_selects_only_enabled_changed_receipts() {
-        let dir = tempfile::tempdir().expect("tmpdir");
-        std::fs::write(dir.path().join("bundle.json"), b"v1").expect("write bundle");
-        let current = digest_tree(dir.path()).expect("digest");
-
-        let fresh = bundle_claim(dir.path(), Some(current));
-        let mut stale = bundle_claim(dir.path(), Some("sha256:enable-time".to_string()));
-        stale.framework = "cosh".to_string();
-        let mut retry_cleanup = stale.clone();
-        retry_cleanup.status = ClaimStatus::CleanupFailed;
-        let no_digest = bundle_claim(dir.path(), None);
-        let mut other_component = stale.clone();
-        other_component.component = "agent-memory".to_string();
-
-        let claims = vec![
-            fresh,
-            stale.clone(),
-            retry_cleanup,
-            no_digest,
-            other_component.clone(),
-        ];
-        assert_eq!(
-            stale_enabled_claims(&claims, "tokenless"),
-            vec![&stale],
-            "only the enabled receipt with a changed bundle qualifies"
+        let mut value = serde_json::to_value(sample_claim()).expect("claim JSON value");
+        value.as_object_mut().expect("claim object").insert(
+            "bundle_digest".to_string(),
+            serde_json::Value::String("sha256:legacy".to_string()),
         );
+        let parsed: AdapterClaim = serde_json::from_value(value).expect("legacy claim");
+        assert_eq!(parsed.bundle_digest.as_deref(), Some("sha256:legacy"));
+        let written = serde_json::to_value(parsed).expect("legacy claim JSON");
         assert_eq!(
-            stale_enabled_claims(&claims, "agent-memory"),
-            vec![&other_component],
-            "a receipt is only ever reported under its own component"
+            written
+                .get("bundle_digest")
+                .and_then(serde_json::Value::as_str),
+            Some("sha256:legacy")
         );
     }
 
     #[test]
-    fn bundle_changed_reason_matches_the_status_condition_wording() {
-        assert_eq!(
-            BUNDLE_CHANGED_REASON,
-            "resource bundle changed since enable"
-        );
+    fn integrity_records_require_normalized_digest_and_nonempty_symlink_target() {
+        let mut claim = sample_claim();
+        claim.source_revision = Some(AdapterSourceRevision {
+            source_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/openclaw"),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                kind: ManagedFileKind::File,
+                sha256: Some("A".repeat(64)),
+                symlink_target: None,
+            }],
+            materialized_sources: Vec::new(),
+        });
+        assert!(validate_integrity_entries(&claim).is_err());
+
+        claim.source_revision = Some(AdapterSourceRevision {
+            source_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/openclaw"),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin-link"),
+                kind: ManagedFileKind::Symlink,
+                sha256: None,
+                symlink_target: Some(PathBuf::new()),
+            }],
+            materialized_sources: Vec::new(),
+        });
+        assert!(validate_integrity_entries(&claim).is_err());
     }
 
     #[test]
@@ -1231,7 +1456,9 @@ mod tests {
             adapter_type: None,
             enabled_at: "2026-06-22T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/agent-sec/hermes"),
-            bundle_digest: Some("sha256:def".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1346,6 +1573,8 @@ mod tests {
             enabled_at: "2026-06-22T12:00:00Z".to_string(),
             resource_root: PathBuf::from("/data/adapters/sec-core/openclaw"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1438,7 +1667,9 @@ mod tests {
             adapter_type: Some("plugin".to_string()),
             enabled_at: "2026-07-04T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/codex"),
-            bundle_digest: Some("sha256:c0de".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1527,7 +1758,9 @@ mod tests {
             adapter_type: Some("extension".to_string()),
             enabled_at: "2026-07-04T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/common"),
-            bundle_digest: Some("sha256:c05h".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1564,6 +1797,8 @@ mod tests {
             enabled_at: "2026-07-04T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/claude-code"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1604,7 +1839,9 @@ mod tests {
             adapter_type: Some("plugin".to_string()),
             enabled_at: "2026-07-08T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/qoder"),
-            bundle_digest: Some("sha256:90de".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -1758,7 +1995,9 @@ mod tests {
             adapter_type: Some("extension".to_string()),
             enabled_at: "2026-07-16T10:30:45Z".to_string(),
             resource_root: PathBuf::from("/usr/local/share/anolisa/adapters/tokenless/qwencode"),
-            bundle_digest: Some("sha256:0wen".to_string()),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/claude_code.rs
@@ -43,7 +43,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{bool_status, cli_failure_reason, display_command, now_iso8601};
 
 /// Default timeout for a Claude Code CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -171,7 +171,6 @@ impl FrameworkDriver for ClaudeCodeDriver {
         );
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id,
         })
     }
@@ -242,7 +241,9 @@ impl FrameworkDriver for ClaudeCodeDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -330,8 +331,6 @@ impl FrameworkDriver for ClaudeCodeDriver {
             reason: Some(detect.reason.clone()),
             resource: None,
         });
-        conditions.push(bundle_match_condition(claim));
-
         let plugin = claim_plugin(claim);
         // Read strictly from the receipt; a receipt with no marketplace
         // resource is malformed and must not be treated as healthy.
@@ -667,31 +666,6 @@ fn list_contains_token(stdout: &str, token: &str) -> bool {
     stdout
         .lines()
         .any(|line| line.split_whitespace().any(|t| t == token))
-}
-
-/// Build the `ResourceBundleMatches` condition.
-fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
-    let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-            kind,
-            status: ConditionStatus::True,
-            reason: None,
-            resource: None,
-        },
-        (Some(_), Some(_)) => AdapterCondition {
-            kind,
-            status: ConditionStatus::False,
-            reason: Some("resource bundle changed since enable".to_string()),
-            resource: None,
-        },
-        _ => AdapterCondition {
-            kind,
-            status: ConditionStatus::Unknown,
-            reason: Some("no digest recorded or resource root unavailable".to_string()),
-            resource: None,
-        },
-    }
 }
 
 /// Roll signals into a summary. Healthy requires the framework detected and

--- a/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/codex.rs
@@ -37,7 +37,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{bool_status, cli_failure_reason, display_command, now_iso8601};
 
 /// Default timeout for a Codex CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -138,7 +138,6 @@ impl FrameworkDriver for CodexDriver {
         );
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id,
         })
     }
@@ -234,7 +233,9 @@ impl FrameworkDriver for CodexDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -316,10 +317,6 @@ impl FrameworkDriver for CodexDriver {
             reason: Some(detect.reason.clone()),
             resource: None,
         });
-        let bundle_condition = bundle_match_condition(claim);
-        let bundle_status = bundle_condition.status;
-        conditions.push(bundle_condition);
-
         // Symlink presence is a reliable filesystem check independent of
         // the CLI.
         let symlink_ok = claim_symlink(claim)
@@ -400,7 +397,6 @@ impl FrameworkDriver for CodexDriver {
             claim.status,
             detect.detected,
             bool_status(symlink_ok),
-            bundle_status,
             mkt_status,
             plugin_status,
         );
@@ -799,41 +795,13 @@ fn claim_symlink(claim: &AdapterClaim) -> Option<(PathBuf, PathBuf)> {
     })
 }
 
-/// Build the `ResourceBundleMatches` condition.
-fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
-    let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-            kind,
-            status: ConditionStatus::True,
-            reason: None,
-            resource: None,
-        },
-        (Some(_), Some(_)) => AdapterCondition {
-            kind,
-            status: ConditionStatus::False,
-            reason: Some("resource bundle changed since enable".to_string()),
-            resource: None,
-        },
-        _ => AdapterCondition {
-            kind,
-            status: ConditionStatus::Unknown,
-            reason: Some("no digest recorded or resource root unavailable".to_string()),
-            resource: None,
-        },
-    }
-}
-
 /// Roll signals into a summary. Healthy requires the framework detected,
-/// the plugin symlink functional, the resource bundle verified unchanged,
-/// and both marketplace and plugin verified present — a broken symlink or
-/// a drifted/vanished bundle means codex is not actually serving this
-/// plugin, so registration alone must not report Healthy.
+/// the plugin symlink functional, and both marketplace and plugin verified
+/// present. Package-owned source integrity is added by the Manager.
 fn summarize(
     claim_status: ClaimStatus,
     detected: bool,
     symlink: ConditionStatus,
-    bundle: ConditionStatus,
     marketplace: ConditionStatus,
     plugin: ConditionStatus,
 ) -> AdapterSummary {
@@ -843,7 +811,7 @@ fn summarize(
     if !detected {
         return AdapterSummary::Degraded;
     }
-    let signals = [symlink, bundle, marketplace, plugin];
+    let signals = [symlink, marketplace, plugin];
     if signals.contains(&ConditionStatus::False) {
         return AdapterSummary::Degraded;
     }
@@ -932,25 +900,21 @@ mod tests {
     }
 
     #[test]
-    fn summarize_folds_symlink_and_bundle_signals() {
+    fn summarize_folds_framework_signals() {
         use ConditionStatus::{False, True, Unknown};
-        let s = |symlink, bundle, mkt, plugin| {
-            summarize(ClaimStatus::Enabled, true, symlink, bundle, mkt, plugin)
+        let s = |symlink, marketplace, plugin| {
+            summarize(ClaimStatus::Enabled, true, symlink, marketplace, plugin)
         };
-        // Registration alone must not report Healthy: a broken symlink or
-        // a drifted bundle degrades even with both registrations intact.
-        assert_eq!(s(False, Unknown, True, True), AdapterSummary::Degraded);
-        assert_eq!(s(True, False, True, True), AdapterSummary::Degraded);
-        // Undecidable drift is Unknown, not Healthy.
-        assert_eq!(s(True, Unknown, True, True), AdapterSummary::Unknown);
-        assert_eq!(s(True, True, True, True), AdapterSummary::Healthy);
+        assert_eq!(s(False, True, True), AdapterSummary::Degraded);
+        assert_eq!(s(True, Unknown, True), AdapterSummary::Unknown);
+        assert_eq!(s(True, True, True), AdapterSummary::Healthy);
         // CleanupFailed and framework-missing keep their priority.
         assert_eq!(
-            summarize(ClaimStatus::CleanupFailed, true, True, True, True, True),
+            summarize(ClaimStatus::CleanupFailed, true, True, True, True),
             AdapterSummary::CleanupFailed
         );
         assert_eq!(
-            summarize(ClaimStatus::Enabled, false, True, True, True, True),
+            summarize(ClaimStatus::Enabled, false, True, True, True),
             AdapterSummary::Degraded
         );
     }

--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -30,7 +30,8 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, digest_tree, now_iso8601};
+use super::managed_files::{MaterializedMapping, copy_materialized_resource};
+use super::util::{bool_status, now_iso8601};
 
 /// Candidate binary names that indicate cosh is installed. `co` and
 /// `copilot` are the short/legacy aliases of the `cosh` CLI.
@@ -140,7 +141,6 @@ impl FrameworkDriver for CoshDriver {
         );
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id,
         })
     }
@@ -184,7 +184,9 @@ impl FrameworkDriver for CoshDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -195,6 +197,23 @@ impl FrameworkDriver for CoshDriver {
             },
             PreparedEnable::None,
         ))
+    }
+
+    fn materialized_mappings(
+        &self,
+        resource_root: &Path,
+        _adapter_type: Option<&str>,
+        _declared_skills: &[super::driver::DeclaredSkill],
+    ) -> Vec<MaterializedMapping> {
+        vec![MaterializedMapping {
+            resource_id: RES_EXTENSION_DIR.to_string(),
+            source_root: resource_root.to_path_buf(),
+            excluded_prefixes: Vec::new(),
+        }]
+    }
+
+    fn materialized_verification_applicable(&self, _claim: &AdapterClaim) -> bool {
+        true
     }
 
     fn apply_enable(
@@ -236,7 +255,7 @@ impl FrameworkDriver for CoshDriver {
             &dst.join(COSH_OWNERSHIP_MARKER),
             b"ANOLISA-managed cosh extension\n",
         )?;
-        ctx.ops.copy_tree(&claim.resource_root, &dst)?;
+        copy_materialized_resource(claim, RES_EXTENSION_DIR, &claim.resource_root, ctx.ops)?;
         Ok(())
     }
 
@@ -258,10 +277,7 @@ impl FrameworkDriver for CoshDriver {
             resource: None,
         });
 
-        // 2. Resource bundle still matches the enable-time digest?
-        conditions.push(bundle_match_condition(claim));
-
-        // 3. Extension tree still present, carrying its manifest AND our
+        // 2. Extension tree still present, carrying its manifest AND our
         //    ownership marker? A dir/manifest without the marker is not
         //    ANOLISA-managed (user replaced it, or a marker write failed),
         //    which is a degraded state — not a healthy one. This is a
@@ -428,32 +444,6 @@ fn claim_extension_dir(claim: &AdapterClaim) -> Option<PathBuf> {
     })
 }
 
-/// Build the `ResourceBundleMatches` condition by re-digesting the resource
-/// root and comparing to the enable-time digest.
-fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
-    let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-            kind,
-            status: ConditionStatus::True,
-            reason: None,
-            resource: None,
-        },
-        (Some(_), Some(_)) => AdapterCondition {
-            kind,
-            status: ConditionStatus::False,
-            reason: Some("resource bundle changed since enable".to_string()),
-            resource: None,
-        },
-        _ => AdapterCondition {
-            kind,
-            status: ConditionStatus::Unknown,
-            reason: Some("no digest recorded or resource root unavailable".to_string()),
-            resource: None,
-        },
-    }
-}
-
 /// Roll the detect and tree-present signals into a summary, honoring a
 /// `cleanup_failed` receipt.
 fn summarize(
@@ -477,6 +467,10 @@ fn summarize(
 mod tests {
     use super::*;
     use crate::adapter::driver::{AdapterOps, CliOutput, FrameworkCommand};
+    use crate::adapter::managed_files::{
+        ManagedFile, ManagedInventory, ManagedInventoryKind, materialized_files, source_revision,
+    };
+    use sha2::{Digest, Sha256};
     use std::sync::{Mutex, MutexGuard};
 
     /// Serializes cosh env mutation across tests in this module.
@@ -545,8 +539,19 @@ mod tests {
                 source,
             })
         }
-        fn copy_file(&self, _: &Path, _: &Path) -> Result<(), AdapterError> {
-            unimplemented!()
+        fn copy_file(&self, src: &Path, dst: &Path) -> Result<(), AdapterError> {
+            if let Some(parent) = dst.parent() {
+                std::fs::create_dir_all(parent).map_err(|source| AdapterError::Io {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+            std::fs::copy(src, dst)
+                .map(|_| ())
+                .map_err(|source| AdapterError::Io {
+                    path: dst.to_path_buf(),
+                    source,
+                })
         }
         fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError> {
             if !path.exists() {
@@ -601,6 +606,31 @@ mod tests {
         root
     }
 
+    fn attach_materialized_inventory(claim: &mut AdapterClaim, root: &Path) {
+        let managed = [root.join(COSH_MANIFEST), root.join("hooks/run-hook.sh")]
+            .into_iter()
+            .map(|path| ManagedFile {
+                sha256: Some(format!(
+                    "{:x}",
+                    Sha256::digest(std::fs::read(&path).expect("managed fixture bytes"))
+                )),
+                path,
+                kind: ManagedInventoryKind::File,
+                symlink_target: None,
+            })
+            .collect();
+        let inventory = ManagedInventory { files: managed };
+        let mappings = vec![MaterializedMapping {
+            resource_id: RES_EXTENSION_DIR.to_string(),
+            source_root: root.to_path_buf(),
+            excluded_prefixes: Vec::new(),
+        }];
+        claim.source_revision =
+            Some(source_revision(&inventory, root, &mappings).expect("revision"));
+        claim.materialized_files =
+            materialized_files(&inventory, &mappings).expect("materialized inventory");
+    }
+
     fn ctx<'a>(
         resource_root: &Path,
         user_home: &Path,
@@ -648,6 +678,7 @@ mod tests {
         assert_eq!(bundle.plugin_id.as_deref(), Some("tokenless"));
 
         let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx).expect("claim");
+        attach_materialized_inventory(&mut claim, &resource_root);
         driver
             .apply_enable(&mut claim, &prepared, &ctx, &mut ())
             .expect("apply");

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -17,6 +17,7 @@ use anolisa_platform::fs_layout::FsLayout;
 
 use super::AdapterError;
 use super::claim::AdapterClaim;
+use super::managed_files::MaterializedMapping;
 
 /// Read-only host facts a driver may inspect during [`FrameworkDriver::detect`].
 #[derive(Debug, Clone, Default)]
@@ -110,9 +111,6 @@ impl DriverCtx<'_> {
 pub struct AdapterBundle {
     /// Resource root the bundle was read from.
     pub resource_root: PathBuf,
-    /// Digest of the resource tree, for drift/upgrade detection. `None`
-    /// when the driver declined to compute one.
-    pub digest: Option<String>,
     /// Framework-native plugin id resolved from the bundle (or the
     /// manifest-declared fallback).
     pub plugin_id: Option<String>,
@@ -265,8 +263,13 @@ pub enum AdapterConditionKind {
     SourceAvailable,
     /// The framework itself is detectable on the host.
     FrameworkDetected,
-    /// The installed resource bundle still matches the enable-time digest.
-    ResourceBundleMatches,
+    /// Package-manager-owned source files still match current package metadata.
+    ManagedBundleMatches,
+    /// The package-manager-owned adapter inputs still equal the enable-time
+    /// revision, including the resolved source root.
+    SourceRevisionMatches,
+    /// Files ANOLISA explicitly copied still match their receipt entries.
+    MaterializedBundleMatches,
     /// The plugin is still present in the framework registry.
     PluginRegistered,
     /// The framework reports the plugin's declared resources as loaded.
@@ -666,6 +669,27 @@ pub trait FrameworkDriver: Send + Sync {
     /// Returns a driver-specific ownership or receipt consistency error.
     fn validate_prepared_enable(&self, _claim: &AdapterClaim) -> Result<(), AdapterError> {
         Ok(())
+    }
+
+    /// Source-to-resource copies this driver will explicitly materialize.
+    ///
+    /// The Manager maps only package-owned source entries through these
+    /// declarations before apply. Framework-native staging or copies remain
+    /// outside this contract.
+    fn materialized_mappings(
+        &self,
+        _resource_root: &Path,
+        _adapter_type: Option<&str>,
+        _declared_skills: &[DeclaredSkill],
+    ) -> Vec<MaterializedMapping> {
+        Vec::new()
+    }
+
+    /// Whether this claim is expected to carry a materialized-file list.
+    /// Receipts with an empty list report `Unknown`; drivers whose framework
+    /// performs its own copy omit the condition entirely.
+    fn materialized_verification_applicable(&self, _claim: &AdapterClaim) -> bool {
+        false
     }
 
     /// Idempotently apply an already-persisted enable receipt to framework

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -18,8 +18,6 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use sha2::{Digest, Sha256};
-
 use super::AdapterError;
 use super::claim::{
     AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
@@ -30,6 +28,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
+use super::managed_files::{MaterializedMapping, copy_materialized_resource};
 
 /// Default timeout for a Hermes CLI invocation.
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
@@ -123,7 +122,6 @@ impl FrameworkDriver for HermesDriver {
 
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id,
         })
     }
@@ -219,7 +217,9 @@ impl FrameworkDriver for HermesDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -238,6 +238,37 @@ impl FrameworkDriver for HermesDriver {
         ))
     }
 
+    fn materialized_mappings(
+        &self,
+        resource_root: &Path,
+        adapter_type: Option<&str>,
+        declared_skills: &[super::driver::DeclaredSkill],
+    ) -> Vec<MaterializedMapping> {
+        let mut mappings = Vec::new();
+        if adapter_type != Some("skill_bundle") {
+            mappings.push(MaterializedMapping {
+                resource_id: RES_PLUGIN.to_string(),
+                source_root: resource_root.to_path_buf(),
+                excluded_prefixes: vec![PathBuf::from("skills")],
+            });
+        }
+        for skill in declared_skills {
+            mappings.push(MaterializedMapping {
+                resource_id: format!("hermes_skill_{}", skill.name),
+                source_root: skill
+                    .source
+                    .clone()
+                    .unwrap_or_else(|| resource_root.join("skills").join(&skill.name)),
+                excluded_prefixes: Vec::new(),
+            });
+        }
+        mappings
+    }
+
+    fn materialized_verification_applicable(&self, _claim: &AdapterClaim) -> bool {
+        true
+    }
+
     fn apply_enable(
         &self,
         claim: &mut AdapterClaim,
@@ -245,7 +276,7 @@ impl FrameworkDriver for HermesDriver {
         ctx: &DriverCtx,
         _progress: &mut dyn super::driver::EnableProgress,
     ) -> Result<(), AdapterError> {
-        let home = require_home(ctx)?;
+        require_home(ctx)?;
 
         if !ctx.is_skill_bundle() {
             let plugin_id = claim_plugin_id(claim).ok_or_else(|| AdapterError::BundleInvalid {
@@ -254,8 +285,7 @@ impl FrameworkDriver for HermesDriver {
             })?;
             validate_plugin_id(&plugin_id)?;
 
-            let plugin_dest = home.join("plugins").join(&plugin_id);
-            copy_bundle_excluding_skills(&claim.resource_root, &plugin_dest, ctx)?;
+            copy_materialized_resource(claim, RES_PLUGIN, &claim.resource_root, ctx.ops)?;
 
             let enable_cmd = build_enable_cmd(&plugin_id);
             let program = enable_cmd.program.clone();
@@ -273,8 +303,8 @@ impl FrameworkDriver for HermesDriver {
                 .source
                 .clone()
                 .unwrap_or_else(|| claim.resource_root.join("skills").join(&skill.name));
-            let dst = home.join("skills").join(&skill.name);
-            ctx.ops.copy_tree(&src, &dst)?;
+            let resource_id = format!("hermes_skill_{}", skill.name);
+            copy_materialized_resource(claim, &resource_id, &src, ctx.ops)?;
         }
 
         Ok(())
@@ -298,10 +328,7 @@ impl FrameworkDriver for HermesDriver {
             resource: None,
         });
 
-        // 2. Resource bundle still matches the enable-time digest?
-        conditions.push(self.bundle_match_condition(claim));
-
-        // 3. Plugin still registered? Skill-only receipts have no plugin
+        // 2. Plugin still registered? Skill-only receipts have no plugin
         //    registry entry by design, so status does not require one.
         let plugin_registered = if claim.is_skill_bundle() {
             conditions.push(AdapterCondition {
@@ -438,32 +465,6 @@ impl FrameworkDriver for HermesDriver {
 }
 
 impl HermesDriver {
-    /// Build the `ResourceBundleMatches` condition by re-digesting the
-    /// resource root and comparing to the enable-time digest.
-    fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
-        let kind = AdapterConditionKind::ResourceBundleMatches;
-        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-                kind,
-                status: ConditionStatus::True,
-                reason: None,
-                resource: None,
-            },
-            (Some(_), Some(_)) => AdapterCondition {
-                kind,
-                status: ConditionStatus::False,
-                reason: Some("resource bundle changed since enable".to_string()),
-                resource: None,
-            },
-            _ => AdapterCondition {
-                kind,
-                status: ConditionStatus::Unknown,
-                reason: Some("no digest recorded or resource root unavailable".to_string()),
-                resource: None,
-            },
-        }
-    }
-
     /// Run `hermes plugins list` and decide whether `plugin_id` is still
     /// registered. Returns `(plugin_condition, verification_condition,
     /// plugin_registered_status)`.
@@ -659,38 +660,6 @@ fn read_yaml_id(root: &Path, filename: &str) -> Result<Option<String>, AdapterEr
     Ok(None)
 }
 
-/// Copy the bundle directory into the plugin destination, skipping the
-/// `skills/` subdirectory (delivered separately to `$HERMES_HOME/skills/`).
-/// All IO goes through `ctx.ops` so the Manager enforces path boundaries.
-fn copy_bundle_excluding_skills(
-    src: &Path,
-    dst: &Path,
-    ctx: &DriverCtx,
-) -> Result<(), AdapterError> {
-    let entries = std::fs::read_dir(src).map_err(|source| AdapterError::Io {
-        path: src.to_path_buf(),
-        source,
-    })?;
-    for entry in entries {
-        let entry = entry.map_err(|source| AdapterError::Io {
-            path: src.to_path_buf(),
-            source,
-        })?;
-        let name = entry.file_name();
-        if name == "skills" {
-            continue;
-        }
-        let src_child = entry.path();
-        let dst_child = dst.join(&name);
-        if src_child.is_dir() {
-            ctx.ops.copy_tree(&src_child, &dst_child)?;
-        } else {
-            ctx.ops.copy_file(&src_child, &dst_child)?;
-        }
-    }
-    Ok(())
-}
-
 /// Human-readable form of a command for dry-run/preview output. Display
 /// only — never parsed back into an argv.
 fn display_command(cmd: &FrameworkCommand) -> String {
@@ -789,43 +758,6 @@ fn summarize(
         ConditionStatus::False => AdapterSummary::Degraded,
         ConditionStatus::Unknown => AdapterSummary::Unknown,
     }
-}
-
-/// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
-fn digest_tree(root: &Path) -> Option<String> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in &files {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let bytes = std::fs::read(path).ok()?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0u8]);
-        hasher.update(&bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
-
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
-    }
-    Ok(())
 }
 
 /// ISO 8601 UTC timestamp, second precision.
@@ -990,22 +922,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn digest_tree_is_stable_and_detects_change() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
-        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
-
-        let d1 = digest_tree(dir.path()).expect("digest");
-        let d2 = digest_tree(dir.path()).expect("digest again");
-        assert_eq!(d1, d2, "digest must be stable");
-
-        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
-        let d3 = digest_tree(dir.path()).expect("digest after change");
-        assert_ne!(d1, d3, "digest must change when a file changes");
-    }
-
     // -- review fix coverage: lazy plugin_id, YAML entry, skills allowlist --
 
     use crate::adapter::claim::{DriverPayload, HermesClaim};
@@ -1070,6 +986,46 @@ mod tests {
     }
 
     #[test]
+    fn materialized_mappings_separate_plugin_and_declared_skills() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let layout = anolisa_platform::fs_layout::FsLayout::user(dir.path().join("home"));
+        let ops = StubOps;
+        let ctx = DriverCtx {
+            component: "agent-sec-core".into(),
+            framework: "hermes".into(),
+            layout: &layout,
+            resource_root: dir.path().join("bundle"),
+            user_home: Some(dir.path().join("home")),
+            declared_plugin_id: Some("agent-sec".into()),
+            adapter_type: Some("plugin".into()),
+            declared_skills: vec![super::super::driver::DeclaredSkill {
+                name: "sec-audit".into(),
+                source: None,
+            }],
+            declared_config: Vec::new(),
+            declared_bundle_entry: None,
+            framework_version_req: None,
+            allow_unsafe_plugin_install: false,
+            dry_run: false,
+            ops: &ops,
+        };
+        let mappings = HermesDriver::new().materialized_mappings(
+            &ctx.resource_root,
+            ctx.adapter_type.as_deref(),
+            &ctx.declared_skills,
+        );
+        assert_eq!(mappings.len(), 2);
+        assert_eq!(mappings[0].resource_id, RES_PLUGIN);
+        assert_eq!(mappings[0].source_root, ctx.resource_root);
+        assert_eq!(mappings[0].excluded_prefixes, vec![PathBuf::from("skills")]);
+        assert_eq!(mappings[1].resource_id, "hermes_skill_sec-audit");
+        assert_eq!(
+            mappings[1].source_root,
+            ctx.resource_root.join("skills/sec-audit")
+        );
+    }
+
+    #[test]
     fn yaml_bundle_entry_parses_id() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(
@@ -1119,7 +1075,6 @@ mod tests {
 
         let bundle = AdapterBundle {
             resource_root: root.to_path_buf(),
-            digest: None,
             plugin_id: Some("test-plugin".to_string()),
         };
 

--- a/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
@@ -1,0 +1,1237 @@
+//! Package-owned adapter input revisions and materialized-file verification.
+
+use std::path::{Component, Path, PathBuf};
+
+use anolisa_platform::pkg_files::{PackageFileDigestAlgorithm, PackageFileKind, PackageFileQuery};
+use sha2::{Digest, Sha256};
+
+use super::AdapterError;
+use super::claim::{
+    AdapterClaim, AdapterSourceRevision, ClaimResourceKind, ManagedFileKind as RevisionFileKind,
+    ManagedSourceFile, MaterializedFile, MaterializedSourceRevision,
+};
+use super::driver::AdapterOps;
+use crate::domain::{Installation, PackageIdentity, ProviderBinding};
+use crate::state::{FileOwner, OwnedFileKind};
+
+/// Package-inventory file type before unsupported entries are scoped out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManagedInventoryKind {
+    /// Regular file whose bytes can be verified.
+    File,
+    /// Symbolic link whose literal target can be verified.
+    Symlink,
+    /// Device, socket, FIFO, or another unsupported adapter input.
+    Unsupported,
+}
+
+/// One authoritative package-managed path before it is scoped to an adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedFile {
+    /// Absolute installed path.
+    pub path: PathBuf,
+    /// File or symbolic link.
+    pub kind: ManagedInventoryKind,
+    /// Lowercase SHA-256 for regular files.
+    pub sha256: Option<String>,
+    /// Literal link target for symbolic links.
+    pub symlink_target: Option<PathBuf>,
+}
+
+/// Package-manager-owned files for one component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedInventory {
+    /// Sorted authoritative file entries.
+    pub files: Vec<ManagedFile>,
+}
+
+/// A driver-declared source-to-resource copy performed by ANOLISA.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaterializedMapping {
+    /// Receipt resource identifying the destination root.
+    pub resource_id: String,
+    /// Absolute source directory copied into the resource.
+    pub source_root: PathBuf,
+    /// Source-relative prefixes deliberately excluded from this copy.
+    pub excluded_prefixes: Vec<PathBuf>,
+}
+
+/// Tri-state managed-file verdict with an operator-facing reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManagedMatch {
+    /// The condition was verified.
+    Matched,
+    /// A managed file or revision differs.
+    Changed(String),
+    /// The authoritative inventory or on-disk bytes could not be verified.
+    Unknown(String),
+}
+
+/// Load the package manager's authoritative file inventory for an installation.
+pub fn inventory_for_installation(
+    installation: &Installation,
+    rpm_query: &dyn PackageFileQuery,
+) -> Result<ManagedInventory, String> {
+    let mut files = match &installation.binding {
+        ProviderBinding::Owned { artifact } => artifact
+            .files
+            .iter()
+            .filter(|file| file.owner == FileOwner::Anolisa)
+            .map(|file| match file.kind {
+                OwnedFileKind::File => ManagedFile {
+                    path: file.path.clone(),
+                    kind: ManagedInventoryKind::File,
+                    sha256: file.sha256.clone(),
+                    symlink_target: None,
+                },
+                OwnedFileKind::Symlink => ManagedFile {
+                    path: file.path.clone(),
+                    kind: ManagedInventoryKind::Symlink,
+                    sha256: None,
+                    symlink_target: file.referent.clone(),
+                },
+            })
+            .collect::<Vec<_>>(),
+        ProviderBinding::Delegated { package, .. } => {
+            let PackageIdentity::Resolved { name } = package else {
+                return Err("native package identity is unresolved; re-enable the adapter".into());
+            };
+            let inventory = rpm_query.query_file_inventory(name).map_err(|err| {
+                format!("native package file query failed: {err}; re-enable the adapter")
+            })?;
+            if inventory.digest_algorithm != PackageFileDigestAlgorithm::Sha256 {
+                return Err(format!(
+                    "native package uses unsupported file digest algorithm {:?}; re-enable the adapter",
+                    inventory.digest_algorithm
+                ));
+            }
+            inventory
+                .files
+                .into_iter()
+                .filter_map(|file| {
+                    let (kind, sha256, symlink_target) = match file.kind {
+                        PackageFileKind::Regular => (ManagedInventoryKind::File, file.digest, None),
+                        PackageFileKind::Symlink => (
+                            ManagedInventoryKind::Symlink,
+                            None,
+                            file.link_target.map(PathBuf::from),
+                        ),
+                        PackageFileKind::Directory => return None,
+                        PackageFileKind::Other => (ManagedInventoryKind::Unsupported, None, None),
+                    };
+                    Some(ManagedFile {
+                        path: PathBuf::from(file.path),
+                        kind,
+                        sha256,
+                        symlink_target,
+                    })
+                })
+                .collect()
+        }
+    };
+
+    for file in &files {
+        if !file.path.is_absolute() {
+            return Err(format!(
+                "managed file path '{}' is not absolute; re-enable the adapter",
+                file.path.display()
+            ));
+        }
+    }
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    if files.windows(2).any(|pair| pair[0].path == pair[1].path) {
+        return Err(
+            "package inventory contains duplicate managed paths; re-enable the adapter".into(),
+        );
+    }
+    Ok(ManagedInventory { files })
+}
+
+/// Scope an authoritative component inventory to one resolved adapter root.
+pub fn source_revision(
+    inventory: &ManagedInventory,
+    source_root: &Path,
+    mappings: &[MaterializedMapping],
+) -> Result<AdapterSourceRevision, String> {
+    let lexical_root = normalize_absolute(source_root)?;
+    let canonical_root = std::fs::canonicalize(&lexical_root).map_err(|err| {
+        format!(
+            "cannot resolve adapter source root '{}': {err}; re-enable the adapter",
+            lexical_root.display()
+        )
+    })?;
+    let files = source_files_below(inventory, &lexical_root, &canonical_root, &[])?;
+    if files.is_empty() {
+        return Err(format!(
+            "package manager reports no managed adapter files below '{}'; re-enable the adapter",
+            lexical_root.display()
+        ));
+    }
+    let mut materialized_sources = Vec::new();
+    for mapping in mappings {
+        let lexical_mapping_root = normalize_absolute(&mapping.source_root)?;
+        let canonical_mapping_root =
+            std::fs::canonicalize(&lexical_mapping_root).map_err(|err| {
+                format!(
+                    "cannot resolve materialized source root '{}': {err}; re-enable the adapter",
+                    lexical_mapping_root.display()
+                )
+            })?;
+        let files = source_files_below(
+            inventory,
+            &lexical_mapping_root,
+            &canonical_mapping_root,
+            &mapping.excluded_prefixes,
+        )?;
+        if files.is_empty() {
+            return Err(format!(
+                "package manager reports no managed files for materialized source '{}' below '{}'; re-enable the adapter",
+                mapping.resource_id,
+                lexical_mapping_root.display()
+            ));
+        }
+        materialized_sources.push(MaterializedSourceRevision {
+            resource_id: mapping.resource_id.clone(),
+            source_root: canonical_mapping_root,
+            files,
+        });
+    }
+    materialized_sources.sort();
+    if materialized_sources.windows(2).any(|pair| {
+        pair[0].resource_id == pair[1].resource_id && pair[0].source_root == pair[1].source_root
+    }) {
+        return Err(
+            "materialized source mappings contain duplicates; re-enable the adapter".into(),
+        );
+    }
+    Ok(AdapterSourceRevision {
+        source_root: canonical_root,
+        files,
+        materialized_sources,
+    })
+}
+
+/// Verify the current package-owned source bytes against current metadata.
+pub fn verify_managed_bundle(revision: &AdapterSourceRevision) -> ManagedMatch {
+    if let Err(verdict) = verify_source_files(&revision.source_root, &revision.files) {
+        return verdict;
+    }
+    for source in &revision.materialized_sources {
+        if let Err(verdict) = verify_source_files(&source.source_root, &source.files) {
+            return verdict;
+        }
+    }
+    ManagedMatch::Matched
+}
+
+/// Compare a claim's enable-time revision with the current authoritative one.
+pub fn compare_source_revision(
+    claim: &AdapterClaim,
+    current: &AdapterSourceRevision,
+) -> ManagedMatch {
+    if let Some(recorded) = &claim.source_revision {
+        return if recorded == current {
+            ManagedMatch::Matched
+        } else {
+            ManagedMatch::Changed(
+                "adapter source revision changed since enable; re-enable the adapter".into(),
+            )
+        };
+    }
+
+    let Ok(recorded_root) = std::fs::canonicalize(&claim.resource_root) else {
+        return ManagedMatch::Unknown(
+            "legacy receipt source root is unavailable; re-enable the adapter".into(),
+        );
+    };
+    if recorded_root != current.source_root {
+        return ManagedMatch::Changed(
+            "adapter source root changed since enable; re-enable the adapter".into(),
+        );
+    }
+    let Some(recorded_digest) = claim.bundle_digest.as_deref() else {
+        return ManagedMatch::Unknown(
+            "receipt has no managed source revision; re-enable the adapter".into(),
+        );
+    };
+    match legacy_subset_digest(current) {
+        Some(digest) if digest == recorded_digest => ManagedMatch::Matched,
+        Some(_) => ManagedMatch::Unknown(
+            "legacy receipt cannot distinguish an older package revision from enable-time unmanaged files; re-enable the adapter".into(),
+        ),
+        None => ManagedMatch::Unknown(
+            "legacy managed source subset could not be read; re-enable the adapter".into(),
+        ),
+    }
+}
+
+/// Map package-managed source entries to files ANOLISA explicitly copied.
+pub fn materialized_files(
+    inventory: &ManagedInventory,
+    mappings: &[MaterializedMapping],
+) -> Result<Vec<MaterializedFile>, String> {
+    let mut files = Vec::new();
+    for mapping in mappings {
+        let lexical_root = normalize_absolute(&mapping.source_root)?;
+        let canonical_root = std::fs::canonicalize(&lexical_root).map_err(|err| {
+            format!(
+                "cannot resolve materialized source root '{}': {err}; re-enable the adapter",
+                lexical_root.display()
+            )
+        })?;
+        for file in &inventory.files {
+            let path = normalize_absolute(&file.path)?;
+            let Some(relative_path) =
+                relative_below_root_aliases(&path, &lexical_root, &canonical_root)
+            else {
+                continue;
+            };
+            validate_relative(&relative_path)?;
+            if mapping
+                .excluded_prefixes
+                .iter()
+                .any(|prefix| relative_path.starts_with(prefix))
+            {
+                continue;
+            }
+            let (kind, sha256, symlink_target) = integrity_metadata(file)?;
+            files.push(MaterializedFile {
+                resource_id: mapping.resource_id.clone(),
+                relative_path,
+                kind,
+                sha256,
+                symlink_target,
+            });
+        }
+    }
+    files.sort();
+    files.dedup();
+    if files.windows(2).any(|pair| {
+        pair[0].resource_id == pair[1].resource_id && pair[0].relative_path == pair[1].relative_path
+    }) {
+        return Err("materialized mappings assign conflicting metadata to one path".into());
+    }
+    Ok(files)
+}
+
+/// Copy one declared materialized resource using only its managed receipt entries.
+///
+/// The source tree is never enumerated here. Runtime-created or otherwise
+/// unowned source entries therefore cannot be delivered merely because a
+/// framework driver materializes the surrounding directory.
+pub(crate) fn copy_materialized_resource(
+    claim: &AdapterClaim,
+    resource_id: &str,
+    source_root: &Path,
+    ops: &dyn AdapterOps,
+) -> Result<(), AdapterError> {
+    let invalid = |reason: String| AdapterError::InvalidAdapterInput {
+        component: claim.component.clone(),
+        framework: claim.framework.clone(),
+        reason,
+    };
+    let revision = claim.source_revision.as_ref().ok_or_else(|| {
+        invalid("receipt has no source revision for materialized copy".to_string())
+    })?;
+    let source = revision
+        .materialized_sources
+        .iter()
+        .find(|source| source.resource_id == resource_id)
+        .ok_or_else(|| {
+            invalid(format!(
+                "receipt has no materialized source revision for resource '{resource_id}'"
+            ))
+        })?;
+    let canonical_source = std::fs::canonicalize(source_root).map_err(|err| {
+        invalid(format!(
+            "cannot resolve materialized source root '{}': {err}",
+            source_root.display()
+        ))
+    })?;
+    if canonical_source != source.source_root {
+        return Err(invalid(format!(
+            "materialized source root for resource '{resource_id}' changed before copy"
+        )));
+    }
+
+    let destination_root = match &claim
+        .resource(resource_id)
+        .ok_or_else(|| invalid(format!("receipt has no resource '{resource_id}'")))?
+        .kind
+    {
+        ClaimResourceKind::OwnedPath { path } | ClaimResourceKind::ExternalPath { path } => path,
+        _ => {
+            return Err(invalid(format!(
+                "materialized resource '{resource_id}' is not a filesystem root"
+            )));
+        }
+    };
+    let materialized = claim
+        .materialized_files
+        .iter()
+        .filter(|file| file.resource_id == resource_id)
+        .collect::<Vec<_>>();
+    let metadata_matches = materialized.len() == source.files.len()
+        && materialized
+            .iter()
+            .zip(&source.files)
+            .all(|(output, input)| {
+                output.relative_path == input.relative_path
+                    && output.kind == input.kind
+                    && output.sha256 == input.sha256
+                    && output.symlink_target == input.symlink_target
+            });
+    if !metadata_matches {
+        return Err(invalid(format!(
+            "materialized files for resource '{resource_id}' do not match its source revision"
+        )));
+    }
+    if let Some(file) = source
+        .files
+        .iter()
+        .find(|file| file.kind == RevisionFileKind::Symlink)
+    {
+        return Err(invalid(format!(
+            "materialized source '{}' contains managed symlink '{}'; explicit copies do not follow source symlinks",
+            source_root.display(),
+            file.relative_path.display()
+        )));
+    }
+
+    for file in &source.files {
+        let source_path = source_root.join(&file.relative_path);
+        verify_file(
+            &source_path,
+            file.kind,
+            file.sha256.as_deref(),
+            file.symlink_target.as_deref(),
+        )
+        .map_err(|verdict| invalid(managed_reason(verdict)))?;
+        let destination_path = destination_root.join(&file.relative_path);
+        ops.copy_file(&source_path, &destination_path)?;
+        verify_file(
+            &destination_path,
+            file.kind,
+            file.sha256.as_deref(),
+            file.symlink_target.as_deref(),
+        )
+        .map_err(|verdict| invalid(managed_reason(verdict)))?;
+    }
+    Ok(())
+}
+
+/// Verify recorded materialized files without scanning for extra entries.
+pub fn verify_materialized_bundle(claim: &AdapterClaim) -> ManagedMatch {
+    for file in &claim.materialized_files {
+        let Some(resource) = claim.resource(&file.resource_id) else {
+            return ManagedMatch::Unknown(format!(
+                "materialized resource '{}' is missing from the receipt; re-enable the adapter",
+                file.resource_id
+            ));
+        };
+        let root = match &resource.kind {
+            ClaimResourceKind::OwnedPath { path } | ClaimResourceKind::ExternalPath { path } => {
+                path
+            }
+            _ => {
+                return ManagedMatch::Unknown(format!(
+                    "materialized resource '{}' is not a filesystem root; re-enable the adapter",
+                    file.resource_id
+                ));
+            }
+        };
+        let path = root.join(&file.relative_path);
+        if let Err(verdict) = verify_file(
+            &path,
+            file.kind,
+            file.sha256.as_deref(),
+            file.symlink_target.as_deref(),
+        ) {
+            return verdict;
+        }
+    }
+    ManagedMatch::Matched
+}
+
+fn verify_file(
+    path: &Path,
+    kind: RevisionFileKind,
+    sha256: Option<&str>,
+    symlink_target: Option<&Path>,
+) -> Result<(), ManagedMatch> {
+    let metadata =
+        std::fs::symlink_metadata(path).map_err(|err| io_verdict(path, "inspect", err))?;
+    match kind {
+        RevisionFileKind::File => {
+            if !metadata.file_type().is_file() {
+                return Err(ManagedMatch::Changed(format!(
+                    "managed file '{}' changed type",
+                    path.display()
+                )));
+            }
+            let expected = sha256.ok_or_else(|| {
+                ManagedMatch::Unknown(format!(
+                    "managed file '{}' has no recorded SHA-256; re-enable the adapter",
+                    path.display()
+                ))
+            })?;
+            let bytes = std::fs::read(path).map_err(|err| io_verdict(path, "read", err))?;
+            let actual = format!("{:x}", Sha256::digest(bytes));
+            if actual != expected {
+                return Err(ManagedMatch::Changed(format!(
+                    "managed file '{}' content changed",
+                    path.display()
+                )));
+            }
+        }
+        RevisionFileKind::Symlink => {
+            if !metadata.file_type().is_symlink() {
+                return Err(ManagedMatch::Changed(format!(
+                    "managed symlink '{}' changed type",
+                    path.display()
+                )));
+            }
+            let expected = symlink_target.ok_or_else(|| {
+                ManagedMatch::Unknown(format!(
+                    "managed symlink '{}' has no recorded target; re-enable the adapter",
+                    path.display()
+                ))
+            })?;
+            let actual = std::fs::read_link(path).map_err(|err| io_verdict(path, "read", err))?;
+            if actual != expected {
+                return Err(ManagedMatch::Changed(format!(
+                    "managed symlink '{}' target changed",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_source_files(
+    source_root: &Path,
+    files: &[ManagedSourceFile],
+) -> Result<(), ManagedMatch> {
+    for file in files {
+        let path = source_root.join(&file.relative_path);
+        verify_file(
+            &path,
+            file.kind,
+            file.sha256.as_deref(),
+            file.symlink_target.as_deref(),
+        )?;
+    }
+    Ok(())
+}
+
+fn source_files_below(
+    inventory: &ManagedInventory,
+    lexical_root: &Path,
+    canonical_root: &Path,
+    excluded_prefixes: &[PathBuf],
+) -> Result<Vec<ManagedSourceFile>, String> {
+    let mut files = Vec::new();
+    for file in &inventory.files {
+        let path = normalize_absolute(&file.path)?;
+        let Some(relative_path) = relative_below_root_aliases(&path, lexical_root, canonical_root)
+        else {
+            continue;
+        };
+        validate_relative(&relative_path)?;
+        if excluded_prefixes
+            .iter()
+            .any(|prefix| relative_path.starts_with(prefix))
+        {
+            continue;
+        }
+        let (kind, sha256, symlink_target) = integrity_metadata(file)?;
+        files.push(ManagedSourceFile {
+            relative_path,
+            kind,
+            sha256,
+            symlink_target,
+        });
+    }
+    files.sort();
+    files.dedup();
+    if files
+        .windows(2)
+        .any(|pair| pair[0].relative_path == pair[1].relative_path)
+    {
+        return Err(
+            "package inventory assigns conflicting metadata to one adapter path; re-enable the adapter"
+                .into(),
+        );
+    }
+    Ok(files)
+}
+
+fn relative_below_root_aliases(
+    path: &Path,
+    lexical_root: &Path,
+    canonical_root: &Path,
+) -> Option<PathBuf> {
+    // Do not canonicalize the inventory entry itself: doing so would follow a
+    // managed leaf symlink and discard the path whose literal target we verify.
+    if path == lexical_root || path == canonical_root {
+        return None;
+    }
+    path.strip_prefix(lexical_root)
+        .or_else(|_| path.strip_prefix(canonical_root))
+        .ok()
+        .map(Path::to_path_buf)
+}
+
+fn io_verdict(path: &Path, action: &str, err: std::io::Error) -> ManagedMatch {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        ManagedMatch::Changed(format!("managed file '{}' is missing", path.display()))
+    } else {
+        ManagedMatch::Unknown(format!(
+            "managed file '{}' could not be {action}: {err}; re-enable the adapter",
+            path.display()
+        ))
+    }
+}
+
+fn managed_reason(verdict: ManagedMatch) -> String {
+    match verdict {
+        ManagedMatch::Matched => "managed file verification unexpectedly returned matched".into(),
+        ManagedMatch::Changed(reason) | ManagedMatch::Unknown(reason) => reason,
+    }
+}
+
+fn legacy_subset_digest(revision: &AdapterSourceRevision) -> Option<String> {
+    let mut hasher = Sha256::new();
+    for file in &revision.files {
+        let path = revision.source_root.join(&file.relative_path);
+        let bytes = std::fs::read(path).ok()?;
+        hasher.update(file.relative_path.to_string_lossy().as_bytes());
+        hasher.update([0]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+    }
+    Some(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn normalize_sha256(value: &str) -> Option<String> {
+    let value = value.strip_prefix("sha256:").unwrap_or(value);
+    (value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+fn integrity_metadata(
+    file: &ManagedFile,
+) -> Result<(RevisionFileKind, Option<String>, Option<PathBuf>), String> {
+    match file.kind {
+        ManagedInventoryKind::File => {
+            let digest = file.sha256.as_deref().ok_or_else(|| {
+                format!(
+                    "managed file '{}' has no SHA-256 digest; re-enable the adapter",
+                    file.path.display()
+                )
+            })?;
+            let digest = normalize_sha256(digest).ok_or_else(|| {
+                format!(
+                    "managed file '{}' has an invalid SHA-256 digest; re-enable the adapter",
+                    file.path.display()
+                )
+            })?;
+            Ok((RevisionFileKind::File, Some(digest), None))
+        }
+        ManagedInventoryKind::Symlink => {
+            let target = file.symlink_target.clone().ok_or_else(|| {
+                format!(
+                    "managed symlink '{}' has no target; re-enable the adapter",
+                    file.path.display()
+                )
+            })?;
+            Ok((RevisionFileKind::Symlink, None, Some(target)))
+        }
+        ManagedInventoryKind::Unsupported => Err(format!(
+            "managed path '{}' has an unsupported package file type; re-enable the adapter",
+            file.path.display()
+        )),
+    }
+}
+
+fn normalize_absolute(path: &Path) -> Result<PathBuf, String> {
+    if !path.is_absolute() {
+        return Err(format!("managed path '{}' is not absolute", path.display()));
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str())
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(format!(
+                        "managed path '{}' escapes its root",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+fn validate_relative(path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(format!(
+            "managed relative path '{}' is invalid; re-enable the adapter",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anolisa_platform::pkg_files::{PackageFile, PackageFileInventory};
+    use anolisa_platform::pkg_query::PackageQueryError;
+
+    use crate::adapter::claim::{
+        CLAIM_SCHEMA_VERSION, ClaimResource, ClaimStatus, CoshClaim, DRIVER_SCHEMA_VERSION,
+        DriverPayload,
+    };
+    use crate::domain::{
+        InstallationScope, LifecycleStatus, ManagementRelation, NativePm, OwnedArtifact,
+    };
+    use crate::state::{ObjectKind, OwnedFile};
+
+    struct FileQuery(Result<PackageFileInventory, &'static str>);
+
+    impl PackageFileQuery for FileQuery {
+        fn query_file_inventory(
+            &self,
+            _package: &str,
+        ) -> Result<PackageFileInventory, PackageQueryError> {
+            self.0
+                .clone()
+                .map_err(|detail| PackageQueryError::QueryFailed {
+                    command: "rpm".into(),
+                    code: Some(1),
+                    stderr: detail.into(),
+                })
+        }
+    }
+
+    fn sha256(bytes: &[u8]) -> String {
+        format!("{:x}", Sha256::digest(bytes))
+    }
+
+    fn legacy_tree_digest(root: &Path, paths: &[&str]) -> String {
+        let mut paths = paths.to_vec();
+        paths.sort_unstable();
+        let mut hasher = Sha256::new();
+        for relative in paths {
+            let bytes = std::fs::read(root.join(relative)).expect("legacy digest input");
+            hasher.update(relative.as_bytes());
+            hasher.update([0]);
+            hasher.update((bytes.len() as u64).to_le_bytes());
+            hasher.update([0]);
+            hasher.update(bytes);
+        }
+        format!("sha256:{:x}", hasher.finalize())
+    }
+
+    fn owned_file(path: PathBuf, bytes: &[u8]) -> OwnedFile {
+        OwnedFile {
+            path,
+            owner: FileOwner::Anolisa,
+            sha256: Some(sha256(bytes)),
+            kind: OwnedFileKind::File,
+            referent: None,
+            mode: None,
+            capabilities: Vec::new(),
+        }
+    }
+
+    fn raw_installation(files: Vec<OwnedFile>) -> Installation {
+        Installation {
+            kind: ObjectKind::Component,
+            name: "tokenless".into(),
+            scope: InstallationScope::System,
+            binding: ProviderBinding::Owned {
+                artifact: OwnedArtifact {
+                    version: "1.0.0".into(),
+                    distribution_source: None,
+                    raw_package: None,
+                    manifest_digest: None,
+                    files,
+                    services: Vec::new(),
+                    external_modified_files: Vec::new(),
+                    provisioned_packages: Vec::new(),
+                },
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-08-01T00:00:00Z".into(),
+            last_operation_id: None,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    fn rpm_installation() -> Installation {
+        Installation {
+            kind: ObjectKind::Component,
+            name: "tokenless".into(),
+            scope: InstallationScope::System,
+            binding: ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved {
+                    name: "tokenless".into(),
+                },
+                relation: ManagementRelation::Managed {
+                    since: "2026-08-01T00:00:00Z".into(),
+                },
+                last_observed: None,
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-08-01T00:00:00Z".into(),
+            last_operation_id: None,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    fn claim(root: &Path) -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: CLAIM_SCHEMA_VERSION,
+            component: "tokenless".into(),
+            framework: "cosh".into(),
+            plugin_id: None,
+            adapter_type: Some("extension".into()),
+            enabled_at: "2026-08-01T01:00:00Z".into(),
+            resource_root: root.to_path_buf(),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
+            driver_schema: DRIVER_SCHEMA_VERSION,
+            status: ClaimStatus::Enabled,
+            notices: Vec::new(),
+            resources: vec![ClaimResource {
+                id: "copy".into(),
+                purpose: "test copy".into(),
+                kind: ClaimResourceKind::OwnedPath {
+                    path: root.to_path_buf(),
+                },
+            }],
+            driver_payload: DriverPayload::Cosh(CoshClaim {
+                extension_dir_resource: "copy".into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn raw_revision_ignores_unmanaged_files_but_detects_managed_changes() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path().join("adapter");
+        std::fs::create_dir_all(root.join("__pycache__")).expect("adapter dirs");
+        let managed = root.join("hook.py");
+        let runtime = root.join("__pycache__/hook.pyc");
+        let external = root.join("operator.log");
+        std::fs::write(&managed, b"managed").expect("managed file");
+        std::fs::write(&runtime, b"bytecode").expect("runtime file");
+        std::fs::write(&external, b"log").expect("external file");
+        let mut external_record = owned_file(external, b"log");
+        external_record.owner = FileOwner::External;
+        let installation = raw_installation(vec![
+            owned_file(managed.clone(), b"managed"),
+            external_record,
+        ]);
+
+        let inventory =
+            inventory_for_installation(&installation, &FileQuery(Err("raw must not query rpm")))
+                .expect("raw inventory");
+        let revision = source_revision(&inventory, &root, &[]).expect("source revision");
+        assert_eq!(revision.files.len(), 1);
+        assert_eq!(verify_managed_bundle(&revision), ManagedMatch::Matched);
+
+        std::fs::write(&managed, b"changed").expect("mutate managed file");
+        assert!(matches!(
+            verify_managed_bundle(&revision),
+            ManagedMatch::Changed(_)
+        ));
+        std::fs::remove_file(&managed).expect("remove managed file");
+        assert!(matches!(
+            verify_managed_bundle(&revision),
+            ManagedMatch::Changed(reason) if reason.contains("missing")
+        ));
+    }
+
+    #[test]
+    fn revision_tracks_inventory_additions_and_canonical_root_migration() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let first_root = tmp.path().join("first");
+        let second_root = tmp.path().join("second");
+        std::fs::create_dir_all(&first_root).expect("first root");
+        std::fs::create_dir_all(&second_root).expect("second root");
+        std::fs::write(first_root.join("a"), b"a").expect("first file");
+        std::fs::write(first_root.join("b"), b"b").expect("second file");
+        std::fs::write(second_root.join("a"), b"a").expect("migrated file");
+        let one = ManagedInventory {
+            files: vec![ManagedFile {
+                path: first_root.join("a"),
+                kind: ManagedInventoryKind::File,
+                sha256: Some(sha256(b"a")),
+                symlink_target: None,
+            }],
+        };
+        let mut two = one.clone();
+        two.files.push(ManagedFile {
+            path: first_root.join("b"),
+            kind: ManagedInventoryKind::File,
+            sha256: Some(sha256(b"b")),
+            symlink_target: None,
+        });
+        let recorded = source_revision(&one, &first_root, &[]).expect("recorded revision");
+        let mut enabled = claim(&first_root);
+        enabled.source_revision = Some(recorded);
+
+        let added = source_revision(&two, &first_root, &[]).expect("added-file revision");
+        assert!(matches!(
+            compare_source_revision(&enabled, &added),
+            ManagedMatch::Changed(_)
+        ));
+
+        let migrated = ManagedInventory {
+            files: vec![ManagedFile {
+                path: second_root.join("a"),
+                kind: ManagedInventoryKind::File,
+                sha256: Some(sha256(b"a")),
+                symlink_target: None,
+            }],
+        };
+        let migrated = source_revision(&migrated, &second_root, &[]).expect("migrated revision");
+        assert!(matches!(
+            compare_source_revision(&enabled, &migrated),
+            ManagedMatch::Changed(_)
+        ));
+    }
+
+    #[test]
+    fn revision_includes_declared_copy_sources_outside_the_adapter_root() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let adapter_root = tmp.path().join("adapters/tokenless/openclaw");
+        let skill_root = tmp.path().join("skills/sec-audit");
+        std::fs::create_dir_all(&adapter_root).expect("adapter root");
+        std::fs::create_dir_all(&skill_root).expect("skill root");
+        std::fs::write(adapter_root.join("plugin.json"), b"plugin").expect("plugin");
+        std::fs::write(skill_root.join("SKILL.md"), b"skill-v1").expect("skill");
+        let inventory = ManagedInventory {
+            files: vec![
+                ManagedFile {
+                    path: adapter_root.join("plugin.json"),
+                    kind: ManagedInventoryKind::File,
+                    sha256: Some(sha256(b"plugin")),
+                    symlink_target: None,
+                },
+                ManagedFile {
+                    path: skill_root.join("SKILL.md"),
+                    kind: ManagedInventoryKind::File,
+                    sha256: Some(sha256(b"skill-v1")),
+                    symlink_target: None,
+                },
+            ],
+        };
+        let mappings = vec![MaterializedMapping {
+            resource_id: "openclaw_skill_sec-audit".into(),
+            source_root: skill_root.clone(),
+            excluded_prefixes: Vec::new(),
+        }];
+        let recorded =
+            source_revision(&inventory, &adapter_root, &mappings).expect("recorded revision");
+        assert_eq!(recorded.materialized_sources.len(), 1);
+        assert_eq!(verify_managed_bundle(&recorded), ManagedMatch::Matched);
+
+        let mut claim = claim(&adapter_root);
+        claim.source_revision = Some(recorded.clone());
+        std::fs::write(skill_root.join("SKILL.md"), b"skill-v2").expect("changed skill");
+        assert!(matches!(
+            verify_managed_bundle(&recorded),
+            ManagedMatch::Changed(_)
+        ));
+
+        let mut updated_inventory = inventory;
+        updated_inventory.files[1].sha256 = Some(sha256(b"skill-v2"));
+        let updated = source_revision(&updated_inventory, &adapter_root, &mappings)
+            .expect("updated revision");
+        assert!(matches!(
+            compare_source_revision(&claim, &updated),
+            ManagedMatch::Changed(_)
+        ));
+    }
+
+    #[test]
+    fn legacy_subset_ignores_later_runtime_files_and_keeps_ambiguity_explicit() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path().join("adapter");
+        std::fs::create_dir_all(&root).expect("adapter root");
+        let managed = root.join("hook.py");
+        std::fs::write(&managed, b"managed").expect("managed file");
+        let inventory = ManagedInventory {
+            files: vec![ManagedFile {
+                path: managed,
+                kind: ManagedInventoryKind::File,
+                sha256: Some(sha256(b"managed")),
+                symlink_target: None,
+            }],
+        };
+        let revision = source_revision(&inventory, &root, &[]).expect("revision");
+        let mut legacy = claim(&root);
+        legacy.claim_schema = 1;
+        legacy.bundle_digest = legacy_subset_digest(&revision);
+        std::fs::write(root.join("runtime.pyc"), b"runtime").expect("runtime file");
+
+        assert_eq!(
+            compare_source_revision(&legacy, &revision),
+            ManagedMatch::Matched
+        );
+        legacy.bundle_digest = Some(legacy_tree_digest(&root, &["hook.py", "runtime.pyc"]));
+        assert!(matches!(
+            compare_source_revision(&legacy, &revision),
+            ManagedMatch::Unknown(reason) if reason.contains("legacy receipt")
+        ));
+    }
+
+    #[test]
+    fn materialized_verification_ignores_extras_but_checks_recorded_files() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let source = tmp.path().join("source");
+        let destination = tmp.path().join("destination");
+        std::fs::create_dir_all(&source).expect("source root");
+        std::fs::create_dir_all(&destination).expect("destination root");
+        std::fs::write(source.join("hook.py"), b"managed").expect("source file");
+        std::fs::write(destination.join("hook.py"), b"managed").expect("copied file");
+        std::fs::write(destination.join("runtime.log"), b"runtime").expect("runtime file");
+        let inventory = ManagedInventory {
+            files: vec![ManagedFile {
+                path: source.join("hook.py"),
+                kind: ManagedInventoryKind::File,
+                sha256: Some(sha256(b"managed")),
+                symlink_target: None,
+            }],
+        };
+        let mut receipt = claim(&destination);
+        receipt.materialized_files = materialized_files(
+            &inventory,
+            &[MaterializedMapping {
+                resource_id: "copy".into(),
+                source_root: source,
+                excluded_prefixes: Vec::new(),
+            }],
+        )
+        .expect("materialized inventory");
+
+        assert_eq!(verify_materialized_bundle(&receipt), ManagedMatch::Matched);
+        std::fs::write(destination.join("hook.py"), b"changed").expect("mutate copy");
+        assert!(matches!(
+            verify_materialized_bundle(&receipt),
+            ManagedMatch::Changed(_)
+        ));
+        std::fs::remove_file(destination.join("hook.py")).expect("remove copy");
+        assert!(matches!(
+            verify_materialized_bundle(&receipt),
+            ManagedMatch::Changed(reason) if reason.contains("missing")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_symlink_uses_literal_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path().join("adapter");
+        std::fs::create_dir_all(&root).expect("adapter root");
+        symlink("first.py", root.join("current.py")).expect("managed symlink");
+        let revision = AdapterSourceRevision {
+            source_root: root.clone(),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("current.py"),
+                kind: RevisionFileKind::Symlink,
+                sha256: None,
+                symlink_target: Some(PathBuf::from("first.py")),
+            }],
+            materialized_sources: Vec::new(),
+        };
+        assert_eq!(verify_managed_bundle(&revision), ManagedMatch::Matched);
+        std::fs::remove_file(root.join("current.py")).expect("remove symlink");
+        symlink("second.py", root.join("current.py")).expect("replace symlink");
+        assert!(matches!(
+            verify_managed_bundle(&revision),
+            ManagedMatch::Changed(reason) if reason.contains("target changed")
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_source_root_scopes_canonical_package_files() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let release_root = tmp.path().join("releases/v2");
+        let lexical_root = tmp.path().join("current");
+        std::fs::create_dir_all(&release_root).expect("release root");
+        std::fs::write(release_root.join("hook.py"), b"managed").expect("managed file");
+        symlink("releases/v2", &lexical_root).expect("source root symlink");
+        let inventory = ManagedInventory {
+            files: vec![
+                ManagedFile {
+                    path: lexical_root.clone(),
+                    kind: ManagedInventoryKind::Symlink,
+                    sha256: None,
+                    symlink_target: Some(PathBuf::from("releases/v2")),
+                },
+                ManagedFile {
+                    path: release_root.join("hook.py"),
+                    kind: ManagedInventoryKind::File,
+                    sha256: Some(sha256(b"managed")),
+                    symlink_target: None,
+                },
+            ],
+        };
+
+        let revision = source_revision(&inventory, &lexical_root, &[]).expect("source revision");
+        assert_eq!(revision.source_root, release_root);
+        assert_eq!(revision.files.len(), 1);
+        assert_eq!(revision.files[0].relative_path, PathBuf::from("hook.py"));
+        assert_eq!(verify_managed_bundle(&revision), ManagedMatch::Matched);
+
+        let copied = materialized_files(
+            &inventory,
+            &[MaterializedMapping {
+                resource_id: "copy".into(),
+                source_root: lexical_root,
+                excluded_prefixes: Vec::new(),
+            }],
+        )
+        .expect("materialized files");
+        assert_eq!(copied.len(), 1);
+        assert_eq!(copied[0].relative_path, PathBuf::from("hook.py"));
+    }
+
+    #[test]
+    fn rpm_inventory_is_authoritative_and_rejects_unverifiable_metadata() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("adapter.py");
+        std::fs::write(&path, b"adapter").expect("managed adapter file");
+        std::fs::write(tmp.path().join("runtime.pyc"), b"runtime").expect("runtime file");
+        let inventory = PackageFileInventory {
+            digest_algorithm: PackageFileDigestAlgorithm::Sha256,
+            files: vec![PackageFile {
+                path: path.display().to_string(),
+                kind: PackageFileKind::Regular,
+                digest: Some(sha256(b"adapter")),
+                link_target: None,
+            }],
+        };
+        let managed = inventory_for_installation(&rpm_installation(), &FileQuery(Ok(inventory)))
+            .expect("rpm inventory");
+        assert_eq!(managed.files.len(), 1);
+        let revision = source_revision(&managed, tmp.path(), &[]).expect("rpm revision");
+        assert_eq!(verify_managed_bundle(&revision), ManagedMatch::Matched);
+        std::fs::write(&path, b"changed").expect("mutate managed adapter file");
+        assert!(matches!(
+            verify_managed_bundle(&revision),
+            ManagedMatch::Changed(_)
+        ));
+        std::fs::write(&path, b"adapter").expect("restore managed adapter file");
+
+        let empty_digest = PackageFileInventory {
+            digest_algorithm: PackageFileDigestAlgorithm::Sha256,
+            files: vec![PackageFile {
+                path: path.display().to_string(),
+                kind: PackageFileKind::Regular,
+                digest: None,
+                link_target: None,
+            }],
+        };
+        let managed = inventory_for_installation(&rpm_installation(), &FileQuery(Ok(empty_digest)))
+            .expect("the package inventory remains queryable");
+        assert!(
+            source_revision(&managed, tmp.path(), &[])
+                .expect_err("an adapter file without a digest is unverifiable")
+                .contains("no SHA-256")
+        );
+
+        let unsupported = PackageFileInventory {
+            digest_algorithm: PackageFileDigestAlgorithm::Unsupported(1),
+            files: Vec::new(),
+        };
+        assert!(
+            inventory_for_installation(&rpm_installation(), &FileQuery(Ok(unsupported)),)
+                .expect_err("unsupported digest must remain unknown")
+                .contains("unsupported")
+        );
+        assert!(
+            inventory_for_installation(&rpm_installation(), &FileQuery(Err("rpmdb unavailable")),)
+                .expect_err("query failure must remain unknown")
+                .contains("query failed")
+        );
+    }
+
+    #[test]
+    fn rpm_inventory_rejects_scoped_unsupported_file_types() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let root = tmp.path().join("adapter");
+        std::fs::create_dir_all(&root).expect("adapter root");
+        let managed_path = root.join("hook.py");
+        std::fs::write(&managed_path, b"adapter").expect("managed file");
+        let inventory = PackageFileInventory {
+            digest_algorithm: PackageFileDigestAlgorithm::Sha256,
+            files: vec![
+                PackageFile {
+                    path: managed_path.display().to_string(),
+                    kind: PackageFileKind::Regular,
+                    digest: Some(sha256(b"adapter")),
+                    link_target: None,
+                },
+                PackageFile {
+                    path: root.join("control.fifo").display().to_string(),
+                    kind: PackageFileKind::Other,
+                    digest: None,
+                    link_target: None,
+                },
+                PackageFile {
+                    path: tmp.path().join("unrelated.sock").display().to_string(),
+                    kind: PackageFileKind::Other,
+                    digest: None,
+                    link_target: None,
+                },
+            ],
+        };
+        let mut managed =
+            inventory_for_installation(&rpm_installation(), &FileQuery(Ok(inventory)))
+                .expect("rpm inventory");
+
+        assert!(
+            source_revision(&managed, &root, &[])
+                .expect_err("unsupported adapter input must be unverifiable")
+                .contains("unsupported package file type")
+        );
+        managed
+            .files
+            .retain(|file| file.path != root.join("control.fifo"));
+        let revision = source_revision(&managed, &root, &[])
+            .expect("unrelated unsupported entries do not affect the adapter");
+        assert_eq!(revision.files.len(), 1);
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -32,13 +32,19 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use anolisa_platform::fs_layout::{FsLayout, InstallMode};
+use anolisa_platform::pkg_files::PackageFileQuery;
+use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use super::AdapterError;
-use super::claim::{AdapterClaim, ClaimStatus};
+use super::claim::{AdapterClaim, AdapterSourceRevision, ClaimStatus};
 use super::driver::{
     AdapterCondition, AdapterConditionKind, AdapterOps, AdapterStatusReport, AdapterSummary,
     CliOutput, ConditionStatus, DisableReport, DriverCtx, DriverPlan, EnableProgress,
     FrameworkCommand, FrameworkRpcSession, HostEnv,
+};
+use super::managed_files::{
+    ManagedMatch, inventory_for_installation, materialized_files, source_revision,
+    verify_managed_bundle, verify_materialized_bundle,
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
@@ -176,6 +182,7 @@ struct SourceProbe {
     status: AdapterSourceStatus,
     resource_root: Option<PathBuf>,
     reason: Option<String>,
+    revision: Result<super::claim::AdapterSourceRevision, String>,
 }
 
 /// Full result of [`AdapterManager::scan`].
@@ -455,6 +462,9 @@ pub struct AdapterManager {
     user_home: Option<PathBuf>,
     /// Identity recorded as the central-log actor.
     actor: String,
+    /// Read-only native package file inventory. Kept separate from lifecycle
+    /// version queries so adapter status can be tested without rpmdb.
+    package_files: Box<dyn PackageFileQuery>,
 }
 
 impl AdapterManager {
@@ -478,7 +488,13 @@ impl AdapterManager {
             visibility_warnings: Vec::new(),
             user_home,
             actor,
+            package_files: Box::new(RpmPackageQuery::system()),
         }
+    }
+
+    /// Replace the read-only native package file query (primarily for tests).
+    pub fn set_package_file_query(&mut self, query: Box<dyn PackageFileQuery>) {
+        self.package_files = query;
     }
 
     /// Replace the visible root set. Receipts still read/write only the
@@ -688,7 +704,7 @@ impl AdapterManager {
         }
 
         for claim in &state.adapter_claims {
-            let source = self.source_probe_for_claim(claim, &state);
+            let source = self.source_probe(&claim.component, &claim.framework, &state);
             let (driver_available, framework_detected) = self.driver_scan_facts(&claim.framework);
             let key = (claim.component.clone(), claim.framework.clone());
             let entry = entries.entry(key).or_insert_with(|| ScanEntry {
@@ -953,9 +969,8 @@ impl AdapterManager {
             ops: &ops,
         };
 
-        let bundle = driver.read_bundle(&ctx)?;
-
         if dry_run {
+            let bundle = driver.read_bundle(&ctx)?;
             let mut plan = driver.plan_enable(&bundle, &ctx)?;
             if let Some(prior) = state.find_adapter_claim(component, &framework) {
                 let claim_allowed_roots = driver.allowed_external_roots(&ctx);
@@ -987,7 +1002,13 @@ impl AdapterManager {
             });
         }
 
+        // Preserve the driver's existing read-only input validation and error
+        // ordering. The authoritative integrity gate runs below after all
+        // pure preparation, immediately before replacement cleanup or apply
+        // can mutate framework state.
+        let bundle = driver.read_bundle(&ctx)?;
         let (mut claim, prepared) = driver.prepare_enable(&bundle, &ctx)?;
+        claim.bundle_digest = None;
         // Persist the manifest's static notices in the receipt so a later
         // disable can show `post_disable` notices from the receipt alone.
         // Inert text — never expanded or executed.
@@ -1005,6 +1026,44 @@ impl AdapterManager {
             )?;
             driver.preserve_reenable_facts(prior, &mut claim)?;
         }
+        let mappings = driver.materialized_mappings(
+            &resource_root,
+            ctx.adapter_type.as_deref(),
+            &ctx.declared_skills,
+        );
+        let managed_inventory = self
+            .find_component_installation(component, &state)?
+            .ok_or_else(|| AdapterError::ComponentNotInstalled {
+                component: component.to_string(),
+            })
+            .and_then(|installation| {
+                inventory_for_installation(&installation, self.package_files.as_ref()).map_err(
+                    |reason| AdapterError::InvalidAdapterInput {
+                        component: component.to_string(),
+                        framework: framework.clone(),
+                        reason,
+                    },
+                )
+            })?;
+        let revision =
+            source_revision(&managed_inventory, &resource_root, &mappings).map_err(|reason| {
+                AdapterError::InvalidAdapterInput {
+                    component: component.to_string(),
+                    framework: framework.clone(),
+                    reason,
+                }
+            })?;
+        claim.source_revision = Some(revision.clone());
+        if !mappings.is_empty() {
+            claim.materialized_files =
+                materialized_files(&managed_inventory, &mappings).map_err(|reason| {
+                    AdapterError::InvalidAdapterInput {
+                        component: component.to_string(),
+                        framework: framework.clone(),
+                        reason,
+                    }
+                })?;
+        }
         // Defense in depth: the driver must not emit a claim that points
         // outside its own declared roots. Reject before persisting.
         claim.validate_with_trust(
@@ -1014,6 +1073,16 @@ impl AdapterManager {
             trust.exact_targets(),
         )?;
         driver.validate_prepared_enable(&claim)?;
+        match verify_managed_bundle(&revision) {
+            ManagedMatch::Matched => {}
+            ManagedMatch::Changed(reason) | ManagedMatch::Unknown(reason) => {
+                return Err(AdapterError::InvalidAdapterInput {
+                    component: component.to_string(),
+                    framework: framework.clone(),
+                    reason,
+                });
+            }
+        }
 
         if let Some(prior) = &prior {
             // Do not overwrite the only durable ownership record until the
@@ -1076,6 +1145,14 @@ impl AdapterManager {
             }
             return Err(err);
         }
+        claim.validate_with_trust(
+            &self.layout,
+            &claim_allowed_roots,
+            &trust.target_roots,
+            trust.exact_targets(),
+        )?;
+        state.upsert_adapter_claim(claim.clone());
+        state.save(&self.state_path)?;
         self.log_operation(&label, component, LogStatus::Ok, "adapter enabled", None);
 
         Ok(EnableOutcome::Enabled(Box::new(claim)))
@@ -1316,7 +1393,7 @@ impl AdapterManager {
                 continue;
             }
             let framework = claim.framework.clone();
-            let source = self.source_probe_for_claim(claim, &state);
+            let source = self.source_probe(&claim.component, &claim.framework, &state);
             let driver = match self.registry.get(&framework) {
                 Some(d) => d,
                 None => {
@@ -1325,9 +1402,11 @@ impl AdapterManager {
                     entries.push(StatusEntry {
                         component: claim.component.clone(),
                         framework,
-                        report: with_source_condition(
+                        report: with_managed_conditions(
                             unverified_report("no built-in driver for framework"),
+                            claim,
                             &source,
+                            false,
                         ),
                     });
                     continue;
@@ -1409,7 +1488,12 @@ impl AdapterManager {
                 &trust.target_roots,
                 trust.exact_targets(),
             )?;
-            let report = with_source_condition(driver.status(claim, &ctx)?, &source);
+            let report = with_managed_conditions(
+                driver.status(claim, &ctx)?,
+                claim,
+                &source,
+                driver.materialized_verification_applicable(claim),
+            );
             entries.push(StatusEntry {
                 component: claim.component.clone(),
                 framework,
@@ -1418,6 +1502,48 @@ impl AdapterManager {
         }
 
         Ok(StatusReport { entries })
+    }
+
+    /// Compare one receipt with the same authoritative source revision used by
+    /// [`Self::status`]. Component update uses this to avoid a second drift
+    /// definition.
+    pub fn source_revision_match(
+        &self,
+        claim: &AdapterClaim,
+        current_state: &StateStore,
+    ) -> ManagedMatch {
+        let source = self.source_probe(&claim.component, &claim.framework, current_state);
+        match source.revision {
+            Ok(current) => super::managed_files::compare_source_revision(claim, &current),
+            Err(reason) => ManagedMatch::Unknown(reason),
+        }
+    }
+
+    /// Capture every declared adapter's authoritative source revision.
+    ///
+    /// Missing package metadata is represented as `None` for that framework
+    /// so update reporting cannot mistake an unverifiable source for an
+    /// unchanged one.
+    pub fn source_revision_snapshot(
+        &self,
+        component: &str,
+        current_state: &StateStore,
+    ) -> BTreeMap<String, Option<AdapterSourceRevision>> {
+        let Ok((manifest, _, _, _)) =
+            self.load_visible_component_manifest(component, current_state)
+        else {
+            return BTreeMap::new();
+        };
+        declared_frameworks(&manifest)
+            .into_iter()
+            .map(|framework| {
+                let revision = self
+                    .source_probe(component, &framework, current_state)
+                    .revision
+                    .ok();
+                (framework, revision)
+            })
+            .collect()
     }
 
     // -- discovery helpers --------------------------------------------------
@@ -1434,14 +1560,6 @@ impl AdapterManager {
             })
             .unwrap_or(false);
         (driver_available, framework_detected)
-    }
-
-    fn source_probe_for_claim(
-        &self,
-        claim: &AdapterClaim,
-        current_state: &StateStore,
-    ) -> SourceProbe {
-        self.source_probe(&claim.component, &claim.framework, current_state)
     }
 
     fn source_probe(
@@ -1510,17 +1628,44 @@ impl AdapterManager {
             // leftover (e.g. the empty skeleton an uninstalled scope left
             // behind). Report Missing rather than letting a hollow
             // directory masquerade as a live source.
-            Ok((resource_root, _))
+            Ok((resource_root, effective_datadir))
                 if self.bundle_root_valid(
                     framework,
                     declared_bundle_entry(&manifest, framework).as_deref(),
                     &resource_root,
                 ) =>
             {
+                let revision = (|| {
+                    let mappings = if let Some(driver) = self.registry.get(framework) {
+                        let skills = resolve_skill_sources(
+                            declared_skills(&manifest, framework),
+                            &self.layout,
+                            &effective_datadir,
+                            component,
+                            framework,
+                            &resource_root,
+                        )
+                        .map_err(|err| format!("adapter skill sources are invalid: {err}"))?;
+                        driver.materialized_mappings(
+                            &resource_root,
+                            declared_adapter_type(&manifest, framework).as_deref(),
+                            &skills,
+                        )
+                    } else {
+                        Vec::new()
+                    };
+                    self.current_source_revision(
+                        component,
+                        current_state,
+                        &resource_root,
+                        &mappings,
+                    )
+                })();
                 SourceProbe {
                     status: AdapterSourceStatus::Available,
-                    resource_root: Some(resource_root),
+                    resource_root: Some(resource_root.clone()),
                     reason: None,
+                    revision,
                 }
             }
             Ok((resource_root, _)) => source_missing(format!(
@@ -1646,6 +1791,46 @@ impl AdapterManager {
             }
         }
         Ok(None)
+    }
+
+    fn find_component_installation(
+        &self,
+        component: &str,
+        current_state: &StateStore,
+    ) -> Result<Option<Installation>, AdapterError> {
+        for vr in &self.visible_roots {
+            let found = if vr.state_dir == self.layout.state_dir {
+                current_state
+                    .find(ObjectKind::Component, component)
+                    .filter(|installation| is_adapter_visible(installation))
+                    .cloned()
+            } else {
+                let state_path = vr.state_dir.join("installed.toml");
+                Self::load_state_at(&state_path)?
+                    .find(ObjectKind::Component, component)
+                    .filter(|installation| is_adapter_visible(installation))
+                    .cloned()
+            };
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
+    }
+
+    fn current_source_revision(
+        &self,
+        component: &str,
+        current_state: &StateStore,
+        resource_root: &Path,
+        mappings: &[super::managed_files::MaterializedMapping],
+    ) -> Result<super::claim::AdapterSourceRevision, String> {
+        let installation = self
+            .find_component_installation(component, current_state)
+            .map_err(|err| format!("installed component state unavailable: {err}"))?
+            .ok_or_else(|| format!("component '{component}' is not installed"))?;
+        let inventory = inventory_for_installation(&installation, self.package_files.as_ref())?;
+        source_revision(&inventory, resource_root, mappings)
     }
 
     /// Adapter declarations from component contracts visible to the
@@ -3814,7 +3999,8 @@ fn source_missing(reason: String) -> SourceProbe {
     SourceProbe {
         status: AdapterSourceStatus::Missing,
         resource_root: None,
-        reason: Some(reason),
+        reason: Some(reason.clone()),
+        revision: Err(reason),
     }
 }
 
@@ -3830,17 +4016,78 @@ fn source_condition(source: &SourceProbe) -> AdapterCondition {
     }
 }
 
-fn with_source_condition(
+fn with_managed_conditions(
     mut report: AdapterStatusReport,
+    claim: &AdapterClaim,
     source: &SourceProbe,
+    materialized_applicable: bool,
 ) -> AdapterStatusReport {
-    if source.status == AdapterSourceStatus::Missing
-        && report.summary != AdapterSummary::CleanupFailed
-    {
-        report.summary = AdapterSummary::Degraded;
+    let (managed, revision) = match &source.revision {
+        Ok(current) => (
+            verify_managed_bundle(current),
+            super::managed_files::compare_source_revision(claim, current),
+        ),
+        Err(reason) => (
+            ManagedMatch::Unknown(reason.clone()),
+            ManagedMatch::Unknown(reason.clone()),
+        ),
+    };
+    let mut integrity = vec![
+        managed_condition(AdapterConditionKind::ManagedBundleMatches, managed),
+        managed_condition(AdapterConditionKind::SourceRevisionMatches, revision),
+    ];
+    if materialized_applicable {
+        let materialized = if claim.materialized_files.is_empty() {
+            ManagedMatch::Unknown(
+                "receipt has no materialized file inventory; re-enable the adapter".into(),
+            )
+        } else {
+            verify_materialized_bundle(claim)
+        };
+        integrity.push(managed_condition(
+            AdapterConditionKind::MaterializedBundleMatches,
+            materialized,
+        ));
     }
+
+    let has_false = integrity
+        .iter()
+        .any(|condition| condition.status == ConditionStatus::False);
+    let has_unknown = integrity
+        .iter()
+        .any(|condition| condition.status == ConditionStatus::Unknown);
+    if report.summary != AdapterSummary::CleanupFailed {
+        if source.status == AdapterSourceStatus::Missing || has_false {
+            report.summary = AdapterSummary::Degraded;
+        } else if has_unknown && report.summary == AdapterSummary::Healthy {
+            report.summary = AdapterSummary::Unknown;
+        }
+    }
+    report.conditions.retain(|condition| {
+        !matches!(
+            condition.kind,
+            AdapterConditionKind::ManagedBundleMatches
+                | AdapterConditionKind::SourceRevisionMatches
+                | AdapterConditionKind::MaterializedBundleMatches
+        )
+    });
     report.conditions.insert(0, source_condition(source));
+    report.conditions.splice(1..1, integrity);
     report
+}
+
+fn managed_condition(kind: AdapterConditionKind, verdict: ManagedMatch) -> AdapterCondition {
+    let (status, reason) = match verdict {
+        ManagedMatch::Matched => (ConditionStatus::True, None),
+        ManagedMatch::Changed(reason) => (ConditionStatus::False, Some(reason)),
+        ManagedMatch::Unknown(reason) => (ConditionStatus::Unknown, Some(reason)),
+    };
+    AdapterCondition {
+        kind,
+        status,
+        reason,
+        resource: None,
+    }
 }
 
 /// Reorder datadir roots so `preferred` is tried first, then the remaining
@@ -4831,6 +5078,8 @@ source = "adapters/openclaw"
             enabled_at: "2026-07-09T00:00:00Z".to_string(),
             resource_root,
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -4842,6 +5091,121 @@ source = "adapters/openclaw"
                 config_resources: Vec::new(),
             }),
         }
+    }
+
+    #[test]
+    fn unavailable_authoritative_inventory_never_reports_healthy() {
+        let claim = openclaw_claim("tokenless", PathBuf::from("/missing/source"));
+        let reason = "native package file query failed; re-enable the adapter".to_string();
+        let source = SourceProbe {
+            status: AdapterSourceStatus::Available,
+            resource_root: Some(claim.resource_root.clone()),
+            reason: None,
+            revision: Err(reason),
+        };
+        let report = with_managed_conditions(
+            AdapterStatusReport {
+                summary: AdapterSummary::Healthy,
+                conditions: Vec::new(),
+            },
+            &claim,
+            &source,
+            false,
+        );
+
+        assert_eq!(report.summary, AdapterSummary::Unknown);
+        assert!(report.conditions.iter().any(|condition| {
+            condition.kind == AdapterConditionKind::ManagedBundleMatches
+                && condition.status == ConditionStatus::Unknown
+        }));
+        assert!(report.conditions.iter().any(|condition| {
+            condition.kind == AdapterConditionKind::SourceRevisionMatches
+                && condition.status == ConditionStatus::Unknown
+        }));
+    }
+
+    #[test]
+    fn changed_managed_file_degrades_an_otherwise_healthy_report() {
+        use crate::adapter::claim::{AdapterSourceRevision, ManagedFileKind, ManagedSourceFile};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("plugin.json"), b"changed").expect("managed file");
+        let revision = AdapterSourceRevision {
+            source_root: tmp.path().to_path_buf(),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                kind: ManagedFileKind::File,
+                sha256: Some("0".repeat(64)),
+                symlink_target: None,
+            }],
+            materialized_sources: Vec::new(),
+        };
+        let mut claim = openclaw_claim("tokenless", tmp.path().to_path_buf());
+        claim.source_revision = Some(revision.clone());
+        let source = SourceProbe {
+            status: AdapterSourceStatus::Available,
+            resource_root: Some(tmp.path().to_path_buf()),
+            reason: None,
+            revision: Ok(revision),
+        };
+        let report = with_managed_conditions(
+            AdapterStatusReport {
+                summary: AdapterSummary::Healthy,
+                conditions: Vec::new(),
+            },
+            &claim,
+            &source,
+            false,
+        );
+
+        assert_eq!(report.summary, AdapterSummary::Degraded);
+        assert!(report.conditions.iter().any(|condition| {
+            condition.kind == AdapterConditionKind::ManagedBundleMatches
+                && condition.status == ConditionStatus::False
+        }));
+    }
+
+    #[test]
+    fn missing_materialized_inventory_is_unknown() {
+        use crate::adapter::claim::{AdapterSourceRevision, ManagedFileKind, ManagedSourceFile};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("plugin.json"), b"").expect("managed file");
+        let revision = AdapterSourceRevision {
+            source_root: tmp.path().to_path_buf(),
+            files: vec![ManagedSourceFile {
+                relative_path: PathBuf::from("plugin.json"),
+                kind: ManagedFileKind::File,
+                sha256: Some(
+                    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".into(),
+                ),
+                symlink_target: None,
+            }],
+            materialized_sources: Vec::new(),
+        };
+        let mut claim = openclaw_claim("tokenless", tmp.path().to_path_buf());
+        claim.source_revision = Some(revision.clone());
+        let source = SourceProbe {
+            status: AdapterSourceStatus::Available,
+            resource_root: Some(tmp.path().to_path_buf()),
+            reason: None,
+            revision: Ok(revision),
+        };
+        let report = with_managed_conditions(
+            AdapterStatusReport {
+                summary: AdapterSummary::Healthy,
+                conditions: Vec::new(),
+            },
+            &claim,
+            &source,
+            true,
+        );
+
+        assert_eq!(report.summary, AdapterSummary::Unknown);
+        assert!(report.conditions.iter().any(|condition| {
+            condition.kind == AdapterConditionKind::MaterializedBundleMatches
+                && condition.status == ConditionStatus::Unknown
+        }));
     }
 
     fn seed_adapter_claim(
@@ -5028,6 +5392,8 @@ entry = "cosh-extension.json"
             enabled_at: "2026-07-09T00:00:00Z".to_string(),
             resource_root,
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -7915,6 +8281,8 @@ dest = "{datadir}/skills"
             enabled_at: "2026-06-30T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/fake/adapters/test-comp/openclaw"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -8100,6 +8468,8 @@ dest = "{datadir}/skills"
             enabled_at: "2026-06-30T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/fake/adapters/test-comp/hermes"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -8172,6 +8542,8 @@ dest = "{datadir}/skills"
             enabled_at: "2026-06-30T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/fake/adapters/test-comp/hermes"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: 1,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -34,8 +34,6 @@ use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
-use sha2::{Digest, Sha256};
-
 use super::AdapterError;
 use super::claim::{
     AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimResource, ClaimResourceKind, ClaimStatus,
@@ -47,6 +45,7 @@ use super::driver::{
     DriverPlan, EnableProgress, FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable,
     find_binary_in_path,
 };
+use super::managed_files::{MaterializedMapping, copy_materialized_resource};
 use crate::manifest::AdapterConfigSetSpec;
 
 /// Default timeout for an OpenClaw CLI invocation.
@@ -143,7 +142,6 @@ impl FrameworkDriver for OpenClawDriver {
 
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id,
         })
     }
@@ -311,7 +309,9 @@ impl FrameworkDriver for OpenClawDriver {
             adapter_type: ctx.adapter_type.clone(),
             enabled_at: now_iso8601(),
             resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -338,6 +338,32 @@ impl FrameworkDriver for OpenClawDriver {
         next: &mut AdapterClaim,
     ) -> Result<(), AdapterError> {
         preserve_openclaw_config_facts(prior, next)
+    }
+
+    fn materialized_mappings(
+        &self,
+        resource_root: &Path,
+        _adapter_type: Option<&str>,
+        declared_skills: &[super::driver::DeclaredSkill],
+    ) -> Vec<MaterializedMapping> {
+        declared_skills
+            .iter()
+            .map(|skill| MaterializedMapping {
+                resource_id: format!("openclaw_skill_{}", skill.name),
+                source_root: skill
+                    .source
+                    .clone()
+                    .unwrap_or_else(|| resource_root.join("skills").join(&skill.name)),
+                excluded_prefixes: Vec::new(),
+            })
+            .collect()
+    }
+
+    fn materialized_verification_applicable(&self, claim: &AdapterClaim) -> bool {
+        matches!(
+            &claim.driver_payload,
+            DriverPayload::OpenClaw(payload) if !payload.skill_resources.is_empty()
+        )
     }
 
     fn cleanup_replaced_claim(
@@ -484,8 +510,8 @@ impl FrameworkDriver for OpenClawDriver {
                 .source
                 .clone()
                 .unwrap_or_else(|| ctx.resource_root.join("skills").join(&skill.name));
-            let dst = home.join("skills").join(&skill.name);
-            ctx.ops.copy_tree(&src, &dst)?;
+            let resource_id = format!("openclaw_skill_{}", skill.name);
+            copy_materialized_resource(claim, &resource_id, &src, ctx.ops)?;
         }
 
         if let Some(plugin_id) = &plugin {
@@ -541,10 +567,7 @@ impl FrameworkDriver for OpenClawDriver {
             resource: None,
         });
 
-        // 2. Resource bundle still matches the enable-time digest?
-        conditions.push(self.bundle_match_condition(claim));
-
-        // 3. Plugin still registered? Skill-only receipts have no plugin
+        // 2. Plugin still registered? Skill-only receipts have no plugin
         //    registry entry by design, so status does not require one.
         let plugin_registered = if claim.is_skill_bundle() {
             conditions.push(AdapterCondition {
@@ -704,32 +727,6 @@ impl FrameworkDriver for OpenClawDriver {
 }
 
 impl OpenClawDriver {
-    /// Build the `ResourceBundleMatches` condition by re-digesting the
-    /// resource root and comparing to the enable-time digest.
-    fn bundle_match_condition(&self, claim: &AdapterClaim) -> AdapterCondition {
-        let kind = AdapterConditionKind::ResourceBundleMatches;
-        match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-            (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-                kind,
-                status: ConditionStatus::True,
-                reason: None,
-                resource: None,
-            },
-            (Some(_), Some(_)) => AdapterCondition {
-                kind,
-                status: ConditionStatus::False,
-                reason: Some("resource bundle changed since enable".to_string()),
-                resource: None,
-            },
-            _ => AdapterCondition {
-                kind,
-                status: ConditionStatus::Unknown,
-                reason: Some("no digest recorded or resource root unavailable".to_string()),
-                resource: None,
-            },
-        }
-    }
-
     /// Run `openclaw plugins list` and decide whether `plugin_id` is still
     /// registered. Returns `(plugin_condition, verification_condition,
     /// plugin_registered_status)`.
@@ -2706,43 +2703,6 @@ fn summarize(
     }
 }
 
-/// SHA-256 digest of a directory tree, stable across runs: files are
-/// hashed in sorted relative-path order as `path\0len\0bytes`. Returns
-/// `None` on any IO error so callers fall back to `Unknown` rather than a
-/// wrong verdict.
-fn digest_tree(root: &Path) -> Option<String> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in &files {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let bytes = std::fs::read(path).ok()?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0u8]);
-        hasher.update(&bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
-
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
 /// Build `openclaw config set <key> <value>`.
 fn build_config_set_cmd(
     key: &str,
@@ -3535,22 +3495,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn digest_tree_is_stable_and_detects_change() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("a.txt"), b"hello").expect("write");
-        std::fs::create_dir(dir.path().join("sub")).expect("mkdir");
-        std::fs::write(dir.path().join("sub/b.txt"), b"world").expect("write");
-
-        let d1 = digest_tree(dir.path()).expect("digest");
-        let d2 = digest_tree(dir.path()).expect("digest again");
-        assert_eq!(d1, d2, "digest must be stable");
-
-        std::fs::write(dir.path().join("sub/b.txt"), b"WORLD").expect("rewrite");
-        let d3 = digest_tree(dir.path()).expect("digest after change");
-        assert_ne!(d1, d3, "digest must change when a file changes");
-    }
-
     // -- config set cmd -------------------------------------------------
 
     #[test]
@@ -3620,6 +3564,8 @@ mod tests {
             enabled_at: "2026-01-01T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/tmp"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::CleanupFailed,
             notices: Vec::new(),
@@ -3810,6 +3756,8 @@ mod tests {
             enabled_at: "2026-01-01T00:00:00Z".to_string(),
             resource_root: PathBuf::from("/tmp/test-home/resource"),
             bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qoder.rs
@@ -36,7 +36,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{bool_status, cli_failure_reason, display_command, now_iso8601};
 
 mod settings;
 
@@ -180,7 +180,6 @@ impl FrameworkDriver for QoderDriver {
         validate_plugin_id(&plugin_id)?;
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id: Some(plugin_id),
         })
     }
@@ -314,7 +313,9 @@ impl FrameworkDriver for QoderDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -373,7 +374,9 @@ impl FrameworkDriver for QoderDriver {
                 adapter_type: ctx.adapter_type.clone(),
                 enabled_at: now_iso8601(),
                 resource_root: bundle.resource_root.clone(),
-                bundle_digest: bundle.digest.clone(),
+                bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: DRIVER_SCHEMA_VERSION,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),
@@ -604,8 +607,6 @@ impl FrameworkDriver for QoderDriver {
             reason: Some(detect.reason.clone()),
             resource: None,
         });
-        conditions.push(bundle_match_condition(claim));
-
         // Resolve strictly from the receipt payload; a receipt missing its
         // plugin or settings resource is malformed and must not be treated as
         // healthy or verifiable.
@@ -1197,15 +1198,12 @@ fn native_status(
     let detect = QoderDriver.detect(&HostEnv {
         user_home: ctx.user_home.clone(),
     });
-    let mut conditions = vec![
-        AdapterCondition {
-            kind: AdapterConditionKind::FrameworkDetected,
-            status: bool_status(detect.detected),
-            reason: Some(detect.reason),
-            resource: None,
-        },
-        bundle_match_condition(claim),
-    ];
+    let mut conditions = vec![AdapterCondition {
+        kind: AdapterConditionKind::FrameworkDetected,
+        status: bool_status(detect.detected),
+        reason: Some(detect.reason),
+        resource: None,
+    }];
     let Some(plugin) = resolve_plugin(claim) else {
         push_native_conditions(
             &mut conditions,
@@ -1677,31 +1675,6 @@ fn build_native_uninstall_cmd(program: &str, plugin: &str) -> FrameworkCommand {
 // ---------------------------------------------------------------------------
 // Status assembly
 // ---------------------------------------------------------------------------
-
-/// Build the `ResourceBundleMatches` condition.
-fn bundle_match_condition(claim: &AdapterClaim) -> AdapterCondition {
-    let kind = AdapterConditionKind::ResourceBundleMatches;
-    match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => AdapterCondition {
-            kind,
-            status: ConditionStatus::True,
-            reason: None,
-            resource: None,
-        },
-        (Some(_), Some(_)) => AdapterCondition {
-            kind,
-            status: ConditionStatus::False,
-            reason: Some("resource bundle changed since enable".to_string()),
-            resource: None,
-        },
-        _ => AdapterCondition {
-            kind,
-            status: ConditionStatus::Unknown,
-            reason: Some("no digest recorded or resource root unavailable".to_string()),
-            resource: None,
-        },
-    }
-}
 
 /// Roll signals into a summary. Healthy requires the framework detected and
 /// our managed settings entries verified present. Plugin registration is

--- a/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/qwencode.rs
@@ -39,7 +39,7 @@ use super::driver::{
     ClaimResourceRef, ConditionStatus, DetectResult, DisableReport, DriverCtx, DriverPlan,
     FrameworkCommand, FrameworkDriver, HostEnv, PreparedEnable, find_binary_in_path,
 };
-use super::util::{bool_status, cli_failure_reason, digest_tree, display_command, now_iso8601};
+use super::util::{bool_status, cli_failure_reason, display_command, now_iso8601};
 
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 // tokenless declares the same floor; earlier Qwen releases expose the
@@ -150,7 +150,6 @@ impl FrameworkDriver for QwenCodeDriver {
 
         Ok(AdapterBundle {
             resource_root: root.clone(),
-            digest: digest_tree(root),
             plugin_id: Some(plugin),
         })
     }
@@ -221,7 +220,9 @@ impl FrameworkDriver for QwenCodeDriver {
             adapter_type: ctx.adapter_type.clone(),
             enabled_at: now_iso8601(),
             resource_root: bundle.resource_root.clone(),
-            bundle_digest: bundle.digest.clone(),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
             driver_schema: DRIVER_SCHEMA_VERSION,
             status: ClaimStatus::Enabled,
             notices: Vec::new(),
@@ -329,7 +330,6 @@ impl FrameworkDriver for QwenCodeDriver {
         let detect = self.detect(&HostEnv {
             user_home: ctx.user_home.clone(),
         });
-        let (bundle_condition, bundle_status) = bundle_match_condition(claim);
         let registration = probe_registration(&layout, claim, ctx)?;
         let registration_status = registration.status();
         let activation = probe_activation(&layout, ctx)?;
@@ -372,7 +372,6 @@ impl FrameworkDriver for QwenCodeDriver {
                 reason: Some(detect.reason),
                 resource: None,
             },
-            bundle_condition,
             AdapterCondition {
                 kind: AdapterConditionKind::PluginRegistered,
                 status: registration_status,
@@ -399,7 +398,6 @@ impl FrameworkDriver for QwenCodeDriver {
         let summary = summarize(
             claim.status,
             detect.detected,
-            bundle_status,
             registration_status,
             activation_status,
             verification_status,
@@ -1157,34 +1155,9 @@ fn parse_qwen_version(output: &str) -> Option<Version> {
     })
 }
 
-fn bundle_match_condition(claim: &AdapterClaim) -> (AdapterCondition, ConditionStatus) {
-    let kind = AdapterConditionKind::ResourceBundleMatches;
-    let (status, reason) = match (&claim.bundle_digest, digest_tree(&claim.resource_root)) {
-        (Some(recorded), Some(current)) if recorded == &current => (ConditionStatus::True, None),
-        (Some(_), Some(_)) => (
-            ConditionStatus::False,
-            Some("resource bundle changed since enable".to_string()),
-        ),
-        _ => (
-            ConditionStatus::Unknown,
-            Some("no digest recorded or resource root unavailable".to_string()),
-        ),
-    };
-    (
-        AdapterCondition {
-            kind,
-            status,
-            reason,
-            resource: None,
-        },
-        status,
-    )
-}
-
 fn summarize(
     claim_status: ClaimStatus,
     framework_detected: bool,
-    bundle: ConditionStatus,
     registration: ConditionStatus,
     activation: ConditionStatus,
     verification: ConditionStatus,
@@ -1193,15 +1166,13 @@ fn summarize(
         return AdapterSummary::CleanupFailed;
     }
     if !framework_detected
-        || bundle == ConditionStatus::False
         || registration == ConditionStatus::False
         || activation == ConditionStatus::False
         || verification == ConditionStatus::False
     {
         return AdapterSummary::Degraded;
     }
-    if bundle == ConditionStatus::Unknown
-        || registration == ConditionStatus::Unknown
+    if registration == ConditionStatus::Unknown
         || activation == ConditionStatus::Unknown
         || verification == ConditionStatus::Unknown
     {

--- a/src/anolisa/crates/anolisa-core/src/adapter/util.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/util.rs
@@ -1,53 +1,11 @@
 //! Pure, side-effect-free helpers shared by the built-in framework
 //! drivers.
 //!
-//! These never spawn a process or mutate the filesystem beyond reading for
-//! a digest, so they are safe to call from `plan`/`status`/`prepare` paths.
-//! The Cosh/Codex/Claude Code drivers share them here rather than each
-//! re-declaring the same digest/timestamp/formatting logic.
-
-use std::path::{Path, PathBuf};
-
-use sha2::{Digest, Sha256};
+//! These never spawn a process or mutate the filesystem, so they are safe to
+//! call from `plan`/`status`/`prepare` paths. Built-in drivers share them here
+//! rather than each re-declaring timestamp and formatting logic.
 
 use super::driver::{CliOutput, ConditionStatus, FrameworkCommand};
-
-/// SHA-256 digest of a directory tree, stable across runs: files are hashed
-/// in sorted relative-path order as `path\0len\0bytes`. Returns `None` on
-/// any IO error so callers fall back to `Unknown` rather than a wrong
-/// verdict.
-pub(crate) fn digest_tree(root: &Path) -> Option<String> {
-    let mut files: Vec<PathBuf> = Vec::new();
-    collect_files(root, &mut files).ok()?;
-    files.sort();
-    let mut hasher = Sha256::new();
-    for path in &files {
-        let rel = path.strip_prefix(root).unwrap_or(path);
-        let bytes = std::fs::read(path).ok()?;
-        hasher.update(rel.to_string_lossy().as_bytes());
-        hasher.update([0u8]);
-        hasher.update((bytes.len() as u64).to_le_bytes());
-        hasher.update([0u8]);
-        hasher.update(&bytes);
-    }
-    Some(format!("sha256:{:x}", hasher.finalize()))
-}
-
-/// Recursively collect regular-file paths under `dir`. Symlinks are not
-/// followed into directories (their link path is recorded as a file).
-fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
-            collect_files(&path, out)?;
-        } else {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
 
 /// ISO 8601 UTC timestamp, second precision.
 pub(crate) fn now_iso8601() -> String {

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -1279,6 +1279,8 @@ mod tests {
                 enabled_at: NOW.to_string(),
                 resource_root: PathBuf::new(),
                 bundle_digest: None,
+                source_revision: None,
+                materialized_files: Vec::new(),
                 driver_schema: 1,
                 status: ClaimStatus::Enabled,
                 notices: Vec::new(),

--- a/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_frameworks.rs
@@ -22,7 +22,15 @@ use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{ClaimResourceKind, ClaimStatus, DriverPayload};
 use anolisa_core::adapter::driver::{AdapterConditionKind, AdapterSummary, ConditionStatus};
 use anolisa_core::adapter::manager::{AdapterManager, EnableOutcome};
+use anolisa_core::domain::{PackageIdentity, ProviderBinding};
+use anolisa_core::state::{FileOwner, OwnedFile, OwnedFileKind};
 use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::pkg_files::{
+    PackageFile, PackageFileDigestAlgorithm, PackageFileInventory, PackageFileKind,
+    PackageFileQuery,
+};
+use anolisa_platform::pkg_query::PackageQueryError;
+use sha2::{Digest, Sha256};
 
 const COMPONENT: &str = "tokenless";
 
@@ -104,11 +112,15 @@ struct World {
 
 impl World {
     fn manager(&self) -> AdapterManager {
-        AdapterManager::new(
+        let mut manager = AdapterManager::new(
             self.layout.clone(),
             Some(self.user_home.clone()),
             "tester".to_string(),
-        )
+        );
+        manager.set_package_file_query(Box::new(FixturePackageFiles {
+            root: self.prefix.clone(),
+        }));
+        manager
     }
 
     fn load_state(&self) -> anolisa_core::state_store::StateStore {
@@ -118,6 +130,112 @@ impl World {
         )
         .expect("load state")
     }
+}
+
+struct FixturePackageFiles {
+    root: PathBuf,
+}
+
+impl PackageFileQuery for FixturePackageFiles {
+    fn query_file_inventory(
+        &self,
+        _package: &str,
+    ) -> Result<PackageFileInventory, PackageQueryError> {
+        Ok(PackageFileInventory {
+            digest_algorithm: PackageFileDigestAlgorithm::Sha256,
+            files: fixture_package_files(&self.root),
+        })
+    }
+}
+
+fn fixture_package_files(root: &Path) -> Vec<PackageFile> {
+    fn collect(root: &Path, files: &mut Vec<PackageFile>) {
+        for entry in std::fs::read_dir(root).expect("read fixture package root") {
+            let entry = entry.expect("fixture package entry");
+            let path = entry.path();
+            let file_type = entry.file_type().expect("fixture file type");
+            if file_type.is_dir() {
+                collect(&path, files);
+            } else if file_type.is_symlink() {
+                files.push(PackageFile {
+                    path: path.display().to_string(),
+                    kind: PackageFileKind::Symlink,
+                    digest: None,
+                    link_target: Some(
+                        std::fs::read_link(&path)
+                            .expect("fixture symlink target")
+                            .display()
+                            .to_string(),
+                    ),
+                });
+            } else if file_type.is_file() {
+                files.push(PackageFile {
+                    path: path.display().to_string(),
+                    kind: PackageFileKind::Regular,
+                    digest: Some(format!(
+                        "{:x}",
+                        Sha256::digest(std::fs::read(&path).expect("fixture file bytes"))
+                    )),
+                    link_target: None,
+                });
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    collect(root, &mut files);
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    files
+}
+
+fn record_owned_adapter_files(layout: &FsLayout, root: &Path) {
+    let state_path = layout.state_dir.join("installed.toml");
+    let mut state = anolisa_core::state_store::StateStore::load(
+        &state_path,
+        anolisa_platform::privilege::effective_uid(),
+    )
+    .expect("load fixture state");
+    let installation = state
+        .find_mut(anolisa_core::state::ObjectKind::Component, COMPONENT)
+        .expect("fixture component");
+    let ProviderBinding::Owned { artifact } = &mut installation.binding else {
+        panic!("fixture component must be raw-owned");
+    };
+    artifact.files = fixture_package_files(root)
+        .into_iter()
+        .map(|file| OwnedFile {
+            path: PathBuf::from(file.path),
+            owner: FileOwner::Anolisa,
+            sha256: file.digest,
+            kind: match file.kind {
+                PackageFileKind::Symlink => OwnedFileKind::Symlink,
+                _ => OwnedFileKind::File,
+            },
+            referent: file.link_target.map(PathBuf::from),
+            mode: None,
+            capabilities: Vec::new(),
+        })
+        .collect();
+    state.save(&state_path).expect("save fixture state");
+}
+
+fn resolve_fixture_rpm_identity(layout: &FsLayout) {
+    let state_path = layout.state_dir.join("installed.toml");
+    let mut state = anolisa_core::state_store::StateStore::load(
+        &state_path,
+        anolisa_platform::privilege::effective_uid(),
+    )
+    .expect("load fixture state");
+    let installation = state
+        .find_mut(anolisa_core::state::ObjectKind::Component, COMPONENT)
+        .expect("fixture component");
+    let ProviderBinding::Delegated { package, .. } = &mut installation.binding else {
+        panic!("fixture component must be delegated");
+    };
+    *package = PackageIdentity::Resolved {
+        name: COMPONENT.to_string(),
+    };
+    state.save(&state_path).expect("save fixture state");
 }
 
 /// Stage a component contract declaring `framework`/`adapter_type` with the
@@ -205,6 +323,10 @@ dest = "{dest}"
         ),
     )
     .expect("seed contract");
+    let resource_root = expand_dest(dest, &layout.datadir);
+    if resource_root.is_dir() {
+        record_owned_adapter_files(layout, &resource_root);
+    }
 }
 
 /// Minimal `{datadir}`/`{component}` expansion for staging (the manager's
@@ -300,6 +422,7 @@ resource_root = "{rpm_root}/"
         std::fs::create_dir_all(path.parent().unwrap()).expect("contract dir");
         std::fs::write(&path, &contract).expect("seed contract");
     }
+    resolve_fixture_rpm_identity(&layout);
 
     World {
         _root: root,
@@ -345,6 +468,15 @@ fn cosh_enable_status_disable_touches_only_extension_dir() {
     std::fs::write(sibling.join("keep.txt"), b"keep").expect("keep");
 
     let manager = world.manager();
+    let source_runtime_cache = world.resource_root.join("__pycache__/runtime.pyc");
+    std::fs::create_dir_all(
+        source_runtime_cache
+            .parent()
+            .expect("source runtime cache parent"),
+    )
+    .expect("source runtime cache dir");
+    std::fs::write(&source_runtime_cache, b"source-runtime-only")
+        .expect("source runtime cache file");
     let claim = match manager
         .enable(COMPONENT, Some("cosh"), false)
         .expect("enable")
@@ -360,6 +492,10 @@ fn cosh_enable_status_disable_touches_only_extension_dir() {
         "extension copied"
     );
     assert!(ext_dir.join("hooks/run-hook.sh").is_file(), "tree copied");
+    assert!(
+        !ext_dir.join("__pycache__/runtime.pyc").exists(),
+        "unowned source files must not be materialized"
+    );
 
     let status = manager.status(Some(COMPONENT)).expect("status");
     assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
@@ -371,6 +507,26 @@ fn cosh_enable_status_disable_touches_only_extension_dir() {
             .any(|c| c.kind == AdapterConditionKind::TreePresent
                 && c.status == ConditionStatus::True)
     );
+
+    let runtime_cache = ext_dir.join("__pycache__/runtime.pyc");
+    std::fs::create_dir_all(runtime_cache.parent().expect("runtime cache parent"))
+        .expect("runtime cache dir");
+    std::fs::write(&runtime_cache, b"runtime-only").expect("runtime cache file");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status with runtime file");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    std::fs::write(ext_dir.join("hooks/run-hook.sh"), b"changed").expect("mutate copied hook");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status with changed copy");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+    assert!(status.entries[0].report.conditions.iter().any(|condition| {
+        condition.kind == AdapterConditionKind::MaterializedBundleMatches
+            && condition.status == ConditionStatus::False
+    }));
+    std::fs::write(ext_dir.join("hooks/run-hook.sh"), b"#!/bin/sh\n").expect("restore copied hook");
 
     let disabled = manager
         .disable(COMPONENT, Some("cosh"), false)
@@ -883,8 +1039,8 @@ resource_root = "{root_b}/"
         .report
         .conditions
         .iter()
-        .find(|c| c.kind == AdapterConditionKind::ResourceBundleMatches)
-        .expect("bundle condition present");
+        .find(|c| c.kind == AdapterConditionKind::SourceRevisionMatches)
+        .expect("source revision condition present");
     assert_ne!(
         bundle.status,
         ConditionStatus::True,
@@ -1248,6 +1404,7 @@ fn codex_enable_succeeds_with_bundle_under_packaged_datadir() {
         "plugin",
         "{datadir}/adapters/{component}/codex/",
     );
+    record_owned_adapter_files(&layout, &resource_root);
 
     let fake = write_fake_codex(&prefix);
     let xdg = prefix.join("xdg-data");
@@ -2380,6 +2537,7 @@ fn qoder_native_reenable_rejects_preexisting_different_plugin_id() {
     std::fs::write(replacement.join("owner.txt"), b"user-owned\n")
         .expect("replacement ownership marker");
     set_native_qoder_plugin_id(&world, "replacement");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
     guard.set("FAKE_QODER_PLUGIN_ID", Path::new("replacement"));
 
     let error = manager
@@ -2440,6 +2598,7 @@ fn qoder_native_reenable_rejects_absent_different_plugin_id() {
         .expect("initial native enable");
 
     set_native_qoder_plugin_id(&world, "replacement");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
     guard.set("FAKE_QODER_PLUGIN_ID", Path::new("replacement"));
     let error = manager
         .enable(COMPONENT, Some("qoder"), false)
@@ -2583,6 +2742,7 @@ fn qoder_cross_layout_reenable_preserves_legacy_receipt_for_cleanup() {
 
     std::fs::remove_file(world.resource_root.join("hooks.json")).expect("remove legacy hooks");
     stage_native_qoder_bundle(&world.resource_root);
+    record_owned_adapter_files(&world.layout, &world.resource_root);
     let error = manager
         .enable(COMPONENT, Some("qoder"), false)
         .expect_err("cross-layout re-enable must be explicit");

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -24,10 +24,14 @@ use anolisa_core::adapter::claim::{
 };
 use anolisa_core::adapter::driver::{AdapterSummary, ConditionStatus};
 use anolisa_core::adapter::manager::{AdapterManager, EnableOptions, EnableOutcome};
+use anolisa_core::domain::ProviderBinding;
 use anolisa_core::manifest::{NoticeLevel, NoticeWhen};
-use anolisa_core::state::InstallMode as StateInstallMode;
+use anolisa_core::state::{
+    FileOwner, InstallMode as StateInstallMode, ObjectKind, OwnedFile, OwnedFileKind,
+};
 use anolisa_core::state_store::StateStore;
 use anolisa_platform::fs_layout::FsLayout;
+use sha2::{Digest, Sha256};
 
 /// Serializes the process-global env mutation across tests.
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -48,6 +52,7 @@ struct World {
 
 impl World {
     fn manager(&self) -> AdapterManager {
+        record_owned_adapter_files(&self.layout, &self.resource_root);
         AdapterManager::new(
             self.layout.clone(),
             Some(self.user_home.clone()),
@@ -86,6 +91,59 @@ impl World {
             .find_adapter_claim(COMPONENT, FRAMEWORK)
             .is_some()
     }
+}
+
+fn record_owned_adapter_files(layout: &FsLayout, root: &Path) {
+    fn collect(root: &Path, files: &mut Vec<OwnedFile>) {
+        for entry in std::fs::read_dir(root).expect("read adapter fixture") {
+            let entry = entry.expect("adapter fixture entry");
+            let path = entry.path();
+            let file_type = entry.file_type().expect("adapter fixture file type");
+            if file_type.is_dir() {
+                collect(&path, files);
+            } else if file_type.is_symlink() {
+                files.push(OwnedFile {
+                    path: path.clone(),
+                    owner: FileOwner::Anolisa,
+                    sha256: None,
+                    kind: OwnedFileKind::Symlink,
+                    referent: Some(std::fs::read_link(path).expect("adapter fixture symlink")),
+                    mode: None,
+                    capabilities: Vec::new(),
+                });
+            } else if file_type.is_file() {
+                files.push(OwnedFile {
+                    path: path.clone(),
+                    owner: FileOwner::Anolisa,
+                    sha256: Some(format!(
+                        "{:x}",
+                        Sha256::digest(std::fs::read(path).expect("adapter fixture bytes"))
+                    )),
+                    kind: OwnedFileKind::File,
+                    referent: None,
+                    mode: None,
+                    capabilities: Vec::new(),
+                });
+            }
+        }
+    }
+
+    if !root.is_dir() {
+        return;
+    }
+    let state_path = layout.state_dir.join("installed.toml");
+    let mut state = load_state_at(&state_path);
+    let installation = state
+        .find_mut(ObjectKind::Component, COMPONENT)
+        .expect("fixture component");
+    let ProviderBinding::Owned { artifact } = &mut installation.binding else {
+        panic!("fixture component must be raw-owned");
+    };
+    let mut files = Vec::new();
+    collect(root, &mut files);
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+    artifact.files = files;
+    state.save(&state_path).expect("save fixture state");
 }
 
 fn recorded_openclaw_state_dir(claim: &AdapterClaim) -> &Path {
@@ -485,6 +543,14 @@ installed_at = "2026-06-15T00:00:00Z"
     );
     std::fs::write(&state_path, toml).expect("seed state");
     write_installed_manifest(layout, FRAMEWORK);
+    record_owned_adapter_files(
+        layout,
+        &layout
+            .datadir
+            .join("adapters")
+            .join(COMPONENT)
+            .join(FRAMEWORK),
+    );
 }
 
 fn write_installed_manifest(layout: &FsLayout, framework: &str) {
@@ -574,6 +640,29 @@ fn enable_status_disable_happy_path() {
             .is_none(),
         "receipt must be gone after successful disable"
     );
+}
+
+#[test]
+fn enable_rejects_modified_package_owned_source() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    std::fs::write(
+        world.resource_root.join("openclaw.plugin.json"),
+        br#"{"id":"modified","name":"Modified"}"#,
+    )
+    .expect("modify package-owned manifest after recording its digest");
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("modified package-owned bytes must block enable");
+    assert!(matches!(
+        err,
+        AdapterError::InvalidAdapterInput { reason, .. } if reason.contains("content changed")
+    ));
+    assert!(!world.registry_marker_exists());
+    assert!(!world.has_claim());
 }
 
 #[test]
@@ -669,6 +758,25 @@ skills = ["sec-audit"]
         &resource.kind,
         ClaimResourceKind::ExternalPath { path } if path == &expected
     )));
+
+    std::fs::write(expected.join("skills/sec-audit/runtime.log"), b"runtime")
+        .expect("runtime file");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status with runtime file");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+
+    std::fs::write(expected.join("skills/sec-audit/marker.txt"), b"changed")
+        .expect("mutate materialized skill");
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status with changed skill");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Degraded);
+    assert!(status.entries[0].report.conditions.iter().any(|condition| {
+        condition.kind
+            == anolisa_core::adapter::driver::AdapterConditionKind::MaterializedBundleMatches
+            && condition.status == ConditionStatus::False
+    }));
 }
 
 #[test]

--- a/src/anolisa/crates/anolisa-platform/src/lib.rs
+++ b/src/anolisa/crates/anolisa-platform/src/lib.rs
@@ -8,6 +8,7 @@ pub mod command;
 pub mod fs_layout;
 pub mod ipc;
 pub mod package_manager;
+pub mod pkg_files;
 pub mod pkg_query;
 pub mod pkg_transaction;
 pub mod privilege;

--- a/src/anolisa/crates/anolisa-platform/src/pkg_files.rs
+++ b/src/anolisa/crates/anolisa-platform/src/pkg_files.rs
@@ -1,0 +1,69 @@
+//! Read-only package-manager file inventory contract.
+//!
+//! Lifecycle package queries answer whether a package is installed; adapter
+//! integrity additionally needs the package manager's authoritative per-file
+//! metadata. Keeping that surface separate avoids forcing transaction/version
+//! fakes to pretend they can query file ownership.
+
+use crate::pkg_query::PackageQueryError;
+
+/// Digest algorithm declared by the package inventory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageFileDigestAlgorithm {
+    /// SHA-256 (RPM algorithm id 8).
+    Sha256,
+    /// An algorithm ANOLISA does not verify.
+    Unsupported(u32),
+}
+
+/// Package-manager file type derived from the authoritative mode metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageFileKind {
+    /// Regular file whose bytes can be hashed.
+    Regular,
+    /// Symbolic link whose literal target can be compared.
+    Symlink,
+    /// Directory; ownership/integrity is handled by the lifecycle layer.
+    Directory,
+    /// Device, socket, FIFO, or another non-adapter-input type.
+    Other,
+}
+
+/// One file entry reported by the native package database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageFile {
+    /// Absolute installed path.
+    pub path: String,
+    /// File type derived from the package-recorded Unix mode.
+    pub kind: PackageFileKind,
+    /// Package-recorded content digest. Directories and symlinks normally
+    /// carry no digest.
+    pub digest: Option<String>,
+    /// Literal link target for [`PackageFileKind::Symlink`].
+    pub link_target: Option<String>,
+}
+
+/// Authoritative file inventory for one installed native package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageFileInventory {
+    /// Digest algorithm shared by the package's per-file digests.
+    pub digest_algorithm: PackageFileDigestAlgorithm,
+    /// Package-owned paths and their metadata.
+    pub files: Vec<PackageFile>,
+}
+
+/// Read-only package file query, intentionally separate from version and
+/// transaction interfaces.
+pub trait PackageFileQuery: Send + Sync {
+    /// Return the installed package's authoritative file inventory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PackageQueryError`] when the package database cannot be
+    /// queried or its output is malformed. Package absence is an error here:
+    /// callers already hold a tracked installation and must surface the drift.
+    fn query_file_inventory(
+        &self,
+        package: &str,
+    ) -> Result<PackageFileInventory, PackageQueryError>;
+}

--- a/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
+++ b/src/anolisa/crates/anolisa-platform/src/rpm_query.rs
@@ -8,6 +8,10 @@
 //! [`SystemCommandRunner`]'s `LC_ALL=C`.
 
 use crate::command::{CommandOutput, CommandRunner, SystemCommandRunner};
+use crate::pkg_files::{
+    PackageFile, PackageFileDigestAlgorithm, PackageFileInventory, PackageFileKind,
+    PackageFileQuery,
+};
 use crate::pkg_query::{PackageInfo, PackageQuery, PackageQueryError, PackageVersion};
 use crate::rpm_repo::DnfRepoSource;
 
@@ -36,6 +40,15 @@ const REPONAME_QF: &str = "%{reponame}\n";
 /// is directly usable as a package name (the default `name-version-release.arch`
 /// is not).
 const PROVIDES_NAME_QF: &str = "%{NAME}\n";
+
+/// File inventory query format.
+///
+/// RPM stores file metadata in parallel arrays. `:shescape` makes path,
+/// digest, and link-target boundaries unambiguous even when values contain
+/// tabs, newlines, quotes, or backslashes; [`parse_file_inventory`] decodes
+/// that quoting without invoking a shell. The scalar digest algorithm is the
+/// first record and the four per-file columns follow in lockstep.
+const FILE_INVENTORY_QF: &str = "%{FILEDIGESTALGO}\n[%{FILENAMES:shescape}\t%{FILEMODES}\t%{FILEDIGESTS:shescape}\t%{FILELINKTOS:shescape}\n]";
 
 const RPM: &str = "rpm";
 const DNF: &str = "dnf";
@@ -141,6 +154,133 @@ impl<R: CommandRunner> RpmPackageQuery<R> {
         }
         args.extend(command_args.iter().map(|arg| (*arg).to_string()));
         args
+    }
+}
+
+impl<R: CommandRunner + Send + Sync> PackageFileQuery for RpmPackageQuery<R> {
+    fn query_file_inventory(
+        &self,
+        package: &str,
+    ) -> Result<PackageFileInventory, PackageQueryError> {
+        let out = self
+            .runner
+            .run(RPM, &["-q", "--qf", FILE_INVENTORY_QF, package])
+            .map_err(|e| map_spawn_error(e, RPM))?;
+        if out.code != Some(0) {
+            let detail = if out.stderr.trim().is_empty() {
+                out.stdout
+            } else {
+                out.stderr
+            };
+            return Err(PackageQueryError::QueryFailed {
+                command: RPM.to_string(),
+                code: out.code,
+                stderr: detail,
+            });
+        }
+        parse_file_inventory(&out.stdout)
+    }
+}
+
+fn parse_file_inventory(stdout: &str) -> Result<PackageFileInventory, PackageQueryError> {
+    let (algorithm, rows) = stdout
+        .split_once('\n')
+        .ok_or_else(|| unexpected_file_inventory("missing digest-algorithm header"))?;
+    let algorithm = algorithm
+        .trim()
+        .parse::<u32>()
+        .map_err(|_| unexpected_file_inventory("digest algorithm is not an integer"))?;
+    let digest_algorithm = match algorithm {
+        8 => PackageFileDigestAlgorithm::Sha256,
+        other => PackageFileDigestAlgorithm::Unsupported(other),
+    };
+
+    let decoded = parse_shell_escaped_table(rows)?;
+    let mut files = Vec::with_capacity(decoded.len());
+    for fields in decoded {
+        if fields.len() != 4 {
+            return Err(unexpected_file_inventory(&format!(
+                "file row has {} columns, expected 4",
+                fields.len()
+            )));
+        }
+        let mode = fields[1]
+            .parse::<u32>()
+            .map_err(|_| unexpected_file_inventory("file mode is not an integer"))?;
+        let kind = match mode & 0o170000 {
+            0o100000 => PackageFileKind::Regular,
+            0o120000 => PackageFileKind::Symlink,
+            0o040000 => PackageFileKind::Directory,
+            _ => PackageFileKind::Other,
+        };
+        files.push(PackageFile {
+            path: fields[0].clone(),
+            kind,
+            digest: (!fields[2].is_empty()).then(|| fields[2].clone()),
+            link_target: (!fields[3].is_empty()).then(|| fields[3].clone()),
+        });
+    }
+    Ok(PackageFileInventory {
+        digest_algorithm,
+        files,
+    })
+}
+
+/// Decode RPM's `:shescape` table while treating separators inside quoted
+/// values as data. RPM emits adjacent single-quoted chunks plus backslash
+/// escapes for embedded quotes; no shell expansion is performed here.
+fn parse_shell_escaped_table(rows: &str) -> Result<Vec<Vec<String>>, PackageQueryError> {
+    let mut records = Vec::new();
+    let mut record = Vec::new();
+    let mut field = String::new();
+    let mut quoted = false;
+    let mut escaped = false;
+
+    for ch in rows.chars() {
+        if escaped {
+            field.push(ch);
+            escaped = false;
+            continue;
+        }
+        if quoted {
+            if ch == '\'' {
+                quoted = false;
+            } else {
+                field.push(ch);
+            }
+            continue;
+        }
+        match ch {
+            '\'' => quoted = true,
+            '\\' => escaped = true,
+            '\t' => record.push(std::mem::take(&mut field)),
+            '\n' => {
+                record.push(std::mem::take(&mut field));
+                if record.iter().any(|value| !value.is_empty()) {
+                    records.push(std::mem::take(&mut record));
+                } else {
+                    record.clear();
+                }
+            }
+            _ => field.push(ch),
+        }
+    }
+    if quoted || escaped {
+        return Err(unexpected_file_inventory(
+            "unterminated shell-escaped file metadata",
+        ));
+    }
+    if !field.is_empty() || !record.is_empty() {
+        record.push(field);
+        records.push(record);
+    }
+    Ok(records)
+}
+
+fn unexpected_file_inventory(detail: &str) -> PackageQueryError {
+    PackageQueryError::UnexpectedOutput {
+        command: RPM.to_string(),
+        detail: detail.to_string(),
     }
 }
 
@@ -779,6 +919,77 @@ mod tests {
             }
             other => panic!("expected QueryFailed, got {other:?}"),
         }
+    }
+
+    fn file_query(
+        stdout: &str,
+        code: Option<i32>,
+        stderr: &str,
+    ) -> RpmPackageQuery<FakeCommandRunner> {
+        RpmPackageQuery::with_runner(FakeCommandRunner {
+            rpm: Some(ok_out(code, stdout, stderr)),
+            dnf: None,
+            expected_package: "adapter-pkg".to_string(),
+            expected_args: Some(
+                ["-q", "--qf", FILE_INVENTORY_QF, "adapter-pkg"]
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect(),
+            ),
+        })
+    }
+
+    #[test]
+    fn file_inventory_parses_escaped_paths_and_symlinks() {
+        let digest = "a".repeat(64);
+        let output = format!(
+            "8\n'/opt/adapter/a'\\''b\tline\nname.py'\t33188\t'{digest}'\t''\n\
+             '/opt/adapter/current'\t41471\t''\t'../adapter/a'\\''b'\n"
+        );
+        let inventory = file_query(&output, Some(0), "")
+            .query_file_inventory("adapter-pkg")
+            .expect("file inventory");
+        assert_eq!(
+            inventory.digest_algorithm,
+            PackageFileDigestAlgorithm::Sha256
+        );
+        assert_eq!(inventory.files.len(), 2);
+        assert_eq!(inventory.files[0].path, "/opt/adapter/a'b\tline\nname.py");
+        assert_eq!(inventory.files[0].kind, PackageFileKind::Regular);
+        assert_eq!(inventory.files[0].digest.as_deref(), Some(digest.as_str()));
+        assert_eq!(inventory.files[1].kind, PackageFileKind::Symlink);
+        assert_eq!(
+            inventory.files[1].link_target.as_deref(),
+            Some("../adapter/a'b")
+        );
+    }
+
+    #[test]
+    fn file_inventory_preserves_unsupported_algorithm_for_fail_closed_callers() {
+        let inventory = file_query(
+            "1\n'/opt/adapter/hook.py'\t33188\t'deadbeef'\t''\n",
+            Some(0),
+            "",
+        )
+        .query_file_inventory("adapter-pkg")
+        .expect("query itself succeeds");
+        assert_eq!(
+            inventory.digest_algorithm,
+            PackageFileDigestAlgorithm::Unsupported(1)
+        );
+    }
+
+    #[test]
+    fn file_inventory_surfaces_empty_digest_and_nonzero_exit() {
+        let inventory = file_query("8\n'/opt/adapter/hook.py'\t33188\t''\t''\n", Some(0), "")
+            .query_file_inventory("adapter-pkg")
+            .expect("empty digest stays explicit for the integrity layer");
+        assert_eq!(inventory.files[0].digest, None);
+
+        let error = file_query("", Some(1), "rpmdb open failed")
+            .query_file_inventory("adapter-pkg")
+            .expect_err("nonzero rpm exit");
+        assert!(matches!(error, PackageQueryError::QueryFailed { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Adapter health currently hashes the whole resource tree, so runtime-generated files such as
`__pycache__/*.pyc` are reported as bundle drift even though no package-owned input changed.
This change aligns drift detection with the package manager's ownership boundary instead of
assuming that adapter directories are immutable.

## What changed

- Build one managed-file inventory from Raw ownership records or a read-only rpmdb query, and
  verify regular-file contents plus literal symlink targets.
- Persist schema-v2 source revisions and expected ANOLISA-materialized files while retaining
  `bundle_digest` only for legacy receipt migration.
- Replace whole-tree matching with tri-state managed, source-revision, and materialized-bundle
  conditions; unavailable or unsupported authoritative metadata remains `Unknown`.
- Apply the same authoritative revision comparison to post-update stale actions, and cover Cosh,
  Hermes, and OpenClaw copies without inventing a materialized condition for Qoder staging.

## Related issue

Fixes #2252

## User / Agent impact

Unmanaged runtime files no longer degrade adapter health. Modified, missing, or newly declared
managed inputs still degrade health, source-root changes still require enable, and unavailable
package metadata is reported as `Unknown` rather than healthy.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

`AdapterClaim` advances to schema 2. Schema-1 receipts are read without mutation and compare only
their current authoritative managed subset; ambiguous receipts and unavailable inventories remain
`Unknown`. The rpmdb path is read-only and rejects unsupported digest algorithms. This deliberately
does not claim that every byte used by a running process is trusted; it verifies package-managed
inputs and ANOLISA's explicitly copied outputs only.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo doc --workspace --no-deps --locked`
- `cargo test --workspace --locked --quiet -- --skip systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking`
- Raw and simulated RPM regression coverage for runtime extras, managed add/change/delete, source
  root migration, legacy receipts, symlinks, query failures, and unsupported or empty digests
- Cosh, Hermes, and OpenClaw materialized-file coverage for ignored runtime extras and changed or
  missing delivered files

A full unfiltered workspace test run passed the adapter suites but hit the existing host-dependent
systemd test above because this development host has a real `agentsight.service`; exercising that
test's enable/disable path against the real service was intentionally avoided. The filtered
workspace run passed.

## Documentation and rollback

No user documentation changed. To roll back, revert this commit; claims created with schema 2 may
need a fresh enable after rollback so the older implementation can write its legacy digest receipt.
