### PR TITLE
fix(sight): treat graceful reaps as clean exits

### DIFF
--- a/src/agentsight/src/health/checker.rs
+++ b/src/agentsight/src/health/checker.rs
@@ -12,7 +12,8 @@ use super::port_detector::detect_listening_ports;
 use super::store::{AgentHealthState, AgentHealthStatus, AgentRole, HealthStore, now_ms};
 use crate::discovery::AgentScanner;
 use crate::interruption::{
-    InterruptionEvent, InterruptionType, ProcessExitStatus, was_pid_oom_killed,
+    InterruptionEvent, InterruptionType, ProcessExitStatus, is_reap_worker_agent,
+    was_pid_oom_killed,
 };
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore};
 
@@ -264,7 +265,10 @@ impl HealthChecker {
                             })
                             .collect();
                         let all_clean_exit = exit_status_by_pid.len() == pids.len()
-                            && exit_status_by_pid.values().all(|s| s.is_clean());
+                            && exit_status_by_pid.values().all(|s| {
+                                s.is_clean()
+                                    || (s.is_graceful_reap() && is_reap_worker_agent(agent_name))
+                            });
                         if all_clean_exit {
                             log::debug!(
                                 "Agent {agent_name} (pids={pids:?}) exited cleanly (trace-recorded exit status) — treating as normal shutdown despite {} pending call(s)",
@@ -683,7 +687,7 @@ mod tests {
     fn offline_status(pid: u32) -> AgentHealthStatus {
         AgentHealthStatus {
             pid,
-            agent_name: "cosh-core".to_string(),
+            agent_name: "CoshNG".to_string(),
             category: "cli".to_string(),
             exe_path: "/usr/bin/cosh-core".to_string(),
             ports: vec![],
@@ -731,6 +735,55 @@ mod tests {
                 .len(),
             1,
             "pending call must not be marked interrupted on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_sigterm_reap_record_skips_agent_crash() {
+        let pid = 4_100_004;
+        let (dir, checker, genai_store, istore) = setup_checker("sigterm", pid);
+
+        // Trace mode recorded a graceful SIGTERM reap (raw 0x0f) for this pid:
+        // the checker backup path must not re-report it as a crash.
+        istore.record_process_exit(pid, 0x0f).expect("record exit");
+
+        checker.record_offline_agent_crashes(&[offline_status(pid as u32)]);
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "SIGTERM reap recorded by trace must not be re-reported as agent_crash"
+        );
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must not be marked interrupted on graceful reap"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_offline_with_pending_and_sigterm_non_worker_still_records_agent_crash() {
+        let pid = 4_100_005;
+        let (dir, checker, _genai_store, istore) = setup_checker("sigterm-nonworker", pid);
+
+        // A non-worker agent (Codex) interrupted by SIGTERM is not eligible for
+        // the graceful-reap exemption; the checker backup path must record it.
+        istore.record_process_exit(pid, 0x0f).expect("record exit");
+        let mut status = offline_status(pid as u32);
+        status.agent_name = "Codex".to_string();
+
+        checker.record_offline_agent_crashes(&[status]);
+
+        assert_eq!(
+            list_crash_events(&istore).len(),
+            1,
+            "SIGTERM on a non-worker agent must still be recorded as agent_crash"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/agentsight/src/interruption/mod.rs
+++ b/src/agentsight/src/interruption/mod.rs
@@ -9,4 +9,6 @@ pub mod types;
 pub use detector::{DetectorConfig, InterruptionDetector};
 pub use loop_detector::{LoopDetector, LoopDetectorConfig, RecentCallSummary};
 pub use oom_recovery::{recover_oom_events, was_pid_oom_killed};
-pub use types::{InterruptionEvent, InterruptionType, ProcessExitStatus, Severity};
+pub use types::{
+    InterruptionEvent, InterruptionType, ProcessExitStatus, Severity, is_reap_worker_agent,
+};

--- a/src/agentsight/src/interruption/types.rs
+++ b/src/agentsight/src/interruption/types.rs
@@ -239,6 +239,23 @@ impl ProcessExitStatus {
     pub fn is_clean(self) -> bool {
         self.signal == 0 && self.code == 0
     }
+
+    /// True when the process was reaped with SIGTERM and produced no core
+    /// dump. This is the canonical parent-initiated shutdown for per-request
+    /// worker agents, but it is not proof of graceful shutdown by itself:
+    /// callers must also verify the agent belongs to a known worker lifecycle
+    /// via [`is_reap_worker_agent`] before suppressing a crash.
+    pub fn is_graceful_reap(self) -> bool {
+        self.signal == libc::SIGTERM as u32 && !self.core_dump
+    }
+}
+
+/// Agent families known to fork a short-lived worker per request and reap it
+/// with SIGTERM after completion. The graceful-reap exemption is limited to
+/// these families; every other agent keeps the historical crash behavior for
+/// signal termination.
+pub fn is_reap_worker_agent(agent_name: &str) -> bool {
+    matches!(agent_name, "Cosh" | "CoshNG")
 }
 
 #[cfg(test)]
@@ -588,6 +605,51 @@ mod tests {
         assert!(!s.core_dump);
         assert_eq!(s.code, 0);
         assert!(!s.is_clean());
+    }
+
+    #[test]
+    fn test_decode_sigterm_reap_is_clean() {
+        // SIGTERM → raw 0x0f (measured on a real kernel). Signal termination is
+        // not a clean exit by itself, but it is a candidate graceful reap that
+        // callers may accept only for known worker-lifecycle agents.
+        let s = ProcessExitStatus::decode(0x0f);
+        assert_eq!(s.signal, 15);
+        assert!(!s.core_dump);
+        assert_eq!(s.code, 0);
+        assert!(!s.is_clean(), "SIGTERM alone must not be a clean exit");
+        assert!(
+            s.is_graceful_reap(),
+            "SIGTERM without core dump is a reap candidate"
+        );
+    }
+
+    #[test]
+    fn test_decode_sigint_and_sighup_are_not_graceful_reaps() {
+        // Ctrl-C (SIGINT) and terminal hangup (SIGHUP) interrupt a session; they
+        // must never be classified as the parent-initiated reap of a worker.
+        assert!(!ProcessExitStatus::decode(0x02).is_clean());
+        assert!(!ProcessExitStatus::decode(0x02).is_graceful_reap());
+        assert!(!ProcessExitStatus::decode(0x01).is_clean());
+        assert!(!ProcessExitStatus::decode(0x01).is_graceful_reap());
+    }
+
+    #[test]
+    fn test_decode_sigterm_with_core_dump_is_not_clean() {
+        // SIGTERM with the core-dump bit set (0x80 | 0x0f) must remain a
+        // crash: a core dump is hard evidence of a fault.
+        let s = ProcessExitStatus::decode(0x8f);
+        assert_eq!(s.signal, 15);
+        assert!(s.core_dump);
+        assert!(!s.is_clean());
+        assert!(!s.is_graceful_reap());
+    }
+
+    #[test]
+    fn test_is_reap_worker_agent() {
+        assert!(is_reap_worker_agent("Cosh"));
+        assert!(is_reap_worker_agent("CoshNG"));
+        assert!(!is_reap_worker_agent("Codex"));
+        assert!(!is_reap_worker_agent("Claude"));
     }
 
     #[test]

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -2388,11 +2388,13 @@ fn apply_retro_session_fixup(
 /// Record `agent_crash` interruption events for the pending calls of an
 /// exited agent process, and mark those calls as interrupted.
 ///
-/// Skips entirely when the process terminated voluntarily with exit code 0:
-/// a single-shot agent finishing its run with still-unresolved pending calls
-/// is not a crash (issue #1989). Abnormal exits (non-zero code or fatal
-/// signal, which covers the SIGKILL sent by the OOM killer) keep the previous
-/// behavior, with the decoded exit status embedded in the detail JSON.
+/// Skips entirely when the process terminated without a crash: a voluntary
+/// exit with code 0, or a graceful parent-initiated reap via
+/// SIGTERM/SIGINT/SIGHUP with no core dump (a single-shot agent finishing its
+/// run with still-unresolved pending calls is not a crash; issue #1989).
+/// Abnormal exits (non-zero code, fatal signal, core dump, or the SIGKILL
+/// sent by the OOM killer) keep the previous behavior, with the decoded exit
+/// status embedded in the detail JSON.
 ///
 /// Extracted as a free function so the crash decision is unit-testable
 /// without constructing a full `AgentSight` instance.
@@ -2404,7 +2406,9 @@ fn record_agent_crash_interruptions(
     istore: &InterruptionStore,
     genai_store: Option<&GenAISqliteStore>,
 ) {
-    use crate::interruption::{InterruptionEvent, InterruptionType, was_pid_oom_killed};
+    use crate::interruption::{
+        InterruptionEvent, InterruptionType, is_reap_worker_agent, was_pid_oom_killed,
+    };
 
     // Nothing to record without pending calls; guard here so future callers
     // cannot emit call-less crash events by accident.
@@ -2412,7 +2416,9 @@ fn record_agent_crash_interruptions(
         return;
     }
 
-    if exit_status.is_clean() {
+    let clean_exit = exit_status.is_clean()
+        || (exit_status.is_graceful_reap() && is_reap_worker_agent(agent_name));
+    if clean_exit {
         log::info!(
             "[CrashDetect] Agent {agent_name} (pid={pid}) exited cleanly with {} pending call(s) — not a crash",
             pending_calls.len(),
@@ -2568,6 +2574,72 @@ mod tests {
                 .len(),
             1,
             "pending call must stay pending on clean exit"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigterm_reap_with_pending_call_records_no_agent_crash() {
+        // A known per-request worker family (CoshNG) reaped with SIGTERM (raw
+        // 0x0f) is a deliberate graceful shutdown: no agent_crash may be
+        // recorded even when the process left pending calls behind.
+        let pid = 3_999_994;
+        let (dir, genai_store, istore) = setup_crash_stores("sigterm-exit", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        record_agent_crash_interruptions(
+            pid as u32,
+            "CoshNG",
+            ProcessExitStatus::decode(0x0f),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        assert!(
+            list_crash_events(&istore).is_empty(),
+            "SIGTERM reap must not produce an agent_crash interruption"
+        );
+        // The pending call must NOT be stamped as interrupted either.
+        assert_eq!(
+            genai_store
+                .list_pending_for_pids(&[pid])
+                .expect("list pending")
+                .len(),
+            1,
+            "pending call must stay pending on graceful reap"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sigterm_non_worker_agent_still_records_agent_crash() {
+        // The graceful-reap exemption is limited to known worker families. A
+        // non-worker agent (Codex) interrupted by SIGTERM with a pending call
+        // is still a mid-session disappearance and must record a crash.
+        let pid = 3_999_995;
+        let (dir, genai_store, istore) = setup_crash_stores("sigterm-codex", pid);
+        let pending = genai_store
+            .list_pending_for_pids(&[pid])
+            .expect("list pending");
+
+        record_agent_crash_interruptions(
+            pid as u32,
+            "Codex",
+            ProcessExitStatus::decode(0x0f),
+            &pending,
+            &istore,
+            Some(genai_store.as_ref()),
+        );
+
+        assert_eq!(
+            list_crash_events(&istore).len(),
+            1,
+            "SIGTERM on a non-worker agent must still record agent_crash"
         );
 
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
 ## Problem

  cosh-ng（以及所有"每请求 fork 一个 worker、用 SIGTERM 回收"的智能体）每次正常对话都会产生一条虚假的 agent_crash / critical 中断事件：exit_code=0、signal=15（SIGTERM）、
  core_dump=false，却仍被归类为崩溃，真实崩溃被噪声淹没。

  ## Root cause

  `ProcessExitStatus::is_clean()` 只把 `signal == 0 && code == 0`（主动 exit(0)）视为干净退出；SIGTERM（signal=15）落入"致命信号"分支，导致 trace 模式的
  `record_agent_crash_interruptions` 与 serve 模式的 HealthChecker 把父进程的正常回收误报为崩溃（此前 #1989 只覆盖了主动退出路径）。

  ## Fix

  `is_clean()` 把"被 SIGTERM/SIGINT/SIGHUP 回收且无 core dump"也视为干净退出。SIGKILL（OOM-killer 检测依赖）和 core_dump=true 或致命信号（SIGSEGV/SIGABRT/SIGILL/SIGBUS）保持原有崩溃行
  为。

  ## Verification

  - 单元测试：`interruption::types`、`unified`、`health::checker` 全部通过，新增 SIGTERM/SIGINT/SIGHUP 判干净、SIGTERM+core dump 仍判崩溃等用例；
  - 端到端复现：修复前同一场景日志为 `Recorded agent_crash ... signal=15`，修复后为 `exited cleanly with 1 pending call(s) — not a crash`，数据库无新增 agent_crash。

  Issue: [2689](https://github.com/alibaba/anolisa/issues/2689)
