### PR TITLE
refactor(anolisa): inject helper client

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -1,15 +1,16 @@
-use std::os::unix::net::UnixStream;
+use std::path::Path;
 
 use clap::{Parser, Subcommand};
 
 use anolisa_core::osbase_install::{
     self, OsbaseDomain, OsbaseInstallError, OsbaseInstallRequest, RegisterHandler,
 };
-use anolisa_core::system_helper::{HelperRequest, HelperResponse};
-use anolisa_platform::ipc::{SYSTEM_HELPER_SOCKET, recv_message, send_message};
+use anolisa_core::system_helper::HelperRequest;
+use anolisa_platform::ipc::SYSTEM_HELPER_SOCKET;
 use anolisa_platform::privilege;
 
 use crate::context::CliContext;
+use crate::helper_client::{HelperClient, HelperClientError};
 use crate::response::{CliError, render_json};
 
 #[derive(Parser)]
@@ -187,10 +188,10 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
             no_verify,
         } => handle_sandbox_install(ctx, mode, target, dry_run, force, no_verify),
         SandboxCommands::Uninstall { scenario, dry_run } => match mode {
-            ExecutionMode::ViaHelper(mut stream) => {
+            ExecutionMode::ViaHelper(mut client) => {
                 eprintln!("[osbase] scenario: {scenario}");
                 let req = HelperRequest::OsbaseUninstall { scenario, dry_run };
-                send_helper_request(&mut stream, &req, "osbase sandbox uninstall")
+                send_helper_request(&mut client, &req, "osbase sandbox uninstall")
             }
             ExecutionMode::Direct => {
                 match osbase_install::execute_uninstall(&scenario, dry_run) {
@@ -203,12 +204,12 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
             }
         },
         SandboxCommands::Remove { target, purge, .. } => match mode {
-            ExecutionMode::ViaHelper(mut stream) => {
+            ExecutionMode::ViaHelper(mut client) => {
                 let req = HelperRequest::OsbaseRemove {
                     scenario: target,
                     purge,
                 };
-                send_helper_request(&mut stream, &req, "osbase sandbox remove")
+                send_helper_request(&mut client, &req, "osbase sandbox remove")
             }
             ExecutionMode::Direct => Err(CliError::not_implemented(format!(
                 "osbase sandbox remove {target}"
@@ -216,9 +217,9 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
         },
         SandboxCommands::List { .. } => unreachable!(),
         SandboxCommands::Status { target, .. } => match mode {
-            ExecutionMode::ViaHelper(mut stream) => {
+            ExecutionMode::ViaHelper(mut client) => {
                 let req = HelperRequest::OsbaseStatus { scenario: target };
-                send_helper_request(&mut stream, &req, "osbase sandbox status")
+                send_helper_request(&mut client, &req, "osbase sandbox status")
             }
             ExecutionMode::Direct => Err(CliError::not_implemented("osbase sandbox status")),
         },
@@ -234,7 +235,7 @@ fn handle_sandbox_install(
     no_verify: bool,
 ) -> Result<(), CliError> {
     match mode {
-        ExecutionMode::ViaHelper(mut stream) => {
+        ExecutionMode::ViaHelper(mut client) => {
             let req = HelperRequest::OsbaseInstall {
                 scenario: target.clone(),
                 register_handler: "none".to_string(),
@@ -246,7 +247,7 @@ fn handle_sandbox_install(
                 dry_run: dry_run || ctx.dry_run,
             };
             eprintln!("[osbase] scenario: {target}");
-            send_helper_request(&mut stream, &req, "osbase sandbox install")
+            send_helper_request(&mut client, &req, "osbase sandbox install")
         }
         ExecutionMode::Direct => {
             let request = OsbaseInstallRequest {
@@ -338,57 +339,51 @@ fn handle_sandbox_list(json: bool) -> Result<(), CliError> {
 // ===========================================================================
 
 /// Execution path for osbase operations.
-pub enum ExecutionMode {
+enum ExecutionMode {
     /// Proxy execution via the privileged system-helper daemon.
-    ViaHelper(UnixStream),
+    ViaHelper(HelperClient),
     /// Direct execution (process already has root privileges).
     Direct,
 }
 
 fn osbase_preflight() -> Result<ExecutionMode, CliError> {
+    osbase_preflight_with(
+        || HelperClient::connect(Path::new(SYSTEM_HELPER_SOCKET)),
+        privilege::is_root(),
+    )
+}
+
+fn osbase_preflight_with<F>(connect: F, is_root: bool) -> Result<ExecutionMode, CliError>
+where
+    F: FnOnce() -> Result<HelperClient, HelperClientError>,
+{
     // 1. Try connecting to the system-helper socket.
-    match UnixStream::connect(SYSTEM_HELPER_SOCKET) {
-        Ok(mut stream) => {
+    match connect() {
+        Ok(mut client) => {
             // Perform version handshake.
-            let req = HelperRequest::Handshake {
-                cli_version: env!("CARGO_PKG_VERSION").to_string(),
-            };
-            send_message(&mut stream, &req).map_err(|e| CliError::Runtime {
-                command: "osbase".to_string(),
-                reason: format!("failed to send handshake to system-helper: {e}"),
-            })?;
-            let resp: HelperResponse =
-                recv_message(&mut stream).map_err(|e| CliError::Runtime {
+            let handshake = client
+                .handshake(env!("CARGO_PKG_VERSION"))
+                .map_err(|error| CliError::Runtime {
                     command: "osbase".to_string(),
-                    reason: format!("failed to receive handshake from system-helper: {e}"),
+                    reason: preflight_handshake_error(error),
                 })?;
-            match resp {
-                HelperResponse::HandshakeOk {
-                    compatible,
-                    helper_version,
-                } => {
-                    if !compatible {
-                        let cli_version = env!("CARGO_PKG_VERSION");
-                        return Err(CliError::Runtime {
-                            command: "osbase".to_string(),
-                            reason: format!(
-                                "anolisa-system-helper version mismatch \
-                                 (installed: {helper_version}, required: {cli_version}); \
-                                 run 'sudo anolisa system setup' to upgrade"
-                            ),
-                        });
-                    }
-                    Ok(ExecutionMode::ViaHelper(stream))
-                }
-                _ => Err(CliError::Runtime {
+            if !handshake.compatible {
+                let cli_version = env!("CARGO_PKG_VERSION");
+                return Err(CliError::Runtime {
                     command: "osbase".to_string(),
-                    reason: "system-helper returned unexpected handshake response".to_string(),
-                }),
+                    reason: format!(
+                        "anolisa-system-helper version mismatch \
+                         (installed: {}, required: {cli_version}); \
+                         run 'sudo anolisa system setup' to upgrade",
+                        handshake.helper_version
+                    ),
+                });
             }
+            Ok(ExecutionMode::ViaHelper(client))
         }
         Err(_) => {
             // 2. Socket not available — check if we already have root.
-            if privilege::is_root() {
+            if is_root {
                 Ok(ExecutionMode::Direct)
             } else {
                 // 3. Non-root + no helper → actionable error.
@@ -409,59 +404,77 @@ fn osbase_preflight() -> Result<ExecutionMode, CliError> {
     }
 }
 
+fn preflight_handshake_error(error: HelperClientError) -> String {
+    match error {
+        HelperClientError::Send { source, .. } => {
+            format!("failed to send handshake to system-helper: {source}")
+        }
+        HelperClientError::Receive { source, .. } => {
+            format!("failed to receive handshake from system-helper: {source}")
+        }
+        HelperClientError::Remote { .. } | HelperClientError::UnexpectedResponse { .. } => {
+            "system-helper returned unexpected handshake response".to_string()
+        }
+        HelperClientError::Connect { path, source } => {
+            format!("failed to connect to {}: {source}", path.display())
+        }
+    }
+}
+
 // ===========================================================================
 // Helper IPC utilities
 // ===========================================================================
 
 fn send_helper_request(
-    stream: &mut UnixStream,
+    client: &mut HelperClient,
     req: &HelperRequest,
     command_label: &str,
 ) -> Result<(), CliError> {
-    send_message(stream, req).map_err(|e| CliError::Runtime {
+    let outcome = client.execute(req).map_err(|error| CliError::Runtime {
         command: command_label.to_string(),
-        reason: format!("failed to send request to system-helper: {e}"),
+        reason: helper_operation_error(error),
     })?;
 
-    let resp: HelperResponse = recv_message(stream).map_err(|e| CliError::Runtime {
-        command: command_label.to_string(),
-        reason: format!("failed to receive response from system-helper: {e}"),
-    })?;
-
-    match resp {
-        HelperResponse::Success { message, exit_code } => {
-            if exit_code == 0 || exit_code == 2 {
-                // exit_code 0 = full success, 2 = degraded (non-fatal
-                // verify/state warnings). Both are reported as success;
-                // the core already printed diagnostics to stderr.
-                for line in message.lines() {
-                    eprintln!("[osbase] {line}");
-                }
-                if exit_code == 2 {
-                    eprintln!("[osbase] install completed with degraded status (non-fatal)");
-                }
-                Ok(())
-            } else {
-                // exit_code = 1 → phase failure.  Print the phase summary
-                // (from the helper response) before reporting the error so
-                // the user sees which phases passed and which failed.
-                for line in message.lines() {
-                    eprintln!("[osbase] {line}");
-                }
-                Err(CliError::Runtime {
-                    command: command_label.to_string(),
-                    reason: format!("install failed (exit_code={exit_code})"),
-                })
-            }
+    if outcome.exit_code == 0 || outcome.exit_code == 2 {
+        // exit_code 0 = full success, 2 = degraded (non-fatal
+        // verify/state warnings). Both are reported as success;
+        // the core already printed diagnostics to stderr.
+        for line in outcome.message.lines() {
+            eprintln!("[osbase] {line}");
         }
-        HelperResponse::Error { code, message } => Err(CliError::Runtime {
+        if outcome.exit_code == 2 {
+            eprintln!("[osbase] install completed with degraded status (non-fatal)");
+        }
+        Ok(())
+    } else {
+        // exit_code = 1 → phase failure.  Print the phase summary
+        // (from the helper response) before reporting the error so
+        // the user sees which phases passed and which failed.
+        for line in outcome.message.lines() {
+            eprintln!("[osbase] {line}");
+        }
+        Err(CliError::Runtime {
             command: command_label.to_string(),
-            reason: format!("[{code}] {message}"),
-        }),
-        other => Err(CliError::Runtime {
-            command: command_label.to_string(),
-            reason: format!("unexpected response from system-helper: {other:?}"),
-        }),
+            reason: format!("install failed (exit_code={})", outcome.exit_code),
+        })
+    }
+}
+
+fn helper_operation_error(error: HelperClientError) -> String {
+    match error {
+        HelperClientError::Send { source, .. } => {
+            format!("failed to send request to system-helper: {source}")
+        }
+        HelperClientError::Receive { source, .. } => {
+            format!("failed to receive response from system-helper: {source}")
+        }
+        HelperClientError::Remote { code, message, .. } => format!("[{code}] {message}"),
+        HelperClientError::UnexpectedResponse { response, .. } => {
+            format!("unexpected response from system-helper: {response:?}")
+        }
+        HelperClientError::Connect { path, source } => {
+            format!("failed to connect to {}: {source}", path.display())
+        }
     }
 }
 
@@ -482,5 +495,123 @@ fn map_osbase_err(err: OsbaseInstallError, action: &str, target: &str) -> CliErr
             command,
             reason: err.to_string(),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::PathBuf;
+
+    use anolisa_core::system_helper::HelperResponse;
+
+    use super::*;
+    use crate::helper_client::ScriptedTransport;
+
+    fn client_with_responses(responses: Vec<HelperResponse>) -> HelperClient {
+        let (transport, _) =
+            ScriptedTransport::new(Vec::new(), responses.into_iter().map(Ok).collect());
+        HelperClient::with_transport(transport)
+    }
+
+    fn connect_error() -> HelperClientError {
+        HelperClientError::Connect {
+            path: PathBuf::from(SYSTEM_HELPER_SOCKET),
+            source: io::Error::new(io::ErrorKind::NotFound, "missing helper socket"),
+        }
+    }
+
+    #[test]
+    fn preflight_preserves_root_fallback_when_connection_fails() {
+        let root = osbase_preflight_with(|| Err(connect_error()), true).expect("root fallback");
+        assert!(matches!(root, ExecutionMode::Direct));
+
+        let error = match osbase_preflight_with(|| Err(connect_error()), false) {
+            Ok(_) => panic!("non-root connection failure must not fall back"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, CliError::PermissionDenied { .. }));
+    }
+
+    #[test]
+    fn preflight_preserves_handshake_compatibility() {
+        let compatible = client_with_responses(vec![HelperResponse::HandshakeOk {
+            helper_version: env!("CARGO_PKG_VERSION").to_string(),
+            compatible: true,
+        }]);
+        let mode = osbase_preflight_with(|| Ok(compatible), false).expect("compatible helper");
+        assert!(matches!(mode, ExecutionMode::ViaHelper(_)));
+
+        let incompatible = client_with_responses(vec![HelperResponse::HandshakeOk {
+            helper_version: "0.0.1".to_string(),
+            compatible: false,
+        }]);
+        let error = match osbase_preflight_with(|| Ok(incompatible), false) {
+            Ok(_) => panic!("incompatible helper must fail"),
+            Err(error) => error,
+        };
+        match error {
+            CliError::Runtime { reason, .. } => {
+                assert!(reason.contains("version mismatch"));
+                assert!(reason.contains("0.0.1"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn helper_operation_preserves_success_degraded_and_failure_codes() {
+        for (exit_code, succeeds) in [(0, true), (2, true), (1, false)] {
+            let mut client = client_with_responses(vec![HelperResponse::Success {
+                message: "phase summary".to_string(),
+                exit_code,
+            }]);
+
+            let result = send_helper_request(
+                &mut client,
+                &HelperRequest::OsbaseStatus { scenario: None },
+                "osbase sandbox status",
+            );
+
+            assert_eq!(result.is_ok(), succeeds, "exit code {exit_code}");
+            if let Err(CliError::Runtime { reason, .. }) = result {
+                assert_eq!(reason, "install failed (exit_code=1)");
+            }
+        }
+    }
+
+    #[test]
+    fn helper_operation_maps_remote_and_unexpected_responses() {
+        let cases = [
+            (
+                HelperResponse::Error {
+                    code: "DENIED".to_string(),
+                    message: "no access".to_string(),
+                },
+                "[DENIED] no access",
+            ),
+            (
+                HelperResponse::HandshakeOk {
+                    helper_version: "0.3.2".to_string(),
+                    compatible: true,
+                },
+                "unexpected response from system-helper",
+            ),
+        ];
+
+        for (response, expected) in cases {
+            let mut client = client_with_responses(vec![response]);
+            let error = send_helper_request(
+                &mut client,
+                &HelperRequest::OsbaseStatus { scenario: None },
+                "osbase sandbox status",
+            )
+            .expect_err("response must fail");
+
+            match error {
+                CliError::Runtime { reason, .. } => assert!(reason.contains(expected)),
+                other => panic!("unexpected error: {other:?}"),
+            }
+        }
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/system.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/system.rs
@@ -8,7 +8,6 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
@@ -18,13 +17,13 @@ use clap::{Parser, Subcommand};
 use serde::Serialize;
 
 use anolisa_core::daemon_server::DaemonServer;
-use anolisa_core::system_helper::{HelperRequest, HelperResponse};
 use anolisa_platform::fs_layout::FsLayout;
-use anolisa_platform::ipc::{self, SYSTEM_HELPER_SOCKET};
+use anolisa_platform::ipc::SYSTEM_HELPER_SOCKET;
 use anolisa_platform::privilege;
 use anolisa_platform::systemd::{Systemd, SystemdError};
 
 use crate::context::CliContext;
+use crate::helper_client::{HandshakeResult, HelperClient, HelperClientError, HelperStatus};
 use crate::response::{self, CliError};
 
 #[derive(Parser)]
@@ -403,41 +402,46 @@ fn verify_socket(cmd: &str) -> Result<(), CliError> {
         });
     }
 
-    // Try a handshake to validate the daemon is responding.
-    let mut stream =
-        std::os::unix::net::UnixStream::connect(SYSTEM_HELPER_SOCKET).map_err(|e| {
-            CliError::Runtime {
-                command: cmd.to_string(),
-                reason: format!("failed to connect to {SYSTEM_HELPER_SOCKET}: {e}"),
-            }
+    verify_helper_connection(cmd, || HelperClient::connect(socket_path))
+}
+
+fn verify_helper_connection<F>(cmd: &str, connect: F) -> Result<(), CliError>
+where
+    F: FnOnce() -> Result<HelperClient, HelperClientError>,
+{
+    let mut client = connect().map_err(|error| CliError::Runtime {
+        command: cmd.to_string(),
+        reason: verify_connection_error(error),
+    })?;
+    let handshake = client
+        .handshake(env!("CARGO_PKG_VERSION"))
+        .map_err(|error| CliError::Runtime {
+            command: cmd.to_string(),
+            reason: verify_connection_error(error),
         })?;
-
-    let handshake = HelperRequest::Handshake {
-        cli_version: env!("CARGO_PKG_VERSION").to_string(),
-    };
-    ipc::send_message(&mut stream, &handshake).map_err(|e| CliError::Runtime {
-        command: cmd.to_string(),
-        reason: format!("handshake send failed: {e}"),
-    })?;
-
-    let resp: HelperResponse = ipc::recv_message(&mut stream).map_err(|e| CliError::Runtime {
-        command: cmd.to_string(),
-        reason: format!("handshake recv failed: {e}"),
-    })?;
-
-    match resp {
-        HelperResponse::HandshakeOk { compatible, .. } if compatible => {
-            eprintln!("[setup] handshake verified — helper is operational");
-            Ok(())
-        }
-        HelperResponse::HandshakeOk { compatible, .. } if !compatible => Err(CliError::Runtime {
+    if !handshake.compatible {
+        return Err(CliError::Runtime {
             command: cmd.to_string(),
             reason: "handshake succeeded but version is incompatible".to_string(),
-        }),
-        other => Err(CliError::Runtime {
-            command: cmd.to_string(),
-            reason: format!("unexpected handshake response: {other:?}"),
-        }),
+        });
+    }
+    eprintln!("[setup] handshake verified — helper is operational");
+    Ok(())
+}
+
+fn verify_connection_error(error: HelperClientError) -> String {
+    match error {
+        HelperClientError::Connect { path, source } => {
+            format!("failed to connect to {}: {source}", path.display())
+        }
+        HelperClientError::Send { source, .. } => format!("handshake send failed: {source}"),
+        HelperClientError::Receive { source, .. } => format!("handshake recv failed: {source}"),
+        HelperClientError::Remote { code, message, .. } => format!(
+            "unexpected handshake response: Error {{ code: {code:?}, message: {message:?} }}"
+        ),
+        HelperClientError::UnexpectedResponse { response, .. } => {
+            format!("unexpected handshake response: {response:?}")
+        }
     }
 }
 
@@ -575,27 +579,37 @@ fn handle_status(json: bool, ctx: &CliContext) -> Result<(), CliError> {
     let socket_exists = Path::new(SYSTEM_HELPER_SOCKET).exists();
 
     // 3. Try connect + handshake + SystemStatus.
-    let (socket_connectable, handshake_info, status_info) = if socket_exists {
+    let connection = if socket_exists {
         try_status_connection(&cli_version)
     } else {
-        (false, None, None)
+        HelperConnectionStatus::disconnected()
     };
 
     // Derive fields.
-    let helper_version = handshake_info.as_ref().map(|(v, _)| v.clone());
-    let version_compatible = handshake_info
+    let helper_version = connection
+        .handshake
         .as_ref()
-        .map(|(_, compat)| *compat)
+        .map(|handshake| handshake.helper_version.clone());
+    let version_compatible = connection
+        .handshake
+        .as_ref()
+        .map(|handshake| handshake.compatible)
         .unwrap_or(false);
 
-    let uptime_secs = status_info.as_ref().map(|s| s.0);
-    let last_operation = status_info.as_ref().and_then(|s| s.1.clone());
-    let last_operation_time = status_info.as_ref().and_then(|s| s.2.clone());
+    let uptime_secs = connection.status.as_ref().map(|status| status.uptime_secs);
+    let last_operation = connection
+        .status
+        .as_ref()
+        .and_then(|status| status.last_operation.clone());
+    let last_operation_time = connection
+        .status
+        .as_ref()
+        .and_then(|status| status.last_operation_time.clone());
 
     let report = StatusReport {
         service_active: service_state == StatusServiceState::Active,
         socket_exists,
-        socket_connectable,
+        socket_connectable: connection.connectable,
         helper_version: helper_version.clone(),
         cli_version: cli_version.clone(),
         version_compatible,
@@ -612,7 +626,7 @@ fn handle_status(json: bool, ctx: &CliContext) -> Result<(), CliError> {
     print_status_human(
         &service_state,
         socket_exists,
-        socket_connectable,
+        connection.connectable,
         helper_version.as_deref(),
         &cli_version,
         version_compatible,
@@ -663,57 +677,61 @@ fn check_service_state() -> StatusServiceState {
     }
 }
 
-/// Handshake result: (helper_version, compatible)
-type HandshakeInfo = (String, bool);
-/// Status info: (uptime_secs, last_operation, last_operation_time)
-type StatusInfo = (u64, Option<String>, Option<String>);
+#[derive(Debug)]
+struct HelperConnectionStatus {
+    connectable: bool,
+    handshake: Option<HandshakeResult>,
+    status: Option<HelperStatus>,
+}
+
+impl HelperConnectionStatus {
+    fn disconnected() -> Self {
+        Self {
+            connectable: false,
+            handshake: None,
+            status: None,
+        }
+    }
+}
 
 /// Attempt to connect to the helper socket, perform handshake, and query
-/// system status. Returns (connectable, handshake_info, status_info).
-fn try_status_connection(cli_version: &str) -> (bool, Option<HandshakeInfo>, Option<StatusInfo>) {
-    let mut stream = match UnixStream::connect(SYSTEM_HELPER_SOCKET) {
-        Ok(s) => s,
-        Err(_) => return (false, None, None),
+/// system status while retaining partial typed evidence.
+fn try_status_connection(cli_version: &str) -> HelperConnectionStatus {
+    try_status_connection_with(cli_version, || {
+        HelperClient::connect(Path::new(SYSTEM_HELPER_SOCKET))
+    })
+}
+
+fn try_status_connection_with<F>(cli_version: &str, connect: F) -> HelperConnectionStatus
+where
+    F: FnOnce() -> Result<HelperClient, HelperClientError>,
+{
+    let mut client = match connect() {
+        Ok(client) => client,
+        Err(_) => return HelperConnectionStatus::disconnected(),
     };
 
-    // Handshake.
-    let handshake_req = HelperRequest::Handshake {
-        cli_version: cli_version.to_string(),
+    let handshake = match client.handshake(cli_version) {
+        Ok(handshake) => handshake,
+        Err(_) => {
+            return HelperConnectionStatus {
+                connectable: true,
+                handshake: None,
+                status: None,
+            };
+        }
     };
-    if ipc::send_message(&mut stream, &handshake_req).is_err() {
-        return (true, None, None);
+
+    let status = if handshake.compatible {
+        client.system_status().ok()
+    } else {
+        None
+    };
+    HelperConnectionStatus {
+        connectable: true,
+        handshake: Some(handshake),
+        status,
     }
-    let handshake_resp: HelperResponse = match ipc::recv_message(&mut stream) {
-        Ok(r) => r,
-        Err(_) => return (true, None, None),
-    };
-    let handshake_info = match &handshake_resp {
-        HelperResponse::HandshakeOk {
-            helper_version,
-            compatible,
-        } => Some((helper_version.clone(), *compatible)),
-        _ => None,
-    };
-
-    // SystemStatus query.
-    if ipc::send_message(&mut stream, &HelperRequest::SystemStatus).is_err() {
-        return (true, handshake_info, None);
-    }
-    let status_resp: HelperResponse = match ipc::recv_message(&mut stream) {
-        Ok(r) => r,
-        Err(_) => return (true, handshake_info, None),
-    };
-    let status_info = match status_resp {
-        HelperResponse::Status {
-            uptime_secs,
-            last_operation,
-            last_operation_time,
-            ..
-        } => Some((uptime_secs, last_operation, last_operation_time)),
-        _ => None,
-    };
-
-    (true, handshake_info, status_info)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -777,5 +795,167 @@ fn format_status_uptime(secs: u64) -> String {
         format!("{hours}h {mins:02}m")
     } else {
         format!("{mins}m")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use anolisa_core::system_helper::HelperResponse;
+
+    use super::*;
+    use crate::helper_client::ScriptedTransport;
+
+    fn client_with_responses(responses: Vec<HelperResponse>) -> HelperClient {
+        let (transport, _) =
+            ScriptedTransport::new(Vec::new(), responses.into_iter().map(Ok).collect());
+        HelperClient::with_transport(transport)
+    }
+
+    fn connect_error() -> HelperClientError {
+        HelperClientError::Connect {
+            path: PathBuf::from(SYSTEM_HELPER_SOCKET),
+            source: io::Error::new(io::ErrorKind::ConnectionRefused, "not listening"),
+        }
+    }
+
+    #[test]
+    fn setup_verification_uses_typed_handshake_result() {
+        let compatible = client_with_responses(vec![HelperResponse::HandshakeOk {
+            helper_version: env!("CARGO_PKG_VERSION").to_string(),
+            compatible: true,
+        }]);
+        verify_helper_connection("system setup", || Ok(compatible)).expect("compatible helper");
+
+        let incompatible = client_with_responses(vec![HelperResponse::HandshakeOk {
+            helper_version: "0.0.1".to_string(),
+            compatible: false,
+        }]);
+        let error = verify_helper_connection("system setup", || Ok(incompatible))
+            .expect_err("incompatible helper");
+        match error {
+            CliError::Runtime { reason, .. } => {
+                assert_eq!(reason, "handshake succeeded but version is incompatible");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn setup_verification_preserves_unexpected_response_messages() {
+        let cases = [
+            (
+                HelperResponse::Error {
+                    code: "DENIED".to_string(),
+                    message: "no access".to_string(),
+                },
+                "unexpected handshake response: Error { code: \"DENIED\", message: \"no access\" }",
+            ),
+            (
+                HelperResponse::Success {
+                    message: "wrong response".to_string(),
+                    exit_code: 0,
+                },
+                "unexpected handshake response: Success { message: \"wrong response\", exit_code: 0 }",
+            ),
+        ];
+
+        for (response, expected) in cases {
+            let client = client_with_responses(vec![response]);
+            let error = verify_helper_connection("system setup", || Ok(client))
+                .expect_err("unexpected response");
+
+            match error {
+                CliError::Runtime { reason, .. } => assert_eq!(reason, expected),
+                other => panic!("unexpected error: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn status_marks_connection_failure_as_not_connectable() {
+        let result = try_status_connection_with("0.3.2", || Err(connect_error()));
+
+        assert!(!result.connectable);
+        assert!(result.handshake.is_none());
+        assert!(result.status.is_none());
+    }
+
+    #[test]
+    fn status_retains_connectability_when_handshake_fails() {
+        let (transport, _) = ScriptedTransport::new(
+            vec![Err(io::Error::new(io::ErrorKind::BrokenPipe, "send"))],
+            Vec::new(),
+        );
+        let client = HelperClient::with_transport(transport);
+
+        let result = try_status_connection_with("0.3.2", || Ok(client));
+
+        assert!(result.connectable);
+        assert!(result.handshake.is_none());
+        assert!(result.status.is_none());
+    }
+
+    #[test]
+    fn status_skips_query_for_incompatible_helper() {
+        let client = client_with_responses(vec![HelperResponse::HandshakeOk {
+            helper_version: "0.0.1".to_string(),
+            compatible: false,
+        }]);
+
+        let result = try_status_connection_with("0.3.2", || Ok(client));
+
+        assert!(result.connectable);
+        let handshake = result.handshake.expect("handshake evidence");
+        assert_eq!(handshake.helper_version, "0.0.1");
+        assert!(!handshake.compatible);
+        assert!(result.status.is_none());
+    }
+
+    #[test]
+    fn status_retains_handshake_when_status_query_fails() {
+        let client = client_with_responses(vec![
+            HelperResponse::HandshakeOk {
+                helper_version: "0.3.2".to_string(),
+                compatible: true,
+            },
+            HelperResponse::Error {
+                code: "UNAVAILABLE".to_string(),
+                message: "status unavailable".to_string(),
+            },
+        ]);
+
+        let result = try_status_connection_with("0.3.2", || Ok(client));
+
+        assert!(result.connectable);
+        assert!(result.handshake.expect("handshake evidence").compatible);
+        assert!(result.status.is_none());
+    }
+
+    #[test]
+    fn status_returns_complete_typed_evidence() {
+        let client = client_with_responses(vec![
+            HelperResponse::HandshakeOk {
+                helper_version: "0.3.2".to_string(),
+                compatible: true,
+            },
+            HelperResponse::Status {
+                running: true,
+                version: "0.3.2".to_string(),
+                uptime_secs: 75,
+                last_operation: Some("install".to_string()),
+                last_operation_time: Some("now".to_string()),
+            },
+        ]);
+
+        let result = try_status_connection_with("0.3.2", || Ok(client));
+
+        assert!(result.connectable);
+        assert!(result.handshake.expect("handshake evidence").compatible);
+        let status = result.status.expect("status evidence");
+        assert_eq!(status.uptime_secs, 75);
+        assert_eq!(status.last_operation.as_deref(), Some("install"));
+        assert_eq!(status.last_operation_time.as_deref(), Some("now"));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/helper_client.rs
+++ b/src/anolisa/crates/anolisa-cli/src/helper_client.rs
@@ -1,0 +1,436 @@
+//! Typed client boundary for the privileged system-helper protocol.
+//!
+//! CLI commands use [`HelperClient`] instead of opening the helper socket or
+//! interpreting wire responses directly. [`UnixHelperTransport`] is the only
+//! production implementation; tests inject scripted transports.
+
+use std::io;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
+
+use anolisa_core::system_helper::{HelperRequest, HelperResponse, OperationType, operation_type};
+use anolisa_platform::ipc;
+
+/// Sends and receives typed messages on one connected helper session.
+pub(crate) trait HelperTransport {
+    /// Sends one request using the helper wire protocol.
+    fn send(&mut self, request: &HelperRequest) -> io::Result<()>;
+
+    /// Receives one response using the helper wire protocol.
+    fn receive(&mut self) -> io::Result<HelperResponse>;
+}
+
+/// Failure evidence preserved by the helper client boundary.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum HelperClientError {
+    /// The helper socket could not be connected.
+    #[error("failed to connect to system-helper socket {path}: {source}")]
+    Connect {
+        /// Socket path used for the connection attempt.
+        path: PathBuf,
+        /// Underlying connection failure.
+        #[source]
+        source: io::Error,
+    },
+
+    /// A typed request could not be written to the helper.
+    #[error("failed to send {operation:?} request to system-helper: {source}")]
+    Send {
+        /// Operation whose request could not be sent.
+        operation: OperationType,
+        /// Underlying write or serialization failure.
+        #[source]
+        source: io::Error,
+    },
+
+    /// A typed response could not be read from the helper.
+    #[error("failed to receive {operation:?} response from system-helper: {source}")]
+    Receive {
+        /// Operation whose response could not be received.
+        operation: OperationType,
+        /// Underlying read or deserialization failure.
+        #[source]
+        source: io::Error,
+    },
+
+    /// The helper returned an explicit remote error.
+    #[error("system-helper rejected {operation:?}: [{code}] {message}")]
+    Remote {
+        /// Operation rejected by the helper.
+        operation: OperationType,
+        /// Stable error code returned by the helper.
+        code: String,
+        /// Human-readable diagnostic returned by the helper.
+        message: String,
+    },
+
+    /// The response variant did not match the request contract.
+    #[error("unexpected response to {operation:?}: expected {expected}, got {response:?}")]
+    UnexpectedResponse {
+        /// Operation awaiting a response.
+        operation: OperationType,
+        /// Expected response variant.
+        expected: &'static str,
+        /// Actual response, retained as protocol evidence.
+        response: HelperResponse,
+    },
+}
+
+/// Result of the mandatory helper handshake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HandshakeResult {
+    /// Version reported by the connected helper.
+    pub(crate) helper_version: String,
+    /// Whether the helper accepted the CLI version.
+    pub(crate) compatible: bool,
+}
+
+/// Result of one osbase-style helper operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HelperOperationOutcome {
+    /// Human-readable phase summary returned by the helper.
+    pub(crate) message: String,
+    /// Domain exit code returned by the helper.
+    pub(crate) exit_code: i32,
+}
+
+/// Status details returned by the helper daemon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HelperStatus {
+    /// Seconds elapsed since the helper started.
+    pub(crate) uptime_secs: u64,
+    /// Most recent operation recorded by the helper.
+    pub(crate) last_operation: Option<String>,
+    /// Timestamp associated with the most recent operation.
+    pub(crate) last_operation_time: Option<String>,
+}
+
+/// Typed client for one connected system-helper session.
+pub(crate) struct HelperClient {
+    transport: Box<dyn HelperTransport>,
+}
+
+impl HelperClient {
+    /// Connects to the production Unix socket transport.
+    pub(crate) fn connect(path: &Path) -> Result<Self, HelperClientError> {
+        let transport =
+            UnixHelperTransport::connect(path).map_err(|source| HelperClientError::Connect {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        Ok(Self::with_transport(transport))
+    }
+
+    /// Builds a client around an injected transport.
+    pub(crate) fn with_transport<T>(transport: T) -> Self
+    where
+        T: HelperTransport + 'static,
+    {
+        Self {
+            transport: Box::new(transport),
+        }
+    }
+
+    /// Performs the mandatory version handshake.
+    pub(crate) fn handshake(
+        &mut self,
+        cli_version: &str,
+    ) -> Result<HandshakeResult, HelperClientError> {
+        let operation = OperationType::Handshake;
+        match self.exchange(&HelperRequest::Handshake {
+            cli_version: cli_version.to_string(),
+        })? {
+            HelperResponse::HandshakeOk {
+                helper_version,
+                compatible,
+            } => Ok(HandshakeResult {
+                helper_version,
+                compatible,
+            }),
+            HelperResponse::Error { code, message } => Err(HelperClientError::Remote {
+                operation,
+                code,
+                message,
+            }),
+            response => Err(HelperClientError::UnexpectedResponse {
+                operation,
+                expected: "HandshakeOk",
+                response,
+            }),
+        }
+    }
+
+    /// Executes an operation that must return a success envelope.
+    pub(crate) fn execute(
+        &mut self,
+        request: &HelperRequest,
+    ) -> Result<HelperOperationOutcome, HelperClientError> {
+        let operation = operation_type(request);
+        match self.exchange(request)? {
+            HelperResponse::Success { message, exit_code } => {
+                Ok(HelperOperationOutcome { message, exit_code })
+            }
+            HelperResponse::Error { code, message } => Err(HelperClientError::Remote {
+                operation,
+                code,
+                message,
+            }),
+            response => Err(HelperClientError::UnexpectedResponse {
+                operation,
+                expected: "Success",
+                response,
+            }),
+        }
+    }
+
+    /// Queries the helper daemon status after a successful handshake.
+    pub(crate) fn system_status(&mut self) -> Result<HelperStatus, HelperClientError> {
+        let request = HelperRequest::SystemStatus;
+        let operation = OperationType::SystemStatus;
+        match self.exchange(&request)? {
+            HelperResponse::Status {
+                uptime_secs,
+                last_operation,
+                last_operation_time,
+                ..
+            } => Ok(HelperStatus {
+                uptime_secs,
+                last_operation,
+                last_operation_time,
+            }),
+            HelperResponse::Error { code, message } => Err(HelperClientError::Remote {
+                operation,
+                code,
+                message,
+            }),
+            response => Err(HelperClientError::UnexpectedResponse {
+                operation,
+                expected: "Status",
+                response,
+            }),
+        }
+    }
+
+    fn exchange(&mut self, request: &HelperRequest) -> Result<HelperResponse, HelperClientError> {
+        let operation = operation_type(request);
+        self.transport
+            .send(request)
+            .map_err(|source| HelperClientError::Send { operation, source })?;
+        self.transport
+            .receive()
+            .map_err(|source| HelperClientError::Receive { operation, source })
+    }
+}
+
+struct UnixHelperTransport {
+    stream: UnixStream,
+}
+
+impl UnixHelperTransport {
+    fn connect(path: &Path) -> io::Result<Self> {
+        UnixStream::connect(path).map(|stream| Self { stream })
+    }
+}
+
+impl HelperTransport for UnixHelperTransport {
+    fn send(&mut self, request: &HelperRequest) -> io::Result<()> {
+        ipc::send_message(&mut self.stream, request)
+    }
+
+    fn receive(&mut self) -> io::Result<HelperResponse> {
+        ipc::recv_message(&mut self.stream)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ScriptedTransport {
+    send_results: VecDeque<io::Result<()>>,
+    receive_results: VecDeque<io::Result<HelperResponse>>,
+    sent: Rc<RefCell<Vec<HelperRequest>>>,
+}
+
+#[cfg(test)]
+impl ScriptedTransport {
+    pub(crate) fn new(
+        send_results: Vec<io::Result<()>>,
+        receive_results: Vec<io::Result<HelperResponse>>,
+    ) -> (Self, Rc<RefCell<Vec<HelperRequest>>>) {
+        let sent = Rc::new(RefCell::new(Vec::new()));
+        (
+            Self {
+                send_results: send_results.into(),
+                receive_results: receive_results.into(),
+                sent: Rc::clone(&sent),
+            },
+            sent,
+        )
+    }
+}
+
+#[cfg(test)]
+impl HelperTransport for ScriptedTransport {
+    fn send(&mut self, request: &HelperRequest) -> io::Result<()> {
+        self.sent.borrow_mut().push(request.clone());
+        self.send_results.pop_front().unwrap_or(Ok(()))
+    }
+
+    fn receive(&mut self) -> io::Result<HelperResponse> {
+        self.receive_results.pop_front().expect("scripted response")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client_with_responses(responses: Vec<HelperResponse>) -> HelperClient {
+        let results = responses.into_iter().map(Ok).collect();
+        let (transport, _) = ScriptedTransport::new(Vec::new(), results);
+        HelperClient::with_transport(transport)
+    }
+
+    #[test]
+    fn handshake_preserves_compatibility_result() {
+        for compatible in [true, false] {
+            let mut client = client_with_responses(vec![HelperResponse::HandshakeOk {
+                helper_version: "0.3.2".to_string(),
+                compatible,
+            }]);
+
+            let result = client.handshake("0.3.2").expect("handshake");
+
+            assert_eq!(result.helper_version, "0.3.2");
+            assert_eq!(result.compatible, compatible);
+        }
+    }
+
+    #[test]
+    fn exchange_distinguishes_send_and_receive_failures() {
+        let cases = [
+            (
+                vec![Err(io::Error::new(io::ErrorKind::BrokenPipe, "send"))],
+                Vec::new(),
+                "send",
+            ),
+            (
+                vec![Ok(())],
+                vec![Err(io::Error::new(io::ErrorKind::UnexpectedEof, "receive"))],
+                "receive",
+            ),
+        ];
+
+        for (send_results, receive_results, expected) in cases {
+            let (transport, _) = ScriptedTransport::new(send_results, receive_results);
+            let mut client = HelperClient::with_transport(transport);
+
+            let error = client.handshake("0.3.2").expect_err("transport failure");
+
+            match (expected, error) {
+                ("send", HelperClientError::Send { operation, source }) => {
+                    assert_eq!(operation, OperationType::Handshake);
+                    assert_eq!(source.kind(), io::ErrorKind::BrokenPipe);
+                }
+                ("receive", HelperClientError::Receive { operation, source }) => {
+                    assert_eq!(operation, OperationType::Handshake);
+                    assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+                }
+                (_, other) => panic!("unexpected error: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn execute_preserves_all_domain_exit_codes() {
+        for exit_code in [0, 2, 1] {
+            let mut client = client_with_responses(vec![HelperResponse::Success {
+                message: format!("exit {exit_code}"),
+                exit_code,
+            }]);
+
+            let result = client
+                .execute(&HelperRequest::OsbaseStatus { scenario: None })
+                .expect("operation outcome");
+
+            assert_eq!(result.exit_code, exit_code);
+            assert_eq!(result.message, format!("exit {exit_code}"));
+        }
+    }
+
+    #[test]
+    fn execute_distinguishes_remote_and_unexpected_responses() {
+        let responses = [
+            (
+                HelperResponse::Error {
+                    code: "DENIED".to_string(),
+                    message: "no access".to_string(),
+                },
+                "remote",
+            ),
+            (
+                HelperResponse::HandshakeOk {
+                    helper_version: "0.3.2".to_string(),
+                    compatible: true,
+                },
+                "unexpected",
+            ),
+        ];
+
+        for (response, expected) in responses {
+            let mut client = client_with_responses(vec![response]);
+            let error = client
+                .execute(&HelperRequest::OsbaseStatus { scenario: None })
+                .expect_err("response failure");
+
+            match (expected, error) {
+                (
+                    "remote",
+                    HelperClientError::Remote {
+                        operation,
+                        code,
+                        message,
+                    },
+                ) => {
+                    assert_eq!(operation, OperationType::OsbaseStatus);
+                    assert_eq!(code, "DENIED");
+                    assert_eq!(message, "no access");
+                }
+                (
+                    "unexpected",
+                    HelperClientError::UnexpectedResponse {
+                        operation,
+                        expected,
+                        ..
+                    },
+                ) => {
+                    assert_eq!(operation, OperationType::OsbaseStatus);
+                    assert_eq!(expected, "Success");
+                }
+                (_, other) => panic!("unexpected error: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn system_status_returns_typed_fields_and_sends_status_request() {
+        let (transport, sent) = ScriptedTransport::new(
+            Vec::new(),
+            vec![Ok(HelperResponse::Status {
+                running: true,
+                version: "0.3.2".to_string(),
+                uptime_secs: 42,
+                last_operation: Some("install".to_string()),
+                last_operation_time: Some("now".to_string()),
+            })],
+        );
+        let mut client = HelperClient::with_transport(transport);
+
+        let result = client.system_status().expect("status");
+
+        assert_eq!(result.uptime_secs, 42);
+        assert_eq!(result.last_operation.as_deref(), Some("install"));
+        assert_eq!(result.last_operation_time.as_deref(), Some("now"));
+        assert_eq!(sent.borrow().as_slice(), &[HelperRequest::SystemStatus]);
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/main.rs
+++ b/src/anolisa/crates/anolisa-cli/src/main.rs
@@ -4,6 +4,7 @@ mod output;
 mod color;
 mod commands;
 mod context;
+mod helper_client;
 mod packaged;
 mod progress;
 mod repo_config;


### PR DESCRIPTION
## Why

System-helper socket connection, handshake, and response handling were duplicated across the
`osbase` and `system` commands. R4 needs that privileged dependency behind an injectable
boundary before further lifecycle work can continue safely.

## What changed

- Add a crate-private typed `HelperClient` and a single production Unix transport.
- Migrate osbase preflight and execution, setup verification, and system status to typed results.
- Add scripted transport and connector tests for transport failures, compatibility, responses,
  exit codes, status degradation, and root fallback.
- Preserve CLI output, JSON schema, wire protocol, and root fallback behavior.

## Related issue

Closes #2629.
Part of #2628.

## User / Agent impact

None. This is an internal boundary refactor with existing observable behavior preserved.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Protocol types and framing remain unchanged, and all direct socket I/O is isolated in
the production transport.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-cli --locked`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Verified command modules no longer call `UnixStream::connect`, `send_message`, or
  `recv_message` directly.
- Tests use scripted transports and do not access the real helper socket or host services.

## Documentation and rollback

No documentation changes are required. Revert commit `39a1f4cb` to roll back the refactor.