### PR TITLE
feat(anolisa): make the component index the sole identity authority

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/common.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/common.rs
@@ -208,55 +208,59 @@ fn reject_visible_non_writable_component_from_view(
 /// Resolve an install target without treating a read-only system record as
 /// the installation being mutated.
 ///
-/// Exact identities across the visible user-plus-system view still precede
-/// repository aliases. The returned state view keeps planning scoped to its
-/// writable root, so a user install can create a user record that shadows an
-/// existing system installation without inheriting or changing it.
+/// Exact identities across the visible user-plus-system view — including
+/// names claimed by an on-disk operation journal — still precede the
+/// component index, which is the sole authority for every other identity:
+/// an input the index does not recognize is rejected instead of being pinned
+/// literally. A normalized `--repo` override in `index_base_override` makes
+/// that repository's published index the identity authority for this
+/// invocation. The returned state view keeps planning scoped to its writable
+/// root, so a user install can create a user record that shadows an existing
+/// system installation without inheriting or changing it.
 pub(crate) fn resolve_install_target(
     input: &str,
     ctx: &CliContext,
     command: &str,
-) -> Result<(String, StateView, bool), CliError> {
-    resolve_lifecycle_target(input, ctx, command, false)
+    index_base_override: Option<&str>,
+) -> Result<(String, StateView), CliError> {
+    resolve_lifecycle_target(input, ctx, command, false, index_base_override)
+        .map(|(component, view, _)| (component, view))
+}
+
+/// Resolve an adopt target under install's narrow identity precedence.
+///
+/// A fresh adopt writes a brand-new component record, so like install it
+/// lets only exact component records (active or quarantined) and
+/// effectively-pending operation journals precede the component index.
+/// Terminal journals, legacy capability rows, and dropped capability names
+/// stay addressable on the mutation paths, which act on the recorded state
+/// and own the migration guidance; here they must not re-authorize an
+/// identity the index no longer recognizes just because `package_map` or
+/// RPM `Provides` could still resolve a package for it.
+pub(crate) fn resolve_adopt_target(
+    input: &str,
+    ctx: &CliContext,
+    command: &str,
+) -> Result<(String, StateView), CliError> {
+    resolve_lifecycle_target(input, ctx, command, false, None)
+        .map(|(component, view, _)| (component, view))
 }
 
 /// Resolve a lifecycle target and reject a visible installation that the
 /// current invocation cannot mutate.
 ///
-/// Missing targets are returned unchanged for the planner's normal
-/// `not-installed` path. Exact component names and package identities are
-/// resolved from visible state before repository aliases are considered.
+/// Exact component names and package identities are resolved from visible
+/// state first; every other identity must come from the component index.
+/// Index-supported but absent targets flow on to the planner's normal
+/// `not-installed` path, while unrecognized names fail as unsupported (or
+/// as index-unavailable when nothing could validate them).
 pub(crate) fn resolve_mutation_target(
     input: &str,
     ctx: &CliContext,
     command: &str,
 ) -> Result<(String, StateView), CliError> {
-    let writable_state = load_state_store(ctx, command)?;
-    let layout = resolve_layout(ctx);
-    let journal_dir = layout.state_dir.join("journal");
-    let inventory = JournalInventory::load(JournalEvidence::new(
-        &journal_dir,
-        &writable_state.operations,
-    ))
-    .map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to inspect pending operation journals: {err}"),
-    })?;
-    let writable_journal_identity = inventory.recoverable_for(input).is_some();
-    let view = StateView::load_with_writable_state(
-        ctx,
-        command,
-        StateVisibility::UserPlusSystem,
-        writable_state,
-    )?;
-
-    if writable_journal_identity {
-        return Ok((input.to_string(), view));
-    }
-    resolve_lifecycle_target_from_view(input, command, true, view, || {
-        component_alias_from_repo_index(input, ctx, command)
-    })
-    .map(|(component, view, _)| (component, view))
+    resolve_lifecycle_target(input, ctx, command, true, None)
+        .map(|(component, view, _)| (component, view))
 }
 
 /// Resolve an adapter target across visible component and local receipt
@@ -274,7 +278,7 @@ pub(crate) fn resolve_adapter_target(
         writable_state,
     )?;
     resolve_adapter_target_from_view(input, command, view, || {
-        component_alias_from_repo_index(input, ctx, command)
+        component_identity_from_repo_index(input, ctx, command, None)
     })
 }
 
@@ -282,7 +286,7 @@ fn resolve_adapter_target_from_view(
     input: &str,
     command: &str,
     view: StateView,
-    alias: impl FnOnce() -> String,
+    identity: impl FnOnce() -> Result<String, CliError>,
 ) -> Result<(String, StateView), CliError> {
     let exact_identity = view.has_exact_component(input)
         || !view
@@ -290,14 +294,11 @@ fn resolve_adapter_target_from_view(
             .state
             .adapter_claims_for_component(input)
             .is_empty();
-    if !exact_identity {
-        view.reject_incomplete_alias_visibility(command, input)?;
+    if exact_identity {
+        return Ok((input.to_string(), view));
     }
-    let component = if exact_identity {
-        input.to_string()
-    } else {
-        alias()
-    };
+    view.reject_incomplete_alias_visibility(command, input)?;
+    let component = identity()?;
     Ok((component, view))
 }
 
@@ -306,16 +307,44 @@ fn resolve_lifecycle_target(
     ctx: &CliContext,
     command: &str,
     reject_read_only: bool,
+    index_base_override: Option<&str>,
 ) -> Result<(String, StateView, bool), CliError> {
     let writable_state = load_state_store(ctx, command)?;
+    let layout = resolve_layout(ctx);
+    let journal_dir = layout.state_dir.join("journal");
+    let inventory = JournalInventory::load(JournalEvidence::new(
+        &journal_dir,
+        &writable_state.operations,
+    ))
+    .map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to inspect pending operation journals: {err}"),
+    })?;
+    // A journal on disk is exact local state: its recorded identity (subject
+    // or legacy step target) stays addressable without index validation so
+    // interrupted or still-uncleared operations remain recoverable offline.
+    // Record-creating commands (install, adopt) share this precedence only
+    // for effectively-pending journals — enough to reach the
+    // pending-operation recovery guidance — because a terminal journal left
+    // behind by a finished operation must not keep authorizing an identity
+    // the component index no longer recognizes.
+    let writable_journal_identity = if reject_read_only {
+        crate::commands::tier1::rpm_install::journal_claims_component(&inventory, input)
+    } else {
+        crate::commands::tier1::rpm_install::pending_journal_claims_component(&inventory, input)
+    };
     let view = StateView::load_with_writable_state(
         ctx,
         command,
         StateVisibility::UserPlusSystem,
         writable_state,
     )?;
+
+    if writable_journal_identity {
+        return Ok((input.to_string(), view, true));
+    }
     resolve_lifecycle_target_from_view(input, command, reject_read_only, view, || {
-        component_alias_from_repo_index(input, ctx, command)
+        component_identity_from_repo_index(input, ctx, command, index_base_override)
     })
 }
 
@@ -324,62 +353,121 @@ fn resolve_lifecycle_target_from_view(
     command: &str,
     reject_read_only: bool,
     view: StateView,
-    alias: impl FnOnce() -> String,
+    identity: impl FnOnce() -> Result<String, CliError>,
 ) -> Result<(String, StateView, bool), CliError> {
-    let exact_identity = view.has_exact_component(input);
+    // Mutations pin any recorded object name so non-component legacy records
+    // (capabilities, dropped capability names) reach their owning command's
+    // migration guidance. Record-creating commands (install, adopt) accept
+    // only exact component records: a historical non-component row must not
+    // authorize a fresh identity the component index no longer recognizes.
+    let exact_identity = if reject_read_only {
+        view.has_exact_object(input)
+    } else {
+        view.has_exact_component(input)
+    };
     if reject_read_only
         && let Some(component) = view.resolve_mutation_component_identity(command, input)?
     {
         return Ok((component, view, true));
     }
-    // Install is allowed to create an independent writable-scope identity,
-    // but incomplete visibility cannot prove that an alias is not an exact
-    // name in the missing root. Pin the literal input instead of remapping it.
-    let literal_identity = exact_identity || !view.unavailable_roots.is_empty();
-    let component = if literal_identity {
-        input.to_string()
-    } else {
-        alias()
-    };
+    if exact_identity {
+        return Ok((input.to_string(), view, true));
+    }
+    // A record-creating command may mint an independent writable-scope
+    // identity, but only one the component index authorizes. Remapping an
+    // alias to its canonical name additionally requires complete visibility:
+    // an unreadable root cannot prove the alias is not an exact name
+    // recorded there.
+    let component = identity()?;
+    if component != input {
+        view.reject_incomplete_alias_visibility(command, input)?;
+    }
     if reject_read_only {
         reject_visible_non_writable_component_from_view(&view, command, &component)?;
     }
-    Ok((component, view, literal_identity))
+    Ok((component, view, false))
 }
 
 /// Resolve a user-supplied component name to the stable state key.
 ///
 /// 1. Exact state match wins — a component installed under its literal name
-///    is never re-mapped.
-/// 2. Otherwise the repo-side component index is consulted for package-name
-///    aliases (e.g., `copilot-shell` → `cosh`) via in-memory lookup only —
-///    no rpmdb/dnf queries are triggered.
-/// 3. Falls back to the literal input when resolution is ambiguous or the
-///    component index is unavailable.
+///    is never re-mapped and stays addressable offline.
+/// 2. Otherwise the repo-side component index is the sole identity authority
+///    (canonical names and declared aliases, e.g. `copilot-shell` → `cosh`)
+///    via in-memory lookup only — no rpmdb/dnf queries are triggered.
+///
+/// # Errors
+///
+/// An input the index does not recognize is an unsupported component; when
+/// no index can be loaded at all, the name cannot be validated and the
+/// explicit index-unavailable error is returned instead (issue #2630).
 pub(crate) fn lookup_component_name_in_store(
     input: &str,
     store: &anolisa_core::state_store::StateStore,
     ctx: &CliContext,
     command: &str,
-) -> String {
+) -> Result<String, CliError> {
     if store.contains_record(ObjectKind::Component, input) {
-        return input.to_string();
+        return Ok(input.to_string());
     }
-    component_alias_from_repo_index(input, ctx, command)
+    component_identity_from_repo_index(input, ctx, command, None)
 }
 
-/// Steps 2–3 of component-name resolution: consult the repo-side component
-/// index for package-name aliases, falling back to the literal input.
-fn component_alias_from_repo_index(input: &str, ctx: &CliContext, command: &str) -> String {
+/// Step 2 of component-name resolution: establish the identity through the
+/// repo-side component index, the sole authority for names absent from
+/// exact local state. A normalized `--repo` base URL in
+/// `index_base_override` replaces the repo.toml chain entirely, so the
+/// overridden repository's index is the authority for the invocation.
+fn component_identity_from_repo_index(
+    input: &str,
+    ctx: &CliContext,
+    command: &str,
+    index_base_override: Option<&str>,
+) -> Result<String, CliError> {
     let layout = resolve_layout(ctx);
-    let repo_config = load_repo_config(ctx, &layout, command, RepoPersistPolicy::BestEffort).ok();
-    let env = anolisa_env::EnvService::detect();
-    let component_index = repo_config
-        .as_ref()
-        .and_then(|cfg| crate::resolution::load_optional_component_index(&layout, &env, cfg));
+    let component_index = match index_base_override {
+        Some(base_url) => crate::resolution::load_component_index_from_base(&layout, base_url).ok(),
+        None => {
+            let repo_config =
+                load_repo_config(ctx, &layout, command, RepoPersistPolicy::BestEffort).ok();
+            let env = anolisa_env::EnvService::detect();
+            repo_config.as_ref().and_then(|cfg| {
+                crate::resolution::load_optional_component_index(&layout, &env, cfg)
+            })
+        }
+    };
 
-    crate::resolution::lookup_component_alias(input, component_index.as_ref())
-        .unwrap_or_else(|| input.to_string())
+    match crate::resolution::resolve_index_identity(input, component_index.as_ref()) {
+        crate::resolution::IndexIdentity::Resolved(component) => Ok(component),
+        crate::resolution::IndexIdentity::Unsupported => {
+            Err(unsupported_component_error(command, input))
+        }
+        crate::resolution::IndexIdentity::Unavailable => {
+            Err(component_index_unavailable_error(command, input))
+        }
+    }
+}
+
+/// Public error for a name the authoritative component index does not know.
+pub(crate) fn unsupported_component_error(command: &str, input: &str) -> CliError {
+    CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!(
+            "unsupported component '{input}'; run `anolisa list` to view supported components"
+        ),
+    }
+}
+
+/// Public error for a name that cannot be validated because no component
+/// index could be loaded. Distinct from [`unsupported_component_error`] so
+/// callers can tell "the index rejected this" from "nothing could check it".
+pub(crate) fn component_index_unavailable_error(command: &str, input: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "component index is unavailable; cannot validate component '{input}'; run `anolisa list` to inspect repository metadata"
+        ),
+    }
 }
 
 /// Path for the component manifest saved as part of an installed component's
@@ -1120,7 +1208,7 @@ mod tests {
             "install legacy-name",
             false,
             view,
-            || "cosh".to_string(),
+            || Ok("cosh".to_string()),
         )
         .expect("a system record must not block a user-scope install");
 
@@ -1159,7 +1247,7 @@ mod tests {
             view,
             || {
                 alias_consulted.set(true);
-                "cosh".to_string()
+                Ok("cosh".to_string())
             },
         )
         .expect_err("the read-only system identity must win over a user alias target");
@@ -1187,7 +1275,7 @@ mod tests {
             "forget copilot-shell",
             true,
             view,
-            || "cosh".to_string(),
+            || Ok("cosh".to_string()),
         );
 
         let err = result.expect_err("the visible system package identity must win");
@@ -1211,7 +1299,7 @@ mod tests {
             view,
             || {
                 alias_consulted.set(true);
-                "cosh".to_string()
+                Ok("cosh".to_string())
             },
         )
         .expect("the writable package owner must be resolved directly");
@@ -1237,7 +1325,7 @@ mod tests {
             "forget shared-package",
             true,
             view,
-            || "repo-target".to_string(),
+            || Ok("repo-target".to_string()),
         )
         .expect_err("ambiguous state package identity must fail closed");
 
@@ -1259,7 +1347,7 @@ mod tests {
             "repair shared-package",
             true,
             view,
-            || "repo-target".to_string(),
+            || Ok("repo-target".to_string()),
         )
         .expect_err("quarantined package claims must remain authoritative");
 
@@ -1282,7 +1370,7 @@ mod tests {
             view,
             || {
                 alias_consulted.set(true);
-                "cosh".to_string()
+                Ok("cosh".to_string())
             },
         )
         .expect("system component must remain a visible adapter source");
@@ -1299,7 +1387,7 @@ mod tests {
             "legacy-name",
             "adapter disable legacy-name",
             view,
-            || "cosh".to_string(),
+            || Ok("cosh".to_string()),
         )
         .expect_err("incomplete visibility must block adapter alias inference");
 
@@ -1320,7 +1408,7 @@ mod tests {
             view,
             || {
                 alias_consulted.set(true);
-                "cosh".to_string()
+                Ok("cosh".to_string())
             },
         )
         .expect("an exact local receipt remains safely addressable");

--- a/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/state_view.rs
@@ -176,6 +176,34 @@ impl StateView {
         self.exact_component_root(component).is_some()
     }
 
+    /// Whether any visible root records an object of any kind under `name`,
+    /// active or quarantined.
+    ///
+    /// Lifecycle target resolution pins such names literally: a non-component
+    /// record (e.g. a legacy capability) is exact local state, and the
+    /// owning command's migration guidance must win over an identity
+    /// rejection for a name local state demonstrably knows.
+    pub(crate) fn has_exact_object(&self, name: &str) -> bool {
+        self.visible_roots.iter().any(|root| {
+            root.state
+                .installations
+                .iter()
+                .any(|installation| installation.name == name)
+                || root
+                    .state
+                    .quarantined
+                    .iter()
+                    .any(|entry| entry.record.name == name)
+                // Dropped legacy capability names still get their dedicated
+                // migration guidance from the owning command.
+                || root
+                    .state
+                    .dropped_capabilities
+                    .iter()
+                    .any(|dropped| dropped == name)
+        })
+    }
+
     pub(crate) fn resolve_mutation_component_identity(
         &self,
         command: &str,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -39,7 +39,7 @@ use crate::commands::tier1::install::{
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::{CliContext, InstallMode};
-use crate::resolution::{ResolutionUse, load_optional_component_index};
+use crate::resolution::load_optional_component_index;
 use crate::response::{CliError, render_json};
 
 /// Command label for JSON envelopes and error routing.
@@ -130,7 +130,7 @@ pub(crate) fn adopt_with_query(
     let now = now_iso8601();
     let env = anolisa_env::EnvService::detect();
 
-    let (mut component, view) = common::resolve_mutation_target(target, ctx, &command)?;
+    let (component, view) = common::resolve_adopt_target(target, ctx, &command)?;
     let store = view.writable.state;
 
     // Quarantined records and pending journals decide the outcome before any
@@ -213,7 +213,7 @@ pub(crate) fn adopt_with_query(
                 // (its first guard), so nothing touches the rpmdb here.
                 (None, AdoptShape::Fresh)
             } else {
-                let (package, resolved_component) = resolve_fresh_adopt(
+                let package = resolve_fresh_adopt(
                     cli_override,
                     ctx,
                     &layout,
@@ -222,7 +222,6 @@ pub(crate) fn adopt_with_query(
                     query,
                     &command,
                 )?;
-                component = resolved_component;
                 (Some(package), AdoptShape::Fresh)
             }
         }
@@ -300,11 +299,12 @@ pub(crate) fn adopt_with_query(
     )
 }
 
-/// Candidate-chain resolution for a component with no record: CLI
+/// Candidate-chain package resolution for a component with no record: CLI
 /// `--package` override, repo-side component index, repo.toml `package_map`,
-/// then rpmdb Provides metadata. repo.toml is supplementary here, so an
-/// unreadable config degrades to "no rpm backend config" rather than
-/// failing the adopt.
+/// then rpmdb Provides metadata. The component identity is already settled;
+/// this only selects the RPM package that backs it. repo.toml is
+/// supplementary here, so an unreadable config degrades to "no rpm backend
+/// config" rather than failing the adopt.
 fn resolve_fresh_adopt(
     cli_override: Option<&str>,
     ctx: &CliContext,
@@ -313,7 +313,7 @@ fn resolve_fresh_adopt(
     component: &str,
     query: &dyn PackageQuery,
     command: &str,
-) -> Result<(String, String), CliError> {
+) -> Result<String, CliError> {
     let repo_config =
         common::load_repo_config(ctx, layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
     let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
@@ -327,7 +327,6 @@ fn resolve_fresh_adopt(
         component_index.as_ref(),
         query,
         component,
-        ResolutionUse::Adopt,
     )
     .map_err(|err| match err {
         PackageQueryError::CommandMissing { command: bin } => {
@@ -339,10 +338,10 @@ fn resolve_fresh_adopt(
         [] => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
-                "component '{component}' is not an ANOLISA RPM component; configure the repo-side component index or publish Provides: anolisa-component({component})"
+                "no RPM package is mapped for component '{component}'; add an rpm backend entry to the repo-side component index or publish Provides: anolisa-component({component})"
             ),
         }),
-        [single] => Ok((single.package.clone(), single.component.clone())),
+        [single] => Ok(single.package.clone()),
         many => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
@@ -701,6 +700,7 @@ mod tests {
         InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, Ownership,
         RpmMetadata,
     };
+    use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus};
     use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
 
     /// In-memory [`PackageQuery`] for the adopt tests. Adopt runs no
@@ -853,14 +853,17 @@ mod tests {
         )
     }
 
-    fn package_component_provide(package: &str, component: &str) -> (String, Vec<String>) {
-        (
-            package.to_string(),
-            vec![format!("anolisa-component({component})")],
-        )
-    }
-
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        // Identity resolution consults the component index for fresh adopt
+        // targets; a seeded local index keeps fixture names supported. The
+        // user-mode refusal test asserts an untouched prefix, so only the
+        // system-mode fixtures seed it.
+        if install_mode == InstallMode::System {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             &prefix,
             install_mode,
@@ -970,7 +973,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
-            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
+            provides: vec![component_provider("copilot-shell", "copilot-shell")],
             origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
@@ -1342,7 +1345,7 @@ mod tests {
                 "copilot-shell".to_string(),
                 pkg_info("copilot-shell", "2.2.0", Some("1.al8"), "x86_64"),
             )],
-            package_provides: vec![package_component_provide("copilot-shell", "copilot-shell")],
+            provides: vec![component_provider("copilot-shell", "copilot-shell")],
             ..Default::default()
         };
         adopt_with_query("copilot-shell", None, &c, &q).expect("dry-run ok");
@@ -1366,6 +1369,124 @@ mod tests {
         let err = adopt_with_query("cosh", Some("copilot-shell"), &c, &q)
             .expect_err("adopt must not bypass a pending managed install");
         assert!(err.reason().contains("repair cosh"));
+    }
+
+    /// Historical evidence that is not an exact component identity must not
+    /// authorize an adopt once the component index cannot vouch for the name
+    /// (issue #2630): a terminal journal left behind by a finished operation
+    /// and a dropped legacy capability row both fail identity validation
+    /// before the candidate chain runs, even though a `package_map` entry or
+    /// rpmdb Provides metadata could still resolve a package — otherwise a
+    /// fresh adopt would mint a component record the index never authorized.
+    #[test]
+    fn historical_state_evidence_does_not_authorize_adopt_identity() {
+        for fixture in ["terminal-journal", "legacy-capability"] {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+            let layout = common::resolve_layout(&c);
+            let state_path = layout.state_dir.join("installed.toml");
+            std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+            // Bait for both fixtures: rpmdb Provides and an installed package
+            // could back the name if the candidate chain were ever consulted.
+            let q = FakeQuery {
+                installed: vec![(
+                    "ghost-pkg".to_string(),
+                    pkg_info("ghost-pkg", "1.0.0", Some("1.al8"), "x86_64"),
+                )],
+                provides: vec![component_provider("ghost", "ghost-pkg")],
+                ..Default::default()
+            };
+            let (expected_code, expected_reason) = match fixture {
+                "terminal-journal" => {
+                    // The seeded index stays available but does not know
+                    // "ghost"; a package_map entry additionally baits the
+                    // candidate chain.
+                    std::fs::write(
+                        layout.etc_dir.join("repo.toml"),
+                        format!(
+                            "schema_version = 1\ndefault_backend = \"raw\"\n\n\
+                             [backends.raw]\nbase_url = \"file://{}\"\n\n\
+                             [backends.rpm]\nbase_url = \"https://repo.example/anolisa\"\n\n\
+                             [backends.rpm.package_map]\nghost = \"ghost-pkg\"\n",
+                            layout.etc_dir.join("test-index-repo").join("v1").display()
+                        ),
+                    )
+                    .expect("write repo.toml");
+                    let mut journal = Transaction::begin_with_subject(
+                        "install",
+                        Some("ghost"),
+                        state_path.clone(),
+                        &rpm_install::journal_dir(&layout),
+                    )
+                    .expect("begin subject journal");
+                    journal
+                        .finish(TransactionOutcomeStatus::Failed)
+                        .expect("finish journal");
+                    ("INVALID_ARGUMENT", "unsupported component 'ghost'")
+                }
+                _ => {
+                    // No repository publishes an index, so nothing can
+                    // validate the name; the dropped capability row must not
+                    // stand in for that validation.
+                    std::fs::write(
+                        layout.etc_dir.join("repo.toml"),
+                        format!(
+                            "schema_version = 1\ndefault_backend = \"raw\"\n\n\
+                             [backends.raw]\nbase_url = \"file://{}\"\n",
+                            tmp.path().join("no-such-repo/v1").display()
+                        ),
+                    )
+                    .expect("write repo.toml");
+                    seed(
+                        &c,
+                        vec![InstalledObject {
+                            kind: ObjectKind::Capability,
+                            name: "ghost".to_string(),
+                            version: "0.1.0".to_string(),
+                            status: ObjectStatus::Installed,
+                            manifest_digest: None,
+                            distribution_source: None,
+                            raw_package: None,
+                            install_backend: None,
+                            ownership: None,
+                            rpm_metadata: None,
+                            installed_at: "2026-06-01T10:00:00Z".to_string(),
+                            last_operation_id: None,
+                            managed: true,
+                            adopted: false,
+                            subscription_scope: Default::default(),
+                            enabled_features: Vec::new(),
+                            component_refs: Vec::new(),
+                            files: Vec::new(),
+                            external_modified_files: Vec::new(),
+                            services: Vec::new(),
+                            health: Vec::new(),
+                            provisioned_packages: Vec::new(),
+                        }],
+                    );
+                    ("EXECUTION_FAILED", "component index is unavailable")
+                }
+            };
+
+            let err = adopt_with_query("ghost", None, &c, &q)
+                .expect_err("historical evidence must not authorize the adopt identity");
+            assert_eq!(err.code(), expected_code, "fixture: {fixture}");
+            assert!(
+                err.reason().contains(expected_reason),
+                "identity validation must reject the name (fixture: {fixture}): {}",
+                err.reason()
+            );
+            assert_eq!(
+                q.calls.get(),
+                0,
+                "the refusal must precede any rpmdb resolution (fixture: {fixture})"
+            );
+            let store = StateStore::load(&state_path, 0).expect("load state");
+            assert!(
+                store.find(ObjectKind::Component, "ghost").is_none(),
+                "no component record may be written (fixture: {fixture})"
+            );
+        }
     }
 
     /// `--package` pins the RPM name, bypassing the candidate chain.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/bug.rs
@@ -107,12 +107,14 @@ fn build_payload(
     ctx: &CliContext,
 ) -> Result<BugReportPayload, CliError> {
     let environment = collect_environment(ctx);
-    // Resolve component alias before filtering state and logs.
-    let resolved = component.map(|name| {
-        let state = common::load_state_store(ctx, COMMAND)
-            .unwrap_or_else(|_| anolisa_core::state_store::StateStore::empty());
-        common::lookup_component_name_in_store(name, &state, ctx, COMMAND)
-    });
+    // Resolve the component identity before filtering state and logs.
+    let resolved = component
+        .map(|name| {
+            let state = common::load_state_store(ctx, COMMAND)
+                .unwrap_or_else(|_| anolisa_core::state_store::StateStore::empty());
+            common::lookup_component_name_in_store(name, &state, ctx, COMMAND)
+        })
+        .transpose()?;
     let components = collect_components(resolved.as_deref(), ctx)?;
     let recent_logs = collect_recent_logs(resolved.as_deref(), limit, ctx)?;
     let markdown = render_markdown(&environment, &components, &recent_logs);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -241,7 +241,9 @@ fn diagnose(component: Option<&str>, ctx: &CliContext) -> Result<DoctorPayload, 
     let mut view = StateView::load(ctx, COMMAND, StateVisibility::UserPlusSystem)?;
     status::migrate_view_states(&mut view);
     let rpm_query = RpmPackageQuery::system();
-    let component = component.map(|name| lookup_component_name_from_view(name, &view, ctx));
+    let component = component
+        .map(|name| lookup_component_name_from_view(name, &view, ctx))
+        .transpose()?;
     let env = anolisa_env::EnvService::detect();
     let resolver_env = resolver_env_from_facts(&env);
     let current_system_service = service_for_install_mode(ctx.install_mode.as_str(), &env);
@@ -327,9 +329,13 @@ fn diagnose_from_view(
     }
 }
 
-fn lookup_component_name_from_view(input: &str, view: &StateView, ctx: &CliContext) -> String {
+fn lookup_component_name_from_view(
+    input: &str,
+    view: &StateView,
+    ctx: &CliContext,
+) -> Result<String, CliError> {
     if view.has_exact_component(input) {
-        return input.to_string();
+        return Ok(input.to_string());
     }
     common::lookup_component_name_in_store(input, &view.writable.state, ctx, COMMAND)
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -395,6 +395,14 @@ mod tests {
     use crate::context::InstallMode;
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        // Identity resolution consults the component index for names absent
+        // from state; a seeded local index keeps fixture names supported.
+        if install_mode == InstallMode::System {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             &prefix,
             install_mode,
@@ -659,9 +667,29 @@ mod tests {
         );
     }
 
-    /// Forgetting an absent component routes to NOT_INSTALLED (exit 2).
+    /// Forgetting an absent but index-supported component routes to
+    /// NOT_INSTALLED (exit 2).
     #[test]
-    fn forget_unknown_component_routes_to_not_installed() {
+    fn forget_absent_supported_component_routes_to_not_installed() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let err = handle(
+            ForgetArgs {
+                component: "agentsight".to_string(),
+            },
+            &c,
+        )
+        .expect_err("absent component must error");
+        assert_eq!(err.code(), "NOT_INSTALLED");
+        assert_eq!(err.exit_code(), 2);
+        assert!(err.reason().contains("not installed"));
+    }
+
+    /// A name neither state nor the component index knows is rejected as an
+    /// unsupported component, not reported as merely not installed
+    /// (issue #2630).
+    #[test]
+    fn forget_unsupported_component_is_rejected() {
         let tmp = tempfile::tempdir().expect("tmpdir");
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         let err = handle(
@@ -670,10 +698,13 @@ mod tests {
             },
             &c,
         )
-        .expect_err("absent component must error");
-        assert_eq!(err.code(), "NOT_INSTALLED");
-        assert_eq!(err.exit_code(), 2);
-        assert!(err.reason().contains("not installed"));
+        .expect_err("unsupported component must error");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert!(
+            err.reason().contains("unsupported component 'ghost'"),
+            "got: {}",
+            err.reason()
+        );
     }
 
     /// A component with an adapter receipt is refused until the adapter is

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -40,6 +40,7 @@ use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::progress::{self, Activity};
+use crate::repo_config::RepoConfig;
 use crate::resolution::ComponentIndex;
 use crate::response::{CliError, render_json, render_json_with_status};
 
@@ -52,8 +53,8 @@ use super::{COMMAND, InstallArgs};
 use super::io_util::now_iso8601;
 use super::{
     PlannedComponent, PlannedRoute, RpmdbProbe, handle_one, handle_one_with_planned_components,
-    host_backends, plan_component, quarantined, require_configured_rpm_backend,
-    revalidate_native_absence, step_label,
+    host_backends, normalized_repo_override, plan_component, quarantined,
+    require_configured_rpm_backend, revalidate_native_absence, step_label,
 };
 // ── --all support ───────────────────────────────────────────────────
 
@@ -93,7 +94,9 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         progress::feedback_for_stderr(ctx.json, ctx.quiet),
         "Preparing batch installation...",
     );
-    let names = resolve_all_components(ctx, args.backend.as_deref())?;
+    let index_base_override = normalized_repo_override(&args)?;
+    let names =
+        resolve_all_components(ctx, args.backend.as_deref(), index_base_override.as_deref())?;
     if names.is_empty() {
         activity.finish();
         if !ctx.quiet && !ctx.json {
@@ -518,7 +521,13 @@ fn execute_merged_group_with_deps(
             Ok(config) => config,
             Err(err) => return all_failed(&group, &err.reason()),
         };
-    if let Err(err) = require_configured_rpm_backend(&repo_config, BATCH_COMMAND) {
+    let index_base_override = match normalized_repo_override(args) {
+        Ok(override_url) => override_url,
+        Err(err) => return all_failed(&group, &err.reason()),
+    };
+    if let Err(err) =
+        require_configured_rpm_backend(&repo_config, index_base_override.as_deref(), BATCH_COMMAND)
+    {
         return all_failed(&group, &err.reason());
     }
     if !is_root {
@@ -856,28 +865,46 @@ fn component_names_for_target(
 pub(crate) fn resolve_all_components(
     ctx: &CliContext,
     backend: Option<&str>,
+    index_base_override: Option<&str>,
 ) -> Result<Vec<String>, CliError> {
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let repo_config =
         common::load_repo_config(ctx, &layout, "install --all", RepoPersistPolicy::Require)?;
-    let index =
-        crate::resolution::load_component_index(&layout, &env, &repo_config).map_err(|err| {
-            CliError::Runtime {
+    // A `--repo` override's published index is the enumeration authority,
+    // matching identity and package resolution for each member install.
+    let index = match index_base_override {
+        Some(base_url) => crate::resolution::load_component_index_from_base(&layout, base_url),
+        None => crate::resolution::load_component_index(&layout, &env, &repo_config),
+    }
+    .map_err(|err| CliError::Runtime {
+        command: "install --all".to_string(),
+        reason: format!("failed to load component index: {err}"),
+    })?;
+    // An override enumerates its own published index and pins the DNF/raw
+    // source, so an explicitly named backend need not be configured in
+    // repo.toml — the name only filters index rows by backend kind. It must
+    // still be a known backend: a typo yields the same INVALID_ARGUMENT as
+    // the single-component path, never a successful empty batch.
+    let selected_backend = match (index_base_override, backend) {
+        (Some(_), Some(name)) => RepoConfig::known_backend_name(name)
+            .map_err(|err| CliError::InvalidArgument {
                 command: "install --all".to_string(),
-                reason: format!("failed to load component index: {err}"),
-            }
-        })?;
-    let (selected_backend, _) =
-        repo_config
+                reason: format!("{err}"),
+            })?
+            .to_string(),
+        _ => repo_config
             .select_backend(backend)
             .map_err(|err| CliError::InvalidArgument {
                 command: "install --all".to_string(),
                 reason: format!("{err}"),
-            })?;
+            })?
+            .0
+            .to_string(),
+    };
     Ok(component_names_for_target(
         &index,
-        selected_backend,
+        &selected_backend,
         &env.os,
         &env.arch,
     ))
@@ -1037,7 +1064,6 @@ mod tests {
         PlannedComponent {
             command: format!("install {component}"),
             component: component.to_string(),
-            component_identity_pinned: false,
             family: "rpm".to_string(),
             native_package: Some(package.to_string()),
             delegated_pin: None,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -45,8 +45,8 @@ use crate::repo_config::{
     BackendConfig, HostVars, RepoConfig, RepoConfigError, normalize_override_url,
 };
 use crate::resolution::{
-    BackendKind, ComponentResolver, ResolutionSet, ResolutionUse, ResolveOptions,
-    load_optional_component_index,
+    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolveOptions,
+    load_component_index_from_base, load_optional_component_index,
 };
 use crate::response::{CliError, render_json};
 
@@ -133,11 +133,13 @@ pub(crate) fn host_backends(
     let layout = common::resolve_layout(ctx);
     let env = anolisa_env::EnvService::detect();
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
-    let (resolved, view, _) = common::resolve_install_target(component, ctx, &command)?;
+    let index_base_override = normalized_repo_override(args)?;
+    let (resolved, view) =
+        common::resolve_install_target(component, ctx, &command, index_base_override.as_deref())?;
     let store = &view.writable.state;
 
     let rpm_repo = if install_family(args, store, &resolved, &repo_config) == "rpm" {
-        configured_rpm_repo_source(&repo_config, &env)?
+        rpm_repo_source_for_invocation(&repo_config, &env, index_base_override.as_deref())?
     } else {
         None
     };
@@ -150,6 +152,34 @@ pub(crate) fn host_backends(
         None => RpmTransaction::system(),
     };
     Ok((query, txn))
+}
+
+/// Validated `--repo` base URL, when the caller supplied one. Normalization
+/// runs before identity resolution so a malformed override is refused as a
+/// bad argument rather than surfacing as an unavailable component index.
+pub(crate) fn normalized_repo_override(args: &InstallArgs) -> Result<Option<String>, CliError> {
+    args.repo
+        .as_deref()
+        .map(|url| normalize_override_url(url).map_err(|err| repo_config_err(err, true)))
+        .transpose()
+}
+
+/// Component index for this invocation, best-effort.
+///
+/// A `--repo` override's published index answers every question the install
+/// asks — identity, package selection, and the batch enumeration — so the
+/// invocation never mixes the override repository with the repo.toml chain.
+/// Without an override the repo.toml raw backend chain is used as usual.
+pub(crate) fn invocation_component_index(
+    layout: &FsLayout,
+    env: &anolisa_env::EnvFacts,
+    repo_config: &RepoConfig,
+    index_base_override: Option<&str>,
+) -> Option<ComponentIndex> {
+    match index_base_override {
+        Some(base_url) => load_component_index_from_base(layout, base_url).ok(),
+        None => load_optional_component_index(layout, env, repo_config),
+    }
 }
 
 /// Provider family for this invocation: explicit `--backend` (canonical
@@ -184,11 +214,6 @@ fn install_family(
 pub(crate) struct PlannedComponent {
     pub(crate) command: String,
     pub(crate) component: String,
-    /// Lifecycle resolution pinned the literal input, so backend-level
-    /// package aliases must not rewrite it to another component. This holds
-    /// for an exact visible identity and for incomplete cross-scope
-    /// visibility where aliasing would be unsafe.
-    pub(crate) component_identity_pinned: bool,
     pub(crate) family: String,
     pub(crate) native_package: Option<String>,
     /// Resolved candidate for a `--version`-pinned delegated install, carried
@@ -259,11 +284,6 @@ impl RawPin {
             source_repo: resolution.base_url.clone(),
         }
     }
-}
-
-struct ResolvedInstallIdentity {
-    component: String,
-    pinned: bool,
 }
 
 /// Which executor family the plan routed to, or the idempotent NoOp.
@@ -398,9 +418,11 @@ pub(crate) fn plan_component(
 
     // Resolve identity across all visible roots, but bind install planning to
     // the writable scope only. A user install may therefore shadow an
-    // existing system installation without mutating or inheriting it.
-    let (mut component, view, component_identity_pinned) =
-        common::resolve_install_target(input, ctx, &command)?;
+    // existing system installation without mutating or inheriting it. A
+    // `--repo` override makes that repository's index the identity authority.
+    let index_base_override = normalized_repo_override(args)?;
+    let (component, view) =
+        common::resolve_install_target(input, ctx, &command, index_base_override.as_deref())?;
     let store = view.writable.state;
 
     if let Some(explicit) = args.backend.as_deref()
@@ -524,7 +546,6 @@ pub(crate) fn plan_component(
                     query,
                     &command,
                 )?;
-                component = fresh.component;
                 delegated_pin = fresh.pin;
                 (fresh.target, Some(fresh.package))
             }
@@ -622,7 +643,6 @@ pub(crate) fn plan_component(
     Ok(PlannedComponent {
         command,
         component,
-        component_identity_pinned,
         family,
         native_package,
         delegated_pin,
@@ -654,7 +674,6 @@ fn execute_planned(
     let PlannedComponent {
         command,
         mut component,
-        component_identity_pinned,
         family,
         native_package,
         delegated_pin,
@@ -665,6 +684,7 @@ fn execute_planned(
     } = planned;
     let layout = common::resolve_layout(ctx);
     let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
+    let index_base_override = normalized_repo_override(args)?;
     let state_path = layout.state_dir.join("installed.toml");
     let journal_dir = rpm_install::journal_dir(&layout);
 
@@ -701,10 +721,7 @@ fn execute_planned(
                 &layout,
                 env,
                 &repo_config,
-                ResolvedInstallIdentity {
-                    component: component.clone(),
-                    pinned: component_identity_pinned,
-                },
+                component.clone(),
                 &command,
             )?;
             component = resolution.component.clone();
@@ -819,6 +836,7 @@ fn execute_planned(
         delegated_pin.as_ref(),
         &provider,
         &repo_config,
+        index_base_override.as_deref(),
         is_root,
         &command,
         reporter,
@@ -887,13 +905,9 @@ fn resolve_owned_artifact(
     layout: &FsLayout,
     env: &anolisa_env::EnvFacts,
     repo_config: &RepoConfig,
-    identity: ResolvedInstallIdentity,
+    component: String,
     command: &str,
 ) -> Result<RawResolution, CliError> {
-    let ResolvedInstallIdentity {
-        component,
-        pinned: component_identity_pinned,
-    } = identity;
     let (backend_name, backend) = repo_config
         .select_backend(Some("raw"))
         .map_err(|err| repo_config_err(err, true))?;
@@ -925,14 +939,15 @@ fn resolve_owned_artifact(
             (base_url, origin)
         }
     };
-    let (component, package) = resolve_raw_identity(
+    let index_base_override = normalized_repo_override(args)?;
+    let package = resolve_raw_package(
         layout,
         env,
         repo_config,
         backend,
-        component,
+        &component,
         args.package.as_deref(),
-        component_identity_pinned,
+        index_base_override.as_deref(),
     );
     resolve_raw(
         ctx,
@@ -1055,14 +1070,15 @@ fn system_probe_package(
             .clone()
             .unwrap_or_else(|| component.to_string())
     };
-    let component_index = load_optional_component_index(layout, env, repo_config);
+    let index_base_override = normalized_repo_override(args)?;
+    let component_index =
+        invocation_component_index(layout, env, repo_config, index_base_override.as_deref());
     let candidates = match rpm_package_candidates_with_index(
         args.package.as_deref(),
         repo_config.backends.get("rpm"),
         component_index.as_ref(),
         query,
         component,
-        ResolutionUse::Install,
     ) {
         Ok(candidates) => candidates,
         Err(PackageQueryError::CommandMissing { command: bin }) => {
@@ -1080,12 +1096,11 @@ fn system_probe_package(
 }
 
 /// Fresh delegated resolution result: the provider target, its bare package,
-/// the resolved component name (aliases may re-map the input), and — when a
-/// `--version` was pinned — the resolved candidate metadata for reporting.
+/// and — when a `--version` was pinned — the resolved candidate metadata for
+/// reporting. The component identity is the caller's and never re-mapped.
 struct FreshDelegated {
     target: ProviderTarget,
     package: String,
-    component: String,
     pin: Option<DelegatedPin>,
 }
 
@@ -1103,14 +1118,15 @@ fn resolve_fresh_delegated(
     query: &dyn PackageQuery,
     command: &str,
 ) -> Result<FreshDelegated, CliError> {
-    let component_index = load_optional_component_index(layout, env, repo_config);
+    let index_base_override = normalized_repo_override(args)?;
+    let component_index =
+        invocation_component_index(layout, env, repo_config, index_base_override.as_deref());
     let candidates = rpm_package_candidates_with_index(
         args.package.as_deref(),
         repo_config.backends.get("rpm"),
         component_index.as_ref(),
         query,
         component,
-        ResolutionUse::Install,
     )
     .map_err(|err| match err {
         PackageQueryError::CommandMissing { command: bin } => {
@@ -1122,12 +1138,11 @@ fn resolve_fresh_delegated(
         [] => Err(CliError::InvalidArgument {
             command: command.to_string(),
             reason: format!(
-                "component '{component}' is not an ANOLISA RPM component; use the ANOLISA component name and configure the repo-side component index or publish Provides: anolisa-component({component})"
+                "no RPM package is mapped for component '{component}'; add an rpm backend entry to the repo-side component index or publish Provides: anolisa-component({component})"
             ),
         }),
         [single] => {
             let package = single.package.clone();
-            let resolved_component = single.component.clone();
             // A `--version` pin resolves the bare package to an exact
             // repository candidate before any mutation; the NEVRA is the only
             // value that reaches the native transaction. An unpinned install
@@ -1136,14 +1151,7 @@ fn resolve_fresh_delegated(
                 Some(version) => {
                     let pinned = resolve_pinned_candidate(query, &package, version, &env.arch)
                         .map_err(|err| {
-                            pin_error_to_cli(
-                                err,
-                                command,
-                                &resolved_component,
-                                &package,
-                                version,
-                                &env.arch,
-                            )
+                            pin_error_to_cli(err, command, component, &package, version, &env.arch)
                         })?;
                     let pin = DelegatedPin {
                         requested_version: version.to_string(),
@@ -1164,7 +1172,6 @@ fn resolve_fresh_delegated(
                     artifact,
                 },
                 package,
-                component: resolved_component,
                 pin,
             })
         }
@@ -1360,14 +1367,15 @@ fn install_delegated(
     delegated_pin: Option<&DelegatedPin>,
     provider: &DelegatedProvider,
     repo_config: &RepoConfig,
+    index_base_override: Option<&str>,
     is_root: bool,
     command: &str,
     reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallOutcome, CliError> {
-    // A fresh delegated install pulls from the configured ANOLISA RPM
-    // repository; without one, dnf would resolve against arbitrary host
-    // repos.
-    require_configured_rpm_backend(repo_config, command)?;
+    // A fresh delegated install pulls from the repository its DNF source was
+    // pinned to: the `--repo` override when one was given, the configured
+    // ANOLISA RPM backend otherwise.
+    require_configured_rpm_backend(repo_config, index_base_override, command)?;
 
     if !is_root {
         return Err(CliError::PermissionDenied {
@@ -1555,6 +1563,34 @@ fn rpmdb_appeared_error(command: &str, target: &str) -> CliError {
     }
 }
 
+/// DNF repository source for this invocation's RPM family.
+///
+/// A normalized `--repo` override replaces the configured base URL — the
+/// flag is a one-off base URL for the selected backend, so the repository
+/// that resolved identity and package also serves availability queries, the
+/// native transaction, and the locked re-checks. Settings other than the URL
+/// (gpgcheck) stay with the repo.toml rpm backend when one is configured.
+pub(crate) fn rpm_repo_source_for_invocation(
+    repo_config: &RepoConfig,
+    env: &anolisa_env::EnvFacts,
+    index_base_override: Option<&str>,
+) -> Result<Option<DnfRepoSource>, CliError> {
+    match index_base_override {
+        Some(base_url) => {
+            let gpgcheck = repo_config
+                .backends
+                .get("rpm")
+                .and_then(|backend| backend.gpgcheck);
+            Ok(Some(DnfRepoSource::new(
+                ANOLISA_RPM_REPO_ID,
+                base_url.to_string(),
+                gpgcheck,
+            )))
+        }
+        None => configured_rpm_repo_source(repo_config, env),
+    }
+}
+
 pub(crate) fn configured_rpm_repo_source(
     repo_config: &RepoConfig,
     env: &anolisa_env::EnvFacts,
@@ -1576,11 +1612,18 @@ pub(crate) fn configured_rpm_repo_source(
     )))
 }
 
+/// Require a repository the delegated transaction can be pinned to.
+///
+/// Without one, dnf would resolve against arbitrary host repos. A normalized
+/// `--repo` override IS that repository — the DNF source is built from it —
+/// so the configured-backend requirement only applies when no override
+/// pinned the source.
 pub(crate) fn require_configured_rpm_backend(
     repo_config: &RepoConfig,
+    index_base_override: Option<&str>,
     command: &str,
 ) -> Result<(), CliError> {
-    if repo_config.backends.contains_key("rpm") {
+    if index_base_override.is_some() || repo_config.backends.contains_key("rpm") {
         Ok(())
     } else {
         Err(repo_config_err(
@@ -1593,44 +1636,31 @@ pub(crate) fn require_configured_rpm_backend(
     }
 }
 
-/// Resolve the raw package while preserving a literal lifecycle identity.
+/// Resolve the raw distribution package for a settled component identity.
 ///
-/// `component_identity_pinned` prevents the backend-specific alias pass from
-/// changing the component selected by lifecycle resolution. Pinning applies
-/// both to exact visible identities and to incomplete cross-scope visibility;
-/// explicit package overrides and package maps may still choose the
-/// distribution package.
-pub(crate) fn resolve_raw_identity(
+/// Explicit package overrides and repo.toml `package_map` entries choose the
+/// distribution package first; otherwise the raw backend row of this
+/// invocation's component index — the `--repo` override's index when one was
+/// given — decides. The component itself is never rewritten — identity was
+/// settled by lifecycle resolution before this pass.
+pub(crate) fn resolve_raw_package(
     layout: &FsLayout,
     env: &anolisa_env::EnvFacts,
     repo_config: &RepoConfig,
     backend: &BackendConfig,
-    component: String,
+    component: &str,
     cli_override: Option<&str>,
-    component_identity_pinned: bool,
-) -> (String, String) {
-    if cli_override.is_some() || backend.package_map.contains_key(&component) {
-        let package = repo_config.package_name(backend, &component, cli_override);
-        return (component, package);
+    index_base_override: Option<&str>,
+) -> String {
+    if cli_override.is_some() || backend.package_map.contains_key(component) {
+        return repo_config.package_name(backend, component, cli_override);
     }
 
-    let component_index = load_optional_component_index(layout, env, repo_config);
+    let component_index = invocation_component_index(layout, env, repo_config, index_base_override);
     let resolver = ComponentResolver::new(component_index.as_ref(), None, None);
-    match resolver.resolve(
-        &component,
-        BackendKind::Raw,
-        ResolutionUse::Install,
-        ResolveOptions::default(),
-    ) {
-        Ok(ResolutionSet::Unique(target))
-            if !component_identity_pinned || target.component == component =>
-        {
-            (target.component, target.package)
-        }
-        _ => {
-            let package = repo_config.package_name(backend, &component, cli_override);
-            (component, package)
-        }
+    match resolver.resolve(component, BackendKind::Raw, ResolveOptions::default()) {
+        Ok(ResolutionSet::Unique(target)) => target.package,
+        _ => repo_config.package_name(backend, component, cli_override),
     }
 }
 
@@ -2422,42 +2452,79 @@ package = "agent-sec-core"
         let layout = FsLayout::system(Some(tmp.path().join("root")));
         let env = anolisa_env::EnvService::detect();
 
-        let exact = resolve_raw_identity(
+        // An exact state identity that only appears as an index alias keeps
+        // its own name as the distribution package: alias rows resolve
+        // identities before this pass and never redirect package selection.
+        let exact_alias_name = resolve_raw_package(
             &layout,
             &env,
             &repo_config,
             backend,
-            "legacy-name".to_string(),
+            "legacy-name",
             None,
-            true,
+            None,
         );
-        let alias = resolve_raw_identity(
+        let canonical =
+            resolve_raw_package(&layout, &env, &repo_config, backend, "cosh", None, None);
+        let mapped_package =
+            resolve_raw_package(&layout, &env, &repo_config, backend, "sec-core", None, None);
+
+        assert_eq!(exact_alias_name, "legacy-name");
+        assert_eq!(canonical, "cosh");
+        assert_eq!(mapped_package, "agent-sec-core");
+    }
+
+    /// A `--repo` override's published index decides the raw package, the
+    /// same authority identity resolution consults — the repo.toml chain is
+    /// never mixed in (issue #2630 review follow-up).
+    #[test]
+    fn repo_override_index_decides_the_raw_package() {
+        let tmp = tempdir().expect("tempdir");
+        let override_v1 = tmp.path().join("override").join("v1");
+        std::fs::create_dir_all(&override_v1).expect("override repo");
+        std::fs::write(
+            override_v1.join("components-v2.toml"),
+            r#"
+schema_version = 2
+
+[[components]]
+name = "cosh"
+targets = [{ os = "linux", arch = "x86_64" }]
+
+[[components.backends]]
+kind = "raw"
+package = "cosh-artifact"
+"#,
+        )
+        .expect("component index");
+        let repo_config = RepoConfig::from_toml_str(
+            "schema_version = 1\ndefault_backend = \"raw\"\n[backends.raw]\nbase_url = \"https://example.invalid/raw\"\n",
+        )
+        .expect("repo config");
+        let backend = repo_config.backends.get("raw").expect("raw backend");
+        let layout = FsLayout::system(Some(tmp.path().join("root")));
+        let env = anolisa_env::EnvService::detect();
+        let override_base = format!("file://{}", override_v1.display());
+
+        let with_override = resolve_raw_package(
             &layout,
             &env,
             &repo_config,
             backend,
-            "legacy-name".to_string(),
+            "cosh",
             None,
-            false,
+            Some(&override_base),
         );
-        let exact_with_mapped_package = resolve_raw_identity(
-            &layout,
-            &env,
-            &repo_config,
-            backend,
-            "sec-core".to_string(),
-            None,
-            true,
-        );
+        let without_override =
+            resolve_raw_package(&layout, &env, &repo_config, backend, "cosh", None, None);
 
         assert_eq!(
-            exact,
-            ("legacy-name".to_string(), "legacy-name".to_string())
+            with_override, "cosh-artifact",
+            "the override repository's index must decide the raw package"
         );
-        assert_eq!(alias, ("cosh".to_string(), "cosh".to_string()));
         assert_eq!(
-            exact_with_mapped_package,
-            ("sec-core".to_string(), "agent-sec-core".to_string())
+            without_override, "cosh",
+            "without an override the unreachable repo.toml index falls back to the component name"
         );
     }
 
@@ -2524,10 +2591,11 @@ package = "agent-sec-core"
     #[test]
     fn install_unconfigured_backend_is_invalid_argument() {
         let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        seed_repo_config_with_index(&FsLayout::system(Some(prefix.clone())), &["agentsight"]);
         let mut a = args("agentsight");
         a.backend = Some("npm".to_string());
-        let err = handle(a, &ctx_with_prefix(false, Some(tmp.path().to_path_buf())))
-            .expect_err("must error");
+        let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("npm"), "got: {}", err.reason());
         assert!(
@@ -2540,10 +2608,11 @@ package = "agent-sec-core"
     #[test]
     fn install_unknown_backend_is_invalid_argument() {
         let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        seed_repo_config_with_index(&FsLayout::system(Some(prefix.clone())), &["agentsight"]);
         let mut a = args("agentsight");
         a.backend = Some("pip".to_string());
-        let err = handle(a, &ctx_with_prefix(false, Some(tmp.path().to_path_buf())))
-            .expect_err("must error");
+        let err = handle(a, &ctx_with_prefix(false, Some(prefix))).expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("pip"));
     }
@@ -2554,18 +2623,23 @@ package = "agent-sec-core"
         let prefix = tmp.path().to_path_buf();
         let layout = FsLayout::system(Some(prefix.clone()));
         std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+        let v1 = layout.etc_dir.join("test-index-repo").join("v1");
+        write_component_index_v2(&v1, &["agentsight"]);
         std::fs::write(
             layout.etc_dir.join("repo.toml"),
-            r#"schema_version = 1
+            format!(
+                r#"schema_version = 1
 default_backend = "raw"
 
 [backends.raw]
-base_url = "https://example.com/anolisa"
+base_url = "file://{}"
 
 [backends.npm]
 base_url = "https://registry.npmjs.org"
 scope = "@anolisa"
 "#,
+                v1.display()
+            ),
         )
         .expect("write repo.toml");
 
@@ -2585,6 +2659,51 @@ scope = "@anolisa"
             .expect_err("must error");
         assert_eq!(err.code(), "INVALID_ARGUMENT");
         assert!(err.reason().contains("ftp"), "got: {}", err.reason());
+    }
+
+    /// A `--repo` override replaces the DNF source's base URL — the same
+    /// repository that resolved identity and package also serves queries and
+    /// the native transaction — while backend-scoped settings (gpgcheck)
+    /// stay with the repo.toml rpm backend when one is configured.
+    #[test]
+    fn rpm_repo_source_honors_the_repo_override() {
+        let repo = RepoConfig::from_toml_str(
+            r#"schema_version = 1
+default_backend = "rpm"
+[backends.rpm]
+base_url = "https://repo.example/anolisa"
+gpgcheck = false
+"#,
+        )
+        .expect("parse repo");
+
+        let overridden =
+            rpm_repo_source_for_invocation(&repo, &linux_env(), Some("https://mirror.example/os"))
+                .expect("resolve rpm repo")
+                .expect("override source");
+        assert_eq!(overridden.id(), ANOLISA_RPM_REPO_ID);
+        assert_eq!(overridden.base_url(), "https://mirror.example/os");
+        assert_eq!(overridden.gpgcheck(), Some(false));
+
+        let configured = rpm_repo_source_for_invocation(&repo, &linux_env(), None)
+            .expect("resolve rpm repo")
+            .expect("configured source");
+        assert_eq!(configured.base_url(), "https://repo.example/anolisa");
+
+        // Without a configured rpm backend the override still yields a
+        // source; backend-scoped settings simply stay unset.
+        let raw_only = RepoConfig::from_toml_str(
+            "schema_version = 1\ndefault_backend = \"raw\"\n[backends.raw]\nbase_url = \"https://example.com/anolisa\"\n",
+        )
+        .expect("parse repo");
+        let overridden = rpm_repo_source_for_invocation(
+            &raw_only,
+            &linux_env(),
+            Some("https://mirror.example/os"),
+        )
+        .expect("resolve rpm repo")
+        .expect("override source");
+        assert_eq!(overridden.gpgcheck(), None);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/rpm.rs
@@ -1,18 +1,19 @@
 //! RPM candidate resolution shared by `install` and `adopt`: mapping a
-//! component name (or `--package` override) to the RPM package(s) that could
-//! back it, via the repo-side component index, repo.toml `package_map`, and
-//! rpmdb `Provides: anolisa-component(...)` metadata.
+//! settled component identity (or `--package` override) to the RPM package(s)
+//! that could back it, via the repo-side component index, repo.toml
+//! `package_map`, and rpmdb `Provides: anolisa-component(...)` metadata.
+//! Identity resolution happens before this layer — the candidate chain
+//! selects packages, it never establishes a new component name.
 //!
 //! Presence probing and adoption both moved to the planner-driven pipelines
-//! (`dispatch.rs`, `adopt.rs`); only the identity resolution lives here.
+//! (`dispatch.rs`, `adopt.rs`); only the package resolution lives here.
 
 use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
 use anolisa_platform::rpm_select::{PinnedSelection, nevra, select_pinned_candidate};
 
 use crate::repo_config::BackendConfig;
 use crate::resolution::{
-    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolutionUse, ResolveOptions,
-    ResolvedTarget,
+    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolveOptions, ResolvedTarget,
 };
 
 /// Resolved RPM component/package pair.
@@ -39,20 +40,19 @@ impl RpmTarget {
     }
 }
 
-/// Resolve candidate RPM component/package pairs for `input`.
+/// Resolve candidate RPM packages for the settled component identity `input`.
 ///
 /// Precedence, in order: CLI `--package`, repo-side component index,
-/// repo.toml `package_map`, installed/available
-/// `anolisa-component(<name>)` providers, then the input package's own
-/// `Provides: anolisa-component(<component>)` metadata.
+/// repo.toml `package_map`, then installed/available
+/// `anolisa-component(<name>)` providers.
 ///
-/// Ordinary RPM packages without ANOLISA metadata return an empty vector:
+/// A component with no package mapping or provider returns an empty vector:
 /// `install --backend rpm <arg>` installs ANOLISA components, not arbitrary
 /// `dnf install <arg>` targets.
 ///
 /// # Errors
 /// Propagates a hard [`PackageQueryError`] from the package query; empty
-/// query results are the normal "no explicit component identity" branch.
+/// query results are the normal "no backend package resolved" branch.
 #[cfg(test)]
 pub(crate) fn rpm_package_candidates(
     cli_override: Option<&str>,
@@ -60,14 +60,7 @@ pub(crate) fn rpm_package_candidates(
     query: &dyn PackageQuery,
     input: &str,
 ) -> Result<Vec<RpmTarget>, PackageQueryError> {
-    rpm_package_candidates_with_index(
-        cli_override,
-        rpm_backend,
-        None,
-        query,
-        input,
-        ResolutionUse::Install,
-    )
+    rpm_package_candidates_with_index(cli_override, rpm_backend, None, query, input)
 }
 
 /// A repository candidate a `--version` pin resolved to.
@@ -143,13 +136,11 @@ pub(crate) fn rpm_package_candidates_with_index(
     component_index: Option<&ComponentIndex>,
     query: &dyn PackageQuery,
     input: &str,
-    use_case: ResolutionUse,
 ) -> Result<Vec<RpmTarget>, PackageQueryError> {
     let resolver = ComponentResolver::new(component_index, rpm_backend, Some(query));
     let resolved = resolver.resolve(
         input,
         BackendKind::Rpm,
-        use_case,
         ResolveOptions {
             package_override: cli_override,
         },

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests.rs
@@ -164,6 +164,55 @@ pub fn capability_manifest(path: Option<&str>, caps: &[&str], optional: bool) ->
     toml
 }
 
+/// Publish a generation-2 component index at `v1/components-v2.toml`.
+///
+/// Entries are identity-only (no backend rows): identity resolution accepts
+/// the names while package resolution keeps flowing through `package_map`
+/// and RPM `Provides` exactly as before the index existed.
+pub fn write_component_index_v2(v1: &Path, components: &[&str]) {
+    let env = anolisa_env::EnvService::detect();
+    let mut index = String::from("schema_version = 2\n");
+    for component in components {
+        index.push_str(&format!(
+            "\n[[components]]\nname = \"{component}\"\ntargets = [{{ os = \"{os}\", arch = \"{arch}\" }}]\n",
+            os = env.os,
+            arch = env.arch,
+        ));
+    }
+    std::fs::create_dir_all(v1).expect("create repo dirs");
+    std::fs::write(v1.join("components-v2.toml"), index).expect("write component index");
+}
+
+/// Component names the shared unit-test contexts accept as supported
+/// identities. Covers the targets exercised across install/adopt/repair
+/// fixtures; tests probing unsupported names use targets outside this set.
+pub const TEST_INDEX_COMPONENTS: &[&str] = &[
+    "agentsight",
+    "cosh",
+    "cosh-ng",
+    "copilot-shell",
+    "tokenless",
+    "sec-core",
+];
+
+/// Seed `<etc>/repo.toml` with a raw backend whose file:// repository
+/// publishes a component index naming `components`, so identity resolution
+/// can validate fresh targets inside the test sandbox.
+pub fn seed_repo_config_with_index(layout: &FsLayout, components: &[&str]) -> String {
+    let v1 = layout.etc_dir.join("test-index-repo").join("v1");
+    write_component_index_v2(&v1, components);
+    let base_url = format!("file://{}", v1.display());
+    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"{base_url}\"\n"
+        ),
+    )
+    .expect("write repo.toml");
+    base_url
+}
+
 pub fn write_empty_repo(root: &Path) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
@@ -175,6 +224,7 @@ publisher = "test"
 "#,
     )
     .expect("write index");
+    write_component_index_v2(&v1, &[]);
     format!("file://{}", v1.display())
 }
 
@@ -192,6 +242,7 @@ pub fn write_local_repo_component_versions(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let env = anolisa_env::EnvService::detect();
     let modes_arr = toml_string_array(modes);
@@ -242,6 +293,7 @@ pub fn write_local_repo_component_with_modes(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let artifact = build_component_artifact(component, version, manifest_modes);
     let artifact_name = format!("{component}.tar.gz");
@@ -324,6 +376,7 @@ sha256 = "{sha}"
         arch = env.arch,
     );
     std::fs::write(root.join("v1/index.toml"), index).expect("write index");
+    write_component_index_v2(&root.join("v1"), &[component]);
     format!("file://{}", root.join("v1").display())
 }
 
@@ -335,6 +388,7 @@ pub fn write_binary_repo_component(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let artifact = format!("#!/bin/sh\necho {component}\n").into_bytes();
     let artifact_name = component.to_string();
@@ -374,6 +428,7 @@ pub fn write_conventional_repo(root: &Path) -> String {
         .join(&env.os)
         .join(&env.arch);
     std::fs::create_dir_all(&artifact_dir).expect("create repo dirs");
+    write_component_index_v2(&root.join("v1"), &["agentsight"]);
 
     let artifact = build_component_artifact("agentsight", "0.2.0", &["system"]);
     let file_name = format!("agentsight-0.2.0-{}-{}.tar.gz", env.os, env.arch);
@@ -451,6 +506,7 @@ pub fn write_local_repo_component_with_capability(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let artifact = build_component_artifact_with_capability(
         component, version, modes, cap_path, caps, optional,
@@ -540,6 +596,7 @@ pub fn write_local_repo_component_with_service(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let artifact =
         build_component_artifact_with_service(component, version, modes, unit, enable, start);
@@ -583,6 +640,7 @@ pub fn write_local_repo_component_with_hook(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let script_rel = format!("hooks/{component}/{}.sh", phase.replace('_', "-"));
     let mut manifest = component_manifest_toml(component, version, &["system"]);
@@ -1046,11 +1104,21 @@ impl PackageQuery for FakeQuery {
                 command: "rpm".to_string(),
             });
         }
+        // Same convention as `provided_capabilities_installed`: unless a
+        // fixture says otherwise, every installed package provides
+        // `anolisa-component(<its own name>)`.
         Ok(self
             .provides
             .iter()
             .find(|(cap, _)| cap == capability)
             .map(|(_, names)| names.clone())
+            .or_else(|| {
+                self.installed
+                    .iter()
+                    .map(|(name, _)| name)
+                    .find(|name| rpm_component_provide(name) == capability)
+                    .map(|name| vec![name.clone()])
+            })
             .unwrap_or_default())
     }
 
@@ -1155,13 +1223,10 @@ pub fn system_ctx_with_raw_repo(dry_run: bool) -> (tempfile::TempDir, CliContext
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().to_path_buf();
     let layout = FsLayout::system(Some(prefix.clone()));
-    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
     std::fs::create_dir_all(&layout.state_dir).expect("state dir");
-    std::fs::write(
-        layout.etc_dir.join("repo.toml"),
-        "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"https://example.com/anolisa\"\n",
-    )
-    .expect("write repo.toml");
+    // The raw backend points at a local index repo so identity resolution
+    // can validate the standard fixture components offline.
+    seed_repo_config_with_index(&layout, TEST_INDEX_COMPONENTS);
     let mut ctx = ctx_with_prefix(false, Some(prefix));
     ctx.dry_run = dry_run;
     (tmp, ctx)
@@ -1171,20 +1236,24 @@ pub fn system_ctx_with_configured_rpm_repo(dry_run: bool) -> (tempfile::TempDir,
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().to_path_buf();
     let layout = FsLayout::system(Some(prefix.clone()));
-    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
     std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    let v1 = layout.etc_dir.join("test-index-repo").join("v1");
+    write_component_index_v2(&v1, TEST_INDEX_COMPONENTS);
     std::fs::write(
         layout.etc_dir.join("repo.toml"),
-        r#"schema_version = 1
+        format!(
+            r#"schema_version = 1
 default_backend = "raw"
 
 [backends.raw]
-base_url = "https://example.com/anolisa"
+base_url = "file://{}"
 
 [backends.rpm]
 base_url = "https://repo.example/anolisa"
 gpgcheck = false
 "#,
+            v1.display()
+        ),
     )
     .expect("write repo.toml");
     let mut ctx = ctx_with_prefix(false, Some(prefix));

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/contract.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/contract.rs
@@ -158,6 +158,7 @@ fn adopt_snapshots_fhs_package_datadir_contract() {
     let prefix = tmp.path().join("sys");
     let ctx = ctx_with_prefix(false, Some(prefix));
     let layout = common::resolve_layout(&ctx);
+    seed_repo_config_with_index(&layout, TEST_INDEX_COMPONENTS);
 
     let contract = component_manifest_toml("copilot-shell", "2.3.0", &["system"]);
     let package_datadir = layout.package_datadir().expect("package datadir");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -142,7 +142,10 @@ fn install_reports_missing_local_repository_index_from_override() {
     let repo_root = tmp.path().join("repo");
     let repo_url = write_local_repo(&repo_root);
     let index_path = repo_root.join("v1/index.toml");
-    std::fs::remove_dir_all(&repo_root).expect("remove repository directory");
+    // Remove only the distribution index: the published component index
+    // stays so identity validation passes and the missing-index diagnostic
+    // below is what surfaces.
+    std::fs::remove_file(&index_path).expect("remove repository index");
 
     let mut a = args("agentsight");
     a.repo = Some(repo_url);
@@ -214,7 +217,10 @@ fn install_reports_config_path_for_missing_local_repository_index() {
     let repo_root = tmp.path().join("repo");
     let repo_url = write_local_repo(&repo_root);
     let index_path = repo_root.join("v1/index.toml");
-    std::fs::remove_dir_all(&repo_root).expect("remove repository directory");
+    // Remove only the distribution index: the published component index
+    // stays so identity validation passes and the config-attributed
+    // missing-index diagnostic below is what surfaces.
+    std::fs::remove_file(&index_path).expect("remove repository index");
 
     std::fs::create_dir_all(&layout.etc_dir).expect("create repo config directory");
     let config_path = layout.etc_dir.join("repo.toml");
@@ -1329,6 +1335,7 @@ fn write_local_repo_with_conflicts(
 ) -> String {
     let v1 = root.join("v1");
     std::fs::create_dir_all(&v1).expect("create repo dirs");
+    write_component_index_v2(&v1, &[component]);
 
     let manifest = component_manifest_toml_with_conflicts(component, version, modes, conflicts);
     let manifest_sha = format!("{:x}", Sha256::digest(manifest.as_bytes()));
@@ -1639,6 +1646,76 @@ fn install_all_dry_run_rejects_conflicts_between_planned_components() {
     assert!(
         cached_names.iter().all(|name| !name.ends_with(".tar.gz")),
         "dry-run must not fetch batch artifacts; cache entries: {cached_names:?}"
+    );
+}
+
+/// `install --all --repo <URL>` enumerates the override repository's
+/// component index — the same authority identity and package resolution
+/// consult — instead of the repo.toml chain, so an override-only component
+/// installs while the default index plays no part (issue #2630 review
+/// follow-up). Runs in user mode like the batch conflict test above, so the
+/// pipeline never consults the host's real rpm tooling.
+#[test]
+fn install_all_with_repo_override_enumerates_the_override_index() {
+    let sandbox = TestSandbox::new();
+    // repo.toml points at a repository whose index lists nothing.
+    let default_repo = write_empty_repo(&sandbox.root().join("default-repo"));
+    let ctx = sandbox.context_with(InstallMode::User, TestContextOptions::default());
+    let layout = common::resolve_layout(&ctx);
+    std::fs::create_dir_all(&layout.etc_dir).expect("create config dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"{default_repo}\"\n"
+        ),
+    )
+    .expect("write repo config");
+    // The override repository publishes agentsight with its meta sidecar. The
+    // batch enumeration only lists entries with a matching backend row, so
+    // the override index declares the raw backend explicitly.
+    let override_root = sandbox.root().join("override");
+    let override_url =
+        write_published_layout_repo_with_meta(&override_root, "agentsight", "0.2.0", &["user"]);
+    let env = anolisa_env::EnvService::detect();
+    std::fs::write(
+        override_root.join("v1/components-v2.toml"),
+        format!(
+            r#"schema_version = 2
+
+[[components]]
+name = "agentsight"
+targets = [{{ os = "{os}", arch = "{arch}" }}]
+
+[[components.backends]]
+kind = "raw"
+package = "agentsight"
+"#,
+            os = env.os,
+            arch = env.arch,
+        ),
+    )
+    .expect("override component index");
+
+    let batch_args = InstallArgs {
+        component: None,
+        all: true,
+        fail_fast: false,
+        version: None,
+        backend: Some("raw".to_string()),
+        repo: Some(override_url),
+        package: None,
+    };
+    handle_all(batch_args, &ctx)
+        .expect("the override-only component must be enumerated and installed");
+
+    assert!(
+        layout.bin_dir.join("agentsight").exists(),
+        "the override-only component must be installed"
+    );
+    let store = load_v5_store(&layout);
+    assert!(
+        store.find(ObjectKind::Component, "agentsight").is_some(),
+        "the override-only component must be recorded"
     );
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/rpm.rs
@@ -76,13 +76,16 @@ fn candidates_provides_multiple_is_ambiguous() {
 }
 
 #[test]
-fn candidates_package_name_uses_package_own_provides() {
+fn candidates_package_name_own_provides_cannot_create_identity() {
+    // A bare package name whose RPM declares `anolisa-component(cosh)` no
+    // longer resolves at the package layer: identity comes from state or the
+    // component index before the candidate chain runs (issue #2630).
     let q = FakeQuery {
         available_package_provides: vec![package_component_provide("copilot-shell", "cosh")],
         ..Default::default()
     };
     let got = rpm_package_candidates(None, None, &q, "copilot-shell").unwrap();
-    assert_eq!(got, vec![target("cosh", "copilot-shell")]);
+    assert!(got.is_empty());
 }
 
 #[test]
@@ -568,6 +571,284 @@ fn pending_journal_blocks_install_before_dnf() {
     }
 }
 
+/// A journal-claimed identity precedes index validation for install: with no
+/// reachable component index at all, an interrupted install still reaches
+/// its recovery guidance instead of failing identity validation
+/// (issue #2630). Covers both journal generations — a modern
+/// subject-attributed journal and a legacy subject-less one whose
+/// `rpm-state` step names the component.
+#[test]
+fn pending_journal_identity_precedes_index_validation_for_install() {
+    for legacy in [true, false] {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+        std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+        // The configured repository publishes no component index.
+        std::fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+                prefix.join("no-such-repo/v1").display()
+            ),
+        )
+        .expect("write repo.toml");
+        let state_path = layout.state_dir.join("installed.toml");
+        if legacy {
+            rpm_install::begin_fresh_install(&layout, "cosh", "copilot-shell", "install cosh")
+                .expect("begin legacy pending install");
+        } else {
+            Transaction::begin_with_subject(
+                "install",
+                Some("cosh"),
+                state_path,
+                &rpm_install::journal_dir(&layout),
+            )
+            .expect("begin subject journal");
+        }
+
+        let err = handle_with_fake_rpm(args("cosh"), &ctx_with_prefix(false, Some(prefix)))
+            .expect_err("the pending journal must block the install");
+        assert!(
+            err.reason().contains("pending recovery") && err.reason().contains("repair cosh"),
+            "the journal recovery guidance must win (legacy: {legacy}): {}",
+            err.reason()
+        );
+        assert!(
+            !err.reason().contains("component index"),
+            "identity validation must not fire before the journal claim (legacy: {legacy}): {}",
+            err.reason()
+        );
+    }
+}
+
+/// With a raw-only repo.toml, `install --backend rpm --repo <URL>` succeeds
+/// end to end: the override repository is the identity, package, and DNF
+/// source authority for the invocation, so the configured-rpm-backend guard
+/// does not apply (issue #2630).
+#[test]
+fn rpm_override_replaces_the_missing_rpm_backend_configuration() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let prefix = tmp.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    // repo.toml configures only the raw backend, whose index lists nothing.
+    let default_v1 = layout.etc_dir.join("default-index").join("v1");
+    write_component_index_v2(&default_v1, &[]);
+    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            default_v1.display()
+        ),
+    )
+    .expect("write repo.toml");
+    // The override repository publishes cosh with its rpm package mapping.
+    let override_v1 = prefix.join("override").join("v1");
+    std::fs::create_dir_all(&override_v1).expect("override repo");
+    let env = anolisa_env::EnvService::detect();
+    std::fs::write(
+        override_v1.join("components-v2.toml"),
+        format!(
+            r#"schema_version = 2
+
+[[components]]
+name = "cosh"
+targets = [{{ os = "{os}", arch = "{arch}" }}]
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+"#,
+            os = env.os,
+            arch = env.arch,
+        ),
+    )
+    .expect("override component index");
+
+    let fake = FakeInstaller::new(
+        "copilot-shell",
+        pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+    );
+    let mut a = args("cosh");
+    a.backend = Some("rpm".to_string());
+    a.repo = Some(format!("file://{}", override_v1.display()));
+    let ctx = ctx_with_prefix(false, Some(prefix));
+
+    let outcome = install_component_with_deps("cosh", &a, &ctx, &fake, &fake, true)
+        .expect("delegated install via the override repository");
+    assert_eq!(outcome, InstallOutcome::Installed);
+    assert_eq!(fake.install_calls.get(), 1, "dnf install must run once");
+
+    let store = load_store(&ctx);
+    let record = store
+        .find(ObjectKind::Component, "cosh")
+        .expect("component recorded");
+    match &record.binding {
+        ProviderBinding::Delegated { package, .. } => {
+            assert_eq!(package.resolved_name(), Some("copilot-shell"));
+        }
+        other => panic!("expected a delegated binding, got {other:?}"),
+    }
+}
+
+/// `install --all --backend rpm --repo <URL>` enumerates the override index
+/// even when repo.toml configures no rpm backend: the backend name only
+/// filters index rows once an override pins the repository.
+#[test]
+fn resolve_all_components_with_override_skips_backend_configuration() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let prefix = tmp.path().to_path_buf();
+    let layout = FsLayout::system(Some(prefix.clone()));
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    let default_v1 = layout.etc_dir.join("default-index").join("v1");
+    write_component_index_v2(&default_v1, &[]);
+    std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+    std::fs::write(
+        layout.etc_dir.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            default_v1.display()
+        ),
+    )
+    .expect("write repo.toml");
+    let override_v1 = prefix.join("override").join("v1");
+    std::fs::create_dir_all(&override_v1).expect("override repo");
+    let env = anolisa_env::EnvService::detect();
+    std::fs::write(
+        override_v1.join("components-v2.toml"),
+        format!(
+            r#"schema_version = 2
+
+[[components]]
+name = "cosh"
+targets = [{{ os = "{os}", arch = "{arch}" }}]
+
+[[components.backends]]
+kind = "rpm"
+package = "copilot-shell"
+"#,
+            os = env.os,
+            arch = env.arch,
+        ),
+    )
+    .expect("override component index");
+    let ctx = ctx_with_prefix(false, Some(prefix));
+
+    let names = crate::commands::tier1::install::resolve_all_components(
+        &ctx,
+        Some("rpm"),
+        Some(&format!("file://{}", override_v1.display())),
+    )
+    .expect("the override enumeration must not require a configured rpm backend");
+    assert_eq!(names, vec!["cosh".to_string()]);
+
+    // A `--repo` override waives only the configured-in-repo.toml
+    // requirement, not name validation: an unknown backend is the same
+    // INVALID_ARGUMENT the single-component path reports, never a
+    // successful empty batch.
+    let err = crate::commands::tier1::install::resolve_all_components(
+        &ctx,
+        Some("pip"),
+        Some(&format!("file://{}", override_v1.display())),
+    )
+    .expect_err("an unknown backend must be refused even with an override");
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason().contains("unknown backend 'pip'"),
+        "must name the unknown backend: {}",
+        err.reason()
+    );
+}
+
+/// Historical state evidence that is not an exact component identity must
+/// not authorize an install once the component index cannot vouch for the
+/// name (issue #2630): a terminal journal left behind by a finished
+/// operation and a dropped legacy capability record both fail identity
+/// validation instead of reaching package resolution. Their names stay
+/// addressable on the mutation paths, which own the recovery and migration
+/// guidance.
+#[test]
+fn historical_state_evidence_does_not_authorize_install_identity() {
+    for fixture in ["terminal-journal", "dropped-capability"] {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
+        std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+        // The configured repository publishes no component index.
+        std::fs::write(
+            layout.etc_dir.join("repo.toml"),
+            format!(
+                "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+                prefix.join("no-such-repo/v1").display()
+            ),
+        )
+        .expect("write repo.toml");
+        let state_path = layout.state_dir.join("installed.toml");
+        match fixture {
+            "terminal-journal" => {
+                let mut journal = Transaction::begin_with_subject(
+                    "install",
+                    Some("ghost"),
+                    state_path,
+                    &rpm_install::journal_dir(&layout),
+                )
+                .expect("begin subject journal");
+                journal
+                    .finish(TransactionOutcomeStatus::Failed)
+                    .expect("finish journal");
+            }
+            _ => {
+                // A legacy `kind = "capability"` row is dropped by the state
+                // migration on load; the dropped name must not pin the
+                // install identity.
+                let mut state = InstalledState {
+                    install_mode: StateInstallMode::System,
+                    prefix: layout.prefix.clone(),
+                    ..Default::default()
+                };
+                state.upsert_object(InstalledObject {
+                    kind: ObjectKind::Capability,
+                    name: "ghost".to_string(),
+                    version: "0.1.0".to_string(),
+                    status: ObjectStatus::Installed,
+                    manifest_digest: None,
+                    distribution_source: None,
+                    raw_package: None,
+                    install_backend: None,
+                    ownership: None,
+                    rpm_metadata: None,
+                    installed_at: "2026-06-01T10:00:00Z".to_string(),
+                    last_operation_id: None,
+                    managed: true,
+                    adopted: false,
+                    subscription_scope: Default::default(),
+                    enabled_features: Vec::new(),
+                    component_refs: Vec::new(),
+                    files: Vec::new(),
+                    external_modified_files: Vec::new(),
+                    services: Vec::new(),
+                    health: Vec::new(),
+                    provisioned_packages: Vec::new(),
+                });
+                state.save(&state_path).expect("seed legacy state");
+            }
+        }
+
+        let err = handle_with_fake_rpm(args("ghost"), &ctx_with_prefix(false, Some(prefix)))
+            .expect_err("historical evidence must not authorize the identity");
+        assert_eq!(err.code(), "EXECUTION_FAILED", "fixture: {fixture}");
+        assert!(
+            err.reason().contains("component index is unavailable"),
+            "identity validation must reject the name (fixture: {fixture}): {}",
+            err.reason()
+        );
+    }
+}
+
 #[test]
 fn pending_journal_injected_after_install_preflight_blocks_locked_execution() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
@@ -868,7 +1149,7 @@ fn explicit_rpm_with_ambiguous_candidates_is_invalid_argument() {
 }
 
 #[test]
-fn explicit_rpm_not_an_anolisa_component_is_invalid_argument() {
+fn explicit_rpm_unsupported_component_is_invalid_argument() {
     let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
     let q = FakeQuery::default();
     let mut a = args("random-package");
@@ -877,7 +1158,8 @@ fn explicit_rpm_not_an_anolisa_component_is_invalid_argument() {
         .expect_err("no component identity → refuse");
     assert_eq!(err.code(), "INVALID_ARGUMENT");
     assert!(
-        err.reason().contains("not an ANOLISA RPM component"),
+        err.reason()
+            .contains("unsupported component 'random-package'"),
         "got: {}",
         err.reason()
     );
@@ -1003,6 +1285,8 @@ fn system_ctx_with_rpm_package_map(pairs: &[(&str, &str)]) -> (tempfile::TempDir
     let layout = FsLayout::system(Some(prefix.clone()));
     std::fs::create_dir_all(&layout.etc_dir).expect("etc dir");
     std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    let v1 = layout.etc_dir.join("test-index-repo").join("v1");
+    write_component_index_v2(&v1, TEST_INDEX_COMPONENTS);
     let map = pairs
         .iter()
         .map(|(component, package)| format!("{component} = \"{package}\""))
@@ -1015,7 +1299,7 @@ fn system_ctx_with_rpm_package_map(pairs: &[(&str, &str)]) -> (tempfile::TempDir
 default_backend = "raw"
 
 [backends.raw]
-base_url = "https://example.com/anolisa"
+base_url = "file://{}"
 
 [backends.rpm]
 base_url = "https://repo.example/anolisa"
@@ -1023,7 +1307,8 @@ gpgcheck = false
 
 [backends.rpm.package_map]
 {map}
-"#
+"#,
+            v1.display()
         ),
     )
     .expect("write repo.toml");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/logs.rs
@@ -58,14 +58,14 @@ pub struct LogsArgs {
 }
 
 pub fn handle(mut args: LogsArgs, ctx: &CliContext) -> Result<(), CliError> {
-    // Resolve component alias (e.g., "copilot-shell" → "cosh") before
+    // Resolve the component identity (e.g., "copilot-shell" → "cosh") before
     // filtering — log records store the canonical component name.
     if let Some(component) = args.component.take() {
         let installed = common::load_state_store(ctx, COMMAND)
             .unwrap_or_else(|_| anolisa_core::state_store::StateStore::empty());
         args.component = Some(common::lookup_component_name_in_store(
             &component, &installed, ctx, COMMAND,
-        ));
+        )?);
     }
     let filter = build_filter(&args)?;
     let layout = common::resolve_layout(ctx);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -61,7 +61,7 @@ use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install::{self, PendingRpmInstall};
 use crate::commands::tier1::update::rpm_repo_source_for_update;
 use crate::context::CliContext;
-use crate::resolution::{ResolutionUse, load_optional_component_index};
+use crate::resolution::load_optional_component_index;
 use crate::response::{CliError, render_json};
 
 /// Command label for JSON envelopes and error routing.
@@ -1981,7 +1981,6 @@ fn resolve_repair_package(
         component_index.as_ref(),
         query,
         component,
-        ResolutionUse::RepairLegacy,
     ) {
         Ok(candidates) => candidates,
         Err(PackageQueryError::CommandMissing { command: bin }) => {
@@ -2512,6 +2511,14 @@ mod tests {
     }
 
     fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        // Identity resolution consults the component index for names absent
+        // from state; a seeded local index keeps fixture names supported.
+        if install_mode == InstallMode::System {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             &prefix,
             install_mode,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -556,6 +556,16 @@ mod tests {
         let root = prefix
             .as_deref()
             .unwrap_or_else(|| std::path::Path::new("/tmp/anolisa-restart-validation"));
+        // Identity resolution consults the component index for names absent
+        // from state; a seeded local index keeps fixture names supported.
+        if install_mode == InstallMode::System
+            && let Some(prefix) = prefix.as_ref()
+        {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             root,
             install_mode,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/rpm_install.rs
@@ -118,6 +118,51 @@ fn has_legacy_state_marker(step: &TransactionStep) -> bool {
     step.phase == STATE_PHASE || step.action == STATE_ACTION
 }
 
+/// Whether one journal claims `component` as its recorded state identity:
+/// an explicit subject attribution or a legacy `rpm-state` step.
+fn journal_claims(entry: &anolisa_core::facts::JournalEntry, component: &str) -> bool {
+    entry.transaction().subject.as_deref() == Some(component)
+        || entry
+            .transaction()
+            .steps
+            .iter()
+            .any(|step| has_legacy_state_marker(step) && step.target == component)
+}
+
+/// Whether any journal on disk claims `component` as its recorded state
+/// identity.
+///
+/// Mutation identity resolution treats such a claim as exact local state, so
+/// an interrupted (or still-uncleared) operation stays addressable under its
+/// recorded name even when the component index cannot validate it
+/// (issue #2630). Deliberately not gated on the pending flag — a terminal
+/// journal that repair has yet to clear still names the component.
+pub(crate) fn journal_claims_component(
+    inventory: &anolisa_core::facts::JournalInventory,
+    component: &str,
+) -> bool {
+    inventory
+        .entries()
+        .iter()
+        .any(|entry| journal_claims(entry, component))
+}
+
+/// [`journal_claims_component`] restricted to effectively-pending journals.
+///
+/// Install uses this narrower claim: only a pending operation needs to reach
+/// its recovery guidance, while a terminal journal left behind by a finished
+/// operation must not keep authorizing an identity the component index no
+/// longer recognizes.
+pub(crate) fn pending_journal_claims_component(
+    inventory: &anolisa_core::facts::JournalInventory,
+    component: &str,
+) -> bool {
+    inventory
+        .entries()
+        .iter()
+        .any(|entry| entry.is_effectively_pending() && journal_claims(entry, component))
+}
+
 /// Find one live RPM claim matching a component or package alias.
 ///
 /// `operations` is the operation history the claims are checked against; the

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -48,7 +48,7 @@ use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::BackendConfig;
 use crate::resolution::{
-    ComponentIndex, ResolutionUse, load_optional_component_index, lookup_component_alias,
+    ComponentIndex, IndexIdentity, load_optional_component_index, resolve_index_identity,
 };
 use crate::response::{CliError, render_json};
 
@@ -271,40 +271,34 @@ fn resolve_component_target(
         return Ok(input.to_string());
     }
 
-    if let Some(index) = component_index {
-        if index.components.iter().any(|entry| entry.name == input) {
-            return Ok(input.to_string());
+    // Exhaustive on the verdict so a future `IndexIdentity` variant is a
+    // compile error here instead of silently collapsing into one refusal.
+    match resolve_index_identity(input, component_index) {
+        IndexIdentity::Resolved(component) => Ok(component),
+        IndexIdentity::Unsupported => {
+            reject_telemetry_service_target(input)?;
+            Err(common::unsupported_component_error(COMMAND, input))
         }
-        if let Some(component) = lookup_component_alias(input, Some(index)) {
-            return Ok(component);
+        IndexIdentity::Unavailable => {
+            reject_telemetry_service_target(input)?;
+            Err(common::component_index_unavailable_error(COMMAND, input))
         }
     }
+}
 
-    let management_command = status_command_for_service_target(input);
-    if let Some(command) = management_command {
-        return Err(CliError::InvalidArgument {
+/// A telemetry service name is a management target, not a component; the
+/// redirect outranks both generic refusals so the guidance stays useful
+/// whether or not an index could be loaded.
+fn reject_telemetry_service_target(input: &str) -> Result<(), CliError> {
+    match status_command_for_service_target(input) {
+        Some(command) => Err(CliError::InvalidArgument {
             command: COMMAND.to_string(),
             reason: format!(
                 "unsupported component '{input}'; run `{command}` to inspect telemetry state"
             ),
-        });
+        }),
+        None => Ok(()),
     }
-
-    if component_index.is_some() {
-        return Err(CliError::InvalidArgument {
-            command: COMMAND.to_string(),
-            reason: format!(
-                "unsupported component '{input}'; run `anolisa list` to view supported components"
-            ),
-        });
-    }
-
-    Err(CliError::Runtime {
-        command: COMMAND.to_string(),
-        reason: format!(
-            "component index is unavailable; cannot validate component '{input}'; run `anolisa list` to inspect repository metadata"
-        ),
-    })
 }
 
 /// Project the quarantined records of every visible root, optionally
@@ -568,15 +562,9 @@ fn observed_record(
 ) -> Option<ComponentRecord> {
     // Same resolver as adopt (§5), minus the CLI `--package` override (status
     // takes no such flag).
-    let candidates = rpm_package_candidates_with_index(
-        None,
-        rpm_backend,
-        component_index,
-        query,
-        component,
-        ResolutionUse::StatusObserved,
-    )
-    .ok()?;
+    let candidates =
+        rpm_package_candidates_with_index(None, rpm_backend, component_index, query, component)
+            .ok()?;
     for target in candidates {
         let Ok(Some(info)) = query.query_installed(&target.package) else {
             // Not this candidate (absent), or a hard error / multi-version
@@ -1202,7 +1190,6 @@ mod tests {
     use super::*;
     use crate::commands::state_view::{ScopedStateRoot, StateScope, StateView};
     use crate::repo_config::RepoConfig;
-    use crate::resolution::resolve_rpm_component_name;
     use anolisa_core::{
         FileOwner, HealthEntry, InstalledObject, InstalledState, NotSupportedServiceManager,
         ObjectKind, ObjectStatus, OwnedFile, OwnedFileKind, SubscriptionScope,
@@ -3003,15 +2990,19 @@ name = "copilot-shell"
                 .find(|(n, _)| n == package)
                 .map(|(_, r)| r.clone()))
         }
-        fn provided_capabilities_installed(
+        fn what_provides_installed(
             &self,
-            package: &str,
+            capability: &str,
         ) -> Result<Vec<String>, PackageQueryError> {
-            if self.installed.iter().any(|(n, _)| n == package) {
-                Ok(vec![format!("anolisa-component({package})")])
-            } else {
-                Ok(Vec::new())
-            }
+            // Fake convention: every installed package provides
+            // `anolisa-component(<its own name>)`.
+            Ok(capability
+                .strip_prefix("anolisa-component(")
+                .and_then(|rest| rest.strip_suffix(')'))
+                .into_iter()
+                .filter(|name| self.installed.iter().any(|(n, _)| n == name))
+                .map(str::to_string)
+                .collect())
         }
     }
 
@@ -3050,19 +3041,6 @@ name = "copilot-shell"
             "components.toml",
         )
         .expect("component index");
-        let q = FakeQuery::default();
-
-        assert_eq!(
-            resolve_rpm_component_name(
-                "copilot-shell",
-                None,
-                Some(&idx),
-                &q,
-                ResolutionUse::StatusObserved,
-            )
-            .unwrap_or_else(|| "copilot-shell".to_string()),
-            "cosh"
-        );
 
         let mut state = InstalledState::default();
         state.upsert_object(component_object(
@@ -3070,14 +3048,11 @@ name = "copilot-shell"
             "2.6.0-1.alnx4",
             ObjectStatus::Installed,
         ));
-        let resolved = resolve_rpm_component_name(
-            "copilot-shell",
-            None,
-            Some(&idx),
-            &q,
-            ResolutionUse::StatusObserved,
-        )
-        .unwrap_or_else(|| "copilot-shell".to_string());
+        let resolved = match resolve_index_identity("copilot-shell", Some(&idx)) {
+            IndexIdentity::Resolved(component) => component,
+            other => panic!("expected the alias to resolve, got {other:?}"),
+        };
+        assert_eq!(resolved, "cosh");
         let records = select_components(
             &store_with(&state),
             &dummy_layout(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -1443,6 +1443,14 @@ mod tests {
         let root = prefix
             .as_deref()
             .expect("stateful uninstall tests require an isolated prefix");
+        // Identity resolution consults the component index for names absent
+        // from state; a seeded local index keeps fixture names supported.
+        if install_mode == InstallMode::System {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(root.to_path_buf())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             root,
             install_mode,

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -2628,6 +2628,14 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn ctx(prefix: PathBuf, install_mode: InstallMode, dry_run: bool) -> CliContext {
+        // Identity resolution consults the component index for names absent
+        // from state; a seeded local index keeps fixture names supported.
+        if install_mode == InstallMode::System {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
         crate::test_support::context_for_root(
             &prefix,
             install_mode,
@@ -3200,7 +3208,14 @@ pub(crate) mod tests {
     #[test]
     fn bare_update_errors_before_repo_config_provisioning() {
         let tmp = tempfile::tempdir().expect("tmpdir");
-        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        // Deliberately not the shared ctx helper: this test asserts that the
+        // invalid invocation writes no repo.toml, so nothing may pre-seed one.
+        let c = crate::test_support::context_for_root(
+            tmp.path(),
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+            Default::default(),
+        );
         let repo_toml = common::resolve_layout(&c).etc_dir.join("repo.toml");
 
         let err = handle(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -58,8 +58,8 @@ use crate::context::CliContext;
 use crate::progress;
 use crate::repo_config::{BackendConfig, RepoConfig};
 use crate::resolution::{
-    BackendKind, ComponentIndex, ComponentResolver, ResolutionSet, ResolutionUse, ResolveOptions,
-    rpm_component_provide,
+    BackendKind, ComponentIndex, ComponentResolver, IndexIdentity, ResolutionSet, ResolveOptions,
+    resolve_index_identity, rpm_component_provide,
 };
 use crate::response::CliError;
 
@@ -407,20 +407,65 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
     }
 
     // Profile defaults absent from ANOLISA state are surfaced as a gap (issue
-    // #1411 performs the install). Absence from `installed.toml` is not the same
-    // as absence from the host, though, so each candidate is cross-checked
-    // against rpmdb first — a default already installed as an RPM (but never
-    // adopted) is evaluated for upgrades instead of falsely reported as missing.
+    // #1411 performs the install). The default's canonical identity comes
+    // first (issue #2630): a name absent from state is a new identity that
+    // only the component index may authorize, and comparing against state and
+    // the other defaults under the canonical name keeps an alias default from
+    // duplicating an already-tracked component as absent. Absence from
+    // `installed.toml` is still not the same as absence from the host, so each
+    // remaining candidate is cross-checked against rpmdb — a default already
+    // installed as an RPM (but never adopted) is evaluated for upgrades
+    // instead of falsely reported as missing.
     if let Some(profile) = &inputs.target {
+        let mut seen_defaults = std::collections::BTreeSet::new();
         for name in &profile.default_components {
+            // An exact state identity precedes index normalization
+            // (issue #2630): a record tracked under the literal default name
+            // was already checked by the installed loop above, and must not
+            // be re-normalized into a second identity — or, with no index,
+            // into a spurious validation error.
             if inputs.installed.find(ObjectKind::Component, name).is_some() {
+                seen_defaults.insert(name.clone());
+                continue;
+            }
+            let canonical = match resolve_index_identity(name, inputs.component_index) {
+                IndexIdentity::Resolved(component) => component,
+                IndexIdentity::Unsupported => {
+                    components.push(default_component_error(
+                        name,
+                        None,
+                        format!(
+                            "unsupported component '{name}' in target-profile defaults; the component index has no entry for it"
+                        ),
+                        &mut summary,
+                    ));
+                    continue;
+                }
+                IndexIdentity::Unavailable => {
+                    components.push(default_component_error(
+                        name,
+                        None,
+                        format!(
+                            "component index is unavailable; cannot validate target-profile default '{name}'"
+                        ),
+                        &mut summary,
+                    ));
+                    continue;
+                }
+            };
+            if !seen_defaults.insert(canonical.clone())
+                || inputs
+                    .installed
+                    .find(ObjectKind::Component, &canonical)
+                    .is_some()
+            {
                 continue;
             }
             components.push(check_default_component(
                 inputs.query,
                 inputs.component_index,
                 inputs.rpm_backend,
-                name,
+                &canonical,
                 inputs.arch,
                 &mut summary,
             ));
@@ -694,16 +739,42 @@ fn check_component(
     }
 }
 
+/// Item error for a target-profile default, counted into the summary.
+fn default_component_error(
+    name: &str,
+    package: Option<String>,
+    reason: String,
+    summary: &mut CheckSummary,
+) -> ComponentCheck {
+    summary.errors += 1;
+    ComponentCheck {
+        component: name.to_string(),
+        package,
+        ownership: None,
+        installed: None,
+        available: None,
+        action: ACTION_ERROR.to_string(),
+        error: Some(reason),
+        absent_from_state: true,
+        backfill_rpm_metadata: false,
+    }
+}
+
 /// Evaluate a profile default that is absent from ANOLISA state.
 ///
-/// A default missing from `installed.toml` may still be installed on the host —
-/// e.g. baked into a system image and never adopted, which is common for
-/// `legacy_adopt` packages predating the `anolisa-component(...)` provide.
-/// Reporting such a default as `install` would be a false positive on the
-/// default-profile MOTD, so rpmdb is consulted first (via the component provide
-/// and its index-mapped package name). A present-but-unadopted default is
-/// checked for upgrades like an rpm-observed component; only a default genuinely
-/// absent from rpmdb too is reported installable.
+/// `name` is the default's canonical identity — the caller validated it
+/// against the component index and deduplicated it against state before
+/// this evaluation runs (issue #2630).
+///
+/// A supported default missing from `installed.toml` may still be installed
+/// on the host — e.g. baked into a system image and never adopted, which is
+/// common for `legacy_adopt` packages predating the `anolisa-component(...)`
+/// provide. Reporting such a default as `install` would be a false positive
+/// on the default-profile MOTD, so rpmdb is consulted first (via the
+/// component provide and its index-mapped package name). A
+/// present-but-unadopted default is checked for upgrades like an rpm-observed
+/// component; only a default genuinely absent from rpmdb too is reported
+/// installable.
 fn check_default_component(
     query: &dyn PackageQuery,
     index: Option<&ComponentIndex>,
@@ -726,18 +797,7 @@ fn check_default_component(
             let package = match resolve_default_install_package(query, index, rpm_backend, name) {
                 Ok(package) => package,
                 Err(reason) => {
-                    summary.errors += 1;
-                    return ComponentCheck {
-                        component: name.to_string(),
-                        package: None,
-                        ownership: None,
-                        installed: None,
-                        available: None,
-                        action: ACTION_ERROR.to_string(),
-                        error: Some(reason),
-                        absent_from_state: true,
-                        backfill_rpm_metadata: false,
-                    };
+                    return default_component_error(name, None, reason, summary);
                 }
             };
             match query.query_installed(&package) {
@@ -746,20 +806,10 @@ fn check_default_component(
                 }
                 Ok(None) => {}
                 Err(err) => {
-                    summary.errors += 1;
-                    return ComponentCheck {
-                        component: name.to_string(),
-                        package: Some(package),
-                        ownership: None,
-                        installed: None,
-                        available: None,
-                        action: ACTION_ERROR.to_string(),
-                        error: Some(format!(
-                            "cannot query installed version of resolved package for default component '{name}': {err}"
-                        )),
-                        absent_from_state: true,
-                        backfill_rpm_metadata: false,
-                    };
+                    let reason = format!(
+                        "cannot query installed version of resolved package for default component '{name}': {err}"
+                    );
+                    return default_component_error(name, Some(package), reason, summary);
                 }
             }
             summary.missing_defaults += 1;
@@ -779,20 +829,7 @@ fn check_default_component(
         // This is an item error, not a missing default — reporting "install"
         // here would be the false positive the rpmdb cross-check exists to
         // avoid.
-        DefaultProbe::Indeterminate(reason) => {
-            summary.errors += 1;
-            ComponentCheck {
-                component: name.to_string(),
-                package: None,
-                ownership: None,
-                installed: None,
-                available: None,
-                action: ACTION_ERROR.to_string(),
-                error: Some(reason),
-                absent_from_state: true,
-                backfill_rpm_metadata: false,
-            }
-        }
+        DefaultProbe::Indeterminate(reason) => default_component_error(name, None, reason, summary),
     }
 }
 
@@ -808,12 +845,7 @@ fn resolve_default_install_package(
     name: &str,
 ) -> Result<String, String> {
     let resolver = ComponentResolver::new(index, rpm_backend, Some(query));
-    match resolver.resolve(
-        name,
-        BackendKind::Rpm,
-        ResolutionUse::Install,
-        ResolveOptions::default(),
-    ) {
+    match resolver.resolve(name, BackendKind::Rpm, ResolveOptions::default()) {
         Ok(ResolutionSet::Unique(target)) => Ok(target.package),
         Ok(ResolutionSet::None) => Err(format!(
             "cannot resolve RPM package for default component '{name}': no package mapping or provider found"
@@ -841,12 +873,7 @@ fn resolve_legacy_component_package(
     name: &str,
 ) -> Result<String, String> {
     let resolver = ComponentResolver::new(index, rpm_backend, Some(query));
-    match resolver.resolve(
-        name,
-        BackendKind::Rpm,
-        ResolutionUse::RepairLegacy,
-        ResolveOptions::default(),
-    ) {
+    match resolver.resolve(name, BackendKind::Rpm, ResolveOptions::default()) {
         Ok(ResolutionSet::Unique(target)) => Ok(target.package),
         Ok(ResolutionSet::None) => Err(format!(
             "component '{name}' is recorded as RPM-backed without package metadata, and no RPM package could be resolved; run `anolisa repair {name}`"

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -262,6 +262,20 @@ fn run_with_index_and_backend(
     })
 }
 
+/// Identity-only component index naming `components`, so profile defaults
+/// pass identity validation while package resolution still flows through
+/// `package_map` and RPM `Provides`.
+fn identity_index(components: &[&str]) -> crate::resolution::ComponentIndex {
+    let mut toml = String::from("schema_version = 2\n");
+    for component in components {
+        toml.push_str(&format!(
+            "\n[[components]]\nname = \"{component}\"\ntargets = [{{ os = \"linux\", arch = \"x86_64\" }}]\n"
+        ));
+    }
+    crate::resolution::ComponentIndex::from_toml_str(&toml, "test-components.toml")
+        .expect("identity index parses")
+}
+
 fn system_ctx() -> CliContext {
     crate::test_support::context_for_root(
         std::path::Path::new("/tmp/anolisa-update-check-validation"),
@@ -466,7 +480,14 @@ fn update_check_missing_default_reports_install() {
         default_components: vec!["cosh".to_string(), "sec-core".to_string()],
     };
 
-    let report = run(&host, &state, Some(profile), Some("image-v1.0".to_string()));
+    let index = identity_index(&["cosh", "sec-core"]);
+    let report = run_with_index(
+        &host,
+        &state,
+        Some(profile),
+        Some("image-v1.0".to_string()),
+        Some(&index),
+    );
     assert_eq!(report.target.as_deref(), Some("image-v1.0"));
     assert_eq!(report.summary.missing_defaults, 2);
     assert!(
@@ -518,11 +539,13 @@ fn update_check_default_present_via_provide_is_not_missing() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
     let item = report
         .components
@@ -559,11 +582,13 @@ fn update_check_default_present_via_provide_reports_upgrade() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_UPDATE);
@@ -618,12 +643,13 @@ fn update_check_default_present_via_package_map_without_provide() {
         default_components: vec!["cosh".to_string()],
     };
 
+    let index = identity_index(&["cosh"]);
     let report = run_with_index_and_backend(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
-        None,
+        Some(&index),
         Some(&backend),
     );
 
@@ -644,11 +670,13 @@ fn update_check_unresolved_missing_default_is_item_error() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_ERROR);
@@ -671,12 +699,13 @@ fn update_check_missing_default_resolves_package_from_package_map() {
     };
     let backend = rpm_backend_with_package_map("cosh", "copilot-shell");
 
+    let index = identity_index(&["cosh"]);
     let report = run_with_index_and_backend(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
-        None,
+        Some(&index),
         Some(&backend),
     );
 
@@ -698,17 +727,282 @@ fn update_check_missing_default_resolves_package_from_available_provide() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
 
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_INSTALL);
     assert_eq!(item.package.as_deref(), Some("copilot-shell"));
     assert_eq!(report.summary.missing_defaults, 1);
+}
+
+/// A profile default the index does not know is rejected even when a
+/// site-local `package_map` entry could name a package for it: package
+/// selection must not create a component identity (issue #2630).
+#[test]
+fn update_check_default_absent_from_index_is_unsupported_despite_package_map() {
+    let host = FakeHost::with_cli_noop();
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["site-only".to_string()],
+    };
+    let backend = rpm_backend_with_package_map("site-only", "site-package");
+
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index_and_backend(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
+        Some(&backend),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_ERROR);
+    assert!(
+        item.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unsupported component 'site-only'"),
+        "package_map must not authorize the identity: {:?}",
+        item.error
+    );
+    assert_eq!(report.summary.missing_defaults, 0);
+    assert_eq!(report.summary.errors, 1);
+}
+
+/// A profile default the index does not know is rejected even when an RPM
+/// repository provider declares `anolisa-component(...)` for it: Provides
+/// resolves packages, never identities (issue #2630).
+#[test]
+fn update_check_default_absent_from_index_is_unsupported_despite_provides() {
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(site-only)".to_string(),
+        vec!["site-package".to_string()],
+    );
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["site-only".to_string()],
+    };
+
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_ERROR);
+    assert!(
+        item.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("unsupported component 'site-only'"),
+        "an RPM provider must not authorize the identity: {:?}",
+        item.error
+    );
+    assert_eq!(report.summary.missing_defaults, 0);
+    assert_eq!(report.summary.errors, 1);
+}
+
+/// Without any component index a profile default absent from state cannot be
+/// validated at all — even a `package_map` entry plus a matching provider
+/// yields the explicit index-unavailable item error, never an install item.
+#[test]
+fn update_check_default_without_index_is_unvalidated() {
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(cosh)".to_string(),
+        vec!["copilot-shell".to_string()],
+    );
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["cosh".to_string()],
+    };
+    let backend = rpm_backend_with_package_map("cosh", "copilot-shell");
+
+    let report = run_with_index_and_backend(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        None,
+        Some(&backend),
+    );
+
+    let item = &report.components[0];
+    assert_eq!(item.action, ACTION_ERROR);
+    assert!(
+        item.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("component index is unavailable"),
+        "an unvalidatable default must name the missing index: {:?}",
+        item.error
+    );
+    assert_eq!(report.summary.missing_defaults, 0);
+    assert_eq!(report.summary.errors, 1);
+}
+
+/// Index naming `cosh` with `copilot-shell` declared as its rpm-package
+/// alias, for the alias-default tests below.
+fn alias_index() -> crate::resolution::ComponentIndex {
+    crate::resolution::ComponentIndex::from_toml_str(
+        "schema_version = 2\n\n[[components]]\nname = \"cosh\"\ntargets = [{ os = \"linux\", arch = \"x86_64\" }]\n\n[[components.aliases]]\nkind = \"rpm-package\"\nname = \"copilot-shell\"\n",
+        "test-components.toml",
+    )
+    .expect("alias index parses")
+}
+
+/// An alias profile default whose canonical component is already tracked in
+/// state must not be re-reported as absent (issue #2630): identity
+/// resolution and the state comparison both run on the canonical name, for
+/// RPM-backed and raw-backed records alike.
+#[test]
+fn update_check_alias_default_with_installed_canonical_is_not_reported() {
+    for object in [
+        rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        ),
+        raw_component("cosh", "1.0.0"),
+    ] {
+        let mut host = FakeHost::with_cli_noop();
+        host.installed.insert(
+            "copilot-shell".to_string(),
+            info("copilot-shell", "1.0.0", Some("1.al4")),
+        );
+        let state = state_with(vec![object]);
+        let profile = TargetProfile {
+            default_components: vec!["copilot-shell".to_string()],
+        };
+
+        let index = alias_index();
+        let report = run_with_index(
+            &host,
+            &state,
+            Some(profile),
+            Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+            Some(&index),
+        );
+
+        assert_eq!(report.summary.missing_defaults, 0);
+        assert!(
+            report.components.iter().all(|c| !c.absent_from_state),
+            "the alias default must dedupe against the tracked canonical record: {:?}",
+            report
+                .components
+                .iter()
+                .map(|c| (&c.component, &c.action, c.absent_from_state))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            report
+                .components
+                .iter()
+                .filter(|c| c.component == "cosh")
+                .count(),
+            1,
+            "the tracked component is reported exactly once"
+        );
+    }
+}
+
+/// Defaults spelling the same component canonically and via an alias
+/// evaluate once, under the canonical name.
+#[test]
+fn update_check_duplicate_alias_defaults_evaluate_once_as_canonical() {
+    let mut host = FakeHost::with_cli_noop();
+    host.available_providers.insert(
+        "anolisa-component(cosh)".to_string(),
+        vec!["copilot-shell".to_string()],
+    );
+    let state = state_with(vec![]);
+    let profile = TargetProfile {
+        default_components: vec!["copilot-shell".to_string(), "cosh".to_string()],
+    };
+
+    let index = alias_index();
+    let report = run_with_index(
+        &host,
+        &state,
+        Some(profile),
+        Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
+    );
+
+    assert_eq!(report.summary.missing_defaults, 1);
+    assert_eq!(
+        report.components.len(),
+        1,
+        "one evaluation for one identity"
+    );
+    let item = &report.components[0];
+    assert_eq!(item.component, "cosh", "reported under the canonical name");
+    assert_eq!(item.action, ACTION_INSTALL);
+}
+
+/// A default already tracked in state under its exact (legacy) name is not
+/// re-normalized into a second identity: the installed loop above owns that
+/// record, so the default neither duplicates it under the canonical name nor
+/// — with no index at all — produces a spurious validation error.
+#[test]
+fn update_check_exact_legacy_default_is_not_renormalized() {
+    let index = alias_index();
+    for index in [Some(&index), None] {
+        let host = FakeHost::with_cli_noop();
+        // "copilot-shell" is the record's exact name and, in the index, an
+        // alias of "cosh".
+        let state = state_with(vec![raw_component("copilot-shell", "1.0.0")]);
+        let profile = TargetProfile {
+            default_components: vec!["copilot-shell".to_string()],
+        };
+
+        let report = run_with_index(
+            &host,
+            &state,
+            Some(profile),
+            Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+            index,
+        );
+
+        assert_eq!(report.summary.missing_defaults, 0);
+        assert_eq!(
+            report.summary.errors,
+            0,
+            "the exact record must preempt index validation: {:?}",
+            report
+                .components
+                .iter()
+                .map(|c| (&c.component, &c.action, &c.error))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            report
+                .components
+                .iter()
+                .all(|c| !c.absent_from_state && c.component != "cosh"),
+            "no second identity may appear: {:?}",
+            report
+                .components
+                .iter()
+                .map(|c| (&c.component, &c.action, c.absent_from_state))
+                .collect::<Vec<_>>()
+        );
+    }
 }
 
 #[test]
@@ -723,11 +1017,13 @@ fn update_check_ambiguous_missing_default_is_item_error() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
 
     let item = &report.components[0];
@@ -749,15 +1045,24 @@ fn update_check_default_provide_query_error_is_item_error() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_ERROR);
-    assert!(item.error.is_some());
+    assert!(
+        item.error
+            .as_deref()
+            .unwrap_or("")
+            .contains("cannot determine"),
+        "the probe failure must be the reported error: {:?}",
+        item.error
+    );
     assert_eq!(
         report.summary.missing_defaults, 0,
         "an indeterminate probe must not count as a missing default"
@@ -779,11 +1084,13 @@ fn update_check_default_multiple_providers_is_item_error() {
         default_components: vec!["cosh".to_string()],
     };
 
-    let report = run(
+    let index = identity_index(&["cosh"]);
+    let report = run_with_index(
         &host,
         &state,
         Some(profile),
         Some(DEFAULT_TARGET_PROFILE_NAME.to_string()),
+        Some(&index),
     );
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_ERROR);

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -430,6 +430,21 @@ impl RepoConfig {
         }
     }
 
+    /// Canonical spelling of `name` when it is a known backend, otherwise the
+    /// same unknown-backend error [`Self::select_backend`] reports. Name
+    /// validation only — whether the backend is configured in repo.toml is a
+    /// separate question some callers (a `--repo` override) do not ask.
+    pub(crate) fn known_backend_name(name: &str) -> Result<&'static str, RepoConfigError> {
+        let canonical = Self::canonical_backend_name(name);
+        KNOWN_BACKENDS
+            .iter()
+            .find(|known| **known == canonical)
+            .copied()
+            .ok_or_else(|| RepoConfigError::UnknownBackend {
+                name: canonical.to_string(),
+            })
+    }
+
     pub(crate) fn backend_name_deprecation_warning(name: &str) -> Option<&'static str> {
         (name == LEGACY_RPM_BACKEND).then_some(LEGACY_RPM_BACKEND_NAME_WARNING)
     }
@@ -505,12 +520,7 @@ impl RepoConfig {
         &self,
         cli_override: Option<&str>,
     ) -> Result<(&str, &BackendConfig), RepoConfigError> {
-        let name = Self::canonical_backend_name(cli_override.unwrap_or(&self.default_backend));
-        if !KNOWN_BACKENDS.contains(&name) {
-            return Err(RepoConfigError::UnknownBackend {
-                name: name.to_string(),
-            });
-        }
+        let name = Self::known_backend_name(cli_override.unwrap_or(&self.default_backend))?;
         match self.backends.get_key_value(name) {
             Some((key, cfg)) => Ok((key.as_str(), cfg)),
             None => Err(RepoConfigError::BackendNotConfigured {
@@ -1247,6 +1257,15 @@ base_url = "https://example.com/$typo_var/repo"
             RepoConfigError::BackendNotConfigured { name } if name == "npm"
         ));
         let err = cfg.select_backend(Some("pip")).expect_err("pip unknown");
+        assert!(matches!(err, RepoConfigError::UnknownBackend { name } if name == "pip"));
+    }
+
+    #[test]
+    fn known_backend_name_validates_without_requiring_configuration() {
+        assert_eq!(RepoConfig::known_backend_name("raw").expect("raw"), "raw");
+        assert_eq!(RepoConfig::known_backend_name("yum").expect("yum"), "rpm");
+        assert_eq!(RepoConfig::known_backend_name("npm").expect("npm"), "npm");
+        let err = RepoConfig::known_backend_name("pip").expect_err("pip unknown");
         assert!(matches!(err, RepoConfigError::UnknownBackend { name } if name == "pip"));
     }
 

--- a/src/anolisa/crates/anolisa-cli/src/resolution.rs
+++ b/src/anolisa/crates/anolisa-cli/src/resolution.rs
@@ -1,9 +1,16 @@
 //! Component identity resolution across install backends.
 //!
-//! This module owns the mapping from user input to two identities: the stable
-//! ANOLISA component name and the selected backend's native package name.
-//! Command handlers should consume this resolved pair instead of duplicating
-//! backend-specific candidate chains.
+//! Two questions are answered here, deliberately kept apart (issue #2630):
+//!
+//! 1. **Identity** — is this input a supported component? Exact identities
+//!    already recorded in local state are settled by the caller; every other
+//!    identity resolves only through the repo-side component index
+//!    ([`resolve_index_identity`]). Site-local `package_map` entries and RPM
+//!    `Provides: anolisa-component(...)` metadata never establish an identity.
+//! 2. **Package** — which backend package implements a known component?
+//!    [`ComponentResolver`] answers this for a *settled* component identity,
+//!    where `package_map`, explicit package overrides, and RPM `Provides`
+//!    may select, validate, or discover the backend package.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -166,19 +173,6 @@ impl BackendKind {
     }
 }
 
-/// Command context for a resolution request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ResolutionUse {
-    /// `install` may install or adopt.
-    Install,
-    /// `adopt` only records an already-installed RPM.
-    Adopt,
-    /// `status` observes without writing state.
-    StatusObserved,
-    /// `repair` only migrates existing legacy RPM state rows.
-    RepairLegacy,
-}
-
 /// Source that produced a resolved component/package pair.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResolutionSource {
@@ -225,7 +219,7 @@ impl ResolvedTarget {
 /// Cardinality result for resolving an input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResolutionSet {
-    /// No ANOLISA component identity could be proven.
+    /// No backend package could be resolved for the component.
     None,
     /// Exactly one target.
     Unique(ResolvedTarget),
@@ -240,7 +234,13 @@ pub(crate) struct ResolveOptions<'a> {
     pub(crate) package_override: Option<&'a str>,
 }
 
-/// Resolver over a repository component index plus backend-specific fallbacks.
+/// Backend package resolver for a settled component identity.
+///
+/// Every `resolve` input must already be a component identity established by
+/// the caller — an exact name from local state or an index-resolved canonical
+/// name. The resolver never returns a target whose `component` differs from
+/// the input: `package_map`, package overrides, and RPM `Provides` select or
+/// validate the backing package, they do not create identities.
 pub(crate) struct ComponentResolver<'a> {
     component_index: Option<&'a ComponentIndex>,
     rpm_backend: Option<&'a BackendConfig>,
@@ -260,31 +260,33 @@ impl<'a> ComponentResolver<'a> {
         }
     }
 
-    /// Resolve `input` for `backend`.
+    /// Resolve the backend package for component identity `component`.
     pub(crate) fn resolve(
         &self,
-        input: &str,
+        component: &str,
         backend: BackendKind,
-        use_case: ResolutionUse,
         opts: ResolveOptions<'_>,
     ) -> Result<ResolutionSet, PackageQueryError> {
         match backend {
-            BackendKind::Rpm => self.resolve_rpm(input, use_case, opts),
-            BackendKind::Raw => Ok(self.resolve_raw(input)),
+            BackendKind::Rpm => self.resolve_rpm(component, opts),
+            BackendKind::Raw => Ok(self.resolve_raw(component)),
             BackendKind::Other => Ok(ResolutionSet::None),
         }
     }
 
-    fn resolve_raw(&self, input: &str) -> ResolutionSet {
+    fn resolve_raw(&self, component: &str) -> ResolutionSet {
         let targets = self
             .component_index
-            .map(|idx| idx.targets_for_backend(input, BackendKind::Raw, "raw-package"))
+            .map(|idx| idx.targets_for_component(component, BackendKind::Raw))
             .unwrap_or_default();
         normalize_resolution_set(if targets.is_empty() {
+            // Not an identity claim: the component is already settled, and a
+            // same-named distribution entry is the raw backend's default
+            // package guess. The distribution index refuses unknown packages.
             vec![ResolvedTarget::new(
-                input,
+                component,
                 BackendKind::Raw,
-                input,
+                component,
                 ResolutionSource::RawDistributionIndex,
                 false,
             )]
@@ -295,20 +297,19 @@ impl<'a> ComponentResolver<'a> {
 
     fn resolve_rpm(
         &self,
-        input: &str,
-        use_case: ResolutionUse,
+        component: &str,
         opts: ResolveOptions<'_>,
     ) -> Result<ResolutionSet, PackageQueryError> {
         let query = self
             .rpm_query
             .expect("rpm resolution requires a PackageQuery");
-        let mapped = self.rpm_backend.and_then(|b| b.package_map.get(input));
+        let mapped = self.rpm_backend.and_then(|b| b.package_map.get(component));
 
         if let Some(package) = opts.package_override {
             let mut targets = Vec::new();
             if mapped.is_some_and(|mapped| mapped == package) {
                 targets.push(ResolvedTarget::new(
-                    input,
+                    component,
                     BackendKind::Rpm,
                     package,
                     ResolutionSource::RepoPackageMap,
@@ -316,16 +317,20 @@ impl<'a> ComponentResolver<'a> {
                 ));
             }
             if let Some(idx) = self.component_index {
-                targets.extend(idx.targets_for_component_package(input, BackendKind::Rpm, package));
+                targets.extend(idx.targets_for_component_package(
+                    component,
+                    BackendKind::Rpm,
+                    package,
+                ));
             }
-            if let Some(target) = rpm_package_provides_component(query, package, input)? {
+            if let Some(target) = rpm_package_provides_component(query, package, component)? {
                 targets.push(target);
             }
             return Ok(normalize_resolution_set(targets));
         }
 
         if let Some(idx) = self.component_index {
-            let targets = idx.targets_for_backend(input, BackendKind::Rpm, "rpm-package");
+            let targets = idx.targets_for_component(component, BackendKind::Rpm);
             if !targets.is_empty() {
                 return Ok(normalize_resolution_set(targets));
             }
@@ -333,7 +338,7 @@ impl<'a> ComponentResolver<'a> {
 
         if let Some(package) = mapped {
             return Ok(ResolutionSet::Unique(ResolvedTarget::new(
-                input,
+                component,
                 BackendKind::Rpm,
                 package,
                 ResolutionSource::RepoPackageMap,
@@ -341,7 +346,7 @@ impl<'a> ComponentResolver<'a> {
             )));
         }
 
-        let provide = rpm_component_provide(input);
+        let provide = rpm_component_provide(component);
         let installed_providers = query.what_provides_installed(&provide)?;
         if !installed_providers.is_empty() {
             return Ok(normalize_resolution_set(
@@ -349,7 +354,7 @@ impl<'a> ComponentResolver<'a> {
                     .into_iter()
                     .map(|package| {
                         ResolvedTarget::new(
-                            input,
+                            component,
                             BackendKind::Rpm,
                             package,
                             ResolutionSource::InstalledRpmProvides,
@@ -362,87 +367,77 @@ impl<'a> ComponentResolver<'a> {
 
         let available_providers = query.what_provides_available(&provide)?;
         if !available_providers.is_empty() {
-            let repo_backed_legacy = matches!(
-                use_case,
-                ResolutionUse::Install
-                    | ResolutionUse::Adopt
-                    | ResolutionUse::StatusObserved
-                    | ResolutionUse::RepairLegacy
-            );
             return Ok(normalize_resolution_set(
                 available_providers
                     .into_iter()
                     .map(|package| {
                         ResolvedTarget::new(
-                            input,
+                            component,
                             BackendKind::Rpm,
                             package,
                             ResolutionSource::AvailableRpmProvides,
-                            repo_backed_legacy,
+                            true,
                         )
                     })
                     .collect(),
             ));
         }
 
-        Ok(normalize_resolution_set(rpm_package_name_targets(
-            query, input,
-        )?))
+        Ok(ResolutionSet::None)
     }
 }
 
-/// Resolve an RPM-oriented user input to a stable component name.
+/// Identity verdict for an input not backed by exact local state.
 ///
-/// This is a read-only projection used by tests that need to exercise the full
-/// RPM resolution chain (component index + package_map + rpmdb provides).
-/// Production code uses [`lookup_component_alias`] which is in-memory only.
-#[cfg(test)]
-pub(crate) fn resolve_rpm_component_name(
-    input: &str,
-    rpm_backend: Option<&BackendConfig>,
-    component_index: Option<&ComponentIndex>,
-    query: &dyn PackageQuery,
-    use_case: ResolutionUse,
-) -> Option<String> {
-    let resolver = ComponentResolver::new(component_index, rpm_backend, Some(query));
-    match resolver.resolve(input, BackendKind::Rpm, use_case, ResolveOptions::default()) {
-        Ok(ResolutionSet::Unique(target)) => Some(target.component),
-        _ => None,
-    }
+/// Produced by [`resolve_index_identity`]; callers translate the two failure
+/// verdicts into their command's public errors so "the index rejected this
+/// name" and "no index was available to consult" stay distinguishable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IndexIdentity {
+    /// The index recognizes the input and names this canonical component.
+    Resolved(String),
+    /// The index is authoritative and has no entry matching the input.
+    Unsupported,
+    /// No index was available, so the input cannot be validated.
+    Unavailable,
 }
 
-/// In-memory alias resolution only — no rpmdb/dnf queries.
+/// Resolve an input to a component identity through the component index.
 ///
-/// Used by [`common::lookup_component_name_in_store`](crate::commands::common::lookup_component_name_in_store)
-/// for commands that address existing state. Checks the component index for
-/// component-name, backend-package, and alias matches across both RPM and Raw
-/// backends. Returns `None` when no match is found or the match is ambiguous
-/// (multiple distinct components share the same alias/package name) so the
-/// caller can fall back to the literal input.
-pub(crate) fn lookup_component_alias(
+/// The index is the sole authority for identities that are not already
+/// present in exact local state (issue #2630): canonical component names,
+/// declared aliases, and backend package names resolve to the entry's
+/// canonical name; anything else is [`IndexIdentity::Unsupported`]. Without
+/// an index no new identity can be established at all.
+pub(crate) fn resolve_index_identity(
     input: &str,
     component_index: Option<&ComponentIndex>,
-) -> Option<String> {
-    let idx = component_index?;
-
-    // Collect unique component names from both backends. A single input
-    // may match across RPM and Raw backends (e.g., the component name plus
-    // an alias), but all matches must resolve to the same component — if two
-    // distinct components share the same alias/package name, the lookup is
-    // ambiguous and must not silently pick one.
-    let mut components: BTreeSet<String> = BTreeSet::new();
-    for target in idx.targets_for_backend(input, BackendKind::Rpm, "rpm-package") {
-        components.insert(target.component);
+) -> IndexIdentity {
+    let Some(index) = component_index else {
+        return IndexIdentity::Unavailable;
+    };
+    // Name-level matching over canonical names, declared aliases, and backend
+    // package names, deliberately ignoring alias kinds and backend rows:
+    // identity is about what the index calls the name, not which backends
+    // exist for it. Canonical spelling earns no precedence — if two distinct
+    // components claim the same name in any role, the lookup is ambiguous and
+    // must not silently pick one.
+    let mut matches: BTreeSet<&str> = BTreeSet::new();
+    for entry in &index.components {
+        if entry.name == input
+            || entry.aliases.iter().any(|alias| alias.name == input)
+            || entry
+                .backends
+                .iter()
+                .any(|backend| backend.package == input)
+        {
+            matches.insert(entry.name.as_str());
+        }
     }
-    for target in idx.targets_for_backend(input, BackendKind::Raw, "raw-package") {
-        components.insert(target.component);
-    }
-
-    // Return only when the lookup resolves to exactly one unique component.
-    if components.len() == 1 {
-        components.into_iter().next()
-    } else {
-        None
+    let mut names = matches.into_iter();
+    match (names.next(), names.next()) {
+        (Some(component), None) => IndexIdentity::Resolved(component.to_string()),
+        _ => IndexIdentity::Unsupported,
     }
 }
 
@@ -550,24 +545,19 @@ impl ComponentIndex {
         Ok(())
     }
 
-    fn targets_for_backend(
-        &self,
-        input: &str,
-        backend: BackendKind,
-        alias_kind: &str,
-    ) -> Vec<ResolvedTarget> {
+    /// Backend targets for the entry whose canonical name is `component`.
+    ///
+    /// Package-resolution matching: aliases and backend package names are
+    /// deliberately not consulted, so a settled identity can never be
+    /// remapped to another component by its backend rows.
+    fn targets_for_component(&self, component: &str, backend: BackendKind) -> Vec<ResolvedTarget> {
         let mut targets = Vec::new();
         for entry in &self.components {
-            let matches_component = entry.name == input;
-            let matches_alias = entry
-                .aliases
-                .iter()
-                .any(|alias| alias.kind == alias_kind && alias.name == input);
+            if entry.name != component {
+                continue;
+            }
             for backend_entry in entry.backends_for(backend) {
-                let matches_package = backend_entry.package == input;
-                if matches_component || matches_alias || matches_package {
-                    targets.push(index_target(entry, backend, backend_entry));
-                }
+                targets.push(index_target(entry, backend, backend_entry));
             }
         }
         targets
@@ -667,52 +657,6 @@ fn rpm_package_provides_component(
         .then(|| ResolvedTarget::new(component, BackendKind::Rpm, package, source, true)))
 }
 
-fn rpm_package_name_targets(
-    query: &dyn PackageQuery,
-    package: &str,
-) -> Result<Vec<ResolvedTarget>, PackageQueryError> {
-    let installed = query.query_installed(package)?.is_some();
-    let capabilities = if installed {
-        query.provided_capabilities_installed(package)?
-    } else {
-        query.provided_capabilities_available(package)?
-    };
-    Ok(rpm_components_from_capabilities(&capabilities)
-        .into_iter()
-        .map(|component| {
-            ResolvedTarget::new(
-                component,
-                BackendKind::Rpm,
-                package,
-                if installed {
-                    ResolutionSource::InstalledRpmProvides
-                } else {
-                    ResolutionSource::AvailableRpmProvides
-                },
-                true,
-            )
-        })
-        .collect())
-}
-
-pub(crate) fn rpm_components_from_capabilities(capabilities: &[String]) -> Vec<String> {
-    let mut components = Vec::new();
-    for capability in capabilities {
-        let Some(rest) = capability.trim().strip_prefix("anolisa-component(") else {
-            continue;
-        };
-        let Some(end) = rest.find(')') else {
-            continue;
-        };
-        let component = rest[..end].trim();
-        if component.is_empty() || components.iter().any(|c| c == component) {
-            continue;
-        }
-        components.push(component.to_string());
-    }
-    components
-}
-
 /// Load repo-side `components-v2.toml`, returning a structured error on failure.
 ///
 /// Used by commands (`ls`, `install --all`) that require the component index
@@ -738,7 +682,18 @@ pub(crate) fn load_component_index(
         .map_err(|err| ComponentIndexError::Fetch {
             reason: format!("cannot resolve base_url for raw backend: {err}"),
         })?;
-    let url = component_index_v2_url(&base_url);
+    load_component_index_from_base(layout, &base_url)
+}
+
+/// Load `components-v2.toml` published under an explicit repository base URL.
+///
+/// Used directly for a CLI `--repo` override, where the named repository is
+/// the identity authority for that invocation.
+pub(crate) fn load_component_index_from_base(
+    layout: &FsLayout,
+    base_url: &str,
+) -> Result<ComponentIndex, ComponentIndexError> {
+    let url = component_index_v2_url(base_url);
 
     let cache = DownloadCache::new(layout.cache_dir.clone());
     #[cfg(test)]
@@ -1002,12 +957,7 @@ targets = {targets}
         let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
 
         let got = resolver
-            .resolve(
-                "sec-core",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("sec-core", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve sec-core");
         match got {
             ResolutionSet::Unique(target) => {
@@ -1018,22 +968,11 @@ targets = {targets}
             other => panic!("expected unique, got {other:?}"),
         }
 
-        let package_name = resolver
-            .resolve(
-                "agent-sec-core",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
-            .expect("resolve package name");
-        match package_name {
-            ResolutionSet::Unique(target) => {
-                assert_eq!(target.component, "sec-core");
-                assert_eq!(target.package, "agent-sec-core");
-                assert_eq!(target.source, ResolutionSource::ComponentIndex);
-            }
-            other => panic!("expected unique, got {other:?}"),
-        }
+        assert_eq!(
+            resolve_index_identity("agent-sec-core", Some(&idx)),
+            IndexIdentity::Resolved("sec-core".to_string()),
+            "the rpm package name is an index-declared identity for sec-core",
+        );
     }
 
     #[test]
@@ -1045,12 +984,7 @@ targets = {targets}
         let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
 
         let got = resolver
-            .resolve(
-                "cosh-ng",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("cosh-ng", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve cosh-ng");
 
         match got {
@@ -1151,12 +1085,7 @@ base_url = "file://{}"
         let query = FakeQuery::default();
         let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
         let got = resolver
-            .resolve(
-                "cosh",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("cosh", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve");
         match got {
             ResolutionSet::Unique(target) => {
@@ -1188,12 +1117,7 @@ cosh = "site-copilot"
         let query = FakeQuery::default();
         let resolver = ComponentResolver::new(Some(&idx), repo.backends.get("rpm"), Some(&query));
         let got = resolver
-            .resolve(
-                "cosh",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("cosh", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve");
         match got {
             ResolutionSet::Unique(target) => {
@@ -1205,51 +1129,92 @@ cosh = "site-copilot"
     }
 
     #[test]
-    fn component_index_resolves_rpm_package_alias_to_component() {
+    fn index_identity_resolves_canonical_alias_and_package_names() {
         let idx = index();
-        let query = FakeQuery::default();
-        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
-        let got = resolver
-            .resolve(
-                "copilot-shell",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
+        assert_eq!(
+            resolve_index_identity("cosh", Some(&idx)),
+            IndexIdentity::Resolved("cosh".to_string()),
+        );
+        assert_eq!(
+            resolve_index_identity("copilot-shell", Some(&idx)),
+            IndexIdentity::Resolved("cosh".to_string()),
+        );
+        assert_eq!(
+            resolve_index_identity("unknown-component", Some(&idx)),
+            IndexIdentity::Unsupported,
+        );
+        assert_eq!(
+            resolve_index_identity("cosh", None),
+            IndexIdentity::Unavailable,
+        );
+    }
+
+    #[test]
+    fn index_identity_resolves_entries_without_backend_rows() {
+        let idx = ComponentIndex::from_toml_str(
+            r#"
+schema_version = 2
+
+[[components]]
+name = "backendless"
+targets = [{ os = "linux", arch = "x86_64" }]
+"#,
+            "components.toml",
+        )
+        .expect("parse index");
+        assert_eq!(
+            resolve_index_identity("backendless", Some(&idx)),
+            IndexIdentity::Resolved("backendless".to_string()),
+        );
+    }
+
+    #[test]
+    fn index_identity_refuses_canonical_names_claimed_by_another_component() {
+        // Canonical spelling earns no precedence: when a second component
+        // also claims the name — through an alias or a backend package —
+        // the lookup is ambiguous and must not silently pick the canonical
+        // entry. The claimant's own canonical name stays unambiguous.
+        for claim in [
+            r#"aliases = [{ kind = "legacy", name = "cosh" }]"#,
+            "[[components.backends]]\nkind = \"raw\"\npackage = \"cosh\"",
+        ] {
+            let idx = ComponentIndex::from_toml_str(
+                &format!(
+                    r#"
+schema_version = 2
+
+[[components]]
+name = "cosh"
+targets = [{{ os = "linux", arch = "x86_64" }}]
+
+[[components]]
+name = "claimant"
+targets = [{{ os = "linux", arch = "x86_64" }}]
+{claim}
+"#
+                ),
+                "components.toml",
             )
-            .expect("resolve");
-        match got {
-            ResolutionSet::Unique(target) => {
-                assert_eq!(target.component, "cosh");
-                assert_eq!(target.package, "copilot-shell");
-            }
-            other => panic!("expected unique, got {other:?}"),
+            .expect("parse index");
+            assert_eq!(
+                resolve_index_identity("cosh", Some(&idx)),
+                IndexIdentity::Unsupported,
+            );
+            assert_eq!(
+                resolve_index_identity("claimant", Some(&idx)),
+                IndexIdentity::Resolved("claimant".to_string()),
+            );
         }
     }
 
     #[test]
-    fn component_index_resolves_raw_component() {
+    fn package_resolution_never_remaps_a_settled_identity() {
+        // `copilot-shell` is an alias/package name of `cosh` in the index and
+        // its installed RPM declares the cosh component capability. Neither
+        // may turn the settled identity `copilot-shell` into `cosh` at the
+        // package layer — identity resolution happens before, through
+        // `resolve_index_identity`.
         let idx = index();
-        let resolver = ComponentResolver::new(Some(&idx), None, None);
-        let got = resolver
-            .resolve(
-                "cosh",
-                BackendKind::Raw,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
-            .expect("resolve");
-        match got {
-            ResolutionSet::Unique(target) => {
-                assert_eq!(target.component, "cosh");
-                assert_eq!(target.package, "cosh");
-                assert_eq!(target.source, ResolutionSource::ComponentIndex);
-            }
-            other => panic!("expected unique, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn rpm_package_name_falls_back_to_package_own_provides() {
         let query = FakeQuery {
             installed: vec![("copilot-shell".to_string(), pkg_info("copilot-shell"))],
             package_provides: vec![(
@@ -1258,20 +1223,25 @@ cosh = "site-copilot"
             )],
             ..Default::default()
         };
-        let resolver = ComponentResolver::new(None, None, Some(&query));
+        let resolver = ComponentResolver::new(Some(&idx), None, Some(&query));
         let got = resolver
-            .resolve(
-                "copilot-shell",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("copilot-shell", BackendKind::Rpm, ResolveOptions::default())
+            .expect("resolve");
+        assert_eq!(got, ResolutionSet::None);
+    }
+
+    #[test]
+    fn component_index_resolves_raw_component() {
+        let idx = index();
+        let resolver = ComponentResolver::new(Some(&idx), None, None);
+        let got = resolver
+            .resolve("cosh", BackendKind::Raw, ResolveOptions::default())
             .expect("resolve");
         match got {
             ResolutionSet::Unique(target) => {
                 assert_eq!(target.component, "cosh");
-                assert_eq!(target.package, "copilot-shell");
-                assert_eq!(target.source, ResolutionSource::InstalledRpmProvides);
+                assert_eq!(target.package, "cosh");
+                assert_eq!(target.source, ResolutionSource::ComponentIndex);
             }
             other => panic!("expected unique, got {other:?}"),
         }
@@ -1288,12 +1258,7 @@ cosh = "site-copilot"
         };
         let resolver = ComponentResolver::new(None, None, Some(&query));
         let got = resolver
-            .resolve(
-                "cosh",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("cosh", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve");
         match got {
             ResolutionSet::Unique(target) => {
@@ -1313,12 +1278,7 @@ cosh = "site-copilot"
         };
         let resolver = ComponentResolver::new(None, None, Some(&query));
         let got = resolver
-            .resolve(
-                "bash",
-                BackendKind::Rpm,
-                ResolutionUse::Install,
-                ResolveOptions::default(),
-            )
+            .resolve("bash", BackendKind::Rpm, ResolveOptions::default())
             .expect("resolve");
         assert_eq!(got, ResolutionSet::None);
     }

--- a/src/anolisa/crates/anolisa-cli/src/response.rs
+++ b/src/anolisa/crates/anolisa-cli/src/response.rs
@@ -15,11 +15,13 @@
 //! - `INVALID_ARGUMENT` -> 2 (POSIX convention shared with clap).
 //! - `NOT_INSTALLED` -> 2 (shares `INVALID_ARGUMENT`'s exit code only so
 //!   shell callers already branching on 2 keep working; `--json` callers
-//!   read the distinction off `error.code`). Reports one fact and only
-//!   one: the target is absent from state, so the operation had nothing
-//!   to act on. It says nothing about whether the name was valid — an
-//!   unknown name resolves to itself and lands here identically. What to
-//!   do about it is the caller's call and depends on the command: an
+//!   read the distinction off `error.code`). Reports a validated identity
+//!   with nothing installed: the name passed identity resolution (exact
+//!   local state or the component index) and the operation found nothing
+//!   to act on. Unknown names never land here — a name the index rejects
+//!   is `INVALID_ARGUMENT`, and a name nothing could validate because no
+//!   index was available is `EXECUTION_FAILED`. What to do about a real
+//!   `NOT_INSTALLED` is the caller's call and depends on the command: an
 //!   absent `uninstall` target is already the desired end state, an
 //!   absent `restart` target is a stale assumption.
 //! - `EXECUTION_FAILED` -> 1 (generic non-zero "the command ran but the
@@ -87,10 +89,11 @@ pub enum CliError {
     /// `--remove-system-package` with several targets are all things the
     /// caller got wrong, whereas this one may be nothing to fix at all.
     ///
-    /// **Not** a claim about the name. Resolution falls back to the literal
-    /// input when the component index has no entry for it, so an unknown
-    /// name and a known-but-absent one arrive here indistinguishably.
-    /// Callers must not read this code as "the name was valid".
+    /// The name itself was validated first: identity resolution accepts only
+    /// exact local-state identities and names the component index recognizes,
+    /// so this code means "a supported component with nothing installed".
+    /// Unknown names fail as `INVALID_ARGUMENT` (index rejected the name) or
+    /// `EXECUTION_FAILED` (no index available to validate it) instead.
     ///
     /// Shares exit code 2 with [`CliError::InvalidArgument`] for backward
     /// compatibility alone — shell callers already branch on 2. It does not

--- a/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/scope_identity.rs
@@ -619,7 +619,7 @@ fn incomplete_system_visibility_blocks_adapter_alias_inference() {
 }
 
 #[test]
-fn incomplete_system_visibility_pins_a_user_install_to_the_literal_name() {
+fn incomplete_system_visibility_blocks_install_alias_inference() {
     for failure in [
         SystemStateFailure::FutureSchema,
         SystemStateFailure::InvalidToml,
@@ -628,16 +628,35 @@ fn incomplete_system_visibility_pins_a_user_install_to_the_literal_name() {
         let fixture = ScopeFixture::new();
         fixture.break_system_state(failure);
 
+        // `legacy-name` is an index alias of `cosh`: remapping it needs
+        // complete visibility, because the unreadable system root could hold
+        // an exact `legacy-name` record. The literal input is no longer
+        // pinned as a new identity (issue #2630) — the install refuses.
         let output = fixture.run("install");
         let envelope = json(&output);
 
+        assert!(
+            !output.status.success(),
+            "alias install must refuse under incomplete visibility: {envelope}"
+        );
+        let reason = envelope["error"]["reason"].as_str().expect("error reason");
+        assert!(
+            reason.contains("visible state is incomplete"),
+            "wrong failure: {reason}"
+        );
+
+        // A canonical index name involves no remapping and stays addressable
+        // even while the system root is unreadable — here it hits the
+        // fixture's existing user record and reports the idempotent NoOp.
+        let output = fixture.run_args(&["install", "cosh"], true);
+        let envelope = json(&output);
         assert_eq!(
             output.status.code(),
             Some(0),
-            "literal user install should remain available: {envelope}; stderr: {}",
+            "canonical user install should remain available: {envelope}; stderr: {}",
             String::from_utf8_lossy(&output.stderr),
         );
-        assert_eq!(envelope["data"]["component"], "legacy-name");
-        assert_eq!(envelope["data"]["action"], "planned");
+        assert_eq!(envelope["data"]["component"], "cosh");
+        assert_eq!(envelope["data"]["action"], "already-installed");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/uninstall_dry_run_json.rs
@@ -3,8 +3,10 @@
 //! Plain uninstall runs the planner pipeline: for an absent component the
 //! dry-run reports the same refusal as a real run would (an error envelope,
 //! `NOT_INSTALLED`, exit 2), so previews never disagree with reality. The
-//! code marks state absence only — it is not a statement about the name, as
-//! `not_installed_does_not_distinguish_a_known_name_from_an_unknown_one`
+//! name itself is validated first — state and the component index are the
+//! identity authorities (issue #2630), so `NOT_INSTALLED` means "a supported
+//! component with nothing installed", as
+//! `unknown_name_is_rejected_while_supported_name_reports_not_installed`
 //! pins. `--purge` keeps the legacy plan view: a unified `data.dry_run`,
 //! plan fields flat under `data`. These tests drive the compiled binary and
 //! assert the full envelope, which in-crate unit tests cannot cover.
@@ -53,7 +55,8 @@ fn assert_plan_dry_run_contract(data: &serde_json::Value) {
 }
 
 /// A temp prefix + system mode isolates the run from real state; a name that
-/// is neither installed nor visible falls through to the absent-plan branch.
+/// is index-supported but not installed falls through to the absent-plan
+/// branch.
 fn absent_uninstall_args<'a>(prefix: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
     let mut args = vec![
         "--json",
@@ -70,20 +73,24 @@ fn absent_uninstall_args<'a>(prefix: &'a str, extra: &[&'a str]) -> Vec<&'a str>
 }
 
 fn seed_local_repo(prefix: &Path) {
-    seed_local_repo_with_index(prefix, "components = []\n");
+    seed_local_repo_with_index(prefix, &["definitely-missing"]);
 }
 
-/// Same layout as [`seed_local_repo`] but with a caller-supplied component
-/// index body, so a test can distinguish a name the index knows from one it
-/// has never heard of.
-fn seed_local_repo_with_index(prefix: &Path, components: &str) {
+/// Seed `repo.toml` plus a generation-2 component index publishing
+/// `components`, so identity resolution can validate targets against a local
+/// authority.
+fn seed_local_repo_with_index(prefix: &Path, components: &[&str]) {
     let repo_v1 = prefix.join("repo/v1");
     std::fs::create_dir_all(&repo_v1).expect("local repo");
-    std::fs::write(
-        repo_v1.join("components.toml"),
-        format!("schema_version = 1\n{components}"),
-    )
-    .expect("component index");
+    let mut index = String::from("schema_version = 2\n");
+    for component in components {
+        index.push_str(&format!(
+            "\n[[components]]\nname = \"{component}\"\ntargets = [{{ os = \"{os}\", arch = \"{arch}\" }}]\n",
+            os = std::env::consts::OS,
+            arch = std::env::consts::ARCH,
+        ));
+    }
+    std::fs::write(repo_v1.join("components-v2.toml"), index).expect("component index");
     let etc = prefix.join("etc/anolisa");
     std::fs::create_dir_all(&etc).expect("config dir");
     std::fs::write(
@@ -126,29 +133,19 @@ fn uninstall_dry_run_json_absent_component_reports_not_installed() {
     );
 }
 
-/// `NOT_INSTALLED` reports state absence and nothing else. Resolution falls
-/// back to the literal input when the component index has no entry for it
-/// (`common::component_alias_from_repo_index`), so a name the index knows and
-/// a name it has never seen reach this code indistinguishably — same `code`,
-/// same exit status, differing only in the name echoed back.
-///
-/// This is pinned deliberately: callers must not read `NOT_INSTALLED` as
-/// "the name was valid, it just isn't installed". Should the CLI ever grow
-/// real identity validation, this test is the one that has to change, and
-/// its failure is the signal to revisit every doc that describes the code.
+/// The issue #2630 identity contract on the public wire: a name the index
+/// knows but state lacks is `NOT_INSTALLED`, a name the index rejects is
+/// `INVALID_ARGUMENT`, and without any index an unseen name cannot be
+/// validated at all (`EXECUTION_FAILED`, exit 1). Callers may therefore read
+/// `NOT_INSTALLED` as "the name was valid, it just isn't installed".
 #[test]
-fn not_installed_does_not_distinguish_a_known_name_from_an_unknown_one() {
+fn unknown_name_is_rejected_while_supported_name_reports_not_installed() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    seed_local_repo_with_index(
-        tmp.path(),
-        "components = [\n  { name = \"cosh\", package = \"copilot-shell\" },\n]\n",
-    );
+    seed_local_repo_with_index(tmp.path(), &["cosh"]);
     let prefix = tmp.path().to_str().expect("utf-8 prefix");
 
-    let mut codes = Vec::new();
-    // "cosh" is in the index but not installed; "coshh" is in no index at all.
-    for component in ["cosh", "coshh"] {
-        let value = run_json(
+    let uninstall = |component: &str, expected: i32| {
+        run_json(
             &[
                 "--json",
                 "--dry-run",
@@ -159,22 +156,67 @@ fn not_installed_does_not_distinguish_a_known_name_from_an_unknown_one() {
                 "uninstall",
                 component,
             ],
-            2,
-        );
-        let error = value.get("error").expect("envelope must carry error");
-        codes.push(
-            error
-                .get("code")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string(),
-        );
-    }
+            expected,
+        )
+    };
+    let code = |value: &serde_json::Value| {
+        value
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string()
+    };
 
-    assert_eq!(
-        codes,
-        vec!["NOT_INSTALLED".to_string(), "NOT_INSTALLED".to_string()],
-        "an index-known name and an unknown one must be reported identically",
+    // "cosh" is in the index but not installed; "coshh" is in no index at all.
+    assert_eq!(code(&uninstall("cosh", 2)), "NOT_INSTALLED");
+    let unknown = uninstall("coshh", 2);
+    assert_eq!(code(&unknown), "INVALID_ARGUMENT");
+    assert!(
+        unknown
+            .get("error")
+            .and_then(|error| error.get("reason"))
+            .and_then(|v| v.as_str())
+            .is_some_and(|reason| reason.contains("unsupported component 'coshh'")),
+        "the unknown name must be rejected as unsupported: {unknown}",
+    );
+
+    // Without an index nothing can validate a new name: explicit failure
+    // instead of a synthesized not_installed. The repo config points at a
+    // repository that publishes no component index, keeping the run hermetic.
+    let bare = tempfile::tempdir().expect("tempdir");
+    let etc = bare.path().join("etc/anolisa");
+    std::fs::create_dir_all(&etc).expect("config dir");
+    std::fs::write(
+        etc.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            bare.path().join("no-such-repo/v1").display()
+        ),
+    )
+    .expect("repo config");
+    let bare_prefix = bare.path().to_str().expect("utf-8 prefix");
+    let unvalidated = run_json(
+        &[
+            "--json",
+            "--dry-run",
+            "--install-mode",
+            "system",
+            "--prefix",
+            bare_prefix,
+            "uninstall",
+            "coshh",
+        ],
+        1,
+    );
+    assert_eq!(code(&unvalidated), "EXECUTION_FAILED");
+    assert!(
+        unvalidated
+            .get("error")
+            .and_then(|error| error.get("reason"))
+            .and_then(|v| v.as_str())
+            .is_some_and(|reason| reason.contains("component index is unavailable")),
+        "an unvalidatable name must name the missing index: {unvalidated}",
     );
 }
 


### PR DESCRIPTION
## Why

ANOLISA mixed two separate questions: whether a string is a supported
component identity, and which backend package implements that component.
Beyond the central component index, site-local `repo.toml package_map`
entries, RPM `Provides: anolisa-component(...)` metadata, and a literal
no-index fallback could each establish a component identity, so hosts
sharing one index could still disagree about which names are valid, and a
mistyped name was indistinguishable from a supported-but-uninstalled
component. PR #2626 fixed the two immediate `status` violations; this PR
converges the remaining command paths on the same contract.

## What changed

One identity contract across `install`, `adopt`, `uninstall`, `forget`,
`restart`, `update`, `repair`, `adapter`, `doctor`, `logs`, and `bug`:

- Exact identities recorded in local state stay addressable offline.
  Mutation paths accept records of any kind (including quarantined rows and
  dropped legacy capability names, which keep their dedicated migration
  guidance) and operation journals — matched by subject or legacy
  `rpm-state` step so interrupted legacy installs remain repairable
  without an index. Install and adopt — the paths that can mint a fresh
  record — are narrower: only exact component records and
  effectively-pending journals pin an identity, so terminal journals or
  historical non-component rows cannot re-authorize a name the index no
  longer recognizes (adopt would otherwise recreate it from
  `package_map` or RPM `Provides`).
- Every other identity resolves only through the component index, via the
  new shared `resolve_index_identity` (canonical names, declared aliases,
  and backend package names; ambiguity is rejected, never silently picked).
  `status` now reuses the shared resolver it pioneered.
- `package_map`, `--package` overrides, and RPM `Provides` select or
  validate a backend package strictly after the identity is known.
  `ComponentResolver` is reduced to package resolution for a settled
  identity: the own-provides identity fallback is gone, backend rows can no
  longer remap a component, and the now-vacuous `ResolutionUse` knob and
  the `component_identity_pinned` plumbing are removed.
- `install --repo <URL>` treats that repository as the authority for the
  whole invocation: its published index drives identity, package
  selection, the system-RPM probe, and the `--all` enumeration, and its
  URL pins the DNF source the availability queries, the native
  transaction, and the locked re-checks use — standing in for a missing
  repo.toml rpm backend. The override URL is validated before identity
  resolution so a malformed URL still reports `INVALID_ARGUMENT`.
- `update --check` validates target-profile defaults through the index
  before package resolution — exact state identities first, deduplicated
  under the canonical name — so `upgrade` can neither mint an identity
  from `package_map`/Provides nor duplicate an already-tracked record.
- Remapping an alias to its canonical name still requires complete state
  visibility. Under an unreadable root, alias installs now refuse instead
  of pinning the literal input as a new identity; canonical names remain
  installable.

## Related issue

Closes #2630

## User / Agent impact

Unknown names now fail explicitly instead of being reported as
`not_installed`: `INVALID_ARGUMENT` (`unsupported component '<name>'`)
when the index is available, `EXECUTION_FAILED` (`component index is
unavailable`) when nothing could validate the name. `NOT_INSTALLED`
therefore now guarantees the name was a valid identity — its documented
meaning in `response.rs` is updated accordingly.

Intentional migration costs from the issue: site-local components defined
only through `package_map` need an entry in the site's authoritative
component index; RPM `Provides`-only discovery no longer authorizes a new
component name (it still resolves packages and probes installation state);
new component targets cannot be resolved offline, while exact local-state
identities continue to work.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

Medium risk by breadth: identity resolution tightens across all
component-targeting commands. Lifecycle continuity for existing state is
preserved by the exact-local-state precedence described above, and
index-supported but absent targets keep flowing to the planner's normal
`not-installed` path.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked --no-fail-fast` (894 passed, 1 ignored, 0 failed)
- `cargo doc --no-deps`
- Test fixtures now publish generation-2 component indexes, modeling the
  accepted migration cost; the wire-contract test that deliberately pinned
  the old "known and unknown names are indistinguishable" behavior is
  rewritten to pin the three-way error distinction instead.

## Documentation and rollback

Behavior contracts are documented on the resolvers (`resolution.rs`,
`common.rs`) and in `response.rs` (module-level error taxonomy and the
`CliError::NotInstalled` variant). Roll back by reverting this PR's
single commit (currently `08031c14`).

