### PR TITLE
fix(sight): match latency agents case-insensitively

### DIFF
--- a/src/agentsight/src/storage/sqlite/genai/stats.rs
+++ b/src/agentsight/src/storage/sqlite/genai/stats.rs
@@ -122,6 +122,47 @@ mod latency_tests {
     }
 
     #[test]
+    fn filters_latency_metrics_case_insensitively_and_combines_variants() {
+        let path = std::env::temp_dir().join(format!(
+            "agentsight_latency_case_insensitive_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let store = GenAISqliteStore::new_with_path(&path).unwrap();
+        {
+            let conn = store.conn.lock().unwrap();
+            for (call_id, agent, start, first, is_sse) in [
+                ("upper", "Qoder", 100_i64, 110_i64, 1_i64),
+                ("lower", "qoder", 200_i64, 220_i64, 0_i64),
+            ] {
+                conn.execute(
+                    "INSERT INTO genai_events
+                     (event_type, status, call_id, start_timestamp_ns, end_timestamp_ns,
+                      first_output_timestamp_ns, output_tokens, is_sse, agent_name, event_json)
+                     VALUES ('llm_call', 'complete', ?1, ?2, ?3, ?4, 10, ?5, ?6, '{}')",
+                    params![call_id, start, start + 30, first, is_sse, agent],
+                )
+                .unwrap();
+            }
+        }
+
+        for query_name in ["Qoder", "qoder"] {
+            let summary = store
+                .get_latency_metrics(50, 250, Some(query_name))
+                .unwrap();
+            assert_eq!(summary.len(), 1);
+            assert_eq!(summary[0].agent_name.as_deref(), Some(query_name));
+            assert_eq!(summary[0].call_count, 2);
+            assert_eq!(summary[0].streaming_call_count, 1);
+            let ttft_p50 = summary[0].ttft_ms.as_ref().unwrap().p50;
+            assert!((ttft_p50 - 0.000015).abs() < 1e-12);
+        }
+
+        drop(store);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn streaming_call_count_uses_is_sse_when_ttft_is_missing() {
         let path = std::env::temp_dir().join(format!(
             "agentsight_streaming_count_{}.db",
@@ -239,13 +280,13 @@ impl GenAISqliteStore {
     ) -> Result<Vec<LatencyMetricsSummary>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
         let sql = if agent_name.is_some() {
-            "SELECT COALESCE(agent_name, process_name) AS agent_name,
+            "SELECT ?3 AS agent_name,
                     start_timestamp_ns, end_timestamp_ns,
                     first_output_timestamp_ns, output_tokens, is_sse
              FROM genai_events
              WHERE event_type = 'llm_call' AND status = 'complete'
                AND start_timestamp_ns BETWEEN ?1 AND ?2
-               AND COALESCE(agent_name, process_name) = ?3"
+               AND COALESCE(agent_name, process_name) COLLATE NOCASE = ?3 COLLATE NOCASE"
         } else {
             "SELECT COALESCE(agent_name, process_name) AS agent_name,
                     start_timestamp_ns, end_timestamp_ns,


### PR DESCRIPTION
## Summary

Correctness follow-up to #2578, discovered during review of #2586.

The existing Agent Sessions UI treats casing variants such as `Qoder` and `qoder` as the same Agent, but the latency API used a case-sensitive SQLite comparison. This could make the selected sessions match while `/api/metrics/latency` returned no rows.

## Changes

- make filtered latency Agent matching case-insensitive with SQLite `COLLATE NOCASE`
- aggregate casing variants into one filtered latency summary
- use the requested Agent casing as the returned `agent_name` label
- keep `process_name` fallback semantics unchanged

## Scope

This PR is limited to `src/agentsight/src/storage/sqlite/genai/stats.rs`.

It does not change:

- frontend code
- source filtering
- auxiliary-call scope
- metric formulas or percentile semantics
- null semantics
- schema or eBPF code

## Merge order

Recommended order: #2583 → this follow-up → #2586.

#2583 is preferred first because it addresses the existing AgentSight Clippy failures and also touches `stats.rs`; it is not a hard dependency of this PR. #2586 has the functional dependency on this case-insensitive latency filtering.

## Validation

- targeted casing regression test passed
- `latency_tests`: 9 passed
- latency handler test: 1 passed
- `cargo +1.89.0 fmt --all -- --check`
- `git diff --check`
- full unit/integration tests passed
- `cargo test` has one unrelated existing doctest failure in `src/genai/helpers.rs`
- Rust 1.89 Clippy is blocked by the two existing lint issues addressed separately by #2583:
  - `clippy::let_and_return` in `src/agentsight/src/analyzer/unified.rs`
  - `clippy::unnecessary_map_or` in `src/agentsight/src/storage/sqlite/genai/stats.rs`
