### PR TITLE
fix(sight): probe companion components for dashboard capabilities

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -228,7 +228,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/sessions/{id}/interruptions` | GET | 指定 session 的所有中断 |
 | `/api/conversations/{id}/interruptions` | GET | 指定 conversation 的所有中断 |
 | `/api/auth/login` | POST | Dashboard 登录（Body: `{"token":"..."}` ），成功设置 httpOnly cookie |
-| `/api/auth/status` | GET | 返回 `{"auth_enabled": bool}`（免认证，供前端判断是否需登录）|
+| `/api/auth/status` | GET | 返回 `{"auth_enabled": bool, "capabilities": [...]}`（免认证）；`capabilities` 为动态探测结果，取决于宿主机上安装的伴随组件（agent-sec / enforcer / tokenless），供前端 NavBar 过滤不可用页面 |
 | `/api/auth/verify` | GET | 校验当前 session cookie/token 是否有效，返回 `{"authenticated": bool}` |
 | `/api/optimize/sessions/{id}/{dim}` | POST | 运行单维度优化分析，`dim` ∈ `perf` / `perf-issues` / `cost` / `cost-waste` / `accuracy` / `summary`（后四者需 LLM 配置，10–60s；`summary` 为单次调用叙事摘要） |
 | `/api/optimize/sessions/{id}/results` | GET | 读取已持久化的优化分析结果 |

--- a/src/agentsight/dashboard/src/App.tsx
+++ b/src/agentsight/dashboard/src/App.tsx
@@ -25,6 +25,7 @@ const DEFAULT_CAPABILITIES: AppCapability[] = [
   'optimization',
   'skills',
   'security',
+  'system_audit',
   'enforcement',
   'atif',
   'settings',
@@ -44,7 +45,7 @@ function pathAllowed(pathname: string, capabilities: AppCapability[]): boolean {
   if (pathname.startsWith('/optimization')) return capabilities.includes('optimization');
   if (pathname.startsWith('/skills')) return capabilities.includes('skills');
   if (pathname.startsWith('/security')) return capabilities.includes('security');
-  if (pathname.startsWith('/audit')) return capabilities.includes('security');
+  if (pathname.startsWith('/audit')) return capabilities.includes('system_audit');
   if (pathname.startsWith('/enforcement')) return capabilities.includes('enforcement');
   if (pathname.startsWith('/atif')) return capabilities.includes('atif');
   if (pathname.startsWith('/settings')) return capabilities.includes('settings');

--- a/src/agentsight/dashboard/src/components/NavBar.tsx
+++ b/src/agentsight/dashboard/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ const navItems: NavItem[] = [
   { path: '/optimization', labelKey: 'nav.optimization', icon: '🔬', capability: 'optimization' },
   { path: '/skills', labelKey: 'nav.skillMetrics', icon: '🧩', capability: 'skills' },
   { path: '/security', labelKey: 'nav.securityObservability', icon: '🛡️', capability: 'security' },
-  { path: '/audit', labelKey: 'nav.systemAudit', icon: '📋', capability: 'security' },
+  { path: '/audit', labelKey: 'nav.systemAudit', icon: '📋', capability: 'system_audit' },
   { path: '/enforcement', labelKey: 'nav.riskEnforcement', icon: '⛔', capability: 'enforcement' },
   { path: '/atif', labelKey: 'nav.trajectoryViewer', icon: '🔍', capability: 'atif' },
   { path: '/settings', labelKey: 'nav.settings', icon: '⚙️', capability: 'settings' },

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -1757,6 +1757,7 @@ export type AppCapability =
   | 'optimization'
   | 'skills'
   | 'security'
+  | 'system_audit'
   | 'enforcement'
   | 'atif'
   | 'settings'

--- a/src/agentsight/src/server/capabilities.rs
+++ b/src/agentsight/src/server/capabilities.rs
@@ -1,0 +1,211 @@
+//! Dashboard capability detection.
+//!
+//! The frontend NavBar hides entries whose capability is absent from the
+//! `/api/auth/status` response. Capabilities backed by companion components
+//! (agent-sec-core, the enforcer service, tokenless) are probed here so a
+//! deployment that ships only agentsight does not advertise features it
+//! cannot serve.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+/// Well-known install directories probed in addition to `PATH`, so a process
+/// launched with a stripped environment (systemd unit, container entrypoint)
+/// still detects installed components.
+const FALLBACK_BIN_DIRS: &[&str] = &["/usr/local/bin", "/usr/bin", "/usr/sbin"];
+
+/// Binary name installed by the agentsight packaging for the enforcer daemon.
+const ENFORCER_BINARY: &str = "agentsight-enforcer";
+
+/// Resolve the enforcer service socket path (env override or default).
+///
+/// Shared with `run_server` so the capability probe and the enforcement
+/// client always agree on the location.
+pub(crate) fn enforcer_socket_path() -> PathBuf {
+    std::env::var_os("AGENTSIGHT_ENFORCER_SOCKET")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/run/agentsight/enforcer.sock"))
+}
+
+/// Probe companion components and return the capability list to advertise.
+///
+/// Re-evaluated per request: probes are cheap filesystem checks, and a
+/// daemon started after agentsight simply appears on the next page load.
+pub(crate) fn app_capabilities() -> Vec<&'static str> {
+    detect_capabilities(
+        agent_sec_available(),
+        enforcement_available(),
+        token_savings_available(),
+    )
+}
+
+/// Assemble the capability list from probe results.
+///
+/// Capabilities served by agentsight itself are unconditional; the
+/// component-backed ones are gated by their probes. `system_audit` is
+/// derived: the audit store and its enforcer-fed ingestion live inside
+/// agentsight, so the page is useful whenever either event source exists.
+/// Order mirrors the dashboard navigation.
+fn detect_capabilities(
+    security: bool,
+    enforcement: bool,
+    token_savings: bool,
+) -> Vec<&'static str> {
+    let mut caps = vec!["agent_observability", "sessions"];
+    if token_savings {
+        caps.push("token_savings");
+    }
+    caps.extend(["optimization", "skills"]);
+    if security {
+        caps.push("security");
+    }
+    if security || enforcement {
+        caps.push("system_audit");
+    }
+    if enforcement {
+        caps.push("enforcement");
+    }
+    caps.extend(["atif", "settings", "agent_health"]);
+    caps
+}
+
+/// agent-sec-core backs the security observability and system audit pages.
+///
+/// A live daemon socket is the strongest signal; fall back to the binaries
+/// being installed so an installed-but-stopped daemon still shows the pages
+/// (which render their own "daemon unavailable" state).
+fn agent_sec_available() -> bool {
+    let socket_exists = crate::agent_sec::AgentSecClient::new(None)
+        .map(|client| client.socket_path().exists())
+        .unwrap_or(false);
+    socket_exists || binary_installed("agent-sec-daemon") || binary_installed("agent-sec-cli")
+}
+
+/// The enforcer backs risk enforcement: a live socket is the strongest
+/// signal, but keep the capability while the daemon is restarting so the
+/// page's own readiness diagnostics stay reachable — gate on the installed
+/// binary as well.
+fn enforcement_available() -> bool {
+    enforcer_socket_path().exists() || binary_installed(ENFORCER_BINARY)
+}
+
+/// tokenless backs the token savings page: stats.db appears once it has
+/// optimized something; the binary alone means it can start producing data.
+fn token_savings_available() -> bool {
+    crate::storage::sqlite::tokenless::default_stats_path().exists()
+        || binary_installed("tokenless")
+}
+
+/// Whether an executable named `name` is reachable via `PATH` or one of the
+/// well-known install directories.
+fn binary_installed(name: &str) -> bool {
+    binary_in_path(name, std::env::var_os("PATH").as_deref())
+        || FALLBACK_BIN_DIRS
+            .iter()
+            .any(|dir| is_executable(&Path::new(dir).join(name)))
+}
+
+/// Whether an executable named `name` exists in any `path_var` directory.
+fn binary_in_path(name: &str, path_var: Option<&OsStr>) -> bool {
+    let Some(paths) = path_var else {
+        return false;
+    };
+    std::env::split_paths(paths).any(|dir| {
+        if dir.as_os_str().is_empty() {
+            return false;
+        }
+        is_executable(&dir.join(name))
+    })
+}
+
+/// Whether `path` is an existing regular file with any execute bit set.
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_all_probes_false_keeps_only_intrinsic_capabilities() {
+        let caps = detect_capabilities(false, false, false);
+        assert_eq!(
+            caps,
+            vec![
+                "agent_observability",
+                "sessions",
+                "optimization",
+                "skills",
+                "atif",
+                "settings",
+                "agent_health",
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_all_probes_true_yields_full_list_in_nav_order() {
+        let caps = detect_capabilities(true, true, true);
+        assert_eq!(
+            caps,
+            vec![
+                "agent_observability",
+                "sessions",
+                "token_savings",
+                "optimization",
+                "skills",
+                "security",
+                "system_audit",
+                "enforcement",
+                "atif",
+                "settings",
+                "agent_health",
+            ]
+        );
+    }
+
+    #[test]
+    fn detect_gates_each_capability_independently() {
+        assert!(detect_capabilities(true, false, false).contains(&"security"));
+        assert!(!detect_capabilities(true, false, false).contains(&"enforcement"));
+        assert!(detect_capabilities(false, true, false).contains(&"enforcement"));
+        assert!(detect_capabilities(false, false, true).contains(&"token_savings"));
+    }
+
+    #[test]
+    fn system_audit_follows_either_event_source() {
+        // Audit ingestion is fed by the enforcer, and agent-sec deployments
+        // used the audit page before this gating existed — either source
+        // must keep it reachable.
+        assert!(detect_capabilities(true, false, false).contains(&"system_audit"));
+        assert!(detect_capabilities(false, true, false).contains(&"system_audit"));
+        assert!(!detect_capabilities(false, false, true).contains(&"system_audit"));
+    }
+
+    #[test]
+    fn binary_in_path_finds_executable_and_rejects_others() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("agentsight-caps-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let exe = dir.join("fake-tool");
+        std::fs::write(&exe, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let non_exec = dir.join("plain-file");
+        std::fs::write(&non_exec, "data").unwrap();
+        std::fs::set_permissions(&non_exec, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let path_var = std::env::join_paths([&dir]).unwrap();
+        assert!(binary_in_path("fake-tool", Some(path_var.as_os_str())));
+        assert!(!binary_in_path("plain-file", Some(path_var.as_os_str())));
+        assert!(!binary_in_path("absent-tool", Some(path_var.as_os_str())));
+        assert!(!binary_in_path("fake-tool", None));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -69,24 +69,15 @@ pub async fn auth_login(
 
 /// GET /api/auth/status
 ///
-/// Returns whether authentication is enabled.  Exempt from auth middleware.
+/// Returns whether authentication is enabled plus the capability list the
+/// dashboard should render (probed from installed companion components).
+/// Exempt from auth middleware.
 #[get("/status")]
 pub async fn auth_status(data: web::Data<AppState>) -> impl Responder {
     HttpResponse::Ok().json(json!({
         "auth_enabled": data.auth.enabled,
         "mode": "linux",
-        "capabilities": [
-            "agent_observability",
-            "sessions",
-            "token_savings",
-            "optimization",
-            "skills",
-            "security",
-            "enforcement",
-            "atif",
-            "settings",
-            "agent_health"
-        ],
+        "capabilities": super::capabilities::app_capabilities(),
     }))
 }
 
@@ -1659,6 +1650,17 @@ mod tests {
             serde_json::from_slice(&actix_web::body::to_bytes(resp.into_body()).await.unwrap())
                 .unwrap();
         assert_eq!(body["auth_enabled"], true);
+        // Intrinsic capabilities must always be advertised; component-backed
+        // ones (security/enforcement/token_savings) depend on the host.
+        let caps = body["capabilities"].as_array().unwrap();
+        for cap in [
+            "agent_observability",
+            "sessions",
+            "agent_health",
+            "settings",
+        ] {
+            assert!(caps.iter().any(|v| v == cap), "missing capability {cap}");
+        }
     }
 
     #[actix_web::test]

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -4,6 +4,7 @@
 //! AgentSight storage data, and optionally serves the embedded frontend.
 
 pub mod auth;
+mod capabilities;
 mod causal;
 mod containment;
 mod enforcement;
@@ -620,10 +621,7 @@ pub async fn run_server(
             .map_err(|error| std::io::Error::other(error.to_string()))?,
     );
 
-    let enforcement_socket = std::env::var_os("AGENTSIGHT_ENFORCER_SOCKET")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/run/agentsight/enforcer.sock"));
-    let enforcement_client = EnforcementClient::new(enforcement_socket);
+    let enforcement_client = EnforcementClient::new(capabilities::enforcer_socket_path());
     let enforcement = Arc::new(EnforcementCoordinator::new(
         enforcement_client.clone(),
         EnforcementStore::open_private(&state_dir)


### PR DESCRIPTION
## Description

The Linux `GET /api/auth/status` handler returned a hardcoded list of all dashboard capabilities, so a deployment that ships only agentsight (e.g. a single-component container image) still rendered the Security Observability, System Audit, Risk Enforcement and Token Savings navigation entries even though none of them can work without agent-sec-core, the enforcer service or tokenless. The frontend NavBar already filters entries by this list and `App.tsx` redirects disallowed routes — only the Linux backend never probed actual availability. This PR adds a `server/capabilities` module that gates the component-backed capabilities with cheap filesystem probes evaluated per request:

- `security`: agent-sec daemon socket exists, or `agent-sec-daemon` / `agent-sec-cli` is installed
- `system_audit` (new capability): granted when either audit event source (agent-sec or the enforcer) is present — the audit store lives inside agentsight and must not disappear with agent-sec alone
- `enforcement`: enforcer socket exists (`AGENTSIGHT_ENFORCER_SOCKET` or `/run/agentsight/enforcer.sock`), or the packaged `agentsight-enforcer` binary is installed — so the page's readiness diagnostics stay reachable across daemon restarts
- `token_savings`: `~/.tokenless/stats.db` exists, or `tokenless` is installed

Binary lookup checks `PATH` and falls back to well-known install dirs (`/usr/local/bin`, `/usr/bin`, `/usr/sbin`) so a stripped environment (systemd unit, container entrypoint) cannot hide installed components. Enforcer socket resolution is extracted from `run_server` and shared so the probe and the enforcement client cannot diverge. Frontend adds the `system_audit` capability to the type union, NavBar mapping and route gating; the macOS local server keeps its curated set.

## Related Issue

no-issue: capability-gating defect found during container image validation; root cause and probe design documented in this PR.

## Risk and compatibility

- **Behavior change**: deployments without tokenless installed will no longer see the Token Savings nav entry (previously always shown). This is intentional — the page renders empty without stats.db anyway. The same applies to Security Observability / System Audit / Risk Enforcement on hosts without agent-sec or the enforcer.
- The `/api/auth/status` response shape is unchanged; only the `capabilities` array content becomes host-dependent. Frontend treats the field as optional and filters on it. AGENTS.md §8 endpoint documentation updated accordingly.
- `App.tsx` redirects routes whose capability is absent, so a probe false-negative would hide a working page; probes are therefore deliberately permissive (socket OR installed binary OR data file, plus fixed-dir fallback).
- Frontend and backend ship together (embedded bundle), so the new `system_audit` capability cannot skew across versions.
- Probes are per-request `stat()` calls (no RPC), so a component started after agentsight appears on the next page load.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo clippy --locked -- -D warnings` — pass
- `cargo test --locked --lib` — pass (server module: 206 tests)
- Dashboard: `npx tsc --noEmit`, `npm run test:api-client`, `npm run build` — all pass
- New unit tests cover the gating matrix (all-off, all-on, each probe independently), the derived `system_audit` capability for both event sources, and the PATH executable lookup (executable found, non-executable rejected, absent name, missing PATH).

## Documentation and rollback

No user-facing documentation changes required; capability semantics match the existing NavBar mapping. Rollback: revert the single commit to restore the static list.
