### PR TITLE
feat(cosh-ng): [shell] bound transcript memory

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/agent/failed_command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/agent/failed_command.rs
@@ -50,11 +50,30 @@ pub(crate) struct FailedCommandAgentStartOptions {
     pub(crate) trigger: FailedCommandAnalysisTrigger,
 }
 
+#[cfg(test)]
 pub(crate) fn collect_failed_command_insights<W: Write>(
     events: &[ShellEvent],
     blocks: &[CommandBlock],
     state: &mut InlineState,
+    output: &mut W,
+    event_index_base: usize,
+) -> std::io::Result<()> {
+    collect_failed_command_insights_with_history_base(
+        events,
+        blocks,
+        state,
+        output,
+        0,
+        event_index_base,
+    )
+}
+
+pub(crate) fn collect_failed_command_insights_with_history_base<W: Write>(
+    events: &[ShellEvent],
+    blocks: &[CommandBlock],
+    state: &mut InlineState,
     _output: &mut W,
+    history_index_base: usize,
     event_index_base: usize,
 ) -> std::io::Result<()> {
     for block in blocks {
@@ -64,7 +83,8 @@ pub(crate) fn collect_failed_command_insights<W: Write>(
         if state.evaluated_failed_command_insights.contains(&block.id) {
             continue;
         }
-        let end_event_index = block_end_event_index(events, block);
+        let end_event_index = block_end_event_index(events, block)
+            .map(|index| history_index_base.saturating_add(index));
         if end_event_index.is_none_or(|idx| idx < event_index_base) {
             continue;
         }

--- a/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/audit.rs
@@ -136,6 +136,21 @@ impl ShellAuditRecorder {
         self.seen_events = events.len();
     }
 
+    /// Projects an already de-duplicated absolute-cursor event batch.
+    pub(crate) fn observe_shell_event_batch(&mut self, events: &[ShellEvent]) {
+        for event in events {
+            if matches!(
+                event.kind,
+                ShellEventKind::CommandStarted
+                    | ShellEventKind::CommandCompleted
+                    | ShellEventKind::CommandFailed
+            ) {
+                self.record_command(event);
+            }
+        }
+        self.seen_events = self.seen_events.saturating_add(events.len());
+    }
+
     /// Returns whether the current session has an unclosed audit gap.
     pub(crate) fn is_degraded(&self) -> bool {
         self.degraded

--- a/src/cosh-ng/crates/cosh-shell/src/journal/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/mod.rs
@@ -1,10 +1,40 @@
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 
 use crate::types::ShellEvent;
 
 pub(crate) mod audit;
+
+#[derive(Debug)]
+pub(crate) struct ShellEventJournal {
+    writer: BufWriter<File>,
+}
+
+impl ShellEventJournal {
+    pub(crate) fn create(path: impl AsRef<Path>) -> io::Result<Self> {
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let file = options.open(path)?;
+        #[cfg(unix)]
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+        })
+    }
+
+    pub(crate) fn append(&mut self, events: &[ShellEvent]) -> io::Result<()> {
+        for event in events {
+            serde_json::to_writer(&mut self.writer, &redacted_event(event)).map_err(json_to_io)?;
+            self.writer.write_all(b"\n")?;
+        }
+        self.writer.flush()
+    }
+}
 
 pub fn write_shell_events(path: impl AsRef<Path>, events: &[ShellEvent]) -> io::Result<()> {
     let mut options = OpenOptions::new();
@@ -33,7 +63,7 @@ pub(crate) fn redacted_shell_events(events: &[ShellEvent]) -> Vec<ShellEvent> {
     events.iter().map(redacted_event).collect()
 }
 
-fn redacted_event(event: &ShellEvent) -> ShellEvent {
+pub(crate) fn redacted_event(event: &ShellEvent) -> ShellEvent {
     let mut event = event.clone();
     event.session_id = redact(&event.session_id);
     event.command_id = event.command_id.as_deref().map(redact);

--- a/src/cosh-ng/crates/cosh-shell/src/journal/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/journal/public.rs
@@ -4,4 +4,4 @@ mod implementation;
 
 pub use implementation::read_shell_events;
 
-pub(crate) use implementation::{redacted_shell_events, write_shell_events};
+pub(crate) use implementation::{redacted_shell_events, write_shell_events, ShellEventJournal};

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller.rs
@@ -6,6 +6,7 @@ use crate::runtime::approval_state::ApprovalRequestStatus;
 use crate::runtime::prelude::*;
 use crate::runtime::question_terminal::redraw_active_question_if_width_changed;
 use crate::runtime::state::InlineState;
+use crate::shell_host::ShellEventView;
 
 use super::dispatcher::RuntimeDispatcher;
 use super::events::ShellEventSnapshot;
@@ -20,15 +21,17 @@ pub(crate) use bootstrap::{
     run_adapter_demo, run_demo, run_host_demo, run_interactive, run_interactive_demo, run_raw,
 };
 
-fn render_raw_inline_events<W: Write>(
-    events: &[ShellEvent],
+fn render_raw_inline_event_view<W: Write>(
+    view: ShellEventView<'_>,
     output: &mut W,
     adapter: &AdapterInstance,
     shell_label: &str,
     inline_state: &mut InlineState,
 ) -> std::io::Result<RawObserverAction> {
+    let snapshot = ShellEventSnapshot::with_base(view.base(), view.events());
     if let Some(audit) = inline_state.audit.as_mut() {
-        audit.observe_shell_events(events);
+        let batch = snapshot.batch_since(inline_state.control.event_cursor());
+        audit.observe_shell_event_batch(batch.events);
     }
     let mut terminal_output = CrLfWriter::new(output);
     if inline_state.questions.active_panel_id.is_some() {
@@ -38,7 +41,6 @@ fn render_raw_inline_events<W: Write>(
             RatatuiInlineRenderer::for_terminal().with_language(inline_state.language),
         )?;
     }
-    let snapshot = ShellEventSnapshot::new(events);
     let actions = RuntimeDispatcher::dispatch_inline_batch(
         &snapshot,
         adapter,
@@ -50,7 +52,7 @@ fn render_raw_inline_events<W: Write>(
     if let Some(request) = inline_state
         .control
         .shell_handoff_mut()
-        .emit_next_approved(snapshot.events().len())
+        .emit_next_approved(snapshot.cursor().position())
     {
         if inline_state.trigger_pty_prompt {
             inline_state.trigger_pty_prompt = false;
@@ -99,6 +101,23 @@ fn render_raw_inline_events<W: Write>(
     } else {
         Ok(RawObserverAction::Continue)
     }
+}
+
+#[cfg(test)]
+fn render_raw_inline_events<W: Write>(
+    events: &[ShellEvent],
+    output: &mut W,
+    adapter: &AdapterInstance,
+    shell_label: &str,
+    inline_state: &mut InlineState,
+) -> std::io::Result<RawObserverAction> {
+    render_raw_inline_event_view(
+        ShellEventView::new(0, events),
+        output,
+        adapter,
+        shell_label,
+        inline_state,
+    )
 }
 
 fn shell_handoff_timeout_recovery_action<W: Write>(

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -16,7 +16,7 @@ use crate::runtime::prelude::*;
 use crate::runtime::startup::bootstrap_process_path_from_shell;
 use crate::runtime::state::{AnalysisMode, InlineState};
 
-use super::render_raw_inline_events;
+use super::render_raw_inline_event_view;
 
 fn build_adapter(kind: AdapterKind) -> AdapterInstance {
     match adapter_for_kind(kind) {
@@ -90,6 +90,7 @@ pub(crate) fn run_raw(
             .unwrap_or_default()
     );
     let mut config = ShellHostConfig::new(session_id, work_dir);
+    config.bound_interactive_transcript();
 
     let isolated = args.iter().any(|a| a == "--isolated")
         || std::env::var("COSH_SHELL_ISOLATED").as_deref() == Ok("1");
@@ -241,15 +242,13 @@ pub(crate) fn run_raw(
 
     let raw_result = match shell_kind {
         RawShellKind::Bash => {
-            run_raw_interactive_bash_with_output_control(&config, |events, output| {
-                render_raw_inline_events(events, output, &adapter, "bash", &mut inline_state)
+            run_raw_interactive_bash_with_event_view(&config, |events, output| {
+                render_raw_inline_event_view(events, output, &adapter, "bash", &mut inline_state)
             })
         }
-        RawShellKind::Zsh => {
-            run_raw_interactive_zsh_with_output_control(&config, |events, output| {
-                render_raw_inline_events(events, output, &adapter, "zsh", &mut inline_state)
-            })
-        }
+        RawShellKind::Zsh => run_raw_interactive_zsh_with_event_view(&config, |events, output| {
+            render_raw_inline_event_view(events, output, &adapter, "zsh", &mut inline_state)
+        }),
         RawShellKind::MissingShellValue => {
             eprintln!("missing value for --shell; supported shells: bash, zsh");
             return 2;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/dispatcher.rs
@@ -6,9 +6,9 @@ use crate::activity::runtime::{
 use crate::adapter::AgentAdapter;
 use crate::agent::events::flush_held_agent_events;
 use crate::agent::failed_command::{
-    block_end_event_index, collect_failed_command_insights, failed_command_candidate,
-    failed_command_intervention, render_post_failure_actions, start_agent_for_block,
-    FailedCommandAgentStartOptions, FailedCommandAnalysisTrigger,
+    block_end_event_index, collect_failed_command_insights_with_history_base,
+    failed_command_candidate, failed_command_intervention, render_post_failure_actions,
+    start_agent_for_block, FailedCommandAgentStartOptions, FailedCommandAnalysisTrigger,
 };
 use crate::agent::intercept::render_intercept_agent_guidance;
 use crate::agent::poll::{poll_active_agent_run, poll_active_agent_run_deferred};
@@ -30,8 +30,9 @@ use crate::runtime::details::render_runtime_details_card_actions;
 use crate::runtime::evidence_delivery::shell_handoff_continuation_requests;
 use crate::runtime::evidence_requests::render_evidence_request_actions;
 use crate::runtime::hooks::{
-    handle_consultation_events, record_blocks_followed_by_user_input, record_command_hook_findings,
-    render_queued_hook_consultation, render_recorded_hook_findings,
+    handle_consultation_events, record_blocks_followed_by_user_input,
+    record_command_hook_findings_with_history_base, render_queued_hook_consultation,
+    render_recorded_hook_findings,
 };
 use crate::runtime::insight::render_pending_command_insight;
 use crate::runtime::prelude::{
@@ -108,6 +109,7 @@ fn render_inline_guidance_from_batch<W: Write>(
 ) -> std::io::Result<()> {
     state.personalization.poll_ready();
     let events = snapshot.events();
+    let history_index_base = snapshot.base();
     let action_events = batch.events;
     let event_index_base = batch.global_index(0);
     if action_events.is_empty() {
@@ -126,11 +128,9 @@ fn render_inline_guidance_from_batch<W: Write>(
     // Positive evidence of command activity (R9): incomplete or
     // unmatched markers produce ledger errors instead of blocks, so an
     // empty `session_blocks` alone never proves the shell has not run
-    // (and cd'd inside) a command. `events` is the session's cumulative
-    // stream (the raw relay always passes the parser's full event vec,
-    // which is append-only), so once a command marker is present it is
-    // present in an incremental batch at most once, so this flag is
-    // monotonic without rescanning the cumulative stream.
+    // (and cd'd inside) a command. Absolute cursors make each marker part of
+    // an incremental batch at most once even after the retained event window
+    // compacts, so this flag stays monotonic without full-history rescans.
     state.shell_command_activity_observed |= action_events.iter().any(|event| {
         matches!(
             event.kind,
@@ -282,7 +282,13 @@ fn render_inline_guidance_from_batch<W: Write>(
     record_blocks_followed_by_user_input(events, &ledger.blocks, state);
     handle_consultation_events(action_events, &ledger.blocks, adapter, state, output)?;
     render_queued_hook_consultation(state, output)?;
-    record_command_hook_findings(events, &ledger.blocks, state, event_index_base);
+    record_command_hook_findings_with_history_base(
+        events,
+        &ledger.blocks,
+        state,
+        history_index_base,
+        event_index_base,
+    );
     render_recorded_hook_findings(&ledger.blocks, state, output)?;
     render_intercept_agent_guidance(
         action_events,
@@ -311,7 +317,9 @@ fn render_inline_guidance_from_batch<W: Write>(
             auto_runtime_available
                 && block.origin == crate::types::CommandOrigin::UserInteractive
                 && !state.hooks.block_followed_by_user_input(&block.id)
-                && block_end_event_index(events, block).is_some_and(|idx| idx >= event_index_base)
+                && block_end_event_index(events, block)
+                    .map(|idx| history_index_base.saturating_add(idx))
+                    .is_some_and(|idx| idx >= event_index_base)
         })
         .collect::<Vec<_>>();
     for block in auto_blocks {
@@ -324,6 +332,7 @@ fn render_inline_guidance_from_batch<W: Write>(
         let user_has_not_continued = !state.hooks.block_followed_by_user_input(&block.id);
         let gates = InterventionGates {
             same_dispatch_batch: block_end_event_index(events, block)
+                .map(|idx| history_index_base.saturating_add(idx))
                 .is_some_and(|idx| idx >= event_index_base),
             input_empty: user_has_not_continued,
             foreground_idle: !shell_busy,
@@ -360,14 +369,22 @@ fn render_inline_guidance_from_batch<W: Write>(
             state,
             output,
             FailedCommandAgentStartOptions {
-                selectable_after_event_index: block_end_event_index(events, block),
+                selectable_after_event_index: block_end_event_index(events, block)
+                    .map(|idx| history_index_base.saturating_add(idx)),
                 trigger: FailedCommandAnalysisTrigger::Auto,
             },
         )?;
         output.flush()?;
     }
 
-    collect_failed_command_insights(events, &ledger.blocks, state, output, event_index_base)?;
+    collect_failed_command_insights_with_history_base(
+        events,
+        &ledger.blocks,
+        state,
+        output,
+        history_index_base,
+        event_index_base,
+    )?;
     if pending_card_capture(state).is_none() {
         render_pending_command_insight(state, output)?;
     } else {

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/events.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/events.rs
@@ -24,12 +24,22 @@ impl ShellEventBatch<'_> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ShellEventSnapshot<'a> {
+    base: usize,
     events: &'a [ShellEvent],
 }
 
 impl<'a> ShellEventSnapshot<'a> {
+    #[cfg(test)]
     pub(crate) fn new(events: &'a [ShellEvent]) -> Self {
-        Self { events }
+        Self { base: 0, events }
+    }
+
+    pub(crate) fn with_base(base: usize, events: &'a [ShellEvent]) -> Self {
+        Self { base, events }
+    }
+
+    pub(crate) fn base(&self) -> usize {
+        self.base
     }
 
     pub(crate) fn events(&self) -> &[ShellEvent] {
@@ -37,15 +47,15 @@ impl<'a> ShellEventSnapshot<'a> {
     }
 
     pub(crate) fn cursor(&self) -> ShellEventCursor {
-        ShellEventCursor(self.events.len())
+        ShellEventCursor(self.base.saturating_add(self.events.len()))
     }
 
     pub(crate) fn batch_since(&self, cursor: ShellEventCursor) -> ShellEventBatch<'a> {
-        let from = cursor.position().min(self.events.len());
+        let from = cursor.position().clamp(self.base, self.cursor().position());
         ShellEventBatch {
             from: ShellEventCursor(from),
             to: self.cursor(),
-            events: &self.events[from..],
+            events: &self.events[from - self.base..],
         }
     }
 }
@@ -93,5 +103,21 @@ mod tests {
         };
 
         assert_eq!(batch.global_index(0), 7);
+    }
+
+    #[test]
+    fn compacted_snapshot_keeps_absolute_cursor_and_batch_indices() {
+        let events = [
+            ShellEvent::user_input_intercepted("s", "one"),
+            ShellEvent::user_input_intercepted("s", "two"),
+        ];
+        let snapshot = ShellEventSnapshot::with_base(4_096, &events);
+        let batch = snapshot.batch_since(ShellEventCursor(4_097));
+
+        assert_eq!(snapshot.cursor().position(), 4_098);
+        assert_eq!(batch.from.position(), 4_097);
+        assert_eq!(batch.to.position(), 4_098);
+        assert_eq!(batch.global_index(0), 4_097);
+        assert_eq!(batch.events[0].input.as_deref(), Some("two"));
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/hooks.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/hooks.rs
@@ -75,10 +75,21 @@ use crate::types::HookFinding;
 
 const MAX_HOOK_FINDINGS: usize = 32;
 
+#[cfg(test)]
 pub(crate) fn record_command_hook_findings(
     events: &[ShellEvent],
     blocks: &[CommandBlock],
     state: &mut InlineState,
+    event_index_base: usize,
+) {
+    record_command_hook_findings_with_history_base(events, blocks, state, 0, event_index_base);
+}
+
+pub(crate) fn record_command_hook_findings_with_history_base(
+    events: &[ShellEvent],
+    blocks: &[CommandBlock],
+    state: &mut InlineState,
+    history_index_base: usize,
     event_index_base: usize,
 ) {
     for block in blocks {
@@ -98,6 +109,7 @@ pub(crate) fn record_command_hook_findings(
         let user_has_not_continued = !state.hooks.block_followed_by_user_input(&block.id);
         let gates = InterventionGates {
             same_dispatch_batch: command_end_event_index(events, block)
+                .map(|index| history_index_base.saturating_add(index))
                 .is_some_and(|idx| idx >= event_index_base),
             input_empty: user_has_not_continued,
             foreground_idle: !shell_has_active_foreground_command(events),

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/prelude.rs
@@ -42,8 +42,8 @@ pub(crate) use crate::parser::{
 };
 pub(crate) use crate::raw_input::{RawInputCapture, RawObserverAction};
 pub(crate) use crate::shell_host::{
-    run_line_interactive_bash, run_raw_interactive_bash_with_output_control,
-    run_raw_interactive_zsh_with_output_control, run_scripted_bash, ScriptedInput, ShellHostConfig,
+    run_line_interactive_bash, run_raw_interactive_bash_with_event_view,
+    run_raw_interactive_zsh_with_event_view, run_scripted_bash, ScriptedInput, ShellHostConfig,
 };
 pub(crate) use crate::slash::registry::{
     active_slash_commands, visible_slash_commands, SlashCommandSpec,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
@@ -127,14 +127,23 @@ fn start_shell_session(
         });
     }
 
-    let child = command.spawn()?;
-    let mut parser = OscParser::new(config.session_id.clone(), output_ref_dir, marker_token);
+    let mut parser = OscParser::with_retention(
+        config.session_id.clone(),
+        output_ref_dir,
+        marker_token,
+        config.transcript_retention,
+        &config.work_dir,
+    )?;
     if let Some(observer) = config.shell_environment_observer.clone() {
         parser = parser.with_environment_observer(observer);
     }
     if let Some(observer) = config.shell_history_file_observer.clone() {
         parser = parser.with_history_file_observer(observer);
     }
+
+    // Build all fallible session-owned storage before spawning the shell so
+    // an unwritable spool cannot leave an unmanaged child process behind.
+    let child = command.spawn()?;
     push_shell_started_event(&mut parser, config);
 
     Ok(PtySession {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/io_loop.rs
@@ -56,7 +56,7 @@ pub(super) fn read_until_streaming<W: Write>(
 ) -> io::Result<bool> {
     let deadline = Instant::now() + timeout;
     let mut buffer = [0_u8; 8192];
-    let mut display_start = parser.display.len();
+    let mut display_start = parser.display_position();
 
     while Instant::now() < deadline {
         loop {
@@ -64,10 +64,11 @@ pub(super) fn read_until_streaming<W: Write>(
                 Ok(0) => break,
                 Ok(n) => {
                     parser.feed(&buffer[..n])?;
-                    if parser.display.len() > display_start {
-                        output.write_all(&parser.display[display_start..])?;
+                    if parser.display_position() > display_start {
+                        let display_end = parser.display_position();
+                        parser.write_display_range(display_start, display_end, output)?;
                         output.flush()?;
-                        display_start = parser.display.len();
+                        display_start = display_end;
                     }
                     if condition(parser) {
                         return Ok(true);

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/lifecycle.rs
@@ -75,16 +75,23 @@ pub(super) fn finish_shell_host_output(
 
 pub(super) fn build_shell_host_output(
     config: &ShellHostConfig,
-    parser: OscParser,
+    mut parser: OscParser,
     exit_status: Option<i32>,
 ) -> io::Result<ShellHostOutput> {
-    let journal_path = config.work_dir.join("events.jsonl");
-    let events = redacted_shell_events(&parser.events);
-    write_shell_events(&journal_path, &events)?;
+    let incremental_journal = parser.uses_incremental_event_journal();
+    let journal_path = parser
+        .incremental_event_journal_path()
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| config.work_dir.join("events.jsonl"));
+    let events = redacted_shell_events(&parser.take_output_events()?);
+    if !incremental_journal {
+        write_shell_events(&journal_path, &events)?;
+    }
+    let terminal_output = parser.clean.into_output_bytes();
 
     Ok(ShellHostOutput {
         events,
-        terminal_output: parser.clean,
+        terminal_output,
         work_dir: config.work_dir.clone(),
         journal_path,
         exit_status,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -17,9 +17,10 @@ mod raw_runner;
 mod routing;
 mod scripted;
 pub(crate) mod sigpipe;
+mod transcript;
 
 pub use line_interactive::{run_line_interactive_bash, LineInteractiveOutput};
-pub(crate) use model::HintCardRenderer;
+pub(crate) use model::{HintCardRenderer, ShellEventView};
 pub use model::{ScriptedInput, ShellHostConfig, ShellHostOutput};
 pub(crate) use raw_relay::interactive_sentinel::InputWaitStatus;
 pub use raw_runner::{
@@ -29,5 +30,8 @@ pub use raw_runner::{
     run_raw_relay_bash_with_actions_output_control, run_raw_relay_bash_with_observer,
     run_raw_relay_bash_with_output_control, run_raw_relay_zsh_with_actions,
     run_raw_relay_zsh_with_output_control,
+};
+pub(crate) use raw_runner::{
+    run_raw_interactive_bash_with_event_view, run_raw_interactive_zsh_with_event_view,
 };
 pub use scripted::{run_scripted_bash, run_scripted_zsh, run_streaming_line_bash};

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/model.rs
@@ -9,6 +9,34 @@ use crate::input::InputClassifier;
 use crate::types::{ShellEnvironmentSnapshot, ShellEvent};
 
 use super::raw_relay::interactive_sentinel::InputWaitStatus;
+use super::transcript::TranscriptRetention;
+
+pub(super) const INTERACTIVE_TRANSCRIPT_WINDOW_BYTES: usize = 256 * 1024;
+pub(super) const INTERACTIVE_EVENT_WINDOW_EVENTS: usize = 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ShellEventView<'a> {
+    base: usize,
+    events: &'a [ShellEvent],
+}
+
+impl<'a> ShellEventView<'a> {
+    pub(crate) fn new(base: usize, events: &'a [ShellEvent]) -> Self {
+        Self { base, events }
+    }
+
+    pub(crate) fn base(self) -> usize {
+        self.base
+    }
+
+    pub(crate) fn events(self) -> &'a [ShellEvent] {
+        self.events
+    }
+
+    pub(crate) fn position(self) -> usize {
+        self.base.saturating_add(self.events.len())
+    }
+}
 
 #[derive(Clone)]
 pub(super) struct ShellEnvironmentObserver(
@@ -119,6 +147,7 @@ pub struct ShellHostConfig {
     pub(crate) input_wait_timeout_secs: u64,
     pub(super) shell_environment_observer: Option<ShellEnvironmentObserver>,
     pub(super) shell_history_file_observer: Option<ShellHistoryFileObserver>,
+    pub(super) transcript_retention: TranscriptRetention,
 }
 
 impl ShellHostConfig {
@@ -143,6 +172,7 @@ impl ShellHostConfig {
             input_wait_timeout_secs: 120,
             shell_environment_observer: None,
             shell_history_file_observer: None,
+            transcript_retention: TranscriptRetention::Full,
         }
     }
 
@@ -189,6 +219,14 @@ impl ShellHostConfig {
 
     pub(crate) fn clear_shell_history_file_observer(&mut self) {
         self.shell_history_file_observer = None;
+    }
+
+    /// Bounds byte-transcript memory for the real interactive runtime. Public
+    /// and scripted callers keep full retention unless they enter this path.
+    pub(crate) fn bound_interactive_transcript(&mut self) {
+        self.transcript_retention = TranscriptRetention::Bounded {
+            window_bytes: INTERACTIVE_TRANSCRIPT_WINDOW_BYTES,
+        };
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -4,12 +4,15 @@
 // state and the display-window helpers are owned by osc/command.rs.
 mod alt_screen;
 mod command;
+mod event_store;
 mod handoff_claim;
 mod routing;
+mod transcript_store;
 
 use alt_screen::AltScreenTracker;
 use command::CurrentCommand;
 pub(crate) use command::{VisibleTailTracker, VISIBLE_TAIL_MAX_CHARS};
+use event_store::EventStore;
 use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
@@ -22,17 +25,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::Deserialize;
 
 use super::model::{ShellEnvironmentObserver, ShellHistoryFileObserver};
+use super::transcript::Transcript;
 use crate::types::{
     CommandOrigin, ShellCaptureLifecycle, ShellCaptureMetadata, ShellCommandAuditIdentity,
     ShellEnvironmentSnapshot, ShellEvent, ShellEventKind, ShellHandoffRequest,
-    SESSION_OUTPUT_REF_MAX_BYTES,
 };
 
 #[cfg(test)]
-pub(super) use super::osc_output::{capped_output_ref_bytes, write_output_ref};
 pub(super) use super::osc_output::{
-    write_output_ref_with_session_cap, OutputRefCapture, OutputRefCaptureStatus,
+    capped_output_ref_bytes, write_output_ref, write_output_ref_with_session_cap,
 };
+pub(super) use super::osc_output::{OutputRefCapture, OutputRefCaptureStatus};
 
 const OSC_PREFIX: &[u8] = b"\x1b]1337;COSH;";
 const BRACKETED_PASTE_ENABLE: &[u8] = b"\x1b[?2004h";
@@ -59,9 +62,9 @@ pub(super) enum DisplayCutKind {
 pub(super) struct OscParser {
     pub(super) session_id: String,
     output_ref_dir: PathBuf,
-    pub(super) events: Vec<ShellEvent>,
-    pub(super) clean: Vec<u8>,
-    pub(super) display: Vec<u8>,
+    pub(super) events: EventStore,
+    pub(super) clean: Transcript,
+    pub(super) display: Transcript,
     marker_token: String,
     pending: Vec<u8>,
     pending_clean_control: Vec<u8>,
@@ -70,6 +73,8 @@ pub(super) struct OscParser {
     intervention_cuts: Vec<usize>,
     intervention_display_cuts: Vec<(usize, DisplayCutKind)>,
     last_prompt_display_start: Option<usize>,
+    last_prompt_display: Vec<u8>,
+    capture_prompt_display: bool,
     prompt_ready_display_start: Option<usize>,
     /// #1932: the soft-newline upgrade submitted a synthetic empty line so
     /// bash repaints PS1; its visually blank accept echo is dropped at the
@@ -115,37 +120,6 @@ enum PendingHandoffEchoAction {
 }
 
 impl OscParser {
-    pub(super) fn new(session_id: String, output_ref_dir: PathBuf, marker_token: String) -> Self {
-        Self {
-            session_id,
-            output_ref_dir,
-            events: Vec::new(),
-            clean: Vec::new(),
-            display: Vec::new(),
-            marker_token,
-            pending: Vec::new(),
-            pending_clean_control: Vec::new(),
-            current: None,
-            command_seq: 0,
-            intervention_cuts: Vec::new(),
-            intervention_display_cuts: Vec::new(),
-            last_prompt_display_start: None,
-            prompt_ready_display_start: None,
-            synthetic_prompt_repaint_armed: false,
-            captured_output_ref_bytes: 0,
-            pending_command_origin: None,
-            expired_handoff_staging: false,
-            pending_handoff_echo: None,
-            shell_environment_snapshot: None,
-            environment_observer: None,
-            history_file_observer: None,
-            main_prompt_gate: crate::raw_input::MainPromptGate::default(),
-            pty_input_barrier_pushed: false,
-            visible_tail: VisibleTailTracker::default(),
-            alt_screen: AltScreenTracker::default(),
-        }
-    }
-
     /// Shares the main-prompt gate with the raw input relay (#1721 D16).
     pub(crate) fn set_main_prompt_gate(&mut self, gate: crate::raw_input::MainPromptGate) {
         self.main_prompt_gate = gate;
@@ -181,7 +155,7 @@ impl OscParser {
                 let flush_len = self.pending.len().saturating_sub(keep);
                 if flush_len > 0 {
                     let passthrough = self.pending[..flush_len].to_vec();
-                    self.append_passthrough(&passthrough);
+                    self.append_passthrough(&passthrough)?;
                     self.pending.drain(..flush_len);
                 }
                 return Ok(());
@@ -189,7 +163,7 @@ impl OscParser {
 
             if start > 0 {
                 let passthrough = self.pending[..start].to_vec();
-                self.append_passthrough(&passthrough);
+                self.append_passthrough(&passthrough)?;
                 self.pending.drain(..start);
             }
 
@@ -266,13 +240,22 @@ impl OscParser {
 
         match marker.event.as_str() {
             "prompt_ready" => {
-                self.prompt_ready_display_start = Some(self.display.len());
+                // In bounded mode user prompt hooks may emit arbitrarily large
+                // output between precmd and this marker. Reset here so replay
+                // retains only the actual PS1 bytes that follow.
+                if !self.display.is_full() {
+                    self.start_prompt_display_capture();
+                }
+                self.prompt_ready_display_start = Some(self.display.position());
                 // #1721 D16: the shell marker emits prompt_ready only for the
                 // primary prompt (PS1), so this is the authoritative "CJK
                 // drafts may open" signal.
                 self.main_prompt_gate.set_at_prompt(true);
             }
             "preexec" => {
+                if !self.display.is_full() {
+                    self.capture_prompt_display = false;
+                }
                 self.main_prompt_gate.set_at_prompt(false);
                 // #2196 R7: the visible-tail window starts at the command
                 // boundary, so earlier output can never resurface as the
@@ -294,7 +277,7 @@ impl OscParser {
                     origin,
                     audit_identity: audit_identity.clone(),
                     started_at_ms: timestamp,
-                    output_start: self.clean.len(),
+                    output_start: self.clean.position(),
                     attempt_generation: marker.generation,
                     shell_environment_generation: marker
                         .path_trusted
@@ -315,10 +298,10 @@ impl OscParser {
             "precmd" => {
                 self.prompt_ready_display_start = None;
                 let Some(current) = self.current.take() else {
-                    self.intervention_cuts.push(self.clean.len());
+                    self.intervention_cuts.push(self.clean.position());
                     self.intervention_display_cuts
-                        .push((self.display.len(), DisplayCutKind::PromptBoundary));
-                    self.last_prompt_display_start = Some(self.display.len());
+                        .push((self.display.position(), DisplayCutKind::PromptBoundary));
+                    self.start_prompt_display_capture();
                     // A fresh command-less prompt report re-arms the
                     // PTY-input invalidation barrier: the cwd carried
                     // here supersedes any earlier barrier.
@@ -362,12 +345,13 @@ impl OscParser {
                 } else {
                     marker.status.unwrap_or(0)
                 };
-                let output = self.clean[current.output_start..].to_vec();
-                let output_ref = self.capture_command_output_ref(&current.id, &output)?;
-                self.intervention_cuts.push(self.clean.len());
+                let output_end = self.clean.position();
+                let output_ref =
+                    self.capture_command_output_ref(&current.id, current.output_start, output_end)?;
+                self.intervention_cuts.push(output_end);
                 self.intervention_display_cuts
-                    .push((self.display.len(), DisplayCutKind::PromptBoundary));
-                self.last_prompt_display_start = Some(self.display.len());
+                    .push((self.display.position(), DisplayCutKind::PromptBoundary));
+                self.start_prompt_display_capture();
                 let kind = if status == 0 {
                     ShellEventKind::CommandCompleted
                 } else {
@@ -386,7 +370,8 @@ impl OscParser {
                 event.cwd = Some(current.cwd.clone());
                 event.end_cwd = marker.cwd.or(Some(current.cwd));
                 event.duration_ms = Some(timestamp.saturating_sub(current.started_at_ms));
-                event.terminal_output_bytes = Some(output.len() as u64);
+                event.terminal_output_bytes =
+                    Some(output_end.saturating_sub(current.output_start) as u64);
                 event.command_origin = Some(current.origin);
                 event.audit_identity = current.audit_identity;
                 event.shell_environment_generation = current.shell_environment_generation;
@@ -453,39 +438,22 @@ impl OscParser {
         }
     }
 
-    fn capture_command_output_ref(
-        &mut self,
-        command_id: &str,
-        output: &[u8],
-    ) -> io::Result<OutputRefCapture> {
-        let capture = write_output_ref_with_session_cap(
-            &self.output_ref_dir,
-            command_id,
-            output,
-            self.captured_output_ref_bytes,
-            SESSION_OUTPUT_REF_MAX_BYTES,
-        )?;
-        self.captured_output_ref_bytes = self
-            .captured_output_ref_bytes
-            .saturating_add(capture.captured_bytes);
-        Ok(capture)
-    }
-
-    pub(super) fn flush_pending(&mut self) {
+    pub(super) fn flush_pending(&mut self) -> io::Result<()> {
         let pending = std::mem::take(&mut self.pending);
-        self.append_passthrough(&pending);
-        self.flush_pending_clean_control();
+        self.append_passthrough(&pending)?;
+        self.flush_pending_clean_control()
     }
 
-    fn append_passthrough(&mut self, data: &[u8]) {
+    fn append_passthrough(&mut self, data: &[u8]) -> io::Result<()> {
         let data = self.filter_pending_handoff_echo(data);
         if data.is_empty() {
-            return;
+            return Ok(());
         }
         self.alt_screen.observe(&data);
         self.visible_tail.feed(&data);
-        self.display.extend_from_slice(&data);
-        self.append_clean(&data);
+        self.display.append(&data)?;
+        self.append_prompt_display_tail(&data);
+        self.append_clean(&data)
     }
 
     /// #2025: whether the foreground application currently owns the
@@ -556,43 +524,54 @@ impl OscParser {
         Some(PendingHandoffEchoAction::Mismatch(bytes))
     }
 
-    fn append_clean(&mut self, data: &[u8]) {
+    fn append_clean(&mut self, data: &[u8]) -> io::Result<()> {
         let mut bytes = Vec::new();
         if !self.pending_clean_control.is_empty() {
             bytes.append(&mut self.pending_clean_control);
         }
         bytes.extend_from_slice(data);
 
+        let mut run = Vec::with_capacity(bytes.len());
         let mut idx = 0;
         while idx < bytes.len() {
             let rest = &bytes[idx..];
             if let Some(control_len) = known_clean_control_len(rest) {
+                self.clean.append(&run)?;
+                run.clear();
                 idx += control_len;
                 continue;
             }
             if is_known_clean_control_prefix(rest) {
+                self.clean.append(&run)?;
                 self.pending_clean_control.extend_from_slice(rest);
-                return;
+                return Ok(());
             }
-
-            self.push_clean_byte(bytes[idx]);
+            if bytes[idx] == b'\x08' {
+                self.clean.append(&run)?;
+                run.clear();
+                self.clean.pop_last_utf8_char()?;
+            } else {
+                run.push(bytes[idx]);
+            }
             idx += 1;
         }
+        self.clean.append(&run)?;
+        Ok(())
     }
 
-    fn push_clean_byte(&mut self, byte: u8) {
+    fn push_clean_byte(&mut self, byte: u8) -> io::Result<()> {
         if byte == b'\x08' {
-            pop_last_utf8_char(&mut self.clean);
-            return;
+            return self.clean.pop_last_utf8_char();
         }
-        self.clean.push(byte);
+        self.clean.append(&[byte])
     }
 
-    fn flush_pending_clean_control(&mut self) {
+    fn flush_pending_clean_control(&mut self) -> io::Result<()> {
         let pending = std::mem::take(&mut self.pending_clean_control);
         for byte in pending {
-            self.push_clean_byte(byte);
+            self.push_clean_byte(byte)?;
         }
+        Ok(())
     }
 
     pub(super) fn finish_current_on_exit(&mut self, status: i32) -> io::Result<()> {
@@ -601,8 +580,9 @@ impl OscParser {
         };
 
         let ended_at = now_ms();
-        let output = self.clean[current.output_start..].to_vec();
-        let output_ref = self.capture_command_output_ref(&current.id, &output)?;
+        let output_end = self.clean.position();
+        let output_ref =
+            self.capture_command_output_ref(&current.id, current.output_start, output_end)?;
         let status = if is_shell_exit_command(&current.command) {
             0
         } else {
@@ -625,7 +605,7 @@ impl OscParser {
         event.cwd = Some(current.cwd.clone());
         event.end_cwd = Some(current.cwd);
         event.duration_ms = Some(ended_at.saturating_sub(current.started_at_ms));
-        event.terminal_output_bytes = Some(output.len() as u64);
+        event.terminal_output_bytes = Some(output_end.saturating_sub(current.output_start) as u64);
         event.command_origin = Some(current.origin);
         event.audit_identity = current.audit_identity;
         event.shell_environment_generation = current.shell_environment_generation;
@@ -637,7 +617,10 @@ impl OscParser {
         if prompt.is_empty() {
             return 0;
         }
+        // Bounded mode uses this only for the isolated-shell startup gate;
+        // the prompt that just painted is necessarily in the resident tail.
         self.clean
+            .resident_slice()
             .windows(prompt.len())
             .filter(|window| *window == prompt)
             .count()
@@ -980,14 +963,6 @@ fn is_known_clean_control_prefix(bytes: &[u8]) -> bool {
     ]
     .into_iter()
     .any(|control| control.starts_with(bytes))
-}
-
-fn pop_last_utf8_char(bytes: &mut Vec<u8>) {
-    while let Some(byte) = bytes.pop() {
-        if byte & 0b1100_0000 != 0b1000_0000 {
-            break;
-        }
-    }
 }
 
 pub(super) fn now_ms() -> u64 {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
@@ -187,16 +187,26 @@ impl OscParser {
         let Some(start) = self.last_prompt_display_start else {
             return &[];
         };
-        if start >= self.display.len() {
-            return &[];
+        if self.display.is_full() {
+            return self
+                .display
+                .resident_slice()
+                .get(start..)
+                .unwrap_or_default();
         }
-        &self.display[start..]
+        &self.last_prompt_display
+    }
+
+    pub(super) fn start_prompt_display_capture(&mut self) {
+        self.last_prompt_display_start = Some(self.display.position());
+        self.last_prompt_display.clear();
+        self.capture_prompt_display = true;
     }
 
     /// True after the shell's post-hook marker is followed by visible prompt
     /// bytes, excluding output produced by user prompt hooks.
     pub(crate) fn has_prompt_painted_since_ready(&self) -> bool {
         self.prompt_ready_display_start
-            .is_some_and(|start| start < self.display.len())
+            .is_some_and(|start| start < self.display.position())
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/event_store.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/event_store.rs
@@ -1,0 +1,368 @@
+//! Absolute-cursor shell-event retention and incremental journaling.
+
+use std::collections::HashSet;
+use std::io;
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use crate::journal::ShellEventJournal;
+use crate::types::{ShellEvent, ShellEventKind};
+
+use super::super::model::{ShellEventView, INTERACTIVE_EVENT_WINDOW_EVENTS};
+use super::super::transcript::TranscriptRetention;
+use super::OscParser;
+
+#[derive(Debug)]
+pub(crate) struct EventStore {
+    events: Vec<ShellEvent>,
+    base: usize,
+    journaled: usize,
+    journal: Option<ShellEventJournal>,
+    journal_path: Option<PathBuf>,
+}
+
+impl EventStore {
+    pub(super) fn new(retention: TranscriptRetention, journal_path: &Path) -> io::Result<Self> {
+        let (journal, incremental_path) = match retention {
+            TranscriptRetention::Full => (None, None),
+            TranscriptRetention::Bounded { .. } => (
+                Some(ShellEventJournal::create(journal_path)?),
+                Some(journal_path.to_path_buf()),
+            ),
+        };
+        Ok(Self {
+            events: Vec::new(),
+            base: 0,
+            journaled: 0,
+            journal,
+            journal_path: incremental_path,
+        })
+    }
+
+    pub(crate) fn push(&mut self, event: ShellEvent) {
+        self.events.push(event);
+    }
+
+    pub(super) fn view(&self) -> ShellEventView<'_> {
+        ShellEventView::new(self.base, &self.events)
+    }
+
+    pub(super) fn position(&self) -> usize {
+        self.base.saturating_add(self.events.len())
+    }
+
+    pub(super) fn persist_pending(&mut self) -> io::Result<()> {
+        if self.journal.is_none() {
+            return Ok(());
+        }
+        let position = self.position();
+        let start = self
+            .journaled
+            .checked_sub(self.base)
+            .ok_or_else(|| {
+                io::Error::other(format!(
+                    "event window compacted before journal persistence: journaled={} base={} position={position}",
+                    self.journaled, self.base
+                ))
+            })?;
+        if start == self.events.len() {
+            return Ok(());
+        }
+        let journal = self
+            .journal
+            .as_mut()
+            .ok_or_else(|| io::Error::other("incremental event journal disappeared"))?;
+        journal.append(&self.events[start..])?;
+        self.journaled = self.position();
+        Ok(())
+    }
+
+    pub(super) fn compact_observed(&mut self, observed: usize) {
+        if self.journal.is_none()
+            || self.events.len() <= INTERACTIVE_EVENT_WINDOW_EVENTS.saturating_mul(2)
+        {
+            return;
+        }
+        let persisted_and_observed = observed.min(self.journaled).min(self.position());
+        let max_drop = persisted_and_observed.saturating_sub(self.base);
+        let desired_drop = self
+            .events
+            .len()
+            .saturating_sub(INTERACTIVE_EVENT_WINDOW_EVENTS)
+            .min(max_drop);
+        let Some(boundary) = safe_compaction_boundary(&self.events, desired_drop, max_drop) else {
+            return;
+        };
+        self.events.drain(..boundary);
+        self.base = self.base.saturating_add(boundary);
+    }
+
+    fn take_output_events(&mut self) -> io::Result<Vec<ShellEvent>> {
+        self.persist_pending()?;
+        if self.journal.is_some() {
+            Ok(Vec::new())
+        } else {
+            Ok(std::mem::take(&mut self.events))
+        }
+    }
+
+    fn is_incremental(&self) -> bool {
+        self.journal.is_some()
+    }
+
+    fn incremental_path(&self) -> Option<&Path> {
+        self.journal_path.as_deref()
+    }
+}
+
+fn safe_compaction_boundary(
+    events: &[ShellEvent],
+    desired_drop: usize,
+    max_drop: usize,
+) -> Option<usize> {
+    let mut active = HashSet::new();
+    let mut intercepted = HashSet::new();
+    let mut boundary = None;
+    for (index, event) in events.iter().take(max_drop).enumerate() {
+        let command_id = event.command_id.as_deref();
+        match event.kind {
+            ShellEventKind::CommandStarted => {
+                if let Some(command_id) = command_id {
+                    active.insert(command_id);
+                }
+            }
+            ShellEventKind::UserInputIntercepted => {
+                if let Some(command_id) = command_id.filter(|id| active.remove(*id)) {
+                    intercepted.insert(command_id);
+                }
+            }
+            ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed => {
+                if let Some(command_id) = command_id {
+                    active.remove(command_id);
+                    intercepted.remove(command_id);
+                }
+            }
+            ShellEventKind::ShellReady => {
+                intercepted.clear();
+            }
+            _ => {}
+        }
+        if active.is_empty() && intercepted.is_empty() {
+            let candidate = index + 1;
+            if candidate >= desired_drop {
+                // Crossing the target is safe within max_drop and releases
+                // an oversized lifecycle as soon as its closing event lands.
+                return Some(candidate);
+            }
+            boundary = Some(candidate);
+        }
+    }
+    boundary
+}
+
+impl Deref for EventStore {
+    type Target = [ShellEvent];
+
+    fn deref(&self) -> &Self::Target {
+        &self.events
+    }
+}
+
+impl OscParser {
+    pub(crate) fn observe_events<W, F, T>(
+        &mut self,
+        output: &mut W,
+        observer: &mut F,
+    ) -> io::Result<T>
+    where
+        F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<T>,
+    {
+        self.events.persist_pending()?;
+        let result = observer(self.events.view(), output)?;
+        let observed = self.events.position();
+        self.events.compact_observed(observed);
+        Ok(result)
+    }
+
+    pub(crate) fn take_output_events(&mut self) -> io::Result<Vec<ShellEvent>> {
+        self.events.take_output_events()
+    }
+
+    pub(crate) fn uses_incremental_event_journal(&self) -> bool {
+        self.events.is_incremental()
+    }
+
+    pub(crate) fn incremental_event_journal_path(&self) -> Option<&Path> {
+        self.events.incremental_path()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ShellEvent;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn ready(index: usize) -> ShellEvent {
+        let mut event = ShellEvent::user_input_intercepted("session", format!("ready-{index}"));
+        event.kind = ShellEventKind::ShellReady;
+        event
+    }
+
+    #[test]
+    fn bounded_store_keeps_absolute_positions_after_compaction() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-event-window-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let mut store = EventStore::new(
+            TranscriptRetention::Bounded { window_bytes: 4 },
+            &work_dir.join("events.jsonl"),
+        )
+        .expect("event store");
+
+        store.push(ShellEvent::user_input_intercepted(
+            "session",
+            "curl --token event-window-secret",
+        ));
+        for index in 0..(INTERACTIVE_EVENT_WINDOW_EVENTS * 3) {
+            store.push(ready(index));
+        }
+        store.persist_pending().expect("persist events");
+        let position = store.position();
+        store.compact_observed(position);
+
+        assert_eq!(store.position(), position);
+        assert!(store.len() <= INTERACTIVE_EVENT_WINDOW_EVENTS);
+        assert!(store.view().base() > 0);
+        let journal =
+            std::fs::read_to_string(work_dir.join("events.jsonl")).expect("incremental journal");
+        assert_eq!(journal.lines().count(), position);
+        assert!(!journal.contains("event-window-secret"), "{journal}");
+        assert_eq!(
+            std::fs::metadata(work_dir.join("events.jsonl"))
+                .expect("journal metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+
+    #[test]
+    fn registered_cursor_reads_each_event_once_across_compactions() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-event-cursor-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let mut store = EventStore::new(
+            TranscriptRetention::Bounded { window_bytes: 4 },
+            &work_dir.join("events.jsonl"),
+        )
+        .expect("event store");
+        let mut cursor = 0;
+        let mut observed = Vec::new();
+        let mut expected = Vec::new();
+
+        for batch in 0..40 {
+            let batch_len = (batch * 37 % 211) + 1;
+            for offset in 0..batch_len {
+                let id = format!("event-{batch}-{offset}");
+                expected.push(id.clone());
+                let mut event = ready(batch * 1_000 + offset);
+                event.input = Some(id);
+                store.push(event);
+            }
+            store.persist_pending().expect("persist batch");
+            let view = store.view();
+            let local_cursor = cursor - view.base();
+            observed.extend(
+                view.events()[local_cursor..]
+                    .iter()
+                    .filter_map(|event| event.input.clone()),
+            );
+            cursor = view.position();
+            store.compact_observed(cursor);
+        }
+
+        assert_eq!(observed, expected);
+        assert_eq!(cursor, store.position());
+        assert!(store.len() <= INTERACTIVE_EVENT_WINDOW_EVENTS * 2);
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+
+    #[test]
+    fn bounded_store_compacts_through_a_long_commands_closing_boundary() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-event-long-command-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let mut store = EventStore::new(
+            TranscriptRetention::Bounded { window_bytes: 4 },
+            &work_dir.join("events.jsonl"),
+        )
+        .expect("event store");
+
+        store.push(ShellEvent::command_started(
+            "session",
+            "command-1",
+            "long-command",
+            "/tmp",
+            1,
+        ));
+        for index in 0..(INTERACTIVE_EVENT_WINDOW_EVENTS * 3) {
+            store.push(ready(index));
+        }
+        store.push(ShellEvent::command_finished(
+            ShellEventKind::CommandCompleted,
+            "session",
+            "command-1",
+            0,
+            2,
+            "",
+        ));
+        store.persist_pending().expect("persist events");
+        let position = store.position();
+        store.compact_observed(position);
+
+        assert_eq!(store.position(), position);
+        assert!(store.len() <= INTERACTIVE_EVENT_WINDOW_EVENTS);
+        assert_eq!(store.view().base(), position);
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+
+    #[test]
+    fn journal_invariant_error_reports_absolute_cursor_context() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-event-invariant-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let mut store = EventStore::new(
+            TranscriptRetention::Bounded { window_bytes: 4 },
+            &work_dir.join("events.jsonl"),
+        )
+        .expect("event store");
+        store.base = 2;
+        store.journaled = 1;
+
+        let error = store.persist_pending().expect_err("invalid cursor");
+        let message = error.to_string();
+        assert!(message.contains("journaled=1"), "{message}");
+        assert!(message.contains("base=2"), "{message}");
+        assert!(message.contains("position=2"), "{message}");
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/routing.rs
@@ -27,16 +27,16 @@ impl OscParser {
                 .reason
                 .unwrap_or_else(|| "natural_language".to_string());
             let sensitive = marker.sensitive.unwrap_or(false);
-            self.intervention_cuts.push(self.clean.len());
+            self.intervention_cuts.push(self.clean.position());
             self.intervention_display_cuts
-                .push((self.display.len(), DisplayCutKind::Intercept));
+                .push((self.display.position(), DisplayCutKind::Intercept));
             // Record the display position at intercept time so that
             // `last_prompt_display()` returns only post-intercept bytes
             // (the new PS1 prompt), not the user-echoed command text that
             // bash already wrote to the terminal before the DEBUG trap fired.
             // Without this, RestorePrompt would re-emit the echoed command
             // below the panel, duplicating it on screen (#1811).
-            self.last_prompt_display_start = Some(self.display.len());
+            self.start_prompt_display_capture();
             self.push_intercept_event_with_routing(
                 &session_id,
                 input,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
@@ -1,0 +1,211 @@
+//! Transcript storage construction and absolute display-range delegation.
+
+use std::borrow::Cow;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use super::super::transcript::TranscriptRetention;
+use super::{AltScreenTracker, OscParser, Transcript, VisibleTailTracker};
+use crate::types::SESSION_OUTPUT_REF_MAX_BYTES;
+
+use super::super::osc_output::{
+    write_output_ref_range_with_session_cap, write_output_ref_with_session_cap, OutputRefCapture,
+};
+
+impl OscParser {
+    pub(crate) fn new(session_id: String, output_ref_dir: PathBuf, marker_token: String) -> Self {
+        let work_dir = output_ref_dir
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        Self::with_retention(
+            session_id,
+            output_ref_dir,
+            marker_token,
+            TranscriptRetention::Full,
+            &work_dir,
+        )
+        .unwrap_or_else(|_| unreachable!("full transcript storage does not open files"))
+    }
+
+    pub(crate) fn with_retention(
+        session_id: String,
+        output_ref_dir: PathBuf,
+        marker_token: String,
+        retention: TranscriptRetention,
+        work_dir: &Path,
+    ) -> io::Result<Self> {
+        // Production marker tokens are random hex. Keeping the token in the
+        // name prevents a crash remnant plus PID reuse from blocking a later
+        // session while create_new still rejects pre-positioned symlinks.
+        let spool_suffix = marker_token
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+            .collect::<String>();
+        Ok(Self {
+            session_id,
+            output_ref_dir,
+            events: super::EventStore::new(
+                retention,
+                &work_dir.join(format!("events-{spool_suffix}.jsonl")),
+            )?,
+            clean: Transcript::new(
+                retention,
+                &work_dir.join(format!("terminal-output-{spool_suffix}.transcript")),
+            )?,
+            display: Transcript::new(
+                retention,
+                &work_dir.join(format!("display-{spool_suffix}.transcript")),
+            )?,
+            marker_token,
+            pending: Vec::new(),
+            pending_clean_control: Vec::new(),
+            current: None,
+            command_seq: 0,
+            intervention_cuts: Vec::new(),
+            intervention_display_cuts: Vec::new(),
+            last_prompt_display_start: None,
+            last_prompt_display: Vec::new(),
+            capture_prompt_display: false,
+            prompt_ready_display_start: None,
+            synthetic_prompt_repaint_armed: false,
+            captured_output_ref_bytes: 0,
+            pending_command_origin: None,
+            expired_handoff_staging: false,
+            pending_handoff_echo: None,
+            shell_environment_snapshot: None,
+            environment_observer: None,
+            history_file_observer: None,
+            main_prompt_gate: crate::raw_input::MainPromptGate::default(),
+            pty_input_barrier_pushed: false,
+            visible_tail: VisibleTailTracker::default(),
+            alt_screen: AltScreenTracker::default(),
+        })
+    }
+
+    pub(crate) fn display_position(&self) -> usize {
+        self.display.position()
+    }
+
+    pub(crate) fn read_display_range(&self, start: usize, end: usize) -> io::Result<Cow<'_, [u8]>> {
+        self.display.read_range(start, end)
+    }
+
+    pub(crate) fn write_display_range<W: Write>(
+        &self,
+        start: usize,
+        end: usize,
+        output: &mut W,
+    ) -> io::Result<()> {
+        self.display.copy_range_to(start, end, output)
+    }
+
+    pub(crate) fn display_starts_with_at(&self, start: usize, prefix: &[u8]) -> io::Result<bool> {
+        self.display.starts_with_at(start, prefix)
+    }
+
+    pub(super) fn append_prompt_display_tail(&mut self, data: &[u8]) {
+        if !self.capture_prompt_display {
+            return;
+        }
+        let Some(max) = self.display.window_bytes() else {
+            return;
+        };
+        if data.len() >= max {
+            self.last_prompt_display.clear();
+            self.last_prompt_display
+                .extend_from_slice(&data[data.len() - max..]);
+            return;
+        }
+        let drop = self
+            .last_prompt_display
+            .len()
+            .saturating_add(data.len())
+            .saturating_sub(max);
+        if drop > 0 {
+            self.last_prompt_display.drain(..drop);
+        }
+        self.last_prompt_display.extend_from_slice(data);
+        debug_assert!(self.last_prompt_display.len() <= max);
+    }
+
+    pub(super) fn capture_command_output_ref(
+        &mut self,
+        command_id: &str,
+        output_start: usize,
+        output_end: usize,
+    ) -> io::Result<OutputRefCapture> {
+        let capture = if self.clean.is_full() {
+            let output = self
+                .clean
+                .read_range(output_start, output_end)?
+                .into_owned();
+            write_output_ref_with_session_cap(
+                &self.output_ref_dir,
+                command_id,
+                &output,
+                self.captured_output_ref_bytes,
+                SESSION_OUTPUT_REF_MAX_BYTES,
+            )?
+        } else {
+            write_output_ref_range_with_session_cap(
+                &self.output_ref_dir,
+                command_id,
+                &self.clean,
+                output_start,
+                output_end,
+                self.captured_output_ref_bytes,
+                SESSION_OUTPUT_REF_MAX_BYTES,
+            )?
+        };
+        self.captured_output_ref_bytes = self
+            .captured_output_ref_bytes
+            .saturating_add(capture.captured_bytes);
+        Ok(capture)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_session_tokens_do_not_collide_in_a_reused_work_dir() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-transcript-reused-work-dir-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        let output_ref_dir = work_dir.join("output-refs");
+        std::fs::create_dir_all(&output_ref_dir).expect("output ref dir");
+
+        let first = OscParser::with_retention(
+            "first".to_string(),
+            output_ref_dir.clone(),
+            "a1b2c3d4".to_string(),
+            TranscriptRetention::Bounded { window_bytes: 64 },
+            &work_dir,
+        )
+        .expect("first parser");
+        let second = OscParser::with_retention(
+            "second".to_string(),
+            output_ref_dir,
+            "e5f6a7b8".to_string(),
+            TranscriptRetention::Bounded { window_bytes: 64 },
+            &work_dir,
+        )
+        .expect("second parser");
+
+        assert!(work_dir
+            .join("terminal-output-a1b2c3d4.transcript")
+            .is_file());
+        assert!(work_dir.join("display-a1b2c3d4.transcript").is_file());
+        assert!(work_dir
+            .join("terminal-output-e5f6a7b8.transcript")
+            .is_file());
+        assert!(work_dir.join("display-e5f6a7b8.transcript").is_file());
+        drop((first, second));
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_output.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_output.rs
@@ -1,9 +1,14 @@
+use std::collections::VecDeque;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use crate::types::COMMAND_OUTPUT_REF_MAX_BYTES;
+
+use super::transcript::Transcript;
+
+const REDACTION_LINE_MAX_BYTES: usize = 64 * 1024;
 
 #[cfg(test)]
 pub(super) fn write_output_ref(dir: &Path, command_id: &str, output: &[u8]) -> io::Result<PathBuf> {
@@ -34,11 +39,51 @@ pub(super) fn write_output_ref_with_session_cap(
     session_captured_bytes: usize,
     session_cap_bytes: usize,
 ) -> io::Result<OutputRefCapture> {
-    fs::create_dir_all(dir)?;
-    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
     let output = String::from_utf8_lossy(output);
     let (output, _) = crate::evidence::redact_sensitive_text(&output);
     let captured = capped_output_ref_bytes(output.as_bytes(), COMMAND_OUTPUT_REF_MAX_BYTES);
+    write_prepared_output_ref_with_session_cap(
+        dir,
+        command_id,
+        &captured,
+        session_captured_bytes,
+        session_cap_bytes,
+    )
+}
+
+pub(super) fn write_output_ref_range_with_session_cap(
+    dir: &Path,
+    command_id: &str,
+    transcript: &Transcript,
+    start: usize,
+    end: usize,
+    session_captured_bytes: usize,
+    session_cap_bytes: usize,
+) -> io::Result<OutputRefCapture> {
+    let mut capture = RedactedRangeCapture::default();
+    transcript.visit_range_chunks(start, end, |chunk| {
+        capture.feed(chunk);
+        Ok(())
+    })?;
+    let captured = capture.finish();
+    write_prepared_output_ref_with_session_cap(
+        dir,
+        command_id,
+        &captured,
+        session_captured_bytes,
+        session_cap_bytes,
+    )
+}
+
+fn write_prepared_output_ref_with_session_cap(
+    dir: &Path,
+    command_id: &str,
+    captured: &[u8],
+    session_captured_bytes: usize,
+    session_cap_bytes: usize,
+) -> io::Result<OutputRefCapture> {
+    fs::create_dir_all(dir)?;
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
     if session_captured_bytes.saturating_add(captured.len()) > session_cap_bytes {
         return Ok(OutputRefCapture {
             path: None,
@@ -52,7 +97,7 @@ pub(super) fn write_output_ref_with_session_cap(
     options.create(true).truncate(true).write(true);
     options.mode(0o600);
     let mut file = options.open(&path)?;
-    file.write_all(&captured)?;
+    file.write_all(captured)?;
     file.sync_all()?;
     fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
     Ok(OutputRefCapture {
@@ -60,6 +105,122 @@ pub(super) fn write_output_ref_with_session_cap(
         captured_bytes: captured.len(),
         status: OutputRefCaptureStatus::Captured,
     })
+}
+
+#[derive(Debug, Default)]
+struct RedactedRangeCapture {
+    line: Vec<u8>,
+    batch: Vec<u8>,
+    line_overflow: bool,
+    in_private_key: bool,
+    head: Vec<u8>,
+    tail: VecDeque<u8>,
+    redacted_len: usize,
+}
+
+impl RedactedRangeCapture {
+    fn feed(&mut self, bytes: &[u8]) {
+        for byte in bytes.iter().copied() {
+            if !self.line_overflow && self.line.len() < REDACTION_LINE_MAX_BYTES {
+                self.line.push(byte);
+            } else {
+                self.line_overflow = true;
+            }
+            if byte == b'\n' {
+                self.finish_line();
+            }
+        }
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        if !self.line.is_empty() || self.line_overflow {
+            self.finish_line();
+        }
+        self.flush_batch();
+        if self.redacted_len <= COMMAND_OUTPUT_REF_MAX_BYTES {
+            self.head.truncate(self.redacted_len);
+            return self.head;
+        }
+
+        let marker = format!(
+            "\n[captured output truncated: original_bytes={}, max_capture_bytes={}]\n",
+            self.redacted_len, COMMAND_OUTPUT_REF_MAX_BYTES
+        )
+        .into_bytes();
+        if COMMAND_OUTPUT_REF_MAX_BYTES <= marker.len() {
+            return marker[..COMMAND_OUTPUT_REF_MAX_BYTES].to_vec();
+        }
+        let available = COMMAND_OUTPUT_REF_MAX_BYTES - marker.len();
+        let head_len = utf8_floor_boundary(&self.head, available / 2);
+        let tail = self.tail.into_iter().collect::<Vec<_>>();
+        let wanted_tail = available.saturating_sub(head_len);
+        let tail_start = utf8_ceil_boundary(&tail, tail.len().saturating_sub(wanted_tail));
+        let mut captured = Vec::with_capacity(COMMAND_OUTPUT_REF_MAX_BYTES);
+        captured.extend_from_slice(&self.head[..head_len]);
+        captured.extend_from_slice(&marker);
+        captured.extend_from_slice(&tail[tail_start..]);
+        captured
+    }
+
+    fn finish_line(&mut self) {
+        if self.line_overflow {
+            self.flush_batch();
+            self.push_redacted(b"<redacted overlong terminal line>\n");
+            self.line.clear();
+            self.line_overflow = false;
+            return;
+        }
+
+        let private_key_candidate = self.line.contains(&b'-');
+        let upper =
+            private_key_candidate.then(|| String::from_utf8_lossy(&self.line).to_ascii_uppercase());
+        let begins_private_key = upper
+            .as_deref()
+            .is_some_and(|line| line.contains("-----BEGIN ") && line.contains("PRIVATE KEY-----"));
+        let ends_private_key = upper
+            .as_deref()
+            .is_some_and(|line| line.contains("-----END ") && line.contains("PRIVATE KEY-----"));
+        if self.in_private_key {
+            if ends_private_key {
+                self.in_private_key = false;
+            }
+        } else if begins_private_key {
+            self.flush_batch();
+            let line = String::from_utf8_lossy(&self.line);
+            let (redacted, _) = crate::evidence::redact_sensitive_text(&line);
+            self.push_redacted(redacted.as_bytes());
+            if !ends_private_key {
+                self.in_private_key = true;
+            }
+        } else {
+            if self.batch.len().saturating_add(self.line.len()) > REDACTION_LINE_MAX_BYTES {
+                self.flush_batch();
+            }
+            self.batch.extend_from_slice(&self.line);
+        }
+        self.line.clear();
+    }
+
+    fn flush_batch(&mut self) {
+        if self.batch.is_empty() {
+            return;
+        }
+        let text = String::from_utf8_lossy(&self.batch);
+        let (redacted, _) = crate::evidence::redact_sensitive_text(&text);
+        self.push_redacted(redacted.as_bytes());
+        self.batch.clear();
+    }
+
+    fn push_redacted(&mut self, bytes: &[u8]) {
+        self.redacted_len = self.redacted_len.saturating_add(bytes.len());
+        if self.head.len() < COMMAND_OUTPUT_REF_MAX_BYTES {
+            let take = (COMMAND_OUTPUT_REF_MAX_BYTES - self.head.len()).min(bytes.len());
+            self.head.extend_from_slice(&bytes[..take]);
+        }
+        self.tail.extend(bytes.iter().copied());
+        let excess = self.tail.len().saturating_sub(COMMAND_OUTPUT_REF_MAX_BYTES);
+        self.tail.drain(..excess);
+    }
 }
 
 pub(super) fn capped_output_ref_bytes(output: &[u8], max_bytes: usize) -> Vec<u8> {
@@ -107,4 +268,66 @@ fn utf8_ceil_boundary(bytes: &[u8], mut index: usize) -> usize {
 
 fn is_utf8_continuation(byte: u8) -> bool {
     byte & 0b1100_0000 == 0b1000_0000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::transcript::TranscriptRetention;
+    use super::*;
+
+    #[test]
+    fn bounded_range_redacts_secret_whose_prefix_is_before_tail_cut() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-output-ref-range-secret-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&work_dir);
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let mut transcript = Transcript::new(
+            TranscriptRetention::Bounded { window_bytes: 128 },
+            &work_dir.join("terminal-output.transcript"),
+        )
+        .expect("transcript");
+        let mut output = Vec::new();
+        append_bounded_lines(&mut output, 1_500_000);
+        let secret = "tail-secret-value";
+        output.extend_from_slice(b"password=");
+        output.resize(output.len() + 32 * 1024, b'a');
+        output.extend_from_slice(secret.as_bytes());
+        output.push(b'\n');
+        append_bounded_lines(&mut output, 500_000);
+        transcript.append(&output).expect("append secret output");
+
+        let capture = write_output_ref_range_with_session_cap(
+            &work_dir.join("output-refs"),
+            "cmd-1",
+            &transcript,
+            0,
+            transcript.position(),
+            0,
+            usize::MAX,
+        )
+        .expect("capture");
+        let captured =
+            std::fs::read_to_string(capture.path.expect("output ref")).expect("captured output");
+
+        assert!(!captured.contains(secret), "{captured}");
+        assert!(captured.contains("[captured output truncated:"));
+        assert!(!captured.contains("<redacted overlong terminal line>"));
+        let _ = std::fs::remove_dir_all(work_dir);
+    }
+
+    fn append_bounded_lines(output: &mut Vec<u8>, bytes: usize) {
+        let full_lines = bytes / 1024;
+        for _ in 0..full_lines {
+            output.resize(output.len() + 1023, b'x');
+            output.push(b'\n');
+        }
+        let remainder = bytes % 1024;
+        if remainder > 0 {
+            output.resize(output.len() + remainder.saturating_sub(1), b'x');
+            output.push(b'\n');
+        }
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -1,7 +1,10 @@
 use super::marker::{bash_marker_script, zsh_marker_script};
-use super::model::{ShellEnvironmentObserver, ShellHistoryFileObserver};
+use super::model::{ShellEnvironmentObserver, ShellHistoryFileObserver, ShellHostConfig};
 use super::osc::*;
+use super::raw_runner::run_raw_relay_bash_with_actions;
+use super::transcript::TranscriptRetention;
 use crate::ledger::build_command_blocks;
+use crate::raw_input::RawRelayAction;
 use crate::types::{
     CommandOrigin, ShellEventKind, ShellHandoffRequest, COMMAND_OUTPUT_REF_MAX_BYTES,
     SESSION_OUTPUT_REF_MAX_BYTES,
@@ -10,6 +13,50 @@ use std::os::unix::fs::PermissionsExt;
 use std::sync::{Arc, Mutex};
 
 const TEST_MARKER_TOKEN: &str = "test-marker-token";
+
+#[test]
+fn bounded_raw_session_spools_output_without_materializing_result() {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-bounded-raw-session-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&work_dir);
+    let mut config = ShellHostConfig::new("bounded-raw-session", &work_dir);
+    config.native_mode = false;
+    config.bound_interactive_transcript();
+
+    let mut rendered = Vec::new();
+    let result = run_raw_relay_bash_with_actions(
+        &config,
+        vec![RawRelayAction::line("yes x | head -c 700000")],
+        &mut rendered,
+    )
+    .expect("bounded raw session");
+
+    assert!(result.terminal_output.is_empty());
+    assert!(result.events.is_empty());
+    assert!(rendered.len() >= 700_000);
+    let journal = std::fs::read_to_string(&result.journal_path).expect("event journal");
+    assert!(journal.lines().count() >= 4, "{journal}");
+    let spool_paths = std::fs::read_dir(&work_dir)
+        .expect("session files")
+        .map(|entry| entry.expect("session entry").path())
+        .filter(|path| {
+            path.file_name().is_some_and(|name| {
+                let name = name.to_string_lossy();
+                name.starts_with("terminal-output-") || name.starts_with("display-")
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(spool_paths.len(), 2);
+    for path in spool_paths {
+        let metadata = std::fs::metadata(&path).expect("spool metadata");
+        assert!(metadata.len() >= 700_000, "{}", path.display());
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+    }
+    let _ = std::fs::remove_dir_all(work_dir);
+}
 
 #[test]
 fn routing_markers_require_matching_attempt_generation() {
@@ -276,10 +323,10 @@ fn parser_clean_strips_zsh_bracketed_paste_and_applies_backspace() {
     parser.feed(input).expect("feed");
 
     assert_eq!(
-        String::from_utf8_lossy(&parser.clean),
+        String::from_utf8_lossy(parser.clean.resident_slice()),
         "cosh-osc$ echo ok\r\n"
     );
-    assert_eq!(parser.display, input);
+    assert_eq!(parser.display.resident_slice(), input);
 }
 
 #[test]
@@ -290,7 +337,10 @@ fn parser_clean_handles_split_zsh_bracketed_paste_control() {
     assert!(parser.clean.is_empty());
     parser.feed(b"04hcmd\x1b[?2004l").expect("feed remainder");
 
-    assert_eq!(String::from_utf8_lossy(&parser.clean), "cmd");
+    assert_eq!(
+        String::from_utf8_lossy(parser.clean.resident_slice()),
+        "cmd"
+    );
 }
 
 #[test]
@@ -731,9 +781,9 @@ fn parser_preserves_pending_handoff_command_echo_for_crlf() {
     parser.register_pending_handoff_origin(&request);
     parser.feed(&echo).expect("feed handoff echo");
 
-    let display = String::from_utf8_lossy(&parser.display);
+    let display = String::from_utf8_lossy(parser.display.resident_slice());
     assert_eq!(display, "prompt$ printf hi\r\nhi");
-    let clean = String::from_utf8_lossy(&parser.clean);
+    let clean = String::from_utf8_lossy(parser.clean.resident_slice());
     assert_eq!(clean, "prompt$ printf hi\r\nhi");
 }
 
@@ -759,9 +809,9 @@ fn parser_preserves_pending_handoff_command_echo_for_cr() {
     parser.register_pending_handoff_origin(&request);
     parser.feed(&echo).expect("feed handoff echo");
 
-    let display = String::from_utf8_lossy(&parser.display);
+    let display = String::from_utf8_lossy(parser.display.resident_slice());
     assert_eq!(display, "prompt$ printf hi\x1b[?2004l\rhi");
-    let clean = String::from_utf8_lossy(&parser.clean);
+    let clean = String::from_utf8_lossy(parser.clean.resident_slice());
     assert_eq!(clean, "prompt$ printf hi\rhi");
 }
 
@@ -1001,6 +1051,118 @@ fn parser_for_test(name: &str) -> OscParser {
         std::env::temp_dir().join(format!("cosh-shell-osc-test-{name}-{}", std::process::id()));
     std::fs::create_dir_all(&dir).expect("output ref dir");
     OscParser::new(name.to_string(), dir, TEST_MARKER_TOKEN.to_string())
+}
+
+fn bounded_parser_for_test(name: &str, window_bytes: usize) -> (OscParser, std::path::PathBuf) {
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-bounded-osc-test-{name}-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&work_dir);
+    let output_ref_dir = work_dir.join("output-refs");
+    std::fs::create_dir_all(&output_ref_dir).expect("output ref dir");
+    let parser = OscParser::with_retention(
+        name.to_string(),
+        output_ref_dir,
+        TEST_MARKER_TOKEN.to_string(),
+        TranscriptRetention::Bounded { window_bytes },
+        &work_dir,
+    )
+    .expect("bounded parser");
+    (parser, work_dir)
+}
+
+#[test]
+fn bounded_parser_caps_long_command_across_multiple_windows() {
+    let (mut parser, work_dir) = bounded_parser_for_test("long-command", 128);
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"preexec\",\"token\":\"test-marker-token\",\"command\":\"long\",\"cwd\":\"/tmp\",\"timestamp_ms\":10}\x07")
+        .expect("preexec");
+    for _ in 0..20 {
+        parser.feed(&[b'x'; 97]).expect("command output");
+        assert!(parser.clean.window_len() <= 256);
+        assert!(parser.display.window_len() <= 256);
+    }
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"status\":0,\"cwd\":\"/tmp\",\"timestamp_ms\":20}\x07")
+        .expect("precmd");
+
+    let completed = parser
+        .events
+        .iter()
+        .find(|event| event.kind == ShellEventKind::CommandCompleted)
+        .expect("completed event");
+    assert_eq!(completed.terminal_output_bytes, Some(20 * 97));
+    let output_ref = completed
+        .terminal_output_ref
+        .as_deref()
+        .expect("output ref");
+    let captured = std::fs::read(output_ref).expect("captured output");
+    assert_eq!(captured.len(), 20 * 97);
+    assert!(parser.clean.window_len() <= 256);
+    assert!(parser.display.window_len() <= 256);
+    let _ = std::fs::remove_dir_all(work_dir);
+}
+
+#[test]
+fn bounded_parser_caps_prompt_capture_on_each_append() {
+    let (mut parser, work_dir) = bounded_parser_for_test("prompt-capture", 64);
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"cwd\":\"/tmp\"}\x07")
+        .expect("precmd");
+    parser.feed(&[b'h'; 256]).expect("large prompt output");
+
+    assert_eq!(parser.last_prompt_display(), &[b'h'; 64]);
+    parser.feed(b"tail").expect("prompt tail");
+    assert_eq!(parser.last_prompt_display().len(), 64);
+    assert!(parser.last_prompt_display().ends_with(b"tail"));
+    let _ = std::fs::remove_dir_all(work_dir);
+}
+
+#[test]
+fn bounded_parser_keeps_prompt_replay_after_hook_output_compacts() {
+    let (mut parser, work_dir) = bounded_parser_for_test("prompt-replay", 64);
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"cwd\":\"/tmp\"}\x07")
+        .expect("precmd");
+    parser.feed(&vec![b'h'; 1024]).expect("large prompt hook");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"prompt_ready\",\"token\":\"test-marker-token\"}\x07cosh$ ")
+        .expect("prompt ready");
+
+    assert_eq!(parser.last_prompt_display(), b"cosh$ ");
+    assert!(parser.has_prompt_painted_since_ready());
+    assert!(parser.display.window_len() <= 128);
+    let _ = std::fs::remove_dir_all(work_dir);
+}
+
+#[test]
+fn bounded_parser_handles_many_commands_without_rebasing_offsets() {
+    let (mut parser, work_dir) = bounded_parser_for_test("many-commands", 96);
+    for command in 0..12 {
+        let preexec = format!(
+            "\x1b]1337;COSH;{{\"event\":\"preexec\",\"token\":\"{TEST_MARKER_TOKEN}\",\"command\":\"echo {command}\",\"cwd\":\"/tmp\"}}\x07"
+        );
+        parser.feed(preexec.as_bytes()).expect("preexec");
+        parser.feed(&[b'a' + command as u8; 41]).expect("output");
+        let precmd = format!(
+            "\x1b]1337;COSH;{{\"event\":\"precmd\",\"token\":\"{TEST_MARKER_TOKEN}\",\"status\":0,\"cwd\":\"/tmp\"}}\x07"
+        );
+        parser.feed(precmd.as_bytes()).expect("precmd");
+    }
+
+    let completed = parser
+        .events
+        .iter()
+        .filter(|event| event.kind == ShellEventKind::CommandCompleted)
+        .collect::<Vec<_>>();
+    assert_eq!(completed.len(), 12);
+    assert!(completed
+        .iter()
+        .all(|event| event.terminal_output_bytes == Some(41)));
+    assert!(parser.clean.window_len() <= 192);
+    assert!(parser.display.window_len() <= 192);
+    let _ = std::fs::remove_dir_all(work_dir);
 }
 
 // S3 (stall-class audit 20260803, fixed by #2142): the pending handoff

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/prompt_replay.rs
@@ -198,6 +198,10 @@ impl PromptReplayTracker {
         strip_replayed_prompt_prefix(bytes, &mut self.pending_prompt)
     }
 
+    pub(super) fn pending_prompt_len(&self) -> usize {
+        self.pending_prompt.as_ref().map_or(0, Vec::len)
+    }
+
     fn expire_on_user_input(&mut self) {
         if self.pending_prompt.is_some() && self.input_generation.current() != self.armed_at {
             self.pending_prompt = None;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay.rs
@@ -17,6 +17,7 @@ use crate::raw_input::{
 };
 use crate::types::{CommandOrigin, ShellEvent, ShellEventKind};
 
+use super::model::ShellEventView;
 use super::osc::{DisplayCutKind, OscParser};
 use super::prompt_replay::{
     prompt_prefixed_replay_bytes, prompt_replay_bytes, PromptReplayTracker,
@@ -78,10 +79,10 @@ pub(super) fn read_raw_until_exit<W: Write, F>(
     hint_card_renderer: Option<&crate::shell_host::HintCardRenderer>,
 ) -> io::Result<bool>
 where
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
     let mut buffer = [0_u8; 8192];
-    let mut display_start = parser.display.len();
+    let mut display_start = parser.display_position();
     let mut native_candidate_echoed_len = 0;
     let mut prompt_replay = PromptReplayTracker::new(input_generation.clone());
     let mut last_pty_output: Option<Instant> = None;
@@ -128,7 +129,7 @@ where
             &mut driver_completed_at,
         )?;
         let mut observer_action = merge_pending_prompt_restore(
-            observe_with_input_mode_lock(event_observer, &parser.events, output, input_mode)?,
+            observe_with_input_mode_lock(event_observer, parser, output, input_mode)?,
             &mut pending_prompt_restore,
         );
         observer_action = resolve_pty_emit(
@@ -152,7 +153,7 @@ where
             latest_capture_submission_generation(&parser.events),
         );
         let mut hold_shell_output = observer_action.hold_shell_output();
-        if !hold_shell_output && parser.display.len() > display_start {
+        if !hold_shell_output && parser.display_position() > display_start {
             write_pending_display_preserving_prompt_ghost(
                 parser,
                 output,
@@ -192,7 +193,7 @@ where
                     }
                     let display_cuts = parser.drain_intervention_display_cuts();
                     for (cut, cut_kind) in display_cuts {
-                        let cut = cut.min(parser.display.len());
+                        let cut = cut.min(parser.display_position());
                         // Only a real prompt boundary (precmd) confirms the
                         // shell finished responding to the relay writes seen
                         // so far; an intercepted line's remaining response is
@@ -207,7 +208,7 @@ where
                                 if parser.take_synthetic_prompt_repaint()
                                     && cut > display_start
                                     && candidate_display_columns(
-                                        &parser.display[display_start..cut],
+                                        parser.read_display_range(display_start, cut)?.as_ref(),
                                     ) == 0
                                 {
                                     display_start = cut;
@@ -229,7 +230,7 @@ where
                         observer_action = merge_pending_prompt_restore(
                             observe_with_input_mode_lock(
                                 event_observer,
-                                &parser.events,
+                                parser,
                                 output,
                                 input_mode,
                             )?,
@@ -259,7 +260,7 @@ where
                             latest_capture_submission_generation(&parser.events),
                         );
                         hold_shell_output = observer_action.hold_shell_output();
-                        if !hold_shell_output && parser.display.len() > display_start {
+                        if !hold_shell_output && parser.display_position() > display_start {
                             write_pending_display_preserving_prompt_ghost(
                                 parser,
                                 output,
@@ -286,7 +287,6 @@ where
                     }
                     release_held_shell_output(
                         event_observer,
-                        &parser.events,
                         parser,
                         output,
                         &mut display_start,
@@ -305,7 +305,6 @@ where
             }
             release_held_shell_output(
                 event_observer,
-                &parser.events,
                 parser,
                 output,
                 &mut display_start,
@@ -362,7 +361,7 @@ where
             &mut driver_completed_at,
         )?;
         observer_action = merge_pending_prompt_restore(
-            observe_with_input_mode_lock(event_observer, &parser.events, output, input_mode)?,
+            observe_with_input_mode_lock(event_observer, parser, output, input_mode)?,
             &mut pending_prompt_restore,
         );
         observer_action = resolve_pty_emit(
@@ -390,7 +389,7 @@ where
             RawObserverAction::HoldShellOutput | RawObserverAction::DelayShellOutput
         );
         hold_shell_output = observer_action.hold_shell_output();
-        if !hold_shell_output && parser.display.len() > display_start {
+        if !hold_shell_output && parser.display_position() > display_start {
             write_pending_display_preserving_prompt_ghost(
                 parser,
                 output,
@@ -452,35 +451,34 @@ fn latest_capture_submission_generation(events: &[ShellEvent]) -> Option<u64> {
 }
 fn observe_with_input_mode_lock<W: Write, F>(
     event_observer: &mut F,
-    events: &[ShellEvent],
+    parser: &mut OscParser,
     output: &mut W,
     input_mode: &Arc<Mutex<RawInputMode>>,
 ) -> io::Result<RawObserverAction>
 where
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
     let Ok(mut mode) = input_mode.lock() else {
-        return event_observer(events, output);
+        return parser.observe_events(output, event_observer);
     };
-    let action = event_observer(events, output)?;
-    let acknowledged = latest_capture_submission_generation(events);
+    let action = parser.observe_events(output, event_observer)?;
+    let acknowledged = latest_capture_submission_generation(&parser.events);
     update_locked_input_mode(&mut mode, &action, acknowledged);
     Ok(action)
 }
 
 fn release_held_shell_output<W: Write, F>(
     event_observer: &mut F,
-    events: &[ShellEvent],
-    parser: &OscParser,
+    parser: &mut OscParser,
     output: &mut W,
     display_start: &mut usize,
     prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()>
 where
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
-    drain_observer_until_released(event_observer, events, output)?;
-    if parser.display.len() > *display_start {
+    drain_observer_until_released(event_observer, parser, output)?;
+    if parser.display_position() > *display_start {
         write_pending_display(parser, output, display_start, prompt_replay)?;
         output.flush()?;
     }
@@ -493,7 +491,7 @@ fn write_pending_display<W: Write>(
     display_start: &mut usize,
     prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
-    let display_end = parser.display.len();
+    let display_end = parser.display_position();
     write_display_slice(parser, output, *display_start, display_end, prompt_replay)?;
     *display_start = display_end;
     Ok(())
@@ -538,21 +536,30 @@ fn write_display_slice<W: Write>(
     display_end: usize,
     prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
-    let bytes = prompt_replay.strip(&parser.display[display_start..display_end]);
     let prompt = parser.last_prompt_display();
-    output.write_all(&prompt_prefixed_replay_bytes(bytes, prompt))
+    let prefix_len = display_end
+        .saturating_sub(display_start)
+        .min(prompt.len().max(prompt_replay.pending_prompt_len()).max(1));
+    let prefix_end = display_start.saturating_add(prefix_len);
+    let prefix = parser.read_display_range(display_start, prefix_end)?;
+    let bytes = prompt_replay.strip(prefix.as_ref());
+    output.write_all(&prompt_prefixed_replay_bytes(bytes, prompt))?;
+    parser.write_display_range(prefix_end, display_end, output)
 }
 
 fn drain_observer_until_released<W: Write, F>(
     event_observer: &mut F,
-    events: &[ShellEvent],
+    parser: &mut OscParser,
     output: &mut W,
 ) -> io::Result<()>
 where
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
     for _ in 0..1_000 {
-        if !event_observer(events, output)?.hold_shell_output() {
+        if !parser
+            .observe_events(output, event_observer)?
+            .hold_shell_output()
+        {
             return Ok(());
         }
         thread::sleep(Duration::from_millis(10));
@@ -631,13 +638,18 @@ fn remember_pending_prompt_restore(
     }
 }
 
-fn mark_pending_prompt_replayed(parser: &OscParser, prompt: &[u8], display_start: &mut usize) {
-    if prompt.is_empty() || *display_start > parser.display.len() {
-        return;
+fn mark_pending_prompt_replayed(
+    parser: &OscParser,
+    prompt: &[u8],
+    display_start: &mut usize,
+) -> io::Result<()> {
+    if prompt.is_empty() || *display_start > parser.display_position() {
+        return Ok(());
     }
-    if parser.display[*display_start..].starts_with(prompt) {
+    if parser.display_starts_with_at(*display_start, prompt)? {
         *display_start += prompt.len();
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
@@ -200,11 +200,11 @@ pub(super) fn resolve_pty_emit<W: Write>(
                     ghost_route,
                 });
             }
-            if parser.display.len() > *display_start {
+            if parser.display_position() > *display_start {
                 write_pending_display(parser, output, display_start, prompt_replay)?;
             } else {
                 output.write_all(prompt)?;
-                mark_pending_prompt_replayed(parser, raw_prompt, display_start);
+                mark_pending_prompt_replayed(parser, raw_prompt, display_start)?;
                 prompt_replay.arm_for_replay(raw_prompt);
             }
             if let Some(text) = &ghost_text {
@@ -269,7 +269,7 @@ pub(super) fn restore_prompt_display_before_handoff<W: Write>(
     display_start: &mut usize,
     prompt_replay: &mut PromptReplayTracker,
 ) -> io::Result<()> {
-    if parser.display.len() > *display_start {
+    if parser.display_position() > *display_start {
         write_pending_display(parser, output, display_start, prompt_replay)?;
         output.flush()?;
         return Ok(());
@@ -282,7 +282,7 @@ pub(super) fn restore_prompt_display_before_handoff<W: Write>(
     }
     output.write_all(prompt)?;
     output.flush()?;
-    mark_pending_prompt_replayed(parser, raw_prompt, display_start);
+    mark_pending_prompt_replayed(parser, raw_prompt, display_start)?;
     prompt_replay.arm_for_replay(raw_prompt);
     Ok(())
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -19,7 +19,7 @@ use crate::types::ShellEvent;
 use super::bootstrap::{start_bash_session, start_zsh_session, PtySession};
 use super::io_loop::{read_until_streaming, wait_child_preserving_signal};
 use super::lifecycle::{build_shell_host_output, push_shell_exited_event};
-use super::model::{ShellHostConfig, ShellHostOutput};
+use super::model::{ShellEventView, ShellHostConfig, ShellHostOutput};
 use super::raw_relay::{read_raw_until_exit, DriverCompletion, RawActionWatchdog};
 
 mod interactive;
@@ -29,6 +29,9 @@ mod wake;
 pub use interactive::{
     run_raw_interactive_bash, run_raw_interactive_bash_with_observer,
     run_raw_interactive_bash_with_output_control, run_raw_interactive_zsh_with_output_control,
+};
+pub(crate) use interactive::{
+    run_raw_interactive_bash_with_event_view, run_raw_interactive_zsh_with_event_view,
 };
 #[cfg(test)]
 use raw_mode_guard::RawModeGuard;
@@ -75,7 +78,14 @@ where
     W: Write,
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
-    run_raw_relay_bash_with_output_control_and_input_fd(config, input, output, event_observer, None)
+    let mut event_observer = event_observer;
+    run_raw_relay_bash_with_output_control_and_input_fd(
+        config,
+        input,
+        output,
+        move |view, output| event_observer(view.events(), output),
+        None,
+    )
 }
 
 fn run_raw_relay_bash_with_output_control_and_input_fd<R, W, F>(
@@ -88,7 +98,7 @@ fn run_raw_relay_bash_with_output_control_and_input_fd<R, W, F>(
 where
     R: Read + Send + 'static,
     W: Write,
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
     run_raw_relay_with_driver(
         config,
@@ -134,7 +144,14 @@ where
     W: Write,
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
-    run_raw_relay_zsh_with_output_control_and_input_fd(config, input, output, event_observer, None)
+    let mut event_observer = event_observer;
+    run_raw_relay_zsh_with_output_control_and_input_fd(
+        config,
+        input,
+        output,
+        move |view, output| event_observer(view.events(), output),
+        None,
+    )
 }
 
 fn run_raw_relay_zsh_with_output_control_and_input_fd<R, W, F>(
@@ -147,7 +164,7 @@ fn run_raw_relay_zsh_with_output_control_and_input_fd<R, W, F>(
 where
     R: Read + Send + 'static,
     W: Write,
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
 {
     run_raw_relay_with_driver(
         config,
@@ -249,8 +266,8 @@ where
         config,
         start_bash_session,
         output,
-        move |events, output| {
-            event_observer(events, output)?;
+        move |view, output| {
+            event_observer(view.events(), output)?;
             Ok(RawObserverAction::Continue)
         },
         config.input_classifier.clone(),
@@ -291,11 +308,12 @@ where
     W: Write,
     F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
 {
+    let mut event_observer = event_observer;
     run_raw_relay_with_driver(
         config,
         start_bash_session,
         output,
-        event_observer,
+        move |view, output| event_observer(view.events(), output),
         config.input_classifier.clone(),
         Some(config.raw_action_watchdog),
         config.slash_via_shell,
@@ -336,7 +354,7 @@ fn run_raw_relay_with_driver<W, F, D>(
 ) -> io::Result<ShellHostOutput>
 where
     W: Write,
-    F: FnMut(&[ShellEvent], &mut W) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut W) -> io::Result<RawObserverAction>,
     D: FnOnce(
         File,
         u32,
@@ -438,14 +456,20 @@ where
         config.input_wait_timeout_secs,
         config.hint_card_renderer.as_ref(),
     )?;
-    let display_start = session.parser.display.len();
-    session.parser.flush_pending();
-    output.write_all(&session.parser.display[display_start..])?;
+    let display_start = session.parser.display_position();
+    session.parser.flush_pending()?;
+    session.parser.write_display_range(
+        display_start,
+        session.parser.display_position(),
+        &mut output,
+    )?;
     output.flush()?;
 
     let exit_status = wait_child_preserving_signal(&mut session.child, eof_shutdown)?;
     push_shell_exited_event(&mut session.parser, config, exit_status)?;
-    event_observer(&session.parser.events, &mut output)?;
+    session
+        .parser
+        .observe_events(&mut output, &mut event_observer)?;
     output.flush()?;
     build_shell_host_output(config, session.parser, exit_status)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/interactive.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/interactive.rs
@@ -10,7 +10,8 @@ use crate::types::ShellEvent;
 use super::raw_mode_guard::{reopen_stdout_blocking, RawModeGuard};
 use super::{
     run_raw_relay_bash_with_output_control_and_input_fd,
-    run_raw_relay_zsh_with_output_control_and_input_fd, ShellHostConfig, ShellHostOutput,
+    run_raw_relay_zsh_with_output_control_and_input_fd, ShellEventView, ShellHostConfig,
+    ShellHostOutput,
 };
 
 pub fn run_raw_interactive_bash(config: &ShellHostConfig) -> io::Result<ShellHostOutput> {
@@ -39,8 +40,8 @@ where
         config,
         io::stdin(),
         io::stdout(),
-        move |events, output| {
-            event_observer(events, output)?;
+        move |view, output| {
+            event_observer(view.events(), output)?;
             Ok(RawObserverAction::Continue)
         },
         Some(libc::STDIN_FILENO),
@@ -54,6 +55,44 @@ pub fn run_raw_interactive_bash_with_output_control<F>(
 where
     F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<RawObserverAction>,
 {
+    let mut event_observer = event_observer;
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    run_raw_relay_bash_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        move |view, output| event_observer(view.events(), output),
+        Some(libc::STDIN_FILENO),
+    )
+}
+
+pub fn run_raw_interactive_zsh_with_output_control<F>(
+    config: &ShellHostConfig,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<RawObserverAction>,
+{
+    let mut event_observer = event_observer;
+    let _raw_mode = RawModeGuard::activate_stdin()?;
+    reopen_stdout_blocking()?;
+    run_raw_relay_zsh_with_output_control_and_input_fd(
+        config,
+        io::stdin(),
+        io::stdout(),
+        move |view, output| event_observer(view.events(), output),
+        Some(libc::STDIN_FILENO),
+    )
+}
+
+pub(crate) fn run_raw_interactive_bash_with_event_view<F>(
+    config: &ShellHostConfig,
+    event_observer: F,
+) -> io::Result<ShellHostOutput>
+where
+    F: FnMut(ShellEventView<'_>, &mut io::Stdout) -> io::Result<RawObserverAction>,
+{
     let _raw_mode = RawModeGuard::activate_stdin()?;
     reopen_stdout_blocking()?;
     run_raw_relay_bash_with_output_control_and_input_fd(
@@ -65,12 +104,12 @@ where
     )
 }
 
-pub fn run_raw_interactive_zsh_with_output_control<F>(
+pub(crate) fn run_raw_interactive_zsh_with_event_view<F>(
     config: &ShellHostConfig,
     event_observer: F,
 ) -> io::Result<ShellHostOutput>
 where
-    F: FnMut(&[ShellEvent], &mut io::Stdout) -> io::Result<RawObserverAction>,
+    F: FnMut(ShellEventView<'_>, &mut io::Stdout) -> io::Result<RawObserverAction>,
 {
     let _raw_mode = RawModeGuard::activate_stdin()?;
     reopen_stdout_blocking()?;

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/scripted.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/scripted.rs
@@ -93,7 +93,7 @@ fn run_scripted_shell(
         Duration::from_millis(300),
         |_| false,
     )?;
-    session.parser.flush_pending();
+    session.parser.flush_pending()?;
     let exit_status = wait_pty_foreground_bounded(
         &session.master,
         &session.terminal,
@@ -167,9 +167,13 @@ where
         Duration::from_millis(300),
         |_| false,
     )?;
-    let display_start = session.parser.display.len();
-    session.parser.flush_pending();
-    output.write_all(&session.parser.display[display_start..])?;
+    let display_start = session.parser.display_position();
+    session.parser.flush_pending()?;
+    session.parser.write_display_range(
+        display_start,
+        session.parser.display_position(),
+        &mut output,
+    )?;
     output.flush()?;
 
     let exit_status = wait_pty_foreground_bounded(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/transcript.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/transcript.rs
@@ -1,0 +1,323 @@
+//! Absolute-offset terminal transcript storage for shell-host sessions.
+
+use std::borrow::Cow;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+
+/// In-memory callers retain the historical complete-output contract. The
+/// interactive runtime opts into a secure spool plus a bounded working window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TranscriptRetention {
+    Full,
+    Bounded { window_bytes: usize },
+}
+
+#[derive(Debug)]
+pub(super) struct Transcript {
+    bytes: Vec<u8>,
+    base: usize,
+    end: usize,
+    window_bytes: Option<usize>,
+    spool: Option<File>,
+}
+
+impl Transcript {
+    pub(super) fn new(retention: TranscriptRetention, spool_path: &Path) -> io::Result<Self> {
+        let (window_bytes, spool) = match retention {
+            TranscriptRetention::Full => (None, None),
+            TranscriptRetention::Bounded { window_bytes } => {
+                let mut options = OpenOptions::new();
+                options.create_new(true).read(true).write(true);
+                options.mode(0o600);
+                let file = options.open(spool_path)?;
+                std::fs::set_permissions(spool_path, std::fs::Permissions::from_mode(0o600))?;
+                (Some(window_bytes.max(4)), Some(file))
+            }
+        };
+        Ok(Self {
+            bytes: Vec::new(),
+            base: 0,
+            end: 0,
+            window_bytes,
+            spool,
+        })
+    }
+
+    /// Absolute byte position immediately after the transcript.
+    pub(super) fn position(&self) -> usize {
+        self.end
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.position()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.end == 0
+    }
+
+    pub(super) fn window_len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(super) fn window_bytes(&self) -> Option<usize> {
+        self.window_bytes
+    }
+
+    pub(super) fn is_full(&self) -> bool {
+        self.spool.is_none()
+    }
+
+    pub(super) fn resident_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub(super) fn append(&mut self, data: &[u8]) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        if let Some(spool) = self.spool.as_mut() {
+            spool.seek(SeekFrom::Start(self.end as u64))?;
+            spool.write_all(data)?;
+        }
+        self.bytes.extend_from_slice(data);
+        self.end = self.end.saturating_add(data.len());
+        self.compact_window();
+        Ok(())
+    }
+
+    pub(super) fn pop_last_utf8_char(&mut self) -> io::Result<()> {
+        if self.end == 0 {
+            return Ok(());
+        }
+        let available = self.end.saturating_sub(self.base);
+        if available == 0 {
+            return Ok(());
+        }
+        let remove = last_utf8_char_len(&self.bytes).min(available);
+        self.bytes.truncate(self.bytes.len().saturating_sub(remove));
+        self.end = self.end.saturating_sub(remove);
+        if let Some(spool) = self.spool.as_mut() {
+            spool.set_len(self.end as u64)?;
+            spool.seek(SeekFrom::Start(self.end as u64))?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn read_range(&self, start: usize, end: usize) -> io::Result<Cow<'_, [u8]>> {
+        self.validate_range(start, end)?;
+        if start >= self.base {
+            return Ok(Cow::Borrowed(
+                &self.bytes[start - self.base..end - self.base],
+            ));
+        }
+        let mut bytes = vec![0_u8; end - start];
+        let mut file = self
+            .spool
+            .as_ref()
+            .ok_or_else(|| io::Error::other("transcript range is no longer resident"))?
+            .try_clone()?;
+        file.seek(SeekFrom::Start(start as u64))?;
+        file.read_exact(&mut bytes)?;
+        Ok(Cow::Owned(bytes))
+    }
+
+    pub(super) fn visit_range_chunks(
+        &self,
+        start: usize,
+        end: usize,
+        mut visit: impl FnMut(&[u8]) -> io::Result<()>,
+    ) -> io::Result<()> {
+        self.validate_range(start, end)?;
+        if start >= self.base {
+            return visit(&self.bytes[start - self.base..end - self.base]);
+        }
+        let mut file = self
+            .spool
+            .as_ref()
+            .ok_or_else(|| io::Error::other("transcript range is no longer resident"))?
+            .try_clone()?;
+        file.seek(SeekFrom::Start(start as u64))?;
+        let mut remaining = end - start;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let take = remaining.min(buffer.len());
+            file.read_exact(&mut buffer[..take])?;
+            visit(&buffer[..take])?;
+            remaining -= take;
+        }
+        Ok(())
+    }
+
+    pub(super) fn starts_with_at(&self, start: usize, prefix: &[u8]) -> io::Result<bool> {
+        let end = start.saturating_add(prefix.len());
+        if end > self.end {
+            return Ok(false);
+        }
+        Ok(self.read_range(start, end)?.as_ref() == prefix)
+    }
+
+    pub(super) fn copy_range_to<W: Write>(
+        &self,
+        start: usize,
+        end: usize,
+        output: &mut W,
+    ) -> io::Result<()> {
+        self.validate_range(start, end)?;
+        if start >= self.base {
+            return output.write_all(&self.bytes[start - self.base..end - self.base]);
+        }
+        let mut file = self
+            .spool
+            .as_ref()
+            .ok_or_else(|| io::Error::other("transcript range is no longer resident"))?
+            .try_clone()?;
+        file.seek(SeekFrom::Start(start as u64))?;
+        let mut remaining = end - start;
+        let mut buffer = [0_u8; 64 * 1024];
+        while remaining > 0 {
+            let take = remaining.min(buffer.len());
+            file.read_exact(&mut buffer[..take])?;
+            output.write_all(&buffer[..take])?;
+            remaining -= take;
+        }
+        Ok(())
+    }
+
+    pub(super) fn into_output_bytes(self) -> Vec<u8> {
+        if self.is_full() {
+            return self.bytes;
+        }
+        Vec::new()
+    }
+
+    fn validate_range(&self, start: usize, end: usize) -> io::Result<()> {
+        if start > end || end > self.end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "invalid transcript range {start}..{end}: base={} position={} resident={} window={:?}",
+                    self.base,
+                    self.end,
+                    self.bytes.len(),
+                    self.window_bytes
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn compact_window(&mut self) {
+        let Some(window_bytes) = self.window_bytes else {
+            return;
+        };
+        if self.bytes.len() <= window_bytes.saturating_mul(2) {
+            return;
+        }
+        let drop = self.bytes.len() - window_bytes;
+        self.bytes.drain(..drop);
+        self.base = self.base.saturating_add(drop);
+    }
+}
+
+fn last_utf8_char_len(bytes: &[u8]) -> usize {
+    let mut start = bytes.len().saturating_sub(1);
+    while start > 0 && bytes[start] & 0b1100_0000 == 0b1000_0000 {
+        start -= 1;
+    }
+    bytes.len() - start
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn temp_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "cosh-transcript-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    #[test]
+    fn bounded_transcript_keeps_absolute_ranges_across_compactions() {
+        let path = temp_path("ranges");
+        let _ = std::fs::remove_file(&path);
+        let mut transcript =
+            Transcript::new(TranscriptRetention::Bounded { window_bytes: 8 }, &path)
+                .expect("transcript");
+        transcript.append(b"abcdefgh").expect("first window");
+        transcript.append(b"ijklmnop").expect("second window");
+        transcript.append(b"qrstuvwx").expect("third window");
+
+        assert_eq!(transcript.position(), 24);
+        assert_eq!(transcript.window_len(), 8);
+        assert_eq!(
+            transcript.read_range(2, 22).expect("range"),
+            &b"cdefghijklmnopqrstuv"[..]
+        );
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn bounded_transcript_backspace_updates_spool_and_absolute_end() {
+        let path = temp_path("backspace");
+        let _ = std::fs::remove_file(&path);
+        let mut transcript =
+            Transcript::new(TranscriptRetention::Bounded { window_bytes: 4 }, &path)
+                .expect("transcript");
+        transcript.append("abc头".as_bytes()).expect("append");
+        transcript.pop_last_utf8_char().expect("pop");
+        transcript.append(b"d").expect("append replacement");
+
+        assert_eq!(transcript.position(), 4);
+        assert_eq!(transcript.read_range(0, 4).expect("range"), &b"abcd"[..]);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_range_reports_absolute_window_context() {
+        let path = temp_path("invalid-range");
+        let _ = std::fs::remove_file(&path);
+        let mut transcript =
+            Transcript::new(TranscriptRetention::Bounded { window_bytes: 4 }, &path)
+                .expect("transcript");
+        transcript.append(b"abcdefghijkl").expect("append");
+
+        let error = transcript.read_range(0, 13).expect_err("invalid range");
+        let message = error.to_string();
+        assert!(message.contains("base=8"), "{message}");
+        assert!(message.contains("position=12"), "{message}");
+        assert!(message.contains("resident=4"), "{message}");
+        assert!(message.contains("window=Some(4)"), "{message}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn full_transcript_returns_every_byte_unchanged() {
+        let path = temp_path("full");
+        let mut transcript =
+            Transcript::new(TranscriptRetention::Full, &path).expect("full transcript");
+        let first = vec![b'a'; 1024];
+        let second = b"\x1b[31mterminal\x1b[0m\n";
+        transcript.append(&first).expect("first append");
+        transcript.append(second).expect("second append");
+
+        let mut expected = first;
+        expected.extend_from_slice(second);
+        assert_eq!(transcript.into_output_bytes(), expected);
+        assert!(!path.exists());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
@@ -59,6 +59,13 @@ fn spawn_hook_session(
     (session, session_started_rx)
 }
 
+fn large_hook_input_command() -> Vec<u8> {
+    let mut command = b"printf '' #".to_vec();
+    command.resize(command.len() + 1024 * 1024, b'x');
+    command.push(b'\n');
+    command
+}
+
 #[test]
 fn raw_cli_external_hook_executes_pinned_file_after_path_replacement() {
     let home = temp_shell_home("external-hook-pinned-exec");
@@ -306,9 +313,11 @@ fn raw_cli_external_hook_ignoring_large_stdin_respects_deadline() {
     );
     install_user_hook(&home, "ignore_stdin.sh", &body);
 
-    // One valid UTF-8 line larger than a pipe buffer makes the serialized
-    // hook payload block when the hook never reads stdin.
-    let (session, session_started) = spawn_hook_session(&home, b"printf '%1048576s' x\n");
+    // Keep the serialized command itself larger than a pipe buffer. Bounded
+    // output retention may replace an oversized output line with a short
+    // fail-closed placeholder before hook evaluation.
+    let command = large_hook_input_command();
+    let (session, session_started) = spawn_hook_session(&home, &command);
     session_started.recv().expect("raw CLI session to start");
     let pids = wait_for_pids(&pid_file, 1);
     let ready_at = std::time::Instant::now();
@@ -366,7 +375,8 @@ fn raw_cli_external_hook_stdin_holder_is_killed() {
     );
     install_user_hook(&home, "stdin_holder.sh", &body);
 
-    let (session, session_started) = spawn_hook_session(&home, b"printf '%1048576s' x\n");
+    let command = large_hook_input_command();
+    let (session, session_started) = spawn_hook_session(&home, &command);
     session_started.recv().expect("raw CLI session to start");
     let pids = wait_for_pids(&pid_file, 2);
     let ready_at = std::time::Instant::now();


### PR DESCRIPTION
## Why

Long-running interactive cosh-shell sessions retain `OscParser` byte and event
history for the full session, so RSS grows with accumulated terminal output and
semantic events. This finishes the remaining #2609 retention work tracked by
#2649 while preserving existing scripted and public output contracts.

## What changed

- Added an absolute-offset transcript store. Interactive sessions spool
  `display` and `clean` data to tokenized mode-0600 session files and keep only
  bounded working windows; scripted and public callers retain full output.
- Added an absolute-cursor event window with safe command-boundary compaction
  and incremental redacted mode-0600 JSONL journaling.
- Kept prompt capture within its configured window on every append and compact
  oversized command lifecycles as soon as their closing event is observed.
- Migrated relay and runtime consumers to global event indices while preserving
  prompt replay, output-reference caps, redaction, and secure cleanup.

## Related issue

Closes #2649

## User / Agent impact

Long-running interactive sessions no longer retain terminal bytes or all shell
events in memory. Scripted and public shell-host callers continue to receive the
complete `ShellHostOutput`; interactive runtime results intentionally avoid
reconstructing unused full transcripts.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The interactive runtime now uses internal bounded retention, while public and
scripted defaults remain full retention. New transcript and event-journal files
use `create_new`, randomized session-token names, mode 0600, redaction before
event persistence, and existing session cleanup. Rollback is the single commit.

## Validation

Linux, rebased onto `up/main` at `76b5a76e`, commit
`81b216bca3ef90797127823104696ff16b668b00`:

- `cargo fmt --all -- --check`
- `cargo check --package cosh-shell --tests`
- Event-store unit group — 4 passed
- Transcript unit group — 4 passed
- Bounded OSC parser unit group — 5 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- Exact shell-host foreground control/output-ref regression — 1 passed
- Exact raw CLI delayed foreground-output regression — 1 passed
- Exact raw CLI prompt-replay delay-window regression — 1 passed
- Exact external-hook large-stdin deadline regression — 1 passed
- Exact external-hook stdin-holder regression — 3 consecutive passes

The first CI revision exposed two test-only `useless_vec` Clippy findings; both
are fixed. The integration gate then exposed an obsolete fixture assumption:
bounded retention replaces a 1 MiB single output line with a short fail-closed
placeholder, so the fixture no longer filled hook stdin. It now sizes the
serialized command field directly and does not depend on output retention.

Release 1 GiB RSS A/B measurement and broader manual coverage remain delegated
to PR/CI validation; no ECS or manual-terminal validation was run.

## Documentation and rollback

No user documentation change: retention selection is internal and public
defaults are unchanged. Revert commit
`81b216bca3ef90797127823104696ff16b668b00` to roll back.
