### PR TITLE
refactor(anolisa): inject systemd runner

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/system.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/system.rs
@@ -22,7 +22,7 @@ use anolisa_core::system_helper::{HelperRequest, HelperResponse};
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::ipc::{self, SYSTEM_HELPER_SOCKET};
 use anolisa_platform::privilege;
-use anolisa_platform::systemd::{self, SystemdError};
+use anolisa_platform::systemd::{Systemd, SystemdError};
 
 use crate::context::CliContext;
 use crate::response::{self, CliError};
@@ -648,18 +648,17 @@ impl StatusServiceState {
 }
 
 fn check_service_state() -> StatusServiceState {
-    match systemd::unit_status(STATUS_SERVICE_UNIT) {
+    match Systemd::system().unit_status(STATUS_SERVICE_UNIT) {
         Ok(status) => {
-            if status.active {
+            if status.failed {
+                StatusServiceState::Failed
+            } else if status.active {
                 StatusServiceState::Active
             } else {
                 StatusServiceState::Inactive
             }
         }
         Err(SystemdError::NotFound(_)) => StatusServiceState::NotInstalled,
-        Err(SystemdError::CommandFailed(ref msg)) if msg.to_lowercase().contains("failed") => {
-            StatusServiceState::Failed
-        }
         Err(_) => StatusServiceState::Unknown,
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
@@ -12,7 +12,7 @@ use anolisa_core::{
     RegistrationManager, TelemetryChannel, Uploader, generate_link_id, require_root,
 };
 use anolisa_platform::fs_layout::FsLayout;
-use anolisa_platform::systemd::{self, SystemdError};
+use anolisa_platform::systemd::{Systemd, SystemdError};
 use clap::{Parser, Subcommand};
 
 use crate::context::CliContext;
@@ -184,7 +184,9 @@ fn install_and_enable_service(ctx: &CliContext) -> Result<(), CliError> {
         ));
     }
 
-    systemd::enable_unit(SERVICE_NAME).map_err(|e| runtime(cmd, e))
+    Systemd::system()
+        .enable_unit(SERVICE_NAME)
+        .map_err(|e| runtime(cmd, e))
 }
 
 /// Best-effort, non-blocking teardown so `telemetry disable` never hangs.
@@ -192,7 +194,7 @@ fn install_and_enable_service(ctx: &CliContext) -> Result<(), CliError> {
 /// See [`handle_disable`] for why we avoid `disable --now`. A missing unit
 /// (never installed) is treated as success.
 fn disable_service() {
-    match systemd::disable_unit_deferred(SERVICE_NAME) {
+    match Systemd::system().disable_unit_deferred(SERVICE_NAME) {
         Ok(()) | Err(SystemdError::NotFound(_)) => {}
         Err(e) => eprintln!("warn: failed to disable {UNIT_FILENAME}: {e}"),
     }

--- a/src/anolisa/crates/anolisa-platform/src/command.rs
+++ b/src/anolisa/crates/anolisa-platform/src/command.rs
@@ -1,10 +1,10 @@
-//! Backend-neutral command execution seam for host package queries.
+//! Backend-neutral command execution seam for host process boundaries.
 //!
 //! [`CommandRunner`] abstracts spawning a process and capturing its output so
-//! that query backends can be tested with a fake runner instead of shelling
-//! out to real `rpm`/`dnf`. The runner stays pure: spawn failures surface as
+//! that process-backed boundaries can be tested with a fake runner instead of
+//! changing the host. The runner stays pure: spawn failures surface as
 //! [`std::io::Error`] and business-level exit-code interpretation lives in the
-//! query layer that consumes the runner.
+//! boundary that consumes the runner.
 
 use std::process::Command;
 

--- a/src/anolisa/crates/anolisa-platform/src/systemd.rs
+++ b/src/anolisa/crates/anolisa-platform/src/systemd.rs
@@ -1,183 +1,558 @@
-//! Systemd service management bridge.
+//! Injectable systemd service-management boundary.
 //!
-//! Thin wrapper around `systemctl(1)`. Each operation spawns the binary,
-//! captures stdout/stderr, and maps the result onto [`SystemdError`].
-//! `NotFound` is reserved for the well-known "unit X not loaded" error
-//! pattern; everything else (binary missing, non-zero exit, parse failure)
-//! collapses to `CommandFailed` with a human-readable message.
-
-use std::process::{Command, Output};
+//! [`Systemd`] runs `systemctl(1)` through [`CommandRunner`], preserving
+//! spawn, exit, and domain-state distinctions for callers and isolated tests.
 
 use thiserror::Error;
+
+use crate::command::{CommandOutput, CommandRunner, SystemCommandRunner};
+
+const SYSTEMCTL: &str = "systemctl";
+
+/// Captured context for an unsuccessful `systemctl` process.
+#[derive(Debug)]
+pub struct SystemdCommandFailure {
+    /// Operation that failed.
+    pub operation: String,
+    /// Unit supplied to `systemctl`, when the operation targets one.
+    pub unit: Option<String>,
+    /// Process exit code; `None` when terminated by a signal.
+    pub code: Option<i32>,
+    /// Captured standard output.
+    pub stdout: String,
+    /// Captured standard error.
+    pub stderr: String,
+    /// Compatibility rendering of the captured command output.
+    detail: String,
+}
+
+impl std::fmt::Display for SystemdCommandFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
 
 /// Errors returned by systemd service operations.
 #[derive(Debug, Error)]
 pub enum SystemdError {
-    /// `systemctl` returned a non-zero status or malformed output.
-    #[error("systemctl command failed: {0}")]
-    CommandFailed(String),
-    /// The requested unit is not known to systemd.
+    /// `systemctl` could not be spawned.
+    #[error("systemctl command failed: failed to spawn systemctl: {source}")]
+    Spawn {
+        /// Operation that could not be started.
+        operation: String,
+        /// Spawn-phase error from the operating system.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The unit name is empty or a successful status query reports it missing.
     #[error("service not found: {0}")]
     NotFound(String),
+    /// `systemctl` exited unsuccessfully.
+    #[error("systemctl command failed: {0}")]
+    NonZeroExit(Box<SystemdCommandFailure>),
 }
 
 /// Snapshot of systemd unit state used by status/restart flows.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnitStatus {
     /// Whether systemd currently reports the unit as active.
     pub active: bool,
+    /// Whether systemd currently reports the unit as failed.
+    pub failed: bool,
     /// Whether the unit is enabled for automatic start.
     pub enabled: bool,
     /// Human-readable unit description from systemd metadata.
     pub description: String,
 }
 
-fn run_systemctl(args: &[&str]) -> Result<Output, SystemdError> {
-    Command::new("systemctl")
-        .args(args)
-        .output()
-        .map_err(|e| SystemdError::CommandFailed(format!("failed to spawn systemctl: {e}")))
+/// Systemd bridge backed by an injectable process runner.
+///
+/// Production code uses [`Systemd::system`]; tests use
+/// [`Systemd::with_runner`] to avoid invoking the host's service manager.
+pub struct Systemd<R: CommandRunner = SystemCommandRunner> {
+    runner: R,
 }
 
-fn classify_error(unit: &str, output: &Output) -> SystemdError {
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let combined = format!("{stderr}{stdout}");
-    let lower = combined.to_lowercase();
-    if lower.contains("could not be found")
-        || lower.contains("not loaded")
-        || lower.contains("no such file or directory")
-        || lower.contains("unit file") && lower.contains("does not exist")
-    {
-        return SystemdError::NotFound(unit.to_string());
+impl Systemd<SystemCommandRunner> {
+    /// Build a bridge that runs the host's real `systemctl` binary.
+    pub fn system() -> Self {
+        Self {
+            runner: SystemCommandRunner,
+        }
     }
-    let trimmed = combined.trim();
-    let detail = if trimmed.is_empty() {
+}
+
+impl Default for Systemd<SystemCommandRunner> {
+    fn default() -> Self {
+        Self::system()
+    }
+}
+
+impl<R: CommandRunner> Systemd<R> {
+    /// Build a bridge backed by a custom runner.
+    pub fn with_runner(runner: R) -> Self {
+        Self { runner }
+    }
+
+    fn run_systemctl(&self, operation: &str, args: &[&str]) -> Result<CommandOutput, SystemdError> {
+        self.runner
+            .run(SYSTEMCTL, args)
+            .map_err(|source| SystemdError::Spawn {
+                operation: operation.to_string(),
+                source,
+            })
+    }
+
+    /// Query the status of a systemd unit via `systemctl show`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SystemdError::NotFound`] for an empty or missing unit and a
+    /// typed command error when `systemctl` cannot run or exits unsuccessfully.
+    pub fn unit_status(&self, unit: &str) -> Result<UnitStatus, SystemdError> {
+        if unit.trim().is_empty() {
+            return Err(SystemdError::NotFound("<empty>".to_string()));
+        }
+        let out = self.run_systemctl(
+            "show",
+            &[
+                "show",
+                unit,
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+        )?;
+        if out.code != Some(0) {
+            return Err(command_failure("show", Some(unit), out));
+        }
+
+        let mut load_state = String::new();
+        let mut active_state = String::new();
+        let mut unit_file_state = String::new();
+        let mut description = String::new();
+        for line in out.stdout.lines() {
+            if let Some(value) = line.strip_prefix("LoadState=") {
+                load_state = value.to_string();
+            } else if let Some(value) = line.strip_prefix("ActiveState=") {
+                active_state = value.to_string();
+            } else if let Some(value) = line.strip_prefix("UnitFileState=") {
+                unit_file_state = value.to_string();
+            } else if let Some(value) = line.strip_prefix("Description=") {
+                description = value.to_string();
+            }
+        }
+        if load_state == "not-found" || (load_state == "masked" && unit_file_state.is_empty()) {
+            return Err(SystemdError::NotFound(unit.to_string()));
+        }
+        Ok(UnitStatus {
+            active: active_state == "active" || active_state == "reloading",
+            failed: active_state == "failed",
+            enabled: matches!(
+                unit_file_state.as_str(),
+                "enabled" | "enabled-runtime" | "alias" | "static" | "indirect"
+            ),
+            description,
+        })
+    }
+
+    /// Enable and start a systemd unit (`systemctl enable --now <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty, missing, or the
+    /// command cannot complete.
+    pub fn enable_unit(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("enable", &["enable", "--now", unit], unit)
+    }
+
+    /// Stop and disable a systemd unit (`systemctl disable --now <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty, missing, or the
+    /// command cannot complete.
+    pub fn disable_unit(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("disable", &["disable", "--now", unit], unit)
+    }
+
+    /// Disable a unit without blocking on its stop sequence.
+    ///
+    /// `stop --no-block` is best-effort; the following `disable` determines the
+    /// operation result. This preserves the persistent opt-out path's bounded
+    /// latency while preventing systemd from restarting the unit.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty, missing, or the
+    /// authoritative `disable` command cannot complete.
+    pub fn disable_unit_deferred(&self, unit: &str) -> Result<(), SystemdError> {
+        if unit.trim().is_empty() {
+            return Err(SystemdError::NotFound("<empty>".to_string()));
+        }
+        let _ = self.run_systemctl("stop", &["stop", "--no-block", unit]);
+        let result = self.run_unit_operation("disable", &["disable", unit], unit);
+        if matches!(&result, Err(SystemdError::NonZeroExit(_)))
+            && matches!(self.unit_status(unit), Err(SystemdError::NotFound(_)))
+        {
+            return Err(SystemdError::NotFound(unit.to_string()));
+        }
+        result
+    }
+
+    fn run_unit_operation(
+        &self,
+        operation: &str,
+        args: &[&str],
+        unit: &str,
+    ) -> Result<(), SystemdError> {
+        if unit.trim().is_empty() {
+            return Err(SystemdError::NotFound("<empty>".to_string()));
+        }
+        let out = self.run_systemctl(operation, args)?;
+        if out.code == Some(0) {
+            return Ok(());
+        }
+        Err(command_failure(operation, Some(unit), out))
+    }
+}
+
+fn command_failure(operation: &str, unit: Option<&str>, out: CommandOutput) -> SystemdError {
+    let combined = format!("{}{}", out.stderr, out.stdout);
+    let detail = if combined.trim().is_empty() {
         format!(
             "systemctl exited with {}",
-            output
-                .status
-                .code()
-                .map(|c| c.to_string())
+            out.code
+                .map(|code| code.to_string())
                 .unwrap_or_else(|| "signal".to_string())
         )
     } else {
-        trimmed.to_string()
+        combined.trim().to_string()
     };
-    SystemdError::CommandFailed(detail)
-}
-
-/// Query the status of a systemd unit via `systemctl show`.
-pub fn unit_status(unit: &str) -> Result<UnitStatus, SystemdError> {
-    if unit.trim().is_empty() {
-        return Err(SystemdError::NotFound("<empty>".to_string()));
-    }
-    let out = run_systemctl(&[
-        "show",
-        unit,
-        "--no-pager",
-        "--property=LoadState,ActiveState,UnitFileState,Description",
-    ])?;
-    if !out.status.success() {
-        return Err(classify_error(unit, &out));
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let mut load_state = String::new();
-    let mut active_state = String::new();
-    let mut unit_file_state = String::new();
-    let mut description = String::new();
-    for line in stdout.lines() {
-        if let Some(v) = line.strip_prefix("LoadState=") {
-            load_state = v.to_string();
-        } else if let Some(v) = line.strip_prefix("ActiveState=") {
-            active_state = v.to_string();
-        } else if let Some(v) = line.strip_prefix("UnitFileState=") {
-            unit_file_state = v.to_string();
-        } else if let Some(v) = line.strip_prefix("Description=") {
-            description = v.to_string();
-        }
-    }
-    if load_state == "not-found" || (load_state == "masked" && unit_file_state.is_empty()) {
-        return Err(SystemdError::NotFound(unit.to_string()));
-    }
-    Ok(UnitStatus {
-        active: active_state == "active" || active_state == "reloading",
-        enabled: matches!(
-            unit_file_state.as_str(),
-            "enabled" | "enabled-runtime" | "alias" | "static" | "indirect"
-        ),
-        description,
-    })
-}
-
-/// Enable and start a systemd unit (`systemctl enable --now <unit>`).
-pub fn enable_unit(unit: &str) -> Result<(), SystemdError> {
-    if unit.trim().is_empty() {
-        return Err(SystemdError::NotFound("<empty>".to_string()));
-    }
-    let out = run_systemctl(&["enable", "--now", unit])?;
-    if out.status.success() {
-        return Ok(());
-    }
-    Err(classify_error(unit, &out))
-}
-
-/// Stop and disable a systemd unit (`systemctl disable --now <unit>`).
-pub fn disable_unit(unit: &str) -> Result<(), SystemdError> {
-    if unit.trim().is_empty() {
-        return Err(SystemdError::NotFound("<empty>".to_string()));
-    }
-    let out = run_systemctl(&["disable", "--now", unit])?;
-    if out.status.success() {
-        return Ok(());
-    }
-    Err(classify_error(unit, &out))
-}
-
-/// Disable a unit without blocking on its stop sequence.
-///
-/// Unlike [`disable_unit`] (`disable --now`), this never waits for the unit to
-/// drain its shutdown: `stop --no-block` enqueues termination and returns
-/// immediately, then plain `disable` removes the `WantedBy` boot symlink. An
-/// explicit stop also suppresses `Restart=`, so the unit will not churn after
-/// it goes down. Use this when the caller has already flipped an authoritative
-/// off-switch (e.g. a persistent opt-out marker) and only needs systemd to
-/// stop relaunching the unit — without paying the unit's `TimeoutStopSec`.
-pub fn disable_unit_deferred(unit: &str) -> Result<(), SystemdError> {
-    if unit.trim().is_empty() {
-        return Err(SystemdError::NotFound("<empty>".to_string()));
-    }
-    // Best-effort, non-blocking stop; the subsequent `disable` reports the
-    // authoritative outcome, so a not-loaded/inactive unit here is ignored.
-    let _ = run_systemctl(&["stop", "--no-block", unit]);
-    let out = run_systemctl(&["disable", unit])?;
-    if out.status.success() {
-        return Ok(());
-    }
-    Err(classify_error(unit, &out))
+    let failure = Box::new(SystemdCommandFailure {
+        operation: operation.to_string(),
+        unit: unit.map(str::to_string),
+        code: out.code,
+        stdout: out.stdout,
+        stderr: out.stderr,
+        detail,
+    });
+    SystemdError::NonZeroExit(failure)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::io;
+
     use super::*;
 
+    enum FakeOutcome {
+        Ok(CommandOutput),
+        Err(io::ErrorKind),
+    }
+
+    struct FakeCall {
+        args: Vec<String>,
+        outcome: FakeOutcome,
+    }
+
+    struct FakeCommandRunner {
+        calls: RefCell<VecDeque<FakeCall>>,
+    }
+
+    impl CommandRunner for FakeCommandRunner {
+        fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
+            assert_eq!(program, SYSTEMCTL);
+            let call = self
+                .calls
+                .borrow_mut()
+                .pop_front()
+                .expect("unexpected systemctl call");
+            assert_eq!(args, call.args);
+            match call.outcome {
+                FakeOutcome::Ok(out) => Ok(out),
+                FakeOutcome::Err(kind) => Err(io::Error::new(kind, "fake systemctl spawn failure")),
+            }
+        }
+    }
+
+    fn call(args: &[&str], code: Option<i32>, stdout: &str, stderr: &str) -> FakeCall {
+        FakeCall {
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            outcome: FakeOutcome::Ok(CommandOutput {
+                code,
+                stdout: stdout.to_string(),
+                stderr: stderr.to_string(),
+            }),
+        }
+    }
+
+    fn spawn_error(args: &[&str], kind: io::ErrorKind) -> FakeCall {
+        FakeCall {
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            outcome: FakeOutcome::Err(kind),
+        }
+    }
+
+    fn systemd(calls: Vec<FakeCall>) -> Systemd<FakeCommandRunner> {
+        Systemd::with_runner(FakeCommandRunner {
+            calls: RefCell::new(calls.into()),
+        })
+    }
+
+    fn assert_finished(systemd: &Systemd<FakeCommandRunner>) {
+        assert!(systemd.runner.calls.borrow().is_empty());
+    }
+
     #[test]
-    fn empty_unit_operations_return_not_found() {
+    fn empty_unit_operations_never_invoke_systemctl() {
+        let systemd = systemd(Vec::new());
         assert!(matches!(
-            unit_status(" "),
+            systemd.unit_status(" "),
             Err(SystemdError::NotFound(unit)) if unit == "<empty>"
         ));
         assert!(matches!(
-            enable_unit(" "),
+            systemd.enable_unit(" "),
             Err(SystemdError::NotFound(unit)) if unit == "<empty>"
         ));
         assert!(matches!(
-            disable_unit(" "),
+            systemd.disable_unit(" "),
             Err(SystemdError::NotFound(unit)) if unit == "<empty>"
         ));
         assert!(matches!(
-            disable_unit_deferred(" "),
+            systemd.disable_unit_deferred(" "),
             Err(SystemdError::NotFound(unit)) if unit == "<empty>"
         ));
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn unit_status_parses_machine_readable_properties() {
+        let systemd = systemd(vec![call(
+            &[
+                "show",
+                "anolisa.service",
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+            Some(0),
+            "LoadState=loaded\nActiveState=reloading\nUnitFileState=enabled-runtime\nDescription=ANOLISA\n",
+            "",
+        )]);
+
+        let status = systemd
+            .unit_status("anolisa.service")
+            .expect("status should parse");
+        assert_eq!(
+            status,
+            UnitStatus {
+                active: true,
+                failed: false,
+                enabled: true,
+                description: "ANOLISA".to_string(),
+            }
+        );
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn spawn_failure_is_distinct_from_process_exit() {
+        let systemd = systemd(vec![spawn_error(
+            &["enable", "--now", "anolisa.service"],
+            io::ErrorKind::PermissionDenied,
+        )]);
+
+        let err = systemd
+            .enable_unit("anolisa.service")
+            .expect_err("spawn should fail");
+        assert!(matches!(
+            &err,
+            SystemdError::Spawn { operation, source }
+                if operation == "enable" && source.kind() == io::ErrorKind::PermissionDenied
+        ));
+        assert_eq!(
+            err.to_string(),
+            "systemctl command failed: failed to spawn systemctl: fake systemctl spawn failure"
+        );
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn missing_unit_has_typed_domain_error() {
+        let systemd = systemd(vec![call(
+            &[
+                "show",
+                "missing.service",
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+            Some(0),
+            "LoadState=not-found\nActiveState=inactive\nUnitFileState=\nDescription=missing.service\n",
+            "",
+        )]);
+
+        assert!(matches!(
+            systemd.unit_status("missing.service"),
+            Err(SystemdError::NotFound(unit)) if unit == "missing.service"
+        ));
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn unit_status_derives_failed_from_active_state() {
+        let systemd = systemd(vec![call(
+            &[
+                "show",
+                "broken.service",
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+            Some(0),
+            "LoadState=loaded\nActiveState=failed\nUnitFileState=enabled\nDescription=Broken\n",
+            "",
+        )]);
+
+        let status = systemd
+            .unit_status("broken.service")
+            .expect("failed is a valid unit state");
+        assert!(!status.active);
+        assert!(status.failed);
+        assert!(status.enabled);
+        assert_eq!(status.description, "Broken");
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn bus_error_with_missing_path_is_non_zero_exit() {
+        let systemd = systemd(vec![call(
+            &[
+                "show",
+                "anolisa.service",
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+            Some(1),
+            "",
+            "Failed to connect to bus: No such file or directory\n",
+        )]);
+
+        let err = systemd
+            .unit_status("anolisa.service")
+            .expect_err("bus failure is not a missing unit");
+        assert!(matches!(
+            err,
+            SystemdError::NonZeroExit(failure)
+                if failure.operation == "show"
+                    && failure.unit.as_deref() == Some("anolisa.service")
+                    && failure.stderr.contains("No such file or directory")
+        ));
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn bus_error_with_failed_text_is_non_zero_exit() {
+        let systemd = systemd(vec![call(
+            &[
+                "show",
+                "anolisa.service",
+                "--no-pager",
+                "--property=LoadState,ActiveState,UnitFileState,Description",
+            ],
+            Some(1),
+            "",
+            "Failed to connect to bus: Host is down\n",
+        )]);
+
+        let err = systemd
+            .unit_status("anolisa.service")
+            .expect_err("diagnostic text is not a failed unit state");
+        assert!(matches!(
+            err,
+            SystemdError::NonZeroExit(failure)
+                if failure.operation == "show"
+                    && failure.unit.as_deref() == Some("anolisa.service")
+                    && failure.stderr.contains("Host is down")
+        ));
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn generic_non_zero_exit_keeps_status_and_streams() {
+        let systemd = systemd(vec![call(
+            &["disable", "--now", "anolisa.service"],
+            Some(4),
+            "out\n",
+            "permission denied\n",
+        )]);
+
+        let err = systemd
+            .disable_unit("anolisa.service")
+            .expect_err("disable should fail");
+        assert!(matches!(
+            &err,
+            SystemdError::NonZeroExit(failure)
+                if failure.operation == "disable"
+                    && failure.unit.as_deref() == Some("anolisa.service")
+                    && failure.code == Some(4)
+                    && failure.stdout == "out\n"
+                    && failure.stderr == "permission denied\n"
+        ));
+        assert_eq!(
+            err.to_string(),
+            "systemctl command failed: permission denied\nout"
+        );
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn deferred_disable_ignores_stop_failure_but_checks_disable() {
+        let systemd = systemd(vec![
+            spawn_error(
+                &["stop", "--no-block", "anolisa.service"],
+                io::ErrorKind::NotFound,
+            ),
+            call(&["disable", "anolisa.service"], Some(0), "", ""),
+        ]);
+
+        systemd
+            .disable_unit_deferred("anolisa.service")
+            .expect("disable is authoritative");
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn deferred_disable_confirms_missing_unit_from_status() {
+        let systemd = systemd(vec![
+            call(
+                &["stop", "--no-block", "missing.service"],
+                Some(5),
+                "",
+                "Unit missing.service not loaded.\n",
+            ),
+            call(
+                &["disable", "missing.service"],
+                Some(1),
+                "",
+                "Failed to disable unit: Unit file missing.service does not exist.\n",
+            ),
+            call(
+                &[
+                    "show",
+                    "missing.service",
+                    "--no-pager",
+                    "--property=LoadState,ActiveState,UnitFileState,Description",
+                ],
+                Some(0),
+                "LoadState=not-found\nActiveState=inactive\nUnitFileState=\nDescription=missing.service\n",
+                "",
+            ),
+        ]);
+
+        assert!(matches!(
+            systemd.disable_unit_deferred("missing.service"),
+            Err(SystemdError::NotFound(unit)) if unit == "missing.service"
+        ));
+        assert_finished(&systemd);
     }
 }


### PR DESCRIPTION
## Why

Systemd operations currently spawn `systemctl` directly and collapse spawn failures,
non-zero exits, and unit state into string-based errors. This first R4 slice introduces
an injectable process boundary so system service behavior can be tested without mutating
the host while retaining structured failure evidence.

## What changed

- Add `Systemd<R: CommandRunner>` with the real runner used in production.
- Preserve operation, unit, exit code, stdout, and stderr in typed systemd failures.
- Migrate system-helper status and telemetry enable/disable callers to the boundary.
- Add fake-runner tests for status parsing, missing units, spawn failures, non-zero exits,
  and deferred disable behavior.

## Related issue

no-issue: bounded R4 refactoring slice with no user-facing feature request

## User / Agent impact

Normal enable, disable, and status command arguments remain unchanged. If `systemctl`
cannot be spawned, system-helper status now reports `unknown` instead of misclassifying
the host failure as a failed unit. Systemctl diagnostics are normalized with `LC_ALL=C`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The systemctl argv and success-path parsing are unchanged. The source-level
API change is limited to the unpublished `anolisa-platform` workspace crate, and every
repository caller is migrated in this change. The checked item records the corrected
`failed` to `unknown` status classification for process-spawn failures.

## Validation

Validated on Linux from `src/anolisa`:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`

The workspace tests include ten isolated systemd boundary tests. No privileged host
service mutation was performed.

## Documentation and rollback

No documentation changes are included because this is an internal refactoring slice.
Rollback is a direct revert of this commit; no state or configuration migration is needed.
