### PR TITLE
chore(tokenless): bump version to 0.7.7

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.6"
+version = "0.7.7"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,24 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-08-17
+
+### Added
+
+- A source-built `anolisa-tokenless` ABI3 wheel now provides stateful in-process JSON response compression and marker-based Stash retrieval for CPython 3.11+ without spawning the CLI ([#2501](https://github.com/alibaba/anolisa/pull/2501)).
+- AgentScope 1.0.11 through 1.x and AgentScope 2.0.x applications can install a separate same-version integration wheel to compress successful final Tool Responses and expose retrieval only for markers visible to the current Agent ([#2507](https://github.com/alibaba/anolisa/pull/2507), [#2528](https://github.com/alibaba/anolisa/pull/2528), [#2553](https://github.com/alibaba/anolisa/pull/2553)).
+- DeepSeek Harness profiles can enable a bundled native Plugin that compresses successful single-block JSON Tool Results while preserving environment-error attribution and fail-open behavior ([#2581](https://github.com/alibaba/anolisa/pull/2581)).
+
+### Changed
+
+- Claude Code Adapter detection now retries transient first-run binary and Plugin-registry initialization failures, reducing false not-ready results immediately after provisioning ([#2519](https://github.com/alibaba/anolisa/pull/2519)).
+- The Tokenless RPM now provides the virtual `anolisa-component(tokenless)` capability, allowing ANOLISA to resolve the Package when the repository component index is unavailable ([#2576](https://github.com/alibaba/anolisa/pull/2576)).
+
+### Fixed
+
+- Cosh-NG extension execution now treats the hard-disabled Tool Ready Hook's empty result as a successful no-op instead of failing closed ([#2506](https://github.com/alibaba/anolisa/pull/2506)).
+- No-savings response compression now removes only Stash rows created by the discarded candidate, avoiding orphaned rows without deleting entries refreshed by another process ([#2480](https://github.com/alibaba/anolisa/pull/2480)).
+
 ## [0.7.6] - 2026-08-13
 
 ### Changed

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,24 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.7] - 2026-08-17
+
+### 新增
+
+- 现在可从源码构建 `anolisa-tokenless` ABI3 Wheel，为 CPython 3.11+ 提供有状态的进程内 JSON Response 压缩和基于 Marker 的 Stash Retrieve，且无需启动 CLI 子进程（[#2501](https://github.com/alibaba/anolisa/pull/2501)）。
+- AgentScope 1.0.11 至 1.x 以及 AgentScope 2.0.x 应用现在可以安装独立的同版本集成 Wheel，压缩成功的最终 Tool Response，并且只允许 Retrieve 当前 Agent 可见 Marker 对应的内容（[#2507](https://github.com/alibaba/anolisa/pull/2507)、[#2528](https://github.com/alibaba/anolisa/pull/2528)、[#2553](https://github.com/alibaba/anolisa/pull/2553)）。
+- DeepSeek Harness Profile 现在可以启用随包提供的原生 Plugin，在保持环境错误归因与 fail-open 行为的同时，压缩成功的单 Block JSON Tool Result（[#2581](https://github.com/alibaba/anolisa/pull/2581)）。
+
+### 变更
+
+- Claude Code Adapter 探测现在会重试首次运行时暂时性的二进制文件与 Plugin Registry 初始化失败，减少预置完成后立即出现的错误未就绪结果（[#2519](https://github.com/alibaba/anolisa/pull/2519)）。
+- Tokenless RPM 现在提供虚拟能力 `anolisa-component(tokenless)`，使 ANOLISA 在仓库组件索引不可用时仍可解析该 Package（[#2576](https://github.com/alibaba/anolisa/pull/2576)）。
+
+### 修复
+
+- Cosh-NG Extension 执行现在会把硬关闭的 Tool Ready Hook 所返回的空结果视为成功 no-op，而不再 fail closed（[#2506](https://github.com/alibaba/anolisa/pull/2506)）。
+- 无节省的 Response 压缩现在只删除已丢弃候选结果所创建的 Stash Row，既避免孤立数据，也不会删除被其他进程刷新过的条目（[#2480](https://github.com/alibaba/anolisa/pull/2480)）。
+
 ## [0.7.6] - 2026-08-13
 
 ### 变更

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "pyo3",
  "tokenless-runtime",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "regex",
  "serde_json",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -45,9 +45,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.6",
-    "@anolisa/tokenless-linux-arm64": "0.7.6",
-    "@anolisa/tokenless-darwin-x64": "0.7.6",
-    "@anolisa/tokenless-darwin-arm64": "0.7.6"
+    "@anolisa/tokenless-linux-x64": "0.7.7",
+    "@anolisa/tokenless-linux-arm64": "0.7.7",
+    "@anolisa/tokenless-darwin-x64": "0.7.7",
+    "@anolisa/tokenless-darwin-arm64": "0.7.7"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -491,6 +491,15 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Mon Aug 17 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.7-1
+- feat(tokenless): expose a source-built Python runtime wheel
+- feat(tokenless): add AgentScope 1.x and 2.x response compression
+- feat(tokenless): add a native DeepSeek Harness plugin
+- fix(tokenless): retry transient Claude Code detection failures
+- fix(tokenless): accept the disabled Tool Ready no-op in Cosh-NG
+- fix(tokenless): roll back discarded no-savings stash rows
+- fix(tokenless): declare the RPM component virtual provide
+
 * Thu Aug 13 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.6-1
 - feat(tokenless): add reproducible raw and prebuilt npm packaging
 - fix(tokenless): allow trusted external data directories without unsafe fallback


### PR DESCRIPTION
## Why

Tokenless has accumulated backward-compatible user-visible features and fixes since 0.7.6.
This patch release establishes one coherent 0.7.7 boundary for those already-merged changes.

## What changed

- Synchronize all 13 historical Cargo, npm, benchmark, RPM, changelog, and component-catalog version surfaces.
- Curate equivalent English and Chinese notes from the verified `0.7.6..main` range.
- Record the source-built Python runtime, AgentScope 1.x/2.x integration, native DSH plugin, adapter reliability changes, RPM discovery, and Stash cleanup behavior.

## Related issue

no-issue: aggregate release boundary for merged Tokenless changes

## User / Agent impact

Published Tokenless artifacts can identify as 0.7.7, with release notes describing the final behavior already present on `main`. The bump commit itself changes metadata and documentation only; it adds no runtime behavior. The Python runtime and AgentScope wheels remain source-built and are not yet published to PyPI.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The release range includes new Python and AgentScope APIs plus a native DSH adapter, but those implementations were merged separately before this bump. The patch version follows Tokenless's existing backward-compatible 0.7.x cadence. Cross-component risk is limited to synchronizing the ANOLISA component catalog and RPM virtual provide with the same version.

## Validation

Completed on Linux x86_64 before the request to skip further local build and test work:

- `cargo check --workspace`
- `cargo check --manifest-path benchmark/l1-compressor/Cargo.toml`
- `cargo check --manifest-path benchmark/l2-module/Cargo.toml`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (passed; two network-probe tests are explicitly ignored)
- `cargo doc --workspace --no-deps`

Static release validation:

- `check_release.py` against the working tree and final committed `HEAD`
- `git diff --check`
- JSON and TOML parsing for active release metadata and templates
- stamped `rpmspec -P` validation for 0.7.7
- final 13-file commit-scope and commit-message line-length checks

Skipped by explicit user request:

- `make build` did not complete; it was interrupted during RTK compilation and is not counted as passed
- `make lint`, `make test`, Python/AgentScope wheel integration tests, and package assembly tests

## Documentation and rollback

`CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM `%changelog` now describe the final 0.7.7 behavior. Roll back by reverting the single version-bump commit; no data or configuration migration is introduced by this PR.
