### PR TITLE
fix(tokenless): align toon CLI with runtime tokens

### DIFF
--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,10 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+### Fixed
+
+- `tokenless compress-toon` now scores TOON savings with the same CJK-aware character estimator as `stats summary` and the Python/SDK path, so dry-run stderr predicted counts match recorded `before_tokens`/`after_tokens`. JSON parse, oversized input, and TOON encode failures still exit 2 ([#2681](https://github.com/alibaba/anolisa/pull/2681)).
+
 ## [0.7.10] - 2026-08-19
 
 ### Added

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,10 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+### 修复
+
+- `tokenless compress-toon` 现在用与 `stats summary` 以及 Python/SDK 路径相同的 CJK 感知字符估算器计算 TOON 节省，因此 dry-run 的 stderr 预测计数与记录的 `before_tokens`/`after_tokens` 一致。JSON 解析、超限输入和 TOON 编码失败仍以退出码 2 结束（[#2681](https://github.com/alibaba/anolisa/pull/2681)）。
+
 ## [0.7.10] - 2026-08-19
 
 ### 新增

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -11,18 +11,18 @@ use std::sync::Arc;
 use tokenless_ccr::{SqliteStore, StashStore};
 use tokenless_runtime::{
     CompressOptions, CompressionDisposition, MAX_INPUT_BYTES, compress_response_with_store,
-    retrieve_from_store,
+    compress_toon, retrieve_from_store,
 };
 use tokenless_schema::SchemaCompressor;
 use tokenless_stats::{
     CompressionMode, DiffSort, OperationType, StatsRecord, StatsRecorder, TokenlessConfig,
+    estimate_tokens,
 };
 use tokenless_stats::{
     ensure_state_dir, format_compare, format_compare_json, format_diff_report, format_list,
     format_show, format_summary, record_report, resolve_data_dir, session_report, tool_use_report,
     validate_database_path,
 };
-use tokenless_stats::{estimate_tokens, estimate_tokens_from_bytes};
 
 #[derive(Parser)]
 #[command(
@@ -879,39 +879,40 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             tool_use_id,
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
-            let value: serde_json::Value = serde_json::from_str(&input)
-                .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
-            let output = toon_format::encode_default(&value)
-                .map_err(|e| (format!("toon encode failed: {}", e), 2))?;
-            let output = output.trim_end().to_string();
-
-            // If no token savings, output original instead of TOON result
-            let before_tokens = estimate_tokens_from_bytes(input.len());
-            let after_tokens = estimate_tokens_from_bytes(output.len());
-            let no_savings = output.is_empty() || after_tokens >= before_tokens;
-            if no_savings {
+            let config = TokenlessConfig::load();
+            let compression_on = config.is_compression_enabled();
+            // Share runtime scoring so CLI dry-run predictions match
+            // `stats summary` and the Python/SDK compress_toon path. The
+            // previous bytes/4 heuristic under-counted CJK.
+            let result = compress_toon(&input, compression_on).map_err(|error| {
+                let code = if matches!(
+                    error,
+                    tokenless_runtime::RuntimeError::InvalidJson(_)
+                        | tokenless_runtime::RuntimeError::InputTooLarge { .. }
+                ) {
+                    2
+                } else {
+                    1
+                };
+                (error.to_string(), code)
+            })?;
+            if result.disposition == CompressionDisposition::NoSavings {
                 eprintln!(
                     "tokenless: TOON encoding did not reduce size ({} -> {} est. tokens), outputting original JSON",
-                    before_tokens, after_tokens
+                    result.before_tokens, result.after_tokens
                 );
             }
 
-            let config = TokenlessConfig::load();
-            let compression_on = config.is_compression_enabled();
-            let mode = resolve_mode(compression_on, before_tokens, after_tokens);
-            // Active: emit the TOON result (or original if no savings).
-            // Dry-run: emit the original so context stays uncompressed, but
-            // still record the TOON result as the predicted savings below.
-            let emit_text = if compression_on && !no_savings {
-                output.clone()
-            } else {
-                input.clone()
-            };
-            println!("{}", emit_text);
+            let mode = resolve_mode(compression_on, result.before_tokens, result.after_tokens);
+            println!("{}", result.output);
 
             // Recorded `after` = the predicted TOON result (or original when
             // TOON did not reduce size), so dry-run captures the prediction.
-            let record_after = if no_savings { input.clone() } else { output };
+            let record_after = if result.disposition == CompressionDisposition::NoSavings {
+                input.clone()
+            } else {
+                result.compressed_output
+            };
             let database_paths = DatabasePathResolver::default();
             record_compression_stats(
                 &config,

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -885,10 +885,13 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             // `stats summary` and the Python/SDK compress_toon path. The
             // previous bytes/4 heuristic under-counted CJK.
             let result = compress_toon(&input, compression_on).map_err(|error| {
+                // JSON parse, oversized input, and TOON encode keep the
+                // documented compress-command exit code 2.
                 let code = if matches!(
                     error,
                     tokenless_runtime::RuntimeError::InvalidJson(_)
                         | tokenless_runtime::RuntimeError::InputTooLarge { .. }
+                        | tokenless_runtime::RuntimeError::ToonEncode(_)
                 ) {
                     2
                 } else {

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -993,6 +993,24 @@ fn compress_toon_cjk_active_emits_toon_and_records_character_tokens() {
     assert_eq!(records[0].after_tokens, estimate_tokens(emitted));
 }
 
+/// Parse failures keep the documented compress-command exit code 2 now
+/// that errors flow through the runtime mapping.
+#[test]
+fn compress_toon_invalid_json_exits_with_code_2() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let output = run_compress_toon(&fixture, "not json", "1", "toon-invalid-json");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "invalid JSON must exit 2, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("JSON parse error"));
+}
+
 #[test]
 fn env_check_without_spec() {
     let output = tokenless_bin().args(["env-check"]).output().unwrap();

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -2,7 +2,10 @@ use std::process::Command;
 
 use tokenless_ccr::StashStore;
 use tokenless_runtime::{CompressOptions, compress_response_with_store};
-use tokenless_stats::{OperationType, StatsRecord, StatsRecorder, estimate_tokens, get_home_dir};
+use tokenless_stats::{
+    OperationType, StatsRecord, StatsRecorder, estimate_tokens, estimate_tokens_from_bytes,
+    get_home_dir,
+};
 
 fn tokenless_bin() -> Command {
     Command::new(env!("CARGO_BIN_EXE_tokenless"))
@@ -838,6 +841,156 @@ fn compress_toon_from_stdin() {
         .unwrap();
     // compress-toon may or may not succeed depending on input format
     let _ = output.status;
+}
+
+fn run_compress_toon(
+    fixture: &TempDataDir,
+    input: &str,
+    compression_enabled: &str,
+    session_id: &str,
+) -> std::process::Output {
+    fixture
+        .command()
+        .env("TOKENLESS_COMPRESSION_ENABLED", compression_enabled)
+        .env("TOKENLESS_STATS_ENABLED", "1")
+        .env("TOKENLESS_SLS_ENABLED", "0")
+        .args([
+            "compress-toon",
+            "--agent-id",
+            "integration-agent",
+            "--session-id",
+            session_id,
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap()
+}
+
+/// CJK payload where bytes/4 and the character estimator disagree. Dry-run
+/// stderr must publish the same predicted counts that `stats summary` stores.
+#[test]
+fn compress_toon_dry_run_predicted_tokens_match_recorded_stats_for_cjk() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let input = serde_json::to_string(&serde_json::json!({
+        "msg": "你好世界你好世界"
+    }))
+    .unwrap();
+    assert_ne!(
+        estimate_tokens(&input),
+        estimate_tokens_from_bytes(input.len()),
+        "fixture must be a CJK case where the two estimators disagree"
+    );
+
+    let output = run_compress_toon(&fixture, &input, "0", "cjk-toon-dry-run");
+    assert!(
+        output.status.success(),
+        "compress-toon dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap().trim_end(),
+        input,
+        "dry-run must emit the original JSON"
+    );
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let recorder = StatsRecorder::new(fixture.data_dir.join("stats.db")).unwrap();
+    let records = recorder
+        .records_by_session("cjk-toon-dry-run", None)
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    let predicted = format!(
+        "predicted {} -> {} est. tokens",
+        records[0].before_tokens, records[0].after_tokens
+    );
+    assert!(
+        stderr.contains(&predicted),
+        "dry-run stderr must match recorded stats, got stderr={stderr:?} stats={}:{} predicted={predicted}",
+        records[0].before_tokens,
+        records[0].after_tokens
+    );
+    assert_eq!(records[0].before_tokens, estimate_tokens(&input));
+}
+
+/// ASCII JSON where both estimators agree still encodes to TOON when smaller.
+#[test]
+fn compress_toon_ascii_emits_toon_when_character_estimator_saves() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let input = r#"{"content":"some content","debug":"remove"}"#;
+    assert_eq!(
+        estimate_tokens(input),
+        estimate_tokens_from_bytes(input.len()),
+        "ascii fixture should keep the two estimators in agreement"
+    );
+
+    let output = run_compress_toon(&fixture, input, "1", "ascii-toon-active");
+    assert!(
+        output.status.success(),
+        "compress-toon failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let emitted = stdout.trim_end();
+    assert_ne!(emitted, input, "active TOON with savings must replace JSON");
+    assert!(
+        emitted.contains("content:") || emitted.starts_with("content:"),
+        "expected TOON object encoding, got {emitted:?}"
+    );
+
+    let recorder = StatsRecorder::new(fixture.data_dir.join("stats.db")).unwrap();
+    let records = recorder
+        .records_by_session("ascii-toon-active", None)
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].before_tokens, estimate_tokens(input));
+    assert_eq!(records[0].after_tokens, estimate_tokens(emitted));
+    assert!(records[0].after_tokens < records[0].before_tokens);
+}
+
+#[test]
+fn compress_toon_cjk_active_emits_toon_and_records_character_tokens() {
+    let fixture = match TempDataDir::new() {
+        Some(fixture) => fixture,
+        None => return,
+    };
+    let input = serde_json::to_string(&serde_json::json!({
+        "msg": "你好世界你好世界"
+    }))
+    .unwrap();
+    let output = run_compress_toon(&fixture, &input, "1", "cjk-toon-active");
+    assert!(
+        output.status.success(),
+        "compress-toon failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let emitted = String::from_utf8(output.stdout).unwrap();
+    let emitted = emitted.trim_end();
+    assert_ne!(emitted, input);
+    assert!(
+        emitted.contains("msg:"),
+        "expected TOON encoding, got {emitted:?}"
+    );
+
+    let recorder = StatsRecorder::new(fixture.data_dir.join("stats.db")).unwrap();
+    let records = recorder
+        .records_by_session("cjk-toon-active", None)
+        .unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].before_tokens, estimate_tokens(&input));
+    assert_eq!(records[0].after_tokens, estimate_tokens(emitted));
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-stats/src/tests/tokenizer_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/tokenizer_tests.rs
@@ -45,6 +45,14 @@ fn byte_estimate_vs_char_estimate() {
 }
 
 #[test]
+fn byte_estimate_undercounts_cjk() {
+    // 4 CJK chars are 12 UTF-8 bytes: bytes/4 → 3, character estimator → 4.
+    let text = "你好世界";
+    assert_eq!(estimate_tokens(text), 4);
+    assert_eq!(estimate_tokens_from_bytes(text.len()), 3);
+}
+
+#[test]
 fn tokenizer_struct_methods() {
     let tokenizer = Tokenizer::new();
     assert_eq!(tokenizer.estimate_tokens("hello world"), 3);


### PR DESCRIPTION
## Why

`tokenless compress-toon` scored TOON savings with `estimate_tokens_from_bytes` (bytes/4) while `record_compression_stats`, runtime `compress_toon`, and the Python/SDK path use the CJK-aware `estimate_tokens`. On CJK JSON, dry-run stderr (`predicted 9 -> 8 est. tokens`) disagreed with `stats summary` (`before_tokens: 11`, `after_tokens: 10`) for the same payload. Tokenizer docs already say to use `estimate_tokens` when the text is available.

Routing the CLI through that shared runtime also mapped `RuntimeError::ToonEncode` to exit 1. The previous encoder path, and CHANGELOG 0.3.2, keep `compress-toon` / `compress-schema` / `compress-response` failures at exit 2.

## What changed

- **`compress-toon` scoring** — `Commands::CompressToon` now calls shared `tokenless_runtime::compress_toon`, so dry-run predictions, the no-savings fallback, and emitted output use the same character estimator as stats recording and the SDK.
- **CJK vs ASCII coverage** — integration tests pin a CJK payload where the two estimators disagree (`compress_toon_dry_run_predicted_tokens_match_recorded_stats_for_cjk`, `compress_toon_cjk_active_emits_toon_and_records_character_tokens`) and keep an ASCII payload where they still agree (`compress_toon_ascii_emits_toon_when_character_estimator_saves`).
- **Tokenizer invariant** — `byte_estimate_undercounts_cjk` records that `"你好世界"` is 4 character-tokens vs 3 from bytes/4.
- **Compress-command exit codes** — JSON parse, oversized input, and TOON encode failures map to exit 2. `compress_toon_invalid_json_exits_with_code_2` pins the reachable parse-failure path. `ToonEncode` stays a defensive mapping: toon-format 0.5 does not fail `encode_default` on legal `serde_json::Value` inputs.
- **Changelog** — bilingual `[Unreleased]` entries record the CJK scoring fix and that parse / size / encode failures still exit 2.

## Related issue

fixes #2680

## User / Agent impact

Dry-run `compress-toon` stderr now prints the same predicted token pair that `stats summary` stores. CJK (and other multi-byte) JSON is scored the same way as `compress-schema` / `compress-response` and the Python/SDK `compress_toon` helper. ASCII payloads where both heuristics already agreed keep the same apply/dry-run behavior. Shell integrations still see exit 2 for JSON parse, oversized input, and TOON encode failures.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Dry-run predicted counts and the no-savings decision now follow `estimate_tokens` instead of bytes/4. Callers that parsed the old byte heuristic from stderr will see larger CJK counts (this payload: 11/10 instead of 9/8). Recorded stats columns were already character-based and do not change.

CLI `read_input` already rejected stdin/file above the shared 64 MiB limit with exit 2 before this PR. The runtime path applies the same `InputTooLarge` check inside `compress_toon`. TOON encode failures stay at exit 2 rather than the transient exit 1 mapping. No config keys, flags, or stdout JSON schema changed.

## Validation

```bash
cd src/tokenless
cargo fmt --all --check
cargo clippy --workspace --locked -- -D warnings
cargo test --workspace --locked -- --test-threads=1
cargo test -p tokenless-cli --test cli_integration compress_toon_ --locked -- --test-threads=1
cargo test -p tokenless-stats byte_estimate_undercounts_cjk --locked -- --test-threads=1
```

Environment: Linux. After the fix, the reproduction prints `predicted 11 -> 10 est. tokens` and `stats summary --json` reports the same `before_tokens` / `after_tokens`. Invalid JSON (`printf 'not json' | tokenless compress-toon`) exits 2. Tip `89cd8c7796a1909718bd4ec6037fe4612f851b0d` passed the three workspace gates above.

## Documentation and rollback

Bilingual `[Unreleased]` changelog entries record the scoring fix and exit-2 contract. Tokenizer comments already direct callers to `estimate_tokens` when text is available. Revert the two commits on this branch to restore the CLI-only bytes/4 scoring path.
