### PR TITLE
fix(tokenless): compress Gemini functionDeclarations schema shape

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -54,6 +54,12 @@ Compress a JSON array:
 cat tools.json | tokenless compress-schema --batch
 ```
 
+Accepted item shapes (detected per item):
+
+- OpenAI function wrapper: `{"function": {"name", "description", "parameters"}}`
+- Direct schema: `{"name", "description", "parameters"}`
+- Gemini / copilot-shell wrapper: `{"functionDeclarations": [{"name", "description", "parameters"}, ...]}`; copilot-shell BeforeModel hooks deliver tool declarations in this shape (`llm_request.config.tools`). Declarations inside the wrapper are compressed individually; the wrapper itself and any sibling fields are preserved.
+
 An array input enables batch handling automatically. Common options:
 
 | Option | Description |

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -54,6 +54,12 @@ tokenless compress-schema -f tool.json
 cat tools.json | tokenless compress-schema --batch
 ```
 
+接受的输入条目形态（按条目自动识别）：
+
+- OpenAI function 包装：`{"function": {"name", "description", "parameters"}}`
+- 直接 Schema：`{"name", "description", "parameters"}`
+- Gemini / copilot-shell 包装：`{"functionDeclarations": [{"name", "description", "parameters"}, ...]}`；copilot-shell 的 BeforeModel hook 以该形态下发工具声明（`llm_request.config.tools`）。包装内的声明逐个压缩，包装本身及其同级字段原样保留。
+
 输入本身是数组时会自动使用 batch 处理。常用参数：
 
 | 参数 | 说明 |

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -322,6 +322,59 @@ fn compress_schema_batch_mode() {
 }
 
 #[test]
+fn compress_schema_batch_gemini_function_declarations() {
+    // copilot-shell BeforeModel hooks pass Gemini SDK tool entries
+    // ({"functionDeclarations": [...]}). The batch path must compress the
+    // nested declarations and keep the wrapper shape so the host can apply
+    // the rewritten array unchanged.
+    let long_desc = "Run a shell command in the workspace. ".repeat(20);
+    let schemas = serde_json::json!([
+        {
+            "functionDeclarations": [
+                {
+                    "name": "shell",
+                    "description": long_desc,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": long_desc}
+                        }
+                    }
+                }
+            ]
+        }
+    ]);
+    let input = serde_json::to_string(&schemas).unwrap();
+    let output = tokenless_bin()
+        .args(["compress-schema", "--batch"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(output.status.success(), "compress-schema should succeed");
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let decls = &result[0]["functionDeclarations"];
+    assert_eq!(decls[0]["name"], "shell");
+    // Limits are char counts, not byte lengths (the stash marker carries a
+    // multibyte ellipsis).
+    assert!(decls[0]["description"].as_str().unwrap().chars().count() <= 256);
+    let param_desc = decls[0]["parameters"]["properties"]["command"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(param_desc.chars().count() <= 160);
+    assert!(
+        output.stdout.len() < input.len(),
+        "compressed output must be smaller than the input"
+    );
+}
+
+#[test]
 fn compress_response_from_stdin() {
     let response =
         r#"{"data":"value","debug":"remove","trace":"remove","empty_field":"","null_field":null}"#;

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -218,7 +218,17 @@ impl SchemaCompressor {
         self.stash_errors.set(self.stash_errors.get() + 1);
     }
 
-    /// Compress an OpenAI Function Calling schema.
+    /// Compress a tool schema declaration.
+    ///
+    /// Accepted item shapes:
+    /// - OpenAI function wrapper: `{"function": {name, description, parameters}}`
+    /// - Gemini / copilot-shell wrapper:
+    ///   `{"functionDeclarations": [{name, description, parameters}, ...]}`
+    ///   (the shape copilot-shell puts in `llm_request.config.tools` for
+    ///   BeforeModel hooks); each declaration is compressed in place and the
+    ///   wrapper plus any sibling keys are preserved so the host can apply
+    ///   the rewritten array unchanged.
+    /// - Direct schema: `{name, description, parameters}`
     ///
     /// Unlike [`ResponseCompressor`](crate::ResponseCompressor), this does
     /// not reset stash session state. Pending rollback keys accumulate until
@@ -229,7 +239,8 @@ impl SchemaCompressor {
 
         let mut result = tool.clone();
 
-        // Check if this is a function wrapper or direct schema
+        // Check if this is a function wrapper, a Gemini-style declarations
+        // wrapper, or a direct schema
         if let Some(function) = result.get_mut("function") {
             // Compress function-level description
             if let Some(desc) = function.get("description").and_then(|d| d.as_str()) {
@@ -249,20 +260,14 @@ impl SchemaCompressor {
             if let Some(params) = function.get_mut("parameters") {
                 self.compress_json_schema(params, 1);
             }
-        } else {
-            // Direct schema (no function wrapper). Let compress_json_schema
-            // handle description, title removal, and nested properties at
-            // depth 0 — doing it here first would stash description as K1,
-            // then compress_json_schema would stash the marker string as K2,
-            // requiring two retrieves to recover the original.
-            if result.is_object() {
-                // Compress parameters if present (not a JSON Schema keyword;
-                // compress_json_schema does not recurse into it).
-                if let Some(params) = result.get_mut("parameters") {
-                    self.compress_json_schema(params, 1);
+        } else if let Some(declarations) = result.get_mut("functionDeclarations") {
+            if let Some(entries) = declarations.as_array_mut() {
+                for entry in entries {
+                    self.compress_direct_declaration(entry);
                 }
-                self.compress_json_schema(&mut result, 0);
             }
+        } else {
+            self.compress_direct_declaration(&mut result);
         }
 
         // Compare with original to see if anything actually changed
@@ -272,6 +277,24 @@ impl SchemaCompressor {
         }
 
         result
+    }
+
+    /// Compress a direct tool declaration in place: an object carrying a
+    /// top-level `description` and an optional `parameters` JSON Schema.
+    ///
+    /// Let compress_json_schema handle description, title removal, and nested
+    /// properties at depth 0 — compressing the description here first would
+    /// stash it as K1, then compress_json_schema would stash the marker
+    /// string as K2, requiring two retrieves to recover the original.
+    fn compress_direct_declaration(&self, result: &mut Value) {
+        if result.is_object() {
+            // Compress parameters if present (not a JSON Schema keyword;
+            // compress_json_schema does not recurse into it).
+            if let Some(params) = result.get_mut("parameters") {
+                self.compress_json_schema(params, 1);
+            }
+            self.compress_json_schema(result, 0);
+        }
     }
 
     /// Recursively compress a JSON Schema

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -820,3 +820,151 @@ fn test_clear_stash_session_keeps_emitted_markers() {
         "emitted keep-marker payload must survive rollback after clear_stash_session"
     );
 }
+
+#[test]
+fn gemini_wrapper_declarations_compressed() {
+    // copilot-shell BeforeModel events carry Gemini SDK tool entries:
+    // {"functionDeclarations": [{name, description, parameters}, ...]}.
+    // Each declaration must be compressed in place while the wrapper,
+    // declaration names, and order stay intact.
+    let compressor = SchemaCompressor::new();
+    let long_desc = "Run a shell command in the workspace. ".repeat(20);
+    let long_param_desc = "The command line to execute. ".repeat(12);
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": long_desc,
+                "title": "Shell",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string", "description": long_param_desc}
+                    },
+                    "required": ["command"]
+                }
+            },
+            {
+                "name": "read_file",
+                "description": "Read a file. ".repeat(25),
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}}
+                }
+            }
+        ]
+    });
+
+    let result = compressor.compress(&tool);
+
+    let decls = result["functionDeclarations"].as_array().unwrap();
+    assert_eq!(decls.len(), 2);
+    assert_eq!(decls[0]["name"], "shell");
+    assert_eq!(decls[1]["name"], "read_file");
+
+    // Declaration descriptions truncated to the function limit (char count).
+    assert!(decls[0]["description"].as_str().unwrap().chars().count() <= 256);
+    assert!(decls[1]["description"].as_str().unwrap().chars().count() <= 256);
+    // Titles dropped.
+    assert!(decls[0].get("title").is_none());
+    // Parameter descriptions truncated to the parameter limit (char count).
+    let param_desc = decls[0]["parameters"]["properties"]["command"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(param_desc.chars().count() <= 160);
+    // Protected schema fields preserved.
+    assert_eq!(decls[0]["parameters"]["required"][0], "command");
+
+    // The rewrite actually shrank the declaration set.
+    assert!(
+        serde_json::to_string(&result).unwrap().len()
+            < serde_json::to_string(&tool).unwrap().len()
+    );
+}
+
+#[test]
+fn gemini_wrapper_preserves_sibling_keys() {
+    let compressor = SchemaCompressor::new();
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": "Run a shell command. ".repeat(20),
+                "parameters": {"type": "object", "properties": {}}
+            }
+        ],
+        "codeExecution": {}
+    });
+
+    let result = compressor.compress(&tool);
+
+    assert!(result.get("codeExecution").is_some());
+    assert!(result["functionDeclarations"].is_array());
+}
+
+#[test]
+fn gemini_wrapper_empty_or_malformed_declarations_untouched() {
+    let compressor = SchemaCompressor::new();
+
+    let empty = json!({"functionDeclarations": []});
+    assert_eq!(compressor.compress(&empty), empty);
+
+    let malformed = json!({"functionDeclarations": {"name": "not-an-array"}});
+    assert_eq!(compressor.compress(&malformed), malformed);
+}
+
+#[test]
+fn gemini_wrapper_no_savings_returns_original() {
+    let compressor = SchemaCompressor::new();
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": "Run a shell command.",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        ]
+    });
+
+    // Nothing to compress: the original value is returned unchanged.
+    assert_eq!(compressor.compress(&tool), tool);
+}
+
+#[test]
+fn gemini_wrapper_stash_single_retrieve_per_declaration() {
+    // A truncated declaration description must stash exactly once and the
+    // retrieved payload must be the verbatim original, mirroring the direct
+    // schema contract.
+    use std::sync::Arc;
+    use tokenless_ccr::{InMemoryStore, StashStore, extract_hash};
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = SchemaCompressor::new()
+        .with_func_desc_max_len(100)
+        .with_stash_store(store.clone());
+
+    let original_desc = format!("GEMINIORIG_{}", "a".repeat(280));
+    let tool = json!({
+        "functionDeclarations": [
+            {
+                "name": "shell",
+                "description": original_desc,
+                "parameters": {"type": "object", "properties": {}}
+            }
+        ]
+    });
+
+    let result = compressor.compress(&tool);
+    let desc = result["functionDeclarations"][0]["description"]
+        .as_str()
+        .unwrap();
+
+    assert!(desc.contains("tokenless:"), "expected a stash marker in output");
+    assert!(desc.chars().count() <= 100);
+
+    let key = extract_hash(desc).expect("marker must carry a valid hash");
+    let retrieved = store.retrieve(key).unwrap().expect("stash entry must exist");
+    assert_eq!(retrieved, original_desc);
+    assert!(!retrieved.contains("tokenless:"));
+    assert_eq!(store.len(), 1);
+}


### PR DESCRIPTION
## 改动说明

**问题**：Schema 压缩 hook 注册在 BeforeModel 事件上，但正常运行中 Schema 压缩从未自动触发（stats 中 0 条自动记录）。

**根因**（源码核对 + 实测复现）：

1. copilot-shell 会发射 BeforeModel 事件，且 `llm_request.config.tools` 携带 Gemini SDK 形态的工具：`[{"functionDeclarations": [{name, description, parameters}, ...]}]`（hookTranslator 原样透传 SDK 请求的 config.tools）；
2. tokenless 的 `SchemaCompressor::compress` 此前只识别 OpenAI `{"function": ...}` 包装与直接 schema 两种条目形态，Gemini 包装形态的条目被原样放行；
3. CLI 仅在实际产生 token 收益（`after_tokens < before_tokens`）时才写入 stats 记录；该形态压缩零收益，因此从未产生 compress-schema 记录，表现为“0 条自动记录”。

cosh-ng 的 BeforeModel 以 `{name, description, parameters}` 直接声明形态下发，解析路径已在此前的修复中对齐，压缩与记录正常。

**修复**：`SchemaCompressor::compress` 新增对 `functionDeclarations` 包装形态的支持——对包装内的每个声明就地压缩（直接 schema 的压缩逻辑抽取为 `compress_direct_declaration`，两条路径共用，语义不变），包装本身及其同级字段原样保留，宿主可直接套用改写后的数组。CLI 参考文档（中/英）同步补充接受的输入形态说明。

**遗留（宿主侧，超出本 PR 范围）**：copilot-shell 的 `fromHookLLMRequest` 目前不会把 hook 返回的 `config.tools` 写回实际请求（仅回写 temperature 等标量字段），因此本修复的压缩结果在 copilot-shell 上暂不会作用到请求，需要 copilot-shell 组件侧另行修复。

## 测试情况

**实际执行的命令与结果**：

- `cargo fmt --all -- --check`：通过
- `cargo clippy --workspace -- -D warnings`：通过
- `cargo test --workspace`（tokenless workspace）：579 passed / 0 failed / 2 ignored（含新增 5 个单元测试与 1 个 CLI 集成测试）
- Python hook 测试（Python 3.11）：`test_compress_schema_hook`、`test_compress_response_hook`、`test_resolve_agent_id` 共 30 项全部通过
- 端到端复现验证（真实 hook 脚本 + 本地编译的 tokenless 二进制，隔离数据目录）：见下

**环境概要**：Linux x86_64；cargo 1.94.1；Python 3.11（测试）/ 3.8（hook 运行兼容性验证）；debug 构建。

**修复前复现 vs 修复后验证**：

- 修复前：copilot-shell（Gemini 包装）形态 BeforeModel 载荷经 hook 后输出与输入完全一致（0% 收益），CLI 因无收益不记录 → 无任何 compress-schema 记录（即“0 条自动记录”的直接原因）
- 修复后：同一载荷 → 工具声明字节大小 2175 → 969（约 55% 收益）；包装结构、声明名称与顺序、`required` 等字段原样保留；正常产生 compress-schema 记录（538 → 232 est. tokens，mode=active）
- 回归：cosh-ng 直接声明形态改动后仍正常（327 → 133 est. tokens，正常产生记录）

**新增测试**：

- 单元测试（tokenless-schema）：包装内压缩与形态/名称/顺序保留、同级字段保留、空/畸形包装放行、零收益原样返回、stash 单次取回契约，共 5 项
- CLI 集成测试：`compress-schema --batch` 包装形态端到端输出校验，共 1 项

**未运行项及原因**：

- `test_rewrite_hook`（11 项）在本地环境失败；已用改动前基线对照验证为同样失败，原因是本机安装的真实 rtk 二进制干扰测试夹具，与本次改动无关
- 未做真实 LLM provider 的端到端联调（环境无可用 provider 凭据）；宿主事件发射与载荷形态通过直接阅读 cosh-ng 与 copilot-shell 两侧源码确认
