### PR TITLE
fix(cosh-ng): [shell] preserve approval batches

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge.rs
@@ -92,9 +92,13 @@ pub(crate) fn render_trusted_tool<W: Write>(
             render_approval_requests(state, &blocked_approval_ids, output)?;
             return Ok(true);
         }
-        if handle_shell_request_policy(state, run_request, &request) {
-            render_approval_requests(state, &blocked_approval_ids, output)?;
-            return Ok(true);
+        match handle_shell_request_policy(state, run_request, &request) {
+            ShellRequestPolicyHandling::Continue => {}
+            ShellRequestPolicyHandling::Refused => continue,
+            ShellRequestPolicyHandling::AwaitingTerminalSweep => {
+                render_approval_requests(state, &blocked_approval_ids, output)?;
+                return Ok(true);
+            }
         }
         if trust_mode_blocks_shell_request(&mut request, AssessmentSource::ProviderShellTool) {
             blocked_approval_ids.extend(record_approval_requests(
@@ -253,8 +257,13 @@ pub(crate) fn render_auto_approved_tool<W: Write>(
             }
             continue;
         }
-        if handle_shell_request_policy(state, run_request, &request) {
-            return Ok(true);
+        match handle_shell_request_policy(state, run_request, &request) {
+            ShellRequestPolicyHandling::Continue => {}
+            ShellRequestPolicyHandling::Refused => continue,
+            ShellRequestPolicyHandling::AwaitingTerminalSweep => {
+                render_approval_requests(state, &blocked_approval_ids, output)?;
+                return Ok(true);
+            }
         }
 
         let raw_cmd = request
@@ -471,23 +480,38 @@ pub(super) enum ShellRequestPolicyDecision {
     DenyDuplicateHostExecuted,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellRequestPolicyHandling {
+    Continue,
+    Refused,
+    AwaitingTerminalSweep,
+}
+
+/// Applies the shell-request policy gate to one event.
+///
+/// A delivered refusal is event-local, so callers keep processing the batch.
+/// Without a live owner, callers stop before the tail record pass so the
+/// detached terminal sweep retains responsibility for the response.
 fn handle_shell_request_policy(
-    state: &InlineState,
+    state: &mut InlineState,
     run_request: Option<&AgentRequest>,
     request: &RuntimeApprovalRequest,
-) -> bool {
-    match shell_request_policy_decision(state, run_request, request) {
-        ShellRequestPolicyDecision::Continue => false,
+) -> ShellRequestPolicyHandling {
+    let reason = match shell_request_policy_decision(state, run_request, request) {
+        ShellRequestPolicyDecision::Continue => return ShellRequestPolicyHandling::Continue,
         ShellRequestPolicyDecision::DenyAnalysisOnly => {
-            deny_shell_tool_during_analysis_continuation(state, request);
-            true
+            crate::adapter::ANALYSIS_ONLY_SHELL_DENY_MESSAGE
         }
         ShellRequestPolicyDecision::DenyDuplicateHostExecuted => {
-            deny_duplicate_host_executed_shell_request(state, request);
-            true
+            DUPLICATE_HOST_EXECUTED_SHELL_DENY_MESSAGE
         }
-    }
+    };
+    deny_policy_refused_shell_request(state, request, reason)
 }
+
+/// Refusal reason for a shell tool call the host already executed once and
+/// whose result was delivered through the control protocol.
+const DUPLICATE_HOST_EXECUTED_SHELL_DENY_MESSAGE: &str = "Duplicate shell tool request was already completed via host-executed shell result; no second foreground execution was run.";
 
 pub(super) fn shell_request_policy_decision(
     state: &InlineState,
@@ -906,15 +930,24 @@ fn respond_auto_approval_to_provider(
     true
 }
 
-fn deny_shell_tool_during_analysis_continuation(
-    state: &InlineState,
+/// Refuses one shell request on policy grounds: answer the owning provider
+/// when there is a control request to answer, then record the refusal.
+///
+/// A successfully delivered control refusal gets a terminal home so the tail
+/// pass cannot resurface it. If delivery is unavailable, the request remains
+/// unhomed for the active or detached terminal sweep. Streamed fallbacks have
+/// no provider response and are recorded as shell-local refusals.
+fn deny_policy_refused_shell_request(
+    state: &mut InlineState,
     request: &RuntimeApprovalRequest,
-) -> bool {
-    let Some(request_id) = request.request_id.as_ref() else {
-        return false;
+    reason: &str,
+) -> ShellRequestPolicyHandling {
+    let Some(request_id) = request.request_id.as_deref() else {
+        record_policy_refused_request(state, request.clone());
+        return ShellRequestPolicyHandling::Refused;
     };
     let Some(active_run) = state.agent_run.active.as_ref() else {
-        return true;
+        return ShellRequestPolicyHandling::AwaitingTerminalSweep;
     };
     let response = provider_deny_response(
         ProviderResponseInput {
@@ -922,30 +955,11 @@ fn deny_shell_tool_during_analysis_continuation(
             tool_use_id: request.tool_use_id.as_deref(),
             tool_input: request.tool_input.as_ref(),
         },
-        "The foreground shell command already completed and its output was injected. Summarize the existing shell evidence or ask the user to start a new request before running another shell command.".to_string(),
+        reason.to_string(),
     );
-    let _ = active_run.handle.respond_approval(response);
-    true
-}
-
-fn deny_duplicate_host_executed_shell_request(
-    state: &InlineState,
-    request: &RuntimeApprovalRequest,
-) -> bool {
-    let Some(request_id) = request.request_id.as_ref() else {
-        return false;
-    };
-    let Some(active_run) = state.agent_run.active.as_ref() else {
-        return true;
-    };
-    let response = provider_deny_response(
-        ProviderResponseInput {
-            request_id,
-            tool_use_id: request.tool_use_id.as_deref(),
-            tool_input: request.tool_input.as_ref(),
-        },
-        "Duplicate shell tool request was already completed via host-executed shell result; no second foreground execution was run.".to_string(),
-    );
-    let _ = active_run.handle.respond_approval(response);
-    true
+    if active_run.handle.respond_approval(response).is_err() {
+        return ShellRequestPolicyHandling::AwaitingTerminalSweep;
+    }
+    record_policy_refused_request(state, request.clone());
+    ShellRequestPolicyHandling::Refused
 }

--- a/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/approval_bridge_tests.rs
@@ -686,8 +686,20 @@ fn analysis_only_continuation_blocks_streamed_shell_tool_fallback() {
     )
     .expect("render auto approval");
 
-    assert!(handled);
-    assert!(state.approvals.requests.is_empty());
+    // #2639: refusing one event no longer claims the batch — that is what
+    // used to strand the control approvals queued behind it. The refusal is
+    // recorded as resolved instead, so nothing executes and no card asks the
+    // user to approve a command the policy already turned down.
+    assert!(!handled);
+    assert_eq!(state.approvals.requests.len(), 1);
+    assert_eq!(
+        state.approvals.requests[0].status,
+        ApprovalRequestStatus::Denied
+    );
+    assert_eq!(
+        state.approvals.requests[0].execution_path,
+        Some("not_executed_shell_request_policy_local")
+    );
     assert!(state.control.shell_handoff().approved_is_empty());
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/structured_events.rs
@@ -403,4 +403,252 @@ mod tests {
             "a request with a pending card must never be drained"
         );
     }
+
+    /// #2639: a hook `ask` decision plus a `tool_input_patch` reaches the
+    /// shell as a control approval carrying the rewritten command. When the
+    /// provider's streamed tool call for the same call escapes the
+    /// control-protocol staging grace, both land in one batch. The refused
+    /// streamed fallback must not abandon the batch, or the control approval
+    /// stays unhomed and the #1940 batch drain denies a card the user is
+    /// still owed.
+    #[test]
+    fn batch_drain_keeps_hook_ask_approval_behind_refused_tool_call() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        // Control-protocol adapter: the tail record pass ignores streamed
+        // tool calls exactly as it does for cosh-core.
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        assert!(adapter.capabilities().control_protocol);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        state.agent_run.active = Some(active_run);
+        // This run already handed a shell command to the foreground, so the
+        // shell-request policy refuses any further streamed shell fallback.
+        state.control.mark_provider_shell_handoff_run("request-1");
+        let mut output = Vec::new();
+
+        {
+            let active_run = state.agent_run.active.as_mut().expect("active run");
+            active_run.governed_events.push(governed(
+                AgentEvent::ToolCall {
+                    run_id: "request-1".to_string(),
+                    tool_id: Some("tool-7".to_string()),
+                    name: "run_shell_command".to_string(),
+                    input: r#"{"command":"rm -rf /tmp/sec_demo"}"#.to_string(),
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+            active_run.governed_events.push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-7".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({
+                        "command": "linux-sandbox --sandbox-policy-cwd /tmp -- bash -c 'rm -rf /tmp/sec_demo'"
+                    }),
+                    tool_use_id: "tool-7".to_string(),
+                    hook_requires_approval: true,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        }
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-7");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render mixed batch");
+
+        let pending = state
+            .approvals
+            .requests
+            .iter()
+            .find(|request| request.request_id.as_deref() == Some("approval-7"))
+            .expect("hook ask approval must reach a decision surface");
+        assert_eq!(pending.status, ApprovalRequestStatus::Pending);
+        assert!(pending.hook_requires_approval);
+        assert_eq!(
+            state.approvals.active_panel_id.as_deref(),
+            Some(pending.id.as_str())
+        );
+        let responses: Vec<_> = approval_rx
+            .try_iter()
+            .filter_map(|message| match message {
+                crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+                crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+            })
+            .collect();
+        assert!(
+            !responses
+                .iter()
+                .any(|response| response.request_id == "approval-7"),
+            "a surfaced approval must never be denied by the batch drain: {responses:?}"
+        );
+    }
+
+    /// #2639 companion: when the shell-request policy itself refuses a
+    /// control approval, that refusal is the request's terminal response. It
+    /// must settle the #1940 ledger, so the batch drain neither re-denies it
+    /// nor lets the tail record pass offer the refused command as a card.
+    #[test]
+    fn policy_refused_control_request_is_answered_exactly_once() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        assert!(adapter.capabilities().control_protocol);
+        let mut active_run = test_active_run();
+        active_run.provider_name = "cosh-core";
+        active_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        state.agent_run.active = Some(active_run);
+        // The host already executed this exact control request and delivered
+        // its result, so the policy refuses the replay.
+        state
+            .control
+            .provider_tool_mut()
+            .claim_host_executed_shell_result("request-1", "approval-5", Some("tool-5"))
+            .expect("claim host result");
+        let mut output = Vec::new();
+
+        state
+            .agent_run
+            .active
+            .as_mut()
+            .expect("active run")
+            .governed_events
+            .push(governed(
+                AgentEvent::ToolPermissionRequest {
+                    run_id: "request-1".to_string(),
+                    request_id: "approval-5".to_string(),
+                    tool_name: "run_shell_command".to_string(),
+                    tool_input: serde_json::json!({ "command": "rm -rf /tmp/sec_demo" }),
+                    tool_use_id: "tool-5".to_string(),
+                    hook_requires_approval: false,
+                    audit_ref: None,
+                },
+                GovernancePolicyDecision::NeedsUserApproval,
+            ));
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-5");
+
+        render_new_agent_structured_events(&mut state, &mut output, &adapter)
+            .expect("render refused batch");
+
+        let responses: Vec<_> = approval_rx
+            .try_iter()
+            .filter_map(|message| match message {
+                crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+                crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+            })
+            .collect();
+        let terminal: Vec<_> = responses
+            .iter()
+            .filter(|response| response.request_id == "approval-5")
+            .collect();
+        assert_eq!(
+            terminal.len(),
+            1,
+            "a policy refusal is the only terminal response: {responses:?}"
+        );
+        assert!(matches!(
+            terminal[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
+        // The refusal is recorded as resolved, never as a card the user
+        // could approve after the provider was already told no.
+        assert!(state
+            .approvals
+            .requests
+            .iter()
+            .all(|request| request.status != ApprovalRequestStatus::Pending));
+        assert!(state.approvals.active_panel_id.is_none());
+        // And the ledger records the response, as every control_response
+        // exit is required to (see runtime::approval_ledger).
+        assert!(state
+            .control
+            .approval_ledger()
+            .unresponded_for_run("request-1")
+            .is_empty());
+    }
+
+    #[test]
+    fn detached_policy_refusal_waits_for_terminal_sweep() {
+        let (approval_tx, approval_rx) = std::sync::mpsc::channel();
+        let mut detached_run = test_active_run();
+        detached_run
+            .request
+            .context_hints
+            .push(crate::types::SHELL_HANDOFF_CONTINUATION_HINT.to_string());
+        detached_run.handle = AgentRunHandle::test_with_approval_sender(approval_tx);
+        let run_request = detached_run.request.clone();
+        let mut state = InlineState::default();
+        let adapter = AdapterInstance::QwenCli(QwenCliAdapter::default());
+        assert!(adapter.capabilities().control_protocol);
+        let mut output = Vec::new();
+        let request = governed(
+            AgentEvent::ToolPermissionRequest {
+                run_id: "request-1".to_string(),
+                request_id: "approval-8".to_string(),
+                tool_name: "run_shell_command".to_string(),
+                tool_input: serde_json::json!({ "command": "rm -rf /tmp/sec_demo" }),
+                tool_use_id: "tool-8".to_string(),
+                hook_requires_approval: false,
+                audit_ref: None,
+            },
+            GovernancePolicyDecision::NeedsUserApproval,
+        );
+        state
+            .control
+            .approval_ledger_mut()
+            .register("request-1", "approval-8");
+
+        render_agent_structured_events(
+            &mut state,
+            &[request],
+            Some(&run_request),
+            detached_run.origin,
+            &mut output,
+            &adapter,
+        )
+        .expect("render detached refusal");
+
+        assert!(state.approvals.requests.is_empty());
+        assert_eq!(
+            state
+                .control
+                .approval_ledger()
+                .unresponded_for_run("request-1"),
+            vec!["approval-8"]
+        );
+        assert!(approval_rx.try_iter().next().is_none());
+
+        crate::approval::runtime::drain_unhomed_control_requests_with_handle(
+            &mut state,
+            "request-1",
+            &detached_run.handle,
+        );
+
+        let responses: Vec<_> = approval_rx
+            .try_iter()
+            .filter_map(|message| match message {
+                crate::adapter::ApprovalChannelMessage::Response(response) => Some(response),
+                crate::adapter::ApprovalChannelMessage::Receipt { .. } => None,
+            })
+            .collect();
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].request_id, "approval-8");
+        assert!(matches!(
+            responses[0].decision,
+            ApprovalDecision::Deny { .. }
+        ));
+        assert!(state
+            .control
+            .approval_ledger()
+            .unresponded_for_run("request-1")
+            .is_empty());
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/approval/requests.rs
@@ -354,6 +354,38 @@ pub(crate) fn record_auto_approved_request(
     request
 }
 
+/// Records a shell request the shell-request policy refused (#2639).
+///
+/// The refusal is already on the wire (or had no provider to reach), so the
+/// entry exists to give the request a terminal home: the tail record pass
+/// dedups on it instead of surfacing a card for a refused command, and
+/// `mark_responded` settles the #1940 lifecycle ledger so the batch drain
+/// cannot deny the same control request a second time.
+pub(crate) fn record_policy_refused_request(
+    state: &mut InlineState,
+    mut request: RuntimeApprovalRequest,
+) {
+    request.status = ApprovalRequestStatus::Denied;
+    request.execution_path = Some(if request.request_id.is_some() {
+        "not_executed_shell_request_policy"
+    } else {
+        // Streamed fallbacks have no provider lifecycle entry. This local
+        // home only prevents the tail pass from resurfacing a refused card.
+        "not_executed_shell_request_policy_local"
+    });
+    if let Some(request_id) = request.request_id.as_deref() {
+        state
+            .control
+            .approval_ledger_mut()
+            .mark_responded(&request.run_id, request_id);
+    }
+    state
+        .approvals
+        .journal
+        .push(approval_journal_entry(&request, "cosh-shell"));
+    state.approvals.requests.push(request);
+}
+
 pub(crate) fn record_deferred_fallback_request(
     state: &mut InlineState,
     mut request: RuntimeApprovalRequest,

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
@@ -104,7 +104,8 @@ pub(crate) use crate::approval::panel::render_approval_requests;
 pub(crate) use crate::approval::requests::{
     approval_request_from_governed_event, record_approval_requests, record_auto_approved_request,
     record_deferred_fallback_request, record_hook_blocked_staged_request,
-    record_staged_unresolved_request, refresh_shell_request_assessment,
+    record_policy_refused_request, record_staged_unresolved_request,
+    refresh_shell_request_assessment,
 };
 pub(crate) use crate::approval::runtime::render_approval_resolution;
 pub(crate) use crate::question::runtime::{


### PR DESCRIPTION
## Why

A policy-refused shell event could stop processing the rest of a governed-event
batch. A later control approval was then left without a decision surface, so the
#1940 terminal-state drain denied a request that should have remained available
for user approval.

## What changed

- Continue processing the batch after refusing an individual shell event.
- Record policy-refused requests only after terminal delivery succeeds.
- Leave detached refusals unhomed for the owning terminal sweep.
- Distinguish shell-local fallback refusals from control lifecycle entries.

## Related issue

closes #2639

## User / Agent impact

Approving a hook-rewritten shell command no longer fails with
`could not route this approval` because another event in the same batch was
refused.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

The change is limited to approval routing. It preserves the #1940 fail-closed
drain for genuinely unhomed requests and keeps policy-refused requests denied.
Detached runs retain terminal-delivery ownership until their response is sent.

## Validation

- `cargo test --package cosh-shell --bin cosh-shell batch_drain_`
- `cargo test --package cosh-shell --bin cosh-shell policy_refusal`
- `cargo test --package cosh-shell --bin cosh-shell analysis_only_continuation_blocks_streamed_shell_tool_fallback`
- `cargo test --package cosh-shell --test protocol` (71 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`

Validated locally on Linux against `up/main`. The detached regression verifies
that an unavailable active owner leaves the request for exactly one terminal
denial from the detached sweep.

## Documentation and rollback

No documentation changes are required. Revert commit `46a18921` to restore the
previous batch-short-circuit behavior.