### PR TITLE
fix(skillfs): tighten sidecar health probes

### DIFF
--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -91,13 +91,22 @@ Edit `src/skillfs/deploy/kubernetes/20-pod.yaml`:
 
 1. replace `skill-source` with your PVC;
 2. remove the example ConfigMap and `seed-example` init container;
-3. set `SKILLFS_PROBE_FILE` to a stable file in the mounted view;
+3. set `SKILLFS_PROBE_FILE` to a stable, non-empty file that remains visible
+   for the lifetime of the mount;
 4. replace the `agent` image and command;
 5. keep `Bidirectional` on the SkillFS mount and `HostToContainer` on the
    workload mount.
 
 The workload readiness probe should read meaningful SkillFS content, not only
 check the directory or run `skillfs --version`.
+
+The reference manifest marks the Pod unready after one failed FUSE read and
+restarts only the SkillFS sidecar after two consecutive liveness failures. The
+single-failure threshold means that a transient probe timeout also immediately
+marks the Pod unready, which may shift traffic under high concurrency. The
+workload intentionally has no liveness probe. After an `EIO` or `ENOTCONN`, a
+consumer must close the failed file descriptor and reopen the file after the
+Pod becomes Ready again.
 
 ## Troubleshoot
 

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -89,13 +89,20 @@ Pod 恢复 Ready 后，重新执行挂载视图验证命令。
 
 1. 将 `skill-source` 替换为自己的 PVC；
 2. 删除示例 ConfigMap 和 `seed-example` init container；
-3. 将 `SKILLFS_PROBE_FILE` 设置为挂载视图中的稳定文件；
+3. 将 `SKILLFS_PROBE_FILE` 设置为挂载视图中在 mount 生命周期内始终可见的稳定非空
+   文件；
 4. 替换 `agent` 镜像和命令；
 5. 保留 SkillFS mount 的 `Bidirectional` 和工作负载 mount 的
    `HostToContainer`。
 
 工作负载 readiness probe 应读取有意义的 SkillFS 内容，不应只检查目录存在或运行
 `skillfs --version`。
+
+参考 manifest 在第一次 FUSE 读取失败后将 Pod 标记为 NotReady，并在连续两次
+liveness 失败后只重启 SkillFS Sidecar。单次失败阈值意味着偶发 probe 超时也会立即
+将 Pod 标记为 NotReady，高并发时可能触发流量切走。工作负载刻意不配置 liveness
+probe。消费方遇到 `EIO` 或 `ENOTCONN` 后必须关闭失败的文件描述符，并在 Pod 恢复
+Ready 后重新打开文件。
 
 ## 故障排查
 

--- a/src/skillfs/deploy/kubernetes/20-pod.yaml
+++ b/src/skillfs/deploy/kubernetes/20-pod.yaml
@@ -208,18 +208,24 @@ spec:
       readinessProbe:
         exec:
           command: ["/usr/local/bin/skillfs-mount-probe", "--readiness"]
-        periodSeconds: 10
-        timeoutSeconds: 10
-        failureThreshold: 3
+        # Remove the Pod from service after the first failed FUSE read. This
+        # probe changes readiness only; it does not restart the sidecar.
+        periodSeconds: 2
+        timeoutSeconds: 5
+        failureThreshold: 1
       # Fails when the FUSE session stops answering, including the hung case
       # where the process is still alive. The startup probe gates this one, so
       # no initialDelaySeconds is needed.
       livenessProbe:
         exec:
           command: ["/usr/local/bin/skillfs-mount-probe", "--liveness"]
-        periodSeconds: 20
-        timeoutSeconds: 10
-        failureThreshold: 3
+        # Restart after two consecutive failed FUSE reads. This 10-second
+        # termination budget is shorter than this Pod's 30-second shutdown
+        # budget so a dead mount cannot leave the container Running indefinitely.
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 2
+        terminationGracePeriodSeconds: 10
       resources:
         requests:
           cpu: 100m
@@ -284,9 +290,9 @@ spec:
               ! ls -1 "$SKILLFS_VIEW" | grep -Fxq skillfs-container-reserve
               timeout 5 grep -q '^name: skillfs-container-reserve$' "$r"
         initialDelaySeconds: 3
-        periodSeconds: 5
+        periodSeconds: 2
         timeoutSeconds: 10
-        failureThreshold: 24
+        failureThreshold: 1
       resources:
         requests:
           cpu: 50m

--- a/src/skillfs/deploy/kubernetes/README.md
+++ b/src/skillfs/deploy/kubernetes/README.md
@@ -42,12 +42,20 @@ virtual `skill-discover/SKILL.md`. It also opens a secondary skill through the
 path advertised by `skill-discover`. Secondary skills stay out of the directory
 listing but remain readable through their advertised paths.
 
+The SkillFS readiness probe removes the Pod from service after one failed FUSE
+read. Its liveness probe restarts the sidecar after two consecutive failures
+and gives that probe-triggered shutdown 10 seconds to finish. The workload has
+no liveness probe, so a broken FUSE view cannot restart the consumer and repeat
+the same failure. Consumers should close failed file descriptors and reopen
+files after the Pod becomes Ready again.
+
 ## Use your own skills
 
 Before using the manifest for a workload:
 
 1. replace `skill-source` with a PVC;
 2. remove the example ConfigMap and `seed-example` init container;
-3. update `SKILLFS_PROBE_FILE`;
+3. update `SKILLFS_PROBE_FILE` to a stable, non-empty file that remains visible
+   for the lifetime of the mount;
 4. replace the `agent` image and command;
 5. keep the shared-volume mount propagation settings unchanged.


### PR DESCRIPTION
## Why

The reference Kubernetes deployment waits too long to mark an unreadable FUSE
view unhealthy and restart the SkillFS sidecar. Consumers also need a clear
recovery contract that avoids restarting the workload for a mount failure.

## What changed

- Mark the Pod unready after the first failed FUSE read.
- Restart the SkillFS sidecar after two consecutive liveness failures.
- Bound probe-triggered sidecar shutdown to 10 seconds.
- Keep the workload readiness-only and document file descriptor reopening.
- Update the deployment README, English and Chinese guides, and changelog.

## Related issue

no-issue: tighten recovery behavior in the published reference deployment

## User / Agent impact

Users adopting the reference manifest get faster readiness loss and sidecar
recovery when the FUSE view becomes unreadable. Workload containers remain
running and must reopen failed file descriptors after the Pod becomes Ready.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change only adjusts health probe timing in the reference manifest. It does
not change privilege boundaries or modify existing custom deployments.

## Validation

- `./scripts/docs-lint.sh`
- `cd src/skillfs && cargo fmt --all -- --check`
- YAML parse and structural assertions for readiness, liveness, privilege, and
  shared tmpfs settings
- `cd src/skillfs && ./scripts/test.sh` (exit 0; the mount test was skipped on
  macOS because `fusermount3` is unavailable)
- Prior Kubernetes 1.36 integration validation with equivalent probe settings:
  an unrelated container restart caused FUSE read failures, then the sidecar
  restarted, remounted the view, and the workload recovered without restarting

## Documentation and rollback

The deployment README and English and Chinese sidecar guides describe the new
probe behavior and consumer recovery contract. Revert this commit or restore
the previous probe values to roll back.
