### PR TITLE
feat(anolisa): add component installer actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Validate public installer
         run: |
           bash -n website/static/install.sh
+          website/scripts/test-install.sh
           cmp website/static/install.sh website/build/install.sh
 
       - name: Smoke-test stable installer

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,8 +29,19 @@ Qwen Code, or cosh, then verify a before/after Token record.
 
 Choose the terminal that matches your environment:
 
-- [Start with cosh-ng](user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md) — an AI-native Linux terminal
+- [Start with cosh-ng](user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md) — an AI-native terminal
 - [Start with Copilot Shell](user-guide/en/user-entrypoint/copilot-shell/QUICKSTART.md) — an extensible Agent Shell
+
+On Alibaba Cloud Linux 4, use the RPM backend so dnf selects the matching
+system libraries. Only the component action uses `sudo`:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`--cosh-ng` remains available as shorthand for `--component cosh-ng`. On
+macOS arm64, use `--backend raw --install-mode user` instead.
 
 ### Add observability, security, or runtime controls
 

--- a/docs/QUICKSTART_zh.md
+++ b/docs/QUICKSTART_zh.md
@@ -28,8 +28,19 @@ Qwen Code 或 cosh，然后确认一条压缩前后的 Token 记录。
 
 根据环境选择终端：
 
-- [开始使用 cosh-ng](user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md)——面向 AI 时代重构的 Linux 终端
+- [开始使用 cosh-ng](user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md)——面向 AI 时代重构的终端
 - [开始使用 Copilot Shell](user-guide/zh/user-entrypoint/copilot-shell/QUICKSTART.md)——可扩展的 Agent Shell
+
+在 Alibaba Cloud Linux 4 上使用 RPM backend，让 dnf 选择匹配的系统库。
+脚本只会为组件操作调用 `sudo`。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`--cosh-ng` 仍可作为 `--component cosh-ng` 的简写。在 macOS arm64 上改用
+`--backend raw --install-mode user`。
 
 ### 增加可观测性、安全或运行时控制
 

--- a/docs/user-guide/en/installation.md
+++ b/docs/user-guide/en/installation.md
@@ -16,6 +16,22 @@ The `anolisa` CLI is the unified entry point for managing all ANOLISA components
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+The same installer can manage one published component immediately after it
+prepares the CLI. Pass the registry name, backend, and scope. Raw is the
+default backend. On Alibaba Cloud Linux 4, install cosh-ng through the RPM
+backend so dnf selects the matching system libraries:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`--cosh-ng` is shorthand for `--component cosh-ng`. Component, backend, and
+platform checks remain owned by the CLI, so the installer does not maintain a
+second component allowlist. In explicit system mode, the script uses `sudo`
+only for the component action; the CLI remains in the current user directory.
+Without `--install-mode`, scope follows the normal ANOLISA euid default.
+
 ### Option B: YUM (Alinux)
 
 ```bash
@@ -75,7 +91,7 @@ anolisa install <component>
 | Component | Description | Supported modes |
 |-----------|-------------|-----------------|
 | `cosh` | Copilot Shell — AI terminal assistant | user, system |
-| `cosh-ng` | AI-native Linux terminal and deterministic Agent runtime (experimental) | **system** |
+| `cosh-ng` | AI-native terminal and deterministic Agent runtime (experimental) | system (Linux), user or system (macOS arm64) |
 | `os-skills` | System management and DevOps skills | user, system |
 | `tokenless` | Token optimization (compression) | user, system |
 | `ws-ckpt` | Workspace checkpoint/rollback | **system** |
@@ -89,11 +105,26 @@ anolisa install <component>
 > sudo anolisa --install-mode system install agentsight
 > ```
 
-Install cosh-ng in system mode, then start the terminal with `cosh`:
+On Alibaba Cloud Linux 4, install cosh-ng from the RPM backend in system mode,
+then start the terminal with `cosh`:
 
 ```bash
-sudo anolisa --install-mode system install cosh-ng
+sudo anolisa --install-mode system install cosh-ng --backend rpm
 cosh
+```
+
+The public installer combines CLI bootstrap and component installation:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+On macOS arm64, the cosh-ng raw package has a separate user-scope contract:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Use the component name `sec-core` with the ANOLISA CLI. The Alinux RPM keeps
@@ -218,6 +249,13 @@ Remove a specific component:
 anolisa uninstall <component>
 ```
 
+The public installer also accepts an installed component name for removal. It
+refreshes the stable CLI first, then delegates to `anolisa uninstall`:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --uninstall
+```
+
 There is no batch uninstall command. List the installed records, then remove
 each intended component explicitly so its authority and package-removal policy
 are reviewed independently:
@@ -235,6 +273,12 @@ Update a specific component:
 
 ```bash
 anolisa update <component>
+```
+
+Update a selected component and the script-installed stable CLI together:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --upgrade
 ```
 
 Update all installed components:

--- a/docs/user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/QUICKSTART.md
@@ -6,14 +6,31 @@ cosh-ng adds an Agent to a normal bash or zsh session. Start `cosh`, run Shell c
 
 ## 1. Install
 
-Install the ANOLISA CLI and cosh-ng:
+On Alibaba Cloud Linux 4, install the ANOLISA CLI, then install cosh-ng from
+the RPM backend in system scope:
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
-sudo anolisa --install-mode system install cosh-ng
+export PATH="$HOME/.local/bin:$PATH"
+sudo "$HOME/.local/bin/anolisa" --install-mode system install cosh-ng --backend rpm
 ```
 
-Alibaba Cloud Linux users can install the RPM instead:
+The public installer can combine the CLI and component installation. It prompts
+for `sudo` only when running the component action:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+On macOS arm64, use user scope instead:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Alibaba Cloud Linux 4 users can also install the RPM directly:
 
 ```bash
 sudo yum install cosh-ng
@@ -28,7 +45,12 @@ cosh-cli --version
 
 Package and service changes normally need root privileges. Workspace checkpoint commands also need a running `ws-ckpt` daemon.
 
-These packaged paths target Linux. Source builds are for contributors; follow the [developer setup](../../../../developer-guide/en/cosh-ng/getting-started.md) after the packaged options above.
+The published Linux raw contract is not currently portable across all routed
+distributions, so it is not the recommended Linux installation path. The raw
+package supports macOS arm64, where Linux-only package and service operations
+remain unavailable. Source builds are for contributors; follow the
+[developer setup](../../../../developer-guide/en/cosh-ng/getting-started.md)
+after the packaged options above.
 
 ## 2. Start the terminal
 

--- a/docs/user-guide/zh/installation.md
+++ b/docs/user-guide/zh/installation.md
@@ -16,6 +16,21 @@
 curl -fsSL https://get.agentic-os.sh | bash
 ```
 
+同一个脚本准备好 CLI 后，可以立即管理一个已发布组件。参数使用 ANOLISA
+registry 中的组件名，并指定 backend 和范围。默认 backend 是 raw。在
+Alibaba Cloud Linux 4 上通过 RPM backend 安装 cosh-ng，让 dnf 选择匹配的
+系统库。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`--cosh-ng` 是 `--component cosh-ng` 的简写。组件、backend 和平台检查仍由
+CLI 负责，安装脚本不维护第二份组件白名单。显式使用 system 模式时，脚本只为
+组件操作调用 `sudo`，CLI 仍安装在当前用户目录。未指定 `--install-mode` 时，
+范围沿用 ANOLISA 的 euid 默认规则。
+
 ### 方式 B YUM（Alinux）
 
 ```bash
@@ -75,7 +90,7 @@ anolisa install <component>
 | 组件 | 说明 | 支持的模式 |
 |------|------|------------|
 | `cosh` | Copilot Shell AI 终端助手 | user、system |
-| `cosh-ng` | AI 原生 Linux 终端与 Agent 运行时（实验阶段） | **system** |
+| `cosh-ng` | AI 原生终端与 Agent 运行时（实验阶段） | system（Linux）、user 或 system（macOS arm64） |
 | `os-skills` | 系统管理与 DevOps 技能 | user、system |
 | `tokenless` | Token 优化（压缩） | user、system |
 | `ws-ckpt` | 工作区快照/回滚 | **system** |
@@ -89,11 +104,26 @@ anolisa install <component>
 > sudo anolisa --install-mode system install agentsight
 > ```
 
-以 system 模式安装 cosh-ng，随后运行 `cosh` 进入终端。
+在 Alibaba Cloud Linux 4 上，通过 RPM backend 把 cosh-ng 安装到 system
+范围，随后运行 `cosh` 进入终端。
 
 ```bash
-sudo anolisa --install-mode system install cosh-ng
+sudo anolisa --install-mode system install cosh-ng --backend rpm
 cosh
+```
+
+公共安装脚本可以合并 CLI 引导和组件安装。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+在 macOS arm64 上，cosh-ng raw 包使用独立的 user scope 契约。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 ANOLISA CLI 使用组件名 `sec-core`。Alinux 的 RPM 包名仍然是
@@ -213,6 +243,13 @@ anolisa doctor
 anolisa uninstall <component>
 ```
 
+公共安装脚本也可以接收已安装的组件名进行卸载。它会先刷新 stable CLI，再把
+操作交给 `anolisa uninstall`。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --uninstall
+```
+
 当前没有批量卸载命令。先列出安装记录，再逐个卸载目标组件，以便分别确认其
 权限来源和系统软件包移除策略。
 
@@ -229,6 +266,12 @@ anolisa uninstall <component>
 
 ```bash
 anolisa update <component>
+```
+
+同时更新指定组件和脚本安装的 stable CLI。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --upgrade
 ```
 
 更新所有已安装组件。

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/QUICKSTART.md
@@ -6,14 +6,30 @@ cosh-ng 在普通 bash 或 zsh 会话中加入 Agent。启动 `cosh` 后可以�
 
 ## 1. 安装
 
-安装 ANOLISA CLI 和 cosh-ng：
+在 Alibaba Cloud Linux 4 上安装 ANOLISA CLI，再通过 RPM backend 把
+cosh-ng 安装到 system 范围。
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
-sudo anolisa --install-mode system install cosh-ng
+export PATH="$HOME/.local/bin:$PATH"
+sudo "$HOME/.local/bin/anolisa" --install-mode system install cosh-ng --backend rpm
 ```
 
-Alibaba Cloud Linux 用户也可以改用 RPM：
+公共安装脚本可以合并 CLI 和组件安装，并且只在执行组件操作时请求 `sudo`。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+在 macOS arm64 上改用 user 范围：
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Alibaba Cloud Linux 4 用户也可以直接安装 RPM。
 
 ```bash
 sudo yum install cosh-ng
@@ -28,7 +44,10 @@ cosh-cli --version
 
 修改软件包和服务通常需要 root 权限；工作区快照命令还需要运行中的 `ws-ckpt` 守护进程。
 
-以上安装方式面向 Linux。源码构建仅供贡献者使用；完成上述安装方式后，请参阅[开发者入门指南](../../../../developer-guide/zh/cosh-ng/getting-started.md)。
+当前发布的 Linux raw 契约无法覆盖所有已路由的发行版，因此不作为推荐的
+Linux 安装路径。raw 包支持 macOS arm64，但依赖 Linux 的软件包和服务操作
+不可用。源码构建仅供贡献者使用，请参阅
+[开发者入门指南](../../../../developer-guide/zh/cosh-ng/getting-started.md)。
 
 ## 2. 启动终端
 

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -2,7 +2,7 @@
 
 [中文版](README_zh.md)
 
-cosh-ng is an AI-native Linux terminal built around the shell you already use.
+cosh-ng is an AI-native terminal built around the shell you already use.
 Start `cosh` to run bash or zsh as usual, then describe larger tasks in natural
 language when you want the Agent to investigate or act. Shell commands, Skills,
 approval cards, and resumable conversations stay in one terminal. Structured
@@ -23,22 +23,47 @@ and `Ctrl+C` continue to work in the foreground terminal.
 
 ## Install
 
-Install with the ANOLISA CLI:
+On Alibaba Cloud Linux 4, install cosh-ng from the RPM backend in system scope
+with the ANOLISA CLI:
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
-sudo anolisa --install-mode system install cosh-ng
+export PATH="$HOME/.local/bin:$PATH"
+sudo "$HOME/.local/bin/anolisa" --install-mode system install cosh-ng --backend rpm
 ```
 
-On Alibaba Cloud Linux, the RPM is an alternative:
+The public installer can combine those steps:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Use the same entry point for later updates or removal:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --install-mode system --upgrade
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --install-mode system --uninstall
+```
+
+On macOS arm64, use user scope instead:
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+On Alibaba Cloud Linux 4, the RPM is also available directly:
 
 ```bash
 sudo yum install cosh-ng
 ```
 
-These packaged installation paths currently target Linux. On macOS, follow
-the [developer setup](../../docs/developer-guide/en/cosh-ng/getting-started.md)
-to build from source.
+The published Linux raw contract is not currently portable across all routed
+distributions, so it is not the recommended Linux installation path. The raw
+package supports macOS arm64, where Linux-only package and service operations
+remain unavailable. Source builds are for contributors; follow the
+[developer setup](../../docs/developer-guide/en/cosh-ng/getting-started.md).
 
 ## Start in 30 seconds
 

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-cosh-ng 是一个 AI 原生 Linux 终端。它以你已经在用的 Shell 为基础。
+cosh-ng 是一个 AI 原生终端。它以你已经在用的 Shell 为基础。
 启动 `cosh` 后，bash 或 zsh 照常工作。遇到更复杂的任务，直接用自然语言请 Agent
 检查或操作即可。Shell 命令、Skills、审批卡片和可恢复对话都留在同一个终端里。
 需要自动化或集成其他 Agent 时，还可以使用结构化 JSON 和 JSONL 接口。
@@ -22,21 +22,46 @@ cosh-ng 是一个 AI 原生 Linux 终端。它以你已经在用的 Shell 为基
 
 ## 安装
 
-使用 ANOLISA CLI 安装。
+在 Alibaba Cloud Linux 4 上，通过 ANOLISA CLI 和 RPM backend 把 cosh-ng
+安装到 system 范围。
 
 ```bash
 curl -fsSL https://get.agentic-os.sh | bash
-sudo anolisa --install-mode system install cosh-ng
+export PATH="$HOME/.local/bin:$PATH"
+sudo "$HOME/.local/bin/anolisa" --install-mode system install cosh-ng --backend rpm
 ```
 
-在 Alibaba Cloud Linux 上，也可以直接安装 RPM。
+公共安装脚本可以合并上述步骤。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend rpm --install-mode system
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+后续升级或卸载也使用同一个入口。
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --install-mode system --upgrade
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --install-mode system --uninstall
+```
+
+在 macOS arm64 上改用 user 范围：
+
+```bash
+curl -fsSL https://get.agentic-os.sh | bash -s -- --cosh-ng --backend raw --install-mode user
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+在 Alibaba Cloud Linux 4 上，也可以直接安装 RPM。
 
 ```bash
 sudo yum install cosh-ng
 ```
 
-以上安装方式目前面向 Linux。macOS 请按照
-[开发者入门指南](../../docs/developer-guide/zh/cosh-ng/getting-started.md)从源码构建。
+当前发布的 Linux raw 契约无法覆盖所有已路由的发行版，因此不作为推荐的
+Linux 安装路径。raw 包支持 macOS arm64，但依赖 Linux 的软件包和服务操作
+不可用。源码构建仅供贡献者使用，请参阅
+[开发者入门指南](../../docs/developer-guide/zh/cosh-ng/getting-started.md)。
 
 ## 30 秒开始使用
 

--- a/website/scripts/test-install.sh
+++ b/website/scripts/test-install.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/../static/install.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/anolisa-installer-test.XXXXXX")"
+FAKE_BIN="${TEST_ROOT}/bin"
+TEST_CLI_VERSION="0.0.0-test"
+REAL_TAR="$(command -v tar)"
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+cat >"${FAKE_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$output" ]; then
+  test -s "$ANOLISA_TEST_SHA_FILE"
+  printf '%s  artifact\n' "$(cat "$ANOLISA_TEST_SHA_FILE")"
+  exit 0
+fi
+
+payload_dir="$(mktemp -d)"
+trap 'rm -rf "$payload_dir"' EXIT
+cat >"${payload_dir}/anolisa" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--version" ]; then
+  echo "anolisa ${ANOLISA_TEST_VERSION}"
+  exit 0
+fi
+printf '%s\n' "$*" >>"$ANOLISA_TEST_LOG"
+SCRIPT
+chmod +x "${payload_dir}/anolisa"
+"$ANOLISA_TEST_TAR" -czf "$output" -C "$payload_dir" anolisa
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$output" | awk '{print $1}' >"$ANOLISA_TEST_SHA_FILE"
+else
+  shasum -a 256 "$output" | awk '{print $1}' >"$ANOLISA_TEST_SHA_FILE"
+fi
+EOF
+
+cat >"${FAKE_BIN}/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) echo Darwin ;;
+  -m) echo arm64 ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"${FAKE_BIN}/id" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -u) echo 1000 ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"${FAKE_BIN}/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$ANOLISA_TEST_SUDO_LOG"
+cat >"${ANOLISA_INSTALL_DIR}/anolisa" <<'SCRIPT'
+#!/usr/bin/env bash
+printf 'tampered CLI executed\n' >"$ANOLISA_TEST_TAMPER_LOG"
+exit 99
+SCRIPT
+chmod +x "${ANOLISA_INSTALL_DIR}/anolisa"
+exec "$@"
+EOF
+
+chmod +x "${FAKE_BIN}/curl" "${FAKE_BIN}/uname" "${FAKE_BIN}/id" \
+  "${FAKE_BIN}/sudo"
+
+run_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+
+  local case_root="${TEST_ROOT}/${name}"
+  local install_dir="${case_root}/install"
+  local command_log="${case_root}/commands.log"
+  mkdir -p "$case_root"
+
+  PATH="${FAKE_BIN}:${PATH}" \
+    ANOLISA_INSTALL_DIR="$install_dir" \
+    ANOLISA_TEST_LOG="$command_log" \
+    ANOLISA_TEST_SUDO_LOG="${case_root}/sudo.log" \
+    ANOLISA_TEST_TAMPER_LOG="${case_root}/tampered.log" \
+    ANOLISA_TEST_SHA_FILE="${case_root}/artifact.sha256" \
+    ANOLISA_TEST_TAR="$REAL_TAR" \
+    ANOLISA_TEST_VERSION="$TEST_CLI_VERSION" \
+    ANOLISA_VERSION="$TEST_CLI_VERSION" \
+    bash -s -- "$@" <"$INSTALLER" >"${case_root}/stdout" 2>"${case_root}/stderr"
+
+  local actual=""
+  if [ -f "$command_log" ]; then
+    actual="$(cat "$command_log")"
+  fi
+  if [ "$actual" != "$expected" ]; then
+    echo "case '$name' invoked '$actual', expected '$expected'" >&2
+    exit 1
+  fi
+  if [ -e "${case_root}/tampered.log" ]; then
+    echo "case '$name' executed a replaced user-local CLI" >&2
+    exit 1
+  fi
+}
+
+run_case cli-only ""
+run_case help "" --help
+grep -Fq -- "--component NAME" "${TEST_ROOT}/help/stdout"
+grep -Fq -- "--backend BACKEND" "${TEST_ROOT}/help/stdout"
+grep -Fq -- "system uses sudo when needed" "${TEST_ROOT}/help/stdout"
+run_case install-component-user \
+  "--install-mode user install tokenless --backend raw" \
+  --component tokenless --install-mode user
+run_case install-component-equals "install agent-memory --backend raw" --component=agent-memory
+run_case install-cosh-ng-alias "install cosh-ng --backend raw" --cosh-ng
+run_case install-cosh-ng-system \
+  "--install-mode system install cosh-ng --backend raw" \
+  --cosh-ng --install-mode=system
+test -s "${TEST_ROOT}/install-cosh-ng-system/sudo.log"
+run_case install-cosh-ng-rpm \
+  "--install-mode system install cosh-ng --backend rpm" \
+  --cosh-ng --backend=rpm --install-mode=system
+run_case upgrade-component \
+  "--install-mode system update cosh-ng" \
+  --component cosh-ng --install-mode system --upgrade
+run_case uninstall-component \
+  "--install-mode system uninstall cosh-ng" \
+  --uninstall --component cosh-ng --install-mode system
+
+expect_rejected() {
+  local name="$1"
+  local expected_error="$2"
+  shift 2
+
+  local case_root="${TEST_ROOT}/${name}"
+  mkdir -p "$case_root"
+  if PATH="${FAKE_BIN}:${PATH}" \
+    ANOLISA_INSTALL_DIR="${case_root}/install" \
+    ANOLISA_TEST_LOG="${case_root}/commands.log" \
+    ANOLISA_TEST_SUDO_LOG="${case_root}/sudo.log" \
+    ANOLISA_TEST_TAMPER_LOG="${case_root}/tampered.log" \
+    ANOLISA_TEST_SHA_FILE="${case_root}/artifact.sha256" \
+    ANOLISA_TEST_TAR="$REAL_TAR" \
+    ANOLISA_TEST_VERSION="$TEST_CLI_VERSION" \
+    ANOLISA_VERSION="$TEST_CLI_VERSION" \
+    bash -s -- "$@" <"$INSTALLER" \
+    >"${case_root}/stdout" 2>"${case_root}/stderr"; then
+    echo "case '$name' unexpectedly succeeded" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "$expected_error" "${case_root}/stderr"; then
+    echo "case '$name' did not report '$expected_error'" >&2
+    cat "${case_root}/stderr" >&2
+    exit 1
+  fi
+}
+
+expect_rejected conflicting-actions \
+  "--upgrade and --uninstall cannot be used together" \
+  --component cosh-ng --upgrade --uninstall
+expect_rejected action-without-component \
+  "--upgrade and --uninstall require --component NAME" \
+  --upgrade
+expect_rejected missing-component-name \
+  "--component requires a component name" \
+  --component
+expect_rejected invalid-component-name \
+  "invalid component name: invalid/name" \
+  --component invalid/name
+expect_rejected duplicate-component \
+  "only one component can be selected" \
+  --component cosh-ng --component tokenless
+expect_rejected missing-install-mode \
+  "--install-mode requires user or system" \
+  --component cosh-ng --install-mode
+expect_rejected invalid-install-mode \
+  "invalid install mode: invalid (expected user or system)" \
+  --component cosh-ng --install-mode invalid
+expect_rejected install-mode-without-component \
+  "--install-mode requires --component NAME" \
+  --install-mode user
+expect_rejected missing-backend-name \
+  "--backend requires a backend name" \
+  --component cosh-ng --backend
+expect_rejected invalid-backend-name \
+  "invalid backend: invalid/name" \
+  --component cosh-ng --backend invalid/name
+expect_rejected duplicate-backend \
+  "only one component backend can be selected" \
+  --component cosh-ng --backend raw --backend rpm
+expect_rejected backend-without-component \
+  "--backend requires --component NAME" \
+  --backend rpm
+expect_rejected backend-with-action \
+  "--backend is only valid when installing a component" \
+  --component cosh-ng --backend rpm --upgrade
+expect_rejected unknown-argument \
+  "unknown argument: --unknown" \
+  --unknown
+
+echo "installer tests passed"

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -3,6 +3,9 @@
 #
 # Usage:
 #   curl -fsSL https://get.agentic-os.sh | bash
+#   curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+#   curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --upgrade
+#   curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --uninstall
 #
 # Environment overrides:
 #   ANOLISA_VERSION      version to install      (default: stable)
@@ -22,10 +25,177 @@ MANIFEST_SCHEMA=""
 RESOLVED_VERSION=""
 ARTIFACT_URL=""
 ARTIFACT_SHA256=""
+VERIFIED_ARCHIVE=""
+VERIFIED_ARCHIVE_SHA256=""
+COMPONENT=""
+COMPONENT_BACKEND="raw"
+COMPONENT_BACKEND_SET=0
+COMPONENT_ACTION="install"
+COMPONENT_ACTION_SET=0
+INSTALL_MODE=""
+COMPONENT_SYSTEM_SCOPE=0
+COMPONENT_USE_SUDO=0
 
 log()  { printf '\033[1;32m%s\033[0m %s\n' "==>" "$*"; }
 warn() { printf '\033[1;33m%s\033[0m %s\n' "warn:" "$*" >&2; }
 err()  { printf '\033[1;31m%s\033[0m %s\n' "error:" "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [OPTIONS]
+
+Install or update the anolisa CLI. Optionally manage one ANOLISA component
+after the CLI is ready. The CLI validates component support for this host.
+
+Options:
+  --component NAME  Manage NAME (installs it by default)
+  --cosh-ng         Shorthand for --component cosh-ng
+  --backend BACKEND Use BACKEND for installation (default: raw)
+  --install-mode MODE
+                    Use user or system scope; system uses sudo when needed
+  --upgrade         Update the selected component
+  --uninstall       Uninstall the selected component
+  -h, --help        Show this help text and exit
+
+Without --install-mode, ANOLISA uses user scope for non-root and system for root.
+
+Piped examples:
+  curl -fsSL https://get.agentic-os.sh | bash
+  curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --backend rpm --install-mode system
+  curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --upgrade
+  curl -fsSL https://get.agentic-os.sh | bash -s -- --component cosh-ng --install-mode system --uninstall
+EOF
+}
+
+select_component() {
+  local component="$1"
+  # Keep only registry-shaped data here; the CLI owns identity and target checks.
+  case "$component" in
+    ""|*[!a-z0-9-]*|-*|*-)
+      err "invalid component name: ${component:-empty}"
+      ;;
+  esac
+  if [ -n "$COMPONENT" ]; then
+    err "only one component can be selected"
+  fi
+  COMPONENT="$component"
+}
+
+select_component_backend() {
+  local backend="$1"
+  # Keep only backend-shaped data here; the CLI owns backend support checks.
+  case "$backend" in
+    ""|*[!a-z0-9-]*|-*|*-)
+      err "invalid backend: ${backend:-empty}"
+      ;;
+  esac
+  if [ "$COMPONENT_BACKEND_SET" -eq 1 ]; then
+    err "only one component backend can be selected"
+  fi
+  COMPONENT_BACKEND="$backend"
+  COMPONENT_BACKEND_SET=1
+}
+
+select_install_mode() {
+  local mode="$1"
+  case "$mode" in
+    user|system) ;;
+    *) err "invalid install mode: ${mode:-empty} (expected user or system)" ;;
+  esac
+  if [ -n "$INSTALL_MODE" ]; then
+    err "only one install mode can be selected"
+  fi
+  INSTALL_MODE="$mode"
+}
+
+select_component_action() {
+  local action="$1"
+  if [ "$COMPONENT_ACTION_SET" -eq 1 ] && [ "$COMPONENT_ACTION" != "$action" ]; then
+    err "--upgrade and --uninstall cannot be used together"
+  fi
+  COMPONENT_ACTION="$action"
+  COMPONENT_ACTION_SET=1
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --component)
+        [ "$#" -ge 2 ] || err "--component requires a component name"
+        select_component "$2"
+        shift 2
+        ;;
+      --component=*)
+        select_component "${1#*=}"
+        shift
+        ;;
+      --cosh-ng)
+        select_component "cosh-ng"
+        shift
+        ;;
+      --backend)
+        [ "$#" -ge 2 ] || err "--backend requires a backend name"
+        select_component_backend "$2"
+        shift 2
+        ;;
+      --backend=*)
+        select_component_backend "${1#*=}"
+        shift
+        ;;
+      --install-mode)
+        [ "$#" -ge 2 ] || err "--install-mode requires user or system"
+        select_install_mode "$2"
+        shift 2
+        ;;
+      --install-mode=*)
+        select_install_mode "${1#*=}"
+        shift
+        ;;
+      --upgrade)
+        select_component_action "update"
+        shift
+        ;;
+      --uninstall)
+        select_component_action "uninstall"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        err "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  if [ "$COMPONENT_ACTION_SET" -eq 1 ] && [ -z "$COMPONENT" ]; then
+    err "--upgrade and --uninstall require --component NAME"
+  fi
+  if [ -n "$INSTALL_MODE" ] && [ -z "$COMPONENT" ]; then
+    err "--install-mode requires --component NAME"
+  fi
+  if [ "$COMPONENT_BACKEND_SET" -eq 1 ] && [ -z "$COMPONENT" ]; then
+    err "--backend requires --component NAME"
+  fi
+  if [ "$COMPONENT_BACKEND_SET" -eq 1 ] && [ "$COMPONENT_ACTION_SET" -eq 1 ]; then
+    err "--backend is only valid when installing a component"
+  fi
+}
+
+check_component_action_prerequisites() {
+  local euid
+  euid="$(id -u)"
+  if [ "$INSTALL_MODE" = "system" ] ||
+    { [ -z "$INSTALL_MODE" ] && [ "$euid" -eq 0 ]; }; then
+    COMPONENT_SYSTEM_SCOPE=1
+  fi
+  if [ "$COMPONENT_SYSTEM_SCOPE" -eq 1 ] && [ "$euid" -ne 0 ]; then
+    command -v sudo >/dev/null 2>&1 ||
+      err "sudo is required for --install-mode system"
+    COMPONENT_USE_SUDO=1
+  fi
+}
 
 cleanup() {
   [ -z "$TMPDIR_INSTALL" ] || rm -rf "$TMPDIR_INSTALL"
@@ -174,7 +344,96 @@ sha256_verify() {
   log "checksum verified"
 }
 
+run_system_anolisa() {
+  [ -n "$VERIFIED_ARCHIVE" ] || err "verified CLI archive is unavailable"
+  if [ "${#VERIFIED_ARCHIVE_SHA256}" -ne 64 ]; then
+    err "a valid CLI checksum is required for system component actions"
+  fi
+  case "$VERIFIED_ARCHIVE_SHA256" in
+    *[!0-9a-fA-F]*)
+      err "a valid CLI checksum is required for system component actions"
+      ;;
+  esac
+
+  local runner
+  runner='
+set -eu
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+umask 077
+
+expected_sha=$1
+shift
+workdir=$(mktemp -d /tmp/anolisa-system.XXXXXX)
+cleanup_root() {
+  rm -rf "$workdir"
+}
+trap cleanup_root EXIT
+
+archive="$workdir/anolisa.tar.gz"
+cat >"$archive"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha=$(sha256sum "$archive")
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha=$(shasum -a 256 "$archive")
+else
+  echo "error: sha256sum/shasum is required for system component actions" >&2
+  exit 1
+fi
+actual_sha=${actual_sha%% *}
+if [ "$actual_sha" != "$expected_sha" ]; then
+  echo "error: privileged CLI archive checksum mismatch" >&2
+  exit 1
+fi
+
+tar -xzf "$archive" -C "$workdir"
+if [ ! -f "$workdir/anolisa" ]; then
+  echo "error: privileged CLI archive does not contain anolisa" >&2
+  exit 1
+fi
+chmod 0755 "$workdir/anolisa"
+"$workdir/anolisa" --install-mode system "$@"
+'
+
+  if [ "$COMPONENT_USE_SUDO" -eq 1 ]; then
+    sudo -- /bin/sh -c "$runner" sh "$VERIFIED_ARCHIVE_SHA256" "$@" \
+      <"$VERIFIED_ARCHIVE"
+  else
+    /bin/sh -c "$runner" sh "$VERIFIED_ARCHIVE_SHA256" "$@" \
+      <"$VERIFIED_ARCHIVE"
+  fi
+}
+
+run_anolisa() {
+  if [ "$COMPONENT_SYSTEM_SCOPE" -eq 1 ]; then
+    run_system_anolisa "$@"
+  elif [ -n "$INSTALL_MODE" ]; then
+    "${INSTALL_DIR}/anolisa" --install-mode "$INSTALL_MODE" "$@"
+  else
+    "${INSTALL_DIR}/anolisa" "$@"
+  fi
+}
+
+run_component_action() {
+  case "$COMPONENT_ACTION" in
+    install)
+      log "installing ${COMPONENT}"
+      run_anolisa install "$COMPONENT" --backend "$COMPONENT_BACKEND"
+      ;;
+    update)
+      log "updating ${COMPONENT}"
+      run_anolisa update "$COMPONENT"
+      ;;
+    uninstall)
+      log "uninstalling ${COMPONENT}"
+      run_anolisa uninstall "$COMPONENT"
+      ;;
+  esac
+}
+
 main() {
+  parse_args "$@"
+  check_component_action_prerequisites
   detect_platform
   command -v curl >/dev/null 2>&1 || err "curl is required but not found"
   command -v tar  >/dev/null 2>&1 || err "tar is required but not found"
@@ -219,6 +478,8 @@ main() {
   else
     warn "checksum file not available, skipping verification"
   fi
+  VERIFIED_ARCHIVE="${TMPDIR_INSTALL}/${artifact}"
+  VERIFIED_ARCHIVE_SHA256="$expected_sha"
 
   log "extracting binary"
   tar -xzf "${TMPDIR_INSTALL}/${artifact}" -C "$TMPDIR_INSTALL"
@@ -249,7 +510,8 @@ main() {
   esac
 
   log "$installed_version"
+  [ -z "$COMPONENT" ] || run_component_action
   log "done"
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Why

Installing a component currently requires users to bootstrap the ANOLISA CLI
and then run a separate lifecycle command. The public installer should provide
a one-step entry point while retaining the CLI registry as the lifecycle,
backend, and component-validation authority.

## What changed

- Add generic `--component NAME`, plus the `--cosh-ng` convenience alias.
- Add `--backend BACKEND` for install selection; raw remains the default.
- Add explicit `--install-mode user|system` component scope selection.
- Run system actions from a checksum-verified, root-owned temporary copy.
- Add `--upgrade` and `--uninstall` actions for the selected component.
- Validate installer-shaped input and conflicting actions before download.
- Assert dispatch, replacement-race handling, and diagnostics in pipe tests.
- Update the paired English and Chinese installation documentation.

## Related issue

no-issue: directly requested one-step component lifecycle entry point

## User / Agent impact

Users can install a registered component without first running a separate CLI
bootstrap command. The installer forwards an explicit backend and scope while
the CLI remains responsible for component, backend, target, and dependency
validation. Alibaba Cloud Linux 4 cosh-ng examples select the RPM backend;
macOS arm64 examples select the raw backend in user scope. Existing
`curl -fsSL https://get.agentic-os.sh | bash` behavior remains unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The installer accepts only registry-shaped component and backend names and
passes each as one quoted argument. For a system action, it streams the
publisher-verified CLI archive to a fixed `/bin/sh`, copies it into a root-owned
temporary directory, verifies the SHA256 again with a fixed system PATH, and
executes the extracted CLI there. The user-local installed CLI is never passed
to sudo. A failed component action can still leave the stable CLI updated. The
published Linux cosh-ng raw dependency contract is not recommended across all
routed distributions; Alibaba Cloud Linux 4 uses the compatible RPM path.

## Validation

- `bash -n website/static/install.sh`
- `bash -n website/scripts/test-install.sh`
- `website/scripts/test-install.sh`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `npm run build --prefix website`
- `npm run typecheck --prefix website`
- `npm run check:links --prefix website`
- `cmp website/static/install.sh website/build/install.sh`

The installer tests cover CLI-only behavior, generic component and backend
selection, the cosh-ng alias, user and system scope forwarding, all lifecycle
actions, exact invalid-input diagnostics, and replacement of the user-local CLI
immediately before the simulated sudo execution. System actions continue with
the verified root-owned copy and never execute the replacement.

## Documentation and rollback

Updated the root Quick Start, full installation guide, and cosh-ng entry points
in English and Chinese. Alibaba Cloud Linux 4 cosh-ng examples use the RPM
backend and restore the user-local PATH; macOS arm64 examples use raw user
scope. Reverting this commit removes the flags and restores the previous
CLI-only installer without a data migration.

### Ship Note

- Changed: the installer now manages scoped component lifecycle actions and
  accepts an explicit install backend.
- Known limitations: one component per invocation; raw is the default backend,
  and published component contracts still determine host compatibility.
- Not covered: destructive live system install or removal after this revision.
- Verification: deterministic user-local replacement regression, isolated
  dispatch tests, Pages build, and docs checks.