### PR TITLE
fix(tokenless): rollback orphan stash entries on no-savings fallback

### DIFF
--- a/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/in_memory.rs
@@ -137,6 +137,17 @@ impl StashStore for InMemoryStore {
             .count()
     }
 
+    fn delete(&self, hash: &str) -> Result<(), StashError> {
+        let key = hash.to_ascii_lowercase();
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| StashError::Backend(format!("in_memory mutex poisoned: {e}")))?;
+        inner.map.remove(&key);
+        inner.order.retain(|k| k != &key);
+        Ok(())
+    }
+
     fn evict_expired(&self) -> Result<usize, StashError> {
         let mut inner = self
             .inner

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -189,6 +189,13 @@ impl StashStore for SqliteStore {
         .unwrap_or(0) as usize
     }
 
+    fn delete(&self, hash: &str) -> Result<(), StashError> {
+        let key = hash.to_ascii_lowercase();
+        let conn = self.lock_conn();
+        conn.execute("DELETE FROM stash WHERE hash = ?", [key])?;
+        Ok(())
+    }
+
     fn evict_expired(&self) -> Result<usize, StashError> {
         let now = now_unix();
         let conn = self.lock_conn();

--- a/src/tokenless/crates/tokenless-ccr/src/store.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/store.rs
@@ -29,6 +29,12 @@ pub trait StashStore: Send + Sync {
 
     /// Drop all expired entries and return how many were removed.
     fn evict_expired(&self) -> Result<usize, StashError>;
+
+    /// Delete a live entry by key. Used to roll back stash writes that were
+    /// only made to produce a compressed output that is later discarded (for
+    /// example, when the compressed form does not actually reduce token count).
+    /// Backends may treat a missing or already-expired key as a success.
+    fn delete(&self, hash: &str) -> Result<(), StashError>;
 }
 
 /// Errors a stash backend can surface. Kept minimal: backends map their

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -632,6 +632,12 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     result.before_tokens, result.after_tokens
                 );
             }
+            // The runtime rolls back stash entries whose markers were
+            // discarded with the compressed output; surface cleanup failures
+            // so orphaned rows don't accumulate silently.
+            if let Some(Err(summary)) = result.stash_rollback.as_ref() {
+                eprintln!("[tokenless] failed to roll back stash entries: {}", summary);
+            }
 
             let mode = resolve_mode(compression_on, result.before_tokens, result.after_tokens);
             let output_text = if result.disposition == CompressionDisposition::NoSavings {

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 
+use tokenless_ccr::{SqliteStore, StashStore};
 use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, estimate_tokens, get_home_dir};
 
 use tokenless_runtime::{CompressOptions, compress_response_with_store};
@@ -508,6 +509,51 @@ fn compress_response_no_stash() {
         })
         .unwrap();
     assert!(output.status.success());
+}
+
+#[test]
+fn compress_response_rollback_orphan_stash_on_no_savings() {
+    let fixture = match TempDataDir::new() {
+        Some(f) => f,
+        None => return,
+    };
+
+    let output = fixture
+        .command()
+        .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+        .env("TOKENLESS_STATS_ENABLED", "0")
+        .env("TOKENLESS_SLS_ENABLED", "0")
+        .args(["compress-response", "--truncate-arrays-at", "1"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(b"[\"a\",\"b\"]")?;
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "[\"a\",\"b\"]\n",
+        "stdout must be the original input when compression does not save tokens"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("outputting original"),
+        "stderr must report no-savings fallback"
+    );
+
+    let stash_db = fixture.data_dir.join("stash.db");
+    let store = SqliteStore::new(&stash_db).unwrap();
+    assert_eq!(
+        store.len(),
+        0,
+        "no-savings fallback must roll back stash writes so the DB has no orphan entries"
+    );
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -139,7 +139,15 @@ pub struct CompressResult {
     /// store was attached.
     pub unrecoverable_truncations: Option<usize>,
     /// Live stash entry count after compression, or `None` without a store.
+    /// Reflects the post-rollback state when the compressed output was
+    /// discarded.
     pub stash_size: Option<usize>,
+    /// Outcome of rolling back stash entries when the compressed output was
+    /// discarded (no savings or reversibility unavailable). `None` when the
+    /// output was applied or no store was attached; `Some(Ok(removed))` when
+    /// cleanup succeeded; `Some(Err(summary))` when at least one delete
+    /// failed and orphan rows may remain until TTL eviction.
+    pub stash_rollback: Option<Result<usize, String>>,
 }
 
 impl CompressResult {
@@ -426,7 +434,6 @@ pub fn compress_response_with_store(
     let stash_writes = attached_store.map(|_| compressor.stash_writes());
     let stash_errors = attached_store.map(|_| compressor.stash_errors());
     let unrecoverable_truncations = attached_store.map(|_| compressor.unrecoverable_truncations());
-    let stash_size = attached_store.map(|store| store.len());
 
     let disposition = if after_tokens >= before_tokens {
         CompressionDisposition::NoSavings
@@ -440,6 +447,20 @@ pub fn compress_response_with_store(
     } else {
         CompressionDisposition::Applied
     };
+    // Roll back stash entries whose markers are about to be discarded: every
+    // disposition other than `Applied` emits the original input, so entries
+    // written during compression would become unretrievable orphans. DryRun
+    // never attaches a store, so this fires for NoSavings and
+    // ReversibilityUnavailable only.
+    let stash_rollback =
+        if attached_store.is_some() && disposition != CompressionDisposition::Applied {
+            Some(compressor.rollback_stash())
+        } else {
+            None
+        };
+    // Count live entries after rollback so stats reflect the net effect.
+    let stash_size = attached_store.map(|store| store.len());
+
     let output = if disposition == CompressionDisposition::Applied {
         compressed_output.clone()
     } else {
@@ -456,6 +477,7 @@ pub fn compress_response_with_store(
         stash_errors,
         unrecoverable_truncations,
         stash_size,
+        stash_rollback,
     })
 }
 
@@ -517,6 +539,10 @@ mod tests {
 
         fn evict_expired(&self) -> Result<usize, StashError> {
             Ok(0)
+        }
+
+        fn delete(&self, _hash: &str) -> Result<(), StashError> {
+            Ok(())
         }
     }
 
@@ -700,6 +726,26 @@ mod tests {
             compress_response_with_store(input, &CompressOptions::default(), true, None).unwrap();
         assert_eq!(result.disposition, CompressionDisposition::NoSavings);
         assert_eq!(result.output, input);
+    }
+
+    #[test]
+    fn no_savings_rolls_back_orphan_stash_entries() {
+        let store = std::sync::Arc::new(InMemoryStore::new());
+        // Truncating this tiny array writes one stash entry but cannot reduce
+        // the token count, so the output is discarded and the entry must be
+        // rolled back instead of orphaned.
+        let input = r#"["a","b"]"#;
+        let options = CompressOptions {
+            truncate_arrays_at: Some(1),
+            ..CompressOptions::default()
+        };
+        let store_ref: std::sync::Arc<dyn StashStore> = store.clone();
+        let result = compress_response_with_store(input, &options, true, Some(&store_ref)).unwrap();
+        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.output, input);
+        assert_eq!(result.stash_writes, Some(1));
+        assert_eq!(result.stash_rollback, Some(Ok(1)));
+        assert_eq!(store.len(), 0, "orphan stash entries must be rolled back");
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -1,5 +1,5 @@
 use serde_json::{Map, Value};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokenless_ccr::{StashStore, marker_for};
@@ -45,6 +45,10 @@ pub struct ResponseCompressor {
     /// can surface persistent backend failures instead of silently degrading
     /// to the lossy marker.
     stash_errors: Cell<usize>,
+    /// Keys written during the last `compress()` call. Tracked so callers can
+    /// roll back stash entries when the compressed output is discarded (e.g.
+    /// no token savings).
+    stash_keys: RefCell<Vec<String>>,
     /// Number of truncations that could not embed a retrievable marker during
     /// the last `compress()` call. Includes backend failures and marker-budget
     /// limits without conflating the two causes.
@@ -80,6 +84,7 @@ impl Default for ResponseCompressor {
             stash_store: None,
             stash_writes: Cell::new(0),
             stash_errors: Cell::new(0),
+            stash_keys: RefCell::new(Vec::new()),
             unrecoverable_truncations: Cell::new(0),
         }
     }
@@ -150,6 +155,7 @@ impl ResponseCompressor {
         self.stash_writes.set(0);
         self.stash_errors.set(0);
         self.unrecoverable_truncations.set(0);
+        self.stash_keys.borrow_mut().clear();
         let original_text = serde_json::to_string(response).unwrap_or_default();
         let result = self.compress_value(response, 0);
 
@@ -173,6 +179,39 @@ impl ResponseCompressor {
     /// I/O) — the caller should log it so the failure isn't invisible.
     pub fn stash_errors(&self) -> usize {
         self.stash_errors.get()
+    }
+
+    /// Delete all stash entries written during the last `compress()` call.
+    /// Returns `Ok(removed)` on full success, or `Err` with a summary of the
+    /// per-key failures (the loop still attempts every delete before returning).
+    /// The caller is responsible for logging the error — the library does not
+    /// print to stderr directly, so all stash-related diagnostics flow through
+    /// the CLI layer with a consistent prefix.
+    pub fn rollback_stash(&self) -> Result<usize, String> {
+        let store = match self.stash_store.as_ref() {
+            Some(s) => s.clone(),
+            None => return Ok(0),
+        };
+        let keys: Vec<String> = self.stash_keys.borrow().clone();
+        let mut removed = 0usize;
+        let mut errors: Vec<String> = Vec::new();
+        for key in &keys {
+            match store.delete(key) {
+                Ok(()) => removed += 1,
+                Err(e) => errors.push(format!("{key}: {e}")),
+            }
+        }
+        self.stash_keys.borrow_mut().clear();
+        if errors.is_empty() {
+            Ok(removed)
+        } else {
+            Err(format!(
+                "{} of {} key(s) failed: {}",
+                errors.len(),
+                keys.len(),
+                errors.join("; ")
+            ))
+        }
     }
 
     /// Number of truncations that lacked a retrievable marker despite an
@@ -372,6 +411,7 @@ impl ResponseCompressor {
         match stash.stash(payload) {
             Ok(k) => {
                 self.stash_writes.set(self.stash_writes.get() + 1);
+                self.stash_keys.borrow_mut().push(k.clone());
                 Some(k)
             }
             Err(_) => {

--- a/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
@@ -20,6 +20,10 @@ impl StashStore for AlwaysFail {
     fn evict_expired(&self) -> Result<usize, StashError> {
         Ok(0)
     }
+
+    fn delete(&self, _hash: &str) -> Result<(), StashError> {
+        Ok(())
+    }
 }
 
 #[test]
@@ -631,4 +635,30 @@ fn test_stash_dropped_empty_not_engaged() {
     let result = compressor.compress(&arr);
     assert_eq!(result.as_array().unwrap().len(), 3);
     assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn test_rollback_stash_removes_orphan_entries() {
+    // When the compressed output is discarded because it does not reduce token
+    // count, the stash entries written during compression must be rolled back.
+    use std::sync::Arc;
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_arrays_at(1)
+        .with_stash_store(store.clone());
+    let arr = json!(["a", "b"]);
+    compressor.compress(&arr);
+
+    // Truncation wrote one stash entry for the dropped tail.
+    assert_eq!(compressor.stash_writes(), 1);
+    assert_eq!(store.len(), 1);
+
+    let removed = compressor.rollback_stash().unwrap();
+    assert_eq!(removed, 1);
+    assert_eq!(store.len(), 0);
+
+    // A second rollback is idempotent: no store and no keys remain.
+    assert_eq!(compressor.rollback_stash().unwrap(), 0);
 }


### PR DESCRIPTION
## Summary

When `compress-response` discards its output because the estimated token count did not decrease, any stash entries written during truncation (e.g. array truncation with `--truncate-arrays-at`) become unretrievable orphans. This change tracks stash keys during compression, adds a `StashStore::delete` method, and rolls back those entries in the CLI's no-savings fallback path.

## Changes

- Added `StashStore::delete` trait method.
- Implemented `delete` for `InMemoryStore` and `SqliteStore` backends.
- `ResponseCompressor` now records every stash key it writes and exposes `rollback_stash()`.
- `tokenless-cli` calls `rollback_stash()` when `after_tokens >= before_tokens`.
- Added unit test in `response_compressor_tests.rs` and integration test in `cli_integration.rs`.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (all green)

Closes #5568