### PR TITLE
chore(anolisa): bump version to 0.3.3

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-18
+
+### Added
+
+- Telemetry instance snapshots now include the detected container runtime as
+  `instance.container` for Docker, Podman, containerd, Kubernetes cgroups, and
+  LXC, while bare-metal hosts omit the field. This gives downstream deployment
+  statistics and troubleshooting a container-aware signal without collecting
+  container or pod identities
+  ([#2642](https://github.com/alibaba/anolisa/pull/2642)).
+
+### Changed
+
+- `anolisa status <component>` now validates new targets against the component
+  index, resolves package aliases, rejects unsupported names with `anolisa list`
+  guidance, and directs telemetry service targets to
+  `anolisa telemetry status`. Exact installed identities remain inspectable
+  when repository metadata is unavailable
+  ([#2626](https://github.com/alibaba/anolisa/pull/2626)).
+
+### Fixed
+
+- Raw adapter bundle installs now preserve each archive file's mode and record
+  the effective mode for integrity checks. Framework hooks and scripts retain
+  their executable bit instead of being installed uniformly as data files
+  ([#2619](https://github.com/alibaba/anolisa/pull/2619)).
+
 ## [0.3.2] - 2026-08-17
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,31 @@
 
 ## [未发布]
 
+## [0.3.3] - 2026-08-18
+
+### 新增
+
+- Telemetry instance snapshot 现会将检测到的 Docker、Podman、containerd、
+  Kubernetes cgroup 或 LXC runtime 写入 `instance.container`，bare-metal host
+  则省略该字段。这为下游 deployment statistics 与 troubleshooting 提供
+  container-aware signal，同时不会采集 container 或 pod identity
+  ([#2642](https://github.com/alibaba/anolisa/pull/2642))。
+
+### 变更
+
+- `anolisa status <component>` 现会依据 component index 验证新 target、解析
+  package alias，并为不支持的名称提示 `anolisa list`，同时将 telemetry service
+  target 引导至 `anolisa telemetry status`。Repository metadata 不可用时，仍可
+  检查已精确记录的 installed identity
+  ([#2626](https://github.com/alibaba/anolisa/pull/2626))。
+
+### 修复
+
+- Raw adapter bundle 安装现会保留 archive 中每个 file 的 mode，并记录 effective
+  mode 供 integrity check 使用。Framework hook 与 script 不再统一按 data file
+  安装，可继续保留 executable bit
+  ([#2619](https://github.com/alibaba/anolisa/pull/2619))。
+
 ## [0.3.2] - 2026-08-17
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Mon Aug 17 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Tue Aug 18 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Telemetry snapshots now report the detected container runtime flavor.
+- Component status now validates targets and redirects telemetry service queries.
+- Raw adapter bundle installs now preserve per-file archive modes.
+
+* Mon Aug 17 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.2-1
 - Native DSH adapters now support explicit multi-profile lifecycle.
 - Component availability and batch installs now match exact OS and architecture targets.
 - Raw dry-runs now validate metadata for the resolved artifact target.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.2",
-    "@anolisa/cli-linux-arm64": "0.3.2",
-    "@anolisa/cli-darwin-arm64": "0.3.2"
+    "@anolisa/cli-linux-x64": "0.3.3",
+    "@anolisa/cli-linux-arm64": "0.3.3",
+    "@anolisa/cli-darwin-arm64": "0.3.3"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.3.3 packages the three user-visible component changes merged after
0.3.2. This release synchronizes every distribution surface and curates
bilingual notes from the actual component range without adding runtime behavior
in the bump commit.

## What changed

- Bumped the Cargo workspace and all five internal lockfile packages to 0.3.3.
- Bumped the npm root package, native platform packages, and optional dependency
  pins to 0.3.3.
- Added equivalent English and Chinese release notes for #2619, #2626, and
  #2642.
- Advanced the RPM changelog placeholder and froze the previous row at 0.3.2.
- Kept historical release rows, SkillFS catalog metadata, upgrade fixtures, and
  generated npm build outputs unchanged.

## Related issue

no-issue: release metadata for already-merged PRs #2619, #2626, and #2642

## User / Agent impact

Published ANOLISA packages will report version 0.3.3. Raw adapter bundle hooks
and scripts retain their archive executable modes, `anolisa status <component>`
validates targets and gives command-specific guidance, and telemetry snapshots
add the optional `instance.container` runtime flavor without collecting
container or pod identities.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The release commit itself changes metadata and documentation only; the runtime
changes were already merged and tested independently. Scripts that passed an
unknown name to `anolisa status` now receive an explicit error, while exact
installed identities remain inspectable without repository metadata. Raw
adapter installs now honor per-file archive modes and record the effective mode
for integrity checks. Telemetry consumers may observe the new optional
`instance.container` field; bare-metal hosts continue to omit it.

## Validation

Linux x86_64; Rust 1.88.0, Cargo 1.88.0, Node.js 24.15.0, npm 11.12.1:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --doc --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64` in an isolated worktree
- The release binary and npm-installed Linux x64 binary reported
  `anolisa 0.3.3`.
- Root and Linux x64 npm tarball metadata read back as version 0.3.3.
- Nightly Raw lifecycle harness syntax, case list, and repository configuration
  checks.
- `bash scripts/docs-lint.sh` and `python3 scripts/docs-link-check.py`
- Website locale validation, typecheck, production build, Agent index
  validation, and 162-page link validation.
- `python3 scripts/check-component-versions.py`
- Rendered `anolisa.spec.in` parsed as `anolisa 0.3.3-1.al8` with
  `rpmspec`.
- The history-derived release audit passed against the 0.3.2 content bump for
  both the working tree and committed `HEAD`.
- `git diff --check` and `git diff --cached --check`.

The macOS arm64 and Linux arm64 package templates were validated but their
binaries were not built on this Linux x86_64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog.
Before artifact publication, rollback is a revert of this release commit. After
publication, issue a corrected follow-up version rather than reusing 0.3.3.
