### PR TITLE
fix(cosh-ng): [core] reject null decision

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/hook.rs
+++ b/src/cosh-ng/crates/cosh-core/src/hook.rs
@@ -63,12 +63,20 @@ pub struct HookOutput {
     pub stop_reason: Option<String>,
     #[serde(alias = "suppressOutput")]
     pub suppress_output: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_present_string")]
     pub decision: Option<String>,
     pub reason: Option<String>,
     #[serde(alias = "systemMessage")]
     pub system_message: Option<String>,
     #[serde(alias = "hookSpecificOutput")]
     pub hook_specific_output: Option<Value>,
+}
+
+fn deserialize_present_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Some)
 }
 
 struct ObjectOnlyHookOutput(HookOutput);
@@ -1537,10 +1545,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_hook_output_accepts_null_decision() {
+    fn parse_hook_output_rejects_null_decision() {
         let json = r#"{"decision":null}"#;
-        let out = decode_hook_output(json.as_bytes()).unwrap();
-        assert_eq!(out.decision, None);
+        assert!(decode_hook_output(json.as_bytes()).is_none());
     }
 
     #[test]
@@ -1667,6 +1674,7 @@ mod tests {
     async fn extension_errors_remain_fail_closed() {
         for (command, expected) in [
             ("printf 'not-json'", HookFailureKind::InvalidJson),
+            ("printf '{\"decision\":null}'", HookFailureKind::InvalidJson),
             ("exit 7", HookFailureKind::NonZero),
         ] {
             let mut system = HookSystem::from_config(&HooksConfig::default());
@@ -1961,6 +1969,7 @@ mod tests {
         let cases = [
             ("exit 7", HookFailureKind::NonZero),
             ("printf 'not-json'", HookFailureKind::InvalidJson),
+            ("printf '{\"decision\":null}'", HookFailureKind::InvalidJson),
             ("true", HookFailureKind::EmptyOutput),
             (
                 "printf 'secret-output' >&2; exit 7",


### PR DESCRIPTION
## Why

An exit-0 hook response with `{"decision":null}` currently deserializes to the same value as a missing decision. The hook therefore becomes pass-through instead of entering the existing invalid-output failure path, leaving the fail-closed fix incomplete.

## What changed

- Require a present `decision` field to contain a string while preserving a missing field as valid pass-through.
- Route explicit `null` through the existing `InvalidJson` handling.
- Cover both configured and extension hook paths, including the compatibility behavior introduced by #2506.

## Related issue

Closes #2101

## User / Agent impact

Hooks that emit `decision:null` now fail closed by default. Hooks can continue to emit `{}` for pass-through, and an explicit `fail_open = true` retains its existing behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The change only rejects an explicitly null decision. Missing decisions, empty JSON objects, valid decision strings, and the extension empty-output compatibility from #2506 are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cosh-core hook::tests::parse_hook_output_rejects_null_decision -- --exact`
- `cargo test -p cosh-core hook::tests::pre_tool_use_failures_block_without_leaking_output -- --exact`
- `cargo test -p cosh-core hook::tests::extension_errors_remain_fail_closed -- --exact`
- `cargo clippy -p cosh-core --all-targets -- -D warnings`
- `bash tests/test-tool-ready-readable-fixer.sh` from `src/tokenless`
- Targeted #2506 regressions for extension empty output, configured-hook collisions, and explicit extension disablement

Full workspace and ECS validation are intentionally delegated to CI because this is a localized decoder change.

## Documentation and rollback

No documentation changes are required. Revert commit `053fec91` to restore the previous behavior.