### PR TITLE
fix(cosh-ng): map missing precmd status to -1

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/lifecycle.rs
@@ -38,7 +38,10 @@ pub(super) fn push_shell_exited_event(
     config: &ShellHostConfig,
     exit_status: Option<i32>,
 ) -> io::Result<()> {
-    parser.finish_current_on_exit(exit_status.unwrap_or(0))?;
+    // A shell exit without a waitable status leaves the in-flight command's
+    // outcome unknown; surface the -1 missing-exit sentinel instead of
+    // fabricating success (#2413), matching the ledger contract from #2105.
+    parser.finish_current_on_exit(exit_status.unwrap_or(-1))?;
     parser.events.push(ShellEvent {
         kind: ShellEventKind::ShellExited,
         session_id: config.session_id.clone(),
@@ -96,4 +99,116 @@ pub(super) fn build_shell_host_output(
         journal_path,
         exit_status,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ShellEventKind;
+
+    // #2413: a shell exit without a waitable status (killed by a signal on
+    // the non-EOF shutdown path) leaves the in-flight command's outcome
+    // unknown; defaulting the missing status to success would fabricate a
+    // completed block for it. Fall toward the -1 sentinel instead, aligned
+    // with the ledger missing-exit contract (#2105/PR #2412).
+    #[test]
+    fn missing_shell_exit_status_fails_in_flight_command_with_sentinel() {
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-lifecycle-missing-status-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&work_dir).expect("work dir");
+        let output_ref_dir = work_dir.join("output-refs");
+        std::fs::create_dir_all(&output_ref_dir).expect("output ref dir");
+        let config = ShellHostConfig::new("lifecycle-missing-status", &work_dir);
+        let mut parser = OscParser::new(
+            "lifecycle-missing-status".to_string(),
+            output_ref_dir,
+            "test-marker-token".to_string(),
+        );
+        parser
+            .feed(b"\x1b]1337;COSH;{\"event\":\"preexec\",\"token\":\"test-marker-token\",\"command\":\"sleep 60\",\"cwd\":\"/tmp\"}\x07")
+            .expect("feed preexec");
+
+        push_shell_exited_event(&mut parser, &config, None).expect("shell exited event");
+
+        let failed = parser
+            .events
+            .iter()
+            .find(|event| event.kind == ShellEventKind::CommandFailed)
+            .expect("in-flight command fails on unknown shell exit");
+        assert_eq!(
+            failed.exit_code,
+            Some(-1),
+            "missing shell exit status must surface the sentinel, not success 0"
+        );
+        assert_eq!(failed.command.as_deref(), Some("sleep 60"));
+
+        // The shell's own exit code stays unknown; only the in-flight command
+        // falls toward failure.
+        let exited = parser
+            .events
+            .iter()
+            .find(|event| event.kind == ShellEventKind::ShellExited)
+            .expect("shell exited event");
+        assert_eq!(exited.exit_code, None);
+
+        let _ = std::fs::remove_dir_all(&work_dir);
+    }
+
+    // qoderai #2709 P1: pin the exit-status mapping at both boundaries of
+    // `push_shell_exited_event` — an explicit status flows through verbatim
+    // to both events, while a missing status surfaces the -1 sentinel for
+    // the in-flight command and keeps `ShellExited` itself unknown.
+    #[test]
+    fn shell_exit_status_mapping_pins_explicit_and_missing_boundaries() {
+        for (exit_status, command_kind, command_exit, shell_exit) in [
+            (Some(0), ShellEventKind::CommandCompleted, Some(0), Some(0)),
+            (None, ShellEventKind::CommandFailed, Some(-1), None),
+        ] {
+            let case = exit_status.map_or(
+                "none",
+                |status| {
+                    if status == 0 {
+                        "zero"
+                    } else {
+                        "nonzero"
+                    }
+                },
+            );
+            let work_dir = std::env::temp_dir().join(format!(
+                "cosh-shell-lifecycle-boundary-{case}-{}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&work_dir).expect("work dir");
+            let output_ref_dir = work_dir.join("output-refs");
+            std::fs::create_dir_all(&output_ref_dir).expect("output ref dir");
+            let config = ShellHostConfig::new("lifecycle-boundary", &work_dir);
+            let mut parser = OscParser::new(
+                "lifecycle-boundary".to_string(),
+                output_ref_dir,
+                "test-marker-token".to_string(),
+            );
+            parser
+                .feed(b"\x1b]1337;COSH;{\"event\":\"preexec\",\"token\":\"test-marker-token\",\"command\":\"sleep 60\",\"cwd\":\"/tmp\"}\x07")
+                .expect("feed preexec");
+
+            push_shell_exited_event(&mut parser, &config, exit_status).expect("shell exited event");
+
+            let command = parser
+                .events
+                .iter()
+                .find(|event| event.kind == command_kind)
+                .unwrap_or_else(|| panic!("command finish event for {exit_status:?}"));
+            assert_eq!(command.exit_code, command_exit, "{exit_status:?}");
+            let exited = parser
+                .events
+                .iter()
+                .find(|event| event.kind == ShellEventKind::ShellExited)
+                .expect("shell exited event");
+            assert_eq!(exited.exit_code, shell_exit, "{exit_status:?}");
+
+            let _ = std::fs::remove_dir_all(&work_dir);
+        }
+    }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -343,7 +343,8 @@ impl OscParser {
                 let status = if is_shell_exit_command(&current.command) {
                     0
                 } else {
-                    marker.status.unwrap_or(0)
+                    // Missing status = truncation/forgery/drift (always emitted) → -1, not success (#2413/#2105).
+                    marker.status.unwrap_or(-1)
                 };
                 let output_end = self.clean.position();
                 let output_ref =

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -392,6 +392,43 @@ fn precmd_count_tracks_shell_ready_and_command_events() {
     assert_eq!(parser.precmd_count(), 3);
 }
 
+// #2413: a status-less precmd marker can only be truncated, forged, or
+// protocol-drifted — both generator scripts (marker/bash.rs, marker/zsh.rs)
+// emit `"status":%s` unconditionally with the shell's `$?` value. Defaulting
+// the missing field to success fabricates a CommandCompleted for a command
+// whose real outcome is unknown; fall toward the -1 missing-exit-code
+// sentinel instead, matching the ledger contract from #2105/PR #2412 and the
+// agent host-executed chain.
+#[test]
+fn precmd_marker_without_status_fails_with_missing_exit_sentinel() {
+    let mut parser = parser_for_test("precmd-missing-status");
+    feed_preexec(&mut parser, "echo maybe-truncated");
+    let marker =
+        b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"cwd\":\"/tmp\"}\x07";
+    parser.feed(marker).expect("feed statusless precmd");
+
+    let finished = parser
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.kind,
+                ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+            )
+        })
+        .expect("command finish event");
+    assert_eq!(finished.kind, ShellEventKind::CommandFailed);
+    assert_eq!(finished.exit_code, Some(-1));
+
+    // The ledger keeps the explicit -1 verbatim with a Failed status, so the
+    // live marker path and the journal-replay path agree on missing status.
+    let ledger = build_command_blocks(&parser.events);
+    assert!(ledger.errors.is_empty(), "{:?}", ledger.errors);
+    assert_eq!(ledger.blocks.len(), 1);
+    assert_eq!(ledger.blocks[0].exit_code, -1);
+    assert_eq!(ledger.blocks[0].status, crate::types::CommandStatus::Failed);
+}
+
 #[test]
 fn pending_handoff_origin_is_consumed_by_matching_preexec() {
     let mut parser = parser_for_test("origin-match");

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1166,6 +1166,176 @@ fn shell_host_rejects_forged_osc_markers_without_session_token() {
 }
 
 #[test]
+fn shell_host_pty_statusless_precmd_marker_fails_inflight_command() {
+    // Issue #2413, live-PTY verification: the unit tests feed the parser
+    // directly, but the issue explicitly asks for live-PTY evidence. A real
+    // scripted bash session prints a syntactically valid, token-carrying
+    // precmd marker whose `status` field is omitted (the protocol-drift /
+    // truncation shape) while that printf's own preexec is still in flight;
+    // the host must finish the command as Failed with the -1 missing-exit
+    // sentinel instead of fabricating success. The `toke""n` split keeps
+    // the literal line out of the marker script's secret-redaction patterns
+    // while the shell still prints a well-formed `"token"` key, and
+    // "$COSH_MARKER_TOKEN" expands the session's real token so the
+    // parser's exact-match check accepts the sequence.
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-pty-precmd-driftless-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+
+    let statusless_injection = "printf \"\\033]1337;COSH;{\\\"event\\\":\\\"precmd\\\",\\\"toke\"\"n\\\":\\\"%s\\\",\\\"cwd\\\":\\\"/tmp/driftless-probe\\\"}\\a\" \"$COSH_MARKER_TOKEN\"";
+
+    // The genuine-chain control runs BEFORE the injection: once the forged
+    // precmd has been consumed mid-command, the marker script's own
+    // history/DEBUG-trap state machine treats follow-up queued lines
+    // differently, so the control must not depend on post-injection input.
+    // Isolated mode keeps the host-environment PROMPT_COMMAND/PS1 (e.g. an
+    // audit hook plus a backticked `pwd` prompt on bash 4.2) out of the
+    // session: those make the marker script's DEBUG-trap snapshot logic
+    // clear _COSH_ACTIVE_DEBUG_TRAP after the first prompt, silencing every
+    // later preexec marker and drowning the assertion under environment
+    // noise unrelated to #2413.
+    let mut config = ShellHostConfig::new("pty-precmd-driftless", &work_dir);
+    config.native_mode = false;
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("echo drift-real-probe"),
+            ScriptedInput::user_line(statusless_injection),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    // Discriminating assertion: the status-less precmd must finish its
+    // in-flight printf as Failed with the -1 sentinel, never Completed/0
+    // (the pre-fix behavior from issue #2413).
+    let drifted = output
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.kind,
+                ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+            ) && event
+                .command
+                .as_deref()
+                .is_some_and(|command| command.contains("driftless-probe"))
+        })
+        .expect("drifted injection command finish event");
+    assert_eq!(drifted.kind, ShellEventKind::CommandFailed);
+    assert_eq!(drifted.exit_code, Some(-1));
+
+    // Control: the genuine marker chain keeps reporting real completions
+    // after the drifted sequence.
+    let real = output
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.kind,
+                ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+            ) && event
+                .command
+                .as_deref()
+                .is_some_and(|command| command.contains("drift-real-probe"))
+        })
+        .expect("real command finish event");
+    assert_eq!(real.kind, ShellEventKind::CommandCompleted);
+    assert_eq!(real.exit_code, Some(0));
+
+    // The ledger agrees: the drifted command lands as a Failed block with
+    // the -1 sentinel, matching the journal-replay contract (#2105/PR
+    // #2412).
+    let ledger = build_command_blocks(&output.events);
+    assert!(ledger.errors.is_empty(), "{:?}", ledger.errors);
+    let drifted_block = ledger
+        .blocks
+        .iter()
+        .find(|block| block.command.contains("driftless-probe"))
+        .expect("drifted command block");
+    assert_eq!(drifted_block.exit_code, -1);
+    assert_eq!(
+        drifted_block.status,
+        cosh_shell::types::CommandStatus::Failed
+    );
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn shell_host_pty_statusful_precmd_marker_completes_inflight_command() {
+    // Control for the #2413 live-PTY verification: the same injection
+    // mechanism carrying an explicit status:0 must finish the in-flight
+    // printf as Completed/0 on both the fixed and the pre-fix code — this
+    // proves the drift verdict above comes from the missing status field,
+    // not from the injection harness itself.
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-pty-precmd-driftzero-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    std::fs::create_dir_all(&work_dir).expect("work dir");
+
+    let status_zero_injection = "printf \"\\033]1337;COSH;{\\\"event\\\":\\\"precmd\\\",\\\"toke\"\"n\\\":\\\"%s\\\",\\\"cwd\\\":\\\"/tmp/drift-zero-probe\\\",\\\"status\\\":0}\\a\" \"$COSH_MARKER_TOKEN\"";
+
+    // Isolated mode, same rationale as the driftless case above.
+    let mut config = ShellHostConfig::new("pty-precmd-driftzero", &work_dir);
+    config.native_mode = false;
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::user_line("echo drift-real-probe"),
+            ScriptedInput::user_line(status_zero_injection),
+        ],
+    )
+    .expect("scripted bash pty");
+
+    let status_zero = output
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.kind,
+                ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+            ) && event
+                .command
+                .as_deref()
+                .is_some_and(|command| command.contains("drift-zero-probe"))
+        })
+        .expect("status-zero injection command finish event");
+    assert_eq!(status_zero.kind, ShellEventKind::CommandCompleted);
+    assert_eq!(status_zero.exit_code, Some(0));
+
+    let real = output
+        .events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.kind,
+                ShellEventKind::CommandCompleted | ShellEventKind::CommandFailed
+            ) && event
+                .command
+                .as_deref()
+                .is_some_and(|command| command.contains("drift-real-probe"))
+        })
+        .expect("real command finish event");
+    assert_eq!(real.kind, ShellEventKind::CommandCompleted);
+    assert_eq!(real.exit_code, Some(0));
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
 fn shell_host_zsh_adapter_emits_shared_command_events() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
## Why

A precmd marker without a `status` field defaulted to exit 0 and emitted `CommandCompleted`, fabricating success for unknown outcomes (truncated markers, forged markers, killed in-flight commands). This violates the ledger contract from #2412/#2105 where a missing exit code must not degrade into success.

## What changed

- Missing `status` in a precmd marker now maps to the `-1` sentinel instead of 0.
- Both live producers are covered: the osc.rs marker path and the killed in-flight path in lifecycle.rs.
- Normal flows always carry a status — verified against the bash/zsh templates, which emit it unconditionally; a missing status only occurs for truncated/forged markers or killed shells.

## Related issue

closes #2413

## User / Agent impact

Only the abnormal path changes: commands with unknown outcomes now surface as `-1` (failure sentinel) in the ledger instead of a fabricated `0`. Hook authors whose `exit_codes` allowlist assumes `0` should account for `-1`.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Behavior change confined to the abnormal path; ledger integrity improves (failure no longer degrades to success). The two same-family sites (bootstrap.rs / readonly_compound.rs) were audited and are not status-decision sources.

## Validation

- ECS cargo test: 1342 passed (baseline 1340 + 2 new).
- Live-PTY integration test with two-direction evidence: old code reproduces the fabricated-success bug, new code passes, and a statusful control case confirms no regression.
- After rebase, confirmed the upstream osc.rs refactor leaves no third producer.

## Documentation and rollback

Single commit — revert it directly.
