### PR TITLE
chore(anolisa): bump version to 0.3.0

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-12
+
+### Fixed
+
+- Adapter enable, status, and update now derive adapter revisions from
+  ANOLISA-owned Raw files or native package metadata instead of hashing whole
+  resource trees. Runtime caches and other unowned files no longer cause false
+  drift or get copied into frameworks, while changed package-owned inputs block
+  enable before framework mutation and unavailable metadata is reported with
+  an `unknown` status
+  ([#2419](https://github.com/alibaba/anolisa/pull/2419)).
+- Re-enabling adapters now removes only stale materialized files recorded by the
+  previous receipt, preserves runtime-created files, previews the cleanup with
+  `--dry-run`, and retains the old receipt when a directory-to-file replacement
+  would discard runtime data
+  ([#2438](https://github.com/alibaba/anolisa/pull/2438)).
+
 ## [0.2.20] - 2026-08-11
 
 ### Changed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,21 @@
 
 ## [未发布]
 
+## [0.3.0] - 2026-08-12
+
+### 修复
+
+- Adapter enable、status 和 update 现基于 ANOLISA-owned Raw file 或 native
+  package metadata 派生 adapter revision，不再对整个 resource tree 计算 hash。
+  Runtime cache 与其他 unowned file 不再造成错误 drift，也不会被复制到 framework；
+  已变化的 package-owned input 会在 framework mutation 前阻止 enable，metadata
+  不可用时则报告为 `unknown` 状态
+  ([#2419](https://github.com/alibaba/anolisa/pull/2419))。
+- Re-enable adapter 现仅删除旧 receipt 记录的 stale materialized file，保留
+  runtime-created file，通过 `--dry-run` 预览 cleanup，并在 directory-to-file
+  replacement 会丢弃 runtime data 时保留旧 receipt
+  ([#2438](https://github.com/alibaba/anolisa/pull/2438))。
+
 ## [0.2.20] - 2026-08-11
 
 ### 变更

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.2.20"
+version = "0.3.0"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.2.20"
+version = "0.3.0"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.2.20"
+version = "0.3.0"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.2.20"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.2.20"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.20"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Tue Aug 11 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Aug 12 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Adapter integrity now verifies package-owned files and ignores unmanaged runtime data.
+- Re-enabling adapters now prunes only receipt-owned stale outputs and preserves runtime files.
+
+* Tue Aug 11 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.2.20-1
 - Component listing now reports host-aware availability in human and JSON output.
 - npm installs now keep the public command link under the root package.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.2.20",
-    "@anolisa/cli-linux-arm64": "0.2.20",
-    "@anolisa/cli-darwin-arm64": "0.2.20"
+    "@anolisa/cli-linux-x64": "0.3.0",
+    "@anolisa/cli-linux-arm64": "0.3.0",
+    "@anolisa/cli-darwin-arm64": "0.3.0"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.2.20",
+  "version": "0.3.0",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.3.0 packages the adapter integrity and stale-output cleanup fixes merged after 0.2.20.
This release bump synchronizes every distribution surface and curates the bilingual notes from the
actual component range without adding new runtime behavior in the bump itself.

## What changed

- Bumped the Cargo workspace and all five internal lockfile package versions to 0.3.0.
- Bumped the npm root package, native platform packages, and optional dependency pins to 0.3.0.
- Added equivalent English and Chinese 0.3.0 changelog entries for #2419 and #2438.
- Advanced the RPM changelog placeholder and froze the previous row at 0.2.20.

## Related issue

no-issue: release metadata for already-merged PRs #2419 and #2438

## User / Agent impact

Published ANOLISA packages will report version 0.3.0. Adapter enable, status, and update now use
package-owned source revisions, while re-enable removes only receipt-owned stale outputs and
preserves runtime-created files.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: the bump commit changes release metadata and documentation only. The released adapter
fixes preserve legacy receipts; unverifiable legacy or package metadata is surfaced as unknown
instead of being treated as healthy.

## Validation

Linux x86_64, non-root user:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo doc --workspace --no-deps --locked`
- `cargo test --workspace --locked` reached one host-dependent failure because this host has a
  loaded `agentsight.service`; all preceding tests passed.
- `cargo test --workspace --locked -- --skip
  systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64`
- `target/release/anolisa --version` reported `anolisa 0.3.0`.
- Nightly raw-lifecycle harness syntax, list, and repository configuration checks.
- `bash scripts/docs-lint.sh`
- `npm run validate:locales --prefix website`
- `npm run build --prefix website`
- `npm run validate:agent-index --prefix website`
- `npm run check:links --prefix website`
- Rendered `anolisa.spec.in` parsed with `rpmspec -P`.
- Release metadata audit passed for commit `ee0abf03`.
- `git diff --cached --check`

The Linux x64 native/root npm tarballs both carry 0.3.0 with the expected binary ownership split.
macOS arm64 and Linux arm64 package templates were validated but not built on this Linux x64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog. Before artifact
publication, rollback is a revert of `ee0abf03`; after publication, issue a corrected follow-up
version rather than reusing 0.3.0.