### PR TITLE
fix(sec-core): refine PII detection and notices

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/regex.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/detectors/regex.py
@@ -7,12 +7,15 @@ from agent_sec_cli.pii_checker.models import PiiCategory, PiiSeverity
 from agent_sec_cli.pii_checker.validators import (
     luhn_check,
     validate_cn_id,
+    validate_email,
     validate_jwt,
 )
 
 _CONTEXT_WINDOW_RADIUS = 64
 _CONTEXT_POSITIVE_DELTA = 0.12
 _CONTEXT_NEGATIVE_DELTA = -0.35
+_REMOTE_COMMAND_CONTEXT_LIMIT = 4_096
+_REMOTE_PATH_CONTEXT_LIMIT = 1_024
 _MAX_PRIVATE_KEY_CHARS = 16_384
 _PRIVATE_KEY_EVIDENCE_PLACEHOLDER = "[PRIVATE_KEY_OMITTED]"
 
@@ -44,12 +47,12 @@ BUILTIN_PII_TYPES = frozenset(
 # | api_key prefix patterns             | 0.86 |
 # | generic_secret_field, email         | 0.82 |
 # | phone_cn                            | 0.78 |
-# | reserved .invalid email             | 0.35 |
+# | reserved/remote-identity email      | 0.35 |
 #
 # Context adjustment uses a 64-character window around each match. Security
-# keywords raise credential-like matches by +0.12; fixture/example markers lower
-# likely test data by -0.35. Scanner-level thresholding hides low-confidence
-# findings unless include_low_confidence is enabled.
+# keywords raise matches by +0.12; fixture/example markers lower non-email test
+# data by -0.35. Scanner-level thresholding hides low-confidence findings unless
+# include_low_confidence is enabled.
 _BASE_CONFIDENCE: dict[str, float] = {
     "private_key": 1.0,
     "jwt": 0.94,
@@ -61,7 +64,7 @@ _BASE_CONFIDENCE: dict[str, float] = {
     "generic_secret_field": 0.82,
     "email": 0.82,
     "phone_cn": 0.78,
-    "email_reserved_invalid": 0.35,
+    "email_low_confidence_context": 0.35,
 }
 
 _POSITIVE_CONTEXT = (
@@ -82,6 +85,96 @@ _POSITIVE_CONTEXT = (
     "访问密钥",
 )
 _NEGATIVE_CONTEXT = ("example", "dummy", "test", "sample", ".invalid")
+_RESERVED_EMAIL_DOMAINS = frozenset(
+    {
+        "example",
+        "example.com",
+        "example.net",
+        "example.org",
+        "invalid",
+        "localhost",
+        "test",
+    }
+)
+_REMOTE_EMAIL_URI_RE = re.compile(
+    r"(?<![\w+.-])(?:git\+ssh|ssh|sftp|scp|rsync)://$", re.IGNORECASE
+)
+_REMOTE_COMMAND_OPTIONS_WITH_VALUE = {
+    "ssh": frozenset(
+        {
+            "-B",
+            "-b",
+            "-c",
+            "-D",
+            "-E",
+            "-e",
+            "-F",
+            "-I",
+            "-i",
+            "-J",
+            "-L",
+            "-l",
+            "-m",
+            "-O",
+            "-o",
+            "-P",
+            "-p",
+            "-R",
+            "-S",
+            "-W",
+            "-w",
+        }
+    ),
+    "sftp": frozenset(
+        {
+            "-B",
+            "-b",
+            "-c",
+            "-F",
+            "-i",
+            "-J",
+            "-l",
+            "-o",
+            "-P",
+            "-R",
+            "-S",
+            "-s",
+            "-X",
+        }
+    ),
+}
+_REMOTE_COMMAND_FLAG_OPTIONS = {
+    "ssh": frozenset(
+        {
+            "-4",
+            "-6",
+            "-A",
+            "-a",
+            "-C",
+            "-f",
+            "-G",
+            "-g",
+            "-K",
+            "-k",
+            "-M",
+            "-N",
+            "-n",
+            "-q",
+            "-s",
+            "-T",
+            "-t",
+            "-v",
+            "-X",
+            "-x",
+            "-Y",
+            "-y",
+        }
+    ),
+    "sftp": frozenset(
+        {"-4", "-6", "-A", "-a", "-C", "-f", "-N", "-p", "-q", "-r", "-v"}
+    ),
+}
+_SHELL_COMMAND_SEPARATOR_RE = re.compile(r"[\n;|&]")
 
 _EMAIL_RE = re.compile(
     r"(?<![\w.+-])[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]+\.[A-Za-z]{2,63}(?![\w.-])"
@@ -129,6 +222,112 @@ def _score_with_context(text: str, start: int, end: int, base: float) -> float:
     if any(marker in compact_context for marker in _NEGATIVE_CONTEXT):
         score += _CONTEXT_NEGATIVE_DELTA
     return max(0.0, min(1.0, score))
+
+
+def _score_email_with_context(text: str, start: int, end: int, base: float) -> float:
+    """Raise email confidence for security context without fixture-word penalties."""
+    context = _context_window(text, start, end)
+    compact_context = context.replace("-", "_")
+    score = base
+    if any(marker in compact_context for marker in _POSITIVE_CONTEXT):
+        score += _CONTEXT_POSITIVE_DELTA
+    return max(0.0, min(1.0, score))
+
+
+def _is_reserved_email_domain(value: str) -> bool:
+    """Return whether an address uses a reserved example or testing domain."""
+    domain = value.rsplit("@", maxsplit=1)[-1].lower()
+    return any(
+        domain == reserved or domain.endswith(f".{reserved}")
+        for reserved in _RESERVED_EMAIL_DOMAINS
+    )
+
+
+def _is_remote_command_target(command_prefix: str) -> bool:
+    """Return whether the candidate immediately follows SSH/SFTP options."""
+    command_prefix = command_prefix.strip()
+    if not command_prefix:
+        return False
+
+    tokens = command_prefix.split()
+    command = tokens[0].rsplit("/", maxsplit=1)[-1].lower()
+    value_options = _REMOTE_COMMAND_OPTIONS_WITH_VALUE.get(command)
+    flag_options = _REMOTE_COMMAND_FLAG_OPTIONS.get(command)
+    if value_options is None or flag_options is None:
+        return False
+
+    index = 1
+    while index < len(tokens):
+        option = tokens[index]
+        if option == "--":
+            return index == len(tokens) - 1
+        if option in flag_options:
+            index += 1
+            continue
+        if option in value_options:
+            index += 2
+            if index > len(tokens):
+                return False
+            continue
+        if len(option) > 2 and option[:2] in value_options:
+            index += 1
+            continue
+        if (
+            len(option) > 2
+            and option.startswith("-")
+            and all(f"-{flag}" in flag_options for flag in option[1:])
+        ):
+            index += 1
+            continue
+        return False
+    return True
+
+
+def _is_remote_identity_context(
+    text: str, start: int, end: int, command_start: int
+) -> bool:
+    """Return whether an email-shaped value is clearly a remote login identity."""
+    prefix = text[max(0, start - _CONTEXT_WINDOW_RADIUS) : start]
+    if _REMOTE_EMAIL_URI_RE.search(prefix) is not None:
+        return True
+
+    if end + 1 < len(text) and text[end] == ":" and not text[end + 1].isspace():
+        path_start = end + 1
+        path_limit = min(len(text), path_start + _REMOTE_PATH_CONTEXT_LIMIT)
+        remote_path = text[path_start:path_limit].split(maxsplit=1)[0]
+        is_uri = re.match(r"[A-Za-z][A-Za-z0-9+.-]*://", remote_path) is not None
+        if not is_uri and (
+            remote_path.startswith(("/", "~", "./", "../"))
+            or "/" in remote_path
+            or remote_path.endswith(".git")
+        ):
+            return True
+
+    target_start = start
+    opening_quote = (
+        text[start - 1] if start > 0 and text[start - 1] in {'"', "'"} else None
+    )
+    closing_quote = text[end] if end < len(text) and text[end] in {'"', "'"} else None
+    if opening_quote is not None or closing_quote is not None:
+        if opening_quote is None or closing_quote != opening_quote:
+            return False
+        after_quote = end + 1
+        if (
+            after_quote < len(text)
+            and not text[after_quote].isspace()
+            and text[after_quote] not in ";|&"
+        ):
+            return False
+        target_start -= 1
+
+    prefix_start = command_start + 1
+    if (
+        target_start <= prefix_start
+        or not text[target_start - 1].isspace()
+        or target_start - prefix_start > _REMOTE_COMMAND_CONTEXT_LIMIT
+    ):
+        return False
+    return _is_remote_command_target(text[prefix_start:target_start])
 
 
 def _severity_for(pii_type: str) -> tuple[str, str]:
@@ -348,15 +547,32 @@ class RegexPiiDetector:
             )
 
     def _detect_emails(self, text: str, candidates: list[PiiCandidate]) -> None:
+        separator_cursor = 0
+        command_start = -1
         for match in _EMAIL_RE.finditer(text):
+            for separator in _SHELL_COMMAND_SEPARATOR_RE.finditer(
+                text, separator_cursor, match.start()
+            ):
+                command_start = separator.start()
+            separator_cursor = match.end()
+
             value = match.group(0)
+            if not validate_email(value):
+                continue
+
             base = _BASE_CONFIDENCE["email"]
-            if value.lower().endswith(".invalid"):
-                base = _BASE_CONFIDENCE["email_reserved_invalid"]
+            metadata = {"validator": "email_syntax"}
+            if _is_remote_identity_context(text, *match.span(), command_start):
+                base = _BASE_CONFIDENCE["email_low_confidence_context"]
+                metadata["context"] = "remote_identity"
+            elif _is_reserved_email_domain(value):
+                base = _BASE_CONFIDENCE["email_low_confidence_context"]
+                metadata["context"] = "reserved_domain"
             self._add_candidate(
                 candidates,
                 pii_type="email",
                 value=value,
                 span=match.span(),
-                confidence=_score_with_context(text, *match.span(), base),
+                confidence=_score_email_with_context(text, *match.span(), base),
+                metadata=metadata,
             )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
@@ -75,7 +75,7 @@ def validate_jwt(value: str) -> bool:
         return False
 
     decoded_parts: list[bytes] = []
-    for part in parts:
+    for index, part in enumerate(parts):
         if len(part) % 4 == 1:
             return False
         padded = part + "=" * (-len(part) % 4)
@@ -85,10 +85,14 @@ def validate_jwt(value: str) -> bool:
             )
         except (binascii.Error, ValueError):
             return False
-        if not decoded or (
-            base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii") != part
-        ):
+        if not decoded:
             return False
+        # Preserve canonical JSON segments while accepting signature aliases
+        # that permissive JWT libraries decode to the same bytes.
+        if index < 2:
+            canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+            if canonical != part:
+                return False
         decoded_parts.append(decoded)
 
     json_parts: list[object] = []

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/pii_checker/validators.py
@@ -2,8 +2,13 @@
 
 import base64
 import binascii
+import json
 import re
 from datetime import datetime
+
+_EMAIL_LOCAL_RE = re.compile(r"[A-Za-z0-9._%+-]+")
+_EMAIL_DOMAIN_LABEL_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?")
+_EMAIL_TLD_RE = re.compile(r"[A-Za-z]{2,63}")
 
 
 def luhn_check(value: str) -> bool:
@@ -42,6 +47,25 @@ def validate_cn_id(value: str) -> bool:
     return normalized[-1] == checks[total % 11]
 
 
+def validate_email(value: str) -> bool:
+    """Validate the supported ASCII email-address syntax."""
+    if len(value) > 254 or value.count("@") != 1:
+        return False
+
+    local, domain = value.split("@")
+    if not local or len(local) > 64 or not domain or len(domain) > 253:
+        return False
+    if local.startswith(".") or local.endswith(".") or ".." in local:
+        return False
+    if _EMAIL_LOCAL_RE.fullmatch(local) is None:
+        return False
+
+    labels = domain.split(".")
+    if len(labels) < 2 or _EMAIL_TLD_RE.fullmatch(labels[-1]) is None:
+        return False
+    return all(_EMAIL_DOMAIN_LABEL_RE.fullmatch(label) is not None for label in labels)
+
+
 def validate_jwt(value: str) -> bool:
     """Validate the structural shape of a JWT."""
     parts = value.split(".")
@@ -50,14 +74,35 @@ def validate_jwt(value: str) -> bool:
     if not all(re.fullmatch(r"[A-Za-z0-9_-]+", part) for part in parts):
         return False
 
-    for part in parts[:2]:
+    decoded_parts: list[bytes] = []
+    for part in parts:
+        if len(part) % 4 == 1:
+            return False
         padded = part + "=" * (-len(part) % 4)
         try:
-            decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+            decoded = base64.b64decode(
+                padded.encode("ascii"), altchars=b"-_", validate=True
+            )
         except (binascii.Error, ValueError):
             return False
-        if not decoded.strip():
+        if not decoded or (
+            base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii") != part
+        ):
             return False
+        decoded_parts.append(decoded)
+
+    json_parts: list[object] = []
+    for decoded in decoded_parts[:2]:
+        try:
+            json_parts.append(json.loads(decoded.decode("utf-8")))
+        except (UnicodeDecodeError, ValueError, RecursionError):
+            return False
+    if not all(isinstance(part, dict) for part in json_parts):
+        return False
+
+    algorithm = json_parts[0].get("alg")
+    if not isinstance(algorithm, str) or not algorithm.strip():
+        return False
     return True
 
 

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/pii_checker_hook.py
@@ -73,10 +73,6 @@ try:
 except (ValueError, TypeError):
     TIMEOUT = 5
 
-_MAX_EVIDENCE_ITEMS = 3
-_MAX_EVIDENCE_CHARS = 80
-
-
 # -- helpers ---------------------------------------------------------------
 
 
@@ -88,125 +84,98 @@ def _safe_text(value: Any) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
-    value = " ".join(value.split())
-    if len(value) <= limit:
-        return value
-    return value[: limit - 1] + "…"
+def _finding_risk(finding: Any, verdict: str) -> str:
+    """Return the user-facing risk for a structured scanner finding."""
+    if isinstance(finding, dict):
+        severity = _safe_text(finding.get("severity"))
+        if severity == "deny":
+            return "high"
+        if severity == "warn":
+            return "general"
+
+    return "high" if verdict == "deny" else "general"
+
+
+def _risk_summary(verdict: str, findings: list[Any]) -> str:
+    """Summarize finding counts without exposing scanner-internal fields."""
+    typed_findings = [finding for finding in findings if isinstance(finding, dict)]
+    high_count = sum(
+        1 for finding in typed_findings if _finding_risk(finding, verdict) == "high"
+    )
+    general_count = len(typed_findings) - high_count
+
+    if high_count and general_count:
+        return (
+            f"检测到 {len(typed_findings)} 项敏感信息"
+            f"（高风险 {high_count}、一般风险 {general_count}）"
+        )
+    if high_count:
+        return f"检测到 {high_count} 项高风险敏感信息"
+    return f"检测到 {general_count} 项一般风险敏感信息"
 
 
 # -- output helpers --------------------------------------------------------
 
 
-def _format_finding_details(findings: list[dict]) -> tuple[int, list[str]]:
-    """Build shared, audit-safe detail lines from structured PII findings."""
-    typed_findings = [item for item in findings if isinstance(item, dict)]
-    count = len(typed_findings)
-    pii_types = sorted(
-        {
-            finding_type
-            for finding in typed_findings
-            if (finding_type := _safe_text(finding.get("type")))
-        }
-    )
-    severities = sorted(
-        {
-            severity
-            for finding in typed_findings
-            if (severity := _safe_text(finding.get("severity")))
-        }
-    )
-    redacted_evidence: list[str] = []
-    for finding in typed_findings:
-        evidence = _safe_text(finding.get("evidence_redacted"))
-        if evidence and evidence not in redacted_evidence:
-            redacted_evidence.append(_shorten(evidence))
-        if len(redacted_evidence) >= _MAX_EVIDENCE_ITEMS:
-            break
-
-    lines = [f"  类型      : {', '.join(pii_types) if pii_types else 'unknown'}"]
-    if severities:
-        lines.append(f"  严重级别  : {', '.join(severities)}")
-    if redacted_evidence:
-        lines.append(f"  脱敏示例  : {', '.join(redacted_evidence)}")
-    return count, lines
+def _format_notice(verdict: str, findings: list[Any], action_message: str) -> str:
+    """Build a concise notice without exposing internal labels or evidence."""
+    return f"[pii-checker] {_risk_summary(verdict, findings)}；{action_message}"
 
 
-def _format_block_reason(
-    findings: list[dict], hook_event: str, source_desc: str
-) -> str:
-    """Build a human-readable block reason from structured PII findings.
-
-    The reason is shown to the user (UserPromptSubmit) or replaces tool
-    output visible to the model (PostToolUse). It contains only PII types
-    and redacted evidence — never the raw PII content itself.
-    """
-    count, details = _format_finding_details(findings)
-    lines = [
-        f"[pii-checker] 🔒 安全拦截：{source_desc}中检测到 {count} 项个人敏感信息",
-        *details,
-    ]
-    lines.append(f"  拦截环节  : {hook_event}")
-
+def _format_block_reason(findings: list[Any], hook_event: str, verdict: str) -> str:
+    """Build an event-specific block reason for the user."""
     if hook_event == "UserPromptSubmit":
-        lines.append("请移除敏感信息后重新提交。")
+        action_message = "当前策略已阻断本次请求。"
     elif hook_event == "PreToolUse":
-        lines.append("该工具调用已被阻止，敏感信息不会外发。")
+        action_message = "当前策略已阻断本次工具调用。"
     else:
-        lines.append("工具输出已被拦截，原始内容不会进入模型上下文。")
+        action_message = (
+            "工具已经执行；原始工具结果不会进入模型上下文，"
+            "已发生的外部副作用不会撤销。"
+        )
 
-    return "\n".join(lines)
+    return _format_notice(verdict, findings, action_message)
 
 
 def _format_warning_message(
-    findings: list[dict],
+    findings: list[Any],
     hook_event: str,
-    source_desc: str,
     verdict: str,
     policy: str,
 ) -> str:
-    """Build a non-blocking warning using only redacted finding evidence."""
-    count, details = _format_finding_details(findings)
-    if policy == "ask":
-        actual_handling = "当前 hook 不支持确认，fallback 为 warn，执行将继续。"
-    elif policy == "block":
-        actual_handling = (
-            "scanner verdict 未达到 block 条件，fallback 为 warn，执行将继续。"
-        )
+    """Build a concise warning that states the actual non-blocking behavior."""
+    if hook_event == "PostToolUse":
+        if verdict == "deny" and policy == "ask":
+            action_message = (
+                "工具已经执行；当前环节不支持确认/阻断，本次仅提醒，不会阻断；"
+                "原始工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+            )
+        else:
+            action_message = (
+                "工具已经执行；本次仅提醒，未触发确认或阻断；"
+                "原始工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+            )
+    elif verdict == "deny" and policy == "ask":
+        action_message = "当前环节不支持确认/阻断，本次仅提醒，不会阻断。"
     else:
-        actual_handling = "warn，执行将继续。"
-    lines = [
-        f"[pii-checker] ⚠️ 隐私告警：{source_desc}中检测到 {count} 项个人敏感信息",
-        *details,
-        f"  告警环节  : {hook_event}",
-        f"扫描判定：{verdict}",
-        f"Hook 策略：{policy}",
-        f"实际处理：{actual_handling}",
-    ]
-    return "\n".join(lines)
+        action_message = "本次仅提醒，未触发确认或阻断。"
+    return _format_notice(verdict, findings, action_message)
 
 
-def _block(findings: list[dict], hook_event: str, source_desc: str) -> None:
+def _block(findings: list[Any], hook_event: str, verdict: str) -> None:
     """Output block decision JSON to stdout."""
-    reason = _format_block_reason(findings, hook_event, source_desc)
+    reason = _format_block_reason(findings, hook_event, verdict)
     print(json.dumps({"decision": "block", "reason": reason}, ensure_ascii=False))
 
 
 def _warn(
-    findings: list[dict],
+    findings: list[Any],
     hook_event: str,
-    source_desc: str,
     verdict: str,
     policy: str,
 ) -> None:
     """Output a user-visible warning without changing execution control."""
-    message = _format_warning_message(
-        findings,
-        hook_event,
-        source_desc,
-        verdict,
-        policy,
-    )
+    message = _format_warning_message(findings, hook_event, verdict, policy)
     print(json.dumps({"systemMessage": message}, ensure_ascii=False))
 
 
@@ -270,15 +239,6 @@ def _source_for_event(hook_event: str) -> str:
     if hook_event == "PostToolUse":
         return "tool_output"
     return "user_input"
-
-
-def _source_desc_for_event(hook_event: str) -> str:
-    """Return a human-readable source description for a PII notice."""
-    if hook_event == "PreToolUse":
-        return "工具输入"
-    if hook_event == "PostToolUse":
-        return "工具输出"
-    return "用户输入"
 
 
 # -- main ------------------------------------------------------------------
@@ -351,12 +311,11 @@ def main() -> None:
     policy = _effective_policy()
     if policy == "observe":
         return  # observe mode: don't block, audit only via CLI events
-    source_desc = _source_desc_for_event(hook_event)
     if policy == "block" and verdict == "deny":
-        _block(findings, hook_event, source_desc)
+        _block(findings, hook_event, verdict)
         return
     # Codex cannot request approval at all PII hook points; ask falls back to warn.
-    _warn(findings, hook_event, source_desc, verdict, policy)
+    _warn(findings, hook_event, verdict, policy)
 
 
 if __name__ == "__main__":

--- a/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/pii_checker_hook.py
@@ -36,8 +36,6 @@ _USER_INPUT_SOURCE = "user_input"
 _TOOL_INPUT_SOURCE = "tool_input"
 _TOOL_OUTPUT_SOURCE = "tool_output"
 _MODEL_OUTPUT_SOURCE = "model_output"
-_MAX_EVIDENCE_ITEMS = 3
-_MAX_EVIDENCE_CHARS = 80
 
 
 def _allow() -> str:
@@ -53,54 +51,44 @@ def _safe_text(value: Any) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
-    value = " ".join(value.split())
-    if len(value) <= limit:
-        return value
-    return value[: limit - 1] + "…"
+def _finding_risk(finding: Any, verdict: str) -> str:
+    """Return the user-facing risk for a structured scanner finding."""
+    if isinstance(finding, dict):
+        severity = _safe_text(finding.get("severity"))
+        if severity == "deny":
+            return "high"
+        if severity == "warn":
+            return "general"
+
+    return "high" if verdict == "deny" else "general"
+
+
+def _risk_summary(verdict: str, findings: list[Any]) -> str:
+    """Summarize finding counts without exposing scanner-internal fields."""
+    typed_findings = [finding for finding in findings if isinstance(finding, dict)]
+    high_count = sum(
+        1 for finding in typed_findings if _finding_risk(finding, verdict) == "high"
+    )
+    general_count = len(typed_findings) - high_count
+
+    if high_count and general_count:
+        return (
+            f"检测到 {len(typed_findings)} 项敏感信息"
+            f"（高风险 {high_count}、一般风险 {general_count}）"
+        )
+    if high_count:
+        return f"检测到 {high_count} 项高风险敏感信息"
+    return f"检测到 {general_count} 项一般风险敏感信息"
 
 
 def _format_pii_warning(
     verdict: str,
     findings: list[Any],
-    action_message: str = "本轮请求将继续处理。",
+    action_message: str = "本次仅提醒，未触发确认或阻断。",
 ) -> str:
-    """Build a minimal-disclosure warning from structured PII findings."""
-    typed_findings = [item for item in findings if isinstance(item, dict)]
-    count = len(typed_findings)
-    pii_types = sorted(
-        {
-            finding_type
-            for finding in typed_findings
-            if (finding_type := _safe_text(finding.get("type")))
-        }
-    )
-    severities = sorted(
-        {
-            severity
-            for finding in typed_findings
-            if (severity := _safe_text(finding.get("severity")))
-        }
-    )
-    redacted_evidence: list[str] = []
-    for finding in typed_findings:
-        evidence = _safe_text(finding.get("evidence_redacted"))
-        if evidence and evidence not in redacted_evidence:
-            redacted_evidence.append(_shorten(evidence))
-        if len(redacted_evidence) >= _MAX_EVIDENCE_ITEMS:
-            break
-
-    risk = "高风险敏感信息" if verdict == "deny" else "敏感信息"
-    parts = [
-        f"[pii-checker] 检测到 {count} 项{risk}",
-        f"类型：{', '.join(pii_types) if pii_types else 'unknown'}",
-    ]
-    if severities:
-        parts.append(f"严重级别：{', '.join(severities)}")
-    if redacted_evidence:
-        parts.append(f"脱敏示例：{', '.join(redacted_evidence)}")
-    parts.append(action_message)
-    return "；".join(parts)
+    """Build a concise warning without exposing internal labels or evidence."""
+    # Cosh strips this exact hook-name prefix from permissive notifications.
+    return f"[pii-checker] {_risk_summary(verdict, findings)}；{action_message}"
 
 
 def _scan_text(
@@ -229,7 +217,11 @@ def _format_cosh(
         verdict == "error" or unknown -> fail-open "allow"
     """
     verdict = _safe_text(scan_result.get("verdict")) or "pass"
-    findings = _as_list(scan_result.get("findings"))
+    findings = [
+        finding
+        for finding in _as_list(scan_result.get("findings"))
+        if isinstance(finding, dict)
+    ]
 
     if verdict == "pass" or not findings:
         return _allow()
@@ -238,37 +230,48 @@ def _format_cosh(
         return _allow()
 
     decision = "allow"
-    action_message = "本轮请求将继续处理。"
+    action_message = "本次仅提醒，未触发确认或阻断。"
+    if event_name in {"PostToolUse", "PostToolUseFailure"}:
+        action_message = (
+            "工具已经执行；本次仅提醒，未触发确认或阻断；"
+            "原始工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+        )
 
     # A scanner warning never escalates into confirmation or blocking.
     if verdict == "deny" and policy == "ask":
         if event_name == "UserPromptSubmit":
             decision = "ask"
-            action_message = "需要确认后才能继续处理本轮请求。"
+            action_message = "当前策略要求确认，请确认后继续。"
         elif event_name == "PreToolUse":
             decision = "ask"
-            action_message = "需要确认后才能执行本次工具调用。"
-        else:
+            action_message = "当前策略要求确认，请确认后继续。"
+        elif event_name in {"PostToolUse", "PostToolUseFailure"}:
             action_message = (
-                "当前 hook 不支持确认，已 fallback 为 warn；本轮处理将继续。"
+                "工具已经执行；当前环节不支持确认/阻断，本次仅提醒，不会阻断；"
+                "原始工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
             )
+        else:
+            action_message = "当前环节不支持确认/阻断，本次仅提醒，不会阻断。"
     elif verdict == "deny" and policy == "block":
         if event_name == "UserPromptSubmit":
             decision = "block"
-            action_message = "本轮请求已被阻断。"
+            action_message = "当前策略已阻断本次请求。"
         elif event_name == "PreToolUse":
             decision = "block"
-            action_message = "本次工具调用已被阻断。"
+            action_message = "当前策略已阻断本次工具调用。"
         elif event_name == "PostToolUse":
             decision = "block"
             action_message = (
                 "工具已经执行；原始工具结果不会进入模型上下文，"
                 "已发生的外部副作用不会撤销。"
             )
-        else:
+        elif event_name == "PostToolUseFailure":
             action_message = (
-                "当前 hook 不支持阻断，已 fallback 为 warn；本轮处理将继续。"
+                "工具已经执行；当前环节不支持确认/阻断，本次仅提醒，不会阻断；"
+                "原始工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
             )
+        else:
+            action_message = "当前环节不支持确认/阻断，本次仅提醒，不会阻断。"
 
     return json.dumps(
         {

--- a/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/pii_scan.py
@@ -21,8 +21,6 @@ from .base import AgentSecCoreCapability
 logger = logging.getLogger("agent-sec-core")
 
 _DEFAULT_WARNING_TTL_SECONDS = 300.0
-_MAX_EVIDENCE_ITEMS = 3
-_MAX_EVIDENCE_CHARS = 80
 _USER_INPUT_SOURCE = "user_input"
 _TOOL_INPUT_SOURCE = "tool_input"
 _TOOL_OUTPUT_SOURCE = "tool_output"
@@ -208,18 +206,25 @@ class PiiScanCapability(AgentSecCoreCapability):
                             f"[agent-sec-core] {self.id} {verdict.upper()} model output observed"
                         )
                         return None
-                    warnings.append(self._format_pii_message(verdict, findings))
                     redacted_text = self._safe_string(scan.get("redacted_text"))
                     if redacted_text:
                         output_text = redacted_text
+                        outcome = "模型输出中的敏感信息已脱敏，本次回复继续交付。"
                         logger.warning(
                             f"[agent-sec-core] {self.id} {verdict.upper()} model output redacted"
                         )
                     else:
                         output_text = ""
+                        outcome = (
+                            "未提供可用的脱敏结果，原始模型输出已停止交付，"
+                            "本次仅显示提醒。"
+                        )
                         logger.warning(
                             f"[agent-sec-core] {self.id} {verdict.upper()} model output redaction missing redacted_text; dropping raw output"
                         )
+                    warnings.append(
+                        self._format_pii_message(verdict, findings, outcome=outcome)
+                    )
                 elif verdict not in {"pass", "warn", "deny"}:
                     logger.warning(
                         f"[agent-sec-core] {self.id} UNKNOWN model output verdict={verdict}, fail-open"
@@ -329,7 +334,7 @@ class PiiScanCapability(AgentSecCoreCapability):
             message = self._format_pii_message(
                 verdict,
                 findings,
-                outcome="本次工具调用已被阻断。",
+                outcome="当前策略已阻断本次工具调用。",
             )
             logger.warning(
                 f"[agent-sec-core] {self.id} {verdict.upper()} blocked source={source}"
@@ -342,7 +347,11 @@ class PiiScanCapability(AgentSecCoreCapability):
             )
             return None
 
-        warning = self._format_pii_message(verdict, findings)
+        warning = self._format_pii_message(
+            verdict,
+            findings,
+            outcome=self._warning_outcome(verdict, source),
+        )
         self._push_warning(cache_key, warning)
         logger.warning(
             f"[agent-sec-core] {self.id} {verdict.upper()} warning cached key={cache_key} source={source}"
@@ -416,50 +425,52 @@ class PiiScanCapability(AgentSecCoreCapability):
         verdict: str,
         findings: list[Any],
         *,
-        outcome: str = "本轮请求将继续处理。",
+        outcome: str = "本次仅提醒，未触发确认或阻断。",
     ) -> str:
-        """Build a minimal-disclosure message from structured PII findings."""
+        """Build a concise warning without exposing scanner-internal fields."""
         typed_findings = [item for item in findings if isinstance(item, dict)]
-        pii_types = sorted(
-            {
-                finding_type
-                for finding in typed_findings
-                if (finding_type := self._safe_string(finding.get("type")))
-            }
-        )
-        severities = sorted(
-            {
-                severity
-                for finding in typed_findings
-                if (severity := self._safe_string(finding.get("severity")))
-            }
-        )
-        redacted_evidence: list[str] = []
-        for finding in typed_findings:
-            evidence = self._safe_string(finding.get("evidence_redacted"))
-            if evidence and evidence not in redacted_evidence:
-                redacted_evidence.append(self._shorten(evidence))
-            if len(redacted_evidence) >= _MAX_EVIDENCE_ITEMS:
-                break
+        return f"[pii-checker] {self._risk_summary(verdict, typed_findings)}；{outcome}"
 
-        risk = "高风险敏感信息" if verdict == "deny" else "敏感信息"
-        parts = [
-            f"[pii-checker] 检测到 {len(typed_findings)} 项{risk}",
-            f"类型：{', '.join(pii_types) if pii_types else 'unknown'}",
-        ]
-        if severities:
-            parts.append(f"严重级别：{', '.join(severities)}")
-        if redacted_evidence:
-            parts.append(f"脱敏示例：{', '.join(redacted_evidence)}")
-        parts.append(outcome)
-        return "；".join(parts)
+    def _warning_outcome(self, verdict: str, source: str) -> str:
+        """Describe the action Hermes actually took at a hook boundary."""
+        if source == _TOOL_OUTPUT_SOURCE:
+            if verdict == "deny" and self._policy in {"ask", "block"}:
+                return (
+                    "工具已经执行；当前环节不支持确认/阻断，本次仅提醒，"
+                    "工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+                )
+            return (
+                "工具已经执行；本次仅提醒，未触发确认或阻断，"
+                "工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+            )
+        if verdict == "deny" and self._policy in {"ask", "block"}:
+            return "当前环节不支持确认/阻断，本次仅提醒，不会阻断。"
+        return "本次仅提醒，未触发确认或阻断。"
 
-    def _shorten(self, value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
-        """Shorten evidence for display."""
-        normalized = " ".join(value.split())
-        if len(normalized) <= limit:
-            return normalized
-        return normalized[: limit - 1] + "…"
+    def _risk_summary(self, verdict: str, findings: list[dict[str, Any]]) -> str:
+        """Summarize per-finding risk without exposing internal labels."""
+        high_count = sum(
+            1 for finding in findings if self._finding_risk(finding, verdict) == "high"
+        )
+        general_count = len(findings) - high_count
+
+        if high_count and general_count:
+            return (
+                f"检测到 {len(findings)} 项敏感信息"
+                f"（高风险 {high_count}、一般风险 {general_count}）"
+            )
+        if high_count:
+            return f"检测到 {high_count} 项高风险敏感信息"
+        return f"检测到 {general_count} 项一般风险敏感信息"
+
+    def _finding_risk(self, finding: dict[str, Any], verdict: str) -> str:
+        """Map a finding severity to its user-facing risk bucket."""
+        severity = self._safe_string(finding.get("severity"))
+        if severity == "deny":
+            return "high"
+        if severity == "warn":
+            return "general"
+        return "high" if verdict == "deny" else "general"
 
     def _as_list(self, value) -> list[Any]:
         return value if isinstance(value, list) else []

--- a/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
+++ b/src/agent-sec-core/openclaw-plugin/src/capabilities/pii-scan.ts
@@ -15,8 +15,6 @@ import {
 } from "../utils.js";
 
 const CLI_TIMEOUT_MS = 10_000;
-const MAX_EVIDENCE_ITEMS = 3;
-const MAX_EVIDENCE_CHARS = 80;
 const BEFORE_DISPATCH_PRIORITY = 200;
 
 type PiiScanConfig = {
@@ -54,60 +52,49 @@ function readConfig(pluginConfig: Record<string, any>, api: any): PiiScanConfig 
   };
 }
 
-function shorten(value: string, limit = MAX_EVIDENCE_CHARS): string {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (normalized.length <= limit) {
-    return normalized;
-  }
-  return `${normalized.slice(0, limit - 1)}…`;
-}
-
 function safeString(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function findingRisk(
+  finding: Record<string, unknown>,
+  verdict: string,
+): "high" | "general" {
+  const severity = safeString(finding.severity);
+  if (severity === "deny") {
+    return "high";
+  }
+  if (severity === "warn") {
+    return "general";
+  }
+  return verdict === "deny" ? "high" : "general";
+}
+
+function riskSummary(verdict: string, findings: Record<string, unknown>[]): string {
+  const highCount = findings.filter(
+    (finding) => findingRisk(finding, verdict) === "high",
+  ).length;
+  const generalCount = findings.length - highCount;
+
+  if (highCount > 0 && generalCount > 0) {
+    return `检测到 ${findings.length} 项敏感信息（高风险 ${highCount}、一般风险 ${generalCount}）`;
+  }
+  if (highCount > 0) {
+    return `检测到 ${highCount} 项高风险敏感信息`;
+  }
+  return `检测到 ${generalCount} 项一般风险敏感信息`;
 }
 
 function formatPiiWarning(
   verdict: string,
   findings: unknown[],
-  finalMessage = "本轮请求将继续处理。",
+  finalMessage = "本次仅提醒，未触发确认或阻断。",
 ): string {
   const typedFindings = findings.filter(
     (finding): finding is Record<string, unknown> =>
       typeof finding === "object" && finding !== null && !Array.isArray(finding),
   );
-  const piiTypes = Array.from(
-    new Set(
-      typedFindings
-        .map((finding) => safeString(finding.type))
-        .filter((value) => value.length > 0),
-    ),
-  ).sort();
-  const severities = Array.from(
-    new Set(
-      typedFindings
-        .map((finding) => safeString(finding.severity))
-        .filter((value) => value.length > 0),
-    ),
-  ).sort();
-  const evidence = typedFindings
-    .map((finding) => safeString(finding.evidence_redacted))
-    .filter((value, index, arr) => value.length > 0 && arr.indexOf(value) === index)
-    .slice(0, MAX_EVIDENCE_ITEMS)
-    .map((value) => shorten(value));
-
-  const risk = verdict === "deny" ? "高风险敏感信息" : "敏感信息";
-  const parts = [
-    `[pii-checker] 检测到 ${typedFindings.length} 项${risk}`,
-    `类型：${piiTypes.length > 0 ? piiTypes.join(", ") : "unknown"}`,
-  ];
-  if (severities.length > 0) {
-    parts.push(`严重级别：${severities.join(", ")}`);
-  }
-  if (evidence.length > 0) {
-    parts.push(`脱敏示例：${evidence.join(", ")}`);
-  }
-  parts.push(finalMessage);
-  return parts.join("；");
+  return `[pii-checker] ${riskSummary(verdict, typedFindings)}；${finalMessage}`;
 }
 
 function buildScanArgs(source: string, includeLowConfidence: boolean): string[] {
@@ -197,9 +184,8 @@ function logPiiWarning(
   finalMessage?: string,
 ): string {
   const warning = formatPiiWarning(verdict, findings, finalMessage);
-  api.logger.warn(
-    `[pii-checker] ${verdict.toUpperCase()} (policy=${cfg.policy}) — ${warning}`,
-  );
+  api.logger.debug?.(`[pii-checker] verdict=${verdict} policy=${cfg.policy}`);
+  api.logger.warn(warning);
   return warning;
 }
 
@@ -251,7 +237,11 @@ export const piiScan: SecurityCapability = {
             verdict,
             findings,
             cfg,
-            verdict === "deny" && cfg.policy === "block" ? "本轮请求已被阻断。" : undefined,
+            verdict === "deny" && cfg.policy === "block"
+              ? "当前策略已阻断本次请求。"
+              : verdict === "deny" && cfg.policy === "ask"
+                ? "当前环节不支持确认/阻断，本次仅提醒，不会阻断。"
+                : undefined,
           );
           if (verdict === "deny" && cfg.policy === "block") {
             return {
@@ -288,8 +278,10 @@ export const piiScan: SecurityCapability = {
             findings,
             cfg,
             verdict === "deny" && cfg.policy === "block"
-              ? "本次工具调用已被阻断。"
-              : undefined,
+              ? "当前策略已阻断本次工具调用。"
+              : verdict === "deny" && cfg.policy === "ask"
+                ? "当前策略要求确认，请确认后继续。"
+                : undefined,
           );
           if (verdict === "deny" && cfg.policy === "ask") {
             return {
@@ -323,7 +315,19 @@ export const piiScan: SecurityCapability = {
         const { verdict, findings } = scanResult;
         if (verdict === "pass" || findings.length === 0) return undefined;
         if (verdict !== "warn" && verdict !== "deny") return undefined;
-        if (cfg.policy !== "observe") logPiiWarning(api, verdict, findings, cfg);
+        if (cfg.policy !== "observe") {
+          const cannotEnforce =
+            verdict === "deny" && (cfg.policy === "ask" || cfg.policy === "block");
+          logPiiWarning(
+            api,
+            verdict,
+            findings,
+            cfg,
+            cannotEnforce
+              ? "工具已经执行；当前环节不支持确认/阻断，本次仅提醒，工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。"
+              : "工具已经执行；本次仅提醒，未触发确认或阻断，工具结果仍会进入模型上下文，已发生的外部副作用不会撤销。",
+          );
+        }
         return undefined;
       } catch (error) {
         api.logger.warn(
@@ -342,7 +346,15 @@ export const piiScan: SecurityCapability = {
         const { verdict, findings } = scanResult;
         if (verdict === "pass" || findings.length === 0) return undefined;
         if (verdict !== "warn" && verdict !== "deny") return undefined;
-        if (cfg.policy !== "observe") logPiiWarning(api, verdict, findings, cfg);
+        if (cfg.policy !== "observe") {
+          logPiiWarning(
+            api,
+            verdict,
+            findings,
+            cfg,
+            "当前环节仅提醒，原始模型输出仍会交付，不会被脱敏或阻断。",
+          );
+        }
         return undefined;
       } catch (error) {
         api.logger.warn(

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/pii-scan-test.ts
@@ -28,6 +28,15 @@ function createMockApi(pluginConfig: Record<string, any> = {}) {
   return { api: api as any, hooks, logs };
 }
 
+function registerHandlersWithoutDebug(pluginConfig: Record<string, any> = {}) {
+  const { api, hooks, logs } = createMockApi(pluginConfig);
+  delete api.logger.debug;
+  piiScan.register(api);
+  const beforeDispatch = hooks.find((hook) => hook.hookName === "before_dispatch");
+  assert.ok(beforeDispatch, "before_dispatch handler should be registered");
+  return { beforeDispatch, hooks, logs };
+}
+
 function registerHandlers(pluginConfig: Record<string, any> = {}) {
   const { api, hooks, logs } = createMockApi(pluginConfig);
   piiScan.register(api);
@@ -184,8 +193,11 @@ describe("pii-scan-user-input", () => {
       const result = await beforeDispatch.handler({ content: "email alice@example.com" });
 
       assert.equal(result, undefined);
-      assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
-      assert.ok(logs.some((log) => log.includes("a***@example.com")));
+      assert.ok(logs.some((log) => log.includes("[WARN] [pii-checker] 检测到")));
+      assert.ok(!logs.some((log) => log.startsWith("[WARN]") && log.includes("verdict=")));
+      assert.ok(logs.some((log) => log.includes("检测到 1 项一般风险敏感信息")));
+      assert.ok(logs.some((log) => log.includes("本次仅提醒，未触发确认或阻断")));
+      assert.ok(!logs.some((log) => log.includes("a***@example.com")));
       assert.ok(!logs.some((log) => log.includes("alice@example.com")));
     });
   }
@@ -208,12 +220,45 @@ describe("pii-scan-user-input", () => {
 
     assert.equal(result?.handled, true);
     assert.match(result?.text, /\[pii-checker\]/);
-    assert.match(result?.text, /高风险/);
-    assert.match(result?.text, /credential/);
-    assert.match(result?.text, /password=\[REDACTED\]/);
-    assert.match(result?.text, /本轮请求已被阻断/);
+    assert.match(result?.text, /检测到 1 项高风险敏感信息/);
+    assert.match(result?.text, /当前策略已阻断本次请求/);
+    assert.doesNotMatch(result?.text, /credential/);
+    assert.doesNotMatch(result?.text, /password=\[REDACTED\]/);
     assert.doesNotMatch(result?.text, /password=secret/);
     assert.doesNotMatch(result?.text, /raw_evidence/);
+  });
+
+  it("block policy works when the host logger has no debug method", async () => {
+    const { beforeDispatch } = registerHandlersWithoutDebug(policyConfig("block"));
+    mockCli(scanResult("deny", [denyFinding]));
+
+    const result = await beforeDispatch.handler({ content: "password=secret" });
+
+    assert.equal(result?.handled, true);
+    assert.match(result?.text, /当前策略已阻断本次请求/);
+  });
+
+  it("summarizes mixed findings by per-finding risk", async () => {
+    const { beforeDispatch } = registerHandlers(policyConfig("block"));
+    mockCli(
+      scanResult("deny", [
+        warnFinding,
+        denyFinding,
+        {
+          type: "custom",
+          severity: "unknown",
+          evidence_redacted: "custom-***",
+        },
+      ]),
+    );
+
+    const result = await beforeDispatch.handler({ content: "sensitive input" });
+
+    assert.equal(result?.handled, true);
+    assert.match(result?.text, /检测到 3 项敏感信息（高风险 2、一般风险 1）/);
+    assert.doesNotMatch(result?.text, /email|credential|custom/);
+    assert.doesNotMatch(result?.text, /warn|deny|unknown/);
+    assert.doesNotMatch(result?.text, /\[REDACTED\]|a\*\*\*|custom-\*\*\*/);
   });
 
   it("block policy blocks a before_tool_call deny verdict", async () => {
@@ -234,7 +279,10 @@ describe("pii-scan-user-input", () => {
 
     assert.equal(result?.block, true);
     assert.match(result?.blockReason, /\[pii-checker\]/);
-    assert.match(result?.blockReason, /本次工具调用已被阻断/);
+    assert.match(result?.blockReason, /检测到 1 项高风险敏感信息/);
+    assert.match(result?.blockReason, /当前策略已阻断本次工具调用/);
+    assert.doesNotMatch(result?.blockReason, /credential/);
+    assert.doesNotMatch(result?.blockReason, /password=\[REDACTED\]/);
     assert.doesNotMatch(result?.blockReason, /password=secret/);
     assert.deepEqual(lastCliArgs, [
       "--trace-context",
@@ -270,8 +318,12 @@ describe("pii-scan-user-input", () => {
 
     assert.equal(result?.requireApproval?.title, "PII Checker Security Review");
     assert.equal(result?.requireApproval?.severity, "critical");
-    assert.match(result?.requireApproval?.description, /password=\[REDACTED\]/);
+    assert.match(result?.requireApproval?.description, /检测到 1 项高风险敏感信息/);
+    assert.match(result?.requireApproval?.description, /当前策略要求确认，请确认后继续/);
+    assert.doesNotMatch(result?.requireApproval?.description, /credential/);
+    assert.doesNotMatch(result?.requireApproval?.description, /password=\[REDACTED\]/);
     assert.doesNotMatch(result?.requireApproval?.description, /password=secret/);
+    assert.doesNotMatch(result?.requireApproval?.description, /仅提醒|继续处理/);
   });
 
   it("ask policy falls back to a warning before dispatch", async () => {
@@ -281,9 +333,15 @@ describe("pii-scan-user-input", () => {
     const result = await beforeDispatch.handler({ content: "password=secret" });
 
     assert.equal(result, undefined);
-    assert.ok(logs.some((log) => log.includes("DENY (policy=ask)")));
-    assert.ok(logs.some((log) => log.includes("本轮请求将继续处理")));
-    assert.ok(!logs.some((log) => log.includes("本轮请求已被阻断")));
+    assert.ok(logs.some((log) => log.includes("verdict=deny policy=ask")));
+    assert.ok(!logs.some((log) => log.startsWith("[WARN]") && log.includes("policy=")));
+    assert.ok(
+      logs.some((log) =>
+        log.includes("当前环节不支持确认/阻断，本次仅提醒，不会阻断"),
+      ),
+    );
+    assert.ok(!logs.some((log) => log.includes("password=[REDACTED]")));
+    assert.ok(!logs.some((log) => log.includes("当前策略已阻断本次请求")));
   });
 
   it("after_tool_call logs warning without raw evidence", async () => {
@@ -302,8 +360,14 @@ describe("pii-scan-user-input", () => {
     );
 
     assert.equal(result, undefined);
-    assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
-    assert.ok(logs.some((log) => log.includes("a***@example.com")));
+    assert.ok(logs.some((log) => log.includes("[WARN] [pii-checker] 检测到")));
+    assert.ok(logs.some((log) => log.includes("检测到 1 项一般风险敏感信息")));
+    assert.ok(logs.some((log) => log.includes("工具已经执行")));
+    assert.ok(logs.some((log) => log.includes("未触发确认或阻断")));
+    assert.ok(!logs.some((log) => log.includes("当前环节不支持")));
+    assert.ok(logs.some((log) => log.includes("工具结果仍会进入模型上下文")));
+    assert.ok(logs.some((log) => log.includes("已发生的外部副作用不会撤销")));
+    assert.ok(!logs.some((log) => log.includes("a***@example.com")));
     assert.ok(!logs.some((log) => log.includes("alice@example.com")));
     assert.equal(lastCliArgs?.at(-1), "tool_output");
   });
@@ -323,8 +387,13 @@ describe("pii-scan-user-input", () => {
     );
 
     assert.equal(result, undefined);
-    assert.ok(logs.some((log) => log.includes("DENY (policy=block)")));
-    assert.ok(logs.some((log) => log.includes("本轮请求将继续处理")));
+    assert.ok(logs.some((log) => log.includes("verdict=deny policy=block")));
+    assert.ok(!logs.some((log) => log.startsWith("[WARN]") && log.includes("policy=")));
+    assert.ok(logs.some((log) => log.includes("工具已经执行")));
+    assert.ok(logs.some((log) => log.includes("本次仅提醒")));
+    assert.ok(logs.some((log) => log.includes("工具结果仍会进入模型上下文")));
+    assert.ok(logs.some((log) => log.includes("已发生的外部副作用不会撤销")));
+    assert.ok(!logs.some((log) => log.includes("password=[REDACTED]")));
     assert.ok(!logs.some((log) => log.includes("已被阻断")));
   });
 
@@ -343,8 +412,11 @@ describe("pii-scan-user-input", () => {
     );
 
     assert.equal(result, undefined);
-    assert.ok(logs.some((log) => log.includes("[pii-checker] WARN")));
-    assert.ok(logs.some((log) => log.includes("a***@example.com")));
+    assert.ok(logs.some((log) => log.includes("[WARN] [pii-checker] 检测到")));
+    assert.ok(logs.some((log) => log.includes("检测到 1 项一般风险敏感信息")));
+    assert.ok(logs.some((log) => log.includes("原始模型输出仍会交付")));
+    assert.ok(logs.some((log) => log.includes("不会被脱敏或阻断")));
+    assert.ok(!logs.some((log) => log.includes("a***@example.com")));
     assert.ok(!logs.some((log) => log.includes("alice@example.com")));
     assert.equal(lastCliArgs?.at(-1), "model_output");
   });

--- a/src/agent-sec-core/qoder-plugin/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/qoder-plugin/hooks/pii_checker_hook.py
@@ -31,9 +31,6 @@ except (TypeError, ValueError):
 _INCLUDE_LOW_CONFIDENCE = os.environ.get(
     "PII_CHECKER_INCLUDE_LOW_CONFIDENCE", ""
 ).strip().lower() in {"1", "true", "yes", "on"}
-_MAX_EVIDENCE_ITEMS = 3
-_MAX_EVIDENCE_CHARS = 80
-
 _USER_INPUT_SOURCE = "user_input"
 _TOOL_INPUT_SOURCE = "tool_input"
 _TOOL_OUTPUT_SOURCE = "tool_output"
@@ -49,37 +46,29 @@ def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
-def _shorten(value: str, limit: int = _MAX_EVIDENCE_CHARS) -> str:
-    """Return compact evidence text for user-visible notices."""
-    normalized = " ".join(value.split())
-    if len(normalized) <= limit:
-        return normalized
-    return normalized[: limit - 1] + "..."
-
-
 def _hook_event(input_data: dict[str, Any]) -> str:
     """Return the Qoder hook event name."""
     return _safe_string(input_data.get("hook_event_name"))
 
 
-def _scan_target(input_data: dict[str, Any]) -> tuple[str, str, str] | None:
-    """Return text, source label, and display source for supported Qoder hooks."""
+def _scan_target(input_data: dict[str, Any]) -> tuple[str, str] | None:
+    """Return text and source label for supported Qoder hooks."""
     event_name = _hook_event(input_data)
     if event_name == "UserPromptSubmit":
         text = _safe_string(input_data.get("prompt"))
-        return (text, _USER_INPUT_SOURCE, "user input") if text.strip() else None
+        return (text, _USER_INPUT_SOURCE) if text.strip() else None
 
     if event_name == "PreToolUse":
         if "tool_input" not in input_data:
             return None
         text = value_to_text(jsonish_value(input_data.get("tool_input")))
-        return (text, _TOOL_INPUT_SOURCE, "tool input") if text.strip() else None
+        return (text, _TOOL_INPUT_SOURCE) if text.strip() else None
 
     if event_name == "PostToolUse":
         if "tool_response" not in input_data:
             return None
         text = value_to_text(jsonish_value(input_data.get("tool_response")))
-        return (text, _TOOL_OUTPUT_SOURCE, "tool output") if text.strip() else None
+        return (text, _TOOL_OUTPUT_SOURCE) if text.strip() else None
 
     return None
 
@@ -125,47 +114,70 @@ def _scan_pii(
     return scan_result if isinstance(scan_result, dict) else None
 
 
-def _format_notice(
-    verdict: str,
-    findings: list[Any],
-    source_desc: str,
-    final_message: str,
-) -> str:
-    """Build a minimal-disclosure PII notice from sanitized findings."""
+def _risk_summary(verdict: str, findings: list[Any]) -> str:
+    """Summarize finding counts without exposing scanner-internal details."""
     typed_findings = [item for item in findings if isinstance(item, dict)]
-    pii_types = sorted(
-        {
-            finding_type
-            for finding in typed_findings
-            if (finding_type := _safe_string(finding.get("type")))
-        }
-    )
-    severities = sorted(
-        {
-            severity
-            for finding in typed_findings
-            if (severity := _safe_string(finding.get("severity")))
-        }
-    )
-    evidence: list[str] = []
+    high_count = 0
+    general_count = 0
     for finding in typed_findings:
-        redacted = _safe_string(finding.get("evidence_redacted"))
-        if redacted and redacted not in evidence:
-            evidence.append(_shorten(redacted))
-        if len(evidence) >= _MAX_EVIDENCE_ITEMS:
-            break
+        severity = _safe_string(finding.get("severity"))
+        if severity == "deny":
+            high_count += 1
+        elif severity == "warn":
+            general_count += 1
 
-    risk = "high-risk sensitive data" if verdict == "deny" else "sensitive data"
-    parts = [
-        f"[pii-checker] Detected {len(typed_findings)} {risk} finding(s) in {source_desc}",
-        f"types: {', '.join(pii_types) if pii_types else 'unknown'}",
-    ]
-    if severities:
-        parts.append(f"severity: {', '.join(severities)}")
-    if evidence:
-        parts.append(f"redacted evidence: {', '.join(evidence)}")
-    parts.append(final_message)
-    return "; ".join(parts)
+    unknown_count = len(typed_findings) - high_count - general_count
+    if verdict == "deny":
+        high_count += unknown_count
+    else:
+        general_count += unknown_count
+
+    total = len(typed_findings)
+    noun = "finding" if total == 1 else "findings"
+    if high_count and general_count:
+        return (
+            f"Detected {total} sensitive data {noun} "
+            f"({high_count} high risk, {general_count} general risk)"
+        )
+    risk = "high-risk" if high_count else "general-risk"
+    return f"Detected {total} {risk} sensitive data {noun}"
+
+
+def _format_notice(verdict: str, findings: list[Any], action: str) -> str:
+    """Build a minimal-disclosure PII notice with the actual host action."""
+    return f"[pii-checker] {_risk_summary(verdict, findings)}. {action}"
+
+
+def _warning_action(event_name: str) -> str:
+    """Describe the event-specific result of a warning-only decision."""
+    if event_name == "PreToolUse":
+        return (
+            "This is a warning only; the tool call will continue without confirmation "
+            "or blocking."
+        )
+    if event_name == "PostToolUse":
+        return (
+            "The tool has already run. This is a warning only; its raw output will enter "
+            "model context, and external side effects were not undone."
+        )
+    return (
+        "This is a warning only; the request will continue without confirmation or "
+        "blocking."
+    )
+
+
+def _unsupported_confirmation_action(event_name: str) -> str:
+    """Describe a warning when the current hook cannot request confirmation."""
+    if event_name == "PostToolUse":
+        return (
+            "The tool has already run. This stage cannot confirm or block; this is a "
+            "warning only, its raw output will enter model context, and external side "
+            "effects were not undone."
+        )
+    return (
+        "This stage cannot confirm or block; this is a warning only and the request will "
+        "continue."
+    )
 
 
 def _warn_output(notice: str) -> str:
@@ -175,10 +187,9 @@ def _warn_output(notice: str) -> str:
 
 def _invalid_policy_output() -> str:
     """Return a visible fail-open warning for an invalid checker policy."""
-    configured_mode = _shorten(_safe_string(_POLICY_RAW), 32) or "<empty>"
     notice = (
-        f"[pii-checker] invalid {_POLICY_ENV_NAME} {configured_mode!r}; expected "
-        "observe, warn, ask, or block. Falling back to observe; execution will continue."
+        "[pii-checker] PII Checker configuration is invalid; processing will continue "
+        "without confirmation or blocking."
     )
     return _warn_output(notice)
 
@@ -187,7 +198,6 @@ def _format_decision(
     input_data: dict[str, Any],
     verdict: str,
     findings: list[Any],
-    source_desc: str,
 ) -> str | None:
     """Map a scan-pii verdict to Qoder hook output."""
     if verdict == "pass" or not findings:
@@ -199,24 +209,22 @@ def _format_decision(
 
     event_name = _hook_event(input_data)
     if verdict == "warn" or _POLICY == "warn":
-        notice = _format_notice(
-            verdict,
-            findings,
-            source_desc,
-            "Execution will continue.",
-        )
+        notice = _format_notice(verdict, findings, _warning_action(event_name))
         return _warn_output(notice)
 
     if _POLICY == "ask" and event_name == "PreToolUse":
-        notice = _format_notice(verdict, findings, source_desc, "Approval is required.")
+        notice = _format_notice(
+            verdict,
+            findings,
+            "Confirmation is required before this tool call can continue.",
+        )
         return pre_tool_decision_output("ask", notice)
 
     if _POLICY == "ask":
         notice = _format_notice(
             verdict,
             findings,
-            source_desc,
-            "Approval is unavailable here; execution continues.",
+            _unsupported_confirmation_action(event_name),
         )
         return _warn_output(notice)
 
@@ -224,8 +232,7 @@ def _format_decision(
         notice = _format_notice(
             verdict,
             findings,
-            source_desc,
-            "Remove the sensitive data and submit again.",
+            "The current protection settings blocked this request.",
         )
         return deny_output(notice)
 
@@ -233,8 +240,7 @@ def _format_decision(
         notice = _format_notice(
             verdict,
             findings,
-            source_desc,
-            "This tool call was blocked.",
+            "The current protection settings blocked this tool call.",
         )
         return pre_tool_decision_output("deny", notice)
 
@@ -242,8 +248,8 @@ def _format_decision(
         notice = _format_notice(
             verdict,
             findings,
-            source_desc,
-            "The raw tool output was replaced before entering model context.",
+            "The tool has already run. Its raw output will not enter model context; "
+            "external side effects were not undone.",
         )
         return post_tool_output_replacement(notice)
 
@@ -262,7 +268,7 @@ def main() -> None:
     target = _scan_target(input_data)
     if target is None:
         return
-    text, source, source_desc = target
+    text, source = target
 
     scan_result = _scan_pii(input_data, text, source)
     if _POLICY_RAW is not None and normalize_hook_policy(_POLICY_RAW, "") == "":
@@ -273,7 +279,7 @@ def main() -> None:
 
     verdict = _safe_string(scan_result.get("verdict")) or "pass"
     findings = _as_list(scan_result.get("findings"))
-    output = _format_decision(input_data, verdict, findings, source_desc)
+    output = _format_decision(input_data, verdict, findings)
     if output:
         print(output)
 

--- a/src/agent-sec-core/qwen-code-extension/hooks/pii_checker_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/pii_checker_hook.py
@@ -32,8 +32,6 @@ from trace_context import with_trace_context
 _DEFAULT_TIMEOUT_SECONDS = 5.0
 _MAX_TIMEOUT_SECONDS = 8.0
 _MAX_PAYLOAD_SIZE = 1024 * 1024
-_MAX_EVIDENCE_ITEMS = 3
-_MAX_EVIDENCE_CHARS = 80
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
 _VALID_VERDICTS = {"pass", "warn", "deny", "error"}
@@ -65,7 +63,11 @@ def _policy() -> str:
     raw = os.environ.get("PII_CHECKER_MODE")
     policy = env_hook_policy("PII_CHECKER_MODE", "observe")
     if "PII_CHECKER_MODE" in os.environ and normalize_hook_policy(raw, "") == "":
-        print("[pii-checker] invalid PII_CHECKER_MODE; using observe", file=sys.stderr)
+        print(
+            "[pii-checker] PII Checker configuration is invalid; processing will "
+            "continue without confirmation or blocking.",
+            file=sys.stderr,
+        )
     return policy
 
 
@@ -160,17 +162,10 @@ def _scan_pii(
     return scan_result if isinstance(scan_result, dict) else None
 
 
-def _shorten_evidence(value: str) -> str:
-    normalized = " ".join(value.split())
-    if len(normalized) <= _MAX_EVIDENCE_CHARS:
-        return normalized
-    return normalized[: _MAX_EVIDENCE_CHARS - 3] + "..."
-
-
 def _validated_result(
     scan_result: dict[str, Any],
-) -> tuple[str, list[str]] | None:
-    """Return a supported verdict with audit-safe evidence only."""
+) -> tuple[str, list[dict[str, str]]] | None:
+    """Return a supported verdict with only fields needed for risk counts."""
     verdict = scan_result.get("verdict")
     if not isinstance(verdict, str) or verdict not in _VALID_VERDICTS:
         return None
@@ -182,30 +177,92 @@ def _validated_result(
     findings = scan_result.get("findings")
     if not isinstance(findings, list):
         return None
-    evidence: list[str] = []
+    sanitized_findings: list[dict[str, str]] = []
+    has_redacted_evidence = False
     for finding in findings:
         if not isinstance(finding, dict):
             continue
         redacted = finding.get("evidence_redacted")
-        if not isinstance(redacted, str) or not redacted.strip():
-            continue
-        shortened = _shorten_evidence(redacted)
-        if shortened not in evidence:
-            evidence.append(shortened)
-        if len(evidence) >= _MAX_EVIDENCE_ITEMS:
-            break
-    return (verdict, evidence) if evidence else None
+        if isinstance(redacted, str) and redacted.strip():
+            has_redacted_evidence = True
+        severity = finding.get("severity")
+        sanitized_findings.append(
+            {"severity": severity} if isinstance(severity, str) else {}
+        )
+    if not sanitized_findings or not has_redacted_evidence:
+        return None
+    return verdict, sanitized_findings
 
 
-def _notice(evidence: list[str], action: str) -> str:
+def _risk_summary(verdict: str, findings: list[dict[str, str]]) -> str:
+    """Summarize finding counts without exposing scanner-internal details."""
+    high_count = sum(finding.get("severity") == "deny" for finding in findings)
+    general_count = sum(finding.get("severity") == "warn" for finding in findings)
+    unknown_count = len(findings) - high_count - general_count
+    if verdict == "deny":
+        high_count += unknown_count
+    else:
+        general_count += unknown_count
+
+    total = len(findings)
+    noun = "finding" if total == 1 else "findings"
+    if high_count and general_count:
+        return (
+            f"Detected {total} sensitive data {noun} "
+            f"({high_count} high risk, {general_count} general risk)"
+        )
+    risk = "high-risk" if high_count else "general-risk"
+    return f"Detected {total} {risk} sensitive data {noun}"
+
+
+def _notice(verdict: str, findings: list[dict[str, str]], action: str) -> str:
+    return f"[pii-checker] {_risk_summary(verdict, findings)}. {action}"
+
+
+def _warning_action(event_name: str) -> str:
+    """Describe the event-specific result of a warning-only decision."""
+    if event_name == "PreToolUse":
+        return (
+            "This is a warning only; the tool call will continue without confirmation "
+            "or blocking."
+        )
+    if event_name == "PostToolUse":
+        return (
+            "The tool has already run. This is a warning only; its raw output will enter "
+            "model context, and external side effects were not undone."
+        )
+    if event_name == "Stop":
+        return "This is a warning only; the response will continue without blocking."
     return (
-        "[pii-checker] Sensitive data detected. Redacted evidence: "
-        f"{', '.join(evidence)}. {action}"
+        "This is a warning only; the request will continue without confirmation or "
+        "blocking."
+    )
+
+
+def _unsupported_confirmation_action(event_name: str) -> str:
+    """Describe a warning when the current hook cannot request confirmation."""
+    if event_name == "PostToolUse":
+        return (
+            "The tool has already run. This stage cannot confirm or block; this is a "
+            "warning only, its raw output will enter model context, and external side "
+            "effects were not undone."
+        )
+    if event_name == "Stop":
+        return (
+            "This stage cannot confirm or block; this is a warning only and the response "
+            "will continue."
+        )
+    return (
+        "This stage cannot confirm or block; this is a warning only and the request will "
+        "continue."
     )
 
 
 def _decision(
-    input_data: dict[str, Any], event_name: str, verdict: str, evidence: list[str]
+    input_data: dict[str, Any],
+    event_name: str,
+    verdict: str,
+    findings: list[dict[str, str]],
 ) -> dict[str, Any]:
     """Map one validated scanner verdict to Qwen Code HookOutput."""
     if event_name in {"PostToolUseFailure", "StopFailure"}:
@@ -218,11 +275,15 @@ def _decision(
         return _noop()
     if verdict == "warn" or policy == "warn":
         return {
-            "systemMessage": _notice(evidence, "Execution will continue."),
+            "systemMessage": _notice(verdict, findings, _warning_action(event_name)),
         }
 
     if policy == "ask" and event_name == "PreToolUse":
-        reason = _notice(evidence, "Approval is required.")
+        reason = _notice(
+            verdict,
+            findings,
+            "Confirmation is required before this tool call can continue.",
+        )
         return {
             "hookSpecificOutput": {
                 "hookEventName": event_name,
@@ -233,19 +294,29 @@ def _decision(
     if policy == "ask":
         return {
             "systemMessage": _notice(
-                evidence, "Approval is unavailable here; execution continues."
+                verdict,
+                findings,
+                _unsupported_confirmation_action(event_name),
             )
         }
 
     if event_name == "UserPromptSubmit":
-        reason = _notice(evidence, "Remove the sensitive data and submit again.")
+        reason = _notice(
+            verdict,
+            findings,
+            "The current protection settings blocked this request.",
+        )
         return {
             "decision": "block",
             "reason": reason,
             "hookSpecificOutput": {"hookEventName": event_name},
         }
     if event_name == "PreToolUse":
-        reason = _notice(evidence, "This tool call was blocked.")
+        reason = _notice(
+            verdict,
+            findings,
+            "The current protection settings blocked this tool call.",
+        )
         return {
             "hookSpecificOutput": {
                 "hookEventName": event_name,
@@ -255,8 +326,10 @@ def _decision(
         }
     if event_name == "PostToolUse":
         reason = _notice(
-            evidence,
-            "Do not use or repeat the sensitive tool output.",
+            verdict,
+            findings,
+            "The tool has already run. Its raw output will not enter model context; "
+            "external side effects were not undone.",
         )
         # Qwen Code 0.19.9 only stops PostToolUse through
         # shouldStopExecution(), which checks continue=false. Keep the
@@ -271,13 +344,17 @@ def _decision(
         if input_data.get("stop_hook_active") is True:
             return {
                 "systemMessage": _notice(
-                    evidence,
-                    "The response will not be blocked again to avoid a retry loop.",
+                    verdict,
+                    findings,
+                    "This pass is warning-only and will not block the response again, "
+                    "avoiding a retry loop.",
                 )
             }
         reason = _notice(
-            evidence,
-            "Rewrite the final response using placeholders; do not repeat the original values.",
+            verdict,
+            findings,
+            "The final response was blocked. Rewrite it without sensitive data, then try "
+            "again.",
         )
         return {"decision": "block", "reason": reason}
     return _noop()
@@ -313,11 +390,11 @@ def main() -> None:
         if validated is None:
             print(json.dumps(_noop()))
             return
-        verdict, evidence = validated
+        verdict, findings = validated
         output = (
             _noop()
             if verdict == "pass"
-            else _decision(input_data, event_name, verdict, evidence)
+            else _decision(input_data, event_name, verdict, findings)
         )
         print(json.dumps(output, ensure_ascii=False))
     except Exception:  # noqa: BLE001 - hook failures must remain silent and fail-open

--- a/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_scan_pii_e2e.py
@@ -93,6 +93,50 @@ def test_scan_pii_text_json(mode: str, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("mode", _MODES)
+def test_scan_pii_filters_email_and_jwt_false_positives(
+    mode: str, tmp_path: Path
+) -> None:
+    text = (
+        "Call resolved.auth_source.as_deref(); then connect to "
+        "ssh://deploy@securecorp.cn/home/deploy or contact alice@example.com"
+    )
+    default_result = _run_cli(
+        mode,
+        "scan-pii",
+        "--text",
+        text,
+        "--format",
+        "json",
+        data_dir=tmp_path / mode / "filtered-default",
+    )
+    default_data = _load_json(default_result)
+
+    assert default_data["verdict"] == "pass"
+    assert default_data["findings"] == []
+
+    detailed_result = _run_cli(
+        mode,
+        "scan-pii",
+        "--text",
+        text,
+        "--format",
+        "json",
+        "--include-low-confidence",
+        data_dir=tmp_path / mode / "filtered-detailed",
+    )
+    detailed_data = _load_json(detailed_result)
+
+    assert detailed_data["verdict"] == "warn"
+    assert detailed_data["summary"]["by_type"] == {"email": 2}
+    assert {
+        finding["metadata"]["context"] for finding in detailed_data["findings"]
+    } == {
+        "remote_identity",
+        "reserved_domain",
+    }
+
+
+@pytest.mark.parametrize("mode", _MODES)
 def test_scan_pii_stdin_json(mode: str, tmp_path: Path) -> None:
     result = _run_cli(
         mode,

--- a/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
+++ b/src/agent-sec-core/tests/e2e/codex-hooks/test_codex_hooks_e2e.py
@@ -177,8 +177,9 @@ class TestPIICheckerE2E:
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
         assert set(output) == {"systemMessage"}
-        assert "phone_cn" in output["systemMessage"]
-        assert "执行将继续" in output["systemMessage"]
+        assert "1 项一般风险敏感信息" in output["systemMessage"]
+        assert "本次仅提醒，未触发确认或阻断。" in output["systemMessage"]
+        assert "phone_cn" not in output["systemMessage"]
 
     def test_phone_in_prompt_passes_observe(self):
         output = _run_hook(
@@ -201,8 +202,8 @@ class TestPIICheckerE2E:
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
         assert set(output) == {"systemMessage"}
-        assert "email" in output["systemMessage"]
-        assert "PostToolUse" in output["systemMessage"]
+        assert "1 项一般风险敏感信息" in output["systemMessage"]
+        assert "email" not in output["systemMessage"]
 
     def test_email_in_tool_output_passes_observe(self):
         output = _run_hook(
@@ -238,8 +239,8 @@ class TestPIICheckerE2E:
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
         assert set(output) == {"systemMessage"}
-        assert "phone_cn" in output["systemMessage"]
-        assert "PreToolUse" in output["systemMessage"]
+        assert "1 项一般风险敏感信息" in output["systemMessage"]
+        assert "phone_cn" not in output["systemMessage"]
 
     def test_api_key_in_prompt_blocks_deny(self):
         output = _run_hook(
@@ -251,7 +252,9 @@ class TestPIICheckerE2E:
             env_extra={"PII_CHECKER_MODE": "deny"},
         )
         assert output.get("decision") == "block"
-        assert "api_key" in output.get("reason", "")
+        assert "1 项高风险敏感信息" in output.get("reason", "")
+        assert "当前策略已阻断本次请求。" in output.get("reason", "")
+        assert "api_key" not in output.get("reason", "")
 
     def test_phone_in_tool_input_passes_observe(self):
         output = _run_hook(

--- a/src/agent-sec-core/tests/e2e/cosh-hooks/test_direct_hook_execution.py
+++ b/src/agent-sec-core/tests/e2e/cosh-hooks/test_direct_hook_execution.py
@@ -192,7 +192,7 @@ def test_cosh_code_scanner_mode_never_changes_fixed_ask_behavior(
             },
             "ask",
             "ask",
-            "需要确认",
+            "当前策略要求确认",
         ),
         (
             {
@@ -201,7 +201,7 @@ def test_cosh_code_scanner_mode_never_changes_fixed_ask_behavior(
             },
             "block",
             "block",
-            "本次工具调用已被阻断",
+            "当前策略已阻断本次工具调用",
         ),
         (
             {
@@ -219,7 +219,7 @@ def test_cosh_code_scanner_mode_never_changes_fixed_ask_behavior(
             },
             "block",
             "allow",
-            "fallback 为 warn",
+            "当前环节不支持确认/阻断",
         ),
     ],
 )
@@ -236,17 +236,20 @@ def test_cosh_pii_policy_uses_event_level_decisions(
     output = json.loads(proc.stdout)
     assert output["decision"] == expected_decision
     assert message_fragment in output["reason"]
-    assert "a***@example.com" in output["reason"]
+    assert "高风险敏感信息" in output["reason"]
+    assert "email" not in output["reason"]
+    assert "deny" not in output["reason"]
+    assert "a***@example.com" not in output["reason"]
     assert "alice@example.com" not in output["reason"]
     assert proc.stderr == ""
     assert capture.exists()
     assert "scan-pii" in json.loads(capture.read_text(encoding="utf-8"))["argv"]
 
     if expected_decision in {"ask", "block"}:
-        assert "将继续" not in output["reason"]
+        assert "不会阻断" not in output["reason"]
     else:
-        assert "已被阻断" not in output["reason"]
-        assert "将继续" in output["reason"]
+        assert "已阻断本次" not in output["reason"]
+        assert "本次仅提醒，不会阻断" in output["reason"]
 
     if payload.get("hook_event_name") == "PostToolUse":
         assert "工具已经执行" in output["reason"]

--- a/src/agent-sec-core/tests/e2e/qwen-code-extension/test_qwen_direct_hook_execution.py
+++ b/src/agent-sec-core/tests/e2e/qwen-code-extension/test_qwen_direct_hook_execution.py
@@ -515,7 +515,11 @@ def test_qwen_pii_hook_blocks_deny_verdicts(tmp_path) -> None:
     assert post_tool_output["continue"] is False
     assert post_tool_output["decision"] == "block"
     assert post_tool_output["stopReason"] == post_tool_output["reason"]
-    assert "[REDACTED]" in post_tool_output["reason"]
+    assert "high-risk sensitive data" in post_tool_output["reason"]
+    assert "tool has already run" in post_tool_output["reason"]
+    assert "raw output will not enter model context" in post_tool_output["reason"]
+    assert "external side effects were not undone" in post_tool_output["reason"]
+    assert "[REDACTED]" not in post_tool_output["reason"]
     assert secret not in post_tool_proc.stdout
 
     failure_proc = _run_hook(

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_pii_checker_hook.py
@@ -153,18 +153,25 @@ _PII_DENY_RESULT = json.dumps(
 
 def _assert_warning_output(
     output: dict,
-    hook_event: str,
     *,
-    pii_type: str = "phone_cn",
-    redacted_evidence: str = "138****8000",
+    expected_risk: str = "一般风险",
+    expected_action: str = "本次仅提醒，未触发确认或阻断。",
 ) -> str:
     """Assert the common non-blocking warning contract."""
     assert set(output) == {"systemMessage"}
     message = output["systemMessage"]
-    assert pii_type in message
-    assert redacted_evidence in message
-    assert hook_event in message
-    assert "执行将继续" in message
+    assert f"1 项{expected_risk}敏感信息" in message
+    assert expected_action in message
+    for hidden_value in (
+        "phone_cn",
+        "credential",
+        "138****8000",
+        "password=[REDACTED]",
+        "扫描判定",
+        "Hook 策略",
+        "fallback",
+    ):
+        assert hidden_value not in message
     return message
 
 
@@ -378,52 +385,39 @@ def test_environment_disabled_short_circuits_before_input_and_cli(
 
 
 class TestUnifiedHookPolicyWarnings:
-    """Warnings preserve scanner verdict, policy, and actual fallback behavior."""
+    """Warnings show user-facing risk and actual behavior only."""
 
     @pytest.mark.parametrize(
         (
             "policy",
             "scan_output",
-            "expected_verdict",
-            "pii_type",
-            "redacted_evidence",
-            "expected_handling",
+            "expected_risk",
+            "expected_action",
         ),
         (
             (
                 "warn",
                 _PII_DENY_RESULT,
-                "deny",
-                "credential",
-                "password=[REDACTED]",
-                "实际处理：warn，执行将继续。",
+                "高风险",
+                "本次仅提醒，未触发确认或阻断。",
             ),
             (
                 "ask",
                 _PII_DENY_RESULT,
-                "deny",
-                "credential",
-                "password=[REDACTED]",
-                "实际处理：当前 hook 不支持确认，fallback 为 warn，执行将继续。",
+                "高风险",
+                "当前环节不支持确认/阻断，本次仅提醒，不会阻断。",
             ),
             (
                 "block",
                 _PII_FOUND_RESULT,
-                "warn",
-                "phone_cn",
-                "138****8000",
-                (
-                    "实际处理：scanner verdict 未达到 block 条件，"
-                    "fallback 为 warn，执行将继续。"
-                ),
+                "一般风险",
+                "本次仅提醒，未触发确认或阻断。",
             ),
             (
                 "warn",
                 _PII_FOUND_RESULT,
-                "warn",
-                "phone_cn",
-                "138****8000",
-                "实际处理：warn，执行将继续。",
+                "一般风险",
+                "本次仅提醒，未触发确认或阻断。",
             ),
         ),
     )
@@ -432,10 +426,8 @@ class TestUnifiedHookPolicyWarnings:
         mock_cli,
         policy,
         scan_output,
-        expected_verdict,
-        pii_type,
-        redacted_evidence,
-        expected_handling,
+        expected_risk,
+        expected_action,
     ):
         env = mock_cli(
             output=scan_output,
@@ -447,17 +439,11 @@ class TestUnifiedHookPolicyWarnings:
 
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
 
-        message = _assert_warning_output(
+        _assert_warning_output(
             output,
-            "UserPromptSubmit",
-            pii_type=pii_type,
-            redacted_evidence=redacted_evidence,
+            expected_risk=expected_risk,
+            expected_action=expected_action,
         )
-        assert f"扫描判定：{expected_verdict}" in message
-        assert f"Hook 策略：{policy}" in message
-        assert expected_handling in message
-        assert "13800138000" not in message
-        assert "password=swordfish" not in message
 
     def test_block_policy_still_blocks_deny_verdict(self, mock_cli):
         env = mock_cli(
@@ -471,9 +457,16 @@ class TestUnifiedHookPolicyWarnings:
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
 
         assert output["decision"] == "block"
-        assert "credential" in output["reason"]
-        assert "password=[REDACTED]" in output["reason"]
-        assert "password=swordfish" not in output["reason"]
+        assert "1 项高风险敏感信息" in output["reason"]
+        assert "当前策略已阻断本次请求。" in output["reason"]
+        for hidden_value in (
+            "credential",
+            "password=[REDACTED]",
+            "password=swordfish",
+            "deny",
+            "block",
+        ):
+            assert hidden_value not in output["reason"]
 
 
 class TestDenyMode:
@@ -498,23 +491,40 @@ class TestDenyMode:
     def test_warn_verdict_alerts_user_prompt(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
-        _assert_warning_output(output, "UserPromptSubmit")
+        _assert_warning_output(output)
 
     def test_warn_verdict_alerts_post_tool_use(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(_POST_TOOL_USE_EVENT, env_override=env)
-        _assert_warning_output(output, "PostToolUse")
+        message = _assert_warning_output(
+            output,
+            expected_action="工具已经执行；本次仅提醒，未触发确认或阻断",
+        )
+        assert "原始工具结果仍会进入模型上下文" in message
+        assert "外部副作用不会撤销" in message
 
     @pytest.mark.parametrize(
-        "event_data",
-        [_USER_PROMPT_EVENT, _PRE_TOOL_USE_EVENT, _POST_TOOL_USE_EVENT],
+        ("event_data", "expected_action"),
+        (
+            (_USER_PROMPT_EVENT, "当前策略已阻断本次请求。"),
+            (_PRE_TOOL_USE_EVENT, "当前策略已阻断本次工具调用。"),
+            (
+                _POST_TOOL_USE_EVENT,
+                (
+                    "工具已经执行；原始工具结果不会进入模型上下文，"
+                    "已发生的外部副作用不会撤销。"
+                ),
+            ),
+        ),
     )
-    def test_deny_verdict_blocks(self, mock_cli, event_data):
+    def test_deny_verdict_blocks(self, mock_cli, event_data, expected_action):
         env = mock_cli(output=_PII_DENY_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(event_data, env_override=env)
         assert output["decision"] == "block"
-        assert "credential" in output["reason"]
-        assert event_data["hook_event_name"] in output["reason"]
+        assert "1 项高风险敏感信息" in output["reason"]
+        assert expected_action in output["reason"]
+        assert "credential" not in output["reason"]
+        assert "password=[REDACTED]" not in output["reason"]
 
     def test_no_raw_pii_in_output(self, mock_cli):
         """Warning output must never contain raw PII content."""
@@ -535,13 +545,13 @@ class TestDenyMode:
             extra={"PII_CHECKER_MODE": "deny"},
         )
         output = _run_hook(_USER_PROMPT_EVENT, env_override=env)
-        message = _assert_warning_output(output, "UserPromptSubmit")
+        message = _assert_warning_output(output)
         assert "13800138000" not in message
 
     def test_warn_verdict_alerts_pre_tool_use(self, mock_cli):
         env = mock_cli(output=_PII_FOUND_RESULT, extra={"PII_CHECKER_MODE": "deny"})
         output = _run_hook(_PRE_TOOL_USE_EVENT, env_override=env)
-        _assert_warning_output(output, "PreToolUse")
+        _assert_warning_output(output)
 
     def test_unknown_verdict_with_findings_fails_open(self, mock_cli: Any) -> None:
         env = mock_cli(
@@ -723,8 +733,8 @@ class TestMainMonkeypatch:
             mode="deny",
         )
         assert output["decision"] == "block"
-        assert "工具输入" in output["reason"]
-        assert "该工具调用已被阻止" in output["reason"]
+        assert "1 项高风险敏感信息" in output["reason"]
+        assert "当前策略已阻断本次工具调用。" in output["reason"]
 
     def test_scan_text_passed_via_stdin(self, monkeypatch, capsys):
         captured = {}
@@ -779,8 +789,9 @@ class TestMainMonkeypatch:
             mode="deny",
         )
         assert set(output) == {"systemMessage"}
-        assert "phone_cn" in output["systemMessage"]
-        assert "执行将继续" in output["systemMessage"]
+        assert "1 项一般风险敏感信息" in output["systemMessage"]
+        assert "本次仅提醒，未触发确认或阻断。" in output["systemMessage"]
+        assert "phone_cn" not in output["systemMessage"]
 
     def test_deny_mode_blocks_post_tool_use(self, monkeypatch, capsys):
         """deny mode + PostToolUse PII → block with tool output message."""
@@ -815,7 +826,10 @@ class TestMainMonkeypatch:
             mode="deny",
         )
         assert output["decision"] == "block"
-        assert "工具输出" in output["reason"]
+        assert "1 项高风险敏感信息" in output["reason"]
+        assert "工具已经执行" in output["reason"]
+        assert "原始工具结果不会进入模型上下文" in output["reason"]
+        assert "已发生的外部副作用不会撤销" in output["reason"]
 
     def test_observe_mode_allows_findings(self, monkeypatch, capsys):
         """observe mode + findings → allow."""
@@ -971,70 +985,77 @@ class TestHelpers:
         assert pii_checker_hook._safe_text(None) == ""
         assert pii_checker_hook._safe_text(123) == ""
 
-    def test_shorten_within_limit(self):
-        assert pii_checker_hook._shorten("short", 80) == "short"
+    @pytest.mark.parametrize(
+        ("severity", "verdict", "expected"),
+        (
+            ("deny", "warn", "high"),
+            ("warn", "deny", "general"),
+            ("unknown", "deny", "high"),
+            ("unknown", "warn", "general"),
+        ),
+    )
+    def test_finding_risk_uses_severity_with_verdict_fallback(
+        self, severity, verdict, expected
+    ):
+        assert (
+            pii_checker_hook._finding_risk({"severity": severity}, verdict) == expected
+        )
 
-    def test_shorten_over_limit(self):
-        long_text = "a" * 100
-        result = pii_checker_hook._shorten(long_text, 10)
-        assert len(result) == 10
-        assert result.endswith("…")
-
-    def test_shorten_collapses_whitespace(self):
-        assert pii_checker_hook._shorten("hello   world") == "hello world"
+    @pytest.mark.parametrize(
+        ("verdict", "findings", "expected"),
+        (
+            ("deny", [{"severity": "deny"}], "检测到 1 项高风险敏感信息"),
+            ("warn", [{"severity": "warn"}], "检测到 1 项一般风险敏感信息"),
+            (
+                "deny",
+                [{"severity": "deny"}, {"severity": "warn"}],
+                "检测到 2 项敏感信息（高风险 1、一般风险 1）",
+            ),
+        ),
+    )
+    def test_risk_summary(self, verdict, findings, expected):
+        assert pii_checker_hook._risk_summary(verdict, findings) == expected
 
 
 class TestFormatBlockReason:
     """Test _format_block_reason output formatting."""
 
-    def test_includes_count_and_types(self):
+    def test_includes_mixed_risk_counts_without_internal_details(self):
         findings = [
-            {"type": "phone_cn", "severity": "warn", "evidence_redacted": "138****"},
+            {"type": "credential", "severity": "deny", "evidence_redacted": "secret"},
             {"type": "email", "severity": "warn", "evidence_redacted": "a***@x.com"},
         ]
         reason = pii_checker_hook._format_block_reason(
-            findings, "UserPromptSubmit", "用户输入"
+            findings, "UserPromptSubmit", "deny"
         )
-        assert "2 项" in reason
-        assert "email" in reason
-        assert "phone_cn" in reason
-        assert "UserPromptSubmit" in reason
-
-    def test_evidence_limited_to_max(self):
-        findings = [{"type": f"t{i}", "evidence_redacted": f"ev{i}"} for i in range(10)]
-        reason = pii_checker_hook._format_block_reason(
-            findings, "PostToolUse", "工具输出"
-        )
-        # Should only include _MAX_EVIDENCE_ITEMS
-        assert reason.count("ev") <= pii_checker_hook._MAX_EVIDENCE_ITEMS + 1
+        assert "检测到 2 项敏感信息（高风险 1、一般风险 1）" in reason
+        for hidden_value in ("credential", "email", "secret", "a***@x.com", "deny"):
+            assert hidden_value not in reason
 
     def test_post_tool_use_message(self):
-        findings = [{"type": "phone_cn", "severity": "warn"}]
-        reason = pii_checker_hook._format_block_reason(
-            findings, "PostToolUse", "工具输出"
-        )
-        assert "工具输出已被拦截" in reason
+        findings = [{"type": "credential", "severity": "deny"}]
+        reason = pii_checker_hook._format_block_reason(findings, "PostToolUse", "deny")
+        assert "工具已经执行" in reason
+        assert "原始工具结果不会进入模型上下文" in reason
+        assert "已发生的外部副作用不会撤销" in reason
 
     def test_pre_tool_use_message(self):
-        findings = [{"type": "phone_cn", "severity": "warn"}]
-        reason = pii_checker_hook._format_block_reason(
-            findings, "PreToolUse", "工具输入"
-        )
-        assert "该工具调用已被阻止" in reason
-        assert "PreToolUse" in reason
+        findings = [{"type": "credential", "severity": "deny"}]
+        reason = pii_checker_hook._format_block_reason(findings, "PreToolUse", "deny")
+        assert "当前策略已阻断本次工具调用。" in reason
 
     def test_user_prompt_submit_message(self):
-        findings = [{"type": "email", "severity": "warn"}]
+        findings = [{"type": "credential", "severity": "deny"}]
         reason = pii_checker_hook._format_block_reason(
-            findings, "UserPromptSubmit", "用户输入"
+            findings, "UserPromptSubmit", "deny"
         )
-        assert "请移除敏感信息" in reason
+        assert "当前策略已阻断本次请求。" in reason
 
 
 class TestFormatWarningMessage:
     """Test non-blocking warning output formatting."""
 
-    def test_includes_redacted_details_and_continuation(self):
+    def test_hides_internal_details_and_reports_warning_behavior(self):
         findings = [
             {
                 "type": "phone_cn",
@@ -1045,17 +1066,51 @@ class TestFormatWarningMessage:
         ]
         message = pii_checker_hook._format_warning_message(
             findings,
-            "PreToolUse",
-            "工具输入",
+            "UserPromptSubmit",
             "warn",
             "warn",
         )
-        assert "隐私告警" in message
-        assert "phone_cn" in message
-        assert "138****8000" in message
-        assert "13800138000" not in message
-        assert "PreToolUse" in message
-        assert "扫描判定：warn" in message
-        assert "Hook 策略：warn" in message
-        assert "实际处理：warn" in message
-        assert "执行将继续" in message
+        assert "检测到 1 项一般风险敏感信息" in message
+        assert "本次仅提醒，未触发确认或阻断。" in message
+        for hidden_value in (
+            "phone_cn",
+            "warn",
+            "138****8000",
+            "13800138000",
+            "扫描判定",
+            "Hook 策略",
+        ):
+            assert hidden_value not in message
+
+    def test_ask_reports_capability_limit(self):
+        message = pii_checker_hook._format_warning_message(
+            [{"severity": "deny"}],
+            "UserPromptSubmit",
+            "deny",
+            "ask",
+        )
+        assert "检测到 1 项高风险敏感信息" in message
+        assert "当前环节不支持确认/阻断，本次仅提醒，不会阻断。" in message
+        assert "ask" not in message
+        assert "fallback" not in message
+
+    def test_warn_finding_does_not_report_capability_degradation(self):
+        message = pii_checker_hook._format_warning_message(
+            [{"severity": "warn"}],
+            "UserPromptSubmit",
+            "warn",
+            "ask",
+        )
+        assert "本次仅提醒，未触发确认或阻断。" in message
+        assert "当前环节不支持" not in message
+
+    def test_post_tool_warning_reports_execution_and_content_boundary(self):
+        message = pii_checker_hook._format_warning_message(
+            [{"severity": "warn"}],
+            "PostToolUse",
+            "warn",
+            "warn",
+        )
+        assert "工具已经执行" in message
+        assert "原始工具结果仍会进入模型上下文" in message
+        assert "外部副作用不会撤销" in message

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_pii_checker_hook.py
@@ -28,7 +28,7 @@ class TestFormatCosh:
         result = json.loads(_format_cosh({"verdict": "pass", "findings": []}))
         assert result == {"decision": "allow"}
 
-    def test_warn_returns_allow_with_reason(self):
+    def test_warn_returns_allow_with_general_risk_summary(self):
         result = json.loads(
             _format_cosh(
                 {
@@ -46,13 +46,16 @@ class TestFormatCosh:
         )
 
         assert result["decision"] == "allow"
-        assert "[pii-checker]" in result["reason"]
-        assert "email" in result["reason"]
-        assert "a***@example.com" in result["reason"]
+        assert result["reason"] == (
+            "[pii-checker] 检测到 1 项一般风险敏感信息；"
+            "本次仅提醒，未触发确认或阻断。"
+        )
+        assert "email" not in result["reason"]
+        assert "a***@example.com" not in result["reason"]
         assert "alice@example.com" not in result["reason"]
         assert "raw_evidence" not in result["reason"]
 
-    def test_deny_returns_allow_with_high_risk_reason(self):
+    def test_unknown_type_uses_severity_for_high_risk_summary(self):
         result = json.loads(
             _format_cosh(
                 {
@@ -69,8 +72,103 @@ class TestFormatCosh:
         )
 
         assert result["decision"] == "allow"
-        assert "高风险" in result["reason"]
-        assert "credential" in result["reason"]
+        assert result["reason"] == (
+            "[pii-checker] 检测到 1 项高风险敏感信息；" "本次仅提醒，未触发确认或阻断。"
+        )
+        assert "credential" not in result["reason"]
+        assert "password=[REDACTED]" not in result["reason"]
+
+    def test_risk_summary_uses_finding_severity(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "deny",
+                    "findings": [
+                        {"type": "jwt", "severity": "deny"},
+                        {"type": "email", "severity": "deny"},
+                        {"type": "custom_secret", "severity": "deny"},
+                        {"type": "custom_contact", "severity": "warn"},
+                    ],
+                },
+                "ask",
+            )
+        )
+
+        assert result == {
+            "decision": "ask",
+            "reason": (
+                "[pii-checker] 检测到 4 项敏感信息（高风险 3、一般风险 1）；"
+                "当前策略要求确认，请确认后继续。"
+            ),
+        }
+
+    @pytest.mark.parametrize(
+        ("pii_type", "severity", "expected_risk"),
+        [
+            ("jwt", "warn", "一般风险"),
+            ("cn_id", "warn", "一般风险"),
+            ("credit_card", "warn", "一般风险"),
+            ("email", "deny", "高风险"),
+            ("phone_cn", "deny", "高风险"),
+            ("custom", "deny", "高风险"),
+            ("custom", "warn", "一般风险"),
+        ],
+    )
+    def test_type_does_not_override_severity(self, pii_type, severity, expected_risk):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": severity,
+                    "findings": [{"type": pii_type, "severity": severity}],
+                },
+                "warn",
+            )
+        )
+
+        assert f"1 项{expected_risk}敏感信息" in result["reason"]
+
+    def test_risk_summary_does_not_count_malformed_findings(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "deny",
+                    "findings": [
+                        {"type": "jwt", "severity": "deny"},
+                        "malformed",
+                        None,
+                    ],
+                },
+                "warn",
+            )
+        )
+
+        assert result["reason"] == (
+            "[pii-checker] 检测到 1 项高风险敏感信息；" "本次仅提醒，未触发确认或阻断。"
+        )
+
+    def test_only_malformed_findings_fail_open(self):
+        result = json.loads(
+            _format_cosh(
+                {"verdict": "deny", "findings": ["malformed", None]},
+                "block",
+            )
+        )
+
+        assert result == {"decision": "allow"}
+
+    @pytest.mark.parametrize(
+        ("verdict", "expected_risk"),
+        [("deny", "高风险"), ("warn", "一般风险")],
+    )
+    def test_missing_finding_fields_fall_back_to_verdict(self, verdict, expected_risk):
+        result = json.loads(
+            _format_cosh(
+                {"verdict": verdict, "findings": [{"type": "custom"}]},
+                "warn",
+            )
+        )
+
+        assert f"1 项{expected_risk}敏感信息" in result["reason"]
 
     def test_warn_without_findings_allows(self):
         result = json.loads(_format_cosh({"verdict": "warn", "findings": []}))
@@ -133,24 +231,52 @@ class TestFormatCosh:
         )
 
         assert result["decision"] == "allow"
-        assert "a***@example.com" in result["reason"]
-        assert "本轮请求将继续处理" in result["reason"]
-        assert "fallback" not in result["reason"]
+        if event_name in {"PostToolUse", "PostToolUseFailure"}:
+            assert "工具已经执行" in result["reason"]
+            assert "原始工具结果仍会进入模型上下文" in result["reason"]
+            assert "外部副作用不会撤销" in result["reason"]
+        else:
+            assert result["reason"] == (
+                "[pii-checker] 检测到 1 项一般风险敏感信息；"
+                "本次仅提醒，未触发确认或阻断。"
+            )
+        assert "a***@example.com" not in result["reason"]
         assert "alice@example.com" not in result["reason"]
+
+    @pytest.mark.parametrize("pii_type", ["cn_id", "credit_card"])
+    def test_warn_personal_data_is_general_and_non_blocking(self, pii_type):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "warn",
+                    "findings": [{"type": pii_type, "severity": "warn"}],
+                },
+                "block",
+                "UserPromptSubmit",
+            )
+        )
+
+        assert result == {
+            "decision": "allow",
+            "reason": (
+                "[pii-checker] 检测到 1 项一般风险敏感信息；"
+                "本次仅提醒，未触发确认或阻断。"
+            ),
+        }
 
     @pytest.mark.parametrize(
         ("event_name", "policy", "expected_decision", "message_fragment"),
         [
-            ("UserPromptSubmit", "ask", "ask", "需要确认"),
-            ("UserPromptSubmit", "block", "block", "本轮请求已被阻断"),
-            ("PreToolUse", "ask", "ask", "需要确认"),
-            ("PreToolUse", "block", "block", "本次工具调用已被阻断"),
-            ("PostToolUse", "ask", "allow", "fallback 为 warn"),
+            ("UserPromptSubmit", "ask", "ask", "当前策略要求确认"),
+            ("UserPromptSubmit", "block", "block", "当前策略已阻断本次请求"),
+            ("PreToolUse", "ask", "ask", "当前策略要求确认"),
+            ("PreToolUse", "block", "block", "当前策略已阻断本次工具调用"),
+            ("PostToolUse", "ask", "allow", "当前环节不支持确认/阻断"),
             ("PostToolUse", "block", "block", "原始工具结果不会进入模型上下文"),
-            ("AfterModel", "ask", "allow", "fallback 为 warn"),
-            ("AfterModel", "block", "allow", "fallback 为 warn"),
-            ("PostToolUseFailure", "ask", "allow", "fallback 为 warn"),
-            ("PostToolUseFailure", "block", "allow", "fallback 为 warn"),
+            ("AfterModel", "ask", "allow", "当前环节不支持确认/阻断"),
+            ("AfterModel", "block", "allow", "当前环节不支持确认/阻断"),
+            ("PostToolUseFailure", "ask", "allow", "当前环节不支持确认/阻断"),
+            ("PostToolUseFailure", "block", "allow", "当前环节不支持确认/阻断"),
         ],
     )
     def test_deny_uses_event_level_policy(
@@ -180,14 +306,15 @@ class TestFormatCosh:
 
         assert result["decision"] == expected_decision
         assert message_fragment in result["reason"]
-        assert "token=[REDACTED]" in result["reason"]
+        assert "token=[REDACTED]" not in result["reason"]
+        assert "credential" not in result["reason"]
         assert "raw-secret-value" not in result["reason"]
         assert "raw_evidence" not in result["reason"]
         if expected_decision in {"ask", "block"}:
-            assert "将继续" not in result["reason"]
+            assert "不会阻断" not in result["reason"]
         else:
-            assert "已被阻断" not in result["reason"]
-            assert "将继续" in result["reason"]
+            assert "已阻断本次" not in result["reason"]
+            assert "本次仅提醒，不会阻断" in result["reason"]
 
     def test_post_tool_block_describes_content_boundary(self):
         result = json.loads(
@@ -211,7 +338,25 @@ class TestFormatCosh:
         assert "工具已经执行" in result["reason"]
         assert "不会进入模型上下文" in result["reason"]
         assert "外部副作用不会撤销" in result["reason"]
-        assert "将继续处理" not in result["reason"]
+        assert "不会阻断" not in result["reason"]
+
+    def test_post_tool_ask_describes_warning_boundary(self):
+        result = json.loads(
+            _format_cosh(
+                {
+                    "verdict": "deny",
+                    "findings": [{"type": "credential", "severity": "deny"}],
+                },
+                "ask",
+                "PostToolUse",
+            )
+        )
+
+        assert result["decision"] == "allow"
+        assert "工具已经执行" in result["reason"]
+        assert "当前环节不支持确认/阻断" in result["reason"]
+        assert "原始工具结果仍会进入模型上下文" in result["reason"]
+        assert "外部副作用不会撤销" in result["reason"]
 
 
 @pytest.mark.parametrize(
@@ -318,7 +463,10 @@ class TestCoshHookMain:
         assert captured["kwargs"]["input"] == "Phone: 13800138000"
         assert captured["kwargs"]["timeout"] == 10
         assert output["decision"] == "allow"
-        assert "phone_cn" in output["reason"]
+        assert output["reason"] == (
+            "[pii-checker] 检测到 1 项一般风险敏感信息；"
+            "本次仅提醒，未触发确认或阻断。"
+        )
 
     def test_missing_event_defaults_to_user_prompt_policy_mapping(
         self, monkeypatch, capsys
@@ -352,7 +500,8 @@ class TestCoshHookMain:
         )
 
         assert output["decision"] == "ask"
-        assert "需要确认" in output["reason"]
+        assert "当前策略要求确认，请确认后继续" in output["reason"]
+        assert "email" not in output["reason"]
         assert "alice@example.com" not in output["reason"]
 
     def test_injects_trace_context_into_scan_pii_command(self, monkeypatch, capsys):
@@ -499,7 +648,16 @@ class TestCoshHookMain:
         ]
         assert captured["kwargs"]["input"] == expected_stdin
         assert output["decision"] == "allow"
-        assert "a***@example.com" in output["reason"]
+        if payload.get("hook_event_name") in {"PostToolUse", "PostToolUseFailure"}:
+            assert "工具已经执行" in output["reason"]
+            assert "原始工具结果仍会进入模型上下文" in output["reason"]
+            assert "外部副作用不会撤销" in output["reason"]
+        else:
+            assert output["reason"] == (
+                "[pii-checker] 检测到 1 项一般风险敏感信息；"
+                "本次仅提醒，未触发确认或阻断。"
+            )
+        assert "a***@example.com" not in output["reason"]
 
     def test_cli_nonzero_allows(self, monkeypatch, capsys):
         def fake_run(args, **kwargs):

--- a/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
+++ b/src/agent-sec-core/tests/unit-test/hermes-plugin/test_pii_scan.py
@@ -187,9 +187,14 @@ class TestPiiScanCapability:
         )
 
         assert output is not None
-        assert "token=[REDACTED]" in output
+        assert "检测到 1 项高风险敏感信息" in output
+        assert "token=[REDACTED]" not in output
         assert output.endswith("\n\nassistant reply")
         assert "blocked" not in output.lower()
+        if policy == "warn":
+            assert "本次仅提醒，未触发确认或阻断" in output
+        else:
+            assert "当前环节不支持确认/阻断，本次仅提醒，不会阻断" in output
 
     @patch("hermes_plugin_src.capabilities.pii_scan.call_agent_sec_cli")
     def test_empty_input_passthrough(self, mock_cli, capability):
@@ -248,7 +253,7 @@ class TestPiiScanCapability:
 
     @patch("hermes_plugin_src.capabilities.pii_scan.call_agent_sec_cli")
     def test_warn_verdict_prepends_warning_once(self, mock_cli, capability):
-        """Warn verdict should prepend one redacted warning to final output."""
+        """Warn verdict should prepend one concise warning to final output."""
         mock_cli.side_effect = [
             _scan_result(
                 "warn",
@@ -281,9 +286,11 @@ class TestPiiScanCapability:
         assert first is not None
         assert first.endswith("\n\nassistant reply")
         assert "[pii-checker]" in first
-        assert "敏感信息" in first
-        assert "email" in first
-        assert "a***@example.com" in first
+        assert "检测到 1 项一般风险敏感信息" in first
+        assert "本次仅提醒，未触发确认或阻断" in first
+        assert "email" not in first
+        assert "a***@example.com" not in first
+        assert "severity" not in first
         assert "alice@example.com" not in first
         assert "raw_evidence" not in first
         assert second is None
@@ -315,9 +322,39 @@ class TestPiiScanCapability:
         )
 
         assert result is not None
-        assert "高风险敏感信息" in result
-        assert "password=[REDACTED]" in result
+        assert "检测到 1 项高风险敏感信息" in result
+        assert "本次仅提醒，未触发确认或阻断" in result
+        assert "generic_secret_field" not in result
+        assert "password=[REDACTED]" not in result
         assert "assistant reply" in result
+
+    def test_mixed_risk_summary_uses_each_finding_severity(self, capability):
+        """Mixed findings should use per-finding severity with verdict fallback."""
+        message = capability._format_pii_message(
+            "deny",
+            [
+                {
+                    "type": "email",
+                    "severity": "warn",
+                    "evidence_redacted": "a***@example.com",
+                },
+                {
+                    "type": "api_key",
+                    "severity": "deny",
+                    "evidence_redacted": "sk-***",
+                },
+                {
+                    "type": "custom",
+                    "severity": "unknown",
+                    "evidence_redacted": "custom-***",
+                },
+            ],
+        )
+
+        assert "检测到 3 项敏感信息（高风险 2、一般风险 1）" in message
+        assert "email" not in message
+        assert "deny" not in message
+        assert "a***@example.com" not in message
 
     @patch("hermes_plugin_src.capabilities.pii_scan.call_agent_sec_cli")
     def test_include_low_confidence_adds_cli_arg(self, mock_cli):
@@ -557,6 +594,12 @@ class TestPiiScanCapability:
         )
 
         assert result is not None
+        warning, redacted_output = result.split("\n\n", 1)
+        assert "检测到 1 项一般风险敏感信息" in warning
+        assert "模型输出中的敏感信息已脱敏，本次回复继续交付" in warning
+        assert "email" not in warning
+        assert "a***@example.com" not in warning
+        assert redacted_output == "Contact a***@example.com"
         assert "Contact a***@example.com" in result
         assert "alice@example.com" not in result
         assert mock_cli.call_args.args[0] == [
@@ -599,7 +642,10 @@ class TestPiiScanCapability:
 
         assert result is not None
         assert "[pii-checker]" in result
-        assert "a***@example.com" in result
+        assert "检测到 1 项一般风险敏感信息" in result
+        assert "原始模型输出已停止交付" in result
+        assert "本次仅显示提醒" in result
+        assert "a***@example.com" not in result
         assert "alice@example.com" not in result
         assert "Contact " not in result
 
@@ -632,8 +678,10 @@ class TestPiiScanCapability:
         )
 
         assert result is not None
-        assert "高风险敏感信息" in result
-        assert "sk-a...[REDACTED]...1234" in result
+        assert "检测到 1 项高风险敏感信息" in result
+        assert "本次仅提醒，未触发确认或阻断" in result
+        assert "api_key" not in result
+        assert "sk-a...[REDACTED]...1234" not in result
         assert result.endswith("\n\nassistant reply")
         assert mock_cli.call_args_list[0].args[0] == [
             "scan-pii",
@@ -675,7 +723,10 @@ class TestPiiScanCapability:
 
         assert result is not None
         assert result["action"] == "block"
-        assert "sk-a...[REDACTED]...1234" in result["message"]
+        assert "检测到 1 项高风险敏感信息" in result["message"]
+        assert "当前策略已阻断本次工具调用" in result["message"]
+        assert "api_key" not in result["message"]
+        assert "sk-a...[REDACTED]...1234" not in result["message"]
         assert "sk-abcdefghijklmnop1234" not in result["message"]
         assert "raw_evidence" not in result["message"]
         assert "继续处理" not in result["message"]
@@ -708,7 +759,10 @@ class TestPiiScanCapability:
 
         assert result is not None
         assert result["action"] == "block"
-        assert "token=[REDACTED]" in result["message"]
+        assert "检测到 1 项高风险敏感信息" in result["message"]
+        assert "当前策略已阻断本次工具调用" in result["message"]
+        assert "credential" not in result["message"]
+        assert "token=[REDACTED]" not in result["message"]
         assert "raw-secret-value" not in result["message"]
         assert capability._warnings_by_key == {}
         mock_cli.assert_called_once()
@@ -748,9 +802,11 @@ class TestPiiScanCapability:
 
         assert pre_result is None
         assert output is not None
-        assert "a***@example.com" in output
+        assert "检测到 1 项一般风险敏感信息" in output
+        assert "本次仅提醒，未触发确认或阻断" in output
+        assert "email" not in output
+        assert "a***@example.com" not in output
         assert "alice@example.com" not in output
-        assert "继续处理" in output
 
     @patch("hermes_plugin_src.capabilities.pii_scan.call_agent_sec_cli")
     def test_ask_deny_pre_tool_falls_back_to_cached_warning(
@@ -787,9 +843,11 @@ class TestPiiScanCapability:
 
         assert pre_result is None
         assert output is not None
-        assert "token=[REDACTED]" in output
+        assert "检测到 1 项高风险敏感信息" in output
+        assert "当前环节不支持确认/阻断，本次仅提醒，不会阻断" in output
+        assert "credential" not in output
+        assert "token=[REDACTED]" not in output
         assert "raw-secret-value" not in output
-        assert "继续处理" in output
 
     @patch("hermes_plugin_src.capabilities.pii_scan.call_agent_sec_cli")
     def test_runtime_hermes_session_context_bridges_missing_tool_session_id(
@@ -831,7 +889,8 @@ class TestPiiScanCapability:
         )
 
         assert output is not None
-        assert "a***@example.com" in output
+        assert "检测到 1 项一般风险敏感信息" in output
+        assert "a***@example.com" not in output
         assert output.endswith("\n\nassistant response")
         assert second is None
 
@@ -856,7 +915,8 @@ class TestPiiScanCapability:
 
         assert output is not None
         assert output.startswith("[pii-checker]")
-        assert "a***" in output
+        assert "检测到 1 项一般风险敏感信息" in output
+        assert "a***" not in output
         assert "\n\n" not in output
         assert second is None
         assert mock_cli.call_count == 1
@@ -891,8 +951,14 @@ class TestPiiScanCapability:
         )
 
         assert result is not None
-        assert "phone_cn" in result
-        assert "138****8000" in result
+        assert "检测到 1 项一般风险敏感信息" in result
+        assert "工具已经执行" in result
+        assert "本次仅提醒，未触发确认或阻断" in result
+        assert "当前环节不支持" not in result
+        assert "工具结果仍会进入模型上下文" in result
+        assert "已发生的外部副作用不会撤销" in result
+        assert "phone_cn" not in result
+        assert "138****8000" not in result
         assert mock_cli.call_args_list[0].args[0] == [
             "scan-pii",
             "--stdin",

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_scanner.py
@@ -1,7 +1,10 @@
 """Unit tests for the PII scanner."""
 
+import time
+
 import pytest
 from agent_sec_cli.pii_checker.detectors.base import PiiCandidate
+from agent_sec_cli.pii_checker.detectors.regex import RegexPiiDetector
 from agent_sec_cli.pii_checker.models import PiiFinding
 from agent_sec_cli.pii_checker.redactor import redact_text
 from agent_sec_cli.pii_checker.scanner import DEFAULT_MAX_BYTES, PiiScanner
@@ -75,6 +78,12 @@ def test_bearer_jwt_preserves_both_types():
     assert result["summary"]["by_type"]["bearer_token"] == 1
     assert result["summary"]["by_type"]["jwt"] == 1
     assert token not in result["redacted_text"]
+
+
+def test_jwt_like_code_identifier_is_not_detected():
+    result = _scan("Call resolved.auth_source.as_deref() before loading credentials.")
+
+    assert "jwt" not in _types(result)
 
 
 def test_chinese_secret_field_is_detected_with_high_confidence():
@@ -183,6 +192,165 @@ def test_low_confidence_hidden_by_default_and_included_on_request():
     assert hidden["findings"] == []
     assert shown["verdict"] == "warn"
     assert shown["findings"][0]["type"] == "email"
+
+
+@pytest.mark.parametrize(
+    "email",
+    (
+        "alice@example.com",
+        "alice@sub.example.net",
+        "alice@company.example",
+        "alice@company.invalid",
+        "alice@company.test",
+        "alice@company.localhost",
+    ),
+)
+def test_reserved_email_domains_are_low_confidence(email):
+    hidden = _scan(f"Contact {email}")
+    shown = _scan(f"Contact {email}", include_low_confidence=True)
+
+    assert "email" not in _types(hidden)
+    assert _types(shown) == {"email"}
+    finding = shown["findings"][0]
+    assert finding["confidence"] < 0.5
+    assert finding["metadata"]["validator"] == "email_syntax"
+    assert finding["metadata"]["context"] == "reserved_domain"
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "ssh://deploy@securecorp.cn/home/deploy",
+        "git clone git@github.com:org/repo.git",
+        "scp /tmp/a deploy@securecorp.cn:/tmp/",
+        "rsync /tmp/a deploy@securecorp.cn:/tmp/",
+        "ssh deploy@securecorp.cn",
+        "ssh -p 22 deploy@securecorp.cn",
+        "ssh -p22 deploy@securecorp.cn",
+        "ssh -vvv deploy@securecorp.cn",
+        'ssh "deploy@securecorp.cn"',
+        "ssh " + "-v " * 30 + "deploy@securecorp.cn",
+        "sftp deploy@securecorp.cn",
+        "sftp -P 22 deploy@securecorp.cn",
+    ),
+)
+def test_remote_identity_emails_are_low_confidence(text):
+    hidden = _scan(text)
+    shown = _scan(text, include_low_confidence=True)
+
+    assert "email" not in _types(hidden)
+    assert _types(shown) == {"email"}
+    finding = shown["findings"][0]
+    assert finding["confidence"] < 0.5
+    assert finding["metadata"]["context"] == "remote_identity"
+
+
+def test_mailto_and_ambiguous_email_shapes_remain_detected():
+    result = _scan(
+        "mailto:alice@securecorp.cn, literal git@github.com, and lhs@module.py"
+    )
+
+    assert result["summary"]["by_type"]["email"] == 3
+    assert all(
+        finding["metadata"]["validator"] == "email_syntax"
+        for finding in result["findings"]
+    )
+
+
+def test_colon_after_email_is_not_enough_to_mark_remote_identity():
+    result = _scan("Contact alice@company.cn:thanks for the quick response")
+
+    assert _types(result) == {"email"}
+    assert "context" not in result["findings"][0]["metadata"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "ssh failed, contact alice@securecorp.cn for help",
+        "Contact alice@securecorp.cn: https://docs.securecorp.cn/help",
+    ),
+)
+def test_remote_keywords_and_colon_prose_do_not_lower_email_confidence(text):
+    result = _scan(text)
+
+    assert _types(result) == {"email"}
+    assert result["findings"][0]["confidence"] >= 0.82
+    assert "context" not in result["findings"][0]["metadata"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "ssh -o note=alice@securecorp.cn target",
+        "ssh -oIdentityFile=alice@securecorp.cn target",
+        "ssh -P alice@securecorp.cn target",
+        "ssh -Q cipher alice@securecorp.cn",
+        "ssh -V alice@securecorp.cn",
+        "ssh -Z alice@securecorp.cn",
+        'ssh "alice@securecorp.cn',
+        'ssh alice@securecorp.cn"',
+        'ssh "alice@securecorp.cn"suffix',
+        "sftp -s alice@securecorp.cn target",
+        "sftp -D /definitely/missing alice@securecorp.cn",
+        "notssh://alice@securecorp.cn",
+        "myrsync://alice@securecorp.cn",
+        "not_ssh://alice@securecorp.cn",
+        "非ssh://alice@securecorp.cn",
+        "notssh " + "-v " * 20 + "alice@securecorp.cn",
+    ),
+)
+def test_ssh_option_values_do_not_look_like_remote_targets(text):
+    result = _scan(text)
+
+    assert _types(result) == {"email"}
+    assert result["findings"][0]["confidence"] >= 0.82
+    assert "context" not in result["findings"][0]["metadata"]
+
+
+def test_scp_style_git_repository_without_slash_is_low_confidence():
+    hidden = _scan("git clone git@github.com:repo.git")
+    shown = _scan("git clone git@github.com:repo.git", include_low_confidence=True)
+
+    assert "email" not in _types(hidden)
+    assert _types(shown) == {"email"}
+    assert shown["findings"][0]["metadata"]["context"] == "remote_identity"
+
+
+def test_many_emails_do_not_trigger_quadratic_remote_context_scans():
+    text = "alice@securecorp.cn " * 15_000
+
+    started = time.perf_counter()
+    findings = RegexPiiDetector().detect(text)
+    elapsed = time.perf_counter() - started
+
+    assert len(findings) == 15_000
+    assert elapsed < 2.0
+
+
+def test_fixture_words_do_not_lower_real_email_confidence():
+    result = _scan(
+        "example dummy test sample: contact test@example.company.cn for help"
+    )
+
+    assert _types(result) == {"email"}
+    assert result["findings"][0]["confidence"] >= 0.82
+
+
+@pytest.mark.parametrize(
+    "email",
+    (
+        ".alice@company.cn",
+        "alice.@company.cn",
+        "alice..bob@company.cn",
+        "alice@-company.cn",
+        "alice@company-.cn",
+        "alice@company..cn",
+        "alice@bad_domain.cn",
+    ),
+)
+def test_invalid_email_syntax_is_not_detected(email):
+    assert "email" not in _types(_scan(f"Contact {email}"))
 
 
 def test_raw_evidence_default_off_and_opt_in():

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
@@ -1,11 +1,26 @@
 """Unit tests for pii_checker validators."""
 
+import base64
+import json
+
+import pytest
 from agent_sec_cli.pii_checker.validators import (
     luhn_check,
     validate_cn_id,
+    validate_email,
     validate_jwt,
     validate_pem_private_key,
 )
+
+
+def _jwt_segment(value):
+    encoded = json.dumps(value, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(encoded).rstrip(b"=").decode("ascii")
+
+
+def _jwt(header, payload, signature=b"signature"):
+    encoded_signature = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    return f"{_jwt_segment(header)}.{_jwt_segment(payload)}.{encoded_signature}"
 
 
 def test_luhn_valid_card():
@@ -32,6 +47,47 @@ def test_cn_id_invalid_checksum():
     assert not validate_cn_id("110105194912310021")
 
 
+@pytest.mark.parametrize(
+    "value",
+    (
+        "alice@company.cn",
+        "first.last+tag@sub-domain.company.cn",
+        "ALICE_01@SECURECORP.COM",
+    ),
+)
+def test_email_valid_ascii_syntax(value):
+    assert validate_email(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        ".alice@company.cn",
+        "alice.@company.cn",
+        "alice..bob@company.cn",
+        "alice@-company.cn",
+        "alice@company-.cn",
+        "alice@bad_domain.cn",
+        "alice@company..cn",
+        "alice@localhost",
+        "alice@company.123",
+        f"{'a' * 65}@company.cn",
+        f"alice@{'a' * 64}.cn",
+    ),
+)
+def test_email_rejects_invalid_ascii_syntax(value):
+    assert not validate_email(value)
+
+
+def test_email_enforces_total_address_length():
+    maximum_domain = ".".join(("a" * 63, "b" * 63, "c" * 60, "d" * 63))
+    oversized_domain = ".".join(("a" * 63, "b" * 63, "c" * 61, "d" * 63))
+
+    assert len(f"a@{maximum_domain}") == 254
+    assert validate_email(f"a@{maximum_domain}")
+    assert not validate_email(f"a@{oversized_domain}")
+
+
 def test_jwt_valid_structure():
     token = (
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
@@ -41,8 +97,40 @@ def test_jwt_valid_structure():
     assert validate_jwt(token)
 
 
+def test_jwt_type_header_is_optional():
+    assert validate_jwt(_jwt({"alg": "HS256"}, {"sub": "123"}))
+
+
 def test_jwt_invalid_structure():
     assert not validate_jwt("not.a.jwt")
+
+
+def test_jwt_requires_json_objects_and_header_algorithm():
+    assert not validate_jwt(_jwt({"typ": "JWT"}, {"sub": "123"}))
+    assert not validate_jwt(_jwt({"alg": "HS256"}, ["not", "an", "object"]))
+    assert not validate_jwt(_jwt({"alg": "   "}, {"sub": "123"}))
+
+
+def test_jwt_rejects_non_json_and_invalid_base64url_segments():
+    payload = _jwt_segment({"sub": "123"})
+    signature = base64.urlsafe_b64encode(b"signature").rstrip(b"=").decode("ascii")
+
+    assert not validate_jwt(f"bm90LWpzb24.{payload}.{signature}")
+    assert not validate_jwt(f"_w.{payload}.{signature}")
+    assert not validate_jwt(f"{_jwt_segment({'alg': 'HS256'})}.{payload}.a")
+
+
+def test_jwt_rejects_json_parser_resource_limits():
+    deeply_nested_payload = "[" * 1_100 + "]" * 1_100
+    oversized_integer_payload = "9" * 4_301
+    header = _jwt_segment({"alg": "HS256"})
+    signature = base64.urlsafe_b64encode(b"signature").rstrip(b"=").decode("ascii")
+
+    for payload in (deeply_nested_payload, oversized_integer_payload):
+        encoded_payload = (
+            base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+        )
+        assert not validate_jwt(f"{header}.{encoded_payload}.{signature}")
 
 
 def test_pem_private_key_matching_markers():

--- a/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
+++ b/src/agent-sec-core/tests/unit-test/pii_checker/test_validators.py
@@ -101,6 +101,24 @@ def test_jwt_type_header_is_optional():
     assert validate_jwt(_jwt({"alg": "HS256"}, {"sub": "123"}))
 
 
+def test_jwt_only_accepts_noncanonical_signature_with_equivalent_bytes():
+    token = _jwt({"alg": "HS256"}, {"sub": "123"}, signature=b"\0" * 32)
+    header, payload, canonical_signature = token.split(".")
+    noncanonical_payload = f"{payload[:-1]}R"
+    noncanonical_signature = f"{canonical_signature[:-1]}B"
+
+    assert payload.endswith("Q")
+    assert base64.urlsafe_b64decode(f"{payload}==") == base64.urlsafe_b64decode(
+        f"{noncanonical_payload}=="
+    )
+    assert canonical_signature.endswith("A")
+    assert base64.urlsafe_b64decode(f"{canonical_signature}=") == (
+        base64.urlsafe_b64decode(f"{noncanonical_signature}=")
+    )
+    assert validate_jwt(f"{header}.{payload}.{noncanonical_signature}")
+    assert not validate_jwt(f"{header}.{noncanonical_payload}.{canonical_signature}")
+
+
 def test_jwt_invalid_structure():
     assert not validate_jwt("not.a.jwt")
 

--- a/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qoder_hooks/test_qoder_pii_checker_hook.py
@@ -189,7 +189,12 @@ def test_warn_policy_warns_and_continues(mock_cli) -> None:
     )
 
     assert output["decision"] == "allow"
-    assert "Execution will continue" in output["systemMessage"]
+    message = output["systemMessage"]
+    assert "1 high-risk sensitive data finding" in message
+    assert "warning only" in message
+    assert "api_key=[REDACTED]" not in message
+    assert "credential" not in message
+    assert "severity" not in message
 
 
 def test_ask_policy_requests_pre_tool_approval(mock_cli) -> None:
@@ -208,7 +213,9 @@ def test_ask_policy_requests_pre_tool_approval(mock_cli) -> None:
         )
     )
 
-    assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
+    hook_output = output["hookSpecificOutput"]
+    assert hook_output["permissionDecision"] == "ask"
+    assert "Confirmation is required" in hook_output["permissionDecisionReason"]
 
 
 def test_ask_policy_falls_back_to_warning_without_confirmation(mock_cli) -> None:
@@ -228,9 +235,32 @@ def test_ask_policy_falls_back_to_warning_without_confirmation(mock_cli) -> None
     )
 
     assert output["decision"] == "allow"
-    assert (
-        "Approval is unavailable here; execution continues" in output["systemMessage"]
+    assert "This stage cannot confirm or block" in output["systemMessage"]
+    assert "warning only" in output["systemMessage"]
+
+
+def test_ask_policy_post_tool_warning_reports_actual_result(mock_cli) -> None:
+    env, _capture = mock_cli(
+        output=_PII_DENY_RESULT,
+        extra={"PII_CHECKER_MODE": "ask"},
     )
+
+    output = _stdout_json(
+        _run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": {"content": "password=secret"},
+            },
+            env,
+        )
+    )
+
+    assert output["decision"] == "allow"
+    message = output["systemMessage"]
+    assert "tool has already run" in message
+    assert "This stage cannot confirm or block" in message
+    assert "raw output will enter model context" in message
+    assert "external side effects were not undone" in message
 
 
 def test_hook_trace_context_contains_only_host_correlation_ids(mock_cli) -> None:
@@ -291,7 +321,9 @@ def test_user_prompt_deny_blocks_without_raw_pii(mock_cli) -> None:
 
     output = _stdout_json(proc)
     assert output["decision"] == "deny"
-    assert "api_key=[REDACTED]" in output["reason"]
+    assert "1 high-risk sensitive data finding" in output["reason"]
+    assert "blocked this request" in output["reason"]
+    assert "api_key=[REDACTED]" not in output["reason"]
     assert "sk-live-secret" not in proc.stdout
     assert "sk-live-secret" not in proc.stderr
 
@@ -313,7 +345,8 @@ def test_warn_in_deny_mode_allows_with_system_message(mock_cli) -> None:
     output = _stdout_json(proc)
     assert output["decision"] == "allow"
     assert "systemMessage" in output
-    assert "a***@example.com" in output["systemMessage"]
+    assert "1 general-risk sensitive data finding" in output["systemMessage"]
+    assert "a***@example.com" not in output["systemMessage"]
     assert "alice@example.com" not in proc.stdout
 
 
@@ -337,7 +370,9 @@ def test_pre_tool_use_deny_uses_permission_decision(mock_cli) -> None:
     hook_output = output["hookSpecificOutput"]
     assert hook_output["hookEventName"] == "PreToolUse"
     assert hook_output["permissionDecision"] == "deny"
-    assert "api_key=[REDACTED]" in hook_output["permissionDecisionReason"]
+    reason = hook_output["permissionDecisionReason"]
+    assert "blocked this tool call" in reason
+    assert "api_key=[REDACTED]" not in reason
     captured = _captured_call(capture)
     assert captured["argv"][captured["argv"].index("--source") + 1] == "tool_input"
 
@@ -378,10 +413,37 @@ def test_post_tool_use_deny_replaces_tool_output(mock_cli) -> None:
     hook_output = output["hookSpecificOutput"]
     assert hook_output["hookEventName"] == "PostToolUse"
     assert "updatedToolOutput" in hook_output
-    assert "api_key=[REDACTED]" in hook_output["updatedToolOutput"]
+    replacement = hook_output["updatedToolOutput"]
+    assert "tool has already run" in replacement
+    assert "raw output will not enter model context" in replacement
+    assert "external side effects were not undone" in replacement
+    assert "api_key=[REDACTED]" not in replacement
     assert "password=secret" not in proc.stdout
     captured = _captured_call(capture)
     assert captured["argv"][captured["argv"].index("--source") + 1] == "tool_output"
+
+
+def test_post_tool_use_warning_states_execution_and_context_result(mock_cli) -> None:
+    env, _capture = mock_cli(
+        output=_PII_WARN_RESULT,
+        extra={"PII_CHECKER_MODE": "warn"},
+    )
+
+    output = _stdout_json(
+        _run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_response": {"content": "alice@example.com"},
+            },
+            env,
+        )
+    )
+
+    message = output["systemMessage"]
+    assert "tool has already run" in message
+    assert "raw output will enter model context" in message
+    assert "external side effects were not undone" in message
+    assert "a***@example.com" not in message
 
 
 def test_include_low_confidence_flag_is_forwarded(mock_cli) -> None:
@@ -438,4 +500,22 @@ def test_invalid_mode_reports_observe_fallback(mock_cli) -> None:
     output = _stdout_json(proc)
 
     assert output["decision"] == "allow"
-    assert "invalid PII_CHECKER_MODE" in output["systemMessage"]
+    assert "PII Checker configuration is invalid" in output["systemMessage"]
+    assert "banana" not in output["systemMessage"]
+    assert "fallback" not in output["systemMessage"].lower()
+
+
+def test_risk_summary_uses_finding_severity_and_verdict_fallback() -> None:
+    hook = load_standalone_hook("qoder_pii_checker_risk_summary_hook", _HOOK_SCRIPT)
+    findings = [
+        {"severity": "deny", "type": "credential"},
+        {"severity": "warn", "type": "email"},
+        {"severity": "custom", "type": "custom"},
+    ]
+
+    assert hook._risk_summary("deny", findings) == (
+        "Detected 3 sensitive data findings (2 high risk, 1 general risk)"
+    )
+    assert hook._risk_summary("warn", findings) == (
+        "Detected 3 sensitive data findings (1 high risk, 2 general risk)"
+    )

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_pii_checker_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_pii_checker_hook.py
@@ -300,7 +300,12 @@ def test_warn_policy_warns_and_continues(monkeypatch, capsys):
     )
 
     assert set(output) == {"systemMessage"}
-    assert "Execution will continue" in output["systemMessage"]
+    message = output["systemMessage"]
+    assert "1 high-risk sensitive data finding" in message
+    assert "warning only" in message
+    assert "token=[REDACTED]" not in message
+    assert "credential" not in message
+    assert "severity" not in message
 
 
 def test_ask_policy_requests_pre_tool_approval(monkeypatch, capsys):
@@ -321,7 +326,9 @@ def test_ask_policy_requests_pre_tool_approval(monkeypatch, capsys):
         _base("PreToolUse", tool_input={"token": "raw-secret-value"}),
     )
 
-    assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
+    hook_output = output["hookSpecificOutput"]
+    assert hook_output["permissionDecision"] == "ask"
+    assert "Confirmation is required" in hook_output["permissionDecisionReason"]
 
 
 def test_ask_policy_falls_back_to_warning_without_confirmation(monkeypatch, capsys):
@@ -343,9 +350,53 @@ def test_ask_policy_falls_back_to_warning_without_confirmation(monkeypatch, caps
     )
 
     assert set(output) == {"systemMessage"}
-    assert (
-        "Approval is unavailable here; execution continues" in output["systemMessage"]
+    assert "This stage cannot confirm or block" in output["systemMessage"]
+    assert "warning only" in output["systemMessage"]
+
+
+@pytest.mark.parametrize(
+    ("event_name", "fields", "continuation"),
+    [
+        (
+            "PostToolUse",
+            {"tool_response": {"stdout": "raw-secret-value"}},
+            "raw output will enter model context",
+        ),
+        (
+            "Stop",
+            {"last_assistant_message": "raw-secret-value"},
+            "response will continue",
+        ),
+    ],
+)
+def test_ask_policy_unsupported_stages_report_actual_warning_result(
+    monkeypatch, capsys, event_name, fields, continuation
+):
+    monkeypatch.setenv("PII_CHECKER_MODE", "ask")
+    monkeypatch.setattr(
+        pii_checker_hook.subprocess,
+        "run",
+        lambda args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(_scan_result("deny", "token=[REDACTED]")),
+            stderr="",
+        ),
     )
+
+    output, _stderr = _run_main(
+        monkeypatch,
+        capsys,
+        _base(event_name, **fields),
+    )
+
+    assert set(output) == {"systemMessage"}
+    message = output["systemMessage"]
+    assert "This stage cannot confirm or block" in message
+    assert "warning only" in message
+    assert continuation in message
+    if event_name == "PostToolUse":
+        assert "tool has already run" in message
+        assert "external side effects were not undone" in message
 
 
 def test_observe_deny_uses_only_redacted_evidence(monkeypatch, capsys):
@@ -387,6 +438,8 @@ def test_warn_never_blocks_in_block_mode(monkeypatch, capsys):
     )
 
     assert set(output) == {"systemMessage"}
+    assert "1 general-risk sensitive data finding" in output["systemMessage"]
+    assert "a***@example.com" not in output["systemMessage"]
 
 
 @pytest.mark.parametrize(
@@ -442,7 +495,19 @@ def test_block_mode_maps_deny_to_qwen_decision(
     else:
         assert output["decision"] == expected["decision"]
         reason = output["reason"]
-    assert "token=[REDACTED]" in reason
+    assert "1 high-risk sensitive data finding" in reason
+    assert "token=[REDACTED]" not in reason
+    if event_name == "UserPromptSubmit":
+        assert "blocked this request" in reason
+    elif event_name == "PreToolUse":
+        assert "blocked this tool call" in reason
+    elif event_name == "PostToolUse":
+        assert "tool has already run" in reason
+        assert "raw output will not enter model context" in reason
+        assert "external side effects were not undone" in reason
+    else:
+        assert "final response was blocked" in reason
+        assert "Rewrite it without sensitive data" in reason
     assert "raw-secret-value" not in json.dumps(output)
 
 
@@ -475,6 +540,9 @@ def test_post_tool_use_warn_or_observe_does_not_stop(
     else:
         assert set(output) == {"systemMessage"}
         assert "continue" not in output
+        assert "tool has already run" in output["systemMessage"]
+        assert "raw output will enter model context" in output["systemMessage"]
+        assert "external side effects were not undone" in output["systemMessage"]
 
 
 @pytest.mark.parametrize("mode", ["observe", "block"])
@@ -541,7 +609,9 @@ def test_stop_hook_active_warns_without_retrying(monkeypatch, capsys):
     )
 
     assert set(output) == {"systemMessage"}
+    assert "warning-only" in output["systemMessage"]
     assert "retry loop" in output["systemMessage"]
+    assert "a***@example.com" not in output["systemMessage"]
 
 
 def test_stop_failure_is_audit_only(monkeypatch, capsys):
@@ -574,6 +644,7 @@ def test_stop_failure_is_audit_only(monkeypatch, capsys):
         {"verdict": "error", "findings": []},
         {"verdict": "unknown", "findings": [{}]},
         {"verdict": "deny", "findings": []},
+        {"verdict": "deny", "findings": ["not-an-object"]},
         {"verdict": "deny", "findings": [{"raw_evidence": "secret"}]},
         {"verdict": "warn", "findings": "not-a-list"},
         [],
@@ -688,27 +759,42 @@ def test_unexpected_error_is_silent_and_fail_open(monkeypatch, capsys):
     assert stderr == ""
 
 
-def test_redacted_evidence_is_deduplicated_bounded_and_shortened():
+def test_validated_result_keeps_only_sanitized_finding_severity():
     findings = [
-        {"evidence_redacted": "a" * 100},
-        {"evidence_redacted": "a" * 100},
-        {"evidence_redacted": "second"},
-        {"evidence_redacted": "third"},
-        {"evidence_redacted": "fourth"},
+        {
+            "type": "credential",
+            "severity": "deny",
+            "evidence_redacted": "token=[REDACTED]",
+            "raw_evidence": "raw-secret-value",
+        },
+        {"type": "email", "severity": "warn", "evidence_redacted": "a***"},
+        {"type": "custom", "severity": "custom"},
     ]
 
-    verdict, evidence = pii_checker_hook._validated_result(
+    verdict, sanitized = pii_checker_hook._validated_result(
         {"verdict": "deny", "findings": findings}
     )
 
     assert verdict == "deny"
-    assert len(evidence) == 3
-    assert len(evidence[0]) == 80
-    assert evidence[0].endswith("...")
+    assert sanitized == [
+        {"severity": "deny"},
+        {"severity": "warn"},
+        {"severity": "custom"},
+    ]
+    assert pii_checker_hook._risk_summary(verdict, sanitized) == (
+        "Detected 3 sensitive data findings (2 high risk, 1 general risk)"
+    )
+    assert pii_checker_hook._risk_summary("warn", sanitized) == (
+        "Detected 3 sensitive data findings (1 high risk, 2 general risk)"
+    )
 
 
 def test_invalid_mode_reports_observe_fallback(monkeypatch, capsys):
     monkeypatch.setenv("PII_CHECKER_MODE", "banana")
 
     assert pii_checker_hook._policy() == "observe"
-    assert "invalid PII_CHECKER_MODE; using observe" in capsys.readouterr().err
+    message = capsys.readouterr().err
+    assert "PII Checker configuration is invalid" in message
+    assert "banana" not in message
+    assert "observe" not in message
+    assert "fallback" not in message.lower()


### PR DESCRIPTION
## Why

PII Checker can misclassify common three-part identifiers and remote-login syntax, while host notices expose internal scanner terms that obscure the action actually taken. This change reduces JWT and Email false positives and aligns the user experience across every shipped host adapter without weakening audit evidence or changing policy enforcement.

## What changed

- Require JWT header and payload segments to decode to JSON objects, require a non-empty `alg`, and validate the signature segment structurally.
- Validate Email syntax more strictly and classify reserved domains plus SSH/SCP/rsync identities as low confidence while preserving `mailto:` detection.
- Align Cosh, Codex, Qoder, Qwen Code, Hermes, and OpenClaw notices around per-finding high/general risk counts and the host's actual warn, confirm, or block result.
- Hide internal verdict/severity/policy labels, finding types, and redacted evidence from user-visible notices while preserving structured scan and audit data.

## Related issue

no-issue: tracked in an internal requirement

## User / Agent impact

Users see fewer JWT and Email false positives and can tell at a glance whether PII Checker only warned, requested confirmation, blocked a request/tool call, or handled a result after the tool had already executed. Post-tool notices also state whether the raw result enters model context and that external side effects are not undone.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The intended compatibility change is stricter built-in candidate validation and clearer notices in all host adapters. Reserved-domain and remote-identity Email candidates remain available with `--include-low-confidence`; public JSON structures, custom rules, audit evidence, and enforcement mappings are unchanged.

## Validation

- `make python-code-pretty` (389 files unchanged)
- `make test-python` (3,645 passed / 3 skipped; CLI E2E 86 passed / 2 skipped; daemon E2E 12 passed / 6 skipped; Skill Ledger E2E 50 passed)
- Focused cross-host PII Checker tests after the final fixes
- Codex Hook E2E (19 passed / 8 skipped)
- OpenClaw `npm run build`, `npm test`, and `npm run smoke`
- Direct Ruff checks and `git diff --check`
- Independent cross-host reviews; all findings addressed and the final review reported no remaining issues

Linux packaging and installed-Cosh smoke remain delegated to CI; direct Cosh Hook execution is covered by the focused E2E suite.

## Documentation and rollback

No documentation files changed. Revert this commit to restore the previous detector and notice behavior; Cosh's shared Chinese wrapping issue remains a separate TODO.
