### PR TITLE
fix(ckpt): reap finished tasks in accept loop

### DIFF
--- a/src/ws-ckpt/src/crates/daemon/src/listener.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/listener.rs
@@ -62,6 +62,14 @@ pub async fn run_listener(
                 break;
             }
         }
+
+        // Reap finished connections. JoinSet holds each task's handle and output
+        // slot until it is joined, so without this the set grows by one entry per
+        // CLI invocation and is only released at shutdown. try_join_next never
+        // awaits, so reaping cannot delay the next accept; a join_next branch in
+        // the select! above would instead need a second mutable borrow of
+        // join_set while the accept arm still spawns into it.
+        while join_set.try_join_next().is_some() {}
     }
 
     // 7. Wait for in-flight tasks to complete (with timeout)


### PR DESCRIPTION
The accept loop spawned every connection into a `JoinSet` but only reaped it at shutdown, so the set kept one entry — task handle plus output slot — for each connection that had already finished. Every ws-ckpt CLI invocation opens one socket connection, so the daemon grew monotonically for its whole lifetime and only released the memory on exit.

Measured on 5.10.134-19.6.3 with ws-ckpt 0.4.2, the growth was linear in connection count and independent of both the storage backend and the kind of operation, which is what identified the connection path rather than snapshot state as the source:

  btrfs-base 10h soak      7.8-7.9 KB per operation
  btrfs-loop 10h soak      7.9-8.0 KB per operation
  loop, direct-io, 10h     8.0 KB per operation
  isolated 60s sample      8.4 KB per operation

VmData tracked VmRSS almost exactly (5418 MB of 5366 MB resident), the file descriptor count stayed flat, and the snapshot pool was held constant during the soaks, so the growth was heap held by the daemon rather than page cache, descriptors, or index state. A `kill -9` returned RSS from 5.7 GB to 46 MB. Under a checkpoint-heavy agent workload this reaches roughly 370 MB/h, and about 1.7 GB/h under the functional suite, so a long-lived daemon eventually OOMs.

Drain completed tasks with `try_join_next` after each select iteration. It is synchronous, so reaping cannot delay the next accept, and it avoids the second mutable borrow of `join_set` that a `join_next` branch inside the same `select!` would need while the accept arm still spawns into the set. Shutdown still drains with `join_next` under the existing timeout, so in-flight connections keep their grace period.

After the change, 20000 operations grow RSS by 2.6 MB (0.13 KB per operation, down from ~8 KB), and a further 40000 operations add 2.0 MB in total with no linear trend, i.e. what remains is allocator headroom rather than accumulation. Descriptors stay at 14.