### PR TITLE
fix(tokenless): fail compare on missing sessions

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -255,6 +255,7 @@ tokenless env-check --tool Shell --fix
 ```bash
 tokenless stats summary
 tokenless stats summary --json
+tokenless stats summary --limit 1000
 tokenless stats list --limit 20
 tokenless stats show <record-id>
 tokenless stats diff <record-id>
@@ -270,6 +271,8 @@ Dual-run comparison:
 ```bash
 tokenless stats summary --compare <baseline-session> <active-session>
 ```
+
+A missing session ID fails with a non-zero exit instead of a 0% comparison, matching `stats diff --session`. `stats summary --limit` must be a positive integer; `--limit 0` is rejected at parse time, matching `stats diff --limit`.
 
 Inspect one record or the verified stages of one tool call:
 

--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -69,6 +69,8 @@ The summary reads at most the latest 10,000 records by default. Limit the query 
 tokenless stats summary --limit 1000
 ```
 
+`--limit` must be a positive integer. `--limit 0` is rejected at parse time with a non-zero exit, matching `stats diff --limit`.
+
 ## Inspect individual records
 
 List recent records:
@@ -194,6 +196,8 @@ tokenless stats summary \
 Notes:
 
 - `--compare` requires exactly two session IDs in baseline, active order.
+- If either session has no records, the command exits with an error instead of reporting 0% savings.
+- `--limit` must be a positive integer. `--limit 0` is rejected at parse time instead of looking like a missing session.
 - The baseline should be a dry-run and the active session should apply compression. The CLI warns on a mode mismatch.
 - For real agent tasks, keep inputs, tool versions, and the environment as similar as possible.
 - Dry-run still writes the complete before/after text to the local statistics database.

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -249,6 +249,7 @@ tokenless env-check --tool Shell --fix
 ```bash
 tokenless stats summary
 tokenless stats summary --json
+tokenless stats summary --limit 1000
 tokenless stats list --limit 20
 tokenless stats show <record-id>
 tokenless stats diff <record-id>
@@ -264,6 +265,8 @@ tokenless stats clear --yes
 ```bash
 tokenless stats summary --compare <baseline-session> <active-session>
 ```
+
+Session ID 不存在时以非零退出码失败，而不是输出 0% 对比，行为与 `stats diff --session` 一致。`stats summary --limit` 必须为正整数；`--limit 0` 会在解析阶段被拒绝，行为与 `stats diff --limit` 一致。
 
 查看单条记录，或一次工具调用中可确认衔接的阶段：
 

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -69,6 +69,8 @@ tokenless stats summary --json
 tokenless stats summary --limit 1000
 ```
 
+`--limit` 必须为正整数。`--limit 0` 会在解析阶段以非零退出码被拒绝，行为与 `stats diff --limit` 一致。
+
 ## 查看单条记录
 
 列出最近记录：
@@ -188,6 +190,8 @@ tokenless stats summary \
 注意：
 
 - `--compare` 必须提供恰好两个 Session ID，顺序为 baseline、active。
+- 任一 Session 没有记录时，命令以错误退出，而不是报告 0% 节省。
+- `--limit` 必须为正整数。`--limit 0` 会在解析阶段被拒绝，而不会被误报为 Session 缺失。
 - baseline 应为 dry-run，active 应为真实压缩；模式不匹配时 CLI 会告警。
 - 对真实 Agent 任务做对比时，应尽量使用相同输入、工具版本和环境。
 - dry-run 仍会把压缩前后文本写入本地统计数据库。

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -323,10 +323,13 @@ echo 'name: Alice\nage: 30' | tokenless decompress-toon
 
 ### Inspect token savings
 
-Use `show` to print the complete stored before/after payload, or `diff` to
-explain the estimated token saving and highlight only changed lines:
+Use `stats summary` for totals, `show` for the stored before/after payload, or
+`diff` to explain the estimated token saving and highlight only changed lines:
 
 ```bash
+tokenless stats summary
+tokenless stats summary --limit 1000
+tokenless stats summary --compare <baseline-session> <active-session>
 tokenless stats show 42
 tokenless stats diff 42
 tokenless stats diff --session <session-id>
@@ -334,10 +337,13 @@ tokenless stats diff --session <session-id> --tool-use-id <tool-use-id>
 tokenless stats diff 42 --json
 ```
 
-Session overviews contain metrics only. Record and tool-use reports include a
-unified content diff; consecutive active stages are linked only when their
-stored output/input content matches exactly, avoiding duplicate intermediate
-token counts. See [Measuring Tokenless Savings](../../docs/user-guide/en/token-saving/tokenless/measuring-savings.md)
+`stats summary --limit` must be a positive integer; `--limit 0` is rejected at
+parse time. `--compare` fails if either session has no records instead of
+reporting 0% savings. Session overviews contain metrics only. Record and
+tool-use reports include a unified content diff; consecutive active stages are
+linked only when their stored output/input content matches exactly, avoiding
+duplicate intermediate token counts. See
+[Measuring Tokenless Savings](../../docs/user-guide/en/token-saving/tokenless/measuring-savings.md)
 for options and measurement limits.
 
 ### Database location

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -353,10 +353,13 @@ node npm/scripts/package-npm.js --all
 
 ## 查看 Token 节省明细
 
-`show` 用于原样打印完整的压缩前后内容；`diff` 用于解释估算 Token
-节省，并只突出发生变化的行：
+`stats summary` 用于查看合计；`show` 用于原样打印完整的压缩前后内容；
+`diff` 用于解释估算 Token 节省，并只突出发生变化的行：
 
 ```bash
+tokenless stats summary
+tokenless stats summary --limit 1000
+tokenless stats summary --compare <baseline-session> <active-session>
 tokenless stats show 42
 tokenless stats diff 42
 tokenless stats diff --session <session-id>
@@ -364,9 +367,11 @@ tokenless stats diff --session <session-id> --tool-use-id <tool-use-id>
 tokenless stats diff 42 --json
 ```
 
-Session 总览只包含指标；单记录和 tool-use 报告包含 unified content
-diff。只有相邻 active 阶段的输出与输入内容完全一致时才会串成一条链，
-从而避免重复计算中间阶段的 Token。完整选项和度量限制见
+`stats summary --limit` 必须为正整数；`--limit 0` 会在解析阶段被拒绝。
+`--compare` 在任一 Session 没有记录时失败，而不是报告 0% 节省。Session
+总览只包含指标；单记录和 tool-use 报告包含 unified content diff。只有相邻
+active 阶段的输出与输入内容完全一致时才会串成一条链，从而避免重复计算中间
+阶段的 Token。完整选项和度量限制见
 [Tokenless 效果度量](../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md)。
 
 ## 数据库位置

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -181,7 +181,7 @@ impl From<DiffSortArg> for DiffSort {
 enum StatsCommands {
     /// Show summary statistics with breakdown by operation
     Summary {
-        #[arg(long)]
+        #[arg(long, value_parser = parse_positive_usize)]
         limit: Option<usize>,
         /// Output machine-readable JSON
         #[arg(long)]
@@ -699,6 +699,14 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         let tokenless = recorder
                             .records_by_session(tokenless_sid, limit)
                             .map_err(|e| (format!("Failed to query tokenless: {}", e), 1))?;
+                        if let Some(message) = missing_compare_sessions(
+                            baseline_sid,
+                            tokenless_sid,
+                            &baseline,
+                            &tokenless,
+                        ) {
+                            return Err((message, 1));
+                        }
                         // Warn if a session's records do not match the expected mode,
                         // i.e. the baseline run was not recorded as dry-run.
                         warn_mode_mismatch("baseline", &baseline, CompressionMode::DryRun);
@@ -972,6 +980,27 @@ fn resolve_mode(
         );
         CompressionMode::DryRun
     }
+}
+
+/// Error text when a `--compare` side has no recorded stats.
+///
+/// An empty side used to format as a successful 0% report, which hid typos
+/// and made A/B scripts look like "no savings". Fail closed like
+/// `stats diff --session` and the Python `TokenlessStats.compare` client.
+fn missing_compare_sessions(
+    baseline_sid: &str,
+    tokenless_sid: &str,
+    baseline: &[StatsRecord],
+    tokenless: &[StatsRecord],
+) -> Option<String> {
+    let mut missing = Vec::new();
+    if baseline.is_empty() {
+        missing.push(format!("baseline session {baseline_sid:?}"));
+    }
+    if tokenless.is_empty() {
+        missing.push(format!("tokenless session {tokenless_sid:?}"));
+    }
+    (!missing.is_empty()).then(|| format!("No records found for {}", missing.join(" and ")))
 }
 
 /// Warn (to stderr) when a session's records were not recorded in the expected

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -985,6 +985,38 @@ fn stats_diff_cli_validates_scope_and_limit() {
 }
 
 #[test]
+fn stats_summary_cli_rejects_zero_limit() {
+    let zero = match Cli::try_parse_from(["tokenless", "stats", "summary", "--limit", "0"]) {
+        Err(error) => error,
+        Ok(_) => panic!("summary --limit 0 must fail at parse time"),
+    };
+    assert!(zero.to_string().contains("greater than zero"));
+
+    let compare_zero = match Cli::try_parse_from([
+        "tokenless",
+        "stats",
+        "summary",
+        "--limit",
+        "0",
+        "--compare",
+        "baseline-run",
+        "active-run",
+    ]) {
+        Err(error) => error,
+        Ok(_) => panic!("compare --limit 0 must fail at parse time"),
+    };
+    assert!(compare_zero.to_string().contains("greater than zero"));
+
+    let parsed = Cli::try_parse_from(["tokenless", "stats", "summary", "--limit", "1"]).unwrap();
+    match parsed.command {
+        Commands::Stats(StatsCommands::Summary { limit, .. }) => {
+            assert_eq!(limit, Some(1));
+        }
+        _ => panic!("expected stats summary"),
+    }
+}
+
+#[test]
 fn run_command_compress_response_large_with_truncation() {
     let _guard = TempDbGuard::new();
 
@@ -1198,25 +1230,173 @@ fn run_command_stats_disable_does_not_persist_env_overrides() {
 }
 
 #[test]
+fn missing_compare_sessions_reports_each_empty_side() {
+    let record = StatsRecord::new(
+        OperationType::CompressSchema,
+        "cli".to_string(),
+        100,
+        40,
+        50,
+        20,
+    );
+    assert!(
+        missing_compare_sessions(
+            "b",
+            "t",
+            std::slice::from_ref(&record),
+            std::slice::from_ref(&record)
+        )
+        .is_none()
+    );
+
+    let both = missing_compare_sessions("b", "t", &[], &[]).unwrap();
+    assert!(both.starts_with("No records found for "));
+    assert!(both.contains("baseline session \"b\""));
+    assert!(both.contains("tokenless session \"t\""));
+    assert!(both.contains(" and "));
+
+    let baseline_only =
+        missing_compare_sessions("b", "t", &[], std::slice::from_ref(&record)).unwrap();
+    assert!(baseline_only.contains("baseline session \"b\""));
+    assert!(!baseline_only.contains("tokenless session"));
+
+    let tokenless_only = missing_compare_sessions("b", "t", &[record], &[]).unwrap();
+    assert!(tokenless_only.contains("tokenless session \"t\""));
+    assert!(!tokenless_only.contains("baseline session"));
+}
+
+#[test]
+fn missing_compare_sessions_debug_escapes_control_chars() {
+    let message = missing_compare_sessions(
+        "base\u{1b}]0;INJECTED\u{7}",
+        "tls\u{1b}]52;c;INJECTED\u{7}",
+        &[],
+        &[],
+    )
+    .unwrap();
+    assert!(!message.contains('\u{1b}'));
+    assert!(!message.contains('\u{7}'));
+    assert!(message.contains("INJECTED"));
+}
+
+fn seed_compare_record(session_id: &str, mode: CompressionMode, before: usize, after: usize) {
+    let recorder = open_recorder().expect("open recorder");
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "cli".to_string(),
+                before * 4,
+                before,
+                after * 4,
+                after,
+            )
+            .with_session_id(session_id)
+            .with_mode(mode),
+        )
+        .expect("seed compare record");
+}
+
+#[test]
 fn run_command_stats_compare() {
-    let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
     let result = run_command(Commands::Stats(StatsCommands::Summary {
         limit: None,
         json: false,
-        compare: Some(vec!["baseline-sess".to_string(), "tokenless-sess".to_string()]),
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "tokenless-sess".to_string(),
+        ]),
     }));
-    assert!(result.is_ok());
+    let err = result.expect_err("empty compare sessions must fail closed");
+    assert_eq!(err.1, 1);
+    assert!(err.0.contains("No records found"));
+    assert!(err.0.contains("baseline session \"baseline-sess\""));
+    assert!(err.0.contains("tokenless session \"tokenless-sess\""));
 }
 
 #[test]
 fn run_command_stats_compare_json() {
-    let _guard = match TempDbGuard::new() { Some(g) => g, None => return };
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
     let result = run_command(Commands::Stats(StatsCommands::Summary {
         limit: None,
         json: true,
-        compare: Some(vec!["baseline-sess".to_string(), "tokenless-sess".to_string()]),
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "tokenless-sess".to_string(),
+        ]),
+    }));
+    let err = result.expect_err("empty JSON compare must not emit a 0% report");
+    assert_eq!(err.1, 1);
+    assert!(err.0.contains("No records found"));
+}
+
+#[test]
+fn run_command_stats_compare_one_side_missing() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    seed_compare_record("tokenless-sess", CompressionMode::Active, 400, 200);
+    let baseline_missing = run_command(Commands::Stats(StatsCommands::Summary {
+        limit: None,
+        json: false,
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "tokenless-sess".to_string(),
+        ]),
+    }))
+    .expect_err("missing baseline must fail");
+    assert!(baseline_missing.0.contains("baseline session \"baseline-sess\""));
+    assert!(!baseline_missing.0.contains("tokenless session"));
+
+    seed_compare_record("baseline-sess", CompressionMode::DryRun, 400, 200);
+    let tokenless_missing = run_command(Commands::Stats(StatsCommands::Summary {
+        limit: None,
+        json: true,
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "absent-tokenless".to_string(),
+        ]),
+    }))
+    .expect_err("missing tokenless side must fail");
+    assert!(tokenless_missing.0.contains("tokenless session \"absent-tokenless\""));
+    assert!(!tokenless_missing.0.contains("baseline session"));
+}
+
+#[test]
+fn run_command_stats_compare_populated_sessions() {
+    let _guard = match TempDbGuard::new() {
+        Some(g) => g,
+        None => return,
+    };
+    seed_compare_record("baseline-sess", CompressionMode::DryRun, 400, 200);
+    seed_compare_record("tokenless-sess", CompressionMode::Active, 400, 200);
+    let result = run_command(Commands::Stats(StatsCommands::Summary {
+        limit: None,
+        json: false,
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "tokenless-sess".to_string(),
+        ]),
     }));
     assert!(result.is_ok());
+
+    let json = run_command(Commands::Stats(StatsCommands::Summary {
+        limit: None,
+        json: true,
+        compare: Some(vec![
+            "baseline-sess".to_string(),
+            "tokenless-sess".to_string(),
+        ]),
+    }));
+    assert!(json.is_ok());
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -3,8 +3,8 @@ use std::process::Command;
 use tokenless_ccr::StashStore;
 use tokenless_runtime::{CompressOptions, compress_response_with_store};
 use tokenless_stats::{
-    OperationType, StatsRecord, StatsRecorder, estimate_tokens, estimate_tokens_from_bytes,
-    get_home_dir,
+    CompressionMode, OperationType, StatsRecord, StatsRecorder, estimate_tokens,
+    estimate_tokens_from_bytes, get_home_dir,
 };
 
 fn tokenless_bin() -> Command {
@@ -1242,4 +1242,190 @@ fn env_check_hard_bypass_json_is_stable_across_processes() {
             index + 1
         );
     }
+}
+
+#[test]
+fn stats_summary_compare_rejects_missing_sessions() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let output = db
+        .command()
+        .args(["stats", "summary", "--compare", "missing-a", "missing-b"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No records found"));
+    assert!(stderr.contains("missing-a"));
+    assert!(stderr.contains("missing-b"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Tokenless Comparison Report"));
+    assert!(!stdout.contains("saved_percent"));
+}
+
+#[test]
+fn stats_summary_compare_json_rejects_one_missing_side() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let output = db
+        .command()
+        .args([
+            "stats",
+            "summary",
+            "--json",
+            "--compare",
+            "missing-baseline",
+            "integration-session",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("baseline session \"missing-baseline\""));
+    assert!(!stderr.contains("tokenless session"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("saved_percent"));
+}
+
+#[test]
+fn stats_summary_compare_reports_populated_sessions() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let recorder = StatsRecorder::new(&db.path).unwrap();
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "integration-agent".to_string(),
+                1600,
+                400,
+                800,
+                200,
+            )
+            .with_session_id("baseline-run")
+            .with_mode(CompressionMode::DryRun),
+        )
+        .unwrap();
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "integration-agent".to_string(),
+                1600,
+                400,
+                800,
+                200,
+            )
+            .with_session_id("active-run")
+            .with_mode(CompressionMode::Active),
+        )
+        .unwrap();
+
+    let text = db
+        .command()
+        .args([
+            "stats",
+            "summary",
+            "--compare",
+            "baseline-run",
+            "active-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        text.status.success(),
+        "compare populated sessions; stderr: {}",
+        String::from_utf8_lossy(&text.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&text.stdout);
+    assert!(stdout.contains("Tokenless Comparison Report"));
+    assert!(stdout.contains("TOTAL"));
+
+    let json = db
+        .command()
+        .args([
+            "stats",
+            "summary",
+            "--json",
+            "--compare",
+            "baseline-run",
+            "active-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(json.status.success());
+    let parsed: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(parsed["baseline_tokens"], 400);
+    assert_eq!(parsed["tokenless_tokens"], 200);
+    assert_eq!(parsed["saved_tokens"], 200);
+}
+
+#[test]
+fn stats_summary_compare_rejects_zero_limit() {
+    let db = match TempStatsDb::new() {
+        Some(db) => db,
+        None => return,
+    };
+    let recorder = StatsRecorder::new(&db.path).unwrap();
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "integration-agent".to_string(),
+                1600,
+                400,
+                800,
+                200,
+            )
+            .with_session_id("baseline-run")
+            .with_mode(CompressionMode::DryRun),
+        )
+        .unwrap();
+    recorder
+        .record(
+            &StatsRecord::new(
+                OperationType::CompressResponse,
+                "integration-agent".to_string(),
+                1600,
+                400,
+                800,
+                200,
+            )
+            .with_session_id("active-run")
+            .with_mode(CompressionMode::Active),
+        )
+        .unwrap();
+
+    let output = db
+        .command()
+        .args([
+            "stats",
+            "summary",
+            "--limit",
+            "0",
+            "--compare",
+            "baseline-run",
+            "active-run",
+        ])
+        .output()
+        .unwrap();
+    assert_ne!(output.status.code(), Some(0));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("greater than zero"),
+        "zero limit must fail at parse time; stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("No records found"),
+        "populated sessions with --limit 0 must not look missing; stderr: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("Tokenless Comparison Report"));
+    assert!(!stdout.contains("saved_percent"));
 }


### PR DESCRIPTION
## Why

`tokenless stats summary --compare` treated unknown session IDs as a successful 0% comparison. A mistyped `--session-id` or a dual-run that never recorded stats looked like "no savings" instead of "this session does not exist." `stats diff --session` and the Python `TokenlessStats.compare` client already fail closed on the same case.

## What changed

- **`--compare` empty-session contract**: if either named session has no records, the CLI now exits 1 with `No records found for …` and does not print a 0% text or JSON report.
- **`--limit 0`**: `stats summary --limit` now uses `parse_positive_usize` like `stats diff`, so `--limit 0` fails at parse time instead of looking like a missing compare session.
- **Docs**: component README (en/zh) and user-guide CLI/measurement pages now summarize both public contracts: missing `--compare` sessions fail closed, and `stats summary --limit` must be a positive integer.
- **Adjacent coverage**: both sides missing, only baseline missing, only tokenless missing, both populated (text + `--json`), control-character session IDs (debug-escaped like `stats diff --session`), and `--limit 0` on populated `--compare`.
- **Binary proof**: `tokenless-cli` integration tests run the same `--compare` invocations against an isolated `TOKENLESS_STATS_DB`.

## Related issue

fixes #2673

## User / Agent impact

`tokenless stats summary --compare <baseline> <active>` now fails when a session was never recorded, matching `tokenless stats diff --session` and `TokenlessStats.compare`. Dual-runs that actually wrote stats are unchanged. `stats summary --limit 0` is now rejected at parse time, matching `stats diff --limit 0`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

CLI `--compare` on an empty session now errors instead of exiting 0 with a zeroed report. That is the bugfix. Callers with two recorded sessions keep the same comparison output. Python compare already raised `StatsNotFoundError` for this case. `--limit 0` now fails at clap parse instead of querying.

## Validation

Current head: `6278f1db9cfcff64bb8cae83ff81009e09664410`

DIRTY rebase onto upstream `main` `a4cb23ea27c9645d7294b7afe65309262e6a0e4b` from previous head `72e92ed2ad094147de313ed8820b7bdcc3a4d05f`. One conflict file: `src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs`. Resolution kept upstream persist snapshot / enable-disable tests (`stats_persist_snapshot_*`, `run_command_stats_{enable,disable}_does_not_persist_env_overrides`) and this PR's `missing_compare_sessions_*` tests plus `seed_compare_record`. `main.rs` auto-merged: upstream `persist_stats_enabled` / `load_from_file` path kept, with this PR's fail-closed `--compare` and `parse_positive_usize` on `--limit` replayed on top.

The previous 3-commit history was squashed into one atomic commit on this rebase, per AGENTS.md §13 and review.

```bash
cd src/tokenless
cargo fmt --all --check
cargo clippy --workspace --locked -- -D warnings
cargo test --workspace --locked -- --test-threads=1
```

Rebased head `6278f1db9cfcff64bb8cae83ff81009e09664410`: fmt/clippy clean; workspace tests 606 passed, 2 ignored. Focused `tokenless-cli`: 9 unit tests (compare fail-closed, persist snapshot, `--limit 0`) + 2 integration tests (`stats_summary_compare_rejects_missing_sessions`, `stats_summary_compare_rejects_zero_limit`) passed.

Exact-head proof (`TOKENLESS_STATS_DB` pointed at an isolated file):

```text
tokenless stats summary --compare missing-a missing-b
# Error: No records found for baseline session "missing-a" and tokenless session "missing-b"
# exit=1

tokenless stats summary --limit 0 --compare missing-a missing-b
# invalid value '0' for '--limit <LIMIT>': value must be greater than zero
# exit=2
```

Review follow-up (`--limit 0` on populated compare sessions): clap rejects with `value must be greater than zero` and does not emit `No records found`. Covered by `stats_summary_cli_rejects_zero_limit` and `stats_summary_compare_rejects_zero_limit`.

Review follow-up (docs): README and user-guide now document both public CLI contracts requested on `1ceb816`.

## Documentation and rollback

User-guide notes in `docs/user-guide/{en,zh}/token-saving/tokenless/measuring-savings.md` and `cli-reference.md`, plus `src/tokenless/README.md` / `README_zh.md`, state that a missing session fails instead of reporting 0%, and that `stats summary --limit` must be a positive integer. Revert the commits on this branch to restore the previous zeroed success report, unvalidated `--limit 0`, and prior docs.
