### PR TITLE
fix(tokenless): hard-disable tool ready

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -13,7 +13,7 @@ The `tokenless` CLI can compress schemas and responses, encode and decode TOON, 
 | `tokenless compress-toon` | Encode JSON as TOON |
 | `tokenless decompress-toon` | Decode TOON to JSON |
 | `tokenless retrieve` | Recover a payload truncated into Stash |
-| `tokenless env-check` | Check tool dependencies and environment |
+| `tokenless env-check` | Report the hard-disabled state of the legacy environment check |
 | `tokenless stats` | Query and control local statistics |
 | `tokenless mcp serve` | Start an MCP stdio server for retrieval |
 
@@ -193,58 +193,34 @@ It exposes `tokenless_retrieve`, allowing an MCP-capable agent to recover Stash 
 
 ## `env-check`
 
-Check one tool:
+Tool Ready is hard-disabled. Text output reports that state without reading the
+specification or changing the environment. No environment variable can
+re-enable it.
+
+Every JSON invocation returns exactly three fields:
+
+```json
+{"tool":"Shell","status":"UNKNOWN","enabled":false}
+```
+
+`tool` is the requested tool name, `all`, or `checklist`. The hard-disabled
+contract never includes the dormant legacy checklist's `tools` or `summary`
+fields.
+
+Report the disabled state for one tool:
 
 ```bash
 tokenless env-check --tool Shell
 ```
 
-Check all declared tools:
+Report the disabled state for all-tools or checklist mode:
 
 ```bash
 tokenless env-check --all
 tokenless env-check --all --json
-tokenless env-check --all --checklist
-```
-
-Full checklist as one JSON object for hooks, plugins, and CI gates:
-
-```bash
+tokenless env-check --checklist
 tokenless env-check --checklist --json
 ```
-
-```json
-{
-  "tools": [
-    {
-      "tool": "Shell",
-      "status": "PARTIAL",
-      "required": [{ "binary": "jq", "status": "INSTALLED" }],
-      "recommended": [{ "binary": "rtk", "status": "MISSING" }],
-      "config": [{ "name": "~/.tokenless/config.json", "ok": true }],
-      "permissions": [{ "name": "exec_shell", "ok": true }],
-      "network": [{ "name": "https_outbound", "ok": true }]
-    }
-  ],
-  "summary": { "ready": 0, "partial": 1, "not_ready": 0, "unknown": 0, "total": 1 }
-}
-```
-
-Checklist JSON contract:
-
-- `tools` is sorted by tool name, so repeated runs produce identical output that is safe to diff, hash, cache, or snapshot.
-- `status` uses the fixed labels `READY` / `PARTIAL` / `NOT_READY` / `UNKNOWN`.
-- Dependency entries report `INSTALLED`, `MISSING`, or `OUTDATED (<installed>/<required>)`; config, permission, and network entries report `ok: true|false`.
-- `summary` aggregates the same results: `ready`, `partial`, `not_ready`, `unknown`, and `total`.
-
-Status meanings:
-
-| Status | Meaning |
-|--------|---------|
-| `READY` | Required and recommended dependencies, configuration, and permissions are satisfied |
-| `PARTIAL` | Required dependencies and permissions are satisfied, but a recommended dependency, configuration item, or network check is missing |
-| `NOT_READY` | A required dependency or permission is missing; the tool should not be retried |
-| `UNKNOWN` | The dependency specification does not contain the tool |
 
 Automatic repair:
 
@@ -252,7 +228,7 @@ Automatic repair:
 tokenless env-check --tool Shell --fix
 ```
 
-> `--fix` attempts only missing required dependencies, not recommended ones. It may invoke a system package manager, install dependencies, or create links. Read the normal check output first and use it only after accepting those environment changes. Follow the output when administrator access is required.
+> While the hard bypass is active, `--fix` does not invoke a package manager or modify the environment. The retained legacy implementation would attempt only missing required dependencies if it were redesigned and re-enabled in a future release.
 
 ## `stats`
 

--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -87,7 +87,7 @@ An environment override still wins after these commands. For example, `TOKENLESS
 | `TOKENLESS_ENV_FIX_SCRIPT` | Override the environment repair script |
 | `TOKENLESS_PACKAGE_MANAGER` | Override package-manager detection, mainly for tests |
 
-The last three are subject to trusted-path or runtime validation and are not recommended for normal users.
+Tool Ready is hard-disabled in this build. Its specification and repair-script overrides are retained for the dormant legacy implementation but have no runtime effect. They are subject to trusted-path validation and are not recommended for normal users.
 
 Database path priority is:
 
@@ -163,7 +163,7 @@ export TOKENLESS_STATS_ENABLED=0
 export TOKENLESS_SLS_ENABLED=0
 ```
 
-Dry-run does not create Stash entries, but it also does not disable RTK rewriting or Tool Ready. Disable the adapter when those behaviors must stop.
+Dry-run does not create Stash entries, but it also does not disable RTK rewriting. Tool Ready is independently hard-disabled. Disable the adapter when all hook behavior must stop.
 
 ### Stop Tokenless completely in an agent
 
@@ -221,7 +221,7 @@ The OpenClaw plugin also provides framework-level options:
 | Option | Purpose |
 |--------|---------|
 | `rtk_enabled` | Command rewriting |
-| `tool_ready_enabled` | Tool Ready checks |
+| `tool_ready_enabled` | OpenClaw-side Tool Ready registration gate |
 | `response_compression_enabled` | Response compression |
 | `toon_compression_enabled` | TOON encoding |
 | `skip_tools` | Tool names that bypass all compression |
@@ -230,7 +230,7 @@ The OpenClaw plugin also provides framework-level options:
 
 The OpenClaw adapter does not currently implement Schema compression; invoke the `tokenless compress-schema` CLI command directly when needed.
 
-The runtime defaults RTK, Tool Ready, and response compression to on, and TOON to off. The current runtime code treats an omitted `verbose` as on, while the plugin schema declares its default as off; set `verbose` explicitly until those definitions are aligned.
+The runtime defaults RTK, its OpenClaw-side Tool Ready gate, and response compression to on, and TOON to off. The Tool Ready option currently has no effect because Tokenless hard-disables the underlying check. The current runtime code treats an omitted `verbose` as on, while the plugin schema declares its default as off; set `verbose` explicitly until those definitions are aligned.
 
 These values are managed by OpenClaw plugin configuration, not `~/.tokenless/config.json`. Restart the gateway as instructed after changing them.
 

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -8,16 +8,18 @@ Tokenless uses adapters to connect compression, command rewriting, and environme
 
 | Framework | Value | Tool Ready | Rewrite behavior | Response delivery | TOON | Schema |
 |-----------|-------|------------|------------------|-------------------|------|--------|
-| cosh | `cosh` | ✅ | Replaces supported shell input | Cosh-NG replaces the response; legacy Copilot Shell appends context | Attempted after response compression | ✅ |
-| OpenClaw | `openclaw` | ✅ | Replaces the `exec` command input | Replaces the persisted tool-result message | Off by default; opt in | — |
-| Hermes | `hermes` | ✅ | Blocks the first call and asks the agent to retry | Replaces the result string | Attempted after response compression | — |
-| Qoder | `qoder` | ✅ | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
-| Claude Code | `claude-code` | ✅ | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Used only when the replacement can remain text | — |
-| Codex | `codex` | ✅ | Replaces supported shell input | Keeps the original and adds analysis or a compressed alternative | Used to build that alternative | — |
-| OpenCode | `opencode` | ✅ | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
-| Qwen Code | `qwencode` | ✅ | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | ✅ |
+| cosh | `cosh` | Hard-disabled | Replaces supported shell input | Cosh-NG replaces the response; legacy Copilot Shell appends context | Attempted after response compression | ✅ |
+| OpenClaw | `openclaw` | Hard-disabled | Replaces the `exec` command input | Replaces the persisted tool-result message | Off by default; opt in | — |
+| Hermes | `hermes` | Hard-disabled | Blocks the first call and asks the agent to retry | Replaces the result string | Attempted after response compression | — |
+| Qoder | `qoder` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
+| Claude Code | `claude-code` | Hard-disabled | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Used only when the replacement can remain text | — |
+| Codex | `codex` | Hard-disabled | Replaces supported shell input | Keeps the original and adds analysis or a compressed alternative | Used to build that alternative | — |
+| OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
+| Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | ✅ |
 
 “—” means that the current adapter does not register that capability. The corresponding Tokenless CLI command may still be available.
+
+Tool Ready remains registered by these adapters but is unconditionally hard-disabled before checking, repair, or blocking. No runtime setting can re-enable it. Post-tool failure attribution is independent.
 
 `additionalContext` is an additive hook field. The Tokenless source does not remove the original result on those paths; the final treatment also depends on the host implementation. A statistics record proves that a candidate became smaller, not that the host removed the original from its model request.
 
@@ -172,7 +174,7 @@ Extensions are discovered at startup. Restart cosh, run a shell-tool task, and i
 
 ### OpenClaw
 
-The install script uses OpenClaw's unsafe-install override as described above. Restart the gateway after accepting and installing the plugin. Response compression, Tool Ready, and RTK rewriting default to enabled in the plugin code; TOON defaults to disabled.
+The install script uses OpenClaw's unsafe-install override as described above. Restart the gateway after accepting and installing the plugin. Response compression and RTK rewriting default to enabled in the plugin code; TOON defaults to disabled. The plugin's Tool Ready option currently has no effect because the underlying check is hard-disabled.
 
 ### Hermes
 

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -14,7 +14,7 @@ anolisa status tokenless
 anolisa doctor tokenless
 anolisa adapter status tokenless
 tokenless stats status
-tokenless env-check --all --checklist
+tokenless env-check --all --json
 ```
 
 When one command fails, resolve that layer before continuing. Preview the install plan without modifying the system:
@@ -170,29 +170,22 @@ If `rtk` is missing:
 
 ```bash
 command -v rtk
-tokenless env-check --tool Shell
 ```
 
 If RTK works directly but not in the agent, inspect the framework support matrix, adapter status, and whether the session was restarted.
 
 `TOKENLESS_COMPRESSION_ENABLED=0` does not disable rewriting. Disable the adapter, or set OpenClaw's `rtk_enabled=false` when using that plugin, if the original shell input must be preserved.
 
-## Tool Ready reports `NOT_READY`
+## Tool Ready still reports `NOT_READY`
 
-View the complete checklist:
-
-```bash
-tokenless env-check --tool <name>
-tokenless env-check --all --checklist
-```
-
-`NOT_READY` means that a required dependency is absent. Resolve the specific binary, configuration, permission, or network issue in the report. Review the change before automatic repair:
+The current build hard-disables Tool Ready and cannot emit `NOT_READY` or block a tool. Confirm the active binary:
 
 ```bash
-tokenless env-check --tool <name> --fix
+tokenless --version
+tokenless env-check --tool <name> --json
 ```
 
-`--fix` may invoke a package manager or create links. Do not add `sudo` without understanding the output.
+The JSON result should contain `"status":"UNKNOWN"` and `"enabled":false`. A `NOT_READY` result indicates a mixed or stale deployment. Update both the Tokenless binary and shared adapter resources, then restart the agent. Setting the former `TOKENLESS_TOOL_READY_ENABLED` variable has no effect.
 
 ## Database errors
 

--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -27,7 +27,7 @@ This path produces only the standalone `tokenless` CLI. It does not install `rtk
 | Response compression | Removes exact, case-sensitive debug-field names, `null`, empty strings/arrays/objects, and truncates values past configured limits | Accepts JSON; content-retrieval tools are intentionally skipped by adapters |
 | TOON encoding | Encodes JSON and keeps the JSON input when the estimated token count does not decrease | Whether TOON replaces or accompanies the original depends on the adapter |
 | Command rewriting | Calls `rtk rewrite` and submits the rewritten shell input when a rule is available | The command actually sent to the shell changes; unsupported or denied rewrites pass through |
-| Tool Ready | Checks declared binaries, versions, configuration, permissions, and optional dependencies | `--fix` installs only missing required dependencies and may change the environment |
+| Tool Ready | Legacy pre-call checks for declared binaries, versions, configuration, permissions, and optional dependencies | Hard-disabled; it cannot inspect, repair, or block tool execution |
 | Stash | Stores content removed by string, array, depth, or schema-description truncation | One-hour TTL and 10,000 live entries by default; other removed fields are not stashed |
 
 The implementation contains no fixed saving-rate guarantee. Results depend on the payload, adapter delivery semantics, and the share of the model context that came from tool data. Measure your own workload as described in [Measuring savings](measuring-savings.md).
@@ -37,7 +37,7 @@ The implementation contains no fixed saving-rate guarantee. Results depend on th
 After an adapter is enabled, a tool call may pass through these stages:
 
 ```text
-Before the tool: Tool Ready check → command rewrite
+Before the tool: hard-disabled Tool Ready hook → command rewrite
 After the tool: response compression → optional Stash → TOON encoding → statistics
 Before the model: schema compression
 ```
@@ -60,7 +60,7 @@ CLI-only use does not require an adapter.
 
 With `compression_enabled=false` or `TOKENLESS_COMPRESSION_ENABLED=0`, `compress-schema`, `compress-response`, and `compress-toon`—whether called directly or through an adapter—still calculate predicted savings and may write statistics, but return the original input. They do not write Stash entries in this mode.
 
-This setting does not disable RTK command rewriting, Tool Ready checks, adapter execution, or retrieval. To stop all Tokenless behavior in an agent, disable the adapter:
+This setting does not disable RTK command rewriting, adapter execution, or retrieval. Tool Ready is independently hard-disabled. To stop all Tokenless behavior in an agent, disable the adapter:
 
 ```bash
 anolisa adapter disable tokenless <framework>
@@ -87,7 +87,7 @@ Stash does not make all compression reversible. Removed `debug`/`trace` fields, 
 
 ### Processing errors usually fail open
 
-Compression and rewrite hooks normally return no modification when `tokenless` or `rtk` is missing, compression provides no savings, or an ordinary processing error occurs. Tool Ready is different: some adapters intentionally block a tool that is still `NOT_READY` after an auto-fix attempt. A Stash write failure may still allow lossy compression to continue.
+Compression and rewrite hooks normally return no modification when `tokenless` or `rtk` is missing, compression provides no savings, or an ordinary processing error occurs. Tool Ready is hard-disabled before its legacy check, repair, and blocking logic. Post-tool failure attribution is independent and remains unchanged. A Stash write failure may still allow lossy compression to continue.
 
 Command rewriting also changes the shell command submitted by the host. Most adapters replace the command input directly; Hermes blocks the first call and tells the agent to retry with the rewritten command. Validate important command workflows as well as compressed output.
 
@@ -95,13 +95,13 @@ Command rewriting also changes the shell command submitted by the host. Most ada
 
 | Framework | Integration | Current code path |
 |-----------|-------------|-------------------|
-| cosh | Extension | Tool Ready, rewrite, response + TOON, Schema; Cosh-NG has a replacement path, while legacy Copilot Shell appends additional context |
-| OpenClaw | Plugin | Tool Ready, `exec` rewrite, persisted-result replacement, optional TOON; no Schema |
-| Hermes | Plugin | Tool Ready, block-and-retry rewrite, result replacement with response + TOON; no Schema |
-| Qoder | Plugin | Tool Ready, rewrite, response + TOON through `additionalContext`; no Schema |
-| Claude Code | Marketplace plugin | Tool Ready, Bash rewrite, response replacement on Claude Code 2.1.121 or later; conditional TOON; no Schema |
-| Codex | Plugin | Tool Ready, rewrite, response/TOON analysis added as context; the original result is retained; no Schema |
-| Qwen Code | Extension | Tool Ready, rewrite, response + TOON through `additionalContext`, Schema |
+| cosh | Extension | Hard-disabled Tool Ready, rewrite, response + TOON, Schema; Cosh-NG has a replacement path, while legacy Copilot Shell appends additional context |
+| OpenClaw | Plugin | Hard-disabled Tool Ready, `exec` rewrite, persisted-result replacement, optional TOON; no Schema |
+| Hermes | Plugin | Hard-disabled Tool Ready, block-and-retry rewrite, result replacement with response + TOON; no Schema |
+| Qoder | Plugin | Hard-disabled Tool Ready, rewrite, response + TOON through `additionalContext`; no Schema |
+| Claude Code | Marketplace plugin | Hard-disabled Tool Ready, Bash rewrite, response replacement on Claude Code 2.1.121 or later; conditional TOON; no Schema |
+| Codex | Plugin | Hard-disabled Tool Ready, rewrite, response/TOON analysis added as context; the original result is retained; no Schema |
+| Qwen Code | Extension | Hard-disabled Tool Ready, rewrite, response + TOON through `additionalContext`, Schema |
 
 ## Find documentation by task
 

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -13,7 +13,7 @@
 | `tokenless compress-toon` | 将 JSON 编码为 TOON |
 | `tokenless decompress-toon` | 将 TOON 解码为 JSON |
 | `tokenless retrieve` | 取回被截断并写入 Stash 的 Payload |
-| `tokenless env-check` | 检查工具依赖与环境 |
+| `tokenless env-check` | 报告旧版环境检查已硬关闭 |
 | `tokenless stats` | 查询和控制本地统计 |
 | `tokenless mcp serve` | 启动提供取回工具的 MCP stdio 服务 |
 
@@ -193,58 +193,32 @@ tokenless mcp serve
 
 ## `env-check`
 
-检查单个工具：
+Tool Ready 已硬关闭。文本输出只报告这一状态，不会读取规范或改变环境。
+任何环境变量都无法重新启用它。
+
+所有 JSON 调用都只返回三个字段：
+
+```json
+{"tool":"Shell","status":"UNKNOWN","enabled":false}
+```
+
+`tool` 是指定的工具名、`all` 或 `checklist`。硬关闭契约绝不会包含休眠旧版
+清单的 `tools` 或 `summary` 字段。
+
+报告单个工具对应的硬关闭状态：
 
 ```bash
 tokenless env-check --tool Shell
 ```
 
-检查全部已声明工具：
+报告全部工具或清单模式的硬关闭状态：
 
 ```bash
 tokenless env-check --all
 tokenless env-check --all --json
-tokenless env-check --all --checklist
-```
-
-以单个 JSON 对象输出完整清单，供 Hook、插件和 CI 门禁消费：
-
-```bash
+tokenless env-check --checklist
 tokenless env-check --checklist --json
 ```
-
-```json
-{
-  "tools": [
-    {
-      "tool": "Shell",
-      "status": "PARTIAL",
-      "required": [{ "binary": "jq", "status": "INSTALLED" }],
-      "recommended": [{ "binary": "rtk", "status": "MISSING" }],
-      "config": [{ "name": "~/.tokenless/config.json", "ok": true }],
-      "permissions": [{ "name": "exec_shell", "ok": true }],
-      "network": [{ "name": "https_outbound", "ok": true }]
-    }
-  ],
-  "summary": { "ready": 0, "partial": 1, "not_ready": 0, "unknown": 0, "total": 1 }
-}
-```
-
-清单 JSON 约定：
-
-- `tools` 按工具名排序，重复运行输出完全一致，可安全用于 diff、hash、缓存或快照。
-- `status` 使用固定标签 `READY` / `PARTIAL` / `NOT_READY` / `UNKNOWN`。
-- 依赖项报告 `INSTALLED`、`MISSING` 或 `OUTDATED (<installed>/<required>)`；配置、权限和网络项报告 `ok: true|false`。
-- `summary` 对同一结果汇总：`ready`、`partial`、`not_ready`、`unknown` 与 `total`。
-
-状态含义：
-
-| 状态 | 含义 |
-|------|------|
-| `READY` | 必需依赖、推荐依赖、配置和权限均满足 |
-| `PARTIAL` | 必需依赖和权限已满足，但缺少推荐依赖、配置项或网络检查 |
-| `NOT_READY` | 缺少必需依赖或权限，不应重复调用该工具 |
-| `UNKNOWN` | 依赖规范中没有该工具 |
 
 自动修复：
 
@@ -252,7 +226,7 @@ tokenless env-check --checklist --json
 tokenless env-check --tool Shell --fix
 ```
 
-> `--fix` 只尝试修复缺失的必需依赖，不会安装推荐依赖。它可能调用系统包管理器、安装依赖或创建链接。应先阅读普通检查输出，并在明确接受环境变更后使用；需要管理员权限时，按输出提示操作。
+> 硬旁路生效期间，`--fix` 不会调用包管理器或修改环境。如果未来重新设计并启用，保留的旧版实现只会尝试修复缺失的必需依赖。
 
 ## `stats`
 

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -87,7 +87,7 @@ tokenless stats disable
 | `TOKENLESS_ENV_FIX_SCRIPT` | 覆盖环境修复脚本路径 |
 | `TOKENLESS_PACKAGE_MANAGER` | 覆盖包管理器探测，主要用于测试 |
 
-后面三项会经过信任路径或运行环境校验，不建议普通用户修改。
+当前构建已硬关闭 Tool Ready。依赖规范和修复脚本覆盖仅为休眠的旧版实现保留，运行时不会生效；这些路径会经过信任校验，也不建议普通用户修改。
 
 数据库路径优先级如下：
 
@@ -163,7 +163,7 @@ export TOKENLESS_STATS_ENABLED=0
 export TOKENLESS_SLS_ENABLED=0
 ```
 
-Dry-run 不会创建 Stash 条目，但也不会关闭 RTK 重写或 Tool Ready。需要停止这些行为时应禁用 Adapter。
+Dry-run 不会创建 Stash 条目，但也不会关闭 RTK 重写。Tool Ready 已独立硬关闭。需要停止全部 Hook 行为时应禁用 Adapter。
 
 ### 完全停止 Agent 中的 Tokenless
 
@@ -221,7 +221,7 @@ OpenClaw Plugin 还提供框架级选项：
 | 选项 | 作用 |
 |------|------|
 | `rtk_enabled` | 命令重写 |
-| `tool_ready_enabled` | Tool Ready 检查 |
+| `tool_ready_enabled` | OpenClaw 侧的 Tool Ready 注册门槛 |
 | `response_compression_enabled` | 响应压缩 |
 | `toon_compression_enabled` | TOON 编码 |
 | `skip_tools` | 完全跳过压缩的工具名列表 |
@@ -230,7 +230,7 @@ OpenClaw Plugin 还提供框架级选项：
 
 OpenClaw Adapter 当前未实现 Schema 压缩；需要时可以直接调用 `tokenless compress-schema` CLI 命令。
 
-运行时代码默认开启 RTK、Tool Ready 和响应压缩，默认关闭 TOON。当前运行时代码把未提供的 `verbose` 当作开启，但 Plugin Schema 声明的默认值是关闭；在二者统一前应显式设置 `verbose`。
+运行时代码默认开启 RTK、OpenClaw 侧的 Tool Ready 门槛和响应压缩，默认关闭 TOON。但由于 Tokenless 已硬关闭底层检查，Tool Ready 选项当前不会生效。当前运行时代码把未提供的 `verbose` 当作开启，但 Plugin Schema 声明的默认值是关闭；在二者统一前应显式设置 `verbose`。
 
 这些值由 OpenClaw Plugin 配置管理，不属于 `~/.tokenless/config.json`。修改后按 OpenClaw 提示重启 gateway。
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -8,16 +8,18 @@ Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。�
 
 | 框架 | 值 | Tool Ready | 命令重写行为 | 响应交付方式 | TOON | Schema |
 |------|----|------------|--------------|--------------|------|--------|
-| cosh | `cosh` | ✅ | 替换受支持的 Shell 输入 | Cosh-NG 替换响应；旧版 Copilot Shell 追加上下文 | 在响应压缩后尝试 | ✅ |
-| OpenClaw | `openclaw` | ✅ | 替换 `exec` 命令输入 | 替换持久化工具结果消息 | 默认关闭，需主动启用 | — |
-| Hermes | `hermes` | ✅ | 阻止第一次调用并要求 Agent 重试 | 替换结果字符串 | 在响应压缩后尝试 | — |
-| Qoder | `qoder` | ✅ | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
-| Claude Code | `claude-code` | ✅ | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 仅在替换结果可保持文本时使用 | — |
-| Codex | `codex` | ✅ | 替换受支持的 Shell 输入 | 保留原文，追加分析或压缩备选内容 | 用于生成该备选内容 | — |
-| OpenCode | `opencode` | ✅ | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
-| Qwen Code | `qwencode` | ✅ | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | ✅ |
+| cosh | `cosh` | 已硬关闭 | 替换受支持的 Shell 输入 | Cosh-NG 替换响应；旧版 Copilot Shell 追加上下文 | 在响应压缩后尝试 | ✅ |
+| OpenClaw | `openclaw` | 已硬关闭 | 替换 `exec` 命令输入 | 替换持久化工具结果消息 | 默认关闭，需主动启用 | — |
+| Hermes | `hermes` | 已硬关闭 | 阻止第一次调用并要求 Agent 重试 | 替换结果字符串 | 在响应压缩后尝试 | — |
+| Qoder | `qoder` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
+| Claude Code | `claude-code` | 已硬关闭 | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 仅在替换结果可保持文本时使用 | — |
+| Codex | `codex` | 已硬关闭 | 替换受支持的 Shell 输入 | 保留原文，追加分析或压缩备选内容 | 用于生成该备选内容 | — |
+| OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
+| Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | ✅ |
 
 “—”表示当前 Adapter 没有注册此能力；对应的 Tokenless CLI 命令仍可能可用。
+
+这些 Adapter 仍会注册 Tool Ready，但会在检查、修复或阻断之前无条件硬退出，任何运行时设置都无法重新启用。工具执行后的失败归因不受影响。
 
 `additionalContext` 是追加型 Hook 字段。在这些路径上，Tokenless 源码本身不会删除原始结果，最终处理方式还取决于宿主实现。统计记录只能证明压缩候选内容变小了，不能证明宿主已经从模型请求中移除原文。
 
@@ -170,7 +172,7 @@ Extension 在启动时发现。启用后重启 cosh，并运行一个 Shell 工�
 
 ### OpenClaw
 
-安装脚本会使用上文说明的 OpenClaw unsafe-install 覆盖参数。确认风险并安装后，重启 Gateway。Plugin 代码默认启用响应压缩、Tool Ready 和 RTK 重写，默认关闭 TOON。
+安装脚本会使用上文说明的 OpenClaw unsafe-install 覆盖参数。确认风险并安装后，重启 Gateway。Plugin 代码默认启用响应压缩和 RTK 重写，默认关闭 TOON。由于底层检查已硬关闭，Plugin 的 Tool Ready 选项当前不会生效。
 
 ### Hermes
 

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -14,7 +14,7 @@ anolisa status tokenless
 anolisa doctor tokenless
 anolisa adapter status tokenless
 tokenless stats status
-tokenless env-check --all --checklist
+tokenless env-check --all --json
 ```
 
 如果某条命令失败，先处理该层问题，再继续后面的检查。查看安装计划但不修改系统：
@@ -165,29 +165,22 @@ rtk rewrite "ls -la"
 
 ```bash
 command -v rtk
-tokenless env-check --tool Shell
 ```
 
 如果 RTK 正常但 Agent 中不生效，检查框架支持矩阵、Adapter 状态和是否已经重启会话。
 
 `TOKENLESS_COMPRESSION_ENABLED=0` 不会关闭命令重写。如果必须保留原始 Shell 输入，应禁用 Adapter；使用 OpenClaw Plugin 时也可以设置 `rtk_enabled=false`。
 
-## Tool Ready 报 `NOT_READY`
+## Tool Ready 仍然报告 `NOT_READY`
 
-查看完整清单：
-
-```bash
-tokenless env-check --tool <name>
-tokenless env-check --all --checklist
-```
-
-`NOT_READY` 表示缺少必需依赖；先处理报告的具体二进制、配置、权限或网络问题。自动修复前先确认变更：
+当前构建已硬关闭 Tool Ready，不会输出 `NOT_READY` 或阻断工具。先确认实际生效的二进制：
 
 ```bash
-tokenless env-check --tool <name> --fix
+tokenless --version
+tokenless env-check --tool <name> --json
 ```
 
-`--fix` 可能调用包管理器或创建链接，不应在不了解输出时直接加 `sudo`。
+JSON 应包含 `"status":"UNKNOWN"` 和 `"enabled":false`。如果仍得到 `NOT_READY`，说明线上混用了新旧版本。请同时更新 Tokenless 二进制和共享 Adapter 资源，然后重启 Agent。旧的 `TOKENLESS_TOOL_READY_ENABLED` 环境变量不会生效。
 
 ## 数据库错误
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -27,7 +27,7 @@ cargo build --release --locked -p tokenless-cli
 | 响应压缩 | 移除名称完全匹配且区分大小写的调试字段、`null`、空字符串/数组/对象，并按配置阈值截断 | 输入必须是 JSON；Adapter 会主动跳过内容读取类工具 |
 | TOON 编码 | 编码 JSON；估算 Token 没有下降时保留 JSON 输入 | TOON 是替换原文还是与原文并存，取决于 Adapter |
 | 命令重写 | 有匹配规则时调用 `rtk rewrite`，再向框架提交改写后的 Shell 输入 | 真正提交给 Shell 的命令会变化；无规则或被拒绝时透传 |
-| Tool Ready | 检查声明的二进制、版本、配置、权限和可选依赖 | `--fix` 只安装缺失的必需依赖，并可能改变环境 |
+| Tool Ready | 旧版调用前能力，用于检查声明的二进制、版本、配置、权限和可选依赖 | 已硬关闭；不会检查、修复或阻断工具调用 |
 | Stash | 保存因字符串、数组、深度或 Schema 描述截断而移除的内容 | 默认 TTL 一小时、最多 10,000 个有效条目；其他被移除字段不会进入 Stash |
 
 代码没有提供固定节省率保证。结果取决于 Payload、Adapter 交付语义，以及工具数据在模型上下文中的占比。请按[效果度量](measuring-savings.md)使用自己的工作负载测量。
@@ -37,7 +37,7 @@ cargo build --release --locked -p tokenless-cli
 启用对应 Adapter 后，一次工具调用可能经过以下阶段：
 
 ```text
-工具调用前：Tool Ready 检查 → 命令重写
+工具调用前：已硬关闭的 Tool Ready Hook → 命令重写
 工具调用后：响应压缩 → 可选 Stash → TOON 编码 → 写入统计
 模型调用前：Schema 压缩
 ```
@@ -60,7 +60,7 @@ CLI-only 用法不需要 Adapter。
 
 设置 `compression_enabled=false` 或 `TOKENLESS_COMPRESSION_ENABLED=0` 后，无论是直接调用还是通过 Adapter 调用，`compress-schema`、`compress-response` 和 `compress-toon` 都仍会计算预测节省并可能写入统计，但会返回原始输入。该模式不会写入 Stash 条目。
 
-这个设置不会关闭 RTK 命令重写、Tool Ready 检查、Adapter 执行或内容取回。如需停止 Agent 中的所有 Tokenless 行为，应禁用 Adapter：
+这个设置不会关闭 RTK 命令重写、Adapter 执行或内容取回。Tool Ready 已独立硬关闭。如需停止 Agent 中的所有 Tokenless 行为，应禁用 Adapter：
 
 ```bash
 anolisa adapter disable tokenless <framework>
@@ -87,7 +87,7 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 
 ### 普通处理错误通常 fail-open
 
-缺少 `tokenless` 或 `rtk`、压缩无收益或发生普通处理错误时，压缩和重写 Hook 通常不返回修改。Tool Ready 不同：部分 Adapter 会在自动修复后仍为 `NOT_READY` 时主动阻止工具执行。Stash 写入失败时，仍可能继续执行有损压缩。
+缺少 `tokenless` 或 `rtk`、压缩无收益或发生普通处理错误时，压缩和重写 Hook 通常不返回修改。Tool Ready 会在旧版检查、修复和阻断逻辑之前硬退出。工具执行后的失败归因是独立能力，保持不变。Stash 写入失败时，仍可能继续执行有损压缩。
 
 命令重写也会改变宿主提交的 Shell 命令。大多数 Adapter 会直接替换命令输入；Hermes 会先阻止第一次调用，再提示 Agent 使用改写命令重试。因此，除了压缩结果，还应验证重要命令工作流。
 
@@ -95,13 +95,13 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 
 | 框架 | 集成方式 | 当前代码路径 |
 |------|----------|--------------|
-| cosh | Extension | Tool Ready、命令重写、响应压缩 + TOON、Schema；Cosh-NG 有替换路径，旧版 Copilot Shell 则追加额外上下文 |
-| OpenClaw | Plugin | Tool Ready、`exec` 命令重写、替换持久化结果、可选 TOON；无 Schema |
-| Hermes | Plugin | Tool Ready、阻止后重试的命令重写、用响应压缩 + TOON 替换结果；无 Schema |
-| Qoder | Plugin | Tool Ready、命令重写、通过 `additionalContext` 交付响应压缩 + TOON；无 Schema |
-| Claude Code | Marketplace Plugin | Tool Ready、Bash 命令重写；Claude Code 2.1.121 及以上可替换响应；条件式 TOON；无 Schema |
-| Codex | Plugin | Tool Ready、命令重写；把响应/TOON 分析追加为上下文，保留原始结果；无 Schema |
-| Qwen Code | Extension | Tool Ready、命令重写、通过 `additionalContext` 交付响应压缩 + TOON、Schema |
+| cosh | Extension | Tool Ready（已硬关闭）、命令重写、响应压缩 + TOON、Schema；Cosh-NG 有替换路径，旧版 Copilot Shell 则追加额外上下文 |
+| OpenClaw | Plugin | Tool Ready（已硬关闭）、`exec` 命令重写、替换持久化结果、可选 TOON；无 Schema |
+| Hermes | Plugin | Tool Ready（已硬关闭）、阻止后重试的命令重写、用响应压缩 + TOON 替换结果；无 Schema |
+| Qoder | Plugin | Tool Ready（已硬关闭）、命令重写、通过 `additionalContext` 交付响应压缩 + TOON；无 Schema |
+| Claude Code | Marketplace Plugin | Tool Ready（已硬关闭）、Bash 命令重写；Claude Code 2.1.121 及以上可替换响应；条件式 TOON；无 Schema |
+| Codex | Plugin | Tool Ready（已硬关闭）、命令重写；把响应/TOON 分析追加为上下文，保留原始结果；无 Schema |
+| Qwen Code | Extension | Tool Ready（已硬关闭）、命令重写、通过 `additionalContext` 交付响应压缩 + TOON、Schema |
 
 ## 按任务查找文档
 

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -9,17 +9,17 @@ Token-Less combines complementary strategies to minimize LLM token consumption:
 - **Schema & Response Compression** — Compresses OpenAI Function Calling tool definitions and API responses via the `tokenless-schema` library, cutting structural overhead before tokens ever reach the context window.
 - **TOON Context Compression** — Encodes JSON responses to TOON (Token-Oriented Object Notation) format via the `toon` binary, reducing token usage by 15-40% for structured data.
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
-- **Tool Ready** — Pre-checks tool execution environments (binaries, configs, permissions, network), auto-fixes missing dependencies, and classifies execution failures as environment issues vs logic errors — reducing wasted retry tokens.
+- **Tool Ready (legacy, hard-disabled)** — Its pre-call dependency checks are retained in source but unconditionally bypassed while the readiness model is redesigned.
 
 Framework integrations are available for:
 
 - **OpenClaw plugin** — covers command rewriting, response compression, and schema compression in one plugin.
 - **copilot-shell hook** — intercepts Shell commands via a PreToolUse hook and delegates to RTK for command rewriting + output filtering.
-- **Hermes Agent plugin** — response compression, TOON encoding, command rewriting (block + suggest), and Tool Ready environment pre-check via Hermes's native plugin system.
-- **Qoder CLI plugin** — Tool Ready, command rewriting, and response compression via Qoder's native hook system.
-- **Claude Code plugin** — RTK command rewriting, response/TOON compression, and Tool Ready via Claude Code's official plugin marketplace.
-- **Codex plugin** — response compression, TOON encoding, Tool Ready, and command rewriting via Codex's native hook system.
-- **OpenCode plugin** — schema/response/TOON compression, Tool Ready, and command rewriting via OpenCode's local plugin API.
+- **Hermes Agent plugin** — response compression, TOON encoding, command rewriting (block + suggest), and registered but hard-disabled Tool Ready via Hermes's native plugin system.
+- **Qoder CLI plugin** — registered but hard-disabled Tool Ready, command rewriting, and response compression via Qoder's native hook system.
+- **Claude Code plugin** — RTK command rewriting, response/TOON compression, and registered but hard-disabled Tool Ready via Claude Code's official plugin marketplace.
+- **Codex plugin** — response compression, TOON encoding, registered but hard-disabled Tool Ready, and command rewriting via Codex's native hook system.
+- **OpenCode plugin** — schema/response/TOON compression, registered but hard-disabled Tool Ready, and command rewriting via OpenCode's local plugin API.
 
 ## Features
 
@@ -30,14 +30,14 @@ Framework integrations are available for:
 | Reversible compression (stash) | — | Dropped array items are stashed and retrievable via `<<tokenless:KEY>>` markers |
 | TOON context compression | 15–40% | Encodes JSON to TOON format for LLMs |
 | Command rewriting | 60–90% | Filters CLI output via RTK (70+ commands supported) |
-| Tool Ready | reduces retry waste | Pre-check env, auto-fix deps, failure attribution |
+| Tool Ready | reduces retry waste | Legacy pre-call check, auto-fix, and blocking; hard-disabled |
 | OpenClaw plugin | — | Command rewriting ✅, Response compression ✅, Schema compression ✅ |
-| copilot-shell hooks | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ✅ |
-| Hermes Agent plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ⏳ |
-| Qoder CLI plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅ |
-| Claude Code plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅ |
-| Codex plugin | — | Tool Ready ✅, Command rewriting ✅, Response compression ✅, TOON ✅ |
-| OpenCode plugin | — | Tool Ready ✅, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅ |
+| copilot-shell hooks | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ✅ |
+| Hermes Agent plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ⏳ |
+| Qoder CLI plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅ |
+| Claude Code plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅ |
+| Codex plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅ |
+| OpenCode plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
 
 ## Applicable Scenarios & Expected Effects
@@ -89,7 +89,7 @@ Token-Less/
 │   ├── common/                  # Shared: hooks, spec, env-fix, commands, cosh-extension
 │   │   ├── hooks/               # copilot-shell hooks (tool-ready + rewrite + compression)
 │   │   ├── cosh-extension.json  # copilot-shell extension manifest (references common/hooks/)
-│   │   ├── tool-ready-spec.json # Tool dependency spec (4 categories)
+│   │   ├── tool-ready-spec.json # Dormant legacy dependency specification
 │   │   ├── tokenless-env-fix.sh # Auto-fix script for missing deps
 │   │   └── commands/            # Hook command configs
 │   ├── openclaw/                # OpenClaw plugin + agent scripts
@@ -271,7 +271,7 @@ The adapter provides hooks that are auto-discovered by copilot-shell via the cos
 
 | Hook | Event | File | Description |
 |------|-------|------|-------------|
-| Tool environment check | PreToolUse (all tools) | `tool_ready_hook.sh` | Pre-check env, auto-fix, skip-retry guidance |
+| Tool Ready (hard-disabled) | PreToolUse (all tools) | `tool_ready_hook.sh` | Silent pass-through; no check, repair, context, or block |
 | Command rewriting | PreToolUse (Shell) | `rewrite_hook.py` | Rewrite commands via RTK |
 | Response compression + attribution + TOON | PostToolUse | `compress_response_hook.py` | Compress + env error attribution + TOON |
 | Schema compression | BeforeModel | `compress_schema_hook.py` | Compress tool schemas |
@@ -286,37 +286,49 @@ Hooks are registered via the cosh extension manifest (`cosh-extension.json`) and
 
 ## Tool Ready
 
-Tool Ready prevents wasted LLM tokens from retrying commands that fail due to missing environment dependencies.
+Tool Ready was designed to prevent wasted LLM tokens from retrying commands that fail due to missing environment dependencies.
 
-**How it works**: Before each tool call, the `tool_ready_hook.sh` hook checks the tool's dependency list (from `tool-ready-spec.json`). If dependencies are missing, it reports `NOT_READY` with "Skip retry" guidance so the LLM doesn't waste tokens retrying a command that can't succeed. After a tool call fails, the compression hook classifies the error (missing binary, permissions, network, etc.) and injects attribution context.
+**Legacy behavior**: Before each tool call, the `tool_ready_hook.sh` hook checked the tool's dependency list (from `tool-ready-spec.json`). Missing dependencies could produce `NOT_READY` with "Skip retry" guidance.
+
+Tool Ready is currently hard-disabled across all adapters. Its registered hooks return before reading the dependency specification, checking the environment, attempting repair, or emitting a block decision. No environment variable can re-enable the legacy behavior; doing so requires an intentional source change and a new release.
+
+Post-tool failure attribution, response compression, command rewriting, TOON encoding, Stash, and statistics are independent and remain active.
 
 ### env-check CLI
 
 ```bash
-# Check a specific tool
+# Report the disabled state for a specific tool
 tokenless env-check --tool Shell
 
-# Check all tools
+# Report the disabled state for all tools
 tokenless env-check --all
 
-# Generate checklist
+# Report the disabled state for checklist mode
 tokenless env-check --checklist
 
-# Machine-readable checklist (single JSON object, tools sorted by name)
+# Machine-readable disabled state; no tools/summary checklist is emitted
 tokenless env-check --checklist --json
 
-# Check and auto-fix missing deps
+# Accepted for compatibility; does not inspect or repair the environment
 tokenless env-check --tool Shell --fix
 ```
 
-`--checklist --json` emits one `{tools, summary}` object with stable ordering
-for hooks, plugins, and CI gates; see the
-[CLI reference](../../docs/user-guide/en/token-saving/tokenless/cli-reference.md#env-check)
-for the full schema.
+These commands currently report that Tool Ready is hard-disabled and do not inspect or modify the environment.
+Every JSON mode returns exactly the same three-field schema:
+
+```json
+{"tool":"checklist","status":"UNKNOWN","enabled":false}
+```
+
+`tool` identifies the requested tool or the `all`/`checklist` scope. The dormant
+legacy `tools` and `summary` checklist fields are never emitted while the hard
+bypass is active.
 
 ### Configuration
 
-Per-tool dependencies are declared in `tool-ready-spec.json` (shipped within the adapter bundle at `common/tool-ready-spec.json`):
+The dormant legacy per-tool dependencies remain in `tool-ready-spec.json`
+(shipped within the adapter bundle at `common/tool-ready-spec.json`). The hard
+bypass does not read this file:
 
 ```json
 {
@@ -343,6 +355,7 @@ The plugin hooks into the OpenClaw agent loop at two stages:
 
 | Hook | Event | Action | Status |
 |---|---|---|---|
+| Tool Ready | `before_tool_call` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `before_tool_call` | Rewrites `exec` commands to RTK equivalents for filtered output | ✅ Active |
 | Response compression | `tool_result_persist` | Compresses tool results before they enter the context window | ✅ Active |
 | Schema compression | — | Not supported by OpenClaw's hook system | ⏳ → ✅ |
@@ -371,7 +384,7 @@ The plugin registers hooks at three Hermes events, covering five strategies:
 
 | Strategy | Event | Action | Status |
 |---|---|---|---|
-| Tool Ready | `pre_tool_call` | Environment readiness pre-check with auto-fix and skip-retry feedback | ✅ Active |
+| Tool Ready | `pre_tool_call` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `pre_tool_call` | Blocks original command, suggests `rtk`-rewritten version (one extra round-trip) | ✅ Active |
 | Response compression | `transform_tool_result` | Compresses tool results via `tokenless compress-response` | ✅ Active |
 | TOON encoding | `transform_tool_result` | Pipeline step after response compression — encodes JSON to TOON format | ✅ Active |
@@ -408,7 +421,7 @@ The plugin registers hooks at three Qoder events, covering three strategies:
 
 | Strategy | Event | Action | Status |
 |---|---|---|---|
-| Tool Ready | `PreToolUse` | Environment readiness pre-check with auto-fix and skip-retry feedback | ✅ Active |
+| Tool Ready | `PreToolUse` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `PreToolUse` | Rewrites shell commands via RTK for token savings | ✅ Active |
 | Response compression | `PostToolUse` | Compresses tool responses and encodes to TOON format | ✅ Active |
 
@@ -426,7 +439,7 @@ The plugin registers hooks at two Claude Code events, covering four strategies:
 
 | Strategy | Event | Action | Status |
 |---|---|---|---|
-| Tool Ready | `PreToolUse` | Environment readiness pre-check with auto-fix and skip-retry feedback | ✅ Active |
+| Tool Ready | `PreToolUse` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `PreToolUse` (Bash) | Rewrites shell commands via RTK for token savings | ✅ Active |
 | Response compression | `PostToolUse` | Compresses tool responses and encodes to TOON format | ✅ Active |
 | TOON encoding | `PostToolUse` | Pipeline step after response compression — encodes JSON to TOON format | ✅ Active |
@@ -446,7 +459,7 @@ The plugin registers hooks at four Codex events, covering four strategies:
 | Strategy | Event | Action | Status |
 |---|---|---|---|
 | Session check | `SessionStart` | Verifies tokenless CLI is installed and functional (non-blocking) | ✅ Active |
-| Tool Ready | `PreToolUse` | Environment readiness pre-check with auto-fix and skip-retry feedback | ✅ Active |
+| Tool Ready | `PreToolUse` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `PreToolUse` | Rewrites shell commands via RTK for token savings | ✅ Active |
 | Response compression | `PostToolUse` | Compresses tool responses and encodes to TOON format, injects compressed summary as `additionalContext` | ✅ Active |
 
@@ -465,7 +478,7 @@ replaces the original model-visible response instead of being appended to it.
 
 | Strategy | Event | Action | Status |
 |---|---|---|---|
-| Tool Ready | `tool.execute.before` | Checks dependencies and blocks calls that cannot run | ✅ Active |
+| Tool Ready | `tool.execute.before` | Registered silent pass-through; no check, repair, context, or block | ⛔ Hard-disabled |
 | Command rewriting | `tool.execute.before` (bash) | Rewrites shell commands via RTK | ✅ Active |
 | Response + TOON compression | `tool.execute.after` | Replaces structured tool output with a smaller representation | ✅ Active |
 | Schema compression | `tool.definition` | Compresses tool descriptions and JSON Schemas | ✅ Active |

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -12,7 +12,11 @@ LLM Token 优化工具包——Schema/响应压缩 + 命令重写 + 工具环境
 | 响应压缩 | ~26–78% | 压缩 API/工具响应（因内容类型而异） |
 | TOON 上下文压缩 | 15–40% | 将 JSON 编码为 TOON 格式 |
 | 命令重写 | 60–90% | 通过 RTK 过滤 CLI 输出（支持 70+ 命令） |
-| Tool Ready | 减少重试浪费 | 预检环境、自动修复依赖、故障归因 |
+| Tool Ready | 减少重试浪费 | 旧版调用前预检、自动修复与阻断；当前硬关闭 |
+
+Tool Ready 当前在所有 Adapter 中无条件硬旁路，不会读取依赖规范、执行调用前检查、自动修复环境或阻止工具调用。任何环境变量都无法恢复旧行为；重新启用必须修改源码并重新发布。
+
+工具执行后的失败归因、响应压缩、RTK 命令重写、TOON、Stash 和统计是独立能力，仍保持原有行为。
 
 ## 适用场景与预期效果
 
@@ -54,12 +58,12 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 ## 集成路径
 
 - **OpenClaw 插件** — 命令重写 + 响应压缩 + Schema 压缩
-- **copilot-shell 钩子** — Tool Ready + 命令重写 + 响应压缩 + TOON
-- **Hermes Agent 插件** — Tool Ready + 命令重写 + 响应压缩 + TOON
-- **Qoder CLI 插件** — Tool Ready + 命令重写 + 响应压缩
-- **Claude Code 插件** — Tool Ready + 命令重写 + 响应压缩 + TOON
-- **Codex 插件** — Tool Ready + 命令重写 + 响应压缩 + TOON
-- **OpenCode 插件** — Tool Ready + 命令重写 + Schema/响应压缩 + TOON
+- **copilot-shell 钩子** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
+- **Hermes Agent 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
+- **Qoder CLI 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩
+- **Claude Code 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
+- **Codex 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
+- **OpenCode 插件** — Tool Ready（已硬关闭）+ 命令重写 + Schema/响应压缩 + TOON
 
 ## 快速开始
 
@@ -120,7 +124,7 @@ make setup
 
 ### OpenCode 安装
 
-OpenCode 适配器通过 `tool.execute.before/after` 原生插件事件执行 Tool Ready、
+OpenCode 适配器通过 `tool.execute.before/after` 原生插件事件注册已硬关闭的 Tool Ready、
 RTK 命令重写和响应/TOON 压缩，并通过 `tool.definition` 压缩工具 Schema。
 压缩后的响应会替换原始模型可见输出，避免重复占用上下文。
 
@@ -199,30 +203,36 @@ export TOKENLESS_DATA_DIR="$HOME/path/to/tokenless-data"
 
 ## Tool Ready
 
-Tool Ready 在工具调用前预检环境依赖（来自 `tool-ready-spec.json`），缺失时
-报告 `NOT_READY` 并提示跳过重试，避免浪费 Token 重试必然失败的命令；调用失败
-后再做错误归因。
+旧版 Tool Ready 会在工具调用前预检 `tool-ready-spec.json` 中声明的环境依赖，
+缺失时报告 `NOT_READY` 并提示跳过重试。当前已无条件硬关闭，Hook 会在读取规范、
+检查、修复或阻断之前返回；工具执行后的失败归因保持独立。
 
 ```bash
-# 检查单个工具
+# 报告单个工具对应的硬关闭状态
 tokenless env-check --tool Shell
 
-# 检查全部工具
+# 报告全部工具模式的硬关闭状态
 tokenless env-check --all
 
-# 生成清单
+# 报告清单模式的硬关闭状态
 tokenless env-check --checklist
 
-# 机器可读清单（单个 JSON 对象，tools 按名称排序）
+# 机器可读的硬关闭状态；不会输出 tools/summary 清单
 tokenless env-check --checklist --json
 
-# 检查并自动修复缺失依赖
+# 为兼容性保留；不会检查或修复环境
 tokenless env-check --tool Shell --fix
 ```
 
-`--checklist --json` 输出单个 `{tools, summary}` 对象，顺序稳定，供 Hook、
-插件和 CI 门禁消费；完整 schema 见
-[CLI 参考](../../docs/user-guide/zh/token-saving/tokenless/cli-reference.md#env-check)。
+这些命令当前只报告 Tool Ready 已硬关闭，不会检查或修改环境。
+所有 JSON 模式都只返回相同的三个字段：
+
+```json
+{"tool":"checklist","status":"UNKNOWN","enabled":false}
+```
+
+`tool` 表示指定的工具或 `all`/`checklist` 范围。硬旁路生效期间绝不会输出
+休眠旧版实现的 `tools` 与 `summary` 清单字段。
 
 ## 架构
 

--- a/src/tokenless/adapters/tokenless/codex/README.md
+++ b/src/tokenless/adapters/tokenless/codex/README.md
@@ -19,10 +19,11 @@ actionable fix hints.
 The plugin registers four hooks with Codex:
 
 1. **`SessionStart`** — verifies the `tokenless` CLI is installed and functional (non-blocking)
-2. **`PreToolUse` (tool-ready)** — runs before every tool execution:
-   - Checks if required dependencies are available via `tokenless env-check`
-   - Auto-installs missing dependencies via `tokenless env-check --fix`
-   - Blocks the tool if critical dependencies are still missing after auto-fix
+2. **`PreToolUse` (tool-ready, hard-disabled)** — remains registered but is a
+   silent pass-through. `tokenless env-check` returns `UNKNOWN` with
+   `enabled:false`, so the hook emits no context, performs no repair, and never
+   blocks a tool. Re-enabling the retained legacy pipeline requires a source
+   change and a new release.
 3. **`PreToolUse` (rewrite)** — runs before shell command execution:
    - Rewrites commands via `rtk rewrite` for token optimization
    - Only applies to Bash/Shell/terminal/programmatic tools
@@ -140,7 +141,7 @@ codex-plugin-tokenless/
 ├── scripts/
 │   ├── compress-response    # PostToolUse: response compression + env error detection
 │   ├── rewrite-hook         # PreToolUse: RTK command rewriting
-│   ├── tool-ready           # PreToolUse: environment check + auto-fix
+│   ├── tool-ready           # PreToolUse: registered hard-disabled pass-through
 │   ├── check-tokenless      # SessionStart: version/availability check
 │   ├── install.sh           # Build and install tokenless CLI + register plugin
 │   ├── detect.sh            # Detect tokenless availability

--- a/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
+++ b/src/tokenless/adapters/tokenless/codex/scripts/tool-ready
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Codex PreToolUse tool-ready environment pre-check with auto-fix.
+"""Codex PreToolUse Tool Ready adapter, currently a silent pass-through.
 
-Reads a PreToolUse hook request from stdin, runs a two-phase
-check-then-fix pipeline via ``tokenless env-check``, and blocks the
-tool if required dependencies are still missing after auto-fix.
+Release builds of ``tokenless env-check`` return ``UNKNOWN`` with
+``enabled:false``, which this adapter silently passes through. The retained
+legacy pipeline below remains dormant until the readiness model is redesigned
+and intentionally re-enabled in source.
 
-Pipeline: Check → Fix → Re-check
+Legacy pipeline: Check → Fix → Re-check
   1. CHECK:   ``tokenless env-check --json --tool <name>``
   2. FIX:     ``tokenless env-check --fix --json --tool <name>``
   3. RE-CHECK: parse result after fix attempt

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -11,7 +11,7 @@
           {
             "type": "command",
             "name": "tokenless-tool-ready",
-            "description": "Pre-checks tool environment readiness, auto-fixes, and provides skip-retry guidance",
+            "description": "Registered hard-disabled Tool Ready pass-through; performs no check, repair, or block",
             "command": "bash ${extensionPath}/hooks/tool_ready_hook.sh",
             "timeout": 10000,
             "env": { "TOKENLESS_AGENT_ID": "copilot-shell" }

--- a/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
+++ b/src/tokenless/adapters/tokenless/common/hooks/tool_ready_hook.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 # tokenless-hook-version: 10
-# Token-Less Tool Ready environment pre-check.
+# Token-Less legacy Tool Ready environment pre-check (hard-disabled).
 #
 # Hook event: PreToolUse (matcher: "" — matches all tools)
-# Requires: jq
+# Requires: none while the hard bypass below is active
 #
 # Design: fail-open. If jq is missing or any phase fails, exit 0 silently.
 #
-# Four-Phase Flow:
+# Dormant legacy four-phase flow (not reached while the hard bypass is active):
 #   Phase 1 — LOOKUP:   Find tool in config dictionary. Not found → skip.
 #   Phase 2 — CHECK:    Scan system readiness. All ready → continue silently.
 #   Phase 3 — FIX:      Auto-install missing deps. Success → continue silently.
 #   Phase 4 — FEEDBACK: Fix failed. Inject additionalContext → "Skip retry".
 
 set -euo pipefail
+
+# HARD BYPASS: the legacy readiness rules can incorrectly block valid agent
+# work. Exit before reading input, loading the spec, running jq, attempting a
+# repair, or emitting a block decision. Re-enable only through a source change
+# accompanied by a redesign of the readiness model.
+exit 0
 
 VERBOSE="${TOKENLESS_VERBOSE:-}"
 log_v() { [ -n "$VERBOSE" ] && echo "[tokenless:ready] $1" >&2 || true; }

--- a/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
+++ b/src/tokenless/adapters/tokenless/common/tool-ready-spec.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "version": "2.0",
-    "description": "Tool Ready dependency spec — defines per-tool system dependencies, detection methods, and install strategies. Edit this JSON to add new tool support without code changes.",
+    "description": "Dormant legacy Tool Ready dependency spec. Release builds do not read it while the hard bypass is active.",
     "related_files": {
       "tool_categories.json": "Unified tool categorization for compression strategies. Tool names in 'aliases' must match those in tool_categories.json to ensure consistent behavior across tool-ready and compression."
     },

--- a/src/tokenless/adapters/tokenless/hermes/plugin.yaml.in
+++ b/src/tokenless/adapters/tokenless/hermes/plugin.yaml.in
@@ -1,6 +1,6 @@
 name: tokenless
 version: "@VERSION@"
-description: "Token-Less context compression for Hermes Agent — response compression, TOON encoding, command rewriting, and Tool Ready environment pre-check"
+description: "Token-Less context compression for Hermes Agent — response compression, TOON encoding, command rewriting, and registered but hard-disabled Tool Ready"
 author: ANOLISA
 requires_env: []
 provides_hooks:

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -477,7 +477,7 @@ export default {
   id: "tokenless",
   name: "Tokenless",
   version: "1.0.0",
-  description: "Unified RTK command rewriting + response/TOON compression + Tool Ready",
+  description: "Unified RTK command rewriting + response/TOON compression + hard-disabled Tool Ready",
   register(api: any) {
   const pluginConfig = api.config ?? {};
   const rtkEnabled = pluginConfig.rtk_enabled !== false;
@@ -532,7 +532,7 @@ export default {
     },
   );
 
-  // ---- 1. Tool Ready environment pre-check (before_tool_call) -----------------
+  // ---- 1. Registered hard-disabled Tool Ready hook (before_tool_call) ---------
 
   if (toolReadyEnabled && checkTokenless()) {
     api.on(
@@ -711,7 +711,6 @@ export default {
   if (verbose) {
     const features = [
       rtkEnabled && rtkAvailable ? "rtk-rewrite" : null,
-      toolReadyEnabled && tokenlessAvailable ? "tool-ready" : null,
       responseCompressionEnabled && tokenlessAvailable ? "response-compression" : null,
       toonCompressionEnabled && tokenlessAvailable ? "toon-compression" : null,
     ].filter(Boolean);

--- a/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
+++ b/src/tokenless/adapters/tokenless/openclaw/openclaw.plugin.json.in
@@ -2,7 +2,7 @@
   "id": "tokenless",
   "name": "Tokenless",
   "version": "@VERSION@",
-  "description": "Unified RTK command rewriting + response/TOON compression + Tool Ready environment pre-check. Wraps tokenless and rtk system binaries via child_process — this is expected and not malicious.",
+  "description": "Unified RTK command rewriting + response/TOON compression + registered but hard-disabled Tool Ready. Wraps tokenless and rtk system binaries via child_process — this is expected and not malicious.",
   "activation": {
     "onCapabilities": ["hook"]
   },
@@ -30,7 +30,7 @@
   },
   "uiHints": {
     "rtk_enabled": { "label": "Enable RTK command rewriting" },
-    "tool_ready_enabled": { "label": "Enable Tool Ready environment pre-check" },
+    "tool_ready_enabled": { "label": "Register Tool Ready hook (hard-disabled)" },
     "response_compression_enabled": { "label": "Enable response compression" },
     "skip_tools": { "label": "Tool names whose responses should not be compressed" },
     "shell_tools": { "label": "Tool names treated as shell/exec (moderate truncation)" },

--- a/src/tokenless/adapters/tokenless/qwencode/qwen-extension.json.in
+++ b/src/tokenless/adapters/tokenless/qwencode/qwen-extension.json.in
@@ -1,7 +1,7 @@
 {
   "name": "tokenless",
   "version": "@VERSION@",
-  "description": "Token-Less context compression for Qwen Code — RTK command rewriting, response/TOON/schema compression, and Tool Ready environment pre-check",
+  "description": "Token-Less context compression for Qwen Code — RTK command rewriting, response/TOON/schema compression, and registered but hard-disabled Tool Ready",
   "author": { "name": "ANOLISA" },
   "license": "MIT",
   "homepage": "https://github.com/alibaba/anolisa/tree/main/src/tokenless",
@@ -15,7 +15,7 @@
           {
             "type": "command",
             "name": "tokenless-tool-ready",
-            "description": "Pre-checks tool environment readiness, auto-fixes, and provides skip-retry guidance",
+            "description": "Registered hard-disabled Tool Ready pass-through; performs no check, repair, or block",
             "command": "bash \"${extensionPath}/hooks/run-hook.sh\" tool_ready_hook.sh",
             "timeout": 10000,
             "env": { "TOKENLESS_AGENT_ID": "qwencode" }

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -1,10 +1,8 @@
-//! Environment readiness checker for Tool Ready feature.
+//! Dormant environment-readiness implementation for Tool Ready.
 //!
-//! Loads per-tool dependency declarations from tool-ready-spec.json.
-//! Supports both string format ("jq") and object format ({binary, version, package, manager, ...}).
-//! Checks binary availability (with version constraints), config files,
-//! permissions, and network connectivity. Generates a structured
-//! ready checklist and supports auto-fix via config-driven install engine.
+//! Release builds hard-bypass the legacy checks before loading a specification,
+//! repairing the environment, or producing a blocking result. The retained
+//! implementation remains covered by unit tests for a future redesign.
 
 use serde_json::Value;
 use std::fs;
@@ -20,6 +18,22 @@ use std::sync::LazyLock;
 // anchored on digit groups avoids these false matches.
 static VERSION_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(\d+\.\d+\.\d+)").unwrap());
+
+fn tool_ready_hard_bypassed() -> bool {
+    // Release builds always bypass Tool Ready. Unit tests retain a test-only
+    // escape hatch so the dormant legacy implementation remains covered.
+    #[cfg(test)]
+    {
+        !matches!(
+            std::env::var("TOKENLESS_TOOL_READY_TEST_LEGACY").as_deref(),
+            Ok("1")
+        )
+    }
+    #[cfg(not(test))]
+    {
+        true
+    }
+}
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -1317,6 +1331,29 @@ pub fn run(
     checklist: bool,
     json: bool,
 ) -> Result<(), (String, i32)> {
+    if tool.is_none() && !all && !checklist {
+        return Err(("Specify --tool <name> or --all".to_string(), 1));
+    }
+
+    // HARD BYPASS: the legacy readiness model can incorrectly block valid
+    // agent work. JSON callers receive only {tool,status,enabled}; in
+    // particular, checklist mode never exposes its dormant tools/summary
+    // schema. Re-enabling checks or expanding this contract requires an
+    // intentional source change.
+    if tool_ready_hard_bypassed() {
+        if json {
+            let result = serde_json::json!({
+                "tool": tool.unwrap_or(if all { "all" } else { "checklist" }),
+                "status": "UNKNOWN",
+                "enabled": false,
+            });
+            println!("{}", serde_json::to_string(&result).unwrap());
+        } else {
+            println!("Tool Ready is hard-disabled in this build");
+        }
+        return Ok(());
+    }
+
     let spec_path = find_spec_path().map_err(|e| (e, 1))?;
     let specs = load_spec(&spec_path).map_err(|e| (e, 1))?;
 
@@ -1372,7 +1409,7 @@ pub fn run(
         }
         vec![resolved]
     } else {
-        return Err(("Specify --tool <name> or --all".to_string(), 1));
+        unreachable!("tool arguments were validated before the readiness gate")
     };
 
     for tool_name in &tool_names {

--- a/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
@@ -6,8 +6,7 @@ static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 struct EnvGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
-    key: &'static str,
-    prev: Option<std::ffi::OsString>,
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
 }
 
 impl EnvGuard {
@@ -15,23 +14,53 @@ impl EnvGuard {
         let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var_os(key);
         unsafe { std::env::set_var(key, value) };
-        EnvGuard { _lock: lock, key, prev }
+        EnvGuard {
+            _lock: lock,
+            previous: vec![(key, prev)],
+        }
     }
 
     fn set_spec(path: &str) -> Self {
-        Self::set("TOKENLESS_TOOL_READY_SPEC", path)
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let spec_prev = std::env::var_os("TOKENLESS_TOOL_READY_SPEC");
+        let legacy_prev = std::env::var_os("TOKENLESS_TOOL_READY_TEST_LEGACY");
+        unsafe {
+            std::env::set_var("TOKENLESS_TOOL_READY_SPEC", path);
+            std::env::set_var("TOKENLESS_TOOL_READY_TEST_LEGACY", "1");
+        }
+        EnvGuard {
+            _lock: lock,
+            previous: vec![
+                ("TOKENLESS_TOOL_READY_SPEC", spec_prev),
+                ("TOKENLESS_TOOL_READY_TEST_LEGACY", legacy_prev),
+            ],
+        }
     }
 }
 
 impl Drop for EnvGuard {
     fn drop(&mut self) {
         unsafe {
-            match &self.prev {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
+            for (key, prev) in self.previous.iter().rev() {
+                match prev {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
             }
         }
     }
+}
+
+#[test]
+fn tool_ready_is_hard_bypassed_by_default() {
+    let _guard = EnvGuard::set("TOKENLESS_TOOL_READY_ENABLED", "1");
+    assert!(tool_ready_hard_bypassed());
+}
+
+#[test]
+fn tool_ready_legacy_path_has_a_test_only_override() {
+    let _guard = EnvGuard::set("TOKENLESS_TOOL_READY_TEST_LEGACY", "1");
+    assert!(!tool_ready_hard_bypassed());
 }
 
 #[test]
@@ -1297,6 +1326,7 @@ fn run_fix_skips_recommended_only_missing_deps() {
     let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     let prev_spec = std::env::var_os("TOKENLESS_TOOL_READY_SPEC");
     let prev_fix = std::env::var_os("TOKENLESS_ENV_FIX_SCRIPT");
+    let prev_legacy = std::env::var_os("TOKENLESS_TOOL_READY_TEST_LEGACY");
 
     let dir = tempfile::tempdir().unwrap();
     let spec_path = dir.path().join("recommended-only-spec.json");
@@ -1323,6 +1353,7 @@ fn run_fix_skips_recommended_only_missing_deps() {
     unsafe {
         std::env::set_var("TOKENLESS_TOOL_READY_SPEC", &spec_path);
         std::env::set_var("TOKENLESS_ENV_FIX_SCRIPT", &fix_script_path);
+        std::env::set_var("TOKENLESS_TOOL_READY_TEST_LEGACY", "1");
     }
 
     let result = run(Some("Shell"), false, true, false, true);
@@ -1335,6 +1366,10 @@ fn run_fix_skips_recommended_only_missing_deps() {
         match prev_fix {
             Some(v) => std::env::set_var("TOKENLESS_ENV_FIX_SCRIPT", v),
             None => std::env::remove_var("TOKENLESS_ENV_FIX_SCRIPT"),
+        }
+        match prev_legacy {
+            Some(v) => std::env::set_var("TOKENLESS_TOOL_READY_TEST_LEGACY", v),
+            None => std::env::remove_var("TOKENLESS_TOOL_READY_TEST_LEGACY"),
         }
     }
 

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -568,8 +568,28 @@ fn compress_toon_from_stdin() {
 #[test]
 fn env_check_without_spec() {
     let output = tokenless_bin().args(["env-check"]).output().unwrap();
-    // May fail if no spec file exists, that's OK
-    let _ = output.status;
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Specify --tool <name> or --all"));
+}
+
+#[test]
+fn env_check_is_hard_bypassed_even_with_legacy_opt_in() {
+    let output = tokenless_bin()
+        .args(["env-check", "--tool", "Shell", "--json"])
+        .env("TOKENLESS_TOOL_READY_ENABLED", "1")
+        .env(
+            "TOKENLESS_TOOL_READY_SPEC",
+            "/path/that/must/not/be-read-while-disabled",
+        )
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result.as_object().unwrap().len(), 3);
+    assert_eq!(result["tool"], "Shell");
+    assert_eq!(result["status"], "UNKNOWN");
+    assert_eq!(result["enabled"], false);
 }
 
 #[test]
@@ -725,12 +745,13 @@ fn write_checklist_spec(dir: &std::path::Path) -> std::path::PathBuf {
 }
 
 #[test]
-fn env_check_checklist_json_output() {
+fn env_check_checklist_json_is_hard_bypassed() {
     let dir = tempfile::tempdir().unwrap();
     let spec_path = write_checklist_spec(dir.path());
 
     let output = tokenless_bin()
         .args(["env-check", "--checklist", "--json"])
+        .env("TOKENLESS_TOOL_READY_ENABLED", "1")
         .env("TOKENLESS_TOOL_READY_SPEC", &spec_path)
         .output()
         .unwrap();
@@ -740,67 +761,18 @@ fn env_check_checklist_json_output() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect(
-        "--checklist --json must print one JSON object on stdout (text output would not parse)",
-    );
-
-    // Tools are ordered by tool name so the array is stable across runs.
-    let tools = value["tools"].as_array().expect("tools must be an array");
-    let names: Vec<&str> = tools
-        .iter()
-        .map(|tool| tool["tool"].as_str().unwrap())
-        .collect();
-    assert_eq!(names, vec!["Read", "Shell", "WebFetch", "Write"]);
-
-    // Every tool entry carries the status label plus all five categories.
-    for tool in tools {
-        assert!(tool["status"].is_string());
-        for category in [
-            "required",
-            "recommended",
-            "config",
-            "permissions",
-            "network",
-        ] {
-            assert!(
-                tool[category].is_array(),
-                "tool {} must serialize category {}",
-                tool["tool"],
-                category
-            );
-        }
-    }
-
-    // READY tool: required dep installed, config present, permission granted.
-    let read = &tools[0];
-    assert_eq!(read["status"], "READY");
-    assert_eq!(read["required"][0]["binary"], "bash");
-    assert_eq!(read["required"][0]["status"], "INSTALLED");
-    assert_eq!(read["config"][0]["ok"], true);
-    assert_eq!(read["permissions"][0]["name"], "exec_shell");
-    assert_eq!(read["permissions"][0]["ok"], true);
-
-    // PARTIAL tool: only a recommended dep missing.
-    let web_fetch = &tools[2];
-    assert_eq!(web_fetch["status"], "PARTIAL");
-    assert_eq!(web_fetch["recommended"][0]["status"], "MISSING");
-    assert_eq!(web_fetch["network"][0]["ok"], true);
-
-    // NOT_READY tool: required dep missing.
-    let write = &tools[3];
-    assert_eq!(write["status"], "NOT_READY");
-    assert_eq!(write["required"][0]["status"], "MISSING");
-
-    // Summary counts must agree with the tools array.
-    assert_eq!(value["summary"]["ready"], 2);
-    assert_eq!(value["summary"]["partial"], 1);
-    assert_eq!(value["summary"]["not_ready"], 1);
-    assert_eq!(value["summary"]["unknown"], 0);
-    assert_eq!(value["summary"]["total"], 4);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("--checklist --json must print one JSON object on stdout");
+    assert_eq!(value.as_object().unwrap().len(), 3);
+    assert_eq!(value["tool"], "checklist");
+    assert_eq!(value["status"], "UNKNOWN");
+    assert_eq!(value["enabled"], false);
+    assert!(value.get("tools").is_none());
+    assert!(value.get("summary").is_none());
 }
 
 #[test]
-fn env_check_checklist_json_stable_across_processes() {
+fn env_check_hard_bypass_json_is_stable_across_processes() {
     let dir = tempfile::tempdir().unwrap();
     let spec_path = write_checklist_spec(dir.path());
 
@@ -808,6 +780,7 @@ fn env_check_checklist_json_stable_across_processes() {
     for _ in 0..8 {
         let output = tokenless_bin()
             .args(["env-check", "--checklist", "--json"])
+            .env("TOKENLESS_TOOL_READY_ENABLED", "1")
             .env("TOKENLESS_TOOL_READY_SPEC", &spec_path)
             .output()
             .unwrap();
@@ -819,7 +792,7 @@ fn env_check_checklist_json_stable_across_processes() {
         assert_eq!(
             stdout,
             &outputs[0],
-            "checklist JSON must be byte-identical across processes (run {})",
+            "hard-bypass JSON must be byte-identical across processes (run {})",
             index + 1
         );
     }

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -361,116 +361,19 @@ test_tool_ready() {
         || log_fail "tool_ready_hook.sh missing/unreadable or bash parse failed"
 
     # ==========================================
-    # 6.2 All 4 spec categories produce valid status
+    # 6.2 Rust env-check: unconditional hard bypass
     # ==========================================
-    log_info "Test 6.2: All 4 categories return valid status"
-    for tool in Shell WebFetch Read Write; do
-        local out=$(tokenless env-check --tool "$tool" 2>&1)
-        if echo "$out" | grep -qE 'READY|PARTIAL|NOT_READY'; then
-            log_pass "env-check --tool $tool returns valid status"
-        else log_fail "env-check --tool $tool invalid: $out"; fi
-    done
+    log_info "Test 6.2: env-check hard bypass ignores legacy opt-in"
+    local json_out
+    json_out=$(TOKENLESS_TOOL_READY_ENABLED=1 \
+        TOKENLESS_TOOL_READY_SPEC=/path/that/must/not/be-read \
+        tokenless env-check --tool Shell --json 2>&1)
+    assert_contains "$json_out" '"status":"UNKNOWN"' "env-check hard bypass returns UNKNOWN"
+    assert_contains "$json_out" '"enabled":false' "env-check hard bypass reports disabled"
 
-    # ==========================================
-    # 6.3 Alias reverse lookup (exec→Shell, Bash→Shell)
-    # ==========================================
-    log_info "Test 6.3: Alias reverse lookup"
-    local exec_out=$(tokenless env-check --tool exec 2>&1)
-    echo "$exec_out" | grep -qE 'READY|PARTIAL|NOT_READY' && log_pass "Alias 'exec' resolves to Shell" || log_fail "Alias 'exec' not resolved"
-    local bash_out=$(tokenless env-check --tool Bash 2>&1)
-    echo "$bash_out" | grep -qE 'READY|PARTIAL|NOT_READY' && log_pass "Alias 'Bash' resolves to Shell" || log_fail "Alias 'Bash' not resolved"
-    # Docker/Git/Uv/Cargo are NOT aliases → UNKNOWN
-    local docker_unknown=$(tokenless env-check --tool Docker 2>&1)
-    assert_contains "$docker_unknown" "UNKNOWN" "Docker is not a spec key → UNKNOWN"
-
-    # ==========================================
-    # 6.4 Case-insensitive spec key lookup
-    # ==========================================
-    log_info "Test 6.4: Case-insensitive spec key"
-    local lower=$(tokenless env-check --tool shell 2>&1)
-    echo "$lower" | grep -qE 'READY|PARTIAL|NOT_READY' && log_pass "Lowercase 'shell' resolves to Shell" || log_fail "Lowercase 'shell' not resolved"
-    local webfetch=$(tokenless env-check --tool webfetch 2>&1)
-    echo "$webfetch" | grep -qE 'READY|PARTIAL|NOT_READY' && log_pass "Lowercase 'webfetch' resolves to WebFetch" || log_fail "Lowercase 'webfetch' not resolved"
-
-    # ==========================================
-    # 6.5 Unknown tool → UNKNOWN status
-    # ==========================================
-    log_info "Test 6.5: Unknown tool → UNKNOWN"
-    local unknown=$(tokenless env-check --tool NonExistentTool99 2>&1)
-    assert_contains "$unknown" "UNKNOWN" "Unknown tool returns UNKNOWN status"
-    local unknown_json=$(tokenless env-check --tool NonExistentTool99 --json 2>&1)
-    assert_contains "$unknown_json" '"UNKNOWN"' "Unknown tool --json returns UNKNOWN"
-    assert_contains "$unknown_json" '"NonExistentTool99"' "Unknown tool --json includes tool name"
-
-    # ==========================================
-    # 6.6 --checklist --all: only 4 categories present
-    # ==========================================
-    log_info "Test 6.6: --checklist --all lists only 4 categories"
-    local checklist=$(tokenless env-check --checklist --all 2>&1)
-    assert_contains "$checklist" "Shell" "--checklist includes Shell"
-    assert_contains "$checklist" "WebFetch" "--checklist includes WebFetch"
-    assert_contains "$checklist" "Read" "--checklist includes Read"
-    assert_contains "$checklist" "Write" "--checklist includes Write"
-    assert_contains "$checklist" "Summary:" "--checklist includes summary"
-    # Verify removed categories absent
-    ! echo "$checklist" | grep -q "^Docker" && log_pass "No Docker category (merged into Shell)" || log_fail "Docker still present"
-    ! echo "$checklist" | grep -q "^Bash" && log_pass "No Bash category (merged into Shell)" || log_fail "Bash still present"
-
-    # ==========================================
-    # 6.7 --all detailed output: correct manager labels
-    # ==========================================
-    log_info "Test 6.7: Manager labels show detected system manager (dnf)"
-    local all_out=$(tokenless env-check --all 2>&1)
-    echo "$all_out" | grep -q '\[dnf\]' && log_pass "Manager labels show [dnf] for rpm deps" || log_fail "Manager labels missing [dnf]"
-    echo "$all_out" | grep -q '\[pip\]' && log_pass "Manager labels show [pip] for pip deps" || log_fail "Manager labels missing [pip]"
-
-    # ==========================================
-    # 6.8 --json output schema validation
-    # ==========================================
-    log_info "Test 6.8: --json output schema"
-    local json_out=$(tokenless env-check --tool Shell --json 2>&1)
-    assert_contains "$json_out" '"tool"' "--json contains tool field"
-    assert_contains "$json_out" '"status"' "--json contains status field"
-    assert_contains "$json_out" '"Shell"' "--json uses exact spec key name"
-
-    # ==========================================
-    # 6.9 Shell: required (bash, jq) + recommended (git, docker, uv, cargo, rustc) + permissions
-    # ==========================================
-    log_info "Test 6.9: Shell required + recommended + permissions"
-    local shell_out=$(tokenless env-check --tool Shell 2>&1)
-    assert_contains "$shell_out" "bash" "Shell lists bash"
-    assert_contains "$shell_out" "jq" "Shell lists jq"
-    assert_contains "$shell_out" "git" "Shell lists git in recommended"
-    assert_contains "$shell_out" "docker" "Shell lists docker in recommended"
-    assert_contains "$shell_out" "uv" "Shell lists uv in recommended"
-    assert_contains "$shell_out" "cargo" "Shell lists cargo in recommended"
-    echo "$shell_out" | grep -q "exec_shell" && log_pass "Shell includes exec_shell permission" || log_fail "Shell missing exec_shell"
-
-    # ==========================================
-    # 6.10 Shell recommended: no rustup (removed from spec)
-    # ==========================================
-    log_info "Test 6.10: Shell recommended has no rustup"
-    ! echo "$shell_out" | grep -q "rustup" && log_pass "Shell does not list rustup (removed)" || log_fail "Shell still lists rustup"
-
-    # ==========================================
-    # 6.11 Shell recommended: no docker-compose (removed from spec)
-    # ==========================================
-    log_info "Test 6.11: Shell recommended has no docker-compose"
-    ! echo "$shell_out" | grep -q "docker-compose" && log_pass "Shell does not list docker-compose (removed)" || log_fail "Shell still lists docker-compose"
-
-    # ==========================================
-    # 6.12 --fix: Shell (rpm + pip deps)
-    # ==========================================
-    log_info "Test 6.12: --fix Shell (deps already available)"
-    local fix_shell=$(tokenless env-check --fix --tool Shell 2>&1)
-    echo "$fix_shell" | grep -qE "READY|already" && log_pass "--fix --tool Shell: available deps handled" || log_fail "--fix --tool Shell unexpected: $fix_shell"
-
-    # ==========================================
-    # 6.13 Alias lookup with --fix (exec → Shell)
-    # ==========================================
-    log_info "Test 6.13: Alias lookup with --fix (exec→Shell)"
-    local fix_exec=$(tokenless env-check --fix --tool exec 2>&1)
-    echo "$fix_exec" | grep -qE "READY|already" && log_pass "--fix --tool exec resolves to Shell" || log_fail "--fix --tool exec unexpected: $fix_exec"
+    local text_out
+    text_out=$(TOKENLESS_TOOL_READY_ENABLED=1 tokenless env-check --tool Shell 2>&1)
+    assert_contains "$text_out" "hard-disabled" "legacy opt-in cannot re-enable env-check"
 
     # ==========================================
     # 6.14 env-fix script: check command
@@ -533,48 +436,41 @@ test_tool_ready() {
     fi
 
     # ==========================================
-    # 6.21 tool-ready hook: READY (silent exit)
+    # 6.21 tool-ready hook: unconditional hard bypass
     # ==========================================
-    log_info "Test 6.21: tool-ready hook — READY silent exit"
-    local ready_out=$(echo '{"tool_name":"Shell","tool_input":{"command":"ls"}}' | bash "$READY_SCRIPT" 2>&1)
-    [ -z "$ready_out" ] && log_pass "tool-ready READY produces no output" || log_fail "tool-ready READY unexpected output: $ready_out"
-
-    # ==========================================
-    # 6.22 tool-ready hook: NOT_READY + Skip retry
-    # ==========================================
-    log_info "Test 6.22: tool-ready hook — NOT_READY"
-    local tmp_dir
-    local tmp_spec
-    local tmp_fixer
-    local fix_marker
-    if ! tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/tokenless-tool-ready.XXXXXX"); then
-        log_fail "unable to create private temporary directory"
-        return
-    fi
-    chmod 0700 "$tmp_dir"
-    tmp_spec="$tmp_dir/tool-ready-spec.json"
-    tmp_fixer="$tmp_dir/tokenless-env-fix.sh"
-    fix_marker="$tmp_dir/fixer-called"
-    cat > "$tmp_spec" << 'EOF'
-{"TestMissing":{"required":[{"binary":"fakebin99","package":"fakebin99","manager":"rpm"}],"recommended":[],"permissions":[],"network":[]}}
+    log_info "Test 6.21: tool-ready hook — hard bypass"
+    local bypass_dir
+    bypass_dir=$(mktemp -d)
+    local bypass_spec="$bypass_dir/tool-ready-spec.json"
+    local bypass_fixer="$bypass_dir/tokenless-env-fix.sh"
+    local bypass_marker="$bypass_dir/fixer-called"
+    cat > "$bypass_spec" <<'EOF'
+{"TestMissing":{"required":[{"binary":"tokenless-missing-for-test","package":"tokenless-missing-for-test","manager":"rpm"}],"recommended":[],"permissions":[]}}
 EOF
-    cat > "$tmp_fixer" << 'EOF'
+    cat > "$bypass_fixer" <<'EOF'
 #!/usr/bin/env bash
+set -euo pipefail
+[ "${1:-}" = "fix-all" ]
+cat >/dev/null
 touch "$TOKENLESS_FIX_MARKER"
 EOF
-    chmod 0644 "$tmp_fixer"
-    local not_ready_out
-    not_ready_out=$(echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \
-        | TOKENLESS_TOOL_READY_SPEC="$tmp_spec" \
-          TOKENLESS_ENV_FIX_SCRIPT="$tmp_fixer" \
-          TOKENLESS_FIX_MARKER="$fix_marker" \
+    chmod 0644 "$bypass_fixer"
+
+    local ready_out
+    ready_out=$(echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \
+        | TOKENLESS_TOOL_READY_ENABLED=1 \
+          TOKENLESS_TOOL_READY_SPEC="$bypass_spec" \
+          TOKENLESS_ENV_FIX_SCRIPT="$bypass_fixer" \
+          TOKENLESS_FIX_MARKER="$bypass_marker" \
           bash "$READY_SCRIPT" 2>&1)
-    [ -f "$fix_marker" ] \
-        && log_pass "tool-ready invokes a non-executable fixer through bash" \
-        || log_fail "tool-ready skipped the readable 0644 fixer"
-    assert_contains "$not_ready_out" "NOT_READY" "hook outputs NOT_READY"
-    assert_contains "$not_ready_out" "Skip retry" "hook includes Skip retry guidance"
-    rm -rf "$tmp_dir"
+    if [ -n "$ready_out" ]; then
+        log_fail "tool-ready hard bypass unexpected output: $ready_out"
+    elif [ -e "$bypass_marker" ]; then
+        log_fail "tool-ready hard bypass invoked the legacy fixer"
+    else
+        log_pass "tool-ready hard bypass emits nothing and skips the fixer"
+    fi
+    rm -rf "$bypass_dir"
 
     # ==========================================
     # 6.23 Attribution: ENV_DEPENDENCY_MISSING

--- a/src/tokenless/tests/test-tool-ready-readable-fixer.sh
+++ b/src/tokenless/tests/test-tool-ready-readable-fixer.sh
@@ -27,14 +27,14 @@ chmod 0644 "$FIXER"
 
 OUTPUT=$(
     echo '{"tool_name":"TestMissing","tool_input":{"command":"test"}}' \
-        | TOKENLESS_TOOL_READY_SPEC="$SPEC" \
+        | TOKENLESS_TOOL_READY_ENABLED=1 \
+          TOKENLESS_TOOL_READY_SPEC="$SPEC" \
           TOKENLESS_ENV_FIX_SCRIPT="$FIXER" \
           TOKENLESS_FIX_MARKER="$MARKER" \
           bash "$HOOK"
 )
 
-[ -f "$MARKER" ]
-grep -q "NOT_READY" <<<"$OUTPUT"
-grep -q "Skip retry" <<<"$OUTPUT"
+[ ! -e "$MARKER" ]
+[ -z "$OUTPUT" ]
 
-echo "tool-ready readable fixer test passed"
+echo "tool-ready hard bypass test passed"


### PR DESCRIPTION
## Why

Tool Ready's category-level readiness model can classify valid agent environments as
`NOT_READY` and block `PreToolUse` calls. This is an immediate fail-open mitigation while
the readiness model is redesigned.

## What changed

- Hard-bypass Rust `env-check` before it reads the spec, checks dependencies, repairs the
  environment, or emits a blocking result.
- Exit the shared shell hook before reading input or running `jq` and the fixer.
- Keep post-tool failure attribution and every other Tokenless feature unchanged.
- Update tests and paired English/Chinese documentation for the hard-disabled behavior.

## Related issue

no-issue: immediate mitigation for production Tool Ready blocking

## User / Agent impact

Tool Ready hooks remain registered but cannot inspect, repair, or block tool execution.
JSON `env-check` calls return only `{tool,status,enabled}`, with `status:"UNKNOWN"` and
`enabled:false`; the former runtime opt-in variable has no effect.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The mitigation changes `env-check` behavior intentionally. Deploy both the Tokenless binary
and shared adapter resources so Rust-backed and shell-backed adapters receive the bypass.

## Validation

- `PATH="$PWD/target/debug:$PATH" make test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc --workspace --no-deps`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`

The full test target includes Rust workspace tests, 72/72 hook tests, Python integration,
OpenClaw build, adapter tests, raw packaging, and four-platform npm packaging.

## Documentation and rollback

Updated the Tokenless READMEs, adapter metadata, and paired user-guide pages. Revert commit
`597f513f` to restore the previous implementation; re-enabling Tool Ready should otherwise
require an intentional source change after the readiness model is redesigned.
