### PR TITLE
fix(anolisa): identify stale repo source

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -59,7 +59,7 @@ use super::render::repo_config_err;
 use super::rpm::{
     PinError, RpmTarget, resolve_pinned_candidate, rpm_package_candidates_with_index,
 };
-use super::types::{InstallOutcome, RawResolution, ResolveInputs};
+use super::types::{InstallOutcome, RawRepositoryOrigin, RawResolution, ResolveInputs};
 use super::{ANOLISA_RPM_REPO_ID, COMMAND, InstallArgs};
 
 /// Dispatch `install <component>` against the live host.
@@ -899,7 +899,7 @@ fn resolve_owned_artifact(
         .map_err(|err| repo_config_err(err, true))?;
 
     let mut warnings: Vec<String> = Vec::new();
-    let base_url = match args.repo.as_deref() {
+    let (base_url, repository_origin) = match args.repo.as_deref() {
         Some(override_url) => {
             let normalized =
                 normalize_override_url(override_url).map_err(|err| repo_config_err(err, true))?;
@@ -908,17 +908,21 @@ fn resolve_owned_artifact(
                     "--repo uses plaintext http ({normalized}) — artifacts are still sha256-verified on the raw backend, but the index itself is unauthenticated",
                 ));
             }
-            normalized
+            (normalized, Some(RawRepositoryOrigin::CliOverride))
         }
         None => {
             let host = HostVars {
                 os: env.os.clone(),
                 arch: env.arch.clone(),
             };
-            repo_config
+            let base_url = repo_config
                 .resolved_base_url(backend_name, backend, &host)
                 // Variable errors are fixed by editing [vars] in repo.toml.
-                .map_err(|err| repo_config_err(err, true))?
+                .map_err(|err| repo_config_err(err, true))?;
+            let origin = repo_config
+                .source_path()
+                .map(|path| RawRepositoryOrigin::Config(path.to_path_buf()));
+            (base_url, origin)
         }
     };
     let (component, package) = resolve_raw_identity(
@@ -939,6 +943,7 @@ fn resolve_owned_artifact(
             package,
             backend: backend_name.to_string(),
             base_url,
+            repository_origin,
             version: args.version.as_deref(),
             warnings,
         },

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -28,7 +28,11 @@ use super::COMMAND;
 use super::render::{artifact_ext, artifact_type_wire, repo_config_err};
 use super::types::*;
 
-pub(super) fn index_fetch_error(index_url: &str, err: DownloadError) -> CliError {
+pub(super) fn index_fetch_error(
+    index_url: &str,
+    err: DownloadError,
+    repository_origin: Option<&RawRepositoryOrigin>,
+) -> CliError {
     match err {
         DownloadError::Io {
             ref path,
@@ -38,11 +42,21 @@ pub(super) fn index_fetch_error(index_url: &str, err: DownloadError) -> CliError
                 .strip_prefix("file://")
                 .is_some_and(|expected| path.as_path() == Path::new(expected)) =>
         {
+            let guidance = match repository_origin {
+                Some(RawRepositoryOrigin::Config(config_path)) => format!(
+                    "repository config: {}; move it aside and retry to restore the default config, or pass --repo <URL> once",
+                    config_path.display()
+                ),
+                Some(RawRepositoryOrigin::CliOverride) =>
+                    "the one-off --repo <URL> override selected this repository; pass a reachable URL or omit the override"
+                        .to_string(),
+                None => "check the raw repository URL in repo.toml or, if supplied, the one-off --repo <URL> override".to_string(),
+            };
             CliError::Runtime {
                 command: COMMAND.to_string(),
                 reason: format!(
-                    "local raw repository index not found at {}; check the raw repository URL in repo.toml or, if supplied, the one-off --repo <URL> override",
-                    path.display()
+                    "local raw repository index not found at {}; {guidance}",
+                    path.display(),
                 ),
             }
         }
@@ -73,6 +87,7 @@ fn remote_file_absent(err: &DownloadError) -> bool {
 fn fetch_raw_index(
     cache: &DownloadCache,
     base_url: &str,
+    repository_origin: Option<&RawRepositoryOrigin>,
 ) -> Result<(String, std::path::PathBuf), CliError> {
     let v2_url = raw_index_v2_url(base_url);
     match cache.fetch(&v2_url, None) {
@@ -83,10 +98,10 @@ fn fetch_raw_index(
             let v1_url = raw_index_url(base_url);
             let downloaded = cache
                 .fetch(&v1_url, None)
-                .map_err(|err| index_fetch_error(&v1_url, err))?;
+                .map_err(|err| index_fetch_error(&v1_url, err, repository_origin))?;
             Ok((v1_url, downloaded.cached_path))
         }
-        Err(err) => Err(index_fetch_error(&v2_url, err)),
+        Err(err) => Err(index_fetch_error(&v2_url, err, repository_origin)),
     }
 }
 
@@ -101,6 +116,7 @@ pub(crate) fn resolve_raw(
         package,
         backend,
         base_url,
+        repository_origin,
         version,
         mut warnings,
     } = inputs;
@@ -108,7 +124,8 @@ pub(crate) fn resolve_raw(
     // The index is always re-fetched (DownloadCache overwrites on conflict),
     // so a republished repo is picked up without a cache flush.
     let cache = DownloadCache::new(layout.cache_dir.clone());
-    let (index_url, cached_index_path) = fetch_raw_index(&cache, &base_url)?;
+    let (index_url, cached_index_path) =
+        fetch_raw_index(&cache, &base_url, repository_origin.as_ref())?;
     // Entry-tolerant parse: a row shaped for a future CLI fails closed for
     // its own component (skipped, surfaced as a warning) instead of taking
     // the whole shared index — and every unrelated component — down with it.
@@ -310,6 +327,9 @@ pub(crate) fn resolve_raw_inputs_for_component(
         package,
         backend: backend_name.to_string(),
         base_url,
+        repository_origin: repo_config
+            .source_path()
+            .map(|path| RawRepositoryOrigin::Config(path.to_path_buf())),
         version: None,
         warnings: Vec::new(),
     })
@@ -1081,7 +1101,8 @@ mod tests {
         std::fs::write(root.join("index-v2.toml"), "schema_version = 2\n").unwrap();
         let cache = tempdir().unwrap();
         let dl = DownloadCache::new(cache.path().to_path_buf());
-        let (url, path) = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap();
+        let (url, path) =
+            fetch_raw_index(&dl, &format!("file://{}", root.display()), None).unwrap();
         assert!(url.ends_with("/index-v2.toml"), "got {url}");
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("schema_version = 2"));
@@ -1096,7 +1117,8 @@ mod tests {
         std::fs::write(root.join("index.toml"), "schema_version = 1\n").unwrap();
         let cache = tempdir().unwrap();
         let dl = DownloadCache::new(cache.path().to_path_buf());
-        let (url, path) = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap();
+        let (url, path) =
+            fetch_raw_index(&dl, &format!("file://{}", root.display()), None).unwrap();
         assert!(url.ends_with("/index.toml"), "got {url}");
         let content = std::fs::read_to_string(path).unwrap();
         assert!(content.contains("schema_version = 1"));
@@ -1111,7 +1133,7 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let cache = tempdir().unwrap();
         let dl = DownloadCache::new(cache.path().to_path_buf());
-        let err = fetch_raw_index(&dl, &format!("file://{}", root.display())).unwrap_err();
+        let err = fetch_raw_index(&dl, &format!("file://{}", root.display()), None).unwrap_err();
         let CliError::Runtime { reason, .. } = err else {
             panic!("expected runtime error");
         };

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -136,7 +136,7 @@ fn install_dry_run_does_not_download_the_artifact() {
 }
 
 #[test]
-fn install_reports_missing_local_repository_index() {
+fn install_reports_missing_local_repository_index_from_override() {
     let tmp = tempdir().expect("tmpdir");
     let prefix = tmp.path().join("sys");
     let repo_root = tmp.path().join("repo");
@@ -158,12 +158,12 @@ fn install_reports_missing_local_repository_index() {
         "missing-index diagnostic must identify {index_path:?}; got: {reason}"
     );
     assert!(
-        reason.contains("repo.toml"),
-        "missing-index diagnostic must name repo.toml; got: {reason}"
+        reason.contains("one-off --repo <URL> override"),
+        "missing-index diagnostic must identify the one-off override; got: {reason}"
     );
     assert!(
-        reason.contains("--repo <URL>"),
-        "missing-index diagnostic must name the one-off override; got: {reason}"
+        !reason.contains("repo.toml"),
+        "override diagnostic must not blame repo.toml; got: {reason}"
     );
     assert!(
         !reason.contains("failed to fetch distribution index"),
@@ -207,6 +207,52 @@ fn install_reports_missing_local_repository_index() {
 }
 
 #[test]
+fn install_reports_config_path_for_missing_local_repository_index() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let layout = FsLayout::system(Some(prefix.clone()));
+    let repo_root = tmp.path().join("repo");
+    let repo_url = write_local_repo(&repo_root);
+    let index_path = repo_root.join("v1/index.toml");
+    std::fs::remove_dir_all(&repo_root).expect("remove repository directory");
+
+    std::fs::create_dir_all(&layout.etc_dir).expect("create repo config directory");
+    let config_path = layout.etc_dir.join("repo.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"{repo_url}\"\n"
+        ),
+    )
+    .expect("write repo config");
+
+    let err = handle_with_fake_rpm(args("agentsight"), &ctx_with_prefix(false, Some(prefix)))
+        .expect_err("missing repository index must fail");
+    let reason = err.reason();
+
+    assert!(
+        reason.contains(&index_path.display().to_string()),
+        "missing-index diagnostic must identify {index_path:?}; got: {reason}"
+    );
+    assert!(
+        reason.contains(&config_path.display().to_string()),
+        "missing-index diagnostic must identify active config {config_path:?}; got: {reason}"
+    );
+    assert!(
+        reason.contains("move it aside and retry"),
+        "config diagnostic must recommend a non-destructive recovery; got: {reason}"
+    );
+    assert!(
+        reason.contains("--repo <URL>"),
+        "config diagnostic must mention the one-off override escape hatch; got: {reason}"
+    );
+    assert!(
+        !reason.contains("one-off --repo <URL> override selected this repository"),
+        "config diagnostic must not claim a CLI override was used; got: {reason}"
+    );
+}
+
+#[test]
 fn install_preserves_non_not_found_index_fetch_error() {
     let tmp = tempdir().expect("tmpdir");
     let index_path = tmp.path().join("repo/v1/index.toml");
@@ -216,7 +262,7 @@ fn install_preserves_non_not_found_index_fetch_error() {
         source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "index access denied"),
     };
     let rendered_download_error = download_error.to_string();
-    let err = super::super::raw::index_fetch_error(&index_url, download_error);
+    let err = super::super::raw::index_fetch_error(&index_url, download_error, None);
 
     assert_eq!(
         err.reason(),
@@ -240,7 +286,7 @@ fn install_preserves_not_found_away_from_index_path() {
         source: std::io::Error::new(std::io::ErrorKind::NotFound, "cache path missing"),
     };
     let rendered_download_error = download_error.to_string();
-    let err = super::super::raw::index_fetch_error(&index_url, download_error);
+    let err = super::super::raw::index_fetch_error(&index_url, download_error, None);
 
     assert_eq!(
         err.reason(),
@@ -707,6 +753,7 @@ fn prepare_raw_execution_resolves_declared_capabilities() {
             package: "agentsight".to_string(),
             backend: "raw".to_string(),
             base_url: repo_url,
+            repository_origin: None,
             version: None,
             warnings: Vec::new(),
         },
@@ -785,6 +832,7 @@ fn prepare_raw_execution_resolves_declared_services() {
             package: "agentsight".to_string(),
             backend: "raw".to_string(),
             base_url: repo_url,
+            repository_origin: None,
             version: None,
             warnings: Vec::new(),
         },
@@ -1721,6 +1769,7 @@ fn agentsight_resolve_inputs(repo_url: String) -> ResolveInputs<'static> {
         package: "agentsight".to_string(),
         backend: "raw".to_string(),
         base_url: repo_url,
+        repository_origin: None,
         version: None,
         warnings: Vec::new(),
     }
@@ -1953,6 +2002,7 @@ install_modes = ["system"]
         package: "sec-core".to_string(),
         backend: "raw".to_string(),
         base_url: repo_url.clone(),
+        repository_origin: None,
         version,
         warnings: Vec::new(),
     };
@@ -2043,6 +2093,7 @@ install_modes = ["system"]
             package: "cosh".to_string(),
             backend: "raw".to_string(),
             base_url: repo_url,
+            repository_origin: None,
             version: None,
             warnings: Vec::new(),
         },
@@ -2105,6 +2156,7 @@ install_modes = [1]
             package: "sec-core".to_string(),
             backend: "raw".to_string(),
             base_url: repo_url,
+            repository_origin: None,
             version: None,
             warnings: Vec::new(),
         },

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/types.rs
@@ -54,6 +54,15 @@ pub(crate) enum InstallContractSource {
     SidecarMeta,
 }
 
+/// Source that selected the raw repository URL for this resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RawRepositoryOrigin {
+    /// URL loaded from the active repository configuration file.
+    Config(PathBuf),
+    /// URL supplied by the invocation's one-off `--repo` option.
+    CliOverride,
+}
+
 /// What `handle_one` did, so `--all` can distinguish outcomes in its batch
 /// summary (§7.5). The dry-run vs real distinction is layered on by the
 /// caller from `CliContext::dry_run`. Install never adopts (I3 refuses and
@@ -73,6 +82,7 @@ pub(crate) struct ResolveInputs<'a> {
     pub(crate) package: String,
     pub(crate) backend: String,
     pub(crate) base_url: String,
+    pub(crate) repository_origin: Option<RawRepositoryOrigin>,
     pub(crate) version: Option<&'a str>,
     pub(crate) warnings: Vec<String>,
 }

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -230,6 +230,9 @@ pub struct RepoConfig {
     pub backends: BTreeMap<String, BackendConfig>,
     #[serde(skip)]
     legacy_rpm_backend: bool,
+    /// Discovery path that supplied this config; absent for in-memory parses.
+    #[serde(skip)]
+    source_path: Option<PathBuf>,
 }
 
 /// `[vars]` overrides for `base_url` substitution. Every field is
@@ -333,7 +336,7 @@ impl RepoConfig {
             .clone()
             .ok_or(RepoConfigProvisionError::Load(RepoConfigError::NotFound))?;
         let body = fetch_repo_config_body(bootstrap_url)?;
-        let config = Self::from_toml_str(&body).map_err(|err| {
+        let mut config = Self::from_toml_str(&body).map_err(|err| {
             RepoConfigProvisionError::InvalidDownloaded {
                 reason: err.to_string(),
             }
@@ -350,13 +353,16 @@ impl RepoConfig {
         }
 
         match write_repo_config(&dest, &body) {
-            Ok(()) => Ok(RepoConfigLoadResult {
-                config,
-                provisioning: RepoConfigProvisioning::Downloaded {
-                    url: bootstrap_url.to_string(),
-                    dest,
-                },
-            }),
+            Ok(()) => {
+                config.source_path = Some(dest.clone());
+                Ok(RepoConfigLoadResult {
+                    config,
+                    provisioning: RepoConfigProvisioning::Downloaded {
+                        url: bootstrap_url.to_string(),
+                        dest,
+                    },
+                })
+            }
             Err(err) => Ok(RepoConfigLoadResult {
                 config,
                 provisioning: RepoConfigProvisioning::DownloadedPersistFailed {
@@ -374,8 +380,9 @@ impl RepoConfig {
             if let Some(path) = candidate.as_deref()
                 && path.is_file()
             {
-                let config = Self::from_path(path)?;
+                let mut config = Self::from_path(path)?;
                 config.emit_deprecation_warnings(path);
+                config.source_path = Some(path.to_path_buf());
                 return Ok(config);
             }
         }
@@ -397,6 +404,11 @@ impl RepoConfig {
     #[allow(dead_code)]
     pub fn from_toml_str(s: &str) -> Result<Self, RepoConfigError> {
         Self::parse_with_path(s, Path::new("<memory>"))
+    }
+
+    /// Path selected by local config discovery, when this config came from disk.
+    pub(crate) fn source_path(&self) -> Option<&Path> {
+        self.source_path.as_deref()
     }
 
     fn parse_with_path(s: &str, path: &Path) -> Result<Self, RepoConfigError> {


### PR DESCRIPTION
## Why

ANOLISA reports the missing path when a local raw-repository index becomes stale, but it does not identify which discovered `repo.toml` supplied that URL. Because repository configuration can come from several locations, users must inspect the source or ask for support before they can recover.

## What changed

- Preserve the selected `repo.toml` path as internal `RepoConfig` metadata without changing discovery precedence.
- Thread a typed raw-repository origin through resolution so diagnostics distinguish configured URLs from one-off `--repo` overrides.
- Attribute exact local-index `NotFound` failures to the active config path or CLI override while preserving all other download diagnostics.
- Add hermetic regressions for both origins and keep JSON error rendering covered.

## Related issue

Closes #2344

## User / Agent impact

Users and agents can now identify the exact stale repository configuration and receive a safe recovery direction. Explicit `--repo` failures no longer incorrectly blame `repo.toml`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: only the human-readable reason for an exact local raw-index `NotFound` changes. Repository discovery, JSON structure, non-`NotFound` I/O failures, and HTTP/network diagnostics remain unchanged.

## Validation

Environment: macOS arm64.

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy -p anolisa-cli --all-targets --locked --no-deps -- -D warnings`
- `cargo test -p anolisa-cli missing_local_repository_index -- --nocapture` (2 passed)
- `cargo test -p anolisa-cli fetch_raw_index -- --nocapture` (3 passed)
- `cargo test -p anolisa-cli repo_config -- --nocapture` (27 passed)
- `cargo doc --no-deps --locked`
- `git diff --check`

The full `cargo test --locked` run completed with 825 passed, 1 ignored, and 1 failure in `raw_update_rollback_hydrates_legacy_required_capability`. The same missing-central-log failure reproduces on the unmodified base commit `33ed384`, so it is not introduced by this patch. Workspace-wide strict Clippy is likewise blocked by an existing `dead_code` warning in `anolisa-core/src/capability.rs`; the changed `anolisa-cli` crate passes strict Clippy with `--no-deps`.

## Documentation and rollback

No documentation change is needed because there is no new command, flag, or configuration field. Reverting commit `a086bdd` restores the previous generic attribution text.
