### PR TITLE
fix(ckpt): add RPM component identity

### DIFF
--- a/src/ws-ckpt/ws-ckpt.spec.in
+++ b/src/ws-ckpt/ws-ckpt.spec.in
@@ -25,6 +25,7 @@ BuildRequires:  npm
 
 Requires:       rsync
 Requires:       btrfs-progs
+Provides:       anolisa-component(ws-ckpt)
 
 %description
 ws-ckpt is an AI-oriented filesystem snapshot tool. It supports workspace


### PR DESCRIPTION
## Why

The ws-ckpt RPM does not advertise its ANOLISA component identity. When the
component index is unavailable, RPM capability fallback cannot resolve the
package.

## What changed

Added `Provides: anolisa-component(ws-ckpt)` to the ws-ckpt RPM spec. The
tokenless change was removed because it already landed in #2576.

## Related issue

Related to #2575.

## User / Agent impact

`anolisa install` and `anolisa upgrade` can resolve ws-ckpt through RPM
Provides when the repository-side component index is unavailable.

## Risk and compatibility

- [x] Cross-component contract changed

Low risk: this adds the component identity capability expected by the existing
ANOLISA resolver and manifest contract.

## Validation

- `git diff --check up/main...HEAD`
- Confirmed the PR contains one changed file and one added line.
- Confirmed ws-ckpt and tokenless each declare exactly one component capability.
- The original PR verified the ws-ckpt RPM build and capability on ALinux 4.
- Local `rpmspec` validation was unavailable because the tool is not installed.

## Documentation and rollback

No documentation change is required. Roll back by reverting the single
`Provides` line.