### PR TITLE
test(blaze): stabilize concurrent test timing

### DIFF
--- a/src/blaze/crates/blazed/src/api.rs
+++ b/src/blaze/crates/blazed/src/api.rs
@@ -883,6 +883,27 @@ mod tests {
         )
     }
 
+    fn build_test_state_after_simulated_restart(
+        config: DaemonConfig,
+        policy: PolicyFile,
+        registry: SpawnerRegistry,
+        active_backend: BackendKind,
+        storage: Arc<dyn StorageProvider>,
+    ) -> Arc<ServerState> {
+        Arc::new(
+            ServerState::build_after_simulated_restart(
+                config,
+                PolicyEngine::with_policies(vec![policy]),
+                PoolManager::new(),
+                HookRegistry::new(),
+                registry,
+                active_backend,
+                storage,
+            )
+            .expect("state after simulated restart"),
+        )
+    }
+
     #[cfg(feature = "test-failpoints")]
     fn mock_state(temp: &tempfile::TempDir, pooled: bool) -> Arc<ServerState> {
         let config = test_config(temp);
@@ -2139,7 +2160,7 @@ mod tests {
                 config.storage.images_dir.clone(),
                 config.storage.instances_dir.clone(),
             ));
-        let recovered = build_test_state(
+        let recovered = build_test_state_after_simulated_restart(
             config.clone(),
             test_policy(BackendKind::Bubblewrap, false),
             spawners(BackendKind::Bubblewrap, Arc::new(BubblewrapSpawner)),
@@ -2484,7 +2505,7 @@ mod tests {
                 config.storage.images_dir.clone(),
                 instances_dir.clone(),
             ));
-        let restarted = build_test_state(
+        let restarted = build_test_state_after_simulated_restart(
             config,
             test_policy(BackendKind::Firecracker, false),
             registry,
@@ -3435,7 +3456,7 @@ mod tests {
                 config.storage.images_dir.clone(),
                 instances_dir.clone(),
             ));
-        let restarted = build_test_state(
+        let restarted = build_test_state_after_simulated_restart(
             config,
             test_policy(BackendKind::Mock, false),
             spawners(

--- a/src/blaze/crates/blazed/src/guest/client.rs
+++ b/src/blaze/crates/blazed/src/guest/client.rs
@@ -478,6 +478,25 @@ mod tests {
         (stream, request)
     }
 
+    async fn wait_for_request_delivery<T: std::fmt::Debug>(
+        deliveries: &mut tokio::sync::mpsc::UnboundedReceiver<&'static str>,
+        expected: &'static str,
+        operation: &mut tokio::task::JoinHandle<Result<T>>,
+    ) -> std::result::Result<(), String> {
+        tokio::select! {
+            biased;
+            delivery = deliveries.recv() => match delivery {
+                Some(delivery) if delivery == expected => Ok(()),
+                other => Err(format!(
+                    "expected {expected} request delivery, received {other:?}"
+                )),
+            },
+            completed = operation => Err(format!(
+                "{expected} operation completed before request delivery: {completed:?}"
+            )),
+        }
+    }
+
     #[test]
     fn side_effect_errors_become_unknown_only_after_delivery_starts() {
         for operation in [GuestOp::Exec, GuestOp::Write] {
@@ -683,30 +702,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_delivery_wait_reports_early_operation_completion() {
+        let (_delivered, mut deliveries) = tokio::sync::mpsc::unbounded_channel();
+        let mut operation = tokio::spawn(async {
+            Err::<(), GuestError>(GuestError::Protocol(
+                "client stopped before request delivery".to_string(),
+            ))
+        });
+
+        let error = wait_for_request_delivery(&mut deliveries, "write", &mut operation)
+            .await
+            .expect_err("early operation completion must stop the delivery wait");
+        assert!(error.contains("write operation completed before request delivery"));
+    }
+
+    #[tokio::test]
+    async fn request_delivery_wait_prefers_queued_delivery() {
+        for _ in 0..32 {
+            let (delivered, mut deliveries) = tokio::sync::mpsc::unbounded_channel();
+            delivered.send("read").expect("queue request delivery");
+            let mut operation = tokio::spawn(async {
+                Err::<(), GuestError>(GuestError::Timeout("response deadline elapsed".to_string()))
+            });
+            while !operation.is_finished() {
+                tokio::task::yield_now().await;
+            }
+
+            wait_for_request_delivery(&mut deliveries, "read", &mut operation)
+                .await
+                .expect("queued delivery must win a ready tie");
+            operation
+                .await
+                .expect("operation task")
+                .expect_err("timeout");
+        }
+    }
+
+    #[tokio::test]
     async fn read_and_write_response_timeouts_are_bounded() {
         let temp = tempfile::tempdir().expect("temp");
         let socket = temp.path().join("vsock.uds");
         let listener = UnixListener::bind(&socket).expect("bind");
+        let (delivered, mut deliveries) = tokio::sync::mpsc::unbounded_channel();
+        let release = CancellationToken::new();
+        let server_release = release.clone();
         let server = tokio::spawn(async move {
-            for _ in 0..2 {
-                let (stream, _) = accept_request(&listener).await;
-                tokio::spawn(async move {
+            let mut connections = Vec::new();
+            for expected_operation in ["read", "write"] {
+                let (stream, request) = accept_request(&listener).await;
+                assert_eq!(request["op"].as_str(), Some(expected_operation));
+                delivered
+                    .send(expected_operation)
+                    .expect("report delivered request");
+                let connection_release = server_release.clone();
+                connections.push(tokio::spawn(async move {
                     let _stream = stream;
-                    tokio::time::sleep(Duration::from_millis(250)).await;
-                });
+                    connection_release.cancelled().await;
+                }));
+            }
+            for connection in connections {
+                connection.await.expect("connection task");
             }
         });
-        let client = GuestClient::new(socket, Duration::from_millis(30), 1024);
-        let read_error = client
-            .read_file("/tmp/x".into())
+        let client = GuestClient::new(socket, Duration::from_secs(1), 1024);
+        let read_client = client.clone();
+        let mut read = tokio::spawn(async move { read_client.read_file("/tmp/x".into()).await });
+        wait_for_request_delivery(&mut deliveries, "read", &mut read)
             .await
-            .expect_err("read timeout");
+            .expect("read request delivery");
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_millis(1_001)).await;
+        let read_error = read.await.expect("read task").expect_err("read timeout");
+        tokio::time::resume();
         assert!(matches!(read_error, GuestError::Timeout(_)));
-        let write_error = client
-            .write_file("/tmp/x".into(), b"value")
+        let mut write =
+            tokio::spawn(async move { client.write_file("/tmp/x".into(), b"value").await });
+        wait_for_request_delivery(&mut deliveries, "write", &mut write)
             .await
-            .expect_err("write timeout");
+            .expect("write request delivery");
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_millis(1_001)).await;
+        let write_error = write.await.expect("write task").expect_err("write timeout");
+        tokio::time::resume();
         assert!(matches!(write_error, GuestError::OutcomeUnknown(_)));
+        release.cancel();
         server.await.expect("server task");
     }
 

--- a/src/blaze/crates/blazed/src/sandbox/template.rs
+++ b/src/blaze/crates/blazed/src/sandbox/template.rs
@@ -319,10 +319,45 @@ impl TemplateCatalog {
         Self::open_pinned(config, root, import_root)
     }
 
+    #[cfg(test)]
+    pub(crate) fn reopen_after_simulated_restart(config: &TemplateSection) -> Result<Self> {
+        Self::reopen_after_simulated_restart_with(config, || {})
+    }
+
+    #[cfg(test)]
+    fn reopen_after_simulated_restart_with(
+        config: &TemplateSection,
+        on_inherited_lock: impl FnOnce(),
+    ) -> Result<Self> {
+        reject_symlink_components(&config.dir, "template.dir")?;
+        if let Some(import_root) = config.import_root.as_deref() {
+            reject_symlink_components(import_root, "template.import_root")?;
+        }
+        let root = create_catalog_root(&config.dir)?;
+        enforce_owned_mode_file(&root, true, CATALOG_DIR_MODE, &config.dir)?;
+        let import_root = config
+            .import_root
+            .as_deref()
+            .map(pin_import_root)
+            .transpose()?;
+        Self::open_pinned_with_lock(config, root, import_root, |root| {
+            Self::acquire_root_lock_after_simulated_restart(root, on_inherited_lock)
+        })
+    }
+
     fn open_pinned(
         config: &TemplateSection,
         root: File,
         import_root: Option<ImportRoot>,
+    ) -> Result<Self> {
+        Self::open_pinned_with_lock(config, root, import_root, Self::acquire_root_lock)
+    }
+
+    fn open_pinned_with_lock(
+        config: &TemplateSection,
+        root: File,
+        import_root: Option<ImportRoot>,
+        acquire_root_lock: impl FnOnce(&File) -> Result<()>,
     ) -> Result<Self> {
         let limits = ImportLimits {
             max_files: config.max_files,
@@ -334,7 +369,7 @@ impl TemplateCatalog {
         let boundary = CatalogBoundary {
             mount_id: opened_mount_id(&root)?,
         };
-        Self::acquire_root_lock(&root)?;
+        acquire_root_lock(&root)?;
         cleanup_staging(&root, limits, boundary)?;
         let usage = catalog_usage(&root, limits, boundary)?;
         if usage.bytes > limits.max_total_bytes {
@@ -388,30 +423,6 @@ impl TemplateCatalog {
     // The root file is retained in `CatalogInner`, so this advisory lock
     // remains held for the complete catalog-owner lifetime.
     fn acquire_root_lock(root: &File) -> Result<()> {
-        #[cfg(test)]
-        {
-            let inherited_descriptor_deadline =
-                std::time::Instant::now() + std::time::Duration::from_millis(100);
-            loop {
-                match Self::acquire_root_lock_once(root) {
-                    Err(BlazeDaemonError::Conflict(_))
-                        if std::time::Instant::now() < inherited_descriptor_deadline =>
-                    {
-                        // Concurrent test processes can briefly inherit a CLOEXEC
-                        // descriptor between fork and exec. Production keeps the
-                        // non-blocking single-attempt behavior.
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                    result => return result,
-                }
-            }
-        }
-
-        #[cfg(not(test))]
-        Self::acquire_root_lock_once(root)
-    }
-
-    fn acquire_root_lock_once(root: &File) -> Result<()> {
         if unsafe { libc::flock(root.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
             return Ok(());
         }
@@ -428,6 +439,35 @@ impl TemplateCatalog {
         Err(BlazeDaemonError::Internal(format!(
             "could not lock runtime template catalog: {error}"
         )))
+    }
+
+    #[cfg(test)]
+    fn acquire_root_lock_after_simulated_restart(
+        root: &File,
+        on_inherited_lock: impl FnOnce(),
+    ) -> Result<()> {
+        match Self::acquire_root_lock(root) {
+            Ok(()) => return Ok(()),
+            Err(BlazeDaemonError::Conflict(message))
+                if message == "runtime template catalog is already owned by another daemon" =>
+            {
+                on_inherited_lock();
+            }
+            Err(error) => return Err(error),
+        }
+
+        loop {
+            if unsafe { libc::flock(root.as_raw_fd(), libc::LOCK_EX) } == 0 {
+                return Ok(());
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(BlazeDaemonError::Internal(format!(
+                "could not wait for the released runtime template catalog: {error}"
+            )));
+        }
     }
 
     async fn list(&self) -> Result<Bytes> {
@@ -5276,7 +5316,8 @@ mod tests {
 
         let mut config = test_config(&root, &import_root);
         config.max_total_bytes = 8;
-        let catalog = TemplateCatalog::open(&config).expect("catalog");
+        let catalog =
+            TemplateCatalog::reopen_after_simulated_restart(&config).expect("catalog restart");
         let error = catalog
             .import("capacity".into(), PathBuf::from("source"), String::new())
             .await
@@ -5311,7 +5352,7 @@ mod tests {
         let owner = Arc::downgrade(&catalog.inner);
         drop(catalog);
         assert!(owner.upgrade().is_none(), "completed list released owner");
-        TemplateCatalog::open(&config).expect("bounded catalog reopens");
+        TemplateCatalog::reopen_after_simulated_restart(&config).expect("bounded catalog reopens");
     }
 
     #[tokio::test]
@@ -5968,9 +6009,10 @@ mod tests {
         }
 
         drop(catalog);
-        let startup_error = TemplateCatalog::open(&test_config(&root, &import_root))
-            .err()
-            .expect("startup must reject special artifact");
+        let startup_error =
+            TemplateCatalog::reopen_after_simulated_restart(&test_config(&root, &import_root))
+                .err()
+                .expect("startup must reject special artifact");
         assert!(matches!(
             startup_error,
             BlazeDaemonError::RecoveryRequired(message)
@@ -6188,9 +6230,43 @@ mod tests {
         assert!(matches!(error, BlazeDaemonError::Conflict(_)));
         assert!(staging.exists(), "second owner must not clean live staging");
 
+        let inherited_root = first.inner.root.try_clone().expect("inherited root owner");
         drop(first);
-        TemplateCatalog::open(&config).expect("catalog lock released with owner");
+        let retry_config = config.clone();
+        let (retrying, retry_observed) = std::sync::mpsc::sync_channel(1);
+        let reopen = std::thread::spawn(move || {
+            TemplateCatalog::reopen_after_simulated_restart_with(&retry_config, || {
+                let _ = retrying.try_send(());
+            })
+            .expect("catalog lock released after inherited owner");
+        });
+        retry_observed
+            .recv()
+            .expect("retry observes inherited owner");
+        drop(inherited_root);
+        reopen.join().expect("restart thread");
         assert!(!staging.exists(), "next owner cleans interrupted staging");
+    }
+
+    #[test]
+    fn production_open_rejects_a_live_catalog_owner() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let import_root = temp.path().join("imports");
+        std::fs::create_dir(&import_root).expect("import root");
+        let root = temp.path().join("catalog");
+        let config = test_config(&root, &import_root);
+        let first = TemplateCatalog::open(&config).expect("first catalog owner");
+        let staging = root.join(".import-live-uuid.tmp");
+        create_private_directory(&staging).expect("live staging");
+
+        let error = match TemplateCatalog::open(&config) {
+            Ok(_) => panic!("live owner must not be replaced"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, BlazeDaemonError::Conflict(_)));
+        assert!(staging.exists(), "second owner must not clean live staging");
+        drop(first);
     }
 
     #[test]

--- a/src/blaze/crates/blazed/src/state.rs
+++ b/src/blaze/crates/blazed/src/state.rs
@@ -109,6 +109,44 @@ impl ServerState {
         )
     }
 
+    #[cfg(test)]
+    // Mirror the production constructor so restart tests replace only the
+    // catalog owner while preserving the same dependency assembly boundary.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn build_after_simulated_restart(
+        config: DaemonConfig,
+        policy: PolicyEngine,
+        pool: PoolManager,
+        hook: HookRegistry,
+        spawners: SpawnerRegistry,
+        active_backend: BackendKind,
+        storage: Arc<dyn StorageProvider>,
+    ) -> Result<Self> {
+        validate_template_roots(
+            &config.template,
+            &config.storage.images_dir,
+            &config.storage.instances_dir,
+            &config.policy.dir,
+            &config.backends,
+            &config.daemon.state_dir,
+            &config.daemon.socket,
+            None,
+        )?;
+        let template_catalog = TemplateCatalog::reopen_after_simulated_restart(&config.template)?;
+        let state_store = StateStore::new(config.daemon.state_dir.clone());
+        Self::assemble(
+            config,
+            policy,
+            pool,
+            hook,
+            spawners,
+            active_backend,
+            storage,
+            template_catalog,
+            state_store,
+        )
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn assemble(
         config: DaemonConfig,


### PR DESCRIPTION
## Why

Two Blaze tests relied on short wall-clock windows while the full workspace
suite ran concurrently.

The guest timeout test could expire before its request reached the server.
Catalog and daemon-restart tests could retain a CLOEXEC catalog descriptor while
another test process was between fork and exec. The restart test also used a
thread-scheduling deadline to observe that inherited owner.

These flakes blocked repeatable validation even though the production paths
were behaving correctly.

## What changed

- Gate guest timeout assertions on complete request delivery, then advance a
  paused Tokio clock past the response deadline.
- Race each delivery gate against its client task and prefer queued delivery
  when delivery and operation completion are both ready.
- Keep production and live-owner catalog lock checks single-attempt.
- When a test explicitly drops an old owner and simulates restart, wait for the
  kernel catalog lock-release event without a retry or thread-start deadline.
- Add deterministic positive and negative catalog lock cases.

This single test-only commit establishes one reliability boundary for the
concurrent workspace validation gate and changes no production entry point.

## Related issue

no-issue: deterministic test-only repair for existing Blaze regression suites

## User / Agent impact

None. Production guest operations, catalog locking, and daemon startup are
unchanged. The simulated-restart helpers are compiled only for tests.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Changes are limited to deterministic test synchronization.

## Validation

Exact head `11c66dbe5553ea364b17ccb50ef1b0bea6934be9` (tree
`28c88cabe89a262de6783357c228a5fce370048f`, parent
`e354a7a7944bc670c57507d5006681bde9ad0b40`) was validated on Linux x86_64
with rustc/cargo 1.88.0. The matching source archive SHA-256 is
`0a7d7f5da1fc377b5caeb0dc5afc211f4748c04009cd01ddb1f099c568a767e0`.

Separate initially empty default and all-feature target directories passed:

- `cargo fmt --all --check`;
- locked workspace metadata and all-target builds;
- strict workspace Clippy;
- default workspace tests: 52/52 blaze-core and 225/225 blazed;
- all-feature workspace tests: 52/52 blaze-core and 243/243 blazed;
- strict default and all-feature workspace rustdoc;
- five exact regressions for early operation completion, ready-tie delivery,
  guest timeout classification, inherited owner release, and live-owner
  rejection;
- commitlint 19.8.1, diff checks, trailer parsing, and a clean worktree.

Hosted PR Lint and Components checks passed for this exact head. Codex
re-reviewed `11c66dbe55` and found no major issues. All committers have signed
the CLA.

## Documentation and rollback

No documentation change is needed because user-visible behavior is unchanged.
Reverting this commit restores only the prior test timing assumptions.