### PR TITLE
fix(tokenless): install tqdm for AgentScope 1.x smoke envs

### DIFF
--- a/src/tokenless/tests/test-agentscope-integration.sh
+++ b/src/tokenless/tests/test-agentscope-integration.sh
@@ -50,15 +50,20 @@ run_smoke() {
     local venv="$TEST_ROOT/$venv_name"
 
     uv venv --python python3 "$venv" >/dev/null
-    uv pip install --python "$venv/bin/python" \
-        "$agentscope_requirement" \
-        "${RUNTIME_WHEELS[0]}" "${INTEGRATION_WHEELS[0]}" >/dev/null
+    local extra_requirements=()
+    local smoke_script="$ROOT/tests/agentscope_integration_smoke.py"
     if [[ "$agentscope_requirement" == agentscope==1.* \
         || "$agentscope_requirement" == 'agentscope>=1.0.11,<1.1' ]]; then
-        "$venv/bin/python" "$ROOT/tests/agentscope_v1_integration_smoke.py"
-    else
-        "$venv/bin/python" "$ROOT/tests/agentscope_integration_smoke.py"
+        # AgentScope 1.x imports tqdm at package import time without
+        # declaring it; it used to arrive transitively through openai,
+        # which dropped the tqdm dependency in openai 3.3.0.
+        extra_requirements+=(tqdm)
+        smoke_script="$ROOT/tests/agentscope_v1_integration_smoke.py"
     fi
+    uv pip install --python "$venv/bin/python" \
+        "$agentscope_requirement" "${extra_requirements[@]}" \
+        "${RUNTIME_WHEELS[0]}" "${INTEGRATION_WHEELS[0]}" >/dev/null
+    "$venv/bin/python" "$smoke_script"
     "$venv/bin/python" - <<'PY'
 import agentscope
 


### PR DESCRIPTION
## Why

CI's `Test tokenless` job started failing on 2026-08-19 in `make test-agentscope-integration`, at the very first (`v1-minimum`) env:

```
File ".../agentscope/evaluate/_ace_benchmark/_ace_benchmark.py", line 11, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```

The smoke test pins only the AgentScope version; everything else resolves to latest. AgentScope 1.x imports `tqdm` from `agentscope.evaluate` at package import time without declaring it — it always arrived transitively through `openai`. `openai 3.3.0` (released between the last green run and now) dropped its `tqdm` dependency:

- last green run (2026-08-18 12:29, main): resolved `openai==3.2.0` + `tqdm==4.70.0`
- first red run (2026-08-19 02:17): resolved `openai==3.3.0`, no `tqdm`

This breaks any PR touching `src/tokenless/**`, independent of its content.

## What

Install `tqdm` explicitly in the AgentScope 1.x envs (`v1-minimum`, `v1-latest`). The 2.x envs stay unchanged — AgentScope 2.x imports cleanly without it. Folding the extra requirement into the existing v1 branch also deduplicates the version check that previously appeared twice in `run_smoke`.

## Testing

- Reproduced locally with `agentscope==1.0.11` + `openai==3.3.0` (and CI's `mcp==1.29.0`): import fails without `tqdm` with the exact CI traceback, succeeds with it.
- `agentscope==2.0.6` + `openai==3.3.0` imports cleanly without `tqdm`.
- `bash -n` passes on the edited script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
