### PR TITLE
fix(tokenless): add missing _common.sh to RPM spec

### DIFF
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -203,6 +203,7 @@ install -m 0755 adapters/tokenless/codex/scripts/tool-ready %{buildroot}%{_datad
 install -m 0755 adapters/tokenless/codex/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
+install -m 0644 adapters/tokenless/codex/scripts/_common.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 
 # Install OpenCode plugin (local JavaScript plugin + lifecycle scripts).
 install -m 0644 adapters/tokenless/opencode/plugin.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/
@@ -317,6 +318,7 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/uninstall.sh
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/_common.sh
 # OpenCode plugin — local JavaScript plugin + lifecycle scripts.
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/plugin.js
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/detect.sh


### PR DESCRIPTION
## Summary
`_common.sh` is sourced by the Codex `install.sh` script but was never installed into the RPM buildroot or listed in `%files`. This causes `install.sh` to fail at runtime with "No such file or directory" after installing the tokenless RPM.

Add the helper to both the `%install` section (with `0644` permissions) and the `%files` section so it is packaged alongside the other Codex lifecycle scripts.

Closes #2420.

## Risk and compatibility
- Packaging-only change; no runtime code changes.
- Permissions (`0644`) match the file's read-only helper nature.

## Validation
- Verified `src/tokenless/adapters/tokenless/codex/scripts/_common.sh` exists in the source tree.
- `bash scripts/rpm-build.sh tokenless` succeeds locally and produces an RPM containing `_common.sh`.