### PR TITLE
fix(tokenless): surface schema compression skips on tool-less BeforeModel

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -54,6 +54,12 @@ Compress a JSON array:
 cat tools.json | tokenless compress-schema --batch
 ```
 
+Accepted item shapes (detected per item):
+
+- OpenAI function wrapper: `{"function": {"name", "description", "parameters"}}`
+- Direct schema: `{"name", "description", "parameters"}`
+- Gemini / copilot-shell wrapper: `{"functionDeclarations": [{"name", "description", "parameters" | "parametersJsonSchema"}, ...]}`; copilot-shell BeforeModel hooks deliver tool declarations in this shape (`llm_request.config.tools`). Declarations inside the wrapper are compressed individually (the parameter schema is read from `parametersJsonSchema` when present, otherwise from `parameters`); the wrapper itself and any sibling fields are preserved.
+
 An array input enables batch handling automatically. Common options:
 
 | Option | Description |

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -18,9 +18,11 @@ Python framework package that application developers install and register explic
 | Codex | `codex` | Hard-disabled | Replaces supported shell input | Keeps the original and adds analysis or a compressed alternative | Used to build that alternative | — |
 | DeepSeek Harness | `dsh` | — | — | Replaces an accepted single-text JSON result when the replacement is smaller | — | — |
 | OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
-| Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | ✅ |
+| Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
 
-“—” means that the current adapter does not register that capability. The corresponding Tokenless CLI command may still be available.
+“—” means that the capability is not available: the current adapter does not register it, or current host releases do not run it. The corresponding Tokenless CLI command may still be available.
+
+Schema compression reaches the model path differently per host: cosh and Cosh-NG fire the `BeforeModel` hook; OpenCode compresses each tool definition through its `tool.definition` plugin hook (MCP tools do not pass through that hook); Qwen Code's manifest declares a `BeforeModel` hook, but current Qwen Code releases skip that unknown event name at registration, so the schema hook does not run there and the matrix marks it unavailable. The entry stays registered, so a future Qwen Code release that implements the event picks it up automatically.
 
 Tool Ready remains registered by these adapters but is unconditionally hard-disabled before checking, repair, or blocking. No runtime setting can re-enable it. Post-tool failure attribution is independent.
 

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -120,6 +120,44 @@ Confirm that `TOKENLESS_STATS_ENABLED=0` is not set unexpectedly and that any
 custom database path remains under the real user home or selected data
 directory.
 
+## Schema compression produces no statistics
+
+How schema compression plugs in depends on the host:
+
+- **cosh and Cosh-NG** run it on the `BeforeModel` hook before every model call; the warnings in this section come from that hook.
+- **OpenCode** runs it per tool definition through its `tool.definition` plugin hook, not through `BeforeModel`. MCP tools do not pass through that hook, so an MCP-only tool set produces no records there, and the `BeforeModel` warnings below never apply.
+- **Qwen Code** ships a `BeforeModel` hook entry in the extension manifest, but current Qwen Code releases do not implement that hook event: the hook registry skips unknown event names, so only the other hook groups are registered and the schema hook never runs. Zero `compress-schema` records on Qwen Code are expected; this section cannot diagnose them.
+
+When there are no `compress-schema` records on a host that actually runs the hook, check the following in order:
+
+### 1. Confirm there is something to compress
+
+Statistics only record invocations that save tokens; a result that is not smaller than the original is not recorded. Built-in tool descriptions are usually short (below the 256-character function and 160-character parameter truncation thresholds, with no `title` or `examples` to remove), so compression yields no savings and zero records are expected. Verify directly with the current tool declarations — replace the sample array below with your real declarations (a valid JSON array; do not keep any placeholder text, angle brackets, or surrounding quotes):
+
+```bash
+echo '[{"name":"example_tool","description":"A deliberately long example tool description that exceeds the 256-character truncation threshold so schema compression has something to remove. A deliberately long example tool description that exceeds the 256-character truncation threshold so schema compression has something to remove."}]' | tokenless compress-schema --batch
+```
+
+If stderr shows `did not reduce size`, the current tool set has nothing to compress; tool sets with long descriptions (for example some MCP tools) record normally.
+
+### 2. Confirm the BeforeModel hook actually fires
+
+On cosh and Cosh-NG, when a BeforeModel event carries nothing schema compression can work on, the hook emits one of the following warnings (each at most once per session) and passes the request through unchanged:
+
+```text
+[tokenless] WARNING: BeforeModel payload is not a JSON object ...
+[tokenless] WARNING: BeforeModel payload carries no llm_request object ...
+[tokenless] WARNING: BeforeModel event carries no tool declarations ...
+```
+
+The first warning means the hook received a payload that is not a JSON object; the second means the payload carries no `llm_request` object; the third means the host fires BeforeModel but its event format carries no tool declarations (`llm_request.config.tools` or `llm_request.tools`) — check or upgrade the host's hook protocol version. With neither a warning nor any records, BeforeModel is not firing at all:
+
+- The extension or plugin is installed and enabled (`anolisa adapter status tokenless`).
+- Hooks are not disabled in the host configuration.
+- The host version supports the BeforeModel event.
+
+Then continue with the generic steps in [No statistics appear after enabling the adapter](#no-statistics-appear-after-enabling-the-adapter).
+
 ## Adapter enable fails
 
 Common causes:

--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -71,7 +71,7 @@ for the state and concurrency contract.
 
 | Capability | Behavior implemented in the current code | Important boundary |
 |------------|------------------------------------------|--------------------|
-| Schema compression | Removes `title` and `examples`, removes fenced and inline code from descriptions, collapses whitespace, and truncates descriptions | Only available through the cosh and Qwen Code schema hooks; other users can call the CLI |
+| Schema compression | Removes `title` and `examples`, removes fenced and inline code from descriptions, collapses whitespace, and truncates descriptions | Runs on the cosh/Cosh-NG `BeforeModel` hook and per OpenCode tool definition (Qwen Code's manifest entry is skipped by current hosts); other users can call the CLI |
 | Response compression | Removes exact, case-sensitive debug-field names, `null`, empty strings/arrays/objects, and truncates values past configured limits | Accepts JSON; content-retrieval tools are intentionally skipped by adapters |
 | TOON encoding | Encodes JSON and keeps the JSON input when the estimated token count does not decrease | Whether TOON replaces or accompanies the original depends on the adapter |
 | Command rewriting | Calls `rtk rewrite` and submits the rewritten shell input when a rule is available | The command actually sent to the shell changes; unsupported or denied rewrites pass through |
@@ -90,7 +90,7 @@ After the tool: response compression → optional Stash → TOON encoding → st
 Before the model: schema compression
 ```
 
-This is a capability map, not a pipeline that every framework runs. For example, OpenClaw disables TOON by default, Codex adds compressed context instead of replacing the original tool result, and only cosh and Qwen Code register schema compression. See [Framework integration](framework-integration.md).
+This is a capability map, not a pipeline that every framework runs. For example, OpenClaw disables TOON by default, Codex adds compressed context instead of replacing the original tool result, and schema compression only runs on cosh/Cosh-NG (`BeforeModel` hook) and OpenCode (per tool definition). See [Framework integration](framework-integration.md).
 
 ## Behaviors to understand
 
@@ -170,6 +170,7 @@ Command rewriting also changes the shell command submitted by the host. Most ada
 | Inspect savings or content changes, or run a dual comparison | [Measuring savings](measuring-savings.md) |
 | Change settings or understand local data | [Configuration and data privacy](configuration-and-privacy.md) |
 | Fix missing statistics, adapter, or Stash issues | [Troubleshooting](troubleshooting.md) |
+| Diagnose missing schema-compression records | [Troubleshooting · Schema compression produces no statistics](troubleshooting.md#schema-compression-produces-no-statistics) |
 | Upgrade or uninstall | [Troubleshooting · Upgrade and uninstall](troubleshooting.md#upgrade-and-uninstall) |
 
 ## Recommended rollout

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -54,6 +54,12 @@ tokenless compress-schema -f tool.json
 cat tools.json | tokenless compress-schema --batch
 ```
 
+接受的输入条目形态（按条目自动识别）：
+
+- OpenAI function 包装：`{"function": {"name", "description", "parameters"}}`
+- 直接 Schema：`{"name", "description", "parameters"}`
+- Gemini / copilot-shell 包装：`{"functionDeclarations": [{"name", "description", "parameters" | "parametersJsonSchema"}, ...]}`；copilot-shell 的 BeforeModel hook 以该形态下发工具声明（`llm_request.config.tools`）。包装内的声明逐个压缩（参数 schema 优先取 `parametersJsonSchema`，其次取 `parameters`），包装本身及其同级字段原样保留。
+
 输入本身是数组时会自动使用 batch 处理。常用参数：
 
 | 参数 | 说明 |

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -18,9 +18,11 @@ Python 框架包。
 | Codex | `codex` | 已硬关闭 | 替换受支持的 Shell 输入 | 保留原文，追加分析或压缩备选内容 | 用于生成该备选内容 | — |
 | DeepSeek Harness | `dsh` | 未注册 | 未注册 | 只在结果更小时替换已接受的单文本块 JSON 结果 | 未注册 | 未注册 |
 | OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
-| Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | ✅ |
+| Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
 
-“—”表示当前 Adapter 没有注册此能力；对应的 Tokenless CLI 命令仍可能可用。
+“—”表示该能力不可用：当前 Adapter 没有注册，或当前宿主版本不会运行；对应的 Tokenless CLI 命令仍可能可用。
+
+Schema 压缩到达模型路径的方式因宿主而异：cosh 与 Cosh-NG 触发 `BeforeModel` Hook；OpenCode 通过其 `tool.definition` 插件 Hook 逐个压缩工具定义（MCP 工具不经过该 Hook）；Qwen Code 的清单声明了 `BeforeModel` Hook，但当前 Qwen Code 版本在注册时会跳过这一未知事件名，Schema Hook 实际不会运行，因此矩阵标记为不可用。该条目保留注册，未来 Qwen Code 版本实现该事件后会自动生效。
 
 这些 Adapter 仍会注册 Tool Ready，但会在检查、修复或阻断之前无条件硬退出，任何运行时设置都无法重新启用。工具执行后的失败归因不受影响。
 

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -116,6 +116,44 @@ env | grep '^TOKENLESS_'
 
 确认没有意外设置 `TOKENLESS_STATS_ENABLED=0`，并检查自定义数据库路径是否仍位于真实用户 home 或选定的数据目录下。
 
+## Schema 压缩没有统计记录
+
+Schema 压缩的接入方式因宿主而异：
+
+- **cosh 与 Cosh-NG**：通过 `BeforeModel` Hook 在每次模型调用前运行；本节的告警来自该 Hook。
+- **OpenCode**：通过其 `tool.definition` 插件 Hook 逐个压缩工具定义，不走 `BeforeModel`。MCP 工具不经过该 Hook，因此工具集只有 MCP 工具时不会有记录，下面的 `BeforeModel` 告警也不适用。
+- **Qwen Code**：扩展清单里带有 `BeforeModel` Hook 条目，但当前 Qwen Code 版本未实现该 Hook 事件：其 Hook 注册器会跳过未知事件名，实际只注册其余 Hook 组，Schema Hook 不会运行。Qwen Code 上没有 `compress-schema` 记录属于预期行为，本节无法用于诊断。
+
+在实际运行该 Hook 的宿主上没有 `compress-schema` 记录时，按以下顺序排查：
+
+### 1. 确认确实有可压缩内容
+
+统计只记录实际产生 Token 节省的调用，压缩结果不比原文更小就不会记录。内置工具的描述通常较短（低于 256 字符函数描述 / 160 字符参数描述的截断阈值，也没有可移除的 `title` 或 `examples`），压缩没有收益，零记录属于预期行为。用当前工具声明直接验证——请把下面的示例数组替换为你的真实工具声明（合法 JSON 数组，不要保留占位文本、尖括号或外侧引号）：
+
+```bash
+echo '[{"name":"example_tool","description":"这是一段刻意写得足够长的示例工具描述，用于演示 Schema 压缩效果，它必须超过函数描述二百五十六个字符的截断阈值，才能产生可记录的压缩收益。这是一段刻意写得足够长的示例工具描述，用于演示 Schema 压缩效果，它必须超过函数描述二百五十六个字符的截断阈值，才能产生可记录的压缩收益。这是一段刻意写得足够长的示例工具描述，用于演示 Schema 压缩效果，它必须超过函数描述二百五十六个字符的截断阈值，才能产生可记录的压缩收益。这是一段刻意写得足够长的示例工具描述，用于演示 Schema 压缩效果，它必须超过函数描述二百五十六个字符的截断阈值，才能产生可记录的压缩收益。"}]' | tokenless compress-schema --batch
+```
+
+如果 stderr 输出 `did not reduce size`，说明当前工具集没有可压缩内容；带有长描述的工具集（例如部分 MCP 工具）会正常产生记录。
+
+### 2. 确认 BeforeModel Hook 已触发
+
+在 cosh 与 Cosh-NG 上，BeforeModel 事件没有可供 Schema 压缩处理的内容时，Hook 会给出以下警告之一（每条均为每个会话最多一次）并原样放行：
+
+```text
+[tokenless] WARNING: BeforeModel payload is not a JSON object ...
+[tokenless] WARNING: BeforeModel payload carries no llm_request object ...
+[tokenless] WARNING: BeforeModel event carries no tool declarations ...
+```
+
+第一条警告表示 Hook 收到的负载不是 JSON 对象；第二条表示负载缺少 `llm_request` 对象；第三条表示宿主已发射 BeforeModel，但事件格式不带工具声明（`llm_request.config.tools` 或 `llm_request.tools`），应升级或检查宿主的 Hook 协议版本。既没有警告也没有记录时，说明 BeforeModel 根本没有触发，确认：
+
+- 扩展或插件已安装并启用（`anolisa adapter status tokenless`）。
+- 宿主配置没有禁用 Hooks。
+- 宿主版本支持 BeforeModel 事件。
+
+之后按[启用后没有产生统计记录](#启用后没有产生统计记录)的通用步骤继续排查。
+
 ## Adapter 启用失败
 
 常见原因：

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -69,7 +69,7 @@ Python API 默认采用可逆 fail-open 策略：请求使用 Stash，但数据�
 
 | 能力 | 当前代码实际执行的行为 | 重要边界 |
 |------|------------------------|----------|
-| Schema 压缩 | 移除 `title` 和 `examples`，删除描述中的围栏代码和行内代码，合并空白并截断描述 | 只有 cosh 和 Qwen Code 注册了 Schema Hook；其他场景可直接调用 CLI |
+| Schema 压缩 | 移除 `title` 和 `examples`，删除描述中的围栏代码和行内代码，合并空白并截断描述 | 通过 cosh/Cosh-NG 的 `BeforeModel` Hook 和 OpenCode 的逐工具定义 Hook 运行（Qwen Code 清单中的条目会被当前宿主跳过）；其他场景可直接调用 CLI |
 | 响应压缩 | 移除名称完全匹配且区分大小写的调试字段、`null`、空字符串/数组/对象，并按配置阈值截断 | 输入必须是 JSON；Adapter 会主动跳过内容读取类工具 |
 | TOON 编码 | 编码 JSON；估算 Token 没有下降时保留 JSON 输入 | TOON 是替换原文还是与原文并存，取决于 Adapter |
 | 命令重写 | 有匹配规则时调用 `rtk rewrite`，再向框架提交改写后的 Shell 输入 | 真正提交给 Shell 的命令会变化；无规则或被拒绝时透传 |
@@ -88,7 +88,7 @@ Python API 默认采用可逆 fail-open 策略：请求使用 Stash，但数据�
 模型调用前：Schema 压缩
 ```
 
-这是能力示意，不是所有框架都会完整执行的固定流水线。例如 OpenClaw 默认关闭 TOON，Codex 追加压缩上下文而不替换原始工具结果，只有 cosh 和 Qwen Code 注册 Schema 压缩。具体见[框架集成](framework-integration.md)。
+这是能力示意，不是所有框架都会完整执行的固定流水线。例如 OpenClaw 默认关闭 TOON，Codex 追加压缩上下文而不替换原始工具结果，Schema 压缩只在 cosh/Cosh-NG（`BeforeModel` Hook）和 OpenCode（逐工具定义）上运行。具体见[框架集成](framework-integration.md)。
 
 ## 需要特别理解的行为
 
@@ -168,6 +168,7 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 | 查看节省或内容变化、做双跑对比 | [效果度量](measuring-savings.md) |
 | 修改配置或了解本地数据 | [配置与数据隐私](configuration-and-privacy.md) |
 | 解决无统计、Adapter 或 Stash 问题 | [故障排查](troubleshooting.md) |
+| 排查 Schema 压缩没有记录 | [故障排查 · Schema 压缩没有统计记录](troubleshooting.md#schema-压缩没有统计记录) |
 | 升级或卸载 | [故障排查 · 升级与卸载](troubleshooting.md#升级与卸载) |
 
 ## 推荐的上线顺序

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_schema_hook.py
@@ -11,10 +11,18 @@ The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 (set by the install action script).
 """
 
+from __future__ import annotations
+
+import contextlib
 import json
 import os
 import subprocess
 import sys
+
+try:  # POSIX hosts (cosh / Cosh-NG) — the platforms these hooks target.
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX fallback keeps best-effort
+    fcntl = None
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -25,6 +33,7 @@ from hook_utils import (
     resolve_agent_id,
     resolve_binary,
     resolve_tool_call_id,
+    secure_write_text,
     skip,
     warn,
 )
@@ -32,6 +41,63 @@ from hook_utils import (
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = resolve_agent_id()
+
+# One marker file holds the session keys that already emitted the "no tool
+# declarations" warning — one key per line, most recent last — so the warning
+# repeats at most once per session even though BeforeModel fires on every
+# model turn. A single-value marker would not survive concurrent sessions
+# under one HOME: session B's first warning would overwrite session A's key
+# and make A warn again on its next turn. The list is bounded (oldest entries
+# trimmed) so it cannot grow without limit; losing an evicted key only
+# re-arms the warning for a long-idle session. All reads and writes of the
+# marker run under the exclusive sidecar lock below: an unlocked
+# read-modify-write lets two hook processes read the same old key set and
+# write back over each other, silently losing one session's key.
+_NO_TOOLS_WARN_MARKER = os.path.join(
+    os.path.expanduser("~"), ".tokenless", ".schema-hook-nowarn-session"
+)
+
+# Best-effort dedup bound: far above any plausible number of concurrently
+# active sessions sharing one HOME.
+_MAX_WARNED_SESSIONS = 64
+
+
+@contextlib.contextmanager
+def _marker_lock():
+    """Exclusive advisory lock guarding the marker read-modify-write.
+
+    Two hook processes warning for different sessions at the same time must
+    not read the same old key set and write back over each other. The lock
+    lives on a dedicated sidecar file that the marker write never replaces,
+    so the locked inode cannot be swapped out mid-section, and the kernel
+    drops an ``flock`` when its holder exits or crashes, so a dead hook
+    process cannot wedge later sessions. On platforms without ``fcntl``, or
+    when the lock file cannot be created, this degrades to the historical
+    unlocked best-effort behaviour instead of failing the warning.
+    """
+    if fcntl is None:
+        yield
+        return
+    lock_path = _NO_TOOLS_WARN_MARKER + ".lock"
+    fd = -1
+    try:
+        os.makedirs(os.path.dirname(lock_path), mode=0o700, exist_ok=True)
+        if os.path.islink(lock_path):
+            os.unlink(lock_path)
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(lock_path, flags, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError:
+        if fd >= 0:
+            os.close(fd)
+        yield  # lock unavailable — keep the unlocked best-effort behaviour
+        return
+    try:
+        yield
+    finally:
+        os.close(fd)
 
 
 # -- helpers -----------------------------------------------------------------
@@ -43,6 +109,100 @@ def _is_json_array(data: str) -> bool:
         return isinstance(obj, list)
     except (json.JSONDecodeError, ValueError):
         return False
+
+
+def _session_warn_key(session_id: str) -> str:
+    """Normalize the session ID into the dedup key for the no-tools warning.
+
+    Hosts that omit a session ID share one key, so the warning still appears
+    at most once for them instead of on every turn.
+    """
+    key = (session_id or "").strip()
+    return key or "<no-session>"
+
+
+def _read_warned_sessions() -> list:
+    """Read the warned session keys (one per line) from the marker file.
+
+    Tolerates a missing or corrupt marker — dedup is best-effort and a miss
+    simply means the session warns once (again).
+    """
+    try:
+        with open(_NO_TOOLS_WARN_MARKER, "r", encoding="utf-8") as handle:
+            return [line.strip() for line in handle if line.strip()]
+    except OSError:
+        return []  # first invocation, or unreadable marker
+    except UnicodeDecodeError:
+        return []  # corrupt marker — rebuild it on the next warning
+
+
+def _should_warn_no_tools(session_id: str) -> bool:
+    """Return True if the no-tools warning has not been emitted for this
+    session yet, and record that it is being emitted now.
+
+    Every warned session key stays in the marker (bounded to the newest
+    ``_MAX_WARNED_SESSIONS`` entries), so concurrent sessions under one HOME
+    do not invalidate each other's dedup state. The check-and-record runs
+    inside ``_marker_lock`` so two first warnings racing for different
+    sessions serialize instead of overwriting each other's keys. Best-effort
+    by design: the marker lives under ``~/.tokenless`` and is read/written
+    with the same hardened helpers as other hook state, but any failure
+    falls back to warning — observability beats silence, and the warning
+    itself never affects the pass-through behaviour.
+    """
+    key = _session_warn_key(session_id)
+    with _marker_lock():
+        warned = _read_warned_sessions()
+        if key in warned:
+            return False
+        warned.append(key)
+        warned = warned[-_MAX_WARNED_SESSIONS:]
+        try:
+            secure_write_text(
+                _NO_TOOLS_WARN_MARKER, "".join(entry + "\n" for entry in warned)
+            )
+        except OSError:
+            pass  # state dir unwritable — still warn this once
+        return True
+
+
+def _skip_with_message(msg: str) -> None:
+    """Pass through unchanged while surfacing ``msg`` to the user.
+
+    ``systemMessage`` is the protocol field both hosts surface for humans:
+    Cosh-NG renders it as a hook notification and copilot-shell records it in
+    its hook log, while neither injects it into the model context. The
+    warning is also printed to stderr so hosts that forward hook stderr get
+    the same text.
+    """
+    warn(msg)
+    print(json.dumps({"systemMessage": msg}))
+    sys.exit(0)
+
+
+def _extract_tools(input_data: dict) -> tuple[object, bool]:
+    """Extract the tool declarations from a BeforeModel payload.
+
+    Returns ``(tools, declared)`` where ``declared`` is True when the host
+    carried a tools field at any known position — even an empty one.
+
+    ``config.tools`` is the canonical position (both copilot-shell's Hook
+    Translator and Cosh-NG put it there); the top-level ``tools`` is the
+    older position, kept for hosts that still emit it. Presence of the
+    canonical key decides, not its truthiness: a host that declares no tools
+    sends an empty canonical array, and falling through to a stale legacy
+    field there would compress declarations this request never carried. This
+    mirrors the host-side precedence.
+    """
+    llm_request = input_data.get("llm_request")
+    if not isinstance(llm_request, dict):
+        return None, False
+    config = llm_request.get("config")
+    if isinstance(config, dict) and "tools" in config:
+        return config["tools"], True
+    if "tools" in llm_request:
+        return llm_request.get("tools"), True
+    return None, False
 
 
 # -- main --------------------------------------------------------------------
@@ -68,21 +228,42 @@ def main() -> None:
     except (json.JSONDecodeError, EOFError, ValueError):
         warn("failed to read BeforeModel payload. Passing through unchanged.")
         skip()
+    if not isinstance(input_data, dict):
+        # No session_id available outside a dict payload — the shared
+        # "<no-session>" key still bounds this to one warning.
+        if _should_warn_no_tools(""):
+            _skip_with_message(
+                "BeforeModel payload is not a JSON object. Passing through "
+                "unchanged (warned once per session)."
+            )
+        skip()
 
-    # 3. Extract tools array. `config.tools` is the canonical position (both
-    # copilot-shell's Hook Translator and Cosh-NG put it there); the top-level
-    # `tools` is the older position, kept for hosts that still emit it.
-    # Presence of the canonical key decides, not its truthiness: a host that
-    # declares no tools sends an empty canonical array, and falling through to
-    # a stale legacy field there would compress declarations this request never
-    # carried. This mirrors the host-side precedence.
-    llm_request = input_data.get("llm_request", {})
-    config = llm_request.get("config")
-    if isinstance(config, dict) and "tools" in config:
-        tools = config["tools"]
-    else:
-        tools = llm_request.get("tools")
+    # 3. Extract tools array.
+    tools, tools_declared = _extract_tools(input_data)
     if not tools:
+        # A host that declares no tools for this turn (empty canonical array)
+        # skips silently — that is a normal request. But a BeforeModel event
+        # with no tools field at any known position means there is nothing
+        # for schema compression to work on. That skip used to be silent, so
+        # "0 schema records" could not be told apart from "hook never ran";
+        # warn once per session instead.
+        if not tools_declared and _should_warn_no_tools(
+            str(input_data.get("session_id", ""))
+        ):
+            if not isinstance(input_data.get("llm_request"), dict):
+                _skip_with_message(
+                    "BeforeModel payload carries no llm_request object, so schema "
+                    "compression cannot find tool declarations. Passing through "
+                    "unchanged (warned once per session)."
+                )
+            else:
+                _skip_with_message(
+                    "BeforeModel event carries no tool declarations at "
+                    "llm_request.config.tools or llm_request.tools, so schema "
+                    "compression was skipped. If the host declares tools, its "
+                    "event format may not match the hook. Passing through "
+                    "unchanged (warned once per session)."
+                )
         skip()
 
     tools_json = json.dumps(tools, separators=(",", ":"))

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -322,6 +322,59 @@ fn compress_schema_batch_mode() {
 }
 
 #[test]
+fn compress_schema_batch_gemini_function_declarations() {
+    // copilot-shell BeforeModel hooks pass Gemini SDK tool entries
+    // ({"functionDeclarations": [...]}). The batch path must compress the
+    // nested declarations and keep the wrapper shape so the host can apply
+    // the rewritten array unchanged.
+    let long_desc = "Run a shell command in the workspace. ".repeat(20);
+    let schemas = serde_json::json!([
+        {
+            "functionDeclarations": [
+                {
+                    "name": "shell",
+                    "description": long_desc,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": long_desc}
+                        }
+                    }
+                }
+            ]
+        }
+    ]);
+    let input = serde_json::to_string(&schemas).unwrap();
+    let output = tokenless_bin()
+        .args(["compress-schema", "--batch"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(output.status.success(), "compress-schema should succeed");
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let decls = &result[0]["functionDeclarations"];
+    assert_eq!(decls[0]["name"], "shell");
+    // Limits are char counts, not byte lengths (the stash marker carries a
+    // multibyte ellipsis).
+    assert!(decls[0]["description"].as_str().unwrap().chars().count() <= 256);
+    let param_desc = decls[0]["parameters"]["properties"]["command"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(param_desc.chars().count() <= 160);
+    assert!(
+        output.stdout.len() < input.len(),
+        "compressed output must be smaller than the input"
+    );
+}
+
+#[test]
 fn compress_response_from_stdin() {
     let response =
         r#"{"data":"value","debug":"remove","trace":"remove","empty_field":"","null_field":null}"#;

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -1033,3 +1033,79 @@ fn test_clear_stash_session_keeps_emitted_markers() {
         "emitted keep-marker payload must survive rollback after clear_stash_session"
     );
 }
+
+#[test]
+fn test_gemini_wrapper_multi_declaration_order_and_titles() {
+    // Multi-declaration wrappers keep declaration names and order, and
+    // declaration-level titles are dropped like in the OpenAI wrapper.
+    let compressor = SchemaCompressor::new();
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": "Run a shell command in the workspace. ".repeat(20),
+                "title": "Shell",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The command line to execute. ".repeat(12)
+                        }
+                    },
+                    "required": ["command"]
+                }
+            },
+            {
+                "name": "read_file",
+                "description": "Read a file. ".repeat(25),
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}}
+                }
+            }
+        ]
+    });
+
+    let result = compressor.compress(&tool);
+
+    let decls = result["functionDeclarations"].as_array().unwrap();
+    assert_eq!(decls.len(), 2);
+    assert_eq!(decls[0]["name"], "shell");
+    assert_eq!(decls[1]["name"], "read_file");
+    // Declaration titles dropped.
+    assert!(decls[0].get("title").is_none());
+    // Protected schema fields preserved.
+    assert_eq!(decls[0]["parameters"]["required"][0], "command");
+    // The rewrite actually shrank the declaration set.
+    assert!(
+        serde_json::to_string(&result).unwrap().len()
+            < serde_json::to_string(&tool).unwrap().len()
+    );
+}
+
+#[test]
+fn test_gemini_malformed_function_declarations_untouched() {
+    // A non-array functionDeclarations value is not a valid wrapper and
+    // must pass through unchanged.
+    let compressor = SchemaCompressor::new();
+    let malformed = json!({"functionDeclarations": {"name": "not-an-array"}});
+    assert_eq!(compressor.compress(&malformed), malformed);
+}
+
+#[test]
+fn test_gemini_wrapper_no_savings_returns_original() {
+    let compressor = SchemaCompressor::new();
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": "Run a shell command.",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        ]
+    });
+
+    // Nothing to compress: the original value is returned unchanged.
+    assert_eq!(compressor.compress(&tool), tool);
+}

--- a/src/tokenless/tests/test_compress_schema_hook.py
+++ b/src/tokenless/tests/test_compress_schema_hook.py
@@ -13,6 +13,7 @@ Uses subprocess to invoke the hook with a mock tokenless binary,
 avoiding Python version issues with the hook_utils module.
 """
 
+import importlib.util
 import json
 import os
 import stat
@@ -21,6 +22,7 @@ import sys
 import shutil
 import tempfile
 import textwrap
+import threading
 import unittest
 
 _TOOLS = [
@@ -33,6 +35,15 @@ _TOOLS = [
         },
     }
 ]
+
+
+def _hook_path() -> str:
+    """Absolute path of compress_schema_hook.py in the shared adapter tree."""
+    hooks_dir = os.path.normpath(os.path.join(
+        os.path.dirname(__file__),
+        os.pardir, "adapters", "tokenless", "common", "hooks",
+    ))
+    return os.path.join(hooks_dir, "compress_schema_hook.py")
 
 
 def _create_mock_tokenless(tmpdir: str, argv_log: str) -> str:
@@ -98,6 +109,35 @@ def _run_hook(stdin_data: dict, mock_tokenless_path: str, extra_env: dict) -> di
         return json.loads(stdout)
     except json.JSONDecodeError:
         return {"_raw_stdout": stdout, "_stderr": proc.stderr}
+
+
+def _run_hook_raw(stdin_text: str, mock_tokenless_path: str, extra_env: dict):
+    """Run the hook as a subprocess and return the CompletedProcess.
+
+    Like ``_run_hook`` but hands back stdout and stderr untouched, for tests
+    that assert on diagnostics rather than only on the hook output JSON.
+    """
+    hooks_dir = os.path.normpath(os.path.join(
+        os.path.dirname(__file__),
+        os.pardir, "adapters", "tokenless", "common", "hooks",
+    ))
+    hook_path = os.path.join(hooks_dir, "compress_schema_hook.py")
+
+    env = os.environ.copy()
+    env.pop("COSH_RUNTIME", None)
+    env.pop("COSH_NG_VERSION", None)
+    env["PATH"] = os.path.dirname(mock_tokenless_path) + ":" + env.get("PATH", "")
+    env.update(extra_env)
+
+    return subprocess.run(
+        [sys.executable, hook_path],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+
 
 
 _needs_py39 = sys.version_info < (3, 9)
@@ -178,13 +218,19 @@ class TestSchemaCompressionProtocol(unittest.TestCase):
         self.assertEqual(result, {})
 
     def test_skips_when_no_tools_present(self):
+        # No tool declarations anywhere: the hook passes through unchanged
+        # but surfaces a once-per-session systemMessage so the silent-skip
+        # era ("0 records, no idea why") is diagnosable.
+        home = os.path.join(self.tmpdir, "home")
+        os.makedirs(home, exist_ok=True)
         result = _run_hook(
             {"session_id": "s1", "llm_request": {"model": "m", "messages": []}},
             self.mock_bin,
-            {"TOKENLESS_AGENT_ID": "copilot-shell"},
+            {"TOKENLESS_AGENT_ID": "copilot-shell", "HOME": home},
         )
 
-        self.assertEqual(result, {})
+        self.assertNotIn("hookSpecificOutput", result)
+        self.assertIn("no tool declarations", result.get("systemMessage", ""))
 
     def test_cosh_ng_runtime_wins_over_manifest_agent_id(self):
         _run_hook(
@@ -207,6 +253,271 @@ class TestSchemaCompressionProtocol(unittest.TestCase):
         )
 
         self.assertEqual(self._recorded_agent_id(), "copilot-shell")
+
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestSchemaHookNoToolsWarning(unittest.TestCase):
+    """The hook must surface — once per session — when a BeforeModel event
+    carries nothing schema compression can work on. The historical silent
+    skip made "0 schema records" indistinguishable from "hook never ran"."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.argv_log = os.path.join(self.tmpdir, "argv.json")
+        self.mock_bin = _create_mock_tokenless(self.tmpdir, self.argv_log)
+        # Isolate ~/.tokenless so the dedup marker never touches real state.
+        self.home = os.path.join(self.tmpdir, "home")
+        os.makedirs(self.home, exist_ok=True)
+        self.env = {"TOKENLESS_AGENT_ID": "copilot-shell", "HOME": self.home}
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _marker_path(self) -> str:
+        return os.path.join(self.home, ".tokenless", ".schema-hook-nowarn-session")
+
+    def test_warns_when_event_carries_no_tools(self):
+        proc = _run_hook_raw(
+            json.dumps({"session_id": "s1", "llm_request": {"model": "m", "messages": []}}),
+            self.mock_bin,
+            self.env,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("no tool declarations", proc.stdout)
+        self.assertIn("no tool declarations", proc.stderr)
+        self.assertNotIn("hookSpecificOutput", proc.stdout)
+        self.assertTrue(os.path.isfile(self._marker_path()))
+
+    def test_warns_when_payload_lacks_llm_request(self):
+        proc = _run_hook_raw(
+            json.dumps({"session_id": "s1"}),
+            self.mock_bin,
+            self.env,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("no llm_request", proc.stdout)
+        self.assertIn("no llm_request", proc.stderr)
+        self.assertNotIn("hookSpecificOutput", proc.stdout)
+
+    def test_no_tools_warning_deduped_per_session(self):
+        payload = json.dumps(
+            {"session_id": "s1", "llm_request": {"model": "m", "messages": []}}
+        )
+        first = _run_hook_raw(payload, self.mock_bin, self.env)
+        second = _run_hook_raw(payload, self.mock_bin, self.env)
+
+        self.assertIn("no tool declarations", first.stderr)
+        self.assertIn("no tool declarations", first.stdout)
+        self.assertEqual(second.stderr, "")
+        self.assertEqual(second.stdout.strip(), "{}")
+
+        # A different session warns again.
+        other = _run_hook_raw(
+            json.dumps(
+                {"session_id": "s2", "llm_request": {"model": "m", "messages": []}}
+            ),
+            self.mock_bin,
+            self.env,
+        )
+        self.assertIn("no tool declarations", other.stderr)
+
+    def test_empty_canonical_tools_skips_silently(self):
+        proc = _run_hook_raw(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "llm_request": {"model": "m", "config": {"tools": []}},
+                }
+            ),
+            self.mock_bin,
+            self.env,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "{}")
+        self.assertEqual(proc.stderr, "")
+        self.assertFalse(os.path.exists(self._marker_path()))
+
+    def test_no_warning_when_tools_present(self):
+        proc = _run_hook_raw(
+            json.dumps(
+                {
+                    "session_id": "s1",
+                    "llm_request": {"model": "m", "config": {"tools": _TOOLS}},
+                }
+            ),
+            self.mock_bin,
+            self.env,
+        )
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertNotIn("WARNING", proc.stderr)
+        self.assertFalse(os.path.exists(self._marker_path()))
+
+    def test_non_object_payload_warns_and_passes_through(self):
+        proc = _run_hook_raw("[1, 2, 3]", self.mock_bin, self.env)
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("not a JSON object", proc.stdout)
+        self.assertIn("not a JSON object", proc.stderr)
+
+    def test_concurrent_sessions_do_not_invalidate_each_other(self):
+        # Two sessions under the same HOME warn in turn; afterwards both must
+        # stay silent. With a single-value marker, session B's warning would
+        # overwrite session A's key and make A warn again on its next turn.
+        payload_a = json.dumps(
+            {"session_id": "s-a", "llm_request": {"model": "m", "messages": []}}
+        )
+        payload_b = json.dumps(
+            {"session_id": "s-b", "llm_request": {"model": "m", "messages": []}}
+        )
+
+        first_a = _run_hook_raw(payload_a, self.mock_bin, self.env)
+        first_b = _run_hook_raw(payload_b, self.mock_bin, self.env)
+        second_a = _run_hook_raw(payload_a, self.mock_bin, self.env)
+        second_b = _run_hook_raw(payload_b, self.mock_bin, self.env)
+
+        self.assertIn("no tool declarations", first_a.stderr)
+        self.assertIn("no tool declarations", first_b.stderr)
+        self.assertEqual(second_a.stderr, "")
+        self.assertEqual(second_a.stdout.strip(), "{}")
+        self.assertEqual(second_b.stderr, "")
+        self.assertEqual(second_b.stdout.strip(), "{}")
+
+    def test_marker_bounded_to_recent_sessions(self):
+        # The marker keeps one key per line, bounded to the newest entries:
+        # eviction trims the oldest keys, so active sessions keep their state
+        # and the file cannot grow without limit.
+        marker = self._marker_path()
+        os.makedirs(os.path.dirname(marker), exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as handle:
+            for index in range(100):
+                handle.write("old-%d\n" % index)
+
+        proc = _run_hook_raw(
+            json.dumps(
+                {"session_id": "s-new", "llm_request": {"model": "m", "messages": []}}
+            ),
+            self.mock_bin,
+            self.env,
+        )
+
+        self.assertIn("no tool declarations", proc.stderr)
+        with open(marker, encoding="utf-8") as handle:
+            keys = [line.strip() for line in handle if line.strip()]
+        self.assertLessEqual(len(keys), 64)
+        self.assertEqual(keys[-1], "s-new")
+        self.assertIn("old-99", keys)  # newest seeded entries survive
+        self.assertNotIn("old-0", keys)  # oldest entries are trimmed first
+
+    def test_racing_first_warnings_are_serialized_by_marker_lock(self):
+        # Forced read-read-write-write interleave: a barrier inside the read
+        # makes both workers finish reading before either may write. With an
+        # unlocked read-modify-write both then write back over each other and
+        # one session key is lost. The marker lock must serialize the pair:
+        # the blocked worker cannot reach its read until the first write has
+        # landed, the barrier breaks, and both keys survive.
+        spec = importlib.util.spec_from_file_location(
+            "compress_schema_hook_under_test", _hook_path()
+        )
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+        hook._NO_TOOLS_WARN_MARKER = self._marker_path()
+
+        barrier = threading.Barrier(2, timeout=2)
+        real_read = hook._read_warned_sessions
+
+        def synchronized_read():
+            keys = real_read()
+            try:
+                barrier.wait()
+            except threading.BrokenBarrierError:
+                pass  # the lock kept the second worker out — expected
+            return keys
+
+        hook._read_warned_sessions = synchronized_read
+        results = {}
+
+        def worker(session_id):
+            results[session_id] = hook._should_warn_no_tools(session_id)
+
+        threads = [
+            threading.Thread(target=worker, args=(session_id,))
+            for session_id in ("race-a", "race-b")
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15)
+        hook._read_warned_sessions = real_read
+
+        for thread in threads:
+            self.assertFalse(thread.is_alive(), "worker wedged on marker lock")
+        self.assertEqual(results, {"race-a": True, "race-b": True})
+        with open(self._marker_path(), encoding="utf-8") as handle:
+            keys = sorted(line.strip() for line in handle if line.strip())
+        self.assertEqual(keys, ["race-a", "race-b"])
+        # Both recorded sessions stay silent on their next turn.
+        self.assertFalse(hook._should_warn_no_tools("race-a"))
+        self.assertFalse(hook._should_warn_no_tools("race-b"))
+
+    def test_parallel_hook_processes_keep_every_session_key(self):
+        # True concurrency across processes: several hook invocations warn
+        # for distinct sessions at the same time. Every session key must
+        # survive the parallel first warnings and stay silent afterwards,
+        # which the historical sequential A/B/A/B coverage never exercised.
+        session_ids = ["par-a", "par-b", "par-c", "par-d", "par-e", "par-f"]
+        payloads = {
+            session_id: json.dumps(
+                {
+                    "session_id": session_id,
+                    "llm_request": {"model": "m", "messages": []},
+                }
+            )
+            for session_id in session_ids
+        }
+
+        env = os.environ.copy()
+        env.pop("COSH_RUNTIME", None)
+        env.pop("COSH_NG_VERSION", None)
+        env["PATH"] = os.path.dirname(self.mock_bin) + ":" + env.get("PATH", "")
+        env.update(self.env)
+
+        procs = [
+            subprocess.Popen(
+                [sys.executable, _hook_path()],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            for _ in session_ids
+        ]
+        outputs = {
+            session_id: proc.communicate(input=payloads[session_id], timeout=30)
+            for session_id, proc in zip(session_ids, procs)
+        }
+        for session_id, proc in zip(session_ids, procs):
+            self.assertEqual(proc.returncode, 0, outputs[session_id][1])
+            self.assertIn(
+                "no tool declarations",
+                outputs[session_id][1],
+                "session %s should warn exactly once" % session_id,
+            )
+
+        with open(self._marker_path(), encoding="utf-8") as handle:
+            keys = {line.strip() for line in handle if line.strip()}
+        self.assertEqual(keys, set(session_ids))
+
+        for session_id in session_ids:
+            repeat = _run_hook_raw(payloads[session_id], self.mock_bin, self.env)
+            self.assertEqual(repeat.stderr, "", "session %s warned twice" % session_id)
+            self.assertEqual(repeat.stdout.strip(), "{}")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 改动说明

让 Schema 压缩 BeforeModel Hook 的跳过路径可诊断，并补充 Gemini 包装形态的增量测试与文档。

**范围说明**：Gemini `functionDeclarations` 包装的压缩器核心已由 #2663（`625f0779`）合入 main，本 PR 不包含该部分，仅保留 main 未覆盖的增量测试与文档（详见文末 rebase 记录）。

### 背景

统计只记录有实际 Token 节省的调用；而「事件不携带工具声明 / 负载不可解析」的跳过路径此前完全静默，「0 条 compress-schema 记录」无法与「Hook 未触发」区分，现场曾误判「cosh 没有发射 BeforeModel」。copilot-shell 的 Gemini 工具形态零收益问题（核心缺陷）已由 main 的 #2663 修复；本 PR 针对的是跳过路径的可诊断化。

### 变更内容

**A. 静默跳过可诊断化（Python hook）**

- BeforeModel payload 不是 JSON 对象、缺少 `llm_request`，或在 canonical / legacy 位置均找不到工具声明时，给出每会话一次的警告（stderr + Hook 输出 `systemMessage`，失败仍放行）；合法的空 canonical tools 数组保持静默；
- marker 记录有界的已告警 session key 集合（最新在最后，超限裁最旧），其读改写整体由专用 sidecar 锁文件上的独占 flock 串行化——同一 HOME 下并发会话的首次告警不再互相覆盖 key（修复前强制交错可 20/20 复现丢 key）；无 fcntl 平台或锁文件创建失败时退回无锁 best-effort 语义；
- 解析逻辑抽取为 `_extract_tools()`，canonical 优先、legacy 回退的既有行为不变，并加固非 dict payload；
- 新增 8 个 hook 测试：协议位置与透传、三类警告与按会话去重、marker 有界裁剪、barrier 强制 read-read-write-write 交错的并发回归、6 进程并行首次告警；
- troubleshooting 文档新增「Schema 压缩没有统计记录」小节，按宿主准确描述 Schema 压缩接入方式：cosh/Cosh-NG 经 BeforeModel；OpenCode 经 `tool.definition` 插件 Hook（MCP 工具不经过）；Qwen Code 的清单声明了 BeforeModel 条目，但当前版本宿主注册器跳过未知事件名，Hook 不运行、零记录为预期；user-manual 任务索引与能力表、framework-integration 支持矩阵与图例同步与同一事实对齐；均含中文镜像。

**B. Gemini 包装形态增量测试与文档（核心已在 main）**

- 3 个补充单元测试：多声明包装保持名称/顺序并移除声明级 title；非数组 `functionDeclarations` 原样放行；零收益包装返回原值；
- `compress-schema --batch` Gemini 包装形态 CLI 集成测试；
- CLI 参考文档（中/英）输入形态说明（含 `parametersJsonSchema` 变体）。

**宿主侧写回（已由当前 base 解决）**：此前 copilot-shell 的 `fromHookLLMRequest` 不会把 hook 返回的 `config.tools` 写回实际请求。当前 base 已包含 `afd3ff58`（fix(cosh): merge hook-modified tools into request）：override 白名单加入 `tools`，BeforeModel hook 改写后的工具集随其余 override 字段一起写回请求。reviewer 已实测确认压缩结果在 copilot-shell 上正常生效（stats 记录亦正常），无需再在宿主侧另行修复。

## 测试情况

**实际执行的命令与结果（当前 HEAD）**：

- `cargo test -p tokenless-schema`：26 passed / 0 failed（含本 PR 新增 Gemini 包装单元测试）
- `cargo test -p tokenless-cli --test cli_integration`：39 passed / 0 failed（含本 PR 新增 Gemini 包装 CLI 集成测试）
- Python hook 测试：`test_compress_schema_hook` 17/17（Python 3.9 与 3.12 双版本）、`test_compress_response_hook` 24/24、`test_resolve_agent_id` 7/7；`py_compile` 对 Python 3.8 / 3.9 / 3.12 通过
- 文档门禁：`scripts/docs-lint.sh`（命名规范 / en-zh 目录一致性）、`scripts/docs-link-check.py` 通过

**复现问题 → 验证修复（真实 hook + 隔离 HOME）**：

- 无工具声明负载：修复前完全静默；修复后首次给出 stderr + systemMessage 警告，同会话去重，新会话重新告警；合法空 tools 数组保持静默；
- 并发竞态：barrier 强制 read-read-write-write 交错下，修复前 20/20 次丢失一个 session key（丢失的会话下一轮重复告警），修复后 0/20；临时禁用锁时新增回归测试按预期失败（回归捕捉有效）；
- 6 个 hook 进程并行首次告警：全部 session key 保留，第二轮全部静默。

**环境概要**：Linux x86_64；Rust/cargo 1.94.1；Python 3.8.17 / 3.9.21 / 3.12.9。

**未运行项及原因**：

- 真实 cosh / Cosh-NG / Qwen Code / OpenCode 会话联调：本环境无法启动真实 LLM 会话；宿主事件发射与载荷形态通过阅读宿主源码并以逐字段一致的 payload 等价验证；
- `test_rewrite_hook`（11 项）等既有失败为本机已安装真实 rtk 二进制干扰导致的既有环境性失败，干净基线上同样失败，与本 PR 无关。

---

> ## Rebase 记录（2026-08-19）
>
> 分支已 rebase 到最新 `main`（`2c95e53b`），`schema_compressor.rs` 的合并冲突已解决，force-push 完成。
>
> **冲突根因**：main 已合入同功能的并行实现 `625f0779`（feat(tokenless): compress Gemini tool schemas，含 `parametersJsonSchema` 支持）。rebase 时压缩器核心改动以 main 版本为准，原提交改写为 `test(tokenless): cover Gemini wrapper edge cases and document input shapes`，仅保留 main 未覆盖的增量：
>
> - 3 个补充单元测试：多声明包装保持名称/顺序并移除声明级 title、非数组 `functionDeclarations` 原样放行、零收益包装返回原值；
> - `compress-schema --batch` 的 Gemini 包装形态 CLI 集成测试；
> - CLI 参考文档（中/英）输入形态说明（含 `parametersJsonSchema` 变体）。
>
> **rebase 后重新执行的验证（全部通过）**：`cargo fmt --check`、`cargo clippy --workspace --all-targets -- -D warnings`、`cargo test --workspace`（585 passed / 0 failed / 2 ignored，含上述新增测试）、Python hook 测试（test_compress_schema_hook 15 + test_compress_response_hook 24 + test_resolve_agent_id 7，共 46 项通过）、hook 文件 py_compile（Python 3.8 / 3.12）、`scripts/docs-lint.sh` 与 `scripts/docs-link-check.py`。CI 在新 HEAD 上全绿（Test tokenless 通过，其余组件检查因未改动按变更检测跳过）。
>
> 以下为本 PR 原始说明（描述 rebase 前的完整改动背景）。
