### PR TITLE
fix(tokenless): allow external data dirs

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -71,9 +71,9 @@ An environment override still wins after these commands. For example, `TOKENLESS
 | `TOKENLESS_STATS_ENABLED` | Override local statistics | Does not affect SLS or Stash |
 | `TOKENLESS_SLS_ENABLED` | Override SLS metrics | Does not affect local statistics |
 | `TOKENLESS_COMPRESSION_ENABLED` | Override active compression | False is dry-run, not a full stop |
-| `TOKENLESS_DATA_DIR` | Directory containing `stats.db` and `stash.db` | Absolute path under the real user home |
-| `TOKENLESS_STATS_DB` | Override the statistics database | The CLI and bundled RTK writer validate the real-user-home boundary and ignore an invalid value |
-| `TOKENLESS_STASH_DB` | Override the Stash database | Must be under the real user home |
+| `TOKENLESS_DATA_DIR` | Directory containing `stats.db` and `stash.db` | Any accessible absolute directory except filesystem root; no parent traversal |
+| `TOKENLESS_STATS_DB` | Override the statistics database | Must be under the real user home or selected data directory |
+| `TOKENLESS_STASH_DB` | Override the Stash database | Must be under the real user home or selected data directory |
 | `TOKENLESS_SLS_PATH` | Override the SLS JSONL path | Must be under `/var/log/` or `/tmp/` |
 
 ### Adapter and diagnostic variables
@@ -94,9 +94,9 @@ Database path priority is:
 - Stats: `TOKENLESS_STATS_DB` > `TOKENLESS_DATA_DIR/stats.db` > `~/.tokenless/stats.db`
 - Stash: `--stash-db` > `TOKENLESS_STASH_DB` > `TOKENLESS_DATA_DIR/stash.db` > `~/.tokenless/stash.db`
 
-Both the CLI and bundled RTK writer validate Stats paths against the real user home. An invalid `TOKENLESS_STATS_DB` is skipped; `TOKENLESS_DATA_DIR` is used only when it passes the same boundary check, otherwise the default path is used.
+`TOKENLESS_DATA_DIR` is an explicit directory-level relocation and may point outside the real user home, including to a managed service directory under `/var/lib`. Both the CLI and bundled RTK writer reject filesystem root, relative paths, parent traversal, and existing non-directory targets. Without a valid higher-priority file override, an invalid explicit data directory disables that operation's SQLite state instead of silently falling back to home.
 
-An empty value is treated as unset. `TOKENLESS_DATA_DIR` may name a directory that does not exist yet; Tokenless creates it after validating its nearest existing ancestor. It does not relocate `~/.tokenless/config.json` or the SLS JSONL output.
+An empty value is treated as unset. `TOKENLESS_DATA_DIR` may name a directory that does not exist yet; Tokenless canonicalizes its nearest existing ancestor before creating it. File-level overrides are accepted only beneath the canonical real home or selected data directory, and existing database symlinks are rejected. `TOKENLESS_DATA_DIR` does not relocate `~/.tokenless/config.json` or the SLS JSONL output.
 
 ## Local and external data
 
@@ -124,7 +124,7 @@ ls -l ~/.tokenless/stats.db*
 
 ### Sensitivity of Stash
 
-Stash saves the original content removed by truncation, not a summary. It does not save fields removed solely because they are blacklisted, `null`, or empty. Its path is restricted to the real user home by the `tokenless` CLI, but also verify that the database and SQLite sidecar files are not readable by other local users:
+Stash saves the original content removed by truncation, not a summary. It does not save fields removed solely because they are blacklisted, `null`, or empty. The `tokenless` CLI restricts its path to the real user home or selected data directory, but also verify that the database and SQLite sidecar files are not readable by other local users:
 
 ```bash
 ls -l ~/.tokenless/stash.db*

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -116,7 +116,9 @@ Run a task that actually passes through a hook, such as a shell command with vis
 env | grep '^TOKENLESS_'
 ```
 
-Confirm that `TOKENLESS_STATS_ENABLED=0` is not set unexpectedly and that any custom database path remains under the real user home.
+Confirm that `TOKENLESS_STATS_ENABLED=0` is not set unexpectedly and that any
+custom database path remains under the real user home or selected data
+directory.
 
 ## Adapter enable fails
 
@@ -202,7 +204,7 @@ ls -l ~/.tokenless/stats.db*
 env | grep -E 'TOKENLESS_(DATA_DIR|STATS_DB|STASH_DB)='
 ```
 
-Confirm that the current user can write the selected data directory and database. The `tokenless` CLI accepts `TOKENLESS_DATA_DIR`, `TOKENLESS_STATS_DB`, and `TOKENLESS_STASH_DB` only under the real user home and falls back when an override is rejected. The bundled RTK statistics writer uses `TOKENLESS_STATS_DB` directly, so remove or correct an unexpected override in the agent environment as well.
+Confirm that the current user can write the selected data directory and database. `TOKENLESS_DATA_DIR` may be outside the real home, but it must be an absolute non-root directory without parent traversal. An invalid explicit data directory does not fall back to home. `TOKENLESS_STATS_DB` and `TOKENLESS_STASH_DB` must remain under the real home or selected data directory; the bundled RTK writer applies the same rule.
 
 Do not share one `stats.db` between users. AgentSight and Tokenless should run so that they can access the same user's database.
 

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -71,9 +71,9 @@ tokenless stats disable
 | `TOKENLESS_STATS_ENABLED` | 覆盖本地统计开关 | 不影响 SLS 或 Stash |
 | `TOKENLESS_SLS_ENABLED` | 覆盖 SLS 度量开关 | 不影响本地统计 |
 | `TOKENLESS_COMPRESSION_ENABLED` | 覆盖真实压缩开关 | false 是 dry-run，不是完全停用 |
-| `TOKENLESS_DATA_DIR` | 存放 `stats.db` 和 `stash.db` 的目录 | 须为真实用户 home 下的绝对路径 |
-| `TOKENLESS_STATS_DB` | 覆盖统计数据库路径 | CLI 和随包 RTK 写入器都会校验真实用户 home 边界，并忽略无效值 |
-| `TOKENLESS_STASH_DB` | 覆盖 Stash 数据库路径 | 必须位于真实用户 home 下 |
+| `TOKENLESS_DATA_DIR` | 存放 `stats.db` 和 `stash.db` 的目录 | 可访问的任意绝对目录，但不能是文件系统根目录或包含父目录遍历 |
+| `TOKENLESS_STATS_DB` | 覆盖统计数据库路径 | 必须位于真实用户 home 或选定的数据目录下 |
+| `TOKENLESS_STASH_DB` | 覆盖 Stash 数据库路径 | 必须位于真实用户 home 或选定的数据目录下 |
 | `TOKENLESS_SLS_PATH` | 覆盖 SLS JSONL 路径 | 必须位于 `/var/log/` 或 `/tmp/` 下 |
 
 ### Adapter 和诊断变量
@@ -94,9 +94,9 @@ tokenless stats disable
 - 统计库：`TOKENLESS_STATS_DB` > `TOKENLESS_DATA_DIR/stats.db` > `~/.tokenless/stats.db`
 - stash 库：`--stash-db` > `TOKENLESS_STASH_DB` > `TOKENLESS_DATA_DIR/stash.db` > `~/.tokenless/stash.db`
 
-CLI 和随包 RTK 写入器都会按真实用户 home 校验 Stats 路径。无效的 `TOKENLESS_STATS_DB` 会被跳过；`TOKENLESS_DATA_DIR` 也必须通过相同的边界校验，否则使用默认路径。
+`TOKENLESS_DATA_DIR` 是显式的目录级迁移配置，可以指向真实用户 home 之外，包括 `/var/lib` 下由服务管理的目录。CLI 和随包 RTK 写入器都会拒绝文件系统根目录、相对路径、父目录遍历以及已存在的非目录目标。若没有有效的更高优先级文件覆盖项，显式数据目录无效时会停用本次操作的 SQLite 状态，不会静默回退到 home。
 
-空值视为未设置。`TOKENLESS_DATA_DIR` 可以指向尚不存在的目录；Tokenless 会先校验其最近的已存在父目录，再创建目标目录。该变量不会迁移 `~/.tokenless/config.json` 或 SLS JSONL 输出。
+空值视为未设置。`TOKENLESS_DATA_DIR` 可以指向尚不存在的目录；Tokenless 会先规范化其最近的已存在父目录，再创建目标目录。文件级覆盖项只能位于规范化后的真实用户 home 或选定的数据目录下，且已存在的数据库软链接会被拒绝。该变量不会迁移 `~/.tokenless/config.json` 或 SLS JSONL 输出。
 
 ## 本地与外部数据
 
@@ -124,7 +124,7 @@ ls -l ~/.tokenless/stats.db*
 
 ### Stash 的敏感性
 
-Stash 保存压缩时被截断的原始内容，而不是摘要。仅因字段在黑名单中、值为 `null` 或为空而被移除的内容不会写入 Stash。`tokenless` CLI 会把路径限制在真实用户 home 下，但仍应确认数据库及 SQLite sidecar 文件不会被其他本机用户读取：
+Stash 保存压缩时被截断的原始内容，而不是摘要。仅因字段在黑名单中、值为 `null` 或为空而被移除的内容不会写入 Stash。`tokenless` CLI 会把路径限制在真实用户 home 或选定的数据目录下，但仍应确认数据库及 SQLite sidecar 文件不会被其他本机用户读取：
 
 ```bash
 ls -l ~/.tokenless/stash.db*

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -114,7 +114,7 @@ anolisa adapter status tokenless
 env | grep '^TOKENLESS_'
 ```
 
-确认没有意外设置 `TOKENLESS_STATS_ENABLED=0`，并检查自定义数据库路径是否仍位于真实用户 home 下。
+确认没有意外设置 `TOKENLESS_STATS_ENABLED=0`，并检查自定义数据库路径是否仍位于真实用户 home 或选定的数据目录下。
 
 ## Adapter 启用失败
 
@@ -199,7 +199,7 @@ ls -l ~/.tokenless/stats.db*
 env | grep -E 'TOKENLESS_(DATA_DIR|STATS_DB|STASH_DB)='
 ```
 
-确认当前用户对选定的数据目录和数据库可写。`tokenless` CLI 只接受真实用户 home 下的 `TOKENLESS_DATA_DIR`、`TOKENLESS_STATS_DB` 和 `TOKENLESS_STASH_DB`，覆盖值被拒绝时会回退。随包提供的 RTK 统计写入器会直接使用 `TOKENLESS_STATS_DB`，因此也要移除或修正 Agent 环境中的异常覆盖值。
+确认当前用户对选定的数据目录和数据库可写。`TOKENLESS_DATA_DIR` 可以位于真实用户 home 之外，但必须是不包含父目录遍历的绝对非根目录；显式数据目录无效时不会回退到 home。`TOKENLESS_STATS_DB` 和 `TOKENLESS_STASH_DB` 必须位于真实用户 home 或选定的数据目录下，随包 RTK 写入器也执行相同规则。
 
 不要让多个用户共享同一个 `stats.db`。AgentSight 和 Tokenless 应以能访问同一用户数据库的方式运行。
 

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -258,10 +258,12 @@ Tokenless stores statistics and reversible-compression data in
 export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 ```
 
-The directory must be an absolute path under the real user home. The existing
-`TOKENLESS_STATS_DB`, `TOKENLESS_STASH_DB`, and `--stash-db` overrides take
-precedence when only one database needs a custom path. Configuration remains
-at `~/.tokenless/config.json`.
+The directory may be any absolute path the current user can access, including
+a managed service directory under `/var/lib`; filesystem root, relative paths,
+and parent traversal are rejected. The existing `TOKENLESS_STATS_DB`,
+`TOKENLESS_STASH_DB`, and `--stash-db` overrides take precedence but must stay
+under the real user home or selected data directory. Configuration remains at
+`~/.tokenless/config.json`.
 
 ## copilot-shell Hooks
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -191,9 +191,11 @@ Tokenless 默认将统计数据和可逆压缩数据分别存储在
 export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 ```
 
-该目录必须是位于真实用户 home 下的绝对路径。若只需自定义一个数据库，
-现有的 `TOKENLESS_STATS_DB`、`TOKENLESS_STASH_DB` 和 `--stash-db` 覆盖项
-优先级更高。配置文件仍位于 `~/.tokenless/config.json`。
+该目录可以是当前用户有权访问的任意绝对路径，包括 `/var/lib` 下由服务管理
+的目录；文件系统根目录、相对路径和父目录遍历会被拒绝。若只需自定义一个
+数据库，现有的 `TOKENLESS_STATS_DB`、`TOKENLESS_STASH_DB` 和 `--stash-db`
+覆盖项优先级更高，但必须位于真实用户 home 或选定的数据目录下。配置文件
+仍位于 `~/.tokenless/config.json`。
 
 ## 架构
 

--- a/src/tokenless/adapters/tokenless/codex/README.md
+++ b/src/tokenless/adapters/tokenless/codex/README.md
@@ -101,8 +101,9 @@ Configuration is managed through the `tokenless` CLI's environment and config fi
 | `TOKENLESS_STASH_DB` | `~/.tokenless/stash.db` | Reversible stash database path |
 
 `TOKENLESS_STATS_DB` and `TOKENLESS_STASH_DB` take precedence over
-`TOKENLESS_DATA_DIR`. Custom database paths must remain under the real user
-home.
+`TOKENLESS_DATA_DIR`, which may be any accessible absolute non-root directory.
+Custom database files must remain under the real user home or selected data
+directory.
 
 ### View Statistics
 

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -5,6 +5,7 @@ mod mcp;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::fs;
 use std::io::{self, IsTerminal as _, Read};
+use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
 use tokenless_ccr::{SqliteStore, StashStore, extract_hash, is_valid_hash};
@@ -12,11 +13,12 @@ use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 use tokenless_stats::{
     CompressionMode, DiffSort, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
 };
-use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
 use tokenless_stats::{
-    format_compare, format_compare_json, format_diff_report, format_list, format_show,
-    format_summary, record_report, session_report, tool_use_report,
+    ensure_state_dir, format_compare, format_compare_json, format_diff_report, format_list,
+    format_show, format_summary, record_report, resolve_data_dir, session_report, tool_use_report,
+    validate_database_path,
 };
+use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
 
 #[derive(Parser)]
 #[command(
@@ -54,7 +56,7 @@ enum Commands {
         no_stash: bool,
         /// Override the stash database path. Defaults to
         /// $TOKENLESS_DATA_DIR/stash.db or ~/.tokenless/stash.db.
-        /// Resolved under the trusted home directory; rejected if outside.
+        /// Must remain under the real home or selected data directory.
         #[arg(long)]
         stash_db: Option<String>,
     },
@@ -87,7 +89,7 @@ enum Commands {
         no_stash: bool,
         /// Override the stash database path. Defaults to
         /// $TOKENLESS_DATA_DIR/stash.db or ~/.tokenless/stash.db.
-        /// Resolved under the trusted home directory; rejected if outside.
+        /// Must remain under the real home or selected data directory.
         #[arg(long)]
         stash_db: Option<String>,
     },
@@ -314,75 +316,15 @@ pub fn get_home_dir() -> String {
     tokenless_stats::get_home_dir()
 }
 
-/// Validate a custom tokenless data directory against the user's home.
-///
-/// Unlike database file overrides, the directory may not exist yet. The
-/// nearest existing ancestor is canonicalized so a symlink cannot redirect
-/// the eventual directory outside the trusted home. Validation and later
-/// directory creation are separate filesystem operations, so callers must
-/// not treat this check as protection from concurrent path replacement.
-fn validate_data_dir_path(env_path: &str, home: &str) -> Result<String, String> {
-    if home.is_empty() {
-        return Err("no trusted home directory available".to_string());
-    }
-
-    let canonical_home = std::path::Path::new(home)
-        .canonicalize()
-        .map_err(|e| format!("home directory '{}' cannot be resolved: {}", home, e))?;
-    let candidate = std::path::Path::new(env_path);
-    if !candidate.is_absolute() {
-        return Err(format!("path '{}' is not absolute", env_path));
-    }
-    if candidate
-        .components()
-        .any(|component| matches!(component, std::path::Component::ParentDir))
-    {
-        return Err(format!("path '{}' contains parent traversal", env_path));
-    }
-    if candidate.exists() && !candidate.is_dir() {
-        return Err(format!("path '{}' is not a directory", env_path));
-    }
-
-    let mut existing_ancestor = candidate;
-    while !existing_ancestor.exists() {
-        existing_ancestor = existing_ancestor
-            .parent()
-            .ok_or_else(|| format!("path '{}' has no existing ancestor to validate", env_path))?;
-    }
-    let resolved_ancestor = existing_ancestor
-        .canonicalize()
-        .map_err(|e| format!("path '{}' cannot be resolved: {}", env_path, e))?;
-    if !resolved_ancestor.starts_with(&canonical_home) {
-        return Err(format!(
-            "path '{}' is outside home directory '{}'",
-            env_path, home
-        ));
-    }
-
-    Ok(env_path.to_string())
-}
-
 /// Resolve the directory containing tokenless SQLite databases.
 ///
-/// `TOKENLESS_DATA_DIR` affects `stats.db` and `stash.db` only. Invalid
-/// overrides are ignored in favor of the existing `~/.tokenless` default.
-/// Returns an error when no trusted home anchor exists.
-fn get_data_dir(home: &str) -> Result<String, String> {
-    if home.is_empty() {
-        return Err("no trusted home directory available".to_string());
-    }
-
-    let data_dir = match std::env::var("TOKENLESS_DATA_DIR") {
-        Ok(env_path) if !env_path.is_empty() => match validate_data_dir_path(&env_path, home) {
-            Ok(path) => path,
-            Err(reason) => {
-                eprintln!("[tokenless] ignoring TOKENLESS_DATA_DIR: {}", reason);
-                format!("{}/.tokenless", home)
-            }
-        },
-        _ => format!("{}/.tokenless", home),
-    };
-    Ok(data_dir)
+/// `TOKENLESS_DATA_DIR` affects `stats.db` and `stash.db` only and may be an
+/// absolute directory outside the real home. An invalid explicit override is
+/// returned as an error so state never silently moves back to the default.
+fn get_data_dir(home: &str) -> Result<PathBuf, String> {
+    let override_path = std::env::var("TOKENLESS_DATA_DIR").ok();
+    let home = (!home.is_empty()).then(|| Path::new(home));
+    resolve_data_dir(home, override_path.as_deref()).map_err(|error| error.to_string())
 }
 
 // Lazily snapshot path inputs for one command so stats and stash share the
@@ -390,7 +332,7 @@ fn get_data_dir(home: &str) -> Result<String, String> {
 #[derive(Default)]
 struct DatabasePathResolver {
     home: std::sync::OnceLock<String>,
-    data_dir: std::sync::OnceLock<Result<String, String>>,
+    data_dir: std::sync::OnceLock<Result<PathBuf, String>>,
 }
 
 impl DatabasePathResolver {
@@ -398,101 +340,51 @@ impl DatabasePathResolver {
         self.home.get_or_init(get_home_dir)
     }
 
-    fn data_dir(&self) -> Result<&str, &str> {
+    fn data_dir(&self) -> Result<&Path, &str> {
         self.data_dir
             .get_or_init(|| get_data_dir(self.home()))
             .as_ref()
-            .map(String::as_str)
+            .map(PathBuf::as_path)
             .map_err(String::as_str)
     }
 }
 
 /// Resolve the database path. When `TOKENLESS_STATS_DB` is set, the path
-/// is validated to ensure it resides under the user's home directory;
+/// is validated against the user's home and selected data directory;
 /// otherwise `TOKENLESS_DATA_DIR` and then the default data directory are
-/// used. This prevents an attacker from redirecting the database to a
-/// system-critical location (e.g. `/etc/evil.db`).
-fn get_db_path_with(paths: &DatabasePathResolver) -> String {
+/// used.
+fn get_db_path_with(paths: &DatabasePathResolver) -> Result<PathBuf, String> {
     let home = paths.home();
-    // When no trusted home is available (empty string from passwd lookup
-    // failure), return a path that will safely fail on open/create rather
-    // than silently writing to / or CWD.
-    if home.is_empty() {
-        eprintln!("[tokenless] no home directory available — stats DB writes disabled");
-        return "/dev/null/.tokenless/stats.db".to_string();
-    }
+    let data_dir = paths.data_dir();
     match std::env::var("TOKENLESS_STATS_DB") {
-        Ok(env_path) if !env_path.is_empty() => match validate_db_path(&env_path, home) {
-            Ok(path) => return path,
-            Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {}", reason),
-        },
+        Ok(env_path) if !env_path.is_empty() => {
+            match validate_db_path(Path::new(&env_path), home, data_dir.ok()) {
+                Ok(path) => return Ok(path),
+                Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {}", reason),
+            }
+        }
         _ => {}
     }
-    let data_dir = match paths.data_dir() {
-        Ok(path) => path,
-        Err(reason) => {
-            eprintln!("[tokenless] {} — stats DB writes disabled", reason);
-            return "/dev/null/.tokenless/stats.db".to_string();
-        }
-    };
-    std::path::Path::new(&data_dir)
-        .join("stats.db")
-        .to_string_lossy()
-        .into_owned()
+    let data_dir = data_dir.map_err(str::to_string)?;
+    let path = data_dir.join("stats.db");
+    validate_db_path(&path, home, Some(data_dir))
 }
 
-/// Validate a TOKENLESS_STATS_DB candidate against the user's home directory.
-/// Returns the original path on success, or a human-readable rejection reason.
-///
-/// Extracted from `get_db_path` so unit tests can exercise the bypass paths
-/// (ParentDir traversal, nonexistent parents, missing home anchor) without
-/// mutating process-wide env vars.
-fn validate_db_path(env_path: &str, home: &str) -> Result<String, String> {
-    // Reject when we have no trusted home anchor:
-    // Path::starts_with("") returns true for every path, which would
-    // let an attacker point the database at any system location.
-    if home.is_empty() {
-        return Err("no trusted home directory available".to_string());
+/// Validate a file-level override against the real home and selected data dir.
+fn validate_db_path(path: &Path, home: &str, data_dir: Option<&Path>) -> Result<PathBuf, String> {
+    let mut roots = Vec::with_capacity(2);
+    if !home.is_empty() {
+        roots.push(Path::new(home));
     }
-    // Canonicalize the home anchor as well as the candidate path. Passwd
-    // entries can name a directory that traverses a symlink (e.g. macOS
-    // /Users/u where /Users is a symlink to /home, or distros that put
-    // /home/u behind /export/home/u). If we compare a canonicalized
-    // env_path against a raw home, the prefix check rejects legitimate
-    // paths AND, conversely, a `home == "/"` slip-through (rejected at
-    // the passwd layer in tokenless-stats::home but defended in depth
-    // here) would match every absolute path under `starts_with`.
-    let canonical_home = std::path::Path::new(home)
-        .canonicalize()
-        .map_err(|e| format!("home directory '{}' cannot be resolved: {}", home, e))?;
-    let p = std::path::Path::new(env_path);
-    // Accept only paths under the user's real home directory.
-    // For not-yet-created DB files, the parent directory MUST itself
-    // canonicalize — falling back to an unresolved parent would let
-    // `~/x/../../etc/evil.db` slip past the starts_with(&home) check,
-    // since Path::starts_with matches components literally and an
-    // unresolved path still begins with the home prefix.
-    let resolved = p
-        .canonicalize()
-        .or_else(|_| {
-            p.parent()
-                .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))
-                .and_then(|parent| parent.canonicalize())
-        })
-        .map_err(|e| format!("path '{}' cannot be resolved: {}", env_path, e))?;
-    if resolved.starts_with(&canonical_home) {
-        Ok(env_path.to_string())
-    } else {
-        Err(format!(
-            "path '{}' is outside home directory '{}'",
-            env_path, home
-        ))
+    if let Some(data_dir) = data_dir {
+        roots.push(data_dir);
     }
+    validate_database_path(path, &roots).map_err(|error| error.to_string())
 }
 
-fn ensure_db_dir(db_path: &str) -> Result<(), (String, i32)> {
-    if let Some(parent) = std::path::Path::new(&db_path).parent() {
-        fs::create_dir_all(parent)
+fn ensure_db_dir(db_path: &Path) -> Result<(), (String, i32)> {
+    if let Some(parent) = db_path.parent() {
+        ensure_state_dir(parent)
             .map_err(|e| (format!("Failed to create database directory: {}", e), 1))?;
     }
     Ok(())
@@ -503,64 +395,49 @@ fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
 }
 
 fn open_recorder_with(paths: &DatabasePathResolver) -> Result<StatsRecorder, (String, i32)> {
-    let db_path = get_db_path_with(paths);
+    let db_path = get_db_path_with(paths)
+        .map_err(|error| (format!("Stats database unavailable: {}", error), 1))?;
     ensure_db_dir(&db_path)?;
     StatsRecorder::new(db_path).map_err(|e| (format!("Failed to open database: {}", e), 1))
 }
 
-/// Resolve the stash database path under the trusted home directory.
+/// Resolve the stash database path under a trusted state root.
 ///
-/// Mirrors `get_db_path`'s trust model (passwd-rooted home, validated env
-/// override) so an attacker cannot redirect the stash to a system-critical
-/// location by setting `TOKENLESS_STASH_DB` or passing `--stash-db`. Returns
-/// `None` when no trusted home anchor exists or an override is rejected —
-/// callers fail open (no stash, lossy truncation) rather than writing state
-/// to an untrusted location.
+/// File-level overrides may reside beneath the passwd-backed home or the
+/// selected data directory. Callers fail open when no valid data directory is
+/// available rather than writing state to an unintended fallback location.
 fn get_stash_db_path_with(
     paths: &DatabasePathResolver,
     override_path: Option<&str>,
-) -> Option<String> {
+) -> Result<PathBuf, String> {
     let home = paths.home();
-    if home.is_empty() {
-        eprintln!("[tokenless] no home directory available — stash disabled");
-        return None;
-    }
+    let data_dir = paths.data_dir();
     // An explicit --stash-db override is validated the same way as the
     // TOKENLESS_STASH_DB env var: on rejection we warn AND fall back to the
-    // default under the trusted home (rather than silently disabling the
-    // stash), so a typo doesn't quietly drop reversibility.
+    // selected data directory, so a bad file override does not silently drop
+    // reversibility. An invalid data-directory override still fails closed.
     if let Some(p) = override_path.filter(|s| !s.is_empty()) {
-        match validate_db_path(p, home) {
-            Ok(valid) => return Some(valid),
+        match validate_db_path(Path::new(p), home, data_dir.ok()) {
+            Ok(valid) => return Ok(valid),
             Err(reason) => eprintln!("[tokenless] rejecting --stash-db {}: {}", p, reason),
         }
     }
     if let Ok(env_path) = std::env::var("TOKENLESS_STASH_DB")
         && !env_path.is_empty()
     {
-        match validate_db_path(&env_path, home) {
-            Ok(path) => return Some(path),
+        match validate_db_path(Path::new(&env_path), home, data_dir.ok()) {
+            Ok(path) => return Ok(path),
             Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {}", reason),
         }
     }
-    let data_dir = match paths.data_dir() {
-        Ok(path) => path,
-        Err(reason) => {
-            eprintln!("[tokenless] {} — stash disabled", reason);
-            return None;
-        }
-    };
-    Some(
-        std::path::Path::new(&data_dir)
-            .join("stash.db")
-            .to_string_lossy()
-            .into_owned(),
-    )
+    let data_dir = data_dir.map_err(str::to_string)?;
+    let path = data_dir.join("stash.db");
+    validate_db_path(&path, home, Some(data_dir))
 }
 
 /// Open a stash store, returning the specific failure cause. Used by
 /// user-initiated paths (`retrieve`) where a generic "unavailable" message
-/// would hide the real reason (no home, path rejected, corrupt DB, …).
+/// would hide the real reason (invalid data dir, path rejected, corrupt DB, …).
 fn open_stash_store_or_err(override_path: Option<&str>) -> Result<Arc<dyn StashStore>, String> {
     open_stash_store_or_err_with(&DatabasePathResolver::default(), override_path)
 }
@@ -569,20 +446,16 @@ fn open_stash_store_or_err_with(
     paths: &DatabasePathResolver,
     override_path: Option<&str>,
 ) -> Result<Arc<dyn StashStore>, String> {
-    let path = get_stash_db_path_with(paths, override_path)
-        .ok_or_else(|| "no trusted home directory available for stash db".to_string())?;
-    if let Some(parent) = std::path::Path::new(&path).parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("cannot create stash directory {}: {}", parent.display(), e))?;
-    }
+    let path = get_stash_db_path_with(paths, override_path)?;
+    ensure_db_dir(&path).map_err(|(message, _)| message)?;
     SqliteStore::new(&path)
-        .map_err(|e| format!("cannot open stash db at {}: {}", path, e))
+        .map_err(|e| format!("cannot open stash db at {}: {}", path.display(), e))
         .map(|s| Arc::new(s) as Arc<dyn StashStore>)
 }
 
 /// Open a stash store, failing open to `None` on any error. Compression
-/// proceeds without stash (lossy truncation) when the home anchor is missing,
-/// the parent directory cannot be created, or the database cannot be opened.
+/// proceeds without stash (lossy truncation) when no valid data directory is
+/// available, the parent cannot be created, or the database cannot be opened.
 fn open_stash_store(override_path: Option<&str>) -> Option<Arc<dyn StashStore>> {
     open_stash_store_with(&DatabasePathResolver::default(), override_path)
 }
@@ -831,14 +704,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             }
         }
         Commands::Stats(stats_cmd) => {
-            let recorder = open_recorder()?;
-
             match stats_cmd {
                 StatsCommands::Summary {
                     limit,
                     json,
                     compare,
                 } => {
+                    let recorder = open_recorder()?;
                     if let Some(sessions) = compare {
                         let baseline_sid = sessions[0].as_str();
                         let tokenless_sid = sessions[1].as_str();
@@ -872,12 +744,14 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     }
                 }
                 StatsCommands::List { limit } => {
+                    let recorder = open_recorder()?;
                     let records = recorder
                         .all_records(Some(limit))
                         .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
                     println!("{}", format_list(&records, limit));
                 }
                 StatsCommands::Show { id } => {
+                    let recorder = open_recorder()?;
                     let record = recorder
                         .record_by_id(id)
                         .map_err(|e| (format!("Failed to query record: {}", e), 1))?
@@ -894,6 +768,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     no_color,
                     json,
                 } => {
+                    let recorder = open_recorder()?;
                     let report = match (id, session) {
                         (Some(id), None) => {
                             let record = recorder
@@ -943,6 +818,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     }
                 }
                 StatsCommands::Clear { yes } => {
+                    let recorder = open_recorder()?;
                     if !yes {
                         print!("Are you sure you want to clear all statistics? [y/N] ");
                         use std::io::Write;

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -5,7 +5,7 @@ static ENV_MUTEX: Mutex<()> = Mutex::new(());
 fn default_path_resolver(home: &str) -> DatabasePathResolver {
     DatabasePathResolver {
         home: std::sync::OnceLock::from(home.to_string()),
-        data_dir: std::sync::OnceLock::from(Ok(format!("{home}/.tokenless"))),
+        data_dir: std::sync::OnceLock::from(Ok(PathBuf::from(home).join(".tokenless"))),
     }
 }
 
@@ -101,11 +101,9 @@ fn temp_subdir(label: &str) -> std::path::PathBuf {
 }
 
 #[test]
-fn validate_db_path_rejects_empty_home() {
-    // No trusted home anchor means starts_with("") would match
-    // any path, so the function must short-circuit to rejection.
-    let err = validate_db_path("/tmp/whatever.db", "").unwrap_err();
-    assert!(err.contains("no trusted home"));
+fn validate_db_path_rejects_without_trusted_root() {
+    let err = validate_db_path(Path::new("/tmp/whatever.db"), "", None).unwrap_err();
+    assert!(err.contains("no trusted root"));
 }
 
 #[test]
@@ -113,14 +111,18 @@ fn validate_db_path_accepts_path_inside_home() {
     let home = temp_subdir("inside");
     let canon_home = std::fs::canonicalize(&home).unwrap();
     let inner = canon_home.join("stats.db");
-    let result =
-        validate_db_path(inner.to_str().unwrap(), canon_home.to_str().unwrap()).unwrap();
-    assert_eq!(result, inner.to_str().unwrap());
+    let result = validate_db_path(
+        &inner,
+        canon_home.to_str().unwrap(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(result, inner);
     std::fs::remove_dir_all(&home).ok();
 }
 
 #[test]
-fn validate_db_path_rejects_path_outside_home() {
+fn validate_db_path_rejects_path_outside_trusted_roots() {
     let home = temp_subdir("outside-home");
     let canon_home = std::fs::canonicalize(&home).unwrap();
     // Pick a known-existing directory that is NOT under home.
@@ -129,8 +131,13 @@ fn validate_db_path_rejects_path_outside_home() {
         std::fs::remove_dir_all(&home).ok();
         return;
     }
-    let err = validate_db_path("/etc/hosts", canon_home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("outside home"));
+    let err = validate_db_path(
+        Path::new("/etc/hosts"),
+        canon_home.to_str().unwrap(),
+        None,
+    )
+    .unwrap_err();
+    assert!(err.contains("outside the trusted home and data directory"));
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -141,12 +148,16 @@ fn validate_db_path_rejects_parent_dir_bypass_with_existing_parent() {
     let home = temp_subdir("pd-existing");
     let canon_home = std::fs::canonicalize(&home).unwrap();
     let escape = canon_home.join("foo/../../etc/evil.db");
-    let err =
-        validate_db_path(escape.to_str().unwrap(), canon_home.to_str().unwrap()).unwrap_err();
+    let err = validate_db_path(
+        &escape,
+        canon_home.to_str().unwrap(),
+        None,
+    )
+    .unwrap_err();
     // Either "outside home" (parent canonicalized away from home) or
     // "cannot be resolved" (parent itself unreachable). Both are valid
     // rejections — what matters is no Ok return.
-    assert!(err.contains("outside home") || err.contains("cannot be resolved"));
+    assert!(err.contains("parent traversal"));
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -160,7 +171,7 @@ fn validate_db_path_canonicalizes_home_with_symlink_prefix() {
     // informational there but real coverage on macOS.
     let home = temp_subdir("sym-prefix");
     let inner = home.join("stats.db");
-    let result = validate_db_path(inner.to_str().unwrap(), home.to_str().unwrap());
+    let result = validate_db_path(&inner, home.to_str().unwrap(), None);
     assert!(
         result.is_ok(),
         "raw (non-canonical) home should be accepted after internal canonicalization: {:?}",
@@ -177,7 +188,11 @@ fn validate_db_path_rejects_parent_dir_bypass_with_nonexistent_parent() {
     let home = temp_subdir("pd-nonexistent");
     let canon_home = std::fs::canonicalize(&home).unwrap();
     let escape = canon_home.join("does-not-exist-xyz/../../etc/evil.db");
-    let result = validate_db_path(escape.to_str().unwrap(), canon_home.to_str().unwrap());
+    let result = validate_db_path(
+        &escape,
+        canon_home.to_str().unwrap(),
+        None,
+    );
     assert!(
         result.is_err(),
         "ParentDir bypass via nonexistent intermediate must be rejected; got {:?}",
@@ -190,40 +205,34 @@ fn validate_db_path_rejects_parent_dir_bypass_with_nonexistent_parent() {
 fn validate_data_dir_path_accepts_nonexistent_descendant() {
     let home = temp_subdir("data-dir-home");
     let candidate = home.join("nested/data");
-    let result =
-        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap();
-    assert_eq!(result, candidate.to_str().unwrap());
+    let result = tokenless_stats::validate_data_dir(&candidate).unwrap();
+    assert_eq!(result, candidate);
     std::fs::remove_dir_all(&home).ok();
 }
 
 #[test]
-fn get_data_dir_rejects_empty_home() {
-    let err = get_data_dir("").unwrap_err();
-    assert!(err.contains("no trusted home"));
-}
-
-#[test]
-fn validate_data_dir_path_rejects_outside_home() {
+fn validate_data_dir_path_accepts_outside_home() {
     let home = temp_subdir("data-dir-outside-home");
     let outside = temp_subdir("data-dir-outside-candidate");
-    let err =
-        validate_data_dir_path(outside.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("outside home"));
+    let resolved = tokenless_stats::resolve_data_dir(
+        Some(home.as_path()),
+        outside.to_str(),
+    )
+    .unwrap();
+    assert_eq!(resolved, outside.canonicalize().unwrap());
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&outside).ok();
 }
 
 #[test]
 fn validate_data_dir_path_rejects_relative_path() {
-    let home = temp_subdir("data-dir-relative");
-    let err = validate_data_dir_path("relative/data", home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("not absolute"));
-    std::fs::remove_dir_all(&home).ok();
+    let error = tokenless_stats::validate_data_dir(Path::new("relative/data")).unwrap_err();
+    assert!(error.to_string().contains("not absolute"));
 }
 
 #[cfg(unix)]
 #[test]
-fn validate_data_dir_path_rejects_symlink_escape() {
+fn validate_data_dir_path_canonicalizes_symlink() {
     use std::os::unix::fs::symlink;
 
     let home = temp_subdir("data-dir-symlink-home");
@@ -231,9 +240,8 @@ fn validate_data_dir_path_rejects_symlink_escape() {
     let link = home.join("redirect");
     symlink(&outside, &link).unwrap();
     let candidate = link.join("data");
-    let err =
-        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("outside home"));
+    let resolved = tokenless_stats::validate_data_dir(&candidate).unwrap();
+    assert_eq!(resolved, outside.canonicalize().unwrap().join("data"));
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&outside).ok();
 }
@@ -242,9 +250,8 @@ fn validate_data_dir_path_rejects_symlink_escape() {
 fn validate_data_dir_path_rejects_parent_traversal() {
     let home = temp_subdir("data-dir-traversal");
     let candidate = home.join("nested/../data");
-    let err =
-        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("parent traversal"));
+    let error = tokenless_stats::validate_data_dir(&candidate).unwrap_err();
+    assert!(error.to_string().contains("parent traversal"));
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -253,9 +260,8 @@ fn validate_data_dir_path_rejects_existing_file() {
     let home = temp_subdir("data-dir-file");
     let candidate = home.join("not-a-directory");
     std::fs::write(&candidate, "").unwrap();
-    let err =
-        validate_data_dir_path(candidate.to_str().unwrap(), home.to_str().unwrap()).unwrap_err();
-    assert!(err.contains("not a directory"));
+    let error = tokenless_stats::validate_data_dir(&candidate).unwrap_err();
+    assert!(error.to_string().contains("not a directory"));
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -333,8 +339,8 @@ fn get_stash_db_path_default() {
         return;
     }
     let path = get_stash_db_path_with(&default_path_resolver(&home), None);
-    assert!(path.is_some());
-    assert!(path.unwrap().contains(".tokenless/stash.db"));
+    assert!(path.is_ok());
+    assert!(path.unwrap().ends_with(".tokenless/stash.db"));
 }
 
 #[test]
@@ -346,7 +352,7 @@ fn get_stash_db_path_with_valid_override() {
         &DatabasePathResolver::default(),
         Some(guard.stash_db_path()),
     );
-    assert_eq!(result, Some(guard.stash_db_path().to_string()));
+    assert_eq!(result.unwrap(), PathBuf::from(guard.stash_db_path()));
 }
 
 #[test]
@@ -371,9 +377,24 @@ fn ensure_db_dir_creates_parent() {
 
     // ensure_db_dir is idempotent — calling it when the dir already exists
     // (which it does for most test envs) succeeds.
-    let result = ensure_db_dir(&get_db_path_with(&DatabasePathResolver::default()));
+    let db_path = get_db_path_with(&DatabasePathResolver::default()).unwrap();
+    let result = ensure_db_dir(&db_path);
     // With TempDbGuard the stats DB path points to a temp dir, so this succeeds.
     assert!(result.is_ok());
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_db_dir_preserves_existing_parent_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let parent = temp_subdir("existing-mode");
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o750)).unwrap();
+
+    ensure_db_dir(&parent.join("stats.db")).unwrap();
+
+    assert_eq!(parent.metadata().unwrap().permissions().mode() & 0o777, 0o750);
+    std::fs::remove_dir_all(parent).ok();
 }
 
 #[test]
@@ -468,7 +489,7 @@ fn record_compression_stats_records_dryrun_mode() {
 fn get_db_path_returns_valid_path() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
     let db_path = get_db_path_with(&DatabasePathResolver::default());
-    assert!(db_path.contains("stats.db"));
+    assert!(db_path.unwrap().ends_with("stats.db"));
 }
 
 #[test]
@@ -1097,8 +1118,8 @@ fn get_stash_db_path_returns_valid() {
         return;
     }
     let path = get_stash_db_path_with(&default_path_resolver(&home), None);
-    assert!(path.is_some());
-    assert!(path.unwrap().contains(".tokenless/stash.db"));
+    assert!(path.is_ok());
+    assert!(path.unwrap().ends_with(".tokenless/stash.db"));
 }
 
 #[test]
@@ -1113,8 +1134,8 @@ fn get_stash_db_path_with_bad_override() {
         Some("/nonexistent/deep/dir/stash.db"),
     );
     // Bad override is rejected, falls back to default
-    assert!(path.is_some());
-    assert!(path.unwrap().contains(".tokenless/stash.db"));
+    assert!(path.is_ok());
+    assert!(path.unwrap().ends_with(".tokenless/stash.db"));
 }
 
 

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -73,19 +73,25 @@ struct TempDataDir {
 impl TempDataDir {
     fn new() -> Option<Self> {
         let home = get_home_dir();
-        if home.is_empty() {
-            return None;
-        }
         let unique = format!(
-            ".tokenless-data-dir-integration-{}-{}",
+            "tokenless-external-data-dir-integration-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .ok()?
                 .as_nanos()
         );
-        let root = std::path::PathBuf::from(home).join(unique);
+        let root = std::env::temp_dir().join(unique);
         std::fs::create_dir_all(&root).ok()?;
+        if !home.is_empty()
+            && root
+                .canonicalize()
+                .ok()?
+                .starts_with(std::path::Path::new(&home).canonicalize().ok()?)
+        {
+            std::fs::remove_dir_all(&root).ok();
+            return None;
+        }
         let data_dir = root.join("databases");
         Some(Self { root, data_dir })
     }
@@ -123,7 +129,16 @@ fn data_dir_env_routes_stats_and_stash_databases() {
         "stats command failed: {}",
         String::from_utf8_lossy(&stats_output.stderr)
     );
+    assert!(!String::from_utf8_lossy(&stats_output.stderr).contains("ignoring TOKENLESS_DATA_DIR"));
     assert!(fixture.data_dir.join("stats.db").is_file());
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fixture.data_dir.metadata().unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
 
     let stash_output = fixture
         .command()
@@ -140,7 +155,7 @@ fn stats_db_env_takes_precedence_over_data_dir() {
         Some(fixture) => fixture,
         None => return,
     };
-    let explicit_dir = fixture.root.join("explicit");
+    let explicit_dir = fixture.data_dir.join("explicit");
     std::fs::create_dir_all(&explicit_dir).unwrap();
     let explicit_db = explicit_dir.join("stats.db");
 
@@ -165,7 +180,7 @@ fn stash_db_env_takes_precedence_over_data_dir() {
         Some(fixture) => fixture,
         None => return,
     };
-    let explicit_dir = fixture.root.join("explicit");
+    let explicit_dir = fixture.data_dir.join("explicit");
     std::fs::create_dir_all(&explicit_dir).unwrap();
     let explicit_db = explicit_dir.join("stash.db");
 
@@ -178,6 +193,71 @@ fn stash_db_env_takes_precedence_over_data_dir() {
     assert!(!output.status.success());
     assert!(explicit_db.is_file());
     assert!(!fixture.data_dir.join("stash.db").exists());
+}
+
+#[test]
+fn invalid_explicit_data_dir_does_not_fall_back_to_home() {
+    let output = tokenless_bin()
+        .env("TOKENLESS_DATA_DIR", "relative/data")
+        .env_remove("TOKENLESS_STATS_DB")
+        .args(["stats", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("path 'relative/data' is not absolute"));
+}
+
+#[test]
+fn invalid_explicit_data_dir_does_not_block_stats_status() {
+    let output = tokenless_bin()
+        .env("TOKENLESS_DATA_DIR", "relative/data")
+        .env_remove("TOKENLESS_STATS_DB")
+        .args(["stats", "status"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Stats recording:"));
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn valid_stats_db_override_wins_over_invalid_data_dir() {
+    let fixture = match TempStatsDb::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let output = fixture
+        .command()
+        .env("TOKENLESS_DATA_DIR", "relative/data")
+        .args(["stats", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(fixture.path.is_file());
+}
+
+#[test]
+fn stats_db_override_cannot_escape_selected_data_dir() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let outside_db = fixture.root.join("outside-stats.db");
+    let output = fixture
+        .command()
+        .env("TOKENLESS_STATS_DB", &outside_db)
+        .args(["stats", "summary"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(!outside_db.exists());
+    assert!(fixture.data_dir.join("stats.db").is_file());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ignoring TOKENLESS_STATS_DB"));
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-stats/src/lib.rs
+++ b/src/tokenless/crates/tokenless-stats/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod config;
 pub mod diff;
 pub mod home;
+pub mod path_policy;
 pub mod query;
 pub mod record;
 pub mod recorder;
@@ -32,6 +33,10 @@ pub use diff::{
 };
 
 pub use home::get_home_dir;
+
+pub use path_policy::{
+    PathPolicyError, ensure_state_dir, resolve_data_dir, validate_data_dir, validate_database_path,
+};
 
 pub use sls::{SlsRecord, SlsWriter};
 

--- a/src/tokenless/crates/tokenless-stats/src/path_policy.rs
+++ b/src/tokenless/crates/tokenless-stats/src/path_policy.rs
@@ -1,0 +1,431 @@
+//! Path validation for Tokenless SQLite state.
+//!
+//! Directory-level relocation may target any absolute filesystem location,
+//! while file-level overrides remain confined to explicitly trusted roots.
+
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
+
+use thiserror::Error;
+
+/// Failure returned when a Tokenless state path violates the path policy.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PathPolicyError {
+    /// No passwd-backed home is available for the default data directory.
+    #[error("no trusted home directory available and TOKENLESS_DATA_DIR is not set")]
+    MissingDefaultHome,
+    /// The configured path is relative.
+    #[error("path '{path}' is not absolute")]
+    NotAbsolute {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// The configured path contains a parent-directory component.
+    #[error("path '{path}' contains parent traversal")]
+    ParentTraversal {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// The filesystem root cannot be used as the Tokenless data directory.
+    #[error("path '{path}' cannot be used as the data directory")]
+    RootDataDirectory {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// The data-directory path resolves to a non-directory.
+    #[error("path '{path}' is not a directory")]
+    NotDirectory {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// A database path resolves to a non-regular file.
+    #[error("path '{path}' is not a regular file")]
+    NotRegularFile {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// A database override names a symbolic link instead of a database file.
+    #[error("database path '{path}' is a symbolic link")]
+    DatabaseSymlink {
+        /// Rejected path.
+        path: PathBuf,
+    },
+    /// An existing path component could not be resolved.
+    #[error("path '{path}' cannot be resolved: {source}")]
+    CannotResolve {
+        /// Path being resolved.
+        path: PathBuf,
+        /// Filesystem error returned while resolving the path.
+        #[source]
+        source: std::io::Error,
+    },
+    /// No trusted root is available for a file-level database override.
+    #[error("no trusted root is available for database path '{path}'")]
+    NoTrustedRoot {
+        /// Rejected database path.
+        path: PathBuf,
+    },
+    /// A file-level override escapes both the real home and selected data directory.
+    #[error("database path '{path}' is outside the trusted home and data directory")]
+    OutsideTrustedRoots {
+        /// Rejected database path.
+        path: PathBuf,
+    },
+}
+
+/// Create a Tokenless state directory with private permissions when supported.
+///
+/// Existing directories retain their permissions. On Unix, every directory
+/// created by this call uses mode `0700`; other platforms use the standard
+/// recursive directory creation behavior.
+///
+/// # Errors
+///
+/// Returns the filesystem error raised while creating the directory tree.
+pub fn ensure_state_dir(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(path)
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+/// Resolve the Tokenless data directory.
+///
+/// A non-empty override may point anywhere on the filesystem, subject to
+/// absolute-path, traversal, and directory-type checks. Without an override,
+/// the default remains `.tokenless` beneath the passwd-backed home.
+///
+/// # Errors
+///
+/// Returns [`PathPolicyError`] when the override is unsafe or unusable, or
+/// when neither an override nor a trusted default home is available.
+pub fn resolve_data_dir(
+    home: Option<&Path>,
+    override_path: Option<&str>,
+) -> Result<PathBuf, PathPolicyError> {
+    if let Some(path) = override_path.filter(|path| !path.is_empty()) {
+        return validate_data_dir(Path::new(path));
+    }
+
+    let home = home
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or(PathPolicyError::MissingDefaultHome)?;
+    validate_data_dir(&home.join(".tokenless"))
+}
+
+/// Validate and normalize a directory-level Tokenless state override.
+///
+/// Unlike file-level overrides, the directory is not confined to the user's
+/// home. Existing symlink prefixes are canonicalized before the path is used.
+///
+/// # Errors
+///
+/// Returns [`PathPolicyError`] for relative paths, parent traversal, the
+/// filesystem root, non-directory targets, or unresolvable components.
+pub fn validate_data_dir(path: &Path) -> Result<PathBuf, PathPolicyError> {
+    validate_absolute_syntax(path)?;
+    let normalized = normalize_with_existing_ancestor(path)?;
+    if normalized.parent().is_none() {
+        return Err(PathPolicyError::RootDataDirectory {
+            path: path.to_path_buf(),
+        });
+    }
+
+    match std::fs::metadata(path) {
+        Ok(metadata) if !metadata.is_dir() => Err(PathPolicyError::NotDirectory {
+            path: path.to_path_buf(),
+        }),
+        Ok(_) => Ok(normalized),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(normalized),
+        Err(source) => Err(PathPolicyError::CannotResolve {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+/// Validate a database file against the real home and selected data directory.
+///
+/// Each supplied root is normalized before comparison. Existing database
+/// files must be regular files and may not be symbolic links.
+///
+/// # Errors
+///
+/// Returns [`PathPolicyError`] when the database path is malformed, cannot be
+/// resolved, names an unsafe file type, or lies outside every trusted root.
+pub fn validate_database_path(
+    path: &Path,
+    trusted_roots: &[&Path],
+) -> Result<PathBuf, PathPolicyError> {
+    validate_absolute_syntax(path)?;
+
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(PathPolicyError::DatabaseSymlink {
+                path: path.to_path_buf(),
+            });
+        }
+        Ok(metadata) if !metadata.is_file() => {
+            return Err(PathPolicyError::NotRegularFile {
+                path: path.to_path_buf(),
+            });
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(PathPolicyError::CannotResolve {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    }
+
+    let normalized = normalize_with_existing_ancestor(path)?;
+    let mut normalized_roots = Vec::with_capacity(trusted_roots.len());
+    for root in trusted_roots
+        .iter()
+        .filter(|root| !root.as_os_str().is_empty())
+    {
+        let normalized_root = normalize_with_existing_ancestor(root)?;
+        if normalized_root.parent().is_some() {
+            normalized_roots.push(normalized_root);
+        }
+    }
+    if normalized_roots.is_empty() {
+        return Err(PathPolicyError::NoTrustedRoot {
+            path: path.to_path_buf(),
+        });
+    }
+    if normalized_roots
+        .iter()
+        .any(|root| normalized.starts_with(root))
+    {
+        Ok(normalized)
+    } else {
+        Err(PathPolicyError::OutsideTrustedRoots {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+fn validate_absolute_syntax(path: &Path) -> Result<(), PathPolicyError> {
+    if !path.is_absolute() {
+        return Err(PathPolicyError::NotAbsolute {
+            path: path.to_path_buf(),
+        });
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(PathPolicyError::ParentTraversal {
+            path: path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn normalize_with_existing_ancestor(path: &Path) -> Result<PathBuf, PathPolicyError> {
+    let mut existing_ancestor = path;
+    let mut missing_components: Vec<OsString> = Vec::new();
+
+    loop {
+        match std::fs::symlink_metadata(existing_ancestor) {
+            Ok(_) => {
+                if existing_ancestor != path {
+                    let metadata = std::fs::metadata(existing_ancestor).map_err(|source| {
+                        PathPolicyError::CannotResolve {
+                            path: existing_ancestor.to_path_buf(),
+                            source,
+                        }
+                    })?;
+                    if !metadata.is_dir() {
+                        return Err(PathPolicyError::NotDirectory {
+                            path: existing_ancestor.to_path_buf(),
+                        });
+                    }
+                }
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let component = existing_ancestor.file_name().ok_or_else(|| {
+                    PathPolicyError::CannotResolve {
+                        path: path.to_path_buf(),
+                        source: error,
+                    }
+                })?;
+                missing_components.push(component.to_os_string());
+                existing_ancestor =
+                    existing_ancestor
+                        .parent()
+                        .ok_or_else(|| PathPolicyError::CannotResolve {
+                            path: path.to_path_buf(),
+                            source: std::io::Error::from(std::io::ErrorKind::NotFound),
+                        })?;
+            }
+            Err(source) => {
+                return Err(PathPolicyError::CannotResolve {
+                    path: existing_ancestor.to_path_buf(),
+                    source,
+                });
+            }
+        }
+    }
+
+    let mut normalized =
+        existing_ancestor
+            .canonicalize()
+            .map_err(|source| PathPolicyError::CannotResolve {
+                path: existing_ancestor.to_path_buf(),
+                source,
+            })?;
+    for component in missing_components.iter().rev() {
+        normalized.push(component);
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_dir_accepts_absolute_path_outside_home() {
+        let external = tempfile::tempdir().unwrap();
+        let resolved =
+            resolve_data_dir(Some(Path::new("/home/example")), external.path().to_str()).unwrap();
+        assert_eq!(resolved, external.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn data_dir_override_does_not_require_home() {
+        let external = tempfile::tempdir().unwrap();
+        let resolved = resolve_data_dir(None, external.path().to_str()).unwrap();
+        assert_eq!(resolved, external.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn data_dir_default_requires_home() {
+        let error = resolve_data_dir(None, None).unwrap_err();
+        assert!(matches!(error, PathPolicyError::MissingDefaultHome));
+    }
+
+    #[test]
+    fn data_dir_rejects_relative_and_parent_paths() {
+        assert!(matches!(
+            validate_data_dir(Path::new("relative/data")),
+            Err(PathPolicyError::NotAbsolute { .. })
+        ));
+        assert!(matches!(
+            validate_data_dir(Path::new("/tmp/../var/tokenless")),
+            Err(PathPolicyError::ParentTraversal { .. })
+        ));
+    }
+
+    #[test]
+    fn data_dir_rejects_root_and_existing_file() {
+        assert!(matches!(
+            validate_data_dir(Path::new("/")),
+            Err(PathPolicyError::RootDataDirectory { .. })
+        ));
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file");
+        std::fs::write(&file, "not a directory").unwrap();
+        assert!(matches!(
+            validate_data_dir(&file),
+            Err(PathPolicyError::NotDirectory { .. })
+        ));
+    }
+
+    #[test]
+    fn database_path_accepts_home_or_selected_data_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let home_db = home.path().join("stats.db");
+        let external_db = external.path().join("stats.db");
+        let roots = [home.path(), external.path()];
+
+        assert!(validate_database_path(&home_db, &roots).is_ok());
+        assert!(validate_database_path(&external_db, &roots).is_ok());
+    }
+
+    #[test]
+    fn database_path_rejects_outside_roots() {
+        let home = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let roots = [home.path(), external.path()];
+        let error = validate_database_path(&outside.path().join("stats.db"), &roots).unwrap_err();
+        assert!(matches!(error, PathPolicyError::OutsideTrustedRoots { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn state_dir_is_private_and_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let created = root.path().join("created/nested");
+        ensure_state_dir(&created).unwrap();
+        assert_eq!(
+            created
+                .parent()
+                .unwrap()
+                .metadata()
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            created.metadata().unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+
+        std::fs::set_permissions(&created, std::fs::Permissions::from_mode(0o750)).unwrap();
+        ensure_state_dir(&created).unwrap();
+        assert_eq!(
+            created.metadata().unwrap().permissions().mode() & 0o777,
+            0o750
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn database_path_rejects_symlink_file() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.db");
+        let link = dir.path().join("stats.db");
+        std::fs::write(&target, "db").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = validate_database_path(&link, &[dir.path()]).unwrap_err();
+        assert!(matches!(error, PathPolicyError::DatabaseSymlink { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn data_dir_canonicalizes_symlink_prefix() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let link = root.path().join("data");
+        symlink(target.path(), &link).unwrap();
+
+        let resolved = validate_data_dir(&link).unwrap();
+        assert_eq!(resolved, target.path().canonicalize().unwrap());
+    }
+}

--- a/src/tokenless/docs/stash-reversible-compression.md
+++ b/src/tokenless/docs/stash-reversible-compression.md
@@ -87,7 +87,7 @@ tokenless retrieve "<... 195 items truncated, retrieve with <<tokenless:c30c…>
 # Opt out of stash (lossy truncation, the pre-stash behavior).
 echo '[...]' | tokenless compress-response --no-stash
 
-# Override the stash db path (must be under the trusted home directory).
+# Override the stash db path under the home or selected data directory.
 tokenless retrieve <hash> --stash-db ~/.tokenless/alt-stash.db
 ```
 
@@ -98,24 +98,27 @@ single-file override.
 
 ## Security model
 
-The stash db path is resolved under the **trusted home directory** — derived
-from `getpwuid_r(getuid())`, never from `$HOME` (which a parent process can
-spoof to redirect state into attacker-writable paths). An override
-(`--stash-db`, `TOKENLESS_STASH_DB`, or `TOKENLESS_DATA_DIR`) is validated
-against the canonical home anchor and must remain under that home. For a data
-directory that does not exist yet, tokenless canonicalizes the nearest existing
-ancestor before checking that boundary; a path outside home is rejected. This
-mirrors the stats DB trust model exactly, so an attacker cannot redirect the
-stash to a system-critical location.
+`TOKENLESS_DATA_DIR` is an explicit directory-level trust decision and may
+point outside the real home, including to a managed service directory. It must
+be absolute, cannot be filesystem root or contain parent traversal, and its
+nearest existing ancestor is canonicalized before use. An invalid explicit
+directory disables SQLite state for that operation instead of silently moving
+it back under home.
+
+File-level overrides (`--stash-db`, `TOKENLESS_STASH_DB`, and
+`TOKENLESS_STATS_DB`) remain confined to the canonical real home — derived
+from `getpwuid_r(getuid())`, never `$HOME` — or the selected data directory.
+Existing database files must be regular files rather than symlinks. The CLI
+and bundled RTK writer use the same path policy.
 
 `retrieve` queries are parameterized SQL; a malformed hash simply yields "no
 payload" rather than an injection.
 
 ## Fail-open policy
 
-- **Compress path**: if the stash cannot be opened (no trusted home, directory
-  cannot be created, db open fails) or `stash()` errors, compression proceeds
-  without stash and the marker degrades to the plain
+- **Compress path**: if the stash cannot be opened (invalid data directory,
+  directory cannot be created, db open fails) or `stash()` errors, compression
+  proceeds without stash and the marker degrades to the plain
   `<... N more items truncated>` form. Compression never fails because of the
   stash.
 - **Retrieve path**: retrieve is user-initiated, so failures surface as

--- a/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
+++ b/src/tokenless/third_party/patches/rtk-tokenless-stats.patch
@@ -1,21 +1,245 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e38c6cf..f0d2742 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -108,7 +108,7 @@ checksum = "e8b5778837666541195063243828c5b6139221b47dc4ec3ba81738e532469ab1"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -208,7 +208,7 @@ dependencies = [
+  "heck",
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -331,7 +331,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -800,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+ dependencies = [
+  "proc-macro2",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -844,7 +844,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+ dependencies = [
+  "getrandom 0.2.17",
+  "libredox",
+- "thiserror",
++ "thiserror 1.0.69",
+ ]
+
+ [[package]]
+@@ -912,6 +912,7 @@ dependencies = [
+  "serde_json",
+  "sha2",
+  "tempfile",
++ "thiserror 2.0.20",
+  "toml",
+  "ureq",
+  "walkdir",
+@@ -1028,7 +1029,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -1112,6 +1113,17 @@ dependencies = [
+  "unicode-ident",
+ ]
+
++[[package]]
++name = "syn"
++version = "3.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "unicode-ident",
++]
++
+ [[package]]
+ name = "synstructure"
+ version = "0.13.2"
+@@ -1120,7 +1132,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -1142,7 +1154,16 @@ version = "1.0.69"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+ dependencies = [
+- "thiserror-impl",
++ "thiserror-impl 1.0.69",
++]
++
++[[package]]
++name = "thiserror"
++version = "2.0.20"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
++dependencies = [
++ "thiserror-impl 2.0.20",
+ ]
+
+ [[package]]
+@@ -1153,7 +1174,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
++]
++
++[[package]]
++name = "thiserror-impl"
++version = "2.0.20"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 3.0.3",
+ ]
+
+ [[package]]
+@@ -1349,7 +1381,7 @@ dependencies = [
+  "bumpalo",
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+  "wasm-bindgen-shared",
+ ]
+
+@@ -1455,7 +1487,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -1466,7 +1498,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -1695,7 +1727,7 @@ dependencies = [
+  "heck",
+  "indexmap",
+  "prettyplease",
+- "syn",
++ "syn 2.0.117",
+  "wasm-metadata",
+  "wit-bindgen-core",
+  "wit-component",
+@@ -1711,7 +1743,7 @@ dependencies = [
+  "prettyplease",
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+  "wit-bindgen-core",
+  "wit-bindgen-rust",
+ ]
+@@ -1778,7 +1810,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+  "synstructure",
+ ]
+
+@@ -1799,7 +1831,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+@@ -1819,7 +1851,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+  "synstructure",
+ ]
+
+@@ -1859,7 +1891,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn",
++ "syn 2.0.117",
+ ]
+
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index a881be9..7e8cfb7 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -24,6 +24,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
+ colored = "2"
+ dirs = "5"
+ rusqlite = { version = "0.31", features = ["bundled"] }
++thiserror = "2"
+ toml = "0.8"
+ chrono = "0.4"
+ tempfile = "3"
 diff --git a/src/core/tracking.rs b/src/core/tracking.rs
-index 359e4f6..0a7507b 100644
+index 359e4f6..934d48c 100644
 --- a/src/core/tracking.rs
 +++ b/src/core/tracking.rs
 @@ -1358,6 +1358,9 @@ impl TimedExecution {
          let input_tokens = estimate_tokens(input);
          let output_tokens = estimate_tokens(output);
- 
+
 +        // Also record to tokenless stats database (fail-silent)
 +        record_to_tokenless_stats(original_cmd, rtk_cmd, input, output);
 +
          if let Ok(tracker) = Tracker::new() {
              let _ = tracker.record(
                  original_cmd,
-@@ -1419,5 +1422,247 @@ pub fn args_display(args: &[OsString]) -> String {
+@@ -1419,10 +1422,269 @@ pub fn args_display(args: &[OsString]) -> String {
          .join(" ")
  }
- 
+
 +/// Estimate token count from character count using ~4 chars/token heuristic.
 +fn estimate_tokens_from_chars(chars: usize) -> usize {
 +    if chars == 0 {
@@ -40,7 +264,7 @@ index 359e4f6..0a7507b 100644
 +    }
 +
 +    // Fallback: .rewrite-context file (legacy compat)
-+    let context_file = dirs::home_dir()
++    let context_file = tokenless_trusted_home_dir()
 +        .map(|d| d.join(".tokenless/.rewrite-context"))
 +        .filter(|p| p.exists())
 +        .and_then(|p| std::fs::read_to_string(p).ok());
@@ -75,7 +299,7 @@ index 359e4f6..0a7507b 100644
 +    if let Ok(val) = std::env::var("TOKENLESS_STATS_ENABLED") {
 +        return val == "1" || val.eq_ignore_ascii_case("true") || val.eq_ignore_ascii_case("yes");
 +    }
-+    dirs::home_dir()
++    tokenless_trusted_home_dir()
 +        .map(|d| d.join(".tokenless/config.json"))
 +        .and_then(|p| std::fs::read_to_string(p).ok())
 +        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
@@ -83,96 +307,54 @@ index 359e4f6..0a7507b 100644
 +        .unwrap_or(true)
 +}
 +
-+#[cfg(unix)]
-+#[allow(unsafe_code)] // libc is required to avoid trusting the mutable HOME environment variable.
++#[allow(unsafe_code)] // Shared passwd lookup requires libc and contains documented safety proofs.
++#[path = "../../../../crates/tokenless-stats/src/home.rs"]
++mod tokenless_home;
++#[path = "../../../../crates/tokenless-stats/src/path_policy.rs"]
++mod tokenless_path_policy;
++
 +fn tokenless_trusted_home_dir() -> Option<std::path::PathBuf> {
-+    use std::ffi::CStr;
-+
-+    // SAFETY: getuid is infallible. getpwuid_r receives valid pointers to a
-+    // live passwd value and buffer, and cannot write beyond the given length.
-+    let uid = unsafe { libc::getuid() };
-+    let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
-+    let mut buffer = vec![0u8; 4096];
-+    let mut result: *mut libc::passwd = std::ptr::null_mut();
-+    let status = unsafe {
-+        libc::getpwuid_r(
-+            uid,
-+            &mut passwd,
-+            buffer.as_mut_ptr().cast(),
-+            buffer.len(),
-+            &mut result,
-+        )
-+    };
-+    if status != 0 || result.is_null() || passwd.pw_dir.is_null() {
-+        return None;
-+    }
-+
-+    // SAFETY: a successful getpwuid_r call provides a NUL-terminated pw_dir
-+    // pointer backed by buffer, which remains alive for this conversion.
-+    let home = unsafe { CStr::from_ptr(passwd.pw_dir) }.to_str().ok()?;
-+    let path = std::path::PathBuf::from(home);
-+    if home == "/" || !path.is_absolute() {
-+        return None;
-+    }
-+    Some(path)
-+}
-+
-+#[cfg(not(unix))]
-+fn tokenless_trusted_home_dir() -> Option<std::path::PathBuf> {
-+    None
-+}
-+
-+fn tokenless_path_is_under_home(path: &std::path::Path, home: &std::path::Path) -> bool {
-+    let Ok(canonical_home) = home.canonicalize() else {
-+        return false;
-+    };
-+    let resolved = path.canonicalize().or_else(|_| {
-+        path.parent()
-+            .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::NotFound))
-+            .and_then(std::path::Path::canonicalize)
-+    });
-+    resolved.is_ok_and(|resolved| resolved.starts_with(canonical_home))
-+}
-+
-+fn validate_tokenless_data_dir(
-+    data_dir: &str,
-+    home: &std::path::Path,
-+) -> Option<std::path::PathBuf> {
-+    let candidate = std::path::PathBuf::from(data_dir);
-+    if !candidate.is_absolute()
-+        || candidate
-+            .components()
-+            .any(|component| matches!(component, std::path::Component::ParentDir))
-+        || (candidate.exists() && !candidate.is_dir())
-+    {
-+        return None;
-+    }
-+
-+    let mut existing_ancestor = candidate.as_path();
-+    while !existing_ancestor.exists() {
-+        existing_ancestor = existing_ancestor.parent()?;
-+    }
-+    tokenless_path_is_under_home(existing_ancestor, home).then_some(candidate)
++    let home = tokenless_home::get_home_dir();
++    (!home.is_empty()).then(|| std::path::PathBuf::from(home))
 +}
 +
 +fn resolve_tokenless_stats_db() -> Option<std::path::PathBuf> {
-+    let home = tokenless_trusted_home_dir()?;
++    let home = tokenless_trusted_home_dir();
++    let data_dir_override = std::env::var("TOKENLESS_DATA_DIR").ok();
++    let stats_db_override = std::env::var("TOKENLESS_STATS_DB").ok();
++    resolve_tokenless_stats_db_with(
++        home.as_deref(),
++        data_dir_override.as_deref(),
++        stats_db_override.as_deref(),
++    )
++}
 +
-+    if let Some(path) = std::env::var("TOKENLESS_STATS_DB")
-+        .ok()
++fn resolve_tokenless_stats_db_with(
++    home: Option<&std::path::Path>,
++    data_dir_override: Option<&str>,
++    stats_db_override: Option<&str>,
++) -> Option<std::path::PathBuf> {
++    let data_dir = tokenless_path_policy::resolve_data_dir(home, data_dir_override);
++
++    let mut trusted_roots = Vec::with_capacity(2);
++    if let Some(home) = home {
++        trusted_roots.push(home);
++    }
++    if let Ok(data_dir) = data_dir.as_deref() {
++        trusted_roots.push(data_dir);
++    }
++
++    if let Some(path) = stats_db_override
 +        .filter(|path| !path.is_empty())
 +        .map(std::path::PathBuf::from)
-+        .filter(|path| tokenless_path_is_under_home(path, &home))
++        .and_then(|path| tokenless_path_policy::validate_database_path(&path, &trusted_roots).ok())
 +    {
 +        return Some(path);
 +    }
 +
-+    let data_dir = std::env::var("TOKENLESS_DATA_DIR")
++    let data_dir = data_dir.ok()?;
++    tokenless_path_policy::validate_database_path(&data_dir.join("stats.db"), &[data_dir.as_path()])
 +        .ok()
-+        .filter(|path| !path.is_empty())
-+        .and_then(|path| validate_tokenless_data_dir(&path, &home))
-+        .unwrap_or_else(|| home.join(".tokenless"));
-+    Some(data_dir.join("stats.db"))
 +}
 +
 +/// Record RTK command output compression stats to the tokenless stats database.
@@ -209,7 +391,7 @@ index 359e4f6..0a7507b 100644
 +
 +    let _ = (|| -> anyhow::Result<()> {
 +        if let Some(parent) = db_path.parent() {
-+            std::fs::create_dir_all(parent)?;
++            tokenless_path_policy::ensure_state_dir(parent)?;
 +        }
 +        let conn = rusqlite::Connection::open(&db_path)?;
 +        conn.execute_batch(
@@ -260,30 +442,30 @@ index 359e4f6..0a7507b 100644
 +
  #[cfg(test)]
  mod tests {
-@@ -1424 +1669,32 @@ mod tests {
      use super::*;
-+
+
 +    #[test]
 +    fn tokenless_data_dir_accepts_nonexistent_descendant() {
 +        let home = tempfile::tempdir().unwrap();
 +        let candidate = home.path().join("nested/data");
 +        let resolved =
-+            validate_tokenless_data_dir(candidate.to_str().unwrap(), home.path()).unwrap();
++            tokenless_path_policy::resolve_data_dir(Some(home.path()), candidate.to_str()).unwrap();
 +        assert_eq!(resolved, candidate);
 +    }
 +
 +    #[test]
-+    fn tokenless_data_dir_rejects_outside_home() {
++    fn tokenless_data_dir_accepts_outside_home() {
 +        let home = tempfile::tempdir().unwrap();
 +        let outside = tempfile::tempdir().unwrap();
-+        assert!(
-+            validate_tokenless_data_dir(outside.path().to_str().unwrap(), home.path()).is_none()
-+        );
++        let resolved =
++            tokenless_path_policy::resolve_data_dir(Some(home.path()), outside.path().to_str())
++                .unwrap();
++        assert_eq!(resolved, outside.path().canonicalize().unwrap());
 +    }
 +
 +    #[cfg(unix)]
 +    #[test]
-+    fn tokenless_data_dir_rejects_symlink_escape() {
++    fn tokenless_data_dir_canonicalizes_symlink() {
 +        use std::os::unix::fs::symlink;
 +
 +        let home = tempfile::tempdir().unwrap();
@@ -291,17 +473,47 @@ index 359e4f6..0a7507b 100644
 +        let link = home.path().join("redirect");
 +        symlink(outside.path(), &link).unwrap();
 +        let candidate = link.join("data");
-+        assert!(validate_tokenless_data_dir(candidate.to_str().unwrap(), home.path()).is_none());
++        let resolved = tokenless_path_policy::validate_data_dir(&candidate).unwrap();
++        assert_eq!(
++            resolved,
++            outside.path().canonicalize().unwrap().join("data")
++        );
 +    }
 +
++    #[test]
++    fn tokenless_stats_db_uses_external_data_dir() {
++        let home = tempfile::tempdir().unwrap();
++        let external = tempfile::tempdir().unwrap();
++        let data_dir = external.path().join("tokenless-data");
++        let resolved =
++            resolve_tokenless_stats_db_with(Some(home.path()), data_dir.to_str(), None).unwrap();
++        assert_eq!(resolved, data_dir.join("stats.db"));
++    }
++
++    #[test]
++    fn tokenless_stats_db_override_wins_over_invalid_data_dir() {
++        let home = tempfile::tempdir().unwrap();
++        let stats_db = home.path().join("stats.db");
++        let resolved = resolve_tokenless_stats_db_with(
++            Some(home.path()),
++            Some("relative/data"),
++            stats_db.to_str(),
++        )
++        .unwrap();
++        assert_eq!(resolved, stats_db);
++    }
++
+     // 1. estimate_tokens — verify ~4 chars/token ratio
+     #[test]
+     fn test_estimate_tokens() {
 diff --git a/src/hooks/hook_check.rs b/src/hooks/hook_check.rs
-index 4dd26d8..3638321 100644
+index ca6faf5..7f12ced 100644
 --- a/src/hooks/hook_check.rs
 +++ b/src/hooks/hook_check.rs
 @@ -1,5 +1,6 @@
  //! Detects whether RTK hooks are installed and warns if they are outdated.
- 
+
 +#[allow(unused_imports)]
  use super::constants::{
-     CLAUDE_DIR, CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-     SETTINGS_JSON,
+     CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+ };


### PR DESCRIPTION
## Why

`TOKENLESS_DATA_DIR` was restricted to the passwd-backed home, which prevented service deployments from placing Tokenless SQLite state in managed directories such as `/var/lib/agent-sec/persistent/.tokenless`. The directory-level setting is already an explicit relocation choice, so it should not inherit the tighter boundary required for individual database-file overrides.

## What changed

- Allow `TOKENLESS_DATA_DIR` to select any accessible absolute non-root directory while rejecting relative paths, parent traversal, and existing non-directory targets.
- Keep `TOKENLESS_STATS_DB`, `TOKENLESS_STASH_DB`, and `--stash-db` confined to the real home or selected data directory, and reject existing database symlinks.
- Share the path policy between the Tokenless CLI and bundled RTK writer, and stop invalid explicit data directories from silently falling back to home.
- Add unit and integration coverage and update the English and Chinese documentation.

## Related issue

no-issue: reported service deployment failure

## User / Agent impact

Service users can place `stats.db` and `stash.db` outside their passwd-backed home through `TOKENLESS_DATA_DIR`. Existing default paths are unchanged when the variable is unset.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Directory relocation is now an explicit trust decision, while file-level overrides retain a bounded trust root. Invalid explicit directory configuration fails closed for SQLite state instead of writing to an unexpected home fallback; CLI and RTK use the same policy.

## Validation

- `cargo fmt --all --manifest-path src/tokenless/Cargo.toml -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked -- --test-threads=1`
- `cargo doc --workspace --no-deps --locked`
- `cargo check --locked` in the patched RTK checkout
- `RUSTFLAGS='--cap-lints=allow' cargo test --locked tokenless_stats_db_ -- --test-threads=1` in the patched RTK checkout
- Manual black-box validation on x86_64 Alibaba Cloud Linux 4 as a temporary `agent-sec` system user: external `/var/lib` stats/stash paths, invalid-path rejection, no home fallback, file-override boundaries, symlink rejection, and RTK recording all passed

## Documentation and rollback

Updated the Tokenless README, Codex adapter README, reversible-compression design document, and bilingual configuration/privacy and troubleshooting guides. Roll back the commit to restore the home-only directory policy.