### PR TITLE
fix(tokenless): add _common.sh to RPM spec %install and %files

### DIFF
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -203,6 +203,7 @@ install -m 0755 adapters/tokenless/codex/scripts/tool-ready %{buildroot}%{_datad
 install -m 0755 adapters/tokenless/codex/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
+install -m 0644 adapters/tokenless/codex/scripts/_common.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 
 # Install OpenCode plugin (local JavaScript plugin + lifecycle scripts).
 install -m 0644 adapters/tokenless/opencode/plugin.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/
@@ -317,6 +318,7 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/uninstall.sh
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/_common.sh
 # OpenCode plugin — local JavaScript plugin + lifecycle scripts.
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/plugin.js
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/detect.sh


### PR DESCRIPTION
## 问题

Fixes #2420

`_common.sh` (introduced in commit 9ca77820) is sourced by `install.sh` line 45 but was never added to `tokenless.spec.in` `%install` or `%files` sections. The file is missing from the RPM, causing `install.sh` to fail at runtime with "No such file or directory".

## 修复

```diff
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -203,6 +203,7 @@
 install -m 0755 adapters/tokenless/codex/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
+install -m 0644 adapters/tokenless/codex/scripts/_common.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
@@ -317,6 +318,7 @@
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/uninstall.sh
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/_common.sh
```

Adds `_common.sh` to both `%install` (copy to buildroot) and `%files` (include in RPM payload) sections of the tokenless spec template.

## 验证

```shell
# Fresh clone + apply patch + build
cd /root && rm -rf anolisa && git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply /tmp/product-fix.patch
bash scripts/rpm-build.sh tokenless
```

实测 `scripts/rpmbuild/RPMS/x86_64/tokenless-0.7.5-1.alnx4.x86_64.rpm` (5.1M)，VERIFY_EXIT=0。
