### PR TITLE
chore(tokenless): bump version to 0.7.6

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.5"
+version = "0.7.6"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,21 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-08-13
+
+### Changed
+
+- `TOKENLESS_DATA_DIR` now accepts absolute non-root directories outside the real user home, while invalid explicit directories disable SQLite state instead of silently falling back to home ([#2434](https://github.com/alibaba/anolisa/pull/2434)).
+- Tool Ready pre-call checks, repairs, and blocking are now hard-disabled across adapters so incorrect readiness results cannot block valid work; post-tool failure attribution and other Tokenless features remain active ([#2487](https://github.com/alibaba/anolisa/pull/2487)).
+
+### Fixed
+
+- Direct JSON Schema descriptions are now stashed once, so one retrieval returns the original content without a nested marker ([#2399](https://github.com/alibaba/anolisa/pull/2399)).
+- Dry-run compression settings from `config.json` now remain effective when statistics and SLS toggles are set through environment variables ([#2380](https://github.com/alibaba/anolisa/pull/2380)).
+- `tokenless retrieve` now writes stored payloads byte-for-byte without appending a trailing newline ([#2396](https://github.com/alibaba/anolisa/pull/2396)).
+- Stash retrieval now scans past malformed markers to find a later valid key and stays linear on adversarial input ([#2386](https://github.com/alibaba/anolisa/pull/2386)).
+- RPM installations now include the shared Codex lifecycle helper required by the adapter install script ([#2425](https://github.com/alibaba/anolisa/pull/2425)).
+
 ## [0.7.5] - 2026-08-10
 
 ### Added
@@ -234,7 +249,7 @@ Releases from 0.7.2 onward follow
 
 - introduce tokenless into ANOLISA (#199)
 
-[Unreleased]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.5...HEAD
+[0.7.6]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.5...tokenless/v0.7.6
 [0.7.5]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.4...tokenless/v0.7.5
 [0.7.4]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.3...tokenless/v0.7.4
 [0.7.3]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.2...tokenless/v0.7.3

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,21 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.6] - 2026-08-13
+
+### 变更
+
+- `TOKENLESS_DATA_DIR` 现在接受真实用户 home 之外的绝对非根目录；显式目录无效时会停用 SQLite 状态，不再静默回退到 home（[#2434](https://github.com/alibaba/anolisa/pull/2434)）。
+- 所有 Adapter 的 Tool Ready 调用前检查、修复和阻断现已硬关闭，避免错误的就绪结果阻止有效工作；工具执行后的失败归因和其他 Tokenless 功能保持启用（[#2487](https://github.com/alibaba/anolisa/pull/2487)）。
+
+### 修复
+
+- 直接 JSON Schema 的 Description 现在只会 Stash 一次，因此一次 Retrieve 即可返回不含嵌套 Marker 的原始内容（[#2399](https://github.com/alibaba/anolisa/pull/2399)）。
+- 通过环境变量设置 Stats 与 SLS 开关时，`config.json` 中的 Dry-run 压缩配置现在仍会生效（[#2380](https://github.com/alibaba/anolisa/pull/2380)）。
+- `tokenless retrieve` 现在会逐字节写出已存储的 Payload，不再追加换行符（[#2396](https://github.com/alibaba/anolisa/pull/2396)）。
+- Stash Retrieve 现在会跳过格式错误的 Marker 以查找后续有效 Key，并在对抗性输入下保持线性扫描（[#2386](https://github.com/alibaba/anolisa/pull/2386)）。
+- RPM 安装现在包含 Codex Adapter 安装脚本所需的共享生命周期 Helper（[#2425](https://github.com/alibaba/anolisa/pull/2425)）。
+
 ## [0.7.5] - 2026-08-10
 
 ### 新增
@@ -233,7 +248,7 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 - 将 Tokenless 引入 ANOLISA（#199）
 
-[未发布]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.5...HEAD
+[0.7.6]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.5...tokenless/v0.7.6
 [0.7.5]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.4...tokenless/v0.7.5
 [0.7.4]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.3...tokenless/v0.7.4
 [0.7.3]: https://github.com/alibaba/anolisa/compare/tokenless/v0.7.2...tokenless/v0.7.3

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "chrono",
  "clap",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "regex",
  "serde_json",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 license = "MIT"
 

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -45,9 +45,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.5",
-    "@anolisa/tokenless-linux-arm64": "0.7.5",
-    "@anolisa/tokenless-darwin-x64": "0.7.5",
-    "@anolisa/tokenless-darwin-arm64": "0.7.5"
+    "@anolisa/tokenless-linux-x64": "0.7.6",
+    "@anolisa/tokenless-linux-arm64": "0.7.6",
+    "@anolisa/tokenless-darwin-x64": "0.7.6",
+    "@anolisa/tokenless-darwin-arm64": "0.7.6"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -473,6 +473,15 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu Aug 13 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.6-1
+- feat(tokenless): add reproducible raw and prebuilt npm packaging
+- fix(tokenless): allow trusted external data directories without unsafe fallback
+- fix(tokenless): keep schema stash and CLI retrieval lossless in one round trip
+- fix(tokenless): honor dry-run config with stats and SLS environment overrides
+- fix(tokenless): scan past malformed stash markers in linear time
+- fix(tokenless): hard-disable Tool Ready pre-call gates
+- fix(tokenless): ship the Codex lifecycle helper in RPM payloads
+
 * Mon Aug 10 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.5-1
 - feat(tokenless): add an OpenCode adapter with shared compression hooks
 - fix(tokenless): support native Qoder plugins and in-place compressed output


### PR DESCRIPTION
## Why

Tokenless has accumulated component-owned raw packaging and user-visible correctness fixes since
0.7.5. This release publishes the verified `tokenless/v0.7.5..main` boundary as 0.7.6 without
adding new runtime behavior in the bump itself.

## What changed

- synchronized the Cargo workspace and benchmark locks, npm root/platform manifests, and ANOLISA
  component catalog at 0.7.6
- curated semantically equivalent English and Chinese changelogs from the final code and tests,
  excluding superseded unreleased Tool Ready behavior
- added the 0.7.6 RPM changelog boundary

## Related issue

no-issue: routine component release; the changelog links each included merged PR

## User / Agent impact

Release metadata now advertises Tokenless 0.7.6. The notes cover reproducible raw/prebuilt
packaging, external data-directory semantics, the Tool Ready hard bypass, lossless Stash
retrieval, dry-run configuration, malformed-marker recovery, and the RPM Codex helper.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: the bump changes release metadata and documentation only. The ANOLISA component catalog
version changes in lockstep with all package surfaces; no schema, minimum-version, or layout
contract changes.

## Validation

Environment: Linux x86_64; Rust/Cargo 1.97.1; Node.js 24.15.0; npm 11.12.1.

- `check_release.py --component tokenless --scope tokenless --version 0.7.6 --previous 0.7.5 --bump-commit dbc05387` (working tree and committed `--revision HEAD`)
- `cargo fmt --all -- --check`
- `git diff --check` and `git diff --cached --check`
- static TOML/npm JSON parsing and cross-surface 0.7.6 consistency assertions
- version-stamped `rpmspec -P`

Local build, test, and package assembly were skipped at the requester's direction. Before that
override, one `make build` attempt stopped on an RTK clone `early EOF`; its retry was interrupted
when local builds were excluded, so no build result is claimed.

## Documentation and rollback

Updated the paired component changelogs and RPM changelog. Roll back by reverting
`190ca2d6fbf34ec31b41113900a3818af09fd3da`; no data migration or runtime toggle is involved.