### PR TITLE
fix(memory): add missing Provides: anolisa-component(agent-memory) to RPM spec

### DIFF
--- a/src/agent-memory/agent-memory.spec.in
+++ b/src/agent-memory/agent-memory.spec.in
@@ -37,6 +37,9 @@ BuildRequires:  jq
 BuildRequires:  systemd-devel
 BuildRequires:  systemd-rpm-macros
 
+# Required for ANOLISA RPM component identity resolution.
+Provides:       anolisa-component(agent-memory)
+
 %description
 Agent memory is a persistent filesystem memory for AI agents, served over
 the MCP (Model Context Protocol) standard. Linux only.


### PR DESCRIPTION
## Summary

Fixes #2559

The `agent-memory` RPM spec file (`src/agent-memory/agent-memory.spec.in`) is missing the `Provides: anolisa-component(agent-memory)` virtual provide line. All other ANOLISA-managed RPM components that ship OpenClaw adapters declare this:

- `agentsight.spec.in:20` → `Provides: anolisa-component(agentsight)`
- `copilot-shell.spec.in:18` → `Provides: anolisa-component(cosh)`
- `cosh-ng.spec.in:21` → `Provides: anolisa-component(cosh-ng)`
- `skillfs.spec.in:26` → `Provides: anolisa-component(skillfs)`

Commit `add5cb7c` added `component.toml` install to agent-memory.spec.in but forgot the `Provides:` line — unlike the parallel commits for agentsight (`07a58557`) and copilot-shell (`e85098fd`).

## Impact

Without this provide, when the repo-side `components-v2.toml` URL returns HTTP 404 and no `package_map` entry exists in `repo.toml`, the ANOLISA RPM resolver falls through all three resolution paths and returns `INVALID_ARGUMENT`. This causes:

- `anolisa install agent-memory --backend rpm --package agent-memory` → fails with INVALID_ARGUMENT
- After `dnf remove` + failed install, `anolisa adapter scan` returns empty list for agent-memory (adapter resources removed by dnf, never restored)
- Nightly test `test_scan_lists_adapter_for_installed_component[agent-memory]` fails

The same issue affects `os-skills`, `tokenless`, `ws-ckpt`, and `agent-sec-core` (their spec files also lack `Provides: anolisa-component(<name>)`).

## Fix

Add `Provides: anolisa-component(agent-memory)` after the BuildRequires section, before `%description`.

## Verification

- `bash scripts/rpm-build.sh agent-memory` on ECS: exit 0, RPM built successfully
- `rpm -qp --provides agent-memory-0.2.6-1.alnx4.x86_64.rpm` now includes `anolisa-component(agent-memory)`
- Functional test: after `dnf remove` + `dnf install` new RPM, `anolisa adapter scan` correctly lists agent-memory/openclaw adapter with `resource_present=true`, `driver_available=true`, `framework_detected=true`
- `anolisa install agent-memory --backend rpm --package agent-memory` now hits the adopt fallback instead of INVALID_ARGUMENT

## Test plan

- [x] verify-build green on ECS (8.217.123.80)
- [x] `rpm -qp --provides` confirms `anolisa-component(agent-memory)` present
- [x] `anolisa adapter scan` lists agent-memory/openclaw adapter after install
- [ ] GitHub CI `Test agent-memory` job passes
