### PR TITLE
docs(tokenless): clarify compression threshold

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -40,6 +40,26 @@ cat response.json | tokenless compress-response
 - JSON commands require valid JSON.
 - If compression does not reduce the estimated token count, the CLI explains this on stderr and returns the original.
 
+### Minimum useful payload
+
+`compress-schema` and `compress-response` have no fixed minimum input size. For
+every accepted valid JSON input, the CLI builds a candidate and estimates both
+versions as one token per CJK character plus one token per four other characters,
+rounded up. In active mode, it emits the candidate only when its estimate is strictly
+lower than the original (`after < before`). Otherwise stdout receives the original
+input, stderr reports `did not reduce size`, and no statistics record is written.
+In dry-run mode (`TOKENLESS_COMPRESSION_ENABLED=0` or
+`compression_enabled=false`), stdout always receives the original input; a smaller
+candidate is recorded as a predicted saving when statistics or SLS recording is enabled.
+
+The break-even point therefore depends on content and JSON shape, not only on
+bytes or characters. A small payload with a removable field can compress, while
+a larger already-compact payload can pass through unchanged. The description,
+string, array, and depth thresholds below only decide when individual
+transformations run; they are not minimum total payload sizes. Agent adapters
+can apply separate pre-spawn size gates; see
+[Adapter processing rules](framework-integration.md#adapter-processing-rules).
+
 ## `compress-schema`
 
 Compress one OpenAI Function Calling schema:

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -40,6 +40,22 @@ cat response.json | tokenless compress-response
 - JSON 相关命令要求输入为合法 JSON。
 - 压缩后没有 Token 收益时，CLI 向 stderr 说明原因，并输出原文。
 
+### 最小有效 Payload
+
+`compress-schema` 和 `compress-response` 没有固定的最小输入大小。对于每个通过输入
+规则的合法 JSON，CLI 都会生成候选结果，并用同一个启发式规则估算两者的 Token 数：每个 CJK
+字符计一个 Token，其他字符每四个计一个 Token 并向上取整。在 Active 模式下，只有候选结果的
+估算值严格小于原文（`after < before`）时才会输出候选结果；否则 stdout 输出原文，stderr
+报告 `did not reduce size`，且不写入统计记录。在 Dry-run 模式
+（`TOKENLESS_COMPRESSION_ENABLED=0` 或 `compression_enabled=false`）下，stdout 始终输出
+原文；候选结果更小时，如果已启用 Stats 或 SLS 记录，则把它记为预测节省。
+
+因此，盈亏平衡点取决于内容和 JSON 结构，而不只取决于字节数或字符数。包含可移除字段
+的小 Payload 仍可能被压缩，而已经紧凑的较大 Payload 也可能原样透传。下文的描述、
+字符串、数组和深度阈值只决定单项转换何时触发，并不是整个 Payload 的最小大小。
+Agent Adapter 还可能在启动 CLI 前应用独立的大小门槛，详见
+[Adapter 处理规则](framework-integration.md#adapter-处理规则)。
+
 ## `compress-schema`
 
 压缩单个 OpenAI Function Calling Schema：

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -62,7 +62,13 @@ tokenless only removes redundancy from **tool call responses** before they enter
 ### Where it pays little or doesn't apply
 
 - **Chat-heavy / few tool calls**: tool-response share is tiny, overall savings approach 0.
-- **Already-short responses**: when `after >= before`, the CLI emits the original and records no stats (expected).
+- **No fixed minimum payload**: `compress-schema` and `compress-response` build a
+  candidate for every accepted valid JSON input. In active mode, they emit it only
+  when its estimated token count is strictly lower than the original. A small input
+  with removable content can still compress, while a larger already-compact input can
+  pass through unchanged; the CLI writes the reason to stderr and records no stats.
+  In dry-run mode, the CLI always emits the original and may record a smaller candidate
+  as a predicted saving.
 - **Model inference tokens / billed tokens**: outside what tokenless touches.
 
 ### Estimating the effect
@@ -231,6 +237,14 @@ For a meaningful comparison, pass a dry-run session first and an active
 Tokenless session second.
 
 ## CLI Usage
+
+The standalone `compress-schema` and `compress-response` commands use this
+content-dependent savings check rather than a fixed byte or character minimum.
+The description, string, array, and depth limits in the
+[CLI reference](../../docs/user-guide/en/token-saving/tokenless/cli-reference.md)
+trigger individual transformations; they are not minimum total payload sizes.
+Agent adapters may apply separate pre-check thresholds; see the
+[framework integration guide](../../docs/user-guide/en/token-saving/tokenless/framework-integration.md#adapter-processing-rules).
 
 ### compress-schema
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -34,7 +34,14 @@ tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不�
 ### 哪些场景收益低或不适用
 
 - **纯对话/少工具调用**：工具响应占比极低，整体节省接近 0。
-- **响应本就短小**：压缩后 `after >= before`，CLI 输出原文且不记录统计（属正常）。
+- **没有固定最小 Payload**：`compress-schema` 和 `compress-response` 会为每个通过输入
+  规则的合法 JSON 生成候选结果。在 Active 模式下，只有候选结果的估算 Token 数严格少于原文时
+  才输出它。包含可移除内容的小输入仍可能被压缩，而已经紧凑的较大输入也可能原样透传；CLI 会把
+  原因写入 stderr，且不记录统计。在 Dry-run 模式下，CLI 始终输出原文，并可能把较小的候选结果
+  记为预测节省。[CLI 参考](../../docs/user-guide/zh/token-saving/tokenless/cli-reference.md)
+  中的描述、字符串、数组和深度阈值只决定单项转换何时触发，并不是整个 Payload 的最小大小；
+  Agent Adapter 还可能应用独立的
+  [预检门槛](../../docs/user-guide/zh/token-saving/tokenless/framework-integration.md#adapter-处理规则)。
 - **模型推理 token / 计费 token**：不在 tokenless 经手范围。
 
 ### 预期效果估算


### PR DESCRIPTION
## Why

The standalone `compress-schema` and `compress-response` commands return the original input when a compression candidate does not reduce the estimated token count. Existing documentation mentioned the fallback but did not explain that there is no fixed minimum payload size, leaving small-payload behavior ambiguous.

## What changed

Clarified the component README and bilingual CLI reference to document the content-dependent `after < before` gate, the token-estimation heuristic, and the no-savings output and statistics behavior. Distinguished standalone CLI transformation thresholds from adapter-specific pre-spawn size gates.

## Related issue

no-issue: documents existing CLI behavior

## User / Agent impact

Users can determine why small or already-compact payloads pass through unchanged and avoid treating per-rule or adapter thresholds as a universal CLI minimum.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Documentation-only clarification of existing behavior; no runtime contract or output changed. Low risk.

## Validation

- `python3 scripts/docs-link-check.py`
- `git diff upstream/main...HEAD --check`
- `cargo test --locked -p tokenless-runtime no_savings_returns_original`
- `cargo test --locked -p tokenless-runtime schema_no_savings_rolls_back_stash`
- `cargo test --locked -p tokenless-stats tokenizer`
- `cargo test --locked -p tokenless-cli compress_response_no_savings_rolls_back_orphan_stash`
- `cargo test --locked -p tokenless-cli compress_schema_no_savings_rolls_back_orphan_stash`

Validated on Linux from `src/tokenless`.

## Documentation and rollback

Updated the Tokenless component README and the English and Chinese CLI references. Revert commit `d828e372` to roll back the documentation change.