### PR TITLE
docs(tokenless): clarify savings-rate field definitions

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -367,6 +367,8 @@ tokenless stats summary --compare <baseline-session> <active-session>
 
 A missing session ID fails with a non-zero exit instead of a 0% comparison, matching `stats diff --session`. `stats summary --limit` must be a positive integer; `--limit 0` is rejected at parse time, matching `stats diff --limit`.
 
+The percentage fields in `stats summary --json` (`chars_saved_percent`, `tokens_saved_percent`) and in `--compare --json` (`saved_percent`) are all computed as saved amount divided by the original, uncompressed amount. See [Measuring savings → Saving-rate field definitions](measuring-savings.md#saving-rate-field-definitions).
+
 Inspect one record or the verified stages of one tool call:
 
 ```bash

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -71,6 +71,20 @@ tokenless stats summary --limit 1000
 
 `--limit` must be a positive integer. `--limit 0` is rejected at parse time with a non-zero exit, matching `stats diff --limit`.
 
+## Saving-rate field definitions
+
+Tokenless always expresses a saving rate as “saved tokens as a share of the original, uncompressed tokens”; only the aggregation scope differs. Every percentage field emitted by `tokenless stats` is defined as follows:
+
+| Field | Where | Formula | Meaning |
+|-------|-------|---------|---------|
+| `chars_saved_percent` | `stats summary --json` | (before_chars − after_chars) ÷ before_chars × 100% | Character-level compression rate for payloads handled by Tokenless |
+| `tokens_saved_percent` | `stats summary --json` | (before_tokens − after_tokens) ÷ before_tokens × 100% | Token-level compression rate for payloads handled by Tokenless |
+| `saved_percent` | `stats summary --compare --json` | (baseline_tokens − tokenless_tokens) ÷ baseline_tokens × 100% | Saving rate of the compression-on run in a dry-run comparison |
+
+`Saved: N tokens (X%)` in the text output corresponds to `tokens_saved_percent`: the denominator is the sum of `before_tokens` over the same records — the original, uncompressed size — not the session's total consumption and not any provider-side cache metric. In other words, Tokenless saving rates follow exactly the “saved tokens ÷ original uncompressed tokens” definition: the numerator is `before − after` (the tokens actually saved) and the denominator is `before` (the original uncompressed tokens).
+
+> `tokenless-stats` does not emit `savings_rate`, `cached_tokens`, or `total_cached_tokens` fields, and it does not collect model-provider prompt-cache hit data. If another tool's report shows a `savings_rate` computed as `cached_tokens ÷ total_tokens`, that number describes the provider-side prompt-cache hit share; it does not represent Tokenless compression savings and is not produced by `tokenless-stats`.
+
 ## Inspect individual records
 
 List recent records:
@@ -205,7 +219,7 @@ Notes:
 
 ## Interpret the saving rate correctly
 
-The compression rate in `stats summary` covers only payloads handled by Tokenless. Estimate the whole-session effect with:
+See [Saving-rate field definitions](#saving-rate-field-definitions) for the definition of each percentage field. The compression rate in `stats summary` covers only payloads handled by Tokenless. Estimate the whole-session effect with:
 
 ```text
 Estimated overall saving rate

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -80,6 +80,9 @@ Tokenless always expresses a saving rate as “saved tokens as a share of the or
 | `chars_saved_percent` | `stats summary --json` | (before_chars − after_chars) ÷ before_chars × 100% | Character-level compression rate for payloads handled by Tokenless |
 | `tokens_saved_percent` | `stats summary --json` | (before_tokens − after_tokens) ÷ before_tokens × 100% | Token-level compression rate for payloads handled by Tokenless |
 | `saved_percent` | `stats summary --compare --json` | (baseline_tokens − tokenless_tokens) ÷ baseline_tokens × 100% | Saving rate of the compression-on run in a dry-run comparison |
+| `saved_percent` | `stats diff --json` (every chain and stage) | (before_tokens − after_tokens) ÷ before_tokens × 100% | Saving rate of one chain or stage in a diff report; computed from that object's own `before_tokens` and `after_tokens`, not the run totals used by `--compare` |
+
+`saved_percent` appears in two schemas with the same formula but different scopes: the `--compare` value is computed from the two runs' totals (`baseline_tokens` and `tokenless_tokens`), while `stats diff --json` reports one `saved_percent` for every chain and every stage, each computed from that object's own `before_tokens` and `after_tokens`.
 
 `Saved: N tokens (X%)` in the text output corresponds to `tokens_saved_percent`: the denominator is the sum of `before_tokens` over the same records — the original, uncompressed size — not the session's total consumption and not any provider-side cache metric. In other words, Tokenless saving rates follow exactly the “saved tokens ÷ original uncompressed tokens” definition: the numerator is `before − after` (the tokens actually saved) and the denominator is `before` (the original uncompressed tokens).
 

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -357,6 +357,8 @@ tokenless stats summary --compare <baseline-session> <active-session>
 
 Session ID 不存在时以非零退出码失败，而不是输出 0% 对比，行为与 `stats diff --session` 一致。`stats summary --limit` 必须为正整数；`--limit 0` 会在解析阶段被拒绝，行为与 `stats diff --limit` 一致。
 
+`stats summary --json` 的 `chars_saved_percent`、`tokens_saved_percent` 与 `--compare --json` 的 `saved_percent` 均按“节省量 ÷ 原始未压缩量”计算，字段定义见[效果度量 → 节省率字段定义](measuring-savings.md#节省率字段定义)。
+
 查看单条记录，或一次工具调用中可确认衔接的阶段：
 
 ```bash

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -80,6 +80,9 @@ Tokenless 统一把“节省率”表达为“节省 Token 数占原始未压缩
 | `chars_saved_percent` | `stats summary --json` | (before_chars − after_chars) ÷ before_chars × 100% | Tokenless 经手 Payload 的字符级压缩率 |
 | `tokens_saved_percent` | `stats summary --json` | (before_tokens − after_tokens) ÷ before_tokens × 100% | Tokenless 经手 Payload 的 Token 级压缩率 |
 | `saved_percent` | `stats summary --compare --json` | (baseline_tokens − tokenless_tokens) ÷ baseline_tokens × 100% | 双跑对比中“开启压缩”一侧的节省率 |
+| `saved_percent` | `stats diff --json`（每个 chain 和 stage） | (before_tokens − after_tokens) ÷ before_tokens × 100% | Diff 报告中单个 chain 或 stage 的节省率；使用该对象自身的 `before_tokens`、`after_tokens` 计算，而非 `--compare` 的运行级总量 |
+
+`saved_percent` 在两种输出中公式相同、口径不同：`--compare` 的值按两次运行的总量（`baseline_tokens` 与 `tokenless_tokens`）计算；`stats diff --json` 则为每个 chain 和每个 stage 各输出一个 `saved_percent`，均按该对象自身的 `before_tokens`、`after_tokens` 计算。
 
 文本输出中的 `Saved: N tokens (X%)` 对应 `tokens_saved_percent`：分母是同一批记录的 `before_tokens` 之和，即原始未压缩大小，既不是会话总消耗，也不是任何提供商侧缓存指标。也就是说，Tokenless 的节省率就是“节省 Token 数占原始未压缩总 Token 数的比例”这一定义：分子是 `before − after`（实际节省的 Token），分母是 `before`（原始未压缩 Token）。
 

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -71,6 +71,20 @@ tokenless stats summary --limit 1000
 
 `--limit` 必须为正整数。`--limit 0` 会在解析阶段以非零退出码被拒绝，行为与 `stats diff --limit` 一致。
 
+## 节省率字段定义
+
+Tokenless 统一把“节省率”表达为“节省 Token 数占原始未压缩 Token 数的比例”，仅统计口径不同。`tokenless stats` 输出的全部百分比字段定义如下：
+
+| 字段 | 来源 | 计算公式 | 含义 |
+|------|------|----------|------|
+| `chars_saved_percent` | `stats summary --json` | (before_chars − after_chars) ÷ before_chars × 100% | Tokenless 经手 Payload 的字符级压缩率 |
+| `tokens_saved_percent` | `stats summary --json` | (before_tokens − after_tokens) ÷ before_tokens × 100% | Tokenless 经手 Payload 的 Token 级压缩率 |
+| `saved_percent` | `stats summary --compare --json` | (baseline_tokens − tokenless_tokens) ÷ baseline_tokens × 100% | 双跑对比中“开启压缩”一侧的节省率 |
+
+文本输出中的 `Saved: N tokens (X%)` 对应 `tokens_saved_percent`：分母是同一批记录的 `before_tokens` 之和，即原始未压缩大小，既不是会话总消耗，也不是任何提供商侧缓存指标。也就是说，Tokenless 的节省率就是“节省 Token 数占原始未压缩总 Token 数的比例”这一定义：分子是 `before − after`（实际节省的 Token），分母是 `before`（原始未压缩 Token）。
+
+> `tokenless-stats` **不输出** `savings_rate`、`cached_tokens`、`total_cached_tokens` 字段，也不采集模型提供商的提示词缓存（Prompt Cache）命中数据。如果在其他工具的报告里看到按 `cached_tokens ÷ total_tokens` 计算的 `savings_rate`，它反映的是提供商提示词缓存命中占比，不代表 Tokenless 的压缩节省，也不是 `tokenless-stats` 的输出。
+
 ## 查看单条记录
 
 列出最近记录：
@@ -199,7 +213,7 @@ tokenless stats summary \
 
 ## 正确解释节省率
 
-`stats summary` 中的压缩率只针对 Tokenless 经手的 Payload。估算会话总体收益时，可以使用：
+各百分比字段的定义见上文[节省率字段定义](#节省率字段定义)。`stats summary` 中的压缩率只针对 Tokenless 经手的 Payload。估算会话总体收益时，可以使用：
 
 ```text
 总体估算节省率


### PR DESCRIPTION
## Why

Customer feedback reported a `savings_rate` field computed as `cached_tokens / total_tokens`, attributed to the `tokenless-stats` program, and asked to either fix the numeric definition of the field or clarify the documentation.

Investigation against current `main` and the full history of the tokenless component:

- `tokenless-stats` has **never** emitted a `savings_rate`, `cached_tokens`, or `total_cached_tokens` field — verified by searching the complete history of `src/tokenless` (`git log -S`) and inspecting every output path (`stats summary` text/JSON, `--compare` text/JSON, `stats diff`, SLS JSONL records).
- Every percentage tokenless-stats reports already follows the definition the customer expects ("saved tokens ÷ original uncompressed tokens"):
  - `chars_saved_percent` = (before_chars − after_chars) ÷ before_chars × 100%
  - `tokens_saved_percent` = (before_tokens − after_tokens) ÷ before_tokens × 100%
  - `saved_percent` (compare) = (baseline_tokens − tokenless_tokens) ÷ baseline_tokens × 100%
- `cached_tokens` / `total_tokens` style fields are model-provider prompt-cache metrics surfaced by other observability tooling; they are not tokenless compression savings and are not produced by this component.

There is therefore no `savings_rate` definition to fix in code; the right remedy is explicit documentation, which this PR adds.

## What changed (docs only)

- `docs/user-guide/{zh,en}/token-saving/tokenless/measuring-savings.md`
  - New "Saving-rate field definitions" section: a formula table for every percentage field emitted by `tokenless stats`; clarification that the text-output percentage (`Saved: N tokens (X%)`) uses `before_tokens` (the original, uncompressed size) as denominator — not the session total and not any provider-side cache metric; and an explicit note that `savings_rate` / `cached_tokens` / `total_cached_tokens` are not tokenless-stats output (prompt-cache hit share ≠ tokenless compression savings).
  - Cross-reference added in the existing "Interpret the saving rate correctly" section.
- `docs/user-guide/{zh,en}/token-saving/tokenless/cli-reference.md`
  - Short note in the `stats` section pointing to the field-definition table.

## Validation (real execution)

Environment: Linux x86_64, Rust cargo/rustc 1.94.1.

1. Build: `cargo build -p tokenless-cli` — success (0 errors).
2. Tests:
   - `cargo test -p tokenless-stats` — 143 passed, 0 failed.
   - `cargo test -p tokenless-cli` — 255 passed, 0 failed, 2 pre-existing `#[ignore]` (env-check tests, unrelated).
3. Targeted verification of every documented formula against real CLI output (isolated data directory via `TOKENLESS_DATA_DIR`, synthetic payload):
   - `stats summary --json`: `chars_saved_percent` = 12343/25300×100 = 48.7866% ✓; `tokens_saved_percent` = 3086/6326×100 = 48.7828% ✓; text output prints `Saved: 3086 tokens (48.8%)` ✓
   - `stats summary --compare baseline-run active-run --json`: `saved_percent` = (3163−1626)/3163×100 = 48.5931% ✓
   - Summary output contains no `savings_rate` / `cached_tokens` fields ✓
4. `git diff --check` — clean.

Not run: none skipped — the repository has no dedicated lint gate for these Markdown docs.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Docs-only change; no behavior, schema, or CLI output changes. Revert the commit to undo.

## Follow-up: review round 1 (stats diff percentages)

Adopted the review comment: `tokenless stats diff --json` also serializes `saved_percent` for every chain and stage, using that object's own `before_tokens`/`after_tokens`. Added the diff variants to the saving-rate field table (both languages) plus a sentence disambiguating the two `saved_percent` scopes (`--compare` run totals vs per-chain/stage totals), keeping the "every percentage field" claim exhaustive. Reply posted in the review thread.

### Validation (real execution, follow-up round)

Environment: Linux x86_64, Rust cargo/rustc 1.94.1.

1. Tests: `cargo test -p tokenless-stats` — 143 passed, 0 failed.
2. Build: `cargo build -p tokenless-cli` — success (0 errors).
3. Targeted verification against real CLI output (isolated data directory via `TOKENLESS_DATA_DIR`, synthetic payloads):
   - `stats diff <record-id> --json`: chain `saved_percent` = (4380 − 3444) ÷ 4380 × 100% = 21.3698630137% ✓ (matches serialized value exactly); the stage row uses the same formula on the record's own totals ✓
   - `stats diff --session <session-id> --json` (multi-chain output): every chain and every stage carries `saved_percent`; all values match `(before_tokens − after_tokens) ÷ before_tokens × 100%` recomputed from the same object's own totals ✓
4. `git diff --check` — clean.

Not run: none skipped — the repository has no dedicated lint gate for these Markdown docs (Docs Lint runs in CI).

## Rebase onto main (merge-conflict resolution)

The branch carried 61 commits over a stale base; 59 of them had already landed on `main` (verified by patch-id / commit-title comparison), which caused the 91-file conflict report. The branch was therefore rebased onto latest `main` keeping only this PR's two docs commits — no code changes, the effective diff remains the 4 docs files.

### Validation (real execution, rebase round)

Environment: Linux x86_64, Rust cargo/rustc 1.96.0.

1. Build: `cargo build -p tokenless-cli` — success (0 errors).
2. Tests:
   - `cargo test -p tokenless-stats` — 153 passed, 0 failed (2 suites).
   - `cargo test -p tokenless-cli` — 295 passed, 0 failed, 2 pre-existing `#[ignore]` (env-check tests, 3 suites).
3. `git diff --check` against `main` — clean; no conflict markers; resulting tree verified docs-only (4 files).

Not run: none skipped — the repository has no dedicated lint gate for these Markdown docs (Docs Lint runs in CI).
