### PR TITLE
fix(tokenless): match cosh shell tool name in rtk rewrite hook matcher

### DIFF
--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -239,6 +239,7 @@ test-integration:
 	python3 tests/test_agentscope_middleware.py
 	python3 tests/test_agentscope_v1.py
 	python3 tests/test_rewrite_hook.py
+	python3 tests/test_cosh_extension_matcher.py
 	python3 tests/test_resolve_agent_id.py
 
 test-adapters: build-openclaw-plugin build-dsh-plugin

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -20,7 +20,7 @@
         ]
       },
       {
-        "matcher": "^(Bash|run_shell_command|terminal|Shell|exec|process)$",
+        "matcher": "^(Bash|run_shell_command|terminal|Shell|shell|exec|process)$",
         "hooks": [
           {
             "type": "command",

--- a/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/rewrite_hook.py
@@ -5,7 +5,10 @@ Reads a PreToolUse JSON from stdin, extracts the shell command,
 invokes ``rtk rewrite`` via subprocess, and writes a HookOutput
 JSON to stdout.
 
-Hook point: **PreToolUse** — matcher: ``Shell``
+Hook point: **PreToolUse** — matcher: shell-family tool names
+(``Bash``, ``run_shell_command``, ``terminal``, ``Shell``, ``shell``,
+``exec``, ``process``).  The lowercase ``shell`` alternative covers
+cosh-ng, whose built-in shell tool is named ``shell`` on the wire.
 
 The agent ID is read from the TOKENLESS_AGENT_ID environment variable
 (set by the install action script).  Fallback paths follow the ANOLISA

--- a/src/tokenless/tests/test_cosh_extension_matcher.py
+++ b/src/tokenless/tests/test_cosh_extension_matcher.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for the cosh extension PreToolUse rewrite matcher.
+
+cosh-ng's built-in shell tool is named ``shell`` on the wire (lowercase
+snake_case), while the matcher historically only listed shell tool names
+used by other agents (``Bash``, ``Shell``, ``run_shell_command``, ...).
+On cosh builds without the hook-system tool-name alias table the rewrite
+hook therefore never fired and rtk command rewriting was silently skipped.
+
+The extension manifest must match cosh's real tool name directly instead
+of relying on host-side aliasing: these tests pin the matcher against the
+exact names cosh fires PreToolUse with, plus the negative space of cosh
+tools that must never be rewritten.
+
+Matching semantics mirror cosh-ng's ``HookSystem::matches_tool``: the
+matcher is compiled as a regex and applied as an *unanchored* search
+(Rust ``Regex::is_match`` ≈ ``re.search``); a matcher that fails to
+compile would fall back to exact string equality, which the anchored
+alternation here never triggers.
+"""
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "adapters"
+    / "tokenless"
+    / "common"
+    / "cosh-extension.json"
+)
+
+# Tool names cosh-ng fires PreToolUse with. ``shell`` is the cosh-ng
+# internal name; ``run_shell_command`` is the copilot-shell standard name
+# kept so both naming conventions keep reaching the rewrite hook.
+MATCHING_TOOLS = [
+    "shell",
+    "run_shell_command",
+    "Bash",
+    "Shell",
+    "terminal",
+    "exec",
+    "process",
+]
+
+# cosh-ng tools (and common foreign shapes) that must never be rewritten:
+# only shell-execution tools may reach rtk.
+NON_MATCHING_TOOLS = [
+    "read_file",
+    "write_file",
+    "edit",
+    "grep",
+    "todo",
+    "glob",
+    "web_search",
+    "shell_prompt",   # anchored: prefix overlap must not match
+    "my_shell",       # anchored: suffix overlap must not match
+    "",
+]
+
+
+class CoshExtensionMatcherTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(MANIFEST, "r", encoding="utf-8") as f:
+            cls.manifest = json.load(f)
+
+    def _rewrite_matcher(self) -> str:
+        """Return the matcher of the PreToolUse rtk rewrite hook group."""
+        for group in self.manifest["hooks"]["PreToolUse"]:
+            for hook in group.get("hooks", []):
+                if hook.get("name") == "tokenless-rewrite":
+                    matcher = group.get("matcher")
+                    self.assertIsInstance(
+                        matcher, str,
+                        "tokenless-rewrite group must declare an explicit "
+                        "matcher so non-shell tools never reach rtk",
+                    )
+                    self.assertTrue(
+                        matcher,
+                        "an empty matcher matches every tool, including "
+                        "non-shell tools",
+                    )
+                    return matcher
+        self.fail("tokenless-rewrite hook not found in PreToolUse groups")
+
+    def test_rewrite_hook_is_registered(self):
+        matcher = self._rewrite_matcher()
+        self.assertTrue(matcher)
+
+    def test_matcher_compiles_as_regex(self):
+        # The pattern must be valid regex syntax in both Python's ``re``
+        # and Rust's ``regex`` crate (cosh compiles it with Regex::new).
+        re.compile(self._rewrite_matcher())
+
+    def test_matcher_hits_cosh_shell_tool_name(self):
+        # The regression itself: cosh-ng names its shell tool ``shell``.
+        pattern = re.compile(self._rewrite_matcher())
+        self.assertIsNotNone(
+            pattern.search("shell"),
+            "matcher must match cosh-ng's lowercase 'shell' tool name "
+            "directly, without relying on host-side tool-name aliasing",
+        )
+
+    def test_matcher_hits_all_shell_family_names(self):
+        pattern = re.compile(self._rewrite_matcher())
+        for name in MATCHING_TOOLS:
+            with self.subTest(tool=name):
+                self.assertIsNotNone(
+                    pattern.search(name),
+                    f"matcher must match shell-family tool name {name!r}",
+                )
+
+    def test_matcher_rejects_non_shell_tools(self):
+        pattern = re.compile(self._rewrite_matcher())
+        for name in NON_MATCHING_TOOLS:
+            with self.subTest(tool=name):
+                self.assertIsNone(
+                    pattern.search(name),
+                    f"matcher must not match non-shell tool name {name!r}",
+                )
+
+    def test_rewrite_hook_command_unchanged(self):
+        # Structural guard: the rewrite group still dispatches to
+        # rewrite_hook.py, so the matcher above gates the real hook.
+        for group in self.manifest["hooks"]["PreToolUse"]:
+            for hook in group.get("hooks", []):
+                if hook.get("name") == "tokenless-rewrite":
+                    self.assertIn("rewrite_hook.py", hook["command"])
+                    return
+        self.fail("tokenless-rewrite hook not found in PreToolUse groups")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动说明

cosh-ng 触发 PreToolUse 时携带的工具名是其内部名 `shell`（小写 snake_case），而 cosh 扩展清单中 rtk 重写 hook 的 matcher 只列出了其他 agent 的 shell 工具名（`Bash`、`Shell`、`run_shell_command` 等）。在没有 hook 工具名别名表的 cosh 构建上，matcher 永远无法命中，rtk 重写 hook 被静默跳过，shell 命令得不到重写优化。

本 PR 在锚定的 matcher 备选项中直接加入 `shell`，使清单不依赖宿主侧别名行为即可命中 cosh 的真实工具名；同时刷新 rewrite hook docstring 中过期的 matcher 说明，并新增回归测试钉住 matcher 对 cosh 工具名（及非 shell 工具的负空间）的匹配行为，注册进 `test-integration` 目标。

**改动文件（均为 tokenless 组件）**
- `adapters/tokenless/common/cosh-extension.json`：PreToolUse rewrite matcher 增加 `shell` 备选项
- `adapters/tokenless/common/hooks/rewrite_hook.py`：docstring 中 matcher 说明与实现保持一致
- `tests/test_cosh_extension_matcher.py`：新增回归测试（6 个用例）
- `Makefile`：`test-integration` 注册新测试

## 测试情况

**环境**：Linux x86_64；rustc/cargo 1.94.1；Python 3.11；rtk 0.43.0。

**实际执行的命令与结果**

| 项目 | 命令 | 结果 |
| --- | --- | --- |
| 格式 | `cargo fmt --all -- --check` | 通过 |
| Lint | `cargo clippy --workspace -- -D warnings` | 0 错误 |
| 编译 | `cargo build --release -p tokenless-cli` | 通过（tokenless 0.7.6） |
| Rust 测试 | `cargo test --workspace -- --test-threads=1` | 12 个测试二进制，573 通过 / 0 失败 / 2 忽略 |
| Python 集成 | `test_compress_response_hook`、`test_compress_schema_hook`、`test_agentscope_middleware`、`test_agentscope_v1`、`test_cosh_extension_matcher`、`test_resolve_agent_id` | 全部 OK |
| 功能 hook 套件 | `make test-hooks`（含 run-all-tests.sh，使用本次改动构建的 release 二进制） | 72/72 通过 |
| 打包 | `make test-raw-package` | 通过 |

**修复验证（复现 → 验证）**
- 新增回归测试模拟 cosh `HookSystem::matches_tool` 的匹配语义（regex 非锚定搜索）：
  - 临时回退 matcher 到旧值复现问题：`shell` 不命中，测试报告 2 个失败；
  - 恢复修复后：`shell` 直接命中，`run_shell_command`/`Bash`/`Shell`/`terminal`/`exec`/`process` 均保持命中，`read_file`/`write_file`/`edit`/`grep`/`todo`/`glob`/`shell_prompt`/`my_shell` 等非 shell 工具名均不命中（锚定生效），6 个用例全部通过。

**未运行项及原因**
- `tests/test_rewrite_hook.py`：本环境存在系统级安装的 tokenless/rtk（/usr/local 前缀），hook 的回退解析会优先命中系统安装，干扰该测试的沙箱假设；在未经改动的基线上运行同样出现相同 11 个失败，确认为环境限制、与本次改动无关（CI 洁净环境不受影响）。
- `tests/test_hermes_plugin_import.py::test_resolves_via_xdg_data_home`：同为系统级安装路径干扰，未改动基线可复现，与本次改动无关。
