### PR TITLE
chore(anolisa): bump version to 0.3.1

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-13
+
+### Fixed
+
+- Adapter discovery now excludes undeclared shared resource directories unless
+  a contract, receipt, or built-in framework driver identifies them as real
+  adapters. Shared assets such as Tokenless common hooks no longer appear as
+  unsupported frameworks in adapter scan and status output
+  ([#2502](https://github.com/alibaba/anolisa/pull/2502)).
+
 ## [0.3.0] - 2026-08-12
 
 ### Fixed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,15 @@
 
 ## [未发布]
 
+## [0.3.1] - 2026-08-13
+
+### 修复
+
+- Adapter discovery 现会忽略未声明的共享 resource directory，除非 contract、
+  receipt 或内置 framework driver 将其识别为实际 adapter。Tokenless common hook
+  等共享 asset 不再于 adapter scan 和 status output 中显示为不支持的 framework
+  ([#2502](https://github.com/alibaba/anolisa/pull/2502))。
+
 ## [0.3.0] - 2026-08-12
 
 ### 修复

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Aug 12 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Thu Aug 13 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Adapter discovery now ignores undeclared shared resource directories.
+
+* Wed Aug 12 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.0-1
 - Adapter integrity now verifies package-owned files and ignores unmanaged runtime data.
 - Re-enabling adapters now prunes only receipt-owned stale outputs and preserves runtime files.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.0",
-    "@anolisa/cli-linux-arm64": "0.3.0",
-    "@anolisa/cli-darwin-arm64": "0.3.0"
+    "@anolisa/cli-linux-x64": "0.3.1",
+    "@anolisa/cli-linux-arm64": "0.3.1",
+    "@anolisa/cli-darwin-arm64": "0.3.1"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.3.1 packages the adapter discovery fix merged after 0.3.0. This release synchronizes every
distribution surface and curates bilingual notes from the actual component range without adding
runtime behavior in the bump commit.

## What changed

- Bumped the Cargo workspace and all five internal lockfile package versions to 0.3.1.
- Bumped the npm root package, native platform packages, and optional dependency pins to 0.3.1.
- Added equivalent English and Chinese changelog entries for #2502.
- Advanced the RPM changelog placeholder and froze the previous row at 0.3.0.
- Kept the remaining 0.3.0 self-update fixture and SkillFS catalog entry unchanged because they are
  not ANOLISA CLI release versions.

## Related issue

no-issue: release metadata for already-merged PR #2502

## User / Agent impact

Published ANOLISA packages will report version 0.3.1. Adapter scan and status no longer report
undeclared shared resources such as Tokenless common hooks as unsupported frameworks.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this commit changes release metadata and documentation only. The underlying adapter fix
was already merged and preserves declared adapters, persisted receipts, and built-in drivers.

## Validation

Linux x86_64, non-root user; Rust 1.88.0 and Node.js 24.15.0:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64`
- `target/release/anolisa --version` reported `anolisa 0.3.1`.
- Root and Linux x64 npm tarball metadata read back as version 0.3.1.
- Nightly raw-lifecycle harness syntax, list, and repository configuration checks.
- Component version metadata and regression tests.
- Rendered `anolisa.spec.in` parsed with `rpmspec -P`.
- Release metadata audit passed against the 0.3.0 bump boundary.
- `bash scripts/docs-lint.sh`
- Website locale, production build, agent-index, and 162-page link validation.
- `git diff --cached --check`

macOS arm64 and Linux arm64 package templates were validated but not built on this Linux x64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog. Before artifact
publication, rollback is a revert of `fd492d93`; after publication, issue a corrected follow-up
version rather than reusing 0.3.1.