### PR TITLE
feat(sight): add agentscope framework to agent discovery rules

### DIFF
--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -89,7 +89,12 @@
       {"rule": ["qwen*"], "agent_name": "QwenCode"},
       {"rule": ["*/qwen*"], "agent_name": "QwenCode"},
       {"rule": ["*node*", "*qwen*"], "agent_name": "QwenCode"},
-      {"rule": ["*node*", "*", "*qwen*"], "agent_name": "QwenCode"}
+      {"rule": ["*node*", "*", "*qwen*"], "agent_name": "QwenCode"},
+      {"rule": ["agentscope*"], "agent_name": "AgentScope"},
+      {"rule": ["*python*", "-m", "*agentscope*"], "agent_name": "AgentScope"},
+      {"rule": ["*python*", "*agentscope*"], "agent_name": "AgentScope"},
+      {"rule": ["*python*", "*", "*agentscope*"], "agent_name": "AgentScope"},
+      {"rule": ["*python*", "*agent_scope*"], "agent_name": "AgentScope"}
     ]
   },
   "codex_offsets": {


### PR DESCRIPTION
## Description

Add 5 `cmdline.allow` rules to `agentsight.json` so the eBPF probe
auto-discovers AgentScope 1.0.x / 2.0.x Python processes and captures
their DashScope HTTPS traffic (native and OpenAI-compatible endpoints).

Rules cover: `agentscope` CLI entry, `python -m agentscope`, python
script invocations (with both `agentscope` and `agent_scope` spellings),
plus a 3-token wildcard for defensive coverage across heterogeneous argv
layouts (the matcher uses prefix matching, but the wildcard guards
against exotic launcher wrappers on different machines).

No `schema_version` bump — purely additive optional fields, fully
backward compatible with older on-disk configs. DashScope HTTPS capture
rides on the existing `dashscope.aliyuncs.com` allowlist entry; no
probe or parser changes needed since Python links against the system
OpenSSL with standard exported `SSL_read`/`SSL_write` symbols.

Validated end-to-end on a live target (kernel 6.6.102, AgentScope 1.0.9
+ 2.0.6 in isolated venvs, DashScope qwen-turbo):

- `agentsight discover` shows `AgentScope [PID: ...]`
- journalctl: `agent: Some("AgentScope")`, `input_tokens: 23, output_tokens: 3`
- `Attached to agent: AgentScope (pid=N)` — uprobe on libssl.so.3.0.12
- SQLite `token_records`: 12 calls captured (276 in / 44 out) across both versions
- v1: model field empty (agentscope 1.0.9 ChatResponse has no model);
  v2: `model: Some("qwen-turbo")` parsed correctly

## Related Issue

no-issue: single-file config addition following the established pattern
used for QwenCode / Hermes / Cosh / Codex — no dedicated tracking issue
needed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: change is JSON-only (config rules), no Rust code touched — `cargo fmt/clippy/test` are no-ops for this diff
- [x] Lock files are up to date (`Cargo.lock`) — not touched

## Testing

Manual validation on live machine (details in Description). eBPF probe
auto-attaches to Python's system OpenSSL via Tier-1 symbol lookup,
captures DashScope requests/responses, parses token counts, and stores
them under `agent_name = "AgentScope"` in `token_records`.
