### PR TITLE
feat(skillfs): authenticate container peers

### DIFF
--- a/docs/user-guide/en/runtime/skillfs.md
+++ b/docs/user-guide/en/runtime/skillfs.md
@@ -480,7 +480,7 @@ skills staying hidden rather than as an obvious error.
 For in-place activation and notify mounts, set `--ledger-backing-root` to a
 daemon-visible backing source path and enable the authenticated resolver.
 Notify v2 carries canonical identity only, so startup rejects an in-place
-notify configuration that omits `--trusted-peer-exe`. The same resolver
+notify configuration that omits authenticated control-peer configuration. The same resolver
 requirement applies to an out-of-place notify mount whenever it explicitly
 configures `--ledger-backing-root`:
 
@@ -512,8 +512,8 @@ skillfs mount /path/to/skills /mnt/skillfs \
 ```
 
 The socket requires `--security --activation-mode file`, is mutually exclusive
-with `--decision-command`, and requires a pinned trusted peer executable. Peer
-validation uses Linux peer credentials and executable identity checks.
+with `--decision-command`, and requires exactly one peer authentication mode.
+The host mode uses Linux peer credentials and executable identity checks.
 
 The packaged AgentSecCore daemon starts the Skill Ledger worker with
 `sys.executable`, which resolves to `/usr/bin/python3.11`; the worker is not a
@@ -539,9 +539,10 @@ priority:
 2. `[control_socket].path` in the config file
 3. the default per-user endpoint `/run/user/<uid>/skillfs/control.sock`
 
-A trusted peer with no explicit path uses the default endpoint; an explicit
-path with no trusted peer is a configuration error; neither leaves the control
-plane off. The default endpoint never falls back to `/tmp` or `/var/tmp` — if
+An executable peer with no explicit path uses the default endpoint; HMAC mode
+requires an explicit path. An explicit path with no peer mode is a
+configuration error; neither leaves the control plane off. The default endpoint
+never falls back to `/tmp` or `/var/tmp` — if
 `/run/user/<uid>` is unavailable, startup fails with an actionable error and
 you must pass `--control-socket` explicitly. A second instance never unlinks an
 active endpoint; only a confirmed-stale socket that SkillFS owns is reclaimed.
@@ -549,13 +550,49 @@ active endpoint; only a confirmed-stale socket that SkillFS owns is reclaimed.
 No `register`, `mountId`, or `generation` handshake is required — the endpoint
 is stable per UID and the resolver is queried directly.
 
-> **Do not use a custom endpoint in a joint deployment with Skill Ledger.** The
-> Skill Ledger resolver client only probes the default
-> `/run/user/<uid>/skillfs/control.sock`; no configuration key or command-line
-> option makes it follow a custom path. If you point `--control-socket` or
-> `[control_socket].path` elsewhere, Ledger fails to find the default socket and
-> silently falls back to host mode, canonical path resolution stops working, and
-> neither side reports an error. This is a current M1 limitation.
+#### Container HMAC profile
+
+The SkillFS side can use the HMAC profile when a trusted peer runs in a
+separate PID or mount namespace. Both processes must read the same secret from
+private files mounted only into the trusted containers:
+
+```bash
+skillfs mount /var/lib/skillfs/source /var/lib/skillfs/shared/mount \
+  --foreground --allow-other \
+  --security --activation-mode file \
+  --notify-socket /run/anolisa/peer/notify.sock \
+  --notify-auth-key-file /run/anolisa/auth/skillfs.key \
+  --control-socket /run/anolisa/skillfs/control.sock \
+  --trusted-peer-key-file /run/anolisa/auth/skillfs.key
+```
+
+The secret file must be an absolute, nonblocking, no-follow regular file owned
+by the effective user, grant no group or other permissions, and contain
+32–4096 raw bytes. FIFO and other non-regular candidates fail startup without
+blocking. HMAC mode does not fall back to executable or plain authentication.
+After mutual authentication, session-bound tags protect both raw business
+requests and responses before either side interprets them.
+For authenticated notify, the daemon socket must be owned by SkillFS's
+effective UID, grant no group or other permissions, and live directly under an
+owner-matched directory that also grants no group or other permissions; `0700`
+is the recommended directory mode. The compatible agent-sec-core listener
+creates that endpoint with mode `0600`; SkillFS checks these properties before
+every connection. This initial profile therefore requires SkillFS and
+agent-sec-core to run with the same effective UID. Mount the runtime socket
+volume read-write only into the trusted containers. A negative-test workload
+may receive it read-only, but never with permission to replace socket entries.
+SkillFS and a resolver peer must see the physical source at the same absolute
+path because the resolver continues to return `transport: shared_path`. Do not
+mount the source or Secret into the workload container.
+
+This repository change implements only the SkillFS server/client surfaces. It
+does not configure or implement agent-sec-core. The peer-side behavior is the
+proposed contract in
+[Container Peer Authentication](../../../../src/skillfs/docs/design/container-peer-authentication.md)
+and remains subject to sec-core maintainer confirmation. Until that follow-up
+lands, use the independent probe and
+[unilateral validation plan](../../../../src/skillfs/docs/testing/container-peer-authentication-unilateral-validation.md)
+instead of treating sec-core integration as available.
 
 Supported JSONL request examples:
 
@@ -694,12 +731,14 @@ shares the same file for compatibility.
 | `--activation-mode file` | Consume activation JSON/xattr state |
 | `--activation-reload-mode poll` | Poll activation after notify triggers |
 | `--notify-socket <PATH>` | Send mutation events to an external daemon |
+| `--notify-auth-key-file <PATH>` | Mutually authenticate notify connections with an owner-only shared key file |
 | `--activation-events-log <PATH>` | Write activation protocol events as JSONL |
 | `--audit-log <PATH>` | Write filesystem audit events as JSONL |
 | `--audit-queue-capacity <N>` | Queue size for the audit writer thread; `0` uses the built-in default, and it only applies with `--audit-log` |
 | `--events-log <PATH>` | Write legacy security decision events as JSONL; only applies with `--security --decision-command` |
-| `--control-socket <PATH>` | Override the control socket endpoint (default: `/run/user/<uid>/skillfs/control.sock`); do not use in a joint deployment with Skill Ledger |
+| `--control-socket <PATH>` | Override the control socket endpoint (default for executable mode: `/run/user/<uid>/skillfs/control.sock`) |
 | `--trusted-peer-exe <PATH>` | Pin the trusted control socket peer (enables the control plane on the default endpoint if no path is given) |
+| `--trusted-peer-key-file <PATH>` | Enable mutually authenticated container peer mode; requires an explicit control socket and is mutually exclusive with `--trusted-peer-exe` |
 | `--trusted-peer-uid <UID>` | Additionally constrain the control socket peer's UID (from `SO_PEERCRED`) |
 | `--trusted-peer-gid <GID>` | Additionally constrain the control socket peer's GID (from `SO_PEERCRED`) |
 | `--trusted-writer-exe <PATH>` | Pin a trusted mount-path writer |

--- a/docs/user-guide/zh/runtime/skillfs.md
+++ b/docs/user-guide/zh/runtime/skillfs.md
@@ -435,8 +435,8 @@ socket。与 Skill Ledger 联合部署时，它就是 agent-sec-core daemon 的 
 
 对于 in-place activation 和 notify mount，需要设置 `--ledger-backing-root`，给
 daemon 一个可见的 backing source path，并启用 authenticated resolver。Notify v2
-只携带 canonical identity，因此缺少 `--trusted-peer-exe` 的 in-place notify 配置会
-在启动阶段被拒绝。out-of-place notify mount 如果显式配置
+只携带 canonical identity，因此缺少 authenticated control-peer 配置的 in-place
+notify 配置会在启动阶段被拒绝。out-of-place notify mount 如果显式配置
 `--ledger-backing-root`，同样必须启用 resolver：
 
 ```bash
@@ -466,8 +466,8 @@ skillfs mount /path/to/skills /mnt/skillfs \
 ```
 
 该 socket 要求 `--security --activation-mode file`，与 `--decision-command` 互斥，
-并且必须指定可信 peer executable。Peer 校验使用 Linux peer credential 和
-executable identity。
+并且必须恰好配置一种 peer authentication mode。宿主机模式使用 Linux peer
+credential 和 executable identity。
 
 packaged AgentSecCore daemon 使用 `sys.executable` 启动 Skill Ledger worker，该路径
 解析为 `/usr/bin/python3.11`；worker 并不是 `/usr/bin/skill-ledger` executable。
@@ -490,20 +490,52 @@ control plane 是 opt-in 且需认证的。endpoint 按优先级解析：
 2. 配置文件 `[control_socket].path`
 3. 默认的每用户 endpoint `/run/user/<uid>/skillfs/control.sock`
 
-仅配置可信 peer 而未给显式 path 时使用默认 endpoint；仅给显式 path 而未配置可信
-peer 为配置错误；两者都没有则 control plane 保持关闭。默认 endpoint 绝不 fallback
-到 `/tmp` 或 `/var/tmp`——若 `/run/user/<uid>` 不可用，启动会返回明确且可操作的
+executable peer 未给显式 path 时使用默认 endpoint；HMAC mode 要求显式 path。仅给
+显式 path 而未配置 peer mode 为配置错误；两者都没有则 control plane 保持关闭。默认
+endpoint 绝不 fallback 到 `/tmp` 或 `/var/tmp`——若 `/run/user/<uid>` 不可用，启动会返回明确且可操作的
 错误，此时必须显式传入 `--control-socket`。第二个实例绝不会 unlink 处于活跃状态
 的 endpoint；只有确认属于 SkillFS 且为 stale 的 socket 才会被回收。
 
 无需 `register`、`mountId` 或 `generation` 握手——endpoint 按 UID 稳定，resolver
 可直接查询。
 
-> **与 Skill Ledger 联合部署时不要使用自定义 endpoint。** Skill Ledger 的 resolver
-> 客户端只探测默认的 `/run/user/<uid>/skillfs/control.sock`，没有任何配置项或命令行
-> 参数可以让它跟随自定义路径。如果用 `--control-socket` 或 `[control_socket].path`
-> 指定了其他路径，Ledger 找不到默认 socket 会静默按 host 模式处理，canonical path
-> 解析随之失效，且两侧都不会报错。这是当前 M1 的限制。
+#### 容器 HMAC profile
+
+可信 peer 运行在独立 PID 或 mount namespace 时，SkillFS 侧可以使用 HMAC
+profile。两个进程必须从只挂载给可信容器的私有文件读取同一个 secret：
+
+```bash
+skillfs mount /var/lib/skillfs/source /var/lib/skillfs/shared/mount \
+  --foreground --allow-other \
+  --security --activation-mode file \
+  --notify-socket /run/anolisa/peer/notify.sock \
+  --notify-auth-key-file /run/anolisa/auth/skillfs.key \
+  --control-socket /run/anolisa/skillfs/control.sock \
+  --trusted-peer-key-file /run/anolisa/auth/skillfs.key
+```
+
+Secret file 必须是绝对路径、nonblocking、no-follow 的普通文件，由 effective user
+所有，不给 group 或 other 任何权限，并包含 32–4096 个 raw bytes。FIFO 等非普通
+文件会立即导致启动失败，不会阻塞。HMAC mode 不会 fallback 到 executable 或
+plain authentication。双向认证后，session-bound tag 会在双方解释 raw business
+request/response 前验证其完整性。Authenticated notify 要求 daemon socket 由
+SkillFS 的 effective UID 所有，不给 group 或 other 任何权限，并直接位于 owner
+匹配且不给 group 或 other 任何权限的目录下，目录推荐使用 `0700`。兼容的
+agent-sec-core listener 会以 `0600` 创建该 endpoint；SkillFS 每次连接前都会检查
+这些属性。因此首版 profile 要求 SkillFS 与 agent-sec-core 使用相同的 effective
+UID。Runtime socket volume 只能以 read-write 方式挂载到可信容器；负向测试中的
+workload 可以只读挂载，但不能替换 socket entry。
+resolver 仍返回 `transport: shared_path`，因此
+SkillFS 和 resolver peer 必须在同一个绝对路径看到物理 source。不要把 source 或
+Secret 挂载到 workload 容器。
+
+本仓库改动只实现 SkillFS server/client surface，不配置或实现 agent-sec-core。
+Peer-side 行为是
+[容器 Peer 认证](../../../../src/skillfs/docs/design/container-peer-authentication_zh.md)
+中的拟议合同，仍需 sec-core maintainer 确认。在其后续实现合入前，应使用独立
+probe 和
+[单方面验证计划](../../../../src/skillfs/docs/testing/container-peer-authentication-unilateral-validation_zh.md)，
+不能把 sec-core 联动描述为已经可用。
 
 支持的 JSONL 请求示例：
 
@@ -623,12 +655,14 @@ mount-session summary 仍共享同一个文件。
 | `--activation-mode file` | 消费 activation JSON/xattr 状态 |
 | `--activation-reload-mode poll` | notify trigger 后 poll activation |
 | `--notify-socket <PATH>` | 向外部 daemon 发送 mutation event |
+| `--notify-auth-key-file <PATH>` | 使用 owner-only 共享 key file 双向认证 notify 连接 |
 | `--activation-events-log <PATH>` | 写 activation protocol events JSONL |
 | `--audit-log <PATH>` | 写 filesystem audit events JSONL |
 | `--audit-queue-capacity <N>` | audit writer 线程队列长度；`0` 用内置默认值，仅配合 `--audit-log` 生效 |
 | `--events-log <PATH>` | 写旧 decision 流程的 security decision events JSONL，仅配合 `--security --decision-command` 生效 |
-| `--control-socket <PATH>` | 覆盖 control socket endpoint（默认 `/run/user/<uid>/skillfs/control.sock`）；与 Skill Ledger 联合部署时不要使用 |
+| `--control-socket <PATH>` | 覆盖 control socket endpoint（executable mode 默认 `/run/user/<uid>/skillfs/control.sock`） |
 | `--trusted-peer-exe <PATH>` | 固定可信 control socket peer（未给 path 时在默认 endpoint 启用 control plane） |
+| `--trusted-peer-key-file <PATH>` | 启用双向认证的容器 peer mode；要求显式 control socket，并与 `--trusted-peer-exe` 互斥 |
 | `--trusted-peer-uid <UID>` | 额外约束 control socket peer 的 UID（取自 `SO_PEERCRED`） |
 | `--trusted-peer-gid <GID>` | 额外约束 control socket peer 的 GID（取自 `SO_PEERCRED`） |
 | `--trusted-writer-exe <PATH>` | 固定可信 mount-path writer |

--- a/src/skillfs/Cargo.lock
+++ b/src/skillfs/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +200,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -302,6 +309,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "id-arena"
@@ -832,11 +848,15 @@ dependencies = [
 name = "skillfs-fuse"
 version = "0.4.0"
 dependencies = [
+ "base64",
  "fuser",
+ "getrandom",
+ "hmac",
  "libc",
  "parking_lot",
  "serde",
  "serde_json",
+ "sha2",
  "skillfs-core",
  "tempfile",
  "thiserror",
@@ -866,6 +886,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/src/skillfs/Cargo.toml
+++ b/src/skillfs/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+hmac = "0.12"
+base64 = "0.22"
+getrandom = "0.4"
 toml = "0.8"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -512,8 +512,17 @@ Related security surfaces:
 - `--notify-socket <PATH>` sends debounced skill mutation notifications to an
   external daemon. Notify v2 identifies the Skill with its canonical path and
   complete flat or Hermes `skillId`; live/backing paths are resolved separately.
+  `--notify-auth-key-file <PATH>` enables mutual HMAC authentication for a
+  container peer implementing the proposed contract. The inner notify v2
+  payload is unchanged, while a session-bound tag protects both the request and
+  acknowledgement. Authenticated notify also requires an owner-matched socket
+  with no group/other permissions under an owner-matched directory that also
+  grants no group/other permissions; `0700` is the recommended directory mode.
+  The initial profile requires SkillFS and sec-core to use the same effective
+  UID. Peer-side sec-core support is not implemented by this SkillFS change and
+  remains tracked in #2439.
   In-place notify mounts, and any notify mount with `--ledger-backing-root`,
-  require `--trusted-peer-exe` so the authenticated resolver is available
+  require an authenticated control-peer mode so the resolver is available
   before the daemon accesses the source.
 - `--activation-events-log <PATH>` writes activation protocol events as JSONL.
 - `--activation-reload-mode poll` re-reads activation state after notify events
@@ -532,19 +541,20 @@ Related security surfaces:
 - `--trusted-writer <NAME>` is a deprecated compatibility gate based on Linux
   TGID `comm`; process names can be spoofed and this should not be used for
   production trust.
-- `--control-socket <PATH>` with `--trusted-peer-exe <PATH>` starts a trusted
-  Unix socket control plane. Trusted peers can write activation JSON or xattr
-  through methods such as `meta.writeActivation` and
-  `meta.setActivationXattr`. The packaged Skill Ledger worker's executable is
-  `/usr/bin/python3.11` because it starts through `sys.executable`, not a
-  `skill-ledger` launcher.
+- `--control-socket <PATH>` starts a trusted Unix socket control plane when
+  exactly one peer mode is configured. `--trusted-peer-exe <PATH>` preserves
+  host executable authentication; `--trusted-peer-key-file <PATH>` enables an
+  explicit container HMAC profile, protects control requests and responses
+  with session-bound tags, and requires an explicit socket path.
+  Trusted peers can write activation JSON or xattr through methods such as
+  `meta.writeActivation` and `meta.setActivationXattr`.
 - The control plane is opt-in and authenticated. The endpoint is resolved by
   priority: CLI `--control-socket` > `[control_socket].path` in the config >
   the default per-user endpoint `/run/user/<uid>/skillfs/control.sock`. A
-  trusted peer without an explicit path uses the default endpoint; an explicit
-  path without a trusted peer is a configuration error; neither leaves the
-  control plane off. The default never falls back to `/tmp` or `/var/tmp`, and
-  a second instance never unlinks an active endpoint.
+  executable peer without an explicit path uses the default endpoint; HMAC
+  mode always requires an explicit path; an explicit path without a peer mode
+  is a configuration error. The default never falls back to `/tmp` or
+  `/var/tmp`, and a second instance never unlinks an active endpoint.
 - `skill.resolveLiveSource` is a read-only query that maps a caller-supplied
   canonical Skill directory to its physical live/backing source. It returns
   `managed=true` (with the derived `skillId`, `relativeSkillDir`,

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -464,8 +464,15 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - `--notify-socket <PATH>` 将 debounce 后的 skill mutation 通知发给外部 daemon。
   Notify v2 使用 canonical 路径和完整 flat/Hermes `skillId` 标识 Skill；
   live/backing 路径通过独立 resolver 解析。in-place notify mount，以及任何配置了
-  `--ledger-backing-root` 的 notify mount，都要求配置 `--trusted-peer-exe`，
-  确保 daemon 访问 source 前 authenticated resolver 已可用。
+  `--ledger-backing-root` 的 notify mount，都要求配置 authenticated control-peer
+  mode，确保 daemon 访问 source 前 resolver 已可用。
+  `--notify-auth-key-file <PATH>` 可以为实现拟议合同的容器 peer 启用双向 HMAC
+  认证。内部 notify v2 业务 payload 保持不变，request 和 acknowledgement 由
+  session-bound tag 保护。Authenticated notify 还要求 owner 匹配的 socket 位于
+  owner 匹配且不给 group/other 任何权限的目录下，目录推荐使用 `0700`；socket
+  同样不能给 group/other 任何权限。首版 profile 要求 SkillFS 与 sec-core 使用相同
+  effective UID。本次 SkillFS 改动不实现 peer-side sec-core 支持，该工作仍由 #2439
+  跟踪。
 - `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
 - `--activation-reload-mode poll` 在 notify events 后重读 activation state，
   无需 remount 即可更新 resolver。
@@ -481,17 +488,18 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
   process-name spoofing 风险。
 - `--trusted-writer <NAME>` 是已废弃的兼容门禁，基于 Linux TGID `comm`；
   进程名可伪造，不应用作生产可信依据。
-- `--control-socket <PATH>` 配合 `--trusted-peer-exe <PATH>` 启动可信 Unix
-  socket control plane。可信 peer 可通过 `meta.writeActivation`、
-  `meta.setActivationXattr` 等方法写 activation JSON 或 xattr。packaged Skill
-  Ledger worker 通过 `sys.executable` 启动，因此其 executable 是
-  `/usr/bin/python3.11`，不是 `skill-ledger` launcher。
+- `--control-socket <PATH>` 在恰好配置一种 peer mode 时启动可信 Unix socket
+  control plane。`--trusted-peer-exe <PATH>` 保持宿主机 executable 认证；
+  `--trusted-peer-key-file <PATH>` 启用显式容器 HMAC profile，以 session-bound tag
+  保护 control request/response，并要求显式 socket path。可信 peer 可通过
+  `meta.writeActivation`、`meta.setActivationXattr` 等方法写 activation JSON 或
+  xattr。
 - control plane 是 opt-in 且需认证的。endpoint 按优先级解析：CLI
   `--control-socket` > 配置 `[control_socket].path` > 默认的每用户 endpoint
-  `/run/user/<uid>/skillfs/control.sock`。仅配置 trusted peer 而未给显式
-  path 时使用默认 endpoint；仅给显式 path 而未配置 trusted peer 为配置错误；
-  两者都没有则 control plane 保持关闭。默认 endpoint 绝不 fallback 到 `/tmp`
-  或 `/var/tmp`，第二个实例也绝不 unlink 处于活跃状态的 endpoint。
+  `/run/user/<uid>/skillfs/control.sock`。executable peer 未给显式 path 时使用默认
+  endpoint；HMAC mode 始终要求显式 path；仅给显式 path 而未配置 peer mode 为配置
+  错误。默认 endpoint 绝不 fallback 到 `/tmp` 或 `/var/tmp`，第二个实例也绝不
+  unlink 处于活跃状态的 endpoint。
 - `skill.resolveLiveSource` 是只读查询，将调用方给定的 canonical Skill 目录
   映射到物理 live/backing source。返回 `managed=true`（含推导出的
   `skillId`、`relativeSkillDir`、`liveSkillDir` 以及实际 live 目录的

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -305,6 +305,10 @@ enum Commands {
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_LEDGER)]
         notify_socket: Option<PathBuf>,
 
+        /// Shared-key file used to authenticate the SkillFS notify client.
+        #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_LEDGER)]
+        notify_auth_key_file: Option<PathBuf>,
+
         /// Write daemon protocol events as JSONL.
         ///
         /// Records debounced FUSE mutations that should be reconciled by an
@@ -341,8 +345,8 @@ enum Commands {
         /// channel. Overrides the default per-user endpoint
         /// `/run/user/<uid>/skillfs/control.sock`. SkillFS creates a
         /// control socket at this path and accepts connections from
-        /// trusted peers; peer identity is verified via `SO_PEERCRED` +
-        /// executable identity. Requires `--trusted-peer-exe`. Linux only.
+        /// trusted peers. Requires exactly one of `--trusted-peer-exe` or
+        /// `--trusted-peer-key-file`. Linux only.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_PEER)]
         control_socket: Option<PathBuf>,
 
@@ -354,6 +358,11 @@ enum Commands {
         /// endpoint `/run/user/<uid>/skillfs/control.sock`.
         #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_PEER)]
         trusted_peer_exe: Option<PathBuf>,
+
+        /// Shared-key file for container-safe control socket authentication.
+        /// Mutually exclusive with `--trusted-peer-exe`.
+        #[arg(long, value_name = "PATH", help_heading = help_text::HEADING_TRUSTED_PEER)]
+        trusted_peer_key_file: Option<PathBuf>,
 
         /// Optional trusted peer UID constraint for control
         /// socket authentication. When set, the peer's UID (from
@@ -558,11 +567,13 @@ async fn run(
             config,
             activation_mode,
             notify_socket,
+            notify_auth_key_file,
             activation_events_log,
             activation_reload_mode,
             ledger_backing_root,
             control_socket,
             trusted_peer_exe,
+            trusted_peer_key_file,
             trusted_peer_uid,
             trusted_peer_gid,
             skill_layout,
@@ -609,11 +620,13 @@ async fn run(
                 config,
                 activation_mode,
                 notify_socket,
+                notify_auth_key_file,
                 activation_events_log,
                 activation_reload_mode,
                 ledger_backing_root,
                 control_socket,
                 trusted_peer_exe,
+                trusted_peer_key_file,
                 trusted_peer_uid,
                 trusted_peer_gid,
                 skill_layout,
@@ -838,11 +851,13 @@ async fn cmd_mount(
     config_path: Option<PathBuf>,
     activation_mode_raw: Option<String>,
     notify_socket: Option<PathBuf>,
+    notify_auth_key_file: Option<PathBuf>,
     activation_events_log: Option<PathBuf>,
     activation_reload_mode_raw: Option<String>,
     ledger_backing_root: Option<PathBuf>,
     control_socket: Option<PathBuf>,
     trusted_peer_exe: Option<PathBuf>,
+    trusted_peer_key_file: Option<PathBuf>,
     trusted_peer_uid: Option<u32>,
     trusted_peer_gid: Option<u32>,
     skill_layout_raw: Option<String>,
@@ -1008,11 +1023,26 @@ async fn cmd_mount(
             .as_ref()
             .and_then(|c| c.control_socket_path().map(PathBuf::from))
     });
-    let trusted_peer_exe = trusted_peer_exe.or_else(|| {
+    let config_peer_exe = || {
         file_config
             .as_ref()
             .and_then(|c| c.control_socket_trusted_peer_exe().map(PathBuf::from))
-    });
+    };
+    let config_peer_key = || {
+        file_config
+            .as_ref()
+            .and_then(|c| c.control_socket_trusted_peer_key_file().map(PathBuf::from))
+    };
+    // An authentication selector supplied on the CLI overrides the selector
+    // in the config as one unit; otherwise a CLI key plus config exe would
+    // accidentally enable two modes instead of applying normal precedence.
+    let (trusted_peer_exe, trusted_peer_key_file) = match (trusted_peer_exe, trusted_peer_key_file)
+    {
+        (Some(exe), None) => (Some(exe), None),
+        (None, Some(key)) => (None, Some(key)),
+        (Some(exe), Some(key)) => (Some(exe), Some(key)),
+        (None, None) => (config_peer_exe(), config_peer_key()),
+    };
     let trusted_peer_uid = trusted_peer_uid.or_else(|| {
         file_config
             .as_ref()
@@ -1033,17 +1063,25 @@ async fn cmd_mount(
     // control plane binds the default per-user endpoint (resolved below).
     // Only an explicit socket path without a trusted peer is an error —
     // the control plane is always authenticated.
-    if let (Some(p), None) = (&control_socket, &trusted_peer_exe) {
+    if trusted_peer_exe.is_some() && trusted_peer_key_file.is_some() {
+        return Err("--trusted-peer-exe and --trusted-peer-key-file are mutually exclusive".into());
+    }
+    if trusted_peer_key_file.is_some() && control_socket.is_none() {
+        return Err("--trusted-peer-key-file requires an explicit --control-socket path".into());
+    }
+    let has_trusted_peer = trusted_peer_exe.is_some() || trusted_peer_key_file.is_some();
+    if control_socket.is_some() && !has_trusted_peer {
+        let p = control_socket.as_ref().expect("presence checked above");
         return Err(format!(
-            "--control-socket {} requires a trusted peer (--trusted-peer-exe \
-             or [control_socket].trusted_peer_exe)",
+            "--control-socket {} requires a trusted peer authentication mode; \
+             configure exactly one of --trusted-peer-exe or --trusted-peer-key-file",
             p.display()
         )
         .into());
     }
     // The control plane is enabled by either an explicit socket path or a
     // trusted peer (which selects the default endpoint).
-    let control_plane_enabled = control_socket.is_some() || trusted_peer_exe.is_some();
+    let control_plane_enabled = control_socket.is_some() || has_trusted_peer;
     if control_plane_enabled {
         if !security {
             return Err("--control-socket requires --security (the control socket \
@@ -1086,6 +1124,11 @@ async fn cmd_mount(
             .as_ref()
             .and_then(|c| c.notify_socket_path().map(PathBuf::from))
     });
+    let notify_auth_key_file = notify_auth_key_file.or_else(|| {
+        file_config
+            .as_ref()
+            .and_then(|c| c.notify_auth_key_file().map(PathBuf::from))
+    });
     let notify_timeout_ms = file_config
         .as_ref()
         .and_then(|c| c.notify_timeout_ms())
@@ -1114,6 +1157,16 @@ async fn cmd_mount(
                     .into(),
             );
         }
+    }
+    if notify_auth_key_file.is_some() && notify_socket.is_none() {
+        return Err("--notify-auth-key-file requires --notify-socket".into());
+    }
+    if trusted_peer_key_file.is_some() && notify_socket.is_some() && notify_auth_key_file.is_none()
+    {
+        return Err(
+            "container HMAC control mode requires --notify-auth-key-file when --notify-socket is enabled"
+                .into(),
+        );
     }
 
     // Merge activation-events-log: CLI flag overrides config file.
@@ -1317,7 +1370,7 @@ async fn cmd_mount(
         return Err(
             "--notify-socket with an in-place mount or --ledger-backing-root requires the \
              authenticated live-source resolver; \
-             configure --trusted-peer-exe (and optionally --control-socket) so the daemon \
+             configure --trusted-peer-exe or the container HMAC peer mode so the daemon \
              can resolve canonicalSkillDir before accessing the source"
                 .into(),
         );
@@ -1824,40 +1877,45 @@ async fn cmd_mount(
             None
         };
 
-    let notify_controller: Option<Arc<NotifyController>> =
-        if let Some(ref socket_path) = notify_socket {
-            let client = Arc::new(UnixSocketNotifyClient::new(
-                socket_path.clone(),
-                std::time::Duration::from_millis(notify_timeout_ms),
-            ));
-            let ctrl = build_notify_controller(
-                client,
-                &runtime_roots,
-                notify_timeout_ms,
-                protocol_event_writer.clone(),
-                reload_controller.clone(),
-            );
-            info!(
-                socket = %socket_path.display(),
-                timeout_ms = notify_timeout_ms,
-                reload = reload_mode != ReloadMode::Off,
-                "notify: change client enabled (Unix socket)"
-            );
-            Some(ctrl)
-        } else if activation_events_log.is_some() {
-            let client = Arc::new(skillfs_fuse::security::NoopNotifyClient);
-            let ctrl = build_notify_controller(
-                client,
-                &runtime_roots,
-                DEFAULT_NOTIFY_TIMEOUT_MS,
-                protocol_event_writer.clone(),
-                reload_controller.clone(),
-            );
-            info!("notify: protocol event log only (no socket)");
-            Some(ctrl)
-        } else {
-            None
+    let notify_controller: Option<Arc<NotifyController>> = if let Some(ref socket_path) =
+        notify_socket
+    {
+        let timeout = std::time::Duration::from_millis(notify_timeout_ms);
+        let client = match notify_auth_key_file.as_deref() {
+            Some(key_file) => Arc::new(
+                UnixSocketNotifyClient::new_authenticated(socket_path.clone(), timeout, key_file)
+                    .map_err(|e| format!("--notify-auth-key-file '{}': {e}", key_file.display()))?,
+            ),
+            None => Arc::new(UnixSocketNotifyClient::new(socket_path.clone(), timeout)),
         };
+        let ctrl = build_notify_controller(
+            client,
+            &runtime_roots,
+            notify_timeout_ms,
+            protocol_event_writer.clone(),
+            reload_controller.clone(),
+        );
+        info!(
+            socket = %socket_path.display(),
+            timeout_ms = notify_timeout_ms,
+            reload = reload_mode != ReloadMode::Off,
+            "notify: change client enabled (Unix socket)"
+        );
+        Some(ctrl)
+    } else if activation_events_log.is_some() {
+        let client = Arc::new(skillfs_fuse::security::NoopNotifyClient);
+        let ctrl = build_notify_controller(
+            client,
+            &runtime_roots,
+            DEFAULT_NOTIFY_TIMEOUT_MS,
+            protocol_event_writer.clone(),
+            reload_controller.clone(),
+        );
+        info!("notify: protocol event log only (no socket)");
+        Some(ctrl)
+    } else {
+        None
+    };
 
     // Merge trusted-writer-exe: CLI flag overrides config file.
     let trusted_writer_exe = trusted_writer_exe.or_else(|| {
@@ -1952,10 +2010,7 @@ async fn cmd_mount(
             EndpointResolution, classify_control_socket_endpoint,
             resolve_default_control_socket_endpoint,
         };
-        match classify_control_socket_endpoint(
-            control_socket.as_deref(),
-            trusted_peer_exe.is_some(),
-        ) {
+        match classify_control_socket_endpoint(control_socket.as_deref(), has_trusted_peer) {
             EndpointResolution::Explicit(path) => Some(path),
             EndpointResolution::UseDefault => {
                 // Trusted peer, no explicit path: bind the default per-user
@@ -1966,7 +2021,7 @@ async fn cmd_mount(
             // path without a trusted peer.
             EndpointResolution::MissingTrustedPeer(p) => {
                 return Err(format!(
-                    "--control-socket {} requires --trusted-peer-exe",
+                    "--control-socket {} requires a trusted peer authentication mode",
                     p.display()
                 )
                 .into());
@@ -1979,56 +2034,71 @@ async fn cmd_mount(
     //
     // Hermes layout is compatible: the resolver and activation write methods
     // use full layout-relative skill ids such as `category/skill`.
-    let control_socket_config: Option<ControlSocketConfig> =
-        match (&effective_socket_path, &trusted_peer_exe) {
-            (Some(socket_path), Some(exe_path)) => {
-                #[cfg(not(target_os = "linux"))]
-                return Err(
-                    "--control-socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into(),
+    let control_socket_server: Option<ControlSocketServer> = match (
+        &effective_socket_path,
+        &trusted_peer_exe,
+        &trusted_peer_key_file,
+    ) {
+        (Some(socket_path), Some(exe_path), None) => {
+            #[cfg(not(target_os = "linux"))]
+            return Err("--control-socket requires Linux (SO_PEERCRED, /proc/<pid>/exe)".into());
+
+            #[cfg(target_os = "linux")]
+            {
+                use skillfs_fuse::security::FileId;
+                use std::os::unix::fs::MetadataExt;
+
+                let canonical = std::fs::canonicalize(exe_path)
+                    .map_err(|e| format!("--trusted-peer-exe '{}': {e}", exe_path.display()))?;
+                let meta = std::fs::metadata(&canonical)
+                    .map_err(|e| format!("--trusted-peer-exe '{}': {e}", canonical.display()))?;
+                if !meta.is_file() {
+                    return Err(format!(
+                        "--trusted-peer-exe '{}': not a regular file",
+                        canonical.display()
+                    )
+                    .into());
+                }
+                let file_id = FileId {
+                    dev: meta.dev(),
+                    ino: meta.ino(),
+                };
+
+                info!(
+                    control_socket = %socket_path.display(),
+                    trusted_peer_exe = %canonical.display(),
+                    trusted_peer_file_id = %file_id,
+                    "control socket enabled"
                 );
 
-                #[cfg(target_os = "linux")]
-                {
-                    use skillfs_fuse::security::FileId;
-                    use std::os::unix::fs::MetadataExt;
-
-                    let canonical = std::fs::canonicalize(exe_path)
-                        .map_err(|e| format!("--trusted-peer-exe '{}': {e}", exe_path.display()))?;
-                    let meta = std::fs::metadata(&canonical).map_err(|e| {
-                        format!("--trusted-peer-exe '{}': {e}", canonical.display())
-                    })?;
-                    if !meta.is_file() {
-                        return Err(format!(
-                            "--trusted-peer-exe '{}': not a regular file",
-                            canonical.display()
-                        )
-                        .into());
-                    }
-                    let file_id = FileId {
-                        dev: meta.dev(),
-                        ino: meta.ino(),
-                    };
-
-                    info!(
-                        control_socket = %socket_path.display(),
-                        trusted_peer_exe = %canonical.display(),
-                        trusted_peer_file_id = %file_id,
-                        "control socket enabled"
-                    );
-
-                    Some(ControlSocketConfig {
-                        socket_path: socket_path.clone(),
-                        trusted_peer: TrustedPeerConfig {
-                            exe_path: canonical,
-                            exe_file_id: file_id,
-                            uid: trusted_peer_uid,
-                            gid: trusted_peer_gid,
-                        },
-                    })
-                }
+                Some(ControlSocketServer::new(ControlSocketConfig {
+                    socket_path: socket_path.clone(),
+                    trusted_peer: TrustedPeerConfig {
+                        exe_path: canonical,
+                        exe_file_id: file_id,
+                        uid: trusted_peer_uid,
+                        gid: trusted_peer_gid,
+                    },
+                }))
             }
-            _ => None,
-        };
+        }
+        (Some(socket_path), None, Some(key_file)) => {
+            let server = ControlSocketServer::new_hmac(
+                socket_path.clone(),
+                key_file,
+                trusted_peer_uid,
+                trusted_peer_gid,
+            )
+            .map_err(|e| format!("--trusted-peer-key-file '{}': {e}", key_file.display()))?;
+            info!(
+                control_socket = %socket_path.display(),
+                auth_mode = "hmac-sha256",
+                "control socket enabled"
+            );
+            Some(server)
+        }
+        _ => None,
+    };
 
     // Mount options
     let options = MountOptions {
@@ -2305,7 +2375,7 @@ async fn cmd_mount(
     };
 
     // Start control socket server before the FUSE mount.
-    let control_socket_handle = if let Some(cs_config) = control_socket_config {
+    let control_socket_handle = if let Some(server) = control_socket_server {
         let ctx = ControlSocketContext {
             // Canonical root: the user-visible Skill root the ledger
             // addresses. Live root (source_root): the physical backing
@@ -2317,8 +2387,8 @@ async fn cmd_mount(
             resolver: active_resolver.clone(),
             protocol_event_writer: Some(protocol_event_writer.clone()),
         };
-        let server = ControlSocketServer::new(cs_config).with_context(ctx);
         let handle = server
+            .with_context(ctx)
             .start()
             .map_err(|e| format!("failed to start control socket server: {e}"))?;
         info!(

--- a/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/cli_startup_tests.rs
@@ -1914,6 +1914,132 @@ fn control_socket_without_trusted_peer_exe_fails_startup() {
 }
 
 #[test]
+fn trusted_peer_auth_modes_are_mutually_exclusive() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--control-socket",
+            "/run/skillfs-test.sock",
+            "--trusted-peer-exe",
+            "/usr/bin/env",
+            "--trusted-peer-key-file",
+            "/run/skillfs-test.key",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.status.success());
+    assert!(combined.contains("mutually exclusive"), "got: {combined}");
+}
+
+#[test]
+fn trusted_peer_key_requires_explicit_socket() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--trusted-peer-key-file",
+            "/run/skillfs-test.key",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.status.success());
+    assert!(
+        combined.contains("requires an explicit --control-socket"),
+        "got: {combined}"
+    );
+}
+
+#[test]
+fn trusted_peer_key_with_insecure_permissions_fails_startup() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let source = non_tmp_dir();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let socket_dir = non_tmp_dir();
+    let socket_path = socket_dir.path().join("control.sock");
+    let key_dir = non_tmp_dir();
+    let key_path = key_dir.path().join("peer.key");
+    std::fs::write(&key_path, [3_u8; 32]).expect("write key");
+    std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o644)).expect("chmod key");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            socket_path.to_str().unwrap(),
+            "--trusted-peer-key-file",
+            key_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("invoke skillfs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.status.success());
+    assert!(
+        combined.contains("must not grant group or other permissions"),
+        "got: {combined}"
+    );
+    assert!(!socket_path.exists(), "socket must not bind with bad key");
+}
+
+#[test]
+fn container_hmac_control_rejects_plain_notify_channel() {
+    let source = empty_source();
+    let mount = tempfile::tempdir().expect("mount tempdir");
+    let out = Command::new(bin_path())
+        .args([
+            "mount",
+            source.path().to_str().unwrap(),
+            mount.path().to_str().unwrap(),
+            "--security",
+            "--activation-mode",
+            "file",
+            "--control-socket",
+            "/run/skillfs-test-control.sock",
+            "--trusted-peer-key-file",
+            "/run/skillfs-test.key",
+            "--notify-socket",
+            "/run/skillfs-test-notify.sock",
+        ])
+        .output()
+        .expect("invoke skillfs");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.status.success());
+    assert!(
+        combined.contains("requires --notify-auth-key-file"),
+        "got: {combined}"
+    );
+}
+
+#[test]
 fn trusted_peer_exe_without_security_fails_startup() {
     // A trusted peer with no explicit --control-socket enables the control
     // plane on the default per-user endpoint, so it is no longer rejected

--- a/src/skillfs/crates/skillfs-fuse/Cargo.toml
+++ b/src/skillfs/crates/skillfs-fuse/Cargo.toml
@@ -17,6 +17,10 @@ thiserror = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+base64 = { workspace = true }
+getrandom = { workspace = true }
 toml = "0.8"
 libc = { workspace = true }
 

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -93,6 +93,7 @@ pub mod activation_reload;
 pub mod activation_watcher;
 pub mod active;
 pub mod audit;
+pub(crate) mod auth;
 pub mod backing_root;
 pub mod config;
 pub mod control_socket;

--- a/src/skillfs/crates/skillfs-fuse/src/security/auth.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/auth.rs
@@ -1,0 +1,794 @@
+//! Shared-key authentication primitives for private Unix socket channels.
+
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+
+const AUTH_VERSION: &str = "1";
+const AUTH_FRAME_LIMIT: usize = 4096;
+const NONCE_LEN: usize = 32;
+const MIN_SECRET_LEN: usize = 32;
+const MAX_SECRET_LEN: usize = 4096;
+const AUTH_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) const CONTROL_CLIENT_DOMAIN: &str = "anolisa.skillfs.control.client.v1";
+pub(crate) const CONTROL_SERVER_DOMAIN: &str = "anolisa.skillfs.control.server.v1";
+pub(crate) const NOTIFY_CLIENT_DOMAIN: &str = "anolisa.skillfs.notify.client.v1";
+pub(crate) const NOTIFY_SERVER_DOMAIN: &str = "anolisa.skillfs.notify.server.v1";
+
+/// Identifies which authenticated peer sent a protected business frame.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum FrameSender {
+    Client,
+    Server,
+}
+
+/// Raw shared secret loaded once at startup.
+#[derive(Clone)]
+pub(crate) struct SharedSecret(std::sync::Arc<[u8]>);
+
+impl std::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SharedSecret([REDACTED])")
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AuthError {
+    #[error("authentication key file path must be absolute")]
+    RelativePath,
+    #[error("failed to open authentication key file: {0}")]
+    Open(std::io::Error),
+    #[error("authentication key must be a regular file")]
+    NotRegular,
+    #[error("authentication key file must not grant group or other permissions")]
+    InsecurePermissions,
+    #[error("authentication key file must be owned by the effective user")]
+    WrongOwner,
+    #[error("authentication key must contain between {MIN_SECRET_LEN} and {MAX_SECRET_LEN} bytes")]
+    InvalidLength,
+    #[error("authentication transport failed: {0}")]
+    Io(std::io::Error),
+    #[error("authentication handshake timed out")]
+    Timeout,
+    #[error("invalid authentication frame")]
+    InvalidFrame,
+    #[error("authenticated frame exceeds {0} byte limit")]
+    FrameTooLarge(usize),
+    #[error("authentication proof verification failed")]
+    VerificationFailed,
+    #[error("failed to obtain secure random bytes: {0}")]
+    Entropy(#[source] getrandom::Error),
+}
+
+impl SharedSecret {
+    /// Loads raw key bytes without following a final-component symlink.
+    pub(crate) fn load(path: &Path) -> Result<Self, AuthError> {
+        if !path.is_absolute() {
+            return Err(AuthError::RelativePath);
+        }
+        let mut file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
+            .open(path)
+            .map_err(AuthError::Open)?;
+        let metadata = file.metadata().map_err(AuthError::Open)?;
+        validate_metadata(&metadata, unsafe { libc::geteuid() })?;
+
+        let mut bytes = Vec::new();
+        Read::by_ref(&mut file)
+            .take((MAX_SECRET_LEN + 1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(AuthError::Open)?;
+        if !(MIN_SECRET_LEN..=MAX_SECRET_LEN).contains(&bytes.len()) {
+            return Err(AuthError::InvalidLength);
+        }
+        Ok(Self(bytes.into()))
+    }
+}
+
+/// Session material that binds business frames to one successful handshake.
+pub(crate) struct AuthenticatedSession {
+    secret: SharedSecret,
+    nonce: [u8; NONCE_LEN],
+    client_domain: String,
+    server_domain: String,
+}
+
+impl AuthenticatedSession {
+    fn new(
+        secret: &SharedSecret,
+        nonce: [u8; NONCE_LEN],
+        client_domain: &str,
+        server_domain: &str,
+    ) -> Self {
+        Self {
+            secret: secret.clone(),
+            nonce,
+            client_domain: client_domain.to_string(),
+            server_domain: server_domain.to_string(),
+        }
+    }
+
+    fn domain(&self, sender: FrameSender) -> &str {
+        match sender {
+            FrameSender::Client => &self.client_domain,
+            FrameSender::Server => &self.server_domain,
+        }
+    }
+
+    /// Writes one raw NDJSON payload followed by its session-bound tag.
+    pub(crate) fn write_frame(
+        &self,
+        stream: &mut UnixStream,
+        sender: FrameSender,
+        payload: &[u8],
+    ) -> Result<(), AuthError> {
+        if payload.contains(&b'\n') {
+            return Err(AuthError::InvalidFrame);
+        }
+        stream.write_all(payload).map_err(AuthError::Io)?;
+        stream.write_all(b"\n").map_err(AuthError::Io)?;
+        write_frame(
+            stream,
+            &AuthFrame {
+                auth_version: AUTH_VERSION.to_string(),
+                kind: "auth.frame".to_string(),
+                nonce: None,
+                proof: Some(encode(&frame_mac(
+                    &self.secret,
+                    self.domain(sender),
+                    &self.nonce,
+                    payload,
+                ))),
+            },
+        )
+    }
+
+    /// Reads and verifies one raw NDJSON payload before returning its bytes.
+    pub(crate) fn read_frame(
+        &self,
+        stream: &mut UnixStream,
+        sender: FrameSender,
+        limit: usize,
+    ) -> Result<Vec<u8>, AuthError> {
+        let original_timeout = stream.read_timeout().map_err(AuthError::Io)?;
+        let deadline = read_deadline(original_timeout);
+        let result = (|| {
+            let mut reader = BufReader::new(&mut *stream);
+            let payload = read_bounded_line(&mut reader, deadline, limit)?;
+            let tag_bytes = read_bounded_line(&mut reader, deadline, AUTH_FRAME_LIMIT)?;
+            let tag: AuthFrame =
+                serde_json::from_slice(&tag_bytes).map_err(|_| AuthError::InvalidFrame)?;
+            validate_frame(&tag, "auth.frame", false, true)?;
+            let actual = decode_32(tag.proof.as_deref().ok_or(AuthError::InvalidFrame)?)?;
+            let verifier = frame_verifier(&self.secret, self.domain(sender), &self.nonce, &payload);
+            verifier
+                .verify_slice(&actual)
+                .map_err(|_| AuthError::VerificationFailed)?;
+            Ok(payload)
+        })();
+        restore_read_timeout(stream, original_timeout, result)
+    }
+}
+
+fn validate_metadata(metadata: &std::fs::Metadata, expected_uid: u32) -> Result<(), AuthError> {
+    if !metadata.is_file() {
+        return Err(AuthError::NotRegular);
+    }
+    if metadata.uid() != expected_uid {
+        return Err(AuthError::WrongOwner);
+    }
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(AuthError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AuthFrame {
+    auth_version: String,
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proof: Option<String>,
+}
+
+fn handshake_deadline(original_timeout: Option<Duration>) -> Instant {
+    let timeout = original_timeout.map_or(AUTH_HANDSHAKE_TIMEOUT, |configured| {
+        configured.min(AUTH_HANDSHAKE_TIMEOUT)
+    });
+    Instant::now() + timeout
+}
+
+fn read_deadline(original_timeout: Option<Duration>) -> Instant {
+    Instant::now() + original_timeout.unwrap_or(AUTH_HANDSHAKE_TIMEOUT)
+}
+
+fn restore_read_timeout<T>(
+    stream: &UnixStream,
+    original_timeout: Option<Duration>,
+    result: Result<T, AuthError>,
+) -> Result<T, AuthError> {
+    let restored = stream
+        .set_read_timeout(original_timeout)
+        .map_err(AuthError::Io);
+    match result {
+        Err(error) => Err(error),
+        Ok(value) => {
+            restored?;
+            Ok(value)
+        }
+    }
+}
+
+fn read_bounded_line(
+    reader: &mut BufReader<&mut UnixStream>,
+    deadline: Instant,
+    limit: usize,
+) -> Result<Vec<u8>, AuthError> {
+    let mut bytes = Vec::new();
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|duration| !duration.is_zero())
+            .ok_or(AuthError::Timeout)?;
+        reader
+            .get_mut()
+            .set_read_timeout(Some(remaining))
+            .map_err(AuthError::Io)?;
+        let available = match reader.fill_buf() {
+            Ok([]) => return Err(AuthError::InvalidFrame),
+            Ok(available) => available,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                return Err(AuthError::Timeout);
+            }
+            Err(error) => return Err(AuthError::Io(error)),
+        };
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let content_len = newline.unwrap_or(available.len());
+        if bytes.len() + content_len > limit {
+            return Err(AuthError::FrameTooLarge(limit));
+        }
+        bytes.extend_from_slice(&available[..content_len]);
+        let consumed = content_len + usize::from(newline.is_some());
+        reader.consume(consumed);
+        if newline.is_some() {
+            return Ok(bytes);
+        }
+    }
+}
+
+fn read_frame(stream: &mut UnixStream, deadline: Instant) -> Result<AuthFrame, AuthError> {
+    let mut bytes = Vec::new();
+    for _ in 0..=AUTH_FRAME_LIMIT {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|duration| !duration.is_zero())
+            .ok_or(AuthError::Timeout)?;
+        stream
+            .set_read_timeout(Some(remaining))
+            .map_err(AuthError::Io)?;
+        let mut byte = [0_u8; 1];
+        match stream.read(&mut byte) {
+            Ok(0) => return Err(AuthError::InvalidFrame),
+            Ok(_) if byte[0] == b'\n' => {
+                return serde_json::from_slice(&bytes).map_err(|_| AuthError::InvalidFrame);
+            }
+            Ok(_) => bytes.push(byte[0]),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+                ) =>
+            {
+                return Err(AuthError::Timeout);
+            }
+            Err(error) => return Err(AuthError::Io(error)),
+        }
+    }
+    Err(AuthError::InvalidFrame)
+}
+
+fn write_frame(stream: &mut UnixStream, frame: &AuthFrame) -> Result<(), AuthError> {
+    serde_json::to_writer(&mut *stream, frame)
+        .map_err(|e| AuthError::Io(std::io::Error::other(e)))?;
+    stream.write_all(b"\n").map_err(AuthError::Io)?;
+    stream.flush().map_err(AuthError::Io)
+}
+
+fn mac(secret: &SharedSecret, domain: &str, nonce: &[u8]) -> [u8; 32] {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(&secret.0).expect("HMAC accepts keys of every valid length");
+    mac.update(domain.as_bytes());
+    mac.update(&[0]);
+    mac.update(nonce);
+    mac.finalize().into_bytes().into()
+}
+
+fn frame_verifier(
+    secret: &SharedSecret,
+    domain: &str,
+    nonce: &[u8; NONCE_LEN],
+    payload: &[u8],
+) -> Hmac<Sha256> {
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(&secret.0).expect("HMAC accepts keys of every valid length");
+    mac.update(domain.as_bytes());
+    mac.update(b"\0frame\0");
+    mac.update(nonce);
+    mac.update(&(payload.len() as u64).to_be_bytes());
+    mac.update(payload);
+    mac
+}
+
+fn frame_mac(
+    secret: &SharedSecret,
+    domain: &str,
+    nonce: &[u8; NONCE_LEN],
+    payload: &[u8],
+) -> [u8; 32] {
+    frame_verifier(secret, domain, nonce, payload)
+        .finalize()
+        .into_bytes()
+        .into()
+}
+
+fn generate_nonce(
+    fill_random: fn(&mut [u8]) -> Result<(), getrandom::Error>,
+) -> Result<[u8; NONCE_LEN], AuthError> {
+    let mut nonce = [0_u8; NONCE_LEN];
+    fill_random(&mut nonce).map_err(AuthError::Entropy)?;
+    Ok(nonce)
+}
+
+fn decode_32(value: &str) -> Result<[u8; 32], AuthError> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|_| AuthError::InvalidFrame)?;
+    if encode(&bytes) != value {
+        return Err(AuthError::InvalidFrame);
+    }
+    bytes.try_into().map_err(|_| AuthError::InvalidFrame)
+}
+
+fn encode(value: &[u8]) -> String {
+    base64::engine::general_purpose::STANDARD.encode(value)
+}
+
+fn validate_frame(
+    frame: &AuthFrame,
+    kind: &str,
+    has_nonce: bool,
+    has_proof: bool,
+) -> Result<(), AuthError> {
+    if frame.auth_version != AUTH_VERSION
+        || frame.kind != kind
+        || frame.nonce.is_some() != has_nonce
+        || frame.proof.is_some() != has_proof
+    {
+        return Err(AuthError::InvalidFrame);
+    }
+    Ok(())
+}
+
+/// Performs the server half of the four-frame challenge-response protocol.
+pub(crate) fn authenticate_server(
+    stream: &mut UnixStream,
+    secret: &SharedSecret,
+    client_domain: &str,
+    server_domain: &str,
+) -> Result<AuthenticatedSession, AuthError> {
+    let original_timeout = stream.read_timeout().map_err(AuthError::Io)?;
+    let deadline = handshake_deadline(original_timeout);
+    let result = (|| {
+        let init = read_frame(stream, deadline)?;
+        validate_frame(&init, "auth.init", false, false)?;
+
+        let nonce = generate_nonce(getrandom::fill)?;
+        write_frame(
+            stream,
+            &AuthFrame {
+                auth_version: AUTH_VERSION.to_string(),
+                kind: "auth.challenge".to_string(),
+                nonce: Some(encode(&nonce)),
+                proof: None,
+            },
+        )?;
+
+        let proof = read_frame(stream, deadline)?;
+        validate_frame(&proof, "auth.proof", false, true)?;
+        let actual = decode_32(proof.proof.as_deref().ok_or(AuthError::InvalidFrame)?)?;
+        let mut verifier = Hmac::<Sha256>::new_from_slice(&secret.0)
+            .expect("HMAC accepts keys of every valid length");
+        verifier.update(client_domain.as_bytes());
+        verifier.update(&[0]);
+        verifier.update(&nonce);
+        verifier
+            .verify_slice(&actual)
+            .map_err(|_| AuthError::VerificationFailed)?;
+
+        write_frame(
+            stream,
+            &AuthFrame {
+                auth_version: AUTH_VERSION.to_string(),
+                kind: "auth.ok".to_string(),
+                nonce: None,
+                proof: Some(encode(&mac(secret, server_domain, &nonce))),
+            },
+        )?;
+        Ok(AuthenticatedSession::new(
+            secret,
+            nonce,
+            client_domain,
+            server_domain,
+        ))
+    })();
+    restore_read_timeout(stream, original_timeout, result)
+}
+
+/// Performs the client half and verifies the server knows the same secret.
+pub(crate) fn authenticate_client(
+    stream: &mut UnixStream,
+    secret: &SharedSecret,
+    client_domain: &str,
+    server_domain: &str,
+) -> Result<AuthenticatedSession, AuthError> {
+    let original_timeout = stream.read_timeout().map_err(AuthError::Io)?;
+    let deadline = handshake_deadline(original_timeout);
+    let result = (|| {
+        write_frame(
+            stream,
+            &AuthFrame {
+                auth_version: AUTH_VERSION.to_string(),
+                kind: "auth.init".to_string(),
+                nonce: None,
+                proof: None,
+            },
+        )?;
+        let challenge = read_frame(stream, deadline)?;
+        validate_frame(&challenge, "auth.challenge", true, false)?;
+        let nonce = decode_32(challenge.nonce.as_deref().ok_or(AuthError::InvalidFrame)?)?;
+        write_frame(
+            stream,
+            &AuthFrame {
+                auth_version: AUTH_VERSION.to_string(),
+                kind: "auth.proof".to_string(),
+                nonce: None,
+                proof: Some(encode(&mac(secret, client_domain, &nonce))),
+            },
+        )?;
+        let ok = read_frame(stream, deadline)?;
+        validate_frame(&ok, "auth.ok", false, true)?;
+        let actual = decode_32(ok.proof.as_deref().ok_or(AuthError::InvalidFrame)?)?;
+        let mut verifier = Hmac::<Sha256>::new_from_slice(&secret.0)
+            .expect("HMAC accepts keys of every valid length");
+        verifier.update(server_domain.as_bytes());
+        verifier.update(&[0]);
+        verifier.update(&nonce);
+        verifier
+            .verify_slice(&actual)
+            .map_err(|_| AuthError::VerificationFailed)?;
+        Ok(AuthenticatedSession::new(
+            secret,
+            nonce,
+            client_domain,
+            server_domain,
+        ))
+    })();
+    restore_read_timeout(stream, original_timeout, result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn fail_entropy(_destination: &mut [u8]) -> Result<(), getrandom::Error> {
+        Err(getrandom::Error::new_custom(1))
+    }
+
+    #[test]
+    fn secret_loader_rejects_short_and_permissive_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("key");
+        std::fs::write(&path, b"short").expect("write key");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        assert!(matches!(
+            SharedSecret::load(&path),
+            Err(AuthError::InvalidLength)
+        ));
+
+        std::fs::write(&path, [7_u8; 32]).expect("write key");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).expect("chmod");
+        assert!(matches!(
+            SharedSecret::load(&path),
+            Err(AuthError::InsecurePermissions)
+        ));
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        let metadata = std::fs::metadata(&path).expect("metadata");
+        assert!(matches!(
+            validate_metadata(&metadata, metadata.uid().wrapping_add(1)),
+            Err(AuthError::WrongOwner)
+        ));
+    }
+
+    #[test]
+    fn secret_loader_rejects_relative_path() {
+        assert!(matches!(
+            SharedSecret::load(Path::new("relative.key")),
+            Err(AuthError::RelativePath)
+        ));
+    }
+
+    #[test]
+    fn secret_loader_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("key.fifo");
+        let c_path = CString::new(path.as_os_str().as_bytes()).expect("fifo path");
+        // SAFETY: `c_path` is a valid NUL-terminated path and mode is valid.
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+        assert!(matches!(
+            SharedSecret::load(&path),
+            Err(AuthError::NotRegular)
+        ));
+    }
+
+    #[test]
+    fn secret_loader_rejects_symlink_directory_and_oversize() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = dir.path().join("key");
+        std::fs::write(&key, [1_u8; 32]).expect("write key");
+        std::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&key, &link).expect("symlink");
+        assert!(matches!(SharedSecret::load(&link), Err(AuthError::Open(_))));
+        assert!(matches!(
+            SharedSecret::load(dir.path()),
+            Err(AuthError::NotRegular)
+        ));
+
+        std::fs::write(&key, vec![2_u8; MAX_SECRET_LEN + 1]).expect("write oversized key");
+        assert!(matches!(
+            SharedSecret::load(&key),
+            Err(AuthError::InvalidLength)
+        ));
+    }
+
+    #[test]
+    fn shared_cross_language_mac_vectors_are_stable() {
+        let secret = SharedSecret(std::sync::Arc::from(
+            (0_u8..32).collect::<Vec<_>>().into_boxed_slice(),
+        ));
+        let nonce: [u8; NONCE_LEN] = (32_u8..64)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("fixed nonce length");
+        assert_eq!(
+            encode(&mac(&secret, CONTROL_CLIENT_DOMAIN, &nonce)),
+            "pqaSiunq07XWqMvQ8xSiSLi6dsLEy5iaCEF3md04AVI="
+        );
+        assert_eq!(
+            encode(&mac(&secret, CONTROL_SERVER_DOMAIN, &nonce)),
+            "naSgjgOT+Zs71EytW6byhJMCkfek2sGmK+CDqHmDsas="
+        );
+        assert_eq!(
+            encode(&mac(&secret, NOTIFY_CLIENT_DOMAIN, &nonce)),
+            "aFcVadTie7FrVTYOjk1OOjBpoQZ6LUvnLGC6stiqt6M="
+        );
+        assert_eq!(
+            encode(&mac(&secret, NOTIFY_SERVER_DOMAIN, &nonce)),
+            "F22J+ua0Pmha2dPyTMmTQNtKjcmed59Mo8FKgdcgBOc="
+        );
+
+        let payload = br#"{"schemaVersion":"1","method":"ping"}"#;
+        assert_eq!(
+            encode(&frame_mac(&secret, CONTROL_CLIENT_DOMAIN, &nonce, payload,)),
+            "zT6arzIjdC4fJqiSM59qNhU2BADHJgFRq8YqifcdHCM="
+        );
+        assert_eq!(
+            encode(&frame_mac(&secret, CONTROL_SERVER_DOMAIN, &nonce, payload,)),
+            "W9lF84f43ROoMXPHkgovtowDiZ5zv0zubs2vmq98T9k="
+        );
+        assert_eq!(
+            encode(&frame_mac(&secret, NOTIFY_CLIENT_DOMAIN, &nonce, payload,)),
+            "Zzf/dpWsuj89DFbpJtwqBk5dHsV+GXwGOytZMh5xDKw="
+        );
+        assert_eq!(
+            encode(&frame_mac(&secret, NOTIFY_SERVER_DOMAIN, &nonce, payload,)),
+            "ut2Pv/8XHmiImbWSfm53ixIcoDimZOPHzrS6g3TtO+M="
+        );
+    }
+
+    #[test]
+    fn nonce_generation_propagates_entropy_failures() {
+        assert!(matches!(
+            generate_nonce(fail_entropy),
+            Err(AuthError::Entropy(_))
+        ));
+    }
+
+    #[test]
+    fn client_and_server_complete_mutual_authentication() {
+        let secret = SharedSecret(std::sync::Arc::from([9_u8; 32]));
+        let (mut client, mut server) = UnixStream::pair().expect("socket pair");
+        let configured_timeout = Duration::from_millis(250);
+        client
+            .set_read_timeout(Some(configured_timeout))
+            .expect("set client timeout");
+        server
+            .set_read_timeout(Some(configured_timeout))
+            .expect("set server timeout");
+        let server_secret = secret.clone();
+        let join = std::thread::spawn(move || {
+            let session = authenticate_server(
+                &mut server,
+                &server_secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            )
+            .expect("server auth");
+            let request = session
+                .read_frame(&mut server, FrameSender::Client, 1024)
+                .expect("authenticated request");
+            assert_eq!(request, br#"{"schemaVersion":"1","method":"ping"}"#);
+            session
+                .write_frame(
+                    &mut server,
+                    FrameSender::Server,
+                    br#"{"schemaVersion":"1","ok":true}"#,
+                )
+                .expect("authenticated response");
+            server.read_timeout().expect("server timeout")
+        });
+        let session = authenticate_client(
+            &mut client,
+            &secret,
+            CONTROL_CLIENT_DOMAIN,
+            CONTROL_SERVER_DOMAIN,
+        )
+        .expect("client auth");
+        session
+            .write_frame(
+                &mut client,
+                FrameSender::Client,
+                br#"{"schemaVersion":"1","method":"ping"}"#,
+            )
+            .expect("authenticated request");
+        let response = session
+            .read_frame(&mut client, FrameSender::Server, 1024)
+            .expect("authenticated response");
+        assert_eq!(response, br#"{"schemaVersion":"1","ok":true}"#);
+        assert_eq!(
+            client.read_timeout().expect("client timeout"),
+            Some(configured_timeout)
+        );
+        let server_timeout = join.join().expect("server thread");
+        assert_eq!(server_timeout, Some(configured_timeout));
+    }
+
+    #[test]
+    fn authenticated_session_rejects_tampered_business_frames() {
+        let secret = SharedSecret(std::sync::Arc::from([9_u8; 32]));
+        let nonce = [4_u8; NONCE_LEN];
+        let original = br#"{"schemaVersion":"1","method":"ping"}"#;
+        let tampered = br#"{"schemaVersion":"1","method":"status"}"#;
+        for (sender, domain) in [
+            (FrameSender::Client, CONTROL_CLIENT_DOMAIN),
+            (FrameSender::Server, CONTROL_SERVER_DOMAIN),
+        ] {
+            let session = AuthenticatedSession::new(
+                &secret,
+                nonce,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            );
+            let (mut writer, mut reader) = UnixStream::pair().expect("socket pair");
+            writer.write_all(tampered).expect("tampered payload");
+            writer.write_all(b"\n").expect("payload delimiter");
+            write_frame(
+                &mut writer,
+                &AuthFrame {
+                    auth_version: AUTH_VERSION.to_string(),
+                    kind: "auth.frame".to_string(),
+                    nonce: None,
+                    proof: Some(encode(&frame_mac(&secret, domain, &nonce, original))),
+                },
+            )
+            .expect("original tag");
+
+            assert!(matches!(
+                session.read_frame(&mut reader, sender, 1024),
+                Err(AuthError::VerificationFailed)
+            ));
+        }
+    }
+
+    #[test]
+    fn server_rejects_oversized_or_timed_out_auth_init() {
+        let secret = SharedSecret(std::sync::Arc::from([9_u8; 32]));
+        let (mut client, mut server) = UnixStream::pair().expect("socket pair");
+        client
+            .write_all(&vec![b'x'; AUTH_FRAME_LIMIT + 1])
+            .expect("write oversized frame");
+        assert!(matches!(
+            authenticate_server(
+                &mut server,
+                &secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            ),
+            Err(AuthError::InvalidFrame)
+        ));
+
+        let (_idle_client, mut timed_server) = UnixStream::pair().expect("socket pair");
+        timed_server
+            .set_read_timeout(Some(std::time::Duration::from_millis(10)))
+            .expect("set timeout");
+        assert!(matches!(
+            authenticate_server(
+                &mut timed_server,
+                &secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            ),
+            Err(AuthError::Timeout)
+        ));
+    }
+
+    #[test]
+    fn server_applies_total_deadline_to_slow_auth_frame() {
+        let secret = SharedSecret(std::sync::Arc::from([9_u8; 32]));
+        let (mut client, mut server) = UnixStream::pair().expect("socket pair");
+        server
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .expect("set timeout");
+        let writer = std::thread::spawn(move || {
+            for byte in br#"{\"authVersion\":\"1\""# {
+                if client.write_all(&[*byte]).is_err() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        });
+
+        let started = Instant::now();
+        assert!(matches!(
+            authenticate_server(
+                &mut server,
+                &secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            ),
+            Err(AuthError::Timeout)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(250));
+        drop(server);
+        writer.join().expect("writer thread");
+    }
+}

--- a/src/skillfs/crates/skillfs-fuse/src/security/config.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/config.rs
@@ -144,6 +144,7 @@ pub struct NotifySection {
     pub mode: Option<String>,
     pub socket_path: Option<String>,
     pub timeout_ms: Option<u64>,
+    pub auth_key_file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -180,6 +181,7 @@ pub struct InstallSection {
 pub struct ControlSocketSection {
     pub path: Option<String>,
     pub trusted_peer_exe: Option<String>,
+    pub trusted_peer_key_file: Option<String>,
     pub trusted_peer_uid: Option<u32>,
     pub trusted_peer_gid: Option<u32>,
 }
@@ -514,6 +516,14 @@ impl SecurityConfig {
         self.notify.as_ref().and_then(|n| n.timeout_ms)
     }
 
+    /// Returns the notify authentication key file when configured.
+    pub fn notify_auth_key_file(&self) -> Option<&str> {
+        self.notify
+            .as_ref()
+            .and_then(|n| n.auth_key_file.as_deref())
+            .filter(|s| !s.trim().is_empty())
+    }
+
     pub fn activation_events_log_path(&self) -> Option<&str> {
         self.activation_events
             .as_ref()
@@ -573,6 +583,14 @@ impl SecurityConfig {
         self.control_socket
             .as_ref()
             .and_then(|c| c.trusted_peer_exe.as_deref())
+            .filter(|s| !s.trim().is_empty())
+    }
+
+    /// Returns the shared-key file for container peer authentication.
+    pub fn control_socket_trusted_peer_key_file(&self) -> Option<&str> {
+        self.control_socket
+            .as_ref()
+            .and_then(|c| c.trusted_peer_key_file.as_deref())
             .filter(|s| !s.trim().is_empty())
     }
 
@@ -1523,6 +1541,33 @@ trusted_peer_gid = 1000
         );
         assert_eq!(cfg.control_socket_trusted_peer_uid(), Some(1000));
         assert_eq!(cfg.control_socket_trusted_peer_gid(), Some(1000));
+        assert!(cfg.control_socket_trusted_peer_key_file().is_none());
+    }
+
+    #[test]
+    fn shared_key_paths_parse_for_control_and_notify() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("security.toml");
+        std::fs::write(
+            &path,
+            r#"
+[notify]
+mode = "unix-socket"
+socket_path = "/run/agent-sec/daemon.sock"
+auth_key_file = "/run/keys/peer.key"
+
+[control_socket]
+path = "/run/skillfs/control.sock"
+trusted_peer_key_file = "/run/keys/peer.key"
+"#,
+        )
+        .unwrap();
+        let cfg = SecurityConfig::load(&path).unwrap();
+        assert_eq!(cfg.notify_auth_key_file(), Some("/run/keys/peer.key"));
+        assert_eq!(
+            cfg.control_socket_trusted_peer_key_file(),
+            Some("/run/keys/peer.key")
+        );
     }
 
     #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/control_socket.rs
@@ -1,11 +1,8 @@
 //! Trusted peer control socket.
 //!
-//! Provides a Unix domain socket control plane authenticated via
-//! `SO_PEERCRED` + executable identity + starttime. External daemons
-//! connect to this socket; SkillFS verifies the peer's pid/uid/gid,
-//! resolves the peer's `/proc/<pid>/exe` to match a pinned `(dev, ino)`,
-//! and reads `/proc/<pid>/stat` field 22 (starttime) for PID reuse
-//! defense.
+//! Provides a Unix domain socket control plane authenticated either by
+//! the legacy executable identity contract or an explicitly configured
+//! shared-key challenge-response contract for isolated containers.
 //!
 //! ## Protocol
 //!
@@ -64,6 +61,12 @@ use tracing::{debug, info, warn};
 use super::activation::{ACTIVATION_XATTR, ActivationRecord};
 use super::activation_reload::ReloadOutcome;
 use super::active::{ActiveSkillResolver, ActiveTarget};
+#[cfg(test)]
+use super::auth::authenticate_client;
+use super::auth::{
+    AuthenticatedSession, CONTROL_CLIENT_DOMAIN, CONTROL_SERVER_DOMAIN, FrameSender, SharedSecret,
+    authenticate_server,
+};
 use super::ledger::validate_skill_name_component;
 use super::protocol_events::{ProtocolEvent, ProtocolEventWriter};
 use super::skill_dir::{SkillDirError, VerifiedSkillDir, open_verified_skill_dir};
@@ -1599,9 +1602,20 @@ impl Drop for BoundSocketGuard {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub struct ControlSocketServer {
-    config: ControlSocketConfig,
+    socket_path: PathBuf,
+    authentication: ControlSocketAuthentication,
     context: Option<Arc<ControlSocketContext>>,
     shutdown: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+enum ControlSocketAuthentication {
+    Executable(TrustedPeerConfig),
+    Hmac {
+        secret: SharedSecret,
+        uid: Option<u32>,
+        gid: Option<u32>,
+    },
 }
 
 /// Handle returned to the caller for shutdown coordination.
@@ -1657,10 +1671,28 @@ impl Drop for ControlSocketHandle {
 impl ControlSocketServer {
     pub fn new(config: ControlSocketConfig) -> Self {
         Self {
-            config,
+            socket_path: config.socket_path,
+            authentication: ControlSocketAuthentication::Executable(config.trusted_peer),
             context: None,
             shutdown: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Builds a server using shared-key authentication without consulting
+    /// the peer executable across process or mount namespaces.
+    pub fn new_hmac(
+        socket_path: PathBuf,
+        key_file: &Path,
+        uid: Option<u32>,
+        gid: Option<u32>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let secret = SharedSecret::load(key_file)?;
+        Ok(Self {
+            socket_path,
+            authentication: ControlSocketAuthentication::Hmac { secret, uid, gid },
+            context: None,
+            shutdown: Arc::new(AtomicBool::new(false)),
+        })
     }
 
     pub fn with_context(mut self, context: ControlSocketContext) -> Self {
@@ -1685,20 +1717,20 @@ impl ControlSocketServer {
         // eliminate the bind-to-chmod permission window. Runs before
         // the lifecycle lock so that create_dir_all provides the parent
         // the lock file lives in.
-        secure_socket_parent(&self.config.socket_path)?;
+        secure_socket_parent(&self.socket_path)?;
 
         // Acquire the non-blocking lifecycle lock before touching the
         // socket path. A second instance targeting the same endpoint
         // fails here instead of unlinking a live socket.
-        let lifecycle_lock = acquire_lifecycle_lock(&self.config.socket_path)?;
+        let lifecycle_lock = acquire_lifecycle_lock(&self.socket_path)?;
 
         // Reclaim only a confirmed-stale, owned socket (checked while the
         // lock is held). Fails closed on non-sockets, wrong owner, or a
         // live listener.
-        preflight_socket_path(&self.config.socket_path)?;
+        preflight_socket_path(&self.socket_path)?;
 
-        let listener = UnixListener::bind(&self.config.socket_path)?;
-        let bound_socket_guard = BoundSocketGuard::new(self.config.socket_path.clone());
+        let listener = UnixListener::bind(&self.socket_path)?;
+        let bound_socket_guard = BoundSocketGuard::new(self.socket_path.clone());
         setup_listener(&listener)?;
 
         // Set socket file permissions to 0o600.
@@ -1706,26 +1738,39 @@ impl ControlSocketServer {
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&self.config.socket_path, perms)?;
+            std::fs::set_permissions(&self.socket_path, perms)?;
         }
 
         let shutdown = self.shutdown.clone();
-        let config = self.config.clone();
+        let authentication = self.authentication.clone();
         let context = self.context.clone();
-        let socket_path = self.config.socket_path.clone();
+        let socket_path = self.socket_path.clone();
 
-        info!(
-            socket = %socket_path.display(),
-            trusted_peer_exe = %config.trusted_peer.exe_path.display(),
-            trusted_peer_file_id = %config.trusted_peer.exe_file_id,
-            "control socket server starting"
-        );
+        match &authentication {
+            ControlSocketAuthentication::Executable(peer) => info!(
+                socket = %socket_path.display(),
+                trusted_peer_exe = %peer.exe_path.display(),
+                trusted_peer_file_id = %peer.exe_file_id,
+                auth_mode = "executable",
+                "control socket server starting"
+            ),
+            ControlSocketAuthentication::Hmac { .. } => info!(
+                socket = %socket_path.display(),
+                auth_mode = "hmac-sha256",
+                "control socket server starting"
+            ),
+        }
 
         let shutdown_for_thread = shutdown.clone();
         let thread = std::thread::Builder::new()
             .name("skillfs-control-socket".to_string())
             .spawn(move || {
-                run_server_loop(&listener, &config, context.as_deref(), &shutdown_for_thread);
+                run_server_loop(
+                    &listener,
+                    &authentication,
+                    context.as_deref(),
+                    &shutdown_for_thread,
+                );
             })?;
 
         // Ownership transfers to the handle only after every fallible
@@ -1748,7 +1793,7 @@ const ACCEPT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_mill
 
 fn run_server_loop(
     listener: &UnixListener,
-    config: &ControlSocketConfig,
+    authentication: &ControlSocketAuthentication,
     ctx: Option<&ControlSocketContext>,
     shutdown: &AtomicBool,
 ) {
@@ -1763,7 +1808,7 @@ fn run_server_loop(
                 if shutdown.load(Ordering::SeqCst) {
                     break;
                 }
-                handle_connection(stream, config, ctx);
+                handle_connection(stream, authentication, ctx);
             }
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(ACCEPT_POLL_INTERVAL);
@@ -1789,76 +1834,118 @@ const CONNECTION_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 const MAX_CONTROL_REQUEST_BYTES: u64 = 64 * 1024;
 
 fn handle_connection(
-    stream: UnixStream,
-    config: &ControlSocketConfig,
+    mut stream: UnixStream,
+    authentication: &ControlSocketAuthentication,
     ctx: Option<&ControlSocketContext>,
 ) {
     // The listener is non-blocking; ensure the accepted stream is blocking
     // so the read timeout governs the per-connection hold time.
     let _ = stream.set_nonblocking(false);
     let _ = stream.set_read_timeout(Some(CONNECTION_READ_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CONNECTION_READ_TIMEOUT));
 
-    let peer_identity = match identify_peer(&stream) {
-        Ok(id) => id,
-        Err(e) => {
-            warn!("failed to identify peer: {e}");
-            let resp = ControlResponse::err("peer_identification_failed", e.to_string());
-            let _ = send_response(&stream, &resp);
-            return;
+    let (credentials, authenticated_session) = match authentication {
+        ControlSocketAuthentication::Executable(config) => {
+            let peer_identity = match identify_peer(&stream) {
+                Ok(id) => id,
+                Err(e) => {
+                    warn!("failed to identify peer executable: {e}");
+                    let resp = ControlResponse::err("peer_identification_failed", e.to_string());
+                    let _ = send_response(&mut stream, &resp, None);
+                    return;
+                }
+            };
+            let verify = verify_peer(config, &peer_identity);
+            if !verify.is_accepted() {
+                let msg = verify
+                    .denial_message()
+                    .unwrap_or_else(|| "peer verification failed".to_string());
+                warn!(pid = peer_identity.credentials.pid, reason = %msg, "control socket peer rejected");
+                let resp = ControlResponse::err("permission_denied", msg);
+                let _ = send_response(&mut stream, &resp, None);
+                return;
+            }
+            (peer_identity.credentials, None)
+        }
+        ControlSocketAuthentication::Hmac { secret, uid, gid } => {
+            let credentials = match get_peer_credentials(&stream) {
+                Ok(credentials) => credentials,
+                Err(e) => {
+                    warn!("failed to identify HMAC peer credentials: {e}");
+                    return;
+                }
+            };
+            if uid.is_some_and(|expected| credentials.uid != expected)
+                || gid.is_some_and(|expected| credentials.gid != expected)
+            {
+                warn!(
+                    pid = credentials.pid,
+                    "control socket peer credentials rejected"
+                );
+                return;
+            }
+            let session = match authenticate_server(
+                &mut stream,
+                secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            ) {
+                Ok(session) => session,
+                Err(error) => {
+                    warn!(pid = credentials.pid, reason = %error, "control socket HMAC peer rejected");
+                    return;
+                }
+            };
+            (credentials, Some(session))
         }
     };
 
-    debug!(
-        pid = peer_identity.credentials.pid,
-        uid = peer_identity.credentials.uid,
-        gid = peer_identity.credentials.gid,
-        exe = ?peer_identity.exe_path,
-        "control socket peer connected"
-    );
+    debug!(pid = credentials.pid, "control socket peer accepted");
 
-    let verify = verify_peer(&config.trusted_peer, &peer_identity);
-    if !verify.is_accepted() {
-        let msg = verify
-            .denial_message()
-            .unwrap_or_else(|| "peer verification failed".to_string());
-        warn!(
-            pid = peer_identity.credentials.pid,
-            reason = %msg,
-            "control socket peer rejected"
-        );
-        let resp = ControlResponse::err("permission_denied", msg);
-        let _ = send_response(&stream, &resp);
-        return;
-    }
-
-    debug!(
-        pid = peer_identity.credentials.pid,
-        "control socket peer accepted"
-    );
-
-    let reader = BufReader::new(&stream);
-    let mut limited = reader.take(MAX_CONTROL_REQUEST_BYTES + 1);
-    let mut line = String::new();
-    match limited.read_line(&mut line) {
-        Ok(0) => return,
-        Ok(n) if n as u64 > MAX_CONTROL_REQUEST_BYTES => {
-            warn!(
-                pid = peer_identity.credentials.pid,
-                "control socket request exceeds {MAX_CONTROL_REQUEST_BYTES} byte limit"
-            );
-            let resp = ControlResponse::err(
-                "invalid_request",
-                format!("request exceeds {MAX_CONTROL_REQUEST_BYTES} byte limit"),
-            );
-            let _ = send_response(&stream, &resp);
-            return;
+    let line = if let Some(session) = &authenticated_session {
+        match session.read_frame(
+            &mut stream,
+            FrameSender::Client,
+            MAX_CONTROL_REQUEST_BYTES as usize,
+        ) {
+            Ok(bytes) => match String::from_utf8(bytes) {
+                Ok(line) => line,
+                Err(error) => {
+                    debug!("control socket request is not UTF-8: {error}");
+                    return;
+                }
+            },
+            Err(error) => {
+                warn!(pid = credentials.pid, reason = %error, "control socket business frame rejected");
+                return;
+            }
         }
-        Ok(_) => {}
-        Err(e) => {
-            debug!("control socket read error: {e}");
-            return;
+    } else {
+        let reader = BufReader::new(&stream);
+        let mut limited = reader.take(MAX_CONTROL_REQUEST_BYTES + 1);
+        let mut line = String::new();
+        match limited.read_line(&mut line) {
+            Ok(0) => return,
+            Ok(n) if n as u64 > MAX_CONTROL_REQUEST_BYTES => {
+                warn!(
+                    pid = credentials.pid,
+                    "control socket request exceeds {MAX_CONTROL_REQUEST_BYTES} byte limit"
+                );
+                let resp = ControlResponse::err(
+                    "invalid_request",
+                    format!("request exceeds {MAX_CONTROL_REQUEST_BYTES} byte limit"),
+                );
+                let _ = send_response(&mut stream, &resp, None);
+                return;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                debug!("control socket read error: {e}");
+                return;
+            }
         }
-    }
+        line
+    };
 
     if line.trim().is_empty() {
         return;
@@ -1869,16 +1956,23 @@ fn handle_connection(
         Err(err_resp) => err_resp,
     };
 
-    let _ = send_response(&stream, &resp);
+    let _ = send_response(&mut stream, &resp, authenticated_session.as_ref());
 }
 
-fn send_response(stream: &UnixStream, resp: &ControlResponse) -> std::io::Result<()> {
-    let mut writer = stream;
-    let json = serde_json::to_string(resp)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    writer.write_all(json.as_bytes())?;
-    writer.write_all(b"\n")?;
-    writer.flush()
+fn send_response(
+    stream: &mut UnixStream,
+    resp: &ControlResponse,
+    session: Option<&AuthenticatedSession>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_vec(resp)?;
+    if let Some(session) = session {
+        session.write_frame(stream, FrameSender::Server, &json)?;
+    } else {
+        stream.write_all(&json)?;
+        stream.write_all(b"\n")?;
+        stream.flush()?;
+    }
+    Ok(())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3586,6 +3680,107 @@ mod tests {
             let mut response = String::new();
             reader.read_line(&mut response).unwrap();
             response
+        }
+
+        fn write_key(path: &Path, byte: u8) {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::write(path, [byte; 32]).unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+
+        fn hmac_connect_and_send(socket_path: &Path, key_path: &Path, request: &str) -> String {
+            let secret = SharedSecret::load(key_path).unwrap();
+            let mut stream = UnixStream::connect(socket_path).unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let session = authenticate_client(
+                &mut stream,
+                &secret,
+                CONTROL_CLIENT_DOMAIN,
+                CONTROL_SERVER_DOMAIN,
+            )
+            .unwrap();
+            session
+                .write_frame(&mut stream, FrameSender::Client, request.as_bytes())
+                .unwrap();
+            let response = session
+                .read_frame(
+                    &mut stream,
+                    FrameSender::Server,
+                    MAX_CONTROL_REQUEST_BYTES as usize,
+                )
+                .unwrap();
+            String::from_utf8(response).unwrap()
+        }
+
+        #[test]
+        fn hmac_server_authenticates_before_dispatch() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let key_path = dir.path().join("key");
+            write_key(&key_path, 7);
+            let handle = ControlSocketServer::new_hmac(
+                socket_path.clone(),
+                &key_path,
+                Some(unsafe { libc::geteuid() }),
+                None,
+            )
+            .unwrap()
+            .start()
+            .unwrap();
+
+            let response = hmac_connect_and_send(
+                &socket_path,
+                &key_path,
+                r#"{"schemaVersion":"1","method":"ping"}"#,
+            );
+            let response: ControlResponse = serde_json::from_str(&response).unwrap();
+            assert!(response.ok);
+            assert_eq!(response.result.unwrap()["pong"], true);
+            handle.shutdown();
+        }
+
+        #[test]
+        fn hmac_server_rejects_plain_or_wrong_key_without_dispatch() {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("test.sock");
+            let key_path = dir.path().join("key");
+            let wrong_path = dir.path().join("wrong-key");
+            write_key(&key_path, 7);
+            write_key(&wrong_path, 8);
+            let handle = ControlSocketServer::new_hmac(socket_path.clone(), &key_path, None, None)
+                .unwrap()
+                .start()
+                .unwrap();
+
+            let mut plain = UnixStream::connect(&socket_path).unwrap();
+            plain
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            plain
+                .write_all(b"{\"schemaVersion\":\"1\",\"method\":\"ping\"}\n")
+                .unwrap();
+            let mut response = String::new();
+            let read = BufReader::new(&plain).read_line(&mut response).unwrap();
+            assert_eq!(read, 0);
+            assert!(response.is_empty());
+
+            let wrong = SharedSecret::load(&wrong_path).unwrap();
+            let mut stream = UnixStream::connect(&socket_path).unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            assert!(
+                authenticate_client(
+                    &mut stream,
+                    &wrong,
+                    CONTROL_CLIENT_DOMAIN,
+                    CONTROL_SERVER_DOMAIN,
+                )
+                .is_err()
+            );
+            handle.shutdown();
         }
 
         #[test]

--- a/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
@@ -20,6 +20,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read as IoRead, Write as IoWrite};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -34,6 +35,11 @@ use tracing::{debug, info, warn};
 
 use super::activation_reload::ActivationReloadController;
 use super::activation_watcher::WatcherRegistrar;
+#[cfg(test)]
+use super::auth::authenticate_server;
+use super::auth::{
+    FrameSender, NOTIFY_CLIENT_DOMAIN, NOTIFY_SERVER_DOMAIN, SharedSecret, authenticate_client,
+};
 use super::lifecycle::is_reserved_lifecycle_name;
 use super::path::is_skill_meta_path;
 use super::protocol_events::{NoopProtocolEventWriter, ProtocolEvent, ProtocolEventWriter};
@@ -171,6 +177,7 @@ pub enum NotifyError {
     Timeout,
     InvalidResponse { body: String },
     Rejected { body: String },
+    Authentication(String),
 }
 
 impl std::fmt::Display for NotifyError {
@@ -186,6 +193,7 @@ impl std::fmt::Display for NotifyError {
             Self::Rejected { body } => {
                 write!(f, "notify: rejected: {body}")
             }
+            Self::Authentication(message) => write!(f, "notify: authentication failed: {message}"),
         }
     }
 }
@@ -206,6 +214,7 @@ pub trait NotifyClient: Send + Sync {
 pub struct UnixSocketNotifyClient {
     socket_path: PathBuf,
     timeout: Duration,
+    auth_secret: Option<SharedSecret>,
 }
 
 impl UnixSocketNotifyClient {
@@ -213,13 +222,31 @@ impl UnixSocketNotifyClient {
         Self {
             socket_path: socket_path.into(),
             timeout,
+            auth_secret: None,
         }
+    }
+
+    /// Creates a notify client that mutually authenticates before sending
+    /// the unchanged notify v2 business frame.
+    pub fn new_authenticated(
+        socket_path: impl Into<PathBuf>,
+        timeout: Duration,
+        key_file: &Path,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            socket_path: socket_path.into(),
+            timeout,
+            auth_secret: Some(SharedSecret::load(key_file)?),
+        })
     }
 }
 
 impl NotifyClient for UnixSocketNotifyClient {
     fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
-        let stream = UnixStream::connect(&self.socket_path).map_err(NotifyError::Connect)?;
+        if self.auth_secret.is_some() {
+            validate_authenticated_notify_endpoint(&self.socket_path)?;
+        }
+        let mut stream = UnixStream::connect(&self.socket_path).map_err(NotifyError::Connect)?;
         stream
             .set_write_timeout(Some(self.timeout))
             .map_err(NotifyError::Write)?;
@@ -227,38 +254,138 @@ impl NotifyClient for UnixSocketNotifyClient {
             .set_read_timeout(Some(self.timeout))
             .map_err(NotifyError::Read)?;
 
-        let mut writer = std::io::BufWriter::new(&stream);
-        serde_json::to_writer(&mut writer, event)
-            .map_err(|e| NotifyError::Write(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
-        writer.write_all(b"\n").map_err(NotifyError::Write)?;
-        writer.flush().map_err(NotifyError::Write)?;
+        let authenticated_session = if let Some(secret) = &self.auth_secret {
+            Some(
+                authenticate_client(
+                    &mut stream,
+                    secret,
+                    NOTIFY_CLIENT_DOMAIN,
+                    NOTIFY_SERVER_DOMAIN,
+                )
+                .map_err(|error| NotifyError::Authentication(error.to_string()))?,
+            )
+        } else {
+            None
+        };
 
-        let reader = BufReader::new(&stream);
-        let mut limited = reader.take(MAX_RESPONSE_BYTES + 1);
-        let mut line = String::new();
-        match limited.read_line(&mut line) {
-            Ok(0) => {
-                return Err(NotifyError::InvalidResponse {
-                    body: "empty response".to_string(),
-                });
-            }
-            Ok(n) if n as u64 > MAX_RESPONSE_BYTES => {
-                return Err(NotifyError::InvalidResponse {
-                    body: format!("response exceeds {MAX_RESPONSE_BYTES} byte limit"),
-                });
-            }
-            Ok(_) => {}
-            Err(e)
-                if e.kind() == std::io::ErrorKind::TimedOut
-                    || e.kind() == std::io::ErrorKind::WouldBlock =>
-            {
-                return Err(NotifyError::Timeout);
-            }
-            Err(e) => return Err(NotifyError::Read(e)),
+        let request = serde_json::to_vec(event)
+            .map_err(|e| NotifyError::Write(std::io::Error::new(std::io::ErrorKind::Other, e)))?;
+        if let Some(session) = &authenticated_session {
+            session
+                .write_frame(&mut stream, FrameSender::Client, &request)
+                .map_err(|error| NotifyError::Authentication(error.to_string()))?;
+        } else {
+            let mut writer = std::io::BufWriter::new(&stream);
+            writer.write_all(&request).map_err(NotifyError::Write)?;
+            writer.write_all(b"\n").map_err(NotifyError::Write)?;
+            writer.flush().map_err(NotifyError::Write)?;
         }
+
+        let line = if let Some(session) = &authenticated_session {
+            let response = session
+                .read_frame(
+                    &mut stream,
+                    FrameSender::Server,
+                    MAX_RESPONSE_BYTES as usize,
+                )
+                .map_err(|error| NotifyError::Authentication(error.to_string()))?;
+            String::from_utf8(response).map_err(|error| NotifyError::InvalidResponse {
+                body: format!("response is not UTF-8: {error}"),
+            })?
+        } else {
+            let reader = BufReader::new(&stream);
+            let mut limited = reader.take(MAX_RESPONSE_BYTES + 1);
+            let mut line = String::new();
+            match limited.read_line(&mut line) {
+                Ok(0) => {
+                    return Err(NotifyError::InvalidResponse {
+                        body: "empty response".to_string(),
+                    });
+                }
+                Ok(n) if n as u64 > MAX_RESPONSE_BYTES => {
+                    return Err(NotifyError::InvalidResponse {
+                        body: format!("response exceeds {MAX_RESPONSE_BYTES} byte limit"),
+                    });
+                }
+                Ok(_) => {}
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::TimedOut
+                        || e.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    return Err(NotifyError::Timeout);
+                }
+                Err(e) => return Err(NotifyError::Read(e)),
+            }
+            line
+        };
 
         validate_response(&line)
     }
+}
+
+fn validate_authenticated_notify_endpoint(socket_path: &Path) -> Result<(), NotifyError> {
+    let expected_uid = unsafe { libc::geteuid() };
+    let parent = socket_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| endpoint_authentication_error("socket path has no parent directory"))?;
+    let parent_metadata = std::fs::symlink_metadata(parent).map_err(|error| {
+        endpoint_authentication_error(format!(
+            "cannot inspect parent '{}': {error}",
+            parent.display()
+        ))
+    })?;
+    if !parent_metadata.file_type().is_dir() {
+        return Err(endpoint_authentication_error(format!(
+            "parent '{}' is not a directory",
+            parent.display()
+        )));
+    }
+    if parent_metadata.uid() != expected_uid {
+        return Err(endpoint_authentication_error(format!(
+            "parent '{}' is not owned by the effective uid",
+            parent.display()
+        )));
+    }
+    if parent_metadata.mode() & 0o077 != 0 {
+        return Err(endpoint_authentication_error(format!(
+            "parent '{}' must not grant group or other permissions",
+            parent.display()
+        )));
+    }
+
+    let socket_metadata = std::fs::symlink_metadata(socket_path).map_err(|error| {
+        endpoint_authentication_error(format!(
+            "cannot inspect socket '{}': {error}",
+            socket_path.display()
+        ))
+    })?;
+    if !socket_metadata.file_type().is_socket() {
+        return Err(endpoint_authentication_error(format!(
+            "endpoint '{}' is not a Unix socket",
+            socket_path.display()
+        )));
+    }
+    if socket_metadata.uid() != expected_uid {
+        return Err(endpoint_authentication_error(format!(
+            "socket '{}' is not owned by the effective uid",
+            socket_path.display()
+        )));
+    }
+    if socket_metadata.mode() & 0o077 != 0 {
+        return Err(endpoint_authentication_error(format!(
+            "socket '{}' must not grant group or other permissions",
+            socket_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn endpoint_authentication_error(message: impl Into<String>) -> NotifyError {
+    NotifyError::Authentication(format!(
+        "notify socket endpoint is not trusted: {}",
+        message.into()
+    ))
 }
 
 fn validate_response(body: &str) -> Result<(), NotifyError> {
@@ -1900,6 +2027,190 @@ mod tests {
             result.is_ok(),
             "normal response must be accepted: {result:?}"
         );
+    }
+
+    #[test]
+    fn authenticated_unix_socket_client_handshakes_before_notify() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let key_path = dir.path().join("key");
+        std::fs::write(&key_path, [5_u8; 32]).unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let client = UnixSocketNotifyClient::new_authenticated(
+            &sock_path,
+            Duration::from_secs(5),
+            &key_path,
+        )
+        .unwrap();
+        let server_secret = SharedSecret::load(&key_path).unwrap();
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Write,
+            vec![],
+            5000,
+        );
+
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let session = authenticate_server(
+                &mut stream,
+                &server_secret,
+                NOTIFY_CLIENT_DOMAIN,
+                NOTIFY_SERVER_DOMAIN,
+            )
+            .unwrap();
+            let request = session
+                .read_frame(
+                    &mut stream,
+                    FrameSender::Client,
+                    MAX_RESPONSE_BYTES as usize,
+                )
+                .unwrap();
+            let request = String::from_utf8(request).unwrap();
+            assert!(request.contains(NOTIFY_METHOD));
+            session
+                .write_frame(
+                    &mut stream,
+                    FrameSender::Server,
+                    br#"{"ok":true,"data":{"schemaVersion":2,"accepted":true}}"#,
+                )
+                .unwrap();
+        });
+
+        let result = client.send(&event);
+        handle.join().unwrap();
+        assert!(result.is_ok(), "authenticated notify failed: {result:?}");
+    }
+
+    #[test]
+    fn authenticated_notify_rejects_permissive_socket() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let key_path = dir.path().join("key");
+        std::fs::write(&key_path, [5_u8; 32]).unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o660)).unwrap();
+        let client = UnixSocketNotifyClient::new_authenticated(
+            &sock_path,
+            Duration::from_secs(5),
+            &key_path,
+        )
+        .unwrap();
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Write,
+            vec![],
+            5000,
+        );
+
+        let result = client.send(&event);
+        assert!(matches!(
+            result,
+            Err(NotifyError::Authentication(message))
+                if message.contains("group or other permissions")
+        ));
+    }
+
+    #[test]
+    fn authenticated_notify_rejects_permissive_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let key_path = dir.path().join("key");
+        std::fs::write(&key_path, [5_u8; 32]).unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o750)).unwrap();
+        let client = UnixSocketNotifyClient::new_authenticated(
+            &sock_path,
+            Duration::from_secs(5),
+            &key_path,
+        )
+        .unwrap();
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Write,
+            vec![],
+            5000,
+        );
+
+        let result = client.send(&event);
+        assert!(matches!(
+            result,
+            Err(NotifyError::Authentication(message))
+                if message.contains("group or other permissions")
+        ));
+    }
+
+    #[test]
+    fn authenticated_notify_accepts_restrictive_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let _listener = UnixListener::bind(&sock_path).unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o300)).unwrap();
+
+        let result = validate_authenticated_notify_endpoint(&sock_path);
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(
+            result.is_ok(),
+            "owner-only parent permissions must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn authenticated_notify_rejects_non_socket_endpoint() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let sock_path = dir.path().join("not-a-socket");
+        let key_path = dir.path().join("key");
+        std::fs::write(&sock_path, b"not a socket").unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        std::fs::write(&key_path, [5_u8; 32]).unwrap();
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let client = UnixSocketNotifyClient::new_authenticated(
+            &sock_path,
+            Duration::from_secs(5),
+            &key_path,
+        )
+        .unwrap();
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Write,
+            vec![],
+            5000,
+        );
+
+        let result = client.send(&event);
+        assert!(matches!(
+            result,
+            Err(NotifyError::Authentication(message)) if message.contains("not a Unix socket")
+        ));
     }
 
     #[test]

--- a/src/skillfs/docs/design/container-peer-authentication.md
+++ b/src/skillfs/docs/design/container-peer-authentication.md
@@ -1,0 +1,237 @@
+# SkillFS Container Peer Authentication
+
+[中文版](container-peer-authentication_zh.md)
+
+Development plan for [issue #2439](https://github.com/alibaba/anolisa/issues/2439).
+This document defines planned behavior; it must not be read as an available
+deployment contract until the implementation and acceptance items are complete.
+
+## Current development status
+
+The development branch implements only the SkillFS-owned surfaces: shared
+authentication primitives, the control server, the notify client, fail-closed
+configuration gates, documentation, regression tests, and an independent
+standard-library Python probe. Fixed handshake and protected-frame vectors,
+plus a real FUSE probe loop, pin the proposed cross-language byte contract.
+
+No agent-sec-core source or tests are changed by this branch. Peer-side
+implementation and ownership remain with the sec-core maintainers after they
+confirm the contract. The real sec-core separate-container fixture, the
+security-integrated Pod profile, and ACK evidence remain open. This issue must
+stay open until those cross-component and deployment acceptance items pass.
+
+## Outcome
+
+Allow SkillFS and agent-sec-core to authenticate their private Unix-socket
+traffic while running in separate PID and mount namespaces. Preserve the
+current executable-identity authentication as the unchanged host default.
+
+The first container profile retains the existing `shared_path` resolver
+transport. SkillFS and agent-sec-core mount the same physical source at the
+same absolute path, while the workload sees only the propagated FUSE view.
+
+## Security boundary
+
+The trusted domain contains the SkillFS and agent-sec-core containers. A
+Kubernetes Secret volume and the physical source are mounted only into this
+domain. A private runtime volume carries their Unix sockets.
+
+An untrusted workload may know the socket path and may intentionally be given
+read-only access to the runtime volume in a negative test. It must still fail
+authentication when it lacks the Secret, including when it uses the same UID,
+GID, process name, or executable basename as the trusted peer. Write access to
+the socket directory remains inside the trusted domain: any writer can unlink
+or replace an endpoint and cause a detectable denial of service.
+
+Node root, a compromised trusted container, and a peer that can read the
+Secret are outside this boundary.
+
+## Profiles
+
+### Host executable profile
+
+This remains the default. SkillFS verifies `SO_PEERCRED`, `/proc/<pid>/exe`
+path and file identity, configured UID/GID, and process start time. Existing
+CLI, configuration, wire format, and failure behavior stay unchanged.
+
+### Container HMAC profile
+
+This profile is explicit and mutually exclusive with executable identity.
+SkillFS and agent-sec-core load the same secret from an absolute, nonblocking,
+no-follow, bounded regular file with restrictive permissions. Nonblocking open
+allows FIFOs and other non-regular candidates to fail metadata validation
+instead of stalling startup. UID/GID remain optional additional constraints;
+they are not treated as container identity.
+
+Before each authenticated notify connection, SkillFS requires the socket's
+immediate parent to be a non-symlink directory owned by its effective UID with
+no group or other permissions; `0700` is the recommended default, while more
+restrictive usable owner permissions such as `0300` remain valid. The endpoint
+must be an owner-matched Unix socket with no group or other permissions; the
+agent-sec-core listener therefore binds it as `0600`. Because agent-sec-core
+creates both paths, the initial profile requires SkillFS and agent-sec-core to
+run with the same effective UID. Supporting different UIDs requires a future,
+explicit endpoint ownership policy. These metadata checks provide a first
+availability and deployment boundary. The HMAC exchange remains the peer
+identity and business-frame integrity boundary, including against a same-UID
+process.
+
+Each connection completes a bounded challenge-response exchange before an
+existing business request is read or dispatched:
+
+1. The client sends a bounded `auth.init` frame.
+2. The server sends a fresh cryptographically random nonce.
+3. The client returns a domain-separated HMAC-SHA256 proof.
+4. The server compares the proof in constant time and returns its own
+   domain-separated proof.
+5. The client verifies the server proof before sending business data.
+6. Each sender writes the existing raw NDJSON business frame followed by an
+   `auth.frame` tag. The receiver verifies the tag before decoding or
+   dispatching the business frame.
+
+Control and notify traffic use distinct domains. A connection is single-use,
+so reconnect and process restart always require a fresh nonce. Authentication
+errors close the connection without falling back to executable identity or
+plain protocol handling. Binding each business frame to the fresh nonce and
+sender direction prevents a socket proxy from relaying the handshake and then
+altering a request, response, or acknowledgement.
+
+The handshake uses a total deadline, not a timeout that restarts after each
+byte. This bounds shutdown latency and prevents a peer from holding the
+single-request control loop indefinitely with a slow partial frame. Socket
+ownership and optional UID/GID constraints remain the first availability
+boundary; the shared secret authenticates the peer after connection.
+
+The authentication frames are NDJSON and use the following fixed envelope:
+
+```json
+{"authVersion":"1","type":"auth.init"}
+{"authVersion":"1","type":"auth.challenge","nonce":"<base64>"}
+{"authVersion":"1","type":"auth.proof","proof":"<base64>"}
+{"authVersion":"1","type":"auth.ok","proof":"<base64>"}
+<existing raw business JSON>
+{"authVersion":"1","type":"auth.frame","proof":"<base64>"}
+```
+
+The nonce is 32 random bytes encoded with padded standard Base64. Each proof
+is `HMAC-SHA256(secret, domain || NUL || raw_nonce)`, also encoded with padded
+standard Base64. The domains are:
+
+- `anolisa.skillfs.control.client.v1`
+- `anolisa.skillfs.control.server.v1`
+- `anolisa.skillfs.notify.client.v1`
+- `anolisa.skillfs.notify.server.v1`
+
+For a business payload, the tag input is:
+
+```text
+domain || NUL || "frame" || NUL || raw_nonce ||
+u64_be(payload_length) || raw_business_json
+```
+
+The tag is HMAC-SHA256 under the shared Secret and uses the same client or
+server domain as its sender. The payload length excludes the NDJSON newline.
+The sender transmits the raw business JSON and newline first, then the
+`auth.frame` line. The receiver retains the raw bytes, verifies the tag in
+constant time, and only then parses or dispatches them. This avoids
+cross-language JSON canonicalization while keeping the inner control schema v1
+and notify schema v2 unchanged.
+
+Secret material and reusable proofs must never appear in logs, responses,
+audit events, protocol events, or checked-in deployment assets.
+
+## Implementation phases
+
+### Phase 1: shared authentication primitive
+
+- Add strict secret-file loading and validation in SkillFS and agent-sec-core.
+- Define compatible challenge, proof, and protected business frames; byte
+  limits; timeouts; domain strings; and fixed cross-language test vectors.
+- Add constant-time proof verification and failure redaction.
+
+### Phase 2: control resolver
+
+- Add a mutually exclusive HMAC peer mode to the SkillFS control server.
+- Add explicit socket and secret paths to the agent-sec-core resolver client.
+- Authenticate before `ping`, `status`, resolver, or activation method
+  dispatch while leaving the business schema unchanged.
+- Retain the existing Flat, Hermes, fd-anchored resolution, and error mapping.
+
+### Phase 3: notify direction
+
+- Authenticate SkillFS as a client of the agent-sec-core daemon.
+- Require authentication only for `skill_ledger.skillfs_notify_change` when
+  the hardened mode is configured; unrelated daemon APIs keep their existing
+  compatibility behavior.
+- Authenticate the daemon response so a fake listener cannot acknowledge a
+  notification.
+- Fail startup when container HMAC control and notify are enabled together but
+  the notify key is omitted, avoiding a partially authenticated profile.
+
+Notification retry and durable reconcile are separate work. Authentication
+failure retains the current rule that normal FUSE I/O continues and the active
+mapping does not change.
+
+### Phase 4: deployment and local acceptance
+
+- Add a separate security-integrated Pod profile rather than changing the
+  standalone Sidecar example.
+- Use distinct source, propagated FUSE, runtime socket, and Secret volumes.
+- Do not enable `shareProcessNamespace`.
+- Add positive and negative local container tests with separate namespaces.
+- Verify restart, readiness, resolver, notify, activation, denied workload,
+  and clean-unmount behavior.
+
+## Local acceptance
+
+Run from `src/skillfs`:
+
+```sh
+cargo +1.86.0 fmt --all -- --check
+cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
+cargo +1.86.0 test --workspace
+cargo +1.86.0 doc --workspace --no-deps
+scripts/test.sh
+```
+
+Run the independent probe fixed-vector check and unilateral real-FUSE plan:
+
+```sh
+python3 scripts/container-peer-auth-probe.py self-test
+```
+
+The sec-core formatter, lint, type, pytest, and bilateral container fixtures
+belong to its follow-up implementation. Those fixtures must fail rather than
+skip authentication or namespace cases.
+
+Required negative cases include missing, empty, short, oversized, symlinked,
+FIFO, over-permissive, and incorrectly owned secret files; wrong, malformed,
+stale, or replayed proofs; a relayed handshake followed by a modified business
+frame; authentication timeouts; UID/GID mismatch; a plain request against HMAC
+mode; insecure notify socket type, owner, mode, or parent directory; and a
+same-UID untrusted peer with socket access but no Secret.
+
+## ACK follow-up
+
+After local completion, run a focused one-off validation on ACK and record:
+
+- Kubernetes version, runtime, node architecture, manifest revision, and image
+  digests;
+- Secret, source, runtime, and propagated-volume visibility from every
+  container;
+- separate PID and mount namespaces without shared process namespace;
+- resolver, notify, activation, readiness, and both sidecar restart paths;
+- denial of an untrusted container that can reach the runtime socket; and
+- Pod termination and residual-mount cleanup.
+
+ACK results are release evidence, not recurring CI evidence. Do not describe
+the security-integrated profile as released until this validation and the
+remaining release gates in issue #2012 are complete.
+
+## Deferred work
+
+- `SCM_RIGHTS` or directory-fd resolver transport.
+- Removing the physical source from agent-sec-core.
+- Shared PID namespace as a supported security dependency.
+- Durable notify queues or reconnect reconciliation.
+- Multi-source registration, source hot refresh, CSI, and rootless FUSE.

--- a/src/skillfs/docs/design/container-peer-authentication_zh.md
+++ b/src/skillfs/docs/design/container-peer-authentication_zh.md
@@ -1,0 +1,210 @@
+# SkillFS 容器 Peer 认证
+
+[English](container-peer-authentication.md)
+
+这是 [issue #2439](https://github.com/alibaba/anolisa/issues/2439) 的开发计划。
+本文描述的是计划行为；在实现和验收完成前，不应将其视为已经可用的部署契约。
+
+## 当前开发状态
+
+开发分支只实现 SkillFS 所有的部分，包括共享认证原语、control server、notify
+client、fail-closed 配置门禁、文档、回归测试和独立的 Python 标准库 probe。
+固定 handshake/protected-frame vector 和真实 FUSE probe loop 用于锁定拟议的
+跨语言字节合同。
+
+本分支不修改任何 agent-sec-core source 或 test。Peer-side 实现及所有权由 sec-core
+maintainer 在确认合同后负责。真实 sec-core 独立容器 fixture、security-integrated
+Pod profile 和 ACK 证据仍未完成。在这些跨组件和部署验收项通过前，本 issue 必须
+保持 open。
+
+## 目标
+
+让 SkillFS 和 agent-sec-core 在独立 PID、mount namespace 中运行时，仍能认证
+私有 Unix socket 流量。现有 executable identity 认证继续作为宿主机默认模式，
+语义保持不变。
+
+第一版容器 profile 保留现有 `shared_path` resolver transport。SkillFS 和
+agent-sec-core 以相同绝对路径挂载同一个物理 source，workload 只获得传播后的
+FUSE view。
+
+## 安全边界
+
+可信域由 SkillFS 和 agent-sec-core 容器组成。Kubernetes Secret volume 和物理
+source 只挂载到该可信域，私有 runtime volume 承载双方的 Unix socket。
+
+非可信 workload 可能知道 socket 路径；负向测试还会故意让它以只读方式看到
+runtime volume。只要没有 Secret，它仍必须认证失败，即使使用与可信 peer 相同的
+UID、GID、进程名或 executable basename。Socket directory 的写权限仍只属于可信
+域；任何能够写入该目录的进程都可以 unlink 或替换 endpoint，造成可检测的拒绝服务。
+
+Node root、可信容器已被攻陷以及能够读取 Secret 的 peer 不在本次安全边界内。
+
+## Profile
+
+### Host executable profile
+
+该 profile 继续作为默认模式。SkillFS 验证 `SO_PEERCRED`、`/proc/<pid>/exe`
+路径及文件身份、配置的 UID/GID 和进程 start time。现有 CLI、配置、wire format
+和失败语义均保持不变。
+
+### Container HMAC profile
+
+该 profile 必须显式启用，并与 executable identity 互斥。SkillFS 和
+agent-sec-core 从同一个绝对路径、nonblocking、no-follow、有大小上限、权限严格的
+普通文件加载 secret。Nonblocking open 让 FIFO 等非普通文件进入 metadata 校验并
+立即失败，避免启动阻塞。UID/GID 仍可作为附加约束，但不能被当作 container
+identity。
+
+每次建立 authenticated notify 连接前，SkillFS 都要求 socket 的直接父目录不是
+symlink、由自己的 effective UID 所有，且不给 group 或 other 任何权限。`0700`
+是推荐默认值，`0300` 等仍可用的更严格 owner 权限同样有效。Endpoint 必须是 owner
+匹配的 Unix socket，且不给 group 或 other 任何权限；因此 agent-sec-core
+listener 应将其 bind 为 `0600`。由于 agent-sec-core 会创建父目录和 endpoint，
+首版 profile 要求 SkillFS
+与 agent-sec-core 使用相同的 effective UID。支持不同 UID 需要未来明确引入新的
+endpoint ownership policy。这些 metadata 检查是第一层可用性和部署边界；HMAC
+交换仍是 peer identity 与业务 frame 完整性的边界，也负责防御同 UID 进程。
+
+每条连接在读取或 dispatch 现有业务请求前，先完成有界 challenge-response：
+
+1. Client 发送有界 `auth.init` frame。
+2. Server 发送密码学安全的随机 nonce。
+3. Client 返回经过 domain separation 的 HMAC-SHA256 proof。
+4. Server 使用 constant-time comparison 验证，并返回自己的 domain-separated
+   proof。
+5. Client 验证 server proof 后，才发送业务数据。
+6. 每个 sender 先发送现有 raw NDJSON 业务 frame，再发送对应的 `auth.frame` tag；
+   receiver 验证 tag 后才能解析或 dispatch 业务 frame。
+
+Control 和 notify 流量使用不同 domain。每条连接只处理一次请求，因此重连和
+进程重启都需要新的 nonce。认证失败直接关闭连接，不得 fallback 到 executable
+identity 或 plain protocol。业务 frame 与新 nonce 和 sender direction 绑定，
+socket proxy 无法在转发握手后篡改 request、response 或 acknowledgement。
+
+握手使用总 deadline，而不是每收到一个字节就重新开始计时的 timeout。这样能限制
+shutdown 延迟，也能避免 peer 通过缓慢发送不完整 frame 永久占住单请求 control
+loop。Socket owner 和可选 UID/GID 约束仍是第一层可用性边界，连接建立后再由共享
+secret 认证 peer。
+
+认证 frame 使用 NDJSON，并固定为以下 envelope：
+
+```json
+{"authVersion":"1","type":"auth.init"}
+{"authVersion":"1","type":"auth.challenge","nonce":"<base64>"}
+{"authVersion":"1","type":"auth.proof","proof":"<base64>"}
+{"authVersion":"1","type":"auth.ok","proof":"<base64>"}
+<existing raw business JSON>
+{"authVersion":"1","type":"auth.frame","proof":"<base64>"}
+```
+
+Nonce 是使用带 padding 的标准 Base64 编码的 32 字节随机值。Proof 是
+`HMAC-SHA256(secret, domain || NUL || raw_nonce)`，同样使用带 padding 的标准
+Base64 编码。Domain 固定为：
+
+- `anolisa.skillfs.control.client.v1`
+- `anolisa.skillfs.control.server.v1`
+- `anolisa.skillfs.notify.client.v1`
+- `anolisa.skillfs.notify.server.v1`
+
+业务 payload 的 tag 输入为：
+
+```text
+domain || NUL || "frame" || NUL || raw_nonce ||
+u64_be(payload_length) || raw_business_json
+```
+
+Tag 使用共享 Secret 计算 HMAC-SHA256，并沿用 sender 对应的 client/server domain。
+Payload length 不包含 NDJSON newline。Sender 先发送 raw business JSON 和 newline，
+再发送 `auth.frame` 行。Receiver 保留 raw bytes，constant-time 验证 tag 后才解析或
+dispatch。这能避免跨 language JSON canonicalization，同时保持内部 control schema
+v1 和 notify schema v2 不变。
+
+Secret 和可重用 proof 禁止出现在日志、响应、audit event、protocol event 或
+提交到仓库的部署资产中。
+
+## 实施阶段
+
+### 第一阶段：共享认证原语
+
+- 在 SkillFS 和 agent-sec-core 中增加严格的 secret-file 加载与验证。
+- 定义兼容的 challenge、proof 和 protected business frame、大小限制、timeout、
+  domain string 和固定的跨语言 test vector。
+- 增加 constant-time proof 验证和失败信息脱敏。
+
+### 第二阶段：Control resolver
+
+- 为 SkillFS control server 增加与现有模式互斥的 HMAC peer mode。
+- 为 agent-sec-core resolver client 增加显式 socket 和 secret 路径。
+- 在 dispatch `ping`、`status`、resolver 或 activation method 前完成认证，同时
+  保持业务 schema 不变。
+- 保持 Flat、Hermes、fd-anchored resolution 和错误映射语义不变。
+
+### 第三阶段：Notify 方向
+
+- 认证作为 agent-sec-core daemon client 的 SkillFS。
+- hardened mode 启用时，仅 `skill_ledger.skillfs_notify_change` 强制认证；daemon
+  其他 API 保持现有兼容行为。
+- SkillFS 验证 daemon response，避免 fake listener 伪造通知已接受。
+- 同时启用 container HMAC control 和 notify 时，如果遗漏 notify key，启动必须失败，
+  避免只认证一半的 profile。
+
+Notify retry 和 durable reconcile 属于独立工作。认证失败继续遵循现有规则，
+普通 FUSE I/O 不受阻断，active mapping 保持不变。
+
+### 第四阶段：部署和本地验收
+
+- 增加独立的 security-integrated Pod profile，不修改 standalone Sidecar 示例。
+- 分别使用 source、propagated FUSE、runtime socket 和 Secret volume。
+- 不启用 `shareProcessNamespace`。
+- 增加使用独立 namespace 的正向和负向本地容器测试。
+- 验证 restart、readiness、resolver、notify、activation、workload 拒绝和干净卸载。
+
+## 本地验收
+
+在 `src/skillfs` 下执行：
+
+```sh
+cargo +1.86.0 fmt --all -- --check
+cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
+cargo +1.86.0 test --workspace
+cargo +1.86.0 doc --workspace --no-deps
+scripts/test.sh
+```
+
+运行独立 probe 的固定 vector 检查和单方面真实 FUSE 计划：
+
+```sh
+python3 scripts/container-peer-auth-probe.py self-test
+```
+
+sec-core formatter、lint、type、pytest 和双方 container fixture 属于其后续实现。
+这些 fixture 遇到认证或 namespace 条件不可用时必须失败，不能 skip。
+
+必须覆盖的负向场景包括 missing、empty、short、oversized、symlinked、FIFO、权限
+过宽和 owner 错误的 secret file；错误、畸形、过期或 replayed proof；转发握手后
+修改业务 frame；认证 timeout；UID/GID 不匹配；向 HMAC mode 发送 plain request；
+不安全的 notify socket 类型、owner、mode 或父目录；以及可以访问 socket、使用
+相同 UID 但没有 Secret 的非可信 peer。
+
+## ACK 后续验收
+
+本地完成后，在 ACK 进行一次聚焦验证，并记录：
+
+- Kubernetes 版本、runtime、node architecture、manifest revision 和 image
+  digest；
+- 每个容器能看到的 Secret、source、runtime 和 propagated volume；
+- 未启用 shared process namespace 时独立的 PID 和 mount namespace；
+- resolver、notify、activation、readiness 和两个 sidecar 的 restart 路径；
+- 能访问 runtime socket 的非可信容器被拒绝；
+- Pod 退出和 residual mount 清理。
+
+ACK 结果属于 release evidence，不是 recurring CI evidence。在完成这项验证和
+issue #2012 中其余发布门禁前，不应宣称 security-integrated profile 已发布。
+
+## 延后事项
+
+- `SCM_RIGHTS` 或 directory-fd resolver transport。
+- 从 agent-sec-core 移除物理 source mount。
+- 把 shared PID namespace 作为受支持的安全依赖。
+- Durable notify queue 或 reconnect reconciliation。
+- Multi-source registration、source hot refresh、CSI 和 rootless FUSE。

--- a/src/skillfs/docs/design/control-socket-resolver.md
+++ b/src/skillfs/docs/design/control-socket-resolver.md
@@ -17,10 +17,12 @@ live/backing source, and is it yours to manage?" S1 provides:
 2. A read-only `skill.resolveLiveSource` query answering the mapping above
    with a strict three-state contract.
 
-Everything reuses the existing control socket, its `schemaVersion "1"`
-envelope, and its `SO_PEERCRED` + trusted-executable-identity +
-process-starttime authentication. No second authentication mechanism and
-no new protocol version are introduced.
+Everything reuses the existing control socket and its `schemaVersion "1"`
+business envelope. The host profile retains its `SO_PEERCRED` +
+trusted-executable-identity + process-starttime authentication unchanged. An
+explicit container profile may instead complete the HMAC preface defined in
+[SkillFS Container Peer Authentication](container-peer-authentication.md).
+Neither profile changes the resolver business protocol version.
 
 ## Endpoint
 
@@ -50,10 +52,13 @@ The control plane stays **opt-in and authenticated**:
 | no | no | control plane stays off |
 | yes | yes | use the explicit path |
 
-Authentication is unchanged: `SO_PEERCRED` credentials, the peer's
-`/proc/<pid>/exe` `(dev, ino)` pinned against the configured trusted
-executable, and `/proc/<pid>/stat` starttime bracketing for PID-reuse
-defense.
+Authentication is selected as one mutually exclusive profile. The host
+profile uses `SO_PEERCRED`, pins the peer's `/proc/<pid>/exe` `(dev, ino)` to
+the configured executable, and brackets the lookup with
+`/proc/<pid>/stat` starttime for PID-reuse defense. The container profile
+requires an explicit endpoint and shared-key mutual authentication before the
+same resolver request is read. It never falls back to host authentication or
+plain NDJSON after an authentication failure.
 
 A single SkillFS instance may in the future manage multiple canonical
 roots behind this same endpoint, selecting the live source by

--- a/src/skillfs/docs/design/notify-v2.md
+++ b/src/skillfs/docs/design/notify-v2.md
@@ -124,6 +124,17 @@ The sec-core consumer switches directly to v2 and must:
 5. return `schemaVersion=2` with `accepted=true` only after accepting the
    event.
 
+The inner v2 business frame stays unchanged in both authentication profiles.
+SkillFS now supports the client half of the explicit container profile,
+verifies the server proof before sending the v2 frame, and follows the raw
+frame with a session-bound `auth.frame` tag. It likewise verifies the daemon's
+response tag before interpreting the acknowledgement. The peer-side behavior
+remains a proposed sec-core contract: it must complete the bounded mutual HMAC
+preface and protected-frame exchange from
+[SkillFS Container Peer Authentication](container-peer-authentication.md), and
+reject plain or incorrectly tagged notify requests when that profile is
+configured.
+
 An in-place notify v2 mount, or any notify mount with an explicit backing root,
 starts only when the authenticated S1 resolver control plane is enabled. The
 canonical path becomes the FUSE over-mount in-place, while an out-of-place

--- a/src/skillfs/docs/testing/container-peer-authentication-unilateral-validation.md
+++ b/src/skillfs/docs/testing/container-peer-authentication-unilateral-validation.md
@@ -1,0 +1,385 @@
+# Container Peer Authentication Unilateral Validation
+
+[中文版](container-peer-authentication-unilateral-validation_zh.md)
+
+This is the tester-run plan for the SkillFS side of
+[issue #2439](https://github.com/alibaba/anolisa/issues/2439). It validates the
+container HMAC contract in a real Linux or Kubernetes environment without
+waiting for an independently released agent-sec-core image.
+
+The independent standard-library Python probe at
+[`scripts/container-peer-auth-probe.py`](../../scripts/container-peer-auth-probe.py)
+acts only as a control client or notify server. Passing this plan proves the
+SkillFS implementation and cross-language wire contract. It does not prove
+agent-sec-core configuration, reconciliation, activation decisions, or release
+readiness; those still require bilateral integration and ACK evidence.
+
+## 1. Freeze the test inputs
+
+Create an evidence directory outside the repository and record the following
+before changing the environment:
+
+```bash
+export C7_EVIDENCE=/var/tmp/skillfs-c7-evidence
+install -d -m 0700 "$C7_EVIDENCE"
+git rev-parse HEAD | tee "$C7_EVIDENCE/git-commit.txt"
+rustc --version | tee "$C7_EVIDENCE/rustc.txt"
+python3 --version | tee "$C7_EVIDENCE/python.txt"
+uname -a | tee "$C7_EVIDENCE/uname.txt"
+```
+
+For Kubernetes, also record immutable cluster and image inputs:
+
+```bash
+kubectl version -o yaml >"$C7_EVIDENCE/kubernetes-version.yaml"
+kubectl get nodes -o wide >"$C7_EVIDENCE/nodes.txt"
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.containerRuntimeVersion}{"\n"}{end}' \
+  >"$C7_EVIDENCE/container-runtime.txt"
+kubectl -n "$C7_NAMESPACE" get pod "$C7_POD" -o yaml \
+  >"$C7_EVIDENCE/pod.yaml"
+kubectl -n "$C7_NAMESPACE" get pod "$C7_POD" \
+  -o jsonpath='{range .status.containerStatuses[*]}{.name}{"\t"}{.imageID}{"\n"}{end}' \
+  >"$C7_EVIDENCE/image-ids.txt"
+```
+
+Do not save the Secret object, raw secret, proof, or reusable credential in
+the evidence directory.
+
+## 2. Required topology
+
+Use three containers with `shareProcessNamespace` absent or `false`:
+
+| Container | Effective UID | Source | FUSE view | Runtime sockets | Auth file |
+| --- | ---: | --- | --- | --- | --- |
+| SkillFS | 0 for this test | read-write | mount creator | read-write | read-only |
+| trusted probe | 0 for this test | same physical source at the same absolute path | optional | read-write | read-only |
+| workload / attacker | different UID for normal I/O; repeat negative socket tests with UID 0 | absent | read-write, propagated | absent normally; read-only for negative tests | absent |
+
+Use separate volumes for:
+
+- the physical source;
+- the propagated FUSE view;
+- private runtime sockets; and
+- the staged authentication file.
+
+Kubernetes Secret projections use symlinked entries, while the production
+loader deliberately opens the final component with `O_NOFOLLOW`. Therefore do
+not pass a projected Secret path directly to SkillFS. Use an init container to
+copy the projected key into a trusted `emptyDir`, set mode `0400` or `0600`,
+and mount that staged file only into SkillFS and the trusted probe. This is an
+acceptance requirement, not a relaxation of the no-follow rule.
+
+The initial profile requires SkillFS and sec-core to use the same effective UID
+for authenticated notify because SkillFS validates the sec-core-owned endpoint
+and its parent against its own effective UID. Each auth file must also be owned
+by its reader's effective UID. A future different-UID profile requires an
+explicit endpoint ownership policy as well as separate private key copies that
+contain the same raw bytes.
+
+Mount or copy the probe script into the trusted probe container. Evidence can
+use a private mounted directory at `$C7_EVIDENCE`; otherwise write inside the
+probe container and retrieve each file with `kubectl cp`. Neither the probe nor
+the evidence volume belongs in the workload container.
+
+## 3. Prepare the fixture
+
+Use these paths consistently in the trusted containers:
+
+```bash
+export C7_SOURCE=/var/lib/skillfs/source
+export C7_MOUNT=/var/lib/skillfs/shared/mount
+export C7_RUNTIME=/run/anolisa
+export C7_SECRET=/run/anolisa/auth/skillfs.key
+export C7_CONTROL=/run/anolisa/skillfs/control.sock
+export C7_NOTIFY=/run/anolisa/probe/notify.sock
+export C7_PROBE=/workspace/src/skillfs/scripts/container-peer-auth-probe.py
+```
+
+Generate one raw random key before creating the Kubernetes Secret:
+
+```bash
+umask 077
+head -c 32 /dev/urandom >skillfs.key
+test "$(wc -c <skillfs.key)" -eq 32
+kubectl -n "$C7_NAMESPACE" create secret generic skillfs-c7-auth \
+  --from-file=skillfs.key=skillfs.key
+```
+
+Seed a Flat-layout Skill with a visible snapshot. The live directory must also
+contain `SKILL.md` so `skill.resolveLiveSource` can verify it:
+
+```bash
+install -d -m 0755 \
+  "$C7_SOURCE/weather/.skill-meta/versions/v000001.snapshot"
+printf '%s\n' '---' 'name: weather' 'description: C7 validation' '---' \
+  >"$C7_SOURCE/weather/SKILL.md"
+cp "$C7_SOURCE/weather/SKILL.md" \
+  "$C7_SOURCE/weather/.skill-meta/versions/v000001.snapshot/SKILL.md"
+printf '%s\n' '{"schemaVersion":1,"target":".skill-meta/versions/v000001.snapshot"}' \
+  >"$C7_SOURCE/weather/.skill-meta/activation.json"
+```
+
+Start SkillFS in the foreground with the explicit container profile:
+
+```bash
+skillfs mount "$C7_SOURCE" "$C7_MOUNT" \
+  --foreground --allow-other \
+  --security --activation-mode file \
+  --notify-socket "$C7_NOTIFY" \
+  --notify-auth-key-file "$C7_SECRET" \
+  --control-socket "$C7_CONTROL" \
+  --trusted-peer-key-file "$C7_SECRET"
+```
+
+Before proceeding, require all of the following:
+
+- the SkillFS process remains running;
+- the mount appears in `/proc/self/mountinfo`;
+- `skills/weather/SKILL.md` is readable through the workload's propagated
+  view; and
+- the control socket is mode `0600` in a private runtime directory; and
+- the notify listener uses an owner-matched socket with no group/other bits
+  under an owner-matched directory with no group/other bits (`0700` is the
+  recommended default).
+
+## 4. Positive control tests
+
+Run these commands from the trusted probe container:
+
+```bash
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"ping"}' \
+  | tee "$C7_EVIDENCE/control-ping.json"
+
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"status"}' \
+  | tee "$C7_EVIDENCE/control-status.json"
+
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request "{\"schemaVersion\":\"1\",\"method\":\"skill.resolveLiveSource\",\"canonicalSkillDir\":\"$C7_SOURCE/weather\"}" \
+  | tee "$C7_EVIDENCE/control-resolve.json"
+```
+
+Expected results:
+
+- each process exits zero after mutual authentication;
+- `ping` returns `ok=true` and `pong=true`;
+- `status` retains the existing schema v1 business response;
+- resolve returns `managed=true`, `skillId=weather`,
+  `liveSkillDir=$C7_SOURCE/weather`, and `transport=shared_path`; and
+- the printed nonce differs for every connection.
+
+## 5. Negative control tests
+
+### 5.1 Plain and wrong-key peers
+
+Intentionally mount the runtime socket, but not the real auth file, into the
+attacker container. Run it first as the normal workload UID and repeat as UID
+0, matching SkillFS's effective UID:
+
+```bash
+python3 "$C7_PROBE" plain --socket "$C7_CONTROL"
+umask 077
+head -c 32 /dev/urandom >/tmp/wrong-skillfs.key
+if python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret /tmp/wrong-skillfs.key \
+  --request '{"schemaVersion":"1","method":"ping"}'; then
+  echo 'FAIL: wrong-key peer was accepted' >&2
+  exit 1
+else
+  echo 'PASS: wrong-key peer was rejected'
+fi
+```
+
+The plain probe must print `PASS`. The wrong-key command must fail without a
+business response. SkillFS must remain mounted and a subsequent trusted `ping`
+must still succeed.
+
+### 5.2 Replay, business tampering, and slow partial frames
+
+```bash
+python3 "$C7_PROBE" replay \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" --timeout 6
+python3 "$C7_PROBE" tamper \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" --timeout 6
+python3 "$C7_PROBE" slow \
+  --socket "$C7_CONTROL" --interval 1 --bound 7
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"ping"}'
+```
+
+The replay must observe a new nonce and receive no `auth.ok`. The tamper probe
+must complete a valid handshake but receive no response after changing the raw
+request without a matching tag. The slow sender must be disconnected within
+seven seconds. The final trusted request must pass, proving the single-request
+listener recovered.
+
+### 5.3 Secret and configuration startup gates
+
+For each row, start a fresh SkillFS process and assert non-zero exit before a
+FUSE mount or socket is left behind:
+
+| Case | Setup | Expected diagnostic |
+| --- | --- | --- |
+| missing | configured file is absent | cannot open authentication key |
+| projected symlink | direct Kubernetes Secret entry | no-follow open failure |
+| FIFO | mode `0600`, no writer | regular-file rejection without blocking |
+| short | 31 raw bytes | must contain 32–4096 bytes |
+| oversized | 4097 raw bytes | must contain 32–4096 bytes |
+| permissive | mode `0640` or `0644` | group or other permissions rejected |
+| wrong owner | owner differs from effective UID | effective-user ownership rejected |
+| half-hardened | HMAC control plus notify socket, but no notify key | notify auth key required |
+| mixed modes | both trusted peer executable and key | mutually exclusive |
+
+After every failure, capture stderr, confirm no residual mount with `findmnt`,
+and confirm that neither control nor notify socket remains.
+
+## 6. Positive notify test
+
+Start the independent notify server in the trusted probe container before
+causing the mutation:
+
+```bash
+python3 "$C7_PROBE" notify-server \
+  --socket "$C7_NOTIFY" --secret "$C7_SECRET" \
+  --output "$C7_EVIDENCE/notify-request.json" \
+  >"$C7_EVIDENCE/notify-probe.log" 2>&1 &
+C7_NOTIFY_PID=$!
+```
+
+Wait for `READY`, then write through the workload-visible FUSE view:
+
+```bash
+grep -q '^READY:' "$C7_EVIDENCE/notify-probe.log"
+date -u +%FT%TZ >"$C7_MOUNT/skills/weather/validation.txt"
+wait "$C7_NOTIFY_PID"
+python3 -m json.tool "$C7_EVIDENCE/notify-request.json"
+```
+
+Expected results:
+
+- the probe prints `PASS: authenticated notify v2 recorded`;
+- the request method is `skill_ledger.skillfs_notify_change`;
+- `params.schemaVersion` is `2`;
+- `params.canonicalSkillDir` is `$C7_SOURCE/weather`;
+- `params.skillId` is `weather` and the changed path is relative; and
+- normal FUSE I/O completes even if notification delivery later fails.
+
+Startup reconcile may produce the first notify. If so, save it as separate
+evidence, restart the one-shot probe, then perform the workload mutation.
+
+## 7. Negative notify server proof
+
+Start the probe with an intentionally invalid server proof, then trigger
+another FUSE mutation:
+
+```bash
+python3 "$C7_PROBE" notify-server \
+  --socket "$C7_NOTIFY" --secret "$C7_SECRET" \
+  --output "$C7_EVIDENCE/notify-must-not-exist.json" \
+  --wrong-server-proof \
+  >"$C7_EVIDENCE/notify-wrong-server.log" 2>&1 &
+C7_BAD_NOTIFY_PID=$!
+date -u +%FT%TZ >"$C7_MOUNT/skills/weather/wrong-server-proof.txt"
+wait "$C7_BAD_NOTIFY_PID"
+test ! -e "$C7_EVIDENCE/notify-must-not-exist.json"
+```
+
+The probe must report that no business frame followed the wrong proof. SkillFS
+must log an authentication failure, keep serving FUSE I/O, and leave activation
+mapping unchanged.
+
+## 8. Namespace and volume isolation
+
+From the workload container, record and assert:
+
+```bash
+test ! -e "$C7_SOURCE"
+test ! -e "$C7_SECRET"
+test ! -e "$C7_CONTROL"
+test ! -e "$C7_NOTIFY"
+cat "$C7_MOUNT/skills/weather/SKILL.md" >/dev/null
+```
+
+Record PID and mount namespace identifiers from each container and require the
+SkillFS and trusted probe values to differ. Do not enable a shared PID
+namespace to make executable authentication work.
+
+For the deliberate attacker case, mount only the runtime volume and repeat the
+plain and wrong-key tests. Seeing the socket must not grant authority.
+
+## 9. Restart and shutdown
+
+1. Record the SkillFS container restart count and a successful nonce.
+2. Terminate PID 1 in the SkillFS sidecar and wait for kubelet to restart it.
+3. Require the mount probe to pass again and issue another authenticated
+   `ping`; its nonce must be fresh.
+4. Restart the trusted notify probe and require a new mutation to authenticate
+   and deliver.
+5. Start the slow control probe, terminate SkillFS, and require shutdown and
+   unmount to finish within the configured handshake bound plus the normal
+   container termination grace period.
+6. Delete the Pod normally, wait for termination, and recreate it on the same
+   node. Startup must not report a residual FUSE mount or stale socket.
+
+Save pre/post restart counts, Pod events, SkillFS logs, probe output, and mount
+probe output.
+
+## 10. Credential disclosure check
+
+Collect SkillFS and probe logs, then run a comparison inside a trusted
+container without printing the credential encodings:
+
+```bash
+python3 - "$C7_SECRET" "$C7_EVIDENCE/combined.log" <<'PY'
+import base64
+import pathlib
+import sys
+
+secret = pathlib.Path(sys.argv[1]).read_bytes()
+logs = pathlib.Path(sys.argv[2]).read_bytes()
+markers = (secret, secret.hex().encode(), base64.b64encode(secret))
+if any(marker in logs for marker in markers):
+    raise SystemExit("FAIL: credential material appears in logs")
+print("PASS: raw, hex, and Base64 credential material absent from logs")
+PY
+```
+
+Also inspect JSON responses and protocol-event output. They may identify the
+authentication mode, but must contain no secret, proof, or reusable credential.
+
+## 11. Acceptance record
+
+Mark each item `PASS`, `FAIL`, or `NOT RUN` with an evidence filename:
+
+| ID | Required result |
+| --- | --- |
+| C7-U01 | real FUSE mount and propagated workload read pass |
+| C7-U02 | authenticated ping, status, and shared-path resolve pass |
+| C7-U03 | nonce differs; replay and modified business frames are rejected |
+| C7-U04 | plain, wrong-key, and same-UID/no-secret peers are rejected |
+| C7-U05 | slow partial authentication is bounded and listener recovers |
+| C7-U06 | all secret/config startup gates fail before mounting |
+| C7-U07 | authenticated notify v2 is received with unchanged business schema |
+| C7-U08 | invalid notify server proof blocks the business request |
+| C7-U09 | workload cannot see source, Secret, or private sockets |
+| C7-U10 | SkillFS and probe restart paths reauthenticate with fresh challenges |
+| C7-U11 | graceful deletion leaves no residual FUSE mount or socket |
+| C7-U12 | logs, responses, and events disclose no credential material |
+
+Any failed required row blocks unilateral acceptance. `NOT RUN` is allowed only
+when the environment cannot supply the required FUSE, privilege, propagation,
+or namespace feature, and the exact blocker is recorded.
+
+## 12. Interpretation
+
+A full pass is sufficient to ask sec-core maintainers to implement or review
+against the frozen contract in
+[`container-peer-authentication.md`](../design/container-peer-authentication.md).
+It is not sufficient to close #2439. Closure additionally requires real
+agent-sec-core resolver, notify, activation, failure, and restart integration in
+separate containers, followed by the focused ACK record.

--- a/src/skillfs/docs/testing/container-peer-authentication-unilateral-validation_zh.md
+++ b/src/skillfs/docs/testing/container-peer-authentication-unilateral-validation_zh.md
@@ -1,0 +1,365 @@
+# 容器 Peer 认证单方面验证计划
+
+[English](container-peer-authentication-unilateral-validation.md)
+
+这是 [issue #2439](https://github.com/alibaba/anolisa/issues/2439) 的 SkillFS
+侧测试执行计划。它可以在真实 Linux 或 Kubernetes 环境验证 container HMAC
+合同，不需要等待独立发布的 agent-sec-core image。
+
+独立的 Python 标准库 probe 位于
+[`scripts/container-peer-auth-probe.py`](../../scripts/container-peer-auth-probe.py)，
+它只扮演 control client 或 notify server。通过本计划可以证明 SkillFS 实现和
+跨语言 wire contract，但不能证明 agent-sec-core 配置、reconcile、activation
+decision 或发布就绪；这些仍需要双方联调和 ACK 证据。
+
+## 1. 固定测试输入
+
+修改环境前，在仓库外创建 evidence 目录并记录以下信息：
+
+```bash
+export C7_EVIDENCE=/var/tmp/skillfs-c7-evidence
+install -d -m 0700 "$C7_EVIDENCE"
+git rev-parse HEAD | tee "$C7_EVIDENCE/git-commit.txt"
+rustc --version | tee "$C7_EVIDENCE/rustc.txt"
+python3 --version | tee "$C7_EVIDENCE/python.txt"
+uname -a | tee "$C7_EVIDENCE/uname.txt"
+```
+
+Kubernetes 环境还需要记录不可变的集群和 image 输入：
+
+```bash
+kubectl version -o yaml >"$C7_EVIDENCE/kubernetes-version.yaml"
+kubectl get nodes -o wide >"$C7_EVIDENCE/nodes.txt"
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.containerRuntimeVersion}{"\n"}{end}' \
+  >"$C7_EVIDENCE/container-runtime.txt"
+kubectl -n "$C7_NAMESPACE" get pod "$C7_POD" -o yaml \
+  >"$C7_EVIDENCE/pod.yaml"
+kubectl -n "$C7_NAMESPACE" get pod "$C7_POD" \
+  -o jsonpath='{range .status.containerStatuses[*]}{.name}{"\t"}{.imageID}{"\n"}{end}' \
+  >"$C7_EVIDENCE/image-ids.txt"
+```
+
+不要把 Secret object、raw secret、proof 或可重用 credential 保存到 evidence
+目录。
+
+## 2. 必需拓扑
+
+使用三个 container，`shareProcessNamespace` 必须省略或设置为 `false`：
+
+| Container | Effective UID | Source | FUSE view | Runtime socket | Auth file |
+| --- | ---: | --- | --- | --- | --- |
+| SkillFS | 本轮使用 0 | read-write | mount 创建方 | read-write | read-only |
+| trusted probe | 本轮使用 0 | 相同绝对路径上的同一物理 source | 可选 | read-write | read-only |
+| workload / attacker | 普通 I/O 使用不同 UID；socket 负向测试再用 UID 0 重复 | 不挂载 | read-write，传播获得 | 默认不挂载；负向测试只读挂载 | 不挂载 |
+
+以下内容分别使用独立 volume：
+
+- physical source；
+- propagated FUSE view；
+- private runtime socket；
+- staged authentication file。
+
+Kubernetes Secret projection 的文件入口是 symlink，而生产 loader 使用
+`O_NOFOLLOW` 打开最终路径。因此不能把 projected Secret 路径直接传给 SkillFS。
+应由 init container 将 projected key 复制到可信 `emptyDir`，设置为 `0400` 或
+`0600`，并且只挂载给 SkillFS 和 trusted probe。这是验收要求，不是放宽
+no-follow 规则。
+
+首版 profile 要求 SkillFS 与 sec-core 在 authenticated notify 场景使用相同的
+effective UID，因为 SkillFS 会用自己的 effective UID 校验 sec-core 创建的 endpoint
+及其父目录。每个 auth file 也必须由读取它的进程 effective UID 所有。未来支持
+不同 UID 时，除了分别 stage 包含相同 raw bytes 的私有 key 副本，还必须明确引入
+新的 endpoint ownership policy。
+
+将 probe script mount 或复制到 trusted probe container。Evidence 可以写入挂载在
+`$C7_EVIDENCE` 的私有目录；否则先写入 probe container，再逐个使用 `kubectl cp`
+取回。Probe 和 evidence volume 都不能出现在 workload container 中。
+
+## 3. 准备 fixture
+
+可信 container 中统一使用以下路径：
+
+```bash
+export C7_SOURCE=/var/lib/skillfs/source
+export C7_MOUNT=/var/lib/skillfs/shared/mount
+export C7_RUNTIME=/run/anolisa
+export C7_SECRET=/run/anolisa/auth/skillfs.key
+export C7_CONTROL=/run/anolisa/skillfs/control.sock
+export C7_NOTIFY=/run/anolisa/probe/notify.sock
+export C7_PROBE=/workspace/src/skillfs/scripts/container-peer-auth-probe.py
+```
+
+创建 Kubernetes Secret 前生成一份 raw random key：
+
+```bash
+umask 077
+head -c 32 /dev/urandom >skillfs.key
+test "$(wc -c <skillfs.key)" -eq 32
+kubectl -n "$C7_NAMESPACE" create secret generic skillfs-c7-auth \
+  --from-file=skillfs.key=skillfs.key
+```
+
+准备带可见 snapshot 的 Flat-layout Skill。Live directory 也必须包含
+`SKILL.md`，这样 `skill.resolveLiveSource` 才能完成验证：
+
+```bash
+install -d -m 0755 \
+  "$C7_SOURCE/weather/.skill-meta/versions/v000001.snapshot"
+printf '%s\n' '---' 'name: weather' 'description: C7 validation' '---' \
+  >"$C7_SOURCE/weather/SKILL.md"
+cp "$C7_SOURCE/weather/SKILL.md" \
+  "$C7_SOURCE/weather/.skill-meta/versions/v000001.snapshot/SKILL.md"
+printf '%s\n' '{"schemaVersion":1,"target":".skill-meta/versions/v000001.snapshot"}' \
+  >"$C7_SOURCE/weather/.skill-meta/activation.json"
+```
+
+使用显式 container profile，以 foreground 方式启动 SkillFS：
+
+```bash
+skillfs mount "$C7_SOURCE" "$C7_MOUNT" \
+  --foreground --allow-other \
+  --security --activation-mode file \
+  --notify-socket "$C7_NOTIFY" \
+  --notify-auth-key-file "$C7_SECRET" \
+  --control-socket "$C7_CONTROL" \
+  --trusted-peer-key-file "$C7_SECRET"
+```
+
+继续测试前必须满足：
+
+- SkillFS process 保持运行；
+- `/proc/self/mountinfo` 中存在 mount；
+- workload 的 propagated view 可以读取 `skills/weather/SKILL.md`；
+- control socket 位于私有 runtime directory，mode 为 `0600`；
+- notify listener 使用 owner 匹配、不含 group/other bits 的 socket，并直接位于
+  owner 匹配且不含 group/other bits 的目录下，目录推荐使用 `0700`。
+
+## 4. Control 正向测试
+
+在 trusted probe container 执行：
+
+```bash
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"ping"}' \
+  | tee "$C7_EVIDENCE/control-ping.json"
+
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"status"}' \
+  | tee "$C7_EVIDENCE/control-status.json"
+
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request "{\"schemaVersion\":\"1\",\"method\":\"skill.resolveLiveSource\",\"canonicalSkillDir\":\"$C7_SOURCE/weather\"}" \
+  | tee "$C7_EVIDENCE/control-resolve.json"
+```
+
+预期结果：
+
+- 每个 process 完成 mutual authentication 后以零退出；
+- `ping` 返回 `ok=true` 和 `pong=true`；
+- `status` 保持现有 schema v1 business response；
+- resolve 返回 `managed=true`、`skillId=weather`、
+  `liveSkillDir=$C7_SOURCE/weather` 和 `transport=shared_path`；
+- 每条连接输出的 nonce 都不同。
+
+## 5. Control 负向测试
+
+### 5.1 Plain 和错误 key peer
+
+在 attacker container 中故意只挂 runtime socket，不挂真实 auth file。先使用普通
+workload UID，再使用与 SkillFS 相同的 UID 0 重复执行：
+
+```bash
+python3 "$C7_PROBE" plain --socket "$C7_CONTROL"
+umask 077
+head -c 32 /dev/urandom >/tmp/wrong-skillfs.key
+if python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret /tmp/wrong-skillfs.key \
+  --request '{"schemaVersion":"1","method":"ping"}'; then
+  echo 'FAIL: wrong-key peer was accepted' >&2
+  exit 1
+else
+  echo 'PASS: wrong-key peer was rejected'
+fi
+```
+
+Plain probe 必须输出 `PASS`。错误 key command 必须失败，并且不能收到 business
+response。SkillFS 必须保持 mounted，随后 trusted `ping` 仍需成功。
+
+### 5.2 Replay、业务篡改和缓慢发送的不完整 frame
+
+```bash
+python3 "$C7_PROBE" replay \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" --timeout 6
+python3 "$C7_PROBE" tamper \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" --timeout 6
+python3 "$C7_PROBE" slow \
+  --socket "$C7_CONTROL" --interval 1 --bound 7
+python3 "$C7_PROBE" control \
+  --socket "$C7_CONTROL" --secret "$C7_SECRET" \
+  --request '{"schemaVersion":"1","method":"ping"}'
+```
+
+Replay 必须观察到新 nonce，并且不能收到 `auth.ok`。Tamper probe 必须完成有效握手，
+但在修改 raw request 且未提供匹配 tag 后不能收到 response。Slow sender 必须在七秒
+内被断开。最后的 trusted request 必须通过，证明单请求 listener 已恢复。
+
+### 5.3 Secret 和配置启动门禁
+
+每一行都启动新的 SkillFS process，并确认它在留下 FUSE mount 或 socket 前以非零
+退出：
+
+| Case | Setup | 预期 diagnostic |
+| --- | --- | --- |
+| missing | 配置的文件不存在 | cannot open authentication key |
+| projected symlink | 直接使用 Kubernetes Secret entry | no-follow open failure |
+| FIFO | mode `0600` 且没有 writer | 不阻塞并拒绝非普通文件 |
+| short | 31 raw bytes | must contain 32–4096 bytes |
+| oversized | 4097 raw bytes | must contain 32–4096 bytes |
+| permissive | mode `0640` 或 `0644` | 拒绝 group 或 other permission |
+| wrong owner | owner 与 effective UID 不同 | 拒绝非 effective-user owner |
+| half-hardened | HMAC control 加 notify socket，但不提供 notify key | 要求 notify auth key |
+| mixed modes | 同时配置 trusted peer executable 和 key | mutually exclusive |
+
+每次失败后都保存 stderr，通过 `findmnt` 确认没有 residual mount，并确认 control、
+notify socket 均未残留。
+
+## 6. Notify 正向测试
+
+触发 mutation 前，在 trusted probe container 启动独立 notify server：
+
+```bash
+python3 "$C7_PROBE" notify-server \
+  --socket "$C7_NOTIFY" --secret "$C7_SECRET" \
+  --output "$C7_EVIDENCE/notify-request.json" \
+  >"$C7_EVIDENCE/notify-probe.log" 2>&1 &
+C7_NOTIFY_PID=$!
+```
+
+等待 `READY`，然后通过 workload 可见的 FUSE view 写入：
+
+```bash
+grep -q '^READY:' "$C7_EVIDENCE/notify-probe.log"
+date -u +%FT%TZ >"$C7_MOUNT/skills/weather/validation.txt"
+wait "$C7_NOTIFY_PID"
+python3 -m json.tool "$C7_EVIDENCE/notify-request.json"
+```
+
+预期结果：
+
+- probe 输出 `PASS: authenticated notify v2 recorded`；
+- request method 是 `skill_ledger.skillfs_notify_change`；
+- `params.schemaVersion` 是 `2`；
+- `params.canonicalSkillDir` 是 `$C7_SOURCE/weather`；
+- `params.skillId` 是 `weather`，changed path 使用相对路径；
+- 即使后续 notification delivery 失败，普通 FUSE I/O 仍能完成。
+
+Startup reconcile 可能产生第一条 notify。若发生，单独保存该证据，重新启动一次性
+probe，再执行 workload mutation。
+
+## 7. 错误 notify server proof
+
+让 probe 故意返回错误 server proof，再触发一次 FUSE mutation：
+
+```bash
+python3 "$C7_PROBE" notify-server \
+  --socket "$C7_NOTIFY" --secret "$C7_SECRET" \
+  --output "$C7_EVIDENCE/notify-must-not-exist.json" \
+  --wrong-server-proof \
+  >"$C7_EVIDENCE/notify-wrong-server.log" 2>&1 &
+C7_BAD_NOTIFY_PID=$!
+date -u +%FT%TZ >"$C7_MOUNT/skills/weather/wrong-server-proof.txt"
+wait "$C7_BAD_NOTIFY_PID"
+test ! -e "$C7_EVIDENCE/notify-must-not-exist.json"
+```
+
+Probe 必须报告错误 proof 后没有 business frame。SkillFS 必须记录 authentication
+failure、继续服务 FUSE I/O，并保持 activation mapping 不变。
+
+## 8. Namespace 和 volume 隔离
+
+在 workload container 中记录并断言：
+
+```bash
+test ! -e "$C7_SOURCE"
+test ! -e "$C7_SECRET"
+test ! -e "$C7_CONTROL"
+test ! -e "$C7_NOTIFY"
+cat "$C7_MOUNT/skills/weather/SKILL.md" >/dev/null
+```
+
+记录每个 container 的 PID 和 mount namespace identifier，SkillFS 与 trusted probe
+的值必须不同。不得为了让 executable authentication 工作而开启 shared PID
+namespace。
+
+对于故意设置的 attacker case，只挂 runtime volume，然后重复 plain 和错误 key
+测试。仅能看到 socket 不能获得 authority。
+
+## 9. Restart 和 shutdown
+
+1. 记录 SkillFS container restart count 和一次成功的 nonce。
+2. 终止 SkillFS sidecar PID 1，等待 kubelet 完成重启。
+3. 再次要求 mount probe 通过，并发送 authenticated `ping`，nonce 必须是新值。
+4. 重启 trusted notify probe，新的 mutation 必须重新认证并成功 delivery。
+5. 启动 slow control probe 后终止 SkillFS，shutdown 和 unmount 必须在 handshake
+   bound 加正常 container termination grace period 内完成。
+6. 正常删除 Pod，等待退出后在同一 node 重新创建。启动不得报告 residual FUSE
+   mount 或 stale socket。
+
+保存重启前后的 restart count、Pod event、SkillFS log、probe output 和 mount probe
+output。
+
+## 10. Credential 泄露检查
+
+收集 SkillFS 和 probe log，然后在 trusted container 内比较，但不要打印
+credential encoding：
+
+```bash
+python3 - "$C7_SECRET" "$C7_EVIDENCE/combined.log" <<'PY'
+import base64
+import pathlib
+import sys
+
+secret = pathlib.Path(sys.argv[1]).read_bytes()
+logs = pathlib.Path(sys.argv[2]).read_bytes()
+markers = (secret, secret.hex().encode(), base64.b64encode(secret))
+if any(marker in logs for marker in markers):
+    raise SystemExit("FAIL: credential material appears in logs")
+print("PASS: raw, hex, and Base64 credential material absent from logs")
+PY
+```
+
+同时检查 JSON response 和 protocol-event output。它们可以标识 authentication
+mode，但不能包含 secret、proof 或可重用 credential。
+
+## 11. 验收记录
+
+每项标记为 `PASS`、`FAIL` 或 `NOT RUN`，并填写 evidence 文件名：
+
+| ID | 必需结果 |
+| --- | --- |
+| C7-U01 | 真实 FUSE mount 和 propagated workload read 通过 |
+| C7-U02 | authenticated ping、status 和 shared-path resolve 通过 |
+| C7-U03 | 每条连接 nonce 不同，并拒绝 replay 和被修改的业务 frame |
+| C7-U04 | 拒绝 plain、错误 key、相同 UID 但无 Secret 的 peer |
+| C7-U05 | 缓慢发送的不完整认证有界，listener 可以恢复 |
+| C7-U06 | 所有 secret/config 启动门禁在 mount 前失败 |
+| C7-U07 | 收到 authenticated notify v2，business schema 保持不变 |
+| C7-U08 | 错误 notify server proof 阻止 business request |
+| C7-U09 | workload 无法看到 source、Secret 和 private socket |
+| C7-U10 | SkillFS 和 probe restart 后使用新 challenge 重新认证 |
+| C7-U11 | graceful deletion 不留下 residual FUSE mount 或 socket |
+| C7-U12 | log、response 和 event 不泄露 credential material |
+
+任意必需项失败都会阻断单方面验收。只有环境无法提供所需 FUSE、privilege、
+propagation 或 namespace feature 时才允许 `NOT RUN`，并且必须记录具体 blocker。
+
+## 12. 结论解释
+
+全部通过后，可以让 sec-core maintainer 根据冻结的
+[`container-peer-authentication.md`](../design/container-peer-authentication.md)
+实现或 review。但这不足以关闭 #2439。关闭前还需要在独立 container 中完成真实
+agent-sec-core resolver、notify、activation、failure、restart 联调，并补充聚焦的
+ACK 记录。

--- a/src/skillfs/scripts/container-peer-auth-probe.py
+++ b/src/skillfs/scripts/container-peer-auth-probe.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Independent probe for the SkillFS container peer authentication contract."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import socket
+import stat
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+AUTH_VERSION = "1"
+FRAME_LIMIT = 4096
+BUSINESS_FRAME_LIMIT = 64 * 1024
+NONCE_BYTES = 32
+MIN_SECRET_BYTES = 32
+MAX_SECRET_BYTES = 4096
+
+CONTROL_CLIENT_DOMAIN = b"anolisa.skillfs.control.client.v1"
+CONTROL_SERVER_DOMAIN = b"anolisa.skillfs.control.server.v1"
+NOTIFY_CLIENT_DOMAIN = b"anolisa.skillfs.notify.client.v1"
+NOTIFY_SERVER_DOMAIN = b"anolisa.skillfs.notify.server.v1"
+
+
+class ProbeError(RuntimeError):
+    """The peer did not satisfy the authentication test contract."""
+
+
+def load_secret(path: str) -> bytes:
+    """Load raw secret bytes without following the final path component."""
+    secret_path = Path(path)
+    if not secret_path.is_absolute():
+        raise ProbeError("secret path must be absolute")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open(secret_path, flags)
+    except OSError as error:
+        raise ProbeError(f"cannot open secret: {error}") from error
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ProbeError("secret must be a regular file")
+        secret = os.read(descriptor, MAX_SECRET_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if not MIN_SECRET_BYTES <= len(secret) <= MAX_SECRET_BYTES:
+        raise ProbeError("secret must contain 32 to 4096 raw bytes")
+    return secret
+
+
+def proof(secret: bytes, domain: bytes, nonce: bytes) -> bytes:
+    """Calculate one domain-separated HMAC-SHA256 proof."""
+    return hmac.new(secret, domain + b"\0" + nonce, hashlib.sha256).digest()
+
+
+def frame_proof(
+    secret: bytes,
+    domain: bytes,
+    nonce: bytes,
+    payload: bytes,
+) -> bytes:
+    """Bind one raw business payload to its handshake and sender direction."""
+    message = domain + b"\0frame\0" + nonce + len(payload).to_bytes(8, "big") + payload
+    return hmac.new(secret, message, hashlib.sha256).digest()
+
+
+def encode_frame(payload: dict[str, Any]) -> bytes:
+    """Encode one compact NDJSON authentication or business frame."""
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+
+
+def read_raw_frame(
+    connection: socket.socket,
+    deadline: float,
+    limit: int = FRAME_LIMIT,
+) -> bytes:
+    """Read one bounded raw frame under a wall-clock deadline."""
+    data = bytearray()
+    while len(data) <= limit:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ProbeError("frame deadline expired")
+        connection.settimeout(remaining)
+        chunk = connection.recv(1)
+        if not chunk:
+            raise ProbeError("peer closed the connection")
+        if chunk == b"\n":
+            return bytes(data)
+        data.extend(chunk)
+    raise ProbeError(f"peer frame exceeds {limit} bytes")
+
+
+def read_frame(
+    connection: socket.socket,
+    deadline: float,
+    limit: int = FRAME_LIMIT,
+) -> dict[str, Any]:
+    """Read and decode one bounded JSON frame."""
+    data = read_raw_frame(connection, deadline, limit)
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProbeError("peer sent invalid JSON") from error
+    if not isinstance(payload, dict):
+        raise ProbeError("peer frame must be an object")
+    return payload
+
+
+def decode_value(payload: dict[str, Any], name: str, size: int) -> bytes:
+    """Decode one canonical padded Base64 field of a fixed size."""
+    value = payload.get(name)
+    if not isinstance(value, str):
+        raise ProbeError(f"missing {name}")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, base64.binascii.Error) as error:
+        raise ProbeError(f"invalid {name}") from error
+    if base64.b64encode(decoded).decode("ascii") != value or len(decoded) != size:
+        raise ProbeError(f"non-canonical or incorrectly sized {name}")
+    return decoded
+
+
+def require_frame(payload: dict[str, Any], kind: str, fields: set[str]) -> None:
+    """Require an exact authentication frame shape."""
+    if (
+        payload.get("authVersion") != AUTH_VERSION
+        or payload.get("type") != kind
+        or set(payload) != fields
+    ):
+        raise ProbeError(f"unexpected {kind} frame")
+
+
+def send_authenticated_frame(
+    connection: socket.socket,
+    secret: bytes,
+    domain: bytes,
+    nonce: bytes,
+    payload: dict[str, Any],
+) -> None:
+    """Send one business frame followed by its session-bound tag."""
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    connection.sendall(raw + b"\n")
+    connection.sendall(
+        encode_frame(
+            {
+                "authVersion": AUTH_VERSION,
+                "type": "auth.frame",
+                "proof": base64.b64encode(
+                    frame_proof(secret, domain, nonce, raw)
+                ).decode("ascii"),
+            }
+        )
+    )
+
+
+def read_authenticated_frame(
+    connection: socket.socket,
+    secret: bytes,
+    domain: bytes,
+    nonce: bytes,
+    timeout: float,
+) -> dict[str, Any]:
+    """Verify a session-bound business frame before decoding its JSON."""
+    deadline = time.monotonic() + timeout
+    raw = read_raw_frame(connection, deadline, BUSINESS_FRAME_LIMIT)
+    tag = read_frame(connection, deadline)
+    require_frame(tag, "auth.frame", {"authVersion", "type", "proof"})
+    actual = decode_value(tag, "proof", hashlib.sha256().digest_size)
+    expected = frame_proof(secret, domain, nonce, raw)
+    if not hmac.compare_digest(actual, expected):
+        raise ProbeError("business frame proof does not match")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ProbeError("peer sent invalid business JSON") from error
+    if not isinstance(payload, dict):
+        raise ProbeError("peer business frame must be an object")
+    return payload
+
+
+def connect(path: str, timeout: float) -> socket.socket:
+    """Connect to one Unix socket with a bounded operation timeout."""
+    connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    connection.settimeout(timeout)
+    connection.connect(path)
+    return connection
+
+
+def client_handshake(
+    connection: socket.socket,
+    secret: bytes,
+    timeout: float,
+) -> bytes:
+    """Authenticate as a control client and return the fresh nonce."""
+    deadline = time.monotonic() + timeout
+    connection.sendall(encode_frame({"authVersion": AUTH_VERSION, "type": "auth.init"}))
+    challenge = read_frame(connection, deadline)
+    require_frame(challenge, "auth.challenge", {"authVersion", "type", "nonce"})
+    nonce = decode_value(challenge, "nonce", NONCE_BYTES)
+    connection.sendall(
+        encode_frame(
+            {
+                "authVersion": AUTH_VERSION,
+                "type": "auth.proof",
+                "proof": base64.b64encode(
+                    proof(secret, CONTROL_CLIENT_DOMAIN, nonce)
+                ).decode("ascii"),
+            }
+        )
+    )
+    accepted = read_frame(connection, deadline)
+    require_frame(accepted, "auth.ok", {"authVersion", "type", "proof"})
+    server_proof = decode_value(accepted, "proof", hashlib.sha256().digest_size)
+    if not hmac.compare_digest(
+        server_proof,
+        proof(secret, CONTROL_SERVER_DOMAIN, nonce),
+    ):
+        raise ProbeError("server proof does not match")
+    return nonce
+
+
+def command_control(arguments: argparse.Namespace) -> None:
+    """Authenticate to the control socket and issue one business request."""
+    secret = load_secret(arguments.secret)
+    request = json.loads(arguments.request)
+    if not isinstance(request, dict):
+        raise ProbeError("control request must be a JSON object")
+    with connect(arguments.socket, arguments.timeout) as connection:
+        nonce = client_handshake(connection, secret, arguments.timeout)
+        send_authenticated_frame(
+            connection,
+            secret,
+            CONTROL_CLIENT_DOMAIN,
+            nonce,
+            request,
+        )
+        response = read_authenticated_frame(
+            connection,
+            secret,
+            CONTROL_SERVER_DOMAIN,
+            nonce,
+            arguments.timeout,
+        )
+    print(
+        json.dumps(
+            {"nonce": base64.b64encode(nonce).decode("ascii"), "response": response}
+        )
+    )
+
+
+def command_plain(arguments: argparse.Namespace) -> None:
+    """Pass only when an HMAC control server rejects a plain request."""
+    with connect(arguments.socket, arguments.timeout) as connection:
+        connection.sendall(arguments.request.encode("utf-8") + b"\n")
+        connection.settimeout(arguments.timeout)
+        response = connection.recv(FRAME_LIMIT + 1)
+    if response:
+        raise ProbeError(f"plain request unexpectedly received data: {response!r}")
+    print("PASS: plain control request rejected")
+
+
+def command_replay(arguments: argparse.Namespace) -> None:
+    """Pass only when a proof from an earlier connection is rejected."""
+    secret = load_secret(arguments.secret)
+    with connect(arguments.socket, arguments.timeout) as first:
+        first.sendall(encode_frame({"authVersion": AUTH_VERSION, "type": "auth.init"}))
+        first_challenge = read_frame(first, time.monotonic() + arguments.timeout)
+        first_nonce = decode_value(first_challenge, "nonce", NONCE_BYTES)
+        stale_proof = proof(secret, CONTROL_CLIENT_DOMAIN, first_nonce)
+
+    # The single-request listener may still be retiring the abandoned first
+    # handshake. Wait for its bounded deadline before opening the replay.
+    time.sleep(min(arguments.timeout, 0.2))
+    with connect(arguments.socket, arguments.timeout) as second:
+        second.sendall(encode_frame({"authVersion": AUTH_VERSION, "type": "auth.init"}))
+        second_challenge = read_frame(second, time.monotonic() + arguments.timeout)
+        second_nonce = decode_value(second_challenge, "nonce", NONCE_BYTES)
+        if hmac.compare_digest(first_nonce, second_nonce):
+            raise ProbeError("server reused a challenge nonce")
+        second.sendall(
+            encode_frame(
+                {
+                    "authVersion": AUTH_VERSION,
+                    "type": "auth.proof",
+                    "proof": base64.b64encode(stale_proof).decode("ascii"),
+                }
+            )
+        )
+        second.settimeout(arguments.timeout)
+        response = second.recv(FRAME_LIMIT + 1)
+    if response:
+        raise ProbeError(f"replayed proof unexpectedly received data: {response!r}")
+    print("PASS: fresh nonce observed and replayed proof rejected")
+
+
+def command_tamper(arguments: argparse.Namespace) -> None:
+    """Pass only when a modified business frame is rejected after auth."""
+    secret = load_secret(arguments.secret)
+    original = json.loads(arguments.original_request)
+    tampered = json.loads(arguments.tampered_request)
+    if not isinstance(original, dict) or not isinstance(tampered, dict):
+        raise ProbeError("control requests must be JSON objects")
+    original_raw = json.dumps(original, separators=(",", ":")).encode("utf-8")
+    tampered_raw = json.dumps(tampered, separators=(",", ":")).encode("utf-8")
+    with connect(arguments.socket, arguments.timeout) as connection:
+        nonce = client_handshake(connection, secret, arguments.timeout)
+        connection.sendall(tampered_raw + b"\n")
+        connection.sendall(
+            encode_frame(
+                {
+                    "authVersion": AUTH_VERSION,
+                    "type": "auth.frame",
+                    "proof": base64.b64encode(
+                        frame_proof(
+                            secret,
+                            CONTROL_CLIENT_DOMAIN,
+                            nonce,
+                            original_raw,
+                        )
+                    ).decode("ascii"),
+                }
+            )
+        )
+        connection.settimeout(arguments.timeout)
+        response = connection.recv(FRAME_LIMIT + 1)
+    if response:
+        raise ProbeError(f"tampered request unexpectedly received data: {response!r}")
+    print("PASS: tampered authenticated business frame rejected")
+
+
+def command_slow(arguments: argparse.Namespace) -> None:
+    """Pass only when a slow partial auth frame cannot retain the server."""
+    frame = encode_frame({"authVersion": AUTH_VERSION, "type": "auth.init"})
+    started = time.monotonic()
+    with connect(arguments.socket, arguments.bound) as connection:
+        rejected = False
+        for byte in frame:
+            if time.monotonic() - started > arguments.bound:
+                break
+            try:
+                connection.sendall(bytes([byte]))
+                connection.settimeout(0.01)
+                if connection.recv(1) == b"":
+                    rejected = True
+                    break
+            except socket.timeout:
+                pass
+            except (BrokenPipeError, ConnectionResetError):
+                rejected = True
+                break
+            time.sleep(arguments.interval)
+    elapsed = time.monotonic() - started
+    if not rejected or elapsed > arguments.bound:
+        raise ProbeError(f"slow auth was not rejected within {arguments.bound}s")
+    print(f"PASS: slow auth rejected after {elapsed:.3f}s")
+
+
+def command_self_test(_arguments: argparse.Namespace) -> None:
+    """Pin handshake and business-frame proofs independently of Rust code."""
+    secret = bytes(range(32))
+    nonce = bytes(range(32, 64))
+    expected = {
+        CONTROL_CLIENT_DOMAIN: "pqaSiunq07XWqMvQ8xSiSLi6dsLEy5iaCEF3md04AVI=",
+        CONTROL_SERVER_DOMAIN: "naSgjgOT+Zs71EytW6byhJMCkfek2sGmK+CDqHmDsas=",
+        NOTIFY_CLIENT_DOMAIN: "aFcVadTie7FrVTYOjk1OOjBpoQZ6LUvnLGC6stiqt6M=",
+        NOTIFY_SERVER_DOMAIN: "F22J+ua0Pmha2dPyTMmTQNtKjcmed59Mo8FKgdcgBOc=",
+    }
+    for domain, encoded in expected.items():
+        actual = base64.b64encode(proof(secret, domain, nonce)).decode("ascii")
+        if not hmac.compare_digest(actual, encoded):
+            raise ProbeError(f"fixed vector mismatch for {domain.decode('ascii')}")
+    payload = b'{"schemaVersion":"1","method":"ping"}'
+    frame_expected = {
+        CONTROL_CLIENT_DOMAIN: "zT6arzIjdC4fJqiSM59qNhU2BADHJgFRq8YqifcdHCM=",
+        CONTROL_SERVER_DOMAIN: "W9lF84f43ROoMXPHkgovtowDiZ5zv0zubs2vmq98T9k=",
+        NOTIFY_CLIENT_DOMAIN: "Zzf/dpWsuj89DFbpJtwqBk5dHsV+GXwGOytZMh5xDKw=",
+        NOTIFY_SERVER_DOMAIN: "ut2Pv/8XHmiImbWSfm53ixIcoDimZOPHzrS6g3TtO+M=",
+    }
+    for domain, encoded in frame_expected.items():
+        actual = base64.b64encode(frame_proof(secret, domain, nonce, payload)).decode(
+            "ascii"
+        )
+        if not hmac.compare_digest(actual, encoded):
+            raise ProbeError(
+                f"fixed frame vector mismatch for {domain.decode('ascii')}"
+            )
+    print("PASS: all handshake and business-frame HMAC vectors match")
+
+
+def server_handshake(
+    connection: socket.socket,
+    secret: bytes,
+    timeout: float,
+    wrong_server_proof: bool,
+) -> bytes:
+    """Authenticate one SkillFS notify client."""
+    deadline = time.monotonic() + timeout
+    init = read_frame(connection, deadline)
+    require_frame(init, "auth.init", {"authVersion", "type"})
+    nonce = secrets.token_bytes(NONCE_BYTES)
+    connection.sendall(
+        encode_frame(
+            {
+                "authVersion": AUTH_VERSION,
+                "type": "auth.challenge",
+                "nonce": base64.b64encode(nonce).decode("ascii"),
+            }
+        )
+    )
+    client = read_frame(connection, deadline)
+    require_frame(client, "auth.proof", {"authVersion", "type", "proof"})
+    client_proof = decode_value(client, "proof", hashlib.sha256().digest_size)
+    if not hmac.compare_digest(
+        client_proof,
+        proof(secret, NOTIFY_CLIENT_DOMAIN, nonce),
+    ):
+        raise ProbeError("notify client proof does not match")
+    server_proof = proof(secret, NOTIFY_SERVER_DOMAIN, nonce)
+    if wrong_server_proof:
+        server_proof = bytes([server_proof[0] ^ 1]) + server_proof[1:]
+    connection.sendall(
+        encode_frame(
+            {
+                "authVersion": AUTH_VERSION,
+                "type": "auth.ok",
+                "proof": base64.b64encode(server_proof).decode("ascii"),
+            }
+        )
+    )
+    return nonce
+
+
+def command_notify_server(arguments: argparse.Namespace) -> None:
+    """Accept and record one mutually authenticated notify v2 request."""
+    secret = load_secret(arguments.secret)
+    socket_path = Path(arguments.socket)
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(socket_path.parent, 0o700)
+    if socket_path.exists():
+        socket_path.unlink()
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        listener.bind(str(socket_path))
+        os.chmod(socket_path, 0o600)
+        listener.listen(1)
+        listener.settimeout(arguments.timeout)
+        print(f"READY: {socket_path}", flush=True)
+        connection, _ = listener.accept()
+        with connection:
+            nonce = server_handshake(
+                connection,
+                secret,
+                arguments.timeout,
+                arguments.wrong_server_proof,
+            )
+            if arguments.wrong_server_proof:
+                connection.settimeout(0.5)
+                try:
+                    unexpected = connection.recv(FRAME_LIMIT + 1)
+                except socket.timeout:
+                    unexpected = b""
+                if unexpected:
+                    raise ProbeError(
+                        "client sent business data after a wrong server proof"
+                    )
+                print("PASS: wrong notify server proof blocked business data")
+                return
+            request = read_authenticated_frame(
+                connection,
+                secret,
+                NOTIFY_CLIENT_DOMAIN,
+                nonce,
+                arguments.timeout,
+            )
+            if request.get("method") != "skill_ledger.skillfs_notify_change":
+                raise ProbeError("unexpected notify business method")
+            Path(arguments.output).write_text(
+                json.dumps(request, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            send_authenticated_frame(
+                connection,
+                secret,
+                NOTIFY_SERVER_DOMAIN,
+                nonce,
+                {
+                    "ok": True,
+                    "data": {"schemaVersion": 2, "accepted": True},
+                },
+            )
+            print("PASS: authenticated notify v2 recorded")
+    finally:
+        listener.close()
+        try:
+            socket_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the probe command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_socket_timeout(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument("--socket", required=True)
+        subparser.add_argument("--timeout", type=float, default=6.0)
+
+    control = subparsers.add_parser("control", help="authenticate and send a request")
+    add_socket_timeout(control)
+    control.add_argument("--secret", required=True)
+    control.add_argument("--request", required=True)
+    control.set_defaults(handler=command_control)
+
+    plain = subparsers.add_parser("plain", help="assert plain control rejection")
+    add_socket_timeout(plain)
+    plain.add_argument(
+        "--request",
+        default='{"schemaVersion":"1","method":"ping"}',
+    )
+    plain.set_defaults(handler=command_plain)
+
+    replay = subparsers.add_parser("replay", help="assert stale proof rejection")
+    add_socket_timeout(replay)
+    replay.add_argument("--secret", required=True)
+    replay.set_defaults(handler=command_replay)
+
+    tamper = subparsers.add_parser("tamper", help="assert business-frame integrity")
+    add_socket_timeout(tamper)
+    tamper.add_argument("--secret", required=True)
+    tamper.add_argument(
+        "--original-request",
+        default='{"schemaVersion":"1","method":"ping"}',
+    )
+    tamper.add_argument(
+        "--tampered-request",
+        default='{"schemaVersion":"1","method":"status"}',
+    )
+    tamper.set_defaults(handler=command_tamper)
+
+    slow = subparsers.add_parser("slow", help="assert total handshake deadline")
+    slow.add_argument("--socket", required=True)
+    slow.add_argument("--interval", type=float, default=1.0)
+    slow.add_argument("--bound", type=float, default=7.0)
+    slow.set_defaults(handler=command_slow)
+
+    self_test = subparsers.add_parser(
+        "self-test",
+        help="verify fixed handshake and business-frame vectors",
+    )
+    self_test.set_defaults(handler=command_self_test)
+
+    notify = subparsers.add_parser("notify-server", help="serve one notify request")
+    add_socket_timeout(notify)
+    notify.add_argument("--secret", required=True)
+    notify.add_argument("--output", required=True)
+    notify.add_argument("--wrong-server-proof", action="store_true")
+    notify.set_defaults(handler=command_notify_server)
+    return parser
+
+
+def main() -> int:
+    """Run one probe command and return a shell-friendly status."""
+    arguments = build_parser().parse_args()
+    try:
+        arguments.handler(arguments)
+    except (OSError, ProbeError, json.JSONDecodeError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

SkillFS currently authenticates a local control peer by executable identity. That
does not work across container PID and mount namespaces, while accepting an
unauthenticated Unix socket peer would weaken the existing security boundary.

This change adds an opt-in, shared-secret HMAC mode owned entirely by SkillFS.
The peer-side implementation remains a separate sec-core follow-up after its
maintainers confirm the proposed contract.

## What changed

- Add mutual HMAC-SHA256 authentication to the SkillFS control server and notify
  client, with domain-separated proofs and fixed cross-language vectors.
- Keep the existing executable-identity control path and plain notify path
  unchanged when the new key flags are absent.
- Load keys fail-closed from strict regular files and enforce one total
  authentication deadline, including slow and replay rejection coverage.
- Add the proposed peer contract, a unilateral real-environment validation plan,
  and an independent Python protocol probe.
- Do not modify any `src/agent-sec-core/**` source, test, or documentation file.

## Related issue

Refs #2439 and #2012. This draft does not close either issue because peer-side
implementation, contract ACK, and ACK-cluster evidence are still pending.

## User / Agent impact

SkillFS gains two opt-in flags: `--trusted-peer-key-file` for its control server
and `--notify-auth-key-file` for its notify client. Existing host deployments are
unchanged. This PR does not configure or implement agent-sec-core support.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The new behavior is gated by explicit key-file flags. Half-configured HMAC paths
fail during startup; the existing host executable authentication and unauthenticated
notify behavior remain the defaults. The peer contract is proposed for review and
is not presented as an implemented sec-core API.

## Validation

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 doc --workspace --no-deps`
- `src/skillfs/scripts/test.sh` on Linux with `/dev/fuse`
- `scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- Independent probe formatting/lint and `container-peer-auth-probe.py self-test`
- Manual real-FUSE probe: valid mutual auth, plain/wrong-key/replay/slow-peer
  rejection, and Rust notify client to Python peer

## Documentation and rollback

The bilingual SkillFS runtime guide, component README, proposed protocol contract,
and unilateral validation plan are updated. To roll back operationally, remove the
new HMAC key flags and continue using the existing host executable control gate and
plain notify transport. The commit can also be reverted without a data migration.
