### PR TITLE
chore(anolisa): bump version to 0.3.5

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-20
+
+### Fixed
+
+- Uninstalling a component with a bare systemd service template now stops
+  every loaded instance through `name@*.service` before disabling the declared
+  `name@.service` template. Template-backed services no longer remain running
+  after `anolisa uninstall`, while individual stop failures continue to surface
+  as warnings without blocking cleanup
+  ([#2603](https://github.com/alibaba/anolisa/pull/2603)).
+
 ## [0.3.4] - 2026-08-19
 
 ### Changed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,16 @@
 
 ## [未发布]
 
+## [0.3.5] - 2026-08-20
+
+### 修复
+
+- 卸载声明 bare systemd service template 的组件时，ANOLISA 现会通过
+  `name@*.service` 停止所有已加载实例，再禁用声明的 `name@.service` template。
+  基于 template 的 service 不会在 `anolisa uninstall` 后继续运行；单个实例停止
+  失败仍会以 warning 呈现，而不会阻止后续清理
+  ([#2603](https://github.com/alibaba/anolisa/pull/2603))。
+
 ## [0.3.4] - 2026-08-19
 
 ### 变更

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Aug 19 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Thu Aug 20 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Component uninstall now stops every loaded systemd template instance.
+
+* Wed Aug 19 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.4-1
 - Component commands now validate new identities through the component index.
 - Missing local Raw index errors now identify the active repository source.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.4",
-    "@anolisa/cli-linux-arm64": "0.3.4",
-    "@anolisa/cli-darwin-arm64": "0.3.4"
+    "@anolisa/cli-linux-x64": "0.3.5",
+    "@anolisa/cli-linux-arm64": "0.3.5",
+    "@anolisa/cli-darwin-arm64": "0.3.5"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA has one user-visible fix on `main` after 0.3.4: component uninstall now
stops every loaded instance of a declared systemd service template. A 0.3.5
patch release keeps the Cargo, npm, RPM, and bilingual documentation surfaces
on one versioned boundary.

## What changed

- Bump the Cargo workspace and all five workspace packages to 0.3.5.
- Bump the npm root package, its three optional native dependencies, and the
  Linux x64, Linux arm64, and macOS arm64 package templates to 0.3.5.
- Advance the RPM changelog boundary to 0.3.5 while freezing the 0.3.4 row.
- Add semantically paired English and Chinese 0.3.5 changelog entries for the
  systemd template-instance uninstall fix from #2603.
- Exclude behavior-preserving application-layer refactors and the repository
  unified-build `ws-ckpt` probe adjustment from ANOLISA runtime release notes.

The bump itself adds no new runtime behavior.

## Related issue

no-issue: package the merged ANOLISA changes since 0.3.4

## User / Agent impact

When a component declares a bare systemd template such as
`name@.service`, `anolisa uninstall` now stops every loaded
`name@*.service` instance before disabling the template. Individual stop
failures remain visible as warnings and do not prevent the remaining cleanup.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The published range changes privileged systemd cleanup behavior, but the
implementation was already merged and covered by targeted and full-workspace
tests. This PR only synchronizes release metadata and documentation. There is
no schema, state, CLI syntax, or configuration migration.

## Validation

Environment: Linux 5.10 x86_64, Rust 1.88.0; website validation used the
CI-pinned Node 20.20.2 with a fresh `npm ci`.

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- Isolated `node npm/scripts/package-npm.js --target linux-x64`; both packed
  manifests reported 0.3.5 and the packaged binary reported `anolisa 0.3.5`
- `rpmspec` rendered `anolisa 0.3.5-1.al8` and a 0.3.5 changelog row
- Nightly Raw harness syntax, scenario listing, and repository configuration
  fixture
- `python3 scripts/check-component-versions.py`
- `scripts/docs-lint.sh` and `python3 scripts/docs-link-check.py`
- Fresh Node 20 website build, typecheck, and static link/duplicate-ID check
  across 164 HTML files
- `check_release.py` against previous bump `20371440`, for both the working
  tree and committed `HEAD`
- `git diff --check` and `git diff --cached --check`

Linux arm64 and macOS arm64 native binaries were not built on this Linux x86_64
host; their package templates passed validation.

## Documentation and rollback

Updated `CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog with equivalent
0.3.5 release notes. Before publication, revert `f35e6850` to restore all nine
release surfaces to 0.3.4; after publishing 0.3.5, issue a subsequent patch
release instead of reusing the version.
