### PR TITLE
fix(cosh-ng): [core] expose runtime context

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -24,7 +24,9 @@ use crate::provider::{
     ContentGenerator, GenerateConfig, GenerateEvent, Message, MAX_TOOL_CALL_INDEX,
 };
 use crate::tool::ask_user_question;
-use crate::tool::{SessionWorkspace, ToolContext, ToolKind, ToolRegistry, ToolResult};
+use crate::tool::{
+    SessionWorkspace, ToolContext, ToolKind, ToolRegistry, ToolResult, ToolRuntimeContext,
+};
 use crate::truncator::OutputTruncator;
 
 use self::tool_execution::{
@@ -65,6 +67,7 @@ pub struct CoshCore {
     /// sees the projected effective context.
     pub compaction: CompactionRuntime,
     pub model: String,
+    session_resumed: bool,
     pub shell_context: Option<ShellContext>,
     project_root: PathBuf,
     workspace: SessionWorkspace,
@@ -90,6 +93,23 @@ pub struct CoshCore {
 impl CoshCore {
     pub fn tool_names(&self) -> Vec<String> {
         self.tools.names()
+    }
+
+    pub(crate) fn set_session_resumed(&mut self, resumed: bool) {
+        self.session_resumed = resumed;
+    }
+
+    fn tool_runtime_context(&self) -> ToolRuntimeContext {
+        let snapshot = self.extension_generation.current();
+        ToolRuntimeContext {
+            model: self.model.clone(),
+            approval_mode: self.config.agent.approval_mode.to_string(),
+            session_resumed: self.session_resumed,
+            compaction_revision: self.compaction.revision(),
+            compacted_through: self.compaction.state().map(|state| state.compacted_through),
+            tools: self.tool_names(),
+            active_extensions: snapshot.active_extensions.iter().cloned().collect(),
+        }
     }
 
     pub fn emit<W: Write>(&self, writer: &mut W, msg: &OutputMessage) {
@@ -975,11 +995,12 @@ impl CoshCore {
             self.messages
                 .push(Message::assistant_with_tool_calls(&text_buf, tc_infos));
 
-            let ctx = ToolContext::with_workspace(
+            let ctx = ToolContext::with_runtime(
                 self.cwd(),
                 self.session_id.clone(),
                 self.project_root.clone(),
                 self.workspace.clone(),
+                self.tool_runtime_context(),
             );
 
             let mut interrupted = false;

--- a/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
@@ -73,6 +73,7 @@ impl CoshCore {
             messages: Vec::new(),
             compaction: CompactionRuntime::default(),
             model,
+            session_resumed: false,
             shell_context: None,
             project_root,
             workspace,

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -601,6 +601,86 @@ async fn project_context_reaches_the_provider_boundary() {
 }
 
 #[tokio::test]
+async fn provider_session_identity_stays_out_of_the_system_prompt() {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let provider = RecordingProvider {
+        messages: Arc::clone(&captured),
+        ..RecordingProvider::default()
+    };
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = ApprovalMode::Trust;
+    let mut core = CoshCore::new(config, Box::new(provider), ToolRegistry::new());
+    let provider_session_id = core.session_id.clone();
+    let mut reader = empty_reader().await;
+    let mut output = Vec::new();
+
+    core.handle_user_message("hello", &mut reader, &mut output)
+        .await
+        .unwrap();
+
+    let messages = captured.lock().unwrap();
+    let prompt = messages
+        .first()
+        .expect("provider system message")
+        .content
+        .as_text();
+    assert!(!prompt.contains(&provider_session_id));
+    assert!(!prompt.contains("provider_session_id"));
+}
+
+#[tokio::test]
+async fn runtime_context_tool_reads_live_core_state_on_demand() {
+    let mut config = CoreConfig::default();
+    config.agent.approval_mode = ApprovalMode::Recommend;
+    config.hooks.enabled = true;
+    config.ai.active_provider = Some("coding".to_string());
+    config.ai.providers.insert(
+        "coding".to_string(),
+        crate::config::ProviderConfig {
+            provider_type: Some("dashscope".to_string()),
+            model: Some("qwen-test".to_string()),
+            ..Default::default()
+        },
+    );
+    let tools = ToolRegistry::with_defaults_for_test();
+    let mut core = CoshCore::new(config, Box::new(MockProvider::new(Vec::new())), tools);
+    core.set_session_resumed(true);
+    core.compaction.load_state(None, 7);
+    // Config reload does not rebuild the bound provider or hook system. The
+    // runtime contract therefore omits those config-only identities.
+    core.config.ai.active_provider = Some("reloaded-provider".to_string());
+    core.config.hooks.enabled = false;
+    let context = ToolContext::with_runtime(
+        core.cwd(),
+        core.session_id.clone(),
+        core.project_root.clone(),
+        core.workspace.clone(),
+        core.tool_runtime_context(),
+    );
+
+    let result = core
+        .tools
+        .get("runtime_context")
+        .expect("default runtime_context tool")
+        .invoke(serde_json::json!({}), &context)
+        .await
+        .expect("runtime context output");
+    let output: serde_json::Value =
+        serde_json::from_str(&result.output).expect("runtime context JSON");
+
+    assert_eq!(output["provider_session_id"], core.session_id);
+    assert_eq!(output["model"], "qwen-test");
+    assert!(output.get("provider").is_none());
+    assert_eq!(output["approval_mode"], "recommend");
+    assert_eq!(output["session"]["resumed"], true);
+    assert_eq!(output["compaction"]["revision"], 7);
+    assert!(output["capabilities"]["tools"]
+        .as_array()
+        .is_some_and(|tools| tools.iter().any(|name| name == "runtime_context")));
+    assert!(output["capabilities"].get("hooks_enabled").is_none());
+}
+
+#[tokio::test]
 async fn raw_shell_input_reaches_prompt_hook_without_changing_provider_content() {
     let captured = Arc::new(Mutex::new(Vec::new()));
     let provider = RecordingProvider {

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -133,6 +133,7 @@ pub async fn run(
         project_root,
         workspace,
     );
+    engine.set_session_resumed(session.resumed);
     let live_extension_runtime = crate::registry::LiveExtensionRuntime::new(
         engine.extension_generation.clone(),
         args.enable_shell_evidence_tool,

--- a/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/mod.rs
@@ -8,6 +8,7 @@ mod list_directory;
 pub mod mcp;
 pub mod read_file;
 mod read_many_files;
+mod runtime_context;
 mod save_memory;
 pub mod shell;
 pub mod shell_evidence;
@@ -77,11 +78,23 @@ pub enum ToolKind {
 
 pub struct ToolContext {
     pub cwd: PathBuf,
-    #[allow(dead_code)]
     pub session_id: String,
-    #[allow(dead_code)]
     pub project_root: PathBuf,
     workspace: SessionWorkspace,
+    runtime: ToolRuntimeContext,
+}
+
+/// Runtime-owned metadata exposed to tools without placing dynamic values in
+/// the provider's cached system prompt.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ToolRuntimeContext {
+    pub(crate) model: String,
+    pub(crate) approval_mode: String,
+    pub(crate) session_resumed: bool,
+    pub(crate) compaction_revision: u64,
+    pub(crate) compacted_through: Option<usize>,
+    pub(crate) tools: Vec<String>,
+    pub(crate) active_extensions: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -154,20 +167,23 @@ impl ToolContext {
             session_id,
             project_root,
             workspace,
+            runtime: ToolRuntimeContext::default(),
         }
     }
 
-    pub(crate) fn with_workspace(
+    pub(crate) fn with_runtime(
         cwd: PathBuf,
         session_id: String,
         project_root: PathBuf,
         workspace: SessionWorkspace,
+        runtime: ToolRuntimeContext,
     ) -> Self {
         Self {
             cwd,
             session_id,
             project_root,
             workspace,
+            runtime,
         }
     }
 
@@ -286,6 +302,7 @@ impl ToolRegistry {
         registry.register(Box::new(glob::GlobTool));
         registry.register(Box::new(list_directory::ListDirectoryTool));
         registry.register(Box::new(read_many_files::ReadManyFilesTool));
+        registry.register(Box::new(runtime_context::RuntimeContextTool));
         registry.register(Box::new(save_memory::SaveMemoryTool));
         registry.register(Box::new(todo::TodoTool::new()));
         registry.register(Box::new(web_fetch::WebFetchTool::new()));
@@ -473,6 +490,7 @@ mod tests {
             "glob",
             "list_directory",
             "read_many_files",
+            "runtime_context",
             "save_memory",
             "web_fetch",
         ] {

--- a/src/cosh-ng/crates/cosh-core/src/tool/runtime_context.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/runtime_context.rs
@@ -1,0 +1,130 @@
+//! Read-only, on-demand access to the current cosh-ng runtime context.
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use super::{Tool, ToolContext, ToolKind, ToolResult};
+
+pub struct RuntimeContextTool;
+
+#[async_trait]
+impl Tool for RuntimeContextTool {
+    fn name(&self) -> &str {
+        "runtime_context"
+    }
+
+    fn description(&self) -> &str {
+        "Return read-only metadata for the current cosh-ng runtime, model, session, workspace, compaction state, and bound capabilities. Use this tool when another command needs the exact provider_session_id; never infer that ID from shell environment variables."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    fn kind(&self) -> ToolKind {
+        ToolKind::ReadOnly
+    }
+
+    async fn invoke(&self, _params: Value, ctx: &ToolContext) -> Result<ToolResult, String> {
+        let payload = json!({
+            "provider_session_id": ctx.session_id,
+            "runtime": {
+                "name": "cosh-ng",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+            "model": ctx.runtime.model,
+            "approval_mode": ctx.runtime.approval_mode,
+            "workspace": {
+                "cwd": ctx.cwd.to_string_lossy(),
+                "project_root": ctx.project_root.to_string_lossy(),
+            },
+            "session": {
+                "resumed": ctx.runtime.session_resumed,
+            },
+            "compaction": {
+                "revision": ctx.runtime.compaction_revision,
+                "active_projection": ctx.runtime.compacted_through.is_some(),
+                "compacted_through": ctx.runtime.compacted_through,
+            },
+            "capabilities": {
+                "tools": ctx.runtime.tools,
+                "active_extensions": ctx.runtime.active_extensions,
+            },
+        });
+
+        Ok(ToolResult::success(
+            serde_json::to_string_pretty(&payload)
+                .map_err(|error| format!("failed to serialize runtime context: {error}"))?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::tool::{SessionWorkspace, ToolRuntimeContext};
+
+    #[tokio::test]
+    async fn returns_current_runtime_metadata() {
+        let project_root = PathBuf::from("/workspace/project");
+        let context = ToolContext::with_runtime(
+            project_root.join("src"),
+            "provider-session-123".to_string(),
+            project_root.clone(),
+            SessionWorkspace::new(&project_root),
+            ToolRuntimeContext {
+                model: "qwen-test".to_string(),
+                approval_mode: "recommend".to_string(),
+                session_resumed: true,
+                compaction_revision: 3,
+                compacted_through: Some(42),
+                tools: vec!["runtime_context".to_string(), "shell".to_string()],
+                active_extensions: vec!["agent-sec-core".to_string()],
+            },
+        );
+
+        let result = RuntimeContextTool
+            .invoke(json!({}), &context)
+            .await
+            .expect("runtime context");
+        let output: Value = serde_json::from_str(&result.output).expect("JSON output");
+
+        assert!(!result.is_error);
+        assert_eq!(output["provider_session_id"], "provider-session-123");
+        assert_eq!(output["runtime"]["name"], "cosh-ng");
+        assert_eq!(output["runtime"]["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(output["model"], "qwen-test");
+        assert!(output.get("provider").is_none());
+        assert_eq!(output["approval_mode"], "recommend");
+        assert_eq!(output["workspace"]["cwd"], "/workspace/project/src");
+        assert_eq!(output["workspace"]["project_root"], "/workspace/project");
+        assert_eq!(output["session"]["resumed"], true);
+        assert_eq!(output["compaction"]["revision"], 3);
+        assert_eq!(output["compaction"]["active_projection"], true);
+        assert_eq!(output["compaction"]["compacted_through"], 42);
+        assert_eq!(
+            output["capabilities"]["tools"],
+            json!(["runtime_context", "shell"])
+        );
+        assert_eq!(
+            output["capabilities"]["active_extensions"],
+            json!(["agent-sec-core"])
+        );
+        assert!(output["capabilities"].get("hooks_enabled").is_none());
+    }
+
+    #[test]
+    fn is_read_only_and_takes_no_parameters() {
+        let tool = RuntimeContextTool;
+
+        assert_eq!(tool.kind(), ToolKind::ReadOnly);
+        assert_eq!(tool.parameters_schema()["properties"], json!({}));
+        assert_eq!(tool.parameters_schema()["additionalProperties"], false);
+    }
+}

--- a/src/cosh-ng/crates/cosh-platform/src/audit.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/audit.rs
@@ -65,7 +65,7 @@ impl AuditTestDir {
 /// Call-site identity captured for a policy audit event.
 #[derive(Debug, Clone)]
 pub struct CallerInfo {
-    /// Provider/session correlation identifier.
+    /// Shell/terminal correlation identifier, with a process-scoped fallback.
     pub session_id: String,
     /// Local user label used only by legacy call sites, never persisted in v1.
     pub user: String,
@@ -91,9 +91,7 @@ impl CallerInfo {
                     .filter(|value| !value.is_empty())
             })
             .unwrap_or_else(|| "unknown".to_string());
-        let session_id = std::env::var("COSH_SESSION_ID")
-            .ok()
-            .filter(|value| !value.is_empty())
+        let session_id = detected_shell_session_id()
             .unwrap_or_else(|| format!("p{}-t{}", std::process::id(), Utc::now().timestamp()));
         let sudo_user = std::env::var("SUDO_USER")
             .ok()
@@ -107,6 +105,12 @@ impl CallerInfo {
             pid: std::process::id(),
         }
     }
+}
+
+fn detected_shell_session_id() -> Option<String> {
+    std::env::var("COSH_SESSION_ID")
+        .ok()
+        .filter(|value| !value.is_empty())
 }
 
 /// Runs a full policy evaluation and durably records its decision.
@@ -155,6 +159,7 @@ fn record_to_log(
     source: LogSource,
 ) -> Result<(), CoshError> {
     let redacted = redact::redact_action(&mut action);
+    let shell_session_id = detected_shell_session_id();
     let caller = CallerInfo::detect();
     let root = config::resolve_audit_root()?;
     let component = match source {
@@ -194,7 +199,7 @@ fn record_to_log(
             version: env!("CARGO_PKG_VERSION").to_string(),
         },
         AuditIdentity {
-            provider_session_id: Some(caller.session_id),
+            shell_session_id,
             ..AuditIdentity::default()
         },
         AuditActor {
@@ -250,22 +255,37 @@ mod tests {
 
     struct AuditEnvGuard {
         directory: AuditTestDir,
+        original_audit_dir: Option<std::ffi::OsString>,
+        original_shell_session_id: Option<std::ffi::OsString>,
         _lock: MutexGuard<'static, ()>,
     }
 
     fn temp_audit_env() -> AuditEnvGuard {
         let lock = env_lock();
         let directory = AuditTestDir::create();
+        let original_audit_dir = std::env::var_os("COSH_AUDIT_DIR");
+        let original_shell_session_id = std::env::var_os("COSH_SESSION_ID");
         std::env::set_var("COSH_AUDIT_DIR", directory.path());
         AuditEnvGuard {
             directory,
+            original_audit_dir,
+            original_shell_session_id,
             _lock: lock,
         }
     }
 
     impl Drop for AuditEnvGuard {
         fn drop(&mut self) {
-            std::env::remove_var("COSH_AUDIT_DIR");
+            if let Some(value) = &self.original_audit_dir {
+                std::env::set_var("COSH_AUDIT_DIR", value);
+            } else {
+                std::env::remove_var("COSH_AUDIT_DIR");
+            }
+            if let Some(value) = &self.original_shell_session_id {
+                std::env::set_var("COSH_SESSION_ID", value);
+            } else {
+                std::env::remove_var("COSH_SESSION_ID");
+            }
         }
     }
 
@@ -291,10 +311,43 @@ mod tests {
     }
 
     #[test]
+    fn policy_event_records_cosh_session_as_shell_identity() {
+        let guard = temp_audit_env();
+        std::env::set_var("COSH_SESSION_ID", "raw-session-identity-test");
+
+        check(package_install(), LogSource::Cli, &builtin::balanced()).unwrap();
+
+        let read = reader::read_all(guard.directory.path(), false).unwrap();
+        let identity = &read.events[0].event.identity;
+        assert_eq!(
+            identity.shell_session_id.as_deref(),
+            Some("raw-session-identity-test")
+        );
+        assert_eq!(identity.provider_session_id, None);
+    }
+
+    #[test]
     fn caller_info_detection_is_infallible() {
+        let _guard = temp_audit_env();
+        std::env::remove_var("COSH_SESSION_ID");
+
         let info = CallerInfo::detect();
+
         assert!(!info.session_id.is_empty());
         assert!(!info.user.is_empty());
+    }
+
+    #[test]
+    fn policy_event_omits_missing_session_identities() {
+        let guard = temp_audit_env();
+        std::env::remove_var("COSH_SESSION_ID");
+
+        check(package_install(), LogSource::Cli, &builtin::balanced()).unwrap();
+
+        let read = reader::read_all(guard.directory.path(), false).unwrap();
+        let identity = &read.events[0].event.identity;
+        assert_eq!(identity.shell_session_id, None);
+        assert_eq!(identity.provider_session_id, None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Security-event queries need the provider session UUID recorded by sec-core hooks. `COSH_SESSION_ID` identifies the shell/terminal instead, while embedding the provider UUID in every system prompt would make the DashScope explicit-cache block session-specific.

## What changed

- Added the read-only `runtime_context` tool. It returns the current provider session ID, cosh-ng name/version, bound model, approval mode, workspace paths, resume state, compaction revision, bound tools, and active extensions.
- Kept all dynamic runtime values out of the system prompt so provider prefix caching remains reusable across sessions. The tool reads live bound runtime state and requires no shell or terminal evidence.
- Omitted config-derived provider name/type and hook state because reload can change configuration without rebuilding the bound provider or hook system.
- Classified `COSH_SESSION_ID` only as `shell_session_id` in policy audit records and corrected the retained `CallerInfo` documentation.
- Defined the sec-core integration contract: `security-observability` should call `runtime_context`, pass its top-level `provider_session_id` explicitly to `agent-sec-cli events` or `observability report`, and never substitute `COSH_SESSION_ID` or silently widen to `--last`.

## Related issue

Part of #2387

## User / Agent impact

Agents can retrieve current runtime and conversation identity on demand without asking the user to copy `/session status`. Security queries remain explicit and unambiguous under concurrent sessions.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The change adds one default read-only tool and fixes an audit identity classification. Existing session, hook, CLI, and shell identifiers are unchanged. The sec-core consumer is being developed in #2245; older runtimes remain compatible through its documented user-provided session-ID fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cosh-core --bin cosh-core runtime_context` — 8 passed
- `cargo test -p cosh-core --bin cosh-core provider_session_identity_stays_out_of_the_system_prompt` — 1 passed
- `cargo test -p cosh-platform policy_event_` — 3 passed
- `cargo clippy -p cosh-core --bin cosh-core --tests -- -D warnings`
- `git diff --check`

The runtime-context regression mutates reloadable provider and hook configuration after construction and verifies that the tool does not report those unbound values. Full workspace coverage is intentionally delegated to CI under the cosh-ng scoped-validation policy.

## Documentation and rollback

The tool declaration is self-describing; the sec-core Skill contract is owned by #2245. Roll back by reverting this commit, after which users can still provide the UUID from `/session status` explicitly.