### PR TITLE
chore(tokenless): bump version to 0.7.10

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.9"
+version = "0.7.10"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,21 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.10] - 2026-08-19
+
+### Added
+
+- Gemini-native `functionDeclarations` tool schemas are now compressed in `BeforeModel` integrations such as copilot-shell, including declarations that use `parametersJsonSchema`, while preserving unrelated Gemini Tool fields ([#2663](https://github.com/alibaba/anolisa/pull/2663)).
+- The `anolisa-tokenless` Python SDK now exposes typed, read-only status, summary, list, show, diff, and comparison queries through `TokenlessStats`, using the same Runtime data directory and returning stored tool content only for explicit show and diff calls ([#2666](https://github.com/alibaba/anolisa/pull/2666)).
+
+### Changed
+
+- Raw, RPM, npm, and source installations no longer build or ship the unused standalone `toon` executable; TOON encoding remains available through `tokenless compress-toon` and `tokenless decompress-toon`, and upgrades remove only Tokenless-owned legacy artifacts ([#2657](https://github.com/alibaba/anolisa/pull/2657)).
+
+### Fixed
+
+- The AgentScope integration wheel now declares `tqdm`, so clean installations using the supported AgentScope 1.x range continue to import with OpenAI 3.3.0 and later without a manual dependency workaround ([#2665](https://github.com/alibaba/anolisa/pull/2665)).
+
 ## [0.7.9] - 2026-08-18
 
 ### Added

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,21 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.10] - 2026-08-19
+
+### 新增
+
+- Gemini 原生 `functionDeclarations` 工具 Schema 现在可在 copilot-shell 等 `BeforeModel` 集成中压缩，包括使用 `parametersJsonSchema` 的声明，同时保留无关的 Gemini Tool 字段（[#2663](https://github.com/alibaba/anolisa/pull/2663)）。
+- `anolisa-tokenless` Python SDK 现在通过 `TokenlessStats` 开放类型化的只读 Status、Summary、List、Show、Diff 和 Comparison 查询，复用同一个 Runtime 数据目录，并且只在显式 Show 和 Diff 调用中返回已存储的 Tool 内容（[#2666](https://github.com/alibaba/anolisa/pull/2666)）。
+
+### 变更
+
+- Raw、RPM、npm 和源码安装不再构建或提供未使用的独立 `toon` 可执行文件；TOON 编码仍可通过 `tokenless compress-toon` 与 `tokenless decompress-toon` 使用，升级时只清理 Tokenless 所属的旧版残留文件（[#2657](https://github.com/alibaba/anolisa/pull/2657)）。
+
+### 修复
+
+- AgentScope 集成 Wheel 现在声明 `tqdm` 依赖，因此使用受支持 AgentScope 1.x 范围的全新安装在搭配 OpenAI 3.3.0 及更高版本时可以直接导入，无需手动补装依赖（[#2665](https://github.com/alibaba/anolisa/pull/2665)）。
+
 ## [0.7.9] - 2026-08-18
 
 ### 新增

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "regex",
  "serde_json",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.9",
-    "@anolisa/tokenless-linux-arm64": "0.7.9",
-    "@anolisa/tokenless-darwin-x64": "0.7.9",
-    "@anolisa/tokenless-darwin-arm64": "0.7.9"
+    "@anolisa/tokenless-linux-x64": "0.7.10",
+    "@anolisa/tokenless-linux-arm64": "0.7.10",
+    "@anolisa/tokenless-darwin-x64": "0.7.10",
+    "@anolisa/tokenless-darwin-arm64": "0.7.10"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -470,6 +470,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Aug 19 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.10-1
+- feat(tokenless): compress Gemini tool schemas
+- feat(tokenless): expose Python stats queries
+- refactor(tokenless): remove the standalone toon binary
+- fix(tokenless): declare tqdm for AgentScope 1.x
+
 * Tue Aug 18 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.9-1
 - feat(tokenless): add the framework-neutral Python SDK
 - feat(tokenless): attach full SDK lifecycles to AgentScope


### PR DESCRIPTION
## Why

Tokenless 0.7.9 predates four user-visible changes merged on August 19: Gemini tool-schema compression, Python statistics queries, an AgentScope installation fix, and removal of the unused standalone `toon` executable. Supported TOON encoding remains available through the `tokenless` subcommands. This release synchronizes all 14 active version surfaces so the Raw, npm, Python, and RPM workflows can publish coherent 0.7.10 artifacts.

## What changed

- Bump the Tokenless workspace, catalog, Cosh extension, npm root/platform packages, and Cargo lock metadata to 0.7.10.
- Add semantically aligned English and Chinese 0.7.10 changelog sections sourced from #2657, #2663, #2665, and #2666.
- Add the matching 0.7.10 RPM changelog boundary.
- Keep this as a version/documentation-only commit; it introduces no runtime code beyond behavior already merged on `main`.

## Related issue

no-issue: scheduled component release after the merged Tokenless changes

## User / Agent impact

- Gemini-native `functionDeclarations`, including `parametersJsonSchema`, can now be compressed in `BeforeModel` integrations such as copilot-shell.
- Python SDK users gain typed, read-only `TokenlessStats` status, summary, list, show, diff, and comparison queries.
- Clean AgentScope 1.x installations receive `tqdm` from the integration Wheel metadata.
- Packages no longer ship the unused standalone `toon` command; users can use `tokenless compress-toon` and `tokenless decompress-toon`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The version commit itself is low risk because the runtime changes are already on `main`. The catalog and package metadata move atomically. Users who directly invoked the formerly bundled standalone `toon` binary must switch to the supported `tokenless` subcommands or install that upstream tool independently.

## Validation

Environment: Linux x86_64; Rust/Cargo 1.97.1; system Python 3.11.13; uv-managed Wheel matrix Python 3.12.13; Node.js 24.15.0; npm 11.12.1; uv 0.11.7; RPM 4.14.3.

- Release audit in the working tree and committed `HEAD` with `check_release.py`: passed for all 14 history-derived surfaces.
- `cargo check --workspace` plus both benchmark manifests: passed and regenerated only the expected lockfile versions.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: passed.
- `cargo test --workspace --locked -- --test-threads=1`: 581 passed, 2 explicitly ignored network tests.
- `cargo doc --workspace --no-deps --locked`: passed.
- `make build`: passed; built CLI reports exactly `tokenless 0.7.10`.
- `make lint && make test`: passed, including hooks, adapters, Raw/npm packaging, and legacy `toon` cleanup.
- Built-artifact `tests/run-all-tests.sh`: 71/71 passed with `target/release/tokenless 0.7.10`.
- `make test-python-runtime`: 28 installed-Wheel tests passed for `anolisa-tokenless 0.7.10`.
- `make test-agentscope-integration`: AgentScope 1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.6 passed with both 0.7.10 Wheels.
- Documentation lint/link checks and component-version regression tests: passed.
- JSON/TOML parsing, stamped `rpmspec -P`, bilingual release-block parity, and `git diff --check`: passed.

## Documentation and rollback

The paired Tokenless changelogs and RPM changelog document the release; user and design documentation for the underlying behavior landed with the source PRs. Before publication, rollback by reverting this version-only commit. After a tag or artifact is published, keep the immutable release history and issue a corrective version instead of moving the tag.