### PR TITLE
fix(tokenless): include _common.sh in codex RPM package

### DIFF
--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -203,6 +203,7 @@ install -m 0755 adapters/tokenless/codex/scripts/tool-ready %{buildroot}%{_datad
 install -m 0755 adapters/tokenless/codex/scripts/detect.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/install.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 install -m 0755 adapters/tokenless/codex/scripts/uninstall.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
+install -m 0644 adapters/tokenless/codex/scripts/_common.sh %{buildroot}%{_datadir}/anolisa/adapters/tokenless/codex/scripts/
 
 # Install OpenCode plugin (local JavaScript plugin + lifecycle scripts).
 install -m 0644 adapters/tokenless/opencode/plugin.js %{buildroot}%{_datadir}/anolisa/adapters/tokenless/opencode/
@@ -317,6 +318,7 @@ install -m 0644 adapters/tokenless/common/commands/tokenless-stats.toml %{buildr
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/detect.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/install.sh
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/uninstall.sh
+%attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/codex/scripts/_common.sh
 # OpenCode plugin — local JavaScript plugin + lifecycle scripts.
 %attr(0644,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/plugin.js
 %attr(0755,root,root) %{_datadir}/anolisa/adapters/tokenless/opencode/scripts/detect.sh


### PR DESCRIPTION
修复 tokenless RPM 打包遗漏 _common.sh 的问题。\n\n_codex adapter 的 install.sh 第 45 行通过 source "\/_common.sh" 引用该文件，但 tokenless.spec.in 的 %install 和 %files 段未将其包含，导致安装 RPM 后运行 install.sh 报错 No such file or directory。\n\n本次改动：\n- 在 %install 段添加 _common.sh 的安装规则（0644）\n- 在 %files 段添加 _common.sh 的打包声明（0644, root, root）\n\n关联 issue：closes #2420\n\n已在本地通过 git diff 确认改动范围，仅涉及 src/tokenless/tokenless.spec.in。