### PR TITLE
fix(anolisa): prune stale adapter outputs

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/cosh.rs
@@ -18,6 +18,7 @@
 //! `COSH_HOME` overrides the cosh home directory (default
 //! `<user_home>/.copilot-shell`).
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use super::AdapterError;
@@ -210,6 +211,17 @@ impl FrameworkDriver for CoshDriver {
             source_root: resource_root.to_path_buf(),
             excluded_prefixes: Vec::new(),
         }]
+    }
+
+    fn materialized_destination_roots(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<BTreeMap<String, PathBuf>, AdapterError> {
+        Ok(BTreeMap::from([(
+            RES_EXTENSION_DIR.to_string(),
+            extension_dir(bundle, ctx)?,
+        )]))
     }
 
     fn materialized_verification_applicable(&self, _claim: &AdapterClaim) -> bool {

--- a/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/driver.rs
@@ -8,6 +8,7 @@
 //! stay centralized. The split is deliberate — **driver owns framework
 //! semantics, Manager owns dangerous-resource boundaries**.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -461,6 +462,30 @@ pub trait AdapterOps {
     /// [`AdapterError::ClaimValidation`] if either path fails boundary check.
     fn copy_file(&self, src: &Path, dst: &Path) -> Result<(), AdapterError>;
 
+    /// Remove exactly one filesystem entry without recursively deleting a
+    /// directory. Files and symlinks are unlinked; empty directories are
+    /// removed so a materialized path can change from a directory prefix to
+    /// a file. Returns `Ok(false)` when the path does not exist.
+    ///
+    /// The Manager validates that `path` is under an allowed root. Refusing
+    /// non-empty directories preserves runtime-created files that were never
+    /// owned by an adapter receipt.
+    ///
+    /// # Errors
+    ///
+    /// [`AdapterError::Io`] on filesystem failure, including a non-empty
+    /// directory; [`AdapterError::ClaimValidation`] if `path` fails boundary
+    /// validation.
+    fn remove_path(&self, path: &Path) -> Result<bool, AdapterError> {
+        Err(AdapterError::Io {
+            path: path.to_path_buf(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "operation provider does not support exact path removal",
+            ),
+        })
+    }
+
     /// Remove a directory tree rooted at `path`. The Manager validates
     /// that `path` is under an allowed external root before executing.
     /// Returns `Ok(false)` when the path does not exist (idempotent).
@@ -683,6 +708,24 @@ pub trait FrameworkDriver: Send + Sync {
         _declared_skills: &[DeclaredSkill],
     ) -> Vec<MaterializedMapping> {
         Vec::new()
+    }
+
+    /// Concrete destination roots for [`Self::materialized_mappings`].
+    ///
+    /// Dry-run cleanup compares these paths with the prior receipt so its
+    /// stale-output plan matches live re-enable even when a stable resource
+    /// id moves to a different framework path.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same destination or identifier validation error as
+    /// [`Self::prepare_enable`].
+    fn materialized_destination_roots(
+        &self,
+        _bundle: &AdapterBundle,
+        _ctx: &DriverCtx,
+    ) -> Result<BTreeMap<String, PathBuf>, AdapterError> {
+        Ok(BTreeMap::new())
     }
 
     /// Whether this claim is expected to carry a materialized-file list.

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -15,6 +15,7 @@
 //! tests to point at a fake CLI); `HERMES_HOME` overrides the home
 //! directory.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -263,6 +264,27 @@ impl FrameworkDriver for HermesDriver {
             });
         }
         mappings
+    }
+
+    fn materialized_destination_roots(
+        &self,
+        bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<BTreeMap<String, PathBuf>, AdapterError> {
+        let home = require_home(ctx)?;
+        let mut roots = BTreeMap::new();
+        if !ctx.is_skill_bundle() {
+            let plugin_id = require_plugin_id(bundle)?;
+            validate_plugin_id(&plugin_id)?;
+            roots.insert(RES_PLUGIN.to_string(), home.join("plugins").join(plugin_id));
+        }
+        for skill in &ctx.declared_skills {
+            roots.insert(
+                format!("hermes_skill_{}", skill.name),
+                home.join("skills").join(&skill.name),
+            );
+        }
+        Ok(roots)
     }
 
     fn materialized_verification_applicable(&self, _claim: &AdapterClaim) -> bool {

--- a/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/managed_files.rs
@@ -1,5 +1,6 @@
 //! Package-owned adapter input revisions and materialized-file verification.
 
+use std::collections::BTreeMap;
 use std::path::{Component, Path, PathBuf};
 
 use anolisa_platform::pkg_files::{PackageFileDigestAlgorithm, PackageFileKind, PackageFileQuery};
@@ -420,6 +421,175 @@ pub(crate) fn copy_materialized_resource(
     Ok(())
 }
 
+/// Remove outputs owned only by a prior receipt before replacing it.
+///
+/// Exact-entry removal deliberately leaves unrelated files in materialized
+/// destination directories intact. When a former directory prefix must
+/// become a file, only an empty prefix directory is removed; runtime content
+/// makes cleanup fail while the prior receipt is still durable.
+pub(crate) fn cleanup_replaced_materialized_files(
+    prior: &AdapterClaim,
+    next: &AdapterClaim,
+    ops: &dyn AdapterOps,
+) -> Result<Vec<String>, AdapterError> {
+    let prior_paths = materialized_paths(prior)?;
+    let next_paths = materialized_paths(next)?;
+    let next_set = next_paths
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut stale = prior_paths
+        .iter()
+        .filter(|path| !next_set.contains(*path))
+        .cloned()
+        .collect::<Vec<_>>();
+    stale.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    stale.dedup();
+
+    let mut messages = Vec::new();
+    for path in &stale {
+        if ops.remove_path(path)? {
+            messages.push(format!(
+                "removed stale materialized file {}",
+                path.display()
+            ));
+        }
+    }
+
+    // Remove every empty ancestor below a file-shaped replacement. Stopping
+    // at the first non-empty directory preserves runtime-created content.
+    for path in replacement_prefixes(&stale, &next_paths) {
+        if ops.remove_path(&path)? {
+            messages.push(format!(
+                "removed empty stale materialized directory {}",
+                path.display()
+            ));
+        }
+    }
+
+    Ok(messages)
+}
+
+/// Describe generic materialized-file cleanup for a re-enable dry-run.
+pub(crate) fn plan_replaced_materialized_files(
+    prior: &AdapterClaim,
+    next_files: &[MaterializedFile],
+    next_roots: &BTreeMap<String, PathBuf>,
+) -> Result<Vec<String>, AdapterError> {
+    let next_paths = next_files
+        .iter()
+        .map(|file| {
+            validate_relative(&file.relative_path)
+                .map_err(|reason| invalid_materialized(prior, reason))?;
+            let root = next_roots.get(&file.resource_id).ok_or_else(|| {
+                invalid_materialized(
+                    prior,
+                    format!(
+                        "next materialized resource '{}' has no destination root",
+                        file.resource_id
+                    ),
+                )
+            })?;
+            Ok(root.join(&file.relative_path))
+        })
+        .collect::<Result<Vec<_>, AdapterError>>()?;
+    let next_set = next_paths.iter().collect::<std::collections::BTreeSet<_>>();
+
+    let mut stale = prior
+        .materialized_files
+        .iter()
+        .map(|file| materialized_path(prior, file))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|path| !next_set.contains(path))
+        .collect::<Vec<_>>();
+    stale.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    stale.dedup();
+
+    let mut actions = stale
+        .iter()
+        .map(|path| format!("remove stale materialized file {}", path.display()))
+        .collect::<Vec<_>>();
+    actions.extend(
+        replacement_prefixes(&stale, &next_paths)
+            .into_iter()
+            .map(|path| {
+                format!(
+                    "remove empty stale materialized directory {}",
+                    path.display()
+                )
+            }),
+    );
+    Ok(actions)
+}
+
+fn materialized_paths(claim: &AdapterClaim) -> Result<Vec<PathBuf>, AdapterError> {
+    claim
+        .materialized_files
+        .iter()
+        .map(|file| materialized_path(claim, file))
+        .collect()
+}
+
+fn materialized_path(
+    claim: &AdapterClaim,
+    file: &MaterializedFile,
+) -> Result<PathBuf, AdapterError> {
+    validate_relative(&file.relative_path).map_err(|reason| invalid_materialized(claim, reason))?;
+    let resource = claim.resource(&file.resource_id).ok_or_else(|| {
+        invalid_materialized(
+            claim,
+            format!(
+                "materialized resource '{}' is missing from the receipt",
+                file.resource_id
+            ),
+        )
+    })?;
+    let root = match &resource.kind {
+        ClaimResourceKind::OwnedPath { path } | ClaimResourceKind::ExternalPath { path } => path,
+        _ => {
+            return Err(invalid_materialized(
+                claim,
+                format!(
+                    "materialized resource '{}' is not a filesystem root",
+                    file.resource_id
+                ),
+            ));
+        }
+    };
+    Ok(root.join(&file.relative_path))
+}
+
+fn invalid_materialized(claim: &AdapterClaim, reason: String) -> AdapterError {
+    AdapterError::InvalidAdapterInput {
+        component: claim.component.clone(),
+        framework: claim.framework.clone(),
+        reason,
+    }
+}
+
+fn replacement_prefixes(stale: &[PathBuf], next: &[PathBuf]) -> Vec<PathBuf> {
+    let mut prefixes = Vec::new();
+    for stale_path in stale {
+        for next_path in next {
+            if !stale_path.starts_with(next_path) {
+                continue;
+            }
+            let mut ancestor = stale_path.parent();
+            while let Some(path) = ancestor.filter(|path| path.starts_with(next_path)) {
+                prefixes.push(path.to_path_buf());
+                if path == next_path {
+                    break;
+                }
+                ancestor = path.parent();
+            }
+        }
+    }
+    prefixes.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    prefixes.dedup();
+    prefixes
+}
+
 /// Verify recorded materialized files without scanning for extra entries.
 pub fn verify_materialized_bundle(claim: &AdapterClaim) -> ManagedMatch {
     for file in &claim.materialized_files {
@@ -837,6 +1007,35 @@ mod tests {
                 extension_dir_resource: "copy".into(),
             }),
         }
+    }
+
+    #[test]
+    fn dry_run_cleanup_compares_concrete_destination_roots() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let old_root = tmp.path().join("plugins/old-id");
+        let new_root = tmp.path().join("plugins/new-id");
+        let file = MaterializedFile {
+            resource_id: "copy".into(),
+            relative_path: PathBuf::from("hook.py"),
+            kind: RevisionFileKind::File,
+            sha256: Some(sha256(b"managed")),
+            symlink_target: None,
+        };
+        let mut prior = claim(&old_root);
+        prior.materialized_files = vec![file.clone()];
+        let next_files = vec![file];
+        let next_roots = BTreeMap::from([("copy".to_string(), new_root)]);
+
+        let actions = plan_replaced_materialized_files(&prior, &next_files, &next_roots)
+            .expect("plan replacement cleanup");
+
+        assert_eq!(
+            actions,
+            vec![format!(
+                "remove stale materialized file {}",
+                old_root.join("hook.py").display()
+            )]
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -43,8 +43,9 @@ use super::driver::{
     FrameworkCommand, FrameworkRpcSession, HostEnv,
 };
 use super::managed_files::{
-    ManagedMatch, inventory_for_installation, materialized_files, source_revision,
-    verify_managed_bundle, verify_materialized_bundle,
+    ManagedInventory, ManagedMatch, cleanup_replaced_materialized_files,
+    inventory_for_installation, materialized_files, plan_replaced_materialized_files,
+    source_revision, verify_managed_bundle, verify_materialized_bundle,
 };
 use super::registry::DriverRegistry;
 use crate::central_log::{CentralLog, LogKind, LogRecord, LogStatus, Severity};
@@ -980,7 +981,30 @@ impl AdapterManager {
                     &trust.target_roots,
                     trust.exact_targets(),
                 )?;
-                let cleanup_actions = driver.plan_reenable_cleanup(prior, &ctx)?;
+                let mappings = driver.materialized_mappings(
+                    &resource_root,
+                    ctx.adapter_type.as_deref(),
+                    &ctx.declared_skills,
+                );
+                let next_files = if mappings.is_empty() {
+                    Vec::new()
+                } else {
+                    let inventory = self.managed_inventory(component, &state, &framework)?;
+                    materialized_files(&inventory, &mappings).map_err(|reason| {
+                        AdapterError::InvalidAdapterInput {
+                            component: component.to_string(),
+                            framework: framework.clone(),
+                            reason,
+                        }
+                    })?
+                };
+                let next_roots = driver.materialized_destination_roots(&bundle, &ctx)?;
+                let mut cleanup_actions = driver.plan_reenable_cleanup(prior, &ctx)?;
+                cleanup_actions.extend(plan_replaced_materialized_files(
+                    prior,
+                    &next_files,
+                    &next_roots,
+                )?);
                 plan.actions.splice(0..0, cleanup_actions);
             }
             let notices = declared_notices(
@@ -1031,20 +1055,7 @@ impl AdapterManager {
             ctx.adapter_type.as_deref(),
             &ctx.declared_skills,
         );
-        let managed_inventory = self
-            .find_component_installation(component, &state)?
-            .ok_or_else(|| AdapterError::ComponentNotInstalled {
-                component: component.to_string(),
-            })
-            .and_then(|installation| {
-                inventory_for_installation(&installation, self.package_files.as_ref()).map_err(
-                    |reason| AdapterError::InvalidAdapterInput {
-                        component: component.to_string(),
-                        framework: framework.clone(),
-                        reason,
-                    },
-                )
-            })?;
+        let managed_inventory = self.managed_inventory(component, &state, &framework)?;
         let revision =
             source_revision(&managed_inventory, &resource_root, &mappings).map_err(|reason| {
                 AdapterError::InvalidAdapterInput {
@@ -1102,6 +1113,13 @@ impl AdapterManager {
                     reason,
                 });
             }
+            cleanup_replaced_materialized_files(prior, &claim, &ops).map_err(|err| {
+                AdapterError::ReenableCleanupIncomplete {
+                    component: component.to_string(),
+                    framework: framework.clone(),
+                    reason: format!("failed to prune stale materialized output: {err}"),
+                }
+            })?;
         }
 
         state.upsert_adapter_claim(claim.clone());
@@ -1816,6 +1834,26 @@ impl AdapterManager {
             }
         }
         Ok(None)
+    }
+
+    fn managed_inventory(
+        &self,
+        component: &str,
+        current_state: &StateStore,
+        framework: &str,
+    ) -> Result<ManagedInventory, AdapterError> {
+        let installation = self
+            .find_component_installation(component, current_state)?
+            .ok_or_else(|| AdapterError::ComponentNotInstalled {
+                component: component.to_string(),
+            })?;
+        inventory_for_installation(&installation, self.package_files.as_ref()).map_err(|reason| {
+            AdapterError::InvalidAdapterInput {
+                component: component.to_string(),
+                framework: framework.to_string(),
+                reason,
+            }
+        })
     }
 
     fn current_source_revision(
@@ -2624,6 +2662,31 @@ impl AdapterOps for ManagerOps {
             source,
         })?;
         Ok(())
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<bool, AdapterError> {
+        validate_ops_path(path, &self.allowed_roots)?;
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.file_type().is_dir() => {
+                std::fs::remove_dir(path).map_err(|source| AdapterError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                Ok(true)
+            }
+            Ok(_) => {
+                std::fs::remove_file(path).map_err(|source| AdapterError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                Ok(true)
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(AdapterError::Io {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
     }
 
     fn remove_tree(&self, path: &Path) -> Result<bool, AdapterError> {

--- a/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/openclaw.rs
@@ -29,7 +29,7 @@
 //! written into the receipt — the receipt stays pure typed data.
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
@@ -357,6 +357,24 @@ impl FrameworkDriver for OpenClawDriver {
                 excluded_prefixes: Vec::new(),
             })
             .collect()
+    }
+
+    fn materialized_destination_roots(
+        &self,
+        _bundle: &AdapterBundle,
+        ctx: &DriverCtx,
+    ) -> Result<BTreeMap<String, PathBuf>, AdapterError> {
+        let home = require_home(ctx)?;
+        Ok(ctx
+            .declared_skills
+            .iter()
+            .map(|skill| {
+                (
+                    format!("openclaw_skill_{}", skill.name),
+                    home.join("skills").join(&skill.name),
+                )
+            })
+            .collect())
     }
 
     fn materialized_verification_applicable(&self, claim: &AdapterClaim) -> bool {

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -258,6 +258,8 @@ const OWNED_ENV: &[&str] = &[
     "FAKE_OC_VERSION_PREAMBLE",
     "FAKE_OC_CONFIG_FAIL_KEY",
     "FAKE_OC_CONFIG_FAIL_AFTER_KEY",
+    "HERMES_BIN",
+    "HERMES_HOME",
 ];
 
 struct OpenClawEnvGuard {
@@ -780,6 +782,177 @@ skills = ["sec-audit"]
 }
 
 #[test]
+fn reenable_prunes_removed_managed_skill_files_but_keeps_runtime_extras() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable initial skill revision");
+    let destination = world.openclaw_home.join("skills/sec-audit");
+    let removed = destination.join("marker.txt");
+    let runtime_extra = destination.join("runtime.log");
+    assert!(removed.is_file());
+    std::fs::write(&runtime_extra, b"runtime").expect("runtime-created extra");
+
+    let source = world.resource_root.join("skills/sec-audit");
+    std::fs::remove_file(source.join("marker.txt")).expect("remove old managed source");
+    std::fs::write(source.join("renamed.txt"), b"skill-v2").expect("write renamed source");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("re-enable updated skill revision");
+
+    assert!(destination.join("renamed.txt").is_file());
+    assert!(
+        !removed.exists(),
+        "a file owned only by the prior receipt must be removed"
+    );
+    assert_eq!(
+        std::fs::read(&runtime_extra).expect("runtime extra must survive"),
+        b"runtime"
+    );
+    let status = manager
+        .status(Some(COMPONENT))
+        .expect("status after re-enable");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+}
+
+#[test]
+fn reenable_prunes_empty_ancestors_before_directory_to_file_change() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    let source = world.resource_root.join("skills/sec-audit");
+    std::fs::create_dir_all(source.join("hook.py/sub")).expect("old nested source directory");
+    std::fs::write(source.join("hook.py/sub/managed.txt"), b"v1").expect("old nested managed file");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable initial directory-shaped output");
+
+    std::fs::remove_dir_all(source.join("hook.py")).expect("remove old source directory");
+    std::fs::write(source.join("hook.py"), b"v2").expect("new file-shaped source");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
+
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("empty ancestors are pruned before replacing the directory");
+
+    let destination = world.openclaw_home.join("skills/sec-audit/hook.py");
+    assert_eq!(
+        std::fs::read(destination).expect("new file-shaped output"),
+        b"v2"
+    );
+}
+
+#[test]
+fn hermes_reenable_prunes_removed_managed_skill_files() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    let hermes_root = world
+        .layout
+        .datadir
+        .join("adapters")
+        .join(COMPONENT)
+        .join("hermes");
+    let source = hermes_root.join("skills/sec-audit");
+    std::fs::create_dir_all(&source).expect("Hermes skill source");
+    std::fs::write(source.join("marker.txt"), b"skill-v1").expect("Hermes skill marker");
+    write_openclaw_manifest(
+        &world.layout,
+        &format!(
+            r#"[[adapters]]
+framework = "hermes"
+adapter_type = "skill_bundle"
+source = "adapters/{COMPONENT}/hermes"
+dest = "{{datadir}}/adapters/{{component}}/hermes/"
+
+[adapters.hermes]
+skills = ["sec-audit"]
+"#
+        ),
+    );
+    record_owned_adapter_files(&world.layout, &hermes_root);
+    let hermes_home = world._root.path().join("hermes-home");
+    guard.set("HERMES_BIN", &world.fake_bin);
+    guard.set("HERMES_HOME", &hermes_home);
+    let manager = AdapterManager::new(
+        world.layout.clone(),
+        Some(world.user_home.clone()),
+        "tester".to_string(),
+    );
+
+    manager
+        .enable(COMPONENT, Some("hermes"), false)
+        .expect("enable initial Hermes skill revision");
+    let destination = hermes_home.join("skills/sec-audit");
+    assert!(destination.join("marker.txt").is_file());
+
+    std::fs::remove_file(source.join("marker.txt")).expect("remove old Hermes source");
+    std::fs::write(source.join("renamed.txt"), b"skill-v2").expect("rename Hermes source");
+    record_owned_adapter_files(&world.layout, &hermes_root);
+    manager
+        .enable(COMPONENT, Some("hermes"), false)
+        .expect("re-enable updated Hermes skill revision");
+
+    assert!(destination.join("renamed.txt").is_file());
+    assert!(!destination.join("marker.txt").exists());
+    let status = manager.status(Some(COMPONENT)).expect("Hermes status");
+    assert_eq!(status.entries[0].report.summary, AdapterSummary::Healthy);
+}
+
+#[test]
+fn reenable_refuses_directory_to_file_change_when_runtime_content_would_be_lost() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    let source = world.resource_root.join("skills/sec-audit");
+    std::fs::create_dir_all(source.join("hook.py")).expect("old source directory");
+    std::fs::write(source.join("hook.py/managed.txt"), b"v1").expect("old managed file");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable initial directory-shaped output");
+
+    let destination = world.openclaw_home.join("skills/sec-audit");
+    std::fs::write(destination.join("hook.py/runtime.log"), b"runtime")
+        .expect("runtime content under old directory");
+    std::fs::remove_dir_all(source.join("hook.py")).expect("remove old source directory");
+    std::fs::write(source.join("hook.py"), b"v2").expect("new file-shaped source");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
+
+    let err = manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect_err("runtime content must not be recursively removed");
+    assert!(matches!(
+        err,
+        AdapterError::ReenableCleanupIncomplete { .. }
+    ));
+    assert_eq!(
+        std::fs::read(destination.join("hook.py/runtime.log")).expect("runtime content survives"),
+        b"runtime"
+    );
+    let claim = world
+        .load_state()
+        .find_adapter_claim(COMPONENT, FRAMEWORK)
+        .cloned()
+        .expect("prior receipt remains durable");
+    assert!(
+        claim
+            .materialized_files
+            .iter()
+            .any(|file| file.relative_path == Path::new("hook.py/managed.txt"))
+    );
+}
+
+#[test]
 fn pre_fix_receipt_remains_visible_and_disable_cleans_recorded_state() {
     let guard = OpenClawEnvGuard::acquire();
     let world = stage();
@@ -976,6 +1149,44 @@ fn migration_dry_run_previews_cleanup_without_mutation() {
         argv_lines(&world.argv_log())
             .iter()
             .all(|line| !line.starts_with("plugins uninstall "))
+    );
+}
+
+#[test]
+fn reenable_dry_run_previews_stale_materialized_file_cleanup() {
+    let guard = OpenClawEnvGuard::acquire();
+    let world = stage();
+    configure_plugin_with_skill(&world, "sec-audit");
+    world.apply_env(&guard, None);
+    let manager = world.manager();
+    manager
+        .enable(COMPONENT, Some(FRAMEWORK), false)
+        .expect("enable initial skill revision");
+
+    let source = world.resource_root.join("skills/sec-audit");
+    std::fs::remove_file(source.join("marker.txt")).expect("remove old managed source");
+    std::fs::write(source.join("renamed.txt"), b"skill-v2").expect("write renamed source");
+    record_owned_adapter_files(&world.layout, &world.resource_root);
+
+    let destination = world.openclaw_home.join("skills/sec-audit");
+    let stale = destination.join("marker.txt");
+    let outcome = manager
+        .enable(COMPONENT, Some(FRAMEWORK), true)
+        .expect("plan stale materialized-file cleanup");
+    let plan = match outcome {
+        EnableOutcome::Planned { plan, .. } => plan,
+        EnableOutcome::Enabled(_) => panic!("dry-run must return a plan"),
+    };
+    let cleanup = format!("remove stale materialized file {}", stale.display());
+    assert!(
+        plan.actions.iter().any(|action| action == &cleanup),
+        "missing '{cleanup}' in plan: {:?}",
+        plan.actions
+    );
+    assert!(stale.is_file(), "dry-run must not remove the stale output");
+    assert!(
+        !destination.join("renamed.txt").exists(),
+        "dry-run must not deliver the replacement output"
     );
 }
 


### PR DESCRIPTION
## Why

Re-enabling an OpenClaw or Hermes adapter only overwrote files present in the
new package revision. Files owned by the prior receipt could remain active
after being removed or renamed upstream, while adapter status still reported
healthy.

## What changed

- Compare prior and next materialized receipt paths during re-enable and remove
  only outputs no longer owned by the replacement receipt.
- Add an exact, non-recursive removal operation so runtime and user-created
  files are preserved; unsafe directory-to-file transitions fail while the
  prior receipt remains durable.
- Add regression coverage for OpenClaw, Hermes, runtime extras, and cleanup
  failure recovery.

## Related issue

Closes #2431

## User / Agent impact

Adapter upgrades no longer leave removed hooks or skills active. Runtime files
that were never owned by an adapter receipt remain untouched.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The public `AdapterOps` trait gains a default exact-removal method. Cleanup is
bounded to receipt-owned materialized paths and refuses recursive deletion of
non-empty directories.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test -p anolisa-core --locked`
- `cargo doc --workspace --no-deps`
- OpenClaw and Hermes re-enable regressions, including runtime-file preservation
  and durable failure on an unsafe directory-to-file transition

## Documentation and rollback

No documentation changes are required. Roll back by reverting this commit; the
prior behavior leaves obsolete materialized outputs for manual cleanup.
