### PR TITLE
fix(cosh-ng): accept quoted dev null as sink

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/lib.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/lib.rs
@@ -3,6 +3,9 @@ pub mod adapter;
 #[path = "agent/public.rs"]
 pub mod agent;
 mod command;
+#[cfg(test)]
+#[path = "tools/command_risk_quoted_tests.rs"]
+mod command_risk_quoted_tests;
 #[allow(dead_code, unused_imports)]
 mod config;
 #[allow(dead_code, unused_imports)]

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_build.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_build.rs
@@ -507,6 +507,11 @@ pub(super) fn basename(program: &str) -> &str {
 /// null-suppression redirections (issue #1667): append the informational
 /// reason and keep the execution boundary unchanged. Risk itself is fully
 /// decided by the shape/segment assessment paths.
+///
+/// Note (issue #1752): this policy deliberately keeps null-redirection
+/// commands at AskUser — the issue's auto-approve request was not granted
+/// by that fix; adjusting the Layer 2 suppression policy is a separate
+/// discussion, see #1752.
 pub(super) fn apply_null_redirection_policy(result: &mut CommandAssessment) {
     result.reasons.push("output-suppressed");
     result.reasons = dedupe_reasons(std::mem::take(&mut result.reasons));

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_parser.rs
@@ -3,17 +3,20 @@ use super::command_risk::CommandShape;
 /// Non-persistent output-suppression sink allowlist (issue #1667
 /// implementation boundaries): a `[N]>` / `[N]>>` redirection is treated
 /// as output suppression instead of a filesystem write only when the
-/// target is an unquoted, non-expanded literal from this table. The fd
-/// words `[N]>&1` / `[N]>&2` (duplication onto the conventional output
-/// targets) and `[N]>&-` (close) are exempted by policy as descriptor
-/// operations, not filesystem writes; see the fd word probe in
-/// `parse_command` for the policy rationale (issue #2054, spec
-/// `shell-fd-dup-redirection-risk`). Every other form (regular files,
-/// quoted or expanded targets, other numeric targets, `&>`, `>&file`,
-/// bash's move form `[N]>&M-`) keeps the fail-closed RedirectionWrite
-/// high-risk path. Extending this table requires revisiting the issue
-/// #1667 boundaries and the decision-matrix tests in
-/// `command_risk_tests.rs`.
+/// target is an unquoted, non-expanded literal from this table, or a
+/// whole-word quoted form of such a literal (`2>'/dev/null'`,
+/// `2>"/dev/null"`, issue #1752 — quotes around a sink entry cannot
+/// introduce expansion because the entries contain no `$`, backtick or
+/// backslash). The fd words `[N]>&1` / `[N]>&2` (duplication onto the
+/// conventional output targets) and `[N]>&-` (close) are exempted by
+/// policy as descriptor operations, not filesystem writes; see the fd
+/// word probe in `parse_command` for the policy rationale (issue #2054,
+/// spec `shell-fd-dup-redirection-risk`). Every other form (regular
+/// files, expanded or partially quoted targets, other numeric targets,
+/// `&>`, `>&file`, bash's move form `[N]>&M-`) keeps the fail-closed
+/// RedirectionWrite high-risk path. Extending this table requires
+/// revisiting the issue #1667 boundaries and the decision-matrix tests
+/// in `command_risk_tests.rs`.
 const SAFE_OUTPUT_SINKS: &[&str] = &["/dev/null"];
 
 /// Segment separator kind recorded at each `&&`/`||`/`;`/newline break.
@@ -257,6 +260,80 @@ pub(super) fn parse_command(command: &str) -> ParsedCommand {
                 {
                     lookahead.next();
                     consumed += 1;
+                }
+                // Issue #1752: a target whose whole word is single- or
+                // double-quoted (`2>'/dev/null'`, `2>"/dev/null"`) still
+                // undergoes quote removal to the literal sink path —
+                // quotes cannot introduce expansion for a SAFE_OUTPUT_SINK
+                // entry, whose bytes contain no `$`, backtick or backslash
+                // — so it joins the null-suppression channel like the
+                // unquoted form. Only this exact whole-word form is
+                // exempted: the closing quote must end the word (a suffix
+                // like `'/dev/null'x` concatenates into a different path,
+                // and `{`/`}` are not word boundaries in the
+                // redirection-word position) and the dequoted content must
+                // match the allowlist byte-for-byte, so expanded
+                // (`"$F"`), suffixed, and non-sink quoted targets keep the
+                // fail-closed path below byte-for-byte.
+                if !guarded {
+                    if let Some(&quote_ch) = lookahead.peek() {
+                        if matches!(quote_ch, '\'' | '"') {
+                            let mut quoted_scan = lookahead.clone();
+                            let mut quoted_consumed = 0usize;
+                            quoted_scan.next();
+                            quoted_consumed += 1;
+                            let mut quoted_target = String::new();
+                            let mut quote_closed = false;
+                            while let Some(&next) = quoted_scan.peek() {
+                                if next == quote_ch {
+                                    quoted_scan.next();
+                                    quoted_consumed += 1;
+                                    quote_closed = true;
+                                    break;
+                                }
+                                if matches!(
+                                    next,
+                                    ' ' | '\t'
+                                        | '\n'
+                                        | ';'
+                                        | '|'
+                                        | '&'
+                                        | '<'
+                                        | '>'
+                                        | '('
+                                        | ')'
+                                        | '{'
+                                        | '}'
+                                ) {
+                                    break;
+                                }
+                                quoted_target.push(next);
+                                quoted_scan.next();
+                                quoted_consumed += 1;
+                            }
+                            // Keep the workspace Rust 1.74 MSRV;
+                            // `Option::is_none_or` is newer.
+                            #[allow(clippy::unnecessary_map_or)]
+                            let word_ends = quote_closed
+                                && quoted_scan.peek().map_or(true, |next| {
+                                    matches!(
+                                        next,
+                                        ' ' | '\t' | '\n' | ';' | '|' | '&' | '<' | '>' | '(' | ')'
+                                    )
+                                });
+                            if word_ends && SAFE_OUTPUT_SINKS.contains(&quoted_target.as_str()) {
+                                if fd_candidate {
+                                    token.clear();
+                                    token_quoted = false;
+                                }
+                                for _ in 0..consumed + quoted_consumed {
+                                    chars.next();
+                                }
+                                null_redirections += 1;
+                                continue;
+                            }
+                        }
+                    }
                 }
                 let mut target = String::new();
                 let mut literal = true;

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_quoted_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_quoted_tests.rs
@@ -1,0 +1,98 @@
+//! Quoted SAFE_OUTPUT_SINK redirection coverage for issue #1752.
+//!
+//! Declared only from `lib.rs` (the `wrap_tests` pattern) so the cases
+//! stay out of the lib/bin test overlap ratchet
+//! (`scripts/check-test-inventory.sh`): the module is compiled for the
+//! `--lib` target only, while `main.rs` does not declare it.
+
+use crate::tools::command_risk::{
+    assess_shell_command, AssessmentPolicy, AssessmentSource, CommandAssessment, ExecutionDecision,
+    RiskImpact,
+};
+
+fn auto(command: &str) -> CommandAssessment {
+    assess_shell_command(
+        command,
+        AssessmentPolicy::auto_with_guarded_diagnostics(AssessmentSource::ProviderShellTool),
+    )
+}
+
+fn ask(command: &str) -> CommandAssessment {
+    assess_shell_command(
+        command,
+        AssessmentPolicy::ask(AssessmentSource::ProviderShellTool),
+    )
+}
+
+#[test]
+fn quoted_safe_output_sink_redirection_is_null_suppression() {
+    // Issue #1752: an agent-emitted stderr suppression whose target word
+    // is wholly quoted (`2>"/dev/null"`, `2>'/dev/null'`) undergoes quote
+    // removal to the same literal sink path as the unquoted form — the
+    // SAFE_OUTPUT_SINK entries contain no `$`, backtick or backslash, so
+    // the quotes cannot introduce expansion — and must join the issue
+    // #1667 null-suppression channel instead of the fail-closed
+    // RedirectionWrite path.
+    for command in [
+        "ps aux 2>\"/dev/null\"",
+        "ps aux 2>'/dev/null'",
+        "cat x 2>>\"/dev/null\"",
+        "cat x 2>>'/dev/null'",
+        "du -sh /var 2> '/dev/null'",
+        "ls >\"/dev/null\"",
+        "ls 1>'/dev/null'",
+        "find /tmp -maxdepth 3 -name '*cosh*' 2>\"/dev/null\"",
+    ] {
+        let assessment = ask(command);
+        assert_ne!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            !assessment.reasons.contains(&"redirection-write"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+        assert!(
+            assessment.reasons.contains(&"output-suppressed"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
+
+    // V-TOK, asserted at the assessment layer: `parse_command` and
+    // `ParsedCommand` are `pub(super)`, unreachable from a lib-root
+    // module, so the no-leak guarantee (the fd word and the quoted
+    // target never enter argv; the sink is counted as a null
+    // redirection) is pinned through its observable effects instead —
+    // `output-suppressed` present proves the null-redirection count,
+    // and any argv leak would leave a plain auto-allowable command and
+    // flip the V-M10 boundary assertion below.
+    let auto_policy = auto("ps aux 2>\"/dev/null\"");
+    assert_eq!(auto_policy.execution, ExecutionDecision::AskUser);
+    assert!(auto_policy.auto_allow.is_none());
+}
+
+#[test]
+fn quoted_non_sink_redirection_targets_stay_fail_closed() {
+    // Issue #1752 narrows the issue #1667 V-M8 fail-closed rule only for
+    // whole-word quoted SAFE_OUTPUT_SINK targets. Every other quoted
+    // target keeps the RedirectionWrite classification: regular files,
+    // expansion, and suffix concatenation (`'/dev/null'x` builds the
+    // different word `/dev/nullx` in every shell).
+    for command in [
+        "cat log 2>\"/tmp/evil\"",
+        "cat log 2>'/tmp/evil'",
+        "cat log 2>\"$F\"",
+        "cat log 2>$FILE",
+        "cat log 2>'/dev/null'x",
+        "cat log 2>'/dev/nul*'",
+        "ls 2>' /dev/null'",
+        "ls &>'/dev/null'",
+    ] {
+        let assessment = ask(command);
+        assert_eq!(assessment.impact, RiskImpact::High, "{command}");
+        assert!(
+            assessment.reasons.contains(&"redirection-write"),
+            "{command}: {:?}",
+            assessment.reasons
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/tools/command_risk_tests.rs
@@ -903,11 +903,14 @@ fn redirection_fail_closed_paths_stay_high() {
     assert_eq!(write.impact, RiskImpact::High);
     assert!(write.reasons.contains(&"redirection-write"));
 
-    // V-M8: quoted or expanded targets fail closed.
+    // V-M8 (narrowed by issue #1752): expanded and non-sink quoted
+    // targets fail closed. Whole-word quoted safe sinks
+    // (`cat log 2>'/dev/null'`) moved to the null-suppression channel —
+    // see `command_risk_quoted_tests` (lib-only test module).
     for command in [
         "cat log 2>\"$F\"",
-        "cat log 2>'/dev/null'",
         "cat log 2>$FILE",
+        "cat log 2>\"/tmp/evil\"",
     ] {
         let assessment = ask(command);
         assert_eq!(assessment.impact, RiskImpact::High, "{command}");


### PR DESCRIPTION
## Why

A quoted redirect target such as `2>"/dev/null"` was classified as a filesystem write (`redirection-write`) instead of a null sink, so the approval card showed a misleading reason even though the unquoted form was already classified correctly (#1667).

## What changed

- Fully quoted `SAFE_OUTPUT_SINKS` targets are now recognized as null redirections.
- Every other quoted form stays fail-closed (unchanged).
- `apply_null_redirection_policy` still resolves to `AskUser` — noted in a code comment. Layer 2 (auto-approving null redirections) is intentionally out of scope and remains a separate discussion.

## Related issue

Refs #1752 (not closing): this PR only fixes the Layer 1 misclassification; the issue's full auto-approve request is not resolved here.

## User / Agent impact

The approval-card reason/impact for quoted null redirections now reads as a null redirection instead of redirection-write, aligning with the unquoted behavior from #1667. The execution decision (AskUser) is unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Execution decision is identical before and after (AskUser); only the approval-card reason/impact changes. Low risk.

## Validation

- ECS discriminative two-direction test: misclassification reproduces on pre-fix code, correct classification on fixed code.
- ECS cargo test: 1342 passed (baseline 1340 + 2 new).
- `cargo fmt` and `clippy` clean with zero warnings.

## Documentation and rollback

Single commit — revert it directly.
