### PR TITLE
fix(tokenless): remove trailing newline from retrieve output

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -693,7 +693,9 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             };
             match store.retrieve(&key) {
                 Ok(Some(payload)) => {
-                    println!("{}", payload);
+                    // print! not println!: stash payloads are byte-exact, and a trailing
+                    // \n breaks lossless retrieval when the original did not end with one.
+                    print!("{}", payload);
                 }
                 Ok(None) => {
                     return Err((format!("no stashed payload for hash: {}", key), 1));

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -613,3 +613,62 @@ fn stats_diff_invalid_scope_and_missing_record_use_expected_exit_codes() {
         .unwrap();
     assert_eq!(missing.status.code(), Some(1));
 }
+
+#[test]
+fn retrieve_output_matches_stashed_payload_without_trailing_newline() {
+    let fixture = match TempDataDir::new() {
+        Some(f) => f,
+        None => return,
+    };
+
+    let payload = "A".repeat(500);
+    let input = serde_json::json!({ "text": payload }).to_string();
+
+    let compress_output = fixture
+        .command()
+        .args(["compress-response", "--truncate-strings-at", "20"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        compress_output.status.success(),
+        "compress-response failed: {}",
+        String::from_utf8_lossy(&compress_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&compress_output.stdout);
+    let start = match stdout.find("<<tokenless:") {
+        Some(i) => i,
+        None => return,
+    };
+    let end = match stdout[start..].find(">>") {
+        Some(i) => start + i + 2,
+        None => return,
+    };
+    let marker = stdout[start..end].to_string();
+
+    let retrieve_output = fixture
+        .command()
+        .args(["retrieve", &marker])
+        .output()
+        .unwrap();
+    assert!(
+        retrieve_output.status.success(),
+        "retrieve failed: {}",
+        String::from_utf8_lossy(&retrieve_output.stderr)
+    );
+
+    let retrieved = &retrieve_output.stdout;
+    assert_eq!(
+        retrieved,
+        payload.as_bytes(),
+        "retrieve output must match stashed payload byte-for-byte (no trailing newline)"
+    );
+}


### PR DESCRIPTION
## Summary

`tokenless retrieve` was appending a trailing `\n` to every stashed payload because the CLI used `println!` instead of `print!`. When the original payload did not end with a newline (common for truncated JSON string values), the CLI output was one byte longer than the stored content — violating the documented end-to-end lossless contract.

## Changes

- **`crates/tokenless-cli/src/main.rs`**: replaced `println!("{}", payload)` with `print!("{}", payload)` in the `Commands::Retrieve` branch, so the CLI stdout matches the stashed payload byte-for-byte.
- **`crates/tokenless-cli/tests/cli_integration.rs`**: added `retrieve_output_matches_stashed_payload_without_trailing_newline` — an integration test that round-trips a 500-byte payload through `compress-response` → stash → `retrieve` and asserts byte-exact equality.

## Testing

- `cargo test -p tokenless-cli` — all 30 tests pass (including the new integration test)
- `cargo clippy -p tokenless-cli --all-targets -- -D warnings` — clean
- `cargo fmt -p tokenless-cli -- --check` — clean

Fixes: alibaba/anolisa#2395