### PR TITLE
fix(skill): add missing Provides: anolisa-component(os-skills) to RPM spec

### DIFF
--- a/src/os-skills/os-skills.spec.in
+++ b/src/os-skills/os-skills.spec.in
@@ -11,6 +11,13 @@ Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
 
+# Virtual provide for ANOLISA component identity resolution.
+# Without this, `anolisa install os-skills --backend rpm` fails with
+# INVALID_ARGUMENT when the repo-side components-v2.toml is unavailable
+# (404) and no package_map entry exists - the resolver falls through to
+# RPM Provides but finds no anolisa-component(os-skills) capability.
+Provides:       anolisa-component(os-skills)
+
 %description
 A collection of agentic OS skills for Copilot Shell, providing capabilities
 including AI tool installation, Alibaba Cloud ECS management, DevOps


### PR DESCRIPTION
## Summary

The os-skills RPM spec was missing the `Provides: anolisa-component(os-skills)` virtual provide line that agentsight, copilot-shell, cosh-ng, and skillfs already declare.

When the repo-side components-v2.toml is unavailable (HTTP 404) and no package_map entry exists in repo.toml, the ANOLISA RPM resolver falls through all three resolution paths (package_map → component_index → rpm_package_provides_component) and returns empty candidates, causing `INVALID_ARGUMENT: not an ANOLISA RPM component`.

## Root Cause

Commit cdd665fc (Jun 26, feat(skill): add anolisa component contract) added component.toml installation to the spec but forgot to add the `Provides: anolisa-component(os-skills)` line.

Compare with other specs that already have it:
- agentsight.spec.in:20
- skillfs.spec.in:26
- copilot-shell.spec.in:18
- cosh-ng.spec.in:21

## Fix

Add the missing `Provides: anolisa-component(os-skills)` line with an explanatory comment block, matching the pattern used by PR #2560 (agent-memory) and PR #2563 (agent-sec-core).

## Verification

Verified on ECS 8.217.123.80:
1. `bash scripts/rpm-build.sh os-skills` → RPM built successfully
2. `rpm -q --provides` on built RPM includes `anolisa-component(os-skills)`
3. `anolisa install os-skills --backend rpm --package os-skills --dry-run` → `ok=true, dry_run=true, plan=[dnf install,observe,record]`
4. `anolisa adopt os-skills` → `ok=true, adopted`
5. `anolisa adapter scan` → lists os-skills adapters (openclaw + hermes, resource_present=true, driver_available=true)

Fixes #2559 (same root cause, covers os-skills).
Complements PR #2560 (agent-memory) and PR #2563 (agent-sec-core).