### PR TITLE
fix(sec-core): add validation on input params

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -531,6 +531,18 @@ def events(
         )
         # Don't reject — allow future categories, just warn
 
+    if last_hours is not None and last_hours < 0:
+        typer.echo("Error: --last-hours must be non-negative.", err=True)
+        raise typer.Exit(code=1)
+
+    if limit <= 0:
+        typer.echo("Error: --limit must be positive.", err=True)
+        raise typer.Exit(code=1)
+
+    if offset < 0:
+        typer.echo("Error: --offset must be non-negative.", err=True)
+        raise typer.Exit(code=1)
+
     if last_hours is not None and (since is not None or until is not None):
         typer.echo(
             "Error: --last-hours is mutually exclusive with --since/--until.",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/handlers/security_query.py
@@ -1,6 +1,7 @@
 """Read-only daemon handlers for security and observability SQLite data."""
 
 import json
+from datetime import datetime
 from pathlib import PurePath
 from typing import Any
 
@@ -28,7 +29,9 @@ from agent_sec_cli.utils.timestamp import (
 
 _DEFAULT_LIMIT = 100
 _MAX_LIMIT = 1000
+_MAX_OFFSET = (1 << 63) - 1
 _SUMMARY_LATEST_LIMIT = 5
+_EVENT_RESULTS = frozenset({"failed", "succeeded"})
 _EVENT_GROUP_FIELDS = {
     "category",
     "event_type",
@@ -337,7 +340,7 @@ def _security_filters(params: dict[str, Any]) -> dict[str, str | None]:
     return {
         "event_type": _optional_string_param(params, "event_type"),
         "category": _optional_string_param(params, "category"),
-        "result": _optional_string_param(params, "result"),
+        "result": _optional_choice_param(params, "result", _EVENT_RESULTS),
         "trace_id": _optional_string_param(params, "trace_id"),
         "session_id": _optional_string_param(params, "session_id"),
         "run_id": _optional_string_param(params, "run_id"),
@@ -486,15 +489,33 @@ def _iso_range(params: dict[str, Any]) -> tuple[str | None, str | None]:
         raise BadRequestError("until and end_ns are mutually exclusive")
     if start_ns is not None:
         # Nanosecond filters are absolute epoch time, so convert directly to UTC.
-        since = ns_to_utc_iso(_integer_param(params, "start_ns"))
+        since = _nanoseconds_to_utc_iso(params, "start_ns")
     elif since is not None:
         # String filters may be naive local time; normalize before reader/repository calls.
         since = _normalize_iso_timestamp(since, "since")
     if end_ns is not None:
-        until = ns_to_utc_iso(_integer_param(params, "end_ns"))
+        until = _nanoseconds_to_utc_iso(params, "end_ns")
     elif until is not None:
         until = _normalize_iso_timestamp(until, "until")
+    _validate_time_range(since, until)
     return since, until
+
+
+def _nanoseconds_to_utc_iso(params: dict[str, Any], name: str) -> str:
+    value = _integer_param(params, name)
+    try:
+        return ns_to_utc_iso(value)
+    except (OSError, OverflowError, ValueError) as exc:
+        raise BadRequestError(
+            f"{name} is outside the supported timestamp range"
+        ) from exc
+
+
+def _validate_time_range(since: str | None, until: str | None) -> None:
+    if since is None or until is None:
+        return
+    if datetime.fromisoformat(since) > datetime.fromisoformat(until):
+        raise BadRequestError("time range start must not be after end")
 
 
 def _epoch_range(params: dict[str, Any]) -> tuple[float | None, float | None]:
@@ -532,6 +553,23 @@ def _optional_string_param(params: dict[str, Any], name: str) -> str | None:
     return value or None
 
 
+def _optional_choice_param(
+    params: dict[str, Any],
+    name: str,
+    choices: frozenset[str],
+) -> str | None:
+    if name not in params or params[name] is None:
+        return None
+    value = params[name]
+    if not isinstance(value, str):
+        raise BadRequestError(f"{name} must be a string")
+    value = value.strip()
+    if value not in choices:
+        allowed = ", ".join(sorted(choices))
+        raise BadRequestError(f"{name} must be one of: {allowed}")
+    return value
+
+
 def _limit_param(
     params: dict[str, Any],
     name: str,
@@ -555,6 +593,8 @@ def _offset_param(params: dict[str, Any]) -> int:
         raise BadRequestError("offset must be an integer")
     if value < 0:
         raise BadRequestError("offset must not be negative")
+    if value > _MAX_OFFSET:
+        raise BadRequestError(f"offset must not exceed {_MAX_OFFSET}")
     return value
 
 

--- a/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_security_query_handler.py
@@ -489,6 +489,100 @@ def test_security_query_validation_errors_are_bad_request(tmp_path: Path) -> Non
     assert count_by_offset.error["code"] == "bad_request"
 
 
+@pytest.mark.parametrize(
+    ("method", "params", "message"),
+    [
+        (
+            "sec.events.list",
+            {"result": "success"},
+            "result must be one of: failed, succeeded",
+        ),
+        (
+            "sec.events.list",
+            {"result": ""},
+            "result must be one of: failed, succeeded",
+        ),
+        (
+            "sec.events.list",
+            {
+                "since": "2026-01-02T00:00:00Z",
+                "until": "2026-01-01T00:00:00Z",
+            },
+            "time range start must not be after end",
+        ),
+        (
+            "obs.sessions.list",
+            {"start_ns": 2_000_000_000, "end_ns": 1_000_000_000},
+            "time range start must not be after end",
+        ),
+        (
+            "obs.runs.list",
+            {
+                "session_id": "session-1",
+                "since": "1970-01-01T00:00:02Z",
+                "end_ns": 1_000_000_000,
+            },
+            "time range start must not be after end",
+        ),
+        (
+            "sec.events.list",
+            {"start_ns": 10**100},
+            "start_ns is outside the supported timestamp range",
+        ),
+        (
+            "obs.timeline.get",
+            {"session_id": "session-1", "run_id": "run-1", "end_ns": 10**100},
+            "end_ns is outside the supported timestamp range",
+        ),
+        (
+            "sec.events.list",
+            {"offset": security_query._MAX_OFFSET + 1},
+            f"offset must not exceed {security_query._MAX_OFFSET}",
+        ),
+    ],
+)
+def test_security_query_rejects_invalid_existing_parameter_values_before_reading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+    params: dict[str, Any],
+    message: str,
+) -> None:
+    def fail_reader() -> None:
+        raise AssertionError(
+            "invalid parameters must be rejected before opening readers"
+        )
+
+    monkeypatch.setattr(security_query, "SqliteEventReader", fail_reader)
+    monkeypatch.setattr(security_query, "ObservabilityReader", fail_reader)
+
+    response = _call_daemon(tmp_path, method, params)
+
+    assert response.ok is False
+    assert response.error == {"code": "bad_request", "message": message}
+
+
+def test_security_query_accepts_parameter_boundaries(tmp_path: Path) -> None:
+    equal_time = "2026-01-01T00:00:00Z"
+    _write_observability_event(tmp_path)
+
+    result_response = _call_daemon(
+        tmp_path,
+        "sec.events.list",
+        {"result": "failed", "since": equal_time, "until": equal_time},
+    )
+    offset_response = _call_daemon(
+        tmp_path,
+        "obs.sessions.list",
+        {"offset": security_query._MAX_OFFSET},
+    )
+
+    assert result_response.ok is True
+    assert result_response.data["items"] == []
+    assert offset_response.ok is True
+    assert offset_response.data["offset"] == security_query._MAX_OFFSET
+
+
 def test_security_events_list_filters_by_verdict(tmp_path: Path) -> None:
     """Events list filtered by verdict returns only matching events."""
     _write_security_event(

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -186,6 +186,49 @@ def test_resolve_time_range_last_hours_returns_utc_iso(
     assert until == "2027-01-15T08:00:00+00:00"
 
 
+@pytest.mark.parametrize(
+    ("args", "error"),
+    [
+        (["--last-hours", "-1", "--count"], "--last-hours must be non-negative"),
+        (["--limit", "0", "--count"], "--limit must be positive"),
+        (["--offset", "-5", "--count"], "--offset must be non-negative"),
+    ],
+)
+def test_events_rejects_out_of_range_query_values_before_opening_reader(
+    args: list[str], error: str
+) -> None:
+    with patch("agent_sec_cli.cli.get_reader") as get_reader:
+        result = CliRunner().invoke(app, ["events", *args])
+
+    assert result.exit_code == 1
+    assert error in result.output
+    get_reader.assert_not_called()
+
+
+def test_events_accepts_query_value_boundaries() -> None:
+    reader = Mock()
+    reader.count.return_value = 0
+
+    with patch("agent_sec_cli.cli.get_reader", return_value=reader):
+        result = CliRunner().invoke(
+            app,
+            [
+                "events",
+                "--last-hours",
+                "0",
+                "--limit",
+                "1",
+                "--offset",
+                "0",
+                "--count",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert result.output == "0\n"
+    reader.count.assert_called_once()
+
+
 def test_extract_trace_context_arg_stops_at_posix_double_dash():
     assert (
         _extract_trace_context_arg(


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->
Some input params don't have validation at entrance which may cause unexpected behavior or unclear error message.

## What changed

<!-- Keep this focused on one logical change. -->
Add validations on input params at both cli and daemon.

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->
fixes https://github.com/alibaba/anolisa/issues/2390
## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
