### PR TITLE
feat(sec-core): add SkillFS HMAC peer auth

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -286,12 +286,84 @@ from conflating them:
 | Socket | Listener | Default path | Purpose |
 |---|---|---|---|
 | daemon socket | agent-sec-core daemon | `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock` (override with `AGENT_SEC_DAEMON_SOCKET`) | SkillFS points `--notify-socket` here to send change notifications |
-| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock` | The daemon queries `skill.resolveLiveSource` back through it and writes activation metadata |
+| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock` (override on the Ledger side with `AGENT_SEC_SKILLFS_CONTROL_SOCKET`) | The daemon queries `skill.resolveLiveSource` back through it and writes activation metadata |
 
-Do **not** customize the control socket path. The Ledger resolver client only
-probes the default path above; no configuration key makes it follow a path given
-to `--control-socket`, and changing it makes Ledger silently fall back to host
-mode. SkillFS and the daemon must also run under the same effective UID.
+The resolver chooses the control endpoint in this order: an explicit
+`socket_path` supplied by an embedding caller, `AGENT_SEC_SKILLFS_CONTROL_SOCKET`,
+then the per-effective-UID default above. The selected path must match the
+SkillFS control socket. A complete ACS deployment should run SkillFS and the
+daemon with the same numeric UID so the default endpoint and key ownership
+checks agree across containers.
+
+#### HMAC-Authenticated Joint Deployment
+
+The HMAC integration is optional for legacy deployments but should be enabled
+in both directions for a complete ACS deployment:
+
+| Variable | Reader | Purpose |
+|---|---|---|
+| `AGENT_SEC_SKILLFS_CONTROL_SOCKET` | Ledger resolver | Select the SkillFS control socket |
+| `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` | Ledger resolver | Authenticate control requests and responses |
+| `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` | agent-sec-core daemon | Authenticate incoming SkillFS notifications |
+
+For example, provide these variables to the agent-sec-core daemon and any CLI
+process that resolves SkillFS paths, and configure SkillFS with the matching
+socket and key material:
+
+```bash
+export AGENT_SEC_SKILLFS_CONTROL_SOCKET="/run/user/$(id -u)/skillfs/control.sock"
+export AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE="/run/agent-sec-keys/skillfs-control.key"
+export AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE="/run/agent-sec-keys/skillfs-notify.key"
+
+skillfs mount /path/to/skills /mnt/skillfs \
+  --security --activation-mode file \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
+  --notify-auth-key-file "$AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE" \
+  --control-socket "$AGENT_SEC_SKILLFS_CONTROL_SOCKET" \
+  --trusted-peer-key-file "$AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE"
+```
+
+The control and notify variables may point to the same key file, but separate
+direction-specific keys are recommended. The control key is loaded on the first
+resolve and cached for that resolver client's lifetime; it is not hot-reloaded.
+The daemon loads the notify key before binding its socket, so an invalid notify
+key prevents daemon startup.
+
+Each key file must satisfy all of these checks:
+
+- the configured path is absolute;
+- the target is a regular file, not a symlink, directory, FIFO, or device;
+- the file owner is the reader's effective UID;
+- no group or other permission bits are set (mode `0600` is recommended);
+- the unmodified file content is between 32 and 4096 bytes.
+
+Control resolution deliberately distinguishes legacy availability from an
+authenticated deployment requirement:
+
+| Control key | Socket `ENOENT` | Other connection, authentication, or protocol failures |
+|---|---|---|
+| Not configured | Fall back to the canonical host path | Fail with `skill_root_resolve_failed` |
+| Configured | Fail with `skill_root_resolve_failed` | Fail with `skill_root_resolve_failed` |
+
+An authenticated `managed=false` response remains a trusted uncovered result
+and uses the canonical host path. After a control key is configured, Ledger
+never retries the request as plaintext.
+
+Notify handling follows the same downgrade boundary:
+
+| Notify key | Behavior |
+|---|---|
+| Not configured | Legacy plaintext notify remains available; an authentication handshake is rejected |
+| Configured | `skill_ledger.skillfs_notify_change` must use HMAC; plaintext notify is rejected, while other daemon methods keep their existing plaintext protocol |
+
+For containerized ACS deployments, share the two Unix socket directories and
+the required key material between the corresponding containers. Use the same
+numeric UID and ensure each mounted key is owned by that UID. Kubernetes Secret
+volumes use symlink-based projections, which the key loader intentionally
+rejects. Copy each Secret into a private shared volume such as `emptyDir`, set
+the owner and mode there, and point the environment variables at the resulting
+regular, non-symlink files. Do not point them directly at the projected Secret
+paths.
 
 Under the Hermes layout the activation flow carries nested identities
 (`category/skill`) rather than flat skill names, and `skillId` keeps both

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -275,11 +275,73 @@ payload 只有 `canonicalSkillDir`、`skillId`、`eventKind` 和 `paths` 四个�
 | Socket | 谁监听 | 默认路径 | 用途 |
 |---|---|---|---|
 | daemon socket | agent-sec-core daemon | `$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock`（`AGENT_SEC_DAEMON_SOCKET` 可覆盖） | SkillFS 用 `--notify-socket` 指向这里，发送变更通知 |
-| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock` | daemon 反向查询 `skill.resolveLiveSource`，并写 activation 元数据 |
+| control socket | SkillFS | `/run/user/<uid>/skillfs/control.sock`（Ledger 侧可用 `AGENT_SEC_SKILLFS_CONTROL_SOCKET` 覆盖） | daemon 反向查询 `skill.resolveLiveSource`，并写 activation 元数据 |
 
-control socket 的路径**不要自定义**。Ledger 的 resolver 客户端只探测上表中的默认路径，
-没有配置项可以让它跟随 `--control-socket` 指定的其他路径；改了之后 Ledger 会静默按
-host 模式处理。SkillFS 与 daemon 还必须运行在相同 effective UID 下。
+resolver 按以下顺序选择 control endpoint：embedding caller 显式传入的 `socket_path`、
+`AGENT_SEC_SKILLFS_CONTROL_SOCKET`、上表中的 per-effective-UID 默认路径。最终路径必须与
+SkillFS control socket 一致。完整 ACS 部署应让 SkillFS 与 daemon 使用相同 numeric UID，
+确保跨容器的默认 endpoint 和 key owner 校验一致。
+
+#### 使用 HMAC 的联合部署
+
+legacy 部署可不启用 HMAC；完整 ACS 部署应在两个方向同时启用：
+
+| 环境变量 | 读取方 | 用途 |
+|---|---|---|
+| `AGENT_SEC_SKILLFS_CONTROL_SOCKET` | Ledger resolver | 选择 SkillFS control socket |
+| `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` | Ledger resolver | 认证 control 请求与响应 |
+| `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` | agent-sec-core daemon | 认证收到的 SkillFS 通知 |
+
+例如，将以下环境变量提供给 agent-sec-core daemon 以及需要解析 SkillFS path 的 CLI
+进程，并在 SkillFS 侧配置匹配的 socket 与 key 内容：
+
+```bash
+export AGENT_SEC_SKILLFS_CONTROL_SOCKET="/run/user/$(id -u)/skillfs/control.sock"
+export AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE="/run/agent-sec-keys/skillfs-control.key"
+export AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE="/run/agent-sec-keys/skillfs-notify.key"
+
+skillfs mount /path/to/skills /mnt/skillfs \
+  --security --activation-mode file \
+  --notify-socket "$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock" \
+  --notify-auth-key-file "$AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE" \
+  --control-socket "$AGENT_SEC_SKILLFS_CONTROL_SOCKET" \
+  --trusted-peer-key-file "$AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE"
+```
+
+control 与 notify 环境变量可以指向同一个 key 文件，但推荐为两个方向使用独立 key。
+control key 在第一次 resolve 时加载，并缓存到该 resolver client 生命周期结束；不支持
+热更新。daemon 在 bind socket 前加载 notify key，因此非法 notify key 会阻止 daemon 启动。
+
+每个 key 文件都必须通过以下校验：
+
+- 配置路径是绝对路径；
+- 目标是普通文件，而不是 symlink、目录、FIFO 或 device；
+- 文件 owner 是读取进程的 effective UID；
+- 不设置任何 group/other 权限位（推荐 mode `0600`）；
+- 未经修改的文件内容长度为 32–4096 bytes。
+
+control resolver 会明确区分 legacy 可用性回退和已认证部署要求：
+
+| Control key | Socket `ENOENT` | 其他连接、认证或协议错误 |
+|---|---|---|
+| 未配置 | 回退到 canonical host path | 返回 `skill_root_resolve_failed` |
+| 已配置 | 返回 `skill_root_resolve_failed` | 返回 `skill_root_resolve_failed` |
+
+通过认证的 `managed=false` 仍是可信的未覆盖结果，会使用 canonical host path。配置 control
+key 后，Ledger 不会再以明文重试请求。
+
+notify 处理遵循相同的防降级边界：
+
+| Notify key | 行为 |
+|---|---|
+| 未配置 | 保留 legacy 明文 notify；收到认证握手时拒绝 |
+| 已配置 | `skill_ledger.skillfs_notify_change` 必须使用 HMAC；拒绝明文 notify，daemon 其他 method 继续使用现有明文协议 |
+
+容器化 ACS 部署需要在对应容器间共享两个 Unix socket 目录和所需 key 内容。各进程使用
+相同 numeric UID，并确保挂载后的 key 由该 UID 所有。Kubernetes Secret volume 使用基于
+symlink 的 projection，key loader 会有意拒绝这种路径。应将各 Secret 复制到 `emptyDir`
+等私有共享卷，在那里设置 owner 和 mode，再让环境变量指向生成的普通非 symlink 文件；
+不要直接指向 projected Secret 路径。
 
 Hermes 布局下 activation 流程携带的是嵌套身份（`category/skill`），而非扁平 skill 名；
 `skillId` 会保留两个分量。

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -365,6 +365,29 @@ agent-sec-cli skill-ledger scan /path/to/skill
 agent-sec-cli skill-ledger status
 ```
 
+### SkillFS Peer Authentication
+
+Skill Ledger can authenticate both directions of its SkillFS integration with
+HMAC-SHA256. The agent-sec-core side uses these environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `AGENT_SEC_SKILLFS_CONTROL_SOCKET` | Override the SkillFS control socket queried by the Ledger resolver |
+| `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` | Authenticate resolver requests and responses on the control socket |
+| `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` | Authenticate SkillFS change notifications received by the daemon |
+
+Without a control authentication key, a missing control socket (`ENOENT`) keeps
+the legacy host-path fallback. Once a control key is configured, a missing
+socket, connection failure, or authentication failure is fail-closed and never
+falls back to the host path or plaintext. Configuring the notify key similarly
+requires HMAC for `skill_ledger.skillfs_notify_change`; other daemon methods
+remain compatible with their existing plaintext protocol.
+
+Authentication key paths must be absolute and refer to regular, non-symlink
+files owned by the effective user, with no group or other permission bits. The
+raw key file must contain 32–4096 bytes. See the Skill Ledger user guide for the
+full two-key deployment and container volume requirements.
+
 The bundled Qoder CLI plugin registers a `PreToolUse` hook for the `Skill`
 tool. It resolves user Skills from `~/.qoder/skills/` before project Skills
 from `<cwd>/.qoder/skills/`, runs a read-only `skill-ledger check`, and applies the

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -360,6 +360,26 @@ agent-sec-cli skill-ledger scan /path/to/skill
 agent-sec-cli skill-ledger status
 ```
 
+### SkillFS 对等认证
+
+Skill Ledger 可使用 HMAC-SHA256 认证 SkillFS 集成的两个通信方向。agent-sec-core
+侧使用以下环境变量：
+
+| 环境变量 | 用途 |
+|----------|------|
+| `AGENT_SEC_SKILLFS_CONTROL_SOCKET` | 覆盖 Ledger resolver 查询的 SkillFS control socket |
+| `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` | 认证 control socket 上的 resolver 请求与响应 |
+| `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` | 认证 daemon 接收的 SkillFS 变更通知 |
+
+未配置 control 认证 key 时，control socket 不存在（`ENOENT`）仍保留 legacy host path
+回退。配置 control key 后，socket 缺失、连接失败或认证失败都会 fail-closed，不会回退到
+host path 或明文协议。配置 notify key 后，`skill_ledger.skillfs_notify_change` 同样必须使用
+HMAC；daemon 的其他 method 继续兼容现有明文协议。
+
+认证 key 路径必须是绝对路径，并指向 effective user 所有的普通非 symlink 文件，且不得
+设置任何 group/other 权限位。key 文件原始长度必须为 32–4096 bytes。完整的双 key 部署和
+容器卷要求见 Skill Ledger 用户手册。
+
 内置 Qoder CLI plugin 为 `Skill` tool 注册 `PreToolUse` hook。hook 先从
 `~/.qoder/skills/` 解析用户级 Skill，再从 `<cwd>/.qoder/skills/` 解析项目级
 Skill，随后执行只读的 `skill-ledger check`，并按

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/server.py
@@ -21,6 +21,7 @@ from agent_sec_cli.daemon.errors import (
     DaemonRuntimePathError,
     DaemonTimeoutError,
     InternalDaemonError,
+    PayloadTooLargeError,
     ResponseTooLargeError,
     ShutdownError,
 )
@@ -36,6 +37,7 @@ from agent_sec_cli.daemon.handlers.security_query import (
     register_security_query_methods,
 )
 from agent_sec_cli.daemon.handlers.skill_ledger import (
+    METHOD_SKILLFS_NOTIFY_CHANGE,
     register_skill_ledger_methods,
 )
 from agent_sec_cli.daemon.health import register_health_methods
@@ -45,7 +47,6 @@ from agent_sec_cli.daemon.protocol import (
     DEFAULT_MAX_REQUEST_BYTES,
     DEFAULT_MAX_RESPONSE_BYTES,
     DaemonResponse,
-    NDJSONFrameParser,
     error_response,
     generate_request_id,
     parse_request_line,
@@ -58,12 +59,82 @@ from agent_sec_cli.daemon.runtime import (
     lock_path_for_socket,
     resolve_socket_path,
 )
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AUTH_FRAME_LIMIT,
+    AUTH_HANDSHAKE_TIMEOUT_SECONDS,
+    NOTIFY_CLIENT_DOMAIN,
+    NOTIFY_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    SkillFsPeerAuthError,
+    build_auth_challenge_frame,
+    build_auth_proof_frame,
+    classify_initial_frame,
+    configured_notify_key_path,
+    verify_auth_proof_frame,
+)
 
 LOGGER = logging.getLogger("agent-sec-core.daemon")
 DEFAULT_MAX_CONNECTIONS = 64
 DEFAULT_DRAIN_TIMEOUT_SECONDS = 2.0
 DEFAULT_REQUEST_READ_TIMEOUT_MS = 5000
 SocketIdentity = tuple[int, int]
+_AUTH_WIRE_FRAME_LIMIT = AUTH_FRAME_LIMIT + 1
+
+
+class _SilentClose(Exception):
+    """Close an unauthenticated or invalid authenticated connection quietly."""
+
+
+class _ConnectionFrameReader:
+    """Read bounded NDJSON frames while retaining coalesced trailing frames."""
+
+    def __init__(self, reader: asyncio.StreamReader) -> None:
+        self._reader = reader
+        self._buffer = bytearray()
+
+    async def read_frame(
+        self,
+        max_frame_bytes_including_delimiter: int,
+        *,
+        deadline: float | None,
+        allow_eof_terminated: bool,
+    ) -> bytes:
+        """Read one frame with a wire-size limit that includes the delimiter."""
+        while True:
+            newline_index = self._buffer.find(b"\n")
+            if newline_index >= 0:
+                frame_size = newline_index + 1
+                if frame_size > max_frame_bytes_including_delimiter:
+                    raise PayloadTooLargeError(max_frame_bytes_including_delimiter)
+                frame = bytes(self._buffer[:frame_size])
+                del self._buffer[:frame_size]
+                return frame
+
+            if len(self._buffer) > max_frame_bytes_including_delimiter:
+                raise PayloadTooLargeError(max_frame_bytes_including_delimiter)
+
+            chunk = await self._read_chunk(deadline)
+            if chunk:
+                self._buffer.extend(chunk)
+                continue
+
+            if self._buffer and allow_eof_terminated:
+                frame = bytes(self._buffer)
+                self._buffer.clear()
+                return frame
+            if self._buffer:
+                raise BadRequestError("incomplete daemon request")
+            raise BadRequestError("empty daemon request")
+
+    async def _read_chunk(self, deadline: float | None) -> bytes:
+        if deadline is None:
+            return await self._reader.read(4096)
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise asyncio.TimeoutError
+        return await asyncio.wait_for(self._reader.read(4096), timeout=remaining)
 
 
 def create_default_registry() -> MethodRegistry:
@@ -142,9 +213,14 @@ class DaemonServer:
         self._drain_timeout_seconds = DEFAULT_DRAIN_TIMEOUT_SECONDS
         self._previous_umask: int | None = None
         self._socket_identity: SocketIdentity | None = None
+        self._notify_auth_secret: SharedSecret | None = None
 
     async def start(self) -> None:
         """Prepare runtime paths, bind the Unix socket, and start jobs."""
+        notify_key_path = configured_notify_key_path()
+        self._notify_auth_secret = (
+            None if notify_key_path is None else SharedSecret.load(notify_key_path)
+        )
         self._set_daemon_umask()
         try:
             self._lock = prepare_socket_path(self.socket_path)
@@ -247,16 +323,101 @@ class DaemonServer:
         started = time.monotonic()
         response: DaemonResponse | None = None
         prepared_request: PreparedDaemonRequest | None = None
+        parsed_request_method: str | None = None
+        authenticated_session: AuthenticatedSession | None = None
+        silent_close = False
+        frame_reader = _ConnectionFrameReader(reader)
 
         try:
-            line = await asyncio.wait_for(
-                read_request_frame(reader, self.max_request_bytes),
-                timeout=self.request_read_timeout_ms / 1000,
+            request_timeout_seconds = self.request_read_timeout_ms / 1000
+            request_deadline = started + request_timeout_seconds
+            auth_deadline = started + min(
+                request_timeout_seconds,
+                AUTH_HANDSHAKE_TIMEOUT_SECONDS,
             )
-            bytes_in = len(line)
-            request = parse_request_line(line, max_request_bytes=self.max_request_bytes)
+            initial_deadline = (
+                auth_deadline
+                if self._notify_auth_secret is not None
+                else request_deadline
+            )
+            # A partial first frame cannot yet be classified safely, so a
+            # configured peer key bounds that pre-authentication hold time.
+            try:
+                initial_frame = await frame_reader.read_frame(
+                    max(self.max_request_bytes, _AUTH_WIRE_FRAME_LIMIT),
+                    deadline=initial_deadline,
+                    allow_eof_terminated=True,
+                )
+            except (asyncio.TimeoutError, DaemonError) as exc:
+                if self._notify_auth_secret is not None:
+                    raise _SilentClose from exc
+                raise
+
+            bytes_in = len(initial_frame)
+            try:
+                is_auth_init = classify_initial_frame(initial_frame)
+            except SkillFsPeerAuthError as exc:
+                raise _SilentClose from exc
+
+            if is_auth_init:
+                if self._notify_auth_secret is None:
+                    raise _SilentClose
+                try:
+                    (
+                        authenticated_session,
+                        handshake_bytes_in,
+                        handshake_bytes_out,
+                    ) = await self._authenticate_notify_client(
+                        frame_reader,
+                        writer,
+                        self._notify_auth_secret,
+                        auth_deadline,
+                    )
+                    bytes_in += handshake_bytes_in
+                    bytes_out += handshake_bytes_out
+                    request_line, protected_bytes_in = (
+                        await self._read_authenticated_request(
+                            frame_reader,
+                            authenticated_session,
+                            started=time.monotonic(),
+                        )
+                    )
+                    bytes_in += protected_bytes_in
+                except (
+                    asyncio.TimeoutError,
+                    ConnectionError,
+                    DaemonError,
+                    OSError,
+                    SkillFsPeerAuthError,
+                ) as exc:
+                    raise _SilentClose from exc
+
+                request = parse_request_line(
+                    request_line,
+                    max_request_bytes=self.max_request_bytes,
+                )
+                parsed_request_method = request.method
+                if request.method != METHOD_SKILLFS_NOTIFY_CHANGE:
+                    raise BadRequestError(
+                        "authenticated daemon connection only accepts "
+                        f"{METHOD_SKILLFS_NOTIFY_CHANGE}"
+                    )
+            else:
+                request = parse_request_line(
+                    initial_frame,
+                    max_request_bytes=self.max_request_bytes,
+                )
+                parsed_request_method = request.method
+                if (
+                    self._notify_auth_secret is not None
+                    and request.method == METHOD_SKILLFS_NOTIFY_CHANGE
+                ):
+                    raise _SilentClose
+
             prepared_request = self.gateway.prepare(request)
             response = await self.gateway.execute(prepared_request)
+        except _SilentClose:
+            silent_close = True
         except asyncio.TimeoutError:
             response = error_response(
                 fallback_request_id,
@@ -286,40 +447,127 @@ class DaemonServer:
             )
             response = error_response(request_id, InternalDaemonError())
         finally:
-            if response is None:
-                response = error_response(
-                    _request_id_for_response(prepared_request, fallback_request_id),
-                    ShutdownError(),
-                )
-            with contextlib.suppress(
-                ConnectionError,
-                BrokenPipeError,
-                OSError,
-                asyncio.CancelledError,
-            ):
-                bytes_out, response = await self._write_response(writer, response)
-            if prepared_request is not None:
-                self.gateway.complete(
-                    prepared=prepared_request,
-                    response=response,
-                    started=started,
-                    bytes_in=bytes_in,
-                    bytes_out=bytes_out,
-                )
-            elif not response.ok:
-                _log_request_completion(
-                    request_id=fallback_request_id,
-                    method=None,
-                    response=response,
-                    started=started,
-                    bytes_in=bytes_in,
-                    bytes_out=bytes_out,
-                )
+            if silent_close:
+                await self._close_writer(writer)
+            else:
+                if response is None:
+                    response = error_response(
+                        _request_id_for_response(
+                            prepared_request,
+                            fallback_request_id,
+                        ),
+                        ShutdownError(),
+                    )
+                with contextlib.suppress(
+                    ConnectionError,
+                    BrokenPipeError,
+                    OSError,
+                    asyncio.CancelledError,
+                ):
+                    response_bytes_out, response = await self._write_response(
+                        writer,
+                        response,
+                        authenticated_session=authenticated_session,
+                    )
+                    bytes_out += response_bytes_out
+                if prepared_request is not None:
+                    self.gateway.complete(
+                        prepared=prepared_request,
+                        response=response,
+                        started=started,
+                        bytes_in=bytes_in,
+                        bytes_out=bytes_out,
+                    )
+                elif not response.ok:
+                    _log_request_completion(
+                        request_id=fallback_request_id,
+                        method=parsed_request_method,
+                        response=response,
+                        started=started,
+                        bytes_in=bytes_in,
+                        bytes_out=bytes_out,
+                    )
+
+    async def _authenticate_notify_client(
+        self,
+        frame_reader: _ConnectionFrameReader,
+        writer: asyncio.StreamWriter,
+        secret: SharedSecret,
+        deadline: float,
+    ) -> tuple[AuthenticatedSession, int, int]:
+        nonce, challenge_frame = build_auth_challenge_frame()
+        await self._write_auth_frame(writer, challenge_frame, deadline)
+
+        proof_frame = await frame_reader.read_frame(
+            _AUTH_WIRE_FRAME_LIMIT,
+            deadline=deadline,
+            allow_eof_terminated=False,
+        )
+        verify_auth_proof_frame(
+            proof_frame,
+            expected_kind="auth.proof",
+            secret=secret,
+            domain=NOTIFY_CLIENT_DOMAIN,
+            nonce=nonce,
+        )
+
+        accepted_frame = build_auth_proof_frame(
+            "auth.ok",
+            secret,
+            NOTIFY_SERVER_DOMAIN,
+            nonce,
+        )
+        await self._write_auth_frame(writer, accepted_frame, deadline)
+        return (
+            AuthenticatedSession(
+                secret,
+                nonce,
+                NOTIFY_CLIENT_DOMAIN,
+                NOTIFY_SERVER_DOMAIN,
+            ),
+            len(proof_frame),
+            len(challenge_frame) + len(accepted_frame),
+        )
+
+    async def _read_authenticated_request(
+        self,
+        frame_reader: _ConnectionFrameReader,
+        session: AuthenticatedSession,
+        *,
+        started: float,
+    ) -> tuple[bytes, int]:
+        deadline = started + (self.request_read_timeout_ms / 1000)
+        payload_frame = await frame_reader.read_frame(
+            self.max_request_bytes,
+            deadline=deadline,
+            allow_eof_terminated=False,
+        )
+        auth_frame = await frame_reader.read_frame(
+            _AUTH_WIRE_FRAME_LIMIT,
+            deadline=deadline,
+            allow_eof_terminated=False,
+        )
+        payload = payload_frame[:-1]
+        session.verify_payload(payload, auth_frame, "client")
+        return payload, len(payload_frame) + len(auth_frame)
+
+    async def _write_auth_frame(
+        self,
+        writer: asyncio.StreamWriter,
+        frame: bytes,
+        deadline: float,
+    ) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise asyncio.TimeoutError
+        writer.write(frame)
+        await asyncio.wait_for(writer.drain(), timeout=remaining)
 
     async def _write_response(
         self,
         writer: asyncio.StreamWriter,
         response: DaemonResponse,
+        authenticated_session: AuthenticatedSession | None = None,
     ) -> tuple[int, DaemonResponse]:
         try:
             raw_response = serialize_response(response)
@@ -342,6 +590,12 @@ class DaemonServer:
             if len(raw_response) > self.max_response_bytes:
                 raw_response = b""
 
+        if raw_response and authenticated_session is not None:
+            raw_response = authenticated_session.protect_payload(
+                raw_response[:-1],
+                "server",
+            )
+
         bytes_out = 0
         try:
             if raw_response:
@@ -351,14 +605,17 @@ class DaemonServer:
                     await writer.drain()
             return bytes_out, response
         finally:
-            writer.close()
-            with contextlib.suppress(
-                ConnectionError,
-                BrokenPipeError,
-                OSError,
-                asyncio.CancelledError,
-            ):
-                await writer.wait_closed()
+            await self._close_writer(writer)
+
+    async def _close_writer(self, writer: asyncio.StreamWriter) -> None:
+        writer.close()
+        with contextlib.suppress(
+            ConnectionError,
+            BrokenPipeError,
+            OSError,
+            asyncio.CancelledError,
+        ):
+            await writer.wait_closed()
 
     async def _write_immediate_error(
         self,
@@ -407,25 +664,6 @@ class DaemonServer:
         if self._previous_umask is not None:
             os.umask(self._previous_umask)
             self._previous_umask = None
-
-
-async def read_request_frame(
-    reader: asyncio.StreamReader,
-    max_request_bytes: int,
-) -> bytes:
-    """Read the first request frame from a stream with a byte limit."""
-    parser = NDJSONFrameParser(max_request_bytes)
-    while True:
-        chunk = await reader.read(4096)
-        if not chunk:
-            frames = parser.flush()
-            if not frames:
-                raise BadRequestError("empty daemon request")
-            return frames[0]
-
-        frames = parser.feed(chunk)
-        if frames:
-            return frames[0]
 
 
 def prepare_socket_path(socket_path: Path) -> SingleInstanceLock:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/live_root.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/live_root.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import socket
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
@@ -19,6 +20,21 @@ from agent_sec_cli.skill_ledger.errors import (
 from agent_sec_cli.skill_ledger.path_identity import (
     normalize_canonical_skill_dir,
     validate_canonical_skill_dir,
+)
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AUTH_FRAME_LIMIT,
+    AUTH_HANDSHAKE_TIMEOUT_SECONDS,
+    CONTROL_CLIENT_DOMAIN,
+    CONTROL_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    SkillFsPeerAuthError,
+    build_auth_init_frame,
+    build_auth_proof_frame,
+    configured_control_key_path,
+    configured_control_socket_path,
+    parse_auth_challenge_frame,
+    verify_auth_proof_frame,
 )
 
 CONTROL_SCHEMA_VERSION = "1"
@@ -44,6 +60,40 @@ class _ResolverSocketMissing(Exception):
 
 class _ResolverProtocolError(Exception):
     """SkillFS returned a response that violates the resolver contract."""
+
+
+class _SocketFrameReader:
+    """Read bounded newline-terminated frames without discarding buffered bytes."""
+
+    def __init__(self, connection: socket.socket) -> None:
+        self._connection = connection
+        self._buffer = bytearray()
+
+    def read_frame(self, limit: int, deadline: float) -> bytes:
+        """Read one frame's content under an absolute monotonic deadline."""
+        while True:
+            newline_index = self._buffer.find(b"\n")
+            if newline_index >= 0:
+                if newline_index > limit:
+                    raise SkillFsPeerAuthError(
+                        f"authenticated frame exceeds {limit} byte limit"
+                    )
+                frame = bytes(self._buffer[:newline_index])
+                del self._buffer[: newline_index + 1]
+                return frame
+            if len(self._buffer) > limit:
+                raise SkillFsPeerAuthError(
+                    f"authenticated frame exceeds {limit} byte limit"
+                )
+
+            self._connection.settimeout(_remaining_seconds(deadline))
+            try:
+                chunk = self._connection.recv(4096)
+            except socket.timeout as exc:
+                raise TimeoutError("authenticated frame read timed out") from exc
+            if not chunk:
+                raise SkillFsPeerAuthError("authenticated frame ended before newline")
+            self._buffer.extend(chunk)
 
 
 @dataclass(frozen=True)
@@ -147,27 +197,71 @@ class SkillFsResolverClient:
     ) -> None:
         if timeout_seconds <= 0:
             raise ValueError("resolver timeout must be positive")
+        self._explicit_socket_path = (
+            Path(socket_path) if socket_path is not None else None
+        )
         self.socket_path = (
-            Path(socket_path)
-            if socket_path is not None
+            self._explicit_socket_path
+            if self._explicit_socket_path is not None
             else default_skillfs_control_socket()
         )
         self.timeout_seconds = timeout_seconds
+        self._control_secret: SharedSecret | None = None
+        self._configuration_error: SkillFsPeerAuthError | None = None
+        self._configuration_loaded = False
 
     def resolve(self, canonical_dir: Path) -> Path | None:
         """Return SkillFS's live directory, or ``None`` when it is not managed."""
+        self._load_configuration()
+        if self.socket_path is None:
+            raise _ResolverProtocolError("SkillFS resolver socket is not configured")
+
         request = {
             "schemaVersion": CONTROL_SCHEMA_VERSION,
             "method": RESOLVE_LIVE_SOURCE_METHOD,
             "canonicalSkillDir": str(canonical_dir),
         }
-        payload = json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n"
+        payload = json.dumps(request, separators=(",", ":")).encode("utf-8")
+
+        if self._control_secret is not None:
+            response_payload = self._resolve_authenticated(payload)
+            return self._parse_response(canonical_dir, response_payload)
+
+        response_line = self._resolve_legacy(payload)
+        return self._parse_response(canonical_dir, response_line)
+
+    def _load_configuration(self) -> None:
+        if self._configuration_loaded:
+            if self._configuration_error is not None:
+                raise self._configuration_error
+            return
+
+        try:
+            socket_path = self._explicit_socket_path
+            if socket_path is None:
+                socket_path = configured_control_socket_path()
+            if socket_path is None:
+                socket_path = default_skillfs_control_socket()
+
+            key_path = configured_control_key_path()
+            secret = SharedSecret.load(key_path) if key_path is not None else None
+            self.socket_path = socket_path
+            self._control_secret = secret
+        except SkillFsPeerAuthError as exc:
+            self._configuration_error = exc
+            raise
+        finally:
+            self._configuration_loaded = True
+
+    def _resolve_legacy(self, payload: bytes) -> bytes:
+        if self.socket_path is None:
+            raise _ResolverProtocolError("SkillFS resolver socket is not configured")
 
         try:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
                 connection.settimeout(self.timeout_seconds)
                 connection.connect(str(self.socket_path))
-                connection.sendall(payload)
+                connection.sendall(payload + b"\n")
                 with connection.makefile("rb") as response_stream:
                     response_line = response_stream.readline(
                         MAX_CONTROL_RESPONSE_BYTES + 1
@@ -179,6 +273,72 @@ class SkillFsResolverClient:
             raise _ResolverProtocolError("empty response")
         if len(response_line) > MAX_CONTROL_RESPONSE_BYTES:
             raise _ResolverProtocolError("response exceeds size limit")
+        return response_line
+
+    def _resolve_authenticated(self, payload: bytes) -> bytes:
+        if self.socket_path is None or self._control_secret is None:
+            raise _ResolverProtocolError(
+                "authenticated SkillFS resolver is not configured"
+            )
+
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as connection:
+                connection.settimeout(self.timeout_seconds)
+                connection.connect(str(self.socket_path))
+                reader = _SocketFrameReader(connection)
+                handshake_deadline = time.monotonic() + min(
+                    self.timeout_seconds, AUTH_HANDSHAKE_TIMEOUT_SECONDS
+                )
+
+                _send_before_deadline(
+                    connection, build_auth_init_frame(), handshake_deadline
+                )
+                challenge = reader.read_frame(AUTH_FRAME_LIMIT, handshake_deadline)
+                nonce = parse_auth_challenge_frame(challenge + b"\n")
+                proof = build_auth_proof_frame(
+                    "auth.proof",
+                    self._control_secret,
+                    CONTROL_CLIENT_DOMAIN,
+                    nonce,
+                )
+                _send_before_deadline(connection, proof, handshake_deadline)
+                ok = reader.read_frame(AUTH_FRAME_LIMIT, handshake_deadline)
+                verify_auth_proof_frame(
+                    ok + b"\n",
+                    expected_kind="auth.ok",
+                    secret=self._control_secret,
+                    domain=CONTROL_SERVER_DOMAIN,
+                    nonce=nonce,
+                )
+
+                session = AuthenticatedSession(
+                    self._control_secret,
+                    nonce,
+                    CONTROL_CLIENT_DOMAIN,
+                    CONTROL_SERVER_DOMAIN,
+                )
+                business_deadline = time.monotonic() + self.timeout_seconds
+                _send_before_deadline(
+                    connection,
+                    session.protect_payload(payload, "client"),
+                    business_deadline,
+                )
+                response_payload = reader.read_frame(
+                    MAX_CONTROL_RESPONSE_BYTES, business_deadline
+                )
+                response_tag = reader.read_frame(AUTH_FRAME_LIMIT, business_deadline)
+                session.verify_payload(response_payload, response_tag + b"\n", "server")
+                return response_payload
+        except FileNotFoundError as exc:
+            raise SkillFsPeerAuthError(
+                "authenticated SkillFS resolver socket is unavailable"
+            ) from exc
+
+    def _parse_response(
+        self,
+        canonical_dir: Path,
+        response_line: bytes,
+    ) -> Path | None:
 
         try:
             response = json.loads(response_line.decode("utf-8"))
@@ -346,6 +506,27 @@ def _public_resolver_failure_reason(exc: Exception) -> str:
         return "SkillFS resolver access was denied"
     if isinstance(exc, ConnectionRefusedError):
         return "SkillFS resolver refused the connection"
+    if isinstance(exc, SkillFsPeerAuthError):
+        return "SkillFS resolver authentication failed"
     if isinstance(exc, _ResolverProtocolError):
         return str(exc)
     return "SkillFS resolver request failed"
+
+
+def _remaining_seconds(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError("authenticated operation timed out")
+    return remaining
+
+
+def _send_before_deadline(
+    connection: socket.socket,
+    payload: bytes,
+    deadline: float,
+) -> None:
+    connection.settimeout(_remaining_seconds(deadline))
+    try:
+        connection.sendall(payload)
+    except socket.timeout as exc:
+        raise TimeoutError("authenticated frame write timed out") from exc

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/skillfs_peer_auth.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/skillfs_peer_auth.py
@@ -1,0 +1,428 @@
+"""Authenticate Skill Ledger and SkillFS over private Unix socket channels."""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+from pathlib import Path
+from typing import Any, Literal
+
+AGENT_SEC_SKILLFS_CONTROL_SOCKET = "AGENT_SEC_SKILLFS_CONTROL_SOCKET"
+AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE = "AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE"
+AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE = "AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE"
+
+AUTH_VERSION = "1"
+AUTH_FRAME_LIMIT = 4096
+AUTH_HANDSHAKE_TIMEOUT_SECONDS = 5.0
+NONCE_LENGTH = 32
+MIN_SECRET_LENGTH = 32
+MAX_SECRET_LENGTH = 4096
+
+CONTROL_CLIENT_DOMAIN = "anolisa.skillfs.control.client.v1"
+CONTROL_SERVER_DOMAIN = "anolisa.skillfs.control.server.v1"
+NOTIFY_CLIENT_DOMAIN = "anolisa.skillfs.notify.client.v1"
+NOTIFY_SERVER_DOMAIN = "anolisa.skillfs.notify.server.v1"
+
+FrameSender = Literal["client", "server"]
+ProofFrameKind = Literal["auth.proof", "auth.ok"]
+
+_AUTH_FIELD_PATTERN = re.compile(
+    rb'"(?:authVersion|nonce|proof)"|"type"\s*:\s*"auth\.|"auth\.'
+)
+
+
+class _JsonObjectPairs(list[tuple[str, Any]]):
+    """Preserve decoded field occurrences while classifying a first frame."""
+
+
+class SkillFsPeerAuthError(Exception):
+    """SkillFS peer authentication configuration or protocol is invalid."""
+
+
+class SharedSecret:
+    """Immutable shared secret whose representation never exposes key bytes."""
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: bytes) -> None:
+        if not MIN_SECRET_LENGTH <= len(value) <= MAX_SECRET_LENGTH:
+            raise SkillFsPeerAuthError(
+                "authentication key must contain between "
+                f"{MIN_SECRET_LENGTH} and {MAX_SECRET_LENGTH} bytes"
+            )
+        self._value = bytes(value)
+
+    def __repr__(self) -> str:
+        return "SharedSecret([REDACTED])"
+
+    @classmethod
+    def load(cls, path: str | Path) -> "SharedSecret":
+        """Load a bounded regular key file without following a final symlink."""
+        key_path = Path(path)
+        if not key_path.is_absolute():
+            raise SkillFsPeerAuthError("authentication key file path must be absolute")
+
+        flags = os.O_RDONLY
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        flags |= getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NONBLOCK", 0)
+        try:
+            file_descriptor = os.open(key_path, flags)
+        except OSError as exc:
+            raise SkillFsPeerAuthError(
+                "failed to open authentication key file"
+            ) from exc
+
+        try:
+            metadata = os.fstat(file_descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise SkillFsPeerAuthError("authentication key must be a regular file")
+            if metadata.st_uid != os.geteuid():
+                raise SkillFsPeerAuthError(
+                    "authentication key file must be owned by the effective user"
+                )
+            if stat.S_IMODE(metadata.st_mode) & 0o077:
+                raise SkillFsPeerAuthError(
+                    "authentication key file must not grant group or other permissions"
+                )
+            value = _read_bounded_secret(file_descriptor)
+        except OSError as exc:
+            raise SkillFsPeerAuthError(
+                "failed to read authentication key file"
+            ) from exc
+        finally:
+            os.close(file_descriptor)
+
+        return cls(value)
+
+    def proof(self, domain: str, nonce: bytes) -> bytes:
+        """Return a domain-separated handshake proof."""
+        _validate_nonce(nonce)
+        return hmac.new(
+            self._value,
+            domain.encode("utf-8") + b"\0" + nonce,
+            hashlib.sha256,
+        ).digest()
+
+    def frame_proof(self, domain: str, nonce: bytes, payload: bytes) -> bytes:
+        """Return a direction- and session-bound business-frame proof."""
+        _validate_nonce(nonce)
+        message = (
+            domain.encode("utf-8")
+            + b"\0frame\0"
+            + nonce
+            + len(payload).to_bytes(8, byteorder="big")
+            + payload
+        )
+        return hmac.new(self._value, message, hashlib.sha256).digest()
+
+
+class AuthenticatedSession:
+    """Session-bound proof helper that does not own the transport socket."""
+
+    __slots__ = ("_client_domain", "_nonce", "_secret", "_server_domain")
+
+    def __init__(
+        self,
+        secret: SharedSecret,
+        nonce: bytes,
+        client_domain: str,
+        server_domain: str,
+    ) -> None:
+        _validate_nonce(nonce)
+        self._secret = secret
+        self._nonce = bytes(nonce)
+        self._client_domain = client_domain
+        self._server_domain = server_domain
+
+    def protect_payload(self, payload: bytes, sender: FrameSender) -> bytes:
+        """Append the NDJSON delimiter and a session-bound authentication tag."""
+        if b"\n" in payload:
+            raise SkillFsPeerAuthError(
+                "authenticated business payload must be one NDJSON frame"
+            )
+        proof = self._secret.frame_proof(self._domain(sender), self._nonce, payload)
+        return payload + b"\n" + _encode_auth_frame("auth.frame", proof=proof)
+
+    def verify_payload(
+        self,
+        payload: bytes,
+        auth_frame: bytes,
+        sender: FrameSender,
+    ) -> None:
+        """Verify a raw business payload before callers parse or dispatch it."""
+        frame = _parse_auth_frame(auth_frame)
+        _validate_auth_frame(
+            frame,
+            expected_kind="auth.frame",
+            require_nonce=False,
+            require_proof=True,
+        )
+        actual = _decode_32(frame["proof"])
+        expected = self._secret.frame_proof(self._domain(sender), self._nonce, payload)
+        if not hmac.compare_digest(actual, expected):
+            raise SkillFsPeerAuthError("authentication proof verification failed")
+
+    def _domain(self, sender: FrameSender) -> str:
+        if sender == "client":
+            return self._client_domain
+        if sender == "server":
+            return self._server_domain
+        raise SkillFsPeerAuthError("invalid authenticated frame sender")
+
+
+def configured_control_socket_path() -> Path | None:
+    """Return the configured SkillFS control socket, if present."""
+    return _optional_environment_path(AGENT_SEC_SKILLFS_CONTROL_SOCKET)
+
+
+def configured_control_key_path() -> Path | None:
+    """Return the configured control authentication key, if present."""
+    return _optional_environment_path(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE)
+
+
+def configured_notify_key_path() -> Path | None:
+    """Return the configured notify authentication key, if present."""
+    return _optional_environment_path(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE)
+
+
+def build_auth_init_frame() -> bytes:
+    """Build the first frame of the four-step handshake."""
+    return _encode_auth_frame("auth.init")
+
+
+def validate_auth_init_frame(frame: bytes) -> None:
+    """Require an exact, versioned authentication init frame."""
+    parsed = _parse_auth_frame(frame)
+    _validate_auth_frame(
+        parsed,
+        expected_kind="auth.init",
+        require_nonce=False,
+        require_proof=False,
+    )
+
+
+def classify_initial_frame(frame: bytes) -> bool:
+    """Return whether a daemon first frame is auth.init, rejecting auth lookalikes."""
+    try:
+        content = _frame_content(frame, None)
+        pairs = _parse_json_object_pairs(content)
+    except SkillFsPeerAuthError:
+        if _contains_auth_field(frame):
+            raise
+        return False
+
+    auth_candidate = any(
+        key in {"authVersion", "nonce", "proof"}
+        or (key == "type" and isinstance(value, str) and value.startswith("auth."))
+        for key, value in pairs
+    )
+    if not auth_candidate:
+        return False
+    if len(content) > AUTH_FRAME_LIMIT:
+        raise SkillFsPeerAuthError(
+            f"authenticated frame exceeds {AUTH_FRAME_LIMIT} byte limit"
+        )
+    payload = _unique_json_object(pairs)
+    _validate_auth_frame(
+        payload,
+        expected_kind="auth.init",
+        require_nonce=False,
+        require_proof=False,
+    )
+    return True
+
+
+def build_auth_challenge_frame(nonce: bytes | None = None) -> tuple[bytes, bytes]:
+    """Build a challenge around a fresh nonce and return both values."""
+    challenge_nonce = secrets.token_bytes(NONCE_LENGTH) if nonce is None else nonce
+    _validate_nonce(challenge_nonce)
+    return bytes(challenge_nonce), _encode_auth_frame(
+        "auth.challenge", nonce=challenge_nonce
+    )
+
+
+def parse_auth_challenge_frame(frame: bytes) -> bytes:
+    """Parse a canonical 32-byte nonce from an auth.challenge frame."""
+    parsed = _parse_auth_frame(frame)
+    _validate_auth_frame(
+        parsed,
+        expected_kind="auth.challenge",
+        require_nonce=True,
+        require_proof=False,
+    )
+    return _decode_32(parsed["nonce"])
+
+
+def build_auth_proof_frame(
+    kind: ProofFrameKind,
+    secret: SharedSecret,
+    domain: str,
+    nonce: bytes,
+) -> bytes:
+    """Build an auth.proof or auth.ok frame for the supplied direction."""
+    return _encode_auth_frame(kind, proof=secret.proof(domain, nonce))
+
+
+def verify_auth_proof_frame(
+    frame: bytes,
+    *,
+    expected_kind: ProofFrameKind,
+    secret: SharedSecret,
+    domain: str,
+    nonce: bytes,
+) -> None:
+    """Verify an auth.proof or auth.ok frame in constant time."""
+    parsed = _parse_auth_frame(frame)
+    _validate_auth_frame(
+        parsed,
+        expected_kind=expected_kind,
+        require_nonce=False,
+        require_proof=True,
+    )
+    actual = _decode_32(parsed["proof"])
+    expected = secret.proof(domain, nonce)
+    if not hmac.compare_digest(actual, expected):
+        raise SkillFsPeerAuthError("authentication proof verification failed")
+
+
+def _optional_environment_path(name: str) -> Path | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    if not value.strip():
+        raise SkillFsPeerAuthError(f"{name} must not be empty")
+    return Path(value)
+
+
+def _read_bounded_secret(file_descriptor: int) -> bytes:
+    remaining = MAX_SECRET_LENGTH + 1
+    chunks: list[bytes] = []
+    while remaining:
+        chunk = os.read(file_descriptor, remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _encode_auth_frame(
+    kind: str,
+    *,
+    nonce: bytes | None = None,
+    proof: bytes | None = None,
+) -> bytes:
+    payload: dict[str, str] = {"authVersion": AUTH_VERSION, "type": kind}
+    if nonce is not None:
+        payload["nonce"] = _encode(nonce)
+    if proof is not None:
+        payload["proof"] = _encode(proof)
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    if len(raw) > AUTH_FRAME_LIMIT:
+        raise SkillFsPeerAuthError(
+            f"authenticated frame exceeds {AUTH_FRAME_LIMIT} byte limit"
+        )
+    return raw + b"\n"
+
+
+def _parse_auth_frame(frame: bytes) -> dict[str, Any]:
+    return _parse_json_object(_frame_content(frame, AUTH_FRAME_LIMIT))
+
+
+def _frame_content(frame: bytes, limit: int | None) -> bytes:
+    if not frame.endswith(b"\n") or b"\n" in frame[:-1]:
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    content = frame[:-1]
+    if limit is not None and len(content) > limit:
+        raise SkillFsPeerAuthError(f"authenticated frame exceeds {limit} byte limit")
+    return content
+
+
+def _contains_auth_field(frame: bytes) -> bool:
+    return _AUTH_FIELD_PATTERN.search(frame) is not None
+
+
+def _parse_json_object(raw: bytes) -> dict[str, Any]:
+    def reject_duplicate_fields(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise SkillFsPeerAuthError("invalid authentication frame")
+            result[key] = value
+        return result
+
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"), object_pairs_hook=reject_duplicate_fields
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise SkillFsPeerAuthError("invalid authentication frame") from exc
+    if not isinstance(payload, dict):
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    return payload
+
+
+def _parse_json_object_pairs(raw: bytes) -> _JsonObjectPairs:
+    try:
+        payload = json.loads(raw.decode("utf-8"), object_pairs_hook=_JsonObjectPairs)
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise SkillFsPeerAuthError("invalid authentication frame") from exc
+    if not isinstance(payload, _JsonObjectPairs):
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    return payload
+
+
+def _unique_json_object(pairs: _JsonObjectPairs) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise SkillFsPeerAuthError("invalid authentication frame")
+        payload[key] = value
+    return payload
+
+
+def _validate_auth_frame(
+    frame: dict[str, Any],
+    *,
+    expected_kind: str,
+    require_nonce: bool,
+    require_proof: bool,
+) -> None:
+    expected_fields = {"authVersion", "type"}
+    if require_nonce:
+        expected_fields.add("nonce")
+    if require_proof:
+        expected_fields.add("proof")
+    if set(frame) != expected_fields:
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    if frame.get("authVersion") != AUTH_VERSION or frame.get("type") != expected_kind:
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    if require_nonce and not isinstance(frame.get("nonce"), str):
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    if require_proof and not isinstance(frame.get("proof"), str):
+        raise SkillFsPeerAuthError("invalid authentication frame")
+
+
+def _encode(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode_32(value: str) -> bytes:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise SkillFsPeerAuthError("invalid authentication frame") from exc
+    if len(decoded) != NONCE_LENGTH or _encode(decoded) != value:
+        raise SkillFsPeerAuthError("invalid authentication frame")
+    return decoded
+
+
+def _validate_nonce(nonce: bytes) -> None:
+    if len(nonce) != NONCE_LENGTH:
+        raise SkillFsPeerAuthError("invalid authentication nonce")

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_SKILLFS_INTEGRATION_zh.md
@@ -70,15 +70,82 @@ symlink-resolved alias 下的路径投影回 canonical 空间。相对路径和�
 
 ## 3. SkillFS Resolver 合同
 
-Resolver 复用 SkillFS trusted control socket 的 JSONL 协议。M1 固定使用：
+Resolver 复用 SkillFS trusted control socket 的 JSONL 业务协议。endpoint 按以下优先级
+选择：
+
+1. embedding caller 显式传给 `SkillFsResolverClient` 的 `socket_path`；
+2. `AGENT_SEC_SKILLFS_CONTROL_SOCKET`；
+3. per-effective-UID 默认路径：
 
 ```text
 /run/user/<effective-uid>/skillfs/control.sock
 ```
 
-Ledger 通过 `os.geteuid()` 计算 endpoint，不增加 Ledger 配置项，也不通过 notify 传递
-endpoint、mount id 或 generation。SkillFS 与 Ledger daemon/CLI 必须位于同一 effective UID 和
-安全域，并且 SkillFS 必须信任实际发起请求的进程。
+最终 endpoint 必须与 SkillFS 的 `--control-socket` 一致。Ledger 不通过 notify 传递 endpoint、
+mount id 或 generation，也不增加 retry、endpoint registry 或 resolver 结果缓存。
+
+### 3.1 HMAC 配置与 key 文件合同
+
+agent-sec-core 使用以下三个环境变量承载 SkillFS 集成配置：
+
+| 环境变量 | 使用方 | 语义 |
+| --- | --- | --- |
+| `AGENT_SEC_SKILLFS_CONTROL_SOCKET` | Ledger resolver | 覆盖 control socket endpoint |
+| `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` | Ledger resolver | 启用 control 双向 HMAC 认证 |
+| `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` | agent-sec-core daemon | 启用 notify 双向 HMAC 认证 |
+
+control key 在 resolver 第一次 resolve 时加载，并缓存到该 client 生命周期结束，不做热更新。
+notify key 在 daemon bind socket 前加载；配置存在但 key 非法时 daemon 启动失败。双方使用
+相同的严格 loader：路径必须为绝对路径，以 `O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK` 打开，
+目标必须是当前 effective UID 所有的普通文件，不能设置任何 group/other 权限位，原始内容
+长度必须在 32–4096 bytes 之间。读取内容不做 trim。symlink、目录、FIFO、device、owner
+不匹配、权限过宽、过短或超长都属于配置错误。
+
+control 和 notify 可以使用同一个 key 文件，但完整 ACS 部署必须同时配置两个方向，且推荐
+使用方向独立的 key。key、proof、nonce 和未验证业务 payload 不得进入日志、响应、audit
+event 或提交到仓库的部署资产。
+
+### 3.2 HMAC wire contract
+
+配置 control key 后，Ledger 是 client，SkillFS 是 server。读取 resolver 业务请求前先完成
+四步 NDJSON challenge-response：
+
+```json
+{"authVersion":"1","type":"auth.init"}
+{"authVersion":"1","type":"auth.challenge","nonce":"<base64>"}
+{"authVersion":"1","type":"auth.proof","proof":"<base64>"}
+{"authVersion":"1","type":"auth.ok","proof":"<base64>"}
+```
+
+nonce 是使用带 padding 的 canonical standard Base64 编码的 32-byte 随机值。握手 proof 为：
+
+```text
+HMAC-SHA256(secret, domain || NUL || raw_nonce)
+```
+
+control 使用固定 domain：
+
+- client：`anolisa.skillfs.control.client.v1`
+- server：`anolisa.skillfs.control.server.v1`
+
+双方验证 proof 后，sender 先发送现有 raw NDJSON 业务 JSON 和 newline，再发送：
+
+```json
+{"authVersion":"1","type":"auth.frame","proof":"<base64>"}
+```
+
+业务 tag 的 HMAC 输入为：
+
+```text
+domain || NUL || "frame" || NUL || raw_nonce ||
+u64_be(payload_length) || raw_business_json
+```
+
+`payload_length` 不包含 NDJSON newline。receiver 必须保留原始 payload bytes，并在解析 JSON
+前 constant-time 验证 tag，不能重新序列化对端 JSON 后计算 MAC。所有 auth frame 上限为
+4096 bytes；业务 frame 继续使用原有协议限额。整个 resolver 握手共享一个 monotonic
+deadline `min(resolver timeout, 5s)`，不会因收到部分字节而重置。认证失败、EOF、超限或
+timeout 都关闭连接，不 retry，也不降级到明文。
 
 请求：
 
@@ -124,15 +191,18 @@ Ledger namespace 中绝对、词法规范化且可访问的 `liveSkillDir`。
 
 | Resolver 结果 | Ledger 行为 |
 | --- | --- |
-| control socket 不存在（`ENOENT`） | 进入 host 模式，`ioSkillDir = canonicalSkillDir` |
+| 未配置 control key，且 socket 不存在（`ENOENT`） | 保留 legacy 行为，进入 host 模式，`ioSkillDir = canonicalSkillDir` |
+| 已配置 control key，且 socket 不存在（`ENOENT`） | 返回 `skill_root_resolve_failed`，不得进入 host 模式 |
 | `ok=true` 且 `managed=false` | 校验 canonical echo 后进入 host 模式 |
 | `ok=true` 且 `managed=true` | 校验 canonical echo 与 `liveSkillDir`，本次 I/O 只使用 live 目录 |
 | `managed` 缺失或不是 boolean | 协议错误，返回 `skill_root_resolve_failed` |
-| `ok=false`、连接拒绝、权限错误、1 秒超时、非法响应或其他错误 | 返回 `skill_root_resolve_failed`，不降级到 host |
+| `ok=false`、连接拒绝、权限错误、timeout、认证失败、非法响应或其他错误 | 返回 `skill_root_resolve_failed`，不降级到 host |
 
-Ledger 不重试、不缓存也不持久化 resolver 结果。socket 不存在时进入 host 模式是 M1
-的已知权衡：它让无 SkillFS 环境保持原有行为，但 SkillFS 异常退出并删除 socket 时可能
-被误判为未部署。除 `ENOENT` 和成功响应中的 `managed=false` 外，其他故障均禁止静默降级。
+Ledger 不重试、不缓存也不持久化 resolver 结果。未配置 HMAC 时，socket 不存在进入 host
+模式是为无 SkillFS 部署保留的 legacy 可用性策略；显式或默认 socket 都维持该行为。配置
+control key 即表示部署要求可信 SkillFS 必须可达，因此 socket 缺失、连接失败、认证失败或
+协议错误全部 fail-closed，不能回退 host 或明文。通过认证的 `managed=false` 是 SkillFS
+明确返回的可信未覆盖结果，仍可进入 host 模式。
 
 ## 4. SkillFS Notify v2 合同
 
@@ -142,10 +212,41 @@ SkillFS 发现受管 source 变化后，调用现有 daemon method：
 skill_ledger.skillfs_notify_change
 ```
 
-通知使用 daemon Unix socket 的单连接 NDJSON request frame。SkillFS 当前会发送本地生成的
-`id`，但 daemon 不消费该字段，而是为请求生成自己的 `request_id`。daemon socket 由
+通知复用 daemon Unix socket，并保持单连接、单请求语义。daemon socket 由
 `AGENT_SEC_DAEMON_SOCKET` 指定，未指定时使用
-`$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock`。
+`$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock`。SkillFS 当前会发送本地生成的 `id`，但
+daemon 不消费该字段，而是为请求生成自己的 `request_id`。
+
+未配置 `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE` 时，现有明文 notify 保持兼容，但收到
+`auth.init` 会直接关闭连接。配置 notify key 后，只有
+`skill_ledger.skillfs_notify_change` 强制使用 HMAC；同一 daemon 的 health、prompt scan 等
+其他 API 继续使用现有明文协议。此时明文 notify 在 handler 和业务 audit 前拒绝，不允许
+认证失败后重试明文。
+
+daemon 按第一帧分流连接：
+
+- 合法 `auth.init` 且已配置 notify key：进入 HMAC notify；
+- 合法 `auth.init` 但未配置 key：关闭连接；
+- 包含 `authVersion`、`nonce` 或 `proof` 等认证字段但不是合法 `auth.init`：关闭连接；
+- 其他普通请求：进入既有明文 daemon 路径，再由 method policy 拒绝不允许的明文 notify。
+
+HMAC notify 中 SkillFS 是 client，daemon 是 server，复用 3.2 节 wire contract，并使用：
+
+- client：`anolisa.skillfs.notify.client.v1`
+- server：`anolisa.skillfs.notify.server.v1`
+
+daemon 使用密码学安全的 32-byte nonce。握手总 deadline 为
+`min(request_read_timeout_ms, 5s)`；auth frame 上限为 4096 bytes，业务 frame 仍使用 daemon
+现有限额。配置 notify key 后，尚未收齐、无法安全分类的第一帧也受这个 pre-auth deadline
+约束；完整且确认不是认证帧的普通请求仍进入既有明文路径。连接级 NDJSON reader 必须保留
+一次 read 中多出的 bytes，确保 coalesced
+payload/tag 不丢失。daemon 先验证 raw request payload 后才解析、记录 audit 或 dispatch，且
+authenticated path 只允许 `skill_ledger.skillfs_notify_change`。成功响应和业务错误响应都先
+写 raw JSON，再用 notify-server domain 的 `auth.frame` 签名；SkillFS 验证后才把通知视为
+已接受。握手、proof、tag、EOF、timeout 或 frame size 校验失败都直接关闭连接，不 dispatch
+也不返回未认证的错误 payload。
+
+下面示例是握手后受 `auth.frame` 保护的原始业务 payload；业务 schema 本身不变。
 
 Hermes nested skill 请求示例：
 
@@ -252,15 +353,32 @@ Ledger 不依赖 SkillFS 的内部模块划分，只依赖以下可观测行为�
 SkillFS 的本地 protocol event log 仅是内部诊断机制，不是 notify v2，也不是 Ledger 的
 canonical 身份来源。Ledger v2 不读取该日志。
 
-## 7. 部署边界与 M1 限制
+## 7. 部署边界与限制
 
-- SkillFS 与 Skill Ledger 必须协调升级：Ledger 明确拒绝 notify v1。
+- SkillFS 与 Skill Ledger 必须协调升级：Ledger 明确拒绝 notify v1；HMAC 联动还要求双方都
+  实现相同的 auth version、domain、大小限制和 fixed vector。
+- 完整 ACS HMAC profile 必须同时配置 control 和 notify key。SkillFS 使用
+  `--trusted-peer-key-file` 与 `--notify-auth-key-file`，agent-sec-core 使用对应的
+  `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE` 与 `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE`。
+  两个方向可以复用一个文件，但推荐使用独立 key。
+- SkillFS `--control-socket` 必须与 `AGENT_SEC_SKILLFS_CONTROL_SOCKET` 一致。未配置 control
+  key 时，默认或显式 endpoint 的 `ENOENT` 都保留 legacy host fallback；配置 key 后任何
+  socket 缺失、连接或认证故障都 fail-closed。
+- 容器化部署需要用 shared volumes 承载 daemon socket、control socket、双方对应的 key，
+  以及 daemon 可见的 source/backing path。SkillFS 与 resolver peer 仍需在相同绝对路径看到
+  physical source。应按部署拓扑尽量缩小 source、key 和私有 runtime volume 的可见范围。
+- SkillFS 与 Ledger 必须使用相同 numeric UID；key 文件必须由该 effective UID 所有，socket
+  路径及父目录也必须授权实际调用的 daemon、CLI 和 SkillFS 进程。
+- Kubernetes Secret volume 是 symlink-based projection，不能直接作为 key path。部署需要先
+  将 Secret bytes 复制到 `emptyDir` 等私有共享卷，生成 owner 正确、mode `0600` 的普通
+  non-symlink 文件，再把双方配置指向复制后的路径。
+- control key 在 resolver client 生命周期内缓存，notify key 在 daemon bind 前加载；本次不
+  支持 key 热更新。轮换 key 需要协调更新双方文件并重启对应进程。
+- 本次不处理 `.skill-meta` 视图策略、Agent 与 Ledger 的 UID/权限隔离、socket ACL/shared GID、
+  Kubernetes manifest、notify 持久化或 daemon 通用认证。尤其在 Agent 与 Ledger 同 UID、同
+  容器运行时，Agent 对 Ledger key/daemon socket 的潜在访问仍是独立的部署安全限制。
 - 既有 `managedSkillDirs` 中的 live/backing path 必须迁移为 canonical path；Ledger 不自动猜测。
-- M1 只使用默认 resolver endpoint。SkillFS 配置自定义 control socket 时，Ledger 无法跟随该
-  endpoint；若默认 socket 不存在，将按 host 模式处理。
-- M1 不引入 mount registry、mountId、generation、endpoint 传递或 canonical/live 缓存。
-- SkillFS 与 Ledger 必须使用相同 effective UID，且 resolver control socket 必须授权实际调用的
-  daemon 和 CLI 进程。
+- 本次不引入 mount registry、mountId、generation、endpoint 传递或 canonical/live 缓存。
 - canonical source 可以是 symlink；notify、resolver request 和 canonical echo 均保留绝对、词法
   规范化的 source 前缀。realpath 只用于双方各自的内部安全检查。
 - `managedSkillDirs` 中的 glob 仍依赖 daemon namespace 的目录可见性；不可见的 canonical

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_daemon_integration.py
@@ -32,6 +32,17 @@ from agent_sec_cli.skill_ledger.core.live_root import (
     SkillRootResolver,
 )
 from agent_sec_cli.skill_ledger.errors import SkillRootResolveError
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE,
+    NOTIFY_CLIENT_DOMAIN,
+    NOTIFY_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    build_auth_init_frame,
+    build_auth_proof_frame,
+    parse_auth_challenge_frame,
+    verify_auth_proof_frame,
+)
 
 PENDING_DECISION_TARGET = ".skill-meta/versions/__pending_decision__.snapshot"
 
@@ -181,6 +192,65 @@ def write_isolated_config(root: Path, extra: dict[str, Any] | None = None) -> No
     )
 
 
+async def send_authenticated_notify(
+    socket_path: Path,
+    secret: SharedSecret,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Send one SkillFS-compatible authenticated notify request."""
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    try:
+        writer.write(build_auth_init_frame())
+        await writer.drain()
+
+        nonce = parse_auth_challenge_frame(await reader.readline())
+        writer.write(
+            build_auth_proof_frame(
+                "auth.proof",
+                secret,
+                NOTIFY_CLIENT_DOMAIN,
+                nonce,
+            )
+        )
+        await writer.drain()
+        verify_auth_proof_frame(
+            await reader.readline(),
+            expected_kind="auth.ok",
+            secret=secret,
+            domain=NOTIFY_SERVER_DOMAIN,
+            nonce=nonce,
+        )
+        session = AuthenticatedSession(
+            secret,
+            nonce,
+            NOTIFY_CLIENT_DOMAIN,
+            NOTIFY_SERVER_DOMAIN,
+        )
+        payload = json.dumps(
+            {
+                "id": "skillfs-integration",
+                "method": METHOD_SKILLFS_NOTIFY_CHANGE,
+                "params": params,
+                "trace_context": {},
+                "timeout_ms": 3000,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+        writer.write(session.protect_payload(payload, "client"))
+        await writer.drain()
+
+        response_payload = await reader.readline()
+        response_tag = await reader.readline()
+        raw_response = response_payload.removesuffix(b"\n")
+        session.verify_payload(raw_response, response_tag, "server")
+        response = json.loads(raw_response)
+        assert isinstance(response, dict)
+        return response
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
@@ -252,6 +322,49 @@ def test_daemon_notify_scans_and_writes_activation(monkeypatch, tmp_path: Path):
     assert second_pid == first_pid
     with pytest.raises(ProcessLookupError):
         os.kill(first_pid, 0)
+
+
+def test_authenticated_daemon_notify_writes_activation(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg_data"))
+    write_isolated_config(tmp_path)
+    skill_dir = make_skill(tmp_path / "skills", "weather", {"run.sh": "echo ok\n"})
+    socket_path = daemon_socket_path(tmp_path)
+    key_path = tmp_path / "notify.key"
+    key_path.write_bytes(b"n" * 32)
+    key_path.chmod(0o600)
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, str(key_path))
+    secret = SharedSecret.load(key_path)
+
+    async def scenario():
+        server = DaemonServer(socket_path=socket_path)
+        await server.start()
+        try:
+            response = await send_authenticated_notify(
+                socket_path,
+                secret,
+                notify_payload(skill_dir),
+            )
+            activation = await wait_for(
+                lambda: (
+                    read_activation(skill_dir)
+                    if (skill_dir / ".skill-meta" / "activation.json").is_file()
+                    else None
+                )
+            )
+        finally:
+            await server.stop()
+        return response, activation
+
+    response, activation = asyncio.run(scenario())
+
+    assert response["ok"] is True
+    assert response["data"]["accepted"] is True
+    assert activation["schemaVersion"] == 1
+    assert activation["target"] == ".skill-meta/versions/v000001.snapshot"
 
 
 def test_daemon_notify_resolves_hidden_canonical_to_live_once(

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -12,6 +12,7 @@ import time
 import uuid
 from pathlib import Path
 
+import pytest
 from agent_sec_cli.correlation_context import (
     TraceContext,
     clear_invocation_context_for_tests,
@@ -20,10 +21,14 @@ from agent_sec_cli.correlation_context import (
     init_invocation_context,
     init_process_trace_context,
 )
+from agent_sec_cli.daemon import server as daemon_server_module
 from agent_sec_cli.daemon.client import DaemonClient, daemon_health_reachable
 from agent_sec_cli.daemon.errors import (
     DaemonProtocolError,
     DaemonRuntimePathError,
+)
+from agent_sec_cli.daemon.handlers.skill_ledger import (
+    METHOD_SKILLFS_NOTIFY_CHANGE,
 )
 from agent_sec_cli.daemon.health import build_health_snapshot
 from agent_sec_cli.daemon.logging import (
@@ -50,6 +55,18 @@ from agent_sec_cli.daemon.server import (
     configure_logging,
     create_default_registry,
     prepare_socket_path,
+)
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE,
+    NOTIFY_CLIENT_DOMAIN,
+    NOTIFY_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    SkillFsPeerAuthError,
+    build_auth_init_frame,
+    build_auth_proof_frame,
+    parse_auth_challenge_frame,
+    verify_auth_proof_frame,
 )
 
 
@@ -1455,6 +1472,501 @@ def test_unknown_method_completion_log_preserves_trace_context(
     assert record.data["method"] == "unknown.method"
 
 
+def test_authenticated_notify_dispatches_and_returns_signed_coalesced_response(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            reader, writer, session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                # A single write deliberately coalesces the business payload and tag.
+                writer.write(
+                    session.protect_payload(_notify_request_payload(), "client")
+                )
+                await writer.drain()
+                response = await _read_authenticated_response(reader, session)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return response, dispatches
+
+    response, dispatches = asyncio.run(scenario())
+
+    assert response.ok is True
+    assert response.data == {"schemaVersion": 2, "accepted": True}
+    assert dispatches == [METHOD_SKILLFS_NOTIFY_CHANGE]
+
+
+def test_authenticated_business_bad_request_response_is_signed(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            reader, writer, session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                writer.write(session.protect_payload(b'{"method":', "client"))
+                await writer.drain()
+                response = await _read_authenticated_response(reader, session)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return response, dispatches
+
+    response, dispatches = asyncio.run(scenario())
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error["code"] == "bad_request"
+    assert dispatches == []
+
+
+def test_authenticated_notify_wrong_key_closes_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        _configure_notify_auth(monkeypatch, tmp_path, value=b"s" * 32)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                writer.write(build_auth_init_frame())
+                await writer.drain()
+                challenge = await _read_frame(reader)
+                nonce = parse_auth_challenge_frame(challenge)
+                writer.write(
+                    build_auth_proof_frame(
+                        "auth.proof",
+                        SharedSecret(b"w" * 32),
+                        NOTIFY_CLIENT_DOMAIN,
+                        nonce,
+                    )
+                )
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_authenticated_notify_slow_handshake_closes_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+            request_read_timeout_ms=100,
+        )
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                writer.write(build_auth_init_frame())
+                await writer.drain()
+                parse_auth_challenge_frame(await _read_frame(reader))
+                writer.write(b'{"authVersion":"1","type":"auth.proof"')
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_authenticated_notify_slow_init_uses_handshake_deadline(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setattr(
+        daemon_server_module,
+        "AUTH_HANDSHAKE_TIMEOUT_SECONDS",
+        0.05,
+    )
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+            request_read_timeout_ms=1000,
+        )
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                writer.write(b'{"authVersion":"1"')
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_authenticated_notify_tamper_closes_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            reader, writer, session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                protected = session.protect_payload(_notify_request_payload(), "client")
+                payload, auth_frame = protected.split(b"\n", maxsplit=1)
+                tampered = payload.replace(b'"write"', b'"rename"')
+                assert tampered != payload
+                writer.write(tampered + b"\n" + auth_frame)
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_authenticated_notify_eof_closes_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            reader, writer, _session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                writer.write(b'{"method":"skill_ledger.skillfs_notify_change"}')
+                await writer.drain()
+                assert writer.can_write_eof()
+                writer.write_eof()
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_authenticated_notify_oversize_closes_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        max_request_bytes = 128
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+            max_request_bytes=max_request_bytes,
+        )
+        await server.start()
+        try:
+            reader, writer, session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                writer.write(
+                    session.protect_payload(b"x" * max_request_bytes, "client")
+                )
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_auth_init_without_key_and_invalid_auth_close_without_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.delenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, raising=False)
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+        )
+        await server.start()
+        try:
+            remainders = []
+            for frame in (
+                build_auth_init_frame(),
+                b'{"authVersion":"1","type":"auth.init","extra":true}\n',
+                b'{"method":"daemon.health","ty\\u0070e":"auth.init",' b'"type":0}\n',
+            ):
+                reader, writer = await asyncio.open_unix_connection(str(socket_path))
+                try:
+                    writer.write(frame)
+                    await writer.drain()
+                    remainders.append(
+                        await asyncio.wait_for(reader.read(), timeout=0.5)
+                    )
+                finally:
+                    await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainders, dispatches
+
+    remainders, dispatches = asyncio.run(scenario())
+
+    assert remainders == [b"", b"", b""]
+    assert dispatches == []
+
+
+def test_notify_auth_first_frame_uses_auth_limit_and_fails_closed(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches),
+            max_request_bytes=32,
+        )
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                writer.write(build_auth_init_frame())
+                await writer.drain()
+                challenge = await _read_frame(reader)
+                parse_auth_challenge_frame(challenge)
+            finally:
+                await _close_stream_writer(writer)
+
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                oversized = b'{"authVersion":"' + (b"x" * 4096) + b'"}\n'
+                writer.write(oversized)
+                await writer.drain()
+                remainder = await asyncio.wait_for(reader.read(), timeout=0.5)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return remainder, dispatches
+
+    remainder, dispatches = asyncio.run(scenario())
+
+    assert remainder == b""
+    assert dispatches == []
+
+
+def test_notify_key_rejects_plain_notify_but_keeps_plain_health(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches, include_health=True),
+        )
+        await server.start()
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(socket_path))
+            try:
+                writer.write(_notify_request_payload() + b"\n")
+                await writer.drain()
+                plain_notify_response = await asyncio.wait_for(
+                    reader.read(), timeout=0.5
+                )
+            finally:
+                await _close_stream_writer(writer)
+
+            health_response = await _send_daemon_request(
+                socket_path,
+                DaemonRequest(method="daemon.health"),
+            )
+        finally:
+            await server.stop()
+        return plain_notify_response, health_response, dispatches
+
+    plain_notify_response, health_response, dispatches = asyncio.run(scenario())
+
+    assert plain_notify_response == b""
+    assert health_response.ok is True
+    assert health_response.data == {"status": "ok"}
+    assert dispatches == ["daemon.health"]
+
+
+def test_authenticated_non_notify_returns_signed_bad_request(
+    monkeypatch,
+    tmp_path: Path,
+):
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        secret = _configure_notify_auth(monkeypatch, tmp_path)
+        dispatches = []
+        server = DaemonServer(
+            socket_path=socket_path,
+            registry=_tracking_notify_registry(dispatches, include_health=True),
+        )
+        await server.start()
+        try:
+            reader, writer, session = await _open_authenticated_notify_connection(
+                socket_path,
+                secret,
+            )
+            try:
+                health_payload = serialize_request(
+                    DaemonRequest(method="daemon.health")
+                )[:-1]
+                writer.write(session.protect_payload(health_payload, "client"))
+                await writer.drain()
+                response = await _read_authenticated_response(reader, session)
+            finally:
+                await _close_stream_writer(writer)
+        finally:
+            await server.stop()
+        return response, dispatches
+
+    response, dispatches = asyncio.run(scenario())
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error["code"] == "bad_request"
+    assert METHOD_SKILLFS_NOTIFY_CHANGE in response.error["message"]
+    assert dispatches == []
+
+
+def test_invalid_notify_key_fails_before_bind_or_job_start(
+    monkeypatch,
+    tmp_path: Path,
+):
+    key_path = tmp_path / "short.key"
+    key_path.write_bytes(b"short")
+    key_path.chmod(0o600)
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, str(key_path))
+
+    async def scenario():
+        socket_path = tmp_path / "runtime" / "daemon.sock"
+        server = DaemonServer(socket_path=socket_path)
+
+        with pytest.raises(SkillFsPeerAuthError, match="between 32 and 4096 bytes"):
+            await server.start()
+
+        return (
+            server._server,
+            server._lock,
+            server.runtime.jobs.started,
+            socket_path.exists(),
+        )
+
+    bound_server, lock, jobs_started, socket_exists = asyncio.run(scenario())
+
+    assert bound_server is None
+    assert lock is None
+    assert jobs_started is False
+    assert socket_exists is False
+
+
 async def _send_daemon_request(
     socket_path: Path,
     request: DaemonRequest,
@@ -1466,3 +1978,137 @@ async def _send_daemon_request(
     writer.close()
     await writer.wait_closed()
     return parse_response_line(line)
+
+
+def _configure_notify_auth(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    value: bytes = b"n" * 32,
+) -> SharedSecret:
+    key_path = tmp_path / "notify.key"
+    key_path.write_bytes(value)
+    key_path.chmod(0o600)
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, str(key_path))
+    return SharedSecret(value)
+
+
+def _tracking_notify_registry(
+    dispatches: list[str],
+    *,
+    include_health: bool = False,
+) -> MethodRegistry:
+    registry = MethodRegistry()
+
+    def notify_handler(
+        request: DaemonRequest,
+        _runtime: DaemonRuntime,
+    ) -> HandlerResult:
+        dispatches.append(request.method)
+        return HandlerResult(data={"schemaVersion": 2, "accepted": True})
+
+    registry.register(
+        MethodSpec(
+            method=METHOD_SKILLFS_NOTIFY_CHANGE,
+            handler=notify_handler,
+            lifecycle="skill_ledger",
+        )
+    )
+    if include_health:
+
+        def health_handler(
+            request: DaemonRequest,
+            _runtime: DaemonRuntime,
+        ) -> HandlerResult:
+            dispatches.append(request.method)
+            return HandlerResult(data={"status": "ok"})
+
+        registry.register(
+            MethodSpec(
+                method="daemon.health",
+                handler=health_handler,
+                lifecycle="admin",
+            )
+        )
+    return registry
+
+
+def _notify_request_payload() -> bytes:
+    return json.dumps(
+        {
+            "id": "skillfs-test",
+            "method": METHOD_SKILLFS_NOTIFY_CHANGE,
+            "params": {
+                "schemaVersion": 2,
+                "canonicalSkillDir": "/srv/skills/demo",
+                "skillId": "demo",
+                "eventKind": "write",
+                "paths": [".skill-meta/activation.json"],
+            },
+            "trace_context": {},
+            "timeout_ms": 5000,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+async def _read_frame(reader: asyncio.StreamReader) -> bytes:
+    return await asyncio.wait_for(reader.readline(), timeout=0.5)
+
+
+async def _open_authenticated_notify_connection(
+    socket_path: Path,
+    secret: SharedSecret,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, AuthenticatedSession]:
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    writer.write(build_auth_init_frame())
+    await writer.drain()
+
+    nonce = parse_auth_challenge_frame(await _read_frame(reader))
+    writer.write(
+        build_auth_proof_frame(
+            "auth.proof",
+            secret,
+            NOTIFY_CLIENT_DOMAIN,
+            nonce,
+        )
+    )
+    await writer.drain()
+    verify_auth_proof_frame(
+        await _read_frame(reader),
+        expected_kind="auth.ok",
+        secret=secret,
+        domain=NOTIFY_SERVER_DOMAIN,
+        nonce=nonce,
+    )
+    return (
+        reader,
+        writer,
+        AuthenticatedSession(
+            secret,
+            nonce,
+            NOTIFY_CLIENT_DOMAIN,
+            NOTIFY_SERVER_DOMAIN,
+        ),
+    )
+
+
+async def _read_authenticated_response(
+    reader: asyncio.StreamReader,
+    session: AuthenticatedSession,
+) -> DaemonResponse:
+    protected = await asyncio.wait_for(reader.read(), timeout=0.5)
+    payload, auth_frame, trailing = protected.split(b"\n", maxsplit=2)
+    assert trailing == b""
+    session.verify_payload(payload, auth_frame + b"\n", "server")
+    return parse_response_line(payload)
+
+
+async def _close_stream_writer(writer: asyncio.StreamWriter) -> None:
+    writer.close()
+    with contextlib.suppress(
+        ConnectionError,
+        BrokenPipeError,
+        OSError,
+    ):
+        await writer.wait_closed()

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_live_root.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_live_root.py
@@ -21,6 +21,18 @@ from agent_sec_cli.skill_ledger.path_identity import (
     normalize_canonical_skill_dir,
     validate_canonical_skill_dir,
 )
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE,
+    AGENT_SEC_SKILLFS_CONTROL_SOCKET,
+    CONTROL_CLIENT_DOMAIN,
+    CONTROL_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    build_auth_challenge_frame,
+    build_auth_proof_frame,
+    validate_auth_init_frame,
+    verify_auth_proof_frame,
+)
 
 
 def _make_skill(parent: Path, name: str) -> Path:
@@ -69,6 +81,76 @@ def _resolver(socket_path: Path, *, timeout_seconds: float = 1.0) -> SkillRootRe
     return SkillRootResolver(
         SkillFsResolverClient(socket_path, timeout_seconds=timeout_seconds)
     )
+
+
+def _write_auth_key(path: Path, value: bytes = b"k" * 32) -> Path:
+    path.write_bytes(value)
+    path.chmod(0o600)
+    return path
+
+
+def _start_authenticated_server(
+    socket_path: Path,
+    secret: SharedSecret,
+    response: dict[str, Any],
+    *,
+    response_secret: SharedSecret | None = None,
+) -> tuple[list[dict[str, Any]], list[BaseException], threading.Thread]:
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(1)
+    requests: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+
+    def serve() -> None:
+        try:
+            with listener:
+                connection, _ = listener.accept()
+                with connection, connection.makefile("rb") as reader:
+                    validate_auth_init_frame(reader.readline())
+                    nonce, challenge = build_auth_challenge_frame(bytes(range(32)))
+                    connection.sendall(challenge)
+                    verify_auth_proof_frame(
+                        reader.readline(),
+                        expected_kind="auth.proof",
+                        secret=secret,
+                        domain=CONTROL_CLIENT_DOMAIN,
+                        nonce=nonce,
+                    )
+                    connection.sendall(
+                        build_auth_proof_frame(
+                            "auth.ok", secret, CONTROL_SERVER_DOMAIN, nonce
+                        )
+                    )
+                    session = AuthenticatedSession(
+                        secret,
+                        nonce,
+                        CONTROL_CLIENT_DOMAIN,
+                        CONTROL_SERVER_DOMAIN,
+                    )
+                    payload = reader.readline().removesuffix(b"\n")
+                    tag = reader.readline()
+                    session.verify_payload(payload, tag, "client")
+                    requests.append(json.loads(payload.decode("utf-8")))
+
+                    response_payload = json.dumps(
+                        response, separators=(",", ":")
+                    ).encode("utf-8")
+                    response_session = AuthenticatedSession(
+                        response_secret or secret,
+                        nonce,
+                        CONTROL_CLIENT_DOMAIN,
+                        CONTROL_SERVER_DOMAIN,
+                    )
+                    connection.sendall(
+                        response_session.protect_payload(response_payload, "server")
+                    )
+        except BaseException as exc:  # pragma: no cover - surfaced in the test thread
+            errors.append(exc)
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    return requests, errors, thread
 
 
 def test_default_socket_follows_effective_uid(
@@ -196,6 +278,199 @@ def test_resolver_uses_host_when_socket_is_missing(tmp_path: Path) -> None:
     root = _resolver(tmp_path / "missing.sock").resolve(canonical)
 
     assert root == ResolvedSkillRoot(canonical, canonical, "host")
+
+
+def test_default_resolver_uses_host_when_socket_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _make_skill(tmp_path, "weather")
+    monkeypatch.setattr(
+        live_root_module,
+        "default_skillfs_control_socket",
+        lambda: tmp_path / "missing.sock",
+    )
+
+    root = SkillRootResolver(SkillFsResolverClient()).resolve(canonical)
+
+    assert root == ResolvedSkillRoot(canonical, canonical, "host")
+
+
+@pytest.mark.parametrize("explicit_socket", [False, True])
+def test_resolver_fails_closed_when_hmac_socket_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit_socket: bool,
+) -> None:
+    canonical = _make_skill(tmp_path, "weather")
+    missing_socket = tmp_path / "missing.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+    monkeypatch.setattr(
+        live_root_module,
+        "default_skillfs_control_socket",
+        lambda: missing_socket,
+    )
+    client = SkillFsResolverClient(missing_socket if explicit_socket else None)
+
+    with pytest.raises(SkillRootResolveError, match="authentication failed"):
+        SkillRootResolver(client).resolve(canonical)
+
+
+@pytest.mark.parametrize("managed", [False, True])
+def test_authenticated_resolver_accepts_trusted_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    managed: bool,
+) -> None:
+    canonical = _make_skill(tmp_path / "mount", "weather")
+    live = _make_skill(tmp_path / "backing", "weather")
+    socket_path = tmp_path / "skillfs.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    secret = SharedSecret.load(key_path)
+    response_result: dict[str, Any] = {
+        "managed": managed,
+        "canonicalSkillDir": str(canonical),
+    }
+    if managed:
+        response_result["liveSkillDir"] = str(live)
+    requests, errors, thread = _start_authenticated_server(
+        socket_path,
+        secret,
+        {"schemaVersion": "1", "ok": True, "result": response_result},
+    )
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_SOCKET, str(socket_path))
+
+    root = SkillRootResolver(SkillFsResolverClient()).resolve(canonical)
+    thread.join(timeout=1)
+
+    expected = ResolvedSkillRoot(
+        canonical, live if managed else canonical, "skillfs" if managed else "host"
+    )
+    assert root == expected
+    assert requests[0]["canonicalSkillDir"] == str(canonical)
+    assert errors == []
+
+
+def test_authenticated_resolver_rejects_wrong_response_mac(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _make_skill(tmp_path / "mount", "weather")
+    socket_path = tmp_path / "skillfs.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    secret = SharedSecret.load(key_path)
+    wrong_secret = SharedSecret(b"w" * 32)
+    _, errors, thread = _start_authenticated_server(
+        socket_path,
+        secret,
+        {
+            "schemaVersion": "1",
+            "ok": True,
+            "result": {
+                "managed": False,
+                "canonicalSkillDir": str(canonical),
+            },
+        },
+        response_secret=wrong_secret,
+    )
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+
+    with pytest.raises(SkillRootResolveError, match="authentication failed"):
+        _resolver(socket_path).resolve(canonical)
+    thread.join(timeout=1)
+
+    assert errors == []
+
+
+def test_authenticated_resolver_rejects_wrong_handshake_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _make_skill(tmp_path / "mount", "weather")
+    socket_path = tmp_path / "skillfs.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    server_secret = SharedSecret(b"s" * 32)
+    _, errors, thread = _start_authenticated_server(
+        socket_path,
+        server_secret,
+        {
+            "schemaVersion": "1",
+            "ok": True,
+            "result": {
+                "managed": False,
+                "canonicalSkillDir": str(canonical),
+            },
+        },
+    )
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+
+    with pytest.raises(SkillRootResolveError, match="authentication failed"):
+        _resolver(socket_path).resolve(canonical)
+    thread.join(timeout=1)
+
+    assert errors
+
+
+def test_authenticated_resolver_handshake_uses_total_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _make_skill(tmp_path / "mount", "weather")
+    socket_path = tmp_path / "skillfs.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(1)
+
+    def serve() -> None:
+        with listener:
+            connection, _ = listener.accept()
+            with connection, connection.makefile("rb") as reader:
+                validate_auth_init_frame(reader.readline())
+                time.sleep(0.05)
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+
+    with pytest.raises(SkillRootResolveError, match="timed out"):
+        _resolver(socket_path, timeout_seconds=0.01).resolve(canonical)
+    thread.join(timeout=1)
+
+
+def test_authenticated_resolver_never_retries_plaintext(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    canonical = _make_skill(tmp_path / "mount", "weather")
+    socket_path = tmp_path / "skillfs.sock"
+    key_path = _write_auth_key(tmp_path / "control.key")
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(socket_path))
+    listener.listen(2)
+    received: list[bytes] = []
+
+    def serve() -> None:
+        with listener:
+            connection, _ = listener.accept()
+            with connection, connection.makefile("rb") as reader:
+                received.append(reader.readline())
+                connection.sendall(b'{"schemaVersion":"1","ok":true}\n')
+            listener.settimeout(0.1)
+            with pytest.raises(socket.timeout):
+                listener.accept()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, str(key_path))
+
+    with pytest.raises(SkillRootResolveError, match="authentication failed"):
+        _resolver(socket_path).resolve(canonical)
+    thread.join(timeout=1)
+
+    assert received == [b'{"authVersion":"1","type":"auth.init"}\n']
 
 
 def test_resolver_uses_host_for_explicit_not_managed(tmp_path: Path) -> None:

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_skillfs_peer_auth.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_skillfs_peer_auth.py
@@ -1,0 +1,385 @@
+"""Unit tests for the SkillFS shared-key peer authentication contract."""
+
+import base64
+import json
+import os
+from pathlib import Path
+
+import pytest
+from agent_sec_cli.skill_ledger import skillfs_peer_auth as peer_auth
+from agent_sec_cli.skill_ledger.skillfs_peer_auth import (
+    AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE,
+    AGENT_SEC_SKILLFS_CONTROL_SOCKET,
+    AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE,
+    AUTH_FRAME_LIMIT,
+    CONTROL_CLIENT_DOMAIN,
+    CONTROL_SERVER_DOMAIN,
+    MAX_SECRET_LENGTH,
+    MIN_SECRET_LENGTH,
+    NOTIFY_CLIENT_DOMAIN,
+    NOTIFY_SERVER_DOMAIN,
+    AuthenticatedSession,
+    SharedSecret,
+    SkillFsPeerAuthError,
+    build_auth_challenge_frame,
+    build_auth_init_frame,
+    build_auth_proof_frame,
+    classify_initial_frame,
+    configured_control_key_path,
+    configured_control_socket_path,
+    configured_notify_key_path,
+    parse_auth_challenge_frame,
+    validate_auth_init_frame,
+    verify_auth_proof_frame,
+)
+
+FIXED_SECRET = bytes(range(32))
+FIXED_NONCE = bytes(range(32, 64))
+FIXED_PAYLOAD = b'{"schemaVersion":"1","method":"ping"}'
+
+HANDSHAKE_VECTORS = (
+    (CONTROL_CLIENT_DOMAIN, "pqaSiunq07XWqMvQ8xSiSLi6dsLEy5iaCEF3md04AVI="),
+    (CONTROL_SERVER_DOMAIN, "naSgjgOT+Zs71EytW6byhJMCkfek2sGmK+CDqHmDsas="),
+    (NOTIFY_CLIENT_DOMAIN, "aFcVadTie7FrVTYOjk1OOjBpoQZ6LUvnLGC6stiqt6M="),
+    (NOTIFY_SERVER_DOMAIN, "F22J+ua0Pmha2dPyTMmTQNtKjcmed59Mo8FKgdcgBOc="),
+)
+
+BUSINESS_FRAME_VECTORS = (
+    (CONTROL_CLIENT_DOMAIN, "zT6arzIjdC4fJqiSM59qNhU2BADHJgFRq8YqifcdHCM="),
+    (CONTROL_SERVER_DOMAIN, "W9lF84f43ROoMXPHkgovtowDiZ5zv0zubs2vmq98T9k="),
+    (NOTIFY_CLIENT_DOMAIN, "Zzf/dpWsuj89DFbpJtwqBk5dHsV+GXwGOytZMh5xDKw="),
+    (NOTIFY_SERVER_DOMAIN, "ut2Pv/8XHmiImbWSfm53ixIcoDimZOPHzrS6g3TtO+M="),
+)
+
+
+def _auth_frame(kind: str, **fields: object) -> bytes:
+    payload = {"authVersion": "1", "type": kind, **fields}
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+
+
+def _write_key(path: Path, value: bytes = b"k" * 32, mode: int = 0o600) -> Path:
+    path.write_bytes(value)
+    path.chmod(mode)
+    return path
+
+
+@pytest.mark.parametrize(("domain", "expected"), HANDSHAKE_VECTORS)
+def test_handshake_hmac_fixed_vectors(domain: str, expected: str) -> None:
+    secret = SharedSecret(FIXED_SECRET)
+
+    actual = base64.b64encode(secret.proof(domain, FIXED_NONCE)).decode("ascii")
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(("domain", "expected"), BUSINESS_FRAME_VECTORS)
+def test_business_frame_hmac_fixed_vectors(domain: str, expected: str) -> None:
+    secret = SharedSecret(FIXED_SECRET)
+
+    actual = base64.b64encode(
+        secret.frame_proof(domain, FIXED_NONCE, FIXED_PAYLOAD)
+    ).decode("ascii")
+
+    assert len(FIXED_PAYLOAD) == 37
+    assert actual == expected
+
+
+def test_auth_frame_builders_and_parsers_use_exact_wire_shapes() -> None:
+    secret = SharedSecret(FIXED_SECRET)
+
+    assert build_auth_init_frame() == b'{"authVersion":"1","type":"auth.init"}\n'
+    validate_auth_init_frame(build_auth_init_frame())
+
+    nonce, challenge = build_auth_challenge_frame(FIXED_NONCE)
+    assert nonce == FIXED_NONCE
+    assert challenge == _auth_frame(
+        "auth.challenge",
+        nonce="ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=",
+    )
+    assert parse_auth_challenge_frame(challenge) == FIXED_NONCE
+
+    for kind, domain in (
+        ("auth.proof", CONTROL_CLIENT_DOMAIN),
+        ("auth.ok", CONTROL_SERVER_DOMAIN),
+    ):
+        proof_frame = build_auth_proof_frame(kind, secret, domain, FIXED_NONCE)
+        verify_auth_proof_frame(
+            proof_frame,
+            expected_kind=kind,
+            secret=secret,
+            domain=domain,
+            nonce=FIXED_NONCE,
+        )
+
+
+@pytest.mark.parametrize(
+    "frame",
+    (
+        b'{"type":"auth.init"}\n',
+        b'{"authVersion":1,"type":"auth.init"}\n',
+        b'{"authVersion":"2","type":"auth.init"}\n',
+        b'{"authVersion":"1","type":"auth.challenge"}\n',
+        b'{"authVersion":"1","type":"auth.init","nonce":null}\n',
+        b'{"authVersion":"1","type":"auth.init","proof":"value"}\n',
+        b'{"authVersion":"1","type":"auth.init","unknown":true}\n',
+        b'{"authVersion":"1","authVersion":"1","type":"auth.init"}\n',
+        b'[{"authVersion":"1","type":"auth.init"}]\n',
+    ),
+)
+def test_auth_init_rejects_non_exact_or_duplicate_fields(frame: bytes) -> None:
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        validate_auth_init_frame(frame)
+
+
+def test_auth_proof_rejects_wrong_secret() -> None:
+    expected_secret = SharedSecret(b"e" * 32)
+    wrong_secret = SharedSecret(b"w" * 32)
+    frame = build_auth_proof_frame(
+        "auth.proof",
+        wrong_secret,
+        CONTROL_CLIENT_DOMAIN,
+        FIXED_NONCE,
+    )
+
+    with pytest.raises(SkillFsPeerAuthError, match="proof verification failed"):
+        verify_auth_proof_frame(
+            frame,
+            expected_kind="auth.proof",
+            secret=expected_secret,
+            domain=CONTROL_CLIENT_DOMAIN,
+            nonce=FIXED_NONCE,
+        )
+
+
+def test_authenticated_payload_rejects_tampering_and_wrong_direction() -> None:
+    session = AuthenticatedSession(
+        SharedSecret(FIXED_SECRET),
+        FIXED_NONCE,
+        CONTROL_CLIENT_DOMAIN,
+        CONTROL_SERVER_DOMAIN,
+    )
+    protected = session.protect_payload(FIXED_PAYLOAD, "client")
+    payload, auth_frame = protected.split(b"\n", maxsplit=1)
+
+    assert payload == FIXED_PAYLOAD
+    session.verify_payload(payload, auth_frame, "client")
+    with pytest.raises(SkillFsPeerAuthError, match="proof verification failed"):
+        session.verify_payload(
+            payload.replace(b"ping", b"status"), auth_frame, "client"
+        )
+    with pytest.raises(SkillFsPeerAuthError, match="proof verification failed"):
+        session.verify_payload(payload, auth_frame, "server")
+
+
+def test_authenticated_payload_rejects_newlines_and_invalid_sender() -> None:
+    session = AuthenticatedSession(
+        SharedSecret(FIXED_SECRET),
+        FIXED_NONCE,
+        CONTROL_CLIENT_DOMAIN,
+        CONTROL_SERVER_DOMAIN,
+    )
+
+    with pytest.raises(SkillFsPeerAuthError, match="one NDJSON frame"):
+        session.protect_payload(b"first\nsecond", "client")
+    with pytest.raises(
+        SkillFsPeerAuthError, match="invalid authenticated frame sender"
+    ):
+        session.protect_payload(FIXED_PAYLOAD, "invalid")
+
+
+def test_nonce_and_proof_require_canonical_padded_base64() -> None:
+    secret = SharedSecret(FIXED_SECRET)
+    canonical_nonce = base64.b64encode(FIXED_NONCE).decode("ascii")
+    canonical_proof = base64.b64encode(
+        secret.proof(CONTROL_CLIENT_DOMAIN, FIXED_NONCE)
+    ).decode("ascii")
+
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        parse_auth_challenge_frame(
+            _auth_frame("auth.challenge", nonce=canonical_nonce.rstrip("="))
+        )
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        verify_auth_proof_frame(
+            _auth_frame("auth.proof", proof=canonical_proof.rstrip("=")),
+            expected_kind="auth.proof",
+            secret=secret,
+            domain=CONTROL_CLIENT_DOMAIN,
+            nonce=FIXED_NONCE,
+        )
+
+
+def test_authenticated_tag_rejects_unknown_and_duplicate_fields() -> None:
+    session = AuthenticatedSession(
+        SharedSecret(FIXED_SECRET),
+        FIXED_NONCE,
+        CONTROL_CLIENT_DOMAIN,
+        CONTROL_SERVER_DOMAIN,
+    )
+    proof = base64.b64encode(
+        SharedSecret(FIXED_SECRET).frame_proof(
+            CONTROL_CLIENT_DOMAIN, FIXED_NONCE, FIXED_PAYLOAD
+        )
+    ).decode("ascii")
+    unknown = _auth_frame("auth.frame", proof=proof, unknown=True)
+    duplicate = (
+        b'{"authVersion":"1","type":"auth.frame","proof":"'
+        + proof.encode("ascii")
+        + b'","proof":"'
+        + proof.encode("ascii")
+        + b'"}\n'
+    )
+
+    for frame in (unknown, duplicate):
+        with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+            session.verify_payload(FIXED_PAYLOAD, frame, "client")
+
+
+def test_auth_frame_limit_is_inclusive_and_rejects_oversize() -> None:
+    init_content = build_auth_init_frame()[:-1]
+    exact_limit = init_content + b" " * (AUTH_FRAME_LIMIT - len(init_content)) + b"\n"
+    oversized = exact_limit[:-1] + b" \n"
+
+    validate_auth_init_frame(exact_limit)
+    with pytest.raises(SkillFsPeerAuthError, match="exceeds 4096 byte limit"):
+        validate_auth_init_frame(oversized)
+
+
+@pytest.mark.parametrize(
+    "frame",
+    (
+        b'{"authVersion":"1","type":"auth.init"}',
+        b'{"authVersion":"1","type":"auth.init"}\nignored',
+        b'{"authVersion":"1",\n"type":"auth.init"}\n',
+    ),
+)
+def test_auth_frame_rejects_eof_or_embedded_newline(frame: bytes) -> None:
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        validate_auth_init_frame(frame)
+
+
+def test_initial_frame_classification_rejects_auth_lookalikes() -> None:
+    assert classify_initial_frame(build_auth_init_frame())
+    assert not classify_initial_frame(b'{"method":"daemon.health"}\n')
+
+    for frame in (
+        b'{"authVersion":"1","type":"auth.init","extra":true}\n',
+        b'{"authVersion":"1","type":"auth.proof"}\n',
+        b'{"authVersion":"1","type":\n',
+        b'{"type" \t : \t "auth.init"\n',
+        b'{"method":"daemon.health","ty\\u0070e":"auth.init",'
+        b'"ty\\u0070e":"ordinary"}\n',
+    ):
+        with pytest.raises(SkillFsPeerAuthError):
+            classify_initial_frame(frame)
+
+
+def test_auth_parsers_reject_excessive_json_nesting() -> None:
+    nested = (b"[" * 1100) + b"0" + (b"]" * 1100)
+    init = b'{"authVersion":"1","type":"auth.init","extra":' + nested + b"}\n"
+    challenge = b'{"authVersion":"1","type":"auth.challenge","nonce":' + nested + b"}\n"
+
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        classify_initial_frame(init)
+    with pytest.raises(SkillFsPeerAuthError, match="invalid authentication frame"):
+        parse_auth_challenge_frame(challenge)
+
+
+def test_configured_peer_paths_follow_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_SOCKET, "/run/skillfs/control.sock")
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE, "/run/keys/control.key")
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, "/run/keys/notify.key")
+
+    assert configured_control_socket_path() == Path("/run/skillfs/control.sock")
+    assert configured_control_key_path() == Path("/run/keys/control.key")
+    assert configured_notify_key_path() == Path("/run/keys/notify.key")
+
+    monkeypatch.setenv(AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE, "")
+    with pytest.raises(SkillFsPeerAuthError, match="must not be empty"):
+        configured_notify_key_path()
+
+
+@pytest.mark.parametrize("length", (MIN_SECRET_LENGTH, MAX_SECRET_LENGTH))
+def test_key_loader_accepts_raw_secret_length_boundaries(
+    tmp_path: Path, length: int
+) -> None:
+    key = _write_key(tmp_path / f"key-{length}", b"x" * length)
+
+    secret = SharedSecret.load(key)
+
+    assert repr(secret) == "SharedSecret([REDACTED])"
+
+
+def test_key_loader_rejects_relative_path() -> None:
+    with pytest.raises(SkillFsPeerAuthError, match="path must be absolute"):
+        SharedSecret.load(Path("relative.key"))
+
+
+def test_key_loader_rejects_final_component_symlink(tmp_path: Path) -> None:
+    target = _write_key(tmp_path / "target.key")
+    link = tmp_path / "link.key"
+    link.symlink_to(target)
+
+    with pytest.raises(SkillFsPeerAuthError, match="failed to open"):
+        SharedSecret.load(link)
+
+
+def test_key_loader_rejects_fifo_without_blocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fifo = tmp_path / "key.fifo"
+    os.mkfifo(fifo, 0o600)
+    real_open = os.open
+
+    def checked_open(path: Path, flags: int) -> int:
+        assert flags & os.O_NONBLOCK
+        assert flags & os.O_CLOEXEC
+        assert flags & os.O_NOFOLLOW
+        return real_open(path, flags)
+
+    monkeypatch.setattr(peer_auth.os, "open", checked_open)
+
+    with pytest.raises(SkillFsPeerAuthError, match="regular file"):
+        SharedSecret.load(fifo)
+
+
+def test_key_loader_rejects_directory(tmp_path: Path) -> None:
+    directory = tmp_path / "key-directory"
+    directory.mkdir(mode=0o700)
+
+    with pytest.raises(SkillFsPeerAuthError, match="regular file"):
+        SharedSecret.load(directory)
+
+
+@pytest.mark.parametrize("mode", (0o640, 0o604, 0o601))
+def test_key_loader_rejects_group_or_other_permissions(
+    tmp_path: Path, mode: int
+) -> None:
+    key = _write_key(tmp_path / f"key-{mode:o}", mode=mode)
+
+    with pytest.raises(SkillFsPeerAuthError, match="group or other permissions"):
+        SharedSecret.load(key)
+
+
+@pytest.mark.parametrize("length", (MIN_SECRET_LENGTH - 1, MAX_SECRET_LENGTH + 1))
+def test_key_loader_rejects_short_or_oversized_secret(
+    tmp_path: Path, length: int
+) -> None:
+    key = _write_key(tmp_path / f"key-{length}", b"x" * length)
+
+    with pytest.raises(SkillFsPeerAuthError, match="between 32 and 4096 bytes"):
+        SharedSecret.load(key)
+
+
+def test_key_loader_rejects_wrong_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _write_key(tmp_path / "key")
+    wrong_uid = os.geteuid() + 1
+    monkeypatch.setattr(peer_auth.os, "geteuid", lambda: wrong_uid)
+
+    with pytest.raises(SkillFsPeerAuthError, match="effective user"):
+        SharedSecret.load(key)


### PR DESCRIPTION
## Why

Skill Ledger and SkillFS currently rely on same-host peer identity. In ACS, Ledger runs in
the main container while SkillFS runs as a sidecar, so the resolver and reverse-notify paths
need an explicit cross-container trust contract without silently downgrading authenticated
deployments.

## What changed

- Add a Skill Ledger-scoped HMAC-SHA256 protocol implementation compatible with SkillFS
  PR #2449.
- Authenticate the control resolver and daemon notify paths over their raw NDJSON frames.
- Preserve legacy `ENOENT` host fallback only when control authentication is not configured;
  configured authentication fails closed.
- Keep unrelated daemon APIs and deployments without HMAC configuration backward compatible.

## Related issue

no-issue: follows up on SkillFS PR #2449 for ACS sidecar interoperability

Depends on #2449.

## User / Agent impact

ACS deployments can configure authenticated Skill Ledger-SkillFS communication with:

- `AGENT_SEC_SKILLFS_CONTROL_SOCKET`
- `AGENT_SEC_SKILLFS_CONTROL_AUTH_KEY_FILE`
- `AGENT_SEC_SKILLFS_NOTIFY_AUTH_KEY_FILE`

Authentication keys must be absolute-path, non-symlink regular files owned by the current
effective UID with no group or other permissions. Configuring a control key makes a missing
or unreachable SkillFS socket an error instead of triggering host fallback.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The authenticated wire contract must remain compatible with SkillFS PR #2449. Legacy behavior
is unchanged when no HMAC key is configured; authenticated deployments intentionally fail
closed on socket, handshake, or frame-authentication failures.

## Validation

- `make python-code-pretty`
- `make test-python`
  - core: 3704 passed, 3 skipped, 20 subtests passed
  - CLI e2e: 87 passed, 2 skipped
  - daemon e2e: 12 passed, 6 skipped
  - Skill Ledger e2e: 50 passed
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check upstream/main...HEAD`
- SkillFS PR #2449 fixed-vector probe at commit `f6e979432e1bc44a4abf67af86321bb8942b59bc`:
  all handshake and business-frame HMAC vectors matched

The real SkillFS FUSE binary and Kubernetes two-container deployment were not exercised on
this macOS development host.

## Documentation and rollback

Updated the English and Chinese component READMEs, Skill Ledger user guides, and the existing
Skill Ledger-SkillFS integration design. To disable the integration, unset the three new
environment variables; to remove the implementation entirely, revert this commit. ACS HMAC
interoperation requires the corresponding SkillFS implementation from #2449.
