### PR TITLE
refactor(anolisa): add adopt application layer

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -1,46 +1,24 @@
 //! `anolisa adopt <component>` — take an already-installed system RPM under
 //! ANOLISA tracking as a delegated-adopted record.
 //!
-//! The handler is a thin shell over the planner pipeline (decision table
-//! A1–A7): resolve the component to its RPM package, assemble host facts,
-//! and execute the planner's step sequence. Adoption fetches nothing and
-//! runs no `dnf`/`rpm` transaction — a fresh adopt observes rpmdb and writes
-//! the record (A1); re-adopting an observed component upgrades the
-//! management consent in place without refreshing the cached observation
-//! (A6); an already-adopted component is a NoOp (A7). Ambiguous, absent, or
-//! differently-owned components are refused with guidance toward the right
-//! command.
+//! The command handler maps CLI input into the lifecycle application layer
+//! and renders its typed outcome. Adoption fetches nothing and runs no
+//! `dnf`/`rpm` transaction.
+
+mod application;
 
 use clap::Parser;
 use serde::Serialize;
 
-use anolisa_core::domain::{InstallationScope, ManagementRelation, NativePm, ProviderBinding};
-use anolisa_core::executor::{DelegatedExecutionTarget, execute_delegated_steps};
-use anolisa_core::facts::{
-    FactsError, JournalEvidence, ObserveRequest, assemble_facts, pending_journal_for,
-};
-use anolisa_core::lock::InstallLock;
-use anolisa_core::planner::{Intent, Plan, PlanError, Step, plan};
-use anolisa_core::providers::{DelegatedProvider, ProviderError};
-use anolisa_core::record_sink::{DelegatedIdentity, RecordContext, StoreRecordSink};
-use anolisa_core::state::{ObjectKind, OperationRecord};
-use anolisa_core::state_store::StateStore;
-use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
-use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
-use anolisa_platform::privilege;
+use anolisa_core::execution::ExecutionIntent;
+use anolisa_core::planner::{NoOpReason, Step};
+use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
-use crate::commands::common;
-use crate::commands::common::RepoPersistPolicy;
-use crate::commands::tier1::install::{
-    installed_version_label, now_iso8601, rpm_package_candidates_with_index,
-    snapshot_datadir_contract,
-};
-use crate::commands::tier1::recovery::LockedJournalGate;
-use crate::commands::tier1::rpm_install;
-use crate::context::{CliContext, InstallMode};
-use crate::resolution::load_optional_component_index;
+use crate::context::CliContext;
 use crate::response::{CliError, render_json};
+
+use self::application::{AdoptOutcome, AdoptRequest};
 
 /// Command label for JSON envelopes and error routing.
 const COMMAND: &str = "adopt";
@@ -62,578 +40,73 @@ pub fn handle(args: AdoptArgs, ctx: &CliContext) -> Result<(), CliError> {
     adopt_with_query(&args.component, args.package.as_deref(), ctx, &query)
 }
 
-/// Adopt runs no native transaction; the provider contract needs one anyway,
-/// so this stub refuses honestly if a plan ever routes a transaction here.
-struct NoNativeTransaction;
-
-impl NoNativeTransaction {
-    fn refused(operation: &str, packages: &[&str]) -> PackageTransactionError {
-        PackageTransactionError::TransactionFailed {
-            command: COMMAND.to_string(),
-            operation: operation.to_string(),
-            code: None,
-            stderr: format!(
-                "adopt never runs a native transaction (attempted {operation} {})",
-                packages.join(" ")
-            ),
-        }
-    }
-}
-
-impl PackageTransaction for NoNativeTransaction {
-    fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
-        Err(Self::refused("install", packages))
-    }
-    fn update(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
-        Err(Self::refused("update", packages))
-    }
-    fn reinstall(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
-        Err(Self::refused("reinstall", packages))
-    }
-    fn remove(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
-        Err(Self::refused("remove", packages))
-    }
-}
-
-/// What the pre-lock plan decided this adopt writes, re-checked against the
-/// store as re-read under the install lock.
-enum AdoptShape {
-    /// A1: no record existed; the adopt writes a fresh delegated-adopted one.
-    Fresh,
-    /// A6: an observed record existed for this package; the adopt upgrades
-    /// its management relation in place.
-    UpgradeObserved {
-        /// RPM package the observed record must still point at.
-        package: String,
-    },
-}
-
-/// Core of [`handle`] with the package query injected so tests drive every
-/// branch without a live rpmdb.
+/// Core of [`handle`] with the package query injected so tests avoid the live rpmdb.
 pub(crate) fn adopt_with_query(
     target: &str,
     cli_override: Option<&str>,
     ctx: &CliContext,
     query: &dyn PackageQuery,
 ) -> Result<(), CliError> {
-    let command = format!("{COMMAND} {target}");
-    if ctx.install_mode == InstallMode::User {
-        return Err(CliError::InvalidArgument {
-            command,
-            reason: "adopt is available only in system mode".to_string(),
-        });
-    }
-    let layout = common::resolve_layout(ctx);
-    let state_path = layout.state_dir.join("installed.toml");
-    let journal_dir = rpm_install::journal_dir(&layout);
-    let scope = InstallationScope::System;
-    let now = now_iso8601();
-    let env = anolisa_env::EnvService::detect();
-
-    let (component, view) = common::resolve_adopt_target(target, ctx, &command)?;
-    let store = view.writable.state;
-
-    // Quarantined records and pending journals decide the outcome before any
-    // rpmdb resolution has to run — the refusal must not depend on the
-    // candidate chain resolving.
-    if quarantined(&store, &component) {
-        return Err(plan_error_to_cli(
-            PlanError::NeedsAttention,
-            &component,
-            &component,
-            &command,
-        ));
-    }
-    let pending = pending_journal_for(
-        JournalEvidence::new(&journal_dir, &store.operations),
-        &component,
-    )
-    .map_err(|err| CliError::Runtime {
-        command: command.clone(),
-        reason: err.to_string(),
-    })?;
-    if pending.is_some() {
-        return Err(plan_error_to_cli(
-            PlanError::PendingOperation,
-            &component,
-            &component,
-            &command,
-        ));
-    }
-
-    // Resolve the RPM package to probe and the shape the write would take.
-    // Active-record arms never run the candidate chain: the planner rules on
-    // the recorded identity (A4–A7), and repointing a tracked component at a
-    // different package is an identity migration adopt refuses up front.
-    let active_binding = store
-        .find(ObjectKind::Component, &component)
-        .map(|installation| installation.binding.clone());
-    let prior_version = store
-        .find(ObjectKind::Component, &component)
-        .map(installed_version_label);
-    let (native_package, shape): (Option<String>, AdoptShape) = match &active_binding {
-        Some(ProviderBinding::Owned { .. }) => {
-            // A4 refuses before any probe; nothing to resolve.
-            (None, AdoptShape::Fresh)
-        }
-        Some(ProviderBinding::Delegated {
-            package: recorded,
-            relation,
-            ..
-        }) => {
-            let recorded_name = recorded.resolved_name().map(str::to_string);
-            if let (Some(requested), Some(prev)) = (cli_override, recorded_name.as_deref())
-                && !prev.is_empty()
-                && prev != requested
-                && !matches!(relation, ManagementRelation::Managed { .. })
-            {
-                return Err(CliError::InvalidArgument {
-                    command,
-                    reason: format!(
-                        "component '{component}' is already adopted from RPM package '{prev}', not '{requested}'; adopt will not silently repoint it to a different package — run `anolisa forget {component}` first, then adopt the new package"
-                    ),
-                });
-            }
-            let package = cli_override
-                .map(str::to_string)
-                .or(recorded_name)
-                .unwrap_or_else(|| component.clone());
-            let shape = if matches!(relation, ManagementRelation::Observed) {
-                AdoptShape::UpgradeObserved {
-                    package: package.clone(),
-                }
-            } else {
-                AdoptShape::Fresh
-            };
-            (Some(package), shape)
-        }
-        None => {
-            if !matches!(scope, InstallationScope::System) {
-                // The planner refuses user scope before consulting the probe
-                // (its first guard), so nothing touches the rpmdb here.
-                (None, AdoptShape::Fresh)
-            } else {
-                let package = resolve_fresh_adopt(
-                    cli_override,
-                    ctx,
-                    &layout,
-                    &env,
-                    &component,
-                    query,
-                    &command,
-                )?;
-                (Some(package), AdoptShape::Fresh)
-            }
-        }
+    let intent = if ctx.dry_run {
+        ExecutionIntent::Plan
+    } else {
+        ExecutionIntent::Apply
     };
-
-    let txn = NoNativeTransaction;
-    let provider = DelegatedProvider::new(query, &txn);
-    let observe_request = ObserveRequest {
-        kind: ObjectKind::Component,
-        name: &component,
-        scope,
-        native_package: native_package.as_deref(),
-        observed_at: &now,
-        verify_owned_files: false,
-    };
-    let facts = assemble_facts(
-        &observe_request,
-        &store,
-        Some(&provider),
-        &layout,
-        &journal_dir,
-    )
-    .map_err(|err| adopt_facts_error(err, &command, &component))?;
-
-    let package_label = native_package.clone().unwrap_or_else(|| component.clone());
-    let steps = match plan(&Intent::Adopt, &facts) {
-        Ok(Plan::Execute { steps, .. }) => steps,
-        Ok(Plan::NoOp { .. }) => {
-            // A7: adopt is idempotent over an already-adopted record.
-            render_result(
-                ctx,
-                &AdoptResultPayload {
-                    component,
-                    package: native_package,
-                    version: prior_version,
-                    action: "already-adopted",
-                    operation_id: None,
-                    dry_run: ctx.dry_run,
-                    plan: Vec::new(),
-                },
-            )?;
-            return Ok(());
-        }
-        Err(err) => return Err(plan_error_to_cli(err, &component, &package_label, &command)),
-    };
-    let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
-
-    if ctx.dry_run {
-        return render_result(
-            ctx,
-            &AdoptResultPayload {
-                component,
-                package: native_package,
-                version: prior_version,
-                action: "planned",
-                operation_id: None,
-                dry_run: true,
-                plan: plan_labels,
-            },
-        );
-    }
-
-    execute_adopt_plan(
-        &component,
-        &package_label,
-        &shape,
+    let outcome = application::run(
+        AdoptRequest {
+            target,
+            package: cli_override,
+            intent,
+        },
         ctx,
-        &layout,
-        &state_path,
-        &journal_dir,
-        scope,
-        &now,
-        &provider,
-        &command,
-    )
-}
-
-/// Candidate-chain package resolution for a component with no record: CLI
-/// `--package` override, repo-side component index, repo.toml `package_map`,
-/// then rpmdb Provides metadata. The component identity is already settled;
-/// this only selects the RPM package that backs it. repo.toml is
-/// supplementary here, so an unreadable config degrades to "no rpm backend
-/// config" rather than failing the adopt.
-fn resolve_fresh_adopt(
-    cli_override: Option<&str>,
-    ctx: &CliContext,
-    layout: &anolisa_platform::fs_layout::FsLayout,
-    env: &anolisa_env::EnvFacts,
-    component: &str,
-    query: &dyn PackageQuery,
-    command: &str,
-) -> Result<String, CliError> {
-    let repo_config =
-        common::load_repo_config(ctx, layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
-    let rpm_backend = repo_config.as_ref().and_then(|c| c.backends.get("rpm"));
-    let component_index = repo_config
-        .as_ref()
-        .and_then(|cfg| load_optional_component_index(layout, env, cfg));
-
-    let candidates = rpm_package_candidates_with_index(
-        cli_override,
-        rpm_backend,
-        component_index.as_ref(),
         query,
-        component,
-    )
-    .map_err(|err| match err {
-        PackageQueryError::CommandMissing { command: bin } => {
-            rpm_tooling_missing_error(command, &bin, component)
-        }
-        err => pkg_query_err(err, command),
-    })?;
-    match candidates.as_slice() {
-        [] => Err(CliError::InvalidArgument {
-            command: command.to_string(),
-            reason: format!(
-                "no RPM package is mapped for component '{component}'; add an rpm backend entry to the repo-side component index or publish Provides: anolisa-component({component})"
-            ),
-        }),
-        [single] => Ok(single.package.clone()),
-        many => Err(CliError::InvalidArgument {
-            command: command.to_string(),
-            reason: format!(
-                "multiple RPM candidates match '{component}': {}; cannot adopt unambiguously — pin one with `--package <name>`",
-                many.iter()
-                    .map(|target| target.package.clone())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-        }),
-    }
+    )?;
+    render_outcome(ctx, outcome)
 }
 
-/// Execute an adopt plan (A1 or A6): at most one observation plus a record
-/// write, under the install lock.
-///
-/// The store and native facts are re-read under the lock, then the planner is
-/// run again so execution never consumes a stale lock-external decision.
-#[expect(clippy::too_many_arguments)]
-fn execute_adopt_plan(
-    component: &str,
-    package: &str,
-    shape: &AdoptShape,
-    ctx: &CliContext,
-    layout: &anolisa_platform::fs_layout::FsLayout,
-    state_path: &std::path::Path,
-    journal_dir: &std::path::Path,
-    scope: InstallationScope,
-    now: &str,
-    provider: &DelegatedProvider,
-    command: &str,
-) -> Result<(), CliError> {
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
-    let mut store = StateStore::load_for_layout(state_path, privilege::effective_uid(), layout)
-        .map_err(|err| CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("failed to load installed state: {err}"),
-        })?;
-    adopt_authorized(&store, component, shape, command)?;
-
-    let observe_request = ObserveRequest {
-        kind: ObjectKind::Component,
-        name: component,
-        scope,
-        native_package: Some(package),
-        observed_at: now,
-        verify_owned_files: false,
-    };
-    let locked_facts = assemble_facts(
-        &observe_request,
-        &store,
-        Some(provider),
-        layout,
-        journal_dir,
-    )
-    .map_err(|err| adopt_facts_error(err, command, component))?;
-    let locked_steps = match plan(&Intent::Adopt, &locked_facts) {
-        Ok(Plan::Execute { steps, .. }) => steps,
-        Ok(Plan::NoOp { .. }) => {
-            return Err(CliError::Runtime {
-                command: command.to_string(),
-                reason: format!(
-                    "the facts for '{component}' changed while this adopt was resolving; nothing was changed — re-run `anolisa adopt {component}`"
-                ),
-            });
-        }
-        Err(err) => return Err(plan_error_to_cli(err, component, package, command)),
-    };
-    let plan_labels = locked_steps.iter().map(step_label).collect::<Vec<_>>();
-    let prior_version = store
-        .find(ObjectKind::Component, component)
-        .map(installed_version_label);
-
-    let evidence = JournalEvidence::new(journal_dir, &store.operations);
-    let mut journal_gate = LockedJournalGate::load(&_lock, evidence, command)?;
-    let mut journal = journal_gate.begin(COMMAND, component, state_path.to_path_buf(), command)?;
-    let operation_id = journal.operation_id.clone();
-
-    let context = RecordContext {
-        kind: ObjectKind::Component,
-        name: component.to_string(),
-        scope,
-        now: now.to_string(),
-        operation_id: Some(operation_id.clone()),
-        delegated: Some(DelegatedIdentity {
-            pm: NativePm::Rpm,
-            package: package.to_string(),
-        }),
-        owned_artifact: None,
-    };
-    let outcome = {
-        let mut sink = StoreRecordSink::new(&mut store, state_path, context);
-        execute_delegated_steps(
-            &locked_steps,
-            DelegatedExecutionTarget::new(NativePm::Rpm, Some(package)),
-            provider,
-            &mut sink,
-            &mut journal,
-            now,
-        )
-    }
-    .map_err(|err| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("adopt of '{component}' failed: {err}"),
-    })?;
-
-    // Operation history is best-effort bookkeeping on top of the committed
-    // record: the adopt already succeeded, so a history-write failure
-    // degrades to a warning instead of unwinding anything.
-    store.operations.push(OperationRecord {
-        id: operation_id.clone(),
-        command: command.to_string(),
-        status: "ok".to_string(),
-        started_at: now.to_string(),
-        finished_at: Some(now_iso8601()),
-        parent_operation_id: None,
-    });
-    if let Err(err) = store.save(state_path) {
-        eprintln!("warning: failed to record operation history: {err}");
-    }
-
-    // Best-effort: snapshot the datadir component contract so adapter
-    // commands can discover declared adapters. Missing or unwritable
-    // contracts produce warnings, never failures.
-    for warning in snapshot_datadir_contract(layout, component, command, ctx.packaged_data_probe())
-    {
-        eprintln!("warning: {warning}");
-    }
-
-    // A1 carries a fresh observation; A6 writes no observation and keeps the
-    // record's cached one.
-    let version = outcome
-        .observation
-        .as_ref()
-        .map(|o| o.version.clone())
-        .or(prior_version);
-    render_result(
-        ctx,
-        &AdoptResultPayload {
-            component: component.to_string(),
-            package: Some(package.to_string()),
-            version,
-            action: "adopted",
-            operation_id: Some(operation_id),
-            dry_run: false,
-            plan: plan_labels,
-        },
-    )
-}
-
-fn adopt_facts_error(err: FactsError, command: &str, component: &str) -> CliError {
-    match err {
-        FactsError::Probe(ProviderError::Query(PackageQueryError::CommandMissing {
-            command: bin,
-        })) => rpm_tooling_missing_error(command, &bin, component),
-        err => CliError::Runtime {
-            command: command.to_string(),
-            reason: err.to_string(),
-        },
-    }
-}
-
-/// Re-validation under the install lock: the plan was made from a pre-lock
-/// read, and a concurrent operation may have won the lock first. Any drift
-/// from the planned shape is refused instead of overwriting what the winner
-/// recorded — an adopt must never clobber a raw install or downgrade a
-/// managed component to adopted.
-fn adopt_authorized(
-    store: &StateStore,
-    component: &str,
-    shape: &AdoptShape,
-    command: &str,
-) -> Result<(), CliError> {
-    let drift = |detail: String| CliError::Runtime {
-        command: command.to_string(),
-        reason: format!(
-            "{detail} while this adopt was resolving; nothing was changed — re-run `anolisa adopt {component}`"
-        ),
-    };
-    match shape {
-        AdoptShape::Fresh => {
-            if store.find(ObjectKind::Component, component).is_some()
-                || quarantined(store, component)
-            {
-                return Err(drift(format!("a record for '{component}' appeared")));
+fn render_outcome(ctx: &CliContext, outcome: AdoptOutcome) -> Result<(), CliError> {
+    let payload = match outcome {
+        AdoptOutcome::NoOp { subject, reason } => {
+            debug_assert_eq!(reason, NoOpReason::AlreadyAdopted);
+            AdoptResultPayload {
+                component: subject.component,
+                package: subject.package,
+                version: subject.version,
+                action: "already-adopted",
+                operation_id: None,
+                dry_run: ctx.dry_run,
+                plan: Vec::new(),
             }
         }
-        AdoptShape::UpgradeObserved { package } => {
-            let Some(installation) = store.find(ObjectKind::Component, component) else {
-                return Err(drift(format!("the record for '{component}' disappeared")));
-            };
-            match &installation.binding {
-                ProviderBinding::Delegated {
-                    relation: ManagementRelation::Observed,
-                    package: recorded,
-                    ..
-                } if recorded.resolved_name().is_none_or(|name| name == package) => {}
-                _ => return Err(drift(format!("the record for '{component}' changed"))),
+        AdoptOutcome::Preview { subject, steps } => AdoptResultPayload {
+            component: subject.component,
+            package: subject.package,
+            version: subject.version,
+            action: "planned",
+            operation_id: None,
+            dry_run: true,
+            plan: steps.iter().map(step_label).collect(),
+        },
+        AdoptOutcome::Applied {
+            subject,
+            steps,
+            outcome,
+        } => {
+            for warning in outcome.warnings() {
+                eprintln!("warning: {warning}");
+            }
+            AdoptResultPayload {
+                component: subject.component,
+                package: subject.package,
+                version: subject.version,
+                action: "adopted",
+                operation_id: outcome.operation_id().map(str::to_string),
+                dry_run: false,
+                plan: steps.iter().map(step_label).collect(),
             }
         }
-    }
-    Ok(())
-}
-
-/// Whether the store holds a quarantined record for this component.
-fn quarantined(store: &StateStore, component: &str) -> bool {
-    store
-        .quarantined
-        .iter()
-        .any(|q| q.record.kind == ObjectKind::Component && q.record.name == component)
-}
-
-/// Map a planning refusal to an actionable CLI error. The planner names the
-/// way out; this mapping only renders it.
-fn plan_error_to_cli(err: PlanError, component: &str, package: &str, command: &str) -> CliError {
-    let command = command.to_string();
-    match err {
-        PlanError::AdoptRequiresSystemScope => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "adopt records a system RPM and requires system scope; re-run as `sudo anolisa adopt {component}`"
-            ),
-        },
-        PlanError::NothingToAdopt => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "no installed RPM '{package}' found for component '{component}'; adopt only records an already-installed system RPM — run `sudo anolisa install {component}` to install it"
-            ),
-        },
-        PlanError::AmbiguousPackage => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first"
-            ),
-        },
-        PlanError::ProvenanceConflict => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "component '{component}' is already tracked as a raw install; run `anolisa uninstall {component}` first to re-adopt it as a system package"
-            ),
-        },
-        PlanError::AlreadyManaged => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "component '{component}' is already tracked as rpm-managed; run `anolisa repair {component}` to refresh its state from rpmdb"
-            ),
-        },
-        PlanError::TrackedButAbsent => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "'{component}' is tracked but its package is no longer installed; run `anolisa forget {component}` to drop the record, then install again"
-            ),
-        },
-        PlanError::NeedsAttention => CliError::InvalidArgument {
-            command,
-            reason: format!(
-                "the record for '{component}' was quarantined by the state migration; run `anolisa repair {component}` to resolve it"
-            ),
-        },
-        PlanError::PendingOperation => CliError::Runtime {
-            command,
-            reason: format!(
-                "a previous operation on '{component}' is pending recovery; run `anolisa repair {component}` before retrying"
-            ),
-        },
-        other => CliError::InvalidArgument {
-            command,
-            reason: format!("cannot adopt '{component}': {other:?}"),
-        },
-    }
-}
-
-/// Warn-and-exit error raised when the rpmdb probe cannot run because
-/// `rpm`/`dnf` is absent: adopt records what rpmdb reports, so without the
-/// tooling there is nothing it could observe.
-fn rpm_tooling_missing_error(command: &str, bin: &str, component: &str) -> CliError {
-    CliError::Runtime {
-        command: command.to_string(),
-        reason: format!(
-            "cannot adopt '{component}': {bin} not found on PATH — adopt reads rpmdb to record the installed package; install rpm/dnf and retry"
-        ),
-    }
-}
-
-fn pkg_query_err(err: PackageQueryError, command: &str) -> CliError {
-    CliError::Runtime {
-        command: command.to_string(),
-        reason: format!("rpm query failed: {err}"),
-    }
+    };
+    render_result(ctx, &payload)
 }
 
 /// Human-facing label for a plan step (preview rendering). Adopt plans only
@@ -689,17 +162,23 @@ fn render_result(ctx: &CliContext, payload: &AdoptResultPayload) -> Result<(), C
 
 #[cfg(test)]
 mod tests {
+    use self::application::{AdoptChange, AdoptShape, adopt_authorized};
     use super::*;
+    use crate::commands::common;
+    use crate::commands::tier1::rpm_install;
     use crate::context::InstallMode;
 
     use std::cell::Cell;
     use std::path::PathBuf;
 
-    use anolisa_core::domain::PackageIdentity;
-    use anolisa_core::state::{
-        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectStatus, Ownership,
-        RpmMetadata,
+    use anolisa_core::domain::{
+        InstallationScope, ManagementRelation, NativePm, PackageIdentity, ProviderBinding,
     };
+    use anolisa_core::state::{
+        InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+        Ownership, RpmMetadata,
+    };
+    use anolisa_core::state_store::StateStore;
     use anolisa_core::transaction::{Transaction, TransactionOutcomeStatus};
     use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
 
@@ -977,7 +456,34 @@ mod tests {
             origins: vec![("copilot-shell".to_string(), "@System".to_string())],
             ..Default::default()
         };
-        adopt_with_query("copilot-shell", None, &c, &q).expect("adopt ok");
+        let application_outcome = application::run(
+            AdoptRequest {
+                target: "copilot-shell",
+                package: None,
+                intent: ExecutionIntent::Apply,
+            },
+            &c,
+            &q,
+        )
+        .expect("adopt ok");
+        let AdoptOutcome::Applied {
+            subject,
+            steps,
+            outcome,
+        } = application_outcome
+        else {
+            panic!("fresh adopt must return an applied outcome");
+        };
+        assert_eq!(subject.component, "copilot-shell");
+        assert_eq!(subject.package.as_deref(), Some("copilot-shell"));
+        assert_eq!(subject.version.as_deref(), Some("2.2.0"));
+        assert!(!steps.is_empty());
+        assert_eq!(
+            outcome.status(),
+            anolisa_core::execution::CommandOutcomeStatus::Completed
+        );
+        assert!(outcome.operation_id().is_some());
+        assert_eq!(outcome.changes(), &[AdoptChange::RecordCreated]);
 
         let store = load_store(&c);
         let (package, relation, evr) = delegated_parts(&store, "copilot-shell");
@@ -1081,7 +587,23 @@ mod tests {
             )],
             ..Default::default()
         };
-        adopt_with_query("copilot-shell", None, &c, &q).expect("noop ok");
+        let outcome = application::run(
+            AdoptRequest {
+                target: "copilot-shell",
+                package: None,
+                intent: ExecutionIntent::Apply,
+            },
+            &c,
+            &q,
+        )
+        .expect("noop ok");
+        assert!(matches!(
+            outcome,
+            AdoptOutcome::NoOp {
+                reason: NoOpReason::AlreadyAdopted,
+                ..
+            }
+        ));
 
         let store = load_store(&c);
         let (_, relation, evr) = delegated_parts(&store, "copilot-shell");
@@ -1348,7 +870,17 @@ mod tests {
             provides: vec![component_provider("copilot-shell", "copilot-shell")],
             ..Default::default()
         };
-        adopt_with_query("copilot-shell", None, &c, &q).expect("dry-run ok");
+        let outcome = application::run(
+            AdoptRequest {
+                target: "copilot-shell",
+                package: None,
+                intent: ExecutionIntent::Plan,
+            },
+            &c,
+            &q,
+        )
+        .expect("dry-run ok");
+        assert!(matches!(outcome, AdoptOutcome::Preview { ref steps, .. } if !steps.is_empty()));
         let layout = common::resolve_layout(&c);
         assert!(
             !layout.state_dir.join("installed.toml").exists(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt/application.rs
@@ -1,0 +1,656 @@
+//! Application orchestration for the delegated-only `adopt` lifecycle verb.
+
+use anolisa_core::component_snapshot::{
+    ComponentSnapshot, ComponentSnapshotRequest, ProbeEvidence, SnapshotProbe, StateSnapshot,
+};
+use anolisa_core::domain::{InstallationScope, ManagementRelation, NativePm, ProviderBinding};
+use anolisa_core::execution::{
+    CommandOutcome, CommandOutcomeStatus, ExecutionIntent, PreparedExecution,
+};
+use anolisa_core::executor::{DelegatedExecutionTarget, execute_delegated_steps};
+use anolisa_core::facts::{
+    FactsError, JournalEvidence, assemble_component_snapshot, lifecycle_facts_from_snapshot,
+};
+use anolisa_core::lock::InstallLock;
+use anolisa_core::planner::{Intent, NoOpReason, PlanError, Step, plan};
+use anolisa_core::providers::{DelegatedProvider, ProviderError};
+use anolisa_core::record_sink::{DelegatedIdentity, RecordContext, StoreRecordSink};
+use anolisa_core::state::{ObjectKind, OperationRecord};
+use anolisa_core::state_store::StateStore;
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+use anolisa_platform::privilege;
+
+use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
+use crate::commands::tier1::install::{
+    installed_version_label, now_iso8601, rpm_package_candidates_with_index,
+    snapshot_datadir_contract,
+};
+use crate::commands::tier1::recovery::LockedJournalGate;
+use crate::commands::tier1::rpm_install;
+use crate::context::{CliContext, InstallMode};
+use crate::resolution::load_optional_component_index;
+use crate::response::CliError;
+
+use super::COMMAND;
+
+/// Resolved command input plus whether the caller requested preview or apply.
+pub(super) struct AdoptRequest<'a> {
+    pub(super) target: &'a str,
+    pub(super) package: Option<&'a str>,
+    pub(super) intent: ExecutionIntent,
+}
+
+/// Component identity and display facts carried to the renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AdoptSubject {
+    pub(super) component: String,
+    pub(super) package: Option<String>,
+    pub(super) version: Option<String>,
+}
+
+/// State transition committed by a successful adopt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AdoptChange {
+    /// A new delegated-adopted record was created.
+    RecordCreated,
+    /// An observed delegated record was upgraded to adopted.
+    ObservationAdopted,
+}
+
+/// Typed application result consumed by the CLI renderer.
+pub(super) enum AdoptOutcome {
+    /// The component was already adopted.
+    NoOp {
+        subject: AdoptSubject,
+        reason: NoOpReason,
+    },
+    /// Plan-only result; no lock or effect executor was acquired.
+    Preview {
+        subject: AdoptSubject,
+        steps: Vec<Step>,
+    },
+    /// Applied result with durable operation evidence.
+    Applied {
+        subject: AdoptSubject,
+        steps: Vec<Step>,
+        outcome: CommandOutcome<AdoptChange>,
+    },
+}
+
+/// Adopt runs no native transaction; refuse if a plan ever routes one here.
+struct NoNativeTransaction;
+
+impl NoNativeTransaction {
+    fn refused(operation: &str, packages: &[&str]) -> PackageTransactionError {
+        PackageTransactionError::TransactionFailed {
+            command: COMMAND.to_string(),
+            operation: operation.to_string(),
+            code: None,
+            stderr: format!(
+                "adopt never runs a native transaction (attempted {operation} {})",
+                packages.join(" ")
+            ),
+        }
+    }
+}
+
+impl PackageTransaction for NoNativeTransaction {
+    fn install(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Err(Self::refused("install", packages))
+    }
+
+    fn update(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Err(Self::refused("update", packages))
+    }
+
+    fn reinstall(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Err(Self::refused("reinstall", packages))
+    }
+
+    fn remove(&self, packages: &[&str]) -> Result<(), PackageTransactionError> {
+        Err(Self::refused("remove", packages))
+    }
+}
+
+/// What the pre-lock plan decided this adopt writes.
+pub(super) enum AdoptShape {
+    /// A1: no record existed; write a fresh delegated-adopted one.
+    Fresh,
+    /// A6: upgrade an observed record without changing package identity.
+    UpgradeObserved { package: String },
+}
+
+/// Run the complete observe → plan → lock → re-observe → execute protocol.
+pub(super) fn run(
+    request: AdoptRequest<'_>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+) -> Result<AdoptOutcome, CliError> {
+    let command = format!("{COMMAND} {}", request.target);
+    if ctx.install_mode == InstallMode::User {
+        return Err(CliError::InvalidArgument {
+            command,
+            reason: "adopt is available only in system mode".to_string(),
+        });
+    }
+    let layout = common::resolve_layout(ctx);
+    let state_path = layout.state_dir.join("installed.toml");
+    let journal_dir = rpm_install::journal_dir(&layout);
+    let scope = InstallationScope::System;
+    let now = now_iso8601();
+    let env = anolisa_env::EnvService::detect();
+
+    let (component, view) = common::resolve_adopt_target(request.target, ctx, &command)?;
+    let store = view.writable.state;
+    let initial_snapshot = observe_snapshot(
+        &component,
+        scope,
+        None,
+        &now,
+        &store,
+        None,
+        &layout,
+        &journal_dir,
+        &command,
+    )?;
+
+    let active = match initial_snapshot.state() {
+        ProbeEvidence::Absent { .. } => None,
+        ProbeEvidence::Present {
+            value: StateSnapshot::Active(installation),
+            ..
+        } => Some(installation.as_ref()),
+        ProbeEvidence::Present {
+            value: StateSnapshot::Quarantined(_),
+            ..
+        } => {
+            return Err(plan_error_to_cli(
+                PlanError::NeedsAttention,
+                &component,
+                &component,
+                &command,
+            ));
+        }
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(CliError::Runtime {
+                command,
+                reason: reason.clone(),
+            });
+        }
+        ProbeEvidence::NotRequested => {
+            unreachable!("observe_snapshot always requests state evidence")
+        }
+    };
+    match initial_snapshot.pending_journal() {
+        ProbeEvidence::Present { .. } => {
+            return Err(plan_error_to_cli(
+                PlanError::PendingOperation,
+                &component,
+                &component,
+                &command,
+            ));
+        }
+        ProbeEvidence::Absent { .. } => {}
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(CliError::Runtime {
+                command,
+                reason: reason.clone(),
+            });
+        }
+        ProbeEvidence::NotRequested => {
+            unreachable!("observe_snapshot always requests pending journal evidence")
+        }
+    }
+
+    // Active records resolve against their recorded package identity. Fresh
+    // adopts use the CLI/index/provides candidate chain.
+    let active_binding = active.map(|installation| installation.binding.clone());
+    let prior_version = active.map(installed_version_label);
+    let (native_package, shape): (Option<String>, AdoptShape) = match &active_binding {
+        Some(ProviderBinding::Owned { .. }) => (None, AdoptShape::Fresh),
+        Some(ProviderBinding::Delegated {
+            package: recorded,
+            relation,
+            ..
+        }) => {
+            let recorded_name = recorded.resolved_name().map(str::to_string);
+            if let (Some(requested), Some(previous)) = (request.package, recorded_name.as_deref())
+                && !previous.is_empty()
+                && previous != requested
+                && !matches!(relation, ManagementRelation::Managed { .. })
+            {
+                return Err(CliError::InvalidArgument {
+                    command,
+                    reason: format!(
+                        "component '{component}' is already adopted from RPM package '{previous}', not '{requested}'; adopt will not silently repoint it to a different package — run `anolisa forget {component}` first, then adopt the new package"
+                    ),
+                });
+            }
+            let package = request
+                .package
+                .map(str::to_string)
+                .or(recorded_name)
+                .unwrap_or_else(|| component.clone());
+            let shape = if matches!(relation, ManagementRelation::Observed) {
+                AdoptShape::UpgradeObserved {
+                    package: package.clone(),
+                }
+            } else {
+                AdoptShape::Fresh
+            };
+            (Some(package), shape)
+        }
+        None => {
+            let package = resolve_fresh_adopt(
+                request.package,
+                ctx,
+                &layout,
+                &env,
+                &component,
+                query,
+                &command,
+            )?;
+            (Some(package), AdoptShape::Fresh)
+        }
+    };
+
+    let transaction = NoNativeTransaction;
+    let provider = DelegatedProvider::new(query, &transaction);
+    let snapshot = observe_snapshot(
+        &component,
+        scope,
+        native_package.as_deref(),
+        &now,
+        &store,
+        Some(&provider),
+        &layout,
+        &journal_dir,
+        &command,
+    )?;
+    let active_adapter_claims = store
+        .adapter_claims
+        .iter()
+        .filter(|claim| claim.component == component)
+        .map(|claim| claim.framework.clone())
+        .collect();
+    let facts = lifecycle_facts_from_snapshot(&snapshot, active_adapter_claims, None)
+        .map_err(|err| adopt_facts_error(err, &command, &component))?;
+    let package_label = native_package.clone().unwrap_or_else(|| component.clone());
+    let prepared = request.intent.prepare(
+        plan(&Intent::Adopt, &facts)
+            .map_err(|err| plan_error_to_cli(err, &component, &package_label, &command))?,
+    );
+    let subject = AdoptSubject {
+        component: component.clone(),
+        package: native_package,
+        version: prior_version,
+    };
+
+    match prepared {
+        PreparedExecution::NoOp { reason } => Ok(AdoptOutcome::NoOp { subject, reason }),
+        PreparedExecution::Preview { steps, .. } => Ok(AdoptOutcome::Preview { subject, steps }),
+        PreparedExecution::Apply { .. } => execute_adopt_plan(
+            &component,
+            &package_label,
+            &shape,
+            ctx,
+            &layout,
+            &state_path,
+            &journal_dir,
+            scope,
+            &now,
+            &provider,
+            &command,
+        ),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn observe_snapshot(
+    component: &str,
+    scope: InstallationScope,
+    native_package: Option<&str>,
+    observed_at: &str,
+    store: &StateStore,
+    provider: Option<&DelegatedProvider<'_>>,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    journal_dir: &std::path::Path,
+    command: &str,
+) -> Result<ComponentSnapshot, CliError> {
+    let mut probes = vec![SnapshotProbe::State, SnapshotProbe::PendingJournal];
+    if native_package.is_some() {
+        probes.push(SnapshotProbe::NativePackage);
+    }
+    assemble_component_snapshot(
+        ComponentSnapshotRequest::new(component, scope, probes),
+        native_package,
+        observed_at,
+        store,
+        provider,
+        layout,
+        journal_dir,
+    )
+    .map_err(|err| adopt_facts_error(err, command, component))
+}
+
+fn resolve_fresh_adopt(
+    cli_override: Option<&str>,
+    ctx: &CliContext,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    env: &anolisa_env::EnvFacts,
+    component: &str,
+    query: &dyn PackageQuery,
+    command: &str,
+) -> Result<String, CliError> {
+    let repo_config =
+        common::load_repo_config(ctx, layout, COMMAND, RepoPersistPolicy::BestEffort).ok();
+    let rpm_backend = repo_config
+        .as_ref()
+        .and_then(|config| config.backends.get("rpm"));
+    let component_index = repo_config
+        .as_ref()
+        .and_then(|config| load_optional_component_index(layout, env, config));
+
+    let candidates = rpm_package_candidates_with_index(
+        cli_override,
+        rpm_backend,
+        component_index.as_ref(),
+        query,
+        component,
+    )
+    .map_err(|err| match err {
+        PackageQueryError::CommandMissing { command: binary } => {
+            rpm_tooling_missing_error(command, &binary, component)
+        }
+        err => pkg_query_err(err, command),
+    })?;
+    match candidates.as_slice() {
+        [] => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "no RPM package is mapped for component '{component}'; add an rpm backend entry to the repo-side component index or publish Provides: anolisa-component({component})"
+            ),
+        }),
+        [single] => Ok(single.package.clone()),
+        many => Err(CliError::InvalidArgument {
+            command: command.to_string(),
+            reason: format!(
+                "multiple RPM candidates match '{component}': {}; cannot adopt unambiguously — pin one with `--package <name>`",
+                many.iter()
+                    .map(|target| target.package.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn execute_adopt_plan(
+    component: &str,
+    package: &str,
+    shape: &AdoptShape,
+    ctx: &CliContext,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    state_path: &std::path::Path,
+    journal_dir: &std::path::Path,
+    scope: InstallationScope,
+    now: &str,
+    provider: &DelegatedProvider<'_>,
+    command: &str,
+) -> Result<AdoptOutcome, CliError> {
+    let lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("failed to acquire install lock: {err}"),
+    })?;
+    let mut store = StateStore::load_for_layout(state_path, privilege::effective_uid(), layout)
+        .map_err(|err| CliError::Runtime {
+            command: command.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+    adopt_authorized(&store, component, shape, command)?;
+
+    let snapshot = observe_snapshot(
+        component,
+        scope,
+        Some(package),
+        now,
+        &store,
+        Some(provider),
+        layout,
+        journal_dir,
+        command,
+    )?;
+    let active_adapter_claims = store
+        .adapter_claims
+        .iter()
+        .filter(|claim| claim.component == component)
+        .map(|claim| claim.framework.clone())
+        .collect();
+    let locked_facts = lifecycle_facts_from_snapshot(&snapshot, active_adapter_claims, None)
+        .map_err(|err| adopt_facts_error(err, command, component))?;
+    let locked_steps = match ExecutionIntent::Apply.prepare(
+        plan(&Intent::Adopt, &locked_facts)
+            .map_err(|err| plan_error_to_cli(err, component, package, command))?,
+    ) {
+        PreparedExecution::Apply { steps, .. } => steps,
+        PreparedExecution::NoOp { .. } => {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "the facts for '{component}' changed while this adopt was resolving; nothing was changed — re-run `anolisa adopt {component}`"
+                ),
+            });
+        }
+        PreparedExecution::Preview { .. } => {
+            unreachable!("ExecutionIntent::Apply cannot produce a preview")
+        }
+    };
+    let prior_version = store
+        .find(ObjectKind::Component, component)
+        .map(installed_version_label);
+
+    let evidence = JournalEvidence::new(journal_dir, &store.operations);
+    let mut journal_gate = LockedJournalGate::load(&lock, evidence, command)?;
+    let mut journal = journal_gate.begin(COMMAND, component, state_path.to_path_buf(), command)?;
+    let operation_id = journal.operation_id.clone();
+    let context = RecordContext {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        scope,
+        now: now.to_string(),
+        operation_id: Some(operation_id.clone()),
+        delegated: Some(DelegatedIdentity {
+            pm: NativePm::Rpm,
+            package: package.to_string(),
+        }),
+        owned_artifact: None,
+    };
+    let delegated_outcome = {
+        let mut sink = StoreRecordSink::new(&mut store, state_path, context);
+        execute_delegated_steps(
+            &locked_steps,
+            DelegatedExecutionTarget::new(NativePm::Rpm, Some(package)),
+            provider,
+            &mut sink,
+            &mut journal,
+            now,
+        )
+    }
+    .map_err(|err| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("adopt of '{component}' failed: {err}"),
+    })?;
+
+    let mut warnings = Vec::new();
+    store.operations.push(OperationRecord {
+        id: operation_id.clone(),
+        command: command.to_string(),
+        status: "ok".to_string(),
+        started_at: now.to_string(),
+        finished_at: Some(now_iso8601()),
+        parent_operation_id: None,
+    });
+    if let Err(err) = store.save(state_path) {
+        warnings.push(format!("failed to record operation history: {err}"));
+    }
+    warnings.extend(snapshot_datadir_contract(
+        layout,
+        component,
+        command,
+        ctx.packaged_data_probe(),
+    ));
+
+    let version = delegated_outcome
+        .observation
+        .as_ref()
+        .map(|observation| observation.version.clone())
+        .or(prior_version);
+    let change = match shape {
+        AdoptShape::Fresh => AdoptChange::RecordCreated,
+        AdoptShape::UpgradeObserved { .. } => AdoptChange::ObservationAdopted,
+    };
+    Ok(AdoptOutcome::Applied {
+        subject: AdoptSubject {
+            component: component.to_string(),
+            package: Some(package.to_string()),
+            version,
+        },
+        steps: locked_steps,
+        outcome: CommandOutcome::new(
+            CommandOutcomeStatus::Completed,
+            Some(operation_id),
+            vec![change],
+            warnings,
+        ),
+    })
+}
+
+fn adopt_facts_error(err: FactsError, command: &str, component: &str) -> CliError {
+    match err {
+        FactsError::Probe(ProviderError::Query(PackageQueryError::CommandMissing {
+            command: binary,
+        })) => rpm_tooling_missing_error(command, &binary, component),
+        err => CliError::Runtime {
+            command: command.to_string(),
+            reason: err.to_string(),
+        },
+    }
+}
+
+/// Refuse lock-time drift from the pre-lock record shape.
+pub(super) fn adopt_authorized(
+    store: &StateStore,
+    component: &str,
+    shape: &AdoptShape,
+    command: &str,
+) -> Result<(), CliError> {
+    let drift = |detail: String| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "{detail} while this adopt was resolving; nothing was changed — re-run `anolisa adopt {component}`"
+        ),
+    };
+    match shape {
+        AdoptShape::Fresh => {
+            if store.find(ObjectKind::Component, component).is_some()
+                || store.quarantined.iter().any(|quarantined| {
+                    quarantined.record.kind == ObjectKind::Component
+                        && quarantined.record.name == component
+                })
+            {
+                return Err(drift(format!("a record for '{component}' appeared")));
+            }
+        }
+        AdoptShape::UpgradeObserved { package } => {
+            let Some(installation) = store.find(ObjectKind::Component, component) else {
+                return Err(drift(format!("the record for '{component}' disappeared")));
+            };
+            match &installation.binding {
+                ProviderBinding::Delegated {
+                    relation: ManagementRelation::Observed,
+                    package: recorded,
+                    ..
+                } if recorded.resolved_name().is_none_or(|name| name == package) => {}
+                _ => return Err(drift(format!("the record for '{component}' changed"))),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn plan_error_to_cli(err: PlanError, component: &str, package: &str, command: &str) -> CliError {
+    let command = command.to_string();
+    match err {
+        PlanError::AdoptRequiresSystemScope => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "adopt records a system RPM and requires system scope; re-run as `sudo anolisa adopt {component}`"
+            ),
+        },
+        PlanError::NothingToAdopt => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "no installed RPM '{package}' found for component '{component}'; adopt only records an already-installed system RPM — run `sudo anolisa install {component}` to install it"
+            ),
+        },
+        PlanError::AmbiguousPackage => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "RPM package '{package}' has multiple installed versions; refusing to adopt a single version automatically — resolve the duplicate first"
+            ),
+        },
+        PlanError::ProvenanceConflict => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "component '{component}' is already tracked as a raw install; run `anolisa uninstall {component}` first to re-adopt it as a system package"
+            ),
+        },
+        PlanError::AlreadyManaged => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "component '{component}' is already tracked as rpm-managed; run `anolisa repair {component}` to refresh its state from rpmdb"
+            ),
+        },
+        PlanError::TrackedButAbsent => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "'{component}' is tracked but its package is no longer installed; run `anolisa forget {component}` to drop the record, then install again"
+            ),
+        },
+        PlanError::NeedsAttention => CliError::InvalidArgument {
+            command,
+            reason: format!(
+                "the record for '{component}' was quarantined by the state migration; run `anolisa repair {component}` to resolve it"
+            ),
+        },
+        PlanError::PendingOperation => CliError::Runtime {
+            command,
+            reason: format!(
+                "a previous operation on '{component}' is pending recovery; run `anolisa repair {component}` before retrying"
+            ),
+        },
+        other => CliError::InvalidArgument {
+            command,
+            reason: format!("cannot adopt '{component}': {other:?}"),
+        },
+    }
+}
+
+fn rpm_tooling_missing_error(command: &str, binary: &str, component: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "cannot adopt '{component}': {binary} not found on PATH — adopt reads rpmdb to record the installed package; install rpm/dnf and retry"
+        ),
+    }
+}
+
+fn pkg_query_err(err: PackageQueryError, command: &str) -> CliError {
+    CliError::Runtime {
+        command: command.to_string(),
+        reason: format!("rpm query failed: {err}"),
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -13,7 +13,12 @@ use std::path::{Path, PathBuf};
 use anolisa_platform::fs_layout::FsLayout;
 use thiserror::Error;
 
-use crate::domain::{InstallationScope, ProviderBinding};
+use crate::component_snapshot::{
+    ComponentSnapshot, ComponentSnapshotRequest, JournalProvenance, NativePackageProvenance,
+    NativePackageSnapshot, PendingJournalSnapshot, ProbeEvidence, SnapshotContractError,
+    SnapshotProbe, StateProvenance, StateSnapshot,
+};
+use crate::domain::{InstallationScope, NativePm, ProviderBinding};
 use crate::integrity::{IntegrityStatus, check_owned_file};
 use crate::planner::{Facts, NativeProbe, RecordFacts};
 use crate::providers::{DelegatedProvider, ProviderError};
@@ -320,6 +325,217 @@ pub enum FactsError {
         #[source]
         source: TransactionError,
     },
+    /// Snapshot request and collected evidence violate the observation contract.
+    #[error(transparent)]
+    SnapshotContract(#[from] SnapshotContractError),
+    /// A requested snapshot probe has no usable source.
+    #[error("snapshot probe {probe:?} has no usable source: {reason}")]
+    SnapshotSource {
+        /// Probe that cannot be collected.
+        probe: SnapshotProbe,
+        /// Why the required source is unavailable.
+        reason: String,
+    },
+    /// Snapshot evidence cannot safely drive lifecycle planning.
+    #[error("snapshot probe {probe:?} cannot drive lifecycle planning: {reason}")]
+    SnapshotEvidence {
+        /// Probe whose evidence is insufficient.
+        probe: SnapshotProbe,
+        /// Why the evidence cannot be projected.
+        reason: String,
+    },
+}
+
+/// Collect the initial component snapshot probes from existing read-only sources.
+///
+/// The native source is currently RPM-only because [`NativePm`] has no other
+/// production adapter. Provider and journal failures remain typed errors for
+/// mutation callers; read-only consumers may later choose to turn them into
+/// [`ProbeEvidence::Unavailable`] without changing the snapshot contract.
+///
+/// # Errors
+///
+/// Returns [`FactsError`] when a requested source is missing, a read fails, or
+/// the collected evidence violates the snapshot request.
+pub fn assemble_component_snapshot(
+    request: ComponentSnapshotRequest,
+    native_package: Option<&str>,
+    observed_at: &str,
+    store: &StateStore,
+    provider: Option<&DelegatedProvider<'_>>,
+    layout: &FsLayout,
+    journal_dir: &Path,
+) -> Result<ComponentSnapshot, FactsError> {
+    if matches!(request.scope(), InstallationScope::User { .. })
+        && request.requests(SnapshotProbe::NativePackage)
+    {
+        return Err(SnapshotContractError::UnsupportedProbeScope {
+            probe: SnapshotProbe::NativePackage,
+            scope: request.scope(),
+        }
+        .into());
+    }
+
+    let state = if request.requests(SnapshotProbe::State) {
+        let provenance = StateProvenance {
+            path: layout.state_dir.join("installed.toml"),
+        };
+        match store.record_facts(ObjectKind::Component, request.component()) {
+            RecordFacts::Absent => ProbeEvidence::Absent { provenance },
+            RecordFacts::Active(installation) => ProbeEvidence::Present {
+                provenance,
+                value: StateSnapshot::Active(Box::new(installation)),
+            },
+            RecordFacts::Quarantined(reason) => ProbeEvidence::Present {
+                provenance,
+                value: StateSnapshot::Quarantined(reason),
+            },
+        }
+    } else {
+        ProbeEvidence::NotRequested
+    };
+
+    let native_package_evidence = if request.requests(SnapshotProbe::NativePackage) {
+        let package = native_package.ok_or_else(|| FactsError::SnapshotSource {
+            probe: SnapshotProbe::NativePackage,
+            reason: "no native package identity was resolved".to_string(),
+        })?;
+        let provider = provider.ok_or_else(|| FactsError::SnapshotSource {
+            probe: SnapshotProbe::NativePackage,
+            reason: "no native package provider was supplied".to_string(),
+        })?;
+        let provenance = NativePackageProvenance {
+            manager: NativePm::Rpm,
+            package: package.to_string(),
+        };
+        match provider.observe(package, observed_at)? {
+            NativeProbe::NotProbed => {
+                unreachable!("DelegatedProvider::observe always performs the requested probe")
+            }
+            NativeProbe::Absent => ProbeEvidence::Absent { provenance },
+            NativeProbe::Present { observation, .. } => ProbeEvidence::Present {
+                provenance,
+                value: NativePackageSnapshot::Installed(observation),
+            },
+            NativeProbe::MultipleVersions { .. } => ProbeEvidence::Present {
+                provenance,
+                value: NativePackageSnapshot::MultipleVersions,
+            },
+        }
+    } else {
+        ProbeEvidence::NotRequested
+    };
+
+    let pending_journal = if request.requests(SnapshotProbe::PendingJournal) {
+        let provenance = JournalProvenance {
+            directory: journal_dir.to_path_buf(),
+        };
+        match pending_journal_for(
+            JournalEvidence::new(journal_dir, &store.operations),
+            request.component(),
+        )? {
+            Some(path) => ProbeEvidence::Present {
+                provenance,
+                value: PendingJournalSnapshot { path },
+            },
+            None => ProbeEvidence::Absent { provenance },
+        }
+    } else {
+        ProbeEvidence::NotRequested
+    };
+
+    ComponentSnapshot::from_parts(request, state, native_package_evidence, pending_journal)
+        .map_err(FactsError::from)
+}
+
+/// Project a component snapshot into the existing lifecycle planner facts.
+///
+/// State and journal evidence are mandatory because the lifecycle planner
+/// cannot represent either probe as not requested. A native probe may remain
+/// unrequested for owned-only and user-scope plans.
+///
+/// # Errors
+///
+/// Returns [`FactsError::SnapshotEvidence`] when required evidence was not
+/// requested or a requested source was unavailable.
+pub fn lifecycle_facts_from_snapshot(
+    snapshot: &ComponentSnapshot,
+    active_adapter_claims: Vec<String>,
+    owned_files_verified: Option<bool>,
+) -> Result<Facts, FactsError> {
+    let record = match snapshot.state() {
+        ProbeEvidence::Absent { .. } => RecordFacts::Absent,
+        ProbeEvidence::Present {
+            value: StateSnapshot::Active(installation),
+            ..
+        } => RecordFacts::Active(installation.as_ref().clone()),
+        ProbeEvidence::Present {
+            value: StateSnapshot::Quarantined(reason),
+            ..
+        } => RecordFacts::Quarantined(reason.clone()),
+        ProbeEvidence::NotRequested => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::State,
+                reason: "state was not requested".to_string(),
+            });
+        }
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::State,
+                reason: reason.clone(),
+            });
+        }
+    };
+
+    let native = match snapshot.native_package() {
+        ProbeEvidence::NotRequested => NativeProbe::NotProbed,
+        ProbeEvidence::Absent { .. } => NativeProbe::Absent,
+        ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::Installed(observation),
+        } => NativeProbe::Present {
+            package: provenance.package.clone(),
+            observation: observation.clone(),
+        },
+        ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::MultipleVersions,
+        } => NativeProbe::MultipleVersions {
+            package: provenance.package.clone(),
+        },
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::NativePackage,
+                reason: reason.clone(),
+            });
+        }
+    };
+
+    let pending_journal = match snapshot.pending_journal() {
+        ProbeEvidence::Absent { .. } => false,
+        ProbeEvidence::Present { .. } => true,
+        ProbeEvidence::NotRequested => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::PendingJournal,
+                reason: "pending journal was not requested".to_string(),
+            });
+        }
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::PendingJournal,
+                reason: reason.clone(),
+            });
+        }
+    };
+
+    Ok(Facts {
+        scope: snapshot.request().scope(),
+        record,
+        native,
+        pending_journal,
+        active_adapter_claims,
+        owned_files_verified,
+    })
 }
 
 /// Assemble [`Facts`] for one object.
@@ -612,6 +828,104 @@ mod tests {
         assert!(matches!(
             facts.native,
             NativeProbe::Present { ref package, .. } if package == "cosh"
+        ));
+    }
+
+    #[test]
+    fn component_snapshot_projects_typed_sources_into_lifecycle_facts() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let layout = layout_under(tmp.path());
+        let store = StateStore::empty();
+        let mut query = FakeQuery::default();
+        query.installed.insert(
+            "cosh".to_string(),
+            InstalledOutcome::Present(pkg_info("cosh", "2.7.0", Some("1.al4"), "x86_64")),
+        );
+        let txn = FakeTxn::default();
+        let provider = DelegatedProvider::new(&query, &txn);
+        let snapshot = assemble_component_snapshot(
+            ComponentSnapshotRequest::new(
+                "cosh",
+                InstallationScope::System,
+                [
+                    SnapshotProbe::State,
+                    SnapshotProbe::NativePackage,
+                    SnapshotProbe::PendingJournal,
+                ],
+            ),
+            Some("cosh"),
+            NOW,
+            &store,
+            Some(&provider),
+            &layout,
+            &layout.state_dir.join("journal"),
+        )
+        .expect("snapshot");
+
+        assert!(matches!(
+            snapshot.state(),
+            ProbeEvidence::Absent { provenance }
+                if provenance.path == layout.state_dir.join("installed.toml")
+        ));
+        assert!(matches!(
+            snapshot.native_package(),
+            ProbeEvidence::Present {
+                provenance,
+                value: NativePackageSnapshot::Installed(observation),
+            } if provenance.manager == NativePm::Rpm
+                && provenance.package == "cosh"
+                && observation.version == "2.7.0"
+        ));
+        assert!(matches!(
+            snapshot.pending_journal(),
+            ProbeEvidence::Absent { provenance }
+                if provenance.directory == layout.state_dir.join("journal")
+        ));
+
+        let facts =
+            lifecycle_facts_from_snapshot(&snapshot, Vec::new(), None).expect("lifecycle facts");
+        assert!(matches!(facts.record, RecordFacts::Absent));
+        assert!(matches!(
+            facts.native,
+            NativeProbe::Present { ref package, ref observation }
+                if package == "cosh" && observation.version == "2.7.0"
+        ));
+        assert!(!facts.pending_journal);
+    }
+
+    #[test]
+    fn component_snapshot_rejects_user_native_probe_before_query() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let layout = layout_under(tmp.path());
+        let store = StateStore::empty();
+        let mut query = FakeQuery::default();
+        query
+            .installed
+            .insert("cosh".to_string(), InstalledOutcome::Fail);
+        let txn = FakeTxn::default();
+        let provider = DelegatedProvider::new(&query, &txn);
+
+        let error = assemble_component_snapshot(
+            ComponentSnapshotRequest::new(
+                "cosh",
+                InstallationScope::User { uid: 1000 },
+                [SnapshotProbe::NativePackage],
+            ),
+            Some("cosh"),
+            NOW,
+            &store,
+            Some(&provider),
+            &layout,
+            &layout.state_dir.join("journal"),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            FactsError::SnapshotContract(SnapshotContractError::UnsupportedProbeScope {
+                probe: SnapshotProbe::NativePackage,
+                scope: InstallationScope::User { uid: 1000 },
+            })
         ));
     }
 


### PR DESCRIPTION
## Why

`adopt` already used the lifecycle planner and delegated executor, but its command handler still owned resolution, observation, lock-time revalidation, execution, and rendering. This makes it the first R1 pilot for a lifecycle application layer and connects the previously landed snapshot and execution contracts to a real command.

## What changed

- Added a crate-private adopt application module that owns observe, plan, lock, re-observe, and execute orchestration.
- Added typed `ComponentSnapshot` collection and lifecycle-facts projection with provenance-preserving evidence.
- Routed no-op, preview, and apply through `ExecutionIntent` and typed `AdoptOutcome` / `CommandOutcome` values.
- Kept the command handler responsible for argument mapping and existing human/JSON rendering.
- Preserved package resolution, journal, install lock, delegated executor, record sink, warnings, and lock-time drift refusal.

## Related issue

resolves #2714

## User / Agent impact

None. CLI arguments, human output, JSON schema, warning text, exit behavior, and dry-run semantics remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low compatibility risk. The Rust facts API gains snapshot collection and projection helpers, while public CLI behavior is unchanged. The privileged adopt path is structurally reorganized but retains its pre-lock and lock-held observations, journal gate, forward-only executor, and concurrent-writer refusals.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- `git diff --check upstream/main...HEAD`

Validated on Linux after rebasing onto `upstream/main` at `f9c82a73`.

## Documentation and rollback

No documentation changes are required for this internal refactor. Roll back by reverting commit `8db3c9e9`; no state, journal, CLI, JSON, or wire migration is involved.