### PR TITLE
chore(anolisa): bump version to 0.3.2

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-17
+
+### Added
+
+- ANOLISA now provides a native DSH adapter driver for plugin bundles.
+  `anolisa adapter enable <component> dsh --profile <name>` accepts repeatable
+  profiles, validates the bundle identity, delegates profile changes to DSH,
+  and remembers the enable-time DSH home so status, disable, and re-enable keep
+  targeting the same profiles even if `DSH_HOME` or the working directory
+  changes. Disable DSH adapters before downgrading to an earlier ANOLISA release
+  ([#2580](https://github.com/alibaba/anolisa/pull/2580)).
+- `anolisa logs --level <LEVEL>` is now a visible alias for the existing
+  `--severity` option, with the same validation and filtering behavior while
+  `severity` remains the canonical JSON field
+  ([#2558](https://github.com/alibaba/anolisa/pull/2558)).
+
+### Changed
+
+- `anolisa list` and `anolisa install --all` now evaluate component
+  availability against an exact OS and architecture target from schema v2
+  `components-v2.toml`. JSON output replaces `platforms` and
+  `platform_available` with `targets` and `target_available`; repository
+  publishers must deploy the v2 index beside the unchanged v1 index
+  ([#2533](https://github.com/alibaba/anolisa/pull/2533)).
+
+### Fixed
+
+- `anolisa --dry-run install` now reads `meta.toml` beside the resolved Raw
+  artifact before falling back to version-level metadata only when the sibling
+  file is absent. Previews now validate the selected target's contract, reject
+  corrupt published metadata instead of masking it, and still avoid downloading
+  the artifact
+  ([#2551](https://github.com/alibaba/anolisa/pull/2551)).
+- System-helper status now reports `unknown` when `systemctl` cannot be started
+  and reports `failed` only for a unit whose actual state is failed
+  ([#2604](https://github.com/alibaba/anolisa/pull/2604)).
+
 ## [0.3.1] - 2026-08-13
 
 ### Fixed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,42 @@
 
 ## [未发布]
 
+## [0.3.2] - 2026-08-17
+
+### 新增
+
+- ANOLISA 现为 plugin bundle 提供原生 DSH adapter driver。
+  `anolisa adapter enable <component> dsh --profile <name>` 支持重复指定
+  profile、验证 bundle identity、将 profile 变更委托给 DSH，并记录 enable
+  时的 DSH home，使 status、disable 和 re-enable 在 `DSH_HOME` 或 working
+  directory 变化后仍针对相同 profile。降级到更早的 ANOLISA release 前需先
+  disable DSH adapter
+  ([#2580](https://github.com/alibaba/anolisa/pull/2580))。
+- `anolisa logs --level <LEVEL>` 现为已有 `--severity` option 的可见别名，
+  使用相同的 validation 和 filtering behavior，同时 `severity` 仍为 canonical
+  JSON field
+  ([#2558](https://github.com/alibaba/anolisa/pull/2558))。
+
+### 变更
+
+- `anolisa list` 和 `anolisa install --all` 现依据 schema v2
+  `components-v2.toml` 中精确的 OS 与 architecture target 判断 component
+  availability。JSON output 以 `targets` 和 `target_available` 取代
+  `platforms` 和 `platform_available`；repository publisher 必须在保持 v1
+  index 不变的同时部署 v2 index
+  ([#2533](https://github.com/alibaba/anolisa/pull/2533))。
+
+### 修复
+
+- `anolisa --dry-run install` 现优先读取 resolved Raw artifact 旁的
+  `meta.toml`，仅在该 sibling file 不存在时回退到 version-level metadata。
+  Preview 现会验证所选 target 的 contract，并拒绝损坏的已发布 metadata，
+  不再掩盖错误，同时仍不会下载 artifact
+  ([#2551](https://github.com/alibaba/anolisa/pull/2551))。
+- System-helper status 现会在 `systemctl` 无法启动时报告 `unknown`，仅在 unit
+  的实际状态为 failed 时报告 `failed`
+  ([#2604](https://github.com/alibaba/anolisa/pull/2604))。
+
 ## [0.3.1] - 2026-08-13
 
 ### 修复

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,14 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Thu Aug 13 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Mon Aug 17 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Native DSH adapters now support explicit multi-profile lifecycle.
+- Component availability and batch installs now match exact OS and architecture targets.
+- Raw dry-runs now validate metadata for the resolved artifact target.
+- Logs now accept --level as an alias for --severity.
+- System-helper status now distinguishes unit failures from systemctl launch failures.
+
+* Thu Aug 13 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.1-1
 - Adapter discovery now ignores undeclared shared resource directories.
 
 * Wed Aug 12 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.0-1

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.1",
-    "@anolisa/cli-linux-arm64": "0.3.1",
-    "@anolisa/cli-darwin-arm64": "0.3.1"
+    "@anolisa/cli-linux-x64": "0.3.2",
+    "@anolisa/cli-linux-arm64": "0.3.2",
+    "@anolisa/cli-darwin-arm64": "0.3.2"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.3.2 packages the five user-visible component changes merged after
0.3.1. This release synchronizes every distribution surface and curates
bilingual notes from the actual component range without adding runtime behavior
in the bump commit.

## What changed

- Bumped the Cargo workspace and all five internal lockfile packages to 0.3.2.
- Bumped the npm root package, native platform packages, and optional dependency
  pins to 0.3.2.
- Added equivalent English and Chinese release notes for #2533, #2551, #2580,
  #2558, and #2604.
- Advanced the RPM changelog placeholder and froze the previous row at 0.3.1.
- Kept historical release rows, status fixtures, Node version examples, and
  unrelated component catalog versions unchanged.

## Related issue

no-issue: release metadata for already-merged PRs #2533, #2551, #2580, #2558,
and #2604

## User / Agent impact

Published ANOLISA packages will report version 0.3.2. Users gain a native DSH
adapter with explicit multi-profile lifecycle, exact OS/architecture component
availability, target-correct Raw install previews, a visible `logs --level`
alias, and accurate system-helper status when `systemctl` cannot start.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The release commit itself changes metadata and documentation only; the runtime
changes were already merged and tested independently. JSON consumers must use
`targets` and `target_available` instead of `platforms` and
`platform_available`. Repository publishers must deploy `components-v2.toml`
beside the unchanged v1 index. Disable DSH adapters before downgrading to an
ANOLISA release without the DSH receipt variant.

## Validation

Linux x86_64; Rust 1.88.0, Cargo 1.88.0, Node.js 24.15.0, npm 11.12.1:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64`
- Release and packaged Linux x64 binaries reported `anolisa 0.3.2`.
- Root and Linux x64 npm tarball metadata read back as version 0.3.2.
- Nightly Raw lifecycle harness syntax, case list, and repository configuration
  checks.
- `bash scripts/docs-lint.sh`
- Website locale validation, typecheck, production build, agent-index
  validation, and 162-page link validation.
- `python3 scripts/check-component-versions.py`
- Rendered `anolisa.spec.in` parsed with `rpmspec -P`.
- The history-derived release audit passed against the 0.3.1 content bump for
  both the working tree and committed `HEAD`.
- `git diff --check` and `git diff --cached --check`.

The macOS arm64 and Linux arm64 package templates were validated but not built
on this Linux x86_64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog.
Before artifact publication, rollback is a revert of this release commit. After
publication, issue a corrected follow-up version rather than reusing 0.3.2.
