### PR TITLE
feat(skillfs): supervise sidecar mounts

### DIFF
--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -71,19 +71,54 @@ propagation described below.
 
 ## How the image starts
 
-With no command arguments, the image runs its preflight checks and then starts
-this fixed container lifecycle:
+With no command arguments, the image starts a PID 1 supervisor that runs
+preflight before each attempt and launches a foreground mount worker:
 
 ```text
-skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" \
-  --foreground --allow-other
+skillfs-supervisor
+  └─ skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" --foreground --allow-other
 ```
 
 `SKILLFS_DISCOVER_ROOT` and `SKILLFS_EXTRA_ARGS` add optional mount arguments.
-Do not add `--managed`; the foreground SkillFS process must remain PID 1 so the
-kubelet can restart it and deliver `SIGTERM` directly. Passing command arguments
-to the image replaces the mount command completely, which is why the version
-smoke check works without `/dev/fuse`.
+Do not add `--managed`; the container supervisor owns worker recovery and
+forwards shutdown signals. Passing command arguments to the image replaces
+this lifecycle completely, so the version smoke check needs no `/dev/fuse`.
+
+## Automatic mount recovery
+
+The supervisor reuses `skillfs-mount-probe` to read `SKILLFS_PROBE_FILE` through
+FUSE. After consecutive failures it stops and reaps the worker, uses preflight
+to clear the residual FUSE mount at the configured mountpoint, and starts a new
+worker. One transient failure does not trigger a remount. Keep the probe file
+stable, nonempty, and readable under the deployed visibility policy; deleting
+or hiding it is also treated as a health failure.
+
+Both image variants accept these environment variables:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS` | `2` | Delay between probes |
+| `SKILLFS_SUPERVISOR_FAILURE_THRESHOLD` | `2` | Consecutive runtime failures before recovery |
+| `SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES` | `3` | Consecutive successful runtime probes needed to reset the recovery budget |
+| `SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS` | `30` | Startup health budget, checked after each probe |
+| `SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS` | `10` | Worker stop budget before SIGKILL |
+| `SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS` | `5` | Consecutive failed cycles before the supervisor exits |
+| `SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS` | `1` | Initial retry delay, doubled after each failed cycle |
+| `SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS` | `30` | Maximum retry delay |
+
+Values must be positive; counts and startup/stop budgets must be integers.
+The initial retry delay must not exceed its maximum. With immediate I/O errors,
+default detection takes roughly 2–4 seconds; probe timeouts, worker shutdown,
+cleanup, and startup add to recovery time. Keep kubelet probes enabled: the
+reference liveness probe runs every 5 seconds and restarts after two failures,
+so it can take over before in-container retries are exhausted.
+
+Recovery restores new path opens. It cannot prevent a runtime from invalidating
+FUSE, guarantee uninterrupted reads, or repair already-open handles. Consumers
+must close failed handles and retry fresh opens within a bounded budget. For
+ACS restart validation, restart an unrelated container in a disposable Pod and
+check reads from both the sidecar and workload, recovery logs, and container
+restart counts; local supervisor tests do not validate mount propagation.
 
 ## Required Pod topology
 

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -67,17 +67,49 @@ docker push "$IMAGE"
 
 ## 镜像启动方式
 
-没有传入 command argument 时，镜像先运行 preflight，然后按下面的固定方式启动。
+没有传入 command argument 时，镜像启动 PID 1 supervisor，在每次尝试前运行
+preflight，并启动前台 mount worker：
 
 ```text
-skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" \
-  --foreground --allow-other
+skillfs-supervisor
+  └─ skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" --foreground --allow-other
 ```
 
-`SKILLFS_DISCOVER_ROOT` 和 `SKILLFS_EXTRA_ARGS` 可以追加可选 mount argument。不要
-加入 `--managed`。前台 SkillFS 进程需要保持为 PID 1，让 kubelet 可以重启它，并把
-`SIGTERM` 直接交给进程。给镜像传入 command argument 会完全替换 mount 命令，因此
-版本 smoke check 不需要 `/dev/fuse`。
+`SKILLFS_DISCOVER_ROOT` 和 `SKILLFS_EXTRA_ARGS` 可以追加可选 mount argument。
+不要加入 `--managed`；容器 supervisor 负责 worker 恢复和关停信号转发。给镜像
+传入 command argument 会完全替换这套生命周期，因此版本 smoke check 不需要
+`/dev/fuse`。
+
+## 自动恢复挂载
+
+Supervisor 复用 `skillfs-mount-probe`，通过 FUSE 读取 `SKILLFS_PROBE_FILE`。
+连续失败后，它停止并回收 worker，通过 preflight 清理配置挂载点上的残留 FUSE
+mount，再启动新 worker。单次瞬时失败不会触发 remount。Probe 文件必须稳定、
+非空，并在部署的可见性策略下可读；删除或隐藏该文件也会被视为健康检查失败。
+
+两种镜像都接受以下环境变量：
+
+| 变量 | 默认值 | 含义 |
+| --- | --- | --- |
+| `SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS` | `2` | 两次 probe 之间的等待时间 |
+| `SKILLFS_SUPERVISOR_FAILURE_THRESHOLD` | `2` | 运行期连续失败多少次后恢复 |
+| `SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES` | `3` | 连续成功多少次运行期 probe 后重置恢复预算 |
+| `SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS` | `30` | 启动健康预算，每次 probe 结束后检查 |
+| `SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS` | `10` | 发送 SIGKILL 前的 worker 停止预算 |
+| `SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS` | `5` | 连续失败多少个周期后 supervisor 退出 |
+| `SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS` | `1` | 初始重试等待时间，每次失败周期后翻倍 |
+| `SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS` | `30` | 最大重试等待时间 |
+
+所有值必须为正数；次数及启动、停止预算必须为整数。初始重试等待时间不能超过
+最大值。I/O 立即报错时，默认检测耗时约 2–4 秒；probe 超时、worker 停止、清理
+和启动耗时还需另外计算。保留 kubelet probe：参考 liveness 每 5 秒检查一次，
+连续失败两次后重启，因此可能在容器内重试耗尽前接管恢复。
+
+恢复作用于新的路径打开操作，不能阻止 runtime 使 FUSE 失效、保证读取不中断，
+或修复已打开的旧句柄。消费方必须关闭失败句柄，并在有限预算内重新打开路径。
+验证 ACS 重启行为时，应在可删除的测试 Pod 中重启无关容器，检查 Sidecar 和
+workload 两侧读取、恢复日志及容器 restart count；本地 supervisor 测试不能
+验证 mount propagation。
 
 ## Pod 必需结构
 

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -425,6 +425,10 @@ SkillFS can expose its FUSE view to a non-privileged workload from a privileged
 sidecar. This requires Kubernetes 1.29+, `/dev/fuse`, and permission to run the
 sidecar as privileged.
 
+The sidecar supervisor detects failed FUSE reads and remounts inside the
+container. Its recovery budget is configurable through `SKILLFS_SUPERVISOR_*`;
+see the sidecar guide below for defaults and recovery limits.
+
 ```bash
 cd src/skillfs
 IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -385,6 +385,9 @@ scripts/          build.sh、test.sh 与可选 POSIX harness
 SkillFS 可以通过特权 Sidecar 向非特权工作负载提供 FUSE view。部署需要
 Kubernetes 1.29+、`/dev/fuse`，并允许 Sidecar 使用特权模式。
 
+Sidecar supervisor 检测 FUSE 读取失败，并在容器内重新挂载。可通过
+`SKILLFS_SUPERVISOR_*` 配置恢复预算；默认值和恢复边界见下方 Sidecar 用户指南。
+
 ```bash
 cd src/skillfs
 IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)

--- a/src/skillfs/container/Dockerfile
+++ b/src/skillfs/container/Dockerfile
@@ -1,8 +1,9 @@
 # Dedicated SkillFS FUSE sidecar image.
 #
-# This image runs ONE process: `skillfs mount ... --foreground --allow-other`.
-# It deliberately does not include or start any other ANOLISA service, and it
-# does not depend on systemd or the SkillFS managed-mount supervisor.
+# This image runs one PID 1 supervisor around
+# `skillfs mount ... --foreground --allow-other`. It deliberately does not
+# include or start any other ANOLISA service, and it does not depend on systemd
+# or the SkillFS managed-mount supervisor.
 #
 # Build context: the `src/skillfs` component directory.
 #   docker build -f container/Dockerfile .
@@ -76,7 +77,7 @@ ARG SOURCE_URL=https://github.com/alibaba/anolisa
 # probe scripts use; they are named explicitly rather than assumed from the base
 # image, so a slimmer base cannot silently break startup:
 #
-#   bash                  all three scripts
+#   bash                  all four scripts
 #   coreutils             stat, realpath, id, timeout, wc, install, sleep, head
 #   grep, gawk, sed       fuse.conf and /proc/self/mountinfo parsing
 #   findutils             the example seeding step in the reference manifest
@@ -110,12 +111,14 @@ COPY --from=builder /build/target/release/skillfs /usr/local/bin/skillfs
 COPY container/entrypoint.sh /usr/local/bin/skillfs-sidecar-entrypoint
 COPY container/preflight.sh /usr/local/bin/skillfs-preflight
 COPY container/mount-probe.sh /usr/local/bin/skillfs-mount-probe
+COPY container/supervisor.sh /usr/local/bin/skillfs-supervisor
 
 RUN set -eux; \
     chmod 0755 /usr/local/bin/skillfs \
         /usr/local/bin/skillfs-sidecar-entrypoint \
         /usr/local/bin/skillfs-preflight \
-        /usr/local/bin/skillfs-mount-probe; \
+        /usr/local/bin/skillfs-mount-probe \
+        /usr/local/bin/skillfs-supervisor; \
     skillfs --version
 
 # Defaults match src/skillfs/deploy/kubernetes. Override per deployment.
@@ -132,6 +135,14 @@ ENV SKILLFS_SOURCE=/var/lib/skillfs/source \
     SKILLFS_EXTRA_ARGS="" \
     SKILLFS_PROBE_FILE=skills/skillfs-container-example/SKILL.md \
     SKILLFS_PROBE_TIMEOUT=5 \
+    SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS=2 \
+    SKILLFS_SUPERVISOR_FAILURE_THRESHOLD=2 \
+    SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES=3 \
+    SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS=30 \
+    SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS=10 \
+    SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS=5 \
+    SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS=1 \
+    SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS=30 \
     RUST_LOG=info
 
 LABEL org.opencontainers.image.title="SkillFS FUSE sidecar" \
@@ -142,6 +153,6 @@ LABEL org.opencontainers.image.title="SkillFS FUSE sidecar" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="The Anolisa Authors"
 
-# The entrypoint runs preflight and then `exec`s skillfs, so skillfs becomes
-# PID 1 and receives SIGTERM directly from the kubelet.
+# The entrypoint execs the supervisor as PID 1. It forwards termination signals
+# to the foreground mount worker and performs bounded cleanup before exiting.
 ENTRYPOINT ["/usr/local/bin/skillfs-sidecar-entrypoint"]

--- a/src/skillfs/container/Dockerfile.alinux4
+++ b/src/skillfs/container/Dockerfile.alinux4
@@ -1,8 +1,9 @@
 # Dedicated SkillFS FUSE sidecar image for Alibaba Cloud Linux 4.
 #
-# This image runs ONE process: `skillfs mount ... --foreground --allow-other`.
-# It deliberately does not include or start any other ANOLISA service, and it
-# does not depend on systemd or the SkillFS managed-mount supervisor.
+# This image runs one PID 1 supervisor around
+# `skillfs mount ... --foreground --allow-other`. It deliberately does not
+# include or start any other ANOLISA service, and it does not depend on systemd
+# or the SkillFS managed-mount supervisor.
 #
 # Build context: the `src/skillfs` component directory.
 #   docker build -f container/Dockerfile.alinux4 .
@@ -111,12 +112,14 @@ COPY --from=builder /build/target/release/skillfs /usr/local/bin/skillfs
 COPY container/entrypoint.sh /usr/local/bin/skillfs-sidecar-entrypoint
 COPY container/preflight.sh /usr/local/bin/skillfs-preflight
 COPY container/mount-probe.sh /usr/local/bin/skillfs-mount-probe
+COPY container/supervisor.sh /usr/local/bin/skillfs-supervisor
 
 RUN set -eux; \
     chmod 0755 /usr/local/bin/skillfs \
         /usr/local/bin/skillfs-sidecar-entrypoint \
         /usr/local/bin/skillfs-preflight \
-        /usr/local/bin/skillfs-mount-probe; \
+        /usr/local/bin/skillfs-mount-probe \
+        /usr/local/bin/skillfs-supervisor; \
     skillfs --version
 
 # Defaults match src/skillfs/deploy/kubernetes. Override per deployment.
@@ -133,6 +136,14 @@ ENV SKILLFS_SOURCE=/var/lib/skillfs/source \
     SKILLFS_EXTRA_ARGS="" \
     SKILLFS_PROBE_FILE=skills/skillfs-container-example/SKILL.md \
     SKILLFS_PROBE_TIMEOUT=5 \
+    SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS=2 \
+    SKILLFS_SUPERVISOR_FAILURE_THRESHOLD=2 \
+    SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES=3 \
+    SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS=30 \
+    SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS=10 \
+    SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS=5 \
+    SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS=1 \
+    SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS=30 \
     RUST_LOG=info
 
 LABEL org.opencontainers.image.title="SkillFS FUSE sidecar for Alibaba Cloud Linux 4" \
@@ -143,6 +154,6 @@ LABEL org.opencontainers.image.title="SkillFS FUSE sidecar for Alibaba Cloud Lin
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="The Anolisa Authors"
 
-# The entrypoint runs preflight and then `exec`s skillfs, so skillfs becomes
-# PID 1 and receives SIGTERM directly from the kubelet.
+# The entrypoint execs the supervisor as PID 1. It forwards termination signals
+# to the foreground mount worker and performs bounded cleanup before exiting.
 ENTRYPOINT ["/usr/local/bin/skillfs-sidecar-entrypoint"]

--- a/src/skillfs/container/entrypoint.sh
+++ b/src/skillfs/container/entrypoint.sh
@@ -2,13 +2,9 @@
 #
 # SkillFS sidecar entrypoint.
 #
-# Runs the preflight checks, then `exec`s SkillFS so the FUSE process replaces
-# this shell as PID 1. That is what makes the kubelet's SIGTERM land directly on
-# SkillFS, which unmounts cleanly on its way out.
-#
-# There is deliberately no `sleep infinity`, no retry loop, and no trap that
-# keeps the container alive after SkillFS exits: a dead mount must surface as a
-# container restart, not as a healthy container serving nothing.
+# Builds the fixed foreground-mount command and hands it to the PID 1
+# supervisor. The supervisor performs preflight before every attempt, verifies
+# real I/O through the existing mount probe, and remounts a failed session.
 #
 # Configuration (environment):
 #   SKILLFS_SOURCE      absolute path to the writable skill source root
@@ -50,17 +46,6 @@ fi
 log "skillfs version: $("$SKILLFS_BIN" --version 2>&1 | head -1)"
 log "uid=$(id -u) gid=$(id -g) source=${SOURCE_DIR:-<unset>} mountpoint=${MOUNTPOINT:-<unset>}"
 
-if [[ "${SKILLFS_SKIP_PREFLIGHT:-0}" == "1" ]]; then
-	log "WARNING: SKILLFS_SKIP_PREFLIGHT=1, skipping prerequisite validation"
-else
-	/usr/local/bin/skillfs-preflight
-	preflight_status=$?
-	if ((preflight_status != 0)); then
-		log "FAIL: preflight exited $preflight_status; not starting the mount"
-		exit "$preflight_status"
-	fi
-fi
-
 # Word splitting on SKILLFS_EXTRA_ARGS is intentional: the value is an argument
 # list, not a single argument.
 declare -a extra=()
@@ -68,8 +53,9 @@ if [[ -n "$EXTRA_ARGS" ]]; then
 	read -r -a extra <<<"$EXTRA_ARGS"
 fi
 
-# `--foreground` keeps SkillFS as the container's main process so kubelet owns
-# restart; `--managed` and its detached supervisor must not be used here.
+# `--foreground` keeps SkillFS as a direct child that this container's PID 1
+# supervisor can stop, reap, and restart. The detached `--managed` mode and its
+# separate supervisor must not be used here.
 # `--allow-other` is what lets the Agent container's UID reach the propagated
 # view. Both flags are fixed by the sidecar contract and are not configurable
 # through SKILLFS_EXTRA_ARGS.
@@ -85,5 +71,11 @@ if ((${#extra[@]} > 0)); then
 	cmd+=("${extra[@]}")
 fi
 
-log "exec: ${cmd[*]}"
-exec "${cmd[@]}"
+SUPERVISOR_BIN="${SKILLFS_SUPERVISOR_BIN:-/usr/local/bin/skillfs-supervisor}"
+if [[ "$SUPERVISOR_BIN" != /* || ! -x "$SUPERVISOR_BIN" ]]; then
+	log "FAIL: supervisor '$SUPERVISOR_BIN' must be an executable absolute path"
+	exit 127
+fi
+
+log "supervise: ${cmd[*]}"
+exec "$SUPERVISOR_BIN" "${cmd[@]}"

--- a/src/skillfs/container/preflight.sh
+++ b/src/skillfs/container/preflight.sh
@@ -2,9 +2,9 @@
 #
 # SkillFS sidecar preflight.
 #
-# Validates every prerequisite the foreground FUSE mount needs before the
-# entrypoint `exec`s SkillFS, so a broken Pod fails during container startup
-# with a specific diagnostic instead of a generic mount error.
+# Validates every prerequisite the foreground FUSE worker needs before the
+# sidecar supervisor starts it, so a broken attempt fails with a specific
+# diagnostic instead of a generic mount error.
 #
 # Configuration (environment):
 #   SKILLFS_SOURCE            absolute path to the writable skill source root
@@ -12,6 +12,10 @@
 #   SKILLFS_FUSE_DEVICE       FUSE character device (default /dev/fuse)
 #   SKILLFS_FUSE_CONF         libfuse config file (default /etc/fuse.conf)
 #   SKILLFS_RESIDUAL_UNMOUNT  1 (default) to clear a stale mount, 0 to only report
+#
+# Usage:
+#   skillfs-preflight                 validate all prerequisites and clean residue
+#   skillfs-preflight --cleanup-only  clean only the configured residual mount
 #
 # Exit codes are stable so operators can identify the failed prerequisite:
 #   0   all prerequisites satisfied
@@ -38,6 +42,7 @@ MOUNTPOINT="${SKILLFS_MOUNTPOINT:-}"
 FUSE_DEVICE="${SKILLFS_FUSE_DEVICE:-/dev/fuse}"
 FUSE_CONF="${SKILLFS_FUSE_CONF:-/etc/fuse.conf}"
 RESIDUAL_UNMOUNT="${SKILLFS_RESIDUAL_UNMOUNT:-1}"
+MODE="full"
 
 log() {
 	printf '[skillfs-preflight] %s\n' "$*" >&2
@@ -288,6 +293,11 @@ check_fuse_conf() {
 main() {
 	log "starting preflight as uid=$(id -u) gid=$(id -g)"
 	check_config
+	if [[ "$MODE" == "cleanup-only" ]]; then
+		check_residual_mount
+		log "residual-mount cleanup complete"
+		return 0
+	fi
 	check_fuse_device
 	check_fusermount
 	check_fuse_conf
@@ -295,5 +305,14 @@ main() {
 	check_mountpoint
 	log "all prerequisites satisfied"
 }
+
+case "${1:-}" in
+"") ;;
+--cleanup-only) MODE="cleanup-only" ;;
+*) die "$EX_CONFIG" "unknown argument '$1' (expected --cleanup-only or no arguments)" ;;
+esac
+if (($# > 1)); then
+	die "$EX_CONFIG" "unexpected extra arguments: ${*:2}"
+fi
 
 main "$@"

--- a/src/skillfs/container/supervisor.sh
+++ b/src/skillfs/container/supervisor.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+#
+# PID 1 supervisor for the SkillFS Kubernetes sidecar.
+#
+# The mount command is passed as argv. Health and cleanup deliberately remain
+# in the existing probe and preflight helpers so the container has one source
+# of truth for real-I/O health and residual FUSE handling.
+
+set -uo pipefail
+
+PROBE_BIN="${SKILLFS_SUPERVISOR_PROBE_BIN:-/usr/local/bin/skillfs-mount-probe}"
+PREFLIGHT_BIN="${SKILLFS_SUPERVISOR_PREFLIGHT_BIN:-/usr/local/bin/skillfs-preflight}"
+PROBE_INTERVAL="${SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS:-2}"
+FAILURE_THRESHOLD="${SKILLFS_SUPERVISOR_FAILURE_THRESHOLD:-2}"
+STABLE_HEALTHY_PROBES="${SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES:-3}"
+STARTUP_TIMEOUT="${SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS:-30}"
+STOP_TIMEOUT="${SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS:-10}"
+MAX_FAILED_ATTEMPTS="${SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS:-5}"
+BACKOFF_INITIAL="${SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS:-1}"
+BACKOFF_MAX="${SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS:-30}"
+
+child_pid=""
+sleep_pid=""
+terminating=0
+termination_signal="TERM"
+stable_health=0
+
+log() {
+	printf '[skillfs-supervisor] %s\n' "$*" >&2
+}
+
+die() {
+	log "FAIL: $*"
+	exit 64
+}
+
+is_positive_decimal() {
+	[[ "$1" =~ ^([0-9]+)([.][0-9]+)?$ ]] &&
+		awk -v value="$1" 'BEGIN { exit !(value > 0) }'
+}
+
+is_positive_integer() {
+	[[ "$1" =~ ^[0-9]+$ ]] && ((10#$1 > 0))
+}
+
+decimal_is_at_most() {
+	awk -v value="$1" -v maximum="$2" 'BEGIN { exit !(value <= maximum) }'
+}
+
+validate_helper() {
+	local name="$1"
+	local path="$2"
+	[[ "$path" == /* ]] || die "$name must be an absolute path, got '$path'"
+	[[ -x "$path" ]] || die "$name '$path' is missing or not executable"
+}
+
+validate_config() {
+	(($# > 0)) || die "no mount command supplied"
+	validate_helper SKILLFS_SUPERVISOR_PROBE_BIN "$PROBE_BIN"
+	validate_helper SKILLFS_SUPERVISOR_PREFLIGHT_BIN "$PREFLIGHT_BIN"
+	is_positive_decimal "$PROBE_INTERVAL" ||
+		die "SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS must be positive, got '$PROBE_INTERVAL'"
+	is_positive_integer "$FAILURE_THRESHOLD" ||
+		die "SKILLFS_SUPERVISOR_FAILURE_THRESHOLD must be a positive integer, got '$FAILURE_THRESHOLD'"
+	is_positive_integer "$STABLE_HEALTHY_PROBES" ||
+		die "SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES must be a positive integer, got '$STABLE_HEALTHY_PROBES'"
+	is_positive_integer "$STARTUP_TIMEOUT" ||
+		die "SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS must be a positive integer, got '$STARTUP_TIMEOUT'"
+	is_positive_integer "$STOP_TIMEOUT" ||
+		die "SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS must be a positive integer, got '$STOP_TIMEOUT'"
+	is_positive_integer "$MAX_FAILED_ATTEMPTS" ||
+		die "SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS must be a positive integer, got '$MAX_FAILED_ATTEMPTS'"
+	is_positive_decimal "$BACKOFF_INITIAL" ||
+		die "SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS must be positive, got '$BACKOFF_INITIAL'"
+	is_positive_decimal "$BACKOFF_MAX" ||
+		die "SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS must be positive, got '$BACKOFF_MAX'"
+	decimal_is_at_most "$BACKOFF_INITIAL" "$BACKOFF_MAX" ||
+		die "SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS ($BACKOFF_INITIAL) must not exceed SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS ($BACKOFF_MAX)"
+}
+
+child_is_running() {
+	local running_pid
+	[[ -n "$child_pid" ]] || return 1
+	# Unlike `kill -0`, Bash's running-jobs view excludes an exited child that
+	# has not been waited yet. That distinction prevents zombie workers from
+	# consuming the entire stop timeout or masking an unexpected exit.
+	while read -r running_pid; do
+		[[ "$running_pid" == "$child_pid" ]] && return 0
+	done < <(jobs -pr)
+	return 1
+}
+
+reap_child() {
+	local status=0
+	if [[ -n "$child_pid" ]]; then
+		wait "$child_pid" 2>/dev/null || status=$?
+		log "mount worker pid=$child_pid exited with status $status"
+		child_pid=""
+	fi
+	return "$status"
+}
+
+forward_signal() {
+	termination_signal="$1"
+	terminating=1
+	log "received SIG$termination_signal; stopping without remount"
+	# Avoid child_is_running here: its process substitution changes $! if a
+	# signal interrupts worker or sleeper launch before PID assignment.
+	if [[ -n "$child_pid" ]]; then
+		kill -s "$termination_signal" "$child_pid" 2>/dev/null || true
+	fi
+	if [[ -n "$sleep_pid" ]]; then
+		# Non-interactive background jobs inherit SIGINT as ignored.
+		kill -TERM "$sleep_pid" 2>/dev/null || true
+	fi
+}
+
+trap 'forward_signal TERM' TERM
+trap 'forward_signal INT' INT
+
+sleep_interruptibly() {
+	local duration="$1"
+	local status=0
+	((terminating == 0)) || return 1
+	sleep "$duration" &
+	sleep_pid=$!
+	# The trap can run after launch but before the sleeper PID is recorded.
+	if ((terminating != 0)); then
+		kill -TERM "$sleep_pid" 2>/dev/null || true
+	fi
+	# `wait` is a Bash builtin, so the signal trap runs immediately instead of
+	# being deferred until a long backoff sleep completes. Waiting a second time
+	# reaps the sleeper when the first wait was interrupted by that trap.
+	wait "$sleep_pid" 2>/dev/null || status=$?
+	if ((status > 128)); then
+		wait "$sleep_pid" 2>/dev/null || true
+	fi
+	sleep_pid=""
+	((terminating == 0))
+}
+
+run_preflight() {
+	if [[ "${SKILLFS_SKIP_PREFLIGHT:-0}" == "1" ]]; then
+		log "WARNING: SKILLFS_SKIP_PREFLIGHT=1; skipping preflight"
+		return 0
+	fi
+	log "running preflight before mount attempt"
+	"$PREFLIGHT_BIN"
+}
+
+run_probe() {
+	local mode="$1"
+	local output
+	local status
+	if output="$("$PROBE_BIN" "--$mode" 2>&1)"; then
+		return 0
+	else
+		status=$?
+	fi
+	if [[ -n "$output" ]]; then
+		while IFS= read -r line; do
+			log "probe diagnostic: $line"
+		done <<<"$output"
+	fi
+	return "$status"
+}
+
+start_child() {
+	log "starting mount worker: $*"
+	"$@" &
+	child_pid=$!
+	log "mount worker started pid=$child_pid"
+}
+
+# Stop and reap the worker within a bounded budget. A TERM already forwarded by
+# the signal trap is harmless; repeating it closes the race with child startup.
+stop_child() {
+	local reason="$1"
+	local ticks=$((10#$STOP_TIMEOUT * 10))
+	local tick
+
+	if [[ -z "$child_pid" ]]; then
+		return 0
+	fi
+	if child_is_running; then
+		log "stopping mount worker pid=$child_pid ($reason)"
+		kill -TERM "$child_pid" 2>/dev/null || true
+		for ((tick = 0; tick < ticks; tick++)); do
+			child_is_running || break
+			sleep 0.1 || true
+		done
+	fi
+	if child_is_running; then
+		log "mount worker pid=$child_pid exceeded ${STOP_TIMEOUT}s; sending SIGKILL"
+		kill -KILL "$child_pid" 2>/dev/null || true
+	fi
+	reap_child || true
+}
+
+cleanup_after_stop() {
+	if [[ "${SKILLFS_SKIP_PREFLIGHT:-0}" == "1" ]]; then
+		return 0
+	fi
+	log "running preflight to clear any residual FUSE mount"
+	if ! "$PREFLIGHT_BIN" --cleanup-only; then
+		log "WARNING: post-stop preflight failed; residual mount may require kubelet recovery"
+		return 1
+	fi
+}
+
+# Return 0 only after real I/O succeeds. Probe exit 2 (not mounted) is expected
+# while the first FUSE session is still coming up and consumes the startup
+# timeout rather than the runtime failure threshold.
+wait_until_healthy() {
+	local started_at=$SECONDS
+	local probe_status
+
+	while ((terminating == 0)); do
+		if ! child_is_running; then
+			reap_child || true
+			cleanup_after_stop || true
+			return 1
+		fi
+		if run_probe startup; then
+			log "mount worker pid=$child_pid passed initial real-I/O health check"
+			return 0
+		else
+			probe_status=$?
+			log "startup probe failed with status $probe_status; waiting for mount readiness"
+		fi
+		if ((SECONDS - started_at >= 10#$STARTUP_TIMEOUT)); then
+			log "mount worker pid=$child_pid did not become healthy within ${STARTUP_TIMEOUT}s"
+			stop_child "startup timeout"
+			cleanup_after_stop || true
+			return 1
+		fi
+		sleep_interruptibly "$PROBE_INTERVAL" || return 2
+	done
+	return 2
+}
+
+# Monitor a previously healthy mount. Returns only when it must be remounted or
+# the supervisor is terminating.
+monitor_healthy_child() {
+	local failures=0
+	local healthy_probes=0
+	local probe_status
+	stable_health=0
+
+	while ((terminating == 0)); do
+		sleep_interruptibly "$PROBE_INTERVAL" || return 2
+		if ! child_is_running; then
+			reap_child || true
+			log "healthy mount worker exited unexpectedly; scheduling remount"
+			cleanup_after_stop || true
+			return 1
+		fi
+		if run_probe liveness; then
+			if ((failures > 0)); then
+				log "mount health recovered after $failures failed probe(s)"
+			fi
+			failures=0
+			if ((stable_health == 0)); then
+				((healthy_probes += 1))
+				if ((healthy_probes >= 10#$STABLE_HEALTHY_PROBES)); then
+					stable_health=1
+					log "mount remained healthy for $healthy_probes consecutive liveness probes; recovery failure budget reset"
+				fi
+			fi
+			continue
+		else
+			probe_status=$?
+		fi
+		((failures += 1))
+		healthy_probes=0
+		log "liveness probe failed with status $probe_status ($failures/$FAILURE_THRESHOLD)"
+		if ((failures >= 10#$FAILURE_THRESHOLD)); then
+			log "mount declared unhealthy after $failures consecutive probe failures"
+			stop_child "unhealthy mount"
+			cleanup_after_stop || true
+			return 1
+		fi
+	done
+	return 2
+}
+
+shutdown() {
+	trap - TERM INT
+	stop_child "supervisor shutdown"
+	cleanup_after_stop || true
+	log "shutdown complete after SIG$termination_signal"
+	exit 0
+}
+
+main() {
+	validate_config "$@"
+	local failed_attempts=0
+	local backoff="$BACKOFF_INITIAL"
+	local startup_status
+
+	log "supervision enabled: interval=${PROBE_INTERVAL}s threshold=$FAILURE_THRESHOLD stable_probes=$STABLE_HEALTHY_PROBES startup_timeout=${STARTUP_TIMEOUT}s max_failed_attempts=$MAX_FAILED_ATTEMPTS"
+	while ((terminating == 0)); do
+		if run_preflight; then
+			# A termination signal may arrive while preflight is running. Do not
+			# launch a fresh FUSE worker after the signal has been observed.
+			((terminating == 0)) || break
+			start_child "$@"
+			wait_until_healthy
+			startup_status=$?
+			if ((startup_status == 0)); then
+				monitor_healthy_child
+				startup_status=$?
+				if ((startup_status == 2)); then
+					break
+				fi
+				if ((stable_health == 1)); then
+					failed_attempts=0
+					backoff="$BACKOFF_INITIAL"
+				fi
+			fi
+			if ((startup_status == 2)); then
+				break
+			fi
+		else
+			log "preflight failed with status $?"
+		fi
+
+		((failed_attempts += 1))
+		if ((failed_attempts >= 10#$MAX_FAILED_ATTEMPTS)); then
+			log "FAIL: exhausted $failed_attempts consecutive failed mount attempts"
+			exit 1
+		fi
+		log "mount or recovery cycle failed ($failed_attempts/$MAX_FAILED_ATTEMPTS); retrying in ${backoff}s"
+		sleep_interruptibly "$backoff" || break
+		backoff="$(awk -v current="$backoff" -v maximum="$BACKOFF_MAX" 'BEGIN { value = current * 2; if (value > maximum) value = maximum; print value }')"
+	done
+	shutdown
+}
+
+main "$@"

--- a/src/skillfs/crates/skillfs-cli/tests/sidecar_supervisor_tests.rs
+++ b/src/skillfs/crates/skillfs-cli/tests/sidecar_supervisor_tests.rs
@@ -1,0 +1,531 @@
+//! Process-level tests for the Kubernetes sidecar mount supervisor.
+//!
+//! Fake worker, preflight, and probe executables keep these tests independent
+//! of `/dev/fuse` while exercising the shipped Bash supervisor end to end.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+const WORKER: &str = r#"#!/usr/bin/env bash
+set -uo pipefail
+printf 'start\n' >> "$TEST_STATE/starts"
+date +%s%N >> "$TEST_STATE/start_times"
+start_count="$(wc -l < "$TEST_STATE/starts")"
+trap 'printf "term\n" >> "$TEST_STATE/terms"; exit 0' TERM INT
+touch "$TEST_STATE/worker-ready"
+if [[ "$TEST_SCENARIO" == "exit-once" && "$start_count" == "1" ]]; then
+    sleep 0.15
+    exit 42
+fi
+if [[ "$TEST_SCENARIO" == "exit-always" || "$TEST_SCENARIO" == "exit-always-healthy-probe" ]]; then
+    sleep 0.08
+    exit 42
+fi
+while :; do sleep 0.05; done
+"#;
+
+const PREFLIGHT: &str = r#"#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "${1:-full}" >> "$TEST_STATE/preflights"
+[[ "$TEST_SCENARIO" == "preflight-failure" ]] && exit 1
+exit 0
+"#;
+
+const PROBE: &str = r#"#!/usr/bin/env bash
+set -uo pipefail
+count=0
+if [[ -f "$TEST_STATE/probes" ]]; then
+    count="$(wc -l < "$TEST_STATE/probes")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >> "$TEST_STATE/probes"
+case "$TEST_SCENARIO" in
+sleep-race)
+    for _ in {1..100}; do
+        [[ -f "$TEST_STATE/worker-ready" ]] && exit 0
+        sleep 0.01
+    done
+    exit 2
+    ;;
+delayed-mount)
+    ((count <= 2)) && exit 2
+    ;;
+transient-failure)
+    ((count == 2)) && exit 3
+    ;;
+io-failure)
+    ((count == 2 || count == 3)) && exit 3
+    ;;
+never-healthy)
+    exit 2
+    ;;
+exit-always)
+    exit 2
+    ;;
+esac
+exit 0
+"#;
+
+struct Harness {
+    _temp: tempfile::TempDir,
+    state: PathBuf,
+    supervisor: PathBuf,
+    worker: PathBuf,
+    preflight: PathBuf,
+    probe: PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("test tempdir");
+        let state = temp.path().join("state");
+        fs::create_dir(&state).expect("state dir");
+
+        let supervisor = temp.path().join("supervisor.sh");
+        let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../container/supervisor.sh");
+        fs::copy(source, &supervisor).expect("copy supervisor");
+        make_executable(&supervisor);
+
+        let worker = write_executable(temp.path(), "worker.sh", WORKER);
+        let preflight = write_executable(temp.path(), "preflight.sh", PREFLIGHT);
+        let probe = write_executable(temp.path(), "probe.sh", PROBE);
+
+        Self {
+            _temp: temp,
+            state,
+            supervisor,
+            worker,
+            preflight,
+            probe,
+        }
+    }
+
+    fn command(&self, scenario: &str) -> Command {
+        let mut command = Command::new("bash");
+        command
+            .process_group(0)
+            .arg(&self.supervisor)
+            .arg(&self.worker)
+            .env("PATH", "/usr/bin:/bin")
+            .env("TEST_STATE", &self.state)
+            .env("TEST_SCENARIO", scenario)
+            .env("SKILLFS_SUPERVISOR_PREFLIGHT_BIN", &self.preflight)
+            .env("SKILLFS_SUPERVISOR_PROBE_BIN", &self.probe)
+            .env("SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS", "0.05")
+            .env("SKILLFS_SUPERVISOR_FAILURE_THRESHOLD", "2")
+            .env("SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES", "2")
+            .env("SKILLFS_SUPERVISOR_STARTUP_TIMEOUT_SECONDS", "3")
+            .env("SKILLFS_SUPERVISOR_STOP_TIMEOUT_SECONDS", "1")
+            .env("SKILLFS_SUPERVISOR_MAX_FAILED_ATTEMPTS", "3")
+            .env("SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS", "0.05")
+            .env("SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS", "0.1")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        command
+    }
+
+    fn spawn(&self, scenario: &str) -> SupervisorProcess {
+        SupervisorProcess {
+            child: Some(self.command(scenario).spawn().expect("spawn supervisor")),
+        }
+    }
+
+    fn line_count(&self, name: &str) -> usize {
+        fs::read_to_string(self.state.join(name))
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
+
+    fn start_times(&self) -> Vec<u128> {
+        fs::read_to_string(self.state.join("start_times"))
+            .expect("start timestamps")
+            .lines()
+            .map(|line| line.parse().expect("nanosecond timestamp"))
+            .collect()
+    }
+
+    fn wait_for_lines(&self, name: &str, minimum: usize) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if self.line_count(name) >= minimum {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        panic!(
+            "timed out waiting for {minimum} lines in {name}; observed {}",
+            self.line_count(name)
+        );
+    }
+}
+
+struct SupervisorProcess {
+    child: Option<Child>,
+}
+
+impl SupervisorProcess {
+    fn terminate_and_wait(&mut self) -> ExitStatus {
+        self.signal_and_wait("-TERM")
+    }
+
+    fn signal_and_wait(&mut self, signal: &str) -> ExitStatus {
+        let started = Instant::now();
+        let child = self.child.as_mut().expect("live supervisor");
+        let status = Command::new("kill")
+            .args([signal, &child.id().to_string()])
+            .status()
+            .expect("send shutdown signal");
+        assert!(status.success(), "kill must succeed");
+        let status = self.wait(Duration::from_secs(5));
+        assert!(
+            started.elapsed() < Duration::from_millis(800),
+            "graceful shutdown should reap the worker without consuming the stop timeout"
+        );
+        status
+    }
+
+    fn wait(&mut self, timeout: Duration) -> ExitStatus {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let child = self.child.as_mut().expect("live supervisor");
+            if let Some(status) = child.try_wait().expect("poll supervisor") {
+                // Retain the process-group ID so Drop also cleans up a sleeper
+                // left behind by a supervisor that exited prematurely.
+                return status;
+            }
+            if Instant::now() >= deadline {
+                panic!("supervisor did not exit within {timeout:?}");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for SupervisorProcess {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = Command::new("kill")
+                .args(["-TERM", "--", &format!("-{}", child.id())])
+                .stderr(Stdio::null())
+                .status();
+            for _ in 0..20 {
+                if matches!(child.try_wait(), Ok(Some(_))) {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            let _ = Command::new("kill")
+                .args(["-KILL", "--", &format!("-{}", child.id())])
+                .stderr(Stdio::null())
+                .status();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn write_executable(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write helper");
+    make_executable(&path);
+    path
+}
+
+fn make_executable(path: &Path) {
+    let mut permissions = fs::metadata(path).expect("helper metadata").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("chmod helper");
+}
+
+#[test]
+fn initial_not_mounted_waits_for_health_without_remounting() {
+    let harness = Harness::new();
+    let mut supervisor = harness.spawn("delayed-mount");
+    harness.wait_for_lines("probes", 4);
+
+    assert_eq!(harness.line_count("starts"), 1);
+    assert!(supervisor.terminate_and_wait().success());
+}
+
+#[test]
+fn one_transient_failure_does_not_remount() {
+    let harness = Harness::new();
+    let mut supervisor = harness.spawn("transient-failure");
+    harness.wait_for_lines("probes", 4);
+
+    assert_eq!(harness.line_count("starts"), 1);
+    assert!(supervisor.terminate_and_wait().success());
+}
+
+#[test]
+fn consecutive_io_failures_remount() {
+    let harness = Harness::new();
+    let mut supervisor = harness.spawn("io-failure");
+    harness.wait_for_lines("starts", 2);
+    harness.wait_for_lines("probes", 4);
+
+    assert_eq!(harness.line_count("starts"), 2);
+    assert!(harness.line_count("preflights") >= 2);
+    assert!(
+        fs::read_to_string(harness.state.join("preflights"))
+            .expect("preflight log")
+            .lines()
+            .any(|line| line == "--cleanup-only")
+    );
+    assert!(supervisor.terminate_and_wait().success());
+}
+
+#[test]
+fn unexpected_worker_exit_remounts() {
+    let harness = Harness::new();
+    let started = Instant::now();
+    let mut supervisor = harness.spawn("exit-once");
+    harness.wait_for_lines("starts", 2);
+
+    assert_eq!(harness.line_count("starts"), 2);
+    assert!(
+        started.elapsed() < Duration::from_millis(800),
+        "an exited worker should be reaped and remounted without consuming the stop timeout"
+    );
+    assert!(supervisor.terminate_and_wait().success());
+}
+
+#[test]
+fn sigterm_exits_cleanly_without_respawn() {
+    let harness = Harness::new();
+    let mut supervisor = SupervisorProcess {
+        child: Some(
+            harness
+                .command("healthy")
+                .env("SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS", "5")
+                .spawn()
+                .expect("spawn supervisor"),
+        ),
+    };
+    harness.wait_for_lines("probes", 1);
+    std::thread::sleep(Duration::from_millis(50));
+
+    assert!(supervisor.terminate_and_wait().success());
+    std::thread::sleep(Duration::from_millis(150));
+    assert_eq!(harness.line_count("starts"), 1);
+    assert_eq!(harness.line_count("terms"), 1);
+}
+
+fn shutdown_during_long_sleep(scenario: &str, inject_race: bool) {
+    let harness = Harness::new();
+    // DEBUG runs before PID assignment, making the launch/registration race
+    // deterministic without changing the shipped supervisor script.
+    let bash_env = write_executable(
+        harness._temp.path(),
+        "sleep-hook.sh",
+        r#"set -T
+trap 'if [[ "$BASH_COMMAND" == '\''sleep_pid=$!'\'' && "$duration" == 30 ]]; then
+    printf "%s\n" "$!" >> "$TEST_STATE/sleepers"
+    trap - DEBUG
+    if [[ "$TEST_INJECT_SLEEP_RACE" == 1 ]]; then
+        kill -TERM "$$"
+    fi
+fi' DEBUG
+"#,
+    );
+    let mut supervisor = SupervisorProcess {
+        child: Some(
+            harness
+                .command(scenario)
+                .env("BASH_ENV", bash_env)
+                .env(
+                    "TEST_INJECT_SLEEP_RACE",
+                    if inject_race { "1" } else { "0" },
+                )
+                .env("SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS", "30")
+                .env("SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS", "30")
+                .env("SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS", "30")
+                .spawn()
+                .expect("spawn supervisor"),
+        ),
+    };
+    harness.wait_for_lines("sleepers", 1);
+
+    let status = if inject_race {
+        supervisor.wait(Duration::from_millis(800))
+    } else {
+        supervisor.signal_and_wait("-INT")
+    };
+    assert!(status.success());
+    let expected_workers = usize::from(scenario != "preflight-failure");
+    assert_eq!(harness.line_count("starts"), expected_workers);
+    assert_eq!(harness.line_count("terms"), expected_workers);
+    assert!(
+        fs::read_to_string(harness.state.join("preflights"))
+            .expect("preflight log")
+            .lines()
+            .any(|line| line == "--cleanup-only")
+    );
+    for pid in fs::read_to_string(harness.state.join("sleepers"))
+        .expect("sleeper PIDs")
+        .lines()
+    {
+        assert!(
+            !Path::new("/proc").join(pid).exists(),
+            "sleeper {pid} must be terminated and reaped"
+        );
+    }
+}
+
+#[test]
+fn sigint_interrupts_probe_interval_without_respawn() {
+    shutdown_during_long_sleep("healthy", false);
+}
+
+#[test]
+fn sigint_interrupts_recovery_backoff_without_respawn() {
+    shutdown_during_long_sleep("preflight-failure", false);
+}
+
+#[test]
+fn sigterm_between_sleep_launch_and_pid_assignment_reaps_sleeper() {
+    shutdown_during_long_sleep("sleep-race", true);
+}
+
+#[test]
+fn repeated_failed_starts_exhaust_with_bounded_backoff() {
+    let harness = Harness::new();
+    let started = Instant::now();
+    // Separate retry intervals enough that worker/probe scheduling jitter
+    // cannot dominate the backoff increase being measured.
+    let mut supervisor = SupervisorProcess {
+        child: Some(
+            harness
+                .command("exit-always")
+                .env("SKILLFS_SUPERVISOR_BACKOFF_INITIAL_SECONDS", "0.2")
+                .env("SKILLFS_SUPERVISOR_BACKOFF_MAX_SECONDS", "0.4")
+                .spawn()
+                .expect("spawn supervisor"),
+        ),
+    };
+    let status = supervisor.wait(Duration::from_secs(5));
+
+    assert!(!status.success());
+    assert_eq!(harness.line_count("starts"), 3);
+    let start_times = harness.start_times();
+    let first_gap = start_times[1] - start_times[0];
+    let second_gap = start_times[2] - start_times[1];
+    assert!(
+        started.elapsed() >= Duration::from_millis(120),
+        "failed attempts should be separated by backoff"
+    );
+    assert!(
+        second_gap >= first_gap + 30_000_000,
+        "exponential backoff should increase retry spacing: first={first_gap}ns second={second_gap}ns"
+    );
+    assert!(started.elapsed() < Duration::from_secs(5));
+}
+
+#[test]
+fn rapid_post_start_flapping_exhausts_recovery_budget() {
+    let harness = Harness::new();
+    let started = Instant::now();
+    let mut supervisor = harness.spawn("exit-always-healthy-probe");
+    let status = supervisor.wait(Duration::from_secs(5));
+
+    assert!(!status.success());
+    assert_eq!(harness.line_count("starts"), 3);
+    assert!(started.elapsed() >= Duration::from_millis(120));
+}
+
+#[test]
+fn invalid_numeric_configuration_fails_before_starting_worker() {
+    let harness = Harness::new();
+    let status = harness
+        .command("healthy")
+        .env("SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS", "NaN")
+        .status()
+        .expect("run supervisor");
+
+    assert_eq!(status.code(), Some(64));
+    assert_eq!(harness.line_count("starts"), 0);
+    assert_eq!(harness.line_count("preflights"), 0);
+}
+
+#[test]
+fn cleanup_only_preflight_does_not_require_fuse_device() {
+    let temp = tempfile::tempdir().expect("test tempdir");
+    let source = temp.path().join("source");
+    let mountpoint = temp.path().join("mount");
+    fs::create_dir(&source).expect("source dir");
+    fs::create_dir(&mountpoint).expect("mountpoint dir");
+    let preflight = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../container/preflight.sh");
+
+    let status = Command::new("bash")
+        .arg(preflight)
+        .arg("--cleanup-only")
+        .env("PATH", "/usr/bin:/bin")
+        .env("SKILLFS_SOURCE", source)
+        .env("SKILLFS_MOUNTPOINT", mountpoint)
+        .env("SKILLFS_FUSE_DEVICE", temp.path().join("missing-fuse"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run cleanup-only preflight");
+
+    assert!(status.success());
+}
+
+#[test]
+fn entrypoint_passes_exact_foreground_mount_argv_to_supervisor() {
+    let temp = tempfile::tempdir().expect("test tempdir");
+    let args_file = temp.path().join("args");
+    let skillfs = write_executable(
+        temp.path(),
+        "skillfs",
+        "#!/usr/bin/env bash\n[[ \"${1:-}\" == --version ]] && echo 'skillfs test'\n",
+    );
+    let supervisor = write_executable(
+        temp.path(),
+        "supervisor",
+        "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > \"$TEST_ARGS_FILE\"\n",
+    );
+    let entrypoint = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../container/entrypoint.sh");
+
+    let status = Command::new("bash")
+        .arg(entrypoint)
+        .env("PATH", "/usr/bin:/bin")
+        .env("TEST_ARGS_FILE", &args_file)
+        .env("SKILLFS_BIN", &skillfs)
+        .env("SKILLFS_SUPERVISOR_BIN", &supervisor)
+        .env("SKILLFS_SOURCE", "/source")
+        .env("SKILLFS_MOUNTPOINT", "/mount")
+        .env("SKILLFS_DISCOVER_ROOT", "/discover")
+        .env("SKILLFS_EXTRA_ARGS", "--security --decision-command helper")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run entrypoint");
+
+    assert!(status.success());
+    let args: Vec<_> = fs::read_to_string(args_file)
+        .expect("captured argv")
+        .lines()
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        args,
+        [
+            skillfs.to_string_lossy().into_owned(),
+            "mount".to_owned(),
+            "/source".to_owned(),
+            "/mount".to_owned(),
+            "--foreground".to_owned(),
+            "--allow-other".to_owned(),
+            "--skill-discover-root".to_owned(),
+            "/discover".to_owned(),
+            "--security".to_owned(),
+            "--decision-command".to_owned(),
+            "helper".to_owned(),
+        ]
+    );
+}

--- a/src/skillfs/deploy/kubernetes/20-pod.yaml
+++ b/src/skillfs/deploy/kubernetes/20-pod.yaml
@@ -170,6 +170,16 @@ spec:
           value: skills/skillfs-container-example/SKILL.md
         - name: SKILLFS_PROBE_TIMEOUT
           value: "5"
+        # The in-container supervisor repairs a failed FUSE session before the
+        # slower kubelet liveness probe needs to restart the whole sidecar.
+        - name: SKILLFS_SUPERVISOR_PROBE_INTERVAL_SECONDS
+          value: "2"
+        - name: SKILLFS_SUPERVISOR_FAILURE_THRESHOLD
+          value: "2"
+        # Only a recovery that survives three liveness probes resets the retry
+        # budget, preventing a rapid mount/crash loop from running forever.
+        - name: SKILLFS_SUPERVISOR_STABLE_HEALTHY_PROBES
+          value: "3"
         - name: RUST_LOG
           value: info
       securityContext:


### PR DESCRIPTION
## Why

On ACS, restarting an unrelated container can leave SkillFS running while real FUSE reads fail. Add container-level recovery so a failed mount can be repaired without waiting for a complete sidecar restart.

## What changed

A PID 1 supervisor wraps the existing foreground mount worker and reuses the real-I/O probe and exact residual-FUSE cleanup. Consecutive-failure detection, a stable-health reset window, bounded retry backoff, and signal handling govern recovery. Both Debian and Alibaba Cloud Linux 4 images install the supervisor; bilingual documentation covers configuration and recovery limits.

## Related issue

no-issue: ACS sidecar recovery validation

## User / Agent impact

With immediate I/O errors, default in-container detection takes roughly 2–4 seconds; stopping, cleanup, and startup add to recovery time. Five consecutive failed cycles exhaust the internal budget. The current reference kubelet liveness probe remains at a 5-second interval and two failures and can take over before that budget is exhausted. Remounting restores new path opens; it does not guarantee uninterrupted reads or repair old file handles.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Migration or rollback guidance is needed

PID 1 moves from the worker to the container supervisor. Cleanup remains restricted to the configured residual FUSE mount; foreground/managed CLI behavior and explicit image command overrides are preserved. Both supported images include the required supervisor executable. Real ACS mount propagation and unrelated-container restart recovery still require cluster validation.

## Validation

Linux ARM64, based on main at c6b8063b8:

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`: 1,600 passed, 7 ignored by the existing suite
- `scripts/test.sh`: real FUSE and managed recovery smoke passed
- 13 sidecar supervisor integration tests repeated 10 times
- Regression tests reproduce the original SIGINT delay and launch/PID-registration race, including process-substitution corruption of `$!`
- Bash syntax checks and reference Kubernetes YAML parsing
- Full Alibaba Cloud Linux 4 image build, binary smoke, and default-entrypoint validation
- Debian image build and ACS/ACK cluster restart validation were not run in this revision

## Documentation and rollback

Updated both component READMEs and the English/Chinese Kubernetes sidecar guides with supervisor configuration, lifecycle, and consumer recovery limits. Roll back by deploying the previous image and manifest, or revert this commit and rebuild both images. No persisted state migration is required.
