### PR TITLE
fix(sec-core): add missing Provides: anolisa-component(sec-core) to RPM spec

### DIFF
--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -61,6 +61,12 @@ Requires:       agent-sec-hermes-hook = %{version}-%{release}
 Requires:       agent-sec-qwen-code-hook = %{version}-%{release}
 Requires:       agent-sec-skills = %{version}-%{release}
 
+# Declare ANOLISA component identity so that `anolisa install sec-core --backend rpm`
+# can resolve this package via RPM Provides when the repo-side components-v2.toml
+# is unavailable (404) and no package_map entry exists — the resolver falls through to
+# RPM Provides but finds no anolisa-component(sec-core) capability.
+Provides:       anolisa-component(sec-core)
+
 %description
 Agent-Sec-Core is an OS-level security baseline and hardening framework for AI Agents.
 This metapackage installs all agent-sec-core components including CLI, hooks, and skills.


### PR DESCRIPTION
## Problem

Fixes #2559 (sec-core component — same root cause as agent-memory, covered separately in PR #2560).

The `agent-sec-core` RPM spec file (`src/agent-sec-core/agent-sec-core.spec.in`) is missing the `Provides: anolisa-component(sec-core)` virtual provide line. All other ANOLISA-managed RPM components that ship OpenClaw adapters already declare this:

- `src/agentsight/agentsight.spec.in` → `Provides: anolisa-component(agentsight)`
- `src/copilot-shell/copilot-shell.spec.in` → `Provides: anolisa-component(cosh)`
- `src/cosh-ng/cosh-ng.spec.in` → `Provides: anolisa-component(cosh-ng)`
- `src/skillfs/skillfs.spec.in` → `Provides: anolisa-component(skillfs)`

When the repo-side `components-v2.toml` is unavailable (HTTP 404) and no `package_map` entry exists in `repo.toml`, the ANOLISA RPM resolver falls through all three resolution paths and returns empty candidates, causing `INVALID_ARGUMENT: component 'sec-core' is not an ANOLISA RPM component`. This makes `anolisa install` and `anolisa adopt` fail, and `anolisa adapter scan` returns an empty adapters list for sec-core.

## Fix

Add `Provides: anolisa-component(sec-core)` to the spec file, after the `Requires` section and before `%description`:

```diff
+Provides:       anolisa-component(sec-core)
```

## Verification

```shell
# On ECS (8.217.123.80), fresh clone + apply patch + rpm-build:
git clone https://github.com/alibaba/anolisa.git && cd anolisa
git apply fix.patch
bash scripts/rpm-build.sh agent-sec-core
# → [OK] agent-sec-core RPM built successfully

# Verify RPM has the provide:
rpm -qp --provides scripts/rpmbuild/RPMS/x86_64/agent-sec-core-*.rpm
# → anolisa-component(sec-core)

# Install + adopt + scan:
dnf install -y scripts/rpmbuild/RPMS/x86_64/agent-sec-*.rpm
anolisa adopt sec-core --package agent-sec-core
anolisa --json adapter scan | python3 -c "import json,sys; d=json.load(sys.stdin); [print(a) for a in d['data']['adapters'] if a['component']=='sec-core' and a['framework']=='openclaw']"
# → {'component': 'sec-core', 'framework': 'openclaw', 'resource_present': True, 'driver_available': True, 'framework_detected': True}
```

Co-Authored-By: Claude <noreply@anthropic.com>
