### PR TITLE
fix(anolisa): read target-specific raw metadata

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -53,11 +53,11 @@ pub(super) fn index_fetch_error(index_url: &str, err: DownloadError) -> CliError
     }
 }
 
-/// Whether a fetch failure means "this index file is not published", as
-/// opposed to a transport or repository fault. Only the former may fall
-/// back from `index-v2.toml` to `index.toml`: falling back on transient
-/// errors could silently downgrade a gen-2 repository to its gen-1 view.
-fn index_not_published(err: &DownloadError) -> bool {
+/// Whether a fetch failure means "this file is not published", as opposed to
+/// a transport or repository fault. Every optional-file fallback in this
+/// module is gated on it: falling back on a transient error would silently
+/// serve a *different* file than the one the repository actually publishes.
+fn remote_file_absent(err: &DownloadError) -> bool {
     match err {
         DownloadError::HttpStatus { status, .. } => *status == 404 || *status == 410,
         // file:// repositories surface a missing index as I/O NotFound.
@@ -77,7 +77,9 @@ fn fetch_raw_index(
     let v2_url = raw_index_v2_url(base_url);
     match cache.fetch(&v2_url, None) {
         Ok(downloaded) => Ok((v2_url, downloaded.cached_path)),
-        Err(err) if index_not_published(&err) => {
+        // Absence only: a transport fault here must not downgrade a gen-2
+        // repository to its gen-1 view.
+        Err(err) if remote_file_absent(&err) => {
             let v1_url = raw_index_url(base_url);
             let downloaded = cache
                 .fetch(&v1_url, None)
@@ -332,70 +334,95 @@ impl InstallContractSource {
 /// Load the published lightweight install contract without fetching the full
 /// artifact, so dry-run can enforce manifest-backed refusals such as component
 /// conflicts.
+///
+/// The contract must describe the artifact that was *resolved*, not merely the
+/// component and version: a repository may publish a different contract per
+/// target (a Linux system-only payload beside a macOS build that also supports
+/// user mode). [`meta_url_candidates`] therefore prefers the metadata beside
+/// the resolved artifact, and the version-level file is consulted only when
+/// that sibling is absent.
 pub(crate) fn load_dry_run_install_contract(
     ctx: &CliContext,
     layout: &FsLayout,
     resolution: &RawResolution,
 ) -> Result<Option<LoadedInstallContract>, CliError> {
-    let Some(meta_url) = sidecar_meta_url(
+    let expected_sha = manifest_digest_sha256(resolution.entry.manifest_digest.as_deref())?;
+    let cache = DownloadCache::new(layout.cache_dir.clone());
+    // Candidates are keyed by full URL in the download cache, so a sibling and
+    // a version-level `meta.toml` never share a cache entry.
+    for meta_url in meta_url_candidates(
         &resolution.artifact_url,
         &resolution.entry.component,
         &resolution.entry.version,
-    ) else {
-        return Ok(None);
-    };
-    let expected_sha = manifest_digest_sha256(resolution.entry.manifest_digest.as_deref())?;
-    let cache = DownloadCache::new(layout.cache_dir.clone());
-    let downloaded = match cache.fetch(&meta_url, expected_sha) {
-        Ok(downloaded) => downloaded,
-        Err(DownloadError::HttpStatus { status: 404, .. }) => return Ok(None),
-        Err(DownloadError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(None);
-        }
-        Err(err) => {
-            return Err(CliError::Runtime {
+    ) {
+        let downloaded = match cache.fetch(&meta_url, expected_sha) {
+            Ok(downloaded) => downloaded,
+            // Absence only. A network, digest, or parse failure on metadata
+            // the repository *does* publish must fail the dry-run: falling
+            // through would validate another target's contract and report a
+            // preview the execution path would never honour.
+            Err(err) if remote_file_absent(&err) => continue,
+            Err(err) => {
+                return Err(CliError::Runtime {
+                    command: COMMAND.to_string(),
+                    reason: format!("failed to fetch sidecar metadata {meta_url}: {err}"),
+                });
+            }
+        };
+        let toml =
+            std::fs::read_to_string(&downloaded.cached_path).map_err(|err| CliError::Runtime {
                 command: COMMAND.to_string(),
-                reason: format!("failed to fetch sidecar metadata {meta_url}: {err}"),
-            });
-        }
-    };
-    let toml =
-        std::fs::read_to_string(&downloaded.cached_path).map_err(|err| CliError::Runtime {
-            command: COMMAND.to_string(),
-            reason: format!(
-                "failed to read sidecar metadata {} from cache: {err}",
-                downloaded.cached_path.display()
-            ),
-        })?;
-    let manifest = ComponentManifest::from_toml_str(&toml).map_err(|err| CliError::Runtime {
-        command: COMMAND.to_string(),
-        reason: format!("failed to parse sidecar metadata {meta_url}: {err}"),
-    })?;
-    validate_manifest_contract_header(
-        &manifest,
-        resolution,
-        ctx.install_mode.as_str(),
-        InstallContractSource::SidecarMeta,
-    )?;
-    Ok(Some(LoadedInstallContract {
-        manifest,
-        source: InstallContractSource::SidecarMeta,
-        toml,
-    }))
+                reason: format!(
+                    "failed to read sidecar metadata {} from cache: {err}",
+                    downloaded.cached_path.display()
+                ),
+            })?;
+        let manifest =
+            ComponentManifest::from_toml_str(&toml).map_err(|err| CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!("failed to parse sidecar metadata {meta_url}: {err}"),
+            })?;
+        validate_manifest_contract_header(
+            &manifest,
+            resolution,
+            ctx.install_mode.as_str(),
+            InstallContractSource::SidecarMeta,
+        )?;
+        return Ok(Some(LoadedInstallContract {
+            manifest,
+            source: InstallContractSource::SidecarMeta,
+            toml,
+        }));
+    }
+    Ok(None)
 }
 
-fn sidecar_meta_url(artifact_url: &str, component: &str, version: &str) -> Option<String> {
+/// `meta.toml` URLs to try for a resolved artifact, in preference order.
+///
+/// The metadata published beside the artifact wins. Replacing the final
+/// artifact URL segment is the same-directory convention already frozen by
+/// [`anolisa_core::registry`], and it is the only form that can describe a
+/// single target: `…/0.10.1/macos/aarch64/meta.toml` documents the macOS
+/// payload, while `…/0.10.1/meta.toml` documents whatever target the
+/// publisher happened to make version-wide.
+///
+/// The version root stays as a fallback so legacy repositories — which
+/// publish one contract for every target — keep working unchanged. It is
+/// omitted when the artifact already sits in the version root, where both
+/// forms derive the same URL and a second fetch would be pure waste.
+fn meta_url_candidates(artifact_url: &str, component: &str, version: &str) -> Vec<String> {
+    let mut candidates = Vec::with_capacity(2);
+    if let Some(index) = artifact_url.rfind('/') {
+        candidates.push(format!("{}/meta.toml", &artifact_url[..index]));
+    }
     let version_marker = format!("/{component}/{version}/");
     if let Some(index) = artifact_url.rfind(&version_marker) {
-        return Some(format!(
-            "{}meta.toml",
-            &artifact_url[..index + version_marker.len()]
-        ));
+        let version_root = format!("{}meta.toml", &artifact_url[..index + version_marker.len()]);
+        if !candidates.contains(&version_root) {
+            candidates.push(version_root);
+        }
     }
-
-    artifact_url
-        .rfind('/')
-        .map(|index| format!("{}/meta.toml", &artifact_url[..index]))
+    candidates
 }
 
 fn manifest_digest_sha256(digest: Option<&str>) -> Result<Option<&str>, CliError> {
@@ -1097,26 +1124,77 @@ mod tests {
         assert!(!reason.contains("index-v2.toml"), "got: {reason}");
     }
 
-    /// Fallback is reserved for "not published"; transport faults on the v2
-    /// fetch must not silently downgrade a gen-2 repository to its v1 view.
+    /// Fallback is reserved for "not published"; transport faults must not
+    /// silently downgrade a gen-2 repository to its v1 view, nor let a
+    /// resolved artifact's sidecar be replaced by version-level metadata
+    /// describing a different target.
     #[test]
-    fn index_not_published_distinguishes_absence_from_faults() {
+    fn remote_file_absent_distinguishes_absence_from_faults() {
         let http = |status| DownloadError::HttpStatus {
             url: "https://example.invalid/index-v2.toml".to_string(),
             status,
         };
-        assert!(index_not_published(&http(404)));
-        assert!(index_not_published(&http(410)));
-        assert!(!index_not_published(&http(500)));
-        assert!(!index_not_published(&http(403)));
-        assert!(index_not_published(&DownloadError::Io {
+        assert!(remote_file_absent(&http(404)));
+        assert!(remote_file_absent(&http(410)));
+        assert!(!remote_file_absent(&http(500)));
+        assert!(!remote_file_absent(&http(403)));
+        assert!(remote_file_absent(&DownloadError::Io {
             path: std::path::PathBuf::from("/repo/v1/index-v2.toml"),
             source: std::io::Error::from(std::io::ErrorKind::NotFound),
         }));
-        assert!(!index_not_published(&DownloadError::Network {
+        assert!(!remote_file_absent(&DownloadError::Network {
             url: "https://example.invalid/index-v2.toml".to_string(),
             reason: "timed out".to_string(),
         }));
+    }
+
+    /// Target-specific metadata is the point of the sibling-first order: the
+    /// macOS contract sits beside the macOS artifact, while the version root
+    /// holds whichever target the publisher made version-wide.
+    #[test]
+    fn meta_url_candidates_prefer_the_artifact_sibling() {
+        let candidates = meta_url_candidates(
+            "file:///repo/v1/agentsight/0.10.1/macos/aarch64/agentsight-0.10.1-macos-aarch64.tar.gz",
+            "agentsight",
+            "0.10.1",
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "file:///repo/v1/agentsight/0.10.1/macos/aarch64/meta.toml".to_string(),
+                "file:///repo/v1/agentsight/0.10.1/meta.toml".to_string(),
+            ]
+        );
+    }
+
+    /// An artifact published directly in the version root derives the same
+    /// URL both ways; the duplicate must not cost a second fetch.
+    #[test]
+    fn meta_url_candidates_dedupe_the_version_root() {
+        let candidates = meta_url_candidates(
+            "file:///repo/v1/agentsight/0.10.1/agentsight-0.10.1.tar.gz",
+            "agentsight",
+            "0.10.1",
+        );
+        assert_eq!(
+            candidates,
+            vec!["file:///repo/v1/agentsight/0.10.1/meta.toml".to_string()]
+        );
+    }
+
+    /// A flat repository (no `<component>/<version>/` path segment, e.g. an
+    /// off-repo `url = "https://…"` escape hatch) still resolves its sibling.
+    #[test]
+    fn meta_url_candidates_handle_a_flat_layout() {
+        let candidates = meta_url_candidates(
+            "https://mirror.invalid/downloads/agentsight.tar.gz",
+            "agentsight",
+            "0.10.1",
+        );
+        assert_eq!(
+            candidates,
+            vec!["https://mirror.invalid/downloads/meta.toml".to_string()]
+        );
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -1248,6 +1248,24 @@ pub fn rpm_host_env() -> anolisa_env::EnvFacts {
     }
 }
 
+/// Host facts for a macOS/aarch64 target, so raw resolution can select a
+/// macOS index entry deterministically on a Linux CI runner. macOS carries
+/// no libc or pkg_base selector, and no BPF facts.
+pub fn macos_arm_env() -> anolisa_env::EnvFacts {
+    anolisa_env::EnvFacts {
+        os: "macos".to_string(),
+        arch: "aarch64".to_string(),
+        libc: None,
+        pkg_base: None,
+        os_id: Some("macos".to_string()),
+        os_id_like: None,
+        os_version: Some("15.0".to_string()),
+        btf: None,
+        cap_bpf: None,
+        ..anolisa_env::EnvService::detect()
+    }
+}
+
 /// Host facts for a distro outside the known rpm/deb families; missing rpm
 /// tooling must fail closed here.
 pub fn unknown_host_env() -> anolisa_env::EnvFacts {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -1634,6 +1634,252 @@ fn install_dry_run_rejects_mismatched_sidecar_digest() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Target-specific sidecar metadata
+// ---------------------------------------------------------------------------
+
+/// Local `file://` repo publishing one component for two targets, each with
+/// its own install contract — the shape a raw repository takes once a
+/// component's payload and lifecycle differ per platform.
+///
+/// The Linux build is system-only and its `meta.toml` sits at the version
+/// root (`<component>/<version>/meta.toml`); the macOS build also supports
+/// user mode and publishes `meta.toml` beside its own artifact. Each index
+/// entry carries the `manifest_digest` of *its own* contract.
+///
+/// `macos_sidecar = false` drops the macOS sidecar, leaving the legacy shape:
+/// one version-level contract covering every target. `digests = false` drops
+/// `manifest_digest` from every entry, the shape of a repository published
+/// before the field existed.
+fn write_local_repo_target_specific_meta(
+    root: &Path,
+    macos_sidecar: bool,
+    digests: bool,
+) -> String {
+    const COMPONENT: &str = "agentsight";
+    const VERSION: &str = "0.10.1";
+
+    let v1 = root.join("v1");
+    let version_dir = v1.join(COMPONENT).join(VERSION);
+    std::fs::create_dir_all(&version_dir).expect("create version dir");
+
+    let linux_meta = component_manifest_toml(COMPONENT, VERSION, &["system"]);
+    std::fs::write(version_dir.join("meta.toml"), &linux_meta).expect("write version-level meta");
+    let macos_meta = component_manifest_toml(COMPONENT, VERSION, &["user"]);
+
+    let mut index =
+        String::from("schema_version = 1\nchannel = \"stable\"\npublisher = \"test\"\n");
+    for (os, arch, modes, meta) in [
+        ("linux", "x86_64", &["system"][..], &linux_meta),
+        ("macos", "aarch64", &["user"][..], &macos_meta),
+    ] {
+        let artifact_dir = version_dir.join(os).join(arch);
+        std::fs::create_dir_all(&artifact_dir).expect("create artifact dir");
+        if os == "macos" && macos_sidecar {
+            std::fs::write(artifact_dir.join("meta.toml"), meta).expect("write macos sidecar");
+        }
+
+        // `build_component_artifact` embeds the same manifest text, so the
+        // executed contract digests to the value published for this entry.
+        let artifact = build_component_artifact(COMPONENT, VERSION, modes);
+        let artifact_name = format!("{COMPONENT}-{VERSION}-{os}-{arch}.tar.gz");
+        std::fs::write(artifact_dir.join(&artifact_name), &artifact).expect("write artifact");
+
+        let digest_line = if digests {
+            format!(
+                "manifest_digest = \"sha256:{:x}\"\n",
+                Sha256::digest(meta.as_bytes())
+            )
+        } else {
+            String::new()
+        };
+        index.push_str(&format!(
+            r#"
+[[entries]]
+component = "{COMPONENT}"
+version = "{VERSION}"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+url = "{COMPONENT}/{VERSION}/{os}/{arch}/{artifact_name}"
+os = "{os}"
+arch = "{arch}"
+install_modes = {modes_arr}
+sha256 = "{artifact_sha:x}"
+{digest_line}"#,
+            modes_arr = toml_string_array(modes),
+            artifact_sha = Sha256::digest(&artifact),
+        ));
+    }
+    std::fs::write(v1.join("index.toml"), index).expect("write distribution index");
+    format!("file://{}", v1.display())
+}
+
+fn agentsight_resolve_inputs(repo_url: String) -> ResolveInputs<'static> {
+    ResolveInputs {
+        component: "agentsight".to_string(),
+        package: "agentsight".to_string(),
+        backend: "raw".to_string(),
+        base_url: repo_url,
+        version: None,
+        warnings: Vec::new(),
+    }
+}
+
+/// File names cached under `<cache>/downloads`, for asserting what a dry-run
+/// did and did not fetch.
+fn cached_download_names(layout: &FsLayout) -> Vec<String> {
+    std::fs::read_dir(layout.cache_dir.join("downloads"))
+        .expect("downloads cache exists")
+        .map(|entry| {
+            entry
+                .expect("cache entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect()
+}
+
+/// The regression, in the shape that fails silently: with no
+/// `manifest_digest` to cross-check, deriving the metadata URL from the
+/// version root loads the *Linux* contract for a resolved macOS artifact.
+/// That contract declares system mode only, so a `--install-mode user`
+/// dry-run refuses an install the execution path — which reads the artifact's
+/// own embedded contract — would have accepted.
+#[test]
+fn dry_run_contract_reads_the_target_sidecar_without_a_digest() {
+    let sandbox = TestSandbox::new();
+    let repo_url = write_local_repo_target_specific_meta(sandbox.repo_root(), true, false);
+    let ctx = sandbox.context(InstallMode::User);
+    let layout = common::resolve_layout(&ctx);
+
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &macos_arm_env(),
+        agentsight_resolve_inputs(repo_url),
+    )
+    .expect("macos/aarch64 entry must resolve");
+
+    let contract = load_dry_run_install_contract(&ctx, &layout, &resolution)
+        .expect("the macOS sidecar must satisfy the user-mode dry-run")
+        .expect("a published sidecar must yield a contract");
+
+    assert_eq!(
+        contract.manifest.install.modes,
+        vec!["user".to_string()],
+        "dry-run must validate the macOS contract, not the version-level Linux one"
+    );
+}
+
+/// The same resolution with `manifest_digest` published per entry: the
+/// sidecar is both selected by target and verified against the digest the
+/// execution path checks the embedded contract against.
+#[test]
+fn dry_run_contract_reads_the_resolved_target_sidecar() {
+    let sandbox = TestSandbox::new();
+    let repo_url = write_local_repo_target_specific_meta(sandbox.repo_root(), true, true);
+    let ctx = sandbox.context(InstallMode::User);
+    let layout = common::resolve_layout(&ctx);
+
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &macos_arm_env(),
+        agentsight_resolve_inputs(repo_url),
+    )
+    .expect("macos/aarch64 entry must resolve");
+    assert!(
+        resolution
+            .artifact_url
+            .ends_with("/macos/aarch64/agentsight-0.10.1-macos-aarch64.tar.gz"),
+        "fixture must resolve the macOS artifact, got: {}",
+        resolution.artifact_url
+    );
+
+    let contract = load_dry_run_install_contract(&ctx, &layout, &resolution)
+        .expect("the macOS sidecar must satisfy the user-mode dry-run")
+        .expect("a published sidecar must yield a contract");
+
+    assert_eq!(
+        contract.manifest.install.modes,
+        vec!["user".to_string()],
+        "dry-run must validate the macOS contract, not the version-level Linux one"
+    );
+    let cached = cached_download_names(&layout);
+    assert!(
+        cached.iter().all(|name| !name.ends_with(".tar.gz")),
+        "dry-run must stay lightweight and skip the artifact; cache entries: {cached:?}"
+    );
+}
+
+/// A repository publishing only version-level metadata — every raw repo
+/// before target-specific contracts existed — must keep resolving its
+/// contract through the version-root fallback.
+#[test]
+fn dry_run_contract_falls_back_to_version_level_meta() {
+    let sandbox = TestSandbox::new();
+    let repo_url = write_local_repo_target_specific_meta(sandbox.repo_root(), false, true);
+    let ctx = sandbox.context(InstallMode::System);
+    let layout = common::resolve_layout(&ctx);
+
+    let sibling = sandbox
+        .repo_root()
+        .join("v1/agentsight/0.10.1/linux/x86_64/meta.toml");
+    assert!(
+        !sibling.exists(),
+        "the legacy fixture must publish no sibling metadata"
+    );
+
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &linux_env(),
+        agentsight_resolve_inputs(repo_url),
+    )
+    .expect("linux/x86_64 entry must resolve");
+
+    let contract = load_dry_run_install_contract(&ctx, &layout, &resolution)
+        .expect("an absent sibling must fall back, not fail")
+        .expect("version-level metadata must still yield a contract");
+
+    assert_eq!(contract.manifest.install.modes, vec!["system".to_string()]);
+    assert_eq!(contract.source, InstallContractSource::SidecarMeta);
+}
+
+/// Fallback is reserved for absence. A published sibling that does not match
+/// the index `manifest_digest` must fail the dry-run — falling through to the
+/// version root would validate a contract the resolved artifact never had.
+#[test]
+fn dry_run_contract_rejects_a_tampered_sidecar_without_falling_back() {
+    let sandbox = TestSandbox::new();
+    let repo_url = write_local_repo_target_specific_meta(sandbox.repo_root(), true, true);
+    std::fs::write(
+        sandbox
+            .repo_root()
+            .join("v1/agentsight/0.10.1/macos/aarch64/meta.toml"),
+        component_manifest_toml("agentsight", "0.10.1", &["user", "system"]),
+    )
+    .expect("replace the macOS sidecar");
+
+    let ctx = sandbox.context(InstallMode::User);
+    let layout = common::resolve_layout(&ctx);
+    let resolution = resolve_raw(
+        &ctx,
+        &layout,
+        &macos_arm_env(),
+        agentsight_resolve_inputs(repo_url),
+    )
+    .expect("macos/aarch64 entry must resolve");
+
+    let Err(err) = load_dry_run_install_contract(&ctx, &layout, &resolution) else {
+        panic!("a sidecar digest mismatch must fail the dry-run, not fall back");
+    };
+    assert_eq!(err.code(), "EXECUTION_FAILED");
+    assert!(err.reason().contains("sha256 mismatch"), "got: {err}");
+}
+
 #[test]
 fn install_no_conflict_when_conflicting_component_not_installed() {
     let tmp = tempdir().expect("tmpdir");


### PR DESCRIPTION
## Why

A raw repository may publish a different install contract per target, because
payloads and lifecycle requirements differ across platforms — AgentSight has a
Linux system contract and a macOS user/system contract.

Raw dry-run derived the metadata URL from the component and version root, so it
always read the version-level `meta.toml` regardless of which artifact it had
resolved. A resolved macOS/aarch64 artifact was therefore validated against the
Linux contract. In macOS user mode that surfaced as a refusal:

```
sidecar meta.toml for component 'agentsight' is inconsistent with the
distribution index: index resolved user-mode support, but manifest declares
modes: system
```

A non-dry-run install reads the artifact's embedded `.anolisa/component.toml`
and receives the correct macOS contract, so dry-run and execution did not
validate the same install contract. In system mode the asymmetry is quieter but
worse: dry-run succeeds while validating the wrong contract.

## What changed

`meta_url_candidates` replaces `sidecar_meta_url` and returns candidates in
preference order:

1. **The artifact sibling** — the final artifact URL segment replaced with
   `meta.toml`. This is the same-directory convention `anolisa-core::registry`
   already freezes, and the only form that can describe a single target.
2. **The version root** — consulted only when the sibling is absent, so legacy
   repositories publishing one contract for every target keep working.

The version root is skipped entirely when the artifact already sits there, where
both forms derive the same URL and a second fetch would be waste.

The fallback is gated on **absence alone**. A network, digest, or parse failure
on metadata the repository does publish now fails the dry-run instead of falling
through to another target's contract. `index_not_published` was renamed to
`remote_file_absent` and reused for this, rather than keeping two near-identical
predicates; this widens sidecar absence to include `410` alongside `404` and
filesystem `NotFound`.

No index schema change: the resolved artifact URL remains the single location
source, so no `meta_path` field is added to `DistributionEntry` and existing
indexes need no republication. Execution-path digest validation needed no change
— `validate_manifest_digest` already checks the embedded contract against the
entry's `manifest_digest`, so once dry-run reads the right file both paths agree
byte for byte.

## Related issue

closes #2547

## User / Agent impact

`anolisa --dry-run install` against a repository with target-specific metadata
now previews the contract belonging to the artifact it resolved. On macOS this
turns a spurious user-mode refusal into a correct preview; in system mode it
replaces a preview validated against the wrong contract with the right one.

Dry-run stays lightweight — the install artifact is still never downloaded.

A repository whose sibling `meta.toml` is published but unfetchable, corrupt, or
digest-mismatched now fails the dry-run where it previously fell back silently.
This is intentional: the previous behaviour previewed an install the execution
path would not have honoured.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. No schema, CLI surface, or state format changed. Legacy repositories
publishing only version-level metadata resolve through the fallback and are
covered by a regression test. The one cost is an extra 404 per dry-run against a
nested legacy repository before the version-root fetch; metadata is small and
`DownloadCache` keys on the full URL, so the two candidates never collide in the
cache.

## Validation

All four pre-commit gates pass from `src/anolisa`:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace          # 2131 passed, 0 failed
cargo doc --workspace --no-deps
```

Tests added — 3 unit tests on candidate ordering (sibling preference, version-root
dedupe, flat layout) and 4 end-to-end tests against a synthetic macOS/aarch64
environment and a `file://` registry:

- `dry_run_contract_reads_the_target_sidecar_without_a_digest` — the issue's
  literal reproduction, where no `manifest_digest` exists to cross-check.
- `dry_run_contract_reads_the_resolved_target_sidecar` — the same resolution with
  per-entry digests; also asserts no `.tar.gz` reaches the cache.
- `dry_run_contract_falls_back_to_version_level_meta` — legacy repository.
- `dry_run_contract_rejects_a_tampered_sidecar_without_falling_back` — fail-closed.

The regression tests were verified to actually catch the old behaviour by
temporarily reversing the candidate order: both target-sidecar tests then fail,
the digest-less one with the exact error quoted above.

## Documentation and rollback

No documentation changed — the same-directory convention this aligns with was
already documented in `anolisa-core::registry::RegistryClient`. No CHANGELOG
entry, per the repository convention of updating it atomically with the version
bump.

Rollback is a plain revert of the single commit. There is no persisted state,
migration, or published-artifact dependency to unwind.
