### PR TITLE
test(cosh-ng): cover SIGKILL atomic writes

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/atomic_file.rs
@@ -428,6 +428,15 @@ mod tests {
     use std::fs;
     use std::io::{Seek, SeekFrom};
 
+    #[cfg(target_os = "linux")]
+    use std::os::unix::process::ExitStatusExt;
+    #[cfg(target_os = "linux")]
+    use std::process::{Command, Stdio};
+    #[cfg(target_os = "linux")]
+    use std::thread;
+    #[cfg(target_os = "linux")]
+    use std::time::{Duration, Instant};
+
     #[cfg(unix)]
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -455,6 +464,72 @@ mod tests {
             .unwrap()
             .prepare_write(parent, name, false)
             .unwrap()
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn sigkill_before_commit_keeps_existing_target_complete() {
+        const CHILD_TARGET_ENV: &str = "COSH_ATOMIC_SIGKILL_CHILD_TARGET";
+        const CHILD_READY_ENV: &str = "COSH_ATOMIC_SIGKILL_CHILD_READY";
+        const TEST_NAME: &str =
+            "tool::atomic_file::tests::sigkill_before_commit_keeps_existing_target_complete";
+
+        if let Some(target) = std::env::var_os(CHILD_TARGET_ENV) {
+            let target = PathBuf::from(target);
+            let ready = PathBuf::from(
+                std::env::var_os(CHILD_READY_ENV).expect("child ready path is configured"),
+            );
+            let write_target = prepare_test_target(&target);
+
+            let _ = replace_with_hooks(
+                &write_target,
+                b"complete replacement",
+                None,
+                |_, _| Ok(()),
+                |_, _| {
+                    fs::write(&ready, b"ready")?;
+                    loop {
+                        thread::park();
+                    }
+                },
+                |_| Ok(()),
+            );
+            unreachable!("the parent must kill the child at the pre-commit barrier");
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("config.toml");
+        let ready = directory.path().join("pre-commit-ready");
+        fs::write(&target, b"complete original").unwrap();
+
+        let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+            .args([TEST_NAME, "--exact", "--nocapture"])
+            .env(CHILD_TARGET_ENV, &target)
+            .env(CHILD_READY_ENV, &ready)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn atomic replacement child");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !ready.exists() {
+            if let Some(status) = child.try_wait().expect("poll atomic replacement child") {
+                panic!("atomic replacement child exited before the barrier: {status}");
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("atomic replacement child did not reach the pre-commit barrier");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        child.kill().expect("send SIGKILL to replacement child");
+        let status = child.wait().expect("wait for replacement child");
+
+        assert_eq!(status.signal(), Some(9), "child status: {status}");
+        assert_eq!(fs::read(&target).unwrap(), b"complete original");
     }
 
     #[test]


### PR DESCRIPTION
## Why

The nightly test for #2510 used a fixed three-second delay before SIGKILL, so provider latency could prevent the write path from being reached. The test needs an explicit synchronization point at the atomic replacement boundary.

## What changed

Adds a Linux-only subprocess regression test that waits for a pre-commit readiness marker before sending SIGKILL. It verifies that the existing target remains complete when the process dies after the temporary file is synced but before the atomic rename.

## Related issue

Closes #2510

## User / Agent impact

None. This is a deterministic test-only change with no production behavior change.

## Risk and compatibility

Low risk. The synchronization environment variables exist only inside the test process, and the test is Linux-only because it validates SIGKILL semantics.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p cosh-core tool::atomic_file::tests -- --nocapture` — 9 passed
- `cargo clippy --locked -p cosh-core --tests -- -D warnings`
- `git diff --check`

## Documentation and rollback

No documentation changes are required. Revert commit `7f914ae5` to remove the regression test.