### PR TITLE
fix(cosh): reject headless hook ask

### DIFF
--- a/src/copilot-shell/packages/cli/src/nonInteractiveCli.test.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractiveCli.test.ts
@@ -257,6 +257,62 @@ describe('runNonInteractive', () => {
     expect(mockShutdownTelemetry).toHaveBeenCalled();
   });
 
+  it('should reject hook confirmation in non-interactive mode', async () => {
+    setupMetricsMock();
+    let resolveDecision!: (confirmed: boolean) => void;
+    const resolveConfirmation = vi.fn((confirmed: boolean) => {
+      resolveDecision(confirmed);
+    });
+
+    async function* createConfirmationStream(
+      signal: AbortSignal,
+    ): AsyncGenerator<ServerGeminiStreamEvent> {
+      const confirmationPromise = new Promise<boolean>((resolve) => {
+        resolveDecision = resolve;
+      });
+      const abortPromise = new Promise<boolean>((resolve) => {
+        signal.addEventListener('abort', () => resolve(false), { once: true });
+      });
+
+      yield {
+        type: GeminiEventType.UserPromptConfirmation,
+        value: {
+          reason: 'The prompt requires approval',
+          resolve: resolveConfirmation,
+        },
+      };
+
+      if (!(await Promise.race([confirmationPromise, abortPromise]))) {
+        yield { type: GeminiEventType.UserCancelled };
+      }
+    }
+
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      (_request, signal: AbortSignal) => createConfirmationStream(signal),
+    );
+    const abortController = new AbortController();
+    const watchdog = setTimeout(() => abortController.abort(), 250);
+
+    try {
+      await expect(
+        runNonInteractive(
+          mockConfig,
+          mockSettings,
+          'Test input',
+          'prompt-id-confirmation',
+          { abortController },
+        ),
+      ).rejects.toThrow(
+        'UserPromptSubmit hook requires confirmation, which is not available in non-interactive mode: The prompt requires approval',
+      );
+    } finally {
+      clearTimeout(watchdog);
+    }
+
+    expect(resolveConfirmation).toHaveBeenCalledOnce();
+    expect(resolveConfirmation).toHaveBeenCalledWith(false);
+  });
+
   it('should handle a single tool call and respond', async () => {
     setupMetricsMock();
     const toolCallEvent: ServerGeminiStreamEvent = {

--- a/src/copilot-shell/packages/cli/src/nonInteractiveCli.ts
+++ b/src/copilot-shell/packages/cli/src/nonInteractiveCli.ts
@@ -276,6 +276,13 @@ export async function runNonInteractive(
           if (abortController.signal.aborted) {
             handleCancellationError(config);
           }
+          if (event.type === GeminiEventType.UserPromptConfirmation) {
+            event.value.resolve(false);
+            adapter.finalizeAssistantMessage();
+            throw new Error(
+              `UserPromptSubmit hook requires confirmation, which is not available in non-interactive mode: ${event.value.reason}`,
+            );
+          }
           // Handle an API error BEFORE feeding it to the adapter. Passing an
           // Error event to processEvent() would emit fresh partial assistant
           // stream events (message_start / content_block_*), and the throw


### PR DESCRIPTION
## Description

Non-interactive cosh sessions now reject `UserPromptSubmit` Hook `ask` decisions instead of waiting forever for a confirmation UI that does not exist. The CLI resolves the deferred confirmation with `false`, finalizes the output adapter, and returns an error containing the Hook reason. Interactive confirmation behavior is unchanged, and a watchdog-backed regression test covers the suspended-stream failure mode.

## Related Issue

closes #2273

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [ ] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test --locked` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Validated on macOS arm64:

- `npm run build:packages`
- `make build`
- `make lint`
- `npm run typecheck`
- `make test` (7,413 tests passed; 9 skipped)

## Additional Notes

Risk is limited to the previously unhandled non-interactive `ask` path. The safe default is denial because headless automation cannot provide user consent; interactive behavior is unchanged. No documentation update is required because this restores terminating error behavior without adding or changing commands, flags, or configuration. Rollback is a revert of commit `1071e409`.
