### PR TITLE
test(tokenless): pin cosh rewrite matcher against Rust regex crate

### DIFF
--- a/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
@@ -118,6 +118,9 @@ fn matcher_compiles_with_rust_regex_crate() {
 }
 
 #[test]
+// The invalid literal is the point of this test, so opt out of the lint
+// that flags invalid regex literals.
+#[allow(clippy::invalid_regex)]
 fn rust_regex_rejects_python_only_syntax() {
     // Sanity check for the contract itself: lookahead is valid Python `re`
     // syntax but unsupported by the Rust `regex` crate, proving that only

--- a/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
@@ -8,53 +8,63 @@
 //! exact string comparison, which an anchored alternation never satisfies, so
 //! the rewrite hook never fires and rtk rewriting is skipped.
 //!
-//! The Python twin of this contract (`tests/test_cosh_extension_matcher.py`)
-//! pins the matcher against Python's `re`, which accepts syntax the Rust
-//! `regex` crate rejects (e.g. lookahead). Only this side of the contract
-//! exercises the engine that actually compiles the matcher; both sides must
-//! stay in sync with the manifest.
+//! The Python twin of this contract (`test_cosh_extension_matcher.py` in the
+//! tokenless test suite) pins the matcher against Python's `re`, which accepts
+//! syntax the Rust `regex` crate rejects (e.g. lookahead). Only this side of
+//! the contract exercises the engine that actually compiles the matcher; both
+//! sides draw their tool-name corpus from the shared
+//! `tests/data/cosh_matcher_corpus.json`.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use serde_json::Value;
 
-/// Tool names cosh-ng fires PreToolUse with. Must stay in sync with
-/// `MATCHING_TOOLS` in `tests/test_cosh_extension_matcher.py`.
-const MATCHING_TOOLS: &[&str] = &[
-    "shell",
-    "run_shell_command",
-    "Bash",
-    "Shell",
-    "terminal",
-    "exec",
-    "process",
-];
+// Embedded at compile time: if the shared corpus moves, the build fails
+// loudly instead of the test silently weakening.
+const MATCHER_CORPUS: &str = include_str!("../../../tests/data/cosh_matcher_corpus.json");
 
-/// cosh-ng tools (and common foreign shapes) that must never be rewritten:
-/// only shell-execution tools may reach rtk. Must stay in sync with
-/// `NON_MATCHING_TOOLS` in `tests/test_cosh_extension_matcher.py`.
-const NON_MATCHING_TOOLS: &[&str] = &[
-    "read_file",
-    "write_file",
-    "edit",
-    "grep",
-    "todo",
-    "glob",
-    "web_search",
-    "shell_prompt", // anchored: prefix overlap must not match
-    "my_shell",     // anchored: suffix overlap must not match
-    "",
-];
+// Resolved against the tokenless root rather than this crate's nesting depth,
+// so relocating the crate inside the workspace cannot break the contract.
+const MANIFEST_RELATIVE: &str = "adapters/tokenless/common/cosh-extension.json";
 
 fn manifest_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../adapters/tokenless/common/cosh-extension.json")
+    let mut dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        let candidate = dir.join(MANIFEST_RELATIVE);
+        if candidate.is_file() {
+            return candidate;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => panic!(
+                "cosh-extension.json not found at {MANIFEST_RELATIVE} \
+                 in any ancestor of {}",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        }
+    }
 }
 
-/// Return the matcher of the PreToolUse rtk rewrite hook group, mirroring
-/// the lookup in `CoshExtensionMatcherTest._rewrite_matcher`.
+fn corpus_tools(key: &str) -> Vec<String> {
+    let corpus: Value =
+        serde_json::from_str(MATCHER_CORPUS).expect("shared matcher corpus must be valid JSON");
+    corpus
+        .get(key)
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("shared matcher corpus must contain a {key:?} array"))
+        .iter()
+        .map(|entry| {
+            entry.as_str().map(str::to_string).unwrap_or_else(|| {
+                panic!("entries of {key:?} in the shared corpus must be strings")
+            })
+        })
+        .collect()
+}
+
+// Mirrors the lookup in the Python suite's `_rewrite_matcher`, so both sides
+// of the contract select the same hook group from the manifest.
 fn rewrite_matcher() -> String {
     let path = manifest_path();
     let raw = fs::read_to_string(&path).unwrap_or_else(|err| {
@@ -130,9 +140,9 @@ fn matcher_hits_cosh_shell_tool_name() {
 #[test]
 fn matcher_hits_all_shell_family_names() {
     let re = Regex::new(&rewrite_matcher()).expect("matcher must compile");
-    for name in MATCHING_TOOLS {
+    for name in corpus_tools("matching_tools") {
         assert!(
-            re.is_match(name),
+            re.is_match(&name),
             "matcher must match shell-family tool name {name:?}"
         );
     }
@@ -141,9 +151,9 @@ fn matcher_hits_all_shell_family_names() {
 #[test]
 fn matcher_rejects_non_shell_tools() {
     let re = Regex::new(&rewrite_matcher()).expect("matcher must compile");
-    for name in NON_MATCHING_TOOLS {
+    for name in corpus_tools("non_matching_tools") {
         assert!(
-            !re.is_match(name),
+            !re.is_match(&name),
             "matcher must not match non-shell tool name {name:?}"
         );
     }

--- a/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs
@@ -1,0 +1,150 @@
+//! Contract test for the cosh extension PreToolUse rewrite matcher.
+//!
+//! The matcher string shipped in `adapters/tokenless/common/cosh-extension.json`
+//! is compiled at runtime by cosh-ng's hook system (`HookSystem::matches_tool`)
+//! with the Rust `regex` crate and applied as an *unanchored*
+//! `Regex::is_match` search (≈ Python's `re.search`). A matcher that fails
+//! `Regex::new` does not raise an error in cosh-ng: it silently degrades to
+//! exact string comparison, which an anchored alternation never satisfies, so
+//! the rewrite hook never fires and rtk rewriting is skipped.
+//!
+//! The Python twin of this contract (`tests/test_cosh_extension_matcher.py`)
+//! pins the matcher against Python's `re`, which accepts syntax the Rust
+//! `regex` crate rejects (e.g. lookahead). Only this side of the contract
+//! exercises the engine that actually compiles the matcher; both sides must
+//! stay in sync with the manifest.
+
+use std::fs;
+use std::path::PathBuf;
+
+use regex::Regex;
+use serde_json::Value;
+
+/// Tool names cosh-ng fires PreToolUse with. Must stay in sync with
+/// `MATCHING_TOOLS` in `tests/test_cosh_extension_matcher.py`.
+const MATCHING_TOOLS: &[&str] = &[
+    "shell",
+    "run_shell_command",
+    "Bash",
+    "Shell",
+    "terminal",
+    "exec",
+    "process",
+];
+
+/// cosh-ng tools (and common foreign shapes) that must never be rewritten:
+/// only shell-execution tools may reach rtk. Must stay in sync with
+/// `NON_MATCHING_TOOLS` in `tests/test_cosh_extension_matcher.py`.
+const NON_MATCHING_TOOLS: &[&str] = &[
+    "read_file",
+    "write_file",
+    "edit",
+    "grep",
+    "todo",
+    "glob",
+    "web_search",
+    "shell_prompt", // anchored: prefix overlap must not match
+    "my_shell",     // anchored: suffix overlap must not match
+    "",
+];
+
+fn manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../adapters/tokenless/common/cosh-extension.json")
+}
+
+/// Return the matcher of the PreToolUse rtk rewrite hook group, mirroring
+/// the lookup in `CoshExtensionMatcherTest._rewrite_matcher`.
+fn rewrite_matcher() -> String {
+    let path = manifest_path();
+    let raw = fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            "cosh-extension.json must be readable at {}: {err}",
+            path.display()
+        )
+    });
+    let manifest: Value =
+        serde_json::from_str(&raw).expect("cosh-extension.json must be valid JSON");
+    let groups = manifest
+        .pointer("/hooks/PreToolUse")
+        .and_then(Value::as_array)
+        .expect("hooks.PreToolUse must be an array of matcher groups");
+    for group in groups {
+        let Some(hooks) = group.get("hooks").and_then(Value::as_array) else {
+            continue;
+        };
+        let is_rewrite = hooks
+            .iter()
+            .any(|hook| hook.get("name").and_then(Value::as_str) == Some("tokenless-rewrite"));
+        if !is_rewrite {
+            continue;
+        }
+        let matcher = group.get("matcher").and_then(Value::as_str).expect(
+            "tokenless-rewrite group must declare an explicit string matcher \
+             so non-shell tools never reach rtk",
+        );
+        assert!(
+            !matcher.is_empty(),
+            "an empty matcher matches every tool, including non-shell tools"
+        );
+        return matcher.to_string();
+    }
+    panic!("tokenless-rewrite hook not found in PreToolUse groups");
+}
+
+#[test]
+fn matcher_compiles_with_rust_regex_crate() {
+    // The gap this contract closes: cosh-ng compiles the matcher with
+    // Regex::new. Python's `re` accepts patterns (e.g. lookahead) that this
+    // engine rejects, so a matcher can pass the Python tests yet fail here
+    // and silently disable the hook in cosh-ng.
+    let matcher = rewrite_matcher();
+    Regex::new(&matcher).unwrap_or_else(|err| {
+        panic!(
+            "matcher {matcher:?} must be valid Rust regex syntax \
+             (cosh-ng compiles it with Regex::new): {err}"
+        )
+    });
+}
+
+#[test]
+fn rust_regex_rejects_python_only_syntax() {
+    // Sanity check for the contract itself: lookahead is valid Python `re`
+    // syntax but unsupported by the Rust `regex` crate, proving that only
+    // this Rust-side test can catch such a matcher.
+    assert!(Regex::new("(?=shell)").is_err());
+}
+
+#[test]
+fn matcher_hits_cosh_shell_tool_name() {
+    // The regression from the original fix: cosh-ng names its shell tool
+    // `shell`, and the matcher must hit it directly without relying on
+    // host-side tool-name aliasing.
+    let re = Regex::new(&rewrite_matcher()).expect("matcher must compile");
+    assert!(
+        re.is_match("shell"),
+        "matcher must match cosh-ng's lowercase 'shell' tool name directly"
+    );
+}
+
+#[test]
+fn matcher_hits_all_shell_family_names() {
+    let re = Regex::new(&rewrite_matcher()).expect("matcher must compile");
+    for name in MATCHING_TOOLS {
+        assert!(
+            re.is_match(name),
+            "matcher must match shell-family tool name {name:?}"
+        );
+    }
+}
+
+#[test]
+fn matcher_rejects_non_shell_tools() {
+    let re = Regex::new(&rewrite_matcher()).expect("matcher must compile");
+    for name in NON_MATCHING_TOOLS {
+        assert!(
+            !re.is_match(name),
+            "matcher must not match non-shell tool name {name:?}"
+        );
+    }
+}

--- a/src/tokenless/tests/data/cosh_matcher_corpus.json
+++ b/src/tokenless/tests/data/cosh_matcher_corpus.json
@@ -1,0 +1,24 @@
+{
+  "description": "Shared tool-name corpus for the cosh extension rewrite-matcher contract. Consumed by the Rust contract test (cosh_extension_matcher_contract in the tokenless-cli crate, embedded at compile time) and by tests/test_cosh_extension_matcher.py. matching_tools are shell-execution tool names agents fire PreToolUse with; non_matching_tools must never reach rtk. shell_prompt and my_shell probe anchoring (prefix/suffix overlap must not match); the empty string probes the empty-matcher guard.",
+  "matching_tools": [
+    "shell",
+    "run_shell_command",
+    "Bash",
+    "Shell",
+    "terminal",
+    "exec",
+    "process"
+  ],
+  "non_matching_tools": [
+    "read_file",
+    "write_file",
+    "edit",
+    "grep",
+    "todo",
+    "glob",
+    "web_search",
+    "shell_prompt",
+    "my_shell",
+    ""
+  ]
+}

--- a/src/tokenless/tests/test_cosh_extension_matcher.py
+++ b/src/tokenless/tests/test_cosh_extension_matcher.py
@@ -20,9 +20,10 @@ alternation here never triggers.
 
 These tests pin the matcher against Python's ``re``. The Rust ``regex``
 crate side of the contract — the engine cosh-ng actually compiles the
-matcher with — is pinned by
-``crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs``; the
-two suites share one tool-name corpus and must stay in sync.
+matcher with — is pinned by the ``cosh_extension_matcher_contract`` test
+in the tokenless-cli crate. Both suites draw their tool-name corpus from
+the shared ``tests/data/cosh_matcher_corpus.json``, so the two sides
+cannot drift apart.
 """
 
 import json
@@ -38,33 +39,26 @@ MANIFEST = (
     / "cosh-extension.json"
 )
 
+CORPUS = Path(__file__).resolve().parent / "data" / "cosh_matcher_corpus.json"
+
+
+def _load_corpus() -> dict:
+    with open(CORPUS, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+_CORPUS = _load_corpus()
+
 # Tool names cosh-ng fires PreToolUse with. ``shell`` is the cosh-ng
 # internal name; ``run_shell_command`` is the copilot-shell standard name
 # kept so both naming conventions keep reaching the rewrite hook.
-MATCHING_TOOLS = [
-    "shell",
-    "run_shell_command",
-    "Bash",
-    "Shell",
-    "terminal",
-    "exec",
-    "process",
-]
+MATCHING_TOOLS = _CORPUS["matching_tools"]
 
 # cosh-ng tools (and common foreign shapes) that must never be rewritten:
-# only shell-execution tools may reach rtk.
-NON_MATCHING_TOOLS = [
-    "read_file",
-    "write_file",
-    "edit",
-    "grep",
-    "todo",
-    "glob",
-    "web_search",
-    "shell_prompt",   # anchored: prefix overlap must not match
-    "my_shell",       # anchored: suffix overlap must not match
-    "",
-]
+# only shell-execution tools may reach rtk. ``shell_prompt`` / ``my_shell``
+# probe anchoring (prefix/suffix overlap must not match); ``""`` probes the
+# empty-matcher guard.
+NON_MATCHING_TOOLS = _CORPUS["non_matching_tools"]
 
 
 class CoshExtensionMatcherTest(unittest.TestCase):
@@ -99,9 +93,8 @@ class CoshExtensionMatcherTest(unittest.TestCase):
     def test_matcher_compiles_as_regex(self):
         # The pattern must be valid Python ``re`` syntax. Rust ``regex``
         # crate validity — what cosh-ng actually compiles with Regex::new
-        # — is enforced by the Rust-side contract test in
-        # crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs,
-        # since ``re`` accepts syntax (e.g. lookahead) Rust's regex
+        # — is enforced by the Rust-side ``cosh_extension_matcher_contract``
+        # test, since ``re`` accepts syntax (e.g. lookahead) Rust's regex
         # rejects and a compile failure silently disables the hook.
         re.compile(self._rewrite_matcher())
 

--- a/src/tokenless/tests/test_cosh_extension_matcher.py
+++ b/src/tokenless/tests/test_cosh_extension_matcher.py
@@ -17,6 +17,12 @@ matcher is compiled as a regex and applied as an *unanchored* search
 (Rust ``Regex::is_match`` ≈ ``re.search``); a matcher that fails to
 compile would fall back to exact string equality, which the anchored
 alternation here never triggers.
+
+These tests pin the matcher against Python's ``re``. The Rust ``regex``
+crate side of the contract — the engine cosh-ng actually compiles the
+matcher with — is pinned by
+``crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs``; the
+two suites share one tool-name corpus and must stay in sync.
 """
 
 import json
@@ -91,8 +97,12 @@ class CoshExtensionMatcherTest(unittest.TestCase):
         self.assertTrue(matcher)
 
     def test_matcher_compiles_as_regex(self):
-        # The pattern must be valid regex syntax in both Python's ``re``
-        # and Rust's ``regex`` crate (cosh compiles it with Regex::new).
+        # The pattern must be valid Python ``re`` syntax. Rust ``regex``
+        # crate validity — what cosh-ng actually compiles with Regex::new
+        # — is enforced by the Rust-side contract test in
+        # crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs,
+        # since ``re`` accepts syntax (e.g. lookahead) Rust's regex
+        # rejects and a compile failure silently disables the hook.
         re.compile(self._rewrite_matcher())
 
     def test_matcher_hits_cosh_shell_tool_name(self):


### PR DESCRIPTION
## 背景

跟进 #2611 上的非阻断 review 意见：cosh 扩展 matcher 契约测试（`src/tokenless/tests/test_cosh_extension_matcher.py`）此前仅通过 Python `re.compile` 校验 PreToolUse rewrite matcher，但注释声称同时覆盖 Rust `regex` crate。Python `re` 支持而 Rust `regex` 不支持的语法（如 lookahead/lookbehind）可以让整个 Python 套件通过，却会在 cosh-ng 的 `HookSystem::matches_tool` 中令 `Regex::new` 编译失败，静默退化为精确字符串比较，从而跳过 rtk rewrite hook。

## 改动

- `src/tokenless/crates/tokenless-cli/tests/cosh_extension_matcher_contract.rs`（新增）：Rust 侧契约测试，让契约实际经过真正编译该 matcher 的引擎。读取真实的 `src/tokenless/adapters/tokenless/common/cosh-extension.json`，提取 `tokenless-rewrite` 组的 matcher（断言其为显式非空字符串），用 `regex::Regex::new` 编译，并以与 Python 套件同一份工具名语料钉住匹配/不匹配语义（unanchored `is_match`）。另含一个 sanity 用例，证明 Rust 引擎确实拒绝 Python-only 的 lookahead 语法。
- `src/tokenless/tests/test_cosh_extension_matcher.py`：修正过度声明的注释——Python 套件现在准确表述其钉住的是 Python `re` 语法，并交叉引用 Rust 侧契约测试（两套共享同一份语料，需保持同步）。

仅新增/调整测试，无运行时与打包行为变更。

## 测试情况

**环境**：Linux x86_64；rustc/cargo 1.94.1；Python 3.8.17。

**命令与结果**：
1. `cargo fmt --all -- --check` — 通过
2. `cargo clippy --workspace -- -D warnings` — 通过，无告警
3. `cargo test --workspace -- --test-threads=1` — 全部通过：581 passed / 0 failed / 2 ignored（ignored 为 tokenless-cli 单测中本就存在的用例）；其中新增契约套件 `cosh_extension_matcher_contract` 5/5 通过
4. `python3 tests/test_cosh_extension_matcher.py` — 6/6 通过
5. `make test-integration` — 除 1 个**既有环境性失败**外全部通过：`test_hermes_plugin_import.py` 的 `test_resolves_via_xdg_data_home` 失败；已用 git stash 验证在不含本次改动时失败完全相同——原因是本机系统前缀下存在已安装的 anolisa 副本，hook 路径解析优先命中系统副本，与本次改动无关。该目标其余用例全部通过（部分用例因环境缺少可选依赖而跳过，与改动前一致）

**复现问题 → 验证修复**（针对 review 意见场景的定向验证）：
- 将 matcher 临时替换为语义等价的 lookbehind 模式 `^(?:Bash|run_shell_command|terminal|Shell|shell|exec|process)(?<!x)$`（Python `re` 支持、Rust `regex` 不支持）：Python 套件仍 6/6 通过（复现了意见指出的漏洞），Rust 契约套件失败，错误信息直接指向 `Regex::new` 解析错误
- 恢复 matcher 后：两套套件全部通过
- 另用语义不等价的 lookahead 模式验证：Rust 契约套件同样失败

**未运行项**：无（与本改动相关的测试项均已实际执行）。
