### PR TITLE
fix(anolisa): isolate systemd unit test

### DIFF
--- a/src/anolisa/crates/anolisa-platform/src/systemd.rs
+++ b/src/anolisa/crates/anolisa-platform/src/systemd.rs
@@ -162,10 +162,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unimplemented_unit_operations_return_errors_instead_of_panicking() {
-        assert!(unit_status("agentsight.service").is_err());
-        assert!(enable_unit("agentsight.service").is_err());
-        assert!(disable_unit("agentsight.service").is_err());
-        assert!(disable_unit_deferred("agentsight.service").is_err());
+    fn empty_unit_operations_return_not_found() {
+        assert!(matches!(
+            unit_status(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            enable_unit(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            disable_unit(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            disable_unit_deferred(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
     }
 }


### PR DESCRIPTION
## Why

The `anolisa-platform` systemd unit test invokes the production implementation against
`agentsight.service`. Its result therefore depends on host state, and later assertions can
enable, start, stop, or disable a real AgentSight service.

## What changed

Replace the host-dependent service operations with empty-unit boundary checks. Empty input is
rejected before `systemctl` is spawned, so all four public operations retain deterministic test
coverage without touching host services or adding a production-only mocking abstraction.

## Related issue

Fixes #2499

## User / Agent impact

No runtime behavior changes. Developers and CI runners can run the test without depending on or
mutating an installed AgentSight service.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this is a test-only change.

## Validation

Linux:

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`

## Documentation and rollback

No documentation changes are needed. Roll back by reverting this commit.
