### PR TITLE
fix(tokenless): retry claude-code detect checks to fix first-run flake

### DIFF
--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -20,12 +20,15 @@ export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 # claude binary may not be visible on PATH yet, and `claude plugin list` may
 # lag a moment behind `claude plugin install` while ~/.claude is still being
 # initialized. Retry such checks briefly before declaring them missing.
-# Tunable via ANOLISA_DETECT_RETRIES / ANOLISA_DETECT_RETRY_DELAY; set
-# retries to 1 to disable.
+# Tunable via ANOLISA_DETECT_RETRIES / ANOLISA_DETECT_RETRY_DELAY.
+# DETECT_RETRIES is the maximum number of probe attempts: 1 means a
+# single probe with no retries, and 0 is accepted as an alias for 1
+# ("no retries"), never as "skip the check entirely".
 DETECT_RETRIES="${ANOLISA_DETECT_RETRIES:-3}"
 DETECT_RETRY_DELAY="${ANOLISA_DETECT_RETRY_DELAY:-1}"
 case "$DETECT_RETRIES" in ''|*[!0-9]*) DETECT_RETRIES=3 ;; esac
 case "$DETECT_RETRY_DELAY" in ''|*[!0-9.]*) DETECT_RETRY_DELAY=1 ;; esac
+if [ "$DETECT_RETRIES" -eq 0 ]; then DETECT_RETRIES=1; fi
 
 line()  { printf '[%s] %s\n' "$COMPONENT" "$*"; }
 field() { printf '[%s]   %-26s %s\n' "$COMPONENT" "$1" "$2"; }
@@ -88,6 +91,11 @@ if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
         # First-run race: `plugin list` may not reflect a fresh
         # `plugin install` until the ~/.claude state settles; retry briefly.
         if [ "$attempt" -ge "$DETECT_RETRIES" ]; then
+            # Explicit status note so operators can tell the check retried
+            # up to the limit instead of failing on a single probe.
+            if [ "$DETECT_RETRIES" -gt 1 ]; then
+                line "plugin check: '$PLUGIN_ID' still not listed after ${attempt} attempts"
+            fi
             break
         fi
         sleep "$DETECT_RETRY_DELAY"

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -16,6 +16,17 @@ PLUGIN_SRC="$ADAPTER_DIR/claude-code"
 CLAUDE_BIN="${CLAUDE_BIN:-}"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 
+# First-run timing races (GH issue #2512): right after a fresh install the
+# claude binary may not be visible on PATH yet, and `claude plugin list` may
+# lag a moment behind `claude plugin install` while ~/.claude is still being
+# initialized. Retry such checks briefly before declaring them missing.
+# Tunable via ANOLISA_DETECT_RETRIES / ANOLISA_DETECT_RETRY_DELAY; set
+# retries to 1 to disable.
+DETECT_RETRIES="${ANOLISA_DETECT_RETRIES:-3}"
+DETECT_RETRY_DELAY="${ANOLISA_DETECT_RETRY_DELAY:-1}"
+case "$DETECT_RETRIES" in ''|*[!0-9]*) DETECT_RETRIES=3 ;; esac
+case "$DETECT_RETRY_DELAY" in ''|*[!0-9.]*) DETECT_RETRY_DELAY=1 ;; esac
+
 line()  { printf '[%s] %s\n' "$COMPONENT" "$*"; }
 field() { printf '[%s]   %-26s %s\n' "$COMPONENT" "$1" "$2"; }
 
@@ -26,6 +37,14 @@ note_install_missing() { INSTALL_MISSING+=("$1"); }
 
 if [ -z "$CLAUDE_BIN" ]; then
     CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
+    # Fresh-install race: the binary may appear on PATH moments after the
+    # installer exits; probe briefly before reporting it missing.
+    attempt=1
+    while [ -z "$CLAUDE_BIN" ] && [ "$attempt" -lt "$DETECT_RETRIES" ]; do
+        sleep "$DETECT_RETRY_DELAY"
+        attempt=$((attempt + 1))
+        CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
+    done
 fi
 
 line "${AGENT} detect"
@@ -59,7 +78,22 @@ else
 fi
 
 if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
-    if "$CLAUDE_BIN" plugin list 2>&1 | grep -qF "$PLUGIN_ID"; then
+    plugin_state="missing"
+    attempt=1
+    while true; do
+        if "$CLAUDE_BIN" plugin list 2>&1 | grep -qF "$PLUGIN_ID"; then
+            plugin_state="installed"
+            break
+        fi
+        # First-run race: `plugin list` may not reflect a fresh
+        # `plugin install` until the ~/.claude state settles; retry briefly.
+        if [ "$attempt" -ge "$DETECT_RETRIES" ]; then
+            break
+        fi
+        sleep "$DETECT_RETRY_DELAY"
+        attempt=$((attempt + 1))
+    done
+    if [ "$plugin_state" = "installed" ]; then
         field "plugin install"    "installed ($PLUGIN_ID)"
     else
         field "plugin install"    "not installed"


### PR DESCRIPTION
## What

Fixes the flaky nightly test `test_detect_installed_framework_ready[claude-code]` (1 of 15 runs failing).

## Root cause

Right after a fresh install, `detect.sh` can race with first-run initialization:

- the `claude` binary may not be visible on `PATH` yet when `command -v claude` probes it;
- `claude plugin list` may lag a moment behind `claude plugin install` while `~/.claude` state is still being initialized.

In that window the script reports `not installed` (exit 1) or `missing prerequisites` (exit 2) instead of `ready` (exit 0).

## Changes

`src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh` (read-only script; tri-state exit semantics unchanged):

- Bounded retry around `claude` binary discovery when the first probe fails.
- Bounded retry around the `claude plugin list` plugin-installed check before recording it as missing.
- Defaults: 3 attempts with a 1s delay — retries only fire on a failed first probe, so the common ready path keeps zero added latency; worst-case added latency on a genuinely missing install is ~2s.
- Tunable via `ANOLISA_DETECT_RETRIES` / `ANOLISA_DETECT_RETRY_DELAY`; invalid values fall back to defaults; set retries to 1 to disable.

## Testing

Verified locally with a flaky-`claude` shim (plugin list failing on first call, binary appearing mid-retry):

- flaky `plugin list` recovers on retry → `installed` / exit 0;
- genuinely missing plugin → `not installed` after exactly 3 attempts;
- `ANOLISA_DETECT_RETRIES=1` → single attempt;
- binary appearing during retry window → discovered, exit 0;
- invalid env values → defaults used, no hang;
- claude truly absent → exit 2 with ~2s added latency.

`bash -n` passes. Repo CI gates for tokenless (cargo fmt/clippy/test, python hook tests) are unaffected by this shell-only change.

Closes #2512
