### PR TITLE
fix(sight): count no_port gateways as healthy in dashboard

### DIFF
--- a/src/agentsight/dashboard/src/pages/AgentHealthPage.tsx
+++ b/src/agentsight/dashboard/src/pages/AgentHealthPage.tsx
@@ -590,7 +590,11 @@ const AgentStatusSection: React.FC<{ addToast: (msg: string) => void }> = ({ add
     [agents],
   );
 
-  const healthyCount = agents.filter(a => a.status === 'healthy').length;
+  // Count promoted gateways (no_port but running) as healthy so the summary
+  // ratio matches the green "Running" rendering of their cards.
+  const healthyCount = agents.filter(
+    a => a.status === 'healthy' || isPromotedGatewayRunning(a)
+  ).length;
   const offlineCount = agents.filter(a => a.status === 'offline').length;
   const hungCount = agents.filter(a => a.status === 'hung').length;
   const totalCount = agents.length;


### PR DESCRIPTION
## Description

The Agent Dashboard header shows a "healthy/total" ratio that only counted `status=healthy` agents, while promoted gateway agents in `no_port` state (client processes that legitimately expose no listening port) are rendered as green "Running" cards on the same page. With two live client-type agents the header showed "0/2 healthy" even though both cards were green. This PR reuses the existing `isPromotedGatewayRunning` predicate in the count so the summary and the card rendering share one definition of a healthy agent.

## Related Issue

no-issue: trivial one-line display fix, root cause and evidence documented in the PR description.

## Risk and compatibility

Frontend-only display change; no API, storage, or config impact. The predicate is the same one already used for card rendering, so no new state semantics are introduced.

## Validation

- `npx tsc --noEmit` — pass
- `npm run build` (webpack production) — pass
- Manual reasoning against `/api/agent-health` payload with two `role=gateway, status=no_port` agents: header ratio now reports 2/2.

## Documentation and rollback

No documentation impact. Rollback: revert the single commit.
