### PR TITLE
feat(anolisa): type system service lifecycle

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/system.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/system.rs
@@ -17,6 +17,7 @@ use clap::{Parser, Subcommand};
 use serde::Serialize;
 
 use anolisa_core::daemon_server::DaemonServer;
+use anolisa_platform::command::CommandRunner;
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::ipc::SYSTEM_HELPER_SOCKET;
 use anolisa_platform::privilege;
@@ -129,11 +130,10 @@ fn handle_setup(
         None => layout.libexec_dir.join("anolisa-system-helper"),
     };
     let unit_path = layout.systemd_unit_dir.join(UNIT_FILENAME);
+    let systemd = Systemd::system();
 
     // 2. Stop the service if it's running (avoids "Text file busy" on binary overwrite)
-    let _ = Command::new("systemctl")
-        .args(["stop", SERVICE_NAME])
-        .output();
+    stop_service_before_setup(&systemd);
 
     // 3. Copy current exe to helper_path
     let current_exe = std::env::current_exe().map_err(|e| CliError::Runtime {
@@ -187,7 +187,7 @@ fn handle_setup(
     deploy_sandbox_config(cmd, &layout)?;
 
     // 10. systemctl daemon-reload + enable + start/restart
-    reload_and_start_service(cmd, upgrade)?;
+    reload_and_start_service(cmd, upgrade, &systemd)?;
 
     // 11. Verify socket
     verify_socket(cmd)?;
@@ -354,36 +354,54 @@ fn write_unit_file(cmd: &str, helper_path: &Path, unit_path: &Path) -> Result<()
     Ok(())
 }
 
-fn reload_and_start_service(cmd: &str, upgrade: bool) -> Result<(), CliError> {
-    run_systemctl(cmd, &["daemon-reload"])?;
-    run_systemctl(cmd, &["enable", SERVICE_NAME])?;
+fn reload_and_start_service<R: CommandRunner>(
+    cmd: &str,
+    upgrade: bool,
+    systemd: &Systemd<R>,
+) -> Result<(), CliError> {
+    systemd
+        .daemon_reload()
+        .map_err(|error| systemd_cli_error(cmd, &["daemon-reload"], error))?;
+    systemd
+        .enable_unit_file(SERVICE_NAME)
+        .map_err(|error| systemd_cli_error(cmd, &["enable", SERVICE_NAME], error))?;
 
     if upgrade {
-        run_systemctl(cmd, &["restart", SERVICE_NAME])?;
+        systemd
+            .restart_unit(SERVICE_NAME)
+            .map_err(|error| systemd_cli_error(cmd, &["restart", SERVICE_NAME], error))?;
     } else {
-        run_systemctl(cmd, &["start", SERVICE_NAME])?;
+        systemd
+            .start_unit(SERVICE_NAME)
+            .map_err(|error| systemd_cli_error(cmd, &["start", SERVICE_NAME], error))?;
     }
     eprintln!("[setup] service {SERVICE_NAME} active");
     Ok(())
 }
 
-fn run_systemctl(cmd: &str, args: &[&str]) -> Result<(), CliError> {
-    let output = Command::new("systemctl")
-        .args(args)
-        .output()
-        .map_err(|e| CliError::Runtime {
-            command: cmd.to_string(),
-            reason: format!("failed to run systemctl {}: {e}", args.join(" ")),
-        })?;
+fn stop_service_before_setup<R: CommandRunner>(systemd: &Systemd<R>) {
+    let _ = systemd.stop_unit(SERVICE_NAME);
+}
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(CliError::Runtime {
-            command: cmd.to_string(),
-            reason: format!("systemctl {} failed: {stderr}", args.join(" ")),
-        });
+fn systemd_cli_error(cmd: &str, args: &[&str], error: SystemdError) -> CliError {
+    let reason = match error {
+        SystemdError::Spawn { source, .. } => {
+            format!("failed to run systemctl {}: {source}", args.join(" "))
+        }
+        SystemdError::NonZeroExit(failure) => {
+            format!("systemctl {} failed: {}", args.join(" "), failure.stderr)
+        }
+        SystemdError::NotFound(unit) => {
+            format!(
+                "systemctl {} failed: service not found: {unit}",
+                args.join(" ")
+            )
+        }
+    };
+    CliError::Runtime {
+        command: cmd.to_string(),
+        reason,
     }
-    Ok(())
 }
 
 fn verify_socket(cmd: &str) -> Result<(), CliError> {
@@ -460,27 +478,10 @@ fn handle_teardown(ctx: &CliContext) -> Result<(), CliError> {
     let helper_path = layout.libexec_dir.join("anolisa-system-helper");
     let unit_path = layout.systemd_unit_dir.join(UNIT_FILENAME);
     let mut warnings: Vec<String> = Vec::new();
+    let systemd = Systemd::system();
 
-    // 2. Stop service (ignore "not loaded" errors)
-    if let Err(e) = run_systemctl(cmd, &["stop", SERVICE_NAME]) {
-        let msg = format!("{e}");
-        if msg.contains("not loaded") || msg.contains("not found") {
-            warnings.push(format!(
-                "service {SERVICE_NAME} was not loaded (already stopped)"
-            ));
-        } else {
-            warnings.push(format!("failed to stop {SERVICE_NAME}: {msg}"));
-        }
-    } else {
-        eprintln!("[teardown] stopped {SERVICE_NAME}");
-    }
-
-    // 3. Disable service (ignore errors)
-    if let Err(e) = run_systemctl(cmd, &["disable", SERVICE_NAME]) {
-        warnings.push(format!("failed to disable {SERVICE_NAME}: {e}"));
-    } else {
-        eprintln!("[teardown] disabled {SERVICE_NAME}");
-    }
+    // 2-3. Stop and disable service while retaining failures as warnings.
+    stop_and_disable_service(cmd, &systemd, &mut warnings);
 
     // 4. Delete unit file
     if unit_path.exists() {
@@ -497,11 +498,7 @@ fn handle_teardown(ctx: &CliContext) -> Result<(), CliError> {
     }
 
     // 5. Reload systemd
-    if let Err(e) = run_systemctl(cmd, &["daemon-reload"]) {
-        warnings.push(format!("daemon-reload failed: {e}"));
-    } else {
-        eprintln!("[teardown] systemd daemon-reload complete");
-    }
+    reload_systemd_after_teardown(cmd, &systemd, &mut warnings);
 
     // 6. Delete helper binary
     if helper_path.exists() {
@@ -549,6 +546,59 @@ fn handle_teardown(ctx: &CliContext) -> Result<(), CliError> {
     }
     eprintln!("[teardown] system helper teardown complete.");
     Ok(())
+}
+
+fn stop_and_disable_service<R: CommandRunner>(
+    cmd: &str,
+    systemd: &Systemd<R>,
+    warnings: &mut Vec<String>,
+) {
+    match systemd.stop_unit(SERVICE_NAME) {
+        Ok(()) => eprintln!("[teardown] stopped {SERVICE_NAME}"),
+        Err(SystemdError::NotFound(_)) => {
+            warnings.push(format!(
+                "service {SERVICE_NAME} was not loaded (already stopped)"
+            ));
+        }
+        Err(error @ SystemdError::NonZeroExit(_)) => {
+            if matches!(
+                systemd.unit_status(SERVICE_NAME),
+                Err(SystemdError::NotFound(_))
+            ) {
+                warnings.push(format!(
+                    "service {SERVICE_NAME} was not loaded (already stopped)"
+                ));
+            } else {
+                let error = systemd_cli_error(cmd, &["stop", SERVICE_NAME], error);
+                warnings.push(format!("failed to stop {SERVICE_NAME}: {error}"));
+            }
+        }
+        Err(error) => {
+            let error = systemd_cli_error(cmd, &["stop", SERVICE_NAME], error);
+            warnings.push(format!("failed to stop {SERVICE_NAME}: {error}"));
+        }
+    }
+
+    match systemd.disable_unit_file(SERVICE_NAME) {
+        Ok(()) => eprintln!("[teardown] disabled {SERVICE_NAME}"),
+        Err(error) => {
+            let error = systemd_cli_error(cmd, &["disable", SERVICE_NAME], error);
+            warnings.push(format!("failed to disable {SERVICE_NAME}: {error}"));
+        }
+    }
+}
+
+fn reload_systemd_after_teardown<R: CommandRunner>(
+    cmd: &str,
+    systemd: &Systemd<R>,
+    warnings: &mut Vec<String>,
+) {
+    if let Err(error) = systemd.daemon_reload() {
+        let error = systemd_cli_error(cmd, &["daemon-reload"], error);
+        warnings.push(format!("daemon-reload failed: {error}"));
+    } else {
+        eprintln!("[teardown] systemd daemon-reload complete");
+    }
 }
 
 // ─── Status command ─────────────────────────────────────────────────────────────────
@@ -800,12 +850,286 @@ fn format_status_uptime(secs: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
     use std::io;
+    use std::rc::Rc;
 
     use anolisa_core::system_helper::HelperResponse;
+    use anolisa_platform::command::{CommandOutput, CommandRunner};
 
     use super::*;
     use crate::helper_client::ScriptedTransport;
+
+    enum FakeOutcome {
+        Output(CommandOutput),
+        Spawn(io::ErrorKind),
+    }
+
+    type FakeCalls = Rc<RefCell<VecDeque<(Vec<String>, FakeOutcome)>>>;
+
+    struct FakeSystemdRunner {
+        calls: FakeCalls,
+    }
+
+    impl CommandRunner for FakeSystemdRunner {
+        fn run(&self, program: &str, args: &[&str]) -> io::Result<CommandOutput> {
+            assert_eq!(program, "systemctl");
+            let (expected, outcome) = self
+                .calls
+                .borrow_mut()
+                .pop_front()
+                .expect("unexpected systemctl call");
+            assert_eq!(args, expected);
+            match outcome {
+                FakeOutcome::Output(output) => Ok(output),
+                FakeOutcome::Spawn(kind) => {
+                    Err(io::Error::new(kind, "fake systemctl spawn failure"))
+                }
+            }
+        }
+    }
+
+    fn fake_systemd(
+        calls: Vec<(Vec<&str>, FakeOutcome)>,
+    ) -> (Systemd<FakeSystemdRunner>, FakeCalls) {
+        let calls = Rc::new(RefCell::new(
+            calls
+                .into_iter()
+                .map(|(args, outcome)| (args.into_iter().map(str::to_string).collect(), outcome))
+                .collect(),
+        ));
+        let runner = FakeSystemdRunner {
+            calls: Rc::clone(&calls),
+        };
+        (Systemd::with_runner(runner), calls)
+    }
+
+    fn success() -> FakeOutcome {
+        FakeOutcome::Output(CommandOutput {
+            code: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+
+    fn non_zero(code: i32, stderr: &str) -> FakeOutcome {
+        FakeOutcome::Output(CommandOutput {
+            code: Some(code),
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        })
+    }
+
+    fn loaded_status() -> FakeOutcome {
+        FakeOutcome::Output(CommandOutput {
+            code: Some(0),
+            stdout: "LoadState=loaded\nActiveState=inactive\nUnitFileState=enabled\nDescription=ANOLISA\n"
+                .to_string(),
+            stderr: String::new(),
+        })
+    }
+
+    fn missing_status() -> FakeOutcome {
+        FakeOutcome::Output(CommandOutput {
+            code: Some(0),
+            stdout:
+                "LoadState=not-found\nActiveState=inactive\nUnitFileState=\nDescription=missing\n"
+                    .to_string(),
+            stderr: String::new(),
+        })
+    }
+
+    fn assert_systemd_finished(calls: &FakeCalls) {
+        assert!(calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn setup_service_lifecycle_preserves_non_upgrade_order() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["daemon-reload"], success()),
+            (vec!["enable", SERVICE_NAME], success()),
+            (vec!["start", SERVICE_NAME], success()),
+        ]);
+
+        reload_and_start_service("system setup", false, &systemd)
+            .expect("setup lifecycle should succeed");
+
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn setup_best_effort_stop_never_probes_status() {
+        let cases = [
+            success(),
+            non_zero(5, "missing\n"),
+            FakeOutcome::Spawn(io::ErrorKind::NotFound),
+        ];
+
+        for outcome in cases {
+            let (systemd, calls) = fake_systemd(vec![(vec!["stop", SERVICE_NAME], outcome)]);
+
+            stop_service_before_setup(&systemd);
+
+            assert_systemd_finished(&calls);
+        }
+    }
+
+    #[test]
+    fn setup_service_lifecycle_restarts_during_upgrade() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["daemon-reload"], success()),
+            (vec!["enable", SERVICE_NAME], success()),
+            (vec!["restart", SERVICE_NAME], success()),
+        ]);
+
+        reload_and_start_service("system setup", true, &systemd)
+            .expect("upgrade lifecycle should succeed");
+
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn setup_service_lifecycle_preserves_spawn_failure_message() {
+        let (systemd, calls) = fake_systemd(vec![(
+            vec!["daemon-reload"],
+            FakeOutcome::Spawn(io::ErrorKind::PermissionDenied),
+        )]);
+
+        let error = reload_and_start_service("system setup", false, &systemd)
+            .expect_err("spawn should fail setup");
+
+        assert_eq!(
+            error.reason(),
+            "failed to run systemctl daemon-reload: fake systemctl spawn failure"
+        );
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn setup_service_lifecycle_preserves_non_zero_exit_message() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["daemon-reload"], success()),
+            (
+                vec!["enable", SERVICE_NAME],
+                non_zero(1, "enable refused\n"),
+            ),
+        ]);
+
+        let error = reload_and_start_service("system setup", false, &systemd)
+            .expect_err("enable should fail setup");
+
+        assert_eq!(
+            error.reason(),
+            format!("systemctl enable {SERVICE_NAME} failed: enable refused\n")
+        );
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn teardown_missing_unit_uses_typed_status_and_continues() {
+        let (systemd, calls) = fake_systemd(vec![
+            (
+                vec!["stop", SERVICE_NAME],
+                non_zero(5, "translated missing-unit diagnostic\n"),
+            ),
+            (
+                vec![
+                    "show",
+                    SERVICE_NAME,
+                    "--no-pager",
+                    "--property=LoadState,ActiveState,UnitFileState,Description",
+                ],
+                missing_status(),
+            ),
+            (vec!["disable", SERVICE_NAME], success()),
+        ]);
+        let mut warnings = Vec::new();
+
+        stop_and_disable_service("system teardown", &systemd, &mut warnings);
+
+        assert_eq!(
+            warnings,
+            vec![format!(
+                "service {SERVICE_NAME} was not loaded (already stopped)"
+            )]
+        );
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn teardown_preserves_stop_disable_reload_order() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["stop", SERVICE_NAME], success()),
+            (vec!["disable", SERVICE_NAME], success()),
+            (vec!["daemon-reload"], success()),
+        ]);
+        let mut warnings = Vec::new();
+
+        stop_and_disable_service("system teardown", &systemd, &mut warnings);
+        reload_systemd_after_teardown("system teardown", &systemd, &mut warnings);
+
+        assert!(warnings.is_empty());
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn teardown_preserves_disable_and_reload_failure_warnings() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["stop", SERVICE_NAME], success()),
+            (
+                vec!["disable", SERVICE_NAME],
+                non_zero(1, "disable refused\n"),
+            ),
+            (vec!["daemon-reload"], non_zero(1, "reload refused\n")),
+        ]);
+        let mut warnings = Vec::new();
+
+        stop_and_disable_service("system teardown", &systemd, &mut warnings);
+        reload_systemd_after_teardown("system teardown", &systemd, &mut warnings);
+
+        assert_eq!(
+            warnings,
+            vec![
+                format!(
+                    "failed to disable {SERVICE_NAME}: execution failed: systemctl disable \
+                     {SERVICE_NAME} failed: disable refused\n"
+                ),
+                "daemon-reload failed: execution failed: systemctl daemon-reload failed: \
+                 reload refused\n"
+                    .to_string(),
+            ]
+        );
+        assert_systemd_finished(&calls);
+    }
+
+    #[test]
+    fn teardown_non_missing_stop_failure_warns_and_disables() {
+        let (systemd, calls) = fake_systemd(vec![
+            (vec!["stop", SERVICE_NAME], non_zero(1, "access denied\n")),
+            (
+                vec![
+                    "show",
+                    SERVICE_NAME,
+                    "--no-pager",
+                    "--property=LoadState,ActiveState,UnitFileState,Description",
+                ],
+                loaded_status(),
+            ),
+            (vec!["disable", SERVICE_NAME], success()),
+        ]);
+        let mut warnings = Vec::new();
+
+        stop_and_disable_service("system teardown", &systemd, &mut warnings);
+
+        assert_eq!(
+            warnings,
+            vec![format!(
+                "failed to stop {SERVICE_NAME}: execution failed: systemctl stop {SERVICE_NAME} failed: access denied\n"
+            )]
+        );
+        assert_systemd_finished(&calls);
+    }
 
     fn client_with_responses(responses: Vec<HelperResponse>) -> HelperClient {
         let (transport, _) =

--- a/src/anolisa/crates/anolisa-platform/src/command.rs
+++ b/src/anolisa/crates/anolisa-platform/src/command.rs
@@ -59,3 +59,35 @@ impl CommandRunner for SystemCommandRunner {
         })
     }
 }
+
+/// Runs real [`std::process::Command`]s with the caller's environment.
+///
+/// Use this runner when command diagnostics are user-visible and must retain
+/// the caller's locale.
+pub struct InheritedLocaleCommandRunner;
+
+impl CommandRunner for InheritedLocaleCommandRunner {
+    fn run(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput> {
+        let output = Command::new(program).args(args).output()?;
+        Ok(CommandOutput {
+            code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherited_locale_runner_preserves_lc_all() {
+        let output = InheritedLocaleCommandRunner
+            .run("sh", &["-c", "printf %s \"$LC_ALL\""])
+            .expect("shell should run");
+
+        assert_eq!(output.code, Some(0));
+        assert_eq!(output.stdout, std::env::var("LC_ALL").unwrap_or_default());
+    }
+}

--- a/src/anolisa/crates/anolisa-platform/src/systemd.rs
+++ b/src/anolisa/crates/anolisa-platform/src/systemd.rs
@@ -5,7 +5,7 @@
 
 use thiserror::Error;
 
-use crate::command::{CommandOutput, CommandRunner, SystemCommandRunner};
+use crate::command::{CommandOutput, CommandRunner, InheritedLocaleCommandRunner};
 
 const SYSTEMCTL: &str = "systemctl";
 
@@ -44,7 +44,7 @@ pub enum SystemdError {
         #[source]
         source: std::io::Error,
     },
-    /// The unit name is empty or a successful status query reports it missing.
+    /// The unit name is empty or typed status evidence reports it missing.
     #[error("service not found: {0}")]
     NotFound(String),
     /// `systemctl` exited unsuccessfully.
@@ -69,20 +69,20 @@ pub struct UnitStatus {
 ///
 /// Production code uses [`Systemd::system`]; tests use
 /// [`Systemd::with_runner`] to avoid invoking the host's service manager.
-pub struct Systemd<R: CommandRunner = SystemCommandRunner> {
+pub struct Systemd<R: CommandRunner = InheritedLocaleCommandRunner> {
     runner: R,
 }
 
-impl Systemd<SystemCommandRunner> {
+impl Systemd<InheritedLocaleCommandRunner> {
     /// Build a bridge that runs the host's real `systemctl` binary.
     pub fn system() -> Self {
         Self {
-            runner: SystemCommandRunner,
+            runner: InheritedLocaleCommandRunner,
         }
     }
 }
 
-impl Default for Systemd<SystemCommandRunner> {
+impl Default for Systemd<InheritedLocaleCommandRunner> {
     fn default() -> Self {
         Self::system()
     }
@@ -155,6 +155,65 @@ impl<R: CommandRunner> Systemd<R> {
         })
     }
 
+    /// Reload systemd manager configuration (`systemctl daemon-reload`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the command cannot complete.
+    pub fn daemon_reload(&self) -> Result<(), SystemdError> {
+        self.run_operation("daemon-reload", &["daemon-reload"])
+    }
+
+    /// Enable a unit without starting it (`systemctl enable <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty or the command
+    /// cannot complete.
+    pub fn enable_unit_file(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("enable", &["enable", unit], unit)
+    }
+
+    /// Start a systemd unit (`systemctl start <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty or the command
+    /// cannot complete.
+    pub fn start_unit(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("start", &["start", unit], unit)
+    }
+
+    /// Restart a systemd unit (`systemctl restart <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty or the command
+    /// cannot complete.
+    pub fn restart_unit(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("restart", &["restart", unit], unit)
+    }
+
+    /// Stop a systemd unit (`systemctl stop <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty or the command
+    /// cannot complete.
+    pub fn stop_unit(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("stop", &["stop", unit], unit)
+    }
+
+    /// Disable a unit without stopping it (`systemctl disable <unit>`).
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed systemd error when the unit is empty or the command
+    /// cannot complete.
+    pub fn disable_unit_file(&self, unit: &str) -> Result<(), SystemdError> {
+        self.run_unit_operation("disable", &["disable", unit], unit)
+    }
+
     /// Enable and start a systemd unit (`systemctl enable --now <unit>`).
     ///
     /// # Errors
@@ -213,6 +272,14 @@ impl<R: CommandRunner> Systemd<R> {
             return Ok(());
         }
         Err(command_failure(operation, Some(unit), out))
+    }
+
+    fn run_operation(&self, operation: &str, args: &[&str]) -> Result<(), SystemdError> {
+        let out = self.run_systemctl(operation, args)?;
+        if out.code == Some(0) {
+            return Ok(());
+        }
+        Err(command_failure(operation, None, out))
     }
 }
 
@@ -323,6 +390,75 @@ mod tests {
         assert!(matches!(
             systemd.disable_unit_deferred(" "),
             Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            systemd.start_unit(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            systemd.restart_unit(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            systemd.stop_unit(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            systemd.enable_unit_file(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert!(matches!(
+            systemd.disable_unit_file(" "),
+            Err(SystemdError::NotFound(unit)) if unit == "<empty>"
+        ));
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn service_lifecycle_operations_preserve_systemctl_argv() {
+        let systemd = systemd(vec![
+            call(&["daemon-reload"], Some(0), "", ""),
+            call(&["enable", "anolisa.service"], Some(0), "", ""),
+            call(&["start", "anolisa.service"], Some(0), "", ""),
+            call(&["restart", "anolisa.service"], Some(0), "", ""),
+            call(&["stop", "anolisa.service"], Some(0), "", ""),
+            call(&["disable", "anolisa.service"], Some(0), "", ""),
+        ]);
+
+        systemd.daemon_reload().expect("reload should succeed");
+        systemd
+            .enable_unit_file("anolisa.service")
+            .expect("enable should succeed");
+        systemd
+            .start_unit("anolisa.service")
+            .expect("start should succeed");
+        systemd
+            .restart_unit("anolisa.service")
+            .expect("restart should succeed");
+        systemd
+            .stop_unit("anolisa.service")
+            .expect("stop should succeed");
+        systemd
+            .disable_unit_file("anolisa.service")
+            .expect("disable should succeed");
+        assert_finished(&systemd);
+    }
+
+    #[test]
+    fn stop_non_zero_exit_does_not_probe_status() {
+        let systemd = systemd(vec![call(
+            &["stop", "missing.service"],
+            Some(5),
+            "",
+            "arbitrary localized diagnostic\n",
+        )]);
+
+        assert!(matches!(
+            systemd.stop_unit("missing.service"),
+            Err(SystemdError::NonZeroExit(failure))
+                if failure.operation == "stop"
+                    && failure.unit.as_deref() == Some("missing.service")
+                    && failure.code == Some(5)
         ));
         assert_finished(&systemd);
     }


### PR DESCRIPTION
## Why

`anolisa system setup` and `system teardown` still spawned `systemctl` directly even after the typed systemd process boundary was introduced. This left privileged service sequencing dependent on host commands in tests and made teardown infer a missing unit from diagnostic strings.

## What changed

- Extend the existing injectable `Systemd<CommandRunner>` boundary with the narrow daemon-reload, enable, start, restart, stop, and disable operations required by the system command.
- Route setup and teardown service operations through that boundary while preserving command order, warnings, exit behavior, and the setup best-effort stop.
- Confirm a missing teardown unit from typed status evidence and add fake-runner coverage without accessing host systemd.
- Cover exact disable and daemon-reload failure warnings and prove teardown continues after a service failure.

## Related issue

closes #2718

## User / Agent impact

No CLI arguments, human output, warning text, JSON schema, or exit codes change. System setup and teardown now use deterministic typed service evidence internally.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The source-level API addition is limited to the internal `anolisa-platform` workspace crate. Privileged setup and teardown keep their existing systemctl argv and ordering; no state, protocol, or configuration migration is introduced.

## Validation

Validated on macOS arm64 from `src/anolisa/`:

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test -p anolisa-platform systemd::tests --locked` — 12 passed
- `cargo test -p anolisa-cli commands::system::tests --locked` — 16 passed
- `cargo clippy -p anolisa-platform --all-targets --locked -- -D warnings`
- `cargo clippy -p anolisa-cli --all-targets --locked --no-deps -- -D warnings`
- `cargo doc --workspace --no-deps`

The local full workspace Clippy gate remains blocked by pre-existing dead-code warnings in `anolisa-core/src/capability.rs`. Linux CI is the authoritative full-workspace and live-systemd platform evidence.

## Documentation and rollback

No documentation change is required because public command behavior is unchanged. Rollback is a direct revert of this commit; no persisted state or configuration migration is involved.

### Ship Note

- Changed: System setup and teardown now use typed, injectable systemd operations.
- Known limitations: Only the system command service lifecycle is migrated in this slice.
- Not covered: No privileged live-systemd mutation was run on macOS; Linux CI is required.
- Verification: `cargo test -p anolisa-platform systemd::tests --locked` and `cargo test -p anolisa-cli commands::system::tests --locked`.