### PR TITLE
ci: probe fast checks on main@8f2416470 (do not merge)

### DIFF
--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -109,3 +109,4 @@ Source builds are a contributor workflow. Start with the
 ## License
 
 Apache-2.0
+


### PR DESCRIPTION
## CI probe — not for merge

Base-only control run: this branch is `origin/main` at `8f2416470` verbatim (zero diff). Purpose: PR #2408's merge tree fails `Test cosh-ng fast checks` deterministically on `provider_lifecycle::cosh_core_sync_drains_child_output_while_writing_large_prompt` (two runs, different runners), while the diff there has zero intersection with provider transport. `499cb530e` and `8f2416470` merged within hours of each other and their combination never ran fast checks together; this probe determines whether the failure is a pre-existing upstream regression. Will be closed immediately after the checks complete.
