### PR TITLE
fix(sight): keep tool_call name across SSE continuation deltas

### DIFF
--- a/src/agentsight/src/analyzer/message/openai.rs
+++ b/src/agentsight/src/analyzer/message/openai.rs
@@ -445,7 +445,12 @@ impl OpenAIParser {
                             }
                             if let Some(func) = tc.get("function") {
                                 if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
-                                    entry.1 = name.to_string();
+                                    if !name.is_empty() {
+                                        entry.1 = name.to_string();
+                                    }
+                                    // Empty string must not overwrite an existing name: some
+                                    // backends (e.g. deepseek models on DashScope) repeat
+                                    // name:"" on every continuation delta.
                                 }
                                 if let Some(args) = func.get("arguments").and_then(|v| v.as_str()) {
                                     entry.2.push_str(args);
@@ -1077,6 +1082,52 @@ mod tests {
         assert_eq!(
             func.get("arguments").unwrap().as_str().unwrap(),
             "{\"city\":\"Beijing\"}"
+        );
+    }
+
+    /// Regression: deepseek models on DashScope repeat `id:""` + `name:""` on every
+    /// continuation delta. The empty name used to overwrite the real one, so the
+    /// aggregated tool call ended up with an empty name.
+    #[test]
+    fn test_aggregate_sse_chunks_empty_name_in_continuation() {
+        let chunk = |tc: serde_json::Value, finish: Option<&str>| {
+            serde_json::json!({
+                "id": "chatcmpl-1",
+                "object": "chat.completion.chunk",
+                "created": 1_786_504_982u64,
+                "model": "deepseek-v4-flash",
+                "choices": [{"index": 0, "delta": {"tool_calls": [tc]}, "finish_reason": finish}]
+            })
+        };
+        let chunks = vec![
+            chunk(
+                serde_json::json!({"index": 0, "id": "call_1", "type": "function", "function": {"name": "read_file", "arguments": ""}}),
+                None,
+            ),
+            chunk(
+                serde_json::json!({"index": 0, "id": "", "type": "function", "function": {"name": "", "arguments": "{\"file_path\""}}),
+                None,
+            ),
+            chunk(
+                serde_json::json!({"index": 0, "id": "", "type": "function", "function": {"name": "", "arguments": ": \"/tmp/a.md\"}"}}),
+                Some("tool_calls"),
+            ),
+        ];
+
+        let body = serde_json::Value::Array(chunks);
+        let resp = OpenAIParser::parse_response(&body).expect("chat SSE chunks should aggregate");
+        assert_eq!(
+            resp.choices[0].finish_reason,
+            Some("tool_calls".to_string())
+        );
+        let tc = resp.choices[0].message.tool_calls.as_ref().unwrap();
+        assert_eq!(tc.len(), 1);
+        assert_eq!(tc[0].get("id").unwrap().as_str().unwrap(), "call_1");
+        let func = tc[0].get("function").unwrap();
+        assert_eq!(func.get("name").unwrap().as_str().unwrap(), "read_file");
+        assert_eq!(
+            func.get("arguments").unwrap().as_str().unwrap(),
+            "{\"file_path\": \"/tmp/a.md\"}"
         );
     }
 }

--- a/src/agentsight/src/genai/openai_parse.rs
+++ b/src/agentsight/src/genai/openai_parse.rs
@@ -398,7 +398,12 @@ impl GenAIBuilder {
                         }
                         if let Some(func) = tc.get("function") {
                             if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
-                                entry.1 = name.to_string();
+                                if !name.is_empty() {
+                                    entry.1 = name.to_string();
+                                }
+                                // Empty string must not overwrite an existing name: some
+                                // backends (e.g. deepseek models on DashScope) repeat
+                                // name:"" on every continuation delta.
                             }
                             if let Some(args) = func.get("arguments").and_then(|v| v.as_str()) {
                                 entry.2.push_str(args);
@@ -648,6 +653,47 @@ mod tests {
                 assert_eq!(id.as_deref(), Some("tc_1"));
                 assert_eq!(name, "search");
                 assert_eq!(arguments.as_ref().unwrap()["q"], "rust");
+            }
+            _ => panic!("expected ToolCall"),
+        }
+        assert_eq!(finish, Some("tool_calls".to_string()));
+    }
+
+    /// Regression: deepseek models on DashScope repeat `id:""` + `name:""` on every
+    /// continuation delta. The empty name used to overwrite the real one, so reported
+    /// tool calls ended up with an empty name.
+    #[test]
+    fn test_extract_parts_from_sse_body_tool_calls_empty_name_in_continuation() {
+        let body = r#"[
+            {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read_file","arguments":""}}]}}]},
+            {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","type":"function","function":{"name":"","arguments":"{\"file_path\""}}]}}]},
+            {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"","type":"function","function":{"name":"","arguments":": \"/tmp/a.md\"}"}}]}}]},
+            {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"list_dir","arguments":""}}]}}]},
+            {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"","type":"function","function":{"name":"","arguments":"{\"path\": \"/tmp\"}"}}]},"finish_reason":"tool_calls"}]}
+        ]"#;
+        let (parts, finish) = GenAIBuilder::extract_parts_from_sse_body(body).unwrap();
+        assert_eq!(parts.len(), 2);
+        match &parts[0] {
+            MessagePart::ToolCall {
+                id,
+                name,
+                arguments,
+            } => {
+                assert_eq!(id.as_deref(), Some("call_1"));
+                assert_eq!(name, "read_file");
+                assert_eq!(arguments.as_ref().unwrap()["file_path"], "/tmp/a.md");
+            }
+            _ => panic!("expected ToolCall"),
+        }
+        match &parts[1] {
+            MessagePart::ToolCall {
+                id,
+                name,
+                arguments,
+            } => {
+                assert_eq!(id.as_deref(), Some("call_2"));
+                assert_eq!(name, "list_dir");
+                assert_eq!(arguments.as_ref().unwrap()["path"], "/tmp");
             }
             _ => panic!("expected ToolCall"),
         }


### PR DESCRIPTION
## Why

  OpenAI 兼容后端下发 tool_call 增量的方式并不一致：DashScope 上的 deepseek 系列
  在每一个续传 delta 里都会重复下发完整的 tool_call 骨架，其中 `id` 和 `name`
  都是空字符串；而 qwen 系列则直接省略这两个 key。

  两处 SSE 合并逻辑都对 `id` 做了"空字符串不覆盖已有值"的保护，但 `name` 是无条件
  赋值的。结果首帧拿到的真实工具名被后续帧的空字符串覆盖，`gen_ai.output.messages`
  里每一个 tool_call 的 `name` 都变成了 `""`。

  实测 deepseek-v4-flash：`arguments` 完整、`id` 保住了，只有 `name` 是空。而 agent
  自己的 session state 里，同一个 call id 记录的是 `"name":"read_file"` —— 说明工具名
  确实在链路上传输过，是在合并阶段丢掉的。

  ## What changed

  给两处 SSE 合并逻辑的 `name` 加上与 `id` 相同的非空判断：

  - `src/agentsight/src/genai/openai_parse.rs` — `extract_parts_from_sse_body`
  - `src/agentsight/src/analyzer/message/openai.rs` — `aggregate_sse_chunks`

  并各补一个回归测试，用 deepseek 的真实 delta 形状（首帧带 `id` + `name`，
  续传帧为 `id:""` + `name:""` + 参数片段）覆盖；其中一个测试同时覆盖
  index 0 / 1 两个并行 tool_call。

  ## Related issue

  no-issue: 单点解析 bug，修复范围为两行判空 + 两个回归测试

  ## User / Agent impact

  修复后 `gen_ai.output.messages` 中 tool_call 的 `name` 恢复为真实工具名。
  此前受影响的下游包括所有按工具名聚合的消费方：skill_metrics、ATIF 导出、
  工具使用分布统计。

  注意：已经上报的历史数据无法回填，需要重新采集。

  ## Risk and compatibility

  - [ ] Public CLI, API, configuration, or documented behavior changed
  - [ ] Privileged or security-sensitive behavior changed
  - [ ] Cross-component contract changed
  - [ ] Migration or rollback guidance is needed

  Low risk：仅在原有赋值上增加判空条件，不改变任何结构、签名或配置。
  之前 `name` 非空的链路（如 qwen 系列，其续传 delta 不带 `name` key）行为完全不变。

  ## Validation

  - `cargo fmt --check`：通过
  - 新增两个回归测试（修复前必然失败，因为空字符串会覆盖首帧的真实 name）：
    - `genai::openai_parse::tests::test_extract_parts_from_sse_body_tool_calls_empty_name_in_continuation`
    - `analyzer::message::openai::tests::test_aggregate_sse_chunks_empty_name_in_continuation`
  - `cargo test` 本地仍在冷编译中，尚未拿到结果，以 CI 为准
  - 线上证据：deepseek-v4-flash 采集记录中 tool_call `name` 为空，
    与 agent session state 里同一 call id 的 `read_file` 对照；
    同机历史库中 16 条 qwen3.5/3.6-plus 的 tool_call 记录 `name` 均正常，
    与"后端行为差异"的判断一致

  ## Documentation and rollback

  无文档变更（不涉及对外行为契约）。回滚直接 revert 本 commit 即可，
  无需迁移、无状态残留。