### PR TITLE
fix(cosh-ng): make raw relay event driven

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -610,7 +610,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "signal-hook",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "signal-hook",
  "tempfile",
  "toml",
  "tracing",

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -46,7 +46,6 @@ rustix.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
-signal-hook.workspace = true
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -32,10 +32,6 @@ mod truncator;
 use clap::Parser;
 use cosh_core::provider;
 #[cfg(unix)]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(unix)]
-use std::sync::Arc;
-#[cfg(unix)]
 use std::time::Duration;
 
 use config::CoreConfig;
@@ -122,11 +118,15 @@ async fn main() {
 
 #[cfg(unix)]
 async fn run_until_sigint() {
-    let sigint_received = install_sigint_handler();
-
     tokio::select! {
-        _ = wait_for_sigint(sigint_received) => {
-            tracing::info!("received SIGINT, shutting down cosh-core");
+        signal = wait_for_sigint() => {
+            match signal {
+                Ok(()) => tracing::info!("received SIGINT, shutting down cosh-core"),
+                Err(error) => {
+                    eprintln!("failed to install SIGINT handler: {error}");
+                    std::process::exit(1);
+                }
+            }
         }
         _ = run() => {}
     }
@@ -195,22 +195,8 @@ fn is_agent_headless_mode(args: &cli::CliArgs) -> bool {
 }
 
 #[cfg(unix)]
-fn install_sigint_handler() -> Arc<AtomicBool> {
-    let received = Arc::new(AtomicBool::new(false));
-    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&received)).unwrap_or_else(
-        |error| {
-            eprintln!("failed to install SIGINT handler: {error}");
-            std::process::exit(1);
-        },
-    );
-    received
-}
-
-#[cfg(unix)]
-async fn wait_for_sigint(received: Arc<AtomicBool>) {
-    while !received.load(Ordering::Relaxed) {
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
+async fn wait_for_sigint() -> std::io::Result<()> {
+    tokio::signal::ctrl_c().await
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-shell/Cargo.toml
@@ -20,6 +20,7 @@ ratatui = "0.28"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+signal-hook.workspace = true
 # Anonymous temp files for guarded executor output capture; already used
 # by cosh-cli, cosh-core, and cosh-platform on the same major line.
 tempfile = "3"

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/capture_bridge.rs
@@ -1,7 +1,7 @@
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use super::card_capture::{events::releases_capture, CardInputState};
+use super::event_sender::RawInputEventSink;
 use super::mode::RawInputMode;
 use super::{RawInputCapture, RawInputEvent};
 
@@ -16,7 +16,7 @@ pub(super) fn consume_captured_input(
     capture: &RawInputCapture,
     generation: u64,
     bytes: &[u8],
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_mode: &Arc<Mutex<RawInputMode>>,
 ) -> CaptureConsumeResult {
     let Ok(mut mode) = input_mode.lock() else {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_sender.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_sender.rs
@@ -1,0 +1,78 @@
+//! Ordered raw-input event delivery with optional output-relay wakeups.
+
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc::{SendError, Sender};
+
+use super::RawInputEvent;
+
+pub(super) trait RawInputEventSink {
+    fn send(&self, event: RawInputEvent) -> Result<(), SendError<RawInputEvent>>;
+}
+
+impl RawInputEventSink for Sender<RawInputEvent> {
+    fn send(&self, event: RawInputEvent) -> Result<(), SendError<RawInputEvent>> {
+        Sender::send(self, event)
+    }
+}
+
+pub(super) struct WakingRawInputEventSender {
+    sender: Sender<RawInputEvent>,
+    wake: Option<UnixStream>,
+}
+
+impl WakingRawInputEventSender {
+    pub(super) fn new(sender: Sender<RawInputEvent>, wake: Option<UnixStream>) -> Self {
+        Self { sender, wake }
+    }
+
+    pub(super) fn notify_relay(&self) {
+        let Some(wake) = self.wake.as_ref() else {
+            return;
+        };
+        let mut wake = wake;
+        match wake.write(&[1]) {
+            Ok(_) => {}
+            // A full socket already represents a pending wakeup.
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => {}
+        }
+    }
+}
+
+impl RawInputEventSink for WakingRawInputEventSender {
+    fn send(&self, event: RawInputEvent) -> Result<(), SendError<RawInputEvent>> {
+        self.sender.send(event)?;
+        self.notify_relay();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::{RawInputEventSink, WakingRawInputEventSender};
+    use crate::raw_input::RawInputEvent;
+
+    #[test]
+    fn event_send_publishes_to_the_final_channel_and_wakes_the_relay() {
+        let (mut wake_reader, wake_writer) = super::UnixStream::pair().expect("wake pair");
+        wake_reader
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("wake timeout");
+        let (sender, receiver) = mpsc::channel();
+        let sender = WakingRawInputEventSender::new(sender, Some(wake_writer));
+
+        sender.send(RawInputEvent::CtrlC).expect("send event");
+
+        assert_eq!(
+            receiver.try_recv().expect("published event"),
+            RawInputEvent::CtrlC
+        );
+        let mut wake = [0_u8; 1];
+        wake_reader.read_exact(&mut wake).expect("relay wake");
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -4,6 +4,7 @@ mod capture_bridge;
 mod card_capture;
 mod draft_editor;
 mod event_parser;
+mod event_sender;
 
 pub(crate) use draft_editor::PromptDraftEditor;
 mod generation;
@@ -23,7 +24,10 @@ pub(crate) use pty::{
     signal_foreground_process_group, signal_process_group, signal_process_group_id, write_all_pty,
 };
 pub use relay_action::RawRelayAction;
-pub(crate) use spawn::{spawn_raw_action_relay, spawn_raw_input_relay};
+pub(crate) use spawn::{
+    spawn_raw_action_relay, spawn_raw_action_relay_with_wake, spawn_raw_input_relay,
+    spawn_raw_input_relay_with_wake,
+};
 
 pub(super) const CTRL_C: u8 = 0x03;
 pub(super) const CTRL_U: u8 = 0x15;

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
@@ -8,7 +8,8 @@ pub use implementation::{RawInputCapture, RawObserverAction, RawRelayAction};
 pub(crate) use implementation::{
     foreground_process_group_for_fds, process_group_exists, redact_extension_setting_value,
     set_pty_winsize, signal_foreground_process_group, signal_process_group,
-    signal_process_group_id, spawn_raw_action_relay, spawn_raw_input_relay, update_input_mode,
+    signal_process_group_id, spawn_raw_action_relay, spawn_raw_action_relay_with_wake,
+    spawn_raw_input_relay, spawn_raw_input_relay_with_wake, update_input_mode,
     update_locked_input_mode, write_all_pty, MainPromptGate, PromptDraftEditor, PromptGhostRoute,
     RawInputEvent, RawInputMode, UserPtyInputGeneration,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::io;
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use crate::input::{InputClassifier, InputDecision, InterceptReason};
@@ -11,6 +10,7 @@ use super::event_parser::{
     starts_native_intercept_candidate, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
     BRACKETED_PASTE_END, BRACKETED_PASTE_START,
 };
+use super::event_sender::RawInputEventSink;
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
 use super::soft_newline::{
@@ -21,7 +21,7 @@ use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawI
 pub(super) struct InputRelayContext<'a> {
     pub(super) master: &'a mut File,
     pub(super) input_classifier: &'a InputClassifier,
-    pub(super) input_events: &'a Sender<RawInputEvent>,
+    pub(super) input_events: &'a dyn RawInputEventSink,
     pub(super) input_mode: &'a Arc<Mutex<RawInputMode>>,
     pub(super) input_generation: &'a UserPtyInputGeneration,
     pub(super) line_submits: &'a mut LineSubmitCounter,
@@ -46,7 +46,7 @@ pub(super) fn write_user_bytes_to_pty(
     master: &mut File,
     input_generation: &UserPtyInputGeneration,
     line_submits: &mut LineSubmitCounter,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     main_prompt_gate: &MainPromptGate,
     bytes: &[u8],
 ) -> io::Result<()> {
@@ -64,20 +64,20 @@ pub(super) fn write_user_bytes_to_pty(
     write_all_pty(master, bytes)
 }
 
-pub(super) fn send_raw_input_events(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
+pub(super) fn send_raw_input_events(bytes: &[u8], input_events: &dyn RawInputEventSink) {
     if bytes.contains(&CTRL_C) {
         let _ = input_events.send(RawInputEvent::CtrlC);
     }
 }
 
-pub(super) fn send_shell_input_state(empty: bool, input_events: &Sender<RawInputEvent>) {
+pub(super) fn send_shell_input_state(empty: bool, input_events: &dyn RawInputEventSink) {
     let _ = input_events.send(RawInputEvent::ShellInputActivity { empty });
 }
 
 fn observe_native_line(
     state: &mut NativeLineState,
     bytes: &[u8],
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
 ) {
     state.observe_shell_bytes(bytes);
     if state.take_multiline_paste_observed() {
@@ -280,7 +280,7 @@ pub(super) fn dismiss_prompt_ghost_input(
     relay_passthrough_input(bytes, relay)
 }
 
-pub(super) fn send_held_input_events(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
+pub(super) fn send_held_input_events(bytes: &[u8], input_events: &dyn RawInputEventSink) {
     send_raw_input_events(bytes, input_events);
     if held_input_requests_cancel(bytes) {
         let _ = input_events.send(RawInputEvent::CtrlC);
@@ -563,7 +563,7 @@ fn submit_line_bytes_to_shell(
 }
 
 fn redraw_candidate_line(
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     line_buffer: &mut CandidateLineBuffer,
 ) {
     let original = line_buffer.visible_line_bytes();
@@ -603,7 +603,7 @@ fn redraw_candidate_line(
 /// shortcut is seen on a passthrough path (candidate buffer inactive), emit
 /// a signal so the runtime can surface a one-time tip at the next
 /// prompt-ready. The bytes themselves are always relayed unchanged.
-fn observe_passthrough_soft_newline(bytes: &[u8], input_events: &Sender<RawInputEvent>) {
+fn observe_passthrough_soft_newline(bytes: &[u8], input_events: &dyn RawInputEventSink) {
     if contains_soft_newline_sequence(bytes) {
         let _ = input_events.send(RawInputEvent::SoftNewlineShortcutObserved);
     }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -30,6 +30,65 @@ fn output_file(label: &str) -> (std::path::PathBuf, File) {
     (path, file)
 }
 
+struct PausingEventSink {
+    sender: mpsc::Sender<RawInputEvent>,
+    published: mpsc::SyncSender<()>,
+    resume: Mutex<mpsc::Receiver<()>>,
+}
+
+impl RawInputEventSink for PausingEventSink {
+    fn send(&self, event: RawInputEvent) -> Result<(), mpsc::SendError<RawInputEvent>> {
+        self.sender.send(event)?;
+        self.published.send(()).expect("publish barrier");
+        self.resume
+            .lock()
+            .expect("resume lock")
+            .recv()
+            .expect("resume event send");
+        Ok(())
+    }
+}
+
+#[test]
+fn pty_user_write_waits_until_its_event_is_visible() {
+    let (path, mut master) = output_file("event-before-pty-write");
+    let (event_tx, event_rx) = mpsc::channel();
+    let (published_tx, published_rx) = mpsc::sync_channel(0);
+    let (resume_tx, resume_rx) = mpsc::channel();
+    let sink = PausingEventSink {
+        sender: event_tx,
+        published: published_tx,
+        resume: Mutex::new(resume_rx),
+    };
+    let writer = thread::spawn(move || {
+        write_user_bytes_to_pty(
+            &mut master,
+            &UserPtyInputGeneration::default(),
+            &mut LineSubmitCounter::default(),
+            &sink,
+            &super::super::MainPromptGate::default(),
+            b"echo ordered\n",
+        )
+    });
+
+    published_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("event publication");
+    assert!(matches!(
+        event_rx.try_recv().expect("visible PTY write event"),
+        RawInputEvent::PtyUserWrite {
+            line_submits: 1,
+            ..
+        }
+    ));
+    assert!(fs::read(&path).expect("read pre-write output").is_empty());
+
+    resume_tx.send(()).expect("allow PTY write");
+    writer.join().expect("writer join").expect("PTY write");
+    assert_eq!(fs::read(&path).expect("read PTY output"), b"echo ordered\n");
+    fs::remove_file(path).ok();
+}
+
 fn selection_input_mode() -> Arc<Mutex<RawInputMode>> {
     let candidates = vec![
         PromptGhostCandidate {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 use std::io::{self, Read};
+use std::os::fd::RawFd;
+use std::os::unix::net::UnixStream;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -10,6 +12,7 @@ use crate::input::InputClassifier;
 use super::capture_bridge::{consume_captured_input, CaptureConsumeResult};
 use super::card_capture::CardInputState;
 use super::event_parser::{CandidateLineBuffer, NativeLineState};
+use super::event_sender::{RawInputEventSink, WakingRawInputEventSender};
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::{
     abandon_active_capture, complete_capture_chain_if_pending, complete_capture_replay,
@@ -25,19 +28,21 @@ use super::{MainPromptGate, PromptGhostRoute, RawInputEvent, ESC};
 
 mod action;
 mod capture;
+mod deadline;
 mod prompt_ghost;
 mod reader;
 mod state;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use action::spawn_raw_action_relay;
 use action::{flush_pending_delay_escape, resolve_pending_delay_escape, PendingDelayEscape};
+pub(crate) use action::{spawn_raw_action_relay, spawn_raw_action_relay_with_wake};
 use capture::{
     capture_generation, capture_owns_input, capture_quarantine_generation, drain_abandoned_capture,
     relay_input_chunk, CaptureOwnedInput,
 };
 pub(super) use capture::{finish_input_relay, relay_late_capture_input};
+use deadline::{next_pending_deadline, receive_input};
 use prompt_ghost::{
     dismiss_replaced_prompt_ghost, PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix,
 };
@@ -70,7 +75,7 @@ struct RelayReadContext<'a> {
 
 pub(crate) fn spawn_raw_input_relay<R>(
     input: R,
-    mut master: File,
+    master: File,
     input_events: Sender<RawInputEvent>,
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
@@ -81,11 +86,42 @@ pub(crate) fn spawn_raw_input_relay<R>(
 where
     R: Read + Send + 'static,
 {
+    spawn_raw_input_relay_with_wake(
+        input,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        input_generation,
+        main_prompt_gate,
+        slash_route_enabled,
+        None,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_raw_input_relay_with_wake<R>(
+    input: R,
+    mut master: File,
+    input_events: Sender<RawInputEvent>,
+    input_classifier: InputClassifier,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    input_generation: UserPtyInputGeneration,
+    main_prompt_gate: MainPromptGate,
+    slash_route_enabled: bool,
+    input_fd: Option<RawFd>,
+    wake: Option<UnixStream>,
+) -> JoinHandle<io::Result<()>>
+where
+    R: Read + Send + 'static,
+{
     thread::spawn(move || {
+        let input_events = WakingRawInputEventSender::new(input_events, wake);
         let (read_tx, read_rx) = mpsc::sync_channel(INPUT_READ_AHEAD_CAPACITY);
         // The relay must wake without a later keystroke to resolve a bare ESC.
         let reader_input_mode = input_mode.clone();
-        thread::spawn(move || read_input_chunks(input, read_tx, reader_input_mode));
+        thread::spawn(move || read_input_chunks(input, read_tx, reader_input_mode, input_fd));
 
         let mut state = RawInputRelayState::with_generation_and_gate(
             input_generation,
@@ -134,6 +170,7 @@ where
                         &input_mode,
                         &mut state,
                     )?;
+                    input_events.notify_relay();
                     continue;
                 }
                 Err(RecvTimeoutError::Disconnected) => InputRead::Eof,
@@ -201,6 +238,7 @@ where
                             },
                         )?;
                     }
+                    input_events.notify_relay();
                 }
                 InputRead::Eof => {
                     finish_input_relay(
@@ -210,6 +248,7 @@ where
                         &input_mode,
                         &mut state,
                     )?;
+                    input_events.notify_relay();
                     return Ok(());
                 }
                 InputRead::Error(error) => return Err(error),
@@ -235,46 +274,11 @@ fn stale_delay_escape_reached_interactive_owner(
         )
 }
 
-fn receive_input(
-    receiver: &Receiver<InputRead>,
-    state: &mut RawInputRelayState,
-) -> Result<InputRead, RecvTimeoutError> {
-    if let Some(input) = state.deferred_input.take() {
-        return Ok(input);
-    }
-    match next_pending_deadline(state) {
-        Some(deadline) => receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())),
-        None => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
-    }
-}
-
-pub(super) fn next_pending_deadline(state: &RawInputRelayState) -> Option<Instant> {
-    state
-        .pending_prompt_ghost_escape
-        .as_ref()
-        .map(|pending| pending.deadline)
-        .into_iter()
-        .chain(
-            state
-                .pending_delay_escape
-                .as_ref()
-                .map(|pending| pending.deadline),
-        )
-        .chain(
-            state
-                .pending_replaced_prompt_ghost_suffix
-                .as_ref()
-                .map(|pending| pending.deadline),
-        )
-        .chain(state.pending_draft_escape_deadline)
-        .min()
-}
-
 pub(super) fn relay_input_bytes(
     bytes: &[u8],
     received_at: Instant,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -295,7 +299,7 @@ fn relay_input_bytes_with_read_ahead(
     bytes: &[u8],
     received_at: Instant,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -544,7 +548,7 @@ fn flush_pending_replaced_prompt_ghost_suffix(
     now: Instant,
     mode: &RawInputMode,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -583,7 +587,7 @@ fn relay_input_for_mode(
     bytes: &[u8],
     mode: RawInputMode,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -631,7 +635,7 @@ fn flush_pending_prompt_ghost_escape(
     force: bool,
     now: Instant,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io;
 use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -14,10 +15,12 @@ use super::super::generation::UserPtyInputGeneration;
 use super::super::mode::RawInputMode;
 use super::super::pty::{set_pty_winsize, signal_process_group};
 use super::super::{MainPromptGate, RawInputEvent, RawRelayAction};
+use super::deadline::next_pending_deadline;
 use super::{
     finish_input_relay, flush_pending_prompt_ghost_escape,
-    flush_pending_replaced_prompt_ghost_suffix, next_pending_deadline, relay_input_bytes,
-    relay_input_bytes_with_read_ahead, relay_input_for_mode, RawInputRelayState, RelayReadContext,
+    flush_pending_replaced_prompt_ghost_suffix, relay_input_bytes,
+    relay_input_bytes_with_read_ahead, relay_input_for_mode, RawInputEventSink, RawInputRelayState,
+    RelayReadContext, WakingRawInputEventSender,
 };
 
 pub(super) struct PendingDelayEscape {
@@ -33,7 +36,7 @@ pub(super) fn resolve_pending_delay_escape(
     received_at: Instant,
     mode: &RawInputMode,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -93,7 +96,7 @@ pub(super) fn flush_pending_delay_escape(
     force: bool,
     now: Instant,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -132,7 +135,7 @@ pub(super) fn flush_pending_delay_escape(
 fn wait_for_raw_action(
     duration: Duration,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &WakingRawInputEventSender,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -172,6 +175,7 @@ fn wait_for_raw_action(
             input_mode,
             state,
         )?;
+        input_events.notify_relay();
     }
     thread::sleep(action_end.saturating_duration_since(Instant::now()));
     Ok(())
@@ -179,6 +183,32 @@ fn wait_for_raw_action(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_raw_action_relay(
+    actions: Vec<RawRelayAction>,
+    master: File,
+    child_pid: u32,
+    input_events: Sender<RawInputEvent>,
+    input_classifier: InputClassifier,
+    input_mode: Arc<Mutex<RawInputMode>>,
+    input_generation: UserPtyInputGeneration,
+    main_prompt_gate: MainPromptGate,
+    slash_route_enabled: bool,
+) -> JoinHandle<io::Result<()>> {
+    spawn_raw_action_relay_with_wake(
+        actions,
+        master,
+        child_pid,
+        input_events,
+        input_classifier,
+        input_mode,
+        input_generation,
+        main_prompt_gate,
+        slash_route_enabled,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_raw_action_relay_with_wake(
     actions: Vec<RawRelayAction>,
     mut master: File,
     child_pid: u32,
@@ -188,8 +218,10 @@ pub(crate) fn spawn_raw_action_relay(
     input_generation: UserPtyInputGeneration,
     main_prompt_gate: MainPromptGate,
     slash_route_enabled: bool,
+    wake: Option<UnixStream>,
 ) -> JoinHandle<io::Result<()>> {
     thread::spawn(move || {
+        let input_events = WakingRawInputEventSender::new(input_events, wake);
         let mut state = RawInputRelayState::with_generation_and_gate(
             input_generation,
             main_prompt_gate,
@@ -248,13 +280,16 @@ pub(crate) fn spawn_raw_action_relay(
                     &mut state,
                 )?,
             }
+            input_events.notify_relay();
         }
-        finish_input_relay(
+        let result = finish_input_relay(
             &mut master,
             &input_events,
             &input_classifier,
             &input_mode,
             &mut state,
-        )
+        );
+        input_events.notify_relay();
+        result
     })
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -413,7 +413,7 @@ pub(in super::super) fn relay_late_capture_input(
     bytes: &[u8],
     generation: u64,
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
@@ -592,7 +592,7 @@ pub(super) fn drain_abandoned_capture(
 
 pub(in super::super) fn finish_input_relay(
     master: &mut File,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_classifier: &InputClassifier,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/deadline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/deadline.rs
@@ -1,0 +1,41 @@
+//! Blocking receive deadlines for split escape-sequence handling.
+
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::Instant;
+
+use super::{InputRead, RawInputRelayState};
+
+pub(super) fn receive_input(
+    receiver: &Receiver<InputRead>,
+    state: &mut RawInputRelayState,
+) -> Result<InputRead, RecvTimeoutError> {
+    if let Some(input) = state.deferred_input.take() {
+        return Ok(input);
+    }
+    match next_pending_deadline(state) {
+        Some(deadline) => receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())),
+        None => receiver.recv().map_err(|_| RecvTimeoutError::Disconnected),
+    }
+}
+
+pub(super) fn next_pending_deadline(state: &RawInputRelayState) -> Option<Instant> {
+    state
+        .pending_prompt_ghost_escape
+        .as_ref()
+        .map(|pending| pending.deadline)
+        .into_iter()
+        .chain(
+            state
+                .pending_delay_escape
+                .as_ref()
+                .map(|pending| pending.deadline),
+        )
+        .chain(
+            state
+                .pending_replaced_prompt_ghost_suffix
+                .as_ref()
+                .map(|pending| pending.deadline),
+        )
+        .chain(state.pending_draft_escape_deadline)
+        .min()
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/prompt_ghost.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/prompt_ghost.rs
@@ -1,8 +1,8 @@
 //! Pending prompt-ghost state shared by raw-input relay paths.
 
-use std::sync::mpsc::Sender;
 use std::time::Instant;
 
+use super::super::event_sender::RawInputEventSink;
 use super::super::mode::RawInputMode;
 use super::super::{PromptGhostRoute, RawInputEvent};
 
@@ -29,7 +29,7 @@ impl PendingPromptGhostEscape {
     }
 }
 
-pub(super) fn dismiss_replaced_prompt_ghost(input_events: &Sender<RawInputEvent>) {
+pub(super) fn dismiss_replaced_prompt_ghost(input_events: &dyn RawInputEventSink) {
     let _ = input_events.send(RawInputEvent::PromptGhostClear);
     let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/reader.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/reader.rs
@@ -1,8 +1,11 @@
 use std::io::{self, Read};
+use std::os::fd::RawFd;
 use std::sync::mpsc::SyncSender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use nix::libc;
 
 use super::{current_raw_input_mode, InputRead, RawInputMode};
 
@@ -10,6 +13,7 @@ pub(super) fn read_input_chunks<R>(
     mut input: R,
     sender: SyncSender<InputRead>,
     input_mode: Arc<Mutex<RawInputMode>>,
+    input_fd: Option<RawFd>,
 ) where
     R: Read,
 {
@@ -36,8 +40,17 @@ pub(super) fn read_input_chunks<R>(
             }
             Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(idle_backoff);
-                idle_backoff = (idle_backoff * 2).min(Duration::from_millis(32));
+                if let Some(fd) = input_fd {
+                    if let Err(error) = wait_until_readable(fd) {
+                        let _ = sender.send(InputRead::Error(error));
+                        return;
+                    }
+                } else {
+                    // Generic test and embedding readers may not expose an
+                    // fd. Interactive stdin always takes the poll path.
+                    thread::sleep(idle_backoff);
+                    idle_backoff = (idle_backoff * 2).min(Duration::from_millis(32));
+                }
                 continue;
             }
             Err(error) => InputRead::Error(error),
@@ -45,6 +58,27 @@ pub(super) fn read_input_chunks<R>(
         let done = !matches!(input, InputRead::Bytes { .. });
         if sender.send(input).is_err() || done {
             return;
+        }
+    }
+}
+
+fn wait_until_readable(fd: RawFd) -> io::Result<()> {
+    let mut poll_fd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    loop {
+        let result = unsafe { libc::poll(&mut poll_fd, 1, -1) };
+        if result > 0 {
+            return Ok(());
+        }
+        if result == 0 {
+            continue;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -2,7 +2,6 @@
 //! split): the per-relay bookkeeping struct and its borrow-splitting helper.
 
 use std::fs::File;
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -11,11 +10,12 @@ use crate::input::InputClassifier;
 use super::super::capture_bridge::consume_captured_input;
 use super::super::card_capture::CardInputState;
 use super::super::event_parser::{CandidateLineBuffer, NativeLineState};
+use super::super::event_sender::RawInputEventSink;
 use super::super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::super::mode::current_raw_input_mode;
 use super::super::mode::RawInputMode;
 use super::super::relay::{ExplicitExitTracker, InputRelayContext};
-use super::super::{MainPromptGate, RawInputEvent};
+use super::super::MainPromptGate;
 use super::action::PendingDelayEscape;
 use super::capture::{drain_capture_submission, CaptureOwnedInput};
 use super::prompt_ghost::{PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix};
@@ -61,7 +61,7 @@ impl RawInputRelayState {
 pub(super) fn input_relay_context<'a>(
     master: &'a mut File,
     input_classifier: &'a InputClassifier,
-    input_events: &'a Sender<RawInputEvent>,
+    input_events: &'a dyn RawInputEventSink,
     input_mode: &'a Arc<Mutex<RawInputMode>>,
     state: &'a mut RawInputRelayState,
 ) -> InputRelayContext<'a> {
@@ -106,7 +106,7 @@ pub(super) fn flush_pending_draft_escape(
     now: Instant,
     master: &mut File,
     input_classifier: &InputClassifier,
-    input_events: &Sender<RawInputEvent>,
+    input_events: &dyn RawInputEventSink,
     input_mode: &Arc<Mutex<RawInputMode>>,
     state: &mut RawInputRelayState,
 ) -> std::io::Result<()> {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/tests.rs
@@ -1,5 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::io;
+use std::os::fd::AsRawFd;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use super::super::{PromptGhostCandidate, RawInputCapture};
@@ -30,7 +31,7 @@ fn idle_reader_backs_off_between_would_block_retries() {
     let reader = thread::spawn({
         let reads = reads.clone();
         let stop = stop.clone();
-        move || read_input_chunks(IdleReader { reads, stop }, sender, input_mode)
+        move || read_input_chunks(IdleReader { reads, stop }, sender, input_mode, None)
     });
 
     thread::sleep(Duration::from_millis(120));
@@ -45,6 +46,45 @@ fn idle_reader_backs_off_between_would_block_retries() {
         "idle reader retried {} times",
         reads.load(Ordering::Relaxed)
     );
+}
+
+#[test]
+fn fd_reader_waits_for_readiness_without_backoff() {
+    let (read_fd, write_fd) = nix::unistd::pipe().expect("pipe");
+    let flags = unsafe { nix::libc::fcntl(read_fd.as_raw_fd(), nix::libc::F_GETFL) };
+    assert!(flags >= 0);
+    assert_eq!(
+        unsafe {
+            nix::libc::fcntl(
+                read_fd.as_raw_fd(),
+                nix::libc::F_SETFL,
+                flags | nix::libc::O_NONBLOCK,
+            )
+        },
+        0
+    );
+    let input_fd = read_fd.as_raw_fd();
+    let input = File::from(read_fd);
+    let mut writer = File::from(write_fd);
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let reader = thread::spawn(move || {
+        read_input_chunks(input, sender, input_mode, Some(input_fd));
+    });
+
+    thread::sleep(Duration::from_millis(10));
+    std::io::Write::write_all(&mut writer, b"x").expect("write input");
+    let received = receiver
+        .recv_timeout(Duration::from_millis(250))
+        .expect("poll wakes for input");
+    assert!(matches!(received, InputRead::Bytes { bytes, .. } if bytes == b"x"));
+
+    drop(writer);
+    assert!(matches!(
+        receiver.recv_timeout(Duration::from_millis(250)),
+        Ok(InputRead::Eof)
+    ));
+    reader.join().expect("fd reader");
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -31,11 +31,13 @@ fn render_raw_inline_events<W: Write>(
         audit.observe_shell_events(events);
     }
     let mut terminal_output = CrLfWriter::new(output);
-    redraw_active_question_if_width_changed(
-        inline_state,
-        &mut terminal_output,
-        RatatuiInlineRenderer::for_terminal().with_language(inline_state.language),
-    )?;
+    if inline_state.questions.active_panel_id.is_some() {
+        redraw_active_question_if_width_changed(
+            inline_state,
+            &mut terminal_output,
+            RatatuiInlineRenderer::for_terminal().with_language(inline_state.language),
+        )?;
+    }
     let snapshot = ShellEventSnapshot::new(events);
     let actions = RuntimeDispatcher::dispatch_inline_batch(
         &snapshot,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
@@ -140,6 +140,27 @@ impl PromptReplayTracker {
         }
     }
 
+    pub(super) fn idle_reconcile_remaining(
+        &self,
+        command_running: bool,
+        prompt_painted: bool,
+        last_pty_output: Option<Instant>,
+    ) -> Option<Duration> {
+        if (self.outstanding_submits == 0 && self.pending_intercepts == 0)
+            || command_running
+            || !prompt_painted
+            || self.input_generation.current() != self.last_written
+        {
+            return None;
+        }
+        let remaining = |at: Option<Instant>| {
+            at.map_or(Duration::ZERO, |at| {
+                self.idle_reconcile_window.saturating_sub(at.elapsed())
+            })
+        };
+        Some(remaining(self.last_write_seen).max(remaining(last_pty_output)))
+    }
+
     /// Arms replay dedup for a synthesized prompt (panel restore or handoff
     /// prompt echo).
     ///

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::process::Child;
 use std::sync::mpsc::Receiver;
@@ -21,6 +22,7 @@ use super::prompt_replay::{
     prompt_prefixed_replay_bytes, prompt_replay_bytes, PromptReplayTracker,
 };
 
+mod activity;
 mod eof_shutdown;
 mod input_events;
 mod input_readiness;
@@ -29,6 +31,11 @@ mod pty_emit;
 mod terminal_recovery;
 mod terminal_size;
 
+use activity::{
+    poll_driver_completion, relay_wait_timeout, wait_for_relay_activity, RelayActivity,
+};
+pub(super) use activity::{DriverCompletion, RawActionWatchdog};
+use eof_shutdown::{advance_eof_shutdown, request_eof_shutdown};
 use input_events::{candidate_display_columns, drain_raw_input_events};
 use input_readiness::RawInputReadinessProbe;
 use interactive_sentinel::{
@@ -44,25 +51,7 @@ use terminal_size::sync_outer_terminal_winsize;
 // terminals. Unlike CSI s/u, they also restore the cursor in macOS Terminal.
 const SAVE_CURSOR: &str = "\x1b7";
 const RESTORE_CURSOR: &str = "\x1b8";
-
-pub(super) struct RawActionWatchdog {
-    grace: Duration,
-}
-
-impl RawActionWatchdog {
-    pub(super) fn new(grace: Duration) -> Self {
-        Self { grace }
-    }
-
-    fn expired(&self, driver_completed_at: Option<Instant>) -> bool {
-        driver_completed_at.is_some_and(|done| done.elapsed() > self.grace)
-    }
-}
-
-pub(super) struct DriverCompletion {
-    pub(super) result: io::Result<()>,
-    pub(super) completed_at: Instant,
-}
+const PTY_READ_BATCH_BYTES: usize = 256 * 1024;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_raw_until_exit<W: Write, F>(
@@ -74,6 +63,8 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     event_observer: &mut F,
     input_events: &Receiver<RawInputEvent>,
     driver_completion: &Receiver<DriverCompletion>,
+    wake: &mut UnixStream,
+    resize: &mut UnixStream,
     input_mode: &Arc<Mutex<RawInputMode>>,
     input_generation: &UserPtyInputGeneration,
     last_winsize: &mut Winsize,
@@ -109,8 +100,8 @@ where
     // unsupporting terminals ignore it, RawModeGuard withdraws it on exit.
     output.write_all(b"\x1b[>4;1m")?;
     output.flush()?;
+    sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
     loop {
-        sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         if restore_terminal_after_interrupted_command(
             terminal.as_raw_fd(),
             parser,
@@ -171,10 +162,12 @@ where
             )?;
             output.flush()?;
         }
+        let mut batch_bytes = 0usize;
         loop {
             match master.read(&mut buffer) {
                 Ok(0) => break,
                 Ok(n) => {
+                    batch_bytes = batch_bytes.saturating_add(n);
                     last_pty_output = Some(Instant::now());
                     sentinel_throttle.note_output();
                     // Output resumed => the foreground is no longer sitting
@@ -197,7 +190,8 @@ where
                     )? {
                         request_eof_shutdown(master, terminal, child, &mut eof_shutdown)?;
                     }
-                    for (cut, cut_kind) in parser.drain_intervention_display_cuts() {
+                    let display_cuts = parser.drain_intervention_display_cuts();
+                    for (cut, cut_kind) in display_cuts {
                         let cut = cut.min(parser.display.len());
                         // Only a real prompt boundary (precmd) confirms the
                         // shell finished responding to the relay writes seen
@@ -276,45 +270,12 @@ where
                             output.flush()?;
                         }
                     }
-                    observer_action = merge_pending_prompt_restore(
-                        observe_with_input_mode_lock(
-                            event_observer,
-                            &parser.events,
-                            output,
-                            input_mode,
-                        )?,
-                        &mut pending_prompt_restore,
-                    );
-                    observer_action = resolve_pty_emit(
-                        master,
-                        child.id(),
-                        terminal.as_raw_fd(),
-                        parser,
-                        output,
-                        input_mode,
-                        observer_action,
-                        &mut display_start,
-                        &mut prompt_replay,
-                        &mut pending_terminal_restore,
-                        recovery_request_file,
-                        handoff_request_file,
-                    )?;
-                    remember_pending_prompt_restore(&observer_action, &mut pending_prompt_restore);
-                    update_input_mode(
-                        input_mode,
-                        &observer_action,
-                        latest_capture_submission_generation(&parser.events),
-                    );
-                    hold_shell_output = observer_action.hold_shell_output();
-                    if !hold_shell_output && parser.display.len() > display_start {
-                        write_pending_display_preserving_prompt_ghost(
-                            parser,
-                            output,
-                            &mut display_start,
-                            &mut prompt_replay,
-                            input_mode,
-                        )?;
-                        output.flush()?;
+                    // Ordinary display and passive runtime transitions are
+                    // resolved once after the readiness batch. Intervention
+                    // cuts stay immediate because they define semantic
+                    // boundaries that can change the input owner.
+                    if batch_bytes >= PTY_READ_BATCH_BYTES {
+                        break;
                     }
                 }
                 Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
@@ -375,7 +336,6 @@ where
                 ));
             }
         }
-        sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         if restore_terminal_after_interrupted_command(
             terminal.as_raw_fd(),
             parser,
@@ -425,6 +385,10 @@ where
             &observer_action,
             latest_capture_submission_generation(&parser.events),
         );
+        let runtime_poll_pending = matches!(
+            &observer_action,
+            RawObserverAction::HoldShellOutput | RawObserverAction::DelayShellOutput
+        );
         hold_shell_output = observer_action.hold_shell_output();
         if !hold_shell_output && parser.display.len() > display_start {
             write_pending_display_preserving_prompt_ghost(
@@ -447,37 +411,28 @@ where
             parser.has_prompt_painted_since_ready(),
             last_pty_output,
         );
-        thread::sleep(Duration::from_millis(10));
-    }
-}
-
-fn poll_driver_completion(
-    receiver: &Receiver<DriverCompletion>,
-    master: &File,
-    terminal: &File,
-    child: &mut Child,
-    completed_at: &mut Option<Instant>,
-) -> io::Result<()> {
-    let Ok(completion) = receiver.try_recv() else {
-        return Ok(());
-    };
-    *completed_at = Some(completion.completed_at);
-    if let Err(error) = completion.result {
-        shutdown_and_reap_child(master, terminal, child);
-        return Err(error);
-    }
-    Ok(())
-}
-
-fn shutdown_and_reap_child(master: &File, terminal: &File, child: &mut Child) {
-    let mut shutdown = None;
-    if request_eof_shutdown(master, terminal, child, &mut shutdown).is_ok() {
-        while let Ok(false) = advance_eof_shutdown(&mut shutdown) {
-            thread::sleep(Duration::from_millis(10));
+        let foreground_command_active = parser.has_active_foreground_command();
+        let activity = wait_for_relay_activity(
+            master.as_raw_fd(),
+            wake,
+            resize,
+            relay_wait_timeout(
+                watchdog,
+                driver_completed_at,
+                eof_shutdown.as_ref(),
+                runtime_poll_pending,
+                foreground_command_active,
+                prompt_replay.idle_reconcile_remaining(
+                    foreground_command_active,
+                    parser.has_prompt_painted_since_ready(),
+                    last_pty_output,
+                ),
+            ),
+        )?;
+        if activity.resize {
+            sync_outer_terminal_winsize(master.as_raw_fd(), child.id(), last_winsize)?;
         }
     }
-    let _ = child.kill();
-    let _ = child.wait();
 }
 
 fn latest_capture_submission_generation(events: &[ShellEvent]) -> Option<u64> {
@@ -688,4 +643,3 @@ fn mark_pending_prompt_replayed(parser: &OscParser, prompt: &[u8], display_start
 #[cfg(test)]
 #[path = "raw_relay_tests.rs"]
 mod tests;
-use eof_shutdown::{advance_eof_shutdown, request_eof_shutdown, EofShutdown};

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/activity.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/activity.rs
@@ -1,0 +1,224 @@
+//! Event-driven wakeups and driver lifecycle checks for the raw relay.
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::process::Child;
+use std::sync::mpsc::Receiver;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use nix::libc;
+
+use super::eof_shutdown::{advance_eof_shutdown, request_eof_shutdown, EofShutdown};
+
+const RELAY_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(1);
+
+pub(in super::super) struct RawActionWatchdog {
+    grace: Duration,
+}
+
+impl RawActionWatchdog {
+    pub(in super::super) fn new(grace: Duration) -> Self {
+        Self { grace }
+    }
+
+    pub(super) fn expired(&self, driver_completed_at: Option<Instant>) -> bool {
+        driver_completed_at.is_some_and(|done| done.elapsed() > self.grace)
+    }
+
+    fn remaining(&self, driver_completed_at: Option<Instant>) -> Option<Duration> {
+        driver_completed_at.map(|done| self.grace.saturating_sub(done.elapsed()))
+    }
+}
+
+pub(in super::super) struct DriverCompletion {
+    pub(in super::super) result: io::Result<()>,
+    pub(in super::super) completed_at: Instant,
+}
+
+pub(super) fn relay_wait_timeout(
+    watchdog: Option<&RawActionWatchdog>,
+    driver_completed_at: Option<Instant>,
+    eof_shutdown: Option<&EofShutdown>,
+    runtime_poll_pending: bool,
+    foreground_command_active: bool,
+    prompt_replay_remaining: Option<Duration>,
+) -> Duration {
+    let mut timeout = RELAY_MAINTENANCE_INTERVAL;
+    if let Some(remaining) = watchdog.and_then(|watchdog| watchdog.remaining(driver_completed_at)) {
+        timeout = timeout.min(remaining);
+    }
+    // Scripted action drivers advance on their own timers. Keep checking
+    // child liveness between actions so a prompt-level Ctrl-D wins the race
+    // against the next scheduled write.
+    if watchdog.is_some() && driver_completed_at.is_none() {
+        timeout = timeout.min(Duration::from_millis(10));
+    }
+    if let Some(shutdown) = eof_shutdown {
+        timeout = timeout.min(shutdown.remaining());
+    }
+    if runtime_poll_pending {
+        timeout = timeout.min(Duration::from_millis(10));
+    }
+    // Foreground commands can make observer-owned timeouts actionable
+    // without producing PTY bytes; 10 Hz preserves them without the old
+    // steady 100 Hz relay baseline.
+    if foreground_command_active {
+        timeout = timeout.min(Duration::from_millis(100));
+    }
+    if let Some(remaining) = prompt_replay_remaining {
+        timeout = timeout.min(remaining);
+    }
+    timeout
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct RelayActivity {
+    pub(super) pty: bool,
+    pub(super) wake: bool,
+    pub(super) resize: bool,
+}
+
+pub(super) fn wait_for_relay_activity(
+    master_fd: RawFd,
+    wake: &mut UnixStream,
+    resize: &mut UnixStream,
+    timeout: Duration,
+) -> io::Result<RelayActivity> {
+    let wake_fd = wake.as_raw_fd();
+    let resize_fd = resize.as_raw_fd();
+    let mut poll_fds = [
+        libc::pollfd {
+            fd: master_fd,
+            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: resize_fd,
+            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: wake_fd,
+            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        },
+    ];
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout_ms = if remaining.is_zero() {
+            0
+        } else {
+            remaining
+                .as_millis()
+                .saturating_add(1)
+                .min(i32::MAX as u128) as i32
+        };
+        let result = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, timeout_ms) };
+        if result >= 0 {
+            break;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+
+    let pty = poll_fds[0].revents != 0;
+    let resize_ready = poll_fds[1].revents != 0;
+    let wake_ready = poll_fds[2].revents != 0;
+    if wake_ready {
+        drain_wake_stream(wake)?;
+    }
+    if resize_ready {
+        drain_wake_stream(resize)?;
+    }
+    Ok(RelayActivity {
+        pty,
+        wake: wake_ready,
+        resize: resize_ready,
+    })
+}
+
+fn drain_wake_stream(wake: &mut UnixStream) -> io::Result<()> {
+    let mut buffer = [0_u8; 256];
+    loop {
+        match wake.read(&mut buffer) {
+            Ok(0) => return Ok(()),
+            Ok(_) => continue,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+pub(super) fn poll_driver_completion(
+    receiver: &Receiver<DriverCompletion>,
+    master: &File,
+    terminal: &File,
+    child: &mut Child,
+    completed_at: &mut Option<Instant>,
+) -> io::Result<()> {
+    let Ok(completion) = receiver.try_recv() else {
+        return Ok(());
+    };
+    *completed_at = Some(completion.completed_at);
+    if let Err(error) = completion.result {
+        shutdown_and_reap_child(master, terminal, child);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn shutdown_and_reap_child(master: &File, terminal: &File, child: &mut Child) {
+    let mut shutdown = None;
+    if request_eof_shutdown(master, terminal, child, &mut shutdown).is_ok() {
+        while let Ok(false) = advance_eof_shutdown(&mut shutdown) {
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_relay_uses_low_frequency_maintenance() {
+        assert_eq!(
+            relay_wait_timeout(None, None, None, false, false, None),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn foreground_command_uses_ten_hertz_timeout_checks() {
+        assert_eq!(
+            relay_wait_timeout(None, None, None, false, true, None),
+            Duration::from_millis(100)
+        );
+    }
+
+    #[test]
+    fn active_runtime_keeps_streaming_poll_cadence() {
+        assert_eq!(
+            relay_wait_timeout(None, None, None, true, false, None),
+            Duration::from_millis(10)
+        );
+    }
+
+    #[test]
+    fn scripted_driver_checks_child_liveness_between_actions() {
+        let watchdog = RawActionWatchdog::new(Duration::from_secs(1));
+        assert_eq!(
+            relay_wait_timeout(Some(&watchdog), None, None, false, false, None),
+            Duration::from_millis(10)
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/eof_shutdown.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/eof_shutdown.rs
@@ -16,6 +16,12 @@ pub(super) struct EofShutdown {
     kill_sent: bool,
 }
 
+impl EofShutdown {
+    pub(super) fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+}
+
 pub(super) fn request_eof_shutdown(
     master: &File,
     terminal: &File,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay_tests.rs
@@ -3,6 +3,92 @@ use crate::raw_input::UserPtyInputGeneration;
 
 const TEST_MARKER_TOKEN: &str = "test-marker-token";
 
+#[test]
+fn relay_wake_bytes_are_coalesced_and_fully_drained() {
+    let (master, _master_writer) = nix::unistd::pipe().expect("master pipe");
+    let (mut wake_reader, mut wake_writer) = UnixStream::pair().expect("wake pair");
+    let (mut resize_reader, _resize_writer) = UnixStream::pair().expect("resize pair");
+    wake_reader.set_nonblocking(true).expect("nonblocking wake");
+    resize_reader
+        .set_nonblocking(true)
+        .expect("nonblocking resize");
+    wake_writer
+        .set_nonblocking(true)
+        .expect("nonblocking writer");
+    wake_writer.write_all(&[1; 128]).expect("queue wakes");
+
+    let activity = wait_for_relay_activity(
+        master.as_raw_fd(),
+        &mut wake_reader,
+        &mut resize_reader,
+        Duration::from_millis(50),
+    )
+    .expect("wait for wake");
+    assert_eq!(
+        activity,
+        RelayActivity {
+            pty: false,
+            wake: true,
+            resize: false,
+        }
+    );
+
+    let drained = wait_for_relay_activity(
+        master.as_raw_fd(),
+        &mut wake_reader,
+        &mut resize_reader,
+        Duration::from_millis(2),
+    )
+    .expect("wait after drain");
+    assert_eq!(drained, RelayActivity::default());
+}
+
+#[test]
+fn relay_wait_returns_when_pty_becomes_readable() {
+    let (master, master_writer) = nix::unistd::pipe().expect("master pipe");
+    let (mut wake_reader, _wake_writer) = UnixStream::pair().expect("wake pair");
+    let (mut resize_reader, _resize_writer) = UnixStream::pair().expect("resize pair");
+    wake_reader.set_nonblocking(true).expect("nonblocking wake");
+    resize_reader
+        .set_nonblocking(true)
+        .expect("nonblocking resize");
+    nix::unistd::write(&master_writer, b"output").expect("write master output");
+
+    let activity = wait_for_relay_activity(
+        master.as_raw_fd(),
+        &mut wake_reader,
+        &mut resize_reader,
+        Duration::from_secs(1),
+    )
+    .expect("wait for pty");
+    assert!(activity.pty);
+    assert!(!activity.wake);
+    assert!(!activity.resize);
+}
+
+#[test]
+fn relay_wait_distinguishes_resize_from_regular_wake() {
+    let (master, _master_writer) = nix::unistd::pipe().expect("master pipe");
+    let (mut wake_reader, _wake_writer) = UnixStream::pair().expect("wake pair");
+    let (mut resize_reader, mut resize_writer) = UnixStream::pair().expect("resize pair");
+    wake_reader.set_nonblocking(true).expect("nonblocking wake");
+    resize_reader
+        .set_nonblocking(true)
+        .expect("nonblocking resize");
+    resize_writer.write_all(&[1]).expect("queue resize");
+
+    let activity = wait_for_relay_activity(
+        master.as_raw_fd(),
+        &mut wake_reader,
+        &mut resize_reader,
+        Duration::from_secs(1),
+    )
+    .expect("wait for resize");
+    assert!(!activity.pty);
+    assert!(!activity.wake);
+    assert!(activity.resize);
+}
+
 fn parser_for_test(name: &str) -> OscParser {
     let dir = std::env::temp_dir().join(format!("cosh-raw-relay-{name}"));
     OscParser::new(name.to_string(), dir, TEST_MARKER_TOKEN.to_string())

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -10,8 +11,8 @@ use nix::libc;
 
 use crate::input::InputClassifier;
 use crate::raw_input::{
-    spawn_raw_action_relay, spawn_raw_input_relay, MainPromptGate, RawInputEvent, RawInputMode,
-    RawObserverAction, RawRelayAction, UserPtyInputGeneration,
+    spawn_raw_action_relay_with_wake, spawn_raw_input_relay_with_wake, MainPromptGate,
+    RawInputEvent, RawInputMode, RawObserverAction, RawRelayAction, UserPtyInputGeneration,
 };
 use crate::types::ShellEvent;
 
@@ -21,9 +22,17 @@ use super::lifecycle::{build_shell_host_output, push_shell_exited_event};
 use super::model::{ShellHostConfig, ShellHostOutput};
 use super::raw_relay::{read_raw_until_exit, DriverCompletion, RawActionWatchdog};
 
+mod interactive;
 mod raw_mode_guard;
+mod wake;
 
-use raw_mode_guard::{reopen_stdout_blocking, RawModeGuard};
+pub use interactive::{
+    run_raw_interactive_bash, run_raw_interactive_bash_with_observer,
+    run_raw_interactive_bash_with_output_control, run_raw_interactive_zsh_with_output_control,
+};
+#[cfg(test)]
+use raw_mode_guard::RawModeGuard;
+use wake::{notify_relay, RelayWake};
 
 pub fn run_raw_relay_bash<R, W>(
     config: &ShellHostConfig,
@@ -66,6 +75,21 @@ where
     W: Write,
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
+    run_raw_relay_bash_with_output_control_and_input_fd(config, input, output, event_observer, None)
+}
+
+fn run_raw_relay_bash_with_output_control_and_input_fd<R, W, F>(
+    config: &ShellHostConfig,
+    input: R,
+    output: W,
+    event_observer: F,
+    input_fd: Option<RawFd>,
+) -> io::Result<ShellHostOutput>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+{
     run_raw_relay_with_driver(
         config,
         start_bash_session,
@@ -74,8 +98,16 @@ where
         config.input_classifier.clone(),
         None,
         config.slash_via_shell,
-        |master, _, input_events, input_classifier, input_mode, input_generation, gate, routed| {
-            spawn_raw_input_relay(
+        |master,
+         _,
+         input_events,
+         input_classifier,
+         input_mode,
+         input_generation,
+         gate,
+         routed,
+         wake| {
+            spawn_raw_input_relay_with_wake(
                 input,
                 master,
                 input_events,
@@ -84,6 +116,8 @@ where
                 input_generation,
                 gate,
                 routed,
+                input_fd,
+                Some(wake),
             )
         },
     )
@@ -100,6 +134,21 @@ where
     W: Write,
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
+    run_raw_relay_zsh_with_output_control_and_input_fd(config, input, output, event_observer, None)
+}
+
+fn run_raw_relay_zsh_with_output_control_and_input_fd<R, W, F>(
+    config: &ShellHostConfig,
+    input: R,
+    output: W,
+    event_observer: F,
+    input_fd: Option<RawFd>,
+) -> io::Result<ShellHostOutput>
+where
+    R: Read + Send + 'static,
+    W: Write,
+    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+{
     run_raw_relay_with_driver(
         config,
         start_zsh_session,
@@ -108,8 +157,16 @@ where
         config.input_classifier.clone(),
         None,
         false,
-        |master, _, input_events, input_classifier, input_mode, input_generation, gate, routed| {
-            spawn_raw_input_relay(
+        |master,
+         _,
+         input_events,
+         input_classifier,
+         input_mode,
+         input_generation,
+         gate,
+         routed,
+         wake| {
+            spawn_raw_input_relay_with_wake(
                 input,
                 master,
                 input_events,
@@ -118,6 +175,8 @@ where
                 input_generation,
                 gate,
                 routed,
+                input_fd,
+                Some(wake),
             )
         },
     )
@@ -157,8 +216,9 @@ where
          input_mode,
          input_generation,
          gate,
-         routed| {
-            spawn_raw_action_relay(
+         routed,
+         wake| {
+            spawn_raw_action_relay_with_wake(
                 actions,
                 master,
                 child_pid,
@@ -168,6 +228,7 @@ where
                 input_generation,
                 gate,
                 routed,
+                Some(wake),
             )
         },
     )
@@ -202,8 +263,9 @@ where
          input_mode,
          input_generation,
          gate,
-         routed| {
-            spawn_raw_action_relay(
+         routed,
+         wake| {
+            spawn_raw_action_relay_with_wake(
                 actions,
                 master,
                 child_pid,
@@ -213,6 +275,7 @@ where
                 input_generation,
                 gate,
                 routed,
+                Some(wake),
             )
         },
     )
@@ -243,8 +306,9 @@ where
          input_mode,
          input_generation,
          gate,
-         routed| {
-            spawn_raw_action_relay(
+         routed,
+         wake| {
+            spawn_raw_action_relay_with_wake(
                 actions,
                 master,
                 child_pid,
@@ -254,6 +318,7 @@ where
                 input_generation,
                 gate,
                 routed,
+                Some(wake),
             )
         },
     )
@@ -281,6 +346,7 @@ where
         UserPtyInputGeneration,
         MainPromptGate,
         bool,
+        UnixStream,
     ) -> JoinHandle<io::Result<()>>,
 {
     let mut session = start_session(config)?;
@@ -314,6 +380,12 @@ where
     // so the prompt gate can prove bash is at its prompt; everything else
     // keeps the Rust intercept path.
     let slash_route_enabled = slash_via_shell && config.native_mode;
+    let (mut wake_reader, wake_writer, mut resize_reader, _resize_wake) =
+        RelayWake::new()?.into_parts();
+    // Keep the channel open after the driver and completion notifier exit;
+    // otherwise POLLHUP would keep the relay readable until the child exits.
+    let _wake_keepalive = wake_writer.try_clone()?;
+    let mut completion_wake = wake_writer.try_clone()?;
     let driver_thread = spawn_driver(
         input_master,
         session.child.id(),
@@ -323,6 +395,7 @@ where
         input_generation.clone(),
         main_prompt_gate,
         slash_route_enabled,
+        wake_writer,
     );
     let (driver_completion_sender, driver_completion_receiver) = mpsc::channel();
     thread::spawn(move || {
@@ -333,6 +406,7 @@ where
             result,
             completed_at: Instant::now(),
         });
+        notify_relay(&mut completion_wake);
     });
     let watchdog = action_watchdog.map(RawActionWatchdog::new);
     let mut last_winsize = config.winsize;
@@ -350,6 +424,8 @@ where
         &mut event_observer,
         &input_event_receiver,
         &driver_completion_receiver,
+        &mut wake_reader,
+        &mut resize_reader,
         &input_mode,
         &input_generation,
         &mut last_winsize,
@@ -372,58 +448,6 @@ where
     event_observer(&session.parser.events, &mut output)?;
     output.flush()?;
     build_shell_host_output(config, session.parser, exit_status)
-}
-
-pub fn run_raw_interactive_bash(config: &ShellHostConfig) -> io::Result<ShellHostOutput> {
-    let _raw_mode = RawModeGuard::activate_stdin()?;
-    reopen_stdout_blocking()?;
-    run_raw_relay_bash(config, std::io::stdin(), std::io::stdout())
-}
-
-pub fn run_raw_interactive_bash_with_observer<F>(
-    config: &ShellHostConfig,
-    event_observer: F,
-) -> io::Result<ShellHostOutput>
-where
-    F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<()>,
-{
-    let _raw_mode = RawModeGuard::activate_stdin()?;
-    reopen_stdout_blocking()?;
-    run_raw_relay_bash_with_observer(config, std::io::stdin(), std::io::stdout(), event_observer)
-}
-
-pub fn run_raw_interactive_bash_with_output_control<F>(
-    config: &ShellHostConfig,
-    event_observer: F,
-) -> io::Result<ShellHostOutput>
-where
-    F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<RawObserverAction>,
-{
-    let _raw_mode = RawModeGuard::activate_stdin()?;
-    reopen_stdout_blocking()?;
-    run_raw_relay_bash_with_output_control(
-        config,
-        std::io::stdin(),
-        std::io::stdout(),
-        event_observer,
-    )
-}
-
-pub fn run_raw_interactive_zsh_with_output_control<F>(
-    config: &ShellHostConfig,
-    event_observer: F,
-) -> io::Result<ShellHostOutput>
-where
-    F: FnMut(&[ShellEvent], &mut std::io::Stdout) -> io::Result<RawObserverAction>,
-{
-    let _raw_mode = RawModeGuard::activate_stdin()?;
-    reopen_stdout_blocking()?;
-    run_raw_relay_zsh_with_output_control(
-        config,
-        std::io::stdin(),
-        std::io::stdout(),
-        event_observer,
-    )
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/interactive.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/interactive.rs
@@ -1,0 +1,84 @@
+//! Real-terminal entry points for the raw bash and zsh relays.
+
+use std::io;
+
+use nix::libc;
+
+use crate::raw_input::RawObserverAction;
+use crate::types::ShellEvent;
+
+use super::raw_mode_guard::{reopen_stdout_blocking, RawModeGuard};
+use super::{
+    run_raw_relay_bash_with_output_control_and_input_fd,
+    run_raw_relay_zsh_with_output_control_and_input_fd, ShellHostConfig, ShellHostOutput,
+};
+
+pub fn run_raw_interactive_bash(config: &ShellHostConfig) -> io::Result<ShellHostOutput> {
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    run_raw_relay_bash_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        |_, _| Ok(RawObserverAction::Continue),
+        Some(libc::STDIN_FILENO),
+    )
+}
+
+pub fn run_raw_interactive_bash_with_observer<F>(
+    config: &ShellHostConfig,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<()>,
+{
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    let mut event_observer = event_observer;
+    run_raw_relay_bash_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        move |events, output| {
+            event_observer(events, output)?;
+            Ok(RawObserverAction::Continue)
+        },
+        Some(libc::STDIN_FILENO),
+    )
+}
+
+pub fn run_raw_interactive_bash_with_output_control<F>(
+    config: &ShellHostConfig,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<RawObserverAction>,
+{
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    run_raw_relay_bash_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        event_observer,
+        Some(libc::STDIN_FILENO),
+    )
+}
+
+pub fn run_raw_interactive_zsh_with_output_control<F>(
+    config: &ShellHostConfig,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<RawObserverAction>,
+{
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    run_raw_relay_zsh_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        event_observer,
+        Some(libc::STDIN_FILENO),
+    )
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/wake.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/wake.rs
@@ -1,0 +1,62 @@
+//! Wake channels shared by the raw input driver and output relay.
+
+use std::io::{self, Write};
+use std::os::unix::net::UnixStream;
+
+use nix::libc;
+
+pub(super) struct SignalWake(signal_hook::SigId);
+
+impl SignalWake {
+    fn register(signal: i32, wake: UnixStream) -> io::Result<Self> {
+        signal_hook::low_level::pipe::register(signal, wake).map(Self)
+    }
+}
+
+impl Drop for SignalWake {
+    fn drop(&mut self) {
+        signal_hook::low_level::unregister(self.0);
+    }
+}
+
+pub(super) struct RelayWake {
+    reader: UnixStream,
+    writer: UnixStream,
+    resize_reader: UnixStream,
+    resize_signal: SignalWake,
+}
+
+impl RelayWake {
+    pub(super) fn new() -> io::Result<Self> {
+        let (reader, writer) = UnixStream::pair()?;
+        let (resize_reader, resize_writer) = UnixStream::pair()?;
+        reader.set_nonblocking(true)?;
+        writer.set_nonblocking(true)?;
+        resize_reader.set_nonblocking(true)?;
+        resize_writer.set_nonblocking(true)?;
+        let resize_signal = SignalWake::register(libc::SIGWINCH, resize_writer)?;
+        Ok(Self {
+            reader,
+            writer,
+            resize_reader,
+            resize_signal,
+        })
+    }
+
+    pub(super) fn into_parts(self) -> (UnixStream, UnixStream, UnixStream, SignalWake) {
+        (
+            self.reader,
+            self.writer,
+            self.resize_reader,
+            self.resize_signal,
+        )
+    }
+}
+
+pub(super) fn notify_relay(wake: &mut UnixStream) {
+    match wake.write(&[1]) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+        Err(_) => {}
+    }
+}


### PR DESCRIPTION
## Why

The raw shell relay and stdin reader used fixed polling intervals, which kept
idle sessions active and imposed a 10-44 ms floor on terminal echo latency.
The core process also polled a SIGINT flag every 10 ms, causing unnecessary
Tokio wakeups while idle.

## What changed

- Wait on PTY, input/action notifications, and SIGWINCH through pollable wake
  channels, while preserving EOF, watchdog, prompt replay, and runtime
  deadlines.
- Publish raw-input events directly to the final relay channel and wake it
  synchronously before the corresponding PTY write, preserving causal order.
- Poll interactive stdin after `EAGAIN`, batch PTY output with a fairness cap,
  and avoid idle terminal-size queries when no question panel is active.
- Await SIGINT through `tokio::signal::ctrl_c()` and remove the core's direct
  `signal-hook` dependency.

The branch is split into two independently validated commits: one for the
cosh-core SIGINT path and one for the cosh-shell relay/input path.

## Related issue

closes #2608

closes #2609

The session-wide `OscParser` transcript retention design is split into #2623.
It requires explicit storage and compatibility semantics; truncating buffers in
this relay PR would break command-output, prompt-replay, and event-index
offsets.

## User / Agent impact

Interactive echo returns to sub-millisecond latency in the local PTY probe,
idle shell/core CPU samples round to zero, and high-output commands perform
less repeated observer and rendering work. CLI, configuration, and protocol
contracts are unchanged.

## Risk and compatibility

Low risk to public interfaces. The relay still performs 1 Hz idle maintenance,
10 Hz foreground timeout checks, and 100 Hz checks only while runtime output or
a scripted driver requires them. SIGWINCH propagation and scripted shutdown
paths are covered by tests and a live PTY check.

The existing session-wide OSC transcript remains memory-proportional to output;
a 16 MiB output probe reached about 40.8 MiB HWM. Its bounded storage contract
and 1 GiB validation are tracked by #2623.

## Validation

Environment: Linux 6.11, aarch64.

- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-shell --package cosh-core --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo test --package cosh-shell --lib --locked`
  - 1324 passed, 0 failed
- `cargo test --package cosh-shell --test raw_cli -- --test-threads=2`
  - 447 passed, 0 failed, 1 ignored manual native-zsh completion test
- `cargo test --package cosh-shell --test shell_host -- --test-threads=1`
  - 158 passed, 0 failed, 1 ignored manual fullscreen test
- `cargo test --package cosh-core --test sigint --locked`
  - 1 passed, 0 failed
- Targeted event-ordering, wake, approval, prompt-replay, config, resize,
  capture, slash interception, Ctrl-D, watchdog, slow-agent, and question-card
  tests passed.
- `cargo build --release --package cosh-shell --package cosh-core`

Release PTY measurements:

- Echo RTT: p50 20.492 ms -> 0.586 ms; p99 22.335 ms -> 0.650 ms.
- Prompt-idle `cosh-shell` CPU: 0.000% sampled over 6 seconds.
- Idle `cosh-core` CPU: 0.000% sampled over 5 seconds; SIGINT exits 0.
- Five-second idle strace: 6 `ppoll`, 5 `read`, 5 `wait4`; no `ioctl`,
  `/dev/tty` `openat`, `close`, or `clock_nanosleep` in the window.
- 16 MiB PTY output: 0.224 seconds elapsed, 0.190 seconds shell CPU.
- Live resize: inner shell changed from 24x80 to 40x100 after SIGWINCH.

## Documentation and rollback

No documentation change is required because public behavior is unchanged.
Rollback by reverting the two commits; no migration or persisted-state cleanup
is needed.