### PR TITLE
fix(tokenless): promote comparability caveat to H2 in L2 report

### DIFF
--- a/src/tokenless/benchmark/l2-module/src/l2/report.rs
+++ b/src/tokenless/benchmark/l2-module/src/l2/report.rs
@@ -508,7 +508,7 @@ impl Report {
             .filter(|c| c.input_asymmetry.is_some())
             .collect();
         if !asymmetric.is_empty() {
-            md.push_str("### Not directly comparable\n\n");
+            md.push_str("## Not directly comparable\n\n");
             for cat in asymmetric {
                 md.push_str(&format!(
                     "- **{}**: {}\n",


### PR DESCRIPTION
> **Rebase note (2026-08-22)**: The retention-missing feature this branch originally carried was merged to `main` separately via #2433 (`af17e862`), so that commit was dropped during conflict resolution. What remains here is the single follow-up commit that promotes the "Not directly comparable" caveat to H2.
>
> **Body updated (2026-09-09)**: the Summary / Test plan below now describe only the current diff (1 file, +1/-1); the entries for the already-merged retention feature were removed.

## Summary

`Report::to_markdown` in `src/tokenless/benchmark/l2-module/src/l2/report.rs` emitted the non-comparability caveat as an H3 (`### Not directly comparable`). The section right before it — `## Retention missing items` — is an H2 that uses H3 for its own per-category/per-side subsections, so the caveat rendered as though it belonged to that retention section instead of standing on its own.

- `report.rs:511`: `### Not directly comparable` -> `## Not directly comparable`, matching its sibling top-level sections (`## Retention missing items`, `## Paired compression gap`, `## Task-level totals`, `## Degradations`, `## Quality gate`)
- No behavioural change: the display condition (`!asymmetric.is_empty()`), the caveat wording, the per-category bullet list and all statistics are untouched
- The quality-gate note that points readers at this section (`report.rs:580`) is plain text — `See "Not directly comparable".` — not an anchor link, so it stays valid

## Test plan

Environment: Linux x86_64, rustc/cargo 1.96.0, crate `tokenless-l2-bench` v0.7.1 (standalone workspace at `src/tokenless/benchmark/l2-module`).

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0, no warnings
- [x] `cargo test --all-targets` — 42 passed / 0 failed / 0 ignored (`l2_compare` bin 7, `l2_protocol` 9, `l2_retention` 12, `l2_samples` 6, `l2_stats` 8)
- [x] Targeted render check (throwaway local test, deliberately not part of this PR): built a minimal `Report` holding one category with `input_asymmetry` set plus retention-missing items, rendered `to_markdown()` and asserted that (a) `## Not directly comparable` is present, (b) no `### Not directly comparable` remains, (c) the section order is `## Retention missing items` -> `## Not directly comparable` -> `## Paired compression gap`, and (d) the `See "Not directly comparable".` cross reference is still emitted. Reverting line 511 back to `###` makes the same check fail, so the assertions really do cover this change.
- [x] CI on head `963ce93`: 21 check runs — 7 success, 14 skipped (other components), 0 failed; CLA status success
- Not run: a full end-to-end L2 benchmark (requires the headroom worker and a live probe model). The change only affects a markdown heading level, which the render check above exercises directly.
