### PR TITLE
chore(anolisa): bump version to 0.3.4

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-08-19
+
+### Changed
+
+- Component-targeting commands now use the repository component index as the
+  sole authority for names absent from local state. Installed and recovery
+  identities remain usable offline, while unsupported names return
+  `INVALID_ARGUMENT`, an unavailable index returns `EXECUTION_FAILED`, and
+  `NOT_INSTALLED` now reliably means a supported component is absent. A
+  `--repo` override also governs identity and package selection for the whole
+  invocation, so site-local package mappings and RPM `Provides` metadata can
+  no longer establish unrecognized component names
+  ([#2637](https://github.com/alibaba/anolisa/pull/2637)).
+
+### Fixed
+
+- Missing local Raw repository index errors now identify whether the active
+  repository came from the exact `repo.toml` path or a one-off `--repo`
+  override and provide matching recovery guidance. Users no longer need to
+  guess which source configured the missing repository
+  ([#2650](https://github.com/alibaba/anolisa/pull/2650)).
+
 ## [0.3.3] - 2026-08-18
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,25 @@
 
 ## [未发布]
 
+## [0.3.4] - 2026-08-19
+
+### 变更
+
+- 面向组件的命令现将 repository component index 作为 local state 中不存在的
+  名称的唯一身份权威。已安装和 recovery identity 在离线时仍可使用；不支持的
+  名称返回 `INVALID_ARGUMENT`，index 不可用返回 `EXECUTION_FAILED`，而
+  `NOT_INSTALLED` 现可明确表示受支持的组件尚未安装。`--repo` override 同时决定
+  整个 invocation 的 identity 与 package selection，因此 site-local package
+  mapping 和 RPM `Provides` metadata 不再能创建 index 未识别的组件名称
+  ([#2637](https://github.com/alibaba/anolisa/pull/2637))。
+
+### 修复
+
+- 本地 Raw repository index 缺失时，错误信息现会指出 active repository 来自
+  具体的 `repo.toml` path 还是一次性的 `--repo` override，并提供对应的 recovery
+  guidance。用户无需再猜测缺失 repository 由哪个配置来源指定
+  ([#2650](https://github.com/alibaba/anolisa/pull/2650))。
+
 ## [0.3.3] - 2026-08-18
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Tue Aug 18 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Aug 19 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Component commands now validate new identities through the component index.
+- Missing local Raw index errors now identify the active repository source.
+
+* Tue Aug 18 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.3-1
 - Telemetry snapshots now report the detected container runtime flavor.
 - Component status now validates targets and redirects telemetry service queries.
 - Raw adapter bundle installs now preserve per-file archive modes.

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.3",
-    "@anolisa/cli-linux-arm64": "0.3.3",
-    "@anolisa/cli-darwin-arm64": "0.3.3"
+    "@anolisa/cli-linux-x64": "0.3.4",
+    "@anolisa/cli-linux-arm64": "0.3.4",
+    "@anolisa/cli-darwin-arm64": "0.3.4"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA has user-visible identity-resolution and repository-diagnostic changes
merged after 0.3.3. This PR creates one atomic 0.3.4 release boundary across
Cargo, npm, RPM, and the required bilingual changelogs without adding new
runtime behavior in the bump itself.

## What changed

- Bumped the Cargo workspace and its five internal lockfile packages to 0.3.4.
- Synchronized the npm root package, three native package templates, and all
  optional native dependency versions.
- Added equivalent English and Chinese notes for #2637 and #2650, and rotated
  the RPM `@VERSION@` changelog boundary while freezing the 0.3.3 row.
- Intentionally omitted #2635 from the changelog because it preserves existing
  helper protocol and output behavior.

## Related issue

no-issue: routine component release for merged PRs #2637 and #2650

## User / Agent impact

The release documents that component names absent from local state are now
validated by the repository component index, with distinct errors for an
unsupported name, an unavailable index, and a supported but absent component.
It also documents source-specific recovery guidance when a local Raw index is
missing. The version bump itself changes no runtime behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Repository package mappings and RPM `Provides` metadata can select a backend
package only after component identity is established; existing installed and
recovery identities remain usable offline. At preparation time,
`anolisa/v0.3.3` did not yet have a public tag or GitHub Release. This PR does
not publish artifacts, so release automation must still require predecessor
completion before tagging 0.3.4.

## Validation

Environment: Linux x86_64, repository-pinned Rust 1.88.0, Node.js 24.15.0.

- Release audit passed for both the working tree and committed `HEAD`.
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (1023 core unit tests plus integration and
  documentation suites passed)
- `cargo test --workspace --doc --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `node npm/scripts/package-npm.js --target linux-x64`; the release binary and
  packaged native binary both reported `anolisa 0.3.4`, and both tarball
  manifests and file lists were inspected.
- Rendered `anolisa.spec.in` through `rpmspec -P`; it reported version 0.3.4,
  release `1.al8`, and the dated 0.3.4 changelog row.
- `python3 scripts/check-component-versions.py`
- Nightly Raw lifecycle harness syntax, case listing, and repository
  configuration checks.
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `npm run typecheck --prefix website`
- `npm run build --prefix website`
- `git diff --cached --check`

Linux arm64 and macOS arm64 package templates were validated but their binaries
were not built on this Linux x86_64 host.

## Documentation and rollback

`CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog were updated with the
same release boundary. Roll back by reverting the atomic version-bump commit;
there is no feature flag or data migration in this PR.
