### PR TITLE
feat(sight): enforce size limits on sqlite stores

### DIFF
--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -39,6 +39,9 @@ pub const DEFAULT_RETENTION_DAYS: u64 = 30;
 /// Default purge check interval (every N inserts)
 pub const DEFAULT_PURGE_INTERVAL: u64 = 1000;
 
+/// Default max database file size in MB (0 = no size-based limit)
+pub const DEFAULT_MAX_DB_SIZE_MB: u64 = 500;
+
 /// Default bounded channel capacity for probe → event loop events.
 pub const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 10_000;
 
@@ -796,6 +799,8 @@ pub struct AgentsightConfig {
     pub retention_days: u64,
     /// Purge check interval (run purge every N inserts, 0 = never auto-purge)
     pub purge_interval: u64,
+    /// Max database file size in MB (0 = no size-based limit)
+    pub max_db_size_mb: u64,
 
     // --- Trace Control ---
     /// Controls whether SLS-uploaded `LLMCall` records carry conversation
@@ -920,6 +925,7 @@ impl Default for AgentsightConfig {
             http_table: DEFAULT_HTTP_TABLE.to_string(),
             retention_days: DEFAULT_RETENTION_DAYS,
             purge_interval: DEFAULT_PURGE_INTERVAL,
+            max_db_size_mb: DEFAULT_MAX_DB_SIZE_MB,
 
             // Trace control defaults
             // Default = false (privacy-safe): SLS uploads carry only token /
@@ -1532,6 +1538,7 @@ mod tests {
         assert!(!config.cgroup_filter_enabled);
         assert_eq!(config.retention_days, 30);
         assert_eq!(config.purge_interval, 1000);
+        assert_eq!(config.max_db_size_mb, 500);
     }
 
     /// `traceEnabled` is **off** by default (privacy-safe). Conversation

--- a/src/agentsight/src/storage/sqlite/audit.rs
+++ b/src/agentsight/src/storage/sqlite/audit.rs
@@ -187,6 +187,32 @@ impl AuditStore {
         Ok(deleted as u64)
     }
 
+    /// Delete the oldest N records by timestamp.
+    ///
+    /// Used for size-based pruning when the database file exceeds its
+    /// configured maximum, regardless of record age.
+    pub fn delete_oldest_batch(&self, limit: usize) -> Result<usize> {
+        let sql = format!(
+            "DELETE FROM {} WHERE id IN (
+                SELECT id FROM {} ORDER BY timestamp_ns ASC LIMIT ?1
+            )",
+            self.table_name, self.table_name
+        );
+        let deleted = self.conn.execute(&sql, params![limit as i64])?;
+        Ok(deleted)
+    }
+
+    /// Run VACUUM to reclaim free pages after bulk deletes.
+    ///
+    /// Since all stores in `Storage` share one database file, calling
+    /// this on any store vacuums the entire file. Re-enables WAL mode
+    /// afterwards as a defensive measure (VACUUM may reset it).
+    pub fn vacuum(&self) -> Result<()> {
+        self.conn
+            .execute_batch("VACUUM; PRAGMA journal_mode=WAL;")?;
+        Ok(())
+    }
+
     /// Execute WAL checkpoint to flush WAL data back to the main database file
     pub fn checkpoint(&self) -> Result<()> {
         wal_checkpoint(&self.conn)

--- a/src/agentsight/src/storage/sqlite/genai/events.rs
+++ b/src/agentsight/src/storage/sqlite/genai/events.rs
@@ -292,7 +292,14 @@ impl GenAISqliteStore {
         Ok(result)
     }
 
-    /// Store a single GenAI event with size limit enforcement
+    /// Store a single GenAI event with size limit enforcement.
+    ///
+    /// Size is checked via [`check_and_prune_if_needed`] before the write.
+    /// If the insert fails with `SQLITE_FULL`, up to `MAX_PRUNE_RETRIES`
+    /// retries are attempted — each retry prunes 5% of the oldest records and
+    /// runs VACUUM. VACUUM failures (e.g. disk-full) are tolerated: the
+    /// `DELETE` still frees internal pages that SQLite can reuse for the
+    /// retry insert.
     pub(super) fn store_event(
         &self,
         event: &GenAISemanticEvent,
@@ -318,7 +325,11 @@ impl GenAISqliteStore {
                                 "Database full (SQLITE_FULL), pruning old records (attempt {retries}/{MAX_PRUNE_RETRIES})"
                             );
                             self.prune_old_records()?;
-                            self.checkpoint()?;
+                            // VACUUM may fail if disk is full; continue
+                            // anyway — freed pages are reusable by the retry.
+                            if let Err(vacuum_err) = self.checkpoint() {
+                                log::warn!("VACUUM failed during SQLITE_FULL retry: {vacuum_err}");
+                            }
                             continue;
                         }
                     }

--- a/src/agentsight/src/storage/sqlite/genai/mod.rs
+++ b/src/agentsight/src/storage/sqlite/genai/mod.rs
@@ -88,6 +88,16 @@ impl GenAISqliteStore {
             store.batch_config.flush_ms,
         );
 
+        // If the database is already oversized on startup (e.g. from a prior
+        // crash or a config change), prune immediately rather than waiting for
+        // the first write to trigger cleanup.
+        if current_size >= threshold {
+            log::info!("Database oversized on startup, triggering cleanup");
+            if let Err(e) = store.check_and_prune_if_needed() {
+                log::warn!("Startup cleanup failed: {e}");
+            }
+        }
+
         Ok(store)
     }
 

--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -92,6 +92,13 @@ impl GenAISqliteStore {
     /// the full response arrives, or marked 'interrupted' by the stale-scan thread
     /// if the agent crashes before the response is received.
     pub fn insert_pending(&self, info: &PendingCallInfo) -> Result<(), Box<dyn std::error::Error>> {
+        // Enforce size limit before creating a new row. Best-effort: if
+        // pruning fails (e.g. VACUUM error), proceed with the INSERT — a
+        // missed prune is better than losing the event entirely.
+        if let Err(e) = self.check_and_prune_if_needed() {
+            log::warn!("Pre-insert size check failed: {e}");
+        }
+
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
         let instance = crate::genai::instance_id::get_instance_id();
         conn.execute(

--- a/src/agentsight/src/storage/sqlite/genai/schema.rs
+++ b/src/agentsight/src/storage/sqlite/genai/schema.rs
@@ -231,9 +231,17 @@ impl GenAISqliteStore {
         total
     }
 
-    /// Check database size and prune if approaching limit
+    /// Check database size and prune if approaching limit.
     ///
-    /// Keeps pruning until size drops below threshold to avoid repeated triggers.
+    /// Uses adaptive pruning: the fraction of records deleted per iteration
+    /// scales with how far the database exceeds the configured maximum, so a
+    /// severely oversized database is brought back under control quickly
+    /// instead of inching down 5% at a time.
+    ///
+    /// VACUUM failures (e.g. insufficient temporary disk space) are
+    /// tolerated — deleted records leave free pages that SQLite reuses for
+    /// future inserts, preventing further file growth even when VACUUM cannot
+    /// shrink the file.
     pub(super) fn check_and_prune_if_needed(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut current_size = self.get_total_db_size();
         let threshold = get_prune_threshold();
@@ -242,45 +250,129 @@ impl GenAISqliteStore {
             return Ok(());
         }
 
+        let max_size = get_max_db_size();
+        let overshoot = current_size as f64 / max_size as f64;
+
+        // Delete a larger fraction when the database is far over the limit.
+        //   1–2× over → 10% per iteration
+        //   2–5× over → 25% per iteration
+        //   5×+  over → 50% per iteration
+        let prune_pct = if overshoot > 5.0 {
+            0.50
+        } else if overshoot > 2.0 {
+            0.25
+        } else {
+            0.10
+        };
+
         log::info!(
-            "Database size {}MB exceeding threshold {}MB, pruning old records",
+            "Database size {}MB exceeding threshold {}MB (overshoot {:.1}×), \
+             pruning {:.0}% per iteration",
             current_size / 1024 / 1024,
-            threshold / 1024 / 1024
+            threshold / 1024 / 1024,
+            overshoot,
+            prune_pct * 100.0
         );
 
-        // Keep pruning until below threshold (max 5 iterations to prevent infinite loop)
-        let mut iterations = 0;
-        while current_size >= threshold && iterations < 5 {
+        const MAX_ITERATIONS: u32 = 20;
+        let mut iterations = 0u32;
+        let mut last_size = current_size;
+        // Consecutive iterations where file size did not decrease — signals
+        // that VACUUM is failing (e.g. disk full). Once this hits the limit
+        // we stop: the freed pages will be reused by future inserts, so the
+        // file will not grow further even without VACUUM.
+        let mut size_stuck_count = 0u32;
+
+        while current_size >= threshold && iterations < MAX_ITERATIONS {
             iterations += 1;
-            self.prune_old_records()?;
-            self.checkpoint()?;
-            current_size = self.get_total_db_size();
+
+            if let Err(e) = self.prune_old_records_with_percent(prune_pct) {
+                log::warn!("Prune failed on iteration {iterations}: {e}");
+                break;
+            }
+
+            // VACUUM may fail when disk space is tight; continue regardless.
+            if let Err(e) = self.checkpoint() {
+                log::warn!("VACUUM/checkpoint failed on iteration {iterations}: {e}");
+            }
+
+            let new_size = self.get_total_db_size();
+            if new_size < last_size {
+                size_stuck_count = 0;
+            } else {
+                size_stuck_count += 1;
+            }
+            last_size = new_size;
+            current_size = new_size;
+
+            // If the file hasn't shrunk for several iterations, VACUUM is
+            // likely failing. Stop — deleted pages are now free and will be
+            // reused, preventing further growth. Escalate with the remaining
+            // record count so operators can judge how much prunable data is
+            // left behind.
+            if size_stuck_count >= 3 {
+                let remaining: i64 = {
+                    let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+                    conn.query_row("SELECT COUNT(*) FROM genai_events", [], |row| row.get(0))
+                        .unwrap_or(-1)
+                };
+                log::error!(
+                    "GenAI prune stalled: file is {}MB (threshold {}MB) with {remaining} \
+                     records remaining after {iterations} iterations. VACUUM is likely \
+                     failing (e.g. disk full) — manual intervention required \
+                     (free disk space or remove the database).",
+                    current_size / 1024 / 1024,
+                    threshold / 1024 / 1024,
+                );
+                break;
+            }
 
             if current_size >= threshold {
                 log::info!(
-                    "Database still {}MB (threshold {}MB), continue pruning (iteration {})",
+                    "Database still {}MB (threshold {}MB), continue pruning \
+                     (iteration {iterations}/{MAX_ITERATIONS})",
                     current_size / 1024 / 1024,
                     threshold / 1024 / 1024,
-                    iterations
                 );
             }
         }
 
-        log::info!(
-            "Pruning complete, database size now {}MB",
-            current_size / 1024 / 1024
-        );
+        if current_size >= threshold {
+            log::warn!(
+                "Database size {}MB still above threshold {}MB after pruning; \
+                 will retry on next write",
+                current_size / 1024 / 1024,
+                threshold / 1024 / 1024,
+            );
+        } else {
+            log::info!(
+                "Pruning complete, database size now {}MB",
+                current_size / 1024 / 1024
+            );
+        }
 
         Ok(())
     }
 
-    /// Prune old records to free up space
+    /// Prune old records using the default 5% ratio.
     ///
-    /// Deletes a percentage of oldest records based on id.
+    /// Thin wrapper around [`prune_old_records_with_percent`] for callers that
+    /// only need the conservative default (e.g. SQLITE_FULL retry).
     pub(super) fn prune_old_records(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.prune_old_records_with_percent(PRUNE_PERCENT)
+    }
+
+    /// Delete the oldest `percent` fraction of records, ordered by id.
+    ///
+    /// `percent` is clamped to \[0.0, 1.0\]. At least one record is deleted
+    /// when the table is non-empty and `percent` > 0.
+    fn prune_old_records_with_percent(
+        &self,
+        percent: f64,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let pct = percent.clamp(0.0, 1.0);
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
 
-        // Get total count
         let count: i64 =
             conn.query_row("SELECT COUNT(*) FROM genai_events", [], |row| row.get(0))?;
 
@@ -288,17 +380,15 @@ impl GenAISqliteStore {
             return Ok(());
         }
 
-        // Calculate how many to delete (5% of total)
-        let delete_count = ((count as f64) * PRUNE_PERCENT).max(1.0) as i64;
+        let delete_count = ((count as f64) * pct).max(1.0) as i64;
 
         log::info!(
             "Pruning {} of {} records ({:.1}%)",
             delete_count,
             count,
-            PRUNE_PERCENT * 100.0
+            pct * 100.0
         );
 
-        // Delete oldest records by id
         let deleted = conn.execute(
             "DELETE FROM genai_events WHERE id IN (
                 SELECT id FROM genai_events ORDER BY id ASC LIMIT ?1

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -1372,3 +1372,131 @@ fn test_update_fallback_session_id_keeps_non_hex_32_chars() {
         assert_eq!(session_id_of(&store, "c1").as_deref(), Some(existing));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Size-based pruning (check_and_prune_if_needed / startup cleanup)
+// ---------------------------------------------------------------------------
+
+/// Cap the genai database at 1MB for size-limit tests.
+///
+/// All tests set the same value, so parallel execution never observes
+/// conflicting limits, and other tests' databases stay far below the
+/// resulting 0.9MB prune threshold.
+fn set_test_db_limit() {
+    unsafe { std::env::set_var("AGENTSIGHT_GENAI_DB_MAX_SIZE_MB", "1") };
+}
+
+fn unique_size_test_db(label: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "test_genai_size_{label}_{}_{}.db",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn cleanup_size_test_db(path: &std::path::Path) {
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+    let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+}
+
+/// Insert `rows` records of roughly `payload` bytes each via direct SQL,
+/// bypassing store_event's size checks so the test controls the file size.
+fn grow_db(store: &GenAISqliteStore, rows: usize, payload: usize) {
+    let blob = "x".repeat(payload);
+    {
+        let conn = store.conn.lock().unwrap();
+        for i in 0..rows {
+            conn.execute(
+                "INSERT INTO genai_events (event_type, start_timestamp_ns, event_json)
+                 VALUES ('llm_call', ?1, ?2)",
+                rusqlite::params![i as i64, blob],
+            )
+            .unwrap();
+        }
+    }
+    store.wal_checkpoint().unwrap();
+}
+
+fn row_count(store: &GenAISqliteStore) -> i64 {
+    let conn = store.conn.lock().unwrap();
+    conn.query_row("SELECT COUNT(*) FROM genai_events", [], |r| r.get(0))
+        .unwrap()
+}
+
+/// Covers all three adaptive prune branches: overshoot 1-2x (10% per
+/// iteration), 2-5x (25%), and 5x+ (50%). Each scenario must converge
+/// below the prune threshold within the iteration bound.
+#[test]
+fn check_and_prune_converges_for_all_overshoot_levels() {
+    set_test_db_limit();
+    // (label, rows x 10KB) => ~1.5MB / ~3MB / ~6MB against a 1MB cap.
+    for (label, rows) in [("low", 150), ("mid", 300), ("high", 600)] {
+        let path = unique_size_test_db(label);
+        let store = GenAISqliteStore::new_with_path(&path).unwrap();
+        grow_db(&store, rows, 10 * 1024);
+        let threshold = super::schema::get_prune_threshold();
+        assert!(
+            store.get_total_db_size() > threshold,
+            "{label}: setup must exceed the prune threshold"
+        );
+
+        store.check_and_prune_if_needed().unwrap();
+
+        assert!(
+            store.get_total_db_size() < threshold,
+            "{label}: database must shrink below threshold, got {} bytes",
+            store.get_total_db_size()
+        );
+        assert!(
+            row_count(&store) < rows as i64,
+            "{label}: oldest records must have been deleted"
+        );
+        drop(store);
+        cleanup_size_test_db(&path);
+    }
+}
+
+/// A no-op when the database is already within the threshold.
+#[test]
+fn check_and_prune_noop_below_threshold() {
+    set_test_db_limit();
+    let path = unique_size_test_db("noop");
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+    grow_db(&store, 10, 64);
+
+    store.check_and_prune_if_needed().unwrap();
+
+    assert_eq!(
+        row_count(&store),
+        10,
+        "below-threshold prune must not delete"
+    );
+    drop(store);
+    cleanup_size_test_db(&path);
+}
+
+/// Reopening an oversized database triggers the startup cleanup path in
+/// `new_with_path_and_batch`.
+#[test]
+fn startup_cleanup_prunes_oversized_db() {
+    set_test_db_limit();
+    let path = unique_size_test_db("startup");
+    {
+        let store = GenAISqliteStore::new_with_path(&path).unwrap();
+        grow_db(&store, 300, 10 * 1024); // ~3MB > 1MB cap
+    }
+
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+
+    let threshold = super::schema::get_prune_threshold();
+    assert!(
+        store.get_total_db_size() < threshold,
+        "startup cleanup must bring the database below the threshold"
+    );
+    drop(store);
+    cleanup_size_test_db(&path);
+}

--- a/src/agentsight/src/storage/sqlite/http.rs
+++ b/src/agentsight/src/storage/sqlite/http.rs
@@ -179,6 +179,21 @@ impl HttpStore {
         Ok(deleted as u64)
     }
 
+    /// Delete the oldest N records by timestamp.
+    ///
+    /// Used for size-based pruning when the database file exceeds its
+    /// configured maximum.
+    pub fn delete_oldest_batch(&self, limit: usize) -> Result<usize> {
+        let sql = format!(
+            "DELETE FROM {} WHERE id IN (
+                SELECT id FROM {} ORDER BY timestamp_ns ASC LIMIT ?1
+            )",
+            self.table_name, self.table_name
+        );
+        let deleted = self.conn.execute(&sql, params![limit as i64])?;
+        Ok(deleted)
+    }
+
     /// Execute WAL checkpoint to flush WAL data back to the main database file
     pub fn checkpoint(&self) -> Result<()> {
         wal_checkpoint(&self.conn)

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -662,8 +662,11 @@ impl InterruptionStore {
                     break;
                 }
             }
-            // Reclaim free pages after bulk deletes.
-            let _ = self.vacuum();
+            // Reclaim free pages after bulk deletes. VACUUM may fail if
+            // disk is full; freed pages are still reusable by future inserts.
+            if let Err(e) = self.vacuum() {
+                log::warn!("VACUUM after interruption purge failed: {e}");
+            }
         }
 
         Ok(total_deleted)

--- a/src/agentsight/src/storage/sqlite/token.rs
+++ b/src/agentsight/src/storage/sqlite/token.rs
@@ -479,6 +479,24 @@ impl TokenStore {
         Ok(deleted as u64)
     }
 
+    /// Delete the oldest N records by timestamp.
+    ///
+    /// Used for size-based pruning when the database file exceeds its
+    /// configured maximum.
+    pub fn delete_oldest_batch(&self, limit: usize) -> anyhow::Result<usize> {
+        let sql = format!(
+            "DELETE FROM {} WHERE id IN (
+                SELECT id FROM {} ORDER BY timestamp_ns ASC LIMIT ?1
+            )",
+            self.table_name, self.table_name
+        );
+        let deleted = self
+            .conn
+            .execute(&sql, params![limit as i64])
+            .map_err(|e| anyhow::anyhow!("Failed to delete oldest token records: {e}"))?;
+        Ok(deleted)
+    }
+
     /// Execute WAL checkpoint to flush WAL data back to the main database file
     pub fn checkpoint(&self) -> anyhow::Result<()> {
         wal_checkpoint(&self.conn)

--- a/src/agentsight/src/storage/sqlite/token_consumption.rs
+++ b/src/agentsight/src/storage/sqlite/token_consumption.rs
@@ -351,6 +351,23 @@ impl TokenConsumptionStore {
         Ok(deleted as u64)
     }
 
+    /// Delete the oldest N records by timestamp.
+    ///
+    /// Used for size-based pruning when the database file exceeds its
+    /// configured maximum.
+    pub fn delete_oldest_batch(&self, limit: usize) -> anyhow::Result<usize> {
+        let deleted = self.conn.execute(
+            &format!(
+                "DELETE FROM {} WHERE id IN (
+                    SELECT id FROM {} ORDER BY timestamp_ns ASC LIMIT ?1
+                )",
+                self.table_name, self.table_name
+            ),
+            params![limit as i64],
+        )?;
+        Ok(deleted)
+    }
+
     /// Execute WAL checkpoint to flush WAL data back to the main database file
     pub fn checkpoint(&self) -> anyhow::Result<()> {
         wal_checkpoint(&self.conn)

--- a/src/agentsight/src/storage/unified.rs
+++ b/src/agentsight/src/storage/unified.rs
@@ -82,6 +82,8 @@ pub struct SqliteConfig {
     pub retention_days: u64,
     /// Auto-purge check interval (every N inserts, 0 = disabled)
     pub purge_interval: u64,
+    /// Max database file size in MB (0 = no size-based limit)
+    pub max_db_size_mb: u64,
 }
 
 impl Default for SqliteConfig {
@@ -95,6 +97,7 @@ impl Default for SqliteConfig {
             token_consumption_table: "token_consumption".to_string(),
             retention_days: 30,
             purge_interval: 100000,
+            max_db_size_mb: 500,
         }
     }
 }
@@ -131,6 +134,10 @@ pub struct Storage {
     retention_days: u64,
     /// Auto-purge check interval (every N inserts, 0 = disabled)
     purge_interval: u64,
+    /// Max database file size in bytes (0 = no size-based limit)
+    max_db_size_bytes: u64,
+    /// Path to the SQLite database file (for size checking)
+    db_path: PathBuf,
     /// Insert counter for auto-purge triggering
     insert_count: AtomicU64,
 }
@@ -159,7 +166,7 @@ impl Storage {
         let http_store = HttpStore::with_table(&db_path, &config.http_table)?;
         let token_consumption_store =
             TokenConsumptionStore::with_table(&db_path, &config.token_consumption_table)?;
-        Ok(Storage {
+        let storage = Storage {
             backend: StorageBackend::Sqlite,
             audit_store,
             token_store,
@@ -167,8 +174,21 @@ impl Storage {
             token_consumption_store,
             retention_days: config.retention_days,
             purge_interval: config.purge_interval,
+            max_db_size_bytes: config.max_db_size_mb * 1024 * 1024,
+            db_path,
             insert_count: AtomicU64::new(0),
-        })
+        };
+
+        // If the database is already oversized on startup (e.g. from a prior
+        // crash or a config change), prune immediately rather than waiting for
+        // the next purge interval.
+        if storage.max_db_size_bytes > 0 {
+            if let Err(e) = storage.purge_oversized() {
+                log::warn!("Startup size-based cleanup failed: {e}");
+            }
+        }
+
+        Ok(storage)
     }
 
     /// Create a new Storage with default SQLite config
@@ -199,6 +219,8 @@ impl Storage {
             token_consumption_store,
             retention_days: 0,
             purge_interval: 0,
+            max_db_size_bytes: 0,
+            db_path,
             insert_count: AtomicU64::new(0),
         }
     }
@@ -268,11 +290,18 @@ impl Storage {
         }?;
 
         // Auto-purge check: trigger every `purge_interval` inserts
-        if self.purge_interval > 0 && self.retention_days > 0 {
+        if self.purge_interval > 0 {
             let count = self.insert_count.fetch_add(1, Ordering::Relaxed) + 1;
             if count.is_multiple_of(self.purge_interval) {
-                if let Err(e) = self.purge_expired() {
-                    log::warn!("Auto-purge failed: {e}");
+                if self.retention_days > 0 {
+                    if let Err(e) = self.purge_expired() {
+                        log::warn!("Auto-purge (age-based) failed: {e}");
+                    }
+                }
+                if self.max_db_size_bytes > 0 {
+                    if let Err(e) = self.purge_oversized() {
+                        log::warn!("Auto-purge (size-based) failed: {e}");
+                    }
                 }
             }
         }
@@ -317,9 +346,137 @@ impl Storage {
                 http_deleted,
                 consumption_deleted,
             );
+
+            // Reclaim free pages after bulk deletes. VACUUM writes through
+            // the WAL, so a TRUNCATE checkpoint is needed for the file to
+            // actually shrink. Both are best-effort: freed pages are reusable
+            // by future inserts even when they fail.
+            if let Err(e) = self.audit_store.vacuum() {
+                log::warn!("VACUUM after age-based purge failed: {e}");
+            }
+            if let Err(e) = self.audit_store.checkpoint() {
+                log::warn!("WAL checkpoint after age-based purge failed: {e}");
+            }
         }
 
         Ok(total_deleted)
+    }
+
+    /// Purge oldest records when the database exceeds the size limit.
+    ///
+    /// Size accounting includes the main file plus the `-wal` and `-shm`
+    /// companions — in WAL mode a large share of recent data lives in the WAL
+    /// file, so checking the main file alone would under-report.
+    ///
+    /// Work is organized in rounds: each round deletes a fixed number of
+    /// oldest-record batches from all tables, then runs one VACUUM +
+    /// checkpoint before re-measuring. VACUUM rewrites the whole file, so it
+    /// must not run per batch — bounding it per round keeps a multi-GB
+    /// cleanup tractable. VACUUM failures are tolerated: freed pages are
+    /// still reusable by future inserts.
+    ///
+    /// Rounds continue until the size is within the limit; termination is
+    /// guaranteed because every round must strictly shrink the file (or empty
+    /// the tables), otherwise the purge stops and reports the stall.
+    ///
+    /// Called automatically by `store()` during purge checks and by
+    /// `with_sqlite_config()` on startup.
+    pub fn purge_oversized(&self) -> Result<()> {
+        if self.max_db_size_bytes == 0 {
+            return Ok(());
+        }
+
+        // Rows deleted per table per batch, and batches per round: up to
+        // 20 000 rows per table between two VACUUM runs.
+        const BATCH_ROWS: usize = 1000;
+        const BATCHES_PER_ROUND: u32 = 20;
+
+        let mut prev_size = u64::MAX;
+        let mut round = 0u32;
+
+        loop {
+            let size = self.total_db_size();
+            if size <= self.max_db_size_bytes {
+                break;
+            }
+
+            // A round of deletes + VACUUM that does not shrink the file means
+            // VACUUM is failing (e.g. disk full). Deleting further rows would
+            // destroy data without freeing disk space, so stop and escalate:
+            // freed pages are still reused by future inserts, which prevents
+            // the main file from growing, but the size cap is no longer
+            // enforceable without operator action.
+            if size >= prev_size {
+                log::error!(
+                    "Size-based purge stalled: database is {} bytes (limit {}) and \
+                     did not shrink after round {round}. VACUUM is likely failing \
+                     (e.g. disk full). Size enforcement is suspended — manual \
+                     intervention required (free disk space or remove the database).",
+                    size,
+                    self.max_db_size_bytes
+                );
+                break;
+            }
+            prev_size = size;
+            round += 1;
+
+            let mut round_deleted = 0usize;
+            for _ in 0..BATCHES_PER_ROUND {
+                let deleted = self.audit_store.delete_oldest_batch(BATCH_ROWS)?
+                    + self.token_store.delete_oldest_batch(BATCH_ROWS)?
+                    + self.http_store.delete_oldest_batch(BATCH_ROWS)?
+                    + self
+                        .token_consumption_store
+                        .delete_oldest_batch(BATCH_ROWS)?;
+                round_deleted += deleted;
+                if deleted == 0 {
+                    break; // All tables empty
+                }
+            }
+
+            // VACUUM first, then checkpoint: in WAL mode VACUUM writes the
+            // rebuilt database through the WAL, so the file only shrinks once
+            // a TRUNCATE checkpoint flushes it back. Both are best-effort:
+            // freed pages are reusable even when they fail.
+            if let Err(e) = self.audit_store.vacuum() {
+                log::warn!("VACUUM during size-based purge failed: {e}");
+            }
+            if let Err(e) = self.audit_store.checkpoint() {
+                log::warn!("WAL checkpoint during size-based purge failed: {e}");
+            }
+
+            log::info!(
+                "Size-based purge round {round}: deleted {round_deleted} rows, \
+                 database now {} bytes (limit {})",
+                self.total_db_size(),
+                self.max_db_size_bytes
+            );
+
+            if round_deleted == 0 {
+                break; // Nothing left to delete
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Total on-disk size of the database: main file + `-wal` + `-shm`.
+    ///
+    /// A missing companion file is normal (e.g. after a TRUNCATE checkpoint)
+    /// and counts as zero; any other metadata error is logged because it can
+    /// under-report the size and mask an oversized database.
+    fn total_db_size(&self) -> u64 {
+        let len = |path: &str| match std::fs::metadata(path) {
+            Ok(m) => m.len(),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
+            Err(e) => {
+                log::warn!("Cannot stat {path} for size accounting, assuming 0 bytes: {e}");
+                0
+            }
+        };
+        len(&self.db_path.display().to_string())
+            + len(&format!("{}-wal", self.db_path.display()))
+            + len(&format!("{}-shm", self.db_path.display()))
     }
 
     /// Compute the cutoff timestamp for retention
@@ -378,6 +535,7 @@ impl Drop for Storage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analyzer::token::TokenRecord;
 
     #[test]
     fn test_noop_storage_is_noop() {
@@ -418,5 +576,236 @@ mod tests {
         // Just verify it doesn't panic
         let _ = storage.is_noop();
         drop(storage);
+    }
+
+    /// Unique per-test directory under the system temp dir.
+    fn unique_base_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agentsight_unified_{label}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn test_config(base_path: PathBuf, max_db_size_mb: u64) -> SqliteConfig {
+        SqliteConfig {
+            base_path,
+            // Disable both auto-purge paths so tests trigger purges explicitly.
+            retention_days: 0,
+            purge_interval: 0,
+            max_db_size_mb,
+            ..Default::default()
+        }
+    }
+
+    /// Token record with a payload of roughly `payload_bytes` for growing the
+    /// database file quickly in size-limit tests.
+    fn bulky_token_record(timestamp_ns: u64, payload_bytes: usize) -> TokenRecord {
+        TokenRecord {
+            id: 0,
+            timestamp_ns,
+            pid: 1,
+            comm: "test".to_string(),
+            agent: None,
+            model: None,
+            provider: "test".to_string(),
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
+            request_id: None,
+            // `endpoint` is a persisted TEXT column, so the payload actually
+            // lands in the database file (`reasoning_content` is not stored).
+            endpoint: Some("x".repeat(payload_bytes)),
+            tool_calls: vec![],
+            reasoning_content: None,
+        }
+    }
+
+    #[test]
+    fn test_purge_oversized_disabled_when_limit_zero() {
+        let dir = unique_base_dir("limit_zero");
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 0)).unwrap();
+
+        for i in 0..10 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(i, 64))
+                .unwrap();
+        }
+        storage.purge_oversized().unwrap();
+
+        assert_eq!(storage.token_store.count(), 10, "limit 0 must never delete");
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_purge_oversized_noop_when_below_limit() {
+        let dir = unique_base_dir("below_limit");
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 500)).unwrap();
+
+        for i in 0..10 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(i, 64))
+                .unwrap();
+        }
+        storage.purge_oversized().unwrap();
+
+        assert_eq!(
+            storage.token_store.count(),
+            10,
+            "below-limit purge must not delete"
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_purge_oversized_shrinks_db_below_limit() {
+        let dir = unique_base_dir("shrink");
+        let limit_mb = 1u64;
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), limit_mb)).unwrap();
+
+        // ~3MB of data: 300 rows × 10KB payload, well over the 1MB limit.
+        for i in 0..300 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(i, 10 * 1024))
+                .unwrap();
+        }
+        storage.checkpoint().unwrap();
+        assert!(
+            storage.total_db_size() > limit_mb * 1024 * 1024,
+            "test setup must produce an oversized database"
+        );
+
+        storage.purge_oversized().unwrap();
+
+        assert!(
+            storage.total_db_size() <= limit_mb * 1024 * 1024,
+            "database must be within the size limit after purge, got {} bytes",
+            storage.total_db_size()
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_purge_oversized_runs_on_startup() {
+        let dir = unique_base_dir("startup");
+        let limit_mb = 1u64;
+
+        // Grow the database past the limit with size checks disabled.
+        {
+            let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 0)).unwrap();
+            for i in 0..300 {
+                storage
+                    .token_store
+                    .insert(&bulky_token_record(i, 10 * 1024))
+                    .unwrap();
+            }
+            storage.checkpoint().unwrap();
+            assert!(storage.total_db_size() > limit_mb * 1024 * 1024);
+        }
+
+        // Reopening with a limit must trigger the startup cleanup.
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), limit_mb)).unwrap();
+        assert!(
+            storage.total_db_size() <= limit_mb * 1024 * 1024,
+            "startup cleanup must bring the database within the limit"
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_total_db_size_counts_wal_file() {
+        let dir = unique_base_dir("wal_size");
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 500)).unwrap();
+
+        // Without a checkpoint, recent writes stay in the -wal file.
+        for i in 0..20 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(i, 1024))
+                .unwrap();
+        }
+
+        let wal_len = std::fs::metadata(format!("{}-wal", storage.db_path.display()))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        assert!(
+            wal_len > 0,
+            "WAL file should hold the un-checkpointed writes"
+        );
+
+        let main_len = std::fs::metadata(&storage.db_path).unwrap().len();
+        assert!(
+            storage.total_db_size() >= main_len + wal_len,
+            "size accounting must include the WAL file"
+        );
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_delete_oldest_batch_removes_oldest_rows() {
+        let dir = unique_base_dir("oldest_batch");
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 0)).unwrap();
+
+        for ts in 1..=10 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(ts, 64))
+                .unwrap();
+        }
+
+        let deleted = storage.token_store.delete_oldest_batch(4).unwrap();
+        assert_eq!(deleted, 4);
+
+        let remaining = storage.token_store.all();
+        assert_eq!(remaining.len(), 6);
+        let min_ts = remaining.iter().map(|r| r.timestamp_ns).min().unwrap();
+        assert_eq!(min_ts, 5, "the four oldest rows (ts 1-4) must be gone");
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `store()` must run both purge paths (age-based and size-based) every
+    /// `purge_interval` inserts, including the VACUUM after an age purge.
+    #[test]
+    fn test_store_triggers_auto_purge() {
+        let dir = unique_base_dir("auto_purge");
+        let config = SqliteConfig {
+            base_path: dir.clone(),
+            retention_days: 1,
+            purge_interval: 1, // purge check on every insert
+            max_db_size_mb: 500,
+            ..Default::default()
+        };
+        let storage = Storage::with_sqlite_config(&config).unwrap();
+
+        // ts=1ns is far older than the 1-day retention cutoff: the purge
+        // check right after this insert must delete it again.
+        let expired = crate::analyzer::AnalysisResult::Token(bulky_token_record(1, 64));
+        storage.store(&expired).unwrap();
+        assert_eq!(storage.token_store.count(), 0, "expired row must be purged");
+
+        let now_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as u64;
+        let fresh = crate::analyzer::AnalysisResult::Token(bulky_token_record(now_ns, 64));
+        storage.store(&fresh).unwrap();
+        assert_eq!(storage.token_store.count(), 1, "fresh row must survive");
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -612,6 +612,7 @@ impl AgentSight {
             token_consumption_table: "token_consumption".to_string(),
             retention_days: config.retention_days,
             purge_interval: config.purge_interval,
+            max_db_size_mb: config.max_db_size_mb,
         };
         Storage::with_sqlite_config(&sqlite_config)
     }


### PR DESCRIPTION
## Description

Users report agentsight SQLite databases growing past 1GB. This PR adds a `max_db_size_mb` cap (default 500MB) to `agentsight.db` with size-based pruning, and fixes the existing genai pruning so the file actually shrinks:

- **Size accounting counts main + `-wal` + `-shm`** — in WAL mode most recent data lives in the WAL file, so checking the main file alone under-reports.
- **VACUUM runs before the TRUNCATE checkpoint** — VACUUM writes the rebuilt database through the WAL, so the file only shrinks once a checkpoint flushes it back. The previous order (checkpoint → VACUUM) left the file size unchanged.
- **One VACUUM per round instead of per batch** — VACUUM rewrites the whole file; each round deletes up to 20k rows per table before a single VACUUM + checkpoint, keeping multi-GB cleanups tractable.
- **genai pruning is adaptive** — 10-50% of rows per iteration based on how far the database exceeds the limit, so a severely oversized database recovers quickly.
- **VACUUM failures are tolerated and logged** (e.g. disk full): freed pages remain reusable by future inserts, preventing further growth.
- Cleanup runs on startup and every purge interval.

Limits stay compile-time defaults, consistent with `retention_days`; JSON-config exposure is deferred.

## Related Issue

closes #2641

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo test --locked --lib`: 1490 passed / 0 failed, including 6 new tests covering: limit=0 never deletes, below-limit no-op, oversized DB shrinks below limit, startup cleanup, WAL file counted in size accounting, `delete_oldest_batch` removes oldest rows first.
- End-to-end verification with a 1MB cap: 1000 rows × 10KB payloads grew the DB to 12,140KB; `purge_oversized()` brought it down to 112KB.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --locked -- -D warnings` pass.

## Additional Notes

Environment override for the genai store remains `AGENTSIGHT_GENAI_DB_MAX_SIZE_MB` (default 200MB).