### PR TITLE
fix(sight): match tool args in loop detection

### DIFF
--- a/src/agentsight/src/interruption/loop_detector.rs
+++ b/src/agentsight/src/interruption/loop_detector.rs
@@ -6,7 +6,8 @@
 //!
 //! # Detection Rules (by priority)
 //!
-//! 1. **Tool Sequence Repetition** — same tool names emitted N times consecutively
+//! 1. **Tool Sequence Repetition** — same tool calls (name + argument
+//!    fingerprint) emitted N times consecutively
 //! 2. **Output Similarity Loop** — similar LLM output text repeated N times
 //! 3. **Token Burn Without Progress** — input tokens growing but output stays the same
 
@@ -38,12 +39,42 @@ impl Default for LoopDetectorConfig {
     }
 }
 
+/// Identity of a single tool call for loop comparison.
+///
+/// Two calls count as a repetition only when both the tool name and the
+/// argument fingerprint match, so the same tool invoked with different
+/// arguments (e.g. a terminal tool running different commands) is not a loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallKey {
+    pub name: String,
+    /// Stable hash of the serialized JSON arguments; `None` when the provider
+    /// omitted arguments. `None == None`, which keeps the legacy name-only
+    /// comparison for providers that never emit arguments.
+    pub args_fingerprint: Option<u64>,
+}
+
+impl ToolCallKey {
+    /// Hash the serialized arguments into a stable per-process fingerprint.
+    ///
+    /// serde_json preserves key order (`preserve_order`), so repeated calls
+    /// serialized by the same agent yield identical strings. Order-differing
+    /// but semantically equal arguments hash differently, which only makes
+    /// detection more conservative (never a new false positive).
+    pub fn fingerprint_args(args: &serde_json::Value) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        args.to_string().hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
 /// Lightweight summary of a recent LLM call used for loop detection.
 #[derive(Debug, Clone)]
 pub struct RecentCallSummary {
     pub call_id: String,
-    /// Tool names invoked by this call's output (e.g. ["read_file", "search"])
-    pub tool_call_names: Vec<String>,
+    /// Tool calls invoked by this call's output, in emission order
+    pub tool_calls: Vec<ToolCallKey>,
     /// Snippet of output text (first ~200 chars) for similarity calculation
     pub output_text_snippet: String,
     pub input_tokens: i64,
@@ -131,7 +162,8 @@ impl LoopDetector {
         None
     }
 
-    /// Rule 1: Check if the last N tool-bearing calls have the same tool sequence.
+    /// Rule 1: Check if the last N tool-bearing calls repeat the same tool sequence
+    /// with identical arguments (see [`ToolCallKey`]).
     ///
     /// Only considers calls that actually have tool_call outputs (ignores pure-text
     /// responses). This handles architectures like OpenClaw where each tool call
@@ -140,10 +172,8 @@ impl LoopDetector {
         let threshold = self.config.tool_sequence_repeat_threshold;
 
         // Filter to only calls that have tool calls (ignore pure-text responses)
-        let tool_bearing: Vec<&RecentCallSummary> = calls
-            .iter()
-            .filter(|c| !c.tool_call_names.is_empty())
-            .collect();
+        let tool_bearing: Vec<&RecentCallSummary> =
+            calls.iter().filter(|c| !c.tool_calls.is_empty()).collect();
 
         if tool_bearing.len() < threshold {
             return None;
@@ -152,13 +182,14 @@ impl LoopDetector {
         // Look at the last N tool-bearing calls
         let tail = &tool_bearing[tool_bearing.len().saturating_sub(threshold)..];
 
-        // Check if all tool sequences in the tail are identical
-        let reference = &tail[0].tool_call_names;
-        let all_same = tail[1..].iter().all(|c| &c.tool_call_names == reference);
+        // Check if all tool call sequences in the tail are identical
+        let reference = &tail[0].tool_calls;
+        let all_same = tail[1..].iter().all(|c| &c.tool_calls == reference);
 
         if all_same {
+            let repeated_tools: Vec<&str> = reference.iter().map(|k| k.name.as_str()).collect();
             Some(serde_json::json!({
-                "repeated_tools": reference,
+                "repeated_tools": repeated_tools,
                 "repeat_count": threshold,
             }))
         } else {
@@ -355,10 +386,38 @@ fn truncate_str(s: &str, max_len: usize) -> String {
 mod tests {
     use super::*;
 
+    /// Build a call whose tool calls carry no arguments (fingerprint `None`).
     fn make_call(tool_names: Vec<&str>, output: &str, input_tokens: i64) -> RecentCallSummary {
         RecentCallSummary {
             call_id: format!("call-{input_tokens}"),
-            tool_call_names: tool_names.into_iter().map(|s| s.to_string()).collect(),
+            tool_calls: tool_names
+                .into_iter()
+                .map(|s| ToolCallKey {
+                    name: s.to_string(),
+                    args_fingerprint: None,
+                })
+                .collect(),
+            output_text_snippet: output.to_string(),
+            input_tokens,
+            output_tokens: 100,
+        }
+    }
+
+    /// Build a call whose tool calls carry JSON arguments.
+    fn make_call_with_args(
+        tools: Vec<(&str, serde_json::Value)>,
+        output: &str,
+        input_tokens: i64,
+    ) -> RecentCallSummary {
+        RecentCallSummary {
+            call_id: format!("call-{input_tokens}"),
+            tool_calls: tools
+                .into_iter()
+                .map(|(name, args)| ToolCallKey {
+                    name: name.to_string(),
+                    args_fingerprint: Some(ToolCallKey::fingerprint_args(&args)),
+                })
+                .collect(),
             output_text_snippet: output.to_string(),
             input_tokens,
             output_tokens: 100,
@@ -415,6 +474,97 @@ mod tests {
         let result = detector.detect("conv-1", None, None, None, 1000, &calls);
         // Rule 1 won't trigger (sequences differ), Rule 2/3 also won't trigger
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_same_tool_different_args_not_a_loop() {
+        // Regression for #2691: five consecutive `terminal` calls each running a
+        // different command are normal multi-step work, not a dead loop.
+        let detector = LoopDetector::default();
+        let commands = [
+            "pip list",
+            "find / -name detect.sh",
+            "cat detect.sh",
+            "bash detect.sh",
+            "bash install.sh",
+        ];
+        let calls: Vec<RecentCallSummary> = commands
+            .iter()
+            .enumerate()
+            .map(|(i, cmd)| {
+                make_call_with_args(
+                    vec![("terminal", serde_json::json!({ "command": cmd }))],
+                    &format!("step {i} done"),
+                    (i as i64 + 1) * 100,
+                )
+            })
+            .collect();
+        let result = detector.detect("conv-1", None, None, None, 1000, &calls);
+        assert!(
+            result.is_none(),
+            "different arguments must not count as repetition"
+        );
+    }
+
+    #[test]
+    fn test_same_tool_same_args_loop_detected() {
+        // Identical tool name AND identical arguments repeated is a genuine loop.
+        let detector = LoopDetector::default();
+        let args = serde_json::json!({ "command": "cat /tmp/missing.txt" });
+        let calls: Vec<RecentCallSummary> = (1..=5)
+            .map(|i| {
+                make_call_with_args(
+                    vec![("terminal", args.clone())],
+                    &format!("attempt {i}"),
+                    i * 100,
+                )
+            })
+            .collect();
+        let result = detector.detect("conv-1", None, None, None, 1000, &calls);
+        assert!(result.is_some());
+        let event = result.unwrap();
+        let detail: serde_json::Value =
+            serde_json::from_str(event.detail.as_ref().unwrap()).unwrap();
+        assert_eq!(detail["rule"], "tool_sequence_repetition");
+        assert_eq!(detail["repeated_tools"], serde_json::json!(["terminal"]));
+    }
+
+    #[test]
+    fn test_args_presence_mismatch_not_a_loop() {
+        // A call with arguments and one without must not compare equal even for
+        // the same tool name.
+        let detector = LoopDetector::default();
+        let args = serde_json::json!({ "command": "ls" });
+        let calls: Vec<RecentCallSummary> = (1..=5)
+            .map(|i| {
+                if i % 2 == 0 {
+                    make_call_with_args(
+                        vec![("terminal", args.clone())],
+                        &format!("out {i}"),
+                        i * 100,
+                    )
+                } else {
+                    make_call(vec!["terminal"], &format!("out {i}"), i * 100)
+                }
+            })
+            .collect();
+        let result = detector.detect("conv-1", None, None, None, 1000, &calls);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fingerprint_args_stability() {
+        let a = serde_json::json!({ "command": "ls", "cwd": "/tmp" });
+        let b = serde_json::json!({ "command": "ls", "cwd": "/tmp" });
+        let c = serde_json::json!({ "command": "ls", "cwd": "/home" });
+        assert_eq!(
+            ToolCallKey::fingerprint_args(&a),
+            ToolCallKey::fingerprint_args(&b)
+        );
+        assert_ne!(
+            ToolCallKey::fingerprint_args(&a),
+            ToolCallKey::fingerprint_args(&c)
+        );
     }
 
     #[test]

--- a/src/agentsight/src/interruption/mod.rs
+++ b/src/agentsight/src/interruption/mod.rs
@@ -7,7 +7,7 @@ pub mod oom_recovery;
 pub mod types;
 
 pub use detector::{DetectorConfig, InterruptionDetector};
-pub use loop_detector::{LoopDetector, LoopDetectorConfig, RecentCallSummary};
+pub use loop_detector::{LoopDetector, LoopDetectorConfig, RecentCallSummary, ToolCallKey};
 pub use oom_recovery::{recover_oom_events, was_pid_oom_killed};
 pub use types::{
     InterruptionEvent, InterruptionType, ProcessExitStatus, Severity, is_reap_worker_agent,

--- a/src/agentsight/src/storage/sqlite/genai/pending.rs
+++ b/src/agentsight/src/storage/sqlite/genai/pending.rs
@@ -551,11 +551,11 @@ impl GenAISqliteStore {
 
         rows.filter_map(|r| r.ok())
             .map(|(call_id, output_json, input_tokens, output_tokens)| {
-                let (tool_call_names, output_text_snippet) =
+                let (tool_calls, output_text_snippet) =
                     parse_output_messages_for_loop_detection(output_json.as_deref());
                 crate::interruption::RecentCallSummary {
                     call_id,
-                    tool_call_names,
+                    tool_calls,
                     output_text_snippet,
                     input_tokens,
                     output_tokens,
@@ -747,15 +747,18 @@ impl GenAISqliteStore {
 
 // ─── Helper for loop detection ───────────────────────────────────────────────
 
-/// Parse the `output_messages` JSON column to extract tool call names and text snippets.
+/// Parse the `output_messages` JSON column to extract tool call keys and text snippets.
 ///
 /// The JSON structure follows the OTel GenAI parts format stored by `store_event()`:
 /// ```json
-/// [{"role":"assistant","parts":[{"type":"tool_call","name":"read_file",...},{"type":"text","content":"..."}]}]
+/// [{"role":"assistant","parts":[{"type":"tool_call","name":"read_file","arguments":{...}},{"type":"text","content":"..."}]}]
 /// ```
+///
+/// Tool call arguments are reduced to a fingerprint so the loop detector can
+/// distinguish the same tool invoked with different arguments (#2691).
 pub(super) fn parse_output_messages_for_loop_detection(
     json_str: Option<&str>,
-) -> (Vec<String>, String) {
+) -> (Vec<crate::interruption::ToolCallKey>, String) {
     let Some(json_str) = json_str else {
         return (vec![], String::new());
     };
@@ -765,7 +768,7 @@ pub(super) fn parse_output_messages_for_loop_detection(
         Err(_) => return (vec![], String::new()),
     };
 
-    let mut tool_names = Vec::new();
+    let mut tool_calls = Vec::new();
     let mut text_parts = Vec::new();
 
     for msg in &messages {
@@ -774,7 +777,13 @@ pub(super) fn parse_output_messages_for_loop_detection(
                 match part.get("type").and_then(|t| t.as_str()) {
                     Some("tool_call") => {
                         if let Some(name) = part.get("name").and_then(|n| n.as_str()) {
-                            tool_names.push(name.to_string());
+                            let args_fingerprint = part
+                                .get("arguments")
+                                .map(crate::interruption::ToolCallKey::fingerprint_args);
+                            tool_calls.push(crate::interruption::ToolCallKey {
+                                name: name.to_string(),
+                                args_fingerprint,
+                            });
                         }
                     }
                     Some("text") => {
@@ -796,5 +805,5 @@ pub(super) fn parse_output_messages_for_loop_detection(
         full_text
     };
 
-    (tool_names, snippet)
+    (tool_calls, snippet)
 }

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -110,8 +110,25 @@ fn test_parse_output_invalid_json() {
 fn test_parse_output_tool_calls_only() {
     let json = r#"[{"role":"assistant","parts":[{"type":"tool_call","name":"read_file"},{"type":"tool_call","name":"write_file"}]}]"#;
     let (tools, text) = parse_output_messages_for_loop_detection(Some(json));
-    assert_eq!(tools, vec!["read_file", "write_file"]);
+    let names: Vec<&str> = tools.iter().map(|k| k.name.as_str()).collect();
+    assert_eq!(names, vec!["read_file", "write_file"]);
+    // No arguments field -> no fingerprint
+    assert!(tools.iter().all(|k| k.args_fingerprint.is_none()));
     assert!(text.is_empty());
+}
+
+#[test]
+fn test_parse_output_tool_call_args_fingerprint() {
+    // Same tool with different arguments must yield different keys (#2691),
+    // while identical arguments yield identical keys.
+    let json_a = r#"[{"role":"assistant","parts":[{"type":"tool_call","name":"terminal","arguments":{"command":"pip list"}}]}]"#;
+    let json_b = r#"[{"role":"assistant","parts":[{"type":"tool_call","name":"terminal","arguments":{"command":"cat foo"}}]}]"#;
+    let (tools_a, _) = parse_output_messages_for_loop_detection(Some(json_a));
+    let (tools_a2, _) = parse_output_messages_for_loop_detection(Some(json_a));
+    let (tools_b, _) = parse_output_messages_for_loop_detection(Some(json_b));
+    assert!(tools_a[0].args_fingerprint.is_some());
+    assert_eq!(tools_a, tools_a2);
+    assert_ne!(tools_a, tools_b);
 }
 
 #[test]
@@ -126,7 +143,8 @@ fn test_parse_output_text_only() {
 fn test_parse_output_mixed() {
     let json = r#"[{"role":"assistant","parts":[{"type":"tool_call","name":"search"},{"type":"text","content":"Found results"}]}]"#;
     let (tools, text) = parse_output_messages_for_loop_detection(Some(json));
-    assert_eq!(tools, vec!["search"]);
+    let names: Vec<&str> = tools.iter().map(|k| k.name.as_str()).collect();
+    assert_eq!(names, vec!["search"]);
     assert_eq!(text, "Found results");
 }
 


### PR DESCRIPTION
## Why

`tool_sequence_repetition` compares only the tool-name sequence of recent calls, so agents doing normal multi-step work (e.g. five consecutive `terminal` calls each running a different command) are flagged as `dead_loop` / `critical`. See #2691.

## What changed

- Add `ToolCallKey { name, args_fingerprint }` to the loop detector: Rule 1 now counts a repetition only when both the tool name and the argument fingerprint match.
- Fingerprints are computed in `parse_output_messages_for_loop_detection` by hashing the serialized `arguments` of each `tool_call` part.
- Calls without arguments keep the legacy name-only comparison (`None == None`), so providers that never emit arguments retain the existing detection capability.

Out of scope (kept as follow-ups per issue suggestions 2/3): wiring `tool_sequence_repeat_threshold` into config.json (behavior-neutral today since the call site uses defaults), and severity re-grading (obsolete once name-only repetition no longer fires).

## Related issue

closes #2691

## User / Agent impact

Fewer false `dead_loop`/`critical` interruption events for terminal/exec-heavy workflows; genuine loops (same tool, same arguments) are still detected. With `deadloop.kill` enabled, this also removes a spurious auto-kill trigger.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Detection-only change; the `detail` JSON shape (`repeated_tools`, `repeat_count`, `rule`) is unchanged. serde_json runs with `preserve_order`, so same-source repeated calls serialize identically; order-differing but semantically equal arguments hash differently, which only makes detection more conservative.

## Validation

On ECS (Alinux, kernel 6.6, rustup 1.89.0 matching CI):

- `cargo fmt --all --check` — pass
- `python3 scripts/check-arch-boundaries.py` — 0 violations
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 1865 passed; the single failure is a pre-existing doctest in `src/genai/helpers.rs` (markdown in a doc comment compiled as a doctest, introduced by 93ccdd06b; CI's llvm-cov does not run doctests) — reported separately.
- New discriminating tests: `test_same_tool_different_args_not_a_loop` (fails if the fix is reverted), `test_same_tool_same_args_loop_detected` (guards against detection regression), `test_args_presence_mismatch_not_a_loop`, `test_fingerprint_args_stability`, `test_parse_output_tool_call_args_fingerprint`.

## Documentation and rollback

Doc comments updated in-module; no user-facing docs affected. Revert the single commit to roll back.
