### PR TITLE
fix(cosh-ng): detect spaced awk system calls

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cosh-gateway"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "agent-client-protocol",
  "bincode",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "cosh-gateway-contracts"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk.rs
@@ -375,7 +375,7 @@ pub(super) fn stage_assessment(program: &str, tokens: &[String]) -> StageAssessm
     }
     if program == "awk" {
         let high = tokens.iter().any(|token| {
-            token.contains("system(") || token.contains("getline") || token.contains('>')
+            has_awk_system_call(token) || token.contains("getline") || token.contains('>')
         });
         return StageAssessment {
             impact: if high {
@@ -480,6 +480,51 @@ pub(super) fn stage_assessment(program: &str, tokens: &[String]) -> StageAssessm
         side_effects: vec![SideEffectClass::Unknown],
         reasons: vec!["unknown-command"],
     }
+}
+
+fn has_awk_system_call(program: &str) -> bool {
+    let bytes = program.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index..].starts_with(b"system")
+            && is_awk_identifier_boundary(bytes, index.checked_sub(1))
+            && is_awk_identifier_boundary(bytes, index.checked_add(6))
+        {
+            let next = skip_awk_call_separators(bytes, index + 6);
+            if bytes.get(next) == Some(&b'(') {
+                return true;
+            }
+            index = next;
+        } else {
+            index += 1;
+        }
+    }
+
+    false
+}
+
+fn skip_awk_call_separators(bytes: &[u8], mut index: usize) -> usize {
+    loop {
+        while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+            index += 1;
+        }
+
+        let continuation_len = match (bytes.get(index + 1), bytes.get(index + 2)) {
+            (Some(b'\n'), _) if bytes.get(index) == Some(&b'\\') => 2,
+            (Some(b'\r'), Some(b'\n')) if bytes.get(index) == Some(&b'\\') => 3,
+            _ => break,
+        };
+        index += continuation_len;
+    }
+
+    index
+}
+
+fn is_awk_identifier_boundary(bytes: &[u8], index: Option<usize>) -> bool {
+    index
+        .and_then(|index| bytes.get(index))
+        .is_none_or(|byte| !matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'))
 }
 
 fn assess_container_or_cluster(program: &str, tokens: &[String]) -> StageAssessment {

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -140,6 +140,63 @@ fn command_risk_assessment_awk_is_not_auto_allowlisted() {
 }
 
 #[test]
+fn command_risk_assessment_detects_awk_system_calls_with_separators() {
+    for command in [
+        "awk 'BEGIN { system(\"id\") }'",
+        "awk 'BEGIN { system (\"id\") }'",
+        "awk 'BEGIN { system\t(\"id\") }'",
+        "awk 'BEGIN { system\n(\"id\") }'",
+        r#"awk 'BEGIN { system \
+(\"id\") }'"#,
+        "awk 'BEGIN { system \\\r\n(\"id\") }'",
+        "awk 'BEGIN { if ($0 ~ /#/) system (\"id\") }'",
+        "awk 'BEGIN { ratio = 8 / 2; system (\"id\"); pattern = /safe/ }'",
+    ] {
+        let assessment = auto(command);
+        assert_eq!(
+            assessment.execution,
+            ExecutionDecision::AskUser,
+            "{command}"
+        );
+        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            assessment
+                .side_effects
+                .contains(&SideEffectClass::RemoteCodeExecution),
+            "{command}: {:?}",
+            assessment.side_effects
+        );
+        assert!(
+            assessment.reasons.contains(&"awk-shell-execution"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
+}
+
+#[test]
+fn command_risk_assessment_fails_closed_for_ambiguous_awk_contexts() {
+    for command in [
+        "awk 'BEGIN { if (\"x\" ~ /\"/) print \"x\"; system(\"id\") }'",
+        "awk 'BEGIN { # \"\nsystem(\"id\") }'",
+    ] {
+        let assessment = auto(command);
+        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            assessment
+                .side_effects
+                .contains(&SideEffectClass::RemoteCodeExecution),
+            "{command}: {:?}",
+            assessment.side_effects
+        );
+        assert!(
+            assessment.reasons.contains(&"awk-shell-execution"),
+            "{command}"
+        );
+    }
+}
+
+#[test]
 fn command_risk_assessment_high_risk_cases() {
     for (command, reason) in [
         ("sudo id", "privilege-escalation"),

--- a/src/cosh-ng/scripts/check-test-inventory.sh
+++ b/src/cosh-ng/scripts/check-test-inventory.sh
@@ -65,7 +65,7 @@ if [[ "$ignored_count" -gt 3 ]]; then
 fi
 
 check_overlap_ceiling cosh-core cosh-core 4
-check_overlap_ceiling cosh-shell cosh-shell 694
+check_overlap_ceiling cosh-shell cosh-shell 696
 
 if [[ "$failures" -ne 0 ]]; then
   echo "test inventory audit failed with $failures violation(s)" >&2


### PR DESCRIPTION
## Why

The awk policy only matched the literal `system(`, letting optional separators bypass high-risk approval classification.

## What changed

Scan awk programs for identifier-bounded `system` calls followed by optional whitespace or a backslash-newline continuation and `(`. The scanner intentionally does not interpret strings, comments, or regex literals: ambiguous syntax fails closed to high-risk approval.

## Related issue

closes #2307

## User / Agent impact

Agent-requested awk shell execution with whitespace or a line continuation before the opening parenthesis now requires high-risk approval. Ambiguous awk source containing the executable-call shape may require approval conservatively.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Security classification becomes stricter only for potential executable awk `system` calls.

## Validation

- `cargo test --package cosh-shell --lib tools::command_risk_tests` (41 passed)
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-test-inventory.sh` (overlap 696/696)
- `git diff --check`
- Local approval E2E confirmed high-risk approval before execution.

## Documentation and rollback

No documentation changes. Revert commits `1493c58d` and `22c39c223` to restore the previous classification behavior and lockfile state.