### PR TITLE
fix(cosh-ng): [core,shell] preflight auth

### DIFF
--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -51,3 +51,4 @@ wait-timeout.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }

--- a/src/cosh-ng/crates/cosh-core/src/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth.rs
@@ -5,9 +5,12 @@ use crate::config::{CoreConfig, ProviderConfig};
 use crate::protocol::{AuthField, AuthProvider};
 
 mod exchange;
+mod preflight;
 mod validation;
 
 pub(crate) use exchange::request_validated_auth;
+pub(crate) use preflight::AuthPreflightError;
+pub(crate) use validation::is_valid_provider_id;
 pub(crate) use validation::AuthConfigValidationError;
 use validation::{validate_auth_response, validate_base_url};
 
@@ -251,6 +254,9 @@ pub(crate) fn apply_auth_credentials(
     config: &mut CoreConfig,
     response: &AuthResponse,
 ) -> Result<(), AuthConfigValidationError> {
+    if !is_valid_provider_id(&response.provider_id) {
+        return Err(AuthConfigValidationError::InvalidProviderId);
+    }
     let template_id = response
         .provider_type
         .as_deref()
@@ -328,12 +334,13 @@ pub(crate) fn apply_auth_credentials(
         .and_then(|p| p.explicit_cache);
 
     config.ai.active_provider = Some(response.provider_id.clone());
+    config.ai.active_model = final_model.clone();
     let provider = ProviderConfig {
         provider_type: Some(provider_type),
         auth_source,
         base_url: Some(base_url),
         api_key: Some(api_key),
-        model: final_model,
+        model: final_model.clone(),
         extra_params: None,
         access_key_id,
         access_key_secret,
@@ -346,12 +353,99 @@ pub(crate) fn apply_auth_credentials(
         .insert(response.provider_id.clone(), provider.clone());
     if response.persist {
         config.user_ai.active_provider = Some(response.provider_id.clone());
+        config.user_ai.active_model = final_model;
         config
             .user_ai
             .providers
             .insert(response.provider_id.clone(), provider);
     }
     Ok(())
+}
+
+/// Authentication configuration failures remain classified across the core/shell boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AuthConfigureError {
+    Validation(AuthConfigValidationError),
+    Preflight(AuthPreflightError),
+    Persistence,
+}
+
+impl AuthConfigureError {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::Validation(AuthConfigValidationError::MissingRequiredField(field)) => {
+                match field.as_str() {
+                    "api_key" => "missing_credentials",
+                    "access_key_id" => "missing_access_key_id",
+                    "access_key_secret" => "missing_access_key_secret",
+                    "model" => "missing_model",
+                    "base_url" => "missing_base_url",
+                    _ => "invalid_configuration",
+                }
+            }
+            Self::Validation(AuthConfigValidationError::InvalidBaseUrl) => "invalid_base_url",
+            Self::Validation(AuthConfigValidationError::InvalidProviderId) => "invalid_provider_id",
+            Self::Preflight(error) => error.code(),
+            Self::Persistence => "persistence_failed",
+        }
+    }
+}
+
+impl fmt::Display for AuthConfigureError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(error) => error.fmt(formatter),
+            Self::Preflight(error) => error.fmt(formatter),
+            Self::Persistence => formatter.write_str(
+                "Configuration was validated but could not be saved. Check config permissions and try again.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuthConfigureError {}
+
+impl From<AuthConfigValidationError> for AuthConfigureError {
+    fn from(error: AuthConfigValidationError) -> Self {
+        Self::Validation(error)
+    }
+}
+
+impl From<AuthPreflightError> for AuthConfigureError {
+    fn from(error: AuthPreflightError) -> Self {
+        Self::Preflight(error)
+    }
+}
+
+/// Builds and validates an auth candidate without mutating the active configuration.
+pub(crate) async fn prepare_auth_candidate(
+    current: &CoreConfig,
+    response: &AuthResponse,
+) -> Result<CoreConfig, AuthConfigureError> {
+    let mut candidate = current.clone();
+    apply_auth_credentials(&mut candidate, response)?;
+    let mut resolved = candidate.resolve_provider();
+    if response.provider_type.as_deref() == Some("openai_compat") {
+        resolved.provider_type = "openai_compat".to_string();
+    }
+    preflight::preflight_auth(&resolved).await?;
+    Ok(candidate)
+}
+
+/// Completes the auth transaction and returns a candidate safe to publish in memory.
+pub(crate) async fn prepare_and_persist_auth_candidate<F>(
+    current: &CoreConfig,
+    response: &AuthResponse,
+    persist: F,
+) -> Result<CoreConfig, AuthConfigureError>
+where
+    F: FnOnce(&CoreConfig) -> Result<(), String>,
+{
+    let candidate = prepare_auth_candidate(current, response).await?;
+    if response.persist {
+        persist(&candidate).map_err(|_| AuthConfigureError::Persistence)?;
+    }
+    Ok(candidate)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -390,6 +484,7 @@ pub(crate) fn remove_auth_provider(
     config.user_ai.providers.remove(provider_id);
     if config.user_ai.active_provider.as_deref() == Some(provider_id) {
         config.user_ai.active_provider = None;
+        config.user_ai.active_model = None;
     }
 
     if let Some(system_provider) = config.system_ai.providers.get(provider_id).cloned() {
@@ -429,7 +524,124 @@ pub fn is_auth_error(error: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
     use super::*;
+
+    fn model_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request);
+            let body = r#"{"id":"test-model","object":"model"}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+        format!("http://{address}/v1")
+    }
+
+    fn transaction_response(base_url: String) -> AuthResponse {
+        AuthResponse {
+            provider_id: "transaction-provider".to_string(),
+            provider_type: Some("openai_compat".to_string()),
+            values: HashMap::from([
+                ("base_url".to_string(), base_url),
+                ("api_key".to_string(), "sk-test".to_string()),
+                ("model".to_string(), "test-model".to_string()),
+            ]),
+            persist: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_transaction_persists_candidate_before_publication() {
+        let current = CoreConfig::default();
+        let persisted = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&persisted);
+        let candidate = prepare_and_persist_auth_candidate(
+            &current,
+            &transaction_response(model_server()),
+            move |candidate| {
+                assert_eq!(
+                    candidate.ai.active_provider.as_deref(),
+                    Some("transaction-provider")
+                );
+                observed.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .await
+        .expect("transaction succeeds");
+
+        assert!(persisted.load(Ordering::SeqCst));
+        assert!(current.ai.providers.is_empty());
+        assert!(candidate.ai.providers.contains_key("transaction-provider"));
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_leaves_runtime_config_unchanged() {
+        let current = CoreConfig::default();
+        let result = prepare_and_persist_auth_candidate(
+            &current,
+            &transaction_response(model_server()),
+            |_| Err("read-only config".to_string()),
+        )
+        .await;
+
+        assert!(matches!(result, Err(AuthConfigureError::Persistence)));
+        assert!(current.ai.providers.is_empty());
+        assert!(current.user_ai.providers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn local_validation_failure_never_invokes_persistence() {
+        let current = CoreConfig::default();
+        let invoked = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&invoked);
+        let temporary = tempfile::tempdir().unwrap();
+        let config_path = temporary.path().join("config.toml");
+        let attempted_path = config_path.clone();
+        let response = transaction_response("not-a-url".to_string());
+        let result = prepare_and_persist_auth_candidate(&current, &response, move |_| {
+            observed.store(true, Ordering::SeqCst);
+            std::fs::write(&attempted_path, "should not exist").unwrap();
+            Ok(())
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(AuthConfigureError::Validation(
+                AuthConfigValidationError::InvalidBaseUrl
+            ))
+        ));
+        assert!(!invoked.load(Ordering::SeqCst));
+        assert!(!config_path.exists());
+        assert!(current.ai.providers.is_empty());
+    }
+
+    #[test]
+    fn aliyun_missing_credentials_preserve_field_codes() {
+        for (field, expected) in [
+            ("access_key_id", "missing_access_key_id"),
+            ("access_key_secret", "missing_access_key_secret"),
+        ] {
+            let error = AuthConfigureError::Validation(
+                AuthConfigValidationError::MissingRequiredField(field.to_string()),
+            );
+            assert_eq!(error.code(), expected);
+        }
+    }
 
     #[test]
     fn builtin_providers_have_correct_ids() {
@@ -791,6 +1003,7 @@ mod tests {
             .providers
             .insert("user-provider".to_string(), provider.clone());
         config.user_ai.active_provider = Some("user-provider".to_string());
+        config.user_ai.active_model = Some("user-model".to_string());
         config
             .user_ai
             .providers
@@ -801,6 +1014,7 @@ mod tests {
         assert_eq!(removed.active_provider, None);
         assert_eq!(config.ai.active_provider, None);
         assert_eq!(config.ai.active_model, None);
+        assert_eq!(config.user_ai.active_model, None);
         assert!(!config.ai.providers.contains_key("user-provider"));
         assert!(!config.user_ai.providers.contains_key("user-provider"));
     }

--- a/src/cosh-ng/crates/cosh-core/src/auth/exchange.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/exchange.rs
@@ -11,13 +11,17 @@ use crate::protocol::{
     CONTROL_PROTOCOL_VERSION,
 };
 
-use super::{apply_auth_credentials, builtin_auth_providers, AuthResponse};
+use super::{builtin_auth_providers, prepare_auth_candidate, AuthConfigureError, AuthResponse};
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
 
 struct AuthWaitResult {
     response: Option<AuthResponse>,
     buffered_lines: Vec<String>,
+}
+
+pub(crate) struct ValidatedAuth {
+    pub(crate) candidate: CoreConfig,
 }
 
 pub(crate) async fn request_validated_auth<W, R>(
@@ -28,7 +32,7 @@ pub(crate) async fn request_validated_auth<W, R>(
     initial_reason: AuthReason,
     initial_error: Option<String>,
     buffered_lines: &mut Vec<String>,
-) -> Option<AuthResponse>
+) -> Option<ValidatedAuth>
 where
     W: Write,
     R: AsyncBufReadExt + Unpin,
@@ -55,8 +59,18 @@ where
         buffered_lines.extend(auth_result.buffered_lines);
         let response = auth_result.response?;
 
-        match apply_auth_credentials(config, &response) {
-            Ok(()) => return Some(response),
+        match prepare_auth_candidate(config, &response).await {
+            Ok(candidate) => {
+                if response.persist && crate::config::persist_config(&candidate).is_err() {
+                    let error = AuthConfigureError::Persistence;
+                    tracing::warn!("auth candidate could not be persisted");
+                    reason = AuthReason::Invalid;
+                    error_message = Some(error.to_string());
+                    attempt = attempt.saturating_add(1);
+                    continue;
+                }
+                return Some(ValidatedAuth { candidate });
+            }
             Err(error) => {
                 tracing::warn!("invalid auth response: {error}");
                 reason = AuthReason::Invalid;
@@ -157,7 +171,28 @@ fn emit<W: Write>(writer: &mut W, message: &OutputMessage) {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use tokio::io::AsyncWriteExt;
+
+    fn model_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request);
+            let body = r#"{"id":"test-model"}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .unwrap();
+        });
+        format!("http://{address}/v1")
+    }
 
     #[tokio::test]
     async fn buffers_invalid_jsonl_during_auth_wait() {
@@ -204,11 +239,13 @@ mod tests {
     #[tokio::test]
     async fn invalid_response_requests_retry_before_returning_success() {
         let (mut input, output) = tokio::io::duplex(4096);
+        let valid_base_url = model_server();
         input
             .write_all(
-                br#"{"type":"control_response","response":{"subtype":"auth","request_id":"auth-test","response":{"provider_id":"test","provider_type":"openai_compat","values":{"base_url":"bad-url","api_key":"test-key","model":"test-model"},"persist":false}}}
-{"type":"control_response","response":{"subtype":"auth","request_id":"auth-test-retry-1","response":{"provider_id":"test","provider_type":"openai_compat","values":{"base_url":"https://api.example.com/v1","api_key":"test-key","model":"test-model"},"persist":false}}}
-"#,
+                format!(
+                    "{{\"type\":\"control_response\",\"response\":{{\"subtype\":\"auth\",\"request_id\":\"auth-test\",\"response\":{{\"provider_id\":\"test\",\"provider_type\":\"openai_compat\",\"values\":{{\"base_url\":\"bad-url\",\"api_key\":\"test-key\",\"model\":\"test-model\"}},\"persist\":false}}}}}}\n{{\"type\":\"control_response\",\"response\":{{\"subtype\":\"auth\",\"request_id\":\"auth-test-retry-1\",\"response\":{{\"provider_id\":\"test\",\"provider_type\":\"openai_compat\",\"values\":{{\"base_url\":{valid_base_url:?},\"api_key\":\"test-key\",\"model\":\"test-model\"}},\"persist\":false}}}}}}\n"
+                )
+                .as_bytes(),
             )
             .await
             .expect("write auth responses");
@@ -229,14 +266,17 @@ mod tests {
         .await
         .expect("valid retry response");
 
-        assert_eq!(response.provider_id, "test");
+        assert_eq!(
+            response.candidate.ai.active_provider.as_deref(),
+            Some("test")
+        );
         let messages = String::from_utf8(protocol_output).expect("protocol output");
         let lines = messages.lines().collect::<Vec<_>>();
         assert_eq!(lines.len(), 2);
         assert!(lines[0].contains(r#""reason":"not_configured""#));
         assert!(lines[1].contains(r#""reason":"invalid""#));
         assert!(lines[1].contains("invalid base_url"));
-        assert!(config.ai.providers.contains_key("test"));
+        assert!(!config.ai.providers.contains_key("test"));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/preflight.rs
@@ -1,0 +1,1313 @@
+//! Provider-specific authentication probes that never emit secrets or response bodies.
+
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+use chrono::Utc;
+use futures::StreamExt;
+use hmac::{Hmac, Mac};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
+use reqwest::{Client, RequestBuilder, Response, StatusCode, Url};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::config::ResolvedProvider;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+const ALIYUN_SYSOM_ENDPOINT: &str = "https://sysom.cn-hangzhou.aliyuncs.com";
+const ALIYUN_PERMISSION_PATH: &str = "/api/v1/openapi/initial";
+const ALIYUN_PERMISSION_ACTION: &str = "InitialSysom";
+const ALIYUN_COPILOT_PATH: &str = "/api/v1/copilot/generate_copilot_stream_response";
+const ALIYUN_COPILOT_ACTION: &str = "GenerateCopilotStreamResponse";
+const ALIYUN_API_VERSION: &str = "2023-12-30";
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+const CODING_AGENT_USER_AGENT: &str =
+    concat!("Cosh/", env!("CARGO_PKG_VERSION"), " (coding-agent)");
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ModelFallback {
+    None,
+    List,
+    Chat,
+    ListThenChat,
+}
+
+/// Stable authentication-preflight classifications consumed by the shell.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AuthPreflightError {
+    InvalidCredentials,
+    PermissionDenied,
+    ModelUnavailable { model: String },
+    EndpointUnreachable,
+    Timeout,
+    RateLimited,
+    ProviderUnavailable,
+    ServiceNotReady,
+    CredentialSourceUnavailable,
+    UnsupportedResponse,
+}
+
+impl AuthPreflightError {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidCredentials => "invalid_credentials",
+            Self::PermissionDenied => "permission_denied",
+            Self::ModelUnavailable { .. } => "model_unavailable",
+            Self::EndpointUnreachable => "endpoint_unreachable",
+            Self::Timeout => "timeout",
+            Self::RateLimited => "rate_limited",
+            Self::ProviderUnavailable => "provider_unavailable",
+            Self::ServiceNotReady => "service_not_ready",
+            Self::CredentialSourceUnavailable => "credential_source_unavailable",
+            Self::UnsupportedResponse => "unsupported_response",
+        }
+    }
+}
+
+impl fmt::Display for AuthPreflightError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCredentials => {
+                formatter.write_str("The API key was rejected. Check the API Key and try again.")
+            }
+            Self::PermissionDenied => formatter.write_str(
+                "The credentials do not have permission to use this endpoint. Check the API Key and permissions.",
+            ),
+            Self::ModelUnavailable { model } => write!(
+                formatter,
+                "Model {model:?} is unavailable. Check the Model name and access entitlement."
+            ),
+            Self::EndpointUnreachable => formatter.write_str(
+                "The endpoint could not be reached. Check the Base URL and network connection.",
+            ),
+            Self::Timeout => formatter.write_str(
+                "The endpoint did not respond in time. Check the Base URL and network connection.",
+            ),
+            Self::RateLimited => formatter.write_str(
+                "The provider rate-limited the validation request. Check quota or try again later.",
+            ),
+            Self::ProviderUnavailable => formatter.write_str(
+                "The provider is temporarily unavailable. Try again later or check the Base URL.",
+            ),
+            Self::ServiceNotReady => formatter.write_str(
+                "Aliyun SysOM is not authorized for this account. Complete service authorization and try again.",
+            ),
+            Self::CredentialSourceUnavailable => formatter.write_str(
+                "ECS RAM Role credentials are not available yet. Authorize the instance role and try again.",
+            ),
+            Self::UnsupportedResponse => formatter.write_str(
+                "The endpoint returned an unsupported validation response. Check the Base URL and provider compatibility.",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AuthPreflightError {}
+
+/// Validates credentials and model availability without retrying or following redirects.
+pub(crate) async fn preflight_auth(provider: &ResolvedProvider) -> Result<(), AuthPreflightError> {
+    preflight_auth_with_timeout(provider, REQUEST_TIMEOUT).await
+}
+
+async fn preflight_auth_with_timeout(
+    provider: &ResolvedProvider,
+    total_timeout: Duration,
+) -> Result<(), AuthPreflightError> {
+    enforce_preflight_deadline(total_timeout, preflight_auth_inner(provider)).await
+}
+
+async fn enforce_preflight_deadline<F>(
+    total_timeout: Duration,
+    preflight: F,
+) -> Result<(), AuthPreflightError>
+where
+    F: Future<Output = Result<(), AuthPreflightError>>,
+{
+    tokio::time::timeout(total_timeout, preflight)
+        .await
+        .unwrap_or(Err(AuthPreflightError::Timeout))
+}
+
+async fn preflight_auth_inner(provider: &ResolvedProvider) -> Result<(), AuthPreflightError> {
+    if provider.provider_type == "mock" {
+        return Ok(());
+    }
+    if provider.provider_type == "aliyun" {
+        return preflight_aliyun(provider).await;
+    }
+
+    let client = build_client()?;
+    match provider.provider_type.as_str() {
+        "dashscope" => {
+            preflight_model_endpoint(&client, provider, ModelFallback::ListThenChat).await
+        }
+        "coding_plan" | "token_plan" => {
+            preflight_model_endpoint(&client, provider, ModelFallback::ListThenChat).await
+        }
+        "openai_compat" => preflight_model_endpoint(&client, provider, ModelFallback::Chat).await,
+        "openai" | "generic" | "deepseek" => {
+            preflight_model_endpoint(&client, provider, ModelFallback::List).await
+        }
+        _ => preflight_model_endpoint(&client, provider, ModelFallback::None).await,
+    }
+}
+
+fn build_client() -> Result<Client, AuthPreflightError> {
+    Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|_| AuthPreflightError::EndpointUnreachable)
+}
+
+async fn preflight_model_endpoint(
+    client: &Client,
+    provider: &ResolvedProvider,
+    fallback: ModelFallback,
+) -> Result<(), AuthPreflightError> {
+    let model_url = endpoint_url(&provider.base_url, &["models", &provider.model])?;
+    let response = send(authenticated_request(client.get(model_url), provider)).await?;
+    let status = response.status();
+
+    if status.is_success() {
+        return validate_model_response(response, &provider.model).await;
+    }
+
+    if status == StatusCode::NOT_FOUND {
+        let explicitly_missing = response_explicitly_reports_missing_model(response).await;
+        if explicitly_missing || fallback == ModelFallback::None {
+            return Err(AuthPreflightError::ModelUnavailable {
+                model: provider.model.clone(),
+            });
+        }
+        return preflight_model_fallback(client, provider, fallback).await;
+    }
+    if fallback != ModelFallback::None
+        && matches!(
+            status,
+            StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED
+        )
+    {
+        return preflight_model_fallback(client, provider, fallback).await;
+    }
+
+    Err(classify_status(status))
+}
+
+async fn preflight_model_fallback(
+    client: &Client,
+    provider: &ResolvedProvider,
+    fallback: ModelFallback,
+) -> Result<(), AuthPreflightError> {
+    match fallback {
+        ModelFallback::List => preflight_model_list(client, provider).await,
+        ModelFallback::Chat => preflight_chat(client, provider).await,
+        ModelFallback::ListThenChat => preflight_model_list_then_chat(client, provider).await,
+        ModelFallback::None => Err(AuthPreflightError::UnsupportedResponse),
+    }
+}
+
+async fn preflight_model_list(
+    client: &Client,
+    provider: &ResolvedProvider,
+) -> Result<(), AuthPreflightError> {
+    let url = endpoint_url(&provider.base_url, &["models"])?;
+    let response = send(authenticated_request(client.get(url), provider)).await?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(classify_status(status));
+    }
+    validate_model_list(response, &provider.model).await
+}
+
+async fn preflight_model_list_then_chat(
+    client: &Client,
+    provider: &ResolvedProvider,
+) -> Result<(), AuthPreflightError> {
+    let url = endpoint_url(&provider.base_url, &["models"])?;
+    let response = send(authenticated_request(client.get(url), provider)).await?;
+    let status = response.status();
+    if status.is_success() {
+        validate_model_list(response, &provider.model).await?;
+    } else if !matches!(
+        status,
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED
+    ) {
+        return Err(classify_status(status));
+    }
+
+    // A model list may be public. A minimal completion is therefore still required
+    // to prove that the submitted credential can use the selected model.
+    preflight_chat(client, provider).await
+}
+
+async fn validate_model_list(
+    response: Response,
+    expected_model: &str,
+) -> Result<(), AuthPreflightError> {
+    let body = response_json(response).await?;
+    let models = body
+        .get("data")
+        .and_then(Value::as_array)
+        .ok_or(AuthPreflightError::UnsupportedResponse)?;
+    if models.iter().any(|entry| {
+        entry
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id == expected_model)
+    }) {
+        Ok(())
+    } else {
+        Err(AuthPreflightError::ModelUnavailable {
+            model: expected_model.to_string(),
+        })
+    }
+}
+
+async fn preflight_chat(
+    client: &Client,
+    provider: &ResolvedProvider,
+) -> Result<(), AuthPreflightError> {
+    let url = endpoint_url(&provider.base_url, &["chat", "completions"])?;
+    let response = send(
+        authenticated_request(client.post(url), provider)
+            .header(CONTENT_TYPE, "application/json")
+            .json(&serde_json::json!({
+                "model": provider.model,
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": false,
+                "max_tokens": 1
+            })),
+    )
+    .await?;
+    let status = response.status();
+    if status.is_success() {
+        let body = response_json(response).await?;
+        return body
+            .get("choices")
+            .and_then(Value::as_array)
+            .filter(|choices| !choices.is_empty())
+            .map(|_| ())
+            .ok_or(AuthPreflightError::UnsupportedResponse);
+    }
+    if matches!(
+        status,
+        StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND | StatusCode::UNPROCESSABLE_ENTITY
+    ) && response_explicitly_reports_missing_model(response).await
+    {
+        return Err(AuthPreflightError::ModelUnavailable {
+            model: provider.model.clone(),
+        });
+    }
+    Err(classify_status(status))
+}
+
+fn authenticated_request(builder: RequestBuilder, provider: &ResolvedProvider) -> RequestBuilder {
+    let builder = builder
+        .header(AUTHORIZATION, bearer(&provider.api_key))
+        .header(ACCEPT, "application/json");
+    if matches!(
+        provider.provider_type.as_str(),
+        "coding_plan" | "token_plan"
+    ) {
+        builder
+            .header(USER_AGENT, CODING_AGENT_USER_AGENT)
+            .header("x-dashscope-useragent", CODING_AGENT_USER_AGENT)
+            .header("x-dashscope-authtype", "openai")
+    } else {
+        builder
+    }
+}
+
+async fn validate_model_response(
+    response: Response,
+    expected_model: &str,
+) -> Result<(), AuthPreflightError> {
+    let body = response_json(response).await?;
+    match body.get("id").and_then(Value::as_str) {
+        Some(id) if id == expected_model => Ok(()),
+        _ => Err(AuthPreflightError::UnsupportedResponse),
+    }
+}
+
+async fn response_explicitly_reports_missing_model(response: Response) -> bool {
+    let Ok(body) = response_json(response).await else {
+        return false;
+    };
+    let error = body.get("error").unwrap_or(&body);
+    let code = error
+        .get("code")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let error_type = error
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let param = error
+        .get("param")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    matches!(
+        code,
+        "model_not_found" | "invalid_model" | "model_not_exist" | "Model.NotFound"
+    ) || matches!(error_type, "model_not_found" | "invalid_model")
+        || param == "model"
+}
+
+async fn preflight_aliyun(provider: &ResolvedProvider) -> Result<(), AuthPreflightError> {
+    if provider.auth_source.as_deref() == Some("ecs_ram_role") {
+        return tokio::task::spawn_blocking(
+            crate::provider::sysom::ecs_ram_role_credentials_available,
+        )
+        .await
+        .map_err(|_| AuthPreflightError::EndpointUnreachable)?
+        .then_some(())
+        .ok_or(AuthPreflightError::CredentialSourceUnavailable);
+    }
+
+    let client = build_client()?;
+    let base_url = if provider.base_url.trim().is_empty() {
+        ALIYUN_SYSOM_ENDPOINT
+    } else {
+        provider.base_url.as_str()
+    };
+    let payload = br#"{"check_only":true,"source":"cosh"}"#;
+    let request = signed_aliyun_request(
+        &client,
+        base_url,
+        ALIYUN_PERMISSION_PATH,
+        ALIYUN_PERMISSION_ACTION,
+        payload,
+        provider,
+    )?;
+    let response = send(request).await?;
+    let status = response.status();
+    let body = response_json(response).await;
+    if status.is_success() {
+        let body = body?;
+        match aliyun_response_code(&body) {
+            Some("Success") if aliyun_role_exists(&body) == Some(true) => {}
+            Some("Success") if aliyun_role_exists(&body) == Some(false) => {
+                return Err(AuthPreflightError::ServiceNotReady);
+            }
+            Some("Success") | None => return Err(AuthPreflightError::UnsupportedResponse),
+            Some(code) => return Err(classify_aliyun_code(code, &provider.model)),
+        }
+    } else {
+        if let Ok(body) = body {
+            if let Some(code) = aliyun_response_code(&body) {
+                return Err(classify_aliyun_code(code, &provider.model));
+            }
+        }
+        return Err(classify_status(status));
+    }
+
+    preflight_aliyun_copilot(&client, base_url, provider).await
+}
+
+fn signed_aliyun_request(
+    client: &Client,
+    base_url: &str,
+    path: &str,
+    action: &str,
+    payload: &[u8],
+    provider: &ResolvedProvider,
+) -> Result<RequestBuilder, AuthPreflightError> {
+    let mut url = Url::parse(base_url).map_err(|_| AuthPreflightError::EndpointUnreachable)?;
+    url.set_path(path);
+    url.set_query(None);
+    let host_name = url
+        .host_str()
+        .ok_or(AuthPreflightError::EndpointUnreachable)?
+        .to_string();
+    let host = url
+        .port()
+        .map(|port| format!("{host_name}:{port}"))
+        .unwrap_or(host_name);
+    let timestamp = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let nonce = Uuid::new_v4().to_string();
+    let payload_hash = hex_sha256(payload);
+    let mut headers = vec![
+        ("host".to_string(), host.clone()),
+        (
+            "content-type".to_string(),
+            "application/json; charset=utf-8".to_string(),
+        ),
+        ("x-acs-action".to_string(), action.to_string()),
+        ("x-acs-content-sha256".to_string(), payload_hash.clone()),
+        ("x-acs-date".to_string(), timestamp.clone()),
+        ("x-acs-signature-nonce".to_string(), nonce.clone()),
+        ("x-acs-version".to_string(), ALIYUN_API_VERSION.to_string()),
+    ];
+    if let Some(token) = provider.security_token.as_ref() {
+        headers.push((
+            "x-acs-accesskey-id".to_string(),
+            provider.access_key_id.clone(),
+        ));
+        headers.push(("x-acs-security-token".to_string(), token.clone()));
+    }
+    let authorization = sign_acs3(
+        "POST",
+        path,
+        "",
+        &headers,
+        &payload_hash,
+        &provider.access_key_id,
+        &provider.access_key_secret,
+    );
+    let mut request = client
+        .post(url)
+        .header("host", host)
+        .header(CONTENT_TYPE, "application/json; charset=utf-8")
+        .header("x-acs-action", action)
+        .header("x-acs-content-sha256", payload_hash)
+        .header("x-acs-date", timestamp)
+        .header("x-acs-signature-nonce", nonce)
+        .header("x-acs-version", ALIYUN_API_VERSION)
+        .header(AUTHORIZATION, authorization)
+        .body(payload.to_vec());
+    if let Some(token) = provider.security_token.as_ref() {
+        request = request
+            .header("x-acs-accesskey-id", &provider.access_key_id)
+            .header("x-acs-security-token", token);
+    }
+    Ok(request)
+}
+
+async fn preflight_aliyun_copilot(
+    client: &Client,
+    base_url: &str,
+    provider: &ResolvedProvider,
+) -> Result<(), AuthPreflightError> {
+    let llm_params = serde_json::json!({
+        "messages": [{"role": "user", "content": "ping"}],
+        "model": provider.model,
+        "stream": true,
+        "use_dashscope": true,
+        "version": 2,
+        "max_tokens": 1
+    });
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "llmParamString": llm_params.to_string()
+    }))
+    .map_err(|_| AuthPreflightError::UnsupportedResponse)?;
+    let request = signed_aliyun_request(
+        client,
+        base_url,
+        ALIYUN_COPILOT_PATH,
+        ALIYUN_COPILOT_ACTION,
+        &payload,
+        provider,
+    )?
+    .header(ACCEPT, "text/event-stream")
+    .header("x-sysom-invoke-source", "cosh");
+    let response = send(request).await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response_json(response).await;
+        if let Ok(body) = body {
+            if let Some(code) = aliyun_response_code(&body) {
+                return Err(classify_aliyun_code(code, &provider.model));
+            }
+        }
+        return Err(classify_status(status));
+    }
+    let bytes = response_bytes(response).await?;
+    validate_aliyun_copilot_stream(&bytes, &provider.model)
+}
+
+fn validate_aliyun_copilot_stream(bytes: &[u8], model: &str) -> Result<(), AuthPreflightError> {
+    if let Ok(body) = serde_json::from_slice::<Value>(bytes) {
+        return Err(aliyun_response_code(&body)
+            .map(|code| classify_aliyun_code(code, model))
+            .unwrap_or(AuthPreflightError::UnsupportedResponse));
+    }
+    let stream = std::str::from_utf8(bytes).map_err(|_| AuthPreflightError::UnsupportedResponse)?;
+    let normalized = stream.replace("\r\n", "\n");
+    let mut saw_success = false;
+    for block in normalized.split("\n\n") {
+        let mut event = "";
+        let mut data = String::new();
+        for line in block.lines() {
+            if let Some(value) = line.strip_prefix("event:") {
+                event = value.trim();
+            } else if let Some(value) = line.strip_prefix("data:") {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(value.strip_prefix(' ').unwrap_or(value));
+            }
+        }
+        if data.is_empty() || data == "[DONE]" {
+            continue;
+        }
+        let body: Value =
+            serde_json::from_str(&data).map_err(|_| AuthPreflightError::UnsupportedResponse)?;
+        if event.eq_ignore_ascii_case("failed") {
+            return Err(aliyun_response_code(&body)
+                .map(|code| classify_aliyun_code(code, model))
+                .unwrap_or(AuthPreflightError::UnsupportedResponse));
+        }
+        if event.eq_ignore_ascii_case("ok")
+            && body.get("choices").and_then(Value::as_array).is_some()
+        {
+            saw_success = true;
+        }
+    }
+    saw_success
+        .then_some(())
+        .ok_or(AuthPreflightError::UnsupportedResponse)
+}
+
+fn aliyun_response_code(body: &Value) -> Option<&str> {
+    body.get("code")
+        .or_else(|| body.get("Code"))
+        .or_else(|| body.get("error").and_then(|error| error.get("code")))
+        .and_then(Value::as_str)
+}
+
+fn aliyun_role_exists(body: &Value) -> Option<bool> {
+    body.get("data")
+        .and_then(|data| data.get("role_exist"))
+        .and_then(Value::as_bool)
+}
+
+fn classify_aliyun_code(code: &str, model: &str) -> AuthPreflightError {
+    let code = code.to_ascii_lowercase();
+    if code.contains("invalidaccesskey")
+        || code.contains("signaturedoesnotmatch")
+        || code.contains("invalidsecuritytoken")
+    {
+        AuthPreflightError::InvalidCredentials
+    } else if code.contains("model")
+        && (code.contains("notfound")
+            || code.contains("not_found")
+            || code.contains("notexist")
+            || code.contains("invalid")
+            || code.contains("unavailable"))
+    {
+        AuthPreflightError::ModelUnavailable {
+            model: model.to_string(),
+        }
+    } else if code.contains("nopermission")
+        || code.contains("forbidden")
+        || code.contains("notauthorized")
+    {
+        AuthPreflightError::PermissionDenied
+    } else if code.contains("throttl") || code.contains("ratelimit") {
+        AuthPreflightError::RateLimited
+    } else if code.contains("serviceunavailable") || code.contains("internalerror") {
+        AuthPreflightError::ProviderUnavailable
+    } else {
+        AuthPreflightError::UnsupportedResponse
+    }
+}
+
+async fn send(builder: reqwest::RequestBuilder) -> Result<Response, AuthPreflightError> {
+    builder.send().await.map_err(|error| {
+        if error.is_timeout() {
+            AuthPreflightError::Timeout
+        } else {
+            AuthPreflightError::EndpointUnreachable
+        }
+    })
+}
+
+async fn response_json(response: Response) -> Result<Value, AuthPreflightError> {
+    let bytes = response_bytes(response).await?;
+    serde_json::from_slice(&bytes).map_err(|_| AuthPreflightError::UnsupportedResponse)
+}
+
+async fn response_bytes(response: Response) -> Result<Vec<u8>, AuthPreflightError> {
+    let mut stream = response.bytes_stream();
+    let mut bytes = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            if error.is_timeout() {
+                AuthPreflightError::Timeout
+            } else {
+                AuthPreflightError::UnsupportedResponse
+            }
+        })?;
+        if bytes.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(AuthPreflightError::UnsupportedResponse);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn classify_status(status: StatusCode) -> AuthPreflightError {
+    match status {
+        StatusCode::UNAUTHORIZED => AuthPreflightError::InvalidCredentials,
+        StatusCode::FORBIDDEN => AuthPreflightError::PermissionDenied,
+        StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => AuthPreflightError::Timeout,
+        StatusCode::TOO_MANY_REQUESTS => AuthPreflightError::RateLimited,
+        status if status.is_server_error() => AuthPreflightError::ProviderUnavailable,
+        _ => AuthPreflightError::UnsupportedResponse,
+    }
+}
+
+fn endpoint_url(base_url: &str, suffix: &[&str]) -> Result<Url, AuthPreflightError> {
+    let mut url = Url::parse(base_url).map_err(|_| AuthPreflightError::EndpointUnreachable)?;
+    url.set_query(None);
+    url.set_fragment(None);
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|_| AuthPreflightError::EndpointUnreachable)?;
+    segments.pop_if_empty();
+    for segment in suffix {
+        segments.push(segment);
+    }
+    drop(segments);
+    Ok(url)
+}
+
+fn bearer(api_key: &str) -> String {
+    format!("Bearer {api_key}")
+}
+
+fn sign_acs3(
+    method: &str,
+    path: &str,
+    query: &str,
+    headers: &[(String, String)],
+    payload_hash: &str,
+    access_key_id: &str,
+    access_key_secret: &str,
+) -> String {
+    let mut sorted = headers
+        .iter()
+        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_string()))
+        .collect::<Vec<_>>();
+    sorted.sort_by(|left, right| left.0.cmp(&right.0));
+    let canonical_headers = sorted
+        .iter()
+        .map(|(name, value)| format!("{name}:{value}\n"))
+        .collect::<String>();
+    let signed_headers = sorted
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<Vec<_>>()
+        .join(";");
+    let canonical =
+        format!("{method}\n{path}\n{query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
+    let string_to_sign = format!("ACS3-HMAC-SHA256\n{}", hex_sha256(canonical.as_bytes()));
+    // HMAC-SHA256 accepts keys of any length, so `InvalidLength` is unreachable here.
+    let mut mac = match Hmac::<Sha256>::new_from_slice(access_key_secret.as_bytes()) {
+        Ok(mac) => mac,
+        Err(_) => unreachable!("HMAC-SHA256 accepts keys of any length"),
+    };
+    mac.update(string_to_sign.as_bytes());
+    format!(
+        "ACS3-HMAC-SHA256 Credential={access_key_id},SignedHeaders={signed_headers},Signature={}",
+        hex::encode(mac.finalize().into_bytes())
+    )
+}
+
+fn hex_sha256(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct Reply {
+        status: u16,
+        body: String,
+        headers: Vec<(String, String)>,
+        delay: Duration,
+    }
+
+    impl Reply {
+        fn json(status: u16, body: impl Into<String>) -> Self {
+            Self {
+                status,
+                body: body.into(),
+                headers: Vec::new(),
+                delay: Duration::ZERO,
+            }
+        }
+    }
+
+    struct MockServer {
+        base_url: String,
+        requests: Arc<Mutex<Vec<String>>>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl MockServer {
+        fn spawn(replies: Vec<Reply>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+            let address = listener.local_addr().expect("mock address");
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let captured = Arc::clone(&requests);
+            let thread = thread::spawn(move || {
+                for reply in replies {
+                    let (mut stream, _) = listener.accept().expect("accept mock request");
+                    let request = read_request(&mut stream);
+                    captured.lock().unwrap().push(request);
+                    if !reply.delay.is_zero() {
+                        thread::sleep(reply.delay);
+                    }
+                    let reason = match reply.status {
+                        200 => "OK",
+                        302 => "Found",
+                        401 => "Unauthorized",
+                        403 => "Forbidden",
+                        404 => "Not Found",
+                        405 => "Method Not Allowed",
+                        429 => "Too Many Requests",
+                        500 => "Internal Server Error",
+                        501 => "Not Implemented",
+                        _ => "Test",
+                    };
+                    let extra_headers = reply
+                        .headers
+                        .iter()
+                        .map(|(name, value)| format!("{name}: {value}\r\n"))
+                        .collect::<String>();
+                    let response = format!(
+                        "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n{}\r\n{}",
+                        reply.status,
+                        reason,
+                        reply.body.len(),
+                        extra_headers,
+                        reply.body
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            });
+            Self {
+                base_url: format!("http://{address}/v1"),
+                requests,
+                thread: Some(thread),
+            }
+        }
+
+        fn finish(mut self) -> Vec<String> {
+            self.thread.take().unwrap().join().expect("mock thread");
+            Arc::try_unwrap(self.requests)
+                .expect("request records")
+                .into_inner()
+                .unwrap()
+        }
+    }
+
+    fn read_request(stream: &mut TcpStream) -> String {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        loop {
+            let count = stream.read(&mut buffer).unwrap_or(0);
+            if count == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&buffer[..count]);
+            let Some(header_end) = bytes.windows(4).position(|part| part == b"\r\n\r\n") else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&bytes[..header_end + 4]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                })
+                .unwrap_or(0);
+            if bytes.len() >= header_end + 4 + content_length {
+                break;
+            }
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    fn provider(base_url: &str, provider_type: &str) -> ResolvedProvider {
+        ResolvedProvider {
+            base_url: base_url.to_string(),
+            api_key: "sk-private-value".to_string(),
+            model: "test-model".to_string(),
+            provider_type: provider_type.to_string(),
+            auth_source: None,
+            extra_params: None,
+            access_key_id: String::new(),
+            access_key_secret: String::new(),
+            security_token: None,
+            explicit_cache: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn model_endpoint_success_validates_credentials_and_model() {
+        let server = MockServer::spawn(vec![Reply::json(
+            200,
+            r#"{"id":"test-model","object":"model"}"#,
+        )]);
+        preflight_auth(&provider(&server.base_url, "dashscope"))
+            .await
+            .expect("valid preflight");
+        let requests = server.finish();
+        assert!(requests[0].starts_with("GET /v1/models/test-model HTTP/1.1"));
+        assert!(requests[0].contains("authorization: Bearer sk-private-value"));
+    }
+
+    #[tokio::test]
+    async fn classifies_auth_rate_limit_and_provider_failures() {
+        for (status, expected) in [
+            (401, AuthPreflightError::InvalidCredentials),
+            (403, AuthPreflightError::PermissionDenied),
+            (429, AuthPreflightError::RateLimited),
+            (500, AuthPreflightError::ProviderUnavailable),
+        ] {
+            let server = MockServer::spawn(vec![Reply::json(status, r#"{"error":{}}"#)]);
+            let result = preflight_auth(&provider(&server.base_url, "dashscope")).await;
+            assert_eq!(result, Err(expected), "status {status}");
+            server.finish();
+        }
+    }
+
+    #[tokio::test]
+    async fn dashscope_list_fallback_still_validates_credentials_with_chat() {
+        let server = MockServer::spawn(vec![
+            Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+            Reply::json(
+                200,
+                r#"{"object":"list","data":[{"id":"vendor/test-model","object":"model"}]}"#,
+            ),
+            Reply::json(200, r#"{"choices":[{"message":{"content":""}}]}"#),
+        ]);
+        let mut dashscope = provider(&server.base_url, "dashscope");
+        dashscope.model = "vendor/test-model".to_string();
+        preflight_auth(&dashscope)
+            .await
+            .expect("model list fallback succeeds");
+        let requests = server.finish();
+        assert_eq!(requests.len(), 3);
+        assert!(requests[0].starts_with("GET /v1/models/vendor%2Ftest-model HTTP/1.1"));
+        assert!(requests[1].starts_with("GET /v1/models HTTP/1.1"));
+        assert!(!requests[1].contains("messages"));
+        assert!(requests[2].starts_with("POST /v1/chat/completions HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn openai_compat_falls_back_for_ambiguous_model_endpoint_failures() {
+        for status in [404, 405, 501] {
+            let server = MockServer::spawn(vec![
+                Reply::json(status, r#"{"error":{"code":"route_not_found"}}"#),
+                Reply::json(200, r#"{"choices":[{"message":{"content":""}}]}"#),
+            ]);
+            preflight_auth(&provider(&server.base_url, "openai_compat"))
+                .await
+                .expect("chat fallback succeeds");
+            let requests = server.finish();
+            assert_eq!(requests.len(), 2);
+            assert!(requests[1].starts_with("POST /v1/chat/completions HTTP/1.1"));
+            assert!(requests[1].contains(r#""stream":false"#));
+            assert!(requests[1].contains(r#""max_tokens":1"#));
+        }
+    }
+
+    #[tokio::test]
+    async fn known_read_only_providers_fall_back_to_model_list_without_chat() {
+        for provider_type in ["openai", "generic", "deepseek"] {
+            let server = MockServer::spawn(vec![
+                Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+                Reply::json(200, r#"{"object":"list","data":[{"id":"test-model"}]}"#),
+            ]);
+            preflight_auth(&provider(&server.base_url, provider_type))
+                .await
+                .expect("model list fallback succeeds");
+            let requests = server.finish();
+            assert_eq!(requests.len(), 2, "provider type {provider_type}");
+            assert!(requests[1].starts_with("GET /v1/models HTTP/1.1"));
+            assert!(!requests[1].contains("messages"));
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_provider_type_does_not_fall_back() {
+        let server = MockServer::spawn(vec![Reply::json(
+            404,
+            r#"{"error":{"code":"route_not_found"}}"#,
+        )]);
+        assert_eq!(
+            preflight_auth(&provider(&server.base_url, "custom-provider")).await,
+            Err(AuthPreflightError::ModelUnavailable {
+                model: "test-model".to_string()
+            })
+        );
+        assert_eq!(server.finish().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_fallback_classifies_explicit_model_errors_from_400_and_422() {
+        for status in [400, 422] {
+            let server = MockServer::spawn(vec![
+                Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+                Reply::json(
+                    status,
+                    r#"{"error":{"code":"model_not_found","param":"model"}}"#,
+                ),
+            ]);
+            assert_eq!(
+                preflight_auth(&provider(&server.base_url, "openai_compat")).await,
+                Err(AuthPreflightError::ModelUnavailable {
+                    model: "test-model".to_string()
+                }),
+                "status {status}"
+            );
+            assert_eq!(server.finish().len(), 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_provider_list_and_chat_validate_model_and_credentials() {
+        for status in [404, 405, 501] {
+            let server = MockServer::spawn(vec![
+                Reply::json(status, r#"{"error":{"code":"route_not_found"}}"#),
+                Reply::json(
+                    200,
+                    r#"{"object":"list","data":[{"id":"test-model","object":"model"}]}"#,
+                ),
+                Reply::json(200, r#"{"choices":[{"message":{"content":""}}]}"#),
+            ]);
+            preflight_auth(&provider(&server.base_url, "coding_plan"))
+                .await
+                .expect("plan fallback succeeds");
+            let requests = server.finish();
+            assert_eq!(requests.len(), 3);
+            assert!(requests[0].starts_with("GET /v1/models/test-model HTTP/1.1"));
+            assert!(requests[1].starts_with("GET /v1/models HTTP/1.1"));
+            assert!(requests[2].starts_with("POST /v1/chat/completions HTTP/1.1"));
+            for request in &requests {
+                assert!(request.contains("user-agent: Cosh/"));
+                assert!(request.contains("x-dashscope-useragent: Cosh/"));
+                assert!(request.contains("x-dashscope-authtype: openai"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn public_model_list_does_not_accept_invalid_credentials() {
+        for provider_type in ["dashscope", "coding_plan"] {
+            let server = MockServer::spawn(vec![
+                Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+                Reply::json(
+                    200,
+                    r#"{"object":"list","data":[{"id":"test-model","object":"model"}]}"#,
+                ),
+                Reply::json(401, r#"{"error":{"code":"invalid_api_key"}}"#),
+            ]);
+            assert_eq!(
+                preflight_auth(&provider(&server.base_url, provider_type)).await,
+                Err(AuthPreflightError::InvalidCredentials),
+                "provider type {provider_type}"
+            );
+            assert_eq!(server.finish().len(), 3);
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_provider_uses_chat_when_model_list_route_is_unavailable() {
+        let server = MockServer::spawn(vec![
+            Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+            Reply::json(405, r#"{"error":"coding agents only"}"#),
+            Reply::json(200, r#"{"choices":[{"message":{"content":""}}]}"#),
+        ]);
+        preflight_auth(&provider(&server.base_url, "token_plan"))
+            .await
+            .expect("chat fallback succeeds");
+        let requests = server.finish();
+        assert_eq!(requests.len(), 3);
+        assert!(requests[2].starts_with("POST /v1/chat/completions HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn plan_model_list_rejects_an_unavailable_model() {
+        let server = MockServer::spawn(vec![
+            Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+            Reply::json(
+                200,
+                r#"{"object":"list","data":[{"id":"another-model","object":"model"}]}"#,
+            ),
+        ]);
+        assert_eq!(
+            preflight_auth(&provider(&server.base_url, "token_plan")).await,
+            Err(AuthPreflightError::ModelUnavailable {
+                model: "test-model".to_string()
+            })
+        );
+        assert_eq!(server.finish().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn model_list_can_exceed_the_old_64_kib_limit() {
+        let padding = "x".repeat(70 * 1024);
+        let body = format!(
+            r#"{{"metadata":"{padding}","data":[{{"id":"test-model","object":"model"}}]}}"#
+        );
+        let server = MockServer::spawn(vec![
+            Reply::json(404, r#"{"error":{"code":"route_not_found"}}"#),
+            Reply::json(200, body),
+        ]);
+        preflight_auth(&provider(&server.base_url, "deepseek"))
+            .await
+            .expect("bounded large model list succeeds");
+        assert_eq!(server.finish().len(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn preflight_phases_share_one_total_deadline() {
+        let two_phases = async {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            Ok(())
+        };
+
+        assert_eq!(
+            enforce_preflight_deadline(Duration::from_millis(250), two_phases).await,
+            Err(AuthPreflightError::Timeout)
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_model_not_found_does_not_fall_back() {
+        let server = MockServer::spawn(vec![Reply::json(
+            404,
+            r#"{"error":{"code":"model_not_found","param":"model"}}"#,
+        )]);
+        assert!(matches!(
+            preflight_auth(&provider(&server.base_url, "openai_compat")).await,
+            Err(AuthPreflightError::ModelUnavailable { .. })
+        ));
+        assert_eq!(server.finish().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn connection_failure_is_endpoint_unreachable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        assert_eq!(
+            preflight_auth(&provider(&format!("http://{address}/v1"), "dashscope")).await,
+            Err(AuthPreflightError::EndpointUnreachable)
+        );
+    }
+
+    #[tokio::test]
+    async fn request_timeout_is_classified() {
+        let server = MockServer::spawn(vec![Reply {
+            delay: Duration::from_millis(50),
+            ..Reply::json(200, r#"{"id":"test-model"}"#)
+        }]);
+        assert_eq!(
+            preflight_auth_with_timeout(
+                &provider(&server.base_url, "dashscope"),
+                Duration::from_millis(10),
+            )
+            .await,
+            Err(AuthPreflightError::Timeout)
+        );
+        server.finish();
+    }
+
+    #[tokio::test]
+    async fn redirect_is_not_followed_and_does_not_forward_credentials() {
+        let target = TcpListener::bind("127.0.0.1:0").unwrap();
+        target.set_nonblocking(true).unwrap();
+        let target_address = target.local_addr().unwrap();
+        let server = MockServer::spawn(vec![Reply {
+            headers: vec![(
+                "Location".to_string(),
+                format!("http://{target_address}/steal"),
+            )],
+            ..Reply::json(302, "")
+        }]);
+        assert_eq!(
+            preflight_auth(&provider(&server.base_url, "dashscope")).await,
+            Err(AuthPreflightError::UnsupportedResponse)
+        );
+        let source_requests = server.finish();
+        assert!(source_requests[0].contains("authorization: Bearer sk-private-value"));
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            target.accept().is_err(),
+            "redirect target received credentials"
+        );
+    }
+
+    #[tokio::test]
+    async fn aliyun_manual_credentials_validate_runtime_permission_and_model() {
+        let server = MockServer::spawn(vec![
+            Reply::json(200, r#"{"code":"Success","data":{"role_exist":true}}"#),
+            Reply::json(
+                200,
+                "event: OK\ndata: {\"choices\":[{\"message\":{\"content\":\"\"}}]}\n\n",
+            ),
+        ]);
+        let mut aliyun = provider(&server.base_url, "aliyun");
+        aliyun.api_key.clear();
+        aliyun.access_key_id = "test-access-key".to_string();
+        aliyun.access_key_secret = "test-secret".to_string();
+
+        preflight_auth(&aliyun)
+            .await
+            .expect("signed permission probe");
+        let requests = server.finish();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].starts_with("POST /api/v1/openapi/initial HTTP/1.1"));
+        assert!(requests[0].contains("x-acs-action: InitialSysom"));
+        assert!(requests[0].contains("x-acs-version: 2023-12-30"));
+        assert!(requests[0].contains(r#"{"check_only":true,"source":"cosh"}"#));
+        assert!(requests[0].contains("authorization: ACS3-HMAC-SHA256 Credential=test-access-key"));
+        assert!(!requests[0].contains("test-secret"));
+        assert!(!requests[0].contains("messages"));
+        assert!(requests[1]
+            .starts_with("POST /api/v1/copilot/generate_copilot_stream_response HTTP/1.1"));
+        assert!(requests[1].contains("x-acs-action: GenerateCopilotStreamResponse"));
+        assert!(requests[1].contains("authorization: ACS3-HMAC-SHA256 Credential=test-access-key"));
+        assert!(requests[1].contains(r#"\"model\":\"test-model\""#));
+        assert!(requests[1].contains(r#"\"max_tokens\":1"#));
+        assert!(!requests[1].contains("test-secret"));
+    }
+
+    #[tokio::test]
+    async fn aliyun_permission_probe_preserves_permission_classification() {
+        let server = MockServer::spawn(vec![Reply::json(
+            200,
+            r#"{"code":"NoPermission","message":"redacted by preflight"}"#,
+        )]);
+        let mut aliyun = provider(&server.base_url, "aliyun");
+        aliyun.api_key.clear();
+        aliyun.access_key_id = "test-access-key".to_string();
+        aliyun.access_key_secret = "test-secret".to_string();
+
+        assert_eq!(
+            preflight_auth(&aliyun).await,
+            Err(AuthPreflightError::PermissionDenied)
+        );
+        server.finish();
+    }
+
+    #[tokio::test]
+    async fn aliyun_permission_probe_rejects_a_missing_service_role() {
+        let server = MockServer::spawn(vec![Reply::json(
+            200,
+            r#"{"code":"Success","data":{"role_exist":false}}"#,
+        )]);
+        let mut aliyun = provider(&server.base_url, "aliyun");
+        aliyun.api_key.clear();
+        aliyun.access_key_id = "test-access-key".to_string();
+        aliyun.access_key_secret = "test-secret".to_string();
+
+        assert_eq!(
+            preflight_auth(&aliyun).await,
+            Err(AuthPreflightError::ServiceNotReady)
+        );
+        server.finish();
+    }
+
+    #[tokio::test]
+    async fn aliyun_non_success_status_preserves_body_error_classification() {
+        let server = MockServer::spawn(vec![Reply::json(
+            404,
+            r#"{"Code":"InvalidAccessKeyId.NotFound"}"#,
+        )]);
+        let mut aliyun = provider(&server.base_url, "aliyun");
+        aliyun.api_key.clear();
+        aliyun.access_key_id = "test-access-key".to_string();
+        aliyun.access_key_secret = "test-secret".to_string();
+
+        assert_eq!(
+            preflight_auth(&aliyun).await,
+            Err(AuthPreflightError::InvalidCredentials)
+        );
+        server.finish();
+    }
+
+    #[tokio::test]
+    async fn aliyun_copilot_permission_failure_rejects_candidate() {
+        for reply in [
+            Reply::json(403, r#"{"Code":"NoPermission"}"#),
+            Reply::json(200, r#"{"Code":"NoPermission"}"#),
+        ] {
+            let server = MockServer::spawn(vec![
+                Reply::json(200, r#"{"code":"Success","data":{"role_exist":true}}"#),
+                reply,
+            ]);
+            let mut aliyun = provider(&server.base_url, "aliyun");
+            aliyun.api_key.clear();
+            aliyun.access_key_id = "test-access-key".to_string();
+            aliyun.access_key_secret = "test-secret".to_string();
+
+            assert_eq!(
+                preflight_auth(&aliyun).await,
+                Err(AuthPreflightError::PermissionDenied)
+            );
+            assert_eq!(server.finish().len(), 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn aliyun_copilot_model_failure_rejects_candidate() {
+        for reply in [
+            Reply::json(400, r#"{"Code":"ModelNotFound"}"#),
+            Reply::json(
+                200,
+                "event: Failed\ndata: {\"error\":{\"code\":\"InvalidModel\"}}\n\n",
+            ),
+        ] {
+            let server = MockServer::spawn(vec![
+                Reply::json(200, r#"{"code":"Success","data":{"role_exist":true}}"#),
+                reply,
+            ]);
+            let mut aliyun = provider(&server.base_url, "aliyun");
+            aliyun.api_key.clear();
+            aliyun.access_key_id = "test-access-key".to_string();
+            aliyun.access_key_secret = "test-secret".to_string();
+
+            assert_eq!(
+                preflight_auth(&aliyun).await,
+                Err(AuthPreflightError::ModelUnavailable {
+                    model: "test-model".to_string()
+                })
+            );
+            assert_eq!(server.finish().len(), 2);
+        }
+    }
+
+    #[test]
+    fn errors_never_render_credentials_or_response_bodies() {
+        for error in [
+            AuthPreflightError::InvalidCredentials,
+            AuthPreflightError::PermissionDenied,
+            AuthPreflightError::ModelUnavailable {
+                model: "test-model".to_string(),
+            },
+            AuthPreflightError::ServiceNotReady,
+            AuthPreflightError::CredentialSourceUnavailable,
+            AuthPreflightError::UnsupportedResponse,
+        ] {
+            let message = error.to_string();
+            assert!(!message.contains("sk-private-value"));
+            assert!(!message.contains("Authorization"));
+            assert!(!message.contains("response body"));
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/auth/validation.rs
+++ b/src/cosh-ng/crates/cosh-core/src/auth/validation.rs
@@ -10,6 +10,7 @@ use super::AuthResponse;
 pub(crate) enum AuthConfigValidationError {
     MissingRequiredField(String),
     InvalidBaseUrl,
+    InvalidProviderId,
 }
 
 impl fmt::Display for AuthConfigValidationError {
@@ -20,6 +21,8 @@ impl fmt::Display for AuthConfigValidationError {
             }
             Self::InvalidBaseUrl => formatter
                 .write_str("invalid base_url: expected an http:// or https:// URL with a host"),
+            Self::InvalidProviderId => formatter
+                .write_str("invalid provider_id: expected letters, digits, '-' and '_' only"),
         }
     }
 }
@@ -58,6 +61,13 @@ pub(super) fn validate_auth_response(
         validate_base_url(base_url)?;
     }
     Ok(())
+}
+
+pub(crate) fn is_valid_provider_id(provider_id: &str) -> bool {
+    !provider_id.is_empty()
+        && provider_id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
 }
 
 pub(super) fn validate_base_url(base_url: &str) -> Result<(), AuthConfigValidationError> {

--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -13,7 +13,9 @@ use cosh_types::audit::{AuditOutcomeStatus, AuditProviderData, AuditToolData, Ou
 use crate::audit::{CoreAuditRecorder, CoreAuditScope};
 use crate::auth::is_auth_error;
 use crate::compaction::{CompactionRuntime, ModelCapability};
-use crate::config::{self, ApprovalMode, CoreConfig};
+#[cfg(test)]
+use crate::config;
+use crate::config::{ApprovalMode, CoreConfig};
 use crate::context::ContextBuilder;
 use crate::extension::{GenerationController, RuntimeGeneration, RuntimeSnapshot};
 use crate::hook::{HookDecision, HookNotification, HookSystem, PreToolUseResult};

--- a/src/cosh-ng/crates/cosh-core/src/core/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/auth.rs
@@ -17,7 +17,7 @@ impl CoshCore {
     {
         let request_id = self.next_request_id();
         let mut discarded_lines = Vec::new();
-        let response = request_validated_auth(
+        let validated = request_validated_auth(
             &mut self.config,
             reader,
             writer,
@@ -27,15 +27,11 @@ impl CoshCore {
             &mut discarded_lines,
         )
         .await;
-        let Some(response) = response else {
+        let Some(validated) = validated else {
             return false;
         };
 
-        if response.persist {
-            if let Err(error) = config::persist_config(&self.config) {
-                tracing::warn!("failed to persist config: {error}");
-            }
-        }
+        self.config = validated.candidate;
 
         let resolved = self.config.resolve_provider();
         if resolved.provider_type == "aliyun" {

--- a/src/cosh-ng/crates/cosh-core/src/headless/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless/auth.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use tokio::io::AsyncBufReadExt;
 
 use crate::auth::request_validated_auth;
-use crate::config::{self, CoreConfig};
+use crate::config::CoreConfig;
 use crate::protocol::{AuthReason, OutputMessage};
 
 /// Requests credentials until they validate or the shell cancels the exchange.
@@ -19,7 +19,7 @@ where
     W: Write,
     R: AsyncBufReadExt + Unpin,
 {
-    let response = request_validated_auth(
+    let validated = request_validated_auth(
         config,
         lines,
         writer,
@@ -30,11 +30,7 @@ where
     )
     .await?;
 
-    if response.persist {
-        if let Err(error) = config::persist_config(config) {
-            tracing::warn!("failed to persist config: {error}");
-        }
-    }
+    *config = validated.candidate;
 
     if let Ok(json) = serde_json::to_string(&OutputMessage::system_status("auth_ok")) {
         let _ = writeln!(writer, "{json}");

--- a/src/cosh-ng/crates/cosh-core/src/registry.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry.rs
@@ -323,7 +323,7 @@ pub(crate) async fn handle_registry_request(
     live_runtime: Option<&LiveExtensionRuntime>,
 ) -> OutputMessage {
     match domain {
-        "auth" => handle_auth(request_id, action, params, config),
+        "auth" => handle_auth(request_id, action, params, config).await,
         "extensions" => {
             handle_extensions(
                 request_id,
@@ -843,8 +843,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn auth_state_marks_system_providers_as_not_editable() {
+    #[tokio::test]
+    async fn auth_state_marks_system_providers_as_not_editable() {
         let mut config = CoreConfig::default();
         config.ai.active_provider = Some("system-provider".to_string());
         config.ai.providers.insert(
@@ -870,7 +870,7 @@ mod tests {
         );
         config.ai.providers.extend(config.user_ai.providers.clone());
 
-        let response = handle_auth("test-1", "state", &Value::Null, &mut config);
+        let response = handle_auth("test-1", "state", &Value::Null, &mut config).await;
         let OutputMessage::RegistryResponse {
             success: true,
             data: Some(data),
@@ -895,8 +895,8 @@ mod tests {
         assert_eq!(user["editable"], true);
     }
 
-    #[test]
-    fn auth_configure_rejects_invalid_provider_id() {
+    #[tokio::test]
+    async fn auth_configure_rejects_invalid_provider_id() {
         let mut config = CoreConfig::default();
         let response = handle_auth(
             "test-1",
@@ -909,7 +909,8 @@ mod tests {
                 }
             }),
             &mut config,
-        );
+        )
+        .await;
 
         let OutputMessage::RegistryResponse { success, error, .. } = response else {
             panic!("unexpected response: {response:?}");
@@ -919,8 +920,8 @@ mod tests {
         assert!(config.user_ai.providers.is_empty());
     }
 
-    #[test]
-    fn auth_configure_rejects_invalid_base_url_without_mutating_config() {
+    #[tokio::test]
+    async fn auth_configure_rejects_invalid_base_url_without_mutating_config() {
         let mut config = CoreConfig::default();
         let response = handle_auth(
             "test-1",
@@ -935,7 +936,8 @@ mod tests {
                 }
             }),
             &mut config,
-        );
+        )
+        .await;
 
         let OutputMessage::RegistryResponse { success, error, .. } = response else {
             panic!("unexpected response: {response:?}");
@@ -946,8 +948,8 @@ mod tests {
         assert!(config.user_ai.providers.is_empty());
     }
 
-    #[test]
-    fn auth_configure_rejects_system_provider_overwrite() {
+    #[tokio::test]
+    async fn auth_configure_rejects_system_provider_overwrite() {
         let mut config = CoreConfig::default();
         config.ai.providers.insert(
             "system-provider".to_string(),
@@ -973,7 +975,8 @@ mod tests {
                 }
             }),
             &mut config,
-        );
+        )
+        .await;
 
         let OutputMessage::RegistryResponse { success, error, .. } = response else {
             panic!("unexpected response: {response:?}");
@@ -983,8 +986,8 @@ mod tests {
         assert!(!config.user_ai.providers.contains_key("system-provider"));
     }
 
-    #[test]
-    fn auth_delete_rejects_system_provider() {
+    #[tokio::test]
+    async fn auth_delete_rejects_system_provider() {
         let mut config = CoreConfig::default();
         config.ai.providers.insert(
             "system-provider".to_string(),
@@ -1004,7 +1007,8 @@ mod tests {
             "delete",
             &serde_json::json!({ "provider_id": "system-provider" }),
             &mut config,
-        );
+        )
+        .await;
 
         let OutputMessage::RegistryResponse { success, error, .. } = response else {
             panic!("unexpected response: {response:?}");

--- a/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
+++ b/src/cosh-ng/crates/cosh-core/src/registry/auth.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-pub(super) fn handle_auth(
+pub(super) async fn handle_auth(
     request_id: &str,
     action: &str,
     params: &Value,
@@ -79,19 +79,20 @@ pub(super) fn handle_auth(
             if provider_id.is_empty() || !config.ai.providers.contains_key(provider_id) {
                 return registry_error(request_id, "provider not found");
             }
-            config.ai.active_provider = Some(provider_id.to_string());
-            config.user_ai.active_provider = Some(provider_id.to_string());
-            if let Some(model) = config
+            let mut candidate = config.clone();
+            candidate.ai.active_provider = Some(provider_id.to_string());
+            candidate.user_ai.active_provider = Some(provider_id.to_string());
+            let model = candidate
                 .ai
                 .providers
                 .get(provider_id)
-                .and_then(|provider| provider.model.clone())
-            {
-                config.ai.active_model = Some(model);
-            }
-            if let Err(e) = crate::config::persist_config(config) {
+                .and_then(|provider| provider.model.clone());
+            candidate.ai.active_model.clone_from(&model);
+            candidate.user_ai.active_model = model;
+            if let Err(e) = crate::config::persist_config(&candidate) {
                 return registry_error(request_id, &format!("failed to persist config: {e}"));
             }
+            *config = candidate;
             OutputMessage::RegistryResponse {
                 request_id: request_id.to_string(),
                 success: true,
@@ -107,13 +108,15 @@ pub(super) fn handle_auth(
             if provider_id.is_empty() {
                 return registry_error(request_id, "missing provider_id");
             }
-            let removed = match crate::auth::remove_auth_provider(config, provider_id) {
+            let mut candidate = config.clone();
+            let removed = match crate::auth::remove_auth_provider(&mut candidate, provider_id) {
                 Ok(removed) => removed,
                 Err(error) => return registry_error(request_id, &error.to_string()),
             };
-            if let Err(error) = crate::config::persist_config(config) {
+            if let Err(error) = crate::config::persist_config(&candidate) {
                 return registry_error(request_id, &format!("failed to persist config: {error}"));
             }
+            *config = candidate;
             OutputMessage::RegistryResponse {
                 request_id: request_id.to_string(),
                 success: true,
@@ -200,9 +203,6 @@ pub(super) fn handle_auth(
             if provider_id.is_empty() || provider_type.is_empty() {
                 return registry_error(request_id, "missing provider_id or provider_type");
             }
-            if !is_valid_provider_id(provider_id) {
-                return registry_error(request_id, "invalid provider_id");
-            }
             if config.ai.providers.contains_key(provider_id)
                 && !config.user_ai.providers.contains_key(provider_id)
             {
@@ -244,12 +244,17 @@ pub(super) fn handle_auth(
                 values,
                 persist: true,
             };
-            if let Err(error) = crate::auth::apply_auth_credentials(config, &response) {
-                return registry_error(request_id, &error.to_string());
-            }
-            if let Err(e) = crate::config::persist_config(config) {
-                return registry_error(request_id, &format!("failed to persist config: {e}"));
-            }
+            let candidate = match crate::auth::prepare_and_persist_auth_candidate(
+                config,
+                &response,
+                crate::config::persist_config,
+            )
+            .await
+            {
+                Ok(candidate) => candidate,
+                Err(error) => return auth_registry_error(request_id, &error),
+            };
+            *config = candidate;
             OutputMessage::RegistryResponse {
                 request_id: request_id.to_string(),
                 success: true,
@@ -264,11 +269,13 @@ pub(super) fn handle_auth(
     }
 }
 
-fn is_valid_provider_id(provider_id: &str) -> bool {
-    !provider_id.is_empty()
-        && provider_id
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+fn auth_registry_error(request_id: &str, error: &crate::auth::AuthConfigureError) -> OutputMessage {
+    OutputMessage::RegistryResponse {
+        request_id: request_id.to_string(),
+        success: false,
+        data: Some(serde_json::json!({ "error_code": error.code() })),
+        error: Some(error.to_string()),
+    }
 }
 
 fn preserve_masked_secret(

--- a/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/registry_protocol.rs
@@ -1,8 +1,106 @@
-use std::io::Write;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 use serde_json::Value;
+
+fn model_server() -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let thread = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 2048];
+        let _ = stream.read(&mut request);
+        let body = r#"{"id":"home-model","object":"model"}"#;
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}/v1"), thread)
+}
+
+fn rejecting_model_server(status: u16) -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let thread = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 2048];
+        let _ = stream.read(&mut request);
+        let body = r#"{"error":{"code":"invalid_api_key"}}"#;
+        write!(
+            stream,
+            "HTTP/1.1 {status} Rejected\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}/v1"), thread)
+}
+
+fn aliyun_response_server(body: &'static str) -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let thread = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 4096];
+        let count = stream.read(&mut request).unwrap();
+        let request = String::from_utf8_lossy(&request[..count]);
+        assert!(request.starts_with("POST /api/v1/openapi/initial HTTP/1.1"));
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}"), thread)
+}
+
+fn aliyun_copilot_rejection_server(
+    status: u16,
+    body: &'static str,
+) -> (String, std::thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let thread = std::thread::spawn(move || {
+        for (expected_path, response_status, response_body) in [
+            (
+                "/api/v1/openapi/initial",
+                200,
+                r#"{"code":"Success","data":{"role_exist":true}}"#,
+            ),
+            (
+                "/api/v1/copilot/generate_copilot_stream_response",
+                status,
+                body,
+            ),
+        ] {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let count = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..count]);
+            assert!(
+                request.starts_with(&format!("POST {expected_path} HTTP/1.1")),
+                "{request}"
+            );
+            write!(
+                stream,
+                "HTTP/1.1 {response_status} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            )
+            .unwrap();
+        }
+    });
+    (format!("http://{address}"), thread)
+}
 
 fn binary_path() -> std::path::PathBuf {
     let mut path = std::env::current_exe()
@@ -824,13 +922,15 @@ api_key = "sk-project"
     )
     .unwrap();
 
+    let (base_url, server) = model_server();
     let resp = run_registry_request_with_context(
         "auth",
         "configure",
         serde_json::json!({
             "provider_id": "home-provider",
-            "provider_type": "dashscope",
+            "provider_type": "openai_compat",
             "values": {
+                "base_url": base_url,
                 "api_key": "sk-home",
                 "model": "home-model"
             }
@@ -838,6 +938,7 @@ api_key = "sk-project"
         home.path(),
         Some(project.path()),
     );
+    server.join().unwrap();
     assert_eq!(resp["success"], true);
 
     let home_config = std::fs::read_to_string(home_config_dir.join("config.toml")).unwrap();
@@ -883,6 +984,135 @@ fn registry_auth_configure_rejects_invalid_base_url_without_writing_config() {
 }
 
 #[test]
+fn registry_auth_preflight_rejection_is_classified_without_writing_config() {
+    for (status, expected_code) in [(401, "invalid_credentials"), (403, "permission_denied")] {
+        let home = tempfile::tempdir().expect("temp home");
+        let config_path = home.path().join(".copilot-shell/config.toml");
+        let (base_url, server) = rejecting_model_server(status);
+        let response = run_registry_request_with_context(
+            "auth",
+            "configure",
+            serde_json::json!({
+                "provider_id": "rejected-provider",
+                "provider_type": "dashscope",
+                "values": {
+                    "base_url": base_url,
+                    "api_key": "sk-not-logged",
+                    "model": "home-model"
+                }
+            }),
+            home.path(),
+            None,
+        );
+        server.join().unwrap();
+
+        assert_eq!(response["success"], false, "{response}");
+        assert_eq!(response["data"]["error_code"], expected_code, "{response}");
+        assert!(!config_path.exists());
+        assert!(!response.to_string().contains("sk-not-logged"));
+    }
+}
+
+#[test]
+fn registry_auth_rejects_missing_aliyun_role_without_writing_config() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_path = home.path().join(".copilot-shell/config.toml");
+    let (base_url, server) =
+        aliyun_response_server(r#"{"code":"Success","data":{"role_exist":false}}"#);
+    let response = run_registry_request_with_context(
+        "auth",
+        "configure",
+        serde_json::json!({
+            "provider_id": "sysom-not-ready",
+            "provider_type": "aliyun",
+            "values": {
+                "base_url": base_url,
+                "access_key_id": "test-access-key",
+                "access_key_secret": "test-secret",
+                "model": "qwen-test"
+            }
+        }),
+        home.path(),
+        None,
+    );
+    server.join().unwrap();
+
+    assert_eq!(response["success"], false, "{response}");
+    assert_eq!(response["data"]["error_code"], "service_not_ready");
+    assert!(!config_path.exists());
+    assert!(!response.to_string().contains("test-secret"));
+}
+
+#[test]
+fn registry_auth_rejects_unusable_aliyun_model_without_writing_config() {
+    let home = tempfile::tempdir().expect("temp home");
+    let config_path = home.path().join(".copilot-shell/config.toml");
+    let (base_url, server) = aliyun_copilot_rejection_server(400, r#"{"Code":"ModelNotFound"}"#);
+    let response = run_registry_request_with_context(
+        "auth",
+        "configure",
+        serde_json::json!({
+            "provider_id": "sysom-bad-model",
+            "provider_type": "aliyun",
+            "values": {
+                "base_url": base_url,
+                "access_key_id": "test-access-key",
+                "access_key_secret": "test-secret",
+                "model": "definitely-not-a-real-sysom-model"
+            }
+        }),
+        home.path(),
+        None,
+    );
+    server.join().unwrap();
+
+    assert_eq!(response["success"], false, "{response}");
+    assert_eq!(response["data"]["error_code"], "model_unavailable");
+    assert!(!config_path.exists());
+    assert!(!response.to_string().contains("test-secret"));
+}
+
+#[test]
+fn registry_auth_activate_clears_a_stale_model() {
+    let home = tempfile::tempdir().expect("temp home");
+    let home_config_dir = home.path().join(".copilot-shell");
+    std::fs::create_dir_all(&home_config_dir).unwrap();
+    let config_path = home_config_dir.join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[ai]
+active_provider = "old-provider"
+active_model = "old-model"
+
+[ai.providers.old-provider]
+type = "dashscope"
+api_key = "sk-old"
+model = "old-model"
+
+[ai.providers.no-model]
+type = "dashscope"
+api_key = "sk-new"
+"#,
+    )
+    .unwrap();
+
+    let response = run_registry_request_with_context(
+        "auth",
+        "activate",
+        serde_json::json!({ "provider_id": "no-model" }),
+        home.path(),
+        None,
+    );
+
+    assert_eq!(response["success"], true, "{response}");
+    assert_eq!(response["data"]["active_provider"], "no-model");
+    let persisted = std::fs::read_to_string(config_path).unwrap();
+    assert!(persisted.contains("active_provider = \"no-model\""));
+    assert!(!persisted.contains("active_model = \"old-model\""));
+}
+
+#[test]
 fn registry_auth_delete_removes_user_provider_and_credentials() {
     let home = tempfile::tempdir().expect("temp home");
     let home_config_dir = home.path().join(".copilot-shell");
@@ -893,6 +1123,7 @@ fn registry_auth_delete_removes_user_provider_and_credentials() {
         r#"
 [ai]
 active_provider = "remove-me"
+active_model = "delete-model"
 
 [ai.providers.keep-me]
 type = "dashscope"
@@ -921,6 +1152,7 @@ model = "remove-model"
     let persisted = std::fs::read_to_string(&config_path).unwrap();
     assert!(!persisted.contains("[ai.providers.remove-me]"));
     assert!(!persisted.contains("sk-remove"));
+    assert!(!persisted.contains("active_model = \"delete-model\""));
     assert!(persisted.contains("[ai.providers.keep-me]"));
     assert!(persisted.contains("sk-keep"));
 }

--- a/src/cosh-ng/crates/cosh-core/tests/session_recovery.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/session_recovery.rs
@@ -1,7 +1,9 @@
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::thread::JoinHandle;
 
 use rustix::fs::{flock, FlockOperation};
 use serde_json::{json, Value};
@@ -61,6 +63,30 @@ model = "mock-history"
 "#,
     )
     .expect("write mock provider config");
+}
+
+fn authentication_model_server(model: &'static str) -> (String, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind auth model server");
+    let address = listener.local_addr().expect("auth model server address");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept auth model request");
+        let mut request = [0_u8; 2048];
+        let count = stream.read(&mut request).expect("read auth model request");
+        let request = String::from_utf8_lossy(&request[..count]);
+        assert!(
+            request.starts_with(&format!("GET /v1/models/{model} HTTP/1.1")),
+            "unexpected auth model request: {request}"
+        );
+        let body = format!(r#"{{"id":"{model}","object":"model"}}"#);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .expect("write auth model response");
+    });
+    (format!("http://{address}/v1"), server)
 }
 
 #[test]
@@ -578,6 +604,7 @@ fn authentication_selected_model_initializes_new_session() {
     let home = temp.path().join("home");
     let workspace = temp.path().join("workspace");
     let store = temp.path().join("sessions");
+    let (auth_base_url, auth_server) = authentication_model_server("gpt-selected");
     fs::create_dir_all(&home).expect("create home");
     fs::create_dir_all(&workspace).expect("create workspace");
     let config_dir = home.join(".copilot-shell");
@@ -619,7 +646,7 @@ persist_dir = "{}"
                         "provider_type": "openai_compat",
                         "values": {
                             "api_key": "test-key",
-                            "base_url": "http://127.0.0.1:9/v1",
+                            "base_url": auth_base_url,
                             "model": "gpt-selected"
                         },
                         "persist": false
@@ -638,6 +665,7 @@ persist_dir = "{}"
             }),
         ],
     ));
+    auth_server.join().expect("auth model server");
     let init = messages
         .iter()
         .find(|message| message["type"] == "system" && message["subtype"] == "init")

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry.rs
@@ -9,6 +9,7 @@ use super::CoshCoreAdapter;
 
 pub(super) const REGISTRY_READ_TIMEOUT: Duration = Duration::from_secs(5);
 pub(super) const REGISTRY_MUTATION_TIMEOUT: Duration = Duration::from_secs(120);
+pub(super) const AUTH_CONFIGURE_TIMEOUT: Duration = Duration::from_secs(12);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Distinguishes registry protocol failures from transport failures.
@@ -16,14 +17,17 @@ pub(crate) enum RegistryQueryError {
     /// The request could not produce a valid, correlated registry response.
     Transport(String),
     /// The core returned a valid registry response that rejected the request.
-    Response(String),
+    Response {
+        message: String,
+        code: Option<String>,
+    },
 }
 
 impl RegistryQueryError {
     /// Preserves the existing string-based adapter API for ordinary callers.
     pub(crate) fn into_message(self) -> String {
         match self {
-            Self::Transport(message) | Self::Response(message) => message,
+            Self::Transport(message) | Self::Response { message, .. } => message,
         }
     }
 }
@@ -176,7 +180,14 @@ impl CoshCoreAdapter {
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown error")
                 .to_string();
-            Err(RegistryQueryError::Response(error))
+            Err(RegistryQueryError::Response {
+                message: error,
+                code: resp
+                    .get("data")
+                    .and_then(|data| data.get("error_code"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            })
         }
     }
 }
@@ -199,6 +210,9 @@ pub(super) fn extension_mutation_requires_reload(domain: &str, action: &str) -> 
 }
 
 pub(super) fn registry_timeout(domain: &str, action: &str) -> Duration {
+    if domain == "auth" && action == "configure" {
+        return AUTH_CONFIGURE_TIMEOUT;
+    }
     let long_running_extension_action = extension_mutation_requires_reload(domain, action)
         || (domain == "extensions"
             && matches!(

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_registry_tests.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use super::cosh_core::CoshCoreAdapter;
 use super::cosh_core_registry::{
     extension_mutation_requires_reload, registry_timeout, RegistryQueryError,
-    REGISTRY_MUTATION_TIMEOUT, REGISTRY_READ_TIMEOUT,
+    AUTH_CONFIGURE_TIMEOUT, REGISTRY_MUTATION_TIMEOUT, REGISTRY_READ_TIMEOUT,
 };
 
 #[test]
@@ -31,6 +31,11 @@ fn candidate_building_mutations_share_the_mutation_timeout() {
         registry_timeout("extensions", "list"),
         REGISTRY_READ_TIMEOUT
     );
+    assert_eq!(
+        registry_timeout("auth", "configure"),
+        AUTH_CONFIGURE_TIMEOUT
+    );
+    assert!(AUTH_CONFIGURE_TIMEOUT > std::time::Duration::from_secs(8));
 }
 
 fn test_adapter_with_program(program: &str) -> CoshCoreAdapter {
@@ -123,9 +128,36 @@ printf '%s\n' '{"type":"registry_response","request_id":"reg-test","success":fal
 
     assert_eq!(
         result,
-        Err(RegistryQueryError::Response(
-            "candidate validation failed".to_string()
-        ))
+        Err(RegistryQueryError::Response {
+            message: "candidate validation failed".to_string(),
+            code: None,
+        })
+    );
+}
+
+#[test]
+fn registry_query_preserves_structured_auth_error_code() {
+    let script = write_mock_script(
+        "classified-auth-failure",
+        r#"read REQUEST
+printf '%s\n' '{"type":"registry_response","request_id":"reg-test","success":false,"data":{"error_code":"invalid_credentials"},"error":"The API key was rejected."}'
+"#,
+    );
+
+    let adapter = test_adapter_with_program(&script.to_string_lossy());
+    let result = adapter.registry_query_classified(
+        "auth",
+        "configure",
+        serde_json::json!({"provider_id": "test"}),
+    );
+    let _ = std::fs::remove_file(&script);
+
+    assert_eq!(
+        result,
+        Err(RegistryQueryError::Response {
+            message: "The API key was rejected.".to_string(),
+            code: Some("invalid_credentials".to_string()),
+        })
     );
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/cosh_core_service/process.rs
@@ -369,13 +369,18 @@ pub(super) fn execute_registry(
         {
             return Ok(response.get("data").cloned().unwrap_or(Value::Null));
         }
-        return Err(RegistryQueryError::Response(
-            response
+        return Err(RegistryQueryError::Response {
+            message: response
                 .get("error")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown live registry error")
                 .to_string(),
-        ));
+            code: response
+                .get("data")
+                .and_then(|data| data.get("error_code"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        });
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/provider_management.rs
@@ -187,12 +187,15 @@ pub(super) fn core_auth_delete(adapter: &AdapterInstance, provider_id: &str) -> 
 pub(super) fn core_auth_configure(
     adapter: &AdapterInstance,
     response: &AuthResponse,
-) -> Result<(), String> {
+) -> Result<(), AuthConfigureFailure> {
     let AdapterInstance::CoshCore(cosh_core) = adapter else {
-        return Err("auth registry requires cosh-core backend".to_string());
+        return Err(AuthConfigureFailure {
+            message: "auth registry requires cosh-core backend".to_string(),
+            code: None,
+        });
     };
     cosh_core
-        .registry_query(
+        .registry_query_classified(
             "auth",
             "configure",
             json!({
@@ -202,6 +205,109 @@ pub(super) fn core_auth_configure(
             }),
         )
         .map(|_| ())
+        .map_err(auth_configure_failure)
+}
+
+fn auth_configure_failure(error: crate::adapter::RegistryQueryError) -> AuthConfigureFailure {
+    match error {
+        crate::adapter::RegistryQueryError::Transport(message) => AuthConfigureFailure {
+            message,
+            code: None,
+        },
+        crate::adapter::RegistryQueryError::Response { message, code } => {
+            AuthConfigureFailure { message, code }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AuthConfigureFailure {
+    pub(super) message: String,
+    pub(super) code: Option<String>,
+}
+
+impl AuthConfigureFailure {
+    pub(super) fn focus_field(&self, provider_template_id: &str) -> Option<&'static str> {
+        match self.code.as_deref() {
+            Some("invalid_provider_id") => Some("provider_id"),
+            Some("missing_access_key_id") => Some("access_key_id"),
+            Some("missing_access_key_secret") => Some("access_key_secret"),
+            Some("invalid_credentials" | "missing_credentials" | "permission_denied")
+                if provider_template_id == "aliyun" =>
+            {
+                Some("access_key_id")
+            }
+            Some("invalid_credentials" | "missing_credentials" | "permission_denied") => {
+                Some("api_key")
+            }
+            Some("model_unavailable" | "missing_model") => Some("model"),
+            Some("invalid_base_url" | "missing_base_url" | "endpoint_unreachable" | "timeout") => {
+                Some("base_url")
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod auth_configure_failure_tests {
+    use super::{auth_configure_failure, AuthConfigureFailure};
+    use crate::adapter::RegistryQueryError;
+
+    fn failure(code: &str) -> AuthConfigureFailure {
+        AuthConfigureFailure {
+            message: "safe message".to_string(),
+            code: Some(code.to_string()),
+        }
+    }
+
+    #[test]
+    fn classified_failures_focus_actionable_fields() {
+        for code in [
+            "invalid_credentials",
+            "permission_denied",
+            "missing_credentials",
+        ] {
+            assert_eq!(failure(code).focus_field("dashscope"), Some("api_key"));
+            assert_eq!(failure(code).focus_field("aliyun"), Some("access_key_id"));
+        }
+        assert_eq!(
+            failure("missing_access_key_id").focus_field("aliyun"),
+            Some("access_key_id")
+        );
+        assert_eq!(
+            failure("missing_access_key_secret").focus_field("aliyun"),
+            Some("access_key_secret")
+        );
+        for code in ["model_unavailable", "missing_model"] {
+            assert_eq!(failure(code).focus_field("dashscope"), Some("model"));
+        }
+        for code in [
+            "invalid_base_url",
+            "missing_base_url",
+            "endpoint_unreachable",
+            "timeout",
+        ] {
+            assert_eq!(failure(code).focus_field("openai_compat"), Some("base_url"));
+        }
+        assert_eq!(
+            failure("provider_unavailable").focus_field("dashscope"),
+            None
+        );
+        for code in ["service_not_ready", "credential_source_unavailable"] {
+            assert_eq!(failure(code).focus_field("aliyun"), None);
+        }
+    }
+
+    #[test]
+    fn shell_core_transport_failures_do_not_impersonate_provider_network_errors() {
+        let failure = auth_configure_failure(RegistryQueryError::Transport(
+            "cosh-core output stream disconnected".to_string(),
+        ));
+
+        assert_eq!(failure.code, None);
+        assert_eq!(failure.focus_field("dashscope"), None);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/retry.rs
@@ -5,15 +5,30 @@ use std::collections::HashSet;
 use super::menu::ECS_RAM_ROLE_AUTH_SOURCE;
 use super::runtime::{AuthPhase, RuntimeAuthState};
 
+#[cfg(test)]
 pub(super) fn restore_after_failed_submission(auth: &mut RuntimeAuthState) {
+    restore_after_failed_submission_at(auth, None);
+}
+
+pub(super) fn restore_after_failed_submission_at(
+    auth: &mut RuntimeAuthState,
+    field_name: Option<&str>,
+) {
     auth.phase = AuthPhase::FillingField;
     auth.field_error = None;
     let Some(provider_id) = auth.editing_provider_name.clone() else {
-        // A brand-new provider retries from scratch: nothing the rejected attempt collected
-        // may leak into the next one (#1769).
-        auth.current_field = 0;
-        auth.collected_values.clear();
-        auth.field_input.clear();
+        let fields = &auth.providers[auth.selected_provider].fields;
+        let secret_fields: HashSet<_> = fields
+            .iter()
+            .filter(|field| field.secret)
+            .map(|field| field.name.as_str())
+            .collect();
+        auth.collected_values
+            .retain(|name, _| !secret_fields.contains(name.as_str()));
+        auth.current_field = field_name
+            .and_then(|name| fields.iter().position(|field| field.name == name))
+            .unwrap_or(0);
+        auth.load_current_field_input();
         return;
     };
 
@@ -39,6 +54,11 @@ pub(super) fn restore_after_failed_submission(auth: &mut RuntimeAuthState) {
         .insert("provider_id".to_string(), provider_id);
     clear_ecs_auth_source(&mut auth.collected_values);
     auth.current_field = 1.min(fields.len());
+    if let Some(field_name) = field_name {
+        if let Some(index) = fields.iter().position(|field| field.name == field_name) {
+            auth.current_field = index;
+        }
+    }
     auth.load_current_field_input();
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime.rs
@@ -22,7 +22,7 @@ use crate::auth::provider_management::{
     core_auth_activate, core_auth_configure, load_core_auth_state, provider_action_choice,
     ExistingProvider, ProviderAction,
 };
-use crate::auth::retry::restore_after_failed_submission;
+use crate::auth::retry::restore_after_failed_submission_at;
 use crate::auth::validation::{
     record_field_edit, record_field_submission, FieldSubmission, PROVIDER_ID_HINT,
 };
@@ -745,6 +745,7 @@ fn send_auth_response<W: std::io::Write>(
     let mut auth = state.auth.state.take().expect("auth state present");
     let provider = &auth.providers[auth.selected_provider];
     let provider_label = provider.label.clone();
+    let provider_template_id = provider.id.clone();
     let provider_id = auth
         .editing_provider_name
         .clone()
@@ -757,6 +758,21 @@ fn send_auth_response<W: std::io::Write>(
         values: auth.collected_values.clone(),
         persist: true,
     };
+
+    let renderer = RatatuiInlineRenderer::for_terminal().with_language(state.language);
+    let validation_body = auth_validation_body(
+        &provider.id,
+        response.values.get("auth_source").map(String::as_str),
+    );
+    renderer.write_notice_panel(
+        output,
+        NoticePanelModel {
+            title: "Validating configuration...",
+            body: validation_body,
+            footer: None,
+        },
+    )?;
+    output.flush()?;
 
     if let Some(active_run) = state.agent_run.active.as_ref() {
         let result = active_run.handle.respond_auth(response);
@@ -777,15 +793,20 @@ fn send_auth_response<W: std::io::Write>(
                     std::io::Error::other("missing adapter for cosh-core auth registry")
                 })?;
                 if let Err(error) = core_auth_configure(adapter, &response) {
-                    restore_after_failed_submission(&mut auth);
+                    restore_after_configure_failure(
+                        &mut auth,
+                        error.code.as_deref(),
+                        error.focus_field(&provider_template_id),
+                    );
                     state.auth.state = Some(auth);
-                    let renderer =
-                        RatatuiInlineRenderer::for_terminal().with_language(state.language);
                     renderer.write_notice_panel(
                         output,
                         NoticePanelModel {
                             title: "Credentials were not saved",
-                            body: vec![error, "Review the values and try again.".to_string()],
+                            body: vec![
+                                error.message,
+                                "Review the highlighted value and try again.".to_string(),
+                            ],
                             footer: None,
                         },
                     )?;
@@ -800,6 +821,35 @@ fn send_auth_response<W: std::io::Write>(
 
     state.auth.completed_ids.insert(auth.id);
     finish_auth_configuration(state, output, &provider_label)
+}
+
+fn restore_after_configure_failure(
+    auth: &mut RuntimeAuthState,
+    error_code: Option<&str>,
+    field_name: Option<&str>,
+) {
+    if error_code == Some("credential_source_unavailable")
+        && matches!(auth.phase, AuthPhase::AliyunEcsChallenge { .. })
+    {
+        auth.field_error = None;
+        return;
+    }
+    restore_after_failed_submission_at(auth, field_name);
+}
+
+pub(super) fn auth_validation_body(provider_id: &str, auth_source: Option<&str>) -> Vec<String> {
+    let mut body = vec!["Checking endpoint, credentials, and model.".to_string()];
+    if matches!(
+        provider_id,
+        "dashscope" | "openai_compat" | "coding_plan" | "token_plan"
+    ) || (provider_id == "aliyun" && auth_source != Some("ecs_ram_role"))
+    {
+        body.push(
+            "If read-only model validation is unavailable or cannot verify credentials, validation may make a minimal chat request (max_tokens=1) that consumes a very small amount of quota or incurs a very small charge."
+                .to_string(),
+        );
+    }
+    body
 }
 
 /// Reports whether `event` carries the capture id the auth panel is currently listening on.

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime/tests.rs
@@ -1,9 +1,10 @@
 //! Unit tests for the `/auth` slash-command state machine.
 
 use super::{
-    apply_aliyun_prepare, begin_sysom_shortcut, clear_ecs_auth_source_for_manual_aliyun_edit,
-    clear_observed_model_after_provider_change, clear_observed_model_after_provider_delete,
-    ecs_ram_role_prepare, handle_auth_answer, management_entry, render_auth_card_actions,
+    apply_aliyun_prepare, auth_validation_body, begin_sysom_shortcut,
+    clear_ecs_auth_source_for_manual_aliyun_edit, clear_observed_model_after_provider_change,
+    clear_observed_model_after_provider_delete, ecs_ram_role_prepare, handle_auth_answer,
+    management_entry, render_auth_card_actions, restore_after_configure_failure,
     should_apply_aliyun_prepare_after_field, should_apply_aliyun_prepare_for_edit,
     should_apply_aliyun_prepare_on_provider_selection, AuthBackend, AuthFieldInfo,
     AuthManagementEntry, AuthPhase, AuthProviderInfo, CoreAuthPrepare, DeleteConfirmationOutcome,
@@ -17,6 +18,37 @@ use std::collections::HashMap;
 /// service a second time turns into a visible error instead of a silent probe.
 fn adapter_without_registry() -> AdapterInstance {
     AdapterInstance::Fake(FakeAgentAdapter)
+}
+
+#[test]
+fn validation_notice_explains_work_and_openai_fallback_cost() {
+    let ordinary = auth_validation_body("deepseek", None);
+    assert!(ordinary[0].contains("endpoint, credentials, and model"));
+    assert_eq!(ordinary.len(), 1);
+
+    let compatible = auth_validation_body("openai_compat", None);
+    assert!(compatible
+        .iter()
+        .any(|line| line.contains("very small charge")));
+    assert!(compatible.iter().any(|line| line.contains("max_tokens=1")));
+
+    let dashscope = auth_validation_body("dashscope", None);
+    assert!(dashscope
+        .iter()
+        .any(|line| line.contains("very small charge")));
+
+    for plan in ["coding_plan", "token_plan"] {
+        let notice = auth_validation_body(plan, None);
+        assert!(notice.iter().any(|line| line.contains("amount of quota")));
+        assert!(notice.iter().any(|line| line.contains("max_tokens=1")));
+    }
+
+    let manual_aliyun = auth_validation_body("aliyun", None);
+    assert!(manual_aliyun
+        .iter()
+        .any(|line| line.contains("very small charge")));
+    let ecs_aliyun = auth_validation_body("aliyun", Some("ecs_ram_role"));
+    assert_eq!(ecs_aliyun.len(), 1);
 }
 
 fn template(id: &str) -> AuthProviderInfo {
@@ -143,6 +175,19 @@ fn prefetched_challenge_is_applied_without_probing_ecs_again() {
         auth.collected_values.get("provider_id").map(String::as_str),
         Some("sysom-trial")
     );
+}
+
+#[test]
+fn unavailable_ecs_credentials_keep_the_authorization_challenge() {
+    let mut auth = slash_auth_state(&["aliyun"], SysomMenu::on_ecs(ecs_prepare()));
+    auth.phase = AuthPhase::AliyunEcsChallenge {
+        instance_id: "i-test-1".to_string(),
+        console_url: "https://example.invalid/guide".to_string(),
+    };
+
+    restore_after_configure_failure(&mut auth, Some("credential_source_unavailable"), None);
+
+    assert!(matches!(auth.phase, AuthPhase::AliyunEcsChallenge { .. }));
 }
 
 /// Slash-auth state on an ECS host with one saved DashScope provider.

--- a/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/auth/runtime_tests.rs
@@ -1,4 +1,4 @@
-use super::retry::restore_after_failed_submission;
+use super::retry::{restore_after_failed_submission, restore_after_failed_submission_at};
 use super::runtime::*;
 use super::validation::{record_field_edit, record_field_submission, FieldSubmission};
 use crate::runtime::prelude::{
@@ -290,7 +290,7 @@ fn editing_the_field_again_clears_the_previous_error() {
 }
 
 #[test]
-fn failed_submission_restarts_with_clean_values() {
+fn failed_submission_returns_to_preserved_non_secret_field() {
     let mut provider = provider("openai_compat", "OpenAI Compatible");
     provider.fields.push(AuthFieldInfo {
         name: "provider_id".to_string(),
@@ -313,8 +313,11 @@ fn failed_submission_restarts_with_clean_values() {
 
     assert_eq!(auth.phase, AuthPhase::FillingField);
     assert_eq!(auth.current_field, 0);
-    assert!(auth.collected_values.is_empty());
-    assert!(auth.field_input.is_empty());
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("bad.provider")
+    );
+    assert_eq!(auth.field_input, "bad.provider");
 }
 
 #[test]
@@ -454,10 +457,9 @@ fn failed_edit_submission_drops_secrets_the_user_actually_typed() {
     );
 }
 
-/// Selective preservation is scoped to edits. A new provider must still retry from empty,
-/// which is what #1769 hardened the retry path for.
+/// A new provider keeps non-secret identity fields while dropping submitted plaintext secrets.
 #[test]
-fn failed_new_provider_submission_still_clears_every_value() {
+fn failed_new_provider_submission_preserves_only_non_secret_values() {
     let mut state = failed_edit_state();
     let auth = state.auth.state.as_mut().unwrap();
     auth.editing_provider_name = None;
@@ -465,7 +467,36 @@ fn failed_new_provider_submission_still_clears_every_value() {
     restore_after_failed_submission(auth);
 
     assert_eq!(auth.current_field, 0);
-    assert!(auth.collected_values.is_empty());
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("qwen-prod")
+    );
+    assert_eq!(
+        auth.collected_values.get("model").map(String::as_str),
+        Some("qwen3.7-plus")
+    );
+    assert!(!auth.collected_values.contains_key("api_key"));
+    assert!(!auth.collected_values.contains_key("access_key_secret"));
+    assert_eq!(auth.field_input, "qwen-prod");
+}
+
+#[test]
+fn classified_retry_focuses_api_key_without_losing_provider_identity() {
+    let mut state = failed_edit_state();
+    let auth = state.auth.state.as_mut().unwrap();
+    auth.editing_provider_name = None;
+
+    restore_after_failed_submission_at(auth, Some("api_key"));
+
+    assert_eq!(
+        auth.current_field_info().map(|field| field.name.as_str()),
+        Some("api_key")
+    );
+    assert_eq!(
+        auth.collected_values.get("provider_id").map(String::as_str),
+        Some("qwen-prod")
+    );
+    assert!(!auth.collected_values.contains_key("api_key"));
     assert!(auth.field_input.is_empty());
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/slash/extensions.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/slash/extensions.rs
@@ -278,7 +278,7 @@ fn commit_or_query_result(
         json!({"operation_id": operation_id, "fingerprint": fingerprint}),
     ) {
         Ok(result) => Ok(result),
-        Err(RegistryQueryError::Response(error)) => Err(error),
+        Err(RegistryQueryError::Response { message, .. }) => Err(message),
         Err(RegistryQueryError::Transport(commit_error)) => adapter
             .registry_query(
                 "extensions",
@@ -302,7 +302,7 @@ fn update_all_or_query_result(adapter: &crate::adapter::CoshCoreAdapter) -> Resu
         json!({"operation_id": operation_id}),
     ) {
         Ok(result) => Ok(result),
-        Err(RegistryQueryError::Response(error)) => Err(error),
+        Err(RegistryQueryError::Response { message, .. }) => Err(message),
         Err(RegistryQueryError::Transport(commit_error)) => adapter
             .registry_query(
                 "extensions",

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/auth.rs
@@ -11,6 +11,13 @@ if [ "$1" = "--registry" ]; then
     *'"action":"state"'*)
       printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"templates":[{"id":"openai_compat","label":"OpenAI Compatible","fields":[{"name":"base_url","label":"Base URL","hint":null,"secret":false,"required":true,"placeholder":null},{"name":"api_key","label":"API Key","hint":null,"secret":true,"required":true,"placeholder":null},{"name":"model","label":"Model","hint":null,"secret":false,"required":true,"placeholder":null}]}],"saved_providers":[]}}'
       ;;
+    *'"action":"configure"'*)
+      if [ -n "$AUTH_CONFIGURE_ERROR" ]; then
+        printf '%s\n' '{"type":"registry_response","request_id":"reg","success":false,"data":{"error_code":"invalid_credentials"},"error":"The API key was rejected. Check the API Key and try again."}'
+      else
+        printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"configured":true}}'
+      fi
+      ;;
     *)
       printf '%s\n' '{"type":"registry_response","request_id":"reg","success":true,"data":{"model":"main-model","configured":true}}'
       ;;
@@ -22,6 +29,57 @@ printf '%s\n' '{"type":"control_response","response":{"subtype":"success","reque
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"auth-inline","model":"main-model","tools":[]}'
 printf '%s\n' '{"type":"result","subtype":"success","session_id":"auth-inline","is_error":false,"result":"done"}'
 "#;
+
+#[test]
+fn raw_cli_auth_failure_keeps_panel_and_never_claims_success() {
+    let home = temp_shell_home("auth-preflight-failure");
+    let bin_dir = home.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let cosh_core_path = bin_dir.join("cosh-core");
+    write_executable(&cosh_core_path, AUTH_REGISTRY_CORE);
+    let registry_log = home.join("registry.log");
+
+    let home_str = home.to_string_lossy().to_string();
+    let core_str = cosh_core_path.to_string_lossy().to_string();
+    let log_str = registry_log.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_current_dir_and_marker_input(
+        "cosh-core",
+        &[],
+        &[
+            ("HOME", &home_str),
+            ("COSH_CORE_PATH", &core_str),
+            ("AUTH_REGISTRY_LOG", &log_str),
+            ("AUTH_CONFIGURE_ERROR", "1"),
+        ],
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        &[
+            ("cosh-osc$", b"/auth\n".as_slice()),
+            ("Left/Right move | Enter send", b"\n".as_slice()),
+            ("Enter Provider ID", b"test-provider\n".as_slice()),
+            ("Enter Base URL", b"http://127.0.0.1:1/v1\n".as_slice()),
+            ("Enter API Key", b"sk-rejected\n".as_slice()),
+            ("Enter Model", b"test-model\n".as_slice()),
+            ("Credentials were not saved", b"".as_slice()),
+        ],
+    );
+    let requests = fs::read_to_string(&registry_log).unwrap_or_default();
+    let _ = fs::remove_dir_all(&home);
+    let compact = compact_terminal_words(&output);
+
+    assert!(compact.contains("Validating configuration..."), "{output}");
+    assert!(
+        compact.contains("Checking endpoint, credentials, and model."),
+        "{output}"
+    );
+    assert!(compact.contains("Credentials were not saved"), "{output}");
+    let failure = compact
+        .rfind("Credentials were not saved")
+        .expect("failure panel is present");
+    assert!(compact[failure..].contains("Enter API Key"), "{output}");
+    assert!(!compact.contains("Auth configured"), "{output}");
+    assert!(!compact.contains("credentials saved"), "{output}");
+    assert_eq!(action_count(&requests, "configure"), 1, "{requests}");
+}
 
 /// A dotted Provider ID must be rejected on the spot instead of at the final `configure`.
 #[test]


### PR DESCRIPTION
## Why

Authentication configuration was published before credentials, endpoints, and models were verified. A failed validation or config write could therefore leave disk and runtime state inconsistent.

## What changed

- Add provider-specific, typed authentication preflight checks with bounded timeouts, no redirects, and no retries.
- Build authentication changes as cloned candidates, persist them first, and only then publish them to runtime state.
- Preserve classified Core errors through the registry so Shell can keep the auth panel open and focus the actionable field.
- Add local mock-server coverage for success, auth and model failures, network failures, redirects, fallback behavior, retries, and persistence rollback.

## Related issue

Closes #1771

## User / Agent impact

`/auth` now validates the endpoint, credentials, and model before saving. Failed validation keeps the current configuration unchanged and returns the user to the relevant field. OpenAI-compatible, DashScope, plan-provider, and manual Aliyun minimal probes warn that they may consume a very small amount of quota or incur a very small charge.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The persisted configuration format is unchanged. The main compatibility risk is provider-specific preflight response handling; unsupported responses fail safely without changing configuration.

## Validation

- `cargo test --locked --workspace -- --test-threads=4`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo build --locked --workspace --release`
- Final review checks: Core authentication 59 passed; preflight 24 passed in 2.36s
- Final review checks: registry delete, activate, Aliyun readiness, and Aliyun model-rejection persistence regressions passed
- Final review checks: formatting and Core/Shell all-target Clippy passed
- Shell authentication tests: 83 passed
- Raw CLI failure-recovery test: passed
- Local mock HTTP servers only; no real provider was contacted
- `scripts/run-test-gates.sh all` passed inventory/layout, then stopped because `shellcheck` is unavailable in the host environment

## Documentation and rollback

No documentation update is required because the command interface and config schema are unchanged. Roll back by reverting commit `de749094`.
