### PR TITLE
fix(tokenless): skip TOON encoding for payloads under 500 chars

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -39,7 +39,7 @@ The standalone `compress-response` defaults are not the defaults used by most ad
 | Shell/exec | 65,536-character strings, 128 retained array items, depth 8 |
 | Other structured tools | 1,048,576-character strings, 65,536 retained array items, depth 32 |
 
-The shared response hook, OpenClaw, and Hermes skip inputs shorter than 200 characters. Codex skips inputs shorter than 500 characters; it includes compressed content only for inputs of at least 4,000 characters and otherwise adds diagnostics or a summary. Skill-like text with YAML frontmatter is also skipped by the shared paths.
+The shared response hook, OpenClaw, and Hermes skip inputs shorter than 200 characters. Codex skips inputs shorter than 500 characters; it includes compressed content only for inputs of at least 4,000 characters and otherwise adds diagnostics or a summary. Skill-like text with YAML frontmatter is also skipped by the shared paths. The TOON encoding step only runs on payloads of at least 500 characters (the current implementation threshold, which may be adjusted later); smaller payloads keep the compressed form, because TOON savings on small JSON are negligible. The threshold applies to every TOON-capable pipeline: the shared response hook, the standalone TOON hook, Codex, OpenClaw, and Hermes.
 
 Claude Code requires version 2.1.121 or later for `updatedToolOutput`. On older or unknown versions, response compression is disabled to avoid duplicating the original. Structured tool outputs preserve their host schema and do not switch to textual TOON; JSON carried as a string can use TOON when it is smaller.
 

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -39,7 +39,7 @@ OpenCode 当前使用下文说明的随附生命周期脚本，本版本尚未�
 | Shell/exec | 字符串 65,536 字符、数组保留 128 项、深度 8 |
 | 其他结构化工具 | 字符串 1,048,576 字符、数组保留 65,536 项、深度 32 |
 
-共享响应 Hook、OpenClaw 和 Hermes 会跳过短于 200 字符的输入。Codex 会跳过短于 500 字符的输入；只有输入至少为 4,000 字符时才附加压缩内容，否则只追加诊断或摘要。共享路径还会跳过带 YAML frontmatter、形似 Skill 的文本。
+共享响应 Hook、OpenClaw 和 Hermes 会跳过短于 200 字符的输入。Codex 会跳过短于 500 字符的输入；只有输入至少为 4,000 字符时才附加压缩内容，否则只追加诊断或摘要。共享路径还会跳过带 YAML frontmatter、形似 Skill 的文本。TOON 编码仅对至少 500 字符的负载执行（当前实现的阈值，后续可能调整）；更小的负载保留压缩后的形式，因为 TOON 对小型 JSON 的节省可以忽略不计。该阈值适用于所有支持 TOON 的管线：共享响应 Hook、独立 TOON Hook、Codex、OpenClaw 和 Hermes。
 
 Claude Code 需要 2.1.121 或更高版本才能使用 `updatedToolOutput`。版本更旧或无法确定时，响应压缩会关闭，以免重复注入原文。结构化工具输出会保留宿主 Schema，不会转换成文本 TOON；以字符串承载的 JSON 在 TOON 更小时可以使用 TOON。
 

--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.7"
+version = "0.7.8"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,16 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-08-18
+
+### Changed
+
+- TOON encoding is now skipped for payloads under 500 characters; below that threshold the token savings are near-zero while the per-event encode cost stays the same ([#2613](https://github.com/alibaba/anolisa/pull/2613)).
+
+### Fixed
+
+- npm platform packages (`@anolisa/tokenless-*`) no longer declare `tokenless`/`rtk`/`toon` bin entries. The name collision with the root package made npm remove every conflicting `.bin` link during install, leaving installs without a usable `tokenless` executable ([#2613](https://github.com/alibaba/anolisa/pull/2613)).
+
 ## [0.7.7] - 2026-08-17
 
 ### Added

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,16 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.8] - 2026-08-18
+
+### 变更
+
+- 当载荷少于 500 字符时跳过 TOON 编码；低于该阈值时 token 节省几乎为零，而每次事件的编码开销保持不变（[#2613](https://github.com/alibaba/anolisa/pull/2613)）。
+
+### 修复
+
+- npm 平台包（`@anolisa/tokenless-*`）不再声明 `tokenless`/`rtk`/`toon` bin 入口。与根包的同名冲突会导致 npm 在安装时删除所有冲突的 `.bin` 链接，使安装后没有可用的 `tokenless` 可执行文件（[#2613](https://github.com/alibaba/anolisa/pull/2613)）。
+
 ## [0.7.7] - 2026-08-17
 
 ### 新增

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "pyo3",
  "tokenless-runtime",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "regex",
  "serde_json",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.7"
+version = "0.7.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -234,6 +234,9 @@ test-claude-code-detect:
 test-integration:
 	@echo "==> Testing hook integration (Python)..."
 	python3 tests/test_compress_response_hook.py
+	python3 tests/test_compress_toon_hook.py
+	python3 tests/test_codex_toon_threshold.py
+	python3 tests/test_hermes_toon_threshold.py
 	python3 tests/test_compress_schema_hook.py
 	python3 tests/test_hermes_plugin_import.py
 	python3 tests/test_agentscope_middleware.py
@@ -244,6 +247,8 @@ test-integration:
 test-adapters: build-openclaw-plugin build-dsh-plugin
 	@echo "==> Testing openclaw RTK context propagation..."
 	node --test tests/test-openclaw-rtk-context.mjs
+	@echo "==> Testing openclaw TOON minimum payload threshold..."
+	node --test tests/test-openclaw-toon-threshold.mjs
 	@echo "==> Testing native dsh adapter bundle..."
 	bash tests/test-dsh-adapter.sh
 	@echo "==> Testing qoder adapter installer..."

--- a/src/tokenless/adapters/tokenless/codex/scripts/compress-response
+++ b/src/tokenless/adapters/tokenless/codex/scripts/compress-response
@@ -166,6 +166,10 @@ else:
 AGENT_ID = os.environ.get("TOKENLESS_AGENT_ID", "codex")
 MIN_RESPONSE_CHARS: int = 500
 LARGE_RESPONSE_CHARS: int = 4000
+# TOON on small JSON saves only a few characters (observed ~0.3% below
+# ~500 chars) while the per-event encode cost stays the same, so payloads
+# under this threshold keep the compressed form and skip the TOON pass.
+MIN_TOON_CHARS: int = 500
 
 # 3-layer compression strategy:
 #   Layer 1: Content retrieval + task management → skip all compression
@@ -372,7 +376,7 @@ def main() -> None:
         toon_input = compression_input
 
     toon_parsed = _try_parse_json(toon_input)
-    if toon_parsed is not None:
+    if toon_parsed is not None and len(toon_input) >= MIN_TOON_CHARS:
         toon_text = _run_tokenless(
             tokenless_bin, "compress-toon",
             toon_input, session_id, tool_use_id, timeout=10,

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -81,6 +81,12 @@ from hook_utils import (
 
 _MIN_RESPONSE_CHARS = 200
 
+# Minimum payload size for the TOON encoding step. TOON on small JSON
+# saves only a few characters (observed ~0.3% below ~500 chars) while the
+# per-event encode cost stays the same, so payloads under this threshold
+# keep the response-compressed form and skip the TOON pass entirely.
+_MIN_TOON_CHARS = 500
+
 # Claude Code added hookSpecificOutput.updatedToolOutput (normal-path tool
 # output replacement for all tools) in v2.1.121. Older versions only support
 # the additive additionalContext, which would duplicate the payload.
@@ -231,7 +237,11 @@ def _build_replacement_output(
         return False, None
 
     # Restoring empty schema fields can cancel out a marginal win.
-    serialized = json.dumps(updated_output, separators=(",", ":"))
+    # ensure_ascii=False keeps the size comparison in Unicode characters,
+    # consistent with the non-escaped normalization below.
+    serialized = json.dumps(
+        updated_output, separators=(",", ":"), ensure_ascii=False
+    )
     if len(serialized) >= len(tool_response):
         return False, None
     return True, updated_output
@@ -313,7 +323,13 @@ def main() -> None:
             skip()  # Plain text, not JSON
         tool_response = unwrapped
     elif isinstance(model_visible_before, (dict, list)):
-        tool_response = json.dumps(model_visible_before, separators=(",", ":"))
+        # ensure_ascii=False: size gates below must count Unicode
+        # characters (code points), not \uXXXX escape sequences, so
+        # structured payloads are measured the same way as JSON string
+        # inputs and the OpenClaw adapter.
+        tool_response = json.dumps(
+            model_visible_before, separators=(",", ":"), ensure_ascii=False
+        )
     else:
         skip()
 
@@ -380,10 +396,12 @@ def main() -> None:
         except Exception as e:
             warn(f"Response compression error: {e}")
 
-    # 16. Step 2: TOON encoding
+    # 16. Step 2: TOON encoding — only for payloads at or above the
+    # minimum threshold; small JSON gains near-zero chars from TOON but
+    # would still pay the full encode cost on every PostToolUse event.
     toon_output = ""
 
-    if tokenless_bin:
+    if tokenless_bin and len(compressed) >= _MIN_TOON_CHARS:
         toon_parsed = try_parse_json(compressed)
         if toon_parsed is not None:
             toon_cmd = [tokenless_bin, "compress-toon", "--agent-id", agent_id]

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_toon_hook.py
@@ -39,7 +39,11 @@ from hook_utils import (
 # -- constants ---------------------------------------------------------------
 
 _AGENT_ID = resolve_agent_id()
-_MIN_RESPONSE_CHARS = 200
+
+# Minimum payload size for TOON encoding. TOON on small JSON saves only a
+# few characters (observed ~0.3% below ~500 chars) while the per-event
+# encode cost stays the same, so smaller responses pass through untouched.
+_MIN_TOON_CHARS = 500
 
 
 # -- main --------------------------------------------------------------------
@@ -84,15 +88,22 @@ def main() -> None:
         if tool_response is None:
             skip()  # Plain text, not JSON
     elif isinstance(tool_response_raw, (dict, list)):
-        tool_response = json.dumps(tool_response_raw, separators=(",", ":"))
+        # ensure_ascii=False: the threshold below counts Unicode
+        # characters (code points), not \uXXXX escape sequences, so
+        # structured payloads are measured the same way as JSON string
+        # inputs and the OpenClaw adapter.
+        tool_response = json.dumps(
+            tool_response_raw, separators=(",", ":"), ensure_ascii=False
+        )
     else:
         skip()
 
     if not tool_response:
         skip()
 
-    # 7. Skip small responses (character count, not byte length)
-    if len(tool_response) < _MIN_RESPONSE_CHARS:
+    # 7. Skip payloads below the TOON minimum threshold (character count,
+    # not byte length): TOON savings on small JSON are near-zero
+    if len(tool_response) < _MIN_TOON_CHARS:
         skip()
 
     # 8. Validate it's JSON

--- a/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/hook_utils.py
@@ -408,7 +408,13 @@ def unwrap_string_json(raw: str) -> str | None:
     if isinstance(inner, str):
         inner_obj = try_parse_json(inner)
         if inner_obj is not None and isinstance(inner_obj, (dict, list)):
-            return json.dumps(inner_obj, separators=(",", ":"))
+            # ensure_ascii=False: downstream size gates count Unicode
+            # characters (code points), not \uXXXX escape sequences, so
+            # string-wrapped payloads are measured the same way as the
+            # dict/list branch and the OpenClaw adapter.
+            return json.dumps(
+                inner_obj, separators=(",", ":"), ensure_ascii=False
+            )
         return None
     return raw
 

--- a/src/tokenless/adapters/tokenless/hermes/__init__.py
+++ b/src/tokenless/adapters/tokenless/hermes/__init__.py
@@ -180,6 +180,12 @@ logger = logging.getLogger(__name__)
 AGENT_ID = "hermes-agent"
 _MIN_RESPONSE_LEN = 200
 
+# Minimum payload size for the TOON encoding step. TOON on small JSON
+# saves only a few characters (observed ~0.3% below ~500 chars) while
+# the per-event encode cost stays the same, so payloads under this
+# threshold keep the response-compressed form and skip TOON entirely.
+_MIN_TOON_CHARS = 500
+
 _SKIP_TOOLS: set[str] = _SKIP_TOOLS_SHARED | {
     "session_search", "list_sessions",
 }
@@ -513,8 +519,12 @@ def on_transform_tool_result(
                                      str(session_id), str(tool_call_id))
     current = compressed if compressed else result
 
-    # Step 2: TOON encoding
-    toon_result = _encode_toon(current, str(session_id), str(tool_call_id))
+    # Step 2: TOON encoding — only for payloads at or above the minimum
+    # threshold; small JSON gains near-zero chars from TOON but would still
+    # pay the full encode cost on every tool result.
+    toon_result = None
+    if len(current) >= _MIN_TOON_CHARS:
+        toon_result = _encode_toon(current, str(session_id), str(tool_call_id))
     used_compression = compressed is not None
     used_toon = toon_result is not None
 

--- a/src/tokenless/adapters/tokenless/openclaw/index.ts
+++ b/src/tokenless/adapters/tokenless/openclaw/index.ts
@@ -88,6 +88,26 @@ function mergeExecContextEnv(
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes — retry after auto-fix installs
 
+// Minimum payload size for the TOON encoding step. TOON on small JSON saves
+// only a few characters (observed ~0.3% below ~500 chars) while the
+// per-event encode cost stays the same, so payloads under this threshold
+// keep the response-compressed form and skip TOON entirely.
+const MIN_TOON_CHARS = 500;
+
+// True when `text` contains at least `threshold` Unicode code points.
+// Iterating a string counts code points (a surrogate pair counts once), so
+// the threshold uses the same unit as the Python adapters' len(). The loop
+// returns as soon as the threshold is reached, so large payloads only pay
+// for scanning the first `threshold` characters.
+function hasAtLeastChars(text: string, threshold: number): boolean {
+  let count = 0;
+  for (const _ch of text) {
+    count += 1;
+    if (count >= threshold) return true;
+  }
+  return false;
+}
+
 let rtkAvailable: boolean | null = null;
 let rtkCheckedAt: number | null = null;
 let tokenlessAvailable: boolean | null = null;
@@ -326,6 +346,12 @@ function tryCompressResponse(response: any, sessionId?: string, toolCallId?: str
 function tryCompressToon(response: any, sessionId?: string, toolCallId?: string): { toonText: string; savingsPct: number } | null {
   try {
     const input = JSON.stringify(response);
+    // Skip payloads below the minimum threshold: TOON savings on small
+    // JSON are near-zero but the encode cost is paid on every tool result.
+    // Count Unicode code points, not UTF-16 code units (String.length), so
+    // non-BMP text (e.g. emoji) is measured the same way as the Python
+    // adapters' character counts.
+    if (!hasAtLeastChars(input, MIN_TOON_CHARS)) return null;
     const beforeChars = input.length;
     const args = ["compress-toon", "--agent-id", "openclaw"];
     if (sessionId) args.push("--session-id", sessionId);

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -45,9 +45,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.7",
-    "@anolisa/tokenless-linux-arm64": "0.7.7",
-    "@anolisa/tokenless-darwin-x64": "0.7.7",
-    "@anolisa/tokenless-darwin-arm64": "0.7.7"
+    "@anolisa/tokenless-linux-x64": "0.7.8",
+    "@anolisa/tokenless-linux-arm64": "0.7.8",
+    "@anolisa/tokenless-darwin-x64": "0.7.8",
+    "@anolisa/tokenless-darwin-arm64": "0.7.8"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -11,11 +11,6 @@
   },
   "os": ["darwin"],
   "cpu": ["arm64"],
-  "bin": {
-    "tokenless": "bin/tokenless",
-    "rtk": "bin/rtk",
-    "toon": "bin/toon"
-  },
   "files": [
     "bin/"
   ],

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -11,11 +11,6 @@
   },
   "os": ["darwin"],
   "cpu": ["x64"],
-  "bin": {
-    "tokenless": "bin/tokenless",
-    "rtk": "bin/rtk",
-    "toon": "bin/toon"
-  },
   "files": [
     "bin/"
   ],

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -12,11 +12,6 @@
   "os": ["linux"],
   "cpu": ["arm64"],
   "libc": ["glibc"],
-  "bin": {
-    "tokenless": "bin/tokenless",
-    "rtk": "bin/rtk",
-    "toon": "bin/toon"
-  },
   "files": [
     "bin/"
   ],

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -12,11 +12,6 @@
   "os": ["linux"],
   "cpu": ["x64"],
   "libc": ["glibc"],
-  "bin": {
-    "tokenless": "bin/tokenless",
-    "rtk": "bin/rtk",
-    "toon": "bin/toon"
-  },
   "files": [
     "bin/"
   ],

--- a/src/tokenless/npm/scripts/package-npm.js
+++ b/src/tokenless/npm/scripts/package-npm.js
@@ -307,13 +307,16 @@ function packagePlatform(target, binaryPaths) {
     chmodSync(destination, 0o755);
   }
 
-  // Build bin map for package.json
-  const binMap = {};
-  for (const bin of Object.keys(binaryPaths)) {
-    binMap[bin] = `bin/${bin}`;
-  }
-
   // Write package.json
+  //
+  // Deliberately declare NO `bin` entries here: the platform packages would
+  // otherwise claim the same `tokenless`/`rtk`/`toon` bin names as the root
+  // package. When multiple packages in a tree claim the same bin, npm's
+  // reify removes every conflicting `.bin` link instead of picking a
+  // winner, leaving installs without a `tokenless` executable. esbuild ships
+  // its platform packages the same way (binaries in bin/, no bin field); the
+  // root package owns the bin entries and its postinstall links them to
+  // these native binaries.
   const archLabel = target.npm_cpu === 'x64' ? 'x86_64' : 'aarch64';
   const pkgJson = {
     name: pkgName,
@@ -330,7 +333,6 @@ function packagePlatform(target, binaryPaths) {
     // Binaries target *-unknown-linux-gnu — keep musl (Alpine) installs from
     // matching a package whose ELF they cannot run.
     ...(target.npm_os === 'linux' ? { libc: ['glibc'] } : {}),
-    bin: binMap,
     files: ['bin/'],
     preferUnplugged: true,
     publishConfig: PUBLISH_CONFIG,

--- a/src/tokenless/tests/test-openclaw-toon-threshold.mjs
+++ b/src/tokenless/tests/test-openclaw-toon-threshold.mjs
@@ -1,0 +1,168 @@
+// Tests for the OpenClaw plugin TOON minimum payload threshold.
+//
+// TOON on small JSON saves only a handful of characters (~0.3% below
+// ~500 chars) while the per-event encode cost stays the same, so the
+// plugin must skip the TOON step for payloads under MIN_TOON_CHARS (500)
+// without spawning `tokenless compress-toon`. Larger payloads keep
+// flowing to TOON.
+//
+// Requires `make build-openclaw-plugin` (loads dist/index.js).
+
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { after, test } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const sandbox = mkdtempSync(join(tmpdir(), "tokenless-openclaw-toon-"));
+const localBinDir = join(sandbox, ".local", "bin");
+const fakeTokenless = join(localBinDir, "tokenless");
+const toonMarker = join(sandbox, "toon_called");
+
+const originalHome = process.env.HOME;
+const originalPath = process.env.PATH;
+process.env.HOME = sandbox;
+
+mkdirSync(localBinDir, { recursive: true });
+
+// Fake tokenless CLI: compress-toon records a call marker and emits a
+// smaller TOON-like output so tests can tell whether the plugin invoked
+// compress-toon at all.
+writeFileSync(
+  fakeTokenless,
+  [
+    "#!/usr/bin/env python3",
+    "import os, sys",
+    "data = sys.stdin.read()",
+    'if len(sys.argv) > 1 and sys.argv[1] == "compress-toon":',
+    "    marker = os.path.join(os.path.dirname(os.path.abspath(__file__)),",
+    '                        "..", "..", "toon_called")',
+    '    open(marker, "a").close()',
+    '    print("toon:" + data[: len(data) // 2])',
+    "else:",
+    '    print("{}")',
+    "",
+  ].join("\n"),
+);
+chmodSync(fakeTokenless, 0o755);
+
+// resolveBinaryPath searches PATH before the fallback locations, so the
+// fake tokenless must shadow any system install.
+process.env.PATH = `${localBinDir}${originalPath ? ":" + originalPath : ""}`;
+
+const pluginPath = resolve(testDir, "../adapters/tokenless/openclaw/dist/index.js");
+assert.ok(
+  existsSync(pluginPath),
+  "OpenClaw plugin build missing; run `make build-openclaw-plugin` before this test",
+);
+
+const { default: plugin } = await import(pathToFileURL(pluginPath).href);
+
+const handlers = new Map();
+plugin.register({
+  config: {
+    rtk_enabled: false,
+    tool_ready_enabled: false,
+    response_compression_enabled: false,
+    toon_compression_enabled: true,
+    verbose: false,
+  },
+  on(name, handler) {
+    handlers.set(name, handler);
+  },
+});
+
+const toolResultPersist = handlers.get("tool_result_persist");
+assert.equal(
+  typeof toolResultPersist,
+  "function",
+  "tool_result_persist hook was not registered",
+);
+
+function messageOfSize(charTarget) {
+  // JSON.stringify adds the {"stdout":"","exit_code":0} frame (~30 chars).
+  const inner = "x".repeat(Math.max(charTarget - 30, 1));
+  return { stdout: inner, exit_code: 0 };
+}
+
+after(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+test("payload under MIN_TOON_CHARS skips compress-toon entirely", () => {
+  const result = toolResultPersist(
+    { toolName: "web_fetch", toolCallId: "tool-small", message: messageOfSize(300) },
+    { toolName: "web_fetch", sessionId: "session-small", toolCallId: "tool-small" },
+  );
+
+  assert.equal(result, undefined, "small payloads pass through unchanged");
+  assert.ok(
+    !existsSync(toonMarker),
+    "compress-toon must not run below the threshold",
+  );
+});
+
+test("payload at/above MIN_TOON_CHARS still TOON encodes", () => {
+  const result = toolResultPersist(
+    { toolName: "web_fetch", toolCallId: "tool-large", message: messageOfSize(800) },
+    { toolName: "web_fetch", sessionId: "session-large", toolCallId: "tool-large" },
+  );
+
+  assert.ok(existsSync(toonMarker), "compress-toon must run for large payloads");
+  assert.ok(result && typeof result.message === "string",
+    "large payloads get the TOON-encoded message");
+  assert.ok(result.message.startsWith("toon:"),
+    `expected TOON output, got: ${String(result.message).slice(0, 40)}`);
+});
+
+function emojiPayload(emojiCount) {
+  // Each "😀" is one Unicode code point but two UTF-16 code units, so a
+  // String.length-based gate counts these payloads roughly double.
+  return { stdout: "😀".repeat(emojiCount), exit_code: 0 };
+}
+
+test("non-BMP payload under MIN_TOON_CHARS code points skips compress-toon", () => {
+  // 244 emoji + the JSON frame ≈ 271 code points but ≈ 515 UTF-16 code
+  // units; a UTF-16 count would wrongly pass the 500 threshold.
+  rmSync(toonMarker, { force: true });
+  const result = toolResultPersist(
+    { toolName: "web_fetch", toolCallId: "tool-emoji", message: emojiPayload(244) },
+    { toolName: "web_fetch", sessionId: "session-emoji", toolCallId: "tool-emoji" },
+  );
+
+  assert.equal(result, undefined, "under-threshold non-BMP payloads pass through unchanged");
+  assert.ok(
+    !existsSync(toonMarker),
+    "compress-toon must not run when the code-point count is below the threshold",
+  );
+});
+
+test("non-BMP payload at/above MIN_TOON_CHARS code points still TOON encodes", () => {
+  // 520 emoji + frame ≈ 547 code points (≈ 1067 UTF-16 units): above the
+  // threshold in either counting unit, so TOON must still run.
+  rmSync(toonMarker, { force: true });
+  const result = toolResultPersist(
+    { toolName: "web_fetch", toolCallId: "tool-emoji-large", message: emojiPayload(520) },
+    { toolName: "web_fetch", sessionId: "session-emoji-large", toolCallId: "tool-emoji-large" },
+  );
+
+  assert.ok(existsSync(toonMarker), "compress-toon must run at/above the code-point threshold");
+  assert.ok(result && typeof result.message === "string",
+    "large non-BMP payloads get the TOON-encoded message");
+  assert.ok(result.message.startsWith("toon:"),
+    `expected TOON output, got: ${String(result.message).slice(0, 40)}`);
+});

--- a/src/tokenless/tests/test-package-npm-prebuilt.sh
+++ b/src/tokenless/tests/test-package-npm-prebuilt.sh
@@ -132,6 +132,25 @@ for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
     done
 done
 
+# Platform packages must not declare bin entries: they would collide with
+# the root package's tokenless/rtk/toon bins, and npm resolves such
+# collisions by removing every conflicting .bin link, leaving installs
+# without a tokenless executable. The root package's postinstall links its
+# bins to these platform binaries instead (esbuild's platform packages use
+# the same model).
+for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+    node - "$ROOT/npm/dist/tokenless-$target/package.json" <<'JS'
+const fs = require('node:fs');
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (manifest.bin !== undefined) {
+  throw new Error(
+    `${manifest.name} must not declare bin entries; ` +
+    'the root package owns the tokenless/rtk/toon bin names',
+  );
+}
+JS
+done
+
 node - "$ROOT/npm/dist/tokenless/package.json" <<'JS'
 const fs = require('node:fs');
 const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));

--- a/src/tokenless/tests/test_codex_toon_threshold.py
+++ b/src/tokenless/tests/test_codex_toon_threshold.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Tests for the Codex adapter TOON minimum payload threshold.
+
+TOON on small JSON saves only a handful of characters (~0.3% below
+~500 chars) while the per-event encode cost stays the same, so the
+Codex compression script must skip the TOON step for payloads under
+``MIN_TOON_CHARS`` (500) — e.g. when response compression shrinks a
+larger input below the threshold — without invoking
+``tokenless compress-toon``. Larger payloads keep flowing to TOON.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "adapters"
+    / "tokenless"
+    / "codex"
+    / "scripts"
+    / "compress-response"
+)
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+def _create_marker_tokenless(tmpdir: str, compressed_len: int) -> str:
+    """Mock tokenless CLI.
+
+    - ``compress-response`` echoes a valid JSON object of roughly
+      ``compressed_len`` characters (simulating a compressed result).
+    - ``compress-toon`` records a call marker and emits a smaller
+      TOON-like output, so tests can tell whether the script invoked
+      compress-toon at all.
+    """
+    mock_script = os.path.join(tmpdir, "tokenless")
+    script = textwrap.dedent(f"""\
+        #!/usr/bin/env python3
+        import os, sys
+        data = sys.stdin.read()
+        if sys.argv[1] == "compress-response":
+            inner = "y" * max({compressed_len} - 30, 1)
+            import json as _json
+            print(_json.dumps({{"stdout": inner, "exit_code": 0}}))
+        elif sys.argv[1] == "compress-toon":
+            marker = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "toon_called")
+            open(marker, "a").close()
+            print("toon:" + data[: len(data) // 2])
+    """)
+    with open(mock_script, "w") as f:
+        f.write(script)
+    os.chmod(
+        mock_script,
+        os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IEXEC,
+    )
+    return mock_script
+
+
+def _run_codex_hook(tool_response: str, mock_bin: str, tmpdir: str) -> dict:
+    """Run the codex compress-response hook against ``tool_response``."""
+    env = os.environ.copy()
+    env["TOKENLESS_BIN"] = mock_bin
+    env["TOKENLESS_AGENT_ID"] = "codex"
+    env["HOME"] = tmpdir
+
+    stdin_data = {
+        "tool_name": "shell",
+        "tool_response": tool_response,
+        "session_id": "test-session",
+        "tool_use_id": "toolu_test",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+    if proc.returncode != 0:
+        return {
+            "_subprocess_error": True,
+            "_returncode": proc.returncode,
+            "_stderr": proc.stderr,
+            "_stdout": proc.stdout,
+        }
+    stdout = proc.stdout.strip()
+    if not stdout or stdout == "{}":
+        return {}
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"_raw_stdout": stdout, "_stderr": proc.stderr}
+
+
+def _json_response(char_target: int) -> str:
+    """A JSON object string of roughly ``char_target`` characters."""
+    inner = "x" * max(char_target - 30, 1)
+    return json.dumps({"stdout": inner, "exit_code": 0})
+
+
+@unittest.skipIf(_needs_py39, "codex hook requires Python 3.9+")
+class CodexToonMinPayloadThresholdTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="test_codex_toon_")
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    def test_compressed_result_below_threshold_skips_toon(self):
+        """Input >= 500 but compressed result < 500: no compress-toon call."""
+        mock_bin = _create_marker_tokenless(self.tmpdir, compressed_len=300)
+        marker = os.path.join(self.tmpdir, "toon_called")
+
+        result = _run_codex_hook(_json_response(700), mock_bin, self.tmpdir)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(marker),
+                         "compress-toon must not run below the threshold")
+        # The compressed form is still injected.
+        ctx = result.get("hookSpecificOutput", {}).get("additionalContext", "")
+        self.assertIn("[tokenless:compressed]", ctx,
+                      f"Expected compressed context, got: {ctx!r}")
+
+    def test_compressed_result_above_threshold_still_toon_encoded(self):
+        """Compressed result >= 500: compress-toon runs and output is used."""
+        mock_bin = _create_marker_tokenless(self.tmpdir, compressed_len=800)
+        marker = os.path.join(self.tmpdir, "toon_called")
+
+        result = _run_codex_hook(_json_response(1200), mock_bin, self.tmpdir)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(marker),
+                        "compress-toon must run for large payloads")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/tokenless/tests/test_compress_response_hook.py
+++ b/src/tokenless/tests/test_compress_response_hook.py
@@ -635,5 +635,263 @@ class TestNonReplacementAdapters(unittest.TestCase):
                          "Non-replacement adapters should not use updatedToolOutput")
 
 
+def _create_toon_marker_tokenless(tmpdir: str) -> str:
+    """Mock tokenless: compress-response passes through; compress-toon
+    records a call marker next to itself and emits a smaller TOON-like
+    output, so tests can tell whether the TOON step ran at all."""
+    mock_script = os.path.join(tmpdir, "tokenless")
+    script = textwrap.dedent("""\
+        #!/usr/bin/env python3
+        import os, sys
+        data = sys.stdin.read()
+        if sys.argv[1] == "compress-response":
+            print(data)
+        elif sys.argv[1] == "compress-toon":
+            marker = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "toon_called")
+            open(marker, "a").close()
+            print("toon:" + data[: len(data) // 2])
+    """)
+    with open(mock_script, "w") as f:
+        f.write(script)
+    os.chmod(mock_script, os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IEXEC)
+    return mock_script
+
+
+def _json_string_payload(char_target: int) -> str:
+    """A JSON string tool_response of roughly ``char_target`` characters."""
+    inner = "x" * max(char_target - 30, 1)
+    return json.dumps({"stdout": inner, "exit_code": 0})
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class TestToonMinPayloadThreshold(unittest.TestCase):
+    """The TOON step must only run for payloads >= _MIN_TOON_CHARS (500).
+
+    TOON on small JSON saves only a handful of characters (~0.3% below
+    ~500 chars) while the per-event encode cost stays the same, so below
+    the threshold the hook must not invoke ``tokenless compress-toon``
+    at all — no subprocess, no encode, no stats noise.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_hook_home_")
+        self.mock_bin = _create_toon_marker_tokenless(self.tmpdir)
+        self.mock_claude = _create_mock_claude(self.tmpdir)
+        self.toon_marker = os.path.join(self.tmpdir, "toon_called")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
+
+    def test_toon_runs_at_or_above_threshold(self):
+        """A >=500-char payload still reaches compress-toon."""
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": _json_string_payload(600),
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run for payloads >= threshold")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertIn("toon:", str(hso.get("updatedToolOutput", "")),
+                      "TOON output should be used for large payloads")
+
+    def test_toon_skipped_below_threshold(self):
+        """A payload under 500 chars never reaches compress-toon."""
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": _json_string_payload(300),
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run below the threshold")
+        self.assertEqual(result, {},
+                         "No compression happened, so the hook skips")
+
+    def test_toon_skipped_for_small_structured_non_bmp_payload(self):
+        """Structured non-BMP payloads are gated by Unicode character count.
+
+        {"stdout": "😀" × 40, ...} is ~67 Unicode characters but 507
+        characters once serialized with \\u escapes; counting the escaped
+        form would wrongly run compress-toon.
+        """
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": {"stdout": "😀" * 40, "exit_code": 0},
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run for a structured payload "
+                         "whose character count is below the threshold")
+        self.assertEqual(result, {},
+                         "No compression happened, so the hook skips")
+
+    def test_toon_skipped_below_threshold_for_medium_structured_non_bmp(self):
+        """200 emoji ≈ 227 Unicode chars (about 2,427 chars once escaped).
+
+        Passes the 200-character entry gate, so this case isolates the
+        TOON gate: the escaped form is above 500 but the character
+        count is not, so compress-toon must still be skipped.
+        """
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": {"stdout": "😀" * 200, "exit_code": 0},
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run below the character "
+                         "threshold even when the escaped form is longer")
+
+    def test_toon_runs_for_large_structured_non_bmp_payload(self):
+        """520 emoji ≈ 547 Unicode chars: above threshold, TOON runs."""
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": {"stdout": "😀" * 520, "exit_code": 0},
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run at/above the character "
+                        "threshold for structured non-BMP payloads")
+        # TOON text cannot replace a structured response without changing
+        # the host tool schema, and the echo-only compress-response mock
+        # yields no JSON win, so the hook still skips the replacement.
+        self.assertEqual(result, {})
+
+    def test_toon_skipped_for_small_string_wrapped_non_bmp_payload(self):
+        """String-wrapped JSON takes the unwrap_string_json path.
+
+        A wrapped {"stdout": "😀" × 40, ...} payload unwraps to ~67
+        Unicode characters (wrapped input ~73), but ASCII-escaping the
+        inner object inflates it to 507 characters; the gate must count
+        the unwrapped code points and never run compress-toon.
+        """
+        inner = json.dumps({"stdout": "😀" * 40, "exit_code": 0},
+                           ensure_ascii=False)
+        wrapped = json.dumps(inner, ensure_ascii=False)
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": wrapped,
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run for a string-wrapped "
+                         "payload whose character count is below the threshold")
+        self.assertEqual(result, {},
+                         "No compression happened, so the hook skips")
+
+    def test_toon_skipped_below_threshold_for_medium_string_wrapped_non_bmp(self):
+        """Wrapped 200-emoji payload unwraps to ~227 Unicode chars.
+
+        Passes the 200-character entry gate, so this case isolates the
+        TOON gate: the ASCII-escaped form is ~2,427 characters but the
+        unwrapped character count is below 500, so compress-toon must
+        still be skipped.
+        """
+        inner = json.dumps({"stdout": "😀" * 200, "exit_code": 0},
+                           ensure_ascii=False)
+        wrapped = json.dumps(inner, ensure_ascii=False)
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": wrapped,
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run below the character "
+                         "threshold even when the escaped form is longer")
+
+    def test_toon_runs_for_large_string_wrapped_non_bmp_payload(self):
+        """Wrapped payload unwrapping to ~547 Unicode chars: TOON runs."""
+        inner = json.dumps({"stdout": "😀" * 520, "exit_code": 0},
+                           ensure_ascii=False)
+        wrapped = json.dumps(inner, ensure_ascii=False)
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_response": wrapped,
+                "session_id": "test-session",
+                "tool_use_id": "toolu_test",
+            },
+            agent_id="claude-code",
+            mock_tokenless_path=self.mock_bin,
+            isolated_home=self.isolated_home,
+        )
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run at/above the character "
+                        "threshold for string-wrapped non-BMP payloads")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertIn("toon:", str(hso.get("updatedToolOutput", "")),
+                      "TOON output should be used for large payloads")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/tokenless/tests/test_compress_toon_hook.py
+++ b/src/tokenless/tests/test_compress_toon_hook.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Tests for compress_toon_hook.py minimum payload threshold.
+
+TOON on small JSON saves only a handful of characters (~0.3% below
+~500 chars) while the per-event encode cost stays the same, so the
+standalone TOON hook must skip payloads under _MIN_TOON_CHARS (500)
+without invoking ``tokenless compress-toon`` — no subprocess, no
+encode, no stats noise. Larger payloads keep flowing to TOON.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+HOOK = (
+    Path(__file__).resolve().parent.parent
+    / "adapters"
+    / "tokenless"
+    / "common"
+    / "hooks"
+    / "compress_toon_hook.py"
+)
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+def _create_toon_marker_tokenless(tmpdir: str) -> str:
+    """Mock tokenless whose compress-toon records a call marker next to
+    itself and emits a smaller TOON-like output, so tests can tell
+    whether the hook invoked compress-toon at all."""
+    mock_script = os.path.join(tmpdir, "tokenless")
+    script = textwrap.dedent("""\
+        #!/usr/bin/env python3
+        import os, sys
+        data = sys.stdin.read()
+        if sys.argv[1] == "compress-toon":
+            marker = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "toon_called")
+            open(marker, "a").close()
+            print("toon:" + data[: len(data) // 2])
+    """)
+    with open(mock_script, "w") as f:
+        f.write(script)
+    os.chmod(
+        mock_script,
+        os.stat(mock_script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IEXEC,
+    )
+    return mock_script
+
+
+def _run_toon_hook(tool_response, mock_tokenless_path: str,
+                   isolated_home: str) -> dict:
+    """Run the standalone TOON hook against ``tool_response`` (a JSON
+    string or a structured dict/list payload)."""
+    env = os.environ.copy()
+    env["TOKENLESS_AGENT_ID"] = "copilot-shell"
+    env["PATH"] = os.path.dirname(mock_tokenless_path) + ":" + env.get("PATH", "")
+    env["HOME"] = isolated_home
+    env.pop("COSH_RUNTIME", None)
+    env.pop("COSH_NG_VERSION", None)
+
+    stdin_data = {
+        "tool_name": "shell",
+        "tool_response": tool_response,
+        "session_id": "test-session",
+        "tool_use_id": "toolu_test",
+    }
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(stdin_data),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+    )
+    if proc.returncode != 0:
+        return {
+            "_subprocess_error": True,
+            "_returncode": proc.returncode,
+            "_stderr": proc.stderr,
+            "_stdout": proc.stdout,
+        }
+    stdout = proc.stdout.strip()
+    if not stdout or stdout == "{}":
+        return {}
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {"_raw_stdout": stdout, "_stderr": proc.stderr}
+
+
+def _json_response(char_target: int) -> str:
+    """A JSON object string of roughly ``char_target`` characters."""
+    inner = "x" * max(char_target - 30, 1)
+    return json.dumps({"stdout": inner, "exit_code": 0})
+
+
+@unittest.skipIf(_needs_py39, "hook_utils requires Python 3.9+")
+class CompressToonMinPayloadThresholdTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.isolated_home = tempfile.mkdtemp(prefix="test_toon_hook_home_")
+        self.mock_bin = _create_toon_marker_tokenless(self.tmpdir)
+        self.toon_marker = os.path.join(self.tmpdir, "toon_called")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(self.isolated_home, ignore_errors=True)
+
+    def test_small_payload_skipped_without_encoding(self):
+        """Under the threshold: no compress-toon call, no output."""
+        result = _run_toon_hook(
+            _json_response(300), self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run below the threshold")
+        self.assertEqual(result, {},
+                         "Small payloads pass through untouched")
+
+    def test_large_payload_still_encoded(self):
+        """At/above the threshold: compress-toon runs and output is used."""
+        result = _run_toon_hook(
+            _json_response(800), self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run for large payloads")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertTrue(
+            str(hso.get("additionalContext", "")).startswith("toon:"),
+            "TOON output should be emitted for large payloads")
+
+    def test_small_structured_non_bmp_payload_skipped(self):
+        """Structured non-BMP payloads are gated by Unicode character count.
+
+        {"stdout": "😀" × 40, ...} is ~67 Unicode characters but 507
+        characters once serialized with \\u escapes; counting the escaped
+        form would wrongly spawn compress-toon.
+        """
+        result = _run_toon_hook(
+            {"stdout": "😀" * 40, "exit_code": 0},
+            self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run for a structured payload "
+                         "whose character count is below the threshold")
+        self.assertEqual(result, {},
+                         "Small payloads pass through untouched")
+
+    def test_large_structured_non_bmp_payload_still_encoded(self):
+        """520 emoji ≈ 547 Unicode chars: above threshold, TOON runs."""
+        result = _run_toon_hook(
+            {"stdout": "😀" * 520, "exit_code": 0},
+            self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run at/above the character "
+                        "threshold for structured non-BMP payloads")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertTrue(
+            str(hso.get("additionalContext", "")).startswith("toon:"),
+            "TOON output should be emitted for large payloads")
+
+    def test_small_string_wrapped_non_bmp_payload_skipped(self):
+        """String-wrapped JSON takes the unwrap_string_json path.
+
+        A wrapped {"stdout": "😀" × 40, ...} payload is ~67 Unicode
+        characters once unwrapped (wrapped input ~73), but re-serializing
+        the inner object with ASCII escapes inflates it to 507 characters;
+        the gate must count the unwrapped code points and skip TOON.
+        """
+        inner = json.dumps({"stdout": "😀" * 40, "exit_code": 0},
+                           ensure_ascii=False)
+        wrapped = json.dumps(inner, ensure_ascii=False)
+        result = _run_toon_hook(wrapped, self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertFalse(os.path.exists(self.toon_marker),
+                         "compress-toon must not run for a string-wrapped "
+                         "payload whose character count is below the threshold")
+        self.assertEqual(result, {},
+                         "Small payloads pass through untouched")
+
+    def test_large_string_wrapped_non_bmp_payload_still_encoded(self):
+        """Wrapped payload unwrapping to ~547 Unicode chars: TOON runs."""
+        inner = json.dumps({"stdout": "😀" * 520, "exit_code": 0},
+                           ensure_ascii=False)
+        wrapped = json.dumps(inner, ensure_ascii=False)
+        result = _run_toon_hook(wrapped, self.mock_bin, self.isolated_home)
+
+        self.assertNotIn("_subprocess_error", result,
+                         f"Hook subprocess failed: {result}")
+        self.assertTrue(os.path.exists(self.toon_marker),
+                        "compress-toon must run at/above the character "
+                        "threshold for string-wrapped non-BMP payloads")
+        hso = result.get("hookSpecificOutput", {})
+        self.assertEqual(hso.get("hookEventName"), "PostToolUse")
+        self.assertTrue(
+            str(hso.get("additionalContext", "")).startswith("toon:"),
+            "TOON output should be emitted for large payloads")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tokenless/tests/test_hermes_toon_threshold.py
+++ b/src/tokenless/tests/test_hermes_toon_threshold.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for the Hermes adapter TOON minimum payload threshold.
+
+TOON on small JSON saves only a handful of characters (~0.3% below
+~500 chars) while the per-event encode cost stays the same, so the
+Hermes pipeline must skip the TOON step for payloads under
+``_MIN_TOON_CHARS`` (500) without invoking ``tokenless compress-toon``.
+Response compression still runs for those payloads; larger payloads
+keep flowing to TOON.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLUGIN_SRC = os.path.join(
+    _REPO_ROOT, "adapters", "tokenless", "hermes", "__init__.py"
+)
+
+_needs_py39 = sys.version_info < (3, 9)
+
+
+def _load_plugin(path: str, name: str):
+    """Load the Hermes plugin module under a unique name."""
+    sys.modules.pop("hook_utils", None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    pre_path = sys.path[:]
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = pre_path
+    return module
+
+
+def _json_payload(char_target: int) -> str:
+    """A JSON object string of roughly ``char_target`` characters."""
+    inner = "x" * max(char_target - 30, 1)
+    return json.dumps({"stdout": inner, "exit_code": 0})
+
+
+@unittest.skipIf(_needs_py39, "hermes plugin requires Python 3.9+")
+class HermesToonMinPayloadThresholdTest(unittest.TestCase):
+    """Spy on _encode_toon to prove it is gated by _MIN_TOON_CHARS."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.plugin = _load_plugin(_PLUGIN_SRC, "hermes_plugin_toon_threshold")
+
+    def setUp(self):
+        self.toon_calls = []
+
+        plugin = self.plugin
+        # Make the pipeline believe tokenless is installed and the input
+        # is a plain tool result (not a skill file).
+        self._orig_have = plugin._have
+        self._orig_is_skill = plugin._is_skill_file
+        self._orig_compress = plugin._compress_response
+        self._orig_encode = plugin._encode_toon
+        plugin._have = lambda *a, **k: True
+        plugin._is_skill_file = lambda result: False
+        # Default: response compression gains nothing.
+        plugin._compress_response = lambda *a, **k: None
+
+        def _spy_encode(data, session_id="", tool_call_id=""):
+            self.toon_calls.append(data)
+            return "toon:" + data[: len(data) // 2], 50
+
+        plugin._encode_toon = _spy_encode
+
+    def tearDown(self):
+        plugin = self.plugin
+        plugin._have = self._orig_have
+        plugin._is_skill_file = self._orig_is_skill
+        plugin._compress_response = self._orig_compress
+        plugin._encode_toon = self._orig_encode
+
+    def test_small_payload_skips_toon_and_passes_through(self):
+        """Under _MIN_TOON_CHARS with no compression savings: no TOON call."""
+        result = self.plugin.on_transform_tool_result(
+            tool_name="some_api_tool",
+            result=_json_payload(300),
+            session_id="s1",
+            tool_call_id="t1",
+        )
+        self.assertEqual(self.toon_calls, [],
+                         "_encode_toon must not run below the threshold")
+        self.assertIsNone(result, "No savings → pass through unchanged")
+
+    def test_small_compressed_result_skips_toon(self):
+        """Compressed result under _MIN_TOON_CHARS keeps compressed form."""
+        compressed = _json_payload(250)
+        self.plugin._compress_response = lambda *a, **k: compressed
+        result = self.plugin.on_transform_tool_result(
+            tool_name="some_api_tool",
+            result=_json_payload(400),
+            session_id="s1",
+            tool_call_id="t1",
+        )
+        self.assertEqual(self.toon_calls, [],
+                         "_encode_toon must not run below the threshold")
+        self.assertEqual(result, compressed,
+                         "Payload keeps the response-compressed form")
+
+    def test_large_payload_still_toon_encoded(self):
+        """At/above _MIN_TOON_CHARS the TOON step still runs."""
+        result = self.plugin.on_transform_tool_result(
+            tool_name="some_api_tool",
+            result=_json_payload(800),
+            session_id="s1",
+            tool_call_id="t1",
+        )
+        self.assertEqual(len(self.toon_calls), 1,
+                         "_encode_toon must run for large payloads")
+        self.assertTrue(str(result).startswith("toon:"),
+                        f"Expected TOON output, got: {result!r}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -491,6 +491,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Tue Aug 18 2026 林生 <linyan.lin@alibaba-inc.com> - 0.7.8-1
+- feat(tokenless): skip TOON encoding for payloads under 500 chars
+- fix(tokenless): drop conflicting bin entries from npm platform packages
+
 * Mon Aug 17 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.7-1
 - feat(tokenless): expose a source-built Python runtime wheel
 - feat(tokenless): add AgentScope 1.x and 2.x response compression


### PR DESCRIPTION
## 改动说明

本 PR 包含两个独立修复（分属两个 commit）。

### 1. TOON 编码最小负载阈值（500 字符）

TOON 编码此前对每个 PostToolUse 负载都会执行。对典型的小型工具输出（<500 字符的 JSON），TOON 平均只能节省个位数字符（约 0.3%），却每次都要付出完整的编码计算开销，并在统计中产生大量近零收益记录，压缩率反馈被稀释。

本 PR 为全部支持 TOON 的管线增加最小负载阈值（500 字符，按 Unicode 字符数 / code point 计数）：

- `compress_response_hook.py`（响应压缩 + TOON 组合管线）：压缩结果 ≥500 字符才进入 TOON 步骤；更小的负载保留响应压缩结果，完全不调用 `compress-toon`（不产生子进程、不编码、不写统计）。
- `compress_toon_hook.py`（独立 TOON hook）：最小响应阈值由 200 提升到 500 字符，原因相同。
- `hermes/__init__.py`、`openclaw/index.ts`、`codex/scripts/compress-response`（adapter 专属管线）：同样应用 500 字符守卫，门槛以下不拉起 `compress-toon` 子进程。
- 计数语义统一：Python hooks 对结构化负载以 `ensure_ascii=False` 规范化后计长（`\u` 转义不膨胀计数）；OpenClaw 按 Unicode code point 计数（`hasAtLeastChars`，代理对计 1 次）；与 JSON 字符串输入路径一致。
- 阈值以下不发生 `compress-toon` 调用，因此不再产生近零收益的统计记录——统计中保留的即为有效压缩，无需在数据库中额外区分跳过情形（保持 DB/diff/SLS 语义不变）。
- 用户文档（en/zh framework-integration）补充阈值说明（注明 500 为当前实现常量、后续可能调整，且覆盖全部 TOON 管线）。
- 新增共享 hooks 与 Hermes、Codex、OpenClaw adapter 的回归测试（call-marker mock 证明阈值以下不调用 compress-toon、阈值以上仍调用；含结构化非 BMP 边界用例），并注册进 `make test-integration` / `make test-adapters`。

直接调用 `tokenless compress-toon` CLI 的语义保持不变（显式调用属用户主动行为，且已有"无收益则输出原文"的保护）。

### 2. npm 平台包 bin 链接修复（独立 commit + 版本号 bump）

`Fixes: 5068b6fe ("feat(tokenless): add npm package support for anolisa-tokenless")`
Related to AGE-3475（CI-Fix #2613）

**根因**：平台包（`@anolisa/tokenless-*`）与根包声明了同名 bin 入口（`tokenless`/`rtk`/`toon`）。当 tree 中多个包声明同名 bin 时，npm（至少到 10.x）的 reify 会删除所有冲突的 `.bin` 链接而不是择一保留。0.7.7 发布到 registry 之后，CI 冒烟测试安装本地 tarball、以及终端用户 `npm install anolisa-tokenless@0.7.7` 都会触发：根包的 optionalDependencies packument（已发布、声明同名 bin）进入 ideal tree，安装结果 `.bin/` 中没有 `tokenless` 可执行文件（exit 127）。这既导致本 PR 的 CI 失败，也使已发布的 0.7.7 对终端用户不可用。

**修复**（与 esbuild 的 `@esbuild/<platform>` 包设计一致）：
- 平台包不再声明 bin（二进制仍放在 `bin/` 目录）；根包独占三个 bin 入口，其 postinstall 将它们链接到已安装平台包内的原生二进制。
- `tests/test-package-npm-prebuilt.sh` 新增断言：平台 manifest 不得包含 bin 条目，防止回归。
- 版本号 0.7.7 → 0.7.8（独立 chore commit，同步 Cargo.toml / component.toml / Cargo.lock×3 / npm manifests / spec.in / CHANGELOG）：0.7.7 已发布且 npm 禁止重复发布，其 registry packument 仍声明 bin；bump 到 0.7.8 使 CI 冒烟测试摆脱已发布 0.7.7 的 registry 状态干扰，下一次发布即可让终端用户拿到修复。
- CI 冒烟测试**不**引入 `npm rebuild` 之类的绕过：冒烟测试的价值在于忠实复现终端用户安装路径，rebuild 会掩盖此类打包损坏；回归由上述打包断言守护。

**验证**：本地以真实源码运行 `make test-npm-package`（全部断言通过），并按 CI 冒烟序列在干净目录安装本地构建的 platform + root tarball：`.bin/tokenless → anolisa-tokenless/bin/tokenless → @anolisa/tokenless-linux-x64/bin/tokenless` 链接链完整，postinstall 正确建立符号链接，openclaw adapter 产物齐全。推送后 CI run 32105553498 全绿（Test tokenless / Check component versions / Test anolisa 通过，0 失败）。

> 分支历史说明：分支已 rebase 到最新 main（包含 main 上的 0.7.7 版本 bump），共 3 个 commit（原始修复 + bin 修复 + 版本 bump）。此前的并行修复 commit（f90fb0ca / 50076e43，方案为 bin 移除 + ci.yaml `npm rebuild` 绕过）已被当前版本取代：当前版本不依赖 registry 状态、不削弱冒烟测试，且为下一次发布准备好了版本号。

## 风险和兼容性

- TOON 阈值：仅影响 <500 字符负载（跳过近零收益的 TOON 步骤），≥500 字符负载行为不变；统计记录减少属预期效果。回滚：还原对应 commit 即可，无数据迁移。
- npm 平台包：bin 字段移除后平台包不再提供可直接执行的 bin 条目，入口统一为根包 postinstall 链接；未发布平台包的环境不受影响。回滚：还原该 commit（注意会重新引入 bin 冲突问题）。
- 版本 bump（0.7.8）：纯版本号同步（Cargo/RPM/npm manifest/CHANGELOG），无代码逻辑变更；如需回滚连同 bin 修复一起还原即可。0.7.7 已发布在 registry 且无法覆盖，勿再基于 0.7.7 发布。

## 测试情况

**环境**：Linux x86_64；rustc/cargo 1.94.1；Python 3.11；Node v22.21.1；tokenless 0.7.6（本地源码 release 构建）。

**实际执行的命令与结果**

| 项目 | 命令 | 结果 |
| --- | --- | --- |
| 格式 | `cargo fmt --all -- --check` | 通过 |
| Lint | `cargo clippy --workspace -- -D warnings` | 0 错误 |
| Rust 测试 | `cargo test --workspace -- --test-threads=1` | 573 通过 / 0 失败 / 2 忽略 |
| Python 集成 | `test_compress_response_hook`（21 用例，含新增 3 个结构化非 BMP 阈值用例）、`test_compress_toon_hook`（4 用例，含新增 2 个结构化非 BMP 用例）、`test_compress_schema_hook`、`test_agentscope_middleware`、`test_agentscope_v1`、`test_resolve_agent_id` | 全部 OK |
| 阈值回归 | `test_codex_toon_threshold`、`test_hermes_toon_threshold`、`test-openclaw-toon-threshold.mjs`（4 用例，含 2 个非 BMP 边界用例） | 全部通过 |
| 功能 hook 套件 | `make test-hooks`（含 run-all-tests.sh，使用本次源码构建的 release 二进制） | 72/72 通过 |
| OpenClaw 插件 | `make build-openclaw-plugin`（tsc）+ `node --test tests/test-openclaw-rtk-context.mjs` | 构建通过 / 6/6 通过 |
| npm 打包 | `make test-npm-package`（含平台 manifest 无 bin 断言） | 通过 |

**修复验证（复现 → 验证）**
- Unicode 计数（复现 → 修复）：结构化 `{"stdout": "😀"×40}`（67 个 Unicode 字符，`\u` 转义序列化后 507 字符）修复前两个 Python hook 均会拉起 compress-toon，修复后直接跳过（call-marker 证明，负向对照成立）；OpenClaw 的 244-emoji 复现样例同样不再拉起。
- 真实二进制端到端：869 字符 JSON 经独立 TOON hook 输出 TOON 表格格式；293 字符 JSON 被直接跳过（空输出、无编码调用）。组合管线：1444 字符负载产出 TOON 表格输出；335 字符负载仅做响应压缩、跳过 TOON 步骤。
- npm bin 链接：平台 manifest 不再声明 bin；`make test-npm-package` 全部断言通过。

**未运行项及原因**
- `tests/test_rewrite_hook.py` 与 `tests/test_hermes_plugin_import.py::test_resolves_via_xdg_data_home`：测试机存在系统级安装的 tokenless/rtk（/usr/local 前缀），干扰测试沙箱；未改动基线上同样复现，与本次改动无关。
- `tests/test-toon.sh` / `test-toon-full.sh`：需要完整安装环境（toon/openclaw/已安装 hook 路径），本环境不具备全部依赖；本次未改变 CLI 语义，不受影响（未运行）。

## 文档和回滚

- 文档更新：`docs/user-guide/{en,zh}/token-saving/tokenless/framework-integration.md`（TOON 阈值说明）。
- 回滚：三个 commit（TOON 阈值 / npm bin 修复 / 版本 bump）相互独立，可分别 revert；TOON 阈值无数据迁移，npm 修复 revert 会重新引入 bin 冲突问题。

