### PR TITLE
feat(cosh-ng): [shell] invert cosh entry to exec-bash passthrough

### DIFF
--- a/src/cosh-ng/cosh-ng.spec.in
+++ b/src/cosh-ng/cosh-ng.spec.in
@@ -45,22 +45,11 @@ install -m 0755 target/release/cosh-shell %{buildroot}%{_libexecdir_cosh}/cosh-s
 install -d %{buildroot}%{_bindir}
 install -m 0755 target/release/cosh-cli %{buildroot}%{_bindir}/cosh-cli
 
-# Install launcher script
-cat > %{buildroot}%{_bindir}/cosh << 'EOF'
-#!/bin/bash
-case "${1:-}" in
-  -c|--|--help|--version)
-    exec %{_libexecdir_cosh}/cosh-shell "$@"
-    ;;
-esac
-
-if [ "$#" -eq 0 ] && [ ! -t 0 ]; then
-  exec %{_libexecdir_cosh}/cosh-shell "$@"
-fi
-
-exec %{_libexecdir_cosh}/cosh-shell raw cosh-core "$@"
-EOF
-chmod 0755 %{buildroot}%{_bindir}/cosh
+# /usr/bin/cosh is the compiled entry: a symlink onto cosh-shell, which
+# dispatches on argv[0]. A script launcher would lose the login argv[0]
+# (binfmt_script) and add an interpreter hop to the execve chain; the
+# TUI-vs-passthrough decision lives in cosh-shell's invocation classifier.
+ln -s %{_libexecdir_cosh}/cosh-shell %{buildroot}%{_bindir}/cosh
 
 # Install cosh-switch script
 cat > %{buildroot}%{_bindir}/cosh-switch << 'EOF'

--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -42,7 +42,8 @@ mod types;
 #[path = "ui/public.rs"]
 mod ui;
 
-use runtime::cli_args::{configured_raw_invocation, should_start_default_raw};
+use runtime::cli_args::configured_raw_invocation;
+use runtime::invocation::{classify_invocation, exec_shell, is_cosh_entry, Invocation};
 use runtime::startup::{
     passthrough_non_interactive, passthrough_raw_non_interactive, print_usage_help,
 };
@@ -74,7 +75,52 @@ mod binary_compat {
 #[allow(unused_imports)]
 pub(crate) use binary_compat::*;
 
+/// Full argv (argv[0] included) when this process was invoked through the
+/// `/usr/bin/cosh` entry; `None` for the `cosh-shell` CLI surface.
+fn cosh_entry_args() -> Option<Vec<std::ffi::OsString>> {
+    let args = std::env::args_os().collect::<Vec<_>>();
+    is_cosh_entry(args.first()?).then_some(args)
+}
+
 fn main() {
+    // `/usr/bin/cosh` entry (argv[0] basename `cosh`, login `-cosh` included):
+    // the invocation-transparency contract dispatches before any runtime
+    // initialization so passthrough leaves no logs or terminal side effects.
+    if let Some(args_os) = cosh_entry_args() {
+        use std::io::IsTerminal;
+
+        let stdin_tty = std::io::stdin().is_terminal();
+        let stdout_tty = std::io::stdout().is_terminal();
+        let stderr_tty = std::io::stderr().is_terminal();
+        match classify_invocation(
+            &args_os[0],
+            &args_os[1..],
+            stdin_tty,
+            stdout_tty,
+            stderr_tty,
+        ) {
+            Invocation::ExecShell(plan) => std::process::exit(exec_shell(plan)),
+            Invocation::Tui(_) => {
+                runtime::terminal::install_terminal_recovery();
+                let cosh_config = config::load_config();
+                runtime::logging::init_logging(&cosh_config.log_level);
+                tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
+                // The allowlist only admits valid UTF-8 tokens in args[1..];
+                // argv[0] may be arbitrary bytes, so it is converted lossily
+                // (the TUI never re-parses it).
+                let args = args_os
+                    .iter()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>();
+                let (adapter_name, shell_kind, launch_options) =
+                    configured_raw_invocation(&args[1..]);
+                let status =
+                    runtime::controller::run_raw(&adapter_name, shell_kind, launch_options);
+                std::process::exit(status);
+            }
+        }
+    }
+
     let args = std::env::args().collect::<Vec<_>>();
 
     if args.get(1).map(String::as_str) == Some("--version") {
@@ -115,11 +161,11 @@ fn main() {
         if let Some(status) = passthrough_non_interactive(&args) {
             std::process::exit(status);
         }
-        if should_start_default_raw(&args[1..]) {
-            let (adapter_name, shell_kind, launch_options) = configured_raw_invocation(&args[1..]);
-            let status = runtime::controller::run_raw(&adapter_name, shell_kind, launch_options);
-            std::process::exit(status);
-        }
+        // The classifier admitted the TUI: only cosh-owned/login tokens on a
+        // terminal reach this point.
+        let (adapter_name, shell_kind, launch_options) = configured_raw_invocation(&args[1..]);
+        let status = runtime::controller::run_raw(&adapter_name, shell_kind, launch_options);
+        std::process::exit(status);
     }
 
     let status = match args.get(1).map(String::as_str) {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/cli_args.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/cli_args.rs
@@ -30,6 +30,10 @@ pub(crate) fn adapter_name_from_args(args: &[String]) -> Option<&str> {
                     idx += 1;
                 }
             }
+            // Standalone allowlist flags share one vocabulary source with the
+            // classifier, so a token admitted into the TUI there can never be
+            // read as an adapter name here.
+            arg if crate::runtime::invocation::TUI_STANDALONE_FLAGS.contains(&arg) => idx += 1,
             arg if arg.starts_with("--shell=") => idx += 1,
             arg if arg.starts_with("--resume=") => idx += 1,
             arg if arg.starts_with("--") => idx += 1,
@@ -74,31 +78,6 @@ pub(crate) fn raw_shell_from_args(args: &[String]) -> Option<RawShellKind> {
     }
 
     None
-}
-
-pub(crate) fn should_start_default_raw(args: &[String]) -> bool {
-    let mut idx = 0;
-    while idx < args.len() {
-        match args[idx].as_str() {
-            "--shell" => {
-                if !matches!(args.get(idx + 1), Some(value) if !value.starts_with("--")) {
-                    return false;
-                }
-                idx += 2;
-            }
-            "--resume" => {
-                idx += 1;
-                if args.get(idx).is_some_and(|value| !value.starts_with('-')) {
-                    idx += 1;
-                }
-            }
-            "--isolated" | "--login" | "-l" => idx += 1,
-            arg if arg.starts_with("--shell=") || arg.starts_with("--resume=") => idx += 1,
-            _ => return false,
-        }
-    }
-
-    true
 }
 
 pub(crate) fn parse_raw_shell(value: &str) -> RawShellKind {
@@ -195,8 +174,8 @@ fn cosh_shell_default_state_path_for_home(home: &std::path::Path) -> std::path::
 mod tests {
     use super::{
         adapter_name_from_args, cosh_shell_default_state_path_for_home, launch_options_from_args,
-        parse_raw_shell, raw_shell_from_args, shell_from_default_or_auto, should_start_default_raw,
-        RawShellKind, ResumeLaunch,
+        parse_raw_shell, raw_shell_from_args, shell_from_default_or_auto, RawShellKind,
+        ResumeLaunch,
     };
 
     #[test]
@@ -290,30 +269,51 @@ mod tests {
     }
 
     #[test]
-    fn no_subcommand_interactive_raw_accepts_only_shell_entry_options() {
-        assert!(should_start_default_raw(&[]));
-        assert!(should_start_default_raw(&["--login".to_string()]));
-        assert!(should_start_default_raw(&["-l".to_string()]));
-        assert!(should_start_default_raw(&[
-            "--shell".to_string(),
-            "zsh".to_string(),
-            "--isolated".to_string()
-        ]));
-        assert!(should_start_default_raw(&["--shell=bash".to_string()]));
-        assert!(should_start_default_raw(&["--resume".to_string()]));
-        assert!(should_start_default_raw(&[
-            "--resume".to_string(),
-            "00000000-0000-4000-8000-000000000000".to_string(),
-            "--shell=zsh".to_string(),
-        ]));
+    fn tui_allowlist_shapes_never_parse_an_adapter_name() {
+        // Vocabulary contract shared with the invocation classifier. The
+        // standalone-flag shapes are generated from the classifier's own
+        // vocabulary (`TUI_STANDALONE_FLAGS`), so a flag added there is
+        // covered here mechanically; only the value-carrying shapes
+        // (`--shell`, `--resume`) remain hand-enumerated because their
+        // shapes are flag-specific.
+        use crate::runtime::invocation::{classify_invocation, Invocation, TUI_STANDALONE_FLAGS};
+        use std::ffi::{OsStr, OsString};
 
-        assert!(!should_start_default_raw(&["fake".to_string()]));
-        assert!(!should_start_default_raw(&["--shell".to_string()]));
-        assert!(!should_start_default_raw(&[
-            "--shell".to_string(),
-            "--isolated".to_string()
-        ]));
-        assert!(!should_start_default_raw(&["--unknown".to_string()]));
+        let mut shapes: Vec<Vec<String>> = vec![vec![]];
+        for flag in TUI_STANDALONE_FLAGS {
+            shapes.push(vec![flag.to_string()]);
+        }
+        // All standalone flags combined, and each behind a consumed --shell.
+        shapes.push(TUI_STANDALONE_FLAGS.iter().map(|s| s.to_string()).collect());
+        for flag in TUI_STANDALONE_FLAGS {
+            shapes.push(vec!["--shell".into(), "zsh".into(), flag.to_string()]);
+        }
+        for value_shape in [
+            vec!["--resume".to_string()],
+            vec![
+                "--resume".to_string(),
+                "00000000-0000-4000-8000-000000000000".to_string(),
+            ],
+            vec!["--shell=bash".to_string()],
+        ] {
+            shapes.push(value_shape);
+        }
+
+        for args in shapes {
+            let os_args: Vec<OsString> = args.iter().map(OsString::from).collect();
+            assert!(
+                matches!(
+                    classify_invocation(OsStr::new("cosh"), &os_args, true, true, true),
+                    Invocation::Tui(_)
+                ),
+                "allowlist shape must stay TUI: {args:?}"
+            );
+            assert_eq!(
+                adapter_name_from_args(&args),
+                None,
+                "allowlist token misread as adapter: {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -67,7 +67,10 @@ pub(crate) fn run_raw(
     shell_kind: RawShellKind,
     launch_options: LaunchOptions,
 ) -> i32 {
-    let args = std::env::args().collect::<Vec<_>>();
+    // args_os: argv[0] may be arbitrary bytes (the classifier admits any
+    // byte sequence whose basename is `cosh`), so String iteration would
+    // panic here.
+    let args = std::env::args_os().collect::<Vec<_>>();
 
     let Some(kind) = AdapterKind::parse(adapter_name) else {
         let adapter_name = crate::evidence::redact_sensitive_text(adapter_name).0;
@@ -98,8 +101,9 @@ pub(crate) fn run_raw(
             }
         }
     }
-    let login = args.first().is_some_and(|a| a.starts_with('-'))
-        || args.iter().any(|a| a == "--login" || a == "-l");
+    let login = args
+        .first()
+        .is_some_and(|argv0| crate::runtime::invocation::is_login_invocation(argv0, &args[1..]));
     config.login_shell = login;
     if config.native_mode {
         bootstrap_process_path_from_shell(&shell_kind, login);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
@@ -1,0 +1,625 @@
+//! Invocation-transparency dispatch for the `/usr/bin/cosh` entry.
+//!
+//! Single source of truth for the TUI-vs-passthrough decision: the TUI is an
+//! allowlist (bare/login invocation on a terminal, cosh-owned flags only) and
+//! every other argv shape is handed verbatim to the inner shell via `execve`,
+//! so unknown or future bash flags degrade to native bash instead of being
+//! hijacked into the TUI.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStrExt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Invocation {
+    /// Allowlist hit: start the interactive TUI.
+    Tui(TuiEntry),
+    /// Everything else: replace this process with the inner shell.
+    ExecShell(ExecPlan),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiEntry {
+    pub(crate) login: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExecPlan {
+    /// `--shell` override consumed from the cosh-owned leading options.
+    pub(crate) shell_override: Option<OsString>,
+    /// argv[0] passed through verbatim (login `-` prefix included) so the
+    /// inner shell observes the same `$0` contract as a direct bash call.
+    pub(crate) arg0: OsString,
+    /// Remaining argv, byte-for-byte. Only a `--shell` with a usable value
+    /// is consumed; TUI-only flags stay in place so the inner shell rejects
+    /// them loudly instead of silently losing their semantics.
+    pub(crate) args: Vec<OsString>,
+}
+
+/// True when argv[0] names the `/usr/bin/cosh` entry (optionally with the
+/// login `-` prefix set by login(1)/su).
+pub(crate) fn is_cosh_entry(argv0: &OsStr) -> bool {
+    entry_basename(argv0) == b"cosh"
+}
+
+fn entry_basename(argv0: &OsStr) -> &[u8] {
+    let bytes = argv0.as_bytes();
+    let bytes = bytes.strip_prefix(b"-").unwrap_or(bytes);
+    match bytes.rsplit(|byte| *byte == b'/').next() {
+        Some(name) => name,
+        None => bytes,
+    }
+}
+
+fn login_argv0(argv0: &OsStr) -> bool {
+    argv0.as_bytes().first() == Some(&b'-')
+}
+
+/// Standalone allowlist flags kept verbatim for the inner shell. Single
+/// vocabulary source shared by the classifier scan, the launch-side adapter
+/// scan (`cli_args::adapter_name_from_args`), and the vocabulary-contract
+/// test, so adding a flag here mechanically updates all three. Value-carrying
+/// flags (`--shell`, `--resume`) have shape-specific arms and stay explicit.
+pub(crate) const TUI_STANDALONE_FLAGS: &[&str] = &["-l", "--login", "--isolated"];
+
+/// Single source of truth for the login-shell bit: argv[0] carries the
+/// login `-` prefix (login(1)/su convention) or an explicit `-l`/`--login`
+/// flag appears anywhere in argv. Shared by the classifier and the TUI
+/// bootstrap so the two sites cannot drift.
+pub(crate) fn is_login_invocation<A: AsRef<OsStr>>(argv0: &OsStr, args: &[A]) -> bool {
+    login_argv0(argv0)
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_ref().to_str(), Some("-l") | Some("--login")))
+}
+
+/// Classify one invocation of the transparency contract entry.
+///
+/// Scan rules (single pass, fail-safe):
+/// 1. `--shell <v>` / `--shell=v` is consumed as exec metadata (it selects
+///    the inner shell). A missing, empty, or dash-leading value is not
+///    consumed: the token is handed to the inner shell verbatim, which
+///    reports it as an invalid option.
+/// 2. Login flags (`-l`/`--login`) and TUI-only flags (`--isolated`,
+///    `--resume [id]`, `--resume=id`) stay eligible for the TUI and are
+///    kept verbatim for the inner shell on the exec side, so a TUI-only
+///    flag that ends up on the exec path fails loudly as an invalid bash
+///    option instead of being silently dropped.
+/// 3. Any other token (options, operands, unknown or future flags, non-UTF-8
+///    bytes) short-circuits to `ExecShell` with the remainder untouched, so
+///    the worst case for an unclassified shape is native bash.
+/// 4. Owned/login flags only: the TUI additionally requires stdin, stdout,
+///    and stderr to all be terminals. This is deliberately stricter than
+///    bash's own interactivity rule (stdin + stderr, INVOCATION in bash(1)):
+///    whenever any fd is not a terminal the invocation degrades to the
+///    inner shell verbatim, and interactivity is decided by bash's native
+///    rule on the real fd topology — so equivalence holds on every
+///    topology, and the TUI only claims fully terminal-backed sessions.
+pub(crate) fn classify_invocation(
+    argv0: &OsStr,
+    args: &[OsString],
+    stdin_tty: bool,
+    stdout_tty: bool,
+    stderr_tty: bool,
+) -> Invocation {
+    let mut kept: Vec<OsString> = Vec::new();
+    let mut shell_override: Option<OsString> = None;
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        match arg.to_str() {
+            Some(text) if TUI_STANDALONE_FLAGS.contains(&text) => {
+                kept.push(arg.clone());
+                idx += 1;
+            }
+            Some("--shell")
+                if args
+                    .get(idx + 1)
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| !value.is_empty() && !value.starts_with('-')) =>
+            {
+                shell_override = Some(args[idx + 1].clone());
+                idx += 2;
+            }
+            Some(text)
+                if text.starts_with("--shell=")
+                    && !text["--shell=".len()..].is_empty()
+                    && !text["--shell=".len()..].starts_with('-') =>
+            {
+                shell_override = Some(OsString::from(&text["--shell=".len()..]));
+                idx += 1;
+            }
+            Some("--resume") => {
+                kept.push(arg.clone());
+                idx += 1;
+                if args
+                    .get(idx)
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| !value.starts_with('-'))
+                {
+                    kept.push(args[idx].clone());
+                    idx += 1;
+                }
+            }
+            Some(text) if text.starts_with("--resume=") => {
+                kept.push(arg.clone());
+                idx += 1;
+            }
+            _ => {
+                // First non-cosh token (including a `--shell` without a
+                // usable value): the rest of argv belongs to the inner shell
+                // byte-for-byte (no reordering, no interpretation).
+                let mut rest = kept;
+                rest.extend(args[idx..].iter().cloned());
+                return Invocation::ExecShell(ExecPlan {
+                    shell_override,
+                    arg0: argv0.to_os_string(),
+                    args: rest,
+                });
+            }
+        }
+    }
+
+    if stdin_tty && stdout_tty && stderr_tty {
+        Invocation::Tui(TuiEntry {
+            login: is_login_invocation(argv0, args),
+        })
+    } else {
+        Invocation::ExecShell(ExecPlan {
+            shell_override,
+            arg0: argv0.to_os_string(),
+            args: kept,
+        })
+    }
+}
+
+/// Extract the passthrough candidate from a `cosh-shell raw [adapter] …`
+/// invocation. `raw` is an explicit TUI request, so only an explicit `-c`
+/// command string or a leading `--` diverts to passthrough (legacy
+/// contract); every other shape — including unknown raw-surface flags such
+/// as `--run` — returns `None` and stays on the TUI launch path.
+pub(crate) fn normalize_raw_invocation(args: &[OsString]) -> Option<Vec<OsString>> {
+    if args.first().and_then(|arg| arg.to_str()) != Some("raw") {
+        return None;
+    }
+
+    let mut out: Vec<OsString> = Vec::new();
+    let mut skipped_adapter = false;
+    let mut idx = 1;
+    while idx < args.len() {
+        let arg = &args[idx];
+        match arg.to_str() {
+            // Legacy gate: `--` only diverts when it is the first normalized
+            // token; after cosh-owned flags it stays a TUI launch error
+            // surface, matching the pre-classifier scan.
+            Some("--") => {
+                if !out.is_empty() {
+                    return None;
+                }
+                out.extend(args[idx..].iter().cloned());
+                return Some(out);
+            }
+            Some("-c") => {
+                out.extend(args[idx..].iter().cloned());
+                return Some(out);
+            }
+            Some("--shell") => {
+                out.push(arg.clone());
+                if let Some(value) = args.get(idx + 1) {
+                    out.push(value.clone());
+                    idx += 2;
+                } else {
+                    idx += 1;
+                }
+            }
+            Some("--isolated") | Some("--login") | Some("-l") => {
+                out.push(arg.clone());
+                idx += 1;
+            }
+            Some(text) if text.starts_with("--shell=") => {
+                out.push(arg.clone());
+                idx += 1;
+            }
+            Some(text) if !text.starts_with('-') && !skipped_adapter => {
+                skipped_adapter = true;
+                idx += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    None
+}
+
+/// Replace the current process with the inner shell (`execve`), preserving
+/// argv[0], argument bytes, and the inherited SIGPIPE disposition. Returns an
+/// exit code only when the exec itself fails (127 missing / 126 otherwise,
+/// matching the shell convention).
+pub(crate) fn exec_shell(plan: ExecPlan) -> i32 {
+    use std::os::unix::process::CommandExt;
+
+    let shell = plan
+        .shell_override
+        .or_else(|| std::env::var_os("COSH_SHELL_DEFAULT_SHELL").filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| OsString::from("bash"));
+    let mut command = std::process::Command::new(&shell);
+    command.args(&plan.args).arg0(&plan.arg0);
+    unsafe {
+        command.pre_exec(crate::shell_host::sigpipe::restore_in_child);
+    }
+    let error = command.exec();
+
+    let program = String::from_utf8_lossy(entry_basename(&plan.arg0)).into_owned();
+    let shell = shell.to_string_lossy();
+    // Match the shell wording for exec failures instead of Rust's
+    // "(os error N)" suffix, keeping stderr bytes shell-shaped.
+    let reason = match error.kind() {
+        std::io::ErrorKind::NotFound => "No such file or directory".to_string(),
+        std::io::ErrorKind::PermissionDenied => "Permission denied".to_string(),
+        _ => error.to_string(),
+    };
+    eprintln!("{program}: {shell}: {reason}");
+    if error.kind() == std::io::ErrorKind::NotFound {
+        127
+    } else {
+        126
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::ffi::OsStringExt;
+
+    fn os(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    fn classify(argv0: &str, args: &[&str], tty: (bool, bool, bool)) -> Invocation {
+        classify_invocation(OsStr::new(argv0), &os(args), tty.0, tty.1, tty.2)
+    }
+
+    const ALL_TTY: (bool, bool, bool) = (true, true, true);
+
+    fn exec_args(invocation: Invocation) -> Vec<OsString> {
+        match invocation {
+            Invocation::ExecShell(plan) => plan.args,
+            Invocation::Tui(entry) => panic!("expected ExecShell, got Tui({entry:?})"),
+        }
+    }
+
+    #[test]
+    fn classify_row_1_bare_terminal_enters_tui() {
+        assert_eq!(
+            classify("cosh", &[], ALL_TTY),
+            Invocation::Tui(TuiEntry { login: false })
+        );
+    }
+
+    #[test]
+    fn classify_row_2_bare_without_all_three_terminals_execs_shell() {
+        for stdin_tty in [true, false] {
+            for stdout_tty in [true, false] {
+                for stderr_tty in [true, false] {
+                    if stdin_tty && stdout_tty && stderr_tty {
+                        continue;
+                    }
+                    let invocation = classify("cosh", &[], (stdin_tty, stdout_tty, stderr_tty));
+                    assert_eq!(
+                        exec_args(invocation),
+                        Vec::<OsString>::new(),
+                        "fd topology ({stdin_tty},{stdout_tty},{stderr_tty})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn classify_row_3_login_argv0_sets_login_and_preserves_arg0() {
+        assert_eq!(
+            classify("-cosh", &[], ALL_TTY),
+            Invocation::Tui(TuiEntry { login: true })
+        );
+        match classify("-cosh", &["-c", "id"], ALL_TTY) {
+            Invocation::ExecShell(plan) => assert_eq!(plan.arg0, OsString::from("-cosh")),
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_row_4_login_flags_enter_tui_and_pass_through_on_exec() {
+        for flag in ["-l", "--login"] {
+            assert_eq!(
+                classify("cosh", &[flag], ALL_TTY),
+                Invocation::Tui(TuiEntry { login: true })
+            );
+            assert_eq!(
+                exec_args(classify("cosh", &[flag], (false, false, false))),
+                os(&[flag])
+            );
+        }
+    }
+
+    #[test]
+    fn classify_rows_5_6_command_string_and_combined_flags_exec_verbatim() {
+        for args in [
+            vec!["-c", "printf ok"],
+            vec!["-lc", "printf ok"],
+            vec!["-cl", "printf ok"],
+            vec!["-ic", "printf ok"],
+            vec!["-i", "-c", "printf ok"],
+        ] {
+            assert_eq!(
+                exec_args(classify("cosh", &args, ALL_TTY)),
+                os(&args),
+                "args {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_rows_7_8_bash_options_exec_verbatim() {
+        for args in [
+            vec!["--posix", "-c", "set -o"],
+            vec!["--norc", "-i"],
+            vec!["--noprofile", "--norc", "-i"],
+            vec!["--restricted", "-c", "cd /"],
+            vec!["--dump-strings", "-c", "true"],
+            vec!["--debugger", "-c", "true"],
+            vec!["--noediting", "-i"],
+            vec!["--rcfile", "/tmp/rc", "-i"],
+            vec!["-O", "extglob", "-c", "shopt -q extglob"],
+            vec!["+O", "extglob", "-c", "shopt -q extglob"],
+        ] {
+            assert_eq!(
+                exec_args(classify("cosh", &args, ALL_TTY)),
+                os(&args),
+                "args {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_rows_9_to_13_operands_and_edge_options_exec_verbatim() {
+        for args in [
+            vec!["-s", "name", "a", "b"],
+            vec!["/definitely/not/present"],
+            vec!["script.sh", "arg1"],
+            vec!["--definitely-invalid"],
+            vec!["-c"],
+            vec!["--", "operand"],
+        ] {
+            assert_eq!(
+                exec_args(classify("cosh", &args, ALL_TTY)),
+                os(&args),
+                "args {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_row_14_force_interactive_flags_exec_even_on_terminals() {
+        for args in [
+            vec!["-i"],
+            vec!["--norc", "-i"],
+            vec!["--noprofile", "--norc", "-i"],
+            vec!["--login", "-i"],
+        ] {
+            let invocation = classify("cosh", &args, ALL_TTY);
+            assert!(
+                matches!(invocation, Invocation::ExecShell(_)),
+                "args {args:?} classified {invocation:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_row_15_shell_override_is_consumed_before_the_trigger_only() {
+        match classify("cosh", &["--shell", "zsh", "-c", "true"], ALL_TTY) {
+            Invocation::ExecShell(plan) => {
+                assert_eq!(plan.shell_override, Some(OsString::from("zsh")));
+                assert_eq!(plan.args, os(&["-c", "true"]));
+            }
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+        // Past the trigger the remainder is inner-shell argv ($0/$@ under
+        // `-c`), so a later `--shell` is data, not a cosh flag.
+        assert_eq!(
+            exec_args(classify("cosh", &["-c", "true", "--shell", "zsh"], ALL_TTY)),
+            os(&["-c", "true", "--shell", "zsh"])
+        );
+    }
+
+    #[test]
+    fn classify_shell_guard_never_consumes_options_or_empty_values() {
+        // A `--shell` without a usable value is not a cosh flag anymore: it
+        // goes to the inner shell verbatim (invalid option, exit 2) instead
+        // of eating the next token or silently vanishing.
+        for args in [
+            vec!["--shell"],
+            vec!["--shell", "-c", "echo hi"],
+            vec!["--shell", "--isolated"],
+            vec!["--shell="],
+        ] {
+            match classify("cosh", &args, ALL_TTY) {
+                Invocation::ExecShell(plan) => {
+                    assert_eq!(plan.shell_override, None, "args {args:?}");
+                    assert_eq!(plan.args, os(&args), "args {args:?}");
+                }
+                other => panic!("expected ExecShell for {args:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn classify_rows_16_17_tui_only_flags_gate_on_terminals_and_fail_loud() {
+        // On terminals the TUI-only flags admit the TUI…
+        for args in [
+            vec!["--resume"],
+            vec!["--resume", "00000000-0000-4000-8000-000000000000"],
+            vec!["--isolated"],
+            vec!["--shell", "zsh", "--isolated"],
+            vec!["--shell=bash"],
+        ] {
+            assert!(
+                matches!(classify("cosh", &args, ALL_TTY), Invocation::Tui(_)),
+                "args {args:?}"
+            );
+        }
+        // …and on the exec path they stay in argv verbatim so the inner
+        // shell rejects them loudly instead of silently dropping semantics.
+        for args in [
+            vec!["--resume"],
+            vec!["--resume", "00000000-0000-4000-8000-000000000000"],
+            vec!["--isolated"],
+        ] {
+            let invocation = classify("cosh", &args, (false, true, true));
+            assert_eq!(
+                exec_args(invocation),
+                os(&args),
+                "args {args:?} must reach the inner shell verbatim"
+            );
+        }
+        // `--shell` with a usable value is consumed even on the exec path
+        // (it selects the inner shell); the TUI-only flag stays.
+        match classify(
+            "cosh",
+            &["--shell", "zsh", "--isolated"],
+            (false, true, true),
+        ) {
+            Invocation::ExecShell(plan) => {
+                assert_eq!(plan.shell_override, Some(OsString::from("zsh")));
+                assert_eq!(plan.args, os(&["--isolated"]));
+            }
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_rows_18_20_version_help_and_future_flags_exec_verbatim() {
+        for args in [vec!["--version"], vec!["--help"], vec!["--future-flag"]] {
+            assert_eq!(
+                exec_args(classify("cosh", &args, ALL_TTY)),
+                os(&args),
+                "args {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_row_19_non_utf8_argv_execs_verbatim() {
+        let raw = OsString::from_vec(b"\xff\xfe".to_vec());
+        let args = vec![raw.clone()];
+        match classify_invocation(OsStr::new("cosh"), &args, true, true, true) {
+            Invocation::ExecShell(plan) => assert_eq!(plan.args, vec![raw]),
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invariant_i1_tui_requires_all_three_terminals_for_every_allowlist_shape() {
+        for args in [
+            vec![],
+            vec!["-l"],
+            vec!["--login"],
+            vec!["--resume"],
+            vec!["--isolated"],
+            vec!["--shell", "zsh"],
+        ] {
+            for stdin_tty in [true, false] {
+                for stdout_tty in [true, false] {
+                    for stderr_tty in [true, false] {
+                        let invocation =
+                            classify("cosh", &args, (stdin_tty, stdout_tty, stderr_tty));
+                        assert_eq!(
+                            matches!(invocation, Invocation::Tui(_)),
+                            stdin_tty && stdout_tty && stderr_tty,
+                            "args {args:?} fd topology ({stdin_tty},{stdout_tty},{stderr_tty})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn invariant_i2_i4_arguments_survive_byte_for_byte_in_order() {
+        let args = os(&["-l", "-lc", "", "printf %s", "--", "-c", "später"]);
+        match classify_invocation(OsStr::new("cosh"), &args, true, true, true) {
+            Invocation::ExecShell(plan) => assert_eq!(plan.args, args),
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invariant_i3_arg0_is_preserved_verbatim() {
+        for argv0 in ["cosh", "-cosh", "/usr/bin/cosh"] {
+            match classify(argv0, &["-c", "true"], ALL_TTY) {
+                Invocation::ExecShell(plan) => assert_eq!(plan.arg0, OsString::from(argv0)),
+                other => panic!("expected ExecShell, got {other:?}"),
+            }
+        }
+        let raw0 = OsString::from_vec(b"-c\xffosh".to_vec());
+        match classify_invocation(&raw0, &os(&["-c", "true"]), true, true, true) {
+            Invocation::ExecShell(plan) => assert_eq!(plan.arg0, raw0),
+            other => panic!("expected ExecShell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_invocation_shares_one_truth_for_argv0_and_flags() {
+        assert!(is_login_invocation(OsStr::new("-cosh"), &os(&[])));
+        assert!(is_login_invocation(OsStr::new("cosh"), &os(&["-l"])));
+        assert!(is_login_invocation(
+            OsStr::new("cosh"),
+            &os(&["--isolated", "--login"])
+        ));
+        assert!(!is_login_invocation(OsStr::new("cosh"), &os(&["-lc"])));
+        assert!(!is_login_invocation(OsStr::new("/usr/bin/cosh"), &os(&[])));
+    }
+
+    #[test]
+    fn cosh_entry_matches_only_the_cosh_basename() {
+        for argv0 in ["cosh", "-cosh", "/usr/bin/cosh", "./cosh"] {
+            assert!(is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
+        }
+        for argv0 in ["cosh-shell", "-cosh-shell", "/usr/libexec/cosh-shell", ""] {
+            assert!(!is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
+        }
+    }
+
+    #[test]
+    fn normalize_raw_diverts_only_command_string_and_double_dash() {
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "cosh-core", "-c", "echo ok"])),
+            Some(os(&["-c", "echo ok"]))
+        );
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "--shell", "bash", "cosh-core", "-c", "x"])),
+            Some(os(&["--shell", "bash", "-c", "x"]))
+        );
+        // A non-dash token after `-c` stays verbatim (it is `-c` payload,
+        // not an adapter).
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "fake", "-c", "cosh-core"])),
+            Some(os(&["-c", "cosh-core"]))
+        );
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "--", "echo", "ok"])),
+            Some(os(&["--", "echo", "ok"]))
+        );
+        // Explicit TUI request: raw-surface flags and bare launches stay on
+        // the TUI path.
+        assert_eq!(normalize_raw_invocation(&os(&["raw", "--run"])), None);
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "fake", "--run"])),
+            None
+        );
+        assert_eq!(normalize_raw_invocation(&os(&["raw", "cosh-core"])), None);
+        assert_eq!(
+            normalize_raw_invocation(&os(&["raw", "fake", "--resume"])),
+            None
+        );
+        assert_eq!(normalize_raw_invocation(&os(&["-c", "echo ok"])), None);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/mod.rs
@@ -18,6 +18,7 @@ mod evidence_requests_tests;
 pub(crate) mod evidence_state;
 pub(crate) mod hooks;
 pub(crate) mod insight;
+pub(crate) mod invocation;
 pub(crate) mod logging;
 pub(crate) mod mode;
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::io::{IsTerminal, Write};
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
-use std::process::{Command, ExitStatus, Stdio};
+use std::process::{Command, ExitStatus};
 use std::time::Duration;
 
 use crate::diagnostics::health::{
@@ -20,6 +21,9 @@ use crate::recommendation::personal_planner::{
     plan_startup, HealthResolution, PlannerCandidate, PlannerContext,
 };
 use crate::runtime::cli_args::RawShellKind;
+use crate::runtime::invocation::{
+    classify_invocation, exec_shell, normalize_raw_invocation, Invocation,
+};
 use crate::runtime::prelude::*;
 use crate::runtime::state::PendingInputGhostBinding;
 
@@ -203,6 +207,9 @@ pub(crate) fn bootstrap_process_path_from_shell(shell_kind: &RawShellKind, login
 }
 
 pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
+    // Documented `cosh-shell` extension: `-- <command> [args…]` executes the
+    // command directly (no shell). The `/usr/bin/cosh` entry never reaches
+    // this path; there `--` is handed to bash verbatim.
     if args.get(1).map(String::as_str) == Some("--") {
         let Some(command) = args.get(2) else {
             eprintln!("cosh-shell: missing command after --");
@@ -221,36 +228,15 @@ pub(crate) fn passthrough_non_interactive(args: &[String]) -> Option<i32> {
         return Some(status);
     }
 
-    if args.iter().any(|a| a == "-c") {
-        let shell = detect_passthrough_shell(args);
-        let pass_args = passthrough_shell_args(args);
-        let status = Command::new(&shell)
-            .args(&pass_args)
-            .status()
-            .map(passthrough_exit_code)
-            .unwrap_or_else(|err| {
-                eprintln!("cosh-shell: exec {shell} failed: {err}");
-                126
-            });
-        return Some(status);
+    let argv0 = OsString::from(args[0].as_str());
+    let rest = args[1..].iter().map(OsString::from).collect::<Vec<_>>();
+    let stdin_tty = std::io::stdin().is_terminal();
+    let stdout_tty = std::io::stdout().is_terminal();
+    let stderr_tty = std::io::stderr().is_terminal();
+    match classify_invocation(&argv0, &rest, stdin_tty, stdout_tty, stderr_tty) {
+        Invocation::ExecShell(plan) => Some(exec_shell(plan)),
+        Invocation::Tui(_) => None,
     }
-
-    if !std::io::stdin().is_terminal() {
-        let shell = detect_passthrough_shell(args);
-        let pass_args = passthrough_shell_args(args);
-        let status = Command::new(&shell)
-            .args(&pass_args)
-            .stdin(Stdio::inherit())
-            .status()
-            .map(passthrough_exit_code)
-            .unwrap_or_else(|err| {
-                eprintln!("cosh-shell: exec {shell} failed: {err}");
-                126
-            });
-        return Some(status);
-    }
-
-    None
 }
 
 fn passthrough_exit_code(status: ExitStatus) -> i32 {
@@ -261,89 +247,27 @@ fn passthrough_exit_code(status: ExitStatus) -> i32 {
 }
 
 pub(crate) fn passthrough_raw_non_interactive(args: &[String]) -> Option<i32> {
-    let passthrough_args = raw_passthrough_args(args)?;
-    passthrough_non_interactive(&passthrough_args)
-}
-
-fn raw_passthrough_args(args: &[String]) -> Option<Vec<String>> {
-    if args.get(1).map(String::as_str) != Some("raw") {
-        return None;
+    let rest = args[1..].iter().map(OsString::from).collect::<Vec<_>>();
+    let normalized = normalize_raw_invocation(&rest)?;
+    // Leading `--`: same documented direct-exec extension as the bare
+    // `cosh-shell` surface.
+    if normalized.first().and_then(|arg| arg.to_str()) == Some("--") {
+        let mut forwarded = vec![args[0].clone()];
+        forwarded.extend(
+            normalized
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned()),
+        );
+        return passthrough_non_interactive(&forwarded);
     }
-
-    let mut out = vec![args[0].clone()];
-    let mut skipped_adapter = false;
-    let mut idx = 2;
-    while idx < args.len() {
-        let arg = &args[idx];
-        match arg.as_str() {
-            "--" => {
-                out.push(arg.clone());
-                out.extend(args[idx + 1..].iter().cloned());
-                break;
-            }
-            "-c" => {
-                out.extend(args[idx..].iter().cloned());
-                break;
-            }
-            "--shell" => {
-                out.push(arg.clone());
-                if let Some(value) = args.get(idx + 1) {
-                    out.push(value.clone());
-                    idx += 2;
-                } else {
-                    idx += 1;
-                }
-            }
-            "--isolated" | "--login" | "-l" => {
-                out.push(arg.clone());
-                idx += 1;
-            }
-            _ if arg.starts_with("--shell=") => {
-                out.push(arg.clone());
-                idx += 1;
-            }
-            _ if !arg.starts_with('-') && !skipped_adapter => {
-                skipped_adapter = true;
-                idx += 1;
-            }
-            _ => return None,
-        }
+    // `raw` is an explicit TUI request, so the remaining `-c` candidate is
+    // classified on argv shape alone (terminals assumed): piped drivers
+    // must never be diverted away from an interactive session.
+    let argv0 = OsString::from(args[0].as_str());
+    match classify_invocation(&argv0, &normalized, true, true, true) {
+        Invocation::ExecShell(plan) => Some(exec_shell(plan)),
+        Invocation::Tui(_) => None,
     }
-
-    let has_dash_c = out.iter().any(|arg| arg == "-c");
-    let has_double_dash = out.get(1).map(String::as_str) == Some("--");
-    (has_dash_c || has_double_dash).then_some(out)
-}
-
-fn detect_passthrough_shell(args: &[String]) -> String {
-    for (i, arg) in args.iter().enumerate() {
-        if arg == "--shell" {
-            if let Some(val) = args.get(i + 1) {
-                return val.clone();
-            }
-        }
-        if let Some(val) = arg.strip_prefix("--shell=") {
-            return val.to_string();
-        }
-    }
-    std::env::var("COSH_SHELL_DEFAULT_SHELL").unwrap_or_else(|_| "bash".to_string())
-}
-
-fn passthrough_shell_args(args: &[String]) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut iter = args.iter().skip(1).peekable();
-    while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "--shell" => {
-                let _ = iter.next();
-            }
-            "--isolated" => {}
-            "--login" => out.push("-l".to_string()),
-            _ if arg.starts_with("--shell=") => {}
-            _ => out.push(arg.clone()),
-        }
-    }
-    out
 }
 
 pub(crate) fn print_usage_help() {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, Instant};
 
 use super::{
     append_startup_auth_hint, extract_bootstrap_path, merge_path_lists, plan_startup_for_render,
-    raw_passthrough_args, record_visible_personal_impressions,
-    render_pending_recommendation_notice, startup_suggestion_mode, visible_personal_candidates,
-    write_startup_suggestion_card, StartupSuggestionMode,
+    record_visible_personal_impressions, render_pending_recommendation_notice,
+    startup_suggestion_mode, visible_personal_candidates, write_startup_suggestion_card,
+    StartupSuggestionMode,
 };
 use crate::config::Language;
 use crate::diagnostics::health::{
@@ -523,46 +523,6 @@ fn bootstrap_path_merge_keeps_existing_and_common_dirs() {
             "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
         ]),
         "/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin"
-    );
-}
-
-#[test]
-fn raw_passthrough_args_strips_raw_adapter_for_dash_c() {
-    assert_eq!(
-        raw_passthrough_args(&[
-            "cosh-shell".to_string(),
-            "raw".to_string(),
-            "cosh-core".to_string(),
-            "-c".to_string(),
-            "echo ok".to_string()
-        ]),
-        Some(vec![
-            "cosh-shell".to_string(),
-            "-c".to_string(),
-            "echo ok".to_string()
-        ])
-    );
-}
-
-#[test]
-fn raw_passthrough_args_preserves_shell_option() {
-    assert_eq!(
-        raw_passthrough_args(&[
-            "cosh-shell".to_string(),
-            "raw".to_string(),
-            "--shell".to_string(),
-            "bash".to_string(),
-            "cosh-core".to_string(),
-            "-c".to_string(),
-            "echo ok".to_string()
-        ]),
-        Some(vec![
-            "cosh-shell".to_string(),
-            "--shell".to_string(),
-            "bash".to_string(),
-            "-c".to_string(),
-            "echo ok".to_string()
-        ])
     );
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
@@ -110,6 +110,9 @@ fn start_shell_session(
 
     unsafe {
         command.pre_exec(|| {
+            // The inner user shell must observe the SIGPIPE disposition the
+            // host process inherited, not the Rust runtime's rewrite.
+            super::sigpipe::restore_in_child()?;
             if libc::setsid() < 0 {
                 return Err(io::Error::last_os_error());
             }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -16,6 +16,7 @@ mod raw_relay;
 mod raw_runner;
 mod routing;
 mod scripted;
+pub(crate) mod sigpipe;
 
 pub use line_interactive::{run_line_interactive_bash, LineInteractiveOutput};
 pub(crate) use model::HintCardRenderer;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/sigpipe.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/sigpipe.rs
@@ -1,0 +1,54 @@
+//! SIGPIPE disposition inherited from the parent process.
+//!
+//! The Rust runtime rewrites SIGPIPE to SIG_IGN before `main`, so the true
+//! inherited disposition is captured from an `.init_array` constructor that
+//! runs earlier. On platforms without the capture the restore is a no-op and
+//! child processes keep today's behavior (fail-safe).
+
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const UNKNOWN: u8 = 0;
+const DEFAULT: u8 = 1;
+const IGNORED: u8 = 2;
+
+static INHERITED: AtomicU8 = AtomicU8::new(UNKNOWN);
+
+#[cfg(target_os = "linux")]
+unsafe extern "C" fn capture_inherited_sigpipe() {
+    use nix::libc;
+
+    let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+    if unsafe { libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut action) } == 0 {
+        // A caught (custom handler) disposition maps to DEFAULT on purpose:
+        // execve(2) resets caught signals to their default action in the new
+        // image, so "default" is exactly what the inner shell would have
+        // inherited from such a parent.
+        let value = if action.sa_sigaction == libc::SIG_IGN {
+            IGNORED
+        } else {
+            DEFAULT
+        };
+        INHERITED.store(value, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[used]
+#[link_section = ".init_array"]
+static CAPTURE_INHERITED_SIGPIPE: unsafe extern "C" fn() = capture_inherited_sigpipe;
+
+/// Restore the captured disposition in a child. Async-signal-safe; meant for
+/// `pre_exec` on every user-shell spawn/exec path.
+pub(crate) fn restore_in_child() -> std::io::Result<()> {
+    use nix::libc;
+
+    let handler = match INHERITED.load(Ordering::Relaxed) {
+        IGNORED => libc::SIG_IGN,
+        DEFAULT => libc::SIG_DFL,
+        _ => return Ok(()),
+    };
+    if unsafe { libc::signal(libc::SIGPIPE, handler) } == libc::SIG_ERR {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -1,3 +1,5 @@
+use std::os::unix::process::ExitStatusExt;
+
 use super::*;
 
 #[test]
@@ -171,7 +173,9 @@ fn raw_cli_dash_c_passthrough_preserves_exit_status() {
 fn raw_cli_dash_c_passthrough_preserves_signal_exit_status() {
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
 
-    for (signal, expected) in [("INT", 130), ("TERM", 143), ("KILL", 137)] {
+    // The passthrough execs the shell in place, so a signal death is
+    // observable as a signal death (bash parity), not a 128+n exit code.
+    for (signal, expected) in [("INT", 2), ("TERM", 15), ("KILL", 9)] {
         let command = format!("kill -{signal} $$");
         let output = raw_cli_command(binary)
             .args(["-c", command.as_str()])
@@ -184,7 +188,7 @@ fn raw_cli_dash_c_passthrough_preserves_signal_exit_status() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(
-            output.status.code(),
+            output.status.signal(),
             Some(expected),
             "signal={signal}\nstdout={stdout}\nstderr={stderr}"
         );
@@ -314,7 +318,9 @@ fn raw_cli_stdin_passthrough_preserves_exit_status() {
 fn raw_cli_stdin_passthrough_preserves_signal_exit_status() {
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
 
-    for (signal, expected) in [("INT", 130), ("TERM", 143), ("KILL", 137)] {
+    // Same exec-in-place parity as the dash-c variant: the shell's signal
+    // death reaches the caller as a signal, exactly like invoking bash.
+    for (signal, expected) in [("INT", 2), ("TERM", 15), ("KILL", 9)] {
         let mut child = raw_cli_command(binary)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -331,7 +337,7 @@ fn raw_cli_stdin_passthrough_preserves_signal_exit_status() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(
-            output.status.code(),
+            output.status.signal(),
             Some(expected),
             "signal={signal}\nstdout={stdout}\nstderr={stderr}"
         );
@@ -511,4 +517,202 @@ fn raw_cli_ai_off_consumes_agent_marker_without_adapter_or_shell_error() {
     assert!(!output.contains("Thinking..."), "{output}");
     assert!(!output.contains("command not found: ??"), "{output}");
     assert!(!output.contains("bash: ??"), "{output}");
+}
+
+#[test]
+fn raw_cli_cosh_entry_combined_login_flags_reach_bash_with_arg0() {
+    // /usr/bin/cosh contract: `-lc` is handed to bash verbatim and `$0`
+    // reflects the invocation name, not a hardcoded shell name.
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .args(["-lc", "printf '[%s]' \"$0\""])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run cosh entry with combined login flags");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert!(
+        stdout.contains("[cosh]"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
+fn raw_cli_cosh_entry_login_argv0_reaches_inner_shell_dollar_zero() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("-cosh")
+        .args(["-c", "printf '[%s]' \"$0\""])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run login cosh entry");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert!(
+        stdout.contains("[-cosh]"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
+fn raw_cli_cosh_entry_invalid_option_is_judged_by_bash() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .arg("--definitely-invalid")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run cosh entry with invalid option");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("Thinking..."),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("usage: cosh-shell"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
+fn raw_cli_cosh_entry_missing_script_file_reports_bash_127() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .arg("/definitely/not/present")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run cosh entry with missing script operand");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(127),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[test]
+fn raw_cli_cosh_entry_tui_only_flag_fails_loud_on_exec_path() {
+    // TUI-only flags reach the inner shell verbatim on the exec path, so
+    // their semantics are rejected loudly (bash: invalid option, exit 2)
+    // instead of being silently dropped.
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .args(["--isolated", "-c", "printf __SHOULD_NOT_RUN__"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run cosh entry with --isolated on the exec path");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stderr.contains("--isolated"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("__SHOULD_NOT_RUN__"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn raw_cli_passthrough_preserves_ignored_sigpipe_disposition() {
+    // An ignored SIGPIPE inherited by the cosh entry must reach the inner
+    // shell (captured before the Rust runtime rewrite, restored in
+    // pre_exec); the default disposition must stay default. SIGPIPE is
+    // signal 13, so bit 13 of SigIgn is mask 0x1000.
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let probe = "grep SigIgn /proc/self/status";
+
+    let sigign_mask = |ignore_pipe: bool| -> u64 {
+        let prefix = if ignore_pipe { "trap '' PIPE; " } else { "" };
+        let script = format!("{prefix}exec -a cosh '{binary}' -c '{probe}'");
+        let output = raw_cli_command("bash")
+            .args(["-c", &script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run sigpipe disposition probe");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+        let hex = stdout
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or_else(|| panic!("no SigIgn value in {stdout:?}"));
+        u64::from_str_radix(hex, 16).expect("parse SigIgn mask")
+    };
+
+    assert_ne!(
+        sigign_mask(true) & 0x1000,
+        0,
+        "ignored SIGPIPE must be inherited by the inner shell"
+    );
+    assert_eq!(
+        sigign_mask(false) & 0x1000,
+        0,
+        "default SIGPIPE must stay default in the inner shell"
+    );
+}
+
+#[test]
+fn raw_cli_interactive_dash_c_passthrough_transports_env_ps1() {
+    // Value-level prompt contract: env PS1 survives the compiled entry and
+    // is visible to an interactive inner bash (non-interactive bash strips
+    // it natively on both the oracle and candidate sides).
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .env("PS1", "__COSH_PS1_PROBE__")
+        .args([
+            "--norc",
+            "--noprofile",
+            "-i",
+            "-c",
+            "printf '[%s]' \"$PS1\"",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run interactive dash-c with env PS1");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("[__COSH_PS1_PROBE__]"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
 }

--- a/src/cosh-ng/packaging/raw/assets/bin/cosh
+++ b/src/cosh-ng/packaging/raw/assets/bin/cosh
@@ -41,15 +41,10 @@ for runtime_dir in \
         [ -x "$runtime_dir/cosh-shell" ] && \
         [ -x "$runtime_dir/cosh-core" ]; then
         export PATH="$runtime_dir:$PATH"
-        case "${1:-}" in
-            -c | -- | --help | --version)
-                exec "$runtime_dir/cosh-shell" "$@"
-                ;;
-        esac
-        if [ "$#" -eq 0 ] && [ ! -t 0 ]; then
-            exec "$runtime_dir/cosh-shell"
-        fi
-        exec "$runtime_dir/cosh-shell" raw cosh-core "$@"
+        # This wrapper only resolves the private runtime; the TUI-vs-
+        # passthrough decision is cosh-shell's invocation classifier,
+        # keyed off the forwarded invocation name.
+        exec -a "$0" "$runtime_dir/cosh-shell" "$@"
     fi
 done
 

--- a/src/cosh-ng/tests/test-package-raw.sh
+++ b/src/cosh-ng/tests/test-package-raw.sh
@@ -255,7 +255,9 @@ LINKED_BIN="$TMP/linked-bin"
 install -d -m 0755 "$LINKED_BIN"
 ln -s "$EXTRACTED/bin/cosh" "$LINKED_BIN/cosh"
 test "$(bash "$LINKED_BIN/cosh" --version)" = $'1\n--version'
-test "$("$EXTRACTED/bin/cosh" prompt)" = $'3\nraw\ncosh-core\nprompt'
+# The wrapper forwards argv untouched (no injected raw/adapter prefix);
+# dispatch belongs to cosh-shell's invocation classifier.
+test "$("$EXTRACTED/bin/cosh" prompt)" = $'1\nprompt'
 test "$(printf '' | "$EXTRACTED/bin/cosh")" = "0"
 
 NO_RPM_OUTPUT="$TMP/cosh-switch-no-rpm.out"


### PR DESCRIPTION
# Summary

`/usr/bin/cosh` used to dispatch through two stacked allowlists (an RPM launcher
script plus passthrough token scans inside `cosh-shell`) and fell into the
interactive TUI for every unlisted invocation shape. This PR inverts the
contract per the umbrella design in #2597: **entering the TUI is the allowlist,
and everything else is handed to the inner shell verbatim via `execve`.**

Invariant (acceptance contract): for any invocation vector
(argv × fd tty topology × login form × inherited signal disposition) outside
the TUI allowlist, the observable behavior of `/usr/bin/cosh`
(stdout/stderr bytes, exit code, `$0`, execve chain, child signal
dispositions) matches `exec bash`.

# Changes

- **Compiled entry (packaging)**: `/usr/bin/cosh` becomes a symlink onto
  `cosh-shell` (`cosh-ng.spec.in`); the raw-install wrapper keeps its runtime
  discovery but forwards argv untouched via `exec -a "$0"`. The script hop that
  destroyed the login `-` prefix / `$0` and doubled the execve chain is gone.
- **Single classifier**: new `runtime/invocation.rs::classify_invocation` —
  the TUI requires stdin, stdout, and stderr to all be terminals (stricter
  than bash's stdin+stderr interactivity rule, so no fd topology can land in
  the TUI where `exec bash` would be non-interactive — review round 1 B1),
  no operands, and only cosh-owned or login flags; any other token (including
  unknown/future bash flags) execs the configured shell with argv and argv[0]
  passed through byte-for-byte. TUI-only flags (`--isolated`/`--resume`) are
  forwarded verbatim on the exec path and fail loudly as invalid bash options
  instead of being silently dropped (B2); the `--shell` value guard rejects
  dash-leading/empty values (B3). The login bit has a single source shared
  with the TUI bootstrap (`is_login_invocation`), and the bootstrap iterates
  `args_os` so a non-UTF-8 argv[0] cannot panic it. The scattered token scans
  (`passthrough_non_interactive` branches, `raw_passthrough_args`,
  `should_start_default_raw`) are deleted or reduced to thin adapters.
- **Entry dispatch**: `main` dispatches on the argv[0] basename before any
  runtime initialization, so the passthrough path has zero logging/termios
  side effects. The `cosh-shell` CLI surface (subcommands, `--version/--help`,
  the documented `--` direct-exec extension, `raw` as an explicit TUI request)
  is preserved.
- **SIGPIPE inheritance** (#2541 sub-item A): `shell_host/sigpipe.rs` captures
  the inherited disposition in an `.init_array` constructor and restores it via
  `pre_exec` on both the exec path and the interactive PTY spawn.
- **Tests**: 17 classifier matrix unit tests (20-row input space from the
  design), 5 new cosh-entry integration tests (argv0/`$0` transparency, bash
  error semantics, env `PS1` value transport), signal-exit tests re-anchored to
  exec-in-place semantics, raw packaging stub assertions re-anchored (no more
  injected `raw cosh-core` prefix).

The earlier concern about `-s` narrowing is resolved: any dash-leading
unknown token (including `-s`) passes through verbatim and bash applies its
own invocation rules. Known discoverability trade-off: cosh-specific flag
help is only visible under the `cosh-shell` entry now (`cosh --help` answers
as bash by design).

Intentional behavior changes bundled with the inversion (design-approved):
`cosh --version/--help` answer as bash under the `cosh` entry; `cosh -- <cmd>`
follows bash semantics (the `cosh-shell` extension is unchanged); unknown
`cosh-shell` flags are judged by bash instead of printing usage; passthrough
signal deaths propagate as signals rather than 128+n exit codes.

# Tests

- `cargo test -p cosh-shell --bin cosh-shell runtime::invocation` — 19/19
  (20-row matrix with the three-fd topology enumerated 2^3).
- `cargo test -p cosh-shell --test raw_cli passthrough::` — 27/27 on macOS
  (28 on Linux: the ignored-SIGPIPE inheritance assertion is a Linux-only
  integration test that pins the pre_exec restore into the cargo gate);
  includes the 5 cosh-entry tests plus the TUI-only-flag fail-loud test.
- Repo gates: `check-layout.sh`, `check-test-inventory.sh`,
  `tests/test-package-raw.sh` (+ shellcheck) — all pass.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
  (rust-toolchain and newer stable) — clean.

# Verification

- **Linux container (alinux3, arm64)**: logic 9/9, protocol 71/71,
  raw_cli 443 passed / 9 failed, shell_host 155 passed / 3 failed,
  lib 1312 passed / 2 failed — every failure reproduces identically on the
  base commit in the same container (pre-existing environment effects:
  SIGINT/SIGQUIT ignored by background-job harness chains, containers without
  init, timeout-sensitive suites). **Zero failures introduced by this diff**
  (`comm -23 <with-diff> <base>` is empty; same result on the macOS host for
  the full bin/lib suites).
- **FAIL→PASS probe matrix (same container, RPM layout + `su -` login chain)**:
  base (script launcher + base binaries) fails 9/11 probes — TUI hijack of
  `-lc`/`--posix`/invalid option/missing script/`--resume`+pipe/`--norc -i`,
  `$0` = `bash` instead of `-cosh`, SIGPIPE SIG_IGN inheritance lost, env `PS1`
  swallowed. Fixed build passes **11/11**, with bare-tty TUI entry and
  SIGPIPE-DFL parity passing on both sides (zero-regression anchors).
- Not run in this PR: the full dual-arch 65-case paired differential matrix on
  ALinux4 ECS (the formal acceptance oracle from #2597; 44/65 cases failed on
  the 2026-08-14 baseline run). Scheduled as follow-up acceptance; the
  in-container probes above cover the same failure families.
- **Expected deviation in the 65-case matrix (acceptance-criteria decision,
  review round 3)**: SYS-003, SYS-005, and the SEM-020/IO-014/
  INV-018.missing-c diagnostics family remain FAIL **by design** under the
  byte-diff criterion. bash prefixes its diagnostics with its own argv[0], so
  argv[0] fidelity (#2538 item 2, a core invariant of this contract) and
  byte-equality with the oracle's `/bin/bash: …` prefix are structurally
  mutually exclusive. These cells are adjudicated as "diagnostic program name
  matches the invoked path" instead — consistent with the acceptance wording
  in #2538, which has a pending problem-statement revision for the same
  reason.

# Evidence

Probe harness and raw outputs (fork assets branch, commit-pinned):

- Probe script (B1–B10, PTY-driven, oracle `/bin/bash`):
  [probes.py](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/probes.py)
- **FAIL baseline** — base commit + original script launcher, 9/11 FAIL:
  [probes-base-launcher.json](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/probes-base-launcher.json)
  (intermediate control, base binaries + symlink layout, 4/11 FAIL:
  [probes-base.json](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/probes-base.json))
- **PASS run** — this PR's binaries, 11/11 PASS:
  [probes-fixed-final.json](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/probes-fixed-final.json)
  (re-run after review round 1, incl. the fail-loud B5 criterion:
  [probes-fixed-r1.json](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/probes-fixed-r1.json))
- Raw packaging gate (shellcheck + test-package-raw.sh) in container:
  [raw-packaging-gate.json](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/raw-packaging-gate.json)
- Full-suite failure-set equivalence (with-diff vs base, serial runs):
  [serial-full-withdiff.log](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/serial-full-withdiff.log)
  vs
  [serial-full-base.log](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/serial-full-base.log)
- Consolidated verification ledger:
  [baseline.md](https://raw.githubusercontent.com/SunnyQjm/anolisa/eecf47b3db81a623127cb3639465f8bc585950bf/baseline.md)

Closes #2536
Closes #2538
Closes #2545
Refs #2597 (umbrella U1), #2537 (`--norc`/flag contract sub-item),
#2541 (sub-item A)
