### PR TITLE
feat(sight): add minimal dsh plugin for DeepSeek Harness

### DIFF
--- a/src/agentsight/dsh-plugin/README.md
+++ b/src/agentsight/dsh-plugin/README.md
@@ -1,0 +1,36 @@
+# @agentsight/dsh-plugin
+
+AgentSight observability plugin for DeepSeek Harness (dsh).
+
+## Install
+
+From the monorepo checkout (local path):
+
+```bash
+cd src/agentsight/dsh-plugin
+pnpm install && pnpm run build
+dsh plugin --profile web add .
+```
+
+Or via `--patch` for a quick trial (no profile modification):
+
+```bash
+dsh --profile web --patch ./src/agentsight/dsh-plugin/cordis.patch.yml
+```
+
+## Capabilities
+
+| Tool | Description |
+|------|-------------|
+| `agentsight_status` | Report plugin status and version |
+
+## Development
+
+```bash
+pnpm install
+pnpm run build
+```
+
+## License
+
+Apache-2.0

--- a/src/agentsight/dsh-plugin/cordis.patch.yml
+++ b/src/agentsight/dsh-plugin/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+  - id: agentsight
+    name: '@agentsight/dsh-plugin'

--- a/src/agentsight/dsh-plugin/package.json
+++ b/src/agentsight/dsh-plugin/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@agentsight/dsh-plugin",
+  "version": "0.1.0",
+  "description": "AgentSight observability plugin for DeepSeek Harness",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/types/index.d.ts",
+  "files": [
+    "lib",
+    "cordis.patch.yml"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.2 <0.2.0"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-tools": ">=0.1.0-rc.2 <0.2.0",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "dsh-plugin",
+    "agentsight",
+    "observability"
+  ]
+}

--- a/src/agentsight/dsh-plugin/src/index.ts
+++ b/src/agentsight/dsh-plugin/src/index.ts
@@ -1,0 +1,49 @@
+import type { Context } from '@deepseek-ai/cordis'
+import type {} from '@deepseek-ai/dsh-tools'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
+
+export const name = 'agentsight'
+
+export const inject = ['tools']
+
+export function apply(ctx: Context) {
+  ctx.tools.register({
+    name: 'agentsight_status',
+    description:
+      'Report AgentSight observability plugin status. Call this to confirm the plugin is active and get version info.',
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    output: {
+      schema: {
+        type: 'object',
+        properties: {
+          plugin: { type: 'string' },
+          version: { type: 'string' },
+          active: { type: 'boolean' },
+          capabilities: { type: 'array', items: { type: 'string' } },
+        },
+        required: ['plugin', 'version', 'active', 'capabilities'],
+      },
+      render: (result: Record<string, unknown>) =>
+        `AgentSight v${result.version} — ${result.active ? 'active' : 'inactive'}`,
+    },
+    async execute() {
+      return {
+        plugin: 'agentsight',
+        version: pkg.version as string,
+        active: true,
+        capabilities: ['status'],
+      }
+    },
+  })
+
+  ctx.logger.info(`[agentsight] plugin loaded (v${pkg.version}), agentsight_status tool registered`)
+}

--- a/src/agentsight/dsh-plugin/tsconfig.json
+++ b/src/agentsight/dsh-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationDir": "lib/types",
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Add `@agentsight/dsh-plugin` — a minimal installable plugin for [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness).

The plugin satisfies the `dsh.bundle` manifest protocol and registers a model-facing `agentsight_status` tool that reports plugin status and version.

## Why

AgentSight currently observes LLM agents externally via eBPF. DeepSeek Harness exposes a plugin architecture (Cordis-based, "everything is a plugin") that allows internal observability. This PR lays the foundation for AgentSight capabilities inside dsh:

- Token usage tracking
- Interruption detection
- Session telemetry export

## How to install

```bash
cd dsh-plugin && pnpm install && pnpm run build
dsh plugin --profile web add .
```

## Structure

```
dsh-plugin/
├── package.json          # dsh.bundle.patch declaration
├── cordis.patch.yml      # profile composition
├── src/index.ts          # inject tools → register agentsight_status
├── tsconfig.json
└── README.md
```

## Test

Start dsh with the plugin and ask the agent to call `agentsight_status`. Expected:

```json
{ "plugin": "agentsight", "version": "0.1.0", "active": true, "capabilities": ["status"] }
```