### PR TITLE
fix(tokenless): persist stats without env merge

### DIFF
--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -845,19 +845,11 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     println!("SLS recording:   {} (via {})", sls_state, sls_source);
                 }
                 StatsCommands::Enable => {
-                    let mut config = TokenlessConfig::load();
-                    config.stats_enabled = true;
-                    config
-                        .save()
-                        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+                    persist_stats_enabled(true)?;
                     println!("Stats recording enabled.");
                 }
                 StatsCommands::Disable => {
-                    let mut config = TokenlessConfig::load();
-                    config.stats_enabled = false;
-                    config
-                        .save()
-                        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+                    persist_stats_enabled(false)?;
                     println!("Stats recording disabled.");
                 }
             }
@@ -984,6 +976,30 @@ fn warn_mode_mismatch(label: &str, records: &[StatsRecord], expected: Compressio
             expected.as_str()
         );
     }
+}
+
+/// Persist only the stats recording toggle to `config.json`.
+///
+/// Starts from the on-disk file rather than [`TokenlessConfig::load`], so a
+/// session `TOKENLESS_COMPRESSION_ENABLED` / `TOKENLESS_SLS_ENABLED` override
+/// is not copied into durable config. Runtime `stats status` still uses
+/// [`TokenlessConfig::load`] and therefore still honors those env vars.
+fn persist_stats_enabled(enabled: bool) -> Result<(), (String, i32)> {
+    let config = stats_persist_snapshot(TokenlessConfig::load_from_file(), enabled);
+    config
+        .save()
+        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+    Ok(())
+}
+
+/// Snapshot written by `stats enable` / `stats disable`.
+///
+/// `file_config` is the on-disk document with no process-env merge. Only
+/// `stats_enabled` changes; compression and SLS stay as stored.
+fn stats_persist_snapshot(file_config: TokenlessConfig, enabled: bool) -> TokenlessConfig {
+    let mut config = file_config;
+    config.stats_enabled = enabled;
+    config
 }
 
 /// Record compression stats — fail-silent so compression output

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -63,6 +63,70 @@ impl TempDbGuard {
     }
 }
 
+struct PersistConfigGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+    prev_stats: Option<std::ffi::OsString>,
+    prev_sls: Option<std::ffi::OsString>,
+    prev_compression: Option<std::ffi::OsString>,
+}
+
+impl PersistConfigGuard {
+    fn with_file_and_env(
+        file_json: &str,
+        stats_env: &str,
+        sls_env: &str,
+        compression_env: &str,
+    ) -> Self {
+        let lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, file_json).unwrap();
+        TokenlessConfig::override_config_path_for_tests(Some(path.clone()));
+        let prev_stats = std::env::var_os("TOKENLESS_STATS_ENABLED");
+        let prev_sls = std::env::var_os("TOKENLESS_SLS_ENABLED");
+        let prev_compression = std::env::var_os("TOKENLESS_COMPRESSION_ENABLED");
+        unsafe {
+            std::env::set_var("TOKENLESS_STATS_ENABLED", stats_env);
+            std::env::set_var("TOKENLESS_SLS_ENABLED", sls_env);
+            std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", compression_env);
+        }
+        Self {
+            _lock: lock,
+            _dir: dir,
+            path,
+            prev_stats,
+            prev_sls,
+            prev_compression,
+        }
+    }
+
+    fn read_persisted(&self) -> TokenlessConfig {
+        serde_json::from_str(&std::fs::read_to_string(&self.path).unwrap()).unwrap()
+    }
+}
+
+impl Drop for PersistConfigGuard {
+    fn drop(&mut self) {
+        TokenlessConfig::override_config_path_for_tests(None);
+        unsafe {
+            match &self.prev_stats {
+                Some(v) => std::env::set_var("TOKENLESS_STATS_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_STATS_ENABLED"),
+            }
+            match &self.prev_sls {
+                Some(v) => std::env::set_var("TOKENLESS_SLS_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_SLS_ENABLED"),
+            }
+            match &self.prev_compression {
+                Some(v) => std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_COMPRESSION_ENABLED"),
+            }
+        }
+    }
+}
+
 impl Drop for TempDbGuard {
     fn drop(&mut self) {
         unsafe {
@@ -1096,6 +1160,38 @@ fn stats_persist_snapshot_disable_keeps_file_compression_and_sls() {
         compression_enabled: false,
     };
     let persisted = stats_persist_snapshot(file, false);
+    assert!(!persisted.stats_enabled);
+    assert!(!persisted.sls_enabled);
+    assert!(!persisted.compression_enabled);
+}
+
+#[test]
+fn run_command_stats_enable_does_not_persist_env_overrides() {
+    // Drive the production Enable arm (load_from_file + save). Replacing
+    // load_from_file() with load() would write the session env values.
+    let guard = PersistConfigGuard::with_file_and_env(
+        "{\"stats_enabled\":false,\"sls_enabled\":true,\"compression_enabled\":true}",
+        "0",
+        "0",
+        "0",
+    );
+    run_command(Commands::Stats(StatsCommands::Enable)).unwrap();
+    let persisted = guard.read_persisted();
+    assert!(persisted.stats_enabled);
+    assert!(persisted.sls_enabled);
+    assert!(persisted.compression_enabled);
+}
+
+#[test]
+fn run_command_stats_disable_does_not_persist_env_overrides() {
+    let guard = PersistConfigGuard::with_file_and_env(
+        "{\"stats_enabled\":true,\"sls_enabled\":false,\"compression_enabled\":false}",
+        "1",
+        "1",
+        "1",
+    );
+    run_command(Commands::Stats(StatsCommands::Disable)).unwrap();
+    let persisted = guard.read_persisted();
     assert!(!persisted.stats_enabled);
     assert!(!persisted.sls_enabled);
     assert!(!persisted.compression_enabled);

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -1073,6 +1073,35 @@ fn run_command_stats_status() {
 }
 
 #[test]
+fn stats_persist_snapshot_enable_keeps_file_compression_and_sls() {
+    // A/B dry-run sets TOKENLESS_COMPRESSION_ENABLED=0 in the process, but
+    // `stats enable` must write the on-disk compression/SLS values, not the
+    // session overrides.
+    let file = TokenlessConfig {
+        stats_enabled: false,
+        sls_enabled: true,
+        compression_enabled: true,
+    };
+    let persisted = stats_persist_snapshot(file, true);
+    assert!(persisted.stats_enabled);
+    assert!(persisted.sls_enabled);
+    assert!(persisted.compression_enabled);
+}
+
+#[test]
+fn stats_persist_snapshot_disable_keeps_file_compression_and_sls() {
+    let file = TokenlessConfig {
+        stats_enabled: true,
+        sls_enabled: false,
+        compression_enabled: false,
+    };
+    let persisted = stats_persist_snapshot(file, false);
+    assert!(!persisted.stats_enabled);
+    assert!(!persisted.sls_enabled);
+    assert!(!persisted.compression_enabled);
+}
+
+#[test]
 fn run_command_stats_compare() {
     let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
     let result = run_command(Commands::Stats(StatsCommands::Summary {

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -7,7 +7,16 @@
 //! those session overrides are not written back.
 
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::path::PathBuf;
+
+thread_local! {
+    /// Test-only redirect for [`TokenlessConfig::config_path`].
+    ///
+    /// This is a thread-local API call, not an environment variable, so it
+    /// does not weaken the passwd-rooted `$HOME` refusal below.
+    static CONFIG_PATH_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
 
 /// Global tokenless configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,6 +60,9 @@ fn parse_env_bool(val: &str) -> bool {
 
 impl TokenlessConfig {
     fn config_path() -> PathBuf {
+        if let Some(path) = CONFIG_PATH_OVERRIDE.with(|slot| slot.borrow().clone()) {
+            return path;
+        }
         // Resolve home via the shared passwd-rooted helper so an attacker
         // cannot redirect the config path by setting $HOME before invoking
         // any tokenless binary. When no trusted home is available, return
@@ -62,6 +74,17 @@ impl TokenlessConfig {
             return PathBuf::from("/dev/null/.tokenless/config.json");
         }
         PathBuf::from(home).join(".tokenless/config.json")
+    }
+
+    /// Redirect [`Self::config_path`] for the current thread.
+    ///
+    /// Production CLI never calls this. Tests use it so [`Self::load`],
+    /// [`Self::load_from_file`], and [`Self::save`] can run against an
+    /// isolated file without writing the passwd-backed
+    /// `~/.tokenless/config.json`.
+    #[doc(hidden)]
+    pub fn override_config_path_for_tests(path: Option<PathBuf>) {
+        CONFIG_PATH_OVERRIDE.with(|slot| *slot.borrow_mut() = path);
     }
 
     /// Whether a config file exists on disk.

--- a/src/tokenless/crates/tokenless-stats/src/config.rs
+++ b/src/tokenless/crates/tokenless-stats/src/config.rs
@@ -1,8 +1,10 @@
 //! Configuration for tokenless.
 //!
 //! Stored at `~/.tokenless/config.json`. Controls global feature flags.
-//! Environment variables `TOKENLESS_STATS_ENABLED` and
-//! `TOKENLESS_SLS_ENABLED` override file config independently.
+//! Environment variables `TOKENLESS_STATS_ENABLED`, `TOKENLESS_SLS_ENABLED`,
+//! and `TOKENLESS_COMPRESSION_ENABLED` override file config at runtime.
+//! `tokenless stats enable` / `disable` persist from the file snapshot so
+//! those session overrides are not written back.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -189,6 +191,16 @@ impl TokenlessConfig {
             compression_env.as_deref(),
             None,
         )
+    }
+
+    /// Load on-disk config without applying process environment overrides.
+    ///
+    /// `tokenless stats enable` / `disable` persist only the stats toggle.
+    /// Loading via [`Self::load`] would copy session env overrides such as
+    /// `TOKENLESS_COMPRESSION_ENABLED` into `config.json`, turning a
+    /// temporary A/B dry-run into a durable setting.
+    pub fn load_from_file() -> Self {
+        Self::load_with_envs_and_path(None, None, None, None)
     }
 
     /// Save config to disk.

--- a/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
@@ -337,6 +337,61 @@ fn test_serde_round_trip() {
     assert!(deserialized.compression_enabled);
 }
 
+static CONFIG_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct ConfigPathEnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev_stats: Option<std::ffi::OsString>,
+    prev_sls: Option<std::ffi::OsString>,
+    prev_compression: Option<std::ffi::OsString>,
+}
+
+impl ConfigPathEnvGuard {
+    fn new(
+        path: std::path::PathBuf,
+        stats_env: &str,
+        sls_env: &str,
+        compression_env: &str,
+    ) -> Self {
+        let lock = CONFIG_ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        TokenlessConfig::override_config_path_for_tests(Some(path));
+        let prev_stats = std::env::var_os("TOKENLESS_STATS_ENABLED");
+        let prev_sls = std::env::var_os("TOKENLESS_SLS_ENABLED");
+        let prev_compression = std::env::var_os("TOKENLESS_COMPRESSION_ENABLED");
+        unsafe {
+            std::env::set_var("TOKENLESS_STATS_ENABLED", stats_env);
+            std::env::set_var("TOKENLESS_SLS_ENABLED", sls_env);
+            std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", compression_env);
+        }
+        Self {
+            _lock: lock,
+            prev_stats,
+            prev_sls,
+            prev_compression,
+        }
+    }
+}
+
+impl Drop for ConfigPathEnvGuard {
+    fn drop(&mut self) {
+        TokenlessConfig::override_config_path_for_tests(None);
+        unsafe {
+            match &self.prev_stats {
+                Some(v) => std::env::set_var("TOKENLESS_STATS_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_STATS_ENABLED"),
+            }
+            match &self.prev_sls {
+                Some(v) => std::env::set_var("TOKENLESS_SLS_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_SLS_ENABLED"),
+            }
+            match &self.prev_compression {
+                Some(v) => std::env::set_var("TOKENLESS_COMPRESSION_ENABLED", v),
+                None => std::env::remove_var("TOKENLESS_COMPRESSION_ENABLED"),
+            }
+        }
+    }
+}
+
 #[test]
 fn load_from_file_ignores_would_be_env_overrides() {
     // `stats enable`/`disable` persist from this snapshot. A session
@@ -344,29 +399,25 @@ fn load_from_file_ignores_would_be_env_overrides() {
     // compression toggle when the user only asked to flip stats recording.
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.json");
-    let _ = std::fs::write(
+    std::fs::write(
         &path,
         "{\"stats_enabled\":false,\"sls_enabled\":true,\"compression_enabled\":true}",
-    );
+    )
+    .unwrap();
+    let _guard = ConfigPathEnvGuard::new(path, "1", "0", "0");
 
-    let runtime = TokenlessConfig::load_with_envs_and_path(
-        Some("1"),
-        Some("0"),
-        Some("0"),
-        Some(&path),
-    );
+    let runtime = TokenlessConfig::load();
     assert!(runtime.is_stats_enabled());
     assert!(!runtime.is_sls_enabled());
     assert!(!runtime.is_compression_enabled());
 
-    let mut persist = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
-    persist.stats_enabled = true;
-    assert!(persist.is_stats_enabled());
+    let persist = TokenlessConfig::load_from_file();
+    assert!(!persist.is_stats_enabled());
     assert!(persist.is_sls_enabled());
     assert!(persist.is_compression_enabled());
 
     let json = serde_json::to_value(&persist).unwrap();
-    assert_eq!(json["stats_enabled"], true);
+    assert_eq!(json["stats_enabled"], false);
     assert_eq!(json["sls_enabled"], true);
     assert_eq!(json["compression_enabled"], true);
 }
@@ -375,24 +426,20 @@ fn load_from_file_ignores_would_be_env_overrides() {
 fn stats_disable_persist_keeps_file_compression_and_sls() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.json");
-    let _ = std::fs::write(
+    std::fs::write(
         &path,
         "{\"stats_enabled\":true,\"sls_enabled\":false,\"compression_enabled\":false}",
-    );
+    )
+    .unwrap();
+    let _guard = ConfigPathEnvGuard::new(path, "0", "1", "1");
 
-    let runtime = TokenlessConfig::load_with_envs_and_path(
-        Some("0"),
-        Some("1"),
-        Some("1"),
-        Some(&path),
-    );
+    let runtime = TokenlessConfig::load();
     assert!(!runtime.is_stats_enabled());
     assert!(runtime.is_sls_enabled());
     assert!(runtime.is_compression_enabled());
 
-    let mut persist = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
-    persist.stats_enabled = false;
-    assert!(!persist.is_stats_enabled());
+    let persist = TokenlessConfig::load_from_file();
+    assert!(persist.is_stats_enabled());
     assert!(!persist.is_sls_enabled());
     assert!(!persist.is_compression_enabled());
 }

--- a/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/config_tests.rs
@@ -336,3 +336,63 @@ fn test_serde_round_trip() {
     assert!(!deserialized.sls_enabled);
     assert!(deserialized.compression_enabled);
 }
+
+#[test]
+fn load_from_file_ignores_would_be_env_overrides() {
+    // `stats enable`/`disable` persist from this snapshot. A session
+    // TOKENLESS_COMPRESSION_ENABLED=0 A/B run must not rewrite the file's
+    // compression toggle when the user only asked to flip stats recording.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(
+        &path,
+        "{\"stats_enabled\":false,\"sls_enabled\":true,\"compression_enabled\":true}",
+    );
+
+    let runtime = TokenlessConfig::load_with_envs_and_path(
+        Some("1"),
+        Some("0"),
+        Some("0"),
+        Some(&path),
+    );
+    assert!(runtime.is_stats_enabled());
+    assert!(!runtime.is_sls_enabled());
+    assert!(!runtime.is_compression_enabled());
+
+    let mut persist = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
+    persist.stats_enabled = true;
+    assert!(persist.is_stats_enabled());
+    assert!(persist.is_sls_enabled());
+    assert!(persist.is_compression_enabled());
+
+    let json = serde_json::to_value(&persist).unwrap();
+    assert_eq!(json["stats_enabled"], true);
+    assert_eq!(json["sls_enabled"], true);
+    assert_eq!(json["compression_enabled"], true);
+}
+
+#[test]
+fn stats_disable_persist_keeps_file_compression_and_sls() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let _ = std::fs::write(
+        &path,
+        "{\"stats_enabled\":true,\"sls_enabled\":false,\"compression_enabled\":false}",
+    );
+
+    let runtime = TokenlessConfig::load_with_envs_and_path(
+        Some("0"),
+        Some("1"),
+        Some("1"),
+        Some(&path),
+    );
+    assert!(!runtime.is_stats_enabled());
+    assert!(runtime.is_sls_enabled());
+    assert!(runtime.is_compression_enabled());
+
+    let mut persist = TokenlessConfig::load_with_envs_and_path(None, None, None, Some(&path));
+    persist.stats_enabled = false;
+    assert!(!persist.is_stats_enabled());
+    assert!(!persist.is_sls_enabled());
+    assert!(!persist.is_compression_enabled());
+}


### PR DESCRIPTION
## Why

`tokenless stats enable` and `tokenless stats disable` loaded the env-merged runtime config and wrote it back to `~/.tokenless/config.json`. A documented A/B dry-run (`TOKENLESS_COMPRESSION_ENABLED=0`) therefore rewrote durable `compression_enabled` / `sls_enabled` even though the user only asked to flip stats recording. After the env var was unset, later compress commands stayed in the accidental file setting.

This is the write-path sibling of #2362 / #2380, which already kept file `compression_enabled` at **read** time when stats/SLS env were set.

## What changed

**Persist snapshot**
- `stats enable` / `disable` load on-disk config via `TokenlessConfig::load_from_file()` (no process-env merge) and flip only `stats_enabled`.
- Runtime `stats status` and compress commands still use `TokenlessConfig::load()`, so session env overrides remain effective until unset.

**Regression matrix**
- Enable while compression/SLS env would have disabled those toggles keeps the file values (`load_from_file_ignores_would_be_env_overrides`, `stats_persist_snapshot_enable_keeps_file_compression_and_sls`, `run_command_stats_enable_does_not_persist_env_overrides`).
- Disable keeps file `compression_enabled` / `sls_enabled` (`stats_disable_persist_keeps_file_compression_and_sls`, `stats_persist_snapshot_disable_keeps_file_compression_and_sls`, `run_command_stats_disable_does_not_persist_env_overrides`).
- CLI Enable/Disable tests drive the production `load_from_file()` + `save()` path with conflicting file and process-env values, so reverting persist to `TokenlessConfig::load()` fails the suite.

## Related issue

fixes #2591

Fixes: b97154e69de824c5ae2d753fb04c9bc0837a95f7 ("feat(tokenless): add SLS JSONL data collection with config toggle")

## User / Agent impact

`tokenless stats enable` / `disable` during a `TOKENLESS_COMPRESSION_ENABLED` or `TOKENLESS_SLS_ENABLED` session no longer bake those session overrides into `config.json`. Compress commands return to the file's compression setting once the env var is unset.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. `stats enable` / `disable` now match their documented job (persist the stats toggle). Session env vars still override at runtime; they are simply not copied into the file. No migration. Tests use a thread-local config-path override (not `$HOME`) so they do not write passwd-backed `~/.tokenless/config.json`.

## Validation

```bash
cd src/tokenless
cargo fmt --all --check
cargo clippy --workspace --locked --all-targets -- -D warnings
cargo test -p tokenless-stats --locked -- --test-threads=1
cargo test -p tokenless-cli --locked -- --test-threads=1
cargo doc --workspace --no-deps
```

Focused coverage: `load_from_file_ignores_would_be_env_overrides`, `stats_disable_persist_keeps_file_compression_and_sls`, `stats_persist_snapshot_enable_keeps_file_compression_and_sls`, `stats_persist_snapshot_disable_keeps_file_compression_and_sls`, `run_command_stats_enable_does_not_persist_env_overrides`, `run_command_stats_disable_does_not_persist_env_overrides`.

Results on `20345036`: fmt/clippy/docs green; `tokenless-stats` 145 passed; `tokenless-cli` 223 passed, 2 ignored, plus 36 CLI integration tests.

Exact-head CLI proof (`aed84d8f`): file `{stats:false, sls:true, compression:true}` then `TOKENLESS_COMPRESSION_ENABLED=0 TOKENLESS_SLS_ENABLED=0 tokenless stats enable` wrote `{stats:true, sls:true, compression:true}`.

## Review feedback

Addressed @ikunkun-sys on `aed84d8f` (`PRR_kwDOR0eWAc8AAAABJ3YiJA`):
- P1: Enable/Disable tests now call the production load-and-save path with conflicting file vs env values (`20345036`).
- P2: introducing-commit trailer is on follow-up `20345036` and in Related issue (so a squash merge can keep it). The original `aed84d8f` message was not rewritten (no force-push).

## Documentation and rollback

No user-guide change; runtime env override behavior is unchanged. Revert this commit to restore the previous persist-from-`load()` behavior.

