### PR TITLE
fix(sec-core): compose transform_llm_output hooks so skill-ledger warning is not dropped

### DIFF
--- a/src/agent-sec-core/hermes-plugin/src/capabilities/base.py
+++ b/src/agent-sec-core/hermes-plugin/src/capabilities/base.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Callable, final
 
-from ..registry import safe_hook_wrapper
+from ..registry import _collect_transform_hook, safe_hook_wrapper
 
 logger = logging.getLogger("agent-sec-core")
 
@@ -45,7 +45,13 @@ class AgentSecCoreCapability(ABC):
         self._on_register(config)
         for hook_name, callback_func in self.get_hooks_define().items():
             wrapper_func = safe_hook_wrapper(callback_func, self.id)
-            ctx.register_hook(hook_name, wrapper_func)
+            if hook_name == "transform_llm_output":
+                # Collect for single composed registration (Hermes applies
+                # transform_llm_output with "first non-empty wins", which would
+                # let one capability's warning silently drop another's).
+                _collect_transform_hook(self.id, wrapper_func)
+            else:
+                ctx.register_hook(hook_name, wrapper_func)
 
     @abstractmethod
     def _on_register(self, config: dict) -> None:

--- a/src/agent-sec-core/hermes-plugin/src/registry.py
+++ b/src/agent-sec-core/hermes-plugin/src/registry.py
@@ -27,6 +27,46 @@ _CAPABILITY_ENABLED_ENV = {
 # If a single hook invocation exceeds this threshold (seconds), emit a warning.
 _SLOW_HOOK_THRESHOLD = 2.0
 
+# ---------------------------------------------------------------------------
+# transform_llm_output composition
+#
+# Hermes applies transform_llm_output hooks with "first hook returning a
+# non-empty string wins" semantics (see Hermes agent/turn_finalizer.py).
+# Multiple agent-sec-core capabilities (pii-scan, prompt-scan, skill-ledger)
+# each register a transform_llm_output hook; under "first-wins", a later
+# capability's warning is silently dropped whenever an earlier capability also
+# fires in the same turn — a security warning (e.g. "status=tampered") becomes
+# invisible to the user. To avoid this, collect all capability transform
+# callbacks here and register a single composed hook that chains them, so every
+# capability's warning is prepended to the response.
+# ---------------------------------------------------------------------------
+_TRANSFORM_HOOKS: list[tuple[str, Any]] = []
+
+
+def _collect_transform_hook(capability_id: str, callback: Any) -> None:
+    """Called by AgentSecCoreCapability.register to collect (not register)
+    a capability's transform_llm_output callback for composition."""
+    _TRANSFORM_HOOKS.append((capability_id, callback))
+
+
+def _compose_transform_chain(callbacks: list[tuple[str, Any]]):
+    """Return a single transform_llm_output callback that chains ``callbacks``.
+
+    Each callback receives the accumulated text as ``response_text`` and
+    prepends its own warnings, so the composed result carries every
+    capability's warning instead of only the first one to fire.
+    """
+
+    def _chain(response_text: str = "", **kwargs: Any) -> str:
+        current = response_text
+        for _capability_id, callback in callbacks:
+            result = callback(response_text=current, **kwargs)
+            if isinstance(result, str) and result:
+                current = result
+        return current
+
+    return _chain
+
 
 def load_config(plugin_dir: Path) -> dict[str, Any]:
     """Load config.toml from the plugin directory.
@@ -70,6 +110,8 @@ def register_capabilities(
     ctx, capabilities: list[AgentSecCoreCapability], config: dict
 ) -> None:
     """Register all enabled capabilities with the Hermes plugin context."""
+    global _TRANSFORM_HOOKS
+    _TRANSFORM_HOOKS = []
     if "capabilities" not in config:
         logger.error(
             f"[agent-sec-core] config missing [capabilities] section, no capabilities registered"
@@ -103,3 +145,15 @@ def register_capabilities(
             logger.info(f"[agent-sec-core] {cap.id} registered successfully")
         except Exception as e:
             logger.error(f"[agent-sec-core] {cap.id} registration failed: {e}")
+
+    # Register a single composed transform_llm_output hook that chains every
+    # capability's transform callback, so all security warnings (prompt-scan,
+    # pii-scan, skill-ledger) are preserved instead of one silently dropping
+    # another under Hermes' "first non-empty wins" semantics.
+    if _TRANSFORM_HOOKS:
+        composed = _compose_transform_chain(_TRANSFORM_HOOKS)
+        ctx.register_hook(
+            "transform_llm_output",
+            safe_hook_wrapper(composed, "transform-compose"),
+        )
+        _TRANSFORM_HOOKS = []


### PR DESCRIPTION
## 问题

Fixes #2620

当 `prompt-scan` 与 `skill-ledger` 在同一 turn 都触发 warning 时，Hermes 的 `transform_llm_output` 采用 "first non-empty string wins" 语义，先注册的 `prompt-scan` 会抢占，导致 `skill-ledger` 的 `status=tampered` 安全告警被静默丢弃 —— 用户看不到"即将使用被篡改 skill"的告警。

## 修复

将 hermes-plugin 多个 capability 的 `transform_llm_output` 回调组合成单一 chained hook，而非各自独立注册。每个 capability 的 `_on_transform_llm_output` 本就只做 prepend（把自己的 warning 前置到传入的 `response_text`），因此 chain 后自然拼接所有告警：

- `registry.py`：新增 `_TRANSFORM_HOOKS` 收集列表 + `_compose_transform_chain()`；`register_capabilities` 末尾注册单一 composed hook。
- `capabilities/base.py`：`register()` 对 `transform_llm_output` 走 `_collect_transform_hook()` 而非独立 `ctx.register_hook()`。

```diff
+def _compose_transform_chain(callbacks):
+    def _chain(response_text="", **kwargs):
+        current = response_text
+        for _cap_id, cb in callbacks:
+            result = cb(response_text=current, **kwargs)
+            if isinstance(result, str) and result:
+                current = result
+        return current
+    return _chain
```

## 验证

- ECS fresh clone + `git apply` + `bash scripts/rpm-build.sh agent-sec-core` → exit 0，产出 `agent-sec-hermes-hook-0.10.1-1.alnx4.x86_64.rpm`（rpm2cpio 解包确认已含 fix）
- hermes-plugin 170 个单元测试全部通过（无回归）
- 独立仿真验证：prompt-scan(DENY) + skill-ledger(tampered) 同 turn 时，composed transform 输出同时包含 `status=tampered` 与 `[prompt-scan] 检测到安全风险`

Co-Authored-By: Claude <noreply@anthropic.com>