### PR TITLE
feat(sight): add component-owned raw packaging

### DIFF
--- a/.github/workflows/agentsight-runner-test.yml
+++ b/.github/workflows/agentsight-runner-test.yml
@@ -66,6 +66,10 @@ jobs:
         working-directory: src/agentsight
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Test raw packaging
+        working-directory: src/agentsight
+        run: uv run --python 3.11.6 --no-project make test-raw-package
+
       - name: Run tests with coverage
         working-directory: src/agentsight
         run: |
@@ -163,4 +167,3 @@ jobs:
               exec "$CARGO_BIN" test --test bpf_load -- \
                 --ignored --nocapture --test-threads=1
             '
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -703,6 +703,10 @@ jobs:
           cd src/agentsight
           cargo clippy --workspace --all-targets -- -D warnings
 
+      - name: Test raw packaging
+        working-directory: src/agentsight
+        run: uv run --python 3.11.6 --no-project make test-raw-package
+
       - name: Run tests with coverage
         run: |
           cd src/agentsight

--- a/scripts/check-component-versions.py
+++ b/scripts/check-component-versions.py
@@ -21,6 +21,8 @@ VERSION_RE = re.compile(
 TOML_CONTRACTS = (
     ("src/agent-sec-core/openclaw-plugin/package.json", "src/agent-sec-core/.anolisa/component.toml"),
     ("src/agentsight/Cargo.toml", "src/agentsight/component.toml"),
+    ("src/agentsight/Cargo.toml", "src/agentsight/.anolisa/component.toml"),
+    ("src/agentsight/Cargo.toml", "src/agentsight/.anolisa/component.macos.toml"),
     ("src/copilot-shell/package.json", "src/copilot-shell/component.toml"),
     ("src/cosh-ng/Cargo.toml", "src/cosh-ng/component.toml"),
     ("src/cosh-ng/Cargo.toml", "src/cosh-ng/.anolisa/component.toml"),

--- a/src/agentsight/.anolisa/component.macos.toml
+++ b/src/agentsight/.anolisa/component.macos.toml
@@ -1,0 +1,37 @@
+[component]
+name = "agentsight"
+version = "0.10.1"
+layer = "runtime"
+domain = "observability"
+display_name = "AgentSight"
+description = "Agent observability with Linux eBPF tracing and cross-platform trajectory collection and analysis"
+owner = "agentsight-team"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/anolisa"
+
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.1.16"
+
+[component.platform]
+os = ["macos"]
+arch = ["aarch64"]
+
+[component.layout]
+modes = ["user", "system"]
+
+[[component.layout.files]]
+source = ".anolisa/component.toml"
+target = "{datadir}/components/agentsight/component.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/agentsight"
+target = "{bindir}/agentsight"
+mode = "0755"
+type = "executable"
+
+[component.health_check]
+type = "binary_version"
+binary = "{bindir}/agentsight"
+timeout_secs = 5

--- a/src/agentsight/.anolisa/component.toml
+++ b/src/agentsight/.anolisa/component.toml
@@ -1,0 +1,92 @@
+[component]
+name = "agentsight"
+version = "0.10.1"
+layer = "runtime"
+domain = "observability"
+display_name = "AgentSight"
+description = "Agent observability with Linux eBPF tracing and cross-platform trajectory collection and analysis"
+owner = "agentsight-team"
+license = "Apache-2.0"
+repository = "https://github.com/alibaba/anolisa"
+
+[component.contract]
+schema_version = "1.0"
+min_anolisa_version = "0.1.16"
+
+[backends.rpm]
+package = "agentsight"
+
+[component.platform]
+os = ["linux"]
+arch = ["x86_64"]
+min_kernel = "5.8"
+
+[[component.dependencies]]
+name = "elfutils-libelf"
+kind = "system-package"
+probe = "grep -aqF libelf.so.1 /etc/ld.so.cache"
+packages = { rpm = "elfutils-libelf", deb = "libelf1" }
+
+[[component.dependencies]]
+name = "ebpf-btf"
+kind = "platform-capability"
+check = "btf"
+min_kernel = "5.8"
+
+[component.layout]
+modes = ["system"]
+
+[[component.layout.files]]
+source = ".anolisa/component.toml"
+target = "{datadir}/components/agentsight/component.toml"
+mode = "0644"
+
+[[component.layout.files]]
+source = "bin/agentsight"
+target = "{bindir}/agentsight"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/agentsight-enforcer"
+target = "{bindir}/agentsight-enforcer"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "bin/agentsight-start"
+target = "{bindir}/agentsight-start"
+mode = "0755"
+type = "executable"
+
+[[component.layout.files]]
+source = "share/anolisa/agentsight/agentsight.service"
+target = "{unitdir}/agentsight.service"
+mode = "0644"
+
+[[component.layout.files]]
+source = "share/anolisa/agentsight/agentsight-enforcer.service"
+target = "{unitdir}/agentsight-enforcer.service"
+mode = "0644"
+
+[[component.capabilities]]
+path = "{bindir}/agentsight"
+caps = ["cap_bpf", "cap_perfmon"]
+optional = true
+
+[[component.services]]
+unit = "agentsight-enforcer.service"
+scope = "system"
+enable = false
+start = false
+
+[[component.services]]
+unit = "agentsight.service"
+scope = "system"
+enable = false
+start = false
+
+[component.health_check]
+type = "binary_version"
+binary = "{bindir}/agentsight"
+timeout_secs = 5

--- a/src/agentsight/Makefile
+++ b/src/agentsight/Makefile
@@ -93,8 +93,18 @@ uninstall:
 # TEST & QUALITY
 # =============================================================================
 
+.PHONY: package-raw stage-raw test-raw-package
+package-raw: ## Package prebuilt AgentSight binaries for one raw target
+	@./packaging/raw/package.sh package
+
+stage-raw: ## Stage one raw payload into DESTDIR
+	@./packaging/raw/package.sh stage
+
+test-raw-package: ## Validate Linux and macOS raw package assembly
+	@bash scripts/test-package-raw.sh
+
 .PHONY: test
-test: test-rpm-packaging ## Run unit tests (fast, no coverage)
+test: test-rpm-packaging test-raw-package ## Run unit tests (fast, no coverage)
 	cd $(CURDIR) && cargo test
 
 .PHONY: test-rpm-packaging

--- a/src/agentsight/packaging/raw/package.sh
+++ b/src/agentsight/packaging/raw/package.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Assemble prebuilt AgentSight binaries into the ANOLISA raw-package layout.
+set -euo pipefail
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux) printf 'linux\n' ;;
+        Darwin) printf 'macos\n' ;;
+        *) die "unsupported host OS; set TARGET_OS explicitly" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported host architecture; set TARGET_ARCH explicitly" ;;
+    esac
+}
+
+normalize_os() {
+    case "$1" in
+        linux) printf 'linux\n' ;;
+        macos | darwin) printf 'macos\n' ;;
+        *) die "unsupported AgentSight target OS: $1" ;;
+    esac
+}
+
+normalize_arch() {
+    case "$1" in
+        x86_64 | amd64 | x64) printf 'x86_64\n' ;;
+        aarch64 | arm64) printf 'aarch64\n' ;;
+        *) die "unsupported AgentSight target architecture: $1" ;;
+    esac
+}
+
+validate_target() {
+    case "$TARGET_OS-$TARGET_ARCH" in
+        linux-x86_64 | macos-aarch64) ;;
+        *) die "unsupported AgentSight raw target: $TARGET_OS-$TARGET_ARCH" ;;
+    esac
+}
+
+require_file() {
+    [ -f "$1" ] || die "missing packaging input: $1"
+}
+
+default_contract_path() {
+    case "$TARGET_OS" in
+        linux) printf '%s/.anolisa/component.toml\n' "$SOURCE_ROOT" ;;
+        macos) printf '%s/.anolisa/component.macos.toml\n' "$SOURCE_ROOT" ;;
+    esac
+}
+
+verify_native_binary_version() {
+    local output reported
+
+    if ! output="$("$BIN_DIR/agentsight" --version 2>&1)"; then
+        die "agentsight --version failed: $output"
+    fi
+    reported="$(printf '%s\n' "$output" | awk 'NR == 1 { print $NF; exit }')"
+    [ "$reported" = "$VERSION" ] || \
+        die "agentsight reports $reported but contract says $VERSION"
+}
+
+normalize_modes() {
+    local stage="$1"
+
+    find "$stage" -type d -exec chmod 0755 {} +
+    find "$stage" -type f -exec chmod 0644 {} +
+    find "$stage/bin" -type f -exec chmod 0755 {} +
+}
+
+stage_payload() {
+    local stage="$1"
+
+    if [ -e "$stage" ] && [ -n "$(find "$stage" -mindepth 1 -print -quit)" ]; then
+        die "DESTDIR must be empty: $stage"
+    fi
+
+    install -d -m 0755 "$stage/.anolisa" "$stage/bin"
+    install -p -m 0644 "$CONTRACT" "$stage/.anolisa/component.toml"
+    install -p -m 0755 "$BIN_DIR/agentsight" "$stage/bin/agentsight"
+    if [ "$TARGET_OS" = "linux" ]; then
+        install -d -m 0755 "$stage/share/anolisa/agentsight"
+        install -p -m 0755 "$BIN_DIR/agentsight-enforcer" \
+            "$stage/bin/agentsight-enforcer"
+        install -p -m 0755 "$SOURCE_ROOT/scripts/agentsight-start.sh" \
+            "$stage/bin/agentsight-start"
+        install -p -m 0644 \
+            "$SOURCE_ROOT/scripts/agentsight.service" \
+            "$SOURCE_ROOT/scripts/agentsight-enforcer.service" \
+            "$stage/share/anolisa/agentsight/"
+    fi
+    normalize_modes "$stage"
+
+    if [ -n "$(find "$stage" -type l -print -quit)" ]; then
+        die "raw payload contains a symbolic link"
+    fi
+}
+
+resolve_epoch() {
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        printf '%s\n' "$SOURCE_DATE_EPOCH"
+        return
+    fi
+    git -C "$SOURCE_ROOT" log -1 --format=%ct -- . 2>/dev/null || \
+        die "SOURCE_DATE_EPOCH is unset and the source commit time is unavailable"
+}
+
+COMMAND="${1:-}"
+[ "$COMMAND" = "stage" ] || [ "$COMMAND" = "package" ] || \
+    die "usage: $0 {stage|package}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_ROOT="${AGENTSIGHT_SOURCE_DIR:-$DEFAULT_ROOT}"
+BIN_DIR="${BIN_DIR:-$SOURCE_ROOT/target/release}"
+TARGET_OS="$(normalize_os "${TARGET_OS:-$(detect_os)}")"
+TARGET_ARCH="$(normalize_arch "${TARGET_ARCH:-$(detect_arch)}")"
+CONTRACT="${RAW_CONTRACT:-$(default_contract_path)}"
+BUILD_METADATA="${AGENTSIGHT_BUILD_METADATA:-$BIN_DIR/agentsight-build.toml}"
+
+validate_target
+for input in \
+    "$CONTRACT" \
+    "$SOURCE_ROOT/Cargo.toml"; do
+    require_file "$input"
+done
+[ -x "$BIN_DIR/agentsight" ] || die "missing executable: $BIN_DIR/agentsight"
+BINARIES=("$BIN_DIR/agentsight")
+if [ "$TARGET_OS" = "linux" ]; then
+    for input in \
+        "$SOURCE_ROOT/scripts/agentsight-start.sh" \
+        "$SOURCE_ROOT/scripts/agentsight.service" \
+        "$SOURCE_ROOT/scripts/agentsight-enforcer.service"; do
+        require_file "$input"
+    done
+    [ -x "$BIN_DIR/agentsight-enforcer" ] || \
+        die "missing executable: $BIN_DIR/agentsight-enforcer"
+    BINARIES+=("$BIN_DIR/agentsight-enforcer")
+fi
+
+VERSION="$(
+    python3 "$SCRIPT_DIR/verify-release.py" \
+        "$SOURCE_ROOT" "$CONTRACT" \
+        --os "$TARGET_OS" --arch "$TARGET_ARCH"
+)"
+if [ -n "${AGENTSIGHT_BUILD_METADATA:-}" ]; then
+    require_file "$BUILD_METADATA"
+fi
+if [ -f "$BUILD_METADATA" ]; then
+    python3 "$SCRIPT_DIR/verify-binaries.py" \
+        --os "$TARGET_OS" \
+        --arch "$TARGET_ARCH" \
+        --metadata "$BUILD_METADATA" \
+        --component-version "$VERSION" \
+        "${BINARIES[@]}"
+elif [ "$(normalize_os "$(detect_os)")-$(normalize_arch "$(detect_arch)")" = \
+    "$TARGET_OS-$TARGET_ARCH" ]; then
+    python3 "$SCRIPT_DIR/verify-binaries.py" \
+        --os "$TARGET_OS" \
+        --arch "$TARGET_ARCH" \
+        "${BINARIES[@]}"
+    verify_native_binary_version
+else
+    die "cross-target packaging requires build metadata: $BUILD_METADATA"
+fi
+
+if [ "$COMMAND" = "stage" ]; then
+    [ -n "${DESTDIR:-}" ] || die "DESTDIR is required by stage"
+    stage_payload "$DESTDIR"
+    printf 'Staged AgentSight %s for %s-%s at %s\n' \
+        "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$DESTDIR"
+    exit 0
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$SOURCE_ROOT/target/raw}"
+EPOCH="$(resolve_epoch)"
+case "$EPOCH" in
+    '' | *[!0-9]*) die "SOURCE_DATE_EPOCH must be a non-negative integer" ;;
+esac
+tar --version 2>/dev/null | grep -q 'GNU tar' || \
+    die "GNU tar is required for reproducible raw packages"
+
+WORK="$(mktemp -d)"
+TEMP_ARTIFACT=""
+cleanup() {
+    rm -rf "$WORK"
+    if [ -n "$TEMP_ARTIFACT" ]; then
+        rm -f "$TEMP_ARTIFACT"
+    fi
+}
+trap cleanup EXIT
+
+STAGE="$WORK/stage"
+stage_payload "$STAGE"
+install -d -m 0755 "$OUTPUT_DIR"
+ARTIFACT="agentsight-${VERSION}-${TARGET_OS}-${TARGET_ARCH}.tar.gz"
+TEMP_ARTIFACT="$OUTPUT_DIR/.${ARTIFACT}.tmp.$$"
+LC_ALL=C tar \
+    --sort=name \
+    --mtime="@$EPOCH" \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    --hard-dereference \
+    --format=gnu \
+    -C "$STAGE" \
+    -cf - . | gzip -n -9 > "$TEMP_ARTIFACT"
+mv -f "$TEMP_ARTIFACT" "$OUTPUT_DIR/$ARTIFACT"
+TEMP_ARTIFACT=""
+printf '%s\n' "$OUTPUT_DIR/$ARTIFACT"

--- a/src/agentsight/packaging/raw/verify-binaries.py
+++ b/src/agentsight/packaging/raw/verify-binaries.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify that prebuilt AgentSight binaries match the requested target."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import struct
+import tomllib
+from pathlib import Path
+
+
+ELF_MACHINES = {
+    "x86_64": 62,
+    "aarch64": 183,
+}
+MACHO_CPUS = {
+    "x86_64": 0x01000007,
+    "aarch64": 0x0100000C,
+}
+
+
+def verify_build_metadata(
+    path: Path,
+    version: str,
+    os_name: str,
+    arch: str,
+    binaries: list[Path],
+) -> None:
+    """Verify build identity and bind it to the supplied binary bytes."""
+    try:
+        with path.open("rb") as stream:
+            metadata = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"cannot read build metadata: {error}") from error
+
+    expected_identity = {
+        "version": version,
+        "target_os": os_name,
+        "target_arch": arch,
+    }
+    for key, expected in expected_identity.items():
+        actual = metadata.get(key)
+        if actual != expected:
+            raise ValueError(f"{key} {actual!r} does not match {expected!r}")
+
+    hashes = metadata.get("binaries")
+    if not isinstance(hashes, dict):
+        raise ValueError("missing [binaries] SHA-256 table")
+    expected_names = {binary.name for binary in binaries}
+    unexpected = sorted(set(hashes) - expected_names)
+    if unexpected:
+        raise ValueError(f"unexpected binaries in metadata: {', '.join(unexpected)}")
+    for binary in binaries:
+        expected_hash = hashes.get(binary.name)
+        if not isinstance(expected_hash, str):
+            raise ValueError(f"missing SHA-256 for {binary.name}")
+        try:
+            actual_hash = hashlib.sha256(binary.read_bytes()).hexdigest()
+        except OSError as error:
+            raise ValueError(f"cannot hash {binary.name}: {error}") from error
+        if expected_hash.lower() != actual_hash:
+            raise ValueError(f"SHA-256 for {binary.name} does not match build metadata")
+
+
+def verify_elf(path: Path, arch: str) -> None:
+    """Verify one 64-bit little-endian ELF binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(64)
+    if len(header) < 20 or header[:4] != b"\x7fELF":
+        raise ValueError("not an ELF binary")
+    if header[4] != 2:
+        raise ValueError("not a 64-bit ELF binary")
+    if header[5] != 1:
+        raise ValueError("not a little-endian ELF binary")
+    machine = struct.unpack_from("<H", header, 18)[0]
+    if machine != ELF_MACHINES[arch]:
+        raise ValueError(f"ELF machine {machine} does not match {arch}")
+
+
+def verify_macho(path: Path, arch: str) -> None:
+    """Verify one thin 64-bit Mach-O binary's architecture."""
+    with path.open("rb") as stream:
+        header = stream.read(32)
+    if len(header) < 8:
+        raise ValueError("Mach-O header is truncated")
+    if header[:4] == b"\xcf\xfa\xed\xfe":
+        byte_order = "<"
+    elif header[:4] == b"\xfe\xed\xfa\xcf":
+        byte_order = ">"
+    else:
+        raise ValueError("not a thin 64-bit Mach-O binary")
+    cpu = struct.unpack_from(f"{byte_order}I", header, 4)[0]
+    if cpu != MACHO_CPUS[arch]:
+        raise ValueError(f"Mach-O CPU {cpu:#x} does not match {arch}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse target identity and binary paths."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=tuple(ELF_MACHINES), required=True)
+    parser.add_argument("--metadata", type=Path)
+    parser.add_argument("--component-version")
+    parser.add_argument("binaries", nargs="+", type=Path)
+    args = parser.parse_args()
+    if (args.metadata is None) != (args.component_version is None):
+        parser.error("--metadata and --component-version must be supplied together")
+    return args
+
+
+def main() -> int:
+    """Validate all binaries without executing cross-target code."""
+    args = parse_args()
+    verifier = verify_elf if args.os == "linux" else verify_macho
+    for path in args.binaries:
+        if not path.is_file():
+            raise SystemExit(f"ERROR: missing binary: {path}")
+        try:
+            verifier(path, args.arch)
+        except (OSError, ValueError) as error:
+            raise SystemExit(f"ERROR: {path}: {error}") from error
+    if args.metadata is not None:
+        try:
+            verify_build_metadata(
+                args.metadata,
+                args.component_version,
+                args.os,
+                args.arch,
+                args.binaries,
+            )
+        except ValueError as error:
+            raise SystemExit(f"ERROR: {args.metadata}: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agentsight/packaging/raw/verify-release.py
+++ b/src/agentsight/packaging/raw/verify-release.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validate AgentSight release metadata before raw packaging."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tomllib
+from pathlib import Path
+
+
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+TARGET_SOURCES = {
+    ("linux", "x86_64"): {
+        ".anolisa/component.toml",
+        "bin/agentsight",
+        "bin/agentsight-enforcer",
+        "bin/agentsight-start",
+        "share/anolisa/agentsight/agentsight.service",
+        "share/anolisa/agentsight/agentsight-enforcer.service",
+    },
+    ("macos", "aarch64"): {
+        ".anolisa/component.toml",
+        "bin/agentsight",
+    },
+}
+
+
+def read_toml(path: Path) -> dict[str, object]:
+    """Read one TOML document with path-aware errors."""
+    try:
+        with path.open("rb") as stream:
+            return tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+
+
+def verify_release(root: Path, contract_path: Path, os_name: str, arch: str) -> str:
+    """Return the synchronized version after validating the raw contract."""
+    cargo = read_toml(root / "Cargo.toml")
+    package = cargo.get("package")
+    source_version = package.get("version") if isinstance(package, dict) else None
+    if not isinstance(source_version, str) or SEMVER.fullmatch(source_version) is None:
+        raise SystemExit(f"ERROR: {root / 'Cargo.toml'} has no valid package version")
+
+    contract = read_toml(contract_path)
+    component = contract.get("component")
+    if not isinstance(component, dict):
+        raise SystemExit(f"ERROR: {contract_path} has no [component] table")
+    if component.get("name") != "agentsight":
+        raise SystemExit(f"ERROR: {contract_path} is not an agentsight contract")
+    contract_version = component.get("version")
+    if contract_version != source_version:
+        raise SystemExit(
+            f"ERROR: {contract_path} version {contract_version!r} does not match "
+            f"Cargo.toml version {source_version}"
+        )
+
+    platform = component.get("platform")
+    operating_systems = platform.get("os") if isinstance(platform, dict) else None
+    architectures = platform.get("arch") if isinstance(platform, dict) else None
+    if not isinstance(operating_systems, list) or os_name not in operating_systems:
+        raise SystemExit(f"ERROR: {contract_path} does not support target OS {os_name}")
+    if not isinstance(architectures, list) or arch not in architectures:
+        raise SystemExit(f"ERROR: {contract_path} does not support target architecture {arch}")
+
+    layout = component.get("layout")
+    files = layout.get("files") if isinstance(layout, dict) else None
+    if not isinstance(files, list):
+        raise SystemExit(f"ERROR: {contract_path} has no component layout files")
+    sources = {
+        row.get("source")
+        for row in files
+        if isinstance(row, dict) and isinstance(row.get("source"), str)
+    }
+    missing_sources = sorted(TARGET_SOURCES[(os_name, arch)] - sources)
+    if missing_sources:
+        raise SystemExit(
+            f"ERROR: {contract_path} is missing packaged layout sources: "
+            + ", ".join(missing_sources)
+        )
+
+    return source_version
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse source, contract, and target identity arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("contract", type=Path)
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=("x86_64", "aarch64"), required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Print the verified AgentSight release version."""
+    args = parse_args()
+    target = (args.os, args.arch)
+    if target not in TARGET_SOURCES:
+        raise SystemExit(f"ERROR: unsupported AgentSight raw target: {args.os}-{args.arch}")
+    print(
+        verify_release(
+            args.source_root.resolve(),
+            args.contract.resolve(),
+            args.os,
+            args.arch,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agentsight/scripts/test-package-raw.sh
+++ b/src/agentsight/scripts/test-package-raw.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Verify AgentSight component-owned Linux and macOS raw packages.
+set -euo pipefail
+
+SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+VERSION="$(
+    python3 - "$SOURCE_ROOT/Cargo.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+with pathlib.Path(sys.argv[1]).open("rb") as stream:
+    print(tomllib.load(stream)["package"]["version"])
+PY
+)"
+LINUX_ARTIFACT="agentsight-$VERSION-linux-x86_64.tar.gz"
+MACOS_ARTIFACT="agentsight-$VERSION-macos-aarch64.tar.gz"
+BIN_DIR="$TMP_ROOT/bin"
+BUILD_METADATA="$BIN_DIR/agentsight-build.toml"
+mkdir -p "$BIN_DIR"
+
+write_elf() {
+    python3 - "$1" <<'PY'
+import pathlib
+import struct
+import sys
+
+header = bytearray(64)
+header[:4] = b"\x7fELF"
+header[4] = 2
+header[5] = 1
+struct.pack_into("<H", header, 18, 62)
+pathlib.Path(sys.argv[1]).write_bytes(header)
+PY
+    chmod 0755 "$1"
+}
+
+write_macho() {
+    python3 - "$1" <<'PY'
+import pathlib
+import struct
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(
+    struct.pack("<IiiIIIII", 0xFEEDFACF, 0x0100000C, 0, 2, 0, 0, 0, 0)
+)
+PY
+    chmod 0755 "$1"
+}
+
+write_metadata() {
+    local os_name="$1"
+    local arch="$2"
+    shift 2
+    {
+        printf 'version = "%s"\n' "$VERSION"
+        printf 'target_os = "%s"\n' "$os_name"
+        printf 'target_arch = "%s"\n\n' "$arch"
+        printf '[binaries]\n'
+        for binary in "$@"; do
+            printf '%s = "%s"\n' \
+                "$(basename "$binary")" \
+                "$(sha256sum "$binary" | awk '{print $1}')"
+        done
+    } > "$BUILD_METADATA"
+}
+
+write_elf "$BIN_DIR/agentsight"
+write_elf "$BIN_DIR/agentsight-enforcer"
+write_metadata linux x86_64 \
+    "$BIN_DIR/agentsight" "$BIN_DIR/agentsight-enforcer"
+
+for output in "$TMP_ROOT/linux-one" "$TMP_ROOT/linux-two"; do
+    AGENTSIGHT_SOURCE_DIR="$SOURCE_ROOT" \
+    AGENTSIGHT_BUILD_METADATA="$BUILD_METADATA" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$output" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$SOURCE_ROOT/packaging/raw/package.sh" package >/dev/null
+done
+
+cmp \
+    "$TMP_ROOT/linux-one/$LINUX_ARTIFACT" \
+    "$TMP_ROOT/linux-two/$LINUX_ARTIFACT"
+tar -tzf "$TMP_ROOT/linux-one/$LINUX_ARTIFACT" > "$TMP_ROOT/linux-members"
+for member in \
+    './.anolisa/component.toml' \
+    './bin/agentsight' \
+    './bin/agentsight-enforcer' \
+    './bin/agentsight-start' \
+    './share/anolisa/agentsight/agentsight.service' \
+    './share/anolisa/agentsight/agentsight-enforcer.service'; do
+    grep -Fxq "$member" "$TMP_ROOT/linux-members"
+done
+tar -xzOf "$TMP_ROOT/linux-one/$LINUX_ARTIFACT" \
+    ./.anolisa/component.toml | cmp - "$SOURCE_ROOT/.anolisa/component.toml"
+
+printf 'stale\n' >> "$BIN_DIR/agentsight"
+if AGENTSIGHT_SOURCE_DIR="$SOURCE_ROOT" \
+    AGENTSIGHT_BUILD_METADATA="$BUILD_METADATA" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$TMP_ROOT/stale-binary" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$SOURCE_ROOT/packaging/raw/package.sh" package >/dev/null 2>&1; then
+    printf 'ERROR: package accepted a binary outside build metadata\n' >&2
+    exit 1
+fi
+write_elf "$BIN_DIR/agentsight"
+write_metadata linux x86_64 \
+    "$BIN_DIR/agentsight" "$BIN_DIR/agentsight-enforcer"
+
+mv "$BIN_DIR/agentsight-enforcer" "$BIN_DIR/agentsight-enforcer.missing"
+if AGENTSIGHT_SOURCE_DIR="$SOURCE_ROOT" \
+    AGENTSIGHT_BUILD_METADATA="$BUILD_METADATA" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$TMP_ROOT/missing-enforcer" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$SOURCE_ROOT/packaging/raw/package.sh" package >/dev/null 2>&1; then
+    printf 'ERROR: Linux package accepted a missing agentsight-enforcer\n' >&2
+    exit 1
+fi
+mv "$BIN_DIR/agentsight-enforcer.missing" "$BIN_DIR/agentsight-enforcer"
+
+write_macho "$BIN_DIR/agentsight"
+write_metadata macos aarch64 "$BIN_DIR/agentsight"
+AGENTSIGHT_SOURCE_DIR="$SOURCE_ROOT" \
+AGENTSIGHT_BUILD_METADATA="$BUILD_METADATA" \
+BIN_DIR="$BIN_DIR" \
+OUTPUT_DIR="$TMP_ROOT/macos" \
+TARGET_OS=macos \
+TARGET_ARCH=aarch64 \
+SOURCE_DATE_EPOCH=1700000000 \
+    "$SOURCE_ROOT/packaging/raw/package.sh" package >/dev/null
+
+tar -tzf "$TMP_ROOT/macos/$MACOS_ARTIFACT" > "$TMP_ROOT/macos-members"
+grep -Fxq './.anolisa/component.toml' "$TMP_ROOT/macos-members"
+grep -Fxq './bin/agentsight' "$TMP_ROOT/macos-members"
+if grep -Eq 'agentsight-(start|enforcer)|agentsight(-enforcer)?\.service' \
+    "$TMP_ROOT/macos-members"; then
+    printf 'ERROR: macOS package contains Linux-only AgentSight files\n' >&2
+    exit 1
+fi
+tar -xzOf "$TMP_ROOT/macos/$MACOS_ARTIFACT" \
+    ./.anolisa/component.toml | cmp - "$SOURCE_ROOT/.anolisa/component.macos.toml"
+
+if AGENTSIGHT_SOURCE_DIR="$SOURCE_ROOT" \
+    AGENTSIGHT_BUILD_METADATA="$BUILD_METADATA" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$TMP_ROOT/unsupported" \
+    TARGET_OS=linux \
+    TARGET_ARCH=aarch64 \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$SOURCE_ROOT/packaging/raw/package.sh" package >/dev/null 2>&1; then
+    printf 'ERROR: package accepted unsupported Linux aarch64 target\n' >&2
+    exit 1
+fi
+
+printf 'AgentSight raw package tests passed\n'


### PR DESCRIPTION
## Why

AgentSight needs a component-owned raw packaging interface so release tooling can consume immutable artifacts without duplicating Linux and macOS payload assembly. The contracts follow the actual build boundary: Linux ships full tracing and enforcement, while macOS ships trajectory and viewer functionality only.

## What changed

- Add deterministic `stage` and `package` entrypoints for AgentSight raw archives.
- Support Linux x86_64 and macOS aarch64 with separate target contracts.
- Include `agentsight-enforcer`, launch script, and services only in the Linux payload.
- Validate contract versions, target binary formats, and hash-bound cross-build metadata.
- Add fixture tests, version-sync checks, and CI coverage for the packaging interface.

## Related issue

Related: #2547 documents the CLI dry-run sidecar metadata limitation. This packaging PR follows that target-specific metadata direction but intentionally does not close the CLI issue.

## User / Agent impact

Release tooling can invoke `make package-raw` or `make stage-raw` for:

- `agentsight-0.10.1-linux-x86_64.tar.gz`
- `agentsight-0.10.1-macos-aarch64.tar.gz`

Linux packages contain AgentSight, the enforcer, launch script, and service units. macOS packages contain only the AgentSight binary and contract; enforcement remains unsupported there. Cross-target packaging requires `agentsight-build.toml` with the target identity and binary SHA-256 values.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The Linux contract declares the existing optional eBPF capabilities and system services. The macOS contract has no capabilities, services, or enforcer. Existing source and RPM installation paths are unchanged, and release-pipeline integration remains outside this PR.

## Validation

Passed:

- `bash src/agentsight/scripts/test-package-raw.sh`
- `python3 scripts/check-component-versions.py`
- `shellcheck src/agentsight/packaging/raw/package.sh src/agentsight/scripts/test-package-raw.sh`
- `cargo fmt --all -- --check`
- `cargo test --quiet --workspace --tests -- --skip test_try_match_process_current`
- `git diff --check origin/main...HEAD`
- Real Linux x86_64 Cross build with Rust 1.93 and glibc 2.28 compatibility; both `agentsight` and the real ActPlane `agentsight-enforcer` were packaged.
- Real macOS aarch64 Cross build; the Mach-O arm64 binary targets macOS 11.0 and the package contains no enforcer.
- Both real archives were imported into one temporary registry and validated as one AgentSight catalog identity.

Known baseline failures outside this diff:

- `cargo clippy --workspace --all-targets -- -D warnings` on Rust 1.97 reports `clippy::question_mark` in `src/analyzer/message/openai.rs:99`.
- Full `cargo test --workspace` reports the existing `test_try_match_process_current` failure and a malformed rustdoc fence in `src/genai/helpers.rs:504`. All non-doctest workspace tests pass when the process-discovery test is skipped.

## Documentation and rollback

No documentation changed. Revert commit `d5d08cb0` to remove the component-owned raw packaging interface and contracts.