### PR TITLE
chore(tokenless): bump version to 0.7.9

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.8"
+version = "0.7.9"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,20 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.9] - 2026-08-18
+
+### Added
+
+- The `anolisa-tokenless` Python wheel now exposes framework-neutral `before_model`, `before_tool_call`, `after_tool_call`, and `retrieve` lifecycles, with bundled RTK plus native schema and response compression, TOON, marker-authorized retrieval, and per-call attribution ([#2627](https://github.com/alibaba/anolisa/pull/2627)).
+
+### Changed
+
+- AgentScope 1.0.11 through 1.x and AgentScope 2.0.x integrations now attach the same complete SDK contract, adding schema compression, command rewriting, TOON, environment-error guidance, and per-call attribution to the existing response compression and retrieval support ([#2627](https://github.com/alibaba/anolisa/pull/2627)).
+
+### Fixed
+
+- The Cosh-NG extension's RTK rewrite hook now matches the lowercase `shell` tool name directly, so shell commands are rewritten without depending on host-side tool-name aliases ([#2611](https://github.com/alibaba/anolisa/pull/2611)).
+
 ## [0.7.8] - 2026-08-18
 
 ### Changed

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,20 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.9] - 2026-08-18
+
+### 新增
+
+- `anolisa-tokenless` Python Wheel 现在开放框架无关的 `before_model`、`before_tool_call`、`after_tool_call` 和 `retrieve` 生命周期，内置 RTK，并提供原生 Schema 与 Response 压缩、TOON、受 Marker 授权的 Retrieve 和逐调用归属（[#2627](https://github.com/alibaba/anolisa/pull/2627)）。
+
+### 变更
+
+- AgentScope 1.0.11 至 1.x 以及 AgentScope 2.0.x 集成现在挂载相同的完整 SDK 契约，在已有 Response 压缩与 Retrieve 支持上增加 Schema 压缩、命令改写、TOON、环境错误提示和逐调用归属（[#2627](https://github.com/alibaba/anolisa/pull/2627)）。
+
+### 修复
+
+- Cosh-NG Extension 的 RTK 重写 Hook 现在直接匹配小写 `shell` 工具名，因此无需依赖宿主侧工具名别名也能重写 Shell 命令（[#2611](https://github.com/alibaba/anolisa/pull/2611)）。
+
 ## [0.7.8] - 2026-08-18
 
 ### 变更

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "pyo3",
  "tokenless-runtime",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "regex",
  "serde_json",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.8"
+version = "0.7.9"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.0",
+  "version": "0.7.9",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -45,9 +45,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.8",
-    "@anolisa/tokenless-linux-arm64": "0.7.8",
-    "@anolisa/tokenless-darwin-x64": "0.7.8",
-    "@anolisa/tokenless-darwin-arm64": "0.7.8"
+    "@anolisa/tokenless-linux-x64": "0.7.9",
+    "@anolisa/tokenless-linux-arm64": "0.7.9",
+    "@anolisa/tokenless-darwin-x64": "0.7.9",
+    "@anolisa/tokenless-darwin-arm64": "0.7.9"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -491,6 +491,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Tue Aug 18 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.9-1
+- feat(tokenless): add the framework-neutral Python SDK
+- feat(tokenless): attach full SDK lifecycles to AgentScope
+- fix(tokenless): match the Cosh-NG shell tool in the RTK hook
+
 * Tue Aug 18 2026 林生 <linyan.lin@alibaba-inc.com> - 0.7.8-1
 - feat(tokenless): skip TOON encoding for payloads under 500 chars
 - fix(tokenless): drop conflicting bin entries from npm platform packages


### PR DESCRIPTION
## Why

Tokenless 0.7.8 predates the merged framework-neutral Python SDK and the Cosh-NG shell matcher fix. A 0.7.9 patch boundary keeps every distribution surface coherent and lets channel workflows publish those backward-compatible changes under one version.

## What changed

- Bump the 14 active Tokenless release surfaces from 0.7.8 to 0.7.9: the component catalog, Cargo workspace and benchmark lockfiles, Cosh extension manifest, npm root and four platform manifests, RPM spec, and paired changelogs.
- Add semantically paired English and Chinese release notes derived from the final behavior in #2627 and #2611.
- Add the matching RPM changelog boundary. This version-only commit introduces no additional runtime behavior.

## Related issue

no-issue: release the already merged Tokenless changes from #2627 and #2611

## User / Agent impact

Tokenless 0.7.9 exposes the framework-neutral `before_model`, `before_tool_call`, `after_tool_call`, and `retrieve` Python SDK lifecycles with bundled RTK and native compression/retrieval support. AgentScope 1.0.11 through 1.x and 2.0.x use the same complete lifecycle contract, and Cosh-NG shell commands now reach the RTK rewrite hook through the lowercase `shell` tool name.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low implementation risk: this PR changes release metadata and documentation only. The public Python API is additive behavior already merged in #2627, and the matcher correction was already merged in #2611. All package formats carry the same version; no data migration is required.

## Validation

Environment: Linux x86_64; rustc/cargo 1.97.1; Python 3.11.13 (ABI3 Wheel tests used CPython 3.12.13); Node 24.15.0; npm 11.12.1.

- `cargo check --workspace`
- `cargo check --manifest-path benchmark/l1-compressor/Cargo.toml`
- `cargo check --manifest-path benchmark/l2-module/Cargo.toml`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (576 passed, 2 explicitly ignored network tests)
- `cargo doc --workspace --no-deps`
- `make build`
- `make test` (Rust, Hook, Python integration, Adapter, Raw, and npm package suites)
- `PATH="$PWD/target/release:$PWD/third_party/rtk/target/release:$PATH" bash tests/run-all-tests.sh` (72/72 against tokenless 0.7.9)
- `make test-python-runtime` (24 installed-Wheel lifecycle tests)
- `make test-agentscope-integration` (AgentScope 1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.6)
- Release audit passed for the working tree and committed `HEAD`
- Generated adapter/component metadata verification, JSON/TOML parsing, stamped `rpmspec -P`, built CLI version check, and `git diff --check`

## Documentation and rollback

Updated `src/tokenless/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog with equivalent 0.7.9 notes. Before publication, rollback is a revert of the version commit; after any registry publishes 0.7.9, use a follow-up version because published versions must not be reused. No data migration is involved.