### PR TITLE
feat(tokenless): add AgentScope middleware

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -878,8 +878,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Build and test Tokenless Python wheel
-        run: make -C src/tokenless test-python-runtime
+      - name: Build and test Tokenless Python packages
+        run: |
+          make -C src/tokenless \
+            test-python-runtime test-agentscope-adapter
 
       - uses: actions/setup-node@v4
         with:

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -2,7 +2,7 @@
 
 [中文版](../../../zh/token-saving/tokenless/framework-integration.md)
 
-Tokenless uses adapters to connect compression, command rewriting, and environment checks to an agent. Installing Tokenless provides the binaries and adapter resources; the target agent calls them automatically only after its adapter is enabled.
+Tokenless uses adapters to connect compression, command rewriting, and environment checks to an agent. Installing Tokenless provides the binaries and adapter resources. Plugin- and hook-based frameworks call them after their adapter is enabled; AgentScope applications install and register the Python middleware explicitly.
 
 ## Support matrix
 
@@ -16,6 +16,7 @@ Tokenless uses adapters to connect compression, command rewriting, and environme
 | Codex | `codex` | Hard-disabled | Replaces supported shell input | Keeps the original and adds analysis or a compressed alternative | Used to build that alternative | — |
 | OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
 | Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | ✅ |
+| AgentScope | Python API | — | — | Replaces successful final tool responses | — | — |
 
 “—” means that the current adapter does not register that capability. The corresponding Tokenless CLI command may still be available.
 
@@ -23,7 +24,7 @@ Tool Ready remains registered by these adapters but is unconditionally hard-disa
 
 `additionalContext` is an additive hook field. The Tokenless source does not remove the original result on those paths; the final treatment also depends on the host implementation. A statistics record proves that a candidate became smaller, not that the host removed the original from its model request.
 
-OpenCode currently uses the bundled lifecycle scripts documented below. It is not registered with the `anolisa adapter enable` driver set in this release.
+OpenCode currently uses the bundled lifecycle scripts documented below. AgentScope uses an installable Python package and explicit application code. Neither is registered with the `anolisa adapter enable` driver set in this release.
 
 ## Adapter processing rules
 
@@ -84,7 +85,7 @@ anolisa adapter enable tokenless qwencode
 
 Enable only frameworks that you use. When enabling more than one, run and verify each command separately.
 
-OpenCode is the exception to this section; use its bundled install script under [Manual integration after npm installation](#manual-integration-after-npm-installation).
+OpenCode and AgentScope are exceptions to this section. Use OpenCode's bundled install script under [Manual integration after npm installation](#manual-integration-after-npm-installation), and use the [AgentScope](#agentscope) instructions below.
 
 For OpenClaw, anolisa first attempts a normal install and does not add an unsafe-install bypass by default. If OpenClaw rejects the plugin on its safety scan, read the reported findings. Only after accepting them, retry explicitly:
 
@@ -199,6 +200,116 @@ OpenCode discovers global local plugins at startup. Use the bundled Tokenless li
 ### Qwen Code
 
 The extension loads in a new Qwen Code session. Restart and run one tool call to verify it.
+
+### AgentScope
+
+The Python package supports `agentscope>=2.0.5,<2.1`. The native
+`anolisa-tokenless` runtime wheel is not currently published to a Python
+package index. Although anolisa stages the adapter source under
+`~/.local/share/anolisa/adapters/tokenless/agentscope` or
+`/usr/share/anolisa/adapters/tokenless/agentscope`, installing that source
+alone cannot resolve its exact runtime dependency in a fresh environment.
+The currently supported installation path is to build and install both
+same-version wheels from a source checkout:
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/agentscope-wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+For a high-code Agent, register the same middleware instance with its Toolkit
+and Agent:
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessMiddleware
+
+toolkit = Toolkit()
+middleware = TokenlessMiddleware(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    min_chars=200,
+)
+await middleware.register_tools(toolkit)
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=[middleware],
+)
+```
+
+AgentScope App accepts a per-request middleware factory. Its toolkit assembly
+calls `list_tools()` automatically, so do not also register the retrieval Tool:
+
+```python
+from hashlib import sha256
+from pathlib import Path
+
+from agentscope.app import create_app
+from tokenless_agentscope import TokenlessMiddleware
+
+tenant_root = Path("/srv/tokenless-tenants")
+
+async def tokenless_middlewares(user_id, agent_id, session_id):
+    del agent_id, session_id
+    tenant_key = sha256(user_id.encode("utf-8")).hexdigest()
+    return [TokenlessMiddleware(data_dir=tenant_root / tenant_key)]
+
+app = create_app(
+    ...,
+    extra_agent_middlewares=tokenless_middlewares,
+)
+```
+
+AgentScope resolves duplicate Tool names by keeping the last Tool, while
+`list_tools()` does not receive the other App tools. If the App already has a
+`tokenless_retrieve` Tool, or installs multiple Tokenless middleware instances,
+assign each Tokenless Tool a unique name:
+
+```python
+TokenlessMiddleware(
+    data_dir=tenant_root / tenant_key,
+    retrieve_tool_name="tenant_tokenless_retrieve",
+)
+```
+
+The middleware uses the configured name for `list_tools()`, high-code
+registration, and permanent compression exclusion. High-code
+`register_tools()` still rejects an existing Tool with that configured name.
+
+Choose a mode according to how much inline truncation the application accepts:
+
+| Mode | Read/Glob/Grep | Other tools |
+|------|----------------|-------------|
+| `conservative` | Compress | 1 MiB strings, 65,536 array items, depth 32 |
+| `balanced` (default) | Skip | Shell: 65,536 / 128 / depth 8; others: conservative limits |
+| `aggressive` | Skip | CLI defaults: 4,096 / 32 / depth 8 |
+
+The middleware passes streaming chunks through unchanged. It only replaces a
+successful final `ToolResponse`, preserves response and block identifiers and
+metadata, and keeps the original whenever Tokenless fails or does not make the
+UTF-8 result strictly smaller. JSON objects and arrays remain JSON; ordinary
+text remains text. `DataBlock` values are never changed.
+
+The middleware also exposes a read-only, concurrency-safe retrieval Tool named
+`tokenless_retrieve` by default. It is auto-allowed only for an exact
+24-character hexadecimal hash whose `<<tokenless:HASH>>` marker is present in
+the current AgentScope context or summary. The Tool is permanently excluded
+from compression. This narrow permission still depends on storage isolation:
+pass a separate absolute `data_dir` for every user or tenant. If `data_dir` is
+omitted, `TOKENLESS_DATA_DIR` is only a process-wide fallback and must not be
+shared by multiple tenants. Retrieval does not work across nodes. Stash entries
+expire after the current fixed one-hour TTL, so the Agent should retrieve
+necessary content before that boundary.
+
+Compression and retrieval call the in-process `anolisa-tokenless` runtime from
+an async worker thread; the adapter does not start a CLI process or grant Shell
+access. It also does not add MCP, TOON, RTK command rewriting, or schema
+compression.
 
 ## Verify the actual integration
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -2,7 +2,7 @@
 
 [English](../../../en/token-saving/tokenless/framework-integration.md)
 
-Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。安装 Tokenless 只提供二进制和 Adapter 资源；启用 Adapter 后，目标 Agent 才会自动调用这些能力。
+Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。安装 Tokenless 会提供二进制和 Adapter 资源。Plugin/Hook 型框架在启用 Adapter 后调用这些能力；AgentScope 应用需要显式安装并注册 Python 中间件。
 
 ## 支持矩阵
 
@@ -16,6 +16,7 @@ Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。�
 | Codex | `codex` | 已硬关闭 | 替换受支持的 Shell 输入 | 保留原文，追加分析或压缩备选内容 | 用于生成该备选内容 | — |
 | OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
 | Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | ✅ |
+| AgentScope | Python API | — | — | 替换成功的最终工具响应 | — | — |
 
 “—”表示当前 Adapter 没有注册此能力；对应的 Tokenless CLI 命令仍可能可用。
 
@@ -23,7 +24,7 @@ Tokenless 通过 Adapter 把压缩、命令重写和环境检查接入 Agent。�
 
 `additionalContext` 是追加型 Hook 字段。在这些路径上，Tokenless 源码本身不会删除原始结果，最终处理方式还取决于宿主实现。统计记录只能证明压缩候选内容变小了，不能证明宿主已经从模型请求中移除原文。
 
-OpenCode 当前使用下文说明的随附生命周期脚本；本版本尚未把它注册到 `anolisa adapter enable` 的驱动集合。
+OpenCode 当前使用下文说明的随附生命周期脚本，AgentScope 则使用可安装的 Python 包和显式应用代码；本版本尚未把两者注册到 `anolisa adapter enable` 的驱动集合。
 
 ## Adapter 处理规则
 
@@ -83,7 +84,7 @@ anolisa adapter enable tokenless qwencode
 
 只需启用实际使用的框架。为多个框架启用时，应逐个执行并分别验证。
 
-OpenCode 不适用本节，应使用 [npm 安装后的手动接入](#npm-安装后的手动接入)中的随附安装脚本。
+OpenCode 和 AgentScope 不适用本节。OpenCode 应使用 [npm 安装后的手动接入](#npm-安装后的手动接入)中的随附安装脚本；AgentScope 请参阅下文的 [AgentScope](#agentscope)。
 
 对于 OpenClaw，anolisa 会先尝试普通安装，默认不会加入 unsafe-install 覆盖参数。如果 OpenClaw 的安全扫描拒绝此 Plugin，应先阅读其报告；确认接受风险后，才显式重试：
 
@@ -207,6 +208,105 @@ OpenCode 启动时会自动加载配置目录下的 Plugin。使用上述 Tokenl
 ### Qwen Code
 
 Extension 在新的 Qwen Code 会话中加载。重启后执行一次工具调用验证。
+
+### AgentScope
+
+Python 包支持 `agentscope>=2.0.5,<2.1`。原生 `anolisa-tokenless` runtime Wheel
+当前尚未发布到 Python 包索引。虽然 anolisa 会把 Adapter 源码部署到
+`~/.local/share/anolisa/adapters/tokenless/agentscope` 或
+`/usr/share/anolisa/adapters/tokenless/agentscope`，但在全新环境中只安装该源码
+无法解析其精确版本的 runtime 依赖。当前唯一受支持的安装方式是从源码 checkout
+构建并同时安装两个相同版本的 Wheel：
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/agentscope-wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+普通高代码 Agent 需要把同一个中间件实例同时注册到 Toolkit 和 Agent：
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessMiddleware
+
+toolkit = Toolkit()
+middleware = TokenlessMiddleware(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    min_chars=200,
+)
+await middleware.register_tools(toolkit)
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=[middleware],
+)
+```
+
+AgentScope App 接受按请求创建中间件的 factory。其 Toolkit 组装过程会自动调用
+`list_tools()`，因此不要再单独注册恢复 Tool：
+
+```python
+from hashlib import sha256
+from pathlib import Path
+
+from agentscope.app import create_app
+from tokenless_agentscope import TokenlessMiddleware
+
+tenant_root = Path("/srv/tokenless-tenants")
+
+async def tokenless_middlewares(user_id, agent_id, session_id):
+    del agent_id, session_id
+    tenant_key = sha256(user_id.encode("utf-8")).hexdigest()
+    return [TokenlessMiddleware(data_dir=tenant_root / tenant_key)]
+
+app = create_app(
+    ...,
+    extra_agent_middlewares=tokenless_middlewares,
+)
+```
+
+AgentScope 遇到同名 Tool 时会保留最后一个，而 `list_tools()` 无法取得 App 的其他
+Tool。如果 App 已有 `tokenless_retrieve` Tool，或安装了多个 Tokenless 中间件实例，
+应为每个 Tokenless Tool 指定唯一名称：
+
+```python
+TokenlessMiddleware(
+    data_dir=tenant_root / tenant_key,
+    retrieve_tool_name="tenant_tokenless_retrieve",
+)
+```
+
+中间件会把配置的名称用于 `list_tools()`、高代码注册和永久压缩排除。高代码路径的
+`register_tools()` 遇到已有同名 Tool 时仍会报错。
+
+请根据应用可接受的 inline 截断程度选择模式：
+
+| 模式 | Read/Glob/Grep | 其他工具 |
+|------|----------------|----------|
+| `conservative` | 压缩 | 字符串 1 MiB、数组 65,536 项、深度 32 |
+| `balanced`（默认） | 跳过 | Shell：65,536 / 128 / 深度 8；其他采用 conservative 限制 |
+| `aggressive` | 跳过 | CLI 默认值：4,096 / 32 / 深度 8 |
+
+中间件会原样转发流式 chunk，只替换成功的最终 `ToolResponse`；响应和 block 的
+标识、元数据都会保留。Tokenless 失败或 UTF-8 结果没有严格变小时保留原文。
+JSON object/array 仍为 JSON，普通文本仍为文本，`DataBlock` 永不修改。
+
+中间件还提供只读、并发安全的恢复 Tool，默认名称为 `tokenless_retrieve`。只有
+参数是严格的 24 位十六进制哈希，且当前 AgentScope 上下文或摘要中存在对应
+`<<tokenless:HASH>>` marker 时才会自动允许；该 Tool 永远不参与压缩。这一窄权限
+仍依赖存储隔离：每个用户或租户必须显式传入独立的绝对 `data_dir`。省略
+`data_dir` 时，`TOKENLESS_DATA_DIR` 只作为进程级回退，不得由多个租户共用；
+也不要依赖跨节点恢复。stash 当前使用固定的一小时 TTL，Agent 应在这一边界前
+恢复所需内容。
+
+压缩和恢复会从 async worker thread 调用进程内 `anolisa-tokenless` runtime；Adapter
+不会启动 CLI 进程或授予 Shell 权限，也不接入 MCP、TOON、RTK 命令重写或
+Schema 压缩。
 
 ## 验证是否真正接入
 

--- a/src/tokenless/.gitignore
+++ b/src/tokenless/.gitignore
@@ -11,6 +11,9 @@ adapters/tokenless/qoder/.qoder-plugin/plugin.json
 adapters/tokenless/claude-code/.claude-plugin/plugin.json
 adapters/tokenless/codex/.codex-plugin/plugin.json
 adapters/tokenless/qwencode/qwen-extension.json
+adapters/tokenless/agentscope/pyproject.toml
+adapters/tokenless/agentscope/build/
+adapters/tokenless/agentscope/src/*.egg-info/
 
 # Python bytecode cache
 __pycache__/

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -28,7 +28,8 @@ ADAPTER_TEMPLATES := \
     $(ADAPTER_SRC_DIR)/qoder/.qoder-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/claude-code/.claude-plugin/plugin.json \
     $(ADAPTER_SRC_DIR)/codex/.codex-plugin/plugin.json \
-    $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json
+    $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json \
+    $(ADAPTER_SRC_DIR)/agentscope/pyproject.toml
 # Canonical RPM/raw component contract — kept separate from the adapter
 # payload tree and stamped from the workspace version before packaging.
 # Shipped to %{_datadir}/anolisa/components/tokenless/component.toml and
@@ -40,7 +41,10 @@ NATIVE_NPM_TARGET := $(shell node -p 'process.platform + "-" + process.arch')
 NATIVE_NPM_INPUT_DIR := $(CURDIR)/target/npm-prebuilt/$(NATIVE_NPM_TARGET)
 PYTHON_RUNTIME_DIR := python/tokenless
 PYTHON_WHEEL_DIR := $(CURDIR)/target/wheels
+AGENTSCOPE_ADAPTER_DIR := $(ADAPTER_SRC_DIR)/agentscope
+AGENTSCOPE_WHEEL_DIR := $(CURDIR)/target/agentscope-wheels
 MATURIN ?= uvx --from 'maturin>=1.9,<2.0' maturin
+PYPROJECT_BUILD ?= uvx --from 'build>=1,<2' pyproject-build
 
 .PHONY: build build-tokenless build-toon build-openclaw-plugin \
         stamp-adapter-templates generate-component-contract \
@@ -58,7 +62,8 @@ MATURIN ?= uvx --from 'maturin>=1.9,<2.0' maturin
         qwencode-install qwencode-uninstall \
         setup help \
         npm-package npm-package-all npm-publish prepare-npm-native-binaries \
-        python-wheel test-python-runtime test-hooks
+        python-wheel test-python-runtime agentscope-wheel \
+        test-agentscope-adapter test-hooks
 
 # Default target
 all: build
@@ -120,6 +125,11 @@ $(ADAPTER_SRC_DIR)/qwencode/qwen-extension.json: \
 	@echo "==> Generating qwencode/qwen-extension.json (version=$(VERSION))..."
 	sed 's/@VERSION@/$(VERSION)/g' $< > $@
 
+$(ADAPTER_SRC_DIR)/agentscope/pyproject.toml: \
+    $(ADAPTER_SRC_DIR)/agentscope/pyproject.toml.in Cargo.toml
+	@echo "==> Generating agentscope/pyproject.toml (version=$(VERSION))..."
+	sed 's/@VERSION@/$(VERSION)/g' $< > $@
+
 # Build the tokenless OpenClaw plugin (TypeScript -> dist/index.js).
 # Produces $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js, which install-adapter-resources
 # then copies into $(SHARE_DIR)/openclaw/dist/index.js. This file is referenced by
@@ -156,6 +166,11 @@ install-adapter-resources: build-openclaw-plugin
 	# Strip build-only artifacts from the installed plugin tree.
 	rm -rf $(DESTDIR)$(SHARE_DIR)/openclaw/node_modules
 	rm -f  $(DESTDIR)$(SHARE_DIR)/openclaw/package-lock.json
+	rm -rf $(DESTDIR)$(SHARE_DIR)/agentscope/build
+	find $(DESTDIR)$(SHARE_DIR)/agentscope -type d \
+	    \( -name '__pycache__' -o -name '*.egg-info' \) -prune -exec rm -rf {} +
+	find $(DESTDIR)$(SHARE_DIR)/agentscope -type f \
+	    \( -name '*.pyc' -o -name '*.pyo' \) -delete
 	find $(DESTDIR)$(SHARE_DIR) -name '*.in' -delete
 	find $(DESTDIR)$(SHARE_DIR) -type f \( -name '*.py' -o -name '*.sh' \) -exec chmod 0755 {} +
 	@test -f $(DESTDIR)$(SHARE_DIR)/openclaw/dist/index.js \
@@ -196,6 +211,7 @@ test-integration:
 	python3 tests/test_compress_response_hook.py
 	python3 tests/test_compress_schema_hook.py
 	python3 tests/test_hermes_plugin_import.py
+	python3 tests/test_agentscope_middleware.py
 	python3 tests/test_rewrite_hook.py
 	python3 tests/test_resolve_agent_id.py
 
@@ -222,6 +238,16 @@ python-wheel:
 
 test-python-runtime: python-wheel
 	@bash tests/test-python-runtime.sh
+
+agentscope-wheel: stamp-adapter-templates
+	@echo "==> Building Tokenless AgentScope adapter wheel..."
+	install -d -m 0755 $(AGENTSCOPE_WHEEL_DIR)
+	rm -f $(AGENTSCOPE_WHEEL_DIR)/anolisa_tokenless_agentscope-*.whl
+	$(PYPROJECT_BUILD) --wheel --outdir $(AGENTSCOPE_WHEEL_DIR) \
+		$(AGENTSCOPE_ADAPTER_DIR)
+
+test-agentscope-adapter: python-wheel agentscope-wheel
+	@bash tests/test-agentscope-adapter.sh
 
 # These targets only assemble the prebuilt BIN_DIR/{tokenless,rtk,toon} files
 # into the portable raw-package contract maintained by this component.

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -20,6 +20,7 @@ Framework integrations are available for:
 - **Claude Code plugin** — RTK command rewriting, response/TOON compression, and registered but hard-disabled Tool Ready via Claude Code's official plugin marketplace.
 - **Codex plugin** — response compression, TOON encoding, registered but hard-disabled Tool Ready, and command rewriting via Codex's native hook system.
 - **OpenCode plugin** — schema/response/TOON compression, registered but hard-disabled Tool Ready, and command rewriting via OpenCode's local plugin API.
+- **AgentScope middleware** — replaces successful final tool responses and provides a marker-scoped native retrieval Tool.
 
 ## Features
 
@@ -38,6 +39,7 @@ Framework integrations are available for:
 | Claude Code plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅ |
 | Codex plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅ |
 | OpenCode plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅ |
+| AgentScope middleware | — | Response compression ✅, Native retrieval Tool ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
 
 ## Applicable Scenarios & Expected Effects
@@ -99,7 +101,8 @@ Token-Less/
 │   ├── qoder/                   # Qoder CLI plugin + scripts
 │   ├── claude-code/             # Claude Code plugin + marketplace + hooks
 │   ├── codex/                   # Codex plugin + scripts
-│   └── opencode/                # OpenCode local plugin + scripts
+│   ├── opencode/                # OpenCode local plugin + scripts
+│   └── agentscope/              # Installable AgentScope Python middleware
 ├── third_party/rtk/           # RTK vendored source (justfile clone+patch from GitHub)
 ├── third_party/patches/      # Patches for vendored third_party sources
 ├── Makefile                   # Unified build system
@@ -519,6 +522,64 @@ The installer creates a `tokenless.js` symbolic link in OpenCode's global
 `plugins/` directory and never overwrites an existing unmanaged file. It honors
 `OPENCODE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and the explicit
 `TOKENLESS_OPENCODE_CONFIG_DIR` override.
+
+## AgentScope Middleware
+
+AgentScope 2.0 applications install two same-version Python wheels explicitly.
+The adapter uses the `anolisa-tokenless` runtime directly and does not start a
+CLI subprocess. The runtime wheel is not currently published to a Python
+package index, so installing only the adapter source staged by anolisa cannot
+resolve its exact dependency in a fresh environment. Build and install both
+wheels from a source checkout:
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/agentscope-wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+Register the same middleware instance with both the high-code Toolkit and the
+Agent. AgentScope App collects its `tokenless_retrieve` Tool through
+`list_tools()`, so App code only supplies the middleware. If an App already
+has a Tool with that name, pass a unique `retrieve_tool_name`; AgentScope uses
+the last Tool when names collide, and middleware cannot inspect the other App
+tools during `list_tools()`.
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessMiddleware
+
+toolkit = Toolkit()
+middleware = TokenlessMiddleware(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    # retrieve_tool_name="tenant_tokenless_retrieve",
+)
+await middleware.register_tools(toolkit)
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=[middleware],
+)
+```
+
+| Mode | Policy |
+|---|---|
+| `conservative` | Compress every non-excluded tool with 1 MiB / 65,536 / depth 32 limits |
+| `balanced` | Skip Read/Glob/Grep; use 65,536 / 128 / depth 8 for Shell and conservative limits elsewhere |
+| `aggressive` | Skip Read/Glob/Grep; use CLI defaults of 4,096 / 32 / depth 8 elsewhere |
+
+`balanced` is the default. The read-only retrieval Tool is auto-allowed only
+for a 24-character hash whose marker is present in the current AgentScope
+context or summary. Pass a different absolute `data_dir` to each user or tenant;
+`TOKENLESS_DATA_DIR` is only a process-wide fallback when `data_dir` is omitted.
+Retain the default one-hour stash TTL unless the application has a deliberate
+lifecycle policy, and do not expect retrieval across nodes. This first adapter
+does not enable Shell, MCP, TOON, RTK, or schema compression, and is not managed
+by `anolisa adapter enable`.
 
 
 ## Build

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -64,6 +64,7 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 - **Claude Code 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
 - **Codex 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
 - **OpenCode 插件** — Tool Ready（已硬关闭）+ 命令重写 + Schema/响应压缩 + TOON
+- **AgentScope 中间件** — 替换成功的最终工具响应，并提供受 marker 约束的原生恢复 Tool
 
 ## 快速开始
 
@@ -158,6 +159,59 @@ make opencode-install
 不会覆盖同名的非托管文件。配置目录支持 `OPENCODE_CONFIG_DIR`、
 `XDG_CONFIG_HOME` 和显式的 `TOKENLESS_OPENCODE_CONFIG_DIR` 覆盖。
 安装后重启 OpenCode 即可加载插件。
+
+### AgentScope 中间件
+
+AgentScope 2.0 应用需要显式安装两个相同版本的 Python Wheel。Adapter 直接调用
+`anolisa-tokenless` runtime，不会启动 CLI 子进程。runtime Wheel 当前尚未发布到
+Python 包索引，因此在全新环境中只安装 anolisa 随附的 Adapter 源码无法解析其
+精确版本依赖。当前应从源码 checkout 构建并同时安装两个 Wheel：
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/agentscope-wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+普通高代码 Agent 需要把同一个中间件实例同时注册到 Toolkit 和 Agent。
+AgentScope App 会通过 `list_tools()` 自动收集 `tokenless_retrieve`，因此 App
+代码只需提供中间件。如果 App 已有同名 Tool，应传入唯一的
+`retrieve_tool_name`；AgentScope 遇到重名时采用最后一个 Tool，而中间件在
+`list_tools()` 阶段无法检查 App 的其他 Tool。
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessMiddleware
+
+toolkit = Toolkit()
+middleware = TokenlessMiddleware(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    # retrieve_tool_name="tenant_tokenless_retrieve",
+)
+await middleware.register_tools(toolkit)
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=[middleware],
+)
+```
+
+| 模式 | 策略 |
+|---|---|
+| `conservative` | 所有未排除工具使用 1 MiB / 65,536 / 深度 32 限制 |
+| `balanced` | 跳过 Read/Glob/Grep；Shell 使用 65,536 / 128 / 深度 8，其他采用 conservative 限制 |
+| `aggressive` | 跳过 Read/Glob/Grep；其他采用 CLI 默认的 4,096 / 32 / 深度 8 |
+
+默认模式为 `balanced`。只读恢复 Tool 仅在 24 位哈希对应的 marker 出现在当前
+AgentScope 上下文或摘要中时自动允许。每个用户或租户必须显式传入不同的绝对
+`data_dir`；省略 `data_dir` 时，`TOKENLESS_DATA_DIR` 只作为进程级回退。除非应用
+有明确生命周期策略，否则保留默认一小时 stash TTL，且不要依赖跨节点恢复。
+首版不启用 Shell、MCP、TOON、RTK 或 Schema 压缩，也不由
+`anolisa adapter enable` 管理。
 
 ## Raw 打包
 
@@ -263,7 +317,7 @@ tokenless env-check --tool Shell --fix
 - `crates/tokenless-runtime/` — CLI 与语言绑定共用的有状态 Rust API
 - `crates/tokenless-cli/` — CLI 二进制
 - `python/tokenless/` — 面向 CPython 3.11+ 的 PyO3 `anolisa_tokenless` 包
-- `adapters/tokenless/` — 适配器包（OpenClaw / Hermes / Qoder / Claude Code / Codex / OpenCode）
+- `adapters/tokenless/` — 适配器包（含 AgentScope 中间件及各框架 Plugin/Hook）
 - `third_party/rtk/` — RTK 命令重写引擎（vendored）
 - `packaging/raw/` — Tokenless 自维护的 ANOLISA Raw 打包与目标校验
 

--- a/src/tokenless/adapters/tokenless/agentscope/LICENSE
+++ b/src/tokenless/adapters/tokenless/agentscope/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Alibaba Cloud
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/tokenless/adapters/tokenless/agentscope/pyproject.toml.in
+++ b/src/tokenless/adapters/tokenless/agentscope/pyproject.toml.in
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "anolisa-tokenless-agentscope"
+version = "@VERSION@"
+description = "Tokenless response-compression middleware for AgentScope"
+requires-python = ">=3.11"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+dependencies = [
+    "agentscope>=2.0.5,<2.1",
+    "anolisa-tokenless==@VERSION@",
+]
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/tokenless/adapters/tokenless/agentscope/src/tokenless_agentscope/__init__.py
+++ b/src/tokenless/adapters/tokenless/agentscope/src/tokenless_agentscope/__init__.py
@@ -1,0 +1,5 @@
+"""AgentScope integration for Tokenless tool-response compression."""
+
+from tokenless_agentscope.middleware import CompressionMode, TokenlessMiddleware
+
+__all__ = ["CompressionMode", "TokenlessMiddleware"]

--- a/src/tokenless/adapters/tokenless/agentscope/src/tokenless_agentscope/middleware.py
+++ b/src/tokenless/adapters/tokenless/agentscope/src/tokenless_agentscope/middleware.py
@@ -1,0 +1,329 @@
+"""AgentScope middleware for reversible Tokenless response compression."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from collections.abc import AsyncGenerator, Callable, Collection
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, ClassVar
+
+from agentscope.message import TextBlock, ToolResultState
+from agentscope.middleware import MiddlewareBase
+from agentscope.permission import PermissionBehavior, PermissionDecision
+from agentscope.tool import ToolBase, ToolChunk, Toolkit, ToolResponse
+from anolisa_tokenless import TokenlessError, TokenlessRuntime
+
+logger = logging.getLogger(__name__)
+
+_RETRIEVE_TOOL_NAME = "tokenless_retrieve"
+_HASH_PATTERN = re.compile(r"^[0-9a-fA-F]{24}$")
+
+# Keep these names aligned with common/hooks/tool_categories.json. The adapter
+# package is installable on its own, so it cannot load that sibling resource at
+# runtime; a repository test guards the copied policy against drift.
+_SKIP_TOOLS = frozenset(
+    {
+        "Read",
+        "read",
+        "read_file",
+        "read_many_files",
+        "Glob",
+        "glob",
+        "search_file",
+        "list_directory",
+        "list_dir",
+        "Grep",
+        "grep",
+        "grep_code",
+        "grep_search",
+        "search_files",
+        "Lsp",
+        "lsp",
+        "NotebookRead",
+        "notebook_read",
+        "notebookread",
+    },
+)
+_SHELL_TOOLS = frozenset(
+    {
+        "Bash",
+        "bash",
+        "Shell",
+        "shell",
+        "exec",
+        "terminal",
+        "run_shell_command",
+        "run_in_terminal",
+        "get_terminal_output",
+        "execute_command",
+        "process",
+    },
+)
+
+_CONSERVATIVE_THRESHOLDS = (1_048_576, 65_536, 32)
+_SHELL_THRESHOLDS = (65_536, 128, 8)
+_AGGRESSIVE_THRESHOLDS = (4_096, 32, 8)
+
+
+class CompressionMode(StrEnum):
+    """Supported AgentScope response-compression policies."""
+
+    CONSERVATIVE = "conservative"
+    BALANCED = "balanced"
+    AGGRESSIVE = "aggressive"
+
+
+def _state_contains_marker(state: Any, hash_value: str) -> bool:
+    """Return whether the current context or summary contains the marker."""
+    marker = f"<<tokenless:{hash_value.lower()}>>"
+    serialized = state.model_dump_json(include={"context", "summary"})
+    return marker in serialized.lower()
+
+
+class _TokenlessRetrieveTool(ToolBase):
+    """Narrow, read-only AgentScope tool for recovering stashed content."""
+
+    name = _RETRIEVE_TOOL_NAME
+    description = (
+        "Recover content omitted at a <<tokenless:HASH>> marker. Call this "
+        "only when the omitted content is necessary, passing the marker's "
+        "24-character hexadecimal HASH."
+    )
+    input_schema: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "hash": {
+                "type": "string",
+                "pattern": "^[0-9a-fA-F]{24}$",
+                "description": "The 24-character hash from a <<tokenless:HASH>> marker.",
+            },
+        },
+        "required": ["hash"],
+        "additionalProperties": False,
+    }
+    is_concurrency_safe = True
+    is_read_only = True
+    is_state_injected = True
+    is_external_tool = False
+    is_mcp = False
+    mcp_name = None
+
+    def __init__(self, runtime: TokenlessRuntime, name: str) -> None:
+        super().__init__()
+        self._runtime = runtime
+        self.name = name
+
+    async def check_permissions(
+        self,
+        tool_input: dict[str, Any],
+        context: Any,
+    ) -> PermissionDecision:
+        """Allow marker-scoped reads without granting general shell access."""
+        del tool_input, context
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="Tokenless retrieval is a read-only, marker-scoped operation.",
+        )
+
+    async def call(self, hash: str, _agent_state: Any) -> ToolChunk:
+        """Retrieve the exact payload referenced from the current context."""
+        if not isinstance(hash, str) or _HASH_PATTERN.fullmatch(hash) is None:
+            return self._error_chunk(
+                "Invalid Tokenless stash hash; expected exactly 24 hexadecimal characters.",
+            )
+
+        normalized = hash.lower()
+        if not _state_contains_marker(_agent_state, normalized):
+            return self._error_chunk(
+                "The requested Tokenless marker is not present in the current session context.",
+            )
+
+        try:
+            payload = await asyncio.to_thread(self._runtime.retrieve, normalized)
+        except TokenlessError as error:
+            return self._error_chunk(str(error))
+        return ToolChunk(content=[TextBlock(text=payload)])
+
+    @staticmethod
+    def _error_chunk(message: str) -> ToolChunk:
+        return ToolChunk(
+            content=[TextBlock(text=message)],
+            state=ToolResultState.ERROR,
+        )
+
+
+class TokenlessMiddleware(MiddlewareBase):
+    """Compress final AgentScope tool responses with the Tokenless runtime."""
+
+    def __init__(
+        self,
+        *,
+        mode: CompressionMode | str = CompressionMode.BALANCED,
+        data_dir: str | os.PathLike[str] | None = None,
+        min_chars: int = 200,
+        excluded_tools: Collection[str] = (),
+        retrieve_tool_name: str = _RETRIEVE_TOOL_NAME,
+    ) -> None:
+        """Configure response compression and its paired retrieval tool."""
+        self.mode = CompressionMode(mode)
+        if min_chars < 0:
+            raise ValueError("min_chars must be non-negative")
+        if not retrieve_tool_name:
+            raise ValueError("retrieve_tool_name must not be empty")
+
+        if data_dir is None:
+            self.data_dir = None
+        else:
+            resolved_data_dir = Path(data_dir).expanduser()
+            if not resolved_data_dir.is_absolute():
+                raise ValueError("data_dir must be an absolute path")
+            self.data_dir = os.fspath(resolved_data_dir)
+        self.min_chars = min_chars
+        self.retrieve_tool_name = retrieve_tool_name
+        self.excluded_tools = frozenset(excluded_tools) | {
+            retrieve_tool_name,
+        }
+        self._runtime = TokenlessRuntime(self.data_dir)
+        self._retrieve_tool = _TokenlessRetrieveTool(
+            self._runtime,
+            retrieve_tool_name,
+        )
+
+    async def list_tools(self) -> list[ToolBase]:
+        """Return the retrieval tool for AgentScope App toolkit assembly."""
+        return [self._retrieve_tool]
+
+    async def register_tools(self, toolkit: Toolkit) -> None:
+        """Register retrieval in a high-code Toolkit without name hijacking."""
+        existing = await toolkit.get_tool(self.retrieve_tool_name)
+        if existing is self._retrieve_tool:
+            return
+        if existing is not None:
+            raise ValueError(
+                f"Toolkit already contains a different '{self.retrieve_tool_name}' tool",
+            )
+        await toolkit.add_tool(self._retrieve_tool)
+
+    async def on_acting(
+        self,
+        agent: Any,
+        input_kwargs: dict[str, Any],
+        next_handler: Callable[..., AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        """Pass chunks through and compress only the successful final response."""
+        tool_call = input_kwargs["tool_call"]
+        tool_name = tool_call.name
+        async for item in next_handler(**input_kwargs):
+            if (
+                not self._is_excluded(tool_name)
+                and isinstance(item, ToolResponse)
+                and item.state == ToolResultState.SUCCESS
+            ):
+                yield await self._compress_response(
+                    item,
+                    tool_name=tool_name,
+                    session_id=agent.state.session_id,
+                    tool_use_id=tool_call.id,
+                )
+            else:
+                yield item
+
+    async def _compress_response(
+        self,
+        response: ToolResponse,
+        *,
+        tool_name: str,
+        session_id: str,
+        tool_use_id: str,
+    ) -> ToolResponse:
+        replacements: dict[int, TextBlock] = {}
+        for index, block in enumerate(response.content):
+            if not isinstance(block, TextBlock) or len(block.text) < self.min_chars:
+                continue
+            compressed = await self._compress_text(
+                block.text,
+                tool_name=tool_name,
+                session_id=session_id,
+                tool_use_id=tool_use_id,
+            )
+            if compressed is not None:
+                replacements[index] = block.model_copy(update={"text": compressed})
+        if not replacements:
+            return response
+        content = [replacements.get(index, block) for index, block in enumerate(response.content)]
+        return response.model_copy(update={"content": content})
+
+    async def _compress_text(
+        self,
+        text: str,
+        *,
+        tool_name: str,
+        session_id: str,
+        tool_use_id: str,
+    ) -> str | None:
+        input_text, expected_type = self._normalize_input(text)
+        thresholds = self._thresholds_for(tool_name)
+        try:
+            result = await asyncio.to_thread(
+                self._runtime.compress_response,
+                input_text,
+                truncate_strings_at=thresholds[0],
+                truncate_arrays_at=thresholds[1],
+                max_depth=thresholds[2],
+                agent_id="agentscope",
+                session_id=session_id,
+                tool_use_id=tool_use_id,
+                require_reversible=True,
+            )
+        except TokenlessError as error:
+            logger.warning("Tokenless compression failed: %s", error)
+            return None
+        if not result.applied:
+            return None
+
+        try:
+            candidate_json = result.output
+            candidate_value = json.loads(candidate_json)
+        except json.JSONDecodeError:
+            logger.warning("Tokenless returned an invalid compression result")
+            return None
+
+        if expected_type is str:
+            if not isinstance(candidate_value, str):
+                return None
+            candidate = candidate_value
+        else:
+            if type(candidate_value) is not expected_type:
+                return None
+            candidate = candidate_json.strip()
+
+        if len(candidate.encode("utf-8")) >= len(text.encode("utf-8")):
+            return None
+        return candidate
+
+    @staticmethod
+    def _normalize_input(text: str) -> tuple[str, type[Any]]:
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError:
+            value = None
+        if isinstance(value, (dict, list)):
+            return text, type(value)
+        return json.dumps(text, ensure_ascii=False), str
+
+    def _thresholds_for(self, tool_name: str) -> tuple[int, int, int]:
+        if self.mode is CompressionMode.AGGRESSIVE:
+            return _AGGRESSIVE_THRESHOLDS
+        if self.mode is CompressionMode.BALANCED and tool_name in _SHELL_TOOLS:
+            return _SHELL_THRESHOLDS
+        return _CONSERVATIVE_THRESHOLDS
+
+    def _is_excluded(self, tool_name: str) -> bool:
+        if tool_name in self.excluded_tools:
+            return True
+        return self.mode is not CompressionMode.CONSERVATIVE and tool_name in _SKIP_TOOLS

--- a/src/tokenless/packaging/raw/package.sh
+++ b/src/tokenless/packaging/raw/package.sh
@@ -99,6 +99,10 @@ stage_payload() {
         codex/.codex-plugin/plugin.json \
         qwencode/qwen-extension.json \
         qwencode/hooks/run-hook.sh \
+        agentscope/LICENSE \
+        agentscope/pyproject.toml \
+        agentscope/src/tokenless_agentscope/__init__.py \
+        agentscope/src/tokenless_agentscope/middleware.py \
         common/cosh-extension.json \
         common/tool-ready-spec.json \
         common/tokenless-env-fix.sh; do
@@ -138,6 +142,11 @@ stage_payload() {
         "$stage/adapters/openclaw/package-lock.json" \
         "$stage/adapters/openclaw/index.ts" \
         "$stage/adapters/openclaw/tsconfig.json"
+    rm -rf "$stage/adapters/agentscope/build"
+    find "$stage/adapters/agentscope" -type d \
+        \( -name '__pycache__' -o -name '*.egg-info' \) -prune -exec rm -rf {} +
+    find "$stage/adapters/agentscope" -type f \
+        \( -name '*.pyc' -o -name '*.pyo' \) -delete
     find "$stage/adapters" "$stage/extensions/tokenless" \
         \( -name '*.in' -o -name '.gitignore' \) -delete
     normalize_modes "$stage"

--- a/src/tokenless/packaging/raw/verify-release.py
+++ b/src/tokenless/packaging/raw/verify-release.py
@@ -13,6 +13,7 @@ WORKSPACE_VERSION = re.compile(
     r"(?ms)^\[workspace\.package\]\s*$.*?^version\s*=\s*\"([^\"]+)\""
 )
 COMPONENT = re.compile(r"(?ms)^\[component\]\s*$.*?(?=^\[|\Z)")
+PROJECT = re.compile(r"(?ms)^\[project\]\s*$.*?(?=^\[|\Z)")
 FIELD = r"(?m)^{}\s*=\s*\"([^\"]+)\""
 
 
@@ -46,6 +47,18 @@ def read_hermes_version(path: Path) -> str:
     if match is None:
         raise SystemExit(f"ERROR: {path} has no version")
     return match.group(1)
+
+
+def read_pyproject_version(path: Path) -> str:
+    """Read the generated AgentScope package version."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+    project_match = PROJECT.search(text)
+    if project_match is None:
+        raise SystemExit(f"ERROR: {path} has no [project] table")
+    return match_field(project_match.group(0), "version", path)
 
 
 def verify_versions(root: Path, contract: Path) -> str:
@@ -88,6 +101,8 @@ def verify_versions(root: Path, contract: Path) -> str:
     versions = {str(path.relative_to(root)): read_json_version(path) for path in json_manifests}
     hermes = adapters / "hermes" / "plugin.yaml"
     versions[str(hermes.relative_to(root))] = read_hermes_version(hermes)
+    agentscope = adapters / "agentscope" / "pyproject.toml"
+    versions[str(agentscope.relative_to(root))] = read_pyproject_version(agentscope)
     drift = [f"{path}={version}" for path, version in versions.items() if version != expected]
     if drift:
         raise SystemExit(

--- a/src/tokenless/tests/agentscope_adapter_smoke.py
+++ b/src/tokenless/tests/agentscope_adapter_smoke.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Exercise the installed adapter with a supported AgentScope and native Tokenless."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import ClassVar
+
+import agentscope
+from agentscope.agent import Agent
+from agentscope.message import TextBlock, ToolCallBlock
+from agentscope.permission import PermissionBehavior, PermissionDecision
+from agentscope.tool import ToolBase, ToolChunk, Toolkit
+from tokenless_agentscope import TokenlessMiddleware
+
+_RECOVERY_PAYLOAD = "RECOVERY_SENTINEL=世界\n" + ("内容" * 3_000) + "TRAILING_NEWLINE\n"
+
+
+class LargeResultTool(ToolBase):
+    """Return enough structured output to exercise reversible compression."""
+
+    name = "large_result"
+    description = "Return a large deterministic JSON result."
+    input_schema: ClassVar[dict] = {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+    is_concurrency_safe = True
+    is_read_only = True
+
+    async def check_permissions(
+        self,
+        tool_input: dict,
+        context: object,
+    ) -> PermissionDecision:
+        del tool_input, context
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="The fixture is read-only.",
+        )
+
+    async def call(self) -> ToolChunk:
+        payload = {
+            "answer": "ORCHID-7291",
+            "payload": _RECOVERY_PAYLOAD,
+        }
+        return ToolChunk(content=[TextBlock(text=json.dumps(payload, ensure_ascii=False))])
+
+
+class ExistingRetrieveTool(ToolBase):
+    """Represent an application tool that already uses the default name."""
+
+    name = "tokenless_retrieve"
+    description = "Existing application retrieval tool."
+    input_schema: ClassVar[dict] = {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+    is_concurrency_safe = True
+    is_read_only = True
+
+    async def check_permissions(
+        self,
+        tool_input: dict,
+        context: object,
+    ) -> PermissionDecision:
+        del tool_input, context
+        return PermissionDecision(
+            behavior=PermissionBehavior.ALLOW,
+            message="The fixture is read-only.",
+        )
+
+    async def call(self) -> ToolChunk:
+        return ToolChunk(content=[TextBlock(text="existing")])
+
+
+async def main() -> None:
+    """Run one real AgentScope middleware and retrieval cycle."""
+    version = tuple(int(part) for part in agentscope.__version__.split(".")[:3])
+    assert (2, 0, 5) <= version < (2, 1, 0)
+    with tempfile.TemporaryDirectory(prefix="tokenless-agentscope-smoke-") as directory:
+        existing_retrieve = ExistingRetrieveTool()
+        middleware = TokenlessMiddleware(
+            mode="aggressive",
+            data_dir=Path(directory),
+            min_chars=0,
+            retrieve_tool_name="tenant_tokenless_retrieve",
+        )
+        middleware_tool = (await middleware.list_tools())[0]
+        app_toolkit = Toolkit(tools=[existing_retrieve, middleware_tool])
+        assert await app_toolkit.get_tool("tokenless_retrieve") is existing_retrieve
+        assert await app_toolkit.get_tool("tenant_tokenless_retrieve") is middleware_tool
+
+        toolkit = Toolkit(tools=[LargeResultTool(), existing_retrieve])
+        await middleware.register_tools(toolkit)
+        await middleware.register_tools(toolkit)
+        assert await toolkit.get_tool("tokenless_retrieve") is existing_retrieve
+        assert await toolkit.get_tool("tenant_tokenless_retrieve") is middleware_tool
+
+        agent = Agent(
+            name="smoke",
+            system_prompt="Exercise one deterministic tool.",
+            model=object(),
+            toolkit=toolkit,
+            middlewares=[middleware],
+        )
+        tool_call = ToolCallBlock(id="call-large", name="large_result", input="{}")
+        events = [event async for event in agent._acting(tool_call)]
+        assert len(events) == 2
+        streamed, response = events
+        assert "TRAILING_NEWLINE" in streamed.content[0].text
+        assert "TRAILING_NEWLINE" not in response.content[0].text
+        marker = re.search(r"<<tokenless:([0-9a-f]{24})>>", response.content[0].text)
+        assert marker is not None
+        assert response.id == "call-large"
+
+        agent.state.summary = response.content
+        retrieve_call = ToolCallBlock(
+            id="call-retrieve",
+            name="tenant_tokenless_retrieve",
+            input=json.dumps({"hash": marker.group(1).upper()}),
+        )
+        retrieved = [event async for event in toolkit.call_tool(retrieve_call, agent.state)]
+        assert len(retrieved) == 2
+        assert retrieved[0].content[0].text == _RECOVERY_PAYLOAD
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/tokenless/tests/test-agentscope-adapter.sh
+++ b/src/tokenless/tests/test-agentscope-adapter.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build, install, and exercise the AgentScope adapter with its real dependencies.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d /tmp/tokenless-agentscope-adapter-test.XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mapfile -t RUNTIME_WHEELS < <(find "$ROOT/target/wheels" -maxdepth 1 -type f \
+    -name 'anolisa_tokenless-*.whl' -print)
+mapfile -t ADAPTER_WHEELS < <(find "$ROOT/target/agentscope-wheels" -maxdepth 1 -type f \
+    -name 'anolisa_tokenless_agentscope-*.whl' -print)
+if [ "${#RUNTIME_WHEELS[@]}" -ne 1 ] || [ "${#ADAPTER_WHEELS[@]}" -ne 1 ]; then
+    echo "ERROR: expected exactly one runtime wheel and one AgentScope wheel" >&2
+    exit 1
+fi
+
+run_smoke() {
+    local venv_name="$1"
+    local agentscope_requirement="$2"
+    local venv="$TEST_ROOT/$venv_name"
+
+    uv venv --python python3 "$venv" >/dev/null
+    uv pip install --python "$venv/bin/python" \
+        "$agentscope_requirement" \
+        "${RUNTIME_WHEELS[0]}" "${ADAPTER_WHEELS[0]}" >/dev/null
+    "$venv/bin/python" "$ROOT/tests/agentscope_adapter_smoke.py"
+    "$venv/bin/python" - <<'PY'
+import agentscope
+
+print(f"AgentScope {agentscope.__version__} smoke test passed")
+PY
+}
+
+run_smoke minimum 'agentscope==2.0.5'
+run_smoke latest 'agentscope>=2.0.5,<2.1'
+
+EXPECTED_VERSION="$(sed -n \
+    's/^version = "\([^"]*\)"/\1/p' "$ROOT/Cargo.toml" | head -1)"
+"$TEST_ROOT/minimum/bin/python" - "$EXPECTED_VERSION" "${ADAPTER_WHEELS[0]}" <<'PY'
+from importlib.metadata import distribution
+from pathlib import Path
+import sys
+
+package = distribution("anolisa-tokenless-agentscope")
+assert package.version == distribution("anolisa-tokenless").version
+assert package.version == sys.argv[1]
+assert package.metadata.get_all("License-File") == ["LICENSE"]
+license_paths = [
+    path for path in package.files or ()
+    if str(path).endswith(".dist-info/licenses/LICENSE")
+]
+assert len(license_paths) == 1
+assert "Apache License" in Path(license_paths[0].locate()).read_text()
+assert Path(sys.argv[2]).is_file()
+PY
+
+printf 'Tokenless AgentScope adapter smoke test passed\n'

--- a/src/tokenless/tests/test-package-raw.sh
+++ b/src/tokenless/tests/test-package-raw.sh
@@ -21,6 +21,9 @@ mkdir -p \
     "$ADAPTERS/claude-code/.claude-plugin" \
     "$ADAPTERS/claude-code/hooks" \
     "$ADAPTERS/codex/.codex-plugin" \
+    "$ADAPTERS/agentscope/build" \
+    "$ADAPTERS/agentscope/src/anolisa_tokenless_agentscope.egg-info" \
+    "$ADAPTERS/agentscope/src/tokenless_agentscope/__pycache__" \
     "$ADAPTERS/qwencode/hooks"
 
 cat > "$SOURCE/Cargo.toml" <<EOF
@@ -49,6 +52,21 @@ write_json_version "$ADAPTERS/qwencode/qwen-extension.json"
 printf '{"name":"anolisa-tokenless"}\n' \
     > "$ADAPTERS/claude-code/.claude-plugin/marketplace.json"
 printf 'version: "%s"\n' "$VERSION" > "$ADAPTERS/hermes/plugin.yaml"
+printf 'Apache License fixture\n' > "$ADAPTERS/agentscope/LICENSE"
+cat > "$ADAPTERS/agentscope/pyproject.toml" <<EOF
+[project]
+name = "anolisa-tokenless-agentscope"
+version = "$VERSION"
+EOF
+printf 'from .middleware import TokenlessMiddleware\n' \
+    > "$ADAPTERS/agentscope/src/tokenless_agentscope/__init__.py"
+printf 'class TokenlessMiddleware: pass\n' \
+    > "$ADAPTERS/agentscope/src/tokenless_agentscope/middleware.py"
+printf 'build artifact\n' > "$ADAPTERS/agentscope/build/junk.txt"
+printf 'metadata\n' \
+    > "$ADAPTERS/agentscope/src/anolisa_tokenless_agentscope.egg-info/PKG-INFO"
+printf 'bytecode\n' \
+    > "$ADAPTERS/agentscope/src/tokenless_agentscope/__pycache__/middleware.pyc"
 printf 'export default {};\n' > "$ADAPTERS/openclaw/dist/index.js"
 printf '{"name":"tokenless","version":"%s"}\n' "$VERSION" \
     > "$ADAPTERS/common/cosh-extension.json"
@@ -155,8 +173,19 @@ for relative in \
 done
 test -f "$EXTRACTED/extensions/tokenless/cosh-extension.json"
 test -f "$EXTRACTED/extensions/tokenless/hooks/run-hook.sh"
+test -f "$EXTRACTED/adapters/agentscope/LICENSE"
+test -f "$EXTRACTED/adapters/agentscope/pyproject.toml"
+test -f "$EXTRACTED/adapters/agentscope/src/tokenless_agentscope/middleware.py"
 test -z "$(find "$EXTRACTED" -type l -print -quit)"
-test -z "$(find "$EXTRACTED" \( -name '*.in' -o -name node_modules \) -print -quit)"
+test -z "$(find "$EXTRACTED" \( \
+    -name '*.in' -o \
+    -name node_modules -o \
+    -name build -o \
+    -name '*.egg-info' -o \
+    -name '__pycache__' -o \
+    -name '*.pyc' -o \
+    -name '*.pyo' \
+\) -print -quit)"
 test "$(stat -c '%a' "$EXTRACTED/bin/tokenless")" = 755
 test "$(stat -c '%a' "$EXTRACTED/adapters/manifest.json")" = 644
 test "$(stat -c '%a' "$EXTRACTED/adapters/common/hooks/run-hook.sh")" = 755

--- a/src/tokenless/tests/test_agentscope_middleware.py
+++ b/src/tokenless/tests/test_agentscope_middleware.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Unit tests for the AgentScope Tokenless middleware adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib
+import json
+import sys
+import threading
+import types
+import unittest
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PACKAGE_SRC = _REPO_ROOT / "adapters" / "tokenless" / "agentscope" / "src"
+
+
+class _TokenlessError(Exception):
+    """Test double for the native package exception."""
+
+
+@dataclass
+class _CompressionResult:
+    output: str
+    applied: bool
+
+
+class _TokenlessRuntime:
+    """Controllable test double for the native runtime."""
+
+    def __init__(self, data_dir: str | None = None) -> None:
+        self.data_dir = data_dir
+        self.compress_impl = None
+        self.retrieve_impl = None
+
+    def compress_response(self, input_text: str, **kwargs: object) -> _CompressionResult:
+        if self.compress_impl is None:
+            return _CompressionResult(input_text, False)
+        return self.compress_impl(input_text, **kwargs)
+
+    def retrieve(self, hash_value: str) -> str:
+        if self.retrieve_impl is None:
+            raise _TokenlessError(f"no stashed payload for hash: {hash_value}")
+        return self.retrieve_impl(hash_value)
+
+
+def _install_dependency_stubs() -> None:
+    """Install the AgentScope and native-runtime API surfaces used here."""
+    runtime = types.ModuleType("anolisa_tokenless")
+    runtime.TokenlessError = _TokenlessError
+    runtime.TokenlessRuntime = _TokenlessRuntime
+
+    agentscope = types.ModuleType("agentscope")
+    agentscope.__path__ = []
+
+    message = types.ModuleType("agentscope.message")
+
+    class ToolResultState(StrEnum):
+        RUNNING = "running"
+        SUCCESS = "success"
+        ERROR = "error"
+        DENIED = "denied"
+        INTERRUPTED = "interrupted"
+
+    @dataclass
+    class TextBlock:
+        text: str
+        id: str = "text-id"
+
+        def model_copy(
+            self,
+            *,
+            update: dict[str, object] | None = None,
+            deep: bool = False,
+        ) -> TextBlock:
+            replacement = copy.deepcopy(self) if deep else copy.copy(self)
+            for key, value in (update or {}).items():
+                setattr(replacement, key, value)
+            return replacement
+
+    message.TextBlock = TextBlock
+    message.ToolResultState = ToolResultState
+
+    middleware = types.ModuleType("agentscope.middleware")
+
+    class MiddlewareBase:
+        pass
+
+    middleware.MiddlewareBase = MiddlewareBase
+
+    permission = types.ModuleType("agentscope.permission")
+
+    class PermissionBehavior(StrEnum):
+        ALLOW = "allow"
+
+    @dataclass
+    class PermissionDecision:
+        behavior: PermissionBehavior
+        message: str
+
+    permission.PermissionBehavior = PermissionBehavior
+    permission.PermissionDecision = PermissionDecision
+
+    tool = types.ModuleType("agentscope.tool")
+
+    class ToolBase:
+        def __init__(self) -> None:
+            pass
+
+    @dataclass
+    class ToolChunk:
+        content: list[object]
+        state: ToolResultState = ToolResultState.RUNNING
+        metadata: dict = field(default_factory=dict)
+        id: str = "chunk-id"
+
+    @dataclass
+    class ToolResponse:
+        content: list[object]
+        state: ToolResultState = ToolResultState.SUCCESS
+        metadata: dict = field(default_factory=dict)
+        id: str = "response-id"
+
+        def model_copy(
+            self,
+            *,
+            update: dict[str, object] | None = None,
+            deep: bool = False,
+        ) -> ToolResponse:
+            replacement = copy.deepcopy(self) if deep else copy.copy(self)
+            for key, value in (update or {}).items():
+                setattr(replacement, key, value)
+            return replacement
+
+    class Toolkit:
+        def __init__(self, tools: list[ToolBase] | None = None) -> None:
+            self.tools = {item.name: item for item in tools or []}
+
+        async def get_tool(self, name: str):
+            return self.tools.get(name)
+
+        async def add_tool(self, item: ToolBase) -> None:
+            self.tools[item.name] = item
+
+    tool.ToolBase = ToolBase
+    tool.ToolChunk = ToolChunk
+    tool.ToolResponse = ToolResponse
+    tool.Toolkit = Toolkit
+
+    sys.modules.update(
+        {
+            "anolisa_tokenless": runtime,
+            "agentscope": agentscope,
+            "agentscope.message": message,
+            "agentscope.middleware": middleware,
+            "agentscope.permission": permission,
+            "agentscope.tool": tool,
+        },
+    )
+
+
+_install_dependency_stubs()
+sys.path.insert(0, str(_PACKAGE_SRC))
+
+adapter = importlib.import_module("tokenless_agentscope.middleware")
+CompressionMode = adapter.CompressionMode
+TokenlessMiddleware = adapter.TokenlessMiddleware
+TextBlock = sys.modules["agentscope.message"].TextBlock
+ToolResultState = sys.modules["agentscope.message"].ToolResultState
+ToolChunk = sys.modules["agentscope.tool"].ToolChunk
+ToolResponse = sys.modules["agentscope.tool"].ToolResponse
+Toolkit = sys.modules["agentscope.tool"].Toolkit
+PermissionBehavior = sys.modules["agentscope.permission"].PermissionBehavior
+
+
+@dataclass
+class _DataBlock:
+    data: bytes
+    id: str = "data-id"
+
+
+@dataclass
+class _ToolCall:
+    name: str
+    id: str
+
+
+class _State:
+    def __init__(
+        self,
+        session_id: str,
+        payload: object | None = None,
+        *,
+        summary: object | None = None,
+        middle_context: object | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.context = payload
+        self.summary = summary
+        self.middle_context = middle_context
+
+    def model_dump_json(self, *, include: set[str]) -> str:
+        return json.dumps(
+            {key: getattr(self, key) for key in include},
+            ensure_ascii=False,
+        )
+
+
+@dataclass
+class _Agent:
+    state: _State
+
+
+async def _collect(generator) -> list[object]:
+    return [item async for item in generator]
+
+
+class MiddlewareTest(unittest.IsolatedAsyncioTestCase):
+    async def test_streams_chunks_and_only_replaces_final_response(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+        chunk = ToolChunk(content=[TextBlock("streamed")], id="chunk-1")
+        data = _DataBlock(b"image", id="image-1")
+        response = ToolResponse(
+            content=[TextBlock('{"debug":"noise","answer":42}', id="text-1"), data],
+            metadata={"source": "tool"},
+            id="result-1",
+        )
+
+        def compress(input_text: str, **_kwargs: object) -> _CompressionResult:
+            self.assertEqual(json.loads(input_text), {"debug": "noise", "answer": 42})
+            return _CompressionResult('{"answer":42}', True)
+
+        middleware._runtime.compress_impl = compress
+
+        async def next_handler(**_kwargs):
+            yield chunk
+            yield response
+
+        output = await _collect(
+            middleware.on_acting(
+                _Agent(_State("session-1")),
+                {"tool_call": _ToolCall("ApiCall", "call-1")},
+                next_handler,
+            ),
+        )
+
+        self.assertIs(output[0], chunk)
+        self.assertIsNot(output[1], response)
+        self.assertEqual(output[1].content[0].text, '{"answer":42}')
+        self.assertEqual(output[1].content[0].id, "text-1")
+        self.assertIs(output[1].content[1], data)
+        self.assertIs(output[1].metadata, response.metadata)
+        self.assertEqual(output[1].id, "result-1")
+        self.assertEqual(response.content[0].text, '{"debug":"noise","answer":42}')
+
+    async def test_data_only_response_is_not_copied(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+        data = _DataBlock(b"x" * 1024, id="image-1")
+        response = ToolResponse(
+            content=[data],
+            metadata={"nested": ["value"]},
+        )
+
+        result = await middleware._compress_response(
+            response,
+            tool_name="ApiCall",
+            session_id="session",
+            tool_use_id="call",
+        )
+
+        self.assertIs(result, response)
+        self.assertIs(result.content[0], data)
+        self.assertIs(result.metadata, response.metadata)
+
+    async def test_plain_text_uses_shell_thresholds_and_attribution(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        def compress(input_text: str, **kwargs: object) -> _CompressionResult:
+            calls.append((input_text, kwargs))
+            return _CompressionResult(
+                json.dumps("short <<tokenless:0123456789abcdef01234567>>"),
+                True,
+            )
+
+        middleware._runtime.compress_impl = compress
+        compressed = await middleware._compress_text(
+            "x" * 100,
+            tool_name="Bash",
+            session_id="session-2",
+            tool_use_id="call-2",
+        )
+
+        self.assertEqual(compressed, "short <<tokenless:0123456789abcdef01234567>>")
+        self.assertEqual(json.loads(calls[0][0]), "x" * 100)
+        self.assertEqual(calls[0][1]["truncate_strings_at"], 65_536)
+        self.assertEqual(calls[0][1]["truncate_arrays_at"], 128)
+        self.assertEqual(calls[0][1]["max_depth"], 8)
+        self.assertEqual(calls[0][1]["agent_id"], "agentscope")
+        self.assertEqual(calls[0][1]["session_id"], "session-2")
+        self.assertEqual(calls[0][1]["tool_use_id"], "call-2")
+        self.assertIs(calls[0][1]["require_reversible"], True)
+
+    async def test_json_array_keeps_its_type(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+
+        def compress(input_text: str, **_kwargs: object) -> _CompressionResult:
+            self.assertEqual(json.loads(input_text), ["noise", "answer"])
+            return _CompressionResult('["answer"]', True)
+
+        middleware._runtime.compress_impl = compress
+        compressed = await middleware._compress_text(
+            '["noise","answer"]',
+            tool_name="ApiCall",
+            session_id="session",
+            tool_use_id="call",
+        )
+        self.assertEqual(compressed, '["answer"]')
+
+    async def test_modes_select_expected_thresholds(self) -> None:
+        conservative = TokenlessMiddleware(mode="conservative")
+        balanced = TokenlessMiddleware(mode=CompressionMode.BALANCED)
+        aggressive = TokenlessMiddleware(mode="aggressive")
+        self.assertEqual(conservative._thresholds_for("Bash"), (1_048_576, 65_536, 32))
+        self.assertEqual(balanced._thresholds_for("Bash"), (65_536, 128, 8))
+        self.assertEqual(balanced._thresholds_for("ApiCall"), (1_048_576, 65_536, 32))
+        self.assertEqual(aggressive._thresholds_for("ApiCall"), (4_096, 32, 8))
+        self.assertFalse(conservative._is_excluded("Read"))
+        self.assertTrue(balanced._is_excluded("Read"))
+        self.assertTrue(aggressive._is_excluded("Read"))
+
+    async def test_skips_excluded_tools_and_unsuccessful_responses(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0, excluded_tools={"CustomRead"})
+
+        def should_not_run(*_args: object, **_kwargs: object) -> _CompressionResult:
+            raise AssertionError("compression should have been skipped")
+
+        middleware._runtime.compress_impl = should_not_run
+        cases = [
+            ("Read", ToolResultState.SUCCESS),
+            ("CustomRead", ToolResultState.SUCCESS),
+            ("tokenless_retrieve", ToolResultState.SUCCESS),
+            ("ApiCall", ToolResultState.ERROR),
+            ("ApiCall", ToolResultState.DENIED),
+            ("ApiCall", ToolResultState.INTERRUPTED),
+        ]
+        for tool_name, state in cases:
+            response = ToolResponse(content=[TextBlock("x" * 500)], state=state)
+
+            async def next_handler(*, _response=response, **_kwargs):
+                yield _response
+
+            output = await _collect(
+                middleware.on_acting(
+                    _Agent(_State("session")),
+                    {"tool_call": _ToolCall(tool_name, "call")},
+                    next_handler,
+                ),
+            )
+            self.assertIs(output[0], response)
+
+    async def test_runtime_and_output_failures_preserve_original(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+        original = '{"value":"' + "x" * 100 + '"}'
+        cases = [
+            _TokenlessError("stash unavailable"),
+            _CompressionResult(original, False),
+            _CompressionResult("not-json", True),
+            _CompressionResult("[]", True),
+            _CompressionResult(original, True),
+            _CompressionResult('{"value":"' + "x" * 120 + '"}', True),
+        ]
+        for result in cases:
+
+            def compress(*_args: object, _result=result, **_kwargs: object):
+                if isinstance(_result, Exception):
+                    raise _result
+                return _result
+
+            middleware._runtime.compress_impl = compress
+            self.assertIsNone(
+                await middleware._compress_text(
+                    original,
+                    tool_name="ApiCall",
+                    session_id="session",
+                    tool_use_id="call",
+                ),
+            )
+
+        middleware._runtime.compress_impl = lambda *_args, **_kwargs: _CompressionResult("{}", True)
+        self.assertIsNone(
+            await middleware._compress_text(
+                "plain text that should remain text",
+                tool_name="ApiCall",
+                session_id="session",
+                tool_use_id="call",
+            ),
+        )
+
+    async def test_data_dir_is_owned_by_runtime(self) -> None:
+        data_dir = "/tmp/tokenless-agentscope-tenant"
+        middleware = TokenlessMiddleware(data_dir=data_dir)
+        self.assertEqual(middleware.data_dir, data_dir)
+        self.assertEqual(middleware._runtime.data_dir, data_dir)
+
+        with self.assertRaisesRegex(ValueError, "absolute path"):
+            TokenlessMiddleware(data_dir="tenant-data")
+
+    async def test_parallel_calls_keep_attribution_separate(self) -> None:
+        middleware = TokenlessMiddleware(min_chars=0)
+        observed: list[tuple[str, str]] = []
+        calling_thread = threading.get_ident()
+        worker_threads: set[int] = set()
+
+        def compress(_input_text: str, **kwargs: object) -> _CompressionResult:
+            worker_threads.add(threading.get_ident())
+            observed.append((str(kwargs["session_id"]), str(kwargs["tool_use_id"])))
+            return _CompressionResult('{"ok":true}', True)
+
+        middleware._runtime.compress_impl = compress
+        await asyncio.gather(
+            middleware._compress_text(
+                '{"debug":"one","ok":true}',
+                tool_name="ApiCall",
+                session_id="session-a",
+                tool_use_id="call-a",
+            ),
+            middleware._compress_text(
+                '{"debug":"two","ok":true}',
+                tool_name="ApiCall",
+                session_id="session-b",
+                tool_use_id="call-b",
+            ),
+        )
+
+        self.assertEqual(
+            set(observed),
+            {("session-a", "call-a"), ("session-b", "call-b")},
+        )
+        self.assertNotIn(calling_thread, worker_threads)
+
+
+class RetrieveToolTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.middleware = TokenlessMiddleware(data_dir="/tmp/tokenless-tenant")
+        self.tool = (await self.middleware.list_tools())[0]
+
+    async def test_register_tools_is_idempotent_and_rejects_conflict(self) -> None:
+        toolkit = Toolkit()
+        await self.middleware.register_tools(toolkit)
+        await self.middleware.register_tools(toolkit)
+        self.assertIs(await toolkit.get_tool("tokenless_retrieve"), self.tool)
+
+        other = type("OtherTool", (), {"name": "tokenless_retrieve"})()
+        conflict = Toolkit([other])
+        with self.assertRaisesRegex(ValueError, "different 'tokenless_retrieve'"):
+            await self.middleware.register_tools(conflict)
+
+    async def test_custom_name_avoids_app_tool_collision(self) -> None:
+        existing = type("ExistingTool", (), {"name": "tokenless_retrieve"})()
+        middleware = TokenlessMiddleware(
+            data_dir="/tmp/tokenless-tenant",
+            retrieve_tool_name="tenant_tokenless_retrieve",
+        )
+        middleware_tool = (await middleware.list_tools())[0]
+        app_toolkit = Toolkit([existing, middleware_tool])
+
+        self.assertIs(await app_toolkit.get_tool("tokenless_retrieve"), existing)
+        self.assertIs(
+            await app_toolkit.get_tool("tenant_tokenless_retrieve"),
+            middleware_tool,
+        )
+        self.assertTrue(middleware._is_excluded("tenant_tokenless_retrieve"))
+
+    async def test_retrieve_tool_name_must_not_be_empty(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            TokenlessMiddleware(retrieve_tool_name="")
+
+    async def test_retrieve_is_auto_allowed_and_byte_exact(self) -> None:
+        stash_hash = "0123456789ABCDEF01234567"
+        state = _State(
+            "session",
+            {"text": "omitted <<tokenless:0123456789abcdef01234567>>"},
+        )
+        worker_threads: set[int] = set()
+
+        def retrieve(hash_value: str) -> str:
+            worker_threads.add(threading.get_ident())
+            self.assertEqual(hash_value, stash_hash.lower())
+            return "你好\n"
+
+        self.middleware._runtime.retrieve_impl = retrieve
+        decision = await self.tool.check_permissions({}, object())
+        self.assertEqual(decision.behavior, PermissionBehavior.ALLOW)
+        calling_thread = threading.get_ident()
+        chunk = await self.tool.call(stash_hash, state)
+        self.assertEqual(chunk.state, ToolResultState.RUNNING)
+        self.assertEqual(chunk.content[0].text, "你好\n")
+        self.assertNotIn(calling_thread, worker_threads)
+
+    async def test_retrieve_rejects_bad_or_unreferenced_hash(self) -> None:
+        def should_not_run(_hash_value: str) -> str:
+            raise AssertionError("runtime retrieval should not run")
+
+        self.middleware._runtime.retrieve_impl = should_not_run
+        bad = await self.tool.call("not-a-hash", _State("session", {}))
+        missing = await self.tool.call(
+            "0123456789abcdef01234567",
+            _State("session", {}),
+        )
+        self.assertEqual(bad.state, ToolResultState.ERROR)
+        self.assertEqual(missing.state, ToolResultState.ERROR)
+
+    async def test_retrieve_accepts_summary_but_not_middle_context(self) -> None:
+        stash_hash = "0123456789abcdef01234567"
+        self.middleware._runtime.retrieve_impl = lambda _hash: "recovered"
+        from_summary = await self.tool.call(
+            stash_hash,
+            _State("session", summary=f"<<tokenless:{stash_hash}>>"),
+        )
+        self.assertEqual(from_summary.content[0].text, "recovered")
+
+        rejected = await self.tool.call(
+            stash_hash,
+            _State(
+                "session",
+                middle_context={"marker": f"<<tokenless:{stash_hash}>>"},
+            ),
+        )
+        self.assertEqual(rejected.state, ToolResultState.ERROR)
+
+    async def test_retrieve_surfaces_missing_or_expired_payload(self) -> None:
+        stash_hash = "0123456789abcdef01234567"
+        state = _State("session", f"<<tokenless:{stash_hash}>>")
+
+        def missing(_hash_value: str) -> str:
+            raise _TokenlessError(f"no stashed payload for hash: {stash_hash}")
+
+        self.middleware._runtime.retrieve_impl = missing
+        chunk = await self.tool.call(stash_hash, state)
+        self.assertEqual(chunk.state, ToolResultState.ERROR)
+        self.assertIn("no stashed payload", chunk.content[0].text)
+
+
+class PolicyTest(unittest.TestCase):
+    def test_categories_match_canonical_policy(self) -> None:
+        policy = json.loads(
+            (_REPO_ROOT / "adapters/tokenless/common/hooks/tool_categories.json").read_text(),
+        )
+        self.assertEqual(adapter._SKIP_TOOLS, frozenset(policy["layer_1_skip"]["tools"]))
+        self.assertEqual(adapter._SHELL_TOOLS, frozenset(policy["layer_2_shell"]["tools"]))
+        thresholds = policy["layer_2_shell"]["thresholds"]
+        self.assertEqual(
+            adapter._SHELL_THRESHOLDS,
+            (
+                thresholds["truncate_strings_at"],
+                thresholds["truncate_arrays_at"],
+                thresholds["max_depth"],
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

AgentScope 2.0 needs a native middleware integration that can replace final tool
responses without spawning the Tokenless CLI. The in-process Python runtime is
now available from #2501, so this follow-up can keep compression and retrieval
in one process and one versioned Python dependency graph.

## What changed

- Add the separately installable `anolisa-tokenless-agentscope` package for
  `agentscope>=2.0.5,<2.1`, backed by the same-version `anolisa-tokenless`
  runtime.
- Compress only successful final `ToolResponse` text blocks, preserve streaming
  chunks and non-text blocks, and fail open unless the typed UTF-8 output is
  strictly smaller.
- Add balanced, conservative, and aggressive policies plus a read-only,
  marker-scoped `tokenless_retrieve` Tool for high-code Agent and App flows.
- Build, install, raw-package, and test the adapter wheel, including its
  Apache-2.0 license, without adding an `anolisa adapter enable` target.

## Related issue

no-issue: agreed follow-up to merged runtime PR #2501

## User / Agent impact

AgentScope applications can explicitly install and register Tokenless as a
middleware. The default balanced policy compresses eligible final tool results,
and the model can recover stashed text only through a marker already present in
its current context or summary.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The new API is isolated to an opt-in package and supports AgentScope 2.0.5
through 2.0.x. Retrieval is auto-allowed but read-only, accepts only a 24-digit
hex hash, validates the marker against current AgentScope state, and requires a
separate absolute data directory per user or tenant. The adapter pins the
native runtime to its own version; existing adapters and CLI behavior are
unchanged.

## Validation

- `make test-python-runtime test-agentscope-adapter`
  - 11 installed-runtime tests
  - real AgentScope 2.0.5 Toolkit/Middleware compression and byte-exact recovery
  - adapter/runtime version and wheel Apache-2.0 license checks
- Real AgentScope 2.0.5 ReAct conversation using the configured Bailian Token
  Plan model `openai/qwen3.6-plus`
  - called the deterministic large-result Tool
  - returned `ORCHID-7291` from the retained field
  - recorded one reversible marker and correct session/tool attribution
  - compressed 132,042 characters to 12,193 with one successful stash write
- `python3 tests/test_agentscope_middleware.py` (14 tests)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `make test-integration test-adapters`
- `bash tests/test-package-raw.sh`
- Real linux-x86_64 raw package assembly; required AgentScope files present and
  zero archive symlinks
- `make test-npm-package`
- `python3 ../../scripts/docs-link-check.py`
- ruff, black, shellcheck, twine, and `git diff --check`

Local `test-hooks` reached 71/72. Its unrelated environment fixture expected
`rtk>=0.35`, while the existing PATH binary reports 0.1.0; all other hook cases
passed and this change does not modify that test or RTK.

## Documentation and rollback

Updated the English and Chinese Tokenless READMEs and framework integration
guides with installation, registration, App collection, policy, TTL, and
per-tenant storage guidance. Roll back by removing the middleware from the
Agent/App and uninstalling `anolisa-tokenless-agentscope`; no existing adapter
configuration is migrated.
