### PR TITLE
fix(anolisa): fallback to v1 components.toml when v2 index is unavailable

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -694,7 +694,6 @@ pub fn raw_index_v2_url(base_url: &str) -> String {
 ///
 /// Released clients continue reading this path, so publishers must preserve its
 /// schema v1 contents when publishing later component-index generations.
-#[cfg(test)]
 pub fn component_index_url(base_url: &str) -> String {
     format!("{}/components.toml", raw_root(base_url))
 }

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -14,7 +14,7 @@ use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::repo_config::{BackendConfig, HostVars, RepoConfig, component_index_v2_url};
+use crate::repo_config::{BackendConfig, HostVars, RepoConfig, component_index_url, component_index_v2_url};
 
 /// On-disk schema version for repo-side `components-v2.toml`.
 pub(crate) const COMPONENT_INDEX_SCHEMA_VERSION: u32 = 2;
@@ -54,6 +54,7 @@ pub(crate) struct ComponentIndexEntry {
     #[serde(default)]
     pub(crate) summary: Option<String>,
     /// Supported host OS/architecture combinations.
+    #[serde(default)]
     pub(crate) targets: Vec<ComponentTarget>,
     /// Backend-native package names for this component.
     ///
@@ -473,7 +474,11 @@ impl ComponentIndex {
     }
 
     fn validate(&self) -> Result<(), ComponentIndexError> {
-        if self.schema_version != COMPONENT_INDEX_SCHEMA_VERSION {
+        // Accept schema v1 and v2: v1 rows simply lack `targets`, which
+        // defaults to an empty vec via `#[serde(default)]`. This lets the
+        // v2 parser gracefully load v1 `components.toml` when the v2 file
+        // has not been published to the mirror yet.
+        if !matches!(self.schema_version, 1 | 2) {
             return Err(ComponentIndexError::UnsupportedSchema {
                 actual: self.schema_version,
                 expected: COMPONENT_INDEX_SCHEMA_VERSION,
@@ -492,7 +497,9 @@ impl ComponentIndex {
                     reason: format!("duplicate component '{name}'"),
                 });
             }
-            if entry.targets.is_empty() {
+            // v1 indexes predate the `targets` field; skip the non-empty
+            // check for schema v1 (targets defaults to empty via serde).
+            if self.schema_version >= 2 && entry.targets.is_empty() {
                 return Err(ComponentIndexError::Invalid {
                     reason: format!("component '{name}' must declare at least one target"),
                 });
@@ -741,18 +748,43 @@ pub(crate) fn load_component_index(
     let url = component_index_v2_url(&base_url);
 
     let cache = DownloadCache::new(layout.cache_dir.clone());
+    let downloaded = match fetch_index_url(&cache, &url) {
+        Ok(art) => art,
+        Err(ComponentIndexError::Fetch { ref reason })
+            if reason.contains("http status 404") =>
+        {
+            // v2 not published yet — fall back to v1 components.toml.
+            // The v2 parser accepts v1 rows because `targets` has
+            // `#[serde(default)]`, so legacy indexes without targets
+            // still load (components simply appear as "no target info").
+            let v1_url = component_index_url(&base_url);
+            fetch_index_url(&cache, &v1_url).map_err(|err| ComponentIndexError::Fetch {
+                reason: format!(
+                    "failed to fetch component index (tried v2 then v1): {err}"
+                ),
+            })?
+        }
+        Err(err) => return Err(err),
+    };
+    ComponentIndex::load(&downloaded.cached_path)
+}
+
+/// Fetch a component index TOML from `url` into `cache`.
+fn fetch_index_url(
+    cache: &DownloadCache,
+    url: &str,
+) -> Result<anolisa_core::download::DownloadedArtifact, ComponentIndexError> {
     #[cfg(test)]
     if !url.starts_with("file://") {
         return Err(ComponentIndexError::Fetch {
             reason: format!("test mode: refusing non-file URL {url}"),
         });
     }
-    let downloaded = cache
-        .fetch(&url, None)
+    cache
+        .fetch(url, None)
         .map_err(|err| ComponentIndexError::Fetch {
             reason: format!("failed to fetch {url}: {err}"),
-        })?;
-    ComponentIndex::load(&downloaded.cached_path)
+        })
 }
 
 /// Best-effort load of repo-side `components-v2.toml`.
@@ -1325,7 +1357,10 @@ cosh = "site-copilot"
 
     #[test]
     fn unsupported_schema_is_rejected() {
-        for actual in [1, 99] {
+        // Schema v1 and v2 are accepted; anything else is rejected.
+        // v1 is accepted because `targets` defaults to an empty vec and
+        // the non-empty-target check is skipped for schema v1.
+        for actual in [99] {
             let source = format!("schema_version = {actual}");
             let err = ComponentIndex::from_toml_str(&source, "components.toml")
                 .expect_err("unsupported schema");

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -759,9 +759,7 @@ pub(crate) fn load_component_index(
             // still load (components simply appear as "no target info").
             let v1_url = component_index_url(&base_url);
             fetch_index_url(&cache, &v1_url).map_err(|err| ComponentIndexError::Fetch {
-                reason: format!(
-                    "failed to fetch component index (tried v2 then v1): {err}"
-                ),
+                reason: format!("failed to fetch component index (tried v2 then v1): {err}"),
             })?
         }
         Err(err) => return Err(err),

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -14,7 +14,9 @@ use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::repo_config::{BackendConfig, HostVars, RepoConfig, component_index_url, component_index_v2_url};
+use crate::repo_config::{
+    BackendConfig, HostVars, RepoConfig, component_index_url, component_index_v2_url,
+};
 
 /// On-disk schema version for repo-side `components-v2.toml`.
 pub(crate) const COMPONENT_INDEX_SCHEMA_VERSION: u32 = 2;
@@ -750,9 +752,7 @@ pub(crate) fn load_component_index(
     let cache = DownloadCache::new(layout.cache_dir.clone());
     let downloaded = match fetch_index_url(&cache, &url) {
         Ok(art) => art,
-        Err(ComponentIndexError::Fetch { ref reason })
-            if reason.contains("http status 404") =>
-        {
+        Err(ComponentIndexError::Fetch { ref reason }) if reason.contains("http status 404") => {
             // v2 not published yet — fall back to v1 components.toml.
             // The v2 parser accepts v1 rows because `targets` has
             // `#[serde(default)]`, so legacy indexes without targets

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -1358,17 +1358,16 @@ cosh = "site-copilot"
         // Schema v1 and v2 are accepted; anything else is rejected.
         // v1 is accepted because `targets` defaults to an empty vec and
         // the non-empty-target check is skipped for schema v1.
-        for actual in [99] {
-            let source = format!("schema_version = {actual}");
-            let err = ComponentIndex::from_toml_str(&source, "components.toml")
-                .expect_err("unsupported schema");
-            assert!(matches!(
-                err,
-                ComponentIndexError::UnsupportedSchema {
-                    actual: rejected,
-                    ..
-                } if rejected == actual
-            ));
-        }
+        let actual = 99;
+        let source = format!("schema_version = {actual}");
+        let err = ComponentIndex::from_toml_str(&source, "components.toml")
+            .expect_err("unsupported schema");
+        assert!(matches!(
+            err,
+            ComponentIndexError::UnsupportedSchema {
+                actual: rejected,
+                ..
+            } if rejected == actual
+        ));
     }
 }


### PR DESCRIPTION
## Problem

Fixes #2565

`anolisa list` hard-fails with HTTP 404 when the CDN mirror has not yet published `components-v2.toml`. Commit `52fa3159` switched from reading v1 `components.toml` to v2 `components-v2.toml`, but the v2 file is not yet deployed. The v1 URL helper was gated behind `#[cfg(test)]`, making it inaccessible in release builds. This is a regression introduced today (2026-08-14 13:58).

## Fix

```diff
- #[cfg(test)]
  pub fn component_index_url(base_url: &str) -> String {
```

Three coordinated changes in `resolution.rs` and `repo_config.rs`:

1. **Remove `#[cfg(test)]`** from `component_index_url()` in `repo_config.rs:698` so the v1 URL is available in release builds.

2. **Add v2→v1 fallback** in `load_component_index()`: if v2 fetch returns `Fetch { reason: "http status 404 ..." }`, retry with the v1 URL. Extract fetch logic into a `fetch_index_url()` helper to keep the main function readable.

3. **Make the parser accept both schemas**:
   - Add `#[serde(default)]` to `targets: Vec<ComponentTarget>` so v1 entries (which lack `targets`) deserialize as an empty vec.
   - Accept `schema_version` 1 and 2 in `validate()` (use `matches!(self.schema_version, 1 | 2)` instead of `!= 2`).
   - Skip the "must declare at least one target" check for schema v1 entries (guarded by `self.schema_version >= 2`).
   - Update the `unsupported_schema_is_rejected` unit test to only test schema 99 (no longer 1).

The v1 index on the mirror (`components.toml`) uses `schema_version = 1` and lacks the `targets` field introduced in v2. With `#[serde(default)]` the v1 rows parse successfully with `targets = []`, and the validator treats them as "no target info" — acceptable for the transition window.

## Verification

On ALinux 4 ECS (8.217.123.80):

```shell
$ cd anolisa/src/anolisa
$ cargo build -p anolisa-cli --release
   Compiling anolisa-cli v0.3.1
    Finished `release` profile [optimized + debuginfo] target(s) in 2m 46s

$ cargo test -p anolisa-cli --release
test result: ok. 814 passed; 0 failed; 1 ignored

$ ./target/release/anolisa -q list
# stdout empty, exit 0 (quiet mode correct)

$ ./target/release/anolisa list
Components for Linux/x86_64
NAME            AVAILABILITY    SCOPE     LOCAL STATE      ACTION
cosh             only           system    observed         -
cosh-ng          only           none      not_installed    -
...
# exit 0, 9 components displayed

$ ./target/release/anolisa status
NAME                          SCOPE     STATUS          VERSION
sec-core                      system    adopted         0.10.1-1.alnx4
# exit 0, unaffected

$ ./target/release/anolisa --no-color list
# exit 0, no ANSI codes in output
```

Verified 2/2 stable runs.

Co-Authored-By: Hermes Agent <noreply@nousresearch.com>
