### PR TITLE
fix(tokenless): declare tqdm in AgentScope integration wheel for 1.x install path

### DIFF
--- a/src/tokenless/python/agentscope/pyproject.toml.in
+++ b/src/tokenless/python/agentscope/pyproject.toml.in
@@ -14,6 +14,12 @@ dependencies = [
     "anolisa-tokenless==@VERSION@",
     # AgentScope 2.0.0 does not cap MCP and is incompatible with MCP 2.x.
     "mcp>=1.13,<2",
+    # AgentScope 1.x imports tqdm at package import time without declaring it;
+    # it used to arrive transitively through openai, which dropped tqdm in
+    # 3.3.0. PEP 508 markers cannot condition on the resolved AgentScope
+    # version, so declare it unconditionally to keep the whole 1.x support
+    # range installable (harmless extra dependency for AgentScope 2.x users).
+    "tqdm",
 ]
 
 [tool.setuptools]

--- a/src/tokenless/tests/test-agentscope-integration.sh
+++ b/src/tokenless/tests/test-agentscope-integration.sh
@@ -50,18 +50,18 @@ run_smoke() {
     local venv="$TEST_ROOT/$venv_name"
 
     uv venv --python python3 "$venv" >/dev/null
-    local extra_requirements=()
     local smoke_script="$ROOT/tests/agentscope_integration_smoke.py"
     if [[ "$agentscope_requirement" == agentscope==1.* \
         || "$agentscope_requirement" == 'agentscope>=1.0.11,<1.1' ]]; then
-        # AgentScope 1.x imports tqdm at package import time without
-        # declaring it; it used to arrive transitively through openai,
-        # which dropped the tqdm dependency in openai 3.3.0.
-        extra_requirements+=(tqdm)
         smoke_script="$ROOT/tests/agentscope_v1_integration_smoke.py"
     fi
+    # Install only the pinned AgentScope requirement plus the two wheels.
+    # AgentScope 1.x imports tqdm at package import time without declaring it
+    # (openai 3.3.0 stopped providing it transitively), so the 1.x envs
+    # intentionally rely on the integration wheel's own tqdm dependency —
+    # this exercises exactly the clean end-user install path.
     uv pip install --python "$venv/bin/python" \
-        "$agentscope_requirement" "${extra_requirements[@]}" \
+        "$agentscope_requirement" \
         "${RUNTIME_WHEELS[0]}" "${INTEGRATION_WHEELS[0]}" >/dev/null
     "$venv/bin/python" "$smoke_script"
     "$venv/bin/python" - <<'PY'
@@ -101,6 +101,9 @@ assert any(
     and "<2" in requirement
     for requirement in requirements
 )
+# AgentScope 1.x needs tqdm at import time but does not declare it, so the
+# wheel must carry the dependency for the whole declared support range.
+assert any(requirement.startswith("tqdm") for requirement in requirements)
 assert package.metadata.get_all("License-File") == ["LICENSE"]
 license_paths = [
     path for path in package.files or ()


### PR DESCRIPTION
## Why

`openai 3.3.0` dropped its `tqdm` dependency. AgentScope 1.x (`agentscope.evaluate._ace_benchmark`) imports `tqdm` at package import time without declaring it, so any clean install that resolves AgentScope 1.x together with current `openai` fails at `import agentscope`:

```
ModuleNotFoundError: No module named 'tqdm'
```

#2662 (merged) hotfixed the CI smoke envs by installing `tqdm` explicitly, but that does not cover the end-user path: `anolisa-tokenless-agentscope` declares support for `agentscope>=1.0.11,<2.1` while its wheel metadata only declared `agentscope` / `anolisa-tokenless` / `mcp`, so CI was exercising an environment the shipped wheel cannot produce on its own.

Decision among the options listed in #2664: adopt **Option 1 — declare `tqdm` unconditionally in the wheel dependencies**.

- PEP 508 markers cannot condition on the resolved AgentScope version, so a conditional dependency is not expressible.
- `tqdm` is small, pure-Python, and ubiquitous; it protects the entire declared 1.x support range and is harmless extra weight for 2.x users.
- Option 2 (document the workaround) leaves clean installs broken; Option 3 (drop 1.x support) is a product decision, not a packaging one; Option 4 (upstream fix) is out of our control and 1.0.x may see no further releases.

## What changed

- `src/tokenless/python/agentscope/pyproject.toml.in`: add `tqdm` to `[project] dependencies`, with a comment explaining why it must be unconditional.
- `src/tokenless/tests/test-agentscope-integration.sh`:
  - Drop the explicit `tqdm` install from the AgentScope 1.x smoke envs (`v1-minimum`, `v1-latest`) so they now exercise exactly the clean end-user install path — `tqdm` must arrive via the integration wheel's own metadata.
  - Extend the wheel-metadata assertion to require a `tqdm` requirement, guarding against regressions.

## Related issue

Closes #2664

Refs #2662 (CI hotfix + review discussion)

## User / Agent impact

`pip install anolisa-tokenless-agentscope` resolving AgentScope 1.x with `openai>=3.3.0` now works out of the box; no manual `pip install tqdm` workaround is needed. AgentScope 2.x users get one extra small pure-Python dependency (installed unconditionally, since markers cannot depend on the resolved AgentScope version).

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: wheel metadata only. The dependency is unconditional but tiny and pure-Python.

## Testing

Environment: Linux x86_64; Python 3.11.14 / 3.12.9 / 3.13.2 (uv-managed); uv 0.9.9; Rust 1.94.1.

1. Build verification
   - `make stamp-python-packages`: generated `python/agentscope/pyproject.toml` contains the `tqdm` entry.
   - `make agentscope-wheel` (pyproject-build under a Python 3.12 build env): wheel builds successfully; `anolisa_tokenless_agentscope-0.7.9.dist-info/METADATA` in the built wheel contains `Requires-Dist: tqdm` (verified by reading the wheel).
   - `make python-wheel` (maturin): runtime wheel builds successfully (required for the integration suite).
   - `bash -n tests/test-agentscope-integration.sh`: syntax OK.
2. Reproduce → fix verification (fresh virtualenvs, Python 3.11, clean end-user install path)
   - Before: installing `agentscope==1.0.11` with the wheel's previous declared dep set (`mcp>=1.13,<2`) resolves `openai==3.3.0` without `tqdm`; `import agentscope` fails with the exact reported traceback:
     ```
     File ".../agentscope/evaluate/_ace_benchmark/_ace_benchmark.py", line 11, in <module>
         from tqdm import tqdm
     ModuleNotFoundError: No module named 'tqdm'
     ```
   - After: installing `agentscope==1.0.11` plus the two freshly built wheels (no explicit `tqdm`) resolves and installs `tqdm==4.70.0` from the wheel metadata; `import agentscope` and `import tokenless_agentscope` both succeed.
3. Full integration suite: `bash tests/test-agentscope-integration.sh` — exit 0
   - en/zh framework-integration guide fragment checks: pass
   - Smoke envs 6/6: AgentScope 1.0.11, 1.0.21 (v1-latest), 2.0.0, 2.0.1, 2.0.3, 2.0.6 — all pass; the 1.x envs now rely solely on the wheel's own `tqdm` dependency (as expected, the 2.x envs also receive `tqdm`, confirming the unconditional declaration)
   - Wheel-metadata assertion block, including the new `tqdm` requirement check: pass
4. Not run / N/A
   - `cargo check` / `cargo test`: no Rust code changed (wheel metadata + shell test only), no affected tokenless crates.
   - No Rust/TS sources touched, so no repo lint/format targets apply; the edited shell script was checked with `bash -n`.

## Documentation and rollback

No documentation changes needed — the wheel now carries the dependency, so there is no user-facing workaround to document. Rollback: revert this commit (which only re-exposes the 1.x install path when `openai>=3.3.0` resolves).
