### PR TITLE
fix(anolisa): ignore shared adapter resources

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -733,6 +733,11 @@ impl AdapterManager {
             entry.source_reason = source.reason;
         }
 
+        // A directory name alone cannot establish an unknown framework. Keep
+        // unknown rows only when a contract or receipt identifies them, so
+        // shared trees such as `adapters/tokenless/common` are not adapters.
+        entries.retain(|_, entry| entry.declared || entry.enabled || entry.driver_available);
+
         let mut warnings = self.visibility_warnings.clone();
         warnings.extend(declaration_warnings);
         Ok(ScanReport {
@@ -5957,6 +5962,53 @@ entry = "custom-entry.json"
         assert!(
             entry.resource_root.is_some(),
             "convention resource must be found by directory discovery"
+        );
+    }
+
+    #[test]
+    fn convention_discovery_ignores_shared_resource_directories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let state_dir = tmp.path().join("state");
+        let datadir = tmp.path().join("data");
+
+        std::fs::create_dir_all(&state_dir).expect("mkdir state");
+        InstalledState::default()
+            .save(&state_dir.join("installed.toml"))
+            .expect("save empty state");
+
+        let adapters = datadir.join("adapters/tokenless");
+        let openclaw = adapters.join("openclaw");
+        std::fs::create_dir_all(&openclaw).expect("mkdir openclaw adapter");
+        std::fs::write(openclaw.join("openclaw.plugin.json"), b"{}").expect("adapter manifest");
+
+        let common = adapters.join("common/hooks");
+        std::fs::create_dir_all(&common).expect("mkdir shared hooks");
+        std::fs::write(common.join("rewrite.sh"), b"#!/bin/sh\n").expect("shared hook");
+
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let mut manager =
+            AdapterManager::new(layout, Some(tmp.path().to_path_buf()), "test".into());
+        manager.state_path = state_dir.join("installed.toml");
+        manager.visible_roots = vec![VisibleRoot {
+            state_dir,
+            contract_datadir_roots: vec![datadir.clone()],
+        }];
+        manager.all_datadir_roots = vec![datadir];
+
+        let report = manager.scan().expect("scan");
+        assert!(
+            report
+                .entries
+                .iter()
+                .any(|entry| entry.component == "tokenless" && entry.framework == "openclaw"),
+            "real framework adapter must remain discoverable"
+        );
+        assert!(
+            report
+                .entries
+                .iter()
+                .all(|entry| entry.component != "tokenless" || entry.framework != "common"),
+            "shared common resources must not be reported as an adapter"
         );
     }
 


### PR DESCRIPTION
## Why

`anolisa adapter scan` treated every non-empty directory under
`adapters/<component>/` as a framework candidate. Tokenless installs shared
hooks and commands under `adapters/tokenless/common`, so scan incorrectly
reported that resource tree as an undeclared adapter.

## What changed

- Keep directory-discovered rows only when they have a built-in driver, a
  manifest declaration, or an existing receipt.
- Add a regression test proving the real Tokenless OpenClaw adapter remains
  visible while the sibling `common` resource tree is omitted.

## Related issue

Closes #2494

## User / Agent impact

`adapter scan` table and JSON output no longer include Tokenless shared
resources as a `framework: "common"` adapter. Declared or enabled adapters
without a built-in driver remain visible for diagnostics.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This only removes unactionable rows inferred solely from unknown
directory names; manifest declarations and persisted receipts still take
precedence.

## Validation

Linux development host:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-core convention_discovery_ --locked`
- `cargo test --workspace --locked -- --skip systemd::tests::unimplemented_unit_operations_return_errors_instead_of_panicking`
- `cargo test -p anolisa-platform package_manager::tests::package_command_does_not_wait_for_background_descendant_holding_progress_fd --locked -- --exact --nocapture`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`

The skipped systemd test assumes `agentsight.service` is absent; this host has
that unit loaded. The unrelated progress-FD test was rerun independently and
passed.

## Documentation and rollback

No documentation change is needed because the command contract is unchanged;
the output now excludes a non-adapter resource. Roll back by reverting
`5d83840b`.
