### PR TITLE
test(sec-core): expand capabilities view e2e coverage

### DIFF
--- a/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
@@ -2,9 +2,12 @@
 
 import json
 import os
+import re
 
 import pytest
 from cli.conftest import run_cli
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 _CAPABILITY_ENV_NAMES = (
     "CODE_SCANNER_HOOK_ENABLED",
@@ -373,10 +376,15 @@ def test_capabilities_rejects_invalid_cli_values(
 
 
 def test_capabilities_help_documents_filters_and_environment_scope() -> None:
-    result = run_cli("capabilities", "--help")
+    # Rich colorizes help output on CI, which splits option names across escape
+    # sequences and rewraps prose at the detected width. Pin both so the literal
+    # matches below describe the documented text rather than the rendering.
+    with _EnvPatch(NO_COLOR="1", COLUMNS="200"):
+        result = run_cli("capabilities", "--help")
 
     assert result.returncode == 0, result.stderr
-    assert "--agent" in result.stdout
-    assert "--capability" in result.stdout
-    assert "--output" in result.stdout
-    assert "current CLI environment" in result.stdout
+    help_text = _ANSI_ESCAPE.sub("", result.stdout)
+    assert "--agent" in help_text
+    assert "--capability" in help_text
+    assert "--output" in help_text
+    assert "current CLI environment" in help_text

--- a/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
+++ b/src/agent-sec-core/tests/e2e/cli/test_capabilities_e2e.py
@@ -3,7 +3,36 @@
 import json
 import os
 
+import pytest
 from cli.conftest import run_cli
+
+_CAPABILITY_ENV_NAMES = (
+    "CODE_SCANNER_HOOK_ENABLED",
+    "CODE_SCANNER_MODE",
+    "CODE_SCANNER_TIMEOUT",
+    "OBSERVABILITY_HOOK_ENABLED",
+    "OBSERVABILITY_TIMEOUT",
+    "PII_CHECKER_ENABLED",
+    "PII_CHECKER_HOOK_ENABLED",
+    "PII_CHECKER_INCLUDE_LOW_CONFIDENCE",
+    "PII_CHECKER_MODE",
+    "PII_CHECKER_TIMEOUT",
+    "PROMPT_SCANNER_HOOK_ENABLED",
+    "PROMPT_SCANNER_MODE",
+    "PROMPT_SCANNER_SCAN_MODE",
+    "PROMPT_SCANNER_TIMEOUT",
+    "SKILL_LEDGER_HOOK_ENABLED",
+    "SKILL_LEDGER_MODE",
+    "SKILL_LEDGER_TIMEOUT",
+)
+_AGENTS = ("qoder", "qwen", "codex", "cosh", "openclaw", "hermes")
+_CAPABILITIES = (
+    "code-scan",
+    "prompt-scan",
+    "pii-check",
+    "skill-ledger",
+    "observability",
+)
 
 
 class _EnvPatch:
@@ -12,9 +41,13 @@ class _EnvPatch:
         self.previous: dict[str, str | None] = {}
 
     def __enter__(self) -> None:
-        for name, value in self.values.items():
+        names = set(_CAPABILITY_ENV_NAMES) | self.values.keys()
+        for name in names:
             self.previous[name] = os.environ.get(name)
-            os.environ[name] = value
+            if name in self.values:
+                os.environ[name] = self.values[name]
+            else:
+                os.environ.pop(name, None)
 
     def __exit__(self, *_args: object) -> None:
         for name, value in self.previous.items():
@@ -97,3 +130,253 @@ def test_capabilities_rejects_noncanonical_capability_name() -> None:
 
     assert result.returncode == 1
     assert "unknown capability" in result.stderr
+
+
+def test_capabilities_json_lists_complete_default_matrix_in_stable_order() -> None:
+    with _EnvPatch():
+        result = run_cli("capabilities", "--output", "json")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert len(payload) == len(_AGENTS) * len(_CAPABILITIES)
+    assert [(item["agent"], item["capability"]) for item in payload] == sorted(
+        (agent, capability) for agent in _AGENTS for capability in _CAPABILITIES
+    )
+    assert all(item["enabled"] == "enabled" for item in payload)
+    assert all(
+        set(item)
+        == {
+            "agent",
+            "capability",
+            "enabled",
+            "mode",
+            "scan_mode",
+            "timeout",
+            "env",
+            "diagnostics",
+        }
+        for item in payload
+    )
+
+
+def test_capabilities_default_table_groups_every_agent_and_capability() -> None:
+    with _EnvPatch():
+        result = run_cli("capabilities")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    assert result.stdout.count("CAPABILITY") == len(_AGENTS)
+    for agent in _AGENTS:
+        assert result.stdout.count(f"[{agent}]") == 1
+    for capability in _CAPABILITIES:
+        assert result.stdout.count(capability) == len(_AGENTS)
+    assert "HOOKS" not in result.stdout
+    assert "SOURCE" not in result.stdout
+
+
+@pytest.mark.parametrize("agent", _AGENTS)
+@pytest.mark.parametrize("capability", _CAPABILITIES)
+def test_capabilities_filters_every_supported_agent_capability_pair(
+    agent: str, capability: str
+) -> None:
+    with _EnvPatch():
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            agent,
+            "--capability",
+            capability,
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload) == 1
+    assert payload[0]["agent"] == agent
+    assert payload[0]["capability"] == capability
+
+
+def test_capabilities_short_filters_trim_and_normalize_case() -> None:
+    with _EnvPatch():
+        result = run_cli(
+            "capabilities",
+            "-a",
+            " QODER ",
+            "-c",
+            " PROMPT-SCAN ",
+            "-o",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert [(item["agent"], item["capability"]) for item in payload] == [
+        ("qoder", "prompt-scan")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("agent", "raw_mode", "expected_mode", "expected_diagnostics"),
+    [
+        ("qoder", "debug", "observe", []),
+        ("qoder", "deny", "block", []),
+        ("codex", "ask", "observe", ["CODE_SCANNER_MODE"]),
+        ("cosh", "block", "ask", ["CODE_SCANNER_MODE"]),
+    ],
+)
+def test_capabilities_applies_agent_specific_code_scanner_modes(
+    agent: str,
+    raw_mode: str,
+    expected_mode: str,
+    expected_diagnostics: list[str],
+) -> None:
+    with _EnvPatch(CODE_SCANNER_MODE=raw_mode):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            agent,
+            "--capability",
+            "code-scan",
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads(result.stdout)[0]
+    assert record["mode"] == expected_mode
+    assert bool(record["diagnostics"]) is bool(expected_diagnostics)
+    for name in expected_diagnostics:
+        assert any(name in diagnostic for diagnostic in record["diagnostics"])
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected_enabled"),
+    [
+        ({"PII_CHECKER_ENABLED": "false"}, "disabled"),
+        (
+            {
+                "PII_CHECKER_ENABLED": "false",
+                "PII_CHECKER_HOOK_ENABLED": "true",
+            },
+            "enabled",
+        ),
+        (
+            {
+                "PII_CHECKER_ENABLED": "true",
+                "PII_CHECKER_HOOK_ENABLED": "false",
+            },
+            "disabled",
+        ),
+    ],
+)
+def test_capabilities_qwen_pii_new_enabled_variable_takes_precedence(
+    environment: dict[str, str], expected_enabled: str
+) -> None:
+    with _EnvPatch(**environment):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            "qwen",
+            "--capability",
+            "pii-check",
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)[0]["enabled"] == expected_enabled
+
+
+@pytest.mark.parametrize(
+    ("agent", "capability", "environment", "expected_timeout", "diagnostic"),
+    [
+        ("qwen", "pii-check", {"PII_CHECKER_TIMEOUT": "99"}, "8", None),
+        ("qoder", "skill-ledger", {"SKILL_LEDGER_TIMEOUT": "0.05"}, "0.05", None),
+        ("qoder", "code-scan", {"CODE_SCANNER_TIMEOUT": "0"}, "0", "fail open"),
+        ("qoder", "code-scan", {"CODE_SCANNER_TIMEOUT": "1.5"}, "10", "invalid"),
+        ("hermes", "observability", {"OBSERVABILITY_TIMEOUT": "999"}, "5", None),
+        ("openclaw", "observability", {"OBSERVABILITY_TIMEOUT": "0"}, "5", "invalid"),
+    ],
+)
+def test_capabilities_reports_runtime_compatible_timeout_semantics(
+    agent: str,
+    capability: str,
+    environment: dict[str, str],
+    expected_timeout: str,
+    diagnostic: str | None,
+) -> None:
+    with _EnvPatch(**environment):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            agent,
+            "--capability",
+            capability,
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads(result.stdout)[0]
+    assert record["timeout"] == expected_timeout
+    if diagnostic is None:
+        assert record["diagnostics"] == []
+    else:
+        assert any(diagnostic in item for item in record["diagnostics"])
+
+
+def test_capabilities_invalid_environment_value_is_diagnosed_without_raw_leak() -> None:
+    sensitive_value = "invalid-token-like-value"
+    with _EnvPatch(PROMPT_SCANNER_MODE=sensitive_value):
+        result = run_cli(
+            "capabilities",
+            "--agent",
+            "qwen",
+            "--capability",
+            "prompt-scan",
+            "--output",
+            "json",
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert sensitive_value not in result.stdout
+    assert sensitive_value not in result.stderr
+    record = json.loads(result.stdout)[0]
+    assert record["mode"] == "observe"
+    assert record["env"]["PROMPT_SCANNER_MODE"] == {
+        "effective": "observe",
+        "default": "observe",
+    }
+    assert record["diagnostics"] == [
+        "PROMPT_SCANNER_MODE has an invalid value; using 'observe'"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("arguments", "error"),
+    [
+        (("--agent", "unsupported"), "unknown agent"),
+        (("--output", "yaml"), "--output must be one of"),
+    ],
+)
+def test_capabilities_rejects_invalid_cli_values(
+    arguments: tuple[str, str], error: str
+) -> None:
+    with _EnvPatch():
+        result = run_cli("capabilities", *arguments)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert error in result.stderr
+
+
+def test_capabilities_help_documents_filters_and_environment_scope() -> None:
+    result = run_cli("capabilities", "--help")
+
+    assert result.returncode == 0, result.stderr
+    assert "--agent" in result.stdout
+    assert "--capability" in result.stdout
+    assert "--output" in result.stdout
+    assert "current CLI environment" in result.stdout


### PR DESCRIPTION
## Why

`capabilities` 视图是环境变量配置的唯一查询入口，此前 E2E 只覆盖 4 个基础场景，
六宿主与五能力的组合矩阵、Agent 特有的模式收窄、超时钳制与诊断文案都没有被锁定。
这些语义分散在 CLI 与各宿主 Hook 两侧且不共享代码，只能靠契约测试保证一致。

此外原测试夹具只还原自己设置的变量，开发机上已存在的 Hook 环境变量会污染断言结果。

## What changed

- 测试夹具改为对全部能力相关环境变量做快照并清理未显式设置的项，消除环境污染
- 新增全量矩阵测试：断言六宿主 × 五能力共 30 条记录、稳定排序与 JSON 字段集合
- 新增默认 table 输出分组断言，以及 30 组 agent/capability 过滤参数化用例
- 新增短选项与大小写归一、Agent 特有 code scanner 模式映射用例
- 新增 Qwen PII 新旧环境变量优先级用例
- 新增超时语义用例，覆盖上限钳制、非法值回退与非正值 fail-open 提示
- 新增非法取值只输出诊断、不回显原始值的用例
- 新增非法 CLI 参数与 help 文档用例

## Related issue

no-issue: 测试覆盖补强，无对应上游 issue

## User / Agent impact

None，仅新增测试，未改动任何运行时代码或环境变量语义。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk：变更范围限于单个测试文件，无生产代码改动。

## Validation

- `make python-code-pretty` — 仅重新格式化本次新增测试文件，363 个既有文件未变动
- `uv run --project agent-sec-cli ruff check tests/e2e/cli/test_capabilities_e2e.py` — All checks passed
- `uv run --project agent-sec-cli pytest tests/e2e/cli/test_capabilities_e2e.py -q` — 54 passed
- `uv run --project agent-sec-cli pytest tests/e2e/cli -q` — 140 passed, 2 skipped
- `git diff --cached --check` — 无 whitespace 问题

## Documentation and rollback

无文档变更：本次只锁定既有行为，未引入新的环境变量或 CLI 选项。
回滚方式为 revert 本次 commit，不影响任何运行时行为。