### PR TITLE
fix(tokenless): roll back schema stash and delete live-only

### DIFF
--- a/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
@@ -172,11 +172,21 @@ impl StashStore for InMemoryStore {
             .inner
             .lock()
             .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
-        let removed = inner.map.remove(&key).is_some();
-        if removed {
-            inner.order.retain(|k| k != &key);
+        let now = Instant::now();
+        let ttl = inner.ttl;
+        let live = inner
+            .map
+            .get(&key)
+            .map(|e| now.duration_since(e.inserted_at) < ttl)
+            .unwrap_or(false);
+        if !live {
+            // Absent or already expired: match retrieve/`Ok(false)` contract.
+            // Do not physically drop an expired row here — `retrieve` / `evict_expired` own that.
+            return Ok(false);
         }
-        Ok(removed)
+        inner.map.remove(&key);
+        inner.order.retain(|k| k != &key);
+        Ok(true)
     }
 }
 
@@ -275,6 +285,32 @@ mod tests {
                 .is_some()
         );
         assert!(store.len() <= 3);
+    }
+
+    #[test]
+    fn delete_live_entry_returns_true() {
+        let store = InMemoryStore::new();
+        let (key, _) = store.stash("payload").unwrap();
+        assert!(store.delete(&key).unwrap());
+        assert_eq!(store.retrieve(&key).unwrap(), None);
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn delete_missing_returns_false() {
+        let store = InMemoryStore::new();
+        assert!(!store.delete("000000000000000000000000").unwrap());
+    }
+
+    #[test]
+    fn delete_expired_returns_false_without_removing_live_contract() {
+        // Trait: Ok(false) when absent or already expired. Must not report a
+        // successful live delete for a row retrieve() would already hide.
+        let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
+        let (key, _) = store.stash("ephemeral").unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(!store.delete(&key).unwrap());
+        assert_eq!(store.retrieve(&key).unwrap(), None);
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
@@ -64,12 +64,18 @@ impl Default for InMemoryStore {
 }
 
 impl StashStore for InMemoryStore {
-    fn stash(&self, payload: &str) -> Result<String, StashError> {
+    fn stash(&self, payload: &str) -> Result<(String, bool), StashError> {
         let key = compute_key(payload.as_bytes());
         let mut inner = self
             .inner
             .lock()
             .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
+        let now = Instant::now();
+        let had_live = inner
+            .map
+            .get(&key)
+            .map(|e| now.duration_since(e.inserted_at) < inner.ttl)
+            .unwrap_or(false);
         // Re-stash refreshes: move the key to the back of the FIFO order so a
         // refreshed entry is evicted last, matching SqliteStore's
         // expires_at-ordered eviction.
@@ -96,7 +102,7 @@ impl StashStore for InMemoryStore {
                 inserted_at: Instant::now(),
             },
         );
-        Ok(key)
+        Ok((key, !had_live))
     }
 
     fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
@@ -184,7 +190,7 @@ mod tests {
         // An LLM may quote a marker back with uppercased hex; keys are stored
         // lowercase, so retrieve must normalize the lookup.
         let store = InMemoryStore::new();
-        let key = store.stash("payload").unwrap();
+        let (key, _) = store.stash("payload").unwrap();
         assert_eq!(key, key.to_ascii_lowercase());
         let upper = key.to_uppercase();
         assert_ne!(upper, key);
@@ -196,20 +202,20 @@ mod tests {
         // A re-stashed (refreshed) entry should survive FIFO eviction, matching
         // SqliteStore's expires_at-ordered eviction.
         let store = InMemoryStore::with_limits(Duration::from_secs(60), 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
+        let (k0, _) = store.stash("0").unwrap();
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
         // Re-stash k0 to refresh it (moves to back); then stash a new key to
         // trigger eviction. k0 must survive (refreshed), k1 (oldest) evicted.
-        store.stash("0").unwrap();
-        store.stash("3").unwrap();
+        let _ = store.stash("0").unwrap();
+        let _ = store.stash("3").unwrap();
         assert!(store.retrieve(&k0).unwrap().is_some());
     }
 
     #[test]
     fn stash_and_retrieve_round_trip() {
         let store = InMemoryStore::new();
-        let key = store.stash("some payload").unwrap();
+        let (key, _) = store.stash("some payload").unwrap();
         assert_eq!(
             store.retrieve(&key).unwrap(),
             Some("some payload".to_string())
@@ -225,13 +231,13 @@ mod tests {
     #[test]
     fn re_stash_is_idempotent_and_refreshes() {
         let store = InMemoryStore::with_limits(Duration::from_millis(50), 100);
-        let k1 = store.stash("payload").unwrap();
-        let k2 = store.stash("payload").unwrap();
+        let (k1, _) = store.stash("payload").unwrap();
+        let (k2, _) = store.stash("payload").unwrap();
         assert_eq!(k1, k2);
         // After the original TTL would have expired, the refreshed entry is
         // still live.
         std::thread::sleep(Duration::from_millis(30));
-        store.stash("payload").unwrap();
+        let _ = store.stash("payload").unwrap();
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.retrieve(&k1).unwrap(), Some("payload".to_string()));
     }
@@ -239,7 +245,7 @@ mod tests {
     #[test]
     fn expired_entry_not_retrievable() {
         let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
-        let key = store.stash("ephemeral").unwrap();
+        let (key, _) = store.stash("ephemeral").unwrap();
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.retrieve(&key).unwrap(), None);
     }
@@ -247,8 +253,8 @@ mod tests {
     #[test]
     fn evict_expired_reports_count() {
         let store = InMemoryStore::with_limits(Duration::from_millis(20), 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         std::thread::sleep(Duration::from_millis(30));
         assert_eq!(store.evict_expired().unwrap(), 2);
         assert_eq!(store.len(), 0);
@@ -257,14 +263,14 @@ mod tests {
     #[test]
     fn fifo_eviction_when_over_capacity() {
         let store = InMemoryStore::with_limits(Duration::from_secs(60), 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
-        store.stash("3").unwrap(); // evicts "0"
+        let (k0, _) = store.stash("0").unwrap();
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
+        let _ = store.stash("3").unwrap(); // evicts "0"
         assert_eq!(store.retrieve(&k0).unwrap(), None);
         assert!(
             store
-                .retrieve(&store.stash("1").unwrap())
+                .retrieve(&store.stash("1").unwrap().0)
                 .unwrap()
                 .is_some()
         );
@@ -279,7 +285,7 @@ mod tests {
                 let s = store.clone();
                 thread::spawn(move || {
                     for j in 0..100 {
-                        s.stash(&format!("p-{i}-{j}")).unwrap();
+                        let _ = s.stash(&format!("p-{i}-{j}")).unwrap();
                     }
                 })
             })

--- a/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
@@ -159,6 +159,19 @@ impl StashStore for InMemoryStore {
         }
         Ok(count)
     }
+
+    fn delete(&self, hash: &str) -> Result<bool, StashError> {
+        let key = hash.to_ascii_lowercase();
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
+        let removed = inner.map.remove(&key).is_some();
+        if removed {
+            inner.order.retain(|k| k != &key);
+        }
+        Ok(removed)
+    }
 }
 
 #[cfg(test)]

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -178,8 +178,12 @@ impl StashStore for SqliteStore {
 
     fn delete(&self, hash: &str) -> Result<bool, StashError> {
         let key = hash.to_ascii_lowercase();
+        let now = now_unix();
         let conn = self.lock_conn();
-        let removed = conn.execute("DELETE FROM stash WHERE hash = ?", [key])?;
+        let removed = conn.execute(
+            "DELETE FROM stash WHERE hash = ? AND expires_at >= ?",
+            rusqlite::params![key, now as i64],
+        )?;
         Ok(removed > 0)
     }
 }
@@ -262,6 +266,32 @@ mod tests {
         let _ = store.stash("3").unwrap(); // surplus=1, evicts oldest live (k0)
         assert_eq!(store.retrieve(&k0).unwrap(), None);
         assert!(store.len() <= 3);
+    }
+
+    #[test]
+    fn delete_live_entry_returns_true() {
+        let (store, _dir) = tmp_store(60, 100);
+        let (key, _) = store.stash("payload").unwrap();
+        assert!(store.delete(&key).unwrap());
+        assert_eq!(store.retrieve(&key).unwrap(), None);
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn delete_missing_returns_false() {
+        let (store, _dir) = tmp_store(60, 100);
+        assert!(!store.delete("000000000000000000000000").unwrap());
+    }
+
+    #[test]
+    fn delete_expired_returns_false() {
+        // Trait: Ok(false) when already expired. DELETE must include
+        // `expires_at >= now` so an expired row is not reported as a live delete.
+        let (store, _dir) = tmp_store(1, 100);
+        let (key, _) = store.stash("ephemeral").unwrap();
+        thread::sleep(std::time::Duration::from_secs(2));
+        assert!(!store.delete(&key).unwrap());
+        assert_eq!(store.retrieve(&key).unwrap(), None);
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -111,17 +111,26 @@ impl SqliteStore {
 }
 
 impl StashStore for SqliteStore {
-    fn stash(&self, payload: &str) -> Result<String, StashError> {
+    fn stash(&self, payload: &str) -> Result<(String, bool), StashError> {
         let key = compute_key(payload.as_bytes());
         let now = now_unix();
         let expires_at = now + self.ttl_seconds;
         let conn = self.lock_conn();
+        let had_live: bool = match conn.query_row(
+            "SELECT 1 FROM stash WHERE hash = ? AND expires_at >= ?",
+            rusqlite::params![key, now as i64],
+            |_| Ok(true),
+        ) {
+            Ok(v) => v,
+            Err(rusqlite::Error::QueryReturnedNoRows) => false,
+            Err(e) => return Err(StashError::from(e)),
+        };
         conn.execute(
             "INSERT OR REPLACE INTO stash (hash, payload, expires_at) VALUES (?, ?, ?)",
             rusqlite::params![key, payload, expires_at as i64],
         )?;
         self.enforce_capacity(&conn)?;
-        Ok(key)
+        Ok((key, !had_live))
     }
 
     fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
@@ -198,7 +207,7 @@ mod tests {
     #[test]
     fn retrieve_is_case_insensitive() {
         let (store, _dir) = tmp_store(60, 100);
-        let key = store.stash("payload").unwrap();
+        let (key, _) = store.stash("payload").unwrap();
         assert_eq!(key, key.to_ascii_lowercase());
         let upper = key.to_uppercase();
         assert_ne!(upper, key);
@@ -208,7 +217,7 @@ mod tests {
     #[test]
     fn round_trip_persists_across_connections() {
         let (store, dir) = tmp_store(60, 100);
-        let key = store.stash("payload-A").unwrap();
+        let (key, _) = store.stash("payload-A").unwrap();
         assert_eq!(store.retrieve(&key).unwrap(), Some("payload-A".to_string()));
 
         // A second connection to the same file sees the entry: proves the
@@ -229,7 +238,7 @@ mod tests {
     #[test]
     fn expired_entry_not_retrievable() {
         let (store, _dir) = tmp_store(1, 100);
-        let key = store.stash("ephemeral").unwrap();
+        let (key, _) = store.stash("ephemeral").unwrap();
         thread::sleep(std::time::Duration::from_secs(2));
         assert_eq!(store.retrieve(&key).unwrap(), None);
     }
@@ -237,8 +246,8 @@ mod tests {
     #[test]
     fn evict_expired_reports_count() {
         let (store, _dir) = tmp_store(1, 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         thread::sleep(std::time::Duration::from_secs(2));
         assert_eq!(store.evict_expired().unwrap(), 2);
         assert_eq!(store.len(), 0);
@@ -247,10 +256,10 @@ mod tests {
     #[test]
     fn fifo_eviction_when_over_capacity() {
         let (store, _dir) = tmp_store(60, 3);
-        let k0 = store.stash("0").unwrap();
-        store.stash("1").unwrap();
-        store.stash("2").unwrap();
-        store.stash("3").unwrap(); // surplus=1, evicts oldest live (k0)
+        let (k0, _) = store.stash("0").unwrap();
+        let _ = store.stash("1").unwrap();
+        let _ = store.stash("2").unwrap();
+        let _ = store.stash("3").unwrap(); // surplus=1, evicts oldest live (k0)
         assert_eq!(store.retrieve(&k0).unwrap(), None);
         assert!(store.len() <= 3);
     }
@@ -264,7 +273,7 @@ mod tests {
                 let s = store.clone();
                 thread::spawn(move || {
                     for j in 0..50 {
-                        s.stash(&format!("p-{i}-{j}")).unwrap();
+                        let _ = s.stash(&format!("p-{i}-{j}")).unwrap();
                     }
                 })
             })
@@ -281,8 +290,8 @@ mod tests {
         // merely filter them via the WHERE clause. Mirrors headroom's
         // `SqliteCcrStore::get` lazy-purge sweep.
         let (store, _dir) = tmp_store(1, 100);
-        store.stash("a").unwrap();
-        store.stash("b").unwrap();
+        let _ = store.stash("a").unwrap();
+        let _ = store.stash("b").unwrap();
         assert_eq!(store.len(), 2);
         thread::sleep(std::time::Duration::from_secs(2));
         // Both rows are now expired. A retrieve for any (absent) key triggers

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -166,6 +166,13 @@ impl StashStore for SqliteStore {
         let evicted = conn.execute("DELETE FROM stash WHERE expires_at < ?", [now as i64])?;
         Ok(evicted)
     }
+
+    fn delete(&self, hash: &str) -> Result<bool, StashError> {
+        let key = hash.to_ascii_lowercase();
+        let conn = self.lock_conn();
+        let removed = conn.execute("DELETE FROM stash WHERE hash = ?", [key])?;
+        Ok(removed > 0)
+    }
 }
 
 /// Current wall-clock seconds since the Unix epoch. Used for expiry math so

--- a/src/tokenless/crates/tokenless-ccr/src/store.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/store.rs
@@ -11,9 +11,14 @@
 /// for key derivation (rather than accepting a caller-supplied hash) removes a
 /// injection footgun: callers cannot mismatch a marker from its payload.
 pub trait StashStore: Send + Sync {
-    /// Stash `payload`, returning its key. Re-stashing the same payload is
-    /// idempotent (same key) and refreshes the entry's expiry.
-    fn stash(&self, payload: &str) -> Result<String, StashError>;
+    /// Stash `payload`, returning `(key, created)`.
+    ///
+    /// Re-stashing the same payload is idempotent (same key) and refreshes the
+    /// entry's expiry. `created` is `true` only when no live entry existed for
+    /// that key before this call — callers that roll back discarded compress
+    /// output must delete only `created` keys so pre-existing markers stay
+    /// retrievable.
+    fn stash(&self, payload: &str) -> Result<(String, bool), StashError>;
 
     /// Retrieve a stashed payload by key. Returns `Ok(None)` if the key is
     /// absent or the entry has expired.

--- a/src/tokenless/crates/tokenless-ccr/src/store.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/store.rs
@@ -29,6 +29,12 @@ pub trait StashStore: Send + Sync {
 
     /// Drop all expired entries and return how many were removed.
     fn evict_expired(&self) -> Result<usize, StashError>;
+
+    /// Delete a live entry by hash. Returns `Ok(true)` when a row was removed,
+    /// `Ok(false)` when the key was absent (or already expired). Used to roll
+    /// back stash writes whose markers never reach the LLM (e.g. CLI discards
+    /// a no-savings compression result).
+    fn delete(&self, hash: &str) -> Result<bool, StashError>;
 }
 
 /// Errors a stash backend can surface. Kept minimal: backends map their

--- a/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
@@ -4,7 +4,7 @@ use crate::InMemoryStore;
 fn is_empty_default_trait_method() {
     let store = InMemoryStore::new();
     assert!(store.is_empty());
-    store.stash("payload").unwrap();
+    let _ = store.stash("payload").unwrap();
     assert!(!store.is_empty());
 }
 
@@ -18,7 +18,7 @@ fn stash_error_display() {
 fn default_trait_creates_working_store() {
     let store = InMemoryStore::default();
     assert!(store.is_empty());
-    let key = store.stash("payload").unwrap();
+    let (key, _) = store.stash("payload").unwrap();
     assert!(!store.is_empty());
     let retrieved = store.retrieve(&key).unwrap();
     assert_eq!(retrieved, Some("payload".to_string()));

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -530,15 +530,24 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     "tokenless: schema compression did not reduce size ({} -> {} est. tokens), outputting original",
                     before_tokens, after_tokens
                 );
-                // No-savings discard edge: if a stash was attached and a
-                // description was truncated, those writes orphan (markers
-                // live in `after_compact`, which is discarded). Truncation
-                // almost always yields savings, so this is rare; orphaned
-                // entries are TTL-cleaned.
+                // Discarded compressed output never reaches the LLM, so roll
+                // back stash keys created during this compress — otherwise
+                // markers live only in `after_compact` and orphan stash rows.
+                compressor.rollback_stash_writes();
                 input.clone()
             } else {
                 after_compact.clone()
             };
+
+            let stash_writes = stash.as_ref().map(|_| compressor.stash_writes());
+            let stash_errors = stash.as_ref().map(|_| compressor.stash_errors());
+            let stash_size = stash.as_ref().map(|s| s.len());
+            if matches!(stash_errors, Some(e) if e > 0) {
+                eprintln!(
+                    "[tokenless] stash: {} stash operation(s) failed; truncated entries are not retrievable (check stash db health)",
+                    stash_errors.expect("checked Some above")
+                );
+            }
 
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {
@@ -558,9 +567,9 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 input,
                 output_text,
                 mode,
-                None,
-                None,
-                None,
+                stash_writes,
+                stash_errors,
+                stash_size,
             );
         }
         Commands::CompressResponse {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -605,12 +605,26 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 compressor = compressor.with_stash_store(store.clone());
             }
             let result = compressor.compress(&value);
+            let after_compact = serde_json::to_string(&result).unwrap_or_else(|_| String::new());
+
+            let before_tokens = estimate_tokens(&input);
+            let after_tokens = estimate_tokens(&after_compact);
+            let output_text = if after_tokens >= before_tokens {
+                eprintln!(
+                    "tokenless: response compression did not reduce size ({} -> {} est. tokens), outputting original",
+                    before_tokens, after_tokens
+                );
+                // Discarded compressed output never reaches the LLM, so roll
+                // back stash keys created during this compress — otherwise
+                // markers live only in `after_compact` and orphan stash rows.
+                compressor.rollback_stash_writes();
+                input.clone()
+            } else {
+                after_compact.clone()
+            };
             // Stash observability: capture write/error counts + live entry
-            // count for stats. All three are None when no stash store is
-            // attached (vs Some(0) when a stash is attached but nothing was
-            // truncated) so stats queries can distinguish "no stash" runs
-            // from "stash, zero writes" runs. Counts are read AFTER compress
-            // so they reflect this call; stash_size reflects entries added.
+            // count for stats AFTER the no-savings rollback so discarded
+            // orphans are not counted as successful writes.
             let stash_writes = stash.as_ref().map(|_| compressor.stash_writes());
             let stash_errors = stash.as_ref().map(|_| compressor.stash_errors());
             let stash_size = stash.as_ref().map(|s| s.len());
@@ -624,24 +638,6 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     stash_errors.expect("checked Some above")
                 );
             }
-            let after_compact = serde_json::to_string(&result).unwrap_or_else(|_| String::new());
-
-            let before_tokens = estimate_tokens(&input);
-            let after_tokens = estimate_tokens(&after_compact);
-            let output_text = if after_tokens >= before_tokens {
-                eprintln!(
-                    "tokenless: response compression did not reduce size ({} -> {} est. tokens), outputting original",
-                    before_tokens, after_tokens
-                );
-                // No-savings discard edge: if a stash was attached and an
-                // array was truncated, those writes orphan (markers live in
-                // `after_compact`, which is discarded). Truncation almost
-                // always yields savings, so this is rare; orphaned entries
-                // are TTL-cleaned.
-                input.clone()
-            } else {
-                after_compact.clone()
-            };
 
             let mode = resolve_mode(compression_on, before_tokens, after_tokens);
             let emit_text = if compression_on {

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -629,12 +629,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             let stash_errors = stash.as_ref().map(|_| compressor.stash_errors());
             let stash_size = stash.as_ref().map(|s| s.len());
             // Surface persistent stash backend failures (disk full, locked DB,
-            // I/O) so they aren't invisible — compression degrades to the
-            // lossy marker per entry, but a non-zero count means the stash
-            // path is broken and retrievals will miss.
+            // I/O, rollback delete) so they aren't invisible. `stash_errors`
+            // counts both compress-time stash writes and no-savings rollback
+            // deletes; a non-zero count means the stash path is broken and
+            // retrievals will miss.
             if matches!(stash_errors, Some(e) if e > 0) {
                 eprintln!(
-                    "[tokenless] stash: {} write(s) failed during compression; truncated entries are not retrievable (check stash db health)",
+                    "[tokenless] stash: {} stash operation(s) failed; truncated entries are not retrievable (check stash db health)",
                     stash_errors.expect("checked Some above")
                 );
             }

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -717,7 +717,7 @@ fn run_command_retrieve_with_marker() {
         return;
     }
     let store = store.unwrap();
-    let key = store.stash("hello world").unwrap();
+    let (key, _) = store.stash("hello world").unwrap();
     let marker = format!("<<tokenless:{}>>", key);
     let result = run_command(Commands::Retrieve {
         hash: marker,
@@ -734,7 +734,7 @@ fn run_command_retrieve_bare_hash() {
         return;
     }
     let store = store.unwrap();
-    let key = store.stash("retrieve bare hash test").unwrap();
+    let (key, _) = store.stash("retrieve bare hash test").unwrap();
     let result = run_command(Commands::Retrieve {
         hash: key,
         stash_db: None,

--- a/src/tokenless/crates/tokenless-cli/src/tests/mcp_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/mcp_tests.rs
@@ -48,7 +48,7 @@ fn retrieve_invalid_hash_format_is_error() {
 #[test]
 fn retrieve_round_trips_via_store() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("payload-body").unwrap();
+    let (key, _) = store.stash("payload-body").unwrap();
     let r = retrieve_from_store(&store, &key);
     assert_eq!(r["isError"], json!(false));
     assert_eq!(r["content"][0]["text"], json!("payload-body"));
@@ -57,7 +57,7 @@ fn retrieve_round_trips_via_store() {
 #[test]
 fn retrieve_accepts_marker_line() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("dropped items").unwrap();
+    let (key, _) = store.stash("dropped items").unwrap();
     let marker_line = format!("<... 5 items truncated, retrieve with <<tokenless:{key}>>");
     // Exercise the public entry point so marker extraction in `retrieve`
     // is covered, not just the bare-key path of `retrieve_from_store`.
@@ -113,7 +113,7 @@ fn retrieve_stash_unavailable_when_store_is_none() {
 #[test]
 fn handle_tool_call_dispatches_retrieve_with_store() {
     let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
-    let key = store.stash("mcp-payload").unwrap();
+    let (key, _) = store.stash("mcp-payload").unwrap();
     let params = json!({
         "name": "tokenless_retrieve",
         "arguments": {"hash": key}

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -540,6 +540,79 @@ fn compress_response_no_savings_rolls_back_orphan_stash() {
 }
 
 #[test]
+fn compress_schema_no_savings_rolls_back_orphan_stash() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let stash_db = fixture.data_dir.join("stash.db");
+    // Description just over the default 256-char cap: truncation + stash
+    // marker often yields after_tokens >= before_tokens (1-char savings
+    // does not always change the estimate). Pad the function name so the
+    // compact JSON length hits that equality.
+    let mut hit_no_savings = false;
+    for name in ["x", "xx", "xxx", "xxxx"] {
+        let schema = serde_json::json!({
+            "function": {
+                "name": name,
+                "description": "A".repeat(257),
+                "parameters": {"type": "object", "properties": {}}
+            }
+        });
+        let original = serde_json::to_string(&schema).unwrap();
+        let output = fixture
+            .command()
+            .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+            .env("TOKENLESS_STATS_ENABLED", "0")
+            .args(["compress-schema", "--stash-db"])
+            .arg(&stash_db)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write;
+                child.stdin.take().unwrap().write_all(original.as_bytes())?;
+                child.wait_with_output()
+            })
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "compress-schema failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.contains("did not reduce size") {
+            continue;
+        }
+        hit_no_savings = true;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("tokenless:"),
+            "no-savings stdout must not expose markers: {stdout}"
+        );
+        let live = if stash_db.exists() {
+            tokenless_ccr::SqliteStore::new(&stash_db)
+                .map(|s| s.len())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        assert_eq!(
+            live,
+            0,
+            "no-savings discard must roll back stash writes; orphan rows remain in {}",
+            stash_db.display()
+        );
+        break;
+    }
+    assert!(
+        hit_no_savings,
+        "failed to hit compress-schema no-savings path with a just-over-limit description"
+    );
+}
+
+#[test]
 fn no_args_shows_error() {
     let output = tokenless_bin().output().unwrap();
     assert!(!output.status.success());

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 
+use tokenless_ccr::StashStore;
 use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, get_home_dir};
 
 fn tokenless_bin() -> Command {
@@ -472,6 +473,69 @@ fn retrieve_stdout_is_byte_exact_without_extra_trailing_newline() {
         stashed_string.as_bytes(),
         "retrieve must restore the stashed payload byte-for-byte; \
          an extra trailing newline breaks end-to-end lossless recovery"
+    );
+}
+
+#[test]
+fn compress_response_no_savings_rolls_back_orphan_stash() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let stash_db = fixture.data_dir.join("stash.db");
+    // Small array + aggressive truncate: marker overhead makes after_tokens
+    // >= before_tokens, so CLI falls back to the original input.
+    let original = r#"["a","b"]"#;
+
+    let output = fixture
+        .command()
+        .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+        .env("TOKENLESS_STATS_ENABLED", "0")
+        .args([
+            "compress-response",
+            "--truncate-arrays-at",
+            "1",
+            "--stash-db",
+        ])
+        .arg(&stash_db)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(original.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "compress-response failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("did not reduce size"),
+        "expected no-savings path, stderr={stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("tokenless:"),
+        "no-savings stdout must not expose markers: {stdout}"
+    );
+    // Discarded markers must not leave orphan rows in stash.db.
+    let live = if stash_db.exists() {
+        tokenless_ccr::SqliteStore::new(&stash_db)
+            .map(|s| s.len())
+            .unwrap_or(0)
+    } else {
+        0
+    };
+    assert_eq!(
+        live,
+        0,
+        "no-savings discard must roll back stash writes; orphan rows remain in {}",
+        stash_db.display()
     );
 }
 

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -188,8 +188,19 @@ impl ResponseCompressor {
         let keys = std::mem::take(&mut *self.stash_keys_created.borrow_mut());
         let mut removed = 0usize;
         for key in &keys {
-            if store.delete(key).unwrap_or(false) {
-                removed += 1;
+            match store.delete(key) {
+                Ok(true) => removed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    // Keep the key list drained so we don't retry forever, but
+                    // surface the failure — a silent orphan is worse than a
+                    // loud warning (AGENTS.md: do not swallow operational errors).
+                    self.record_stash_error();
+                    eprintln!(
+                        "[tokenless] stash: rollback delete failed for key {}: {e}",
+                        key
+                    );
+                }
             }
         }
         // Keep counters consistent with the rolled-back store.
@@ -198,9 +209,14 @@ impl ResponseCompressor {
         removed
     }
 
-    fn record_stash_success(&self, key: String) {
+    fn record_stash_success(&self, key: String, created: bool) {
         self.stash_writes.set(self.stash_writes.get() + 1);
-        self.stash_keys_created.borrow_mut().push(key);
+        // Only newly inserted keys are safe to delete on discard. Refreshing an
+        // existing content-addressed entry must not put that key on the
+        // rollback list — another emitted marker may still need it.
+        if created {
+            self.stash_keys_created.borrow_mut().push(key);
+        }
     }
 
     fn record_stash_error(&self) {
@@ -227,8 +243,8 @@ impl ResponseCompressor {
                 && let Ok(serialized) = serde_json::to_string(value)
             {
                 match store.stash(&serialized) {
-                    Ok(key) => {
-                        self.record_stash_success(key.clone());
+                    Ok((key, created)) => {
+                        self.record_stash_success(key.clone(), created);
                         return Value::String(format!(
                             "<{type_name} truncated at depth {depth}, retrieve with {}>",
                             marker_for(&key)
@@ -286,8 +302,8 @@ impl ResponseCompressor {
             && let Some(store) = self.stash_store.as_ref()
         {
             match store.stash(s) {
-                Ok(key) => {
-                    self.record_stash_success(key.clone());
+                Ok((key, created)) => {
+                    self.record_stash_success(key.clone(), created);
                     let target = self.truncate_strings_at - stash_suffix_char_len();
                     let truncate_pos = s
                         .char_indices()
@@ -393,8 +409,8 @@ impl ResponseCompressor {
             return None;
         }
         let key = match stash.stash(&payload) {
-            Ok(k) => {
-                self.record_stash_success(k.clone());
+            Ok((k, created)) => {
+                self.record_stash_success(k.clone(), created);
                 k
             }
             Err(_) => {

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -1,5 +1,5 @@
 use serde_json::{Map, Value};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokenless_ccr::{StashStore, marker_for};
@@ -45,6 +45,11 @@ pub struct ResponseCompressor {
     /// can surface persistent backend failures instead of silently degrading
     /// to the lossy marker.
     stash_errors: Cell<usize>,
+    /// Keys created during the last `compress()` call. Cleared at the start of
+    /// each compress; used by [`Self::rollback_stash_writes`] when a caller
+    /// discards the compressed output (no-savings path) so markers never reach
+    /// the LLM.
+    stash_keys_created: RefCell<Vec<String>>,
 }
 
 impl Default for ResponseCompressor {
@@ -76,6 +81,7 @@ impl Default for ResponseCompressor {
             stash_store: None,
             stash_writes: Cell::new(0),
             stash_errors: Cell::new(0),
+            stash_keys_created: RefCell::new(Vec::new()),
         }
     }
 }
@@ -144,6 +150,7 @@ impl ResponseCompressor {
         // impression that a reset-then-increment AtomicUsize pattern would give.
         self.stash_writes.set(0);
         self.stash_errors.set(0);
+        self.stash_keys_created.borrow_mut().clear();
         let original_text = serde_json::to_string(response).unwrap_or_default();
         let result = self.compress_value(response, 0);
 
@@ -169,6 +176,37 @@ impl ResponseCompressor {
         self.stash_errors.get()
     }
 
+    /// Delete stash entries created during the last `compress()` call.
+    ///
+    /// Call this when the compressed output (and its embedded markers) will
+    /// never be emitted — e.g. the CLI no-savings path that falls back to the
+    /// original input. Returns how many keys were successfully removed.
+    pub fn rollback_stash_writes(&self) -> usize {
+        let Some(store) = self.stash_store.as_ref() else {
+            return 0;
+        };
+        let keys = std::mem::take(&mut *self.stash_keys_created.borrow_mut());
+        let mut removed = 0usize;
+        for key in &keys {
+            if store.delete(key).unwrap_or(false) {
+                removed += 1;
+            }
+        }
+        // Keep counters consistent with the rolled-back store.
+        self.stash_writes
+            .set(self.stash_writes.get().saturating_sub(removed));
+        removed
+    }
+
+    fn record_stash_success(&self, key: String) {
+        self.stash_writes.set(self.stash_writes.get() + 1);
+        self.stash_keys_created.borrow_mut().push(key);
+    }
+
+    fn record_stash_error(&self) {
+        self.stash_errors.set(self.stash_errors.get() + 1);
+    }
+
     /// Recursively compress a JSON value
     fn compress_value(&self, value: &Value, depth: usize) -> Value {
         // Check depth limit
@@ -187,12 +225,17 @@ impl ResponseCompressor {
             // the plain lossy depth marker.
             if let Some(store) = self.stash_store.as_ref()
                 && let Ok(serialized) = serde_json::to_string(value)
-                && let Ok(key) = store.stash(&serialized)
             {
-                return Value::String(format!(
-                    "<{type_name} truncated at depth {depth}, retrieve with {}>",
-                    marker_for(&key)
-                ));
+                match store.stash(&serialized) {
+                    Ok(key) => {
+                        self.record_stash_success(key.clone());
+                        return Value::String(format!(
+                            "<{type_name} truncated at depth {depth}, retrieve with {}>",
+                            marker_for(&key)
+                        ));
+                    }
+                    Err(_) => self.record_stash_error(),
+                }
             }
             return Value::String(format!("<{type_name} truncated at depth {depth}>"));
         }
@@ -241,15 +284,20 @@ impl ResponseCompressor {
         if self.add_truncation_marker
             && self.truncate_strings_at > stash_suffix_char_len()
             && let Some(store) = self.stash_store.as_ref()
-            && let Ok(key) = store.stash(s)
         {
-            let target = self.truncate_strings_at - stash_suffix_char_len();
-            let truncate_pos = s
-                .char_indices()
-                .nth(target)
-                .map(|(i, _)| i)
-                .unwrap_or(s.len());
-            return Value::String(format!("{}{}", &s[..truncate_pos], stash_suffix(&key)));
+            match store.stash(s) {
+                Ok(key) => {
+                    self.record_stash_success(key.clone());
+                    let target = self.truncate_strings_at - stash_suffix_char_len();
+                    let truncate_pos = s
+                        .char_indices()
+                        .nth(target)
+                        .map(|(i, _)| i)
+                        .unwrap_or(s.len());
+                    return Value::String(format!("{}{}", &s[..truncate_pos], stash_suffix(&key)));
+                }
+                Err(_) => self.record_stash_error(),
+            }
         }
 
         // Lossy path: existing behavior. Only attach the marker when the
@@ -346,13 +394,13 @@ impl ResponseCompressor {
         }
         let key = match stash.stash(&payload) {
             Ok(k) => {
-                self.stash_writes.set(self.stash_writes.get() + 1);
+                self.record_stash_success(k.clone());
                 k
             }
             Err(_) => {
                 // Surface the backend failure via the counter so the CLI can
                 // log it; degrade to the lossy marker for this entry.
-                self.stash_errors.set(self.stash_errors.get() + 1);
+                self.record_stash_error();
                 return None;
             }
         };

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -288,7 +288,7 @@ impl SchemaCompressor {
         let stash_key = if stash_active {
             self.stash_store
                 .as_ref()
-                .and_then(|store| store.stash(desc).ok())
+                .and_then(|store| store.stash(desc).ok().map(|(k, _)| k))
         } else {
             None
         };

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use serde_json::Value;
+use std::cell::{Cell, RefCell};
 use std::sync::{Arc, LazyLock};
 use tokenless_ccr::StashStore;
 
@@ -31,6 +32,16 @@ pub struct SchemaCompressor {
     /// full original. When `None`, truncation is lossy — the pre-stash
     /// behavior. Mirrors `ResponseCompressor::stash_store`.
     stash_store: Option<Arc<dyn StashStore>>,
+    /// Number of stash writes performed since construction (or last rollback
+    /// that cleared them). CLI `compress-schema --batch` calls `compress()`
+    /// once per item, so these counters accumulate across the invocation.
+    stash_writes: Cell<usize>,
+    /// Number of stash writes / rollback deletes that failed. Same session
+    /// accumulator as `stash_writes`.
+    stash_errors: Cell<usize>,
+    /// Keys created during this compressor session. Not reset at each
+    /// `compress()` so CLI `--batch` can roll back every discarded item.
+    stash_keys_created: RefCell<Vec<String>>,
 }
 
 impl Default for SchemaCompressor {
@@ -51,6 +62,9 @@ impl Default for SchemaCompressor {
             // ~1024-frame default stack while leaving real schemas intact.
             max_depth: 32,
             stash_store: None,
+            stash_writes: Cell::new(0),
+            stash_errors: Cell::new(0),
+            stash_keys_created: RefCell::new(Vec::new()),
         }
     }
 }
@@ -104,6 +118,57 @@ impl SchemaCompressor {
     pub fn with_max_depth(mut self, depth: usize) -> Self {
         self.max_depth = depth;
         self
+    }
+
+    /// Number of stash writes performed during this compressor session.
+    pub fn stash_writes(&self) -> usize {
+        self.stash_writes.get()
+    }
+
+    /// Number of stash writes / rollback deletes that failed this session.
+    pub fn stash_errors(&self) -> usize {
+        self.stash_errors.get()
+    }
+
+    /// Delete stash entries created during this compressor session.
+    ///
+    /// Call this when the compressed output (and its embedded markers) will
+    /// never be emitted — e.g. the CLI no-savings path that falls back to the
+    /// original input, including `compress-schema --batch`. Returns how many
+    /// keys were successfully removed.
+    pub fn rollback_stash_writes(&self) -> usize {
+        let Some(store) = self.stash_store.as_ref() else {
+            return 0;
+        };
+        let keys = std::mem::take(&mut *self.stash_keys_created.borrow_mut());
+        let mut removed = 0usize;
+        for key in &keys {
+            match store.delete(key) {
+                Ok(true) => removed += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    self.record_stash_error();
+                    eprintln!(
+                        "[tokenless] stash: rollback delete failed for key {}: {e}",
+                        key
+                    );
+                }
+            }
+        }
+        self.stash_writes
+            .set(self.stash_writes.get().saturating_sub(removed));
+        removed
+    }
+
+    fn record_stash_success(&self, key: String, created: bool) {
+        self.stash_writes.set(self.stash_writes.get() + 1);
+        if created {
+            self.stash_keys_created.borrow_mut().push(key);
+        }
+    }
+
+    fn record_stash_error(&self) {
+        self.stash_errors.set(self.stash_errors.get() + 1);
     }
 
     /// Compress an OpenAI Function Calling schema
@@ -286,9 +351,19 @@ impl SchemaCompressor {
         // ResponseCompressor's "retrieval yields the original content
         // verbatim" contract.
         let stash_key = if stash_active {
-            self.stash_store
-                .as_ref()
-                .and_then(|store| store.stash(desc).ok().map(|(k, _)| k))
+            match self.stash_store.as_ref() {
+                Some(store) => match store.stash(desc) {
+                    Ok((k, created)) => {
+                        self.record_stash_success(k.clone(), created);
+                        Some(k)
+                    }
+                    Err(_) => {
+                        self.record_stash_error();
+                        None
+                    }
+                },
+                None => None,
+            }
         } else {
             None
         };

--- a/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
@@ -348,6 +348,36 @@ fn test_rollback_stash_writes_removes_created_entries() {
 }
 
 #[test]
+fn test_rollback_preserves_preexisting_same_payload_entry() {
+    // Codex P1: idempotent re-stash of an already-emitted payload must not
+    // put that key on the rollback list — discarding a later no-savings
+    // compress must not make earlier markers unretrievable.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let arr = json!([1, 2, 3, 4, 5]);
+    let first = compressor.compress(&arr);
+    let marker = first.as_array().unwrap().last().unwrap().as_str().unwrap();
+    let hash = extract_hash(marker).expect("marker");
+    assert!(store.retrieve(hash).unwrap().is_some());
+
+    // Second compress refreshes the same content-addressed key.
+    let _ = compressor.compress(&arr);
+    assert_eq!(store.len(), 1);
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 0, "refresh must not be treated as created");
+    assert_eq!(
+        store.retrieve(hash).unwrap().as_deref(),
+        Some(r#"[3,4,5]"#),
+        "pre-existing emitted marker must remain retrievable after rollback"
+    );
+}
+
+#[test]
 fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
     // A stash that always errors must not break compression: the marker
     // degrades to the plain lossy form.
@@ -356,7 +386,7 @@ fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
 
     struct AlwaysFail;
     impl StashStore for AlwaysFail {
-        fn stash(&self, _payload: &str) -> Result<String, StashError> {
+        fn stash(&self, _payload: &str) -> Result<(String, bool), StashError> {
             Err(StashError::Backend("simulated".to_string()))
         }
         fn retrieve(&self, _hash: &str) -> Result<Option<String>, StashError> {

--- a/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
@@ -326,6 +326,28 @@ fn test_stash_writes_counter_resets_per_compress() {
 }
 
 #[test]
+fn test_rollback_stash_writes_removes_created_entries() {
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(2)
+        .with_stash_store(store.clone());
+    let arr: Vec<i32> = (1..=5).collect();
+    let _ = compressor.compress(&json!(arr));
+    assert_eq!(compressor.stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+    // Second rollback is a no-op.
+    assert_eq!(compressor.rollback_stash_writes(), 0);
+}
+
+#[test]
 fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
     // A stash that always errors must not break compression: the marker
     // degrades to the plain lossy form.
@@ -345,6 +367,9 @@ fn test_array_truncation_with_failing_stash_falls_back_to_lossy() {
         }
         fn evict_expired(&self) -> Result<usize, StashError> {
             Ok(0)
+        }
+        fn delete(&self, _hash: &str) -> Result<bool, StashError> {
+            Ok(false)
         }
     }
 

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -549,3 +549,90 @@ fn test_compress_parameters_with_nested_schema() {
         .unwrap();
     assert!(nested_desc.chars().count() <= 160);
 }
+
+#[test]
+fn test_rollback_stash_writes_removes_created_entries() {
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let schema = json!({
+        "function": {
+            "name": "test",
+            "description": "A".repeat(300),
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let _ = compressor.compress(&schema);
+    assert_eq!(compressor.stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 1);
+    assert_eq!(store.len(), 0);
+    assert_eq!(compressor.stash_writes(), 0);
+    assert_eq!(compressor.rollback_stash_writes(), 0);
+}
+
+#[test]
+fn test_rollback_preserves_preexisting_same_payload_entry() {
+    // Refreshing an already-emitted description must not put that key on the
+    // rollback list — discarding a later no-savings compress must not make
+    // earlier markers unretrievable.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore};
+
+    let store = Arc::new(InMemoryStore::new());
+    let long_desc = "A".repeat(300);
+    let (hash, created) = store.stash(&long_desc).unwrap();
+    assert!(created);
+
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    let schema = json!({
+        "function": {
+            "name": "test",
+            "description": long_desc,
+            "parameters": {"type": "object", "properties": {}}
+        }
+    });
+    let _ = compressor.compress(&schema);
+    assert_eq!(store.len(), 1);
+    let removed = compressor.rollback_stash_writes();
+    assert_eq!(removed, 0, "refresh must not be treated as created");
+    assert_eq!(
+        store.retrieve(&hash).unwrap().as_deref(),
+        Some(long_desc.as_str()),
+        "pre-existing emitted marker must remain retrievable after rollback"
+    );
+}
+
+#[test]
+fn test_batch_rollback_removes_keys_from_every_item() {
+    // CLI --batch calls compress() once per item then discards the whole
+    // batch on no-savings. Keys must accumulate across compress() calls.
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+    for i in 0..3 {
+        let schema = json!({
+            "function": {
+                "name": format!("f{i}"),
+                "description": format!("DESC{i}_{}", "A".repeat(300)),
+                "parameters": {"type": "object", "properties": {}}
+            }
+        });
+        let _ = compressor.compress(&schema);
+    }
+    assert_eq!(store.len(), 3);
+    assert_eq!(compressor.rollback_stash_writes(), 3);
+    assert_eq!(store.len(), 0);
+}


### PR DESCRIPTION
## Why

Forrest 在 #2480 的非阻塞建议：`compress-schema` 有与 `compress-response` 相同的无节省孤儿 stash；`StashStore::delete` 应对 live 行返回 `Ok(true)`、对过期行返回 `Ok(false)`。#2480 只覆盖 response 路径与 stderr 文案。

Depends on #2480（需要 `delete` / `(key, created)`）。#2480 合入后请 rebase 本分支，去掉前序 commit。

## What changed

- `InMemoryStore::delete` / `SqliteStore::delete` 只删除 live 行；过期或缺失返回 `Ok(false)`。
- `SchemaCompressor` 跟踪本次新建 stash key，提供 `rollback_stash_writes()`（含 `--batch` 跨 `compress()` 累积）。
- CLI `compress-schema` 无节省回退时 rollback；stash 计数在 rollback 之后读取；stderr 与 #2480 相同（`stash operation(s) failed`）。
- 单测覆盖 live-only delete、schema rollback / 预存 payload / batch；集成测试断言 schema no-savings 后 `stash.db` 无孤儿行。

## Related issue

fixes #2488

Depends on #2480

## User / Agent impact

`compress-schema` 无节省回退不再留下不可达 stash 行。`delete` 与 `retrieve` 的 live 语义对齐，rollback 计数不再把过期行当成一次成功删除。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`StashStore::delete` 对过期 key 的返回值从 `Ok(true)` 改为 `Ok(false)`，与已文档化契约对齐。CLI 无节省路径从「TTL 清理孤儿」改为立即 rollback。MCP 路径未改。

## Validation

```bash
cd src/tokenless
cargo fmt --all --check
cargo clippy --workspace --locked -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test -p tokenless-cli --locked --test cli_integration \
  compress_schema_no_savings_rolls_back_orphan_stash
```

## Documentation and rollback

无需文档变更。回滚本 PR 即恢复 schema 无节省孤儿，以及 `delete` 对过期行返回 `Ok(true)` 的旧行为。
