### PR TITLE
refactor(anolisa): add execution contract

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/execution.rs
+++ b/src/anolisa/crates/anolisa-core/src/execution.rs
@@ -1,0 +1,181 @@
+//! Pure execution contracts shared by lifecycle application services.
+//!
+//! These types separate plan-only requests from apply-ready work while keeping
+//! the planner's existing step vocabulary as the single source of truth.
+
+use crate::planner::{NoOpReason, Plan, PlanNote, Step};
+
+/// Whether a planned lifecycle operation is previewed or applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionIntent {
+    /// Return the planned work without performing side effects.
+    Plan,
+    /// Make the planned work available to an effect executor.
+    Apply,
+}
+
+impl ExecutionIntent {
+    /// Classifies planner output for this execution intent.
+    pub fn prepare(self, plan: Plan) -> PreparedExecution {
+        match plan {
+            Plan::NoOp { reason } => PreparedExecution::NoOp { reason },
+            Plan::Execute { steps, notes } => match self {
+                Self::Plan => PreparedExecution::Preview { steps, notes },
+                Self::Apply => PreparedExecution::Apply { steps, notes },
+            },
+        }
+    }
+}
+
+/// Planner output classified for preview or application.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreparedExecution {
+    /// Facts already satisfy the requested lifecycle intent.
+    NoOp {
+        /// Why no work is required.
+        reason: NoOpReason,
+    },
+    /// Ordered work exposed only for rendering a plan-only request.
+    Preview {
+        /// Planner steps in execution order.
+        steps: Vec<Step>,
+        /// Non-fatal findings attached by the planner.
+        notes: Vec<PlanNote>,
+    },
+    /// Ordered work authorized for an effect executor.
+    Apply {
+        /// Planner steps in execution order.
+        steps: Vec<Step>,
+        /// Non-fatal findings attached by the planner.
+        notes: Vec<PlanNote>,
+    },
+}
+
+/// Terminal classification of an applied command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutcomeStatus {
+    /// The requested work completed without a terminal failure.
+    Completed,
+    /// Some effects completed, but the operation needs reconciliation.
+    Partial,
+    /// The operation failed without reporting partial completion.
+    Failed,
+}
+
+/// Typed terminal result returned by a lifecycle application service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutcome<C> {
+    status: CommandOutcomeStatus,
+    operation_id: Option<String>,
+    changes: Vec<C>,
+    warnings: Vec<String>,
+}
+
+impl<C> CommandOutcome<C> {
+    /// Creates a terminal outcome from domain-specific changes and warnings.
+    pub fn new(
+        status: CommandOutcomeStatus,
+        operation_id: Option<String>,
+        changes: Vec<C>,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self {
+            status,
+            operation_id,
+            changes,
+            warnings,
+        }
+    }
+
+    /// Returns the terminal classification.
+    pub fn status(&self) -> CommandOutcomeStatus {
+        self.status
+    }
+
+    /// Returns the durable operation identifier when one was created.
+    pub fn operation_id(&self) -> Option<&str> {
+        self.operation_id.as_deref()
+    }
+
+    /// Returns the domain-specific objects changed before termination.
+    pub fn changes(&self) -> &[C] {
+        &self.changes
+    }
+
+    /// Returns non-fatal diagnostics accumulated during the operation.
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn executable_plan() -> Plan {
+        Plan::Execute {
+            steps: vec![Step::DownloadVerify],
+            notes: vec![PlanNote::PackageAlreadyAbsent],
+        }
+    }
+
+    #[test]
+    fn plan_intent_preserves_steps_and_notes_for_preview() {
+        assert_eq!(
+            ExecutionIntent::Plan.prepare(executable_plan()),
+            PreparedExecution::Preview {
+                steps: vec![Step::DownloadVerify],
+                notes: vec![PlanNote::PackageAlreadyAbsent],
+            }
+        );
+    }
+
+    #[test]
+    fn apply_intent_preserves_steps_and_notes_for_execution() {
+        assert_eq!(
+            ExecutionIntent::Apply.prepare(executable_plan()),
+            PreparedExecution::Apply {
+                steps: vec![Step::DownloadVerify],
+                notes: vec![PlanNote::PackageAlreadyAbsent],
+            }
+        );
+    }
+
+    #[test]
+    fn no_op_never_becomes_apply_ready() {
+        for intent in [ExecutionIntent::Plan, ExecutionIntent::Apply] {
+            assert_eq!(
+                intent.prepare(Plan::NoOp {
+                    reason: NoOpReason::AlreadyAdopted,
+                }),
+                PreparedExecution::NoOp {
+                    reason: NoOpReason::AlreadyAdopted,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_outcomes_preserve_all_evidence() {
+        for status in [
+            CommandOutcomeStatus::Completed,
+            CommandOutcomeStatus::Partial,
+            CommandOutcomeStatus::Failed,
+        ] {
+            let outcome = CommandOutcome::new(
+                status,
+                Some("op-adopt-1".to_string()),
+                vec!["tokenless"],
+                vec!["service state needs verification".to_string()],
+            );
+
+            assert_eq!(outcome.status(), status);
+            assert_eq!(outcome.operation_id(), Some("op-adopt-1"));
+            assert_eq!(outcome.changes(), &["tokenless"]);
+            assert_eq!(
+                outcome.warnings(),
+                &["service state needs verification".to_string()]
+            );
+        }
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod dependency;
 pub mod distribution;
 pub mod domain;
 pub mod download;
+pub mod execution;
 pub mod executor;
 pub mod facts;
 pub mod feature_flags;
@@ -80,6 +81,7 @@ pub use distribution::{
     ResolveQuery,
 };
 pub use download::{DownloadCache, DownloadError, DownloadedArtifact};
+pub use execution::{CommandOutcome, CommandOutcomeStatus, ExecutionIntent, PreparedExecution};
 pub use feature_flags::FeatureStore;
 pub use health::{
     CheckEnv, CheckOutcome, CheckSpec, CheckStatus, Protocol, ServiceProbes, run_check,


### PR DESCRIPTION
## Why

Lifecycle planning already returns a typed `Plan`, but mutation handlers still classify no-op, preview, apply, and terminal outcomes independently. R3 needs a small CLI-agnostic contract before the `adopt` application-layer pilot can migrate without introducing another step model.

## What changed

- Add `ExecutionIntent` and a pure mapping from the existing planner output to no-op, preview, or apply dispositions.
- Add a generic typed `CommandOutcome` for completed, partial, and failed terminal states.
- Preserve ordered steps, plan notes, operation IDs, typed changes, and warnings with pure unit tests.

## Related issue

closes #2703

Part of #2702.

## User / Agent impact

None. No command handler consumes the new contract yet, so CLI behavior and output remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This adds a source-level API to the unpublished `anolisa-core` workspace crate. It does not add serde contracts, migrate consumers, or change planner, executor, transaction, JSON, or exit-code behavior.

## Validation

Validated on Linux from `src/anolisa`:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- `git diff --check`

The execution contract adds four pure unit tests and performs no host I/O.

## Documentation and rollback

No documentation changed. Revert commit `3501878e` to remove the contract; no data migration or cleanup is required.