### PR TITLE
perf(cosh-ng): [core] replace SIGINT flag polling with tokio ctrl_c

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -610,7 +610,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "signal-hook",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -46,7 +46,6 @@ rustix.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
-signal-hook.workspace = true
 wait-timeout.workspace = true
 
 [dev-dependencies]

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -32,10 +32,6 @@ mod truncator;
 use clap::Parser;
 use cosh_core::provider;
 #[cfg(unix)]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(unix)]
-use std::sync::Arc;
-#[cfg(unix)]
 use std::time::Duration;
 
 use config::CoreConfig;
@@ -122,10 +118,8 @@ async fn main() {
 
 #[cfg(unix)]
 async fn run_until_sigint() {
-    let sigint_received = install_sigint_handler();
-
     tokio::select! {
-        _ = wait_for_sigint(sigint_received) => {
+        _ = wait_for_sigint() => {
             tracing::info!("received SIGINT, shutting down cosh-core");
         }
         _ = run() => {}
@@ -195,21 +189,18 @@ fn is_agent_headless_mode(args: &cli::CliArgs) -> bool {
 }
 
 #[cfg(unix)]
-fn install_sigint_handler() -> Arc<AtomicBool> {
-    let received = Arc::new(AtomicBool::new(false));
-    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&received)).unwrap_or_else(
-        |error| {
-            eprintln!("failed to install SIGINT handler: {error}");
-            std::process::exit(1);
-        },
-    );
-    received
-}
-
-#[cfg(unix)]
-async fn wait_for_sigint(received: Arc<AtomicBool>) {
-    while !received.load(Ordering::Relaxed) {
-        tokio::time::sleep(Duration::from_millis(10)).await;
+async fn wait_for_sigint() {
+    // Event-driven SIGINT wait (#2608): the previous 10ms flag-polling loop
+    // kept the multi-thread runtime waking ~100 times per second while idle.
+    // If handler registration fails (restricted environments), fall back to
+    // the kernel default SIGINT disposition: warn once and never resolve,
+    // so the process keeps serving and Ctrl-C still terminates it.
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        eprintln!(
+            "failed to install SIGINT handler: {error}; \
+             falling back to the default SIGINT disposition"
+        );
+        std::future::pending::<()>().await;
     }
 }
 


### PR DESCRIPTION
## Summary

Refs #2608（PR1/3，per SDD cosh-2608-2609-relay-event-driven D7/D10）

cosh-core 主任务此前以 10ms `tokio::time::sleep` 轮询 signal_hook 的
SIGINT AtomicBool 标志，空闲时驱动 multi-thread runtime 每秒 ~100 次
唤醒（epoll_pwait + futex + eventfd write + sched_yield 跨线程链），
实测空闲 CPU 1.37%（4 vCPU 容器，worker 线程占 0.90%）。

本 PR 将 `run_until_sigint` 的等待分支替换为 `tokio::signal::ctrl_c()`，
删除 `install_sigint_handler`/`wait_for_sigint` 与 cosh-core 对
signal-hook 的依赖（workspace 级条目保留，后续 relay 事件驱动化 PR
将在 cosh-shell 使用）。select/shutdown 结构不变；handler 注册窗口
语义与现状等价（注册完成前 SIGINT 均为默认终止行为）。

## FAIL → PASS

| 指标 | main@91f4d9ab（基线） | 本分支 |
| --- | --- | --- |
| 空闲 CPU（pidstat 60s 均值） | 1.37%（主线程 0.47% + worker 0.90%） | **0.00%** |
| strace 12s syscall | futex 1838 / epoll_pwait 1954 / write 919 / sched_yield 845 | **0（6 线程完全静默）** |

测量环境：alinux3 arm64 容器 4 vCPU，release 构建，`--headless` +
fifo 持 stdin 空闲常驻，同 #2608 基线口径。测量时段宿主 doctor
`contention=true`（load ~10），pidstat 数字作上界口径；strace 计数
与负载无关，为主要证据。

## 行为回归

- `cargo test -p cosh-core`：783 passed / 3 failed —— 失败集与同环境
  main 基线完全一致（3 个 session::store root 权限类已知环境项，
  root 用户下权限拒绝路径不可构造），本改动零新增失败。
- `cargo clippy -p cosh-core --all-targets`：无警告。
- SIGINT 优雅退出：空闲常驻进程收到首个 SIGINT 即退出（进程转
  zombie 待收割，确认非存活）。

## 验证范围声明

focused green（cosh-core crate 测试 + clippy）；workspace 全量 gate
未在本地重跑，交由 CI。空闲测量为 arm64 容器单架构口径。
