### PR TITLE
chore(sec-core): bump version to v0.10.1

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -2,7 +2,7 @@ manifest_version = 2
 
 [component]
 name = "sec-core"
-version = "0.10.0"
+version = "0.10.1"
 layer = "runtime"
 domain = "security"
 display_name = "Agent Security Core"

--- a/src/agent-sec-core/CHANGELOG.md
+++ b/src/agent-sec-core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.10.1
+
+**OpenClaw & cosh Hook Integrations**
+
+- Piped prompt text through stdin instead of command-line arguments in the OpenClaw and cosh prompt scanner hooks. (#2445)
+
+**Security Events & CLI**
+
+- Validated events query parameters in the CLI and the daemon security query handlers. (#2451)
+
 ## 0.10.0
 
 **Agent Hook Policy Controls**

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "pyo3",
 ]

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-sec-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Agent Security Core CLI - Native Rust extensions"
 license = "Apache-2.0"

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-sec-cli"
-version = "0.10.0"
+version = "0.10.1"
 description = "Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification for AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
@@ -1,3 +1,3 @@
 """Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification."""
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -35,7 +35,7 @@ try:
 
     __version__ = get_version("agent-sec-cli")
 except Exception:
-    __version__ = "0.10.0"  # pragma: no cover
+    __version__ = "0.10.1"  # pragma: no cover
 
 app = typer.Typer(
     name="agent-sec-cli",

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -261,6 +261,9 @@ rm -rf $RPM_BUILD_ROOT
 make install-all-for-rpmbuild DESTDIR=$RPM_BUILD_ROOT
 
 %changelog
+* Wed Aug 12 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.1-1
+- Update version to 0.10.1
+
 * Fri Aug 07 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.0-1
 - Update version to 0.10.0
 

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, skill ledger integrity verification, and turn/tool observability."
 }

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "hooks": {
     "PreToolUse": [
       {

--- a/src/agent-sec-core/hermes-plugin/src/plugin.yaml
+++ b/src/agent-sec-core/hermes-plugin/src/plugin.yaml
@@ -1,5 +1,5 @@
 name: agent-sec-core-hermes-plugin
-version: 0.10.0
+version: 0.10.1
 description: "OS-level security guardrails for Hermes Agent — powered by agent-sec-cli"
 provides_hooks:
   - pre_llm_call

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-sec",
   "name": "Agent Security",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Security hooks powered by agent-sec-cli",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-sec-openclaw-plugin",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
+++ b/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Agent security core hooks for Qoder CLI."
 }

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core-qwen-code-extension",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "ANOLISA security integration for Qwen Code",
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Why

release/agent-sec-core/v0.10.0 分支上已合入两个修复（#2445、#2451），需要发布 0.10.1 子版本，
统一提升版本号并补齐发布材料，使 CLI、各 Agent 插件清单与 RPM 打包链路对外报告一致的版本。

## What changed

- 将版本号从 0.10.0 提升到 0.10.1：组件清单、CLI 包（含 `cli.py` 中的 `__version__` 回退常量）
  以及 cosh / OpenClaw / Codex / Qoder / Qwen Code / Hermes 六个 Agent 插件清单。
- `CHANGELOG.md` 新增 0.10.1 section，按交付能力维度记录 #2445、#2451。
- `agent-sec-core.spec.in` 的 `%changelog` 顶部新增 0.10.1-1 条目。

## Related issue

no-issue: 版本号提升与发布材料补齐，不对应单独 issue。

## User / Agent impact

用户可见的仅为版本号变化：`agent-sec-cli --version` 与各 Agent 插件清单报告 0.10.1。
本提交不改变扫描、hook 或 daemon 的任何运行行为；0.10.1 的实际行为变化来自已合入的 #2445、#2451。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk：仅版本字符串与发布材料变更，无逻辑改动，无需迁移。

## Validation

- `make python-code-pretty` — 无文件改动（`389 files left unchanged`），Python 格式已符合规范
- `git --no-pager diff --cached --check` — 无 whitespace 问题
- `git --no-pager diff -U0` 复核 13 个清单/配置文件 — 均为 `0.10.0` → `0.10.1` 单行版本号替换
- 核对 `%files` 与 `Makefile install-all-for-rpmbuild` — 确认 #2445、#2451 的改动确实随 RPM 安装

## Documentation and rollback

- 文档变更：`CHANGELOG.md` 新增 0.10.1 section；`agent-sec-core.spec.in` 新增 `%changelog` 条目。
  RPM 制品 release note 位于 `my_data/` 下并被 `.gitignore` 排除，不随本 PR 提交。
- 回滚方式：`git revert` 本次 commit 即可将全部版本号与发布材料回退到 0.10.0，无需数据迁移或清理。