### PR TITLE
fix(sec-core): route Rust logs to Python logging

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -14,6 +14,7 @@ version = "0.10.1"
 dependencies = [
  "prompt-scanner",
  "pyo3",
+ "pyo3-log",
  "serde_json",
 ]
 
@@ -24,6 +25,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -464,6 +474,17 @@ checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.22"
 log = "0.4"
 percent-encoding = "2.3"
 pyo3 = { version = "0.20", features = ["extension-module"] }
+pyo3-log = "0.9"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
@@ -39,5 +40,8 @@ crate-type = ["cdylib"]
 [dependencies]
 # PyO3: Rust bindings for Python
 pyo3 = { workspace = true }
+# Installs the `log` implementation for the whole extension; without it every
+# log::warn! in the dependency tree is a no-op.
+pyo3-log = { workspace = true }
 prompt-scanner = { path = "crates/prompt-scanner" }
 serde_json = { workspace = true }

--- a/src/agent-sec-core/agent-sec-cli/crates/model-service/src/lib.rs
+++ b/src/agent-sec-core/agent-sec-cli/crates/model-service/src/lib.rs
@@ -276,7 +276,7 @@ fn is_transient(err: &ureq::Error) -> bool {
 ///
 /// Returns [`ModelServiceError::Config`] for an unsupported backend name or
 /// a base URL without an `http://`/`https://` scheme.  An unparseable or
-/// out-of-range timeout silently falls back to the default, matching the
+/// out-of-range timeout is logged and falls back to the default, matching the
 /// tolerant behaviour of the surrounding tooling.
 pub fn create_client() -> Result<Box<dyn ModelClient>, ModelServiceError> {
     Ok(Box::new(ollama_from_env()?))
@@ -338,11 +338,28 @@ fn is_loopback_url(base_url: &str) -> bool {
 }
 
 /// Parse a timeout in seconds, falling back to [`DEFAULT_TIMEOUT_SECS`] when
-/// the value is missing, unparseable, zero, or above [`MAX_TIMEOUT_SECS`].
+/// the value is missing.  A present but unusable value (unparseable, zero, or
+/// above [`MAX_TIMEOUT_SECS`]) also falls back, but is logged rather than
+/// silently dropped: the operator picked a scan budget deliberately, so
+/// quietly serving a different one turns a typo into unexplained latency with
+/// nothing to trace it to.
 fn timeout_secs_or_default(raw: Option<String>) -> u64 {
-    raw.and_then(|raw| raw.trim().parse::<u64>().ok())
-        .filter(|secs| (1..=MAX_TIMEOUT_SECS).contains(secs))
-        .unwrap_or(DEFAULT_TIMEOUT_SECS)
+    let Some(raw) = raw
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+    else {
+        return DEFAULT_TIMEOUT_SECS;
+    };
+    match raw.parse::<u64>() {
+        Ok(secs) if (1..=MAX_TIMEOUT_SECS).contains(&secs) => secs,
+        _ => {
+            log::warn!(
+                "Ignoring {ENV_TIMEOUT}={raw:?}: expected an integer in 1..={MAX_TIMEOUT_SECS}; \
+                 falling back to {DEFAULT_TIMEOUT_SECS}s"
+            );
+            DEFAULT_TIMEOUT_SECS
+        }
+    }
 }
 
 fn env_or(key: &str, default: &str) -> String {
@@ -485,6 +502,7 @@ mod tests {
     fn timeout_in_range_is_used() {
         assert_eq!(timeout_secs_or_default(Some("45".into())), 45);
         assert_eq!(timeout_secs_or_default(Some("1".into())), 1);
+        assert_eq!(timeout_secs_or_default(Some(" 45 ".into())), 45);
         assert_eq!(
             timeout_secs_or_default(Some(MAX_TIMEOUT_SECS.to_string())),
             MAX_TIMEOUT_SECS
@@ -505,15 +523,21 @@ mod tests {
 
     #[test]
     fn timeout_missing_or_unparseable_falls_back_to_default() {
-        assert_eq!(timeout_secs_or_default(None), DEFAULT_TIMEOUT_SECS);
-        assert_eq!(
-            timeout_secs_or_default(Some("not-a-number".into())),
-            DEFAULT_TIMEOUT_SECS
-        );
-        assert_eq!(
-            timeout_secs_or_default(Some("-5".into())),
-            DEFAULT_TIMEOUT_SECS
-        );
+        for raw in [
+            None,
+            Some(String::new()),
+            Some("   ".into()),
+            Some("not-a-number".into()),
+            Some("-5".into()),
+            // A digit-transposing typo: 30 mistyped as 3O.
+            Some("3O".into()),
+        ] {
+            assert_eq!(
+                timeout_secs_or_default(raw.clone()),
+                DEFAULT_TIMEOUT_SECS,
+                "{raw:?} must fall back to the default timeout"
+            );
+        }
     }
 
     #[test]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli_logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli_logging.py
@@ -11,6 +11,12 @@ from agent_sec_cli.diagnostic_logging import (
 )
 
 _LOGGER_NAME = "agent_sec_cli"
+# Rust records reach Python through pyo3-log, which names the logger after the
+# emitting crate's `log` target — `model_service`, `prompt_scanner.<module>` —
+# not after `agent_sec_cli`. Left out of the CLI tree they bubble to a root
+# with no handler, hit logging.lastResort on stderr, and are then discarded by
+# hooks that capture stderr and parse only stdout.
+_RUST_LOGGER_NAMES = ("model_service", "prompt_scanner")
 _ENV_LOG_LEVEL = "AGENT_SEC_CLI_LOG_LEVEL"
 # Diagnostic stream is sized smaller than the business streams: default
 # WARNING volume is low, and DEBUG bursts roll over quickly.
@@ -30,6 +36,7 @@ class CliDiagnosticLogging(PythonLogRecordDiagnosticLogging):
     max_bytes = CLI_LOG_MAX_BYTES
     backup_count = CLI_LOG_BACKUP_COUNT
     python_logger_name = _LOGGER_NAME
+    extra_logger_names = _RUST_LOGGER_NAMES
     event = "cli_log"
     propagate_on_enable = False
     propagate_on_reset = True

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/diagnostic_logging.py
@@ -308,6 +308,11 @@ class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
     """Base class for components that route Python logging into JSONL."""
 
     python_logger_name = ""
+    # Logger trees outside `python_logger_name` whose records still belong to
+    # this component's stream. Needed because a record's logger name is not
+    # always chosen by this codebase: pyo3-log maps Rust `log` targets onto
+    # top-level Python logger names that no component namespace covers.
+    extra_logger_names: tuple[str, ...] = ()
     event = "python_log"
     propagate_on_enable: bool | None = None
     propagate_on_reset: bool | None = None
@@ -319,20 +324,32 @@ class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
         self._handler: logging.Handler | None = None
 
     def _setup_enabled(self, config: DiagnosticLoggingConfig) -> None:
-        python_logger = self.get_python_logger()
         handler = self.create_record_handler(config.log_file)
         handler.setLevel(config.level)
-        # Keep the component logger's level under application control. Changing
-        # it here would affect every other handler attached to the same logger
-        # tree, not just this diagnostic JSONL handler.
-        python_logger.addHandler(handler)
-        if self.propagate_on_enable is not None:
-            python_logger.propagate = self.propagate_on_enable
+        # One handler instance serves every tree so that a single stream, and a
+        # single level, stay authoritative for the component.
+        for python_logger in self.get_python_loggers():
+            # Keep the component logger's level under application control. Changing
+            # it here would affect every other handler attached to the same logger
+            # tree, not just this diagnostic JSONL handler.
+            python_logger.addHandler(handler)
+            if self.propagate_on_enable is not None:
+                python_logger.propagate = self.propagate_on_enable
         self._handler = handler
 
     def get_python_logger(self) -> logging.Logger:
         """Return the Python logger tree this diagnostic logger owns."""
         return logging.getLogger(self.python_logger_name)
+
+    def get_python_loggers(self) -> tuple[logging.Logger, ...]:
+        """Return every logger tree this diagnostic logger attaches to.
+
+        The owned tree comes first, followed by the `extra_logger_names` trees.
+        """
+        return (
+            self.get_python_logger(),
+            *(logging.getLogger(name) for name in self.extra_logger_names),
+        )
 
     def create_record_handler(self, path: str | Path) -> "DiagnosticLogRecordHandler":
         """Create the handler that converts LogRecord objects into JSONL."""
@@ -444,13 +461,19 @@ class PythonLogRecordDiagnosticLogging(BaseDiagnosticLogging):
 
     def reset_for_tests(self) -> None:
         """Reset attached Python logging handler state for tests."""
-        python_logger = self.get_python_logger()
-        for handler in list(python_logger.handlers):
-            if self.should_remove_handler(handler):
-                python_logger.removeHandler(handler)
-                handler.close()
-        if self.propagate_on_reset is not None:
-            python_logger.propagate = self.propagate_on_reset
+        detached: list[logging.Handler] = []
+        for python_logger in self.get_python_loggers():
+            for handler in list(python_logger.handlers):
+                if self.should_remove_handler(handler):
+                    python_logger.removeHandler(handler)
+                    if handler not in detached:
+                        detached.append(handler)
+            if self.propagate_on_reset is not None:
+                python_logger.propagate = self.propagate_on_reset
+        # The same handler is shared by several trees, so it can only be closed
+        # once it is detached from all of them.
+        for handler in detached:
+            handler.close()
         self._handler = None
         super().reset_for_tests()
 

--- a/src/agent-sec-core/agent-sec-cli/src/lib.rs
+++ b/src/agent-sec-core/agent-sec-cli/src/lib.rs
@@ -154,6 +154,14 @@ fn scanner_engine_info() -> String {
 /// Available as `from agent_sec_cli._native import ...` in Python.
 #[pymodule]
 fn _native(_py: Python, m: &PyModule) -> PyResult<()> {
+    // Route Rust `log` records into Python's `logging`.  This is the only
+    // place a logger can be installed: the crate ships as a cdylib with no
+    // `main`, so without this call the `log` facade discards every record —
+    // including the model-service warnings about a non-loopback base URL and
+    // about rejected tuning values.  An Err means a logger is already
+    // installed (module reload, sub-interpreter); the existing bridge stays
+    // valid, so importing must not fail over it.
+    let _ = pyo3_log::try_init();
     m.add_function(wrap_pyfunction!(scan_prompt_json, m)?)?;
     m.add_function(wrap_pyfunction!(scan_multi_turn_json, m)?)?;
     m.add_function(wrap_pyfunction!(warmup_scanner, m)?)?;

--- a/src/agent-sec-core/agent-sec-cli/src/lib.rs
+++ b/src/agent-sec-core/agent-sec-cli/src/lib.rs
@@ -153,15 +153,27 @@ fn scanner_engine_info() -> String {
 /// Python module implemented in Rust.
 /// Available as `from agent_sec_cli._native import ...` in Python.
 #[pymodule]
-fn _native(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _native(py: Python, m: &PyModule) -> PyResult<()> {
     // Route Rust `log` records into Python's `logging`.  This is the only
     // place a logger can be installed: the crate ships as a cdylib with no
     // `main`, so without this call the `log` facade discards every record —
     // including the model-service warnings about a non-loopback base URL and
-    // about rejected tuning values.  An Err means a logger is already
-    // installed (module reload, sub-interpreter); the existing bridge stays
-    // valid, so importing must not fail over it.
-    let _ = pyo3_log::try_init();
+    // about rejected tuning values.
+    //
+    // Caching is off on purpose.  The cached variants pin each target's Python
+    // logger and level on first use and can only be invalidated through the
+    // `ResetHandle` returned here, so any later reconfiguration on the Python
+    // side — attaching a handler at runtime, or the per-test logging reset in
+    // `cli_logging` — would silently keep routing records by stale settings.
+    // Holding the handle instead would mean exposing a reset hook back to
+    // Python; not worth it for a dependency tree that logs a handful of
+    // warnings per invocation.
+    //
+    // A failing `install` means a logger is already registered (module reload,
+    // sub-interpreter); the existing bridge stays valid, so importing must not
+    // fail over it.  A failing `new` means `import logging` itself broke, which
+    // is worth propagating.
+    let _ = pyo3_log::Logger::new(py, pyo3_log::Caching::Nothing)?.install();
     m.add_function(wrap_pyfunction!(scan_prompt_json, m)?)?;
     m.add_function(wrap_pyfunction!(scan_multi_turn_json, m)?)?;
     m.add_function(wrap_pyfunction!(warmup_scanner, m)?)?;

--- a/src/agent-sec-core/tests/unit-test/test_cli_logging.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli_logging.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import stat
 import sys
 from datetime import datetime, timezone
@@ -11,6 +12,7 @@ from pathlib import Path
 import pytest
 from agent_sec_cli import diagnostic_logging
 from agent_sec_cli.cli_logging import (
+    _RUST_LOGGER_NAMES,
     CLI_LOG_BACKUP_COUNT,
     CLI_LOG_MAX_BYTES,
     JsonlCliLogHandler,
@@ -25,6 +27,9 @@ from agent_sec_cli.correlation_context import (
     init_invocation_context,
     init_process_trace_context,
 )
+
+_AGENT_SEC_CLI_DIR = Path(__file__).resolve().parents[2] / "agent-sec-cli"
+_LOG_MACRO_RE = re.compile(r"\blog::(?:error|warn|info|debug|trace)!")
 
 
 @pytest.fixture(autouse=True)
@@ -513,3 +518,122 @@ def test_handler_ignores_non_string_correlation_field_overrides(tmp_path: Path) 
     assert payload["trace_id"] == "real-trace"
     assert payload["session_id"] == "real-session"
     assert payload["run_id"] == "real-run"
+
+
+def test_setup_cli_logging_collects_rust_bridge_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # pyo3-log names each logger after the emitting Rust crate's `log` target,
+    # so these records never pass through the `agent_sec_cli` tree. They still
+    # belong to the CLI stream: they describe this invocation's scan.
+    _clear_cli_env(monkeypatch)
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_SEC_INVOCATION_ID", "invocation-rust")
+    init_invocation_context()
+
+    setup_cli_logging()
+    logging.getLogger("model_service").warning(
+        "Ignoring AGENT_SEC_MODEL_SERVICE_TIMEOUT"
+    )
+    logging.getLogger("prompt_scanner.scanner").warning("Detector is not available")
+
+    payloads = [
+        json.loads(line)
+        for line in (tmp_path / "cli.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [payload["logger"] for payload in payloads] == [
+        "model_service",
+        "prompt_scanner.scanner",
+    ]
+    assert {payload["component"] for payload in payloads} == {"cli"}
+    assert {payload["event"] for payload in payloads} == {"cli_log"}
+    # Correlation still works: Rust records join the rest of the invocation.
+    assert {payload["invocation_id"] for payload in payloads} == {"invocation-rust"}
+
+
+def test_setup_cli_logging_shares_one_handler_across_rust_loggers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A single handler instance keeps one stream and one level authoritative;
+    # disabling propagation stops the records from also reaching the
+    # handler-less root, where logging.lastResort would print raw text to
+    # stderr that hook layers capture and discard.
+    _clear_cli_env(monkeypatch)
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+
+    setup_cli_logging()
+
+    attached = set()
+    for name in ("agent_sec_cli", *_RUST_LOGGER_NAMES):
+        logger = logging.getLogger(name)
+        handlers = [
+            handler
+            for handler in logger.handlers
+            if isinstance(handler, JsonlCliLogHandler)
+        ]
+        assert len(handlers) == 1
+        assert logger.propagate is False
+        attached.add(id(handlers[0]))
+    assert len(attached) == 1
+
+
+def test_reset_detaches_handlers_from_rust_loggers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A handler left behind on a Rust logger would keep writing to the previous
+    # test's log path for the rest of the process.
+    _clear_cli_env(monkeypatch)
+    monkeypatch.setenv("AGENT_SEC_DATA_DIR", str(tmp_path))
+    setup_cli_logging()
+
+    _reset_cli_logging_for_tests()
+
+    for name in ("agent_sec_cli", *_RUST_LOGGER_NAMES):
+        logger = logging.getLogger(name)
+        assert [
+            handler
+            for handler in logger.handlers
+            if isinstance(handler, JsonlCliLogHandler)
+        ] == []
+        assert logger.propagate is True
+
+
+def test_logging_rust_crates_are_covered_by_cli_logger_names() -> None:
+    # The set of bridged logger names is maintained by hand, so a new crate
+    # that starts logging would silently fall out of the CLI stream again.
+    # Fail here instead of losing its records in production.
+    crates_dir = _AGENT_SEC_CLI_DIR / "crates"
+    if not crates_dir.is_dir():
+        pytest.skip("Rust sources are unavailable outside a source checkout")
+
+    logging_crates = {
+        source.relative_to(crates_dir).parts[0].replace("-", "_")
+        for source in crates_dir.glob("*/src/**/*.rs")
+        if _LOG_MACRO_RE.search(source.read_text(encoding="utf-8"))
+    }
+
+    assert logging_crates, "expected at least one Rust crate to emit log records"
+    assert logging_crates <= set(_RUST_LOGGER_NAMES), (
+        "Rust crates emitting log records but missing from _RUST_LOGGER_NAMES: "
+        f"{sorted(logging_crates - set(_RUST_LOGGER_NAMES))}"
+    )
+
+
+def test_native_extension_crate_emits_no_log_records() -> None:
+    # Records from the cdylib itself would arrive under `agent_sec_cli_native`
+    # (its Cargo `[lib] name`) — a top-level logger that neither the
+    # `agent_sec_cli` tree nor _RUST_LOGGER_NAMES covers.
+    native_src_dir = _AGENT_SEC_CLI_DIR / "src"
+    if not native_src_dir.is_dir():
+        pytest.skip("Rust sources are unavailable outside a source checkout")
+
+    offenders = sorted(
+        source.name
+        for source in native_src_dir.glob("*.rs")
+        if _LOG_MACRO_RE.search(source.read_text(encoding="utf-8"))
+    )
+
+    assert offenders == [], (
+        "log records emitted from the cdylib crate would bypass the CLI "
+        f"diagnostic stream: {offenders}"
+    )


### PR DESCRIPTION
这个pr原来是想想添加一个环境变量来方便做不同线程下的性能测试。
但是看起来比较担心ollama 在部署的时候的 reload thrashing。
我觉得直接修复ollama 服务端部署来达到目的就行， 环境变量的灵活性需要修改很多运维文档和代码，得不偿失。

但是由于发现了log的问题，这个pr 改成了修改rust log的问题。

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
