### PR TITLE
chore(cosh-ng): [shell] remove draft alias

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -78,10 +78,4 @@ Plain text without a Skill or references is also valid. Other provider runtimes
 leave `/agent` unavailable; use an ordinary natural-language request or
 multiline input instead.
 
-`/draft` remains accepted as a hidden compatibility alias and is omitted from
-help and command completion. With cosh-core it opens the same Agent Composer as
-`/agent`; the Fake testing adapter follows the same route. With other provider
-runtimes it retains the legacy multiline draft editor. Existing scripts may
-migrate to `/agent` while this compatibility phase remains in place.
-
 For approval behavior, see [Tool approval](approval.md). For proactive failure help, see [AI analysis](ai-analysis.md).

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -72,9 +72,4 @@
 不指定 Skill 或引用的纯文本请求同样有效。其他 provider runtime 不提供`/agent`；
 此时可直接输入自然语言请求或使用多行输入。
 
-`/draft`仍作为隐藏兼容别名被接受，但不会出现在帮助和命令联想中。使用 cosh-core
-时，它与`/agent`打开同一个 Agent Composer，Fake 测试 adapter 也使用相同路由；使用
-其他 provider runtime 时，它继续打开旧版多行 Draft Editor。兼容阶段内，已有脚本
-可以逐步迁移到`/agent`。
-
 审批行为见[工具审批](approval.md)，主动的失败帮助见[AI分析](ai-analysis.md)。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -62,8 +62,7 @@ commands, and `/mode approval recommend` when every Agent tool call should wait
 for confirmation. Approval settings use `recommend`, `auto`, or `trust` across
 the shell and Core. With the cosh-core runtime, `/agent` opens a one-shot
 Composer that accepts a leading `/skill:<name>` and validated workspace-local
-`@path` references. The legacy `/draft` spelling remains a hidden compatibility
-alias and is not advertised by help or command completion.
+`@path` references.
 
 ## Documentation
 

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -59,7 +59,7 @@ $ /session status
 调用工具前都等待确认，运行 `/mode approval recommend`。Shell 和 Core 的审批设置
 统一使用 `recommend`、`auto` 或 `trust`。使用 cosh-core runtime 时，`/agent`
 会打开一次性 Composer，可在开头指定 `/skill:<name>`，并添加经过验证的工作空间内
-`@路径`引用。旧的`/draft`写法仍作为隐藏兼容别名保留，不会出现在帮助或命令联想中。
+`@路径`引用。
 
 ## 文档
 

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/help.rs
@@ -42,7 +42,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::HelpGroupPrompt => "Prompt",
         MessageId::HelpSummaryDraft => "open the multi-line prompt draft card (same as ?? + Enter)",
         MessageId::PromptMultilineEntryHint => {
-            "For multi-line prompts type ?? then Enter, or use /draft to open the draft card"
+            "For multi-line prompts type ?? then Enter; use /agent for a one-shot cosh-core request"
         }
         MessageId::HelpGroupConfig => "Config",
         MessageId::HelpGroupHealth => "Health",

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/help.rs
@@ -42,7 +42,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::HelpGroupPrompt => "Prompt",
         MessageId::HelpSummaryDraft => "打开多行 Prompt 草稿卡（?? 回车等效）",
         MessageId::PromptMultilineEntryHint => {
-            "多行提问可输入 ?? 后回车，或使用 /draft 打开草稿卡"
+            "多行提问可输入 ?? 后回车；一次性 cosh-core 请求可使用 /agent"
         }
         MessageId::HelpGroupConfig => "配置",
         MessageId::HelpGroupHealth => "健康",

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prompt_draft.rs
@@ -78,9 +78,9 @@ enum CardPhase {
     Cancelled,
 }
 
-/// Opens a fresh prompt-draft card immediately (#1932): shared by the
-/// relay-driven `open` lifecycle event and the `/draft` slash entry. The
-/// pending card capture picks the draft up on the next controller pass.
+/// Opens a fresh prompt-draft card immediately (#1932) for relay-driven
+/// multiline input. The pending card capture picks the draft up on the next
+/// controller pass.
 /// `line_break_before` distinguishes the relay path (cursor still sits on
 /// the bash prompt line, the card must open on a fresh line) from the
 /// slash path (the dispatcher already left the cursor at a fresh column).

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -243,7 +243,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -169,7 +169,7 @@ _cosh_should_intercept_unknown() {
 _cosh_is_slash_control_candidate() {
   local command="$1"
   case "$command" in
-    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/draft|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
+    /about|/agent|/allow|/answer|/approval-mode|/approve|/audit|/auth|/cancel|/clear|/config|/copy|/debug|/deny|/details|/explain|/extensions|/health|/help|/hooks|/mcp|/mode|/new|/recommendations|/resume|/select|/send-to-shell|/session|/shell|/skills|/stats|/status)
       return 0
       ;;
   esac
@@ -610,7 +610,7 @@ _cosh_precmd_marker() {
 # Slash command function stubs — prevent "zsh: no such file or directory" for
 # commands starting with / that zsh would try to exec as an absolute path.
 # The actual interception and marker emission happens in _cosh_preexec_marker.
-for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details draft explain extensions health help hooks mcp mode new recommendations resume select send-to-shell session shell skills stats status; do
+for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mcp mode new recommendations resume select send-to-shell session shell skills stats status; do
   functions[/$_cosh_sc]=':'
 done
 unset _cosh_sc

--- a/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/commands.rs
@@ -40,33 +40,6 @@ pub(super) fn render_slash_command<W: Write>(
             render_help(state, output)?;
             Ok(true)
         }
-        SlashCommand::Draft => {
-            if let Some((workspace_cwd, skill_names)) =
-                agent_composer_context(adapter, state, shell_cwd)
-            {
-                crate::runtime::prompt_draft::open_agent_composer(
-                    state,
-                    output,
-                    adapter.name(),
-                    workspace_cwd.as_deref(),
-                    skill_names,
-                )?;
-                // `/draft` remains accepted as a compatibility alias, but it
-                // must share the Composer terminal lifecycle with `/agent`.
-                Ok(false)
-            } else {
-                // Preserve the legacy multi-provider draft for adapters that
-                // do not expose cosh-core Composer metadata.
-                crate::runtime::prompt_draft::open_prompt_draft(
-                    state,
-                    output,
-                    String::new(),
-                    false,
-                    adapter.name(),
-                )?;
-                Ok(true)
-            }
-        }
         SlashCommand::Agent => {
             let Some((workspace_cwd, skill_names)) =
                 agent_composer_context(adapter, state, shell_cwd)

--- a/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/parser.rs
@@ -15,7 +15,6 @@ pub(super) fn slash_input(event: &ShellEvent) -> Option<&str> {
 pub(super) enum SlashCommand<'a> {
     Noop,
     Help,
-    Draft,
     Agent,
     Auth,
     Audit(&'a str),
@@ -61,7 +60,6 @@ impl<'a> SlashCommand<'a> {
         }
         Ok(match token {
             "/help" => Some(Self::Help),
-            "/draft" => Some(Self::Draft),
             "/agent" => Some(Self::Agent),
             "/auth" => Some(Self::Auth),
             "/hooks" => {
@@ -201,14 +199,10 @@ mod tests {
     use super::{RemovedCommand, SlashCommand, SlashCommandSpec, SlashParseError};
 
     #[test]
-    fn routing_c4_draft_grammar_no_drift() {
+    fn removed_draft_alias_is_unknown() {
         assert!(matches!(
-            SlashCommand::parse("/draft extra"),
-            Ok(Some(SlashCommand::Draft))
-        ));
-        assert!(matches!(
-            SlashCommand::parse("/draft 'extra'"),
-            Ok(Some(SlashCommand::Draft))
+            SlashCommand::parse("/draft"),
+            Ok(Some(SlashCommand::Unknown("/draft")))
         ));
         assert!(matches!(
             SlashCommand::parse("/agent"),

--- a/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/registry.rs
@@ -49,16 +49,6 @@ pub fn slash_command_registry() -> &'static [SlashCommandSpec] {
             state: SlashCommandState::Public,
         },
         SlashCommandSpec {
-            // Compatibility alias: keep exact routing while `/agent` is the
-            // only discoverable Composer entry during the migration window.
-            name: "/draft",
-            usage: "/draft",
-            summary_id: MessageId::HelpSummaryDraft,
-            group: Some("Prompt"),
-            scope: "session",
-            state: SlashCommandState::Hidden,
-        },
-        SlashCommandSpec {
             name: "/health",
             usage: "/health",
             summary_id: MessageId::HelpSummaryHealth,
@@ -401,12 +391,10 @@ mod tests {
         assert!(visible.contains(&"/recommendations [on|off|status|privacy|clear]"));
         assert!(visible.contains(&"/agent"));
         assert!(!visible.contains(&"/draft"));
-        let draft = slash_command_registry()
+        assert!(!slash_command_registry()
             .iter()
-            .find(|spec| spec.name == "/draft")
-            .expect("draft compatibility alias");
-        assert_eq!(draft.state, SlashCommandState::Hidden);
-        assert!(exact_slash_control_commands().any(|name| name == "/draft"));
+            .any(|spec| spec.name == "/draft"));
+        assert!(!exact_slash_control_commands().any(|name| name == "/draft"));
         assert!(!active_slash_commands().any(|name| name == "/draft"));
         assert!(!active_slash_hint_commands().any(|name| name == "/draft"));
         assert!(!visible.iter().any(|usage| usage.starts_with("/explain")));

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/composer.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/composer.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 #[test]
-fn raw_cli_draft_alias_opens_agent_composer() {
-    let home = temp_shell_home("agent-composer-draft-alias");
+fn raw_cli_removed_draft_alias_falls_through_to_shell() {
+    let home = temp_shell_home("agent-composer-removed-draft-alias");
     fs::write(home.join(".bashrc"), "PS1='alias-test$ '\n").unwrap();
     let home_str = home.to_string_lossy().to_string();
     let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
@@ -17,14 +17,13 @@ fn raw_cli_draft_alias_opens_agent_composer() {
         Path::new(env!("CARGO_MANIFEST_DIR")),
         &[
             ("alias-test$", b"/draft\n"),
-            ("Agent Composer", b"cancel alias\x1b"),
-            ("Draft cancelled", b"exit\n"),
+            ("No such file or directory", b"exit 0\n"),
         ],
     );
     let _ = fs::remove_dir_all(&home);
 
-    assert!(output.contains("Runtime: fake"), "{output}");
-    assert!(!output.contains("bash: /draft"), "{output}");
+    assert!(output.contains("bash: /draft"), "{output}");
+    assert!(!output.contains("Agent Composer"), "{output}");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1246,7 +1246,7 @@ fn routing_c4_zsh_stubs_intercept_bypass_only_commands() {
         unique_suffix()
     ));
     let config = ShellHostConfig::new("routing-c4-zsh-stubs", &work_dir);
-    let inputs = ["/draft", "/resume", "/session"];
+    let inputs = ["/resume", "/session"];
     let steps = inputs
         .iter()
         .map(|input| ScriptedInput::user_line(*input))

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -101,7 +101,7 @@ fn routing_c4_zsh_rust_route_uses_shared_event_contract() {
 }
 
 #[test]
-fn routing_c4_draft_grammar_no_drift_preserves_raw_arguments() {
+fn removed_draft_alias_preserves_native_shell_routing() {
     let work_dir = std::env::temp_dir().join(format!(
         "cosh-shell-c4-draft-grammar-{}-{}",
         std::process::id(),
@@ -116,13 +116,16 @@ fn routing_c4_draft_grammar_no_drift_preserves_raw_arguments() {
         ],
         Vec::new(),
     )
-    .expect("draft grammar routing");
+    .expect("removed draft routing");
 
     for input in ["/draft extra", "/draft 'extra'"] {
-        assert!(output.events.iter().any(|event| {
+        assert!(!output.events.iter().any(|event| {
             event.kind == ShellEventKind::UserInputIntercepted
                 && event.input.as_deref() == Some(input)
                 && event.component.as_deref() == Some("slash")
+        }));
+        assert!(output.events.iter().any(|event| {
+            event.kind == ShellEventKind::CommandStarted && event.command.as_deref() == Some(input)
         }));
     }
 }

--- a/src/cosh-ng/docs/design/runtime-contracts.md
+++ b/src/cosh-ng/docs/design/runtime-contracts.md
@@ -102,11 +102,10 @@ directory remains inside the workspace. The Composer passes reference metadata
 to cosh-core without reading or embedding referenced contents. Invalid or
 out-of-workspace references are reported in the structured Composer envelope.
 
-`/agent` is the only public Composer entry point. `/draft` remains accepted as
-a hidden compatibility alias: it reuses the Composer with cosh-core and the
-Fake adapter, while other providers retain the legacy multiline draft editor.
-Ordinary command input continues through shell-first routing, and cancellation
-restores the native Bash or Zsh prompt without submitting a turn.
+`/agent` is the only Composer command. The former `/draft` compatibility alias
+is not intercepted and follows native shell routing. Ordinary command input
+continues through shell-first routing, and cancellation restores the native
+Bash or Zsh prompt without submitting a turn.
 
 ## Compatibility and rollback
 


### PR DESCRIPTION
## Why

PR #2403 made `/agent` the only discoverable Agent Composer entry and kept
`/draft` temporarily as a hidden compatibility alias. The migration window is
now complete, so retaining a second command path adds routing and documentation
debt without a separate capability.

## What changed

- Removed `/draft` from slash parsing, registry, dispatch, and Bash/Zsh markers.
- Returned `/draft` to native shell routing instead of opening a Composer card.
- Kept the internal multiline editor used by `/agent`, `??`, paste, and soft
  newline flows.
- Updated bilingual README/user guides, runtime contract, hints, and regression
  coverage.

## Related issue

no-issue: staged compatibility cleanup after #2403

## User / Agent impact

`/draft` no longer opens a draft or Agent Composer card. Users should use
`/agent` for one-shot cosh-core requests or `??` followed by Enter for generic
multiline input. An exact `/draft` input now follows native shell semantics.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Migration or rollback guidance is needed

This intentionally removes the hidden alias. `/agent` behavior and the shared
multiline editor are unchanged. Reverting the single commit restores the alias
without a data migration.

## Validation

- `cargo test --locked --package cosh-shell --bin cosh-shell removed_draft_alias_is_unknown`
- `cargo test --locked --package cosh-shell --lib public_discovery_excludes_card_first_and_diagnostic_commands`
- Exact Raw CLI Bash fallthrough, shell relay, and Zsh marker tests
- `cargo test --locked --package cosh-shell --test raw_cli composer` — 7 passed
- `cargo test --locked --package cosh-shell --lib` — 1306 passed
- `cargo clippy --locked --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/docs-lint.sh` and `scripts/docs-link-check.py`
- `git diff --check`

## Documentation and rollback

Removed the compatibility wording from both component READMEs and the paired
English/Chinese interactive guides. The runtime contract now states that
`/draft` is not intercepted. Roll back by reverting `78188cce`; no stored data
or configuration migration is involved.