### PR TITLE
fix(anolisa): preserve raw adapter modes

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/owned_ops.rs
@@ -1473,7 +1473,11 @@ fn owned_file_rows(
                 OwnedFileKind::File
             },
             referent: f.referent.clone(),
-            mode: expected_mode_for_path(&f.path, contract_files),
+            mode: expected_mode_for_path(&f.path, contract_files).or_else(|| {
+                (f.referent.is_none())
+                    .then(|| recorded_mode(&f.path))
+                    .flatten()
+            }),
             capabilities: capabilities_for_path(&f.path, applied_capabilities),
         })
         .collect();
@@ -1502,7 +1506,17 @@ fn expected_mode_for_path(path: &Path, contract_files: &[ResolvedInstallFile]) -
                     && path.starts_with(&file.dest))
         })
         .and_then(|file| {
-            let raw = file.mode.as_deref().unwrap_or("0755");
+            let raw = match file.mode.as_deref() {
+                Some(raw) => raw,
+                None if file
+                    .source
+                    .as_deref()
+                    .is_some_and(|source| source.ends_with('/')) =>
+                {
+                    return None;
+                }
+                None => "0755",
+            };
             let octal = raw.trim().strip_prefix("0o").unwrap_or(raw.trim());
             u32::from_str_radix(octal, 8)
                 .ok()
@@ -1639,6 +1653,69 @@ mod tests {
 
         assert_eq!(row.mode.as_deref(), Some("0755"));
         assert_eq!(row.capabilities, vec!["CAP_BPF".to_string()]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn owned_file_rows_record_directory_source_modes_from_placed_files() {
+        use anolisa_core::{IntegrityStatus, check_owned_file};
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout =
+            FsLayout::user_with_overrides(tmp.path().to_path_buf(), None, None, None, None, None);
+        let adapter_root = layout.datadir.join("adapters/tokenless/codex");
+        let script = adapter_root.join("scripts/tool-ready");
+        let hooks = adapter_root.join("hooks/hooks.json");
+        let manifest = layout.datadir.join("components/tokenless/component.toml");
+        fs::create_dir_all(script.parent().expect("script parent")).expect("script parent");
+        fs::create_dir_all(hooks.parent().expect("hooks parent")).expect("hooks parent");
+        fs::create_dir_all(manifest.parent().expect("manifest parent")).expect("manifest parent");
+        fs::write(&script, b"#!/usr/bin/env python3\n").expect("script");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).expect("chmod script");
+        fs::write(&hooks, br#"{"hooks":{}}"#).expect("hooks");
+        fs::set_permissions(&hooks, fs::Permissions::from_mode(0o644)).expect("chmod hooks");
+        fs::write(&manifest, b"[component]\nname = \"tokenless\"\n").expect("manifest");
+
+        let placed = vec![
+            InstalledFile {
+                path: script.clone(),
+                sha256: sha256_hex(b"#!/usr/bin/env python3\n"),
+                referent: None,
+            },
+            InstalledFile {
+                path: hooks.clone(),
+                sha256: sha256_hex(br#"{"hooks":{}}"#),
+                referent: None,
+            },
+        ];
+
+        let rows = owned_file_rows(
+            &placed,
+            &manifest,
+            "[component]\nname = \"tokenless\"\n",
+            &[ResolvedInstallFile {
+                source: Some("adapters/tokenless/codex/".to_string()),
+                dest: adapter_root,
+                mode: None,
+                kind: FileKind::Data,
+                render: None,
+            }],
+            &[],
+        );
+
+        let script_row = rows
+            .iter()
+            .find(|row| row.path == script)
+            .expect("script row");
+        let hooks_row = rows
+            .iter()
+            .find(|row| row.path == hooks)
+            .expect("hooks row");
+        assert_eq!(script_row.mode.as_deref(), Some("0755"));
+        assert_eq!(hooks_row.mode.as_deref(), Some("0644"));
+        assert_eq!(check_owned_file(&layout, script_row), IntegrityStatus::Ok);
+        assert_eq!(check_owned_file(&layout, hooks_row), IntegrityStatus::Ok);
     }
 
     /// Teardown pruning must remove the directory chain the file removal

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -962,10 +962,9 @@ pub(crate) fn resolve_adapter_files(
         files.push(ResolvedInstallFile {
             source: Some(source),
             dest,
-            // Bundle contents are framework-loaded data, not directly
-            // executed by ANOLISA; lay them 0644. Per-file modes inside a
-            // bundle are not expressible in `[[adapters]]` in the MVP.
-            mode: Some("0644".to_string()),
+            // Preserve per-entry archive modes so framework-executed adapter
+            // hooks and scripts keep their executable bit after raw installs.
+            mode: None,
             kind: FileKind::Data,
             render: None,
         });
@@ -1216,7 +1215,7 @@ mod tests {
         assert_eq!(f.source.as_deref(), Some("adapters/tokenless/openclaw/"));
         assert_eq!(f.dest, layout.datadir.join("adapters/tokenless/openclaw"));
         assert_eq!(f.kind, FileKind::Data);
-        assert_eq!(f.mode.as_deref(), Some("0644"));
+        assert_eq!(f.mode, None);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -642,11 +642,15 @@ impl<'a> InstallRunner<'a> {
                 }
                 for (key, relative, index) in matches {
                     let claim = staged.claim(index)?;
+                    let mode = file
+                        .mode
+                        .clone()
+                        .or_else(|| claim.mode.map(|mode| format!("{mode:04o}")));
                     expanded.push(PreparedRegularFile {
                         file: ResolvedInstallFile {
                             source: Some(key),
                             dest: file.dest.join(relative),
-                            mode: file.mode.clone(),
+                            mode,
                             kind: file.kind,
                             render: None,
                         },
@@ -954,6 +958,7 @@ struct StagedClaim {
     path: PathBuf,
     sha256: String,
     size: u64,
+    mode: Option<u32>,
 }
 
 /// One archive entry spooled to disk.
@@ -961,6 +966,7 @@ struct StagedEntry {
     path: PathBuf,
     sha256: String,
     size: u64,
+    mode: Option<u32>,
 }
 
 /// Contract-selected archive entries spooled into a private staging directory,
@@ -1015,6 +1021,7 @@ impl StagedArchive {
             if !entry.header().entry_type().is_file() {
                 continue;
             }
+            let mode = entry.header().mode().ok().map(|mode| mode & 0o7777);
             let entry_path = entry
                 .path()
                 .map_err(|e| InstallError::Archive(format!("path: {e}")))?
@@ -1028,7 +1035,7 @@ impl StagedArchive {
             if !selector.selects(&path_key, &basename) {
                 continue;
             }
-            let index = staged.spool_entry(&mut entry, &path_key)?;
+            let index = staged.spool_entry(&mut entry, &path_key, mode)?;
             // Basename first, then the full path — the same insertion order as
             // the map this replaces, so which entry wins a basename/full-path
             // collision does not change.
@@ -1044,6 +1051,7 @@ impl StagedArchive {
         &mut self,
         source: &mut impl Read,
         path_key: &str,
+        mode: Option<u32>,
     ) -> Result<usize, InstallError> {
         let path = self.next_staged_path();
         let mut out = create_exclusive_no_follow(&path)?;
@@ -1073,6 +1081,7 @@ impl StagedArchive {
             path,
             sha256: to_lower_hex(&hasher.finalize()),
             size,
+            mode,
         });
         self.claimed.push(false);
         Ok(self.entries.len() - 1)
@@ -1083,7 +1092,7 @@ impl StagedArchive {
     /// The result is claimed immediately: rendered content belongs to exactly
     /// the destination that requested it and is not addressable by archive key.
     fn stage_bytes(&mut self, bytes: &[u8]) -> Result<StagedClaim, InstallError> {
-        let index = self.spool_entry(&mut &bytes[..], "<rendered>")?;
+        let index = self.spool_entry(&mut &bytes[..], "<rendered>", None)?;
         self.claim(index)
     }
 
@@ -1114,7 +1123,12 @@ impl StagedArchive {
         let entry = self.entries.get(index).ok_or_else(|| {
             InstallError::Archive(format!("internal: staged entry {index} is missing"))
         })?;
-        let (source, sha256, size) = (entry.path.clone(), entry.sha256.clone(), entry.size);
+        let (source, sha256, size, mode) = (
+            entry.path.clone(),
+            entry.sha256.clone(),
+            entry.size,
+            entry.mode,
+        );
         let already_claimed = self.claimed.get(index).copied().unwrap_or(false);
         if !already_claimed {
             self.claimed[index] = true;
@@ -1122,6 +1136,7 @@ impl StagedArchive {
                 path: source,
                 sha256,
                 size,
+                mode,
             });
         }
         let path = self.next_staged_path();
@@ -1141,7 +1156,12 @@ impl StagedArchive {
                 source: err,
             })?;
         }
-        Ok(StagedClaim { path, sha256, size })
+        Ok(StagedClaim {
+            path,
+            sha256,
+            size,
+            mode,
+        })
     }
 
     /// Read a staged payload back into memory. Only used for rendering, which
@@ -1582,13 +1602,22 @@ mod tests {
     }
 
     fn build_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        build_tar_gz_with_modes(
+            &entries
+                .iter()
+                .map(|(path, data)| (*path, *data, 0o644))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn build_tar_gz_with_modes(entries: &[(&str, &[u8], u32)]) -> Vec<u8> {
         let buf: Vec<u8> = Vec::new();
         let enc = GzEncoder::new(buf, Compression::default());
         let mut tar = Builder::new(enc);
-        for (path, data) in entries {
+        for (path, data, mode) in entries {
             let mut hdr = Header::new_gnu();
             hdr.set_size(data.len() as u64);
-            hdr.set_mode(0o644);
+            hdr.set_mode(*mode);
             hdr.set_cksum();
             tar.append_data(&mut hdr, path, *data).unwrap();
         }
@@ -1960,6 +1989,60 @@ mod tests {
 
         let mode = fs::metadata(dest).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o644);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn directory_source_without_manifest_mode_preserves_archive_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz_with_modes(&[
+            (
+                "adapters/tokenless/codex/scripts/tool-ready",
+                b"#!/usr/bin/env python3\n",
+                0o755,
+            ),
+            (
+                "adapters/tokenless/codex/hooks/hooks.json",
+                br#"{"hooks":{}}"#,
+                0o644,
+            ),
+        ]);
+        let cached = cache.path().join("payload.tar.gz");
+        fs::write(&cached, &gz).unwrap();
+
+        let dest_root = layout.datadir.join("adapters/tokenless/codex");
+        runner
+            .install_files(
+                "tar_gz",
+                &cached,
+                &[ResolvedInstallFile {
+                    source: Some("adapters/tokenless/codex/".to_string()),
+                    dest: dest_root.clone(),
+                    mode: None,
+                    kind: FileKind::Data,
+                    render: None,
+                }],
+            )
+            .expect("install ok");
+
+        let script_mode = fs::metadata(dest_root.join("scripts/tool-ready"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let json_mode = fs::metadata(dest_root.join("hooks/hooks.json"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(script_mode, 0o755);
+        assert_eq!(json_mode, 0o644);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix raw installs so adapter bundle files keep their archive permissions instead of being flattened to `0644`.

## Why

When `tokenless` is installed through the raw backend on macOS, Codex adapter hook scripts such as `scripts/tool-ready`, `scripts/rewrite-hook`, `scripts/compress-response`, and `scripts/check-tokenless` are installed without the executable bit.

Codex then tries to run those hook commands directly and reports:

```text
PreToolUse hook (failed)
error: hook exited with code 126
```

The source tree and RPM spec already mark these files as executable. The issue is specific to the raw install path:

- `resolve_adapter_files()` turns adapter directories into one directory-prefix install mapping.
- That mapping previously forced `mode = 0644`.
- `InstallRunner` expands the directory into individual files and applies that same mode to every file.

As a result, executable hook scripts inside adapter bundles lose `0755`.

## Changes

- Preserve tar archive entry modes while spooling selected archive files.
- When expanding directory-source install entries, use an explicit manifest mode if present; otherwise, use the archive entry mode.
- Stop forcing raw adapter bundle mappings to `0644`.
- Add regression coverage for a directory-source adapter bundle containing both an executable script and a regular JSON hook file.

## Test Plan

- `rustfmt --check src/anolisa/crates/anolisa-core/src/install_runner.rs src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs`
- `git diff --check`

I could not complete `cargo test` locally because the machine's Cargo configuration replaces crates.io with `https://rsproxy.cn/crates.io-index/`, which returned `repository not found`; offline mode also lacked the required dependency cache.