### PR TITLE
fix(cosh-ng): [shell] allow quoted newlines

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_tool_approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/adapter/fake/stream_tool_approval.rs
@@ -28,7 +28,11 @@ pub(super) fn emit_fake_tool_approval_stream(
         // turn and offers "Allow all this turn". Portable medium-risk
         // commands keep the scripted-PTY case green on macOS and Linux.
         thread::sleep(Duration::from_millis(100));
-        for command in ["ps aux | head", "ps aux | head -20", "df -h | head"] {
+        for command in [
+            "ps aux | head",
+            "ps aux | head -20",
+            "printf 'alpha\\nbeta\\n' | awk '\n{ print $0 }\n'",
+        ] {
             sink(AgentEvent::ToolCall {
                 run_id: run_id.clone(),
                 tool_id: None,
@@ -218,6 +222,23 @@ pub(super) fn emit_fake_tool_approval_stream(
         sink(AgentEvent::AgentCompleted {
             run_id,
             summary: "multiline stream approval fake analysis completed".to_string(),
+        })?;
+        return Ok(true);
+    }
+
+    if input.contains("stream quoted multiline pipeline approval") {
+        sink(AgentEvent::TextDelta {
+            run_id: run_id.clone(),
+            text: "Preparing a quoted multiline pipeline request before finishing.".to_string(),
+        })?;
+        emit_bash_tool_after_short_delay(
+            sink,
+            &run_id,
+            "printf 'alpha\\nbeta\\n' | awk '\n{ print $0 }\n'",
+        )?;
+        sink(AgentEvent::AgentCompleted {
+            run_id,
+            summary: "quoted multiline pipeline fake analysis completed".to_string(),
         })?;
         return Ok(true);
     }

--- a/src/cosh-ng/crates/cosh-shell/src/approval/handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/handoff.rs
@@ -162,7 +162,7 @@ pub(crate) fn approval_shell_handoff_validation_message(i18n: &I18n, message: &s
         "empty shell handoff command" => {
             Some(MessageId::ApprovalShellHandoffValidationEmptyCommand)
         }
-        "shell handoff command contains newline; multiline handoff is not enabled" => {
+        "shell handoff command contains an unsupported line break" => {
             Some(MessageId::ApprovalShellHandoffValidationMultilineCommand)
         }
         "shell handoff command contains blocked control character" => {

--- a/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/tests.rs
@@ -793,11 +793,11 @@ fn shell_handoff_validation_message_uses_active_language() {
     let zh = I18n::new(Language::ZhCn);
     let text = approval_shell_handoff_validation_message(
         &zh,
-        "shell handoff command contains newline; multiline handoff is not enabled",
+        "shell handoff command contains an unsupported line break",
     );
 
     assert!(text.contains("换行"), "{text}");
-    assert!(!text.contains("multiline handoff is not enabled"), "{text}");
+    assert!(!text.contains("unsupported line break"), "{text}");
 
     let unknown = approval_shell_handoff_validation_message(&zh, "custom validation");
     assert_eq!(unknown, "custom validation");

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/en/approval.rs
@@ -82,7 +82,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         }
         MessageId::ApprovalShellHandoffValidationEmptyCommand => "Shell handoff command is empty.",
         MessageId::ApprovalShellHandoffValidationMultilineCommand => {
-            "Shell handoff command contains a newline; multiline handoff is not enabled."
+            "Shell handoff command contains an unsupported line break. Only line feeds inside complete single-quoted arguments are allowed."
         }
         MessageId::ApprovalShellHandoffValidationControlCharacter => {
             "Shell handoff command contains a blocked control character."

--- a/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/i18n/zh/approval.rs
@@ -72,7 +72,7 @@ pub(super) fn message(id: MessageId) -> Option<&'static str> {
         MessageId::ApprovalShellHandoffBlockedFooter => "命令没有写入前台 shell。",
         MessageId::ApprovalShellHandoffValidationEmptyCommand => "Shell handoff 命令为空。",
         MessageId::ApprovalShellHandoffValidationMultilineCommand => {
-            "Shell handoff 命令包含换行；尚未启用多行 handoff。"
+            "Shell handoff 命令包含不受支持的换行；仅允许完整单引号参数内的换行。"
         }
         MessageId::ApprovalShellHandoffValidationControlCharacter => {
             "Shell handoff 命令包含被阻止的控制字符。"

--- a/src/cosh-ng/crates/cosh-shell/src/types/shell_handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/types/shell_handoff.rs
@@ -110,16 +110,13 @@ impl ShellHandoffRequest {
         if self.command.contains('\0') {
             return Err("shell handoff command contains NUL byte".to_string());
         }
-        if self.command.chars().any(|ch| matches!(ch, '\n' | '\r')) {
-            return Err(
-                "shell handoff command contains newline; multiline handoff is not enabled"
-                    .to_string(),
-            );
+        if has_unsafe_line_break(&self.command) {
+            return Err("shell handoff command contains an unsupported line break".to_string());
         }
         if self
             .command
             .chars()
-            .any(|ch| ch.is_control() && !matches!(ch, '\t'))
+            .any(|ch| ch.is_control() && !matches!(ch, '\t' | '\n'))
         {
             return Err("shell handoff command contains blocked control character".to_string());
         }
@@ -162,6 +159,73 @@ impl ShellHandoffRequest {
     }
 }
 
+// A quoted line feed continues one shell command, which covers multiline
+// jq, awk, and interpreter programs carried by an approved pipeline. Bare
+// line feeds could dispatch additional commands under one approval, while
+// carriage returns and escaped continuations have terminal-dependent input
+// semantics, so those remain fail-closed.
+//
+// This scans physical line-feed and carriage-return characters in the raw
+// command. Textual escape sequences such as `\n` are ordinary command bytes.
+fn has_unsafe_line_break(command: &str) -> bool {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Quote {
+        Single,
+        Double,
+    }
+
+    let mut quote = None;
+    let mut saw_quoted_line_feed = false;
+    let mut comment_can_start = true;
+    let mut in_comment = false;
+    let mut chars = command.chars();
+    while let Some(ch) = chars.next() {
+        if in_comment {
+            if matches!(ch, '\n' | '\r') {
+                return true;
+            }
+            continue;
+        }
+
+        match (quote, ch) {
+            (_, '\r') => return true,
+            (Some(Quote::Single), '\n') => saw_quoted_line_feed = true,
+            (Some(Quote::Single), '\'') => quote = None,
+            (Some(Quote::Single), _) => {}
+            (Some(Quote::Double), '\n') => return true,
+            (Some(Quote::Double), '"') => quote = None,
+            (Some(Quote::Double), '\\') => {
+                if chars.next().is_some_and(|next| matches!(next, '\n' | '\r')) {
+                    return true;
+                }
+            }
+            (Some(Quote::Double), _) => {}
+            (None, '\n') => return true,
+            (None, '\'') => {
+                quote = Some(Quote::Single);
+                comment_can_start = false;
+            }
+            (None, '"') => {
+                quote = Some(Quote::Double);
+                comment_can_start = false;
+            }
+            (None, '\\') => {
+                if chars.next().is_some_and(|next| matches!(next, '\n' | '\r')) {
+                    return true;
+                }
+                comment_can_start = false;
+            }
+            (None, '#') if comment_can_start => in_comment = true,
+            (None, ' ' | '\t' | ';' | '|' | '&' | '(' | ')' | '<' | '>') => {
+                comment_can_start = true;
+            }
+            (None, _) => comment_can_start = false,
+        }
+    }
+
+    saw_quoted_line_feed && quote == Some(Quote::Single)
+}
+
 fn preview_hash(value: &str) -> String {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     const FNV_PRIME: u64 = 0x100000001b3;
@@ -194,15 +258,33 @@ mod tests {
     }
 
     #[test]
-    fn shell_handoff_rejects_empty_nul_newline_and_control_chars() {
+    fn shell_handoff_rejects_empty_nul_unquoted_newline_and_control_chars() {
         for command in [
             "",
             "printf '\0'",
             "printf one\nprintf two",
+            "printf 'one\ntwo'\nprintf three",
+            "printf \"one\ntwo\"",
+            "printf \"apostrophe ' one\ntwo\"",
+            "printf \\'one\nprintf two",
+            "printf approved # '\nprintf UNAPPROVED\n# '",
+            "printf 'one\ntwo",
+            "printf 'one\rtwo'",
             "printf '\u{1b}[31mred'",
         ] {
             assert!(handoff(command).is_err(), "{command:?}");
         }
+    }
+
+    #[test]
+    fn shell_handoff_allows_pipeline_with_quoted_multiline_script() {
+        let command = "printf 'alpha\\nbeta\\n' | awk '\n# shell-literal comment\n{ print $0 }\n'";
+        let request = handoff(command).expect("quoted multiline pipeline handoff");
+
+        assert_eq!(
+            request.pty_bytes().unwrap(),
+            format!("{command}\n").as_bytes()
+        );
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/foreground.rs
@@ -651,3 +651,42 @@ fn raw_cli_user_approved_bash_tool_supports_pipe() {
     assert!(!output.contains("Analysis continued after the approved command"));
     assert!(!output.contains("Thinking...Approval"));
 }
+
+#[test]
+fn raw_cli_user_approved_pipeline_supports_quoted_multiline_script() {
+    assert_user_approved_pipeline_supports_quoted_multiline_script(&[]);
+}
+
+#[test]
+fn raw_cli_zsh_user_approved_pipeline_supports_quoted_multiline_script() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+    assert_user_approved_pipeline_supports_quoted_multiline_script(&["--shell", "zsh"]);
+}
+
+fn assert_user_approved_pipeline_supports_quoted_multiline_script(args: &[&str]) {
+    let output = run_raw_cli_with_args_and_delayed_input(
+        "fake",
+        args,
+        vec![
+            (
+                b"?? stream quoted multiline pipeline approval\n".to_vec(),
+                Duration::ZERO,
+            ),
+            (b"\n".to_vec(), Duration::from_millis(1_200)),
+            (b"exit\n".to_vec(), Duration::from_millis(1_000)),
+        ],
+    );
+    let normalized = strip_ansi_escape(&output).replace('\r', "");
+
+    assert!(
+        output.contains("Preparing a quoted multiline pipeline request before finishing."),
+        "{output}"
+    );
+    assert_approval_prompt_visible(&output);
+    assert!(output.contains("Approved req-1"), "{output}");
+    assert!(!output.contains("Blocked req-1"), "{output}");
+    assert!(normalized.contains("\nalpha\nbeta\n"), "{output}");
+    assert!(output.contains("sent to shell"), "{output}");
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/approval/input.rs
@@ -105,6 +105,7 @@ fn assert_turn_batch_consent_serializes_handoffs(args: &[&str]) {
             ),
         ],
     );
+    let normalized = strip_ansi_escape(&output).replace('\r', "");
 
     assert!(output.contains("Allow all this turn"), "{output}");
     assert!(output.contains("Approved for this turn req-1"), "{output}");
@@ -113,6 +114,8 @@ fn assert_turn_batch_consent_serializes_handoffs(args: &[&str]) {
     // The swept requests never present their own cards.
     assert!(!output.contains("Approval req-2"), "{output}");
     assert!(!output.contains("Approval req-3"), "{output}");
+    assert!(!output.contains("Blocked req-3"), "{output}");
+    assert!(normalized.contains("\nalpha\nbeta\n"), "{output}");
     assert!(
         output.contains("Received shell prompt request: ?? batch-handoff-follow-up"),
         "a follow-up Agent run must start after every batched handoff closes: {output}"


### PR DESCRIPTION
## Why

Approved Bash pipelines were downgraded to `Blocked` whenever a jq, awk, or
interpreter program contained physical line feeds inside a single-quoted
argument. The pipeline itself was supported, but the handoff validator rejected
the quoted program before it reached the foreground shell.

## What changed

- Track shell quote state while validating approved handoffs.
- Allow line feeds only inside complete POSIX single-quoted arguments.
- Keep bare line feeds, double-quoted line feeds, unterminated quotes, carriage
  returns, NUL bytes, and other control characters fail-closed.
- Exercise both one-shot and turn-batch approval paths with a real pipeline on
  Bash and Zsh scripted PTYs.

## Related issue

fixes #2636

## User / Agent impact

`Allow once` and `Allow all this turn` now execute approved pipelines whose
jq, awk, or interpreter program is formatted across lines inside single quotes.
A bare newline still cannot dispatch multiple commands under one approval.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

The change narrowly relaxes the shell-handoff validation boundary. Commands
remain byte-identical when written to the PTY, and ambiguous line-break forms
remain blocked. There is no protocol, configuration, or migration change.

## Validation

- Before the fix, the new raw-PTY reproduction rendered `Blocked req-1`
  after approval.
- `cargo test --package cosh-shell --bin cosh-shell shell_handoff_`
  — 39 passed.
- `cargo test --package cosh-shell --test raw_cli turn_batch_consent -- --test-threads=1`
  — 2 passed, Bash and Zsh.
- `cargo test --package cosh-shell --test raw_cli user_approved_pipeline_supports_quoted_multiline_script -- --test-threads=1`
  — 2 passed, Bash and Zsh.
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `scripts/check-test-inventory.sh`

## Documentation and rollback

No documentation change is required. Reverting commit
`8b4890bcb2a13e14c820f655002e70477cdebb7f` restores the previous
fail-closed behavior for every physical line feed.
