### PR TITLE
fix(sight): address latency metrics CI follow-ups

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -210,6 +210,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/conversations/{id}` | GET | conversation 事件详情 |
 | `/api/agent-names` | GET | Agent 名称列表 |
 | `/api/timeseries` | GET | 时序 Token 统计 |
+| `/api/metrics/latency` | GET | LLM 延迟与吞吐 percentile 指标 |
 | `/api/agent-health` | GET | Agent 健康状态 |
 | `/api/agent-health/{pid}` | DELETE | 删除健康条目 |
 | `/api/agent-health/{pid}/restart` | POST | 重启 Agent |

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -210,7 +210,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/conversations/{id}` | GET | conversation 事件详情 |
 | `/api/agent-names` | GET | Agent 名称列表 |
 | `/api/timeseries` | GET | 时序 Token 统计 |
-| `/api/metrics/latency` | GET | LLM 延迟与吞吐 percentile 指标 |
+| `/api/metrics/latency` | GET | LLM latency and throughput percentile metrics |
 | `/api/agent-health` | GET | Agent 健康状态 |
 | `/api/agent-health/{pid}` | DELETE | 删除健康条目 |
 | `/api/agent-health/{pid}/restart` | POST | 重启 Agent |

--- a/src/agentsight/src/aggregator/http2.rs
+++ b/src/agentsight/src/aggregator/http2.rs
@@ -322,6 +322,8 @@ impl Http2Stream {
 
         let mut body = Vec::new();
         let mut parsed_event_count = 0usize;
+        // Re-parsing the accumulated body is O(frames^2) worst-case, but meaningful output
+        // normally arrives early and returns; an algorithm redesign is out of scope here.
         for frame in &self.response_data_frames {
             body.extend_from_slice(frame.payload());
             let Ok(body_str) = std::str::from_utf8(&body) else {

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -1086,11 +1086,10 @@ impl Analyzer {
                     Some(serde_json::to_string(sse_json).unwrap_or_default())
                 } else {
                     // Not SSE, try regular JSON or raw text
-                    let body = stream
+                    stream
                         .response_json_body()
                         .map(|v| serde_json::to_string(&v).unwrap_or_default())
-                        .or_else(|| stream.response_body_str());
-                    body
+                        .or_else(|| stream.response_body_str())
                 };
                 let is_sse = stream.is_response_sse() || sse_event_count > 0;
 

--- a/src/agentsight/src/storage/sqlite/genai/stats.rs
+++ b/src/agentsight/src/storage/sqlite/genai/stats.rs
@@ -270,7 +270,9 @@ impl GenAISqliteStore {
             Ok(CallMetrics {
                 agent_name: row.get(0)?,
                 ttft_ms: first
-                    .filter(|first| *first >= start && end.is_none_or(|end| *first <= end))
+                    .filter(|first| {
+                        *first >= start && (end.is_none() || end.is_some_and(|end| *first <= end))
+                    })
                     .map(|first| (first - start) as f64 / 1_000_000.0),
                 is_sse: is_sse == Some(1),
                 // By #2339 convention, TPS/TPOT use total output_tokens N; do not use N - 1.

--- a/src/agentsight/src/storage/sqlite/genai/stats.rs
+++ b/src/agentsight/src/storage/sqlite/genai/stats.rs
@@ -270,9 +270,10 @@ impl GenAISqliteStore {
             Ok(CallMetrics {
                 agent_name: row.get(0)?,
                 ttft_ms: first
-                    .filter(|first| *first >= start && end.map_or(true, |end| *first <= end))
+                    .filter(|first| *first >= start && end.is_none_or(|end| *first <= end))
                     .map(|first| (first - start) as f64 / 1_000_000.0),
                 is_sse: is_sse == Some(1),
+                // By #2339 convention, TPS/TPOT use total output_tokens N; do not use N - 1.
                 tps_tokens_per_second: stream_ns
                     .zip(tokens)
                     .map(|(duration, tokens)| tokens as f64 * 1_000_000_000.0 / duration as f64),
@@ -325,6 +326,7 @@ impl GenAISqliteStore {
             })
             .collect())
     }
+
     /// One bucket in a token time-series query.
     pub fn get_token_timeseries(
         &self,


### PR DESCRIPTION
## Summary

Follow-up to #2578.

This fixes the AgentSight Clippy failures found after merge and addresses the non-blocking review follow-ups.

## Changes

- Fix `clippy::let_and_return` in `analyzer/unified.rs`.
- Replace `map_or` with `is_none_or` for Rust 1.89 Clippy compatibility.
- Document the #2339 TPS/TPOT convention using total output tokens `N`.
- Document the HTTP/2 incremental SSE re-parse trade-off.
- Add `/api/metrics/latency` to the AgentSight API documentation.

No metric semantics or runtime behavior are changed.

## Validation

- `cargo +1.89.0 fmt --all --check`
- `cargo +1.89.0 clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

All passed.