### PR TITLE
feat(anolisa): accept --level alias in logs

### DIFF
--- a/docs/user-guide/en/troubleshooting.md
+++ b/docs/user-guide/en/troubleshooting.md
@@ -41,7 +41,7 @@ View component logs:
 # View logs for a specific component
 anolisa logs <component>
 
-# Show warning and error records
+# Show warning and error records (--level is an alias for --severity)
 anolisa logs <component> --severity warn
 
 # Show last N lines

--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -181,6 +181,8 @@ anolisa logs <component> --severity warn
 anolisa bug
 ```
 
+`--level` is an alias for `--severity`.
+
 ---
 
 ## Recovery Behavior

--- a/docs/user-guide/zh/troubleshooting.md
+++ b/docs/user-guide/zh/troubleshooting.md
@@ -41,7 +41,7 @@ anolisa bug
 # 查看特定组件日志
 anolisa logs <component>
 
-# 查看 warning 和 error 记录
+# 查看 warning 和 error 记录（--level 是 --severity 的别名）
 anolisa logs <component> --severity warn
 
 # 显示最后 N 行

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -172,6 +172,8 @@ anolisa logs <component> --severity warn
 anolisa bug
 ```
 
+`--level` 是 `--severity` 的别名。
+
 ---
 
 ## 恢复行为

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -33,7 +33,7 @@ anolisa update all
 | `upgrade` | Apply an RPM/system-image upgrade plan (system scope) |
 | `status` | Show component health |
 | `doctor` | Diagnose issues and suggest fixes |
-| `logs` | Query component logs |
+| `logs` | Query component logs (`--severity`, alias `--level`) |
 | `restart` | Restart a component service |
 | `repair` | Reconcile state after manual RPM changes |
 | `adopt` | Record an existing system RPM as adopted without default removal authority |

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -33,7 +33,7 @@ anolisa update all
 | `upgrade` | 应用 RPM/system image 升级计划（system scope） |
 | `status` | 显示组件健康状态 |
 | `doctor` | 诊断问题并给出修复建议 |
-| `logs` | 查询组件日志 |
+| `logs` | 查询组件日志（`--severity`，别名 `--level`） |
 | `restart` | 重启组件服务 |
 | `repair` | 手工修改 RPM 后协调 ANOLISA 状态与 rpmdb |
 | `adopt` | 将已有 system RPM 记录为已采纳安装 |

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
@@ -44,7 +44,10 @@ pub struct LogsArgs {
     #[arg(long, value_name = "COMP")]
     pub component: Option<String>,
     /// Minimum severity: `debug` | `info` | `warn` | `error`.
-    #[arg(long, value_name = "LEVEL")]
+    // Aliased rather than duplicated: log CLIs commonly name this filter
+    // "level", and one field keeps both spellings on the same validation and
+    // filtering path. Visible so clap advertises `[aliases: --level]` itself.
+    #[arg(long, visible_alias = "level", value_name = "LEVEL")]
     pub severity: Option<String>,
     /// Lexicographic ISO8601 lower bound on `started_at`.
     #[arg(long, value_name = "ISO")]
@@ -155,7 +158,9 @@ fn parse_severity(raw: &str) -> Result<Severity, CliError> {
         "error" => Ok(Severity::Error),
         other => Err(CliError::InvalidArgument {
             command: COMMAND.to_string(),
-            reason: format!("--severity expects one of debug|info|warn|error, got '{other}'"),
+            reason: format!(
+                "--severity/--level expects one of debug|info|warn|error, got '{other}'"
+            ),
         }),
     }
 }
@@ -246,6 +251,7 @@ fn truncate(value: &str, max: usize) -> String {
 mod tests {
     use super::*;
     use anolisa_core::{CentralLog, LogFilter};
+    use clap::CommandFactory;
 
     fn default_args() -> LogsArgs {
         LogsArgs {
@@ -308,6 +314,40 @@ mod tests {
         assert_eq!(parse_severity("warning").unwrap(), Severity::Warn);
         assert_eq!(parse_severity("error").unwrap(), Severity::Error);
         assert!(parse_severity("loud").is_err());
+    }
+
+    #[test]
+    fn level_alias_parses_like_severity() {
+        let severity = LogsArgs::try_parse_from(["logs", "--severity", "warn"]).expect("parse");
+        let level = LogsArgs::try_parse_from(["logs", "--level", "warn"]).expect("parse");
+
+        assert_eq!(severity.severity.as_deref(), Some("warn"));
+        assert_eq!(level.severity.as_deref(), Some("warn"));
+        assert_eq!(
+            build_filter(&severity).expect("filter").severity_at_least,
+            build_filter(&level).expect("filter").severity_at_least
+        );
+    }
+
+    #[test]
+    fn level_alias_rejects_unknown_severity() {
+        let args = LogsArgs::try_parse_from(["logs", "--level", "loud"]).expect("parse");
+
+        let err = build_filter(&args).expect_err("unknown severity should fail");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        // Names both spellings so the message stays actionable for whichever
+        // one the user typed.
+        assert!(err.reason().contains("--severity/--level"));
+    }
+
+    #[test]
+    fn help_advertises_level_alias() {
+        let mut cmd = LogsArgs::command();
+        let help = cmd.render_help().to_string();
+        assert!(
+            help.contains("--severity <LEVEL>") && help.contains("--level"),
+            "help must relate --level to --severity, got:\n{help}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

`anolisa logs` describes its filter as a "level" — the option's own value name
is `<LEVEL>` — but only accepted `--severity`. Users arriving from other log
CLIs typed `--level` and got a bare `unexpected argument '--level' found`, with
nothing pointing at the correct spelling.

## What changed

`--level` is now a clap **visible alias** on the existing `severity` argument,
so both spellings land on one field with one validation and filtering path.
A second option was deliberately not added: there is no way for the spellings
to diverge, and no way to pass both at once. Help renders
`[aliases: --level]` next to the option, so the relationship is discoverable
without hand-maintained help text.

```
--severity <LEVEL>  Minimum severity: `debug` | `info` | `warn` | `error` [aliases: --level]
```

The invalid-value message now names both spellings
(`--severity/--level expects one of debug|info|warn|error, got 'loud'`), since
either entry point can produce it.

## Related issue

closes #2556

## User / Agent impact

`anolisa logs --level warn` now filters identically to
`anolisa logs --severity warn`. `--severity` is unchanged and remains the
canonical name in JSON output and in the user guide, so existing scripts and
agent integrations are unaffected.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Additive only — a previously rejected spelling is now accepted. No existing
invocation changes behavior, and the JSON envelope is untouched.

## Validation

From `src/anolisa/`:

- `cargo test --workspace` — 2134 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo doc --workspace --no-deps` — clean

New unit tests in `commands::tier1::logs::tests`:

- `level_alias_parses_like_severity` — both spellings produce the same
  `LogFilter.severity_at_least`
- `level_alias_rejects_unknown_severity` — `--level loud` fails with
  `INVALID_ARGUMENT` and a message naming both spellings
- `help_advertises_level_alias` — rendered help relates `--level` to
  `--severity`

Manual check: `anolisa logs --level warn --json` returns the standard success
envelope (exit 0); `anolisa logs --level loud --json` returns
`INVALID_ARGUMENT` (exit 2).

## Documentation and rollback

User guide updated in both languages — `docs/user-guide/{en,zh}/troubleshooting.md`
and `docs/user-guide/{en,zh}/user-entrypoint/anolisa-cli.md` note the alias.
Per `specs/documentation-standard.md` §5, no CHANGELOG entry here; it belongs
in the release version bump PR.

Rollback: revert the commit. Dropping `visible_alias = "level"` restores the
previous parse error for `--level` and leaves `--severity` untouched.
