### PR TITLE
fix(cosh-ng): block path traversal in readonly

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/lib.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/lib.rs
@@ -38,6 +38,9 @@ mod path_prompt_tests;
 mod question;
 #[path = "raw_input/public.rs"]
 pub mod raw_input;
+#[cfg(test)]
+#[path = "tools/readonly_rules/traversal_tests.rs"]
+mod readonly_traversal_tests;
 #[path = "shell_host/public.rs"]
 pub mod shell_host;
 #[allow(dead_code)]

--- a/src/cosh-ng/crates/cosh-shell/src/tools/broker.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/broker.rs
@@ -130,6 +130,14 @@ mod tests {
 
         assert!(piped.contains("metacharacter"));
         assert!(mutation.contains("allowlist"));
+
+        // Issue #2184 vector-level pin: ANSI-C `$'...'` quoting is denied
+        // by the shell-meta gate before any path check, so the quoting
+        // bypass never reaches the readonly path predicate.
+        for command in ["cat $'/proc/version'", "cat $'/etc/shadow'"] {
+            let err = readonly_tokens(command).unwrap_err();
+            assert!(err.contains("metacharacter"), "{command}: {err}");
+        }
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_compound_tests.rs
@@ -86,6 +86,11 @@ fn build_plan_fails_closed_for_ineligible_shapes() {
         "pwd && echo x > f",
         "pwd && echo $(id)",
         "pwd && echo `id`",
+        // issue #2184 vector-level pin: ANSI-C `$'...'` quoting is
+        // rejected before any path check (rule 5 denies `$`), so the
+        // quoting bypass cannot reach the executor
+        "cat $'/proc/version' && pwd",
+        "cat $'/etc/shadow' && pwd",
         // expansion intent the executor would not honor
         "pwd && echo $HOME",
         // complex shapes

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_rules/evaluator.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_rules/evaluator.rs
@@ -379,11 +379,123 @@ pub fn is_bounded_positive_count(value: &str, max: u32) -> bool {
     count > 0 && count <= max
 }
 
+/// Returns true when the path targets the special kernel filesystems
+/// (`/dev`, `/proc`, `/sys`) under any lexical spelling: the raw prefix
+/// match runs first so a blocked spelling stays blocked even when its
+/// lexical resolution escapes the blocklist (`/proc/../etc` fails
+/// closed), then traversal spellings (`/../proc`, `/./proc`, `//proc`)
+/// are caught by re-matching the lexically normalized form (issue #2184).
+/// Relative spellings (`../proc/version`, `proc/version`) are blocked
+/// cwd-independently — see `first_component_targets_special_dir` — and
+/// a leading `~`/`~user` that a `..` would pop is unresolvable at this
+/// layer (the shell expands it only at execution time), so those
+/// spellings fail closed as well.
+///
+/// `$`-quoting and variable-expansion spellings (`2>$DEV_NULL`,
+/// `$'/proc/self/cmdline'`) are intentionally out of scope: this layer
+/// passes them through, and both automatic-execution chains upstream
+/// intercept them — the broker's `is_shell_meta` hard-denies `$` and
+/// quote characters, and the readonly compound executor's rule 5 rejects
+/// tokens containing `$` or backticks (issue #2184 investigation).
+/// Evaluate-pass / execute-intercept is the division of labor; new
+/// callers must not treat this predicate as a complete sandbox check.
 pub fn is_blocked_special_path(path: &str) -> bool {
+    if has_blocked_special_prefix(path) {
+        return true;
+    }
+    // Unresolvable normalization (a `..` popping a leading `~`) fails
+    // closed.
+    let Some(normalized) = normalize_path_lexically(path) else {
+        return true;
+    };
+    has_blocked_special_prefix(&normalized) || first_component_targets_special_dir(&normalized)
+}
+
+/// Blocks relative spellings whose first surviving component — after
+/// skipping any leading `..` chain — names a special directory
+/// (`../proc/version`, `proc/version`, `./proc/version`). The readonly
+/// executors run with the shell's working directory, so a relative
+/// spelling resolves against whatever the cwd happens to be; this layer
+/// has no filesystem access and no cwd, so it fails closed and refuses
+/// the spelling for every cwd — one of them (`/`, or a child of it when
+/// a `..` chain leads) resolves the spelling into the blocklist.
+/// Accepted cost: an ordinary directory literally named
+/// `proc`/`dev`/`sys` is refused too — the user can still approve the
+/// command interactively.
+fn first_component_targets_special_dir(normalized: &str) -> bool {
+    // After lexical normalization surviving `..` segments can only lead
+    // the path (inner ones are popped by the normalizer).
+    let mut rest = normalized;
+    while let Some(suffix) = rest.strip_prefix("../") {
+        rest = suffix;
+    }
+    if rest == ".." {
+        // Pure traversal with no target component.
+        return false;
+    }
+    matches!(rest.split('/').next(), Some("dev" | "proc" | "sys"))
+}
+
+fn has_blocked_special_prefix(path: &str) -> bool {
     path == "/dev"
         || path.starts_with("/dev/")
         || path == "/proc"
         || path.starts_with("/proc/")
         || path == "/sys"
         || path.starts_with("/sys/")
+}
+
+/// Lexically normalizes `.` / `..` segments and duplicate slashes. Pure
+/// string operation — never touches the filesystem.
+///
+/// Contract:
+/// - Absolute inputs keep the leading `/`; `..` above the root is dropped
+///   (POSIX: `/..` resolves to `/`).
+/// - Relative inputs keep leading `..` segments verbatim: they cannot be
+///   resolved without the working directory.
+/// - A leading `~`/`~user` segment of a relative path expands to a
+///   home directory only when the shell executes the command, so a `..`
+///   that would pop it is unresolvable here: the function returns
+///   `None` and the caller fails closed. A `~` appearing after another
+///   segment is a literal directory name (no shell expansion) and pops
+///   normally.
+/// - Symlink aliases are intentionally not covered: resolving them would
+///   require filesystem access, which this purely lexical pass never
+///   performs by contract.
+fn normalize_path_lexically(path: &str) -> Option<String> {
+    let absolute = path.starts_with('/');
+    let mut segments: Vec<&str> = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            // Empty segments come from leading/duplicate slashes.
+            "" | "." => {}
+            ".." => {
+                let last = segments.last().copied();
+                match last {
+                    Some(seg) if !absolute && segments.len() == 1 && seg.starts_with('~') => {
+                        return None;
+                    }
+                    Some(seg) if seg != ".." => {
+                        segments.pop();
+                    }
+                    _ => {
+                        if !absolute {
+                            // Relative `..` with nothing to pop stays in the path.
+                            segments.push("..");
+                        }
+                    }
+                }
+            }
+            other => segments.push(other),
+        }
+    }
+
+    let joined = if absolute {
+        format!("/{}", segments.join("/"))
+    } else if segments.is_empty() {
+        ".".to_string()
+    } else {
+        segments.join("/")
+    };
+    Some(joined)
 }

--- a/src/cosh-ng/crates/cosh-shell/src/tools/readonly_rules/traversal_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/readonly_rules/traversal_tests.rs
@@ -1,0 +1,130 @@
+//! Path-traversal blocking coverage for issue #2184.
+//!
+//! Declared only from `lib.rs` (the `wrap_tests` pattern) so the cases
+//! stay out of the lib/bin test overlap ratchet
+//! (`scripts/check-test-inventory.sh`): the module is compiled for the
+//! `--lib` target only, while `main.rs` does not declare it.
+
+use crate::tools::readonly_rules::{is_readonly_command, is_safe_readonly_path};
+
+fn tokens(cmd: &str) -> Vec<String> {
+    cmd.split_whitespace().map(String::from).collect()
+}
+
+fn allowed(cmd: &str) -> bool {
+    is_readonly_command(&tokens(cmd))
+}
+
+#[test]
+fn absolute_traversal_spellings_are_blocked() {
+    // Issue #2184: these spellings resolve into /proc, /sys, or /dev at
+    // the OS level but do not carry the blocked prefix verbatim, so a
+    // plain prefix match lets them through.
+    for path in [
+        "/../proc/version",
+        "/./proc/version",
+        "/tmp/../proc/version",
+        "/../dev/urandom",
+        "/../sys/kernel/ostype",
+        "//proc//version",
+        "/proc/../proc/version",
+    ] {
+        assert!(!is_safe_readonly_path(path), "{path}");
+    }
+    assert!(!allowed("cat /../proc/version"));
+    // The `--` separator path checks the blocklist on its own.
+    assert!(!allowed("cat -n -- /../proc/version"));
+}
+
+#[test]
+fn blocked_prefix_spellings_stay_blocked_after_normalization() {
+    // Fail closed: a raw /proc-prefixed spelling stays blocked even when
+    // its lexical resolution escapes the blocklist.
+    assert!(!is_safe_readonly_path("/proc/../etc/hostname"));
+}
+
+#[test]
+fn relative_traversal_into_special_dirs_is_blocked() {
+    // Readonly executors run with the shell's working directory, so when
+    // the cwd is a child of `/`, `../proc/version` resolves into /proc at
+    // the OS level. The blocklist has no cwd and fails closed instead.
+    for path in [
+        "../proc/version",
+        "../../proc/version",
+        "../dev/urandom",
+        "../../sys/kernel/ostype",
+        "../proc",
+        "../foo/../proc/version",
+    ] {
+        assert!(!is_safe_readonly_path(path), "{path}");
+    }
+    assert!(!allowed("cat ../proc/version"));
+}
+
+#[test]
+fn bare_relative_spellings_into_special_dirs_are_blocked() {
+    // Same cwd-independent fail-closed rule as `..`-led spellings: with
+    // cwd=`/` these resolve into the blocklist at the OS level, so the
+    // spelling is refused for every cwd.
+    for path in [
+        "proc/version",
+        "./proc/version",
+        "proc/../proc/version",
+        "dev/urandom",
+        "sys/kernel/ostype",
+        "proc",
+        "dev",
+        "sys",
+    ] {
+        assert!(!is_safe_readonly_path(path), "{path}");
+    }
+    assert!(!allowed("cat proc/version"));
+    assert!(!allowed("cat ./proc/version"));
+}
+
+#[test]
+fn tilde_popping_traversal_fails_closed() {
+    // The shell expands a leading `~` to $HOME only at execution time,
+    // so a `..` that would pop it is unresolvable at this layer; the
+    // spelling is refused rather than normalized into a bare relative
+    // form that might escape the blocklist.
+    for path in [
+        "~/../proc/version",
+        "~root/../proc/version",
+        "~/../../proc/version",
+        "~root/..",
+    ] {
+        assert!(!is_safe_readonly_path(path), "{path}");
+    }
+    assert!(!allowed("cat ~/../proc/version"));
+}
+
+#[test]
+fn traversal_normalization_does_not_over_block() {
+    for path in [
+        "/home/../usr/bin/ls",
+        "/var/log/../lib/foo",
+        "./local/file",
+        "/home/user/x",
+        "usr/../local/file",
+        // Traversal into non-special directories stays allowed.
+        "../notes.txt",
+        "../../tmp/x",
+        // Pure traversal with no target component.
+        "..",
+        "../..",
+        // A leading `~` that no `..` pops stays an ordinary path.
+        "~/notes.txt",
+        "~/.bashrc",
+        "~/foo/../bar",
+        // Component match is exact: a `proc`-prefixed name is not `proc`.
+        "procx/file",
+        // A special name below the first component is not blocked.
+        "local/dev/file",
+    ] {
+        assert!(is_safe_readonly_path(path), "{path}");
+    }
+    assert!(allowed("cat ../notes.txt"));
+    assert!(allowed("cat /home/../usr/bin/ls"));
+    assert!(allowed("cat ~/notes.txt"));
+}


### PR DESCRIPTION
## Why

`is_blocked_special_path` matched `/proc`, `/dev` and `/sys` by raw prefix only, so spellings like `/../proc/version` bypassed the blocklist and were allowed through the readonly auto-execution chain — a real bypass of the readonly safety check.

## What changed

- Paths are normalized lexically (no filesystem access) before matching the special-path blocklist.
- The raw-prefix pass is kept first so the check stays fail-closed for anything normalization cannot resolve.
- `$`-quoting forms remain intercepted upstream by the exec layer; noted in a code comment.

## Related issue

closes #2184

## User / Agent impact

Commands whose path arguments lexically resolve into `/proc`, `/dev` or `/sys` — previously executed via the readonly chain — are now blocked. Legitimate paths are unaffected.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Security tightening: the newly intercepted set is exactly the spellings that lexically resolve into `/proc`, `/dev` or `/sys`, all of which were genuine bypasses before the fix. An anti-false-positive matrix pins legitimate paths that must keep passing.

## Validation

- ECS discriminative two-direction test: bypass reproduces (allowed) on pre-fix code, blocked on fixed code.
- ECS cargo test: 1343 passed (baseline 1340 + 3 new).
- `cargo fmt` and `clippy` clean with zero warnings.

## Documentation and rollback

Single commit — revert it directly to restore the previous matching behavior if ever needed.
