### PR TITLE
fix(tokenless): roll back stash on no-savings

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -882,6 +882,7 @@ version = "0.7.6"
 dependencies = [
  "regex",
  "serde_json",
+ "tempfile",
  "tokenless-ccr",
 ]
 

--- a/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use crate::key::compute_key;
-use crate::store::{StashError, StashStore};
+use crate::store::{MAX_GENERATION, StashError, StashStore, StashWrite};
 
 /// Default time-to-live for an entry: 5 minutes.
 const DEFAULT_TTL: Duration = Duration::from_secs(5 * 60);
@@ -21,10 +21,13 @@ const DEFAULT_CAPACITY: usize = 1000;
 struct Entry {
     payload: String,
     inserted_at: Instant,
+    generation: u64,
 }
 
 struct Inner {
     map: HashMap<String, Entry>,
+    /// Store-wide ownership high-water mark. Lifecycle cleanup never changes it.
+    last_generation: u64,
     /// Insertion order for FIFO eviction, front = oldest. A re-stash refreshes
     /// the entry by moving its key to the back so a refreshed entry survives
     /// eviction — matching `SqliteStore`'s `expires_at`-ordered eviction.
@@ -49,6 +52,7 @@ impl InMemoryStore {
         Self {
             inner: Mutex::new(Inner {
                 map: HashMap::new(),
+                last_generation: 0,
                 order: VecDeque::new(),
                 ttl,
                 capacity,
@@ -64,12 +68,24 @@ impl Default for InMemoryStore {
 }
 
 impl StashStore for InMemoryStore {
-    fn stash(&self, payload: &str) -> Result<String, StashError> {
+    fn stash(&self, payload: &str) -> Result<StashWrite, StashError> {
         let key = compute_key(payload.as_bytes());
         let mut inner = self
             .inner
             .lock()
             .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
+        let now = Instant::now();
+        let previous_generation = match inner.map.get(&key) {
+            Some(e) if now.duration_since(e.inserted_at) < inner.ttl => Some(e.generation),
+            _ => None,
+        };
+        let had_live = previous_generation.is_some();
+        let generation = inner
+            .last_generation
+            .checked_add(1)
+            .filter(|generation| *generation <= MAX_GENERATION)
+            .ok_or_else(|| StashError::Backend("stash generation exhausted".to_string()))?;
+        inner.last_generation = generation;
         // Re-stash refreshes: move the key to the back of the FIFO order so a
         // refreshed entry is evicted last, matching SqliteStore's
         // expires_at-ordered eviction.
@@ -79,24 +95,28 @@ impl StashStore for InMemoryStore {
             inner.order.retain(|k| k != &key);
             inner.order.push_back(key.clone());
         }
+        inner.map.insert(
+            key.clone(),
+            Entry {
+                payload: payload.to_string(),
+                inserted_at: now,
+                generation,
+            },
+        );
         // Evict oldest entries until we are within capacity. Evicting after
         // re-inserting means we allow capacity entries to coexist with the
         // newcomer before trimming back to the limit.
         while inner.order.len() > inner.capacity {
             if let Some(old) = inner.order.pop_front() {
                 inner.map.remove(&old);
-            } else {
-                break;
             }
         }
-        inner.map.insert(
-            key.clone(),
-            Entry {
-                payload: payload.to_string(),
-                inserted_at: Instant::now(),
-            },
-        );
-        Ok(key)
+        Ok(StashWrite {
+            key,
+            created: !had_live,
+            generation,
+            previous_generation,
+        })
     }
 
     fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
@@ -159,6 +179,28 @@ impl StashStore for InMemoryStore {
         }
         Ok(count)
     }
+
+    fn delete(&self, hash: &str, generation: u64) -> Result<bool, StashError> {
+        let key = hash.to_ascii_lowercase();
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
+        let now = Instant::now();
+        let ttl = inner.ttl;
+        let matches = inner
+            .map
+            .get(&key)
+            .map(|e| now.duration_since(e.inserted_at) < ttl && e.generation == generation)
+            .unwrap_or(false);
+        if !matches {
+            // Absent, expired, or adopted by a later stash (generation moved).
+            return Ok(false);
+        }
+        inner.map.remove(&key);
+        inner.order.retain(|k| k != &key);
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -171,7 +213,7 @@ mod tests {
         // An LLM may quote a marker back with uppercased hex; keys are stored
         // lowercase, so retrieve must normalize the lookup.
         let store = InMemoryStore::new();
-        let key = store.stash("payload").unwrap();
+        let key = store.stash("payload").unwrap().key;
         assert_eq!(key, key.to_ascii_lowercase());
         let upper = key.to_uppercase();
         assert_ne!(upper, key);
@@ -183,20 +225,20 @@ mod tests {
         // A re-stashed (refreshed) entry should survive FIFO eviction, matching
         // SqliteStore's expires_at-ordered eviction.
         let store = InMemoryStore::with_limits(Duration::from_secs(60), 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
+        let k0 = store.stash("0").unwrap().key;
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
         // Re-stash k0 to refresh it (moves to back); then stash a new key to
         // trigger eviction. k0 must survive (refreshed), k1 (oldest) evicted.
-        store.stash("0").unwrap();
-        store.stash("3").unwrap();
+        let _ = store.stash("0").unwrap();
+        let _ = store.stash("3").unwrap();
         assert!(store.retrieve(&k0).unwrap().is_some());
     }
 
     #[test]
     fn stash_and_retrieve_round_trip() {
         let store = InMemoryStore::new();
-        let key = store.stash("some payload").unwrap();
+        let key = store.stash("some payload").unwrap().key;
         assert_eq!(
             store.retrieve(&key).unwrap(),
             Some("some payload".to_string())
@@ -212,13 +254,13 @@ mod tests {
     #[test]
     fn re_stash_is_idempotent_and_refreshes() {
         let store = InMemoryStore::with_limits(Duration::from_millis(50), 100);
-        let k1 = store.stash("payload").unwrap();
-        let k2 = store.stash("payload").unwrap();
+        let k1 = store.stash("payload").unwrap().key;
+        let k2 = store.stash("payload").unwrap().key;
         assert_eq!(k1, k2);
         // After the original TTL would have expired, the refreshed entry is
         // still live.
         std::thread::sleep(Duration::from_millis(30));
-        store.stash("payload").unwrap();
+        let _ = store.stash("payload").unwrap();
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.retrieve(&k1).unwrap(), Some("payload".to_string()));
     }
@@ -226,7 +268,7 @@ mod tests {
     #[test]
     fn expired_entry_not_retrievable() {
         let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
-        let key = store.stash("ephemeral").unwrap();
+        let key = store.stash("ephemeral").unwrap().key;
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.retrieve(&key).unwrap(), None);
     }
@@ -234,8 +276,8 @@ mod tests {
     #[test]
     fn evict_expired_reports_count() {
         let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.evict_expired().unwrap(), 2);
         assert_eq!(store.len(), 0);
@@ -244,18 +286,132 @@ mod tests {
     #[test]
     fn fifo_eviction_when_over_capacity() {
         let store = InMemoryStore::with_limits(Duration::from_secs(60), 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
-        store.stash("3").unwrap(); // evicts "0"
+        let k0 = store.stash("0").unwrap().key;
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
+        let _ = store.stash("3").unwrap(); // evicts "0"
         assert_eq!(store.retrieve(&k0).unwrap(), None);
         assert!(
             store
-                .retrieve(&store.stash("1").unwrap())
+                .retrieve(&store.stash("1").unwrap().key)
                 .unwrap()
                 .is_some()
         );
         assert!(store.len() <= 3);
+    }
+
+    #[test]
+    fn delete_live_entry_returns_true() {
+        let store = InMemoryStore::new();
+        let write = store.stash("payload").unwrap();
+        assert!(store.delete(&write.key, write.generation).unwrap());
+        assert_eq!(store.retrieve(&write.key).unwrap(), None);
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn delete_missing_returns_false() {
+        let store = InMemoryStore::new();
+        assert!(!store.delete("000000000000000000000000", 1).unwrap());
+    }
+
+    #[test]
+    fn delete_expired_returns_false_without_removing_live_contract() {
+        // Trait: Ok(false) when absent or already expired. Must not report a
+        // successful live delete for a row retrieve() would already hide.
+        let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
+        let write = store.stash("ephemeral").unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(!store.delete(&write.key, write.generation).unwrap());
+        assert_eq!(store.retrieve(&write.key).unwrap(), None);
+    }
+
+    #[test]
+    fn delete_stale_generation_after_refresh_returns_false() {
+        // After a later refresh of the same payload, delete with the create
+        // generation must be a no-op so the live row stays retrievable.
+        let store = InMemoryStore::new();
+        let first = store.stash("payload").unwrap();
+        assert!(first.created);
+        let second = store.stash("payload").unwrap();
+        assert!(!second.created);
+        assert_ne!(first.generation, second.generation);
+        assert_eq!(first.previous_generation, None);
+        assert_eq!(second.previous_generation, Some(first.generation));
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+        assert_eq!(
+            store.retrieve(&second.key).unwrap(),
+            Some("payload".to_string())
+        );
+        assert!(store.delete(&second.key, second.generation).unwrap());
+    }
+
+    #[test]
+    fn lazy_expiry_recreate_never_reuses_generation() {
+        let store = InMemoryStore::with_limits(Duration::from_secs(60), 100);
+        let first = store.stash("payload").unwrap();
+        {
+            let mut inner = store.inner.lock().unwrap();
+            let expired_at = Instant::now() - inner.ttl - Duration::from_secs(1);
+            inner.map.get_mut(&first.key).unwrap().inserted_at = expired_at;
+        }
+        assert_eq!(store.retrieve(&first.key).unwrap(), None);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+        assert_eq!(store.retrieve(&second.key).unwrap(), Some("payload".into()));
+    }
+
+    #[test]
+    fn evict_expired_recreate_never_reuses_generation() {
+        let store = InMemoryStore::with_limits(Duration::from_secs(60), 100);
+        let first = store.stash("payload").unwrap();
+        {
+            let mut inner = store.inner.lock().unwrap();
+            let expired_at = Instant::now() - inner.ttl - Duration::from_secs(1);
+            inner.map.get_mut(&first.key).unwrap().inserted_at = expired_at;
+        }
+        assert_eq!(store.evict_expired().unwrap(), 1);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+    }
+
+    #[test]
+    fn capacity_eviction_recreate_never_reuses_generation() {
+        let store = InMemoryStore::with_limits(Duration::from_secs(60), 1);
+        let first = store.stash("payload").unwrap();
+        let _other = store.stash("other").unwrap();
+        assert_eq!(store.retrieve(&first.key).unwrap(), None);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+    }
+
+    #[test]
+    fn delete_recreate_never_reuses_generation() {
+        let store = InMemoryStore::new();
+        let first = store.stash("payload").unwrap();
+        assert!(store.delete(&first.key, first.generation).unwrap());
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+        assert_eq!(store.retrieve(&second.key).unwrap(), Some("payload".into()));
+    }
+
+    #[test]
+    fn generation_exhaustion_does_not_mutate_stash() {
+        let store = InMemoryStore::new();
+        let existing = store.stash("existing").unwrap();
+        {
+            let mut inner = store.inner.lock().unwrap();
+            inner.last_generation = MAX_GENERATION;
+        }
+        let before = store.retrieve(&existing.key).unwrap();
+        let error = store.stash("new").unwrap_err();
+        assert!(error.to_string().contains("generation exhausted"));
+        assert_eq!(store.retrieve(&existing.key).unwrap(), before);
+        assert_eq!(store.len(), 1);
     }
 
     #[test]
@@ -266,7 +422,7 @@ mod tests {
                 let s = store.clone();
                 thread::spawn(move || {
                     for j in 0..100 {
-                        s.stash(&format!("p-{i}-{j}")).unwrap();
+                        let _ = s.stash(&format!("p-{i}-{j}")).unwrap();
                     }
                 })
             })

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -2,17 +2,16 @@
 //!
 //! Persists stashed payloads to a single file so state survives across the
 //! short-lived processes that tokenless hooks fork+exec on every call. Uses
-//! WAL mode and a single-writer `Mutex<Connection>` to serialize writes,
-//! mirroring the approach in `tokenless-stats`.
+//! WAL mode and `BEGIN IMMEDIATE` for database-wide write serialization.
 
 use std::path::Path;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
 
 use crate::key::compute_key;
-use crate::store::{StashError, StashStore};
+use crate::store::{MAX_GENERATION, StashError, StashStore, StashWrite};
 
 /// Default time-to-live for an entry: 1 hour. A retrieve window of an hour
 /// comfortably covers a typical agent session's compress→retrieve round trip.
@@ -70,24 +69,59 @@ impl SqliteStore {
                     ))
                 })?;
         }
-        let conn = Connection::open(path)?;
+        let mut conn = Connection::open(path)?;
         conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              PRAGMA busy_timeout=5000;
              PRAGMA synchronous=NORMAL;",
         )?;
-        conn.execute(
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
             "CREATE TABLE IF NOT EXISTS stash (
                 hash TEXT PRIMARY KEY,
                 payload TEXT NOT NULL,
-                expires_at INTEGER NOT NULL
+                expires_at INTEGER NOT NULL,
+                generation INTEGER NOT NULL DEFAULT 0
             )",
             [],
         )?;
-        conn.execute(
+        let has_generation: bool = tx.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM pragma_table_info('stash') WHERE name = 'generation'
+             )",
+            [],
+            |row| row.get(0),
+        )?;
+        if !has_generation {
+            tx.execute(
+                "ALTER TABLE stash ADD COLUMN generation INTEGER NOT NULL DEFAULT 0",
+                [],
+            )?;
+        }
+        tx.execute(
             "CREATE INDEX IF NOT EXISTS idx_stash_expires_at ON stash(expires_at)",
             [],
         )?;
+        tx.execute(
+            "CREATE TABLE IF NOT EXISTS stash_metadata (
+                singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                last_generation INTEGER NOT NULL CHECK(last_generation >= 0)
+            )",
+            [],
+        )?;
+        let max_generation: i64 = tx.query_row(
+            "SELECT COALESCE(MAX(generation), 0) FROM stash",
+            [],
+            |row| row.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO stash_metadata(singleton, last_generation)
+             VALUES (1, ?)
+             ON CONFLICT(singleton) DO UPDATE SET
+                 last_generation = max(stash_metadata.last_generation, excluded.last_generation)",
+            [max_generation],
+        )?;
+        tx.commit()?;
         Ok(Self {
             conn: Mutex::new(conn),
             ttl_seconds,
@@ -111,46 +145,103 @@ impl SqliteStore {
         })
     }
 
-    /// FIFO-evict oldest entries once the live count exceeds `capacity`.
-    /// Returns the number evicted. "Oldest" is approximated by the lowest
-    /// `expires_at` (earliest-inserted, since all entries share the same TTL).
-    fn enforce_capacity(&self, conn: &Connection) -> Result<usize, StashError> {
-        let now = now_unix();
-        let live: i64 = conn.query_row(
+    /// Evict oldest live entries once the live count exceeds `capacity`.
+    /// The caller holds the `BEGIN IMMEDIATE` transaction used for the stash
+    /// write, so no other connection can change ownership between counting
+    /// and eviction.
+    fn enforce_capacity(&self, tx: &Transaction<'_>, now: i64) -> Result<usize, StashError> {
+        let live: i64 = tx.query_row(
             "SELECT COUNT(*) FROM stash WHERE expires_at >= ?",
-            [now as i64],
+            [now],
             |row| row.get(0),
         )?;
-        let surplus = live.saturating_sub(self.capacity as i64);
+        let capacity = i64::try_from(self.capacity).unwrap_or(i64::MAX);
+        let surplus = live.saturating_sub(capacity);
         if surplus <= 0 {
             return Ok(0);
         }
-        let evicted = conn.execute(
+        let evicted = tx.execute(
             "DELETE FROM stash
              WHERE hash IN (
                  SELECT hash FROM stash
                  WHERE expires_at >= ?
-                 ORDER BY expires_at ASC
+                 ORDER BY expires_at ASC, generation ASC
                  LIMIT ?
              )",
-            rusqlite::params![now as i64, surplus],
+            rusqlite::params![now, surplus],
         )?;
         Ok(evicted)
     }
 }
 
-impl StashStore for SqliteStore {
-    fn stash(&self, payload: &str) -> Result<String, StashError> {
+impl SqliteStore {
+    fn stash_inner(
+        &self,
+        payload: &str,
+        #[cfg(test)] after_live_read: Option<&dyn Fn()>,
+        #[cfg(not(test))] _after_live_read: Option<&dyn Fn()>,
+    ) -> Result<StashWrite, StashError> {
         let key = compute_key(payload.as_bytes());
         let now = now_unix();
-        let expires_at = now + self.ttl_seconds;
-        let conn = self.lock_conn();
-        conn.execute(
-            "INSERT OR REPLACE INTO stash (hash, payload, expires_at) VALUES (?, ?, ?)",
-            rusqlite::params![key, payload, expires_at as i64],
+        let expires_at = now
+            .checked_add(self.ttl_seconds)
+            .and_then(|expires_at| i64::try_from(expires_at).ok())
+            .ok_or_else(|| StashError::Backend("stash expiry overflow".to_string()))?;
+        let mut conn = self.lock_conn();
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_generation: Option<u64> = match tx.query_row(
+            "SELECT generation FROM stash WHERE hash = ? AND expires_at >= ?",
+            rusqlite::params![key, now as i64],
+            |row| row.get::<_, i64>(0),
+        ) {
+            Ok(generation) => Some(generation as u64),
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(e) => return Err(StashError::from(e)),
+        };
+        let had_live = previous_generation.is_some();
+        #[cfg(test)]
+        if let Some(after_live_read) = after_live_read {
+            after_live_read();
+        }
+        let generation: i64 = match tx.query_row(
+            "UPDATE stash_metadata
+             SET last_generation = last_generation + 1
+             WHERE singleton = 1 AND last_generation < ?
+             RETURNING last_generation",
+            [MAX_GENERATION as i64],
+            |row| row.get(0),
+        ) {
+            Ok(value) => value,
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                return Err(StashError::Backend(
+                    "stash generation exhausted".to_string(),
+                ));
+            }
+            Err(e) => return Err(StashError::from(e)),
+        };
+        tx.execute(
+            "INSERT INTO stash (hash, payload, expires_at, generation)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(hash) DO UPDATE SET
+                 payload = excluded.payload,
+                 expires_at = excluded.expires_at,
+                 generation = excluded.generation",
+            rusqlite::params![key, payload, expires_at, generation],
         )?;
-        self.enforce_capacity(&conn)?;
-        Ok(key)
+        self.enforce_capacity(&tx, now as i64)?;
+        tx.commit()?;
+        Ok(StashWrite {
+            key,
+            created: !had_live,
+            generation: generation as u64,
+            previous_generation,
+        })
+    }
+}
+
+impl StashStore for SqliteStore {
+    fn stash(&self, payload: &str) -> Result<StashWrite, StashError> {
+        self.stash_inner(payload, None)
     }
 
     fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
@@ -195,6 +286,21 @@ impl StashStore for SqliteStore {
         let evicted = conn.execute("DELETE FROM stash WHERE expires_at < ?", [now as i64])?;
         Ok(evicted)
     }
+
+    fn delete(&self, hash: &str, generation: u64) -> Result<bool, StashError> {
+        let key = hash.to_ascii_lowercase();
+        let generation = match i64::try_from(generation) {
+            Ok(generation) => generation,
+            Err(_) => return Ok(false),
+        };
+        let now = now_unix();
+        let conn = self.lock_conn();
+        let removed = conn.execute(
+            "DELETE FROM stash WHERE hash = ? AND generation = ? AND expires_at >= ?",
+            rusqlite::params![key, generation, now as i64],
+        )?;
+        Ok(removed > 0)
+    }
 }
 
 /// Current wall-clock seconds since the Unix epoch. Used for expiry math so
@@ -220,7 +326,7 @@ mod tests {
     #[test]
     fn retrieve_is_case_insensitive() {
         let (store, _dir) = tmp_store(60, 100);
-        let key = store.stash("payload").unwrap();
+        let key = store.stash("payload").unwrap().key;
         assert_eq!(key, key.to_ascii_lowercase());
         let upper = key.to_uppercase();
         assert_ne!(upper, key);
@@ -230,7 +336,7 @@ mod tests {
     #[test]
     fn round_trip_persists_across_connections() {
         let (store, dir) = tmp_store(60, 100);
-        let key = store.stash("payload-A").unwrap();
+        let key = store.stash("payload-A").unwrap().key;
         assert_eq!(store.retrieve(&key).unwrap(), Some("payload-A".to_string()));
 
         // A second connection to the same file sees the entry: proves the
@@ -268,7 +374,7 @@ mod tests {
     #[test]
     fn expired_entry_not_retrievable() {
         let (store, _dir) = tmp_store(1, 100);
-        let key = store.stash("ephemeral").unwrap();
+        let key = store.stash("ephemeral").unwrap().key;
         thread::sleep(std::time::Duration::from_secs(2));
         assert_eq!(store.retrieve(&key).unwrap(), None);
     }
@@ -276,8 +382,8 @@ mod tests {
     #[test]
     fn evict_expired_reports_count() {
         let (store, _dir) = tmp_store(1, 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         thread::sleep(std::time::Duration::from_secs(2));
         assert_eq!(store.evict_expired().unwrap(), 2);
         assert_eq!(store.len(), 0);
@@ -286,12 +392,60 @@ mod tests {
     #[test]
     fn fifo_eviction_when_over_capacity() {
         let (store, _dir) = tmp_store(60, 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
-        store.stash("3").unwrap(); // surplus=1, evicts oldest live (k0)
+        let k0 = store.stash("0").unwrap().key;
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
+        let _ = store.stash("3").unwrap(); // surplus=1, evicts oldest live (k0)
         assert_eq!(store.retrieve(&k0).unwrap(), None);
         assert!(store.len() <= 3);
+    }
+
+    #[test]
+    fn delete_live_entry_returns_true() {
+        let (store, _dir) = tmp_store(60, 100);
+        let write = store.stash("payload").unwrap();
+        assert!(store.delete(&write.key, write.generation).unwrap());
+        assert_eq!(store.retrieve(&write.key).unwrap(), None);
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn delete_missing_returns_false() {
+        let (store, _dir) = tmp_store(60, 100);
+        assert!(!store.delete("000000000000000000000000", 1).unwrap());
+    }
+
+    #[test]
+    fn delete_expired_returns_false() {
+        // Trait: Ok(false) when already expired. DELETE must include
+        // `expires_at >= now` so an expired row is not reported as a live delete.
+        let (store, _dir) = tmp_store(1, 100);
+        let write = store.stash("ephemeral").unwrap();
+        thread::sleep(std::time::Duration::from_secs(2));
+        assert!(!store.delete(&write.key, write.generation).unwrap());
+        assert_eq!(store.retrieve(&write.key).unwrap(), None);
+    }
+
+    #[test]
+    fn delete_stale_generation_across_connections_returns_false() {
+        // Two independent connections on one file (hook fork+exec). A creates;
+        // B refreshes (as if emitting a marker); A's stale-generation delete
+        // must not remove B's live row.
+        let (store_a, dir) = tmp_store(60, 100);
+        let first = store_a.stash("payload").unwrap();
+        assert!(first.created);
+        let store_b = SqliteStore::new(dir.path().join("stash.db")).unwrap();
+        let second = store_b.stash("payload").unwrap();
+        assert!(!second.created);
+        assert_ne!(first.generation, second.generation);
+        assert_eq!(first.previous_generation, None);
+        assert_eq!(second.previous_generation, Some(first.generation));
+        assert!(!store_a.delete(&first.key, first.generation).unwrap());
+        assert_eq!(
+            store_b.retrieve(&second.key).unwrap(),
+            Some("payload".to_string())
+        );
+        assert!(store_b.delete(&second.key, second.generation).unwrap());
     }
 
     #[test]
@@ -303,7 +457,7 @@ mod tests {
                 let s = store.clone();
                 thread::spawn(move || {
                     for j in 0..50 {
-                        s.stash(&format!("p-{i}-{j}")).unwrap();
+                        let _ = s.stash(&format!("p-{i}-{j}")).unwrap();
                     }
                 })
             })
@@ -320,8 +474,8 @@ mod tests {
         // merely filter them via the WHERE clause. Mirrors headroom's
         // `SqliteCcrStore::get` lazy-purge sweep.
         let (store, _dir) = tmp_store(1, 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         assert_eq!(store.len(), 2);
         thread::sleep(std::time::Duration::from_secs(2));
         // Both rows are now expired. A retrieve for any (absent) key triggers
@@ -329,5 +483,184 @@ mod tests {
         // physically deleted, not just hidden.
         assert_eq!(store.retrieve("000000000000000000000000").unwrap(), None);
         assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn lazy_purge_recreate_never_reuses_generation() {
+        let (store, dir) = tmp_store(60, 100);
+        let first = store.stash("payload").unwrap();
+        store
+            .lock_conn()
+            .execute("UPDATE stash SET expires_at = 0", [])
+            .unwrap();
+        assert_eq!(store.retrieve(&first.key).unwrap(), None);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+        assert_eq!(store.retrieve(&second.key).unwrap(), Some("payload".into()));
+        drop(dir);
+    }
+
+    #[test]
+    fn evict_expired_recreate_never_reuses_generation() {
+        let (store, _dir) = tmp_store(60, 100);
+        let first = store.stash("payload").unwrap();
+        store
+            .lock_conn()
+            .execute("UPDATE stash SET expires_at = 0", [])
+            .unwrap();
+        assert_eq!(store.evict_expired().unwrap(), 1);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+    }
+
+    #[test]
+    fn capacity_eviction_recreate_never_reuses_generation() {
+        let (store, _dir) = tmp_store(60, 1);
+        let first = store.stash("payload").unwrap();
+        let _other = store.stash("other").unwrap();
+        assert_eq!(store.retrieve(&first.key).unwrap(), None);
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+    }
+
+    #[test]
+    fn delete_recreate_never_reuses_generation() {
+        let (store, _dir) = tmp_store(60, 100);
+        let first = store.stash("payload").unwrap();
+        assert!(store.delete(&first.key, first.generation).unwrap());
+        let second = store.stash("payload").unwrap();
+        assert!(second.generation > first.generation);
+        assert!(!store.delete(&first.key, first.generation).unwrap());
+        assert_eq!(store.retrieve(&second.key).unwrap(), Some("payload".into()));
+    }
+
+    #[test]
+    fn current_generation_schema_migrates_high_water_mark() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stash.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "CREATE TABLE stash (
+                hash TEXT PRIMARY KEY,
+                payload TEXT NOT NULL,
+                expires_at INTEGER NOT NULL,
+                generation INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO stash(hash, payload, expires_at, generation)
+             VALUES ('hash', 'payload', 9999999999, 7)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let store = SqliteStore::with_limits(&path, 60, 100).unwrap();
+        assert_eq!(store.stash("next").unwrap().generation, 8);
+    }
+
+    #[test]
+    fn pre_generation_schema_migrates_and_starts_at_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stash.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "CREATE TABLE stash (
+                hash TEXT PRIMARY KEY,
+                payload TEXT NOT NULL,
+                expires_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO stash(hash, payload, expires_at)
+             VALUES ('hash', 'payload', 9999999999)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+        let store = SqliteStore::with_limits(&path, 60, 100).unwrap();
+        assert_eq!(store.stash("next").unwrap().generation, 1);
+        let conn = Connection::open(&path).unwrap();
+        let generation: i64 = conn
+            .query_row(
+                "SELECT generation FROM stash WHERE hash = 'hash'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(generation, 0);
+    }
+
+    #[test]
+    fn generation_exhaustion_does_not_mutate_stash() {
+        let (store, _dir) = tmp_store(60, 100);
+        let existing = store.stash("existing").unwrap();
+        store
+            .lock_conn()
+            .execute(
+                "UPDATE stash_metadata SET last_generation = ? WHERE singleton = 1",
+                [MAX_GENERATION as i64],
+            )
+            .unwrap();
+        let before = store.retrieve(&existing.key).unwrap();
+        let error = store.stash("new").unwrap_err();
+        assert!(error.to_string().contains("generation exhausted"));
+        assert_eq!(store.retrieve(&existing.key).unwrap(), before);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn concurrent_stash_serializes_ownership_across_connections() {
+        let (store_a, dir) = tmp_store(60, 100);
+        let store_b = std::sync::Arc::new(SqliteStore::new(dir.path().join("stash.db")).unwrap());
+        let store_a = std::sync::Arc::new(store_a);
+        let (read_done_tx, read_done_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let a = {
+            let store_a = store_a.clone();
+            thread::spawn(move || {
+                let hook = || {
+                    read_done_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                };
+                store_a.stash_inner("payload", Some(&hook)).unwrap()
+            })
+        };
+        read_done_rx.recv().unwrap();
+        let (b_done_tx, b_done_rx) = std::sync::mpsc::channel();
+        let b = {
+            let store_b = store_b.clone();
+            thread::spawn(move || {
+                let result = store_b.stash("payload");
+                b_done_tx.send(result).unwrap();
+            })
+        };
+        // B cannot complete while A's IMMEDIATE transaction is held after
+        // its live-row read; releasing A makes the overlap deterministic.
+        assert!(
+            b_done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err()
+        );
+        release_tx.send(()).unwrap();
+        let first = a.join().unwrap();
+        let second = b_done_rx.recv().unwrap().unwrap();
+        b.join().unwrap();
+        assert!(first.created);
+        assert!(!second.created);
+        assert!(second.generation > first.generation);
+        assert_eq!(first.previous_generation, None);
+        assert_eq!(second.previous_generation, Some(first.generation));
+        assert!(!store_a.delete(&first.key, first.generation).unwrap());
+        assert_eq!(
+            store_b.retrieve(&second.key).unwrap(),
+            Some("payload".into())
+        );
     }
 }

--- a/src/tokenless/crates/tokenless-ccr/src/lib.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/lib.rs
@@ -31,4 +31,4 @@ pub use key::compute_key;
 pub use marker::{
     MARKER_PREFIX, MARKER_SUFFIX, extract_hash, is_valid_hash, marker_for, parse_marker,
 };
-pub use store::{StashError, StashStore};
+pub use store::{StashError, StashStore, StashWrite};

--- a/src/tokenless/crates/tokenless-ccr/src/store.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/store.rs
@@ -3,6 +3,32 @@
 //! The trait is deliberately dependency-free so compressors can hold an
 //! `Option<Arc<dyn StashStore>>` without pulling in any backend crate.
 
+/// Result of a successful [`StashStore::stash`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StashWrite {
+    /// Content-addressed BLAKE3 key (24 lowercase hex chars).
+    pub key: String,
+    /// `true` only when no live entry existed for this key before this call.
+    pub created: bool,
+    /// Store-wide ownership token, never reused after expiry, deletion, or
+    /// eviction. Rollback must pass this to [`StashStore::delete`] so a later
+    /// refresh by another compressor/process is not removed.
+    pub generation: u64,
+    /// Live generation immediately before this write, if a live row existed.
+    /// `None` when this call created the row (`created == true`).
+    ///
+    /// Compressors compare this to the generation they last recorded for the
+    /// key: equality means the ownership chain is unbroken (in-session
+    /// refresh); inequality means another writer refreshed in between, and
+    /// rollback must not re-adopt this generation.
+    pub previous_generation: Option<u64>,
+}
+
+/// SQLite stores generations as signed INTEGER values. Keeping the same
+/// ceiling in both backends makes exhaustion behavior and the ownership-token
+/// contract independent of the storage representation.
+pub(crate) const MAX_GENERATION: u64 = i64::MAX as u64;
+
 /// A reversible stash of compressed-out payloads.
 ///
 /// `stash` stores a payload and returns its BLAKE3-derived key; the caller
@@ -11,9 +37,20 @@
 /// for key derivation (rather than accepting a caller-supplied hash) removes a
 /// injection footgun: callers cannot mismatch a marker from its payload.
 pub trait StashStore: Send + Sync {
-    /// Stash `payload`, returning its key. Re-stashing the same payload is
-    /// idempotent (same key) and refreshes the entry's expiry.
-    fn stash(&self, payload: &str) -> Result<String, StashError>;
+    /// Stash `payload`, returning the key, whether this call created a live
+    /// row, the new ownership token, and the previous live generation.
+    ///
+    /// Re-stashing the same payload is idempotent (same key) and refreshes the
+    /// entry's expiry, allocating a new store-wide ownership token.
+    /// `created` is `true` only when no live entry existed for that key before
+    /// this call. `previous_generation` is the live token just before this
+    /// write (`None` on create). Callers that roll back discarded compress
+    /// output must delete only writes whose ownership chain is unbroken:
+    /// re-adopt the new token only when `previous_generation` still matches
+    /// the token this session last recorded. A later refresh by another
+    /// compressor stays live because that mismatch drops the key from the
+    /// rollback list (and a stale `delete(hash, generation)` is a no-op).
+    fn stash(&self, payload: &str) -> Result<StashWrite, StashError>;
 
     /// Retrieve a stashed payload by key. Returns `Ok(None)` if the key is
     /// absent or the entry has expired.
@@ -29,6 +66,13 @@ pub trait StashStore: Send + Sync {
 
     /// Drop all expired entries and return how many were removed.
     fn evict_expired(&self) -> Result<usize, StashError>;
+
+    /// Delete a live entry by hash **and generation**. Returns `Ok(true)` when
+    /// a matching live row was removed, `Ok(false)` when the key was absent,
+    /// already expired, or the generation no longer matches (another writer
+    /// refreshed/adopted the row). Used to roll back stash writes whose
+    /// markers never reach the LLM (e.g. CLI discards a no-savings result).
+    fn delete(&self, hash: &str, generation: u64) -> Result<bool, StashError>;
 }
 
 /// Errors a stash backend can surface. Kept minimal: backends map their

--- a/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
@@ -4,7 +4,7 @@ use crate::InMemoryStore;
 fn is_empty_default_trait_method() {
     let store = InMemoryStore::new();
     assert!(store.is_empty());
-    store.stash("payload").unwrap();
+    let _ = store.stash("payload").unwrap();
     assert!(!store.is_empty());
 }
 
@@ -18,7 +18,7 @@ fn stash_error_display() {
 fn default_trait_creates_working_store() {
     let store = InMemoryStore::default();
     assert!(store.is_empty());
-    let key = store.stash("payload").unwrap();
+    let key = store.stash("payload").unwrap().key;
     assert!(!store.is_empty());
     let retrieved = store.retrieve(&key).unwrap();
     assert_eq!(retrieved, Some("payload".to_string()));

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -531,15 +531,24 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     "tokenless: schema compression did not reduce size ({} -> {} est. tokens), outputting original",
                     before_tokens, after_tokens
                 );
-                // No-savings discard edge: if a stash was attached and a
-                // description was truncated, those writes orphan (markers
-                // live in `after_compact`, which is discarded). Truncation
-                // almost always yields savings, so this is rare; orphaned
-                // entries are TTL-cleaned.
+                // Discarded compressed output never reaches the LLM, so roll
+                // back stash keys created during this compress — otherwise
+                // markers live only in `after_compact` and orphan stash rows.
+                compressor.rollback_stash_writes();
                 input.clone()
             } else {
                 after_compact.clone()
             };
+
+            let stash_writes = stash.as_ref().map(|_| compressor.stash_writes());
+            let stash_errors = stash.as_ref().map(|_| compressor.stash_errors());
+            let stash_size = stash.as_ref().map(|s| s.len());
+            if matches!(stash_errors, Some(e) if e > 0) {
+                eprintln!(
+                    "[tokenless] stash: {} stash operation(s) failed; truncated entries are not retrievable (check stash db health)",
+                    stash_errors.expect("checked Some above")
+                );
+            }
 
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
@@ -559,9 +568,9 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 input,
                 output_text,
                 mode,
-                None,
-                None,
-                None,
+                stash_writes,
+                stash_errors,
+                stash_size,
             );
         }
         Commands::CompressResponse {
@@ -617,12 +626,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 (error.to_string(), code)
             })?;
             // Surface persistent stash backend failures (disk full, locked DB,
-            // I/O) so they aren't invisible — compression degrades to the
-            // lossy marker per entry, but a non-zero count means the stash
-            // path is broken and retrievals will miss.
+            // I/O, rollback delete) so they aren't invisible. `stash_errors`
+            // counts both compress-time stash writes and no-savings rollback
+            // deletes; a non-zero count means the stash path is broken and
+            // retrievals will miss.
             if matches!(result.stash_errors, Some(errors) if errors > 0) {
                 eprintln!(
-                    "[tokenless] stash: {} write(s) failed during compression; truncated entries are not retrievable (check stash db health)",
+                    "[tokenless] stash: {} stash operation(s) failed; truncated entries are not retrievable (check stash db health)",
                     result.stash_errors.expect("checked Some above")
                 );
             }

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -717,7 +717,7 @@ fn run_command_retrieve_with_marker() {
         return;
     }
     let store = store.unwrap();
-    let key = store.stash("hello world").unwrap();
+    let key = store.stash("hello world").unwrap().key;
     let marker = format!("<<tokenless:{}>>", key);
     let result = run_command(Commands::Retrieve {
         hash: marker,
@@ -734,7 +734,7 @@ fn run_command_retrieve_bare_hash() {
         return;
     }
     let store = store.unwrap();
-    let key = store.stash("retrieve bare hash test").unwrap();
+    let key = store.stash("retrieve bare hash test").unwrap().key;
     let result = run_command(Commands::Retrieve {
         hash: key,
         stash_db: None,

--- a/src/tokenless/crates/tokenless-cli/src/tests/mcp_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/mcp_tests.rs
@@ -48,7 +48,7 @@ fn retrieve_invalid_hash_format_is_error() {
 #[test]
 fn retrieve_round_trips_via_store() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("payload-body").unwrap();
+    let key = store.stash("payload-body").unwrap().key;
     let r = retrieve_from_store(&store, &key);
     assert_eq!(r["isError"], json!(false));
     assert_eq!(r["content"][0]["text"], json!("payload-body"));
@@ -57,7 +57,7 @@ fn retrieve_round_trips_via_store() {
 #[test]
 fn retrieve_accepts_marker_line() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("dropped items").unwrap();
+    let key = store.stash("dropped items").unwrap().key;
     let marker_line = format!("<... 5 items truncated, retrieve with <<tokenless:{key}>>");
     // Exercise the public entry point so marker extraction in `retrieve`
     // is covered, not just the bare-key path of `retrieve_from_store`.
@@ -113,7 +113,7 @@ fn retrieve_stash_unavailable_when_store_is_none() {
 #[test]
 fn handle_tool_call_dispatches_retrieve_with_store() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("mcp-payload").unwrap();
+    let key = store.stash("mcp-payload").unwrap().key;
     let params = json!({
         "name": "tokenless_retrieve",
         "arguments": {"hash": key}

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -1,8 +1,8 @@
 use std::process::Command;
 
-use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, estimate_tokens, get_home_dir};
-
+use tokenless_ccr::StashStore;
 use tokenless_runtime::{CompressOptions, compress_response_with_store};
+use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, estimate_tokens, get_home_dir};
 
 fn tokenless_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_tokenless"))
@@ -609,6 +609,144 @@ fn retrieve_stdout_is_byte_exact_without_extra_trailing_newline() {
         stashed_string.as_bytes(),
         "retrieve must restore the stashed payload byte-for-byte; \
          an extra trailing newline breaks end-to-end lossless recovery"
+    );
+}
+
+#[test]
+fn compress_response_no_savings_rolls_back_orphan_stash() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let stash_db = fixture.data_dir.join("stash.db");
+    // Small array + aggressive truncate: marker overhead makes after_tokens
+    // >= before_tokens, so CLI falls back to the original input.
+    let original = r#"["a","b"]"#;
+
+    let output = fixture
+        .command()
+        .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+        .env("TOKENLESS_STATS_ENABLED", "0")
+        .args([
+            "compress-response",
+            "--truncate-arrays-at",
+            "1",
+            "--stash-db",
+        ])
+        .arg(&stash_db)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(original.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "compress-response failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("did not reduce size"),
+        "expected no-savings path, stderr={stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("tokenless:"),
+        "no-savings stdout must not expose markers: {stdout}"
+    );
+    // Discarded markers must not leave orphan rows in stash.db.
+    let live = if stash_db.exists() {
+        tokenless_ccr::SqliteStore::new(&stash_db)
+            .map(|s| s.len())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    assert_eq!(
+        live,
+        0,
+        "no-savings discard must roll back stash writes; orphan rows remain in {}",
+        stash_db.display()
+    );
+}
+
+#[test]
+fn compress_schema_no_savings_rolls_back_orphan_stash() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    // Description just over the default 256-char cap: truncation + stash
+    // marker often yields after_tokens >= before_tokens (1-char savings
+    // does not always change the estimate). Pad the function name so the
+    // compact JSON length hits that equality.
+    let mut hit_no_savings = false;
+    for name in ["x", "xx", "xxx", "xxxx"] {
+        // Each candidate owns its database so a prior savings-path marker
+        // cannot make this candidate's orphan-row assertion fail.
+        let stash_db = fixture.data_dir.join(format!("stash-{name}.db"));
+        let schema = serde_json::json!({
+            "function": {
+                "name": name,
+                "description": "A".repeat(257),
+                "parameters": {"type": "object", "properties": {}}
+            }
+        });
+        let original = serde_json::to_string(&schema).unwrap();
+        let output = fixture
+            .command()
+            .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+            .env("TOKENLESS_STATS_ENABLED", "0")
+            .args(["compress-schema", "--stash-db"])
+            .arg(&stash_db)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write;
+                child.stdin.take().unwrap().write_all(original.as_bytes())?;
+                child.wait_with_output()
+            })
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "compress-schema failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("did not reduce size") {
+            continue;
+        }
+        hit_no_savings = true;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("tokenless:"),
+            "no-savings stdout must not expose markers: {stdout}"
+        );
+        let live = if stash_db.exists() {
+            tokenless_ccr::SqliteStore::new(&stash_db)
+                .map(|s| s.len())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        assert_eq!(
+            live,
+            0,
+            "no-savings discard must roll back stash writes; orphan rows remain in {}",
+            stash_db.display()
+        );
+        break;
+    }
+    assert!(
+        hit_no_savings,
+        "failed to hit compress-schema no-savings path with a just-over-limit description"
     );
 }
 

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -423,10 +423,7 @@ pub fn compress_response_with_store(
         serde_json::to_string(&compressed_value).map_err(RuntimeError::Serialize)?;
     let before_tokens = estimate_tokens(input);
     let after_tokens = estimate_tokens(&compressed_output);
-    let stash_writes = attached_store.map(|_| compressor.stash_writes());
-    let stash_errors = attached_store.map(|_| compressor.stash_errors());
     let unrecoverable_truncations = attached_store.map(|_| compressor.unrecoverable_truncations());
-    let stash_size = attached_store.map(|store| store.len());
 
     let disposition = if after_tokens >= before_tokens {
         CompressionDisposition::NoSavings
@@ -440,6 +437,15 @@ pub fn compress_response_with_store(
     } else {
         CompressionDisposition::Applied
     };
+    // Discarded compressed output never reaches the LLM, so roll back stash
+    // keys created during this compress — otherwise markers live only in
+    // `compressed_output` and orphan stash rows.
+    if disposition != CompressionDisposition::Applied {
+        compressor.rollback_stash_writes();
+    }
+    let stash_writes = attached_store.map(|_| compressor.stash_writes());
+    let stash_errors = attached_store.map(|_| compressor.stash_errors());
+    let stash_size = attached_store.map(|store| store.len());
     let output = if disposition == CompressionDisposition::Applied {
         compressed_output.clone()
     } else {
@@ -503,7 +509,7 @@ mod tests {
     struct AlwaysFail;
 
     impl StashStore for AlwaysFail {
-        fn stash(&self, _payload: &str) -> Result<String, StashError> {
+        fn stash(&self, _payload: &str) -> Result<tokenless_ccr::StashWrite, StashError> {
             Err(StashError::Backend("simulated".to_string()))
         }
 
@@ -517,6 +523,10 @@ mod tests {
 
         fn evict_expired(&self) -> Result<usize, StashError> {
             Ok(0)
+        }
+
+        fn delete(&self, _hash: &str, _generation: u64) -> Result<bool, StashError> {
+            Ok(false)
         }
     }
 
@@ -703,6 +713,26 @@ mod tests {
     }
 
     #[test]
+    fn no_savings_rolls_back_orphan_stash() {
+        let input = r#"["a","b"]"#;
+        let store = Arc::new(InMemoryStore::new()) as Arc<dyn StashStore>;
+        let result = compress_response_with_store(
+            input,
+            &CompressOptions {
+                truncate_arrays_at: Some(1),
+                ..CompressOptions::default()
+            },
+            true,
+            Some(&store),
+        )
+        .unwrap();
+        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.output, input);
+        assert_eq!(store.len(), 0);
+        assert_eq!(result.stash_writes, Some(0));
+    }
+
+    #[test]
     fn invalid_json_is_structured_error() {
         let error =
             compress_response_with_store("not json", &CompressOptions::default(), true, None)
@@ -800,6 +830,13 @@ mod tests {
 
         let directory = tempfile::tempdir().unwrap();
         std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o500)).unwrap();
+        // Directory mode bits do not constrain euid 0; skip rather than
+        // asserting a permission failure that cannot happen as root.
+        if std::fs::File::create(directory.path().join(".probe")).is_ok() {
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .unwrap();
+            return;
+        }
         let runtime = TokenlessRuntime::new(RuntimeConfig {
             data_dir: Some(directory.path().to_path_buf()),
             stats_enabled: false,

--- a/src/tokenless/crates/tokenless-schema/Cargo.toml
+++ b/src/tokenless/crates/tokenless-schema/Cargo.toml
@@ -11,3 +11,7 @@ regex.workspace = true
 # Stash trait + key + marker only — no SQLite backend here. The CLI supplies
 # the concrete backend, so the schema crate stays free of rusqlite.
 tokenless-ccr = { path = "../tokenless-ccr", default-features = false }
+
+[dev-dependencies]
+tempfile.workspace = true
+tokenless-ccr = { path = "../tokenless-ccr", features = ["sqlite"] }

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -1,8 +1,8 @@
 use serde_json::{Map, Value};
-use std::cell::Cell;
-use std::collections::HashSet;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokenless_ccr::{StashStore, marker_for};
+use tokenless_ccr::{StashStore, StashWrite, marker_for};
 
 /// Build the stash-augmented truncation suffix for `key`:
 /// `… (truncated, retrieve with <<tokenless:KEY>>)`.
@@ -36,19 +36,25 @@ pub struct ResponseCompressor {
     /// pre-stash behavior. Keeping this optional means the stash stays off
     /// the core compression path unless a caller explicitly enables it.
     stash_store: Option<Arc<dyn StashStore>>,
-    /// Number of stash writes performed during the last `compress()` call.
-    /// Exposed for stats recording so callers can observe stash usage without
-    /// the schema crate depending on the stats crate.
+    /// Unique stash rows this `compress()` created, plus refreshes of keys
+    /// it did not create. An in-compress refresh of a key already pending
+    /// rollback does not increment again, so after `rollback_stash_writes`
+    /// the counter matches remaining live rows from this call.
     stash_writes: Cell<usize>,
-    /// Number of stash writes that **failed** during the last `compress()`
-    /// call (backend error — disk full, locked DB, I/O). Exposed so the CLI
-    /// can surface persistent backend failures instead of silently degrading
-    /// to the lossy marker.
+    /// Number of stash writes or rollback deletes that failed for the most
+    /// recent `compress()` call. Non-zero signals a persistent backend problem
+    /// (disk full, locked DB, I/O) — the caller should log it so the failure
+    /// isn't invisible.
     stash_errors: Cell<usize>,
     /// Number of truncations that could not embed a retrievable marker during
     /// the last `compress()` call. Includes backend failures and marker-budget
     /// limits without conflating the two causes.
     unrecoverable_truncations: Cell<usize>,
+    /// Keys created during the last `compress()` call, mapped to the latest
+    /// generation this call still owns. An in-compress refresh updates the
+    /// generation only when `StashWrite::previous_generation` matches, so a
+    /// foreign refresh in between cannot be re-adopted and later deleted.
+    stash_keys_created: RefCell<HashMap<String, u64>>,
 }
 
 impl Default for ResponseCompressor {
@@ -81,6 +87,7 @@ impl Default for ResponseCompressor {
             stash_writes: Cell::new(0),
             stash_errors: Cell::new(0),
             unrecoverable_truncations: Cell::new(0),
+            stash_keys_created: RefCell::new(HashMap::new()),
         }
     }
 }
@@ -150,6 +157,7 @@ impl ResponseCompressor {
         self.stash_writes.set(0);
         self.stash_errors.set(0);
         self.unrecoverable_truncations.set(0);
+        self.stash_keys_created.borrow_mut().clear();
         let original_text = serde_json::to_string(response).unwrap_or_default();
         let result = self.compress_value(response, 0);
 
@@ -162,15 +170,19 @@ impl ResponseCompressor {
         result
     }
 
-    /// Number of stash writes performed during the last `compress()` call.
-    /// Zero when no stash store is attached or no value was stashed.
+    /// Unique stash rows created during the last `compress()` call, plus
+    /// refresh operations for keys this call did not create. Duplicate
+    /// payloads first created by this call count once; repeated refreshes of
+    /// a pre-existing key count once per refresh. Zero when no stash store is
+    /// attached or no value was stashed.
     pub fn stash_writes(&self) -> usize {
         self.stash_writes.get()
     }
 
-    /// Number of stash writes that failed during the last `compress()` call.
-    /// Non-zero signals a persistent backend problem (disk full, locked DB,
-    /// I/O) — the caller should log it so the failure isn't invisible.
+    /// Number of stash writes or rollback deletes that failed for the most
+    /// recent `compress()` call. Non-zero signals a persistent backend problem
+    /// (disk full, locked DB, I/O) — the caller should log it so the failure
+    /// isn't invisible.
     pub fn stash_errors(&self) -> usize {
         self.stash_errors.get()
     }
@@ -179,6 +191,67 @@ impl ResponseCompressor {
     /// attached stash. A non-zero value means the candidate is partly lossy.
     pub fn unrecoverable_truncations(&self) -> usize {
         self.unrecoverable_truncations.get()
+    }
+
+    /// Delete stash entries created during the last `compress()` call.
+    ///
+    /// Call this when the compressed output (and its embedded markers) will
+    /// never be emitted — e.g. the CLI no-savings path that falls back to the
+    /// original input. Returns how many keys were successfully removed.
+    pub fn rollback_stash_writes(&self) -> usize {
+        let Some(store) = self.stash_store.as_ref() else {
+            return 0;
+        };
+        let writes = std::mem::take(&mut *self.stash_keys_created.borrow_mut());
+        let mut removed = 0usize;
+        for (key, generation) in &writes {
+            match store.delete(key, *generation) {
+                Ok(true) => removed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    // Keep the key list drained so we don't retry forever, but
+                    // surface the failure — a silent orphan is worse than a
+                    // loud warning (AGENTS.md: do not swallow operational errors).
+                    self.record_stash_error();
+                    eprintln!(
+                        "[tokenless] stash: rollback delete failed for key {}: {e}",
+                        key
+                    );
+                }
+            }
+        }
+        // Keep counters consistent with the rolled-back store.
+        self.stash_writes
+            .set(self.stash_writes.get().saturating_sub(removed));
+        removed
+    }
+
+    fn record_stash_success(&self, write: &StashWrite) {
+        let mut pending = self.stash_keys_created.borrow_mut();
+        if write.created {
+            self.stash_writes.set(self.stash_writes.get() + 1);
+            pending.insert(write.key.clone(), write.generation);
+        } else if let Some(&expected) = pending.get(&write.key) {
+            if write.previous_generation == Some(expected) {
+                // Unbroken in-session refresh: update generation so rollback
+                // CAS matches the live row. Do not double-count stash_writes.
+                pending.insert(write.key.clone(), write.generation);
+            } else {
+                // A foreign writer refreshed (and likely emitted a marker)
+                // between our create and this write. Drop ownership so
+                // rollback cannot delete the live row those markers need.
+                pending.remove(&write.key);
+            }
+        } else {
+            // Refresh of a key this compress never created. Another emitted
+            // marker may still need it, so it stays off the rollback list,
+            // but the write still counts.
+            self.stash_writes.set(self.stash_writes.get() + 1);
+        }
+    }
+
+    fn record_stash_error(&self) {
+        self.stash_errors.set(self.stash_errors.get() + 1);
     }
 
     /// Recursively compress a JSON value
@@ -370,12 +443,12 @@ impl ResponseCompressor {
     fn stash_payload(&self, payload: &str) -> Option<String> {
         let stash = self.stash_store.as_ref()?;
         match stash.stash(payload) {
-            Ok(k) => {
-                self.stash_writes.set(self.stash_writes.get() + 1);
-                Some(k)
+            Ok(write) => {
+                self.record_stash_success(&write);
+                Some(write.key)
             }
             Err(_) => {
-                self.stash_errors.set(self.stash_errors.get() + 1);
+                self.record_stash_error();
                 self.mark_unrecoverable_truncation();
                 None
             }

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -1,7 +1,9 @@
 use regex::Regex;
 use serde_json::Value;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
-use tokenless_ccr::StashStore;
+use tokenless_ccr::{StashStore, StashWrite};
 
 use crate::response_compressor::{stash_suffix, stash_suffix_char_len};
 
@@ -31,6 +33,20 @@ pub struct SchemaCompressor {
     /// full original. When `None`, truncation is lossy — the pre-stash
     /// behavior. Mirrors `ResponseCompressor::stash_store`.
     stash_store: Option<Arc<dyn StashStore>>,
+    /// Unique stash rows created this session, plus refreshes of keys this
+    /// session did not create. CLI `compress-schema --batch` calls
+    /// `compress()` once per item, so the counter accumulates until rollback
+    /// or [`Self::clear_stash_session`]. An in-session refresh of a pending
+    /// key does not increment again.
+    stash_writes: Cell<usize>,
+    /// Number of stash writes / rollback deletes that failed. Same session
+    /// accumulator as `stash_writes`.
+    stash_errors: Cell<usize>,
+    /// Keys created during this compressor session, mapped to the latest
+    /// generation this session still owns. Not reset at each `compress()` so
+    /// CLI `--batch` can roll back every discarded item. In-session refreshes
+    /// update the generation only when the store reports an unbroken chain.
+    stash_keys_created: RefCell<HashMap<String, u64>>,
 }
 
 impl Default for SchemaCompressor {
@@ -51,6 +67,9 @@ impl Default for SchemaCompressor {
             // ~1024-frame default stack while leaving real schemas intact.
             max_depth: 32,
             stash_store: None,
+            stash_writes: Cell::new(0),
+            stash_errors: Cell::new(0),
+            stash_keys_created: RefCell::new(HashMap::new()),
         }
     }
 }
@@ -106,7 +125,105 @@ impl SchemaCompressor {
         self
     }
 
-    /// Compress an OpenAI Function Calling schema
+    /// Unique stash rows created this session, plus refreshes of keys this
+    /// session did not create. Duplicate payloads first created this session
+    /// (including `--batch` items that stash the same description) count once;
+    /// repeated refreshes of a pre-existing key count once per refresh.
+    pub fn stash_writes(&self) -> usize {
+        self.stash_writes.get()
+    }
+
+    /// Number of stash writes / rollback deletes that failed this session.
+    pub fn stash_errors(&self) -> usize {
+        self.stash_errors.get()
+    }
+
+    /// Delete stash entries created during this compressor session.
+    ///
+    /// Call this when the compressed output (and its embedded markers) will
+    /// never be emitted — e.g. the CLI no-savings path that falls back to the
+    /// original input, including `compress-schema --batch`. Returns how many
+    /// keys were successfully removed.
+    ///
+    /// Session semantics: [`compress`](Self::compress) does **not** reset the
+    /// pending-key list. Keys accumulate from construction until this method
+    /// or [`clear_stash_session`](Self::clear_stash_session). That matches
+    /// CLI `--batch` (compress every item, then one all-or-nothing rollback).
+    /// Call rollback only after every emit/discard decision for the session.
+    /// If a programmatic caller emits some results and later discards others
+    /// on the same instance, call [`clear_stash_session`](Self::clear_stash_session)
+    /// after keeping output so a later rollback cannot delete those markers.
+    pub fn rollback_stash_writes(&self) -> usize {
+        let Some(store) = self.stash_store.as_ref() else {
+            return 0;
+        };
+        let writes = std::mem::take(&mut *self.stash_keys_created.borrow_mut());
+        let mut removed = 0usize;
+        for (key, generation) in &writes {
+            match store.delete(key, *generation) {
+                Ok(true) => removed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    self.record_stash_error();
+                    eprintln!(
+                        "[tokenless] stash: rollback delete failed for key {}: {e}",
+                        key
+                    );
+                }
+            }
+        }
+        self.stash_writes
+            .set(self.stash_writes.get().saturating_sub(removed));
+        removed
+    }
+
+    /// Forget pending rollback keys without deleting stash rows.
+    ///
+    /// Use after deciding to **keep** compressed output from this session
+    /// (markers were emitted) and starting a new independent
+    /// compress/rollback cycle on the same `SchemaCompressor`. Does not
+    /// touch the store. [`ResponseCompressor`](crate::ResponseCompressor)
+    /// does not need this: it resets pending keys at the start of each
+    /// `compress()`.
+    pub fn clear_stash_session(&self) {
+        self.stash_keys_created.borrow_mut().clear();
+        self.stash_writes.set(0);
+        self.stash_errors.set(0);
+    }
+
+    fn record_stash_success(&self, write: &StashWrite) {
+        let mut pending = self.stash_keys_created.borrow_mut();
+        if write.created {
+            self.stash_writes.set(self.stash_writes.get() + 1);
+            pending.insert(write.key.clone(), write.generation);
+        } else if let Some(&expected) = pending.get(&write.key) {
+            if write.previous_generation == Some(expected) {
+                // Unbroken in-session refresh (duplicate payloads, including
+                // `--batch`): update generation so rollback CAS matches.
+                pending.insert(write.key.clone(), write.generation);
+            } else {
+                // A foreign writer refreshed (and likely emitted a marker)
+                // between our create and this write. Drop ownership so
+                // rollback cannot delete the live row those markers need.
+                pending.remove(&write.key);
+            }
+        } else {
+            // Refresh of a key this session never created. Another emitted
+            // marker may still need it, so it stays off the rollback list.
+            self.stash_writes.set(self.stash_writes.get() + 1);
+        }
+    }
+
+    fn record_stash_error(&self) {
+        self.stash_errors.set(self.stash_errors.get() + 1);
+    }
+
+    /// Compress an OpenAI Function Calling schema.
+    ///
+    /// Unlike [`ResponseCompressor`](crate::ResponseCompressor), this does
+    /// not reset stash session state. Pending rollback keys accumulate until
+    /// [`rollback_stash_writes`](Self::rollback_stash_writes) or
+    /// [`clear_stash_session`](Self::clear_stash_session).
     pub fn compress(&self, tool: &Value) -> Value {
         let original_text = serde_json::to_string(tool).unwrap_or_default();
 
@@ -286,9 +403,19 @@ impl SchemaCompressor {
         // ResponseCompressor's "retrieval yields the original content
         // verbatim" contract.
         let stash_key = if stash_active {
-            self.stash_store
-                .as_ref()
-                .and_then(|store| store.stash(desc).ok())
+            match self.stash_store.as_ref() {
+                Some(store) => match store.stash(desc) {
+                    Ok(write) => {
+                        self.record_stash_success(&write);
+                        Some(write.key)
+                    }
+                    Err(_) => {
+                        self.record_stash_error();
+                        None
+                    }
+                },
+                None => None,
+            }
         } else {
             None
         };

--- a/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
@@ -5,7 +5,7 @@ use tokenless_ccr::{StashError, StashStore};
 struct AlwaysFail;
 
 impl StashStore for AlwaysFail {
-    fn stash(&self, _payload: &str) -> Result<String, StashError> {
+    fn stash(&self, _payload: &str) -> Result<tokenless_ccr::StashWrite, StashError> {
         Err(StashError::Backend("simulated".to_string()))
     }
 
@@ -19,6 +19,10 @@ impl StashStore for AlwaysFail {
 
     fn evict_expired(&self) -> Result<usize, StashError> {
         Ok(0)
+    }
+
+    fn delete(&self, _hash: &str, _generation: u64) -> Result<bool, StashError> {
+        Ok(false)
     }
 }
 
@@ -348,6 +352,180 @@ fn test_stash_writes_counter_resets_per_compress() {
 }
 
 #[test]
+fn test_rollback_stash_writes_removes_created_entries() {
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let arr: Vec<i32> = (1..=5).collect();
+    let _ = compressor.compress(&json!(arr));
+    assert_eq!(compressor.stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+    // Second rollback is a no-op.
+    assert_eq!(compressor.rollback_stash_writes(), 0);
+}
+
+#[test]
+fn test_rollback_preserves_preexisting_same_payload_entry() {
+    // Refreshing a payload that already has an emitted marker must not put
+    // that key on the rollback list. Discarding a later no-savings compress
+    // must leave the earlier marker retrievable.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let arr = json!([1, 2, 3, 4, 5]);
+    let first = compressor.compress(&arr);
+    let marker = first.as_array().unwrap().last().unwrap().as_str().unwrap();
+    let hash = extract_hash(marker).expect("marker");
+    assert!(store.retrieve(hash).unwrap().is_some());
+
+    // Second compress refreshes the same content-addressed key.
+    let _ = compressor.compress(&arr);
+    assert_eq!(store.len(), 1);
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 0, "refresh must not be treated as created");
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(r#"[3,4,5]"#),
+        "pre-existing emitted marker must remain retrievable after rollback"
+    );
+}
+
+#[test]
+fn test_rollback_does_not_delete_key_adopted_by_another_compressor() {
+    // Compressor A creates the row; compressor B refreshes it and emits a
+    // marker. A's no-savings rollback must not delete B's live generation.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let a = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let b = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let arr = json!([1, 2, 3, 4, 5]);
+    let _ = a.compress(&arr);
+    let emitted = b.compress(&arr);
+    let marker = emitted.as_array().unwrap().last().unwrap().as_str().unwrap();
+    let hash = extract_hash(marker).expect("marker");
+    assert_eq!(a.rollback_stash_writes(), 0);
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(r#"[3,4,5]"#),
+        "B's emitted marker must remain retrievable after A's rollback"
+    );
+}
+
+#[test]
+fn test_rollback_updates_generation_after_in_compress_refresh() {
+    // Two identical truncated arrays stash the same payload twice in one
+    // compress(). The second write refreshes generation; rollback must delete
+    // with that latest generation, not the create-time one.
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let value = json!({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]});
+    let _ = compressor.compress(&value);
+    assert_eq!(store.len(), 1);
+    assert_eq!(
+        compressor.stash_writes(),
+        1,
+        "in-compress refresh of the same key must not double-count stash_writes"
+    );
+    assert_eq!(compressor.rollback_stash_writes(), 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+}
+
+#[test]
+fn test_rollback_does_not_re_adopt_after_intervening_foreign_refresh() {
+    // Duplicate payloads in one compress(), with another writer refreshing
+    // the key between the two stashes. The wrapper performs that refresh
+    // before the second stash so the interleaving is deterministic
+    // (`ResponseCompressor` resets pending state at each `compress()`).
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashError, StashStore, StashWrite, extract_hash};
+
+    struct ForeignRefreshOnSecondStash {
+        inner: Arc<InMemoryStore>,
+        n: AtomicUsize,
+    }
+
+    impl StashStore for ForeignRefreshOnSecondStash {
+        fn stash(&self, payload: &str) -> Result<StashWrite, StashError> {
+            let n = self.n.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 2 {
+                let _ = self.inner.stash(payload)?;
+            }
+            self.inner.stash(payload)
+        }
+        fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
+            self.inner.retrieve(hash)
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+        fn evict_expired(&self) -> Result<usize, StashError> {
+            self.inner.evict_expired()
+        }
+        fn delete(&self, hash: &str, generation: u64) -> Result<bool, StashError> {
+            self.inner.delete(hash, generation)
+        }
+    }
+
+    let inner = Arc::new(InMemoryStore::new());
+    let wrapped = Arc::new(ForeignRefreshOnSecondStash {
+        inner: inner.clone(),
+        n: AtomicUsize::new(0),
+    });
+    let a = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(wrapped);
+    let value = json!({"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5]});
+    let compressed = a.compress(&value);
+    let marker = compressed["a"]
+        .as_array()
+        .and_then(|arr| arr.last())
+        .and_then(|v| v.as_str())
+        .expect("truncation marker");
+    let hash = extract_hash(marker).expect("marker");
+    assert_eq!(
+        inner.retrieve(hash).unwrap().as_deref(),
+        Some(r#"[3,4,5]"#),
+        "B's marker must be retrievable before A's rollback"
+    );
+    let removed = a.rollback_stash_writes();
+    assert_eq!(
+        removed, 0,
+        "A must not re-adopt a key after an intervening foreign refresh"
+    );
+    assert_eq!(
+        inner.retrieve(hash).unwrap().as_deref(),
+        Some(r#"[3,4,5]"#),
+        "B's emitted marker must remain retrievable after A's rollback"
+    );
+}
+
+#[test]
 fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
     // A stash that always errors must not break compression: the marker
     // degrades to the plain lossy form.
@@ -416,7 +594,7 @@ fn test_string_truncation_counts_unrecoverable_marker_budget() {
 #[test]
 fn test_stash_round_trip_with_cjk_items() {
     // CJK payloads are multi-byte; the stashed JSON must round-trip
-    // byte-for-byte (review §12: char vs byte semantics).
+    // byte-for-byte, not by Unicode scalar count.
     use std::sync::Arc;
     use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
 

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -549,3 +549,274 @@ fn test_compress_parameters_with_nested_schema() {
         .unwrap();
     assert!(nested_desc.chars().count() <= 160);
 }
+
+#[test]
+fn test_rollback_stash_writes_removes_created_entries() {
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let schema = json!({
+        "function": {
+            "name": "test",
+            "description": "A".repeat(300),
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let _ = compressor.compress(&schema);
+    assert_eq!(compressor.stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+    assert_eq!(compressor.rollback_stash_writes(), 0);
+}
+
+#[test]
+fn test_rollback_preserves_preexisting_same_payload_entry() {
+    // Refreshing an already-emitted description must not put that key on the
+    // rollback list — discarding a later no-savings compress must not make
+    // earlier markers unretrievable.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore};
+
+    let store = Arc::new(InMemoryStore::new());
+    let long_desc = "A".repeat(300);
+    let write = store.stash(&long_desc).unwrap();
+    let hash = write.key;
+    assert!(write.created);
+
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let schema = json!({
+        "function": {
+            "name": "test",
+            "description": long_desc,
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let _ = compressor.compress(&schema);
+    assert_eq!(store.len(), 1);
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 0, "refresh must not be treated as created");
+    assert_eq!(
+        store.retrieve(&hash).unwrap().as_deref(),
+        Some(long_desc.as_str()),
+        "pre-existing emitted marker must remain retrievable after rollback"
+    );
+}
+
+#[test]
+fn test_batch_rollback_removes_keys_from_every_item() {
+    // CLI --batch calls compress() once per item then discards the whole
+    // batch on no-savings. Keys must accumulate across compress() calls.
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    for i in 0..3 {
+        let schema = json!({
+            "function": {
+                "name": format!("f{i}"),
+                "description": format!("DESC{i}_{}", "A".repeat(300)),
+                "parameters": {"type": "object", "properties": {}}
+            }
+        });
+        let _ = compressor.compress(&schema);
+    }
+    assert_eq!(store.len(), 3);
+    assert_eq!(compressor.rollback_stash_writes(), 3);
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn test_rollback_updates_generation_after_same_description_refresh() {
+    // Two schemas with the same long description stash the same payload twice
+    // in one session. Rollback must use the refreshed generation.
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let desc = "A".repeat(300);
+    for name in ["f1", "f2"] {
+        let schema = json!({
+            "function": {
+                "name": name,
+                "description": desc,
+                "parameters": {"type": "object", "properties": {}}
+            }
+        });
+        let _ = compressor.compress(&schema);
+    }
+    assert_eq!(store.len(), 1);
+    assert_eq!(
+        compressor.stash_writes(),
+        1,
+        "in-session refresh of the same key must not double-count stash_writes"
+    );
+    assert_eq!(compressor.rollback_stash_writes(), 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+}
+
+#[test]
+fn test_rollback_does_not_re_adopt_after_intervening_foreign_refresh() {
+    // A creates the row, B refreshes it and emits a marker, then A stashes
+    // the same payload again. Re-adopting B's generation would make A's
+    // rollback delete the row B's marker still needs.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let a = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let b = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let desc = "A".repeat(300);
+    let schema = |name: &str| {
+        json!({
+            "function": {
+                "name": name,
+                "description": desc,
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })
+    };
+    let _ = a.compress(&schema("f1"));
+    let emitted = b.compress(&schema("f2"));
+    let hash = extract_hash(
+        emitted["function"]["description"]
+            .as_str()
+            .expect("truncated description"),
+    )
+    .expect("B marker");
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(desc.as_str()),
+        "B's marker must be retrievable before A's re-stash"
+    );
+    let _ = a.compress(&schema("f3"));
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(desc.as_str()),
+        "B's marker must stay retrievable after A's re-stash"
+    );
+    let removed = a.rollback_stash_writes();
+    assert_eq!(
+        removed, 0,
+        "A must not re-adopt a key after an intervening foreign refresh"
+    );
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(desc.as_str()),
+        "B's emitted marker must remain retrievable after A's rollback"
+    );
+}
+
+#[test]
+fn test_rollback_does_not_re_adopt_after_foreign_refresh_across_sqlite_connections() {
+    // Same interleaving as the in-memory test, with two independent
+    // SqliteStore connections on one file (CLI processes share stash.db).
+    use std::sync::Arc;
+    use tokenless_ccr::{SqliteStore, StashStore, extract_hash};
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("stash.db");
+    let store_a = Arc::new(SqliteStore::new(&path).unwrap());
+    let store_b = Arc::new(SqliteStore::new(&path).unwrap());
+    let a = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store_a.clone());
+    let b = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store_b.clone());
+    let desc = "A".repeat(300);
+    let schema = |name: &str| {
+        json!({
+            "function": {
+                "name": name,
+                "description": desc,
+                "parameters": {"type": "object", "properties": {}}
+            }
+        })
+    };
+    let _ = a.compress(&schema("f1"));
+    let emitted = b.compress(&schema("f2"));
+    let hash = extract_hash(
+        emitted["function"]["description"]
+            .as_str()
+            .expect("truncated description"),
+    )
+    .expect("B marker");
+    assert!(store_b.retrieve(hash).unwrap().is_some());
+    let _ = a.compress(&schema("f3"));
+    assert!(store_b.retrieve(hash).unwrap().is_some());
+    let removed = a.rollback_stash_writes();
+    assert_eq!(removed, 0);
+    assert_eq!(
+        store_b.retrieve(hash).unwrap().as_deref(),
+        Some(desc.as_str())
+    );
+}
+
+#[test]
+fn test_clear_stash_session_keeps_emitted_markers() {
+    // SchemaCompressor accumulates keys across compress(). After emitting
+    // one result, clear_stash_session() must drop it from the pending list
+    // so a later rollback cannot delete that marker.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let desc_keep = "K".repeat(300);
+    let desc_discard = "D".repeat(300);
+    let keep = json!({
+        "function": {
+            "name": "keep",
+            "description": desc_keep,
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let discard = json!({
+        "function": {
+            "name": "discard",
+            "description": desc_discard,
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let kept = compressor.compress(&keep);
+    let keep_hash = extract_hash(
+        kept["function"]["description"]
+            .as_str()
+            .expect("truncated description"),
+    )
+    .expect("keep marker");
+    assert_eq!(store.len(), 1);
+    compressor.clear_stash_session();
+    let _ = compressor.compress(&discard);
+    assert_eq!(store.len(), 2);
+    assert_eq!(compressor.rollback_stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+    assert_eq!(
+        store.retrieve(keep_hash).unwrap().as_deref(),
+        Some(desc_keep.as_str()),
+        "emitted keep-marker payload must survive rollback after clear_stash_session"
+    );
+}

--- a/src/tokenless/docs/stash-reversible-compression.md
+++ b/src/tokenless/docs/stash-reversible-compression.md
@@ -14,7 +14,10 @@ called **stash** to avoid the proprietary abbreviation.
 
 1. **Compress**: `ResponseCompressor` truncates oversized arrays (default:
    keep the first 32 items). The dropped tail is serialized to JSON and
-   `stash.stash(payload)` stores it, returning a 24-hex BLAKE3 key.
+   `stash.stash(payload)` stores it, returning a 24-hex BLAKE3 key plus a
+   store-wide, monotonically increasing ownership token used if the write must
+   later be rolled back. Tokens are never reused after expiry, deletion, or
+   eviction.
 2. **Mark**: the truncation marker becomes
    `<... N items truncated, retrieve with <<tokenless:KEY>>`.
 3. **Retrieve**: the LLM emits the marker (or the bare key); the agent calls
@@ -25,6 +28,39 @@ When no stash store is attached (`Option<Arc<dyn StashStore>>` = `None`),
 truncation is lossy and non-retrievable — the original pre-stash behavior.
 This keeps the stash off the core compression path unless a caller explicitly
 enables it.
+
+## No-savings rollback
+
+If compressed output is discarded (CLI no-savings fallback), call
+`rollback_stash_writes()` so markers that never reached the LLM do not leave
+orphan stash rows. Pending rollback is a `HashMap<key, generation>`: a key
+created in this session is recorded, and a later in-session refresh of that
+same payload updates the generation **only when the store reports an unbroken
+ownership chain** (`previous_generation` equals the token this session last
+recorded). A refresh of a key this session never created stays off the list.
+
+That chain check is required because content-addressed keys are shared across
+processes. If compressor A creates P, compressor B refreshes P and emits a
+marker, then A stashes P again, re-adopting B's generation would make A's
+no-savings rollback delete the row B's marker still needs. A mismatch drops
+the key from the pending list instead; rollback of the stale create-time
+token is a CAS no-op.
+
+`stash_writes` counts unique keys created this session, plus refreshes of
+keys this session did not create. An in-session refresh does not increment
+again, so after a successful rollback the counter matches remaining live
+rows from that session.
+
+Session scope differs by compressor:
+
+- `ResponseCompressor` resets pending keys at the start of each `compress()`.
+- `SchemaCompressor` accumulates across `compress()` calls until rollback or
+  `clear_stash_session()`. That matches `compress-schema --batch` (compress
+  every item, then one all-or-nothing rollback). Call rollback only after
+  every emit/discard decision for the session. Programmatic callers that
+  emit some results and later discard others on the same instance must call
+  `clear_stash_session()` after keeping output; otherwise a later rollback
+  deletes those emitted markers.
 
 ## Marker format
 
@@ -69,6 +105,15 @@ Both backends enforce:
 - **Capacity** (FIFO): once the live entry count exceeds the limit (InMemory
   1000; SQLite 10 000), the oldest entries are evicted. This prevents
   unbounded growth from runaway compression.
+
+SQLite allocates ownership tokens and performs the live-row check, `created`
+decision, upsert, and capacity enforcement in one `BEGIN IMMEDIATE`
+transaction. A singleton `stash_metadata` row persists the generation
+high-water mark across row deletion, expiry, lazy purge, and eviction; opening
+older databases migrates the generation column and repairs that high-water
+mark from the existing rows. InMemory keeps the equivalent high-water counter
+under its store lock. Both backends fail without changing stash state when the
+signed SQLite generation limit is exhausted.
 
 ## CLI
 
@@ -130,10 +175,13 @@ payload" rather than an injection.
   marker but the tail is not stashed. The stash marker (~65 chars) against
   small per-field limits would be proportionally large overhead; the
   high-value case is array truncation, which is covered.
-- **Schema description truncation**: `SchemaCompressor::truncate_description`
-  remains lossy for the same marker-overhead reason.
 - **MCP `tokenless_retrieve`**: not yet implemented; retrieval is via the CLI
   today. MCP integration is tracked separately.
+
+Schema description truncation **is** stashed when a store is attached (CLI
+default): `SchemaCompressor::truncate_description` writes the verbatim
+original and appends a `<<tokenless:KEY>>` marker. It stays lossy only when
+stash is off or the stash write fails.
 
 ## Mapping to Headroom CCR
 
@@ -142,7 +190,7 @@ payload" rather than an injection.
 | CCR Store | stash store (`StashStore` trait) | InMemory / SQLite(WAL) / Redis* |
 | `<<ccr:HASH>>` | `<<tokenless:HASH>>` | 24-hex BLAKE3, same key length |
 | `headroom_retrieve` (MCP) | `tokenless retrieve` (CLI) | MCP tool pending |
-| DashMap `remove_if` TOCTOU fix | single-writer `Mutex<Connection>` | SQLite path |
+| DashMap `remove_if` TOCTOU fix | `BEGIN IMMEDIATE` ownership transaction | SQLite path |
 | default TTL 5 min / cap 1000 | InMemory 5 min / 1000; SQLite 1 h / 10 000 | tuned for hook process model |
 
 \* Redis backend is not yet implemented; it is tracked for the


### PR DESCRIPTION
## Why

`tokenless compress-response` / `compress-schema` fall back to original stdout when compression has no net savings, but stash rows written during truncation were not rolled back. Those rows have no marker on stdout, so they cannot be retrieved and they pollute the shared `stash.db`.

Rollback on a shared, content-addressed store also must not delete a row another compress already emitted. The last hole on that path: this session creates P, another compressor refreshes P and emits a marker, then this session stashes P again and re-adopts the new generation — no-savings rollback then deletes the live row that marker still needs.

Head: `53f418b4`, rebased onto current `main`.

## What changed

**No-savings must not leave orphans**

- Both CLI paths (`compress-response`, `compress-schema` including `--batch`) roll back stash writes when the candidate is discarded.
- Response rollback lives in `compress_response_with_store`, shared by CLI and the Python runtime.
- `compress-schema` reports `stash_writes` / `stash_errors` / `stash_size` (previously `None`). Stats are read after rollback.
- Tests: `compress_response_no_savings_rolls_back_orphan_stash`, `compress_schema_no_savings_rolls_back_orphan_stash` (one stash db per candidate).

**Rollback must not delete another compressor's emitted marker**

- `StashStore::stash` returns `StashWrite { key, created, generation, previous_generation }`. `delete(hash, generation)` is a live-only CAS.
- A refresh of a key this session never created stays off the rollback list.
- An in-session refresh updates the pending generation only when `previous_generation` still matches the token this session last recorded. An intervening foreign refresh drops the key instead of re-adopting.
- Tests: `test_rollback_preserves_preexisting_same_payload_entry`, `test_rollback_does_not_delete_key_adopted_by_another_compressor`, `test_rollback_does_not_re_adopt_after_intervening_foreign_refresh` (both compressors), `test_rollback_does_not_re_adopt_after_foreign_refresh_across_sqlite_connections`.

**In-session duplicate payloads must still roll back**

- Pending keys are a `HashMap<key, generation>`. A second stash of the same payload in one `compress()` / schema session updates the generation when the chain is unbroken, so rollback hits the live row rather than leaking it.
- That in-session refresh does not increment `stash_writes` again.
- Tests: `test_rollback_updates_generation_after_in_compress_refresh`, `test_rollback_updates_generation_after_same_description_refresh`.

**Ownership tokens are atomic and never reused**

- SQLite live-state/`created` decision, high-water allocation, UPSERT, and capacity enforcement are one `BEGIN IMMEDIATE` transaction.
- Generations are store-wide and survive expiry, purge, eviction, and delete (SQLite `stash_metadata` + in-memory high-water counter). Old `stash.db` files migrate a `generation` column and repair the high-water mark.
- Tests: `concurrent_stash_serializes_ownership_across_connections`, both-backend `*_recreate_never_reuses_generation`.

**Failures are visible; schema session is explicit**

- Rollback `delete` errors increment `stash_errors` and stderr says `stash operation(s) failed`.
- `SchemaCompressor` accumulates pending keys across `compress()` until rollback or `clear_stash_session()` (CLI `--batch`). `ResponseCompressor` resets per `compress()`.
- Test: `test_clear_stash_session_keeps_emitted_markers`.

**Rebase onto `main`**

- `unrecoverable_truncations` is kept alongside stash rollback.
- Single commit, title ≤50 chars, `Fixes:` + `Signed-off-by`.

## Related issue

fixes #2479

## User / Agent impact

No-savings fallback no longer leaves unreachable stash rows, and it no longer deletes a marker another compress already emitted — including after this session stashes the same payload again. Duplicate payloads in one compress still roll back when the ownership chain is unbroken. Stash backend failures on write or rollback delete are visible on stderr. Schema compression stats now include stash fields.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`StashStore` `stash` / `delete` signatures are updated in-tree. `StashWrite` includes `previous_generation`. Existing `stash.db` files migrate `generation` + high-water metadata automatically. `SchemaCompressor::clear_stash_session` is new; CLI `--batch` does not need it. MCP is unchanged. Schema stats fields that used to be `None` now carry counts when stash is enabled. Response no-savings rollback is in the shared runtime, so CLI and Python bindings share the same discard path.

## Validation

Validated with Rust 1.89.0:

```bash
cd src/tokenless
cargo +1.89.0 fmt --all -- --check
cargo +1.89.0 clippy --workspace --all-targets --locked -- -D warnings
cargo +1.89.0 test --workspace --locked -- --test-threads=1
cargo +1.89.0 doc --workspace --no-deps --locked
cargo +1.89.0 test -p tokenless-cli --locked --test cli_integration \
  no_savings_rolls_back_orphan_stash
```

## Documentation and rollback

`src/tokenless/docs/stash-reversible-compression.md` documents no-savings rollback, generation CAS, the `previous_generation` chain check, schema session / `clear_stash_session`, and stash-backed schema description truncation.

Reverting this PR restores no-savings orphans and hash-only delete.
