### PR TITLE
fix(sec-core): install runtime deps in user install mode

### DIFF
--- a/.github/workflows/sec-core-source-code-build.yaml
+++ b/.github/workflows/sec-core-source-code-build.yaml
@@ -60,6 +60,12 @@ jobs:
         run: agent-sec-daemon --help
       - name: Verify sandbox
         run: linux-sandbox --help
+      - name: Verify runtime dependencies
+        run: |
+          command -v bwrap
+          bwrap --version
+          jq --version
+          command -v gpg || command -v gpg2
       - name: Verify deployment
         run: |
           echo "=== Skills ==="
@@ -113,6 +119,12 @@ jobs:
           agent-sec-cli scan-pii --help >/dev/null
           agent-sec-daemon --help
           linux-sandbox --help
+      - name: Verify runtime dependencies
+        run: |
+          command -v bwrap
+          bwrap --version
+          jq --version
+          command -v gpg || command -v gpg2
       - name: Verify system deployment
         run: |
           echo "=== System binaries ==="

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1799,17 +1799,26 @@ install_skills() {
     fi
 }
 
+# Package providing `gpg` on the detected distro family.
+gpg_pkg_name() {
+    if [[ "$PKG_BASE" == "deb" ]]; then echo "gnupg"; else echo "gnupg2"; fi
+}
+
+# Runtime dependencies are installed in both user and system mode: they are
+# system packages either way, and `bwrap` is a hard requirement of
+# linux-sandbox (the RPM declares `Requires: bubblewrap` for the same reason).
+# Skipping them in user mode makes the install look successful and defers the
+# failure to the first sandbox launch.
 install_sec_core_runtime_deps() {
-    if cmd_exists bwrap && { cmd_exists gpg || cmd_exists gpg2; } && cmd_exists jq; then
-        return 0
+    step "Runtime dependencies (for agent-sec-core)"
+
+    local need_gpg=false
+    if ! cmd_exists gpg && ! cmd_exists gpg2; then
+        need_gpg=true
     fi
 
-    if [[ "$INSTALL_MODE" != "system" ]]; then
-        cmd_exists bwrap || warn "bubblewrap not found; linux-sandbox may not run until it is installed."
-        if ! cmd_exists gpg && ! cmd_exists gpg2; then
-            warn "gpg/gpg2 not found; skill signature setup will need GnuPG."
-        fi
-        cmd_exists jq || warn "jq not found; sec-core helper scripts may need jq."
+    if cmd_exists bwrap && ! $need_gpg && cmd_exists jq; then
+        ok "agent-sec-core runtime dependencies already installed"
         return 0
     fi
 
@@ -1817,20 +1826,47 @@ install_sec_core_runtime_deps() {
         detect_distro
     fi
 
+    local missing=()
+    cmd_exists bwrap || missing+=("bubblewrap")
+    if $need_gpg; then
+        missing+=("$(gpg_pkg_name)")
+    fi
+    cmd_exists jq || missing+=("jq")
+
+    info "Installing: ${missing[*]}"
+    # shellcheck disable=SC2086
+    as_root $PKG_INSTALL "${missing[@]}" || \
+        warn "Failed to install: ${missing[*]}"
+
+    # Re-check instead of trusting the package manager exit code: a partially
+    # satisfied install must still surface the specific missing capability.
+    local unresolved=()
+    local unresolved_pkgs=()
     if ! cmd_exists bwrap; then
-        info "Installing runtime dependency: bubblewrap ..."
-        as_root $PKG_INSTALL bubblewrap || warn "bubblewrap not installed (linux-sandbox runtime dep)"
+        unresolved+=("bubblewrap (linux-sandbox cannot launch without bwrap)")
+        unresolved_pkgs+=("bubblewrap")
     fi
     if ! cmd_exists gpg && ! cmd_exists gpg2; then
-        local gpg_pkg="gnupg2"
-        [[ "$PKG_BASE" == "deb" ]] && gpg_pkg="gnupg"
-        info "Installing runtime dependency: ${gpg_pkg} ..."
-        as_root $PKG_INSTALL "$gpg_pkg" || warn "${gpg_pkg} not installed (skill signature verification)"
+        unresolved+=("gnupg (skill signature verification)")
+        unresolved_pkgs+=("$(gpg_pkg_name)")
     fi
     if ! cmd_exists jq; then
-        info "Installing runtime dependency: jq ..."
-        as_root $PKG_INSTALL jq || warn "jq not installed (sec-core helper/signing dependency)"
+        unresolved+=("jq (sec-core helper/signing scripts)")
+        unresolved_pkgs+=("jq")
     fi
+
+    if [[ ${#unresolved[@]} -eq 0 ]]; then
+        ok "agent-sec-core runtime dependencies installed"
+        return 0
+    fi
+
+    local item
+    for item in "${unresolved[@]}"; do
+        warn "Unresolved runtime dependency: ${item}"
+    done
+    local sudo_prefix="sudo "
+    [[ "$(id -u)" -eq 0 ]] && sudo_prefix=""
+    info "Install manually with: ${BOLD}${sudo_prefix}${PKG_INSTALL} ${unresolved_pkgs[*]}${NC}"
 }
 
 install_sec_core() {


### PR DESCRIPTION
## Why

源码安装默认走 user 模式。在该模式下 `install_sec_core_runtime_deps` 只在缺少
`bwrap` 时打印一条 warning 就返回，于是 sec-core 会被完整装好、但沙箱不可用。
故障要等到第一次真正启动沙箱时才暴露：

    failed to exec bwrap: No such file or directory (os error 2)

bubblewrap 对 `linux-sandbox` 是硬依赖，RPM 侧用 `Requires: bubblewrap` 表达了
这一点，源码安装路径却把它降级成了一条警告，两条安装路径给出的功能承诺不一致。

## What changed

- 去掉运行时依赖安装的 `INSTALL_MODE` 门控，user 与 system 模式统一用 `as_root`
  安装 `bubblewrap`、`gnupg`/`gnupg2`、`jq`。
- 改为「收集缺失项 → 一次性安装 → 重新探测」：不信任包管理器的退出码，安装后
  重新检查，部分成功时只报告真正仍然缺失的能力。
- 无法自动修复时打印按发行版取值的手动安装命令，并按 `id -u` 决定是否带 `sudo`。
- 新增 `gpg_pkg_name()`，集中 deb/rpm 下 `gnupg` 与 `gnupg2` 的命名差异。
- 源码构建 CI 的 user 与 system 两个 job 各新增一个 `Verify runtime dependencies`
  步骤，安装后校验 `bwrap` / `jq` / `gpg` 确实可用。

### 设计说明：为什么 user 模式选择自动安装

issue 中设想的是 user 模式下停止安装并提示用户手动补齐。本 PR 选择自动安装，
理由是与 `build-all.sh` 的既有行为保持一致：该脚本的依赖安装从不按
`INSTALL_MODE` 分叉，user 模式下同样会用 `sudo` 装系统包 —— 包括 cosh-ng 的
`install_cosh_ng_native_deps`（`pkg-config`、OpenSSL 开发文件），以及 Node.js、
gcc/make、Rust 工具链、pipx、eBPF 开发包。运行时依赖此前是唯一按安装模式分叉
的一类，本 PR 消除的正是这处不一致。

如果维护者更倾向「user 模式停止并提示」，需要同时调整上述所有依赖安装点，
否则 user 模式仍会在别处 sudo 改动系统，单独收紧运行时依赖并不能达到
「user 模式不触碰系统状态」的效果。

### 未包含的验收项

issue 中另有两项本 PR 未覆盖，建议单独处理：

- `linux-sandbox` 在 `bwrap` 缺失时独立早失败并给出专门的依赖错误。
- 覆盖 preflight 与 missing-`bwrap` 运行时路径的测试，以及 cosh-ng + Tokenless
  + 已安装 sec-core 的回归场景。

另外，`src/agent-sec-core/.anolisa/component.toml` 已用 `[[component.dependencies]]`
声明了同一组依赖（含 `probe` 与 rpm/deb 包名映射）。本 PR 在 `build-all.sh` 内
维护了一份等价的包名映射，属于重复来源。后续可以让 `build-all.sh` 直接消费
manifest 声明，避免两处漂移。

## Related issue

closes #2520

## User / Agent impact

source 安装的 user 模式下，`build-all.sh` 现在会用 `sudo` 安装 bubblewrap、
gnupg 与 jq。此前这三个包在 user 模式下不会被安装，缺失时仅有一条警告。
RPM 与 ANOLISA raw 安装路径行为不变。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

user 模式的安装行为发生变化：新增了通过 `as_root` 安装三个系统包的动作。
`as_root` 在非 root 身份下调用 `sudo`，因此 user 模式安装可能提示输入密码。
安装失败不会中断整体安装流程，只输出警告与手动安装命令，因此不会让原本可以
完成的安装变为失败。

## Validation

- `bash -n scripts/build-all.sh` — 通过
- `./scripts/build-all.sh --component sec-core --dry-run` — user 模式的安装计划
  中出现运行时依赖检查步骤
- 用桩函数注入 `cmd_exists` / `as_root` / `detect_distro` 后直接调用
  `install_sec_core_runtime_deps`，覆盖 6 种场景：依赖齐全、缺 bubblewrap 安装
  成功、全部缺失安装失败、部分成功、rpm + root、`PKG_INSTALL` 未初始化 —— 输出
  与预期一致
- workflow YAML 解析通过，两个 job 的 step 顺序符合预期

## Documentation and rollback

无文档变更。回滚方式：还原 `scripts/build-all.sh` 中
`install_sec_core_runtime_deps` 与 `gpg_pkg_name()`，以及 workflow 中新增的
`Verify runtime dependencies` 步骤；无持久化状态或迁移需要撤销。