### PR TITLE
fix(tokenless): retry transient detect failures

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -61,7 +61,7 @@ PYPROJECT_BUILD ?= uvx --from 'build>=1,<2' pyproject-build
         setup help \
         npm-package npm-package-all npm-publish prepare-npm-native-binaries \
         python-wheel test-python-runtime agentscope-wheel \
-        test-agentscope-integration test-hooks
+        test-agentscope-integration test-hooks test-claude-code-detect
 
 # Default target
 all: build
@@ -190,7 +190,7 @@ uninstall:
 
 # Run tests
 test: test-tokenless test-hooks test-integration test-adapters \
-      test-raw-package test-npm-package
+      test-claude-code-detect test-raw-package test-npm-package
 
 test-tokenless:
 	@echo "==> Testing tokenless..."
@@ -201,6 +201,10 @@ test-hooks:
 	bash tests/test-run-hook-install-scope.sh
 	bash tests/test-tool-ready-readable-fixer.sh
 	bash tests/run-all-tests.sh
+
+test-claude-code-detect:
+	@echo "==> Testing claude-code detect.sh first-run retry..."
+	bash tests/test-claude-code-detect-retry.sh
 
 test-integration:
 	@echo "==> Testing hook integration (Python)..."
@@ -388,7 +392,9 @@ claude-code-install:
 	@echo "==> Installing Claude Code plugin..."
 	@# detect.sh exits 1 (installable) or 2 (missing prereq); we tolerate both
 	@# and let install.sh make the final call (it gracefully no-ops without claude CLI).
-	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/detect.sh || true
+	@# This pre-install probe runs on a steady-state machine and its output is
+	@# informational only, so skip detect.sh's first-run settling retries.
+	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code TOKENLESS_DETECT_RETRIES=0 bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/detect.sh || true
 	@$(ADAPTER_ENV) ANOLISA_TARGET=claude-code bash $(CLAUDE_CODE_ADAPTER_DIR)/scripts/install.sh
 
 claude-code-uninstall:

--- a/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
+++ b/src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh
@@ -16,6 +16,33 @@ PLUGIN_SRC="$ADAPTER_DIR/claude-code"
 CLAUDE_BIN="${CLAUDE_BIN:-}"
 export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 
+# First-run settling retries: right after provisioning, the claude binary or
+# the plugin registry may be transiently invisible on the very first detect.sh
+# execution (filesystem/PATH init timing race). settle() only retries checks
+# that report a retryable failure (exit status 1); checks that succeed or
+# report a definitive result return immediately, so steady-state runs stay
+# fast.
+DETECT_RETRIES="${TOKENLESS_DETECT_RETRIES:-3}"
+DETECT_RETRY_DELAY="${TOKENLESS_DETECT_RETRY_DELAY:-1}"
+
+# settle <cmd...> — run cmd once; if it reports a retryable failure (exit
+# status 1), sleep DETECT_RETRY_DELAY and retry, up to DETECT_RETRIES retries
+# (that is, at most 1 + DETECT_RETRIES attempts in total). Exit status 0 is
+# success. Any other exit status is a definitive result and is returned
+# immediately without further retries. Returns the final exit status.
+# Callers must therefore reserve exit status 1 for conditions that a retry
+# may still resolve.
+settle() {
+    local retry=0 rc=0
+    "$@"; rc=$?
+    while [ "$rc" -eq 1 ] && [ "$retry" -lt "$DETECT_RETRIES" ]; do
+        retry=$((retry + 1))
+        sleep "$DETECT_RETRY_DELAY"
+        "$@"; rc=$?
+    done
+    return "$rc"
+}
+
 line()  { printf '[%s] %s\n' "$COMPONENT" "$*"; }
 field() { printf '[%s]   %-26s %s\n' "$COMPONENT" "$1" "$2"; }
 
@@ -24,8 +51,17 @@ INSTALL_MISSING=()
 note_prereq_missing()  { PREREQ_MISSING+=("$1"); }
 note_install_missing() { INSTALL_MISSING+=("$1"); }
 
-if [ -z "$CLAUDE_BIN" ]; then
+find_claude_bin() {
     CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
+    [ -n "$CLAUDE_BIN" ]
+}
+
+if [ -z "$CLAUDE_BIN" ]; then
+    # PATH/filesystem may still be settling right after install; re-check
+    # briefly before declaring the CLI missing. A genuinely absent CLI cannot
+    # be distinguished from that settling race, so it spends one retry budget
+    # (set TOKENLESS_DETECT_RETRIES=0 to opt out).
+    settle find_claude_bin || true
 fi
 
 line "${AGENT} detect"
@@ -38,7 +74,10 @@ else
 fi
 
 # Informational only: claude creates ~/.claude on first run; absence is
-# not a prerequisite failure.
+# not a prerequisite failure. Check once, without settling retries: nothing in
+# this script creates the directory before `claude plugin list` runs, and that
+# call carries its own retry budget and initializes ~/.claude itself, so
+# retrying this probe would only delay the report.
 if [ -d "$HOME/.claude" ]; then
     field "claude config dir" "present ($HOME/.claude)"
 else
@@ -58,8 +97,30 @@ else
     field "plugin.json"       "missing (run: make stamp-adapter-templates)"
 fi
 
+# claude_plugin_listed — probe the plugin registry, using the settle()
+# exit-status contract: 0 = plugin listed; 1 = `claude plugin list` itself
+# failed (the CLI may still be initializing ~/.claude on first run, so a
+# retry may still succeed); 2 = `plugin list` ran successfully but did not
+# list the plugin. That is a definitive absent result — no retry can change
+# it — so settle() must return immediately instead of sleeping out the
+# retry budget and invoking the CLI DETECT_RETRIES + 1 times.
+claude_plugin_listed() {
+    local listing
+    if ! listing="$("$CLAUDE_BIN" plugin list 2>&1)"; then
+        return 1
+    fi
+    if printf '%s\n' "$listing" | grep -qF "$PLUGIN_ID"; then
+        return 0
+    fi
+    return 2
+}
+
 if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
-    if "$CLAUDE_BIN" plugin list 2>&1 | grep -qF "$PLUGIN_ID"; then
+    # First-run race: `claude plugin list` may transiently fail while the CLI
+    # initializes ~/.claude; settle() retries while that failure (status 1)
+    # persists. A successful list that simply omits the plugin is definitive
+    # (status 2) and is reported as "not installed" without further retries.
+    if settle claude_plugin_listed; then
         field "plugin install"    "installed ($PLUGIN_ID)"
     else
         field "plugin install"    "not installed"

--- a/src/tokenless/tests/test-claude-code-detect-retry.sh
+++ b/src/tokenless/tests/test-claude-code-detect-retry.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Regression test for the detect.sh first-run settling retries.
+#
+# Background: GH #2512 reported test_detect_installed_framework_ready
+# [claude-code] flaking in nightly runs. The reported cause was a
+# filesystem/PATH initialization timing race on the first detect.sh
+# execution right after provisioning: the claude binary under
+# $HOME/.local/bin and the $HOME/.claude state dir are transiently
+# invisible. #2512 itself was closed as a test-side flaky misclassification
+# (issuecomment-5288391676), but the detect.sh-side weakness it exposed is
+# real, and only one exit-status-affecting check can actually race: the
+# claude binary lookup. A binary that is not yet visible makes detect.sh
+# exit 2 ("missing prerequisites"), which is exactly what turns a
+# "framework ready" assertion into a failure. (The $HOME/.claude config-dir
+# probe is informational only and never changes the exit status.)
+#
+# Scenario 1 therefore reproduces that real failure path: the claude binary
+# becomes visible in $HOME/.local/bin only after a delay (simulated with a
+# background provisioner), and $HOME/.claude does not exist until the CLI's
+# first `plugin list`. With settling retries, detect.sh must ride out the
+# race and report ready (exit 0); without retries (scenario 2) the same
+# first execution must fail with exit 2, proving the retries are what fix
+# it. Scenarios 3-4 pin the plugin probe's retry semantics: a successful
+# `plugin list` that omits the plugin is a definitive result and must not
+# consume the retry budget, while a failing `plugin list` is transient and
+# is retried.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+DETECT="$SCRIPT_DIR/../adapters/tokenless/claude-code/scripts/detect.sh"
+TEST_DIR="$(mktemp -d)"
+
+FAKE_HOME="$TEST_DIR/home"
+FAKE_BIN="$FAKE_HOME/.local/bin"
+SHARED_HOOKS="$FAKE_HOME/.local/share/anolisa/adapters/tokenless/common/hooks"
+PLUGIN_ID="tokenless@anolisa-tokenless"
+CALL_LOG="$TEST_DIR/claude-calls.log"
+STUB_MODE_FILE="$TEST_DIR/stub-mode"
+FLAKY_MARKER="$TEST_DIR/flaky-marker"
+PROVISIONER_PID=""
+
+cleanup() {
+    if [ -n "$PROVISIONER_PID" ]; then
+        kill "$PROVISIONER_PID" 2>/dev/null || true
+        wait "$PROVISIONER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN" "$SHARED_HOOKS"
+
+# detect.sh also requires `tokenless` and `rtk` on PATH (their absence is a
+# prerequisite failure). Provide isolated stubs so this test is
+# self-contained: run_detect restricts PATH to the fake home plus system
+# directories, and a fresh runner or detached worktree may not have either
+# binary installed globally.
+printf '#!/bin/sh\nexit 0\n' >"$FAKE_BIN/tokenless"
+printf '#!/bin/sh\nexit 0\n' >"$FAKE_BIN/rtk"
+chmod +x "$FAKE_BIN/tokenless" "$FAKE_BIN/rtk"
+
+fail() {
+    echo "FAIL: $1" >&2
+    printf '%s\n' "${2:-}" >&2
+    exit 1
+}
+
+# Stub claude CLI. `plugin list` behaviour is steered via $STUB_MODE_FILE:
+#   ready  — the list succeeds and contains the tokenless plugin (default)
+#   absent — the list succeeds but does not contain the plugin
+#   flaky  — the first `plugin list` call fails while the registry
+#            initializes; later calls succeed
+# Like the real CLI, `plugin list` creates $HOME/.claude when it first
+# runs; the config dir does not exist before that. Every invocation is
+# appended to $CALL_LOG so the tests can count CLI calls.
+install_claude_stub() {
+    cat >"$FAKE_BIN/claude" <<'STUB'
+#!/bin/sh
+printf '%s\n' "${1:-}" >>"$CALL_LOG"
+mode=ready
+[ -f "$STUB_MODE_FILE" ] && mode=$(cat "$STUB_MODE_FILE")
+case "${1:-}" in
+--version)
+    echo "claude 9.9.9-test"
+    ;;
+plugin)
+    if [ "$mode" = "absent" ]; then
+        echo "NAME                          STATUS"
+        exit 0
+    fi
+    if [ "$mode" = "flaky" ] && [ ! -f "$FLAKY_MARKER" ]; then
+        : >"$FLAKY_MARKER"
+        echo "initializing plugin registry" >&2
+        exit 1
+    fi
+    mkdir -p "$HOME/.claude"
+    echo "NAME                          STATUS"
+    echo "tokenless@anolisa-tokenless   enabled"
+    ;;
+*)
+    exit 0
+    ;;
+esac
+STUB
+    chmod +x "$FAKE_BIN/claude"
+}
+
+schedule_claude() { # schedule_claude <delay-seconds>
+    # Simulate provisioning: the binary becomes visible only after the delay.
+    (
+        sleep "$1"
+        install_claude_stub
+    ) &
+    PROVISIONER_PID=$!
+}
+
+finish_provisioner() {
+    wait "$PROVISIONER_PID"
+    PROVISIONER_PID=""
+}
+
+cancel_provisioner() {
+    kill "$PROVISIONER_PID" 2>/dev/null || true
+    wait "$PROVISIONER_PID" 2>/dev/null || true
+    PROVISIONER_PID=""
+}
+
+reset_env() {
+    rm -rf "$FAKE_HOME/.claude"
+    rm -f "$FAKE_BIN/claude" "$FLAKY_MARKER"
+    echo ready >"$STUB_MODE_FILE"
+}
+
+run_detect() { # run_detect <retries> <retry-delay>
+    : >"$CALL_LOG"
+    rm -f "$FLAKY_MARKER"
+    # Inherit only /usr/local/bin:/usr/bin:/bin (detect.sh itself prepends
+    # $HOME/.local/bin): a claude installed elsewhere in the CI PATH must
+    # not leak into the window while the stub is not yet provisioned.
+    HOME="$FAKE_HOME" \
+    PATH="/usr/local/bin:/usr/bin:/bin" \
+    CALL_LOG="$CALL_LOG" \
+    STUB_MODE_FILE="$STUB_MODE_FILE" \
+    FLAKY_MARKER="$FLAKY_MARKER" \
+    TOKENLESS_DETECT_RETRIES="$1" \
+    TOKENLESS_DETECT_RETRY_DELAY="$2" \
+        bash "$DETECT" 2>&1
+}
+
+plugin_list_calls() {
+    grep -c '^plugin$' "$CALL_LOG" || true
+}
+
+# --- Scenario 1: the #2512 failure path, with settling retries ------------
+# The claude binary is not yet visible in $HOME/.local/bin when detect.sh
+# starts (first execution right after provisioning); it appears ~0.2s later
+# while detect.sh is still settling (retry delay 0.5s). $HOME/.claude does
+# not exist until the CLI's first `plugin list`. Expect ready (exit 0).
+reset_env
+schedule_claude 0.2
+if ! out="$(run_detect 3 0.5)"; then
+    fail "detect.sh should exit 0 (ready) once the settling retries find the claude binary" "$out"
+fi
+finish_provisioner
+grep -qF "installed ($PLUGIN_ID)" <<<"$out" \
+    || fail "plugin should be reported installed after the race settles" "$out"
+grep -qF "claude-code: ready" <<<"$out" \
+    || fail "claude-code should be reported ready after the race settles" "$out"
+# Self-containment: detect.sh must have resolved the isolated stubs above,
+# not any runner-installed binaries.
+grep -qF "present ($FAKE_BIN/tokenless)" <<<"$out" \
+    || fail "detect.sh should resolve the isolated tokenless stub, not a host binary" "$out"
+grep -qF "present ($FAKE_BIN/rtk)" <<<"$out" \
+    || fail "detect.sh should resolve the isolated rtk stub, not a host binary" "$out"
+# The $HOME/.claude half of the reported race: the config dir is still
+# invisible at probe time. detect.sh must report it as missing without
+# letting that affect readiness (the probe is informational only).
+grep -qF "missing (created on first claude run)" <<<"$out" \
+    || fail "the config-dir probe should have observed the not-yet-created ~/.claude" "$out"
+
+# --- Scenario 2 (control): same first execution, retries disabled ---------
+# Without settling retries detect.sh checks once, does not see the binary
+# (provisioning completes only after the check), and must fail exactly like
+# the nightly framework-ready check did: exit 2, missing prerequisites.
+reset_env
+schedule_claude 2
+set +e
+out="$(run_detect 0 0)"
+rc=$?
+set -e
+cancel_provisioner
+[ "$rc" -eq 2 ] \
+    || fail "without retries the first execution should exit 2 (missing prerequisites), got $rc" "$out"
+grep -qF "claude CLI" <<<"$out" \
+    || fail "the first execution without retries should mention the claude CLI" "$out"
+grep -qF "missing prerequisites" <<<"$out" \
+    || fail "the first execution without retries should report missing prerequisites" "$out"
+
+# --- Scenario 3: definitive plugin-absent must not retry (PR review P2) ---
+# The CLI is installed and `plugin list` works, but the tokenless plugin is
+# not registered — the ordinary pre-install state. A successful list that
+# omits the plugin is definitive: detect.sh must report "not installed"
+# after exactly one `plugin list` invocation, without sleeping out the
+# retry budget.
+reset_env
+install_claude_stub
+echo absent >"$STUB_MODE_FILE"
+mkdir -p "$FAKE_HOME/.claude"
+set +e
+out="$(run_detect 3 1)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] \
+    || fail "plugin-absent detection should exit 1 (installable), got $rc" "$out"
+grep -qF "not installed" <<<"$out" \
+    || fail "plugin should be reported not installed" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 1 ] \
+    || fail "definitive plugin-absent must not retry: plugin list ran $calls times" "$out"
+
+# --- Scenario 4: transient plugin-list failures are still retried ---------
+# A `plugin list` call that fails outright (as opposed to one that succeeds
+# without listing the plugin) is not definitive — the CLI may still be
+# initializing — so settle() retries it.
+reset_env
+install_claude_stub
+echo flaky >"$STUB_MODE_FILE"
+if ! out="$(run_detect 3 0)"; then
+    fail "detect.sh should exit 0 after retrying a transient plugin-list failure" "$out"
+fi
+grep -qF "installed ($PLUGIN_ID)" <<<"$out" \
+    || fail "plugin should be reported installed after the transient failure" "$out"
+calls="$(plugin_list_calls)"
+[ "$calls" -eq 2 ] \
+    || fail "the transient plugin-list failure should be retried once (saw $calls calls)" "$out"
+
+echo "claude-code detect retry test passed"


### PR DESCRIPTION
## Summary

Defensive hardening of the claude-code `detect.sh` against first-run initialization races.

Background: #2512 reported an intermittent nightly failure of `test_detect_installed_framework_ready[claude-code]`, attributed to a filesystem/PATH initialization timing race on detect.sh's first execution. That issue was closed as a **test-side flaky misclassification** (see the closing comment on #2512) and no failing trace was attached. Following the review's elimination analysis, the `~/.claude` config-dir probe is informational only and cannot change the exit status — so the only exit-status-affecting check that can race under the reported `$HOME/.claude`/PATH visibility mechanism is the claude binary lookup itself: a binary that is not yet visible makes detect.sh exit 2 (missing prerequisites), which is exactly what turns a "framework ready" assertion into a failure.

This PR therefore:

- Retries the transient first-run failures: the claude binary not yet visible under `$HOME/.local/bin` (PATH is fixed within one run, but the filesystem is not — the file itself can appear mid-execution, and `command -v` re-scans on every attempt), and a `claude plugin list` invocation failing while the CLI initializes `~/.claude`.
- Never retries definitive results: a **successful** `plugin list` that omits the plugin is a definitive not-installed and is reported after exactly one invocation — that is the ordinary pre-install state, which previously slept through the whole retry budget (~3.02s, 4 CLI invocations).
- Pins the behavior with a regression test anchored on that reported failure path (binary appearing late), with a no-retry control reproducing the nightly failure mode (exit 2, missing prerequisites), plus cases pinning the plugin probe's retry semantics.

## Changes

`src/tokenless/adapters/tokenless/claude-code/scripts/detect.sh`:

- `settle()` retry helper with bounded, tunable retries (`TOKENLESS_DETECT_RETRIES`, default 3; `TOKENLESS_DETECT_RETRY_DELAY`, default 1s). It retries only while the check reports a retryable failure (exit status 1); any other status is definitive and returned immediately (at most `1 + DETECT_RETRIES` attempts in total).
- The claude binary lookup goes through `settle()`: it catches a binary appearing while detect.sh settles. A genuinely absent CLI cannot be distinguished from that race, so it spends one retry budget (documented; `TOKENLESS_DETECT_RETRIES=0` opts out).
- `claude_plugin_listed` classifies the outcome: 0 = plugin listed; 1 = the `plugin list` invocation itself failed (retryable first-run init); 2 = a successful list that omits the plugin (definitive absent, never retried).
- The `~/.claude` config-dir check stays a single informational probe; nothing in the script creates the directory before `claude plugin list` runs.
- The tri-state exit contract (0 ready / 1 installable / 2 missing prereqs) is unchanged.

`src/tokenless/Makefile`:

- The `claude-code-install` pre-install detect call now runs with `TOKENLESS_DETECT_RETRIES=0`: that probe is informational only (`|| true`, install.sh makes the final call) and runs on a steady-state machine, so it returns immediately.
- Registers `make test-claude-code-detect` and wires it into the `test` aggregate.

`src/tokenless/tests/test-claude-code-detect-retry.sh` (new):

- Case 1: the claude binary becomes visible in `$HOME/.local/bin` only after a delay (background provisioner simulating the provisioning race); `~/.claude` does not exist until the CLI's first `plugin list`. With retries, detect.sh exits 0 and reports `installed`/`ready`; the test also asserts the config-dir probe observed the not-yet-created `~/.claude` without affecting readiness.
- Case 2 (control): the same first execution with retries disabled exits 2 with missing prerequisites — the nightly framework-ready failure mode — proving the retries are what fix it.
- Case 3: definitive plugin-absent — the CLI runs successfully but never lists the plugin → detect.sh exits 1 after **exactly one** `plugin list` invocation regardless of the retry budget.
- Case 4: a `plugin list` invocation that fails outright is transient and is retried → exit 0.

## Testing

Environment: Linux x86_64, GNU bash.

- `bash -n` on `detect.sh` and the new test script — pass.
- `make -C src/tokenless test-claude-code-detect` — pass (all 4 cases).
- Manual steady-state latency verification (default retries=3, delay=1s): plugin-absent path exits 1 in ~0.02s with exactly one CLI invocation (previously ~3.02s and 4 invocations); the `make claude-code-install` pre-install probe returns immediately (retries disabled).
- Manual first-run race verification: a binary appearing mid-execution is found on the first retry (elapsed >= one retry delay), exit 0 ready.
- Not run: the full `make -C src/tokenless test` aggregate (requires the full toolchain/npm environment); the change is confined to one adapter detect script, its dedicated test, and one opt-out env var on an informational Makefile call.