### PR TITLE
fix(os-skills,tokenless): add Provides: anolisa-component() to RPM spec

### DIFF
--- a/src/os-skills/os-skills.spec.in
+++ b/src/os-skills/os-skills.spec.in
@@ -10,6 +10,7 @@ URL:            https://github.com/alibaba/anolisa
 Source0:        %{name}-%{version}.tar.gz
 
 BuildArch:      noarch
+Provides:       anolisa-component(os-skills)
 
 %description
 A collection of agentic OS skills for Copilot Shell, providing capabilities

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -30,6 +30,7 @@ BuildRequires:  npm
 Requires:       python3
 Requires:       jq
 Requires:       bash
+Provides:       anolisa-component(tokenless)
 
 %description
 Token-Less is an LLM token optimization toolkit that significantly reduces token


### PR DESCRIPTION
## 问题

Fixes #2575 (partial — covers os-skills and tokenless)

`anolisa upgrade --assume-yes` returns `status: blocked` because os-skills and tokenless RPM spec files are missing `Provides: anolisa-component(<name>)`. When the repo-side component index is unavailable (HTTP 404), the resolver falls through to RPM Provides — but finds no `anolisa-component(...)` capability for these 2 packages.

## 修复

```diff
+Provides:       anolisa-component(os-skills)        # src/os-skills/os-skills.spec.in
+Provides:       anolisa-component(tokenless)        # src/tokenless/tokenless.spec.in
```

## 验证

```shell
# On ECS (ALinux 4, anolisa 0.3.1, anolisa main a50e34de):
cd /root/anolisa && git apply patch && bash scripts/rpm-build.sh os-skills  # exit=0
bash scripts/rpm-build.sh tokenless  # exit=0
rpm -qp --provides scripts/rpmbuild/RPMS/noarch/os-skills-*.rpm | grep anolisa-component
# → anolisa-component(os-skills)
rpm -qp --provides scripts/rpmbuild/RPMS/x86_64/tokenless-*.rpm | grep anolisa-component
# → anolisa-component(tokenless)
```

两个 RPM 均构建成功，`rpm -qp --provides` 包含 `anolisa-component(<name>)`。

Co-Authored-By: Claude <noreply@anthropic.com>
