### PR TITLE
feat(cosh-ng): [core,gateway] bind profile

### DIFF
--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -746,6 +746,7 @@ version = "0.19.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "uuid",
 ]

--- a/src/cosh-ng/crates/cosh-core/src/brokered_profile.rs
+++ b/src/cosh-ng/crates/cosh-core/src/brokered_profile.rs
@@ -1,0 +1,85 @@
+//! Private brokered-profile handshake values owned by the Core binary.
+//!
+//! Gateway remains authoritative for admission. Core mirrors only the closed
+//! private wire values it must reject before accepting a brokered user turn.
+
+use serde::{Deserialize, Serialize};
+
+const TASK_ONLY_V1_PROFILE: &str = "task-only-v1";
+const TASK_ONLY_V1_MANIFEST_DIGEST: &str =
+    "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a";
+const TASK_ONLY_V1_RUNTIME_TOOLS: &[&str] = &["ask_user_question"];
+
+/// Profile identity carried by the private brokered Core wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BrokeredCapabilityProfileIdentity {
+    /// Exact versioned profile name selected by Gateway.
+    pub profile_id: String,
+    /// Exact canonical manifest digest selected by Gateway.
+    pub manifest_digest: String,
+}
+
+impl BrokeredCapabilityProfileIdentity {
+    /// Returns the only capability profile understood by private Core v3.
+    pub fn task_only_v1() -> Self {
+        Self {
+            profile_id: TASK_ONLY_V1_PROFILE.to_owned(),
+            manifest_digest: TASK_ONLY_V1_MANIFEST_DIGEST.to_owned(),
+        }
+    }
+
+    /// Verifies that the requested identity is the closed private v3 profile.
+    pub fn verify_task_only_v1(&self) -> Result<(), &'static str> {
+        if self.profile_id != TASK_ONLY_V1_PROFILE {
+            return Err("capability profile identity does not match the brokered profile");
+        }
+        if self.manifest_digest != TASK_ONLY_V1_MANIFEST_DIGEST {
+            return Err("capability profile manifest digest does not match the brokered profile");
+        }
+        Ok(())
+    }
+}
+
+/// Verifies the actual Core inventory against the private v3 task-only profile.
+pub fn verify_task_only_runtime_tools(actual: &[String]) -> Result<(), &'static str> {
+    if actual
+        .iter()
+        .map(String::as_str)
+        .eq(TASK_ONLY_V1_RUNTIME_TOOLS.iter().copied())
+    {
+        Ok(())
+    } else {
+        Err("Runtime tool inventory does not match the brokered capability profile")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_only_identity_and_inventory_are_exact() {
+        let identity = BrokeredCapabilityProfileIdentity::task_only_v1();
+        assert_eq!(identity.profile_id, "task-only-v1");
+        assert_eq!(identity.manifest_digest, TASK_ONLY_V1_MANIFEST_DIGEST);
+        assert_eq!(identity.verify_task_only_v1(), Ok(()));
+        assert_eq!(
+            verify_task_only_runtime_tools(&["ask_user_question".to_owned()]),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn task_only_identity_and_inventory_reject_drift() {
+        let mut identity = BrokeredCapabilityProfileIdentity::task_only_v1();
+        identity.manifest_digest = "0".repeat(64);
+        assert!(identity.verify_task_only_v1().is_err());
+        assert!(verify_task_only_runtime_tools(&[]).is_err());
+        assert!(verify_task_only_runtime_tools(&[
+            "ask_user_question".to_owned(),
+            "shell".to_owned(),
+        ])
+        .is_err());
+    }
+}

--- a/src/cosh-ng/crates/cosh-core/src/cli.rs
+++ b/src/cosh-ng/crates/cosh-core/src/cli.rs
@@ -8,7 +8,7 @@ pub(crate) enum ExecutionProfile {
     /// Existing direct Core/Shell behavior and private control protocol v1.
     #[default]
     Legacy,
-    /// Gateway owns every hosted side effect through private protocol v2.
+    /// Gateway owns every hosted side effect through private protocol v3.
     GatewayBrokeredV1,
 }
 

--- a/src/cosh-ng/crates/cosh-core/src/config.rs
+++ b/src/cosh-ng/crates/cosh-core/src/config.rs
@@ -847,7 +847,7 @@ impl CoreConfig {
     /// The launch profile is already fixed before this method is called. It
     /// deliberately excludes the project layer and clears every local runtime
     /// contribution so startup cannot run hooks, skills, MCP, or registry
-    /// migration before the private v2 handshake.
+    /// migration before the private v3 handshake.
     pub(crate) fn load_gateway_brokered() -> Self {
         let user_path = config_dir().join("config.toml");
         let system_path = PathBuf::from("/etc/copilot-shell/config.toml");

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 
+use crate::brokered_profile::{verify_task_only_runtime_tools, BrokeredCapabilityProfileIdentity};
 use crate::cli::CliArgs;
 use crate::compaction::{ContextBudget, ModelCapability};
 #[cfg(test)]
@@ -328,6 +329,8 @@ fn negotiate_profile(
     profile: crate::cli::ExecutionProfile,
     protocol_version: Option<u32>,
     requested_profile: Option<&str>,
+    requested_capability_profile: Option<&BrokeredCapabilityProfileIdentity>,
+    runtime_tools: &[String],
 ) -> Result<(), String> {
     if profile.is_brokered() {
         if protocol_version != Some(BROKERED_CONTROL_PROTOCOL_VERSION) {
@@ -341,6 +344,13 @@ fn negotiate_profile(
                 profile.wire_name()
             ));
         }
+        let requested_capability_profile = requested_capability_profile.ok_or_else(|| {
+            "gateway brokered profile requires a capability_profile identity".to_string()
+        })?;
+        requested_capability_profile
+            .verify_task_only_v1()
+            .map_err(str::to_owned)?;
+        verify_task_only_runtime_tools(runtime_tools).map_err(str::to_owned)?;
         return Ok(());
     }
 
@@ -418,13 +428,21 @@ where
                 protocol_version,
                 capabilities,
                 execution_profile,
+                capability_profile,
             } => {
                 engine.client_capabilities = capabilities;
+                let runtime_tools = engine.tool_names();
                 let negotiation = negotiate_profile(
                     protocol.profile,
                     protocol_version,
                     execution_profile.as_deref(),
+                    capability_profile.as_ref(),
+                    &runtime_tools,
                 );
+                let expected_capability_profile = protocol
+                    .profile
+                    .is_brokered()
+                    .then(BrokeredCapabilityProfileIdentity::task_only_v1);
                 if let Err(error) = negotiation {
                     let expected_version = if protocol.profile.is_brokered() {
                         BROKERED_CONTROL_PROTOCOL_VERSION
@@ -440,6 +458,7 @@ where
                                 .profile
                                 .is_brokered()
                                 .then(|| protocol.profile.wire_name()),
+                            expected_capability_profile,
                             error,
                         ),
                     );
@@ -459,13 +478,18 @@ where
                             .profile
                             .is_brokered()
                             .then(|| protocol.profile.wire_name()),
+                        expected_capability_profile,
+                        protocol
+                            .profile
+                            .is_brokered()
+                            .then(|| runtime_tools.clone()),
                         !protocol.profile.is_brokered() && args.enable_shell_evidence_tool,
                     ),
                 );
                 let init_msg = OutputMessage::system_init(
                     &engine.session_id,
                     &engine.model,
-                    engine.tool_names(),
+                    runtime_tools,
                     session.resumable(),
                 );
                 engine.emit(writer, &init_msg);
@@ -982,33 +1006,83 @@ mod tests {
     use super::*;
 
     #[test]
-    fn brokered_profile_requires_exact_v2_and_profile_ack() {
+    fn brokered_profile_requires_exact_v3_profile_and_inventory() {
         let profile = crate::cli::ExecutionProfile::GatewayBrokeredV1;
+        let capability_profile = BrokeredCapabilityProfileIdentity::task_only_v1();
+        let runtime_tools = vec!["ask_user_question".to_string()];
         assert!(negotiate_profile(
             profile,
             Some(BROKERED_CONTROL_PROTOCOL_VERSION),
-            Some(profile.wire_name())
+            Some(profile.wire_name()),
+            Some(&capability_profile),
+            &runtime_tools,
         )
         .is_ok());
-        assert!(negotiate_profile(profile, None, Some(profile.wire_name())).is_err());
-        assert!(negotiate_profile(profile, Some(CONTROL_PROTOCOL_VERSION), None).is_err());
+        assert!(negotiate_profile(
+            profile,
+            None,
+            Some(profile.wire_name()),
+            Some(&capability_profile),
+            &runtime_tools,
+        )
+        .is_err());
         assert!(negotiate_profile(
             profile,
             Some(BROKERED_CONTROL_PROTOCOL_VERSION),
-            Some("legacy")
+            Some(profile.wire_name()),
+            None,
+            &runtime_tools,
+        )
+        .is_err());
+        assert!(negotiate_profile(
+            profile,
+            Some(BROKERED_CONTROL_PROTOCOL_VERSION),
+            Some("legacy"),
+            Some(&capability_profile),
+            &runtime_tools,
         )
         .is_err());
     }
 
     #[test]
-    fn legacy_profile_keeps_unversioned_and_v1_compatibility() {
-        let profile = crate::cli::ExecutionProfile::Legacy;
-        assert!(negotiate_profile(profile, None, None).is_ok());
-        assert!(negotiate_profile(profile, Some(CONTROL_PROTOCOL_VERSION), None).is_ok());
+    fn brokered_profile_rejects_digest_and_inventory_drift() {
+        let profile = crate::cli::ExecutionProfile::GatewayBrokeredV1;
+        let mut drifted_identity = BrokeredCapabilityProfileIdentity::task_only_v1();
+        drifted_identity.manifest_digest = "0".repeat(64);
+
         assert!(negotiate_profile(
             profile,
             Some(BROKERED_CONTROL_PROTOCOL_VERSION),
-            Some("gateway_brokered_v1")
+            Some(profile.wire_name()),
+            Some(&drifted_identity),
+            &["ask_user_question".to_string()],
+        )
+        .unwrap_err()
+        .contains("manifest digest"));
+        assert!(negotiate_profile(
+            profile,
+            Some(BROKERED_CONTROL_PROTOCOL_VERSION),
+            Some(profile.wire_name()),
+            Some(&BrokeredCapabilityProfileIdentity::task_only_v1()),
+            &["ask_user_question".to_string(), "shell".to_string()],
+        )
+        .unwrap_err()
+        .contains("tool inventory"));
+    }
+
+    #[test]
+    fn legacy_profile_keeps_unversioned_and_v1_compatibility() {
+        let profile = crate::cli::ExecutionProfile::Legacy;
+        assert!(negotiate_profile(profile, None, None, None, &[]).is_ok());
+        assert!(
+            negotiate_profile(profile, Some(CONTROL_PROTOCOL_VERSION), None, None, &[],).is_ok()
+        );
+        assert!(negotiate_profile(
+            profile,
+            Some(BROKERED_CONTROL_PROTOCOL_VERSION),
+            Some("gateway_brokered_v1"),
+            None,
+            &[],
         )
         .is_err());
     }

--- a/src/cosh-ng/crates/cosh-core/src/main.rs
+++ b/src/cosh-ng/crates/cosh-core/src/main.rs
@@ -3,6 +3,7 @@
 
 mod audit;
 mod auth;
+mod brokered_profile;
 mod cli;
 mod compaction;
 mod compression;

--- a/src/cosh-ng/crates/cosh-core/src/protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/src/protocol.rs
@@ -4,12 +4,13 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::brokered_profile::BrokeredCapabilityProfileIdentity;
 use crate::config::ApprovalMode;
 
 /// Exact legacy shell-to-core control protocol version supported by this binary.
 pub const CONTROL_PROTOCOL_VERSION: u32 = 1;
 /// Exact private protocol version for the Gateway-owned execution profile.
-pub const BROKERED_CONTROL_PROTOCOL_VERSION: u32 = 2;
+pub const BROKERED_CONTROL_PROTOCOL_VERSION: u32 = 3;
 
 // =====================================================================
 // Auth types (used by CoreControlRequest::AuthRequired)
@@ -152,9 +153,12 @@ pub enum ShellControlRequest {
         protocol_version: Option<u32>,
         #[serde(default)]
         capabilities: ClientControlCapabilities,
-        /// Exact launch profile requested by a v2 Gateway peer.
+        /// Exact launch profile requested by a brokered Gateway peer.
         #[serde(default)]
         execution_profile: Option<String>,
+        /// Closed capability identity requested by a v3 Gateway peer.
+        #[serde(default)]
+        capability_profile: Option<BrokeredCapabilityProfileIdentity>,
     },
 
     #[serde(rename = "interrupt")]
@@ -308,6 +312,10 @@ pub struct CoreControlResponseBody {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution_profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_profile: Option<BrokeredCapabilityProfileIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_tools: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<CoreControlCapabilities>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -323,7 +331,7 @@ pub struct CoreControlCapabilities {
     /// sends receipts to a core that understands them; older or mock
     /// providers without this capability never see receipt lines.
     pub can_handle_approval_receipt: bool,
-    /// v2 can suspend one side-effect-free question for Gateway resolution.
+    /// Brokered control can suspend one side-effect-free question for Gateway resolution.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub can_handle_brokered_ask_user: bool,
 }
@@ -532,6 +540,8 @@ impl OutputMessage {
             request_id,
             CONTROL_PROTOCOL_VERSION,
             None,
+            None,
+            None,
             can_handle_shell_evidence_tool,
         )
     }
@@ -541,6 +551,8 @@ impl OutputMessage {
         request_id: &str,
         protocol_version: u32,
         execution_profile: Option<&str>,
+        capability_profile: Option<BrokeredCapabilityProfileIdentity>,
+        runtime_tools: Option<Vec<String>>,
         can_handle_shell_evidence_tool: bool,
     ) -> Self {
         Self::ControlResponse {
@@ -551,6 +563,8 @@ impl OutputMessage {
                     subtype: "initialize".to_string(),
                     protocol_version,
                     execution_profile: execution_profile.map(str::to_string),
+                    capability_profile,
+                    runtime_tools,
                     capabilities: Some(CoreControlCapabilities {
                         can_handle_can_use_tool: true,
                         can_handle_host_executed_shell_tool_result: execution_profile.is_none(),
@@ -570,6 +584,7 @@ impl OutputMessage {
             request_id,
             CONTROL_PROTOCOL_VERSION,
             None,
+            None,
             format!(
                 "unsupported control protocol version {received_version}; expected exact version {CONTROL_PROTOCOL_VERSION}"
             ),
@@ -581,6 +596,7 @@ impl OutputMessage {
         request_id: &str,
         protocol_version: u32,
         execution_profile: Option<&str>,
+        capability_profile: Option<BrokeredCapabilityProfileIdentity>,
         error: String,
     ) -> Self {
         Self::ControlResponse {
@@ -591,6 +607,8 @@ impl OutputMessage {
                     subtype: "initialize".to_string(),
                     protocol_version,
                     execution_profile: execution_profile.map(str::to_string),
+                    capability_profile,
+                    runtime_tools: None,
                     capabilities: None,
                     error: Some(error),
                 },
@@ -998,12 +1016,14 @@ mod tests {
                         protocol_version,
                         capabilities,
                         execution_profile,
+                        capability_profile,
                     } => {
                         assert!(fire_session_start);
                         assert!(protocol_version.is_none());
                         assert!(!capabilities.can_handle_can_use_tool);
                         assert!(!capabilities.can_handle_host_executed_shell);
                         assert!(execution_profile.is_none());
+                        assert!(capability_profile.is_none());
                     }
                     _ => panic!("expected Initialize variant"),
                 }
@@ -1014,23 +1034,42 @@ mod tests {
 
     #[test]
     fn parse_initialize_request_preserves_profile_and_capabilities() {
-        let json = r#"{"request_id":"init-2","type":"control_request","request":{"subtype":"initialize","protocol_version":2,"capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell":true},"execution_profile":"gateway_brokered_v1"}}"#;
-        let msg: InputMessage = serde_json::from_str(json).expect("should parse initialize");
+        let identity = BrokeredCapabilityProfileIdentity::task_only_v1();
+        let json = serde_json::json!({
+            "request_id": "init-3",
+            "type": "control_request",
+            "request": {
+                "subtype": "initialize",
+                "protocol_version": BROKERED_CONTROL_PROTOCOL_VERSION,
+                "capabilities": {
+                    "can_handle_can_use_tool": true,
+                    "can_handle_host_executed_shell": true
+                },
+                "execution_profile": "gateway_brokered_v1",
+                "capability_profile": identity
+            }
+        });
+        let msg: InputMessage = serde_json::from_value(json).expect("should parse initialize");
         match msg {
             InputMessage::ControlRequest {
                 request_id,
                 request,
             } => {
-                assert_eq!(request_id, "init-2");
+                assert_eq!(request_id, "init-3");
                 match request {
                     ShellControlRequest::Initialize {
                         capabilities,
                         execution_profile,
+                        capability_profile,
                         ..
                     } => {
                         assert!(capabilities.can_handle_can_use_tool);
                         assert!(capabilities.can_handle_host_executed_shell);
                         assert_eq!(execution_profile.as_deref(), Some("gateway_brokered_v1"));
+                        assert_eq!(
+                            capability_profile,
+                            Some(BrokeredCapabilityProfileIdentity::task_only_v1())
+                        );
                     }
                     _ => panic!("expected Initialize variant"),
                 }
@@ -1212,11 +1251,14 @@ mod tests {
     }
 
     #[test]
-    fn serialize_brokered_initialize_ack_is_v2_and_profile_bound() {
+    fn serialize_brokered_initialize_ack_is_v3_and_profile_bound() {
+        let capability_profile = BrokeredCapabilityProfileIdentity::task_only_v1();
         let msg = OutputMessage::initialize_success_for_profile(
             "init-brokered",
             BROKERED_CONTROL_PROTOCOL_VERSION,
             Some("gateway_brokered_v1"),
+            Some(capability_profile.clone()),
+            Some(vec!["ask_user_question".to_string()]),
             false,
         );
         let value = serde_json::to_value(msg).unwrap();
@@ -1226,6 +1268,14 @@ mod tests {
             BROKERED_CONTROL_PROTOCOL_VERSION
         );
         assert_eq!(response["execution_profile"], "gateway_brokered_v1");
+        assert_eq!(
+            response["capability_profile"],
+            serde_json::json!(capability_profile)
+        );
+        assert_eq!(
+            response["runtime_tools"],
+            serde_json::json!(["ask_user_question"])
+        );
         assert!(response["capabilities"]
             .get("can_handle_hosted_checkpoint_create")
             .is_none());
@@ -1249,6 +1299,8 @@ mod tests {
             "gateway-init-1",
             CONTROL_PROTOCOL_VERSION,
             None,
+            None,
+            None,
             false,
         );
         assert_eq!(
@@ -1257,14 +1309,16 @@ mod tests {
         );
 
         let brokered_ack = OutputMessage::initialize_success_for_profile(
-            "gateway-init-v2",
+            "gateway-init-v3",
             BROKERED_CONTROL_PROTOCOL_VERSION,
             Some("gateway_brokered_v1"),
+            Some(BrokeredCapabilityProfileIdentity::task_only_v1()),
+            Some(vec!["ask_user_question".to_string()]),
             false,
         );
         assert_eq!(
             serde_json::to_value(brokered_ack).unwrap(),
-            corpus["gateway_brokered_v2"]["initialize_ack"]
+            corpus["gateway_brokered_v3"]["initialize_ack"]
         );
 
         let ask_user_request = OutputMessage::ControlRequest {
@@ -1282,11 +1336,11 @@ mod tests {
         };
         assert_eq!(
             serde_json::to_value(ask_user_request).unwrap(),
-            corpus["gateway_brokered_v2"]["ask_user_request"]
+            corpus["gateway_brokered_v3"]["ask_user_request"]
         );
 
         let ask_user_answer: InputMessage =
-            serde_json::from_value(corpus["gateway_brokered_v2"]["ask_user_answer"].clone())
+            serde_json::from_value(corpus["gateway_brokered_v3"]["ask_user_answer"].clone())
                 .unwrap();
         assert!(matches!(
             ask_user_answer,

--- a/src/cosh-ng/crates/cosh-core/tests/fixtures/cosh-private-wire-dual-version.json
+++ b/src/cosh-ng/crates/cosh-core/tests/fixtures/cosh-private-wire-dual-version.json
@@ -27,26 +27,37 @@
       }
     }
   },
-  "gateway_brokered_v2": {
+  "gateway_brokered_v3": {
     "initialize_request": {
       "type": "control_request",
-      "request_id": "gateway-init-v2",
+      "request_id": "gateway-init-v3",
       "request": {
         "subtype": "initialize",
         "fire_session_start": false,
-        "protocol_version": 2,
-        "execution_profile": "gateway_brokered_v1"
+        "protocol_version": 3,
+        "execution_profile": "gateway_brokered_v1",
+        "capability_profile": {
+          "profile_id": "task-only-v1",
+          "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+        }
       }
     },
     "initialize_ack": {
       "type": "control_response",
       "response": {
         "subtype": "success",
-        "request_id": "gateway-init-v2",
+        "request_id": "gateway-init-v3",
         "response": {
           "subtype": "initialize",
-          "protocol_version": 2,
+          "protocol_version": 3,
           "execution_profile": "gateway_brokered_v1",
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+          },
+          "runtime_tools": [
+            "ask_user_question"
+          ],
           "capabilities": {
             "can_handle_can_use_tool": true,
             "can_handle_host_executed_shell_tool_result": false,
@@ -91,7 +102,11 @@
         "request_id": "init",
         "request": {
           "subtype": "initialize",
-          "execution_profile": "gateway_brokered_v1"
+          "execution_profile": "gateway_brokered_v1",
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+          }
         }
       },
       "wrong_version": {
@@ -99,8 +114,12 @@
         "request_id": "init",
         "request": {
           "subtype": "initialize",
-          "protocol_version": 1,
-          "execution_profile": "gateway_brokered_v1"
+          "protocol_version": 2,
+          "execution_profile": "gateway_brokered_v1",
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+          }
         }
       },
       "missing_profile": {
@@ -108,7 +127,11 @@
         "request_id": "init",
         "request": {
           "subtype": "initialize",
-          "protocol_version": 2
+          "protocol_version": 3,
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+          }
         }
       },
       "wrong_profile": {
@@ -116,8 +139,34 @@
         "request_id": "init",
         "request": {
           "subtype": "initialize",
-          "protocol_version": 2,
-          "execution_profile": "legacy"
+          "protocol_version": 3,
+          "execution_profile": "legacy",
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+          }
+        }
+      },
+      "missing_capability_profile": {
+        "type": "control_request",
+        "request_id": "init",
+        "request": {
+          "subtype": "initialize",
+          "protocol_version": 3,
+          "execution_profile": "gateway_brokered_v1"
+        }
+      },
+      "drifted_capability_profile": {
+        "type": "control_request",
+        "request_id": "init",
+        "request": {
+          "subtype": "initialize",
+          "protocol_version": 3,
+          "execution_profile": "gateway_brokered_v1",
+          "capability_profile": {
+            "profile_id": "task-only-v1",
+            "manifest_digest": "0000000000000000000000000000000000000000000000000000000000000000"
+          }
         }
       }
     },
@@ -126,10 +175,14 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
             "execution_profile": "gateway_brokered_v1",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
             "capabilities": {}
           }
         }
@@ -138,11 +191,15 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
-            "protocol_version": 1,
+            "protocol_version": 2,
             "execution_profile": "gateway_brokered_v1",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
             "capabilities": {}
           }
         }
@@ -151,10 +208,14 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
-            "protocol_version": 2,
+            "protocol_version": 3,
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
             "capabilities": {}
           }
         }
@@ -163,11 +224,45 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
-            "protocol_version": 2,
+            "protocol_version": 3,
             "execution_profile": "legacy",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
+            "capabilities": {}
+          }
+        }
+      },
+      "missing_capability_profile": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "gateway-init-v3",
+          "response": {
+            "subtype": "initialize",
+            "protocol_version": 3,
+            "execution_profile": "gateway_brokered_v1",
+            "capabilities": {}
+          }
+        }
+      },
+      "drifted_capability_profile": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "gateway-init-v3",
+          "response": {
+            "subtype": "initialize",
+            "protocol_version": 3,
+            "execution_profile": "gateway_brokered_v1",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
             "capabilities": {}
           }
         }
@@ -176,11 +271,18 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
-            "protocol_version": 2,
-            "execution_profile": "gateway_brokered_v1"
+            "protocol_version": 3,
+            "execution_profile": "gateway_brokered_v1",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
+            "runtime_tools": [
+              "ask_user_question"
+            ]
           }
         }
       },
@@ -188,11 +290,18 @@
         "type": "control_response",
         "response": {
           "subtype": "success",
-          "request_id": "gateway-init-v2",
+          "request_id": "gateway-init-v3",
           "response": {
             "subtype": "initialize",
-            "protocol_version": 2,
+            "protocol_version": 3,
             "execution_profile": "gateway_brokered_v1",
+            "capability_profile": {
+              "profile_id": "task-only-v1",
+              "manifest_digest": "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"
+            },
+            "runtime_tools": [
+              "ask_user_question"
+            ],
             "capabilities": {
               "can_handle_can_use_tool": true,
               "can_handle_host_executed_shell_tool_result": true,

--- a/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/jsonl_protocol.rs
@@ -232,9 +232,9 @@ fn versioned_initialize_returns_negotiated_version() {
 }
 
 #[test]
-fn gateway_brokered_profile_acks_v2_without_initializing_local_runtime() {
+fn gateway_brokered_profile_acks_v3_without_initializing_local_runtime() {
     let corpus = private_wire_corpus();
-    let initialize = json_line(&corpus["gateway_brokered_v2"]["initialize_request"]);
+    let initialize = json_line(&corpus["gateway_brokered_v3"]["initialize_request"]);
     let home = tempfile::tempdir().expect("temp home");
     let workspace = tempfile::tempdir().expect("temp workspace");
     let hook_marker = home.path().join("hook-ran");
@@ -299,7 +299,7 @@ startup_timeout_ms = 1000
         .iter()
         .find(|message| message["type"] == "control_response")
         .expect("profile acknowledgement");
-    assert_eq!(response, &corpus["gateway_brokered_v2"]["initialize_ack"]);
+    assert_eq!(response, &corpus["gateway_brokered_v3"]["initialize_ack"]);
     let init = messages
         .iter()
         .find(|message| message["type"] == "system" && message["subtype"] == "init")
@@ -318,7 +318,7 @@ startup_timeout_ms = 1000
 #[test]
 fn gateway_brokered_profile_rejects_legacy_or_missing_ack_without_fallback() {
     let corpus = private_wire_corpus();
-    let invalid = corpus["gateway_brokered_v2"]["invalid_initialize_requests"]
+    let invalid = corpus["gateway_brokered_v3"]["invalid_initialize_requests"]
         .as_object()
         .expect("invalid initialize request map");
     for (case, initialize) in invalid {
@@ -339,7 +339,7 @@ fn gateway_brokered_profile_rejects_legacy_or_missing_ack_without_fallback() {
             .find(|message| message["type"] == "control_response")
             .unwrap_or_else(|| panic!("profile error for {case}"));
         assert_eq!(response["response"]["subtype"], "error");
-        assert_eq!(response["response"]["response"]["protocol_version"], 2);
+        assert_eq!(response["response"]["response"]["protocol_version"], 3);
         assert_eq!(
             response["response"]["response"]["execution_profile"],
             "gateway_brokered_v1"
@@ -352,12 +352,14 @@ fn gateway_brokered_profile_rejects_legacy_or_missing_ack_without_fallback() {
 
 #[test]
 fn gateway_brokered_profile_rejects_runtime_and_registry_mutation() {
+    let corpus = private_wire_corpus();
+    let initialize = json_line(&corpus["gateway_brokered_v3"]["initialize_request"]);
     let home = tempfile::tempdir().expect("temp home");
     let output = run_process_at_home_args(
         home.path(),
         &["--headless", "--execution-profile", "gateway-brokered-v1"],
         &[
-            r#"{"type":"control_request","request_id":"init","request":{"subtype":"initialize","protocol_version":2,"execution_profile":"gateway_brokered_v1"}}"#,
+            &initialize,
             r#"{"type":"control_request","request_id":"config","request":{"subtype":"config_override","approval_mode":"trust","allowed_tools":["shell"]}}"#,
             r#"{"type":"control_request","request_id":"reload","request":{"subtype":"reload_config"}}"#,
             r#"{"type":"registry_request","request_id":"registry","domain":"extensions","action":"install","params":{}}"#,

--- a/src/cosh-ng/crates/cosh-gateway-contracts/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-gateway-contracts/Cargo.toml
@@ -13,3 +13,4 @@ uuid.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+sha2.workspace = true

--- a/src/cosh-ng/crates/cosh-gateway-contracts/src/lib.rs
+++ b/src/cosh-ng/crates/cosh-gateway-contracts/src/lib.rs
@@ -10,5 +10,6 @@ pub mod common;
 pub mod error;
 pub mod external;
 pub mod ids;
+pub mod profile;
 pub mod runtime;
 pub mod task;

--- a/src/cosh-ng/crates/cosh-gateway-contracts/src/profile.rs
+++ b/src/cosh-ng/crates/cosh-gateway-contracts/src/profile.rs
@@ -1,0 +1,316 @@
+//! Versioned Gateway capability profiles and their closed Runtime tool manifests.
+//!
+//! Profiles are fixed contracts selected by trusted Gateway configuration. Task
+//! input and Runtime output may verify a profile, but cannot extend its tools.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::common::{BoundedName, BoundedOpaque, Digest, TargetRef};
+
+/// Canonical wire and configuration name of the portable Task-only profile.
+pub const TASK_ONLY_V1_PROFILE: &str = "task-only-v1";
+/// Runtime tool resolved by the Gateway without a host side effect.
+pub const ASK_USER_QUESTION_TOOL: &str = "ask_user_question";
+/// Domain separator for the first capability-profile manifest format.
+pub const CAPABILITY_PROFILE_MANIFEST_DOMAIN: &str = "cosh.gateway.capability-profile.v1";
+/// Canonical manifest of the portable Task-only profile.
+pub const TASK_ONLY_V1_CANONICAL_MANIFEST: &str = concat!(
+    "cosh.gateway.capability-profile.v1\n",
+    "profile:task-only-v1\n",
+    "target:\n",
+    "workspace/cosh/task-only-v1\n",
+    "runtime-tools:\n",
+    "ask_user_question\n",
+);
+/// Pinned SHA-256 digest of [`TASK_ONLY_V1_CANONICAL_MANIFEST`].
+pub const TASK_ONLY_V1_MANIFEST_DIGEST: &str =
+    "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a";
+
+const TASK_ONLY_V1_RUNTIME_TOOLS: &[&str] = &[ASK_USER_QUESTION_TOOL];
+
+/// Failure returned when a profile name is not an admitted production profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("unsupported capability profile; expected `task-only-v1`")]
+pub struct CapabilityProfileParseError;
+
+/// Failure returned when advertised profile state differs from its closed contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum CapabilityProfileVerificationError {
+    /// The profile name differs from the configured profile.
+    #[error("capability profile identity does not match the configured profile")]
+    ProfileMismatch,
+    /// The profile manifest digest differs from the pinned contract digest.
+    #[error("capability profile manifest digest does not match the configured profile")]
+    ManifestDigestMismatch,
+    /// The Runtime tool inventory differs from the profile's closed inventory.
+    #[error("Runtime tool inventory does not match the configured capability profile")]
+    RuntimeToolInventoryMismatch,
+}
+
+/// Versioned identity of an admitted Gateway capability profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GatewayCapabilityProfileId {
+    /// Portable profile whose only Runtime tool asks the user a question.
+    TaskOnlyV1,
+}
+
+impl GatewayCapabilityProfileId {
+    /// Returns the canonical wire and configuration name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TaskOnlyV1 => TASK_ONLY_V1_PROFILE,
+        }
+    }
+
+    /// Parses an exact canonical production profile name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CapabilityProfileParseError`] for every unknown name. Unknown
+    /// names never fall back to the Task-only profile.
+    pub fn parse(value: &str) -> Result<Self, CapabilityProfileParseError> {
+        match value {
+            TASK_ONLY_V1_PROFILE => Ok(Self::TaskOnlyV1),
+            _ => Err(CapabilityProfileParseError),
+        }
+    }
+
+    /// Returns the complete closed profile for this identity.
+    #[must_use]
+    pub const fn profile(self) -> GatewayCapabilityProfile {
+        match self {
+            Self::TaskOnlyV1 => GatewayCapabilityProfile::task_only_v1(),
+        }
+    }
+}
+
+/// Durable identity that binds a profile name to its exact manifest revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GatewayCapabilityProfileIdentity {
+    /// Versioned profile name.
+    pub profile_id: GatewayCapabilityProfileId,
+    /// Digest of the complete canonical profile manifest.
+    pub manifest_digest: Digest,
+}
+
+/// Closed capability profile admitted by a production Gateway.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GatewayCapabilityProfile {
+    id: GatewayCapabilityProfileId,
+}
+
+impl GatewayCapabilityProfile {
+    /// Returns the only production profile currently admitted by this contract.
+    #[must_use]
+    pub const fn task_only_v1() -> Self {
+        Self {
+            id: GatewayCapabilityProfileId::TaskOnlyV1,
+        }
+    }
+
+    /// Returns the versioned profile identity.
+    #[must_use]
+    pub const fn id(self) -> GatewayCapabilityProfileId {
+        self.id
+    }
+
+    /// Returns the canonical manifest covered by [`Self::manifest_digest`].
+    #[must_use]
+    pub const fn canonical_manifest(self) -> &'static str {
+        match self.id {
+            GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_CANONICAL_MANIFEST,
+        }
+    }
+
+    /// Returns the pinned digest of the complete canonical manifest.
+    #[must_use]
+    pub fn manifest_digest(self) -> Digest {
+        let digest = match self.id {
+            GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_MANIFEST_DIGEST,
+        };
+        Digest::parse(digest)
+            .unwrap_or_else(|_| unreachable!("reviewed static profile digests are canonical"))
+    }
+
+    /// Returns the durable identity for this exact manifest revision.
+    #[must_use]
+    pub fn identity(self) -> GatewayCapabilityProfileIdentity {
+        GatewayCapabilityProfileIdentity {
+            profile_id: self.id,
+            manifest_digest: self.manifest_digest(),
+        }
+    }
+
+    /// Returns the single governed target bound into the profile manifest.
+    #[must_use]
+    pub fn governed_target(self) -> TargetRef {
+        match self.id {
+            GatewayCapabilityProfileId::TaskOnlyV1 => TargetRef {
+                kind: BoundedName::new("workspace")
+                    .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
+                authority: BoundedName::new("cosh")
+                    .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
+                identifier: BoundedOpaque::new(TASK_ONLY_V1_PROFILE)
+                    .unwrap_or_else(|_| unreachable!("static profile target IDs are bounded")),
+            },
+        }
+    }
+
+    /// Returns the exact ordered Runtime tool inventory admitted by the profile.
+    #[must_use]
+    pub const fn runtime_tools(self) -> &'static [&'static str] {
+        match self.id {
+            GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_RUNTIME_TOOLS,
+        }
+    }
+
+    /// Verifies a durable or advertised identity against the configured profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns a mismatch when either the versioned name or manifest digest
+    /// differs. Callers must reject the binding instead of selecting a fallback.
+    pub fn verify_identity(
+        self,
+        actual: &GatewayCapabilityProfileIdentity,
+    ) -> Result<(), CapabilityProfileVerificationError> {
+        if actual.profile_id != self.id {
+            return Err(CapabilityProfileVerificationError::ProfileMismatch);
+        }
+        if actual.manifest_digest != self.manifest_digest() {
+            return Err(CapabilityProfileVerificationError::ManifestDigestMismatch);
+        }
+        Ok(())
+    }
+
+    /// Verifies that a Runtime advertises exactly the closed profile inventory.
+    ///
+    /// # Errors
+    ///
+    /// Returns a mismatch for missing, additional, reordered, or renamed tools.
+    pub fn verify_runtime_tools(
+        self,
+        actual: &[&str],
+    ) -> Result<(), CapabilityProfileVerificationError> {
+        if actual == self.runtime_tools() {
+            Ok(())
+        } else {
+            Err(CapabilityProfileVerificationError::RuntimeToolInventoryMismatch)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest as _, Sha256};
+
+    use super::*;
+
+    #[test]
+    fn task_only_manifest_and_digest_are_pinned() {
+        let profile = GatewayCapabilityProfile::task_only_v1();
+        let actual_digest = format!("{:x}", Sha256::digest(profile.canonical_manifest()));
+
+        assert_eq!(profile.id().as_str(), TASK_ONLY_V1_PROFILE);
+        assert!(profile
+            .canonical_manifest()
+            .starts_with(CAPABILITY_PROFILE_MANIFEST_DOMAIN));
+        assert_eq!(
+            profile.canonical_manifest(),
+            TASK_ONLY_V1_CANONICAL_MANIFEST
+        );
+        assert_eq!(
+            profile.manifest_digest().as_str(),
+            TASK_ONLY_V1_MANIFEST_DIGEST
+        );
+        assert_eq!(actual_digest, TASK_ONLY_V1_MANIFEST_DIGEST);
+        assert_eq!(profile.runtime_tools(), [ASK_USER_QUESTION_TOOL]);
+        assert_eq!(profile.verify_identity(&profile.identity()), Ok(()));
+        let target = profile.governed_target();
+        assert_eq!(target.kind.as_str(), "workspace");
+        assert_eq!(target.authority.as_str(), "cosh");
+        assert_eq!(target.identifier.as_str(), TASK_ONLY_V1_PROFILE);
+        assert!(profile.canonical_manifest().contains(&format!(
+            "target:\n{}/{}/{}\n",
+            target.kind.as_str(),
+            target.authority.as_str(),
+            target.identifier.as_str(),
+        )));
+    }
+
+    #[test]
+    fn profile_names_are_exact_and_fail_closed() {
+        assert_eq!(
+            GatewayCapabilityProfileId::parse(TASK_ONLY_V1_PROFILE),
+            Ok(GatewayCapabilityProfileId::TaskOnlyV1)
+        );
+        assert_eq!(
+            GatewayCapabilityProfileId::TaskOnlyV1.profile(),
+            GatewayCapabilityProfile::task_only_v1()
+        );
+        for unknown in [
+            "",
+            "task-only",
+            "task-only-v2",
+            "TASK-ONLY-V1",
+            "ws-ckpt-v1",
+        ] {
+            assert_eq!(
+                GatewayCapabilityProfileId::parse(unknown),
+                Err(CapabilityProfileParseError)
+            );
+        }
+    }
+
+    #[test]
+    fn profile_identity_rejects_digest_drift() {
+        let profile = GatewayCapabilityProfile::task_only_v1();
+        let drifted = GatewayCapabilityProfileIdentity {
+            profile_id: GatewayCapabilityProfileId::TaskOnlyV1,
+            manifest_digest: Digest::parse("0".repeat(64)).expect("test digest is canonical"),
+        };
+
+        assert_eq!(
+            profile.verify_identity(&drifted),
+            Err(CapabilityProfileVerificationError::ManifestDigestMismatch)
+        );
+    }
+
+    #[test]
+    fn runtime_inventory_rejects_missing_or_additional_tools() {
+        let profile = GatewayCapabilityProfile::task_only_v1();
+
+        assert_eq!(
+            profile.verify_runtime_tools(&[ASK_USER_QUESTION_TOOL]),
+            Ok(())
+        );
+        for drifted in [
+            &[][..],
+            &[ASK_USER_QUESTION_TOOL, "workspace_checkpoint_create"][..],
+            &["ask_user"][..],
+        ] {
+            assert_eq!(
+                profile.verify_runtime_tools(drifted),
+                Err(CapabilityProfileVerificationError::RuntimeToolInventoryMismatch)
+            );
+        }
+    }
+
+    #[test]
+    fn profile_identity_uses_canonical_wire_names() {
+        let identity = GatewayCapabilityProfile::task_only_v1().identity();
+        let encoded = serde_json::to_value(&identity).expect("profile identity serializes");
+
+        assert_eq!(encoded["profile_id"], TASK_ONLY_V1_PROFILE);
+        assert_eq!(encoded["manifest_digest"], TASK_ONLY_V1_MANIFEST_DIGEST);
+        assert_eq!(
+            serde_json::from_value::<GatewayCapabilityProfileIdentity>(encoded)
+                .expect("profile identity deserializes"),
+            identity
+        );
+    }
+}

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
@@ -36,6 +36,7 @@ use cosh_gateway_contracts::{
     ids::{
         ApprovalId, InputRequestId, InstallationId, RequestId, RunId, RuntimeInstanceId, TaskId,
     },
+    profile::GatewayCapabilityProfile,
     runtime::{RuntimeInputResponse, RuntimeInputSelections},
 };
 use serde_json::{json, Value};
@@ -53,7 +54,9 @@ mod serve;
 #[cfg(test)]
 use acp_command::with_observation_sequence;
 use acp_command::{doctor, install_interrupt_handler, run};
-use control::{admin, task, task_only_target};
+#[cfg(test)]
+use control::task_only_target;
+use control::{admin, task};
 use input::{read_intent, read_prompt, terminal_safe};
 use serve::{serve, ServeArgs};
 
@@ -62,13 +65,6 @@ const MAX_PROMPT_BYTES: usize = 256 * 1024;
 const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const EVENT_DEADLINE: Duration = Duration::from_secs(15);
 const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
-
-// Task submission is intentionally bound to a side-effect-free target. The
-// target identity remains explicit in durable Task records without exposing
-// target assembly to a local CLI caller.
-const TASK_ONLY_TARGET_KIND: &str = "workspace";
-const TASK_ONLY_TARGET_AUTHORITY: &str = "cosh";
-const TASK_ONLY_TARGET_IDENTIFIER: &str = "task-only-v1";
 
 const EXIT_INPUT: u8 = 10;
 const EXIT_PROFILE: u8 = 11;

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/control.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/control.rs
@@ -138,12 +138,7 @@ fn bounded_name(value: String) -> Result<BoundedName, CliError> {
 }
 
 pub(super) fn task_only_target() -> TargetRef {
-    TargetRef {
-        kind: BoundedName::new(TASK_ONLY_TARGET_KIND).unwrap_or_else(|_| unreachable!()),
-        authority: BoundedName::new(TASK_ONLY_TARGET_AUTHORITY).unwrap_or_else(|_| unreachable!()),
-        identifier: BoundedOpaque::new(TASK_ONLY_TARGET_IDENTIFIER)
-            .unwrap_or_else(|_| unreachable!()),
-    }
+    GatewayCapabilityProfile::task_only_v1().governed_target()
 }
 
 fn parse_task(value: &str) -> Result<TaskId, CliError> {

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/serve.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/serve.rs
@@ -37,7 +37,8 @@ pub(super) fn serve(args: ServeArgs, reporter: &Reporter) -> Result<u8, CliError
         .map_err(|error| CliError::Daemon(error.to_string()))?;
     // The production daemon owns one neutral target. Keeping this mapping in
     // the entrypoint prevents a caller from widening authority with flags.
-    let target = task_only_target();
+    let capability_profile = GatewayCapabilityProfile::task_only_v1();
+    let target = capability_profile.governed_target();
     let configured_workspace = if args.workspace.is_absolute() {
         args.workspace.clone()
     } else {
@@ -71,7 +72,7 @@ pub(super) fn serve(args: ServeArgs, reporter: &Reporter) -> Result<u8, CliError
         socket_path: daemon_socket_path(args.socket.as_ref())?,
         database_path: daemon_database_path(args.database.as_ref())?,
         installation_id,
-        target,
+        capability_profile,
         workspace: workspace.workspace_ref().clone(),
         runtime,
     };

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh_gateway/tests.rs
@@ -92,14 +92,9 @@ fn task_submit_defaults_to_brokered_core_and_fixed_task_only_target() {
         defaults.runtime_profile,
         GATEWAY_BROKERED_CORE_RUNTIME_PROFILE
     );
-    assert_eq!(task_only_target().kind.as_str(), TASK_ONLY_TARGET_KIND);
     assert_eq!(
-        task_only_target().authority.as_str(),
-        TASK_ONLY_TARGET_AUTHORITY
-    );
-    assert_eq!(
-        task_only_target().identifier.as_str(),
-        TASK_ONLY_TARGET_IDENTIFIER
+        task_only_target(),
+        GatewayCapabilityProfile::task_only_v1().governed_target()
     );
 
     let explicit = Cli::try_parse_from([

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon.rs
@@ -33,6 +33,7 @@ use cosh_gateway_contracts::ids::{
     ActorId, ApprovalId, DeliveryId, InputRequestId, InstallationId, MessageId, RequestId, RunId,
     TaskId,
 };
+use cosh_gateway_contracts::profile::GatewayCapabilityProfile;
 use cosh_gateway_contracts::runtime::RuntimeInputResponse;
 use cosh_gateway_contracts::task::{
     CancelReason, CancellationStage, TaskEvent, TaskEventEnvelope, TaskState,

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/coordinator.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/coordinator.rs
@@ -2,6 +2,7 @@
 pub struct TaskCoordinator {
     store: SqliteTaskStore,
     installation_id: InstallationId,
+    expected_profile: GatewayCapabilityProfile,
 }
 
 impl TaskCoordinator {
@@ -14,11 +15,24 @@ impl TaskCoordinator {
         database_path: impl AsRef<Path>,
         requested_installation_id: Option<InstallationId>,
     ) -> Result<Self, GatewayDaemonError> {
+        Self::open_for_capability_profile(
+            database_path,
+            requested_installation_id,
+            GatewayCapabilityProfile::task_only_v1(),
+        )
+    }
+
+    fn open_for_capability_profile(
+        database_path: impl AsRef<Path>,
+        requested_installation_id: Option<InstallationId>,
+        expected_profile: GatewayCapabilityProfile,
+    ) -> Result<Self, GatewayDaemonError> {
         let mut store = SqliteTaskStore::open(database_path)?;
         let installation_id = store.bind_installation_id(requested_installation_id.as_ref())?;
         Ok(Self {
             store,
             installation_id,
+            expected_profile,
         })
     }
 
@@ -66,6 +80,7 @@ impl TaskCoordinator {
             intent: request.intent,
             target: submitted_target(&submitted)?,
             workspace: workspace.clone(),
+            capability_profile: self.expected_profile.identity(),
         };
         let outbox = OutboxIntent {
             delivery_id: DeliveryId::new(),
@@ -279,9 +294,9 @@ impl TaskCoordinator {
             &request.task_id,
             &request.previous_run_id,
         )?;
-        let mut start_intent = serde_json::from_value::<scheduler::RuntimeStartIntent>(payload)?;
-        if start_intent.schema_version != scheduler::RUNTIME_START_SCHEMA_VERSION
-            || start_intent.actor != *actor
+        let mut start_intent =
+            scheduler::decode_runtime_start_intent(payload, self.expected_profile)?;
+        if start_intent.actor != *actor
             || start_intent.task_id != request.task_id
             || start_intent.run_id != request.previous_run_id
             || current.target() != target

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/protocol.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/protocol.rs
@@ -7,8 +7,8 @@ pub struct GatewayDaemonConfig {
     pub database_path: PathBuf,
     /// Durable identity shared by events in this database.
     pub installation_id: Option<InstallationId>,
-    /// Exact target admitted by this per-user daemon instance.
-    pub target: TargetRef,
+    /// Closed capability profile selected by trusted daemon configuration.
+    pub capability_profile: GatewayCapabilityProfile,
     /// Canonical workspace projection resolved from trusted daemon config.
     pub workspace: WorkspaceRef,
     /// Exact installed Runtime kind and profile admitted by this daemon instance.

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler.rs
@@ -19,6 +19,7 @@ use cosh_gateway_contracts::common::{
 };
 use cosh_gateway_contracts::error::{ContractError, ErrorCategory};
 use cosh_gateway_contracts::ids::{ActorId, InputRequestId, InstallationId, RunId, TaskId};
+use cosh_gateway_contracts::profile::{GatewayCapabilityProfile, GatewayCapabilityProfileIdentity};
 use cosh_gateway_contracts::task::{
     CancelReason, CancellationStage, RuntimeUpdate, TaskEvent, TaskState,
 };

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/brokered/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/brokered/tests.rs
@@ -810,6 +810,57 @@ struct ConclusiveSchedulerFixture {
     resolve_calls: Arc<Mutex<usize>>,
 }
 
+#[test]
+fn default_task_only_driver_rejects_before_approval() {
+    let root = TempDir::new().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    let database_path = root.path().join("gateway.db");
+    let installation = InstallationId::new();
+    let mut coordinator =
+        TaskCoordinator::open(&database_path, Some(installation.clone())).unwrap();
+    let actor_id = actor_id_for_uid(&installation, 1000).unwrap();
+    let task = coordinator
+        .submit(&actor_id, submission("task-only-rejects-side-effect"))
+        .unwrap();
+    drop(coordinator);
+    let writes = Arc::new(Mutex::new(RuntimeWrites::default()));
+    let started_at = now_ms().unwrap().saturating_add(1);
+    let mut scheduler = TaskScheduler::open(
+        &database_path,
+        Some(installation),
+        BoundedOpaque::new("task-only-rejecting-worker").unwrap(),
+        BrokeredFactory {
+            writes: Arc::clone(&writes),
+            expires_at_ms: started_at + 10_000,
+            fail_acknowledgement: false,
+            fail_result: false,
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        scheduler.tick(started_at).unwrap(),
+        SchedulerTick::Started(_)
+    ));
+    assert!(matches!(
+        scheduler.tick(started_at + 1).unwrap(),
+        SchedulerTick::Settled(TaskView {
+            state: TaskState::Failed,
+            ..
+        })
+    ));
+    let events = scheduler
+        .coordinator
+        .events(&actor_id, &task.task_id, None, 64)
+        .unwrap();
+    assert!(!events
+        .events
+        .iter()
+        .any(|event| matches!(event.event, TaskEvent::ApprovalRequested { .. })));
+    let writes = writes.lock().unwrap();
+    assert!(writes.acknowledgements.is_empty());
+    assert!(writes.results.is_empty());
+}
+
 fn conclusive_scheduler(
     mode: ConclusiveDriverMode,
     submission_key: &str,
@@ -1496,14 +1547,10 @@ fn submission(key: &str) -> SubmitTask {
         request_id: RequestId::new(),
         idempotency_key: IdempotencyKey::new(key).unwrap(),
         intent: BoundedText::new("create a checkpoint").unwrap(),
-        target: TargetRef {
-            kind: BoundedName::new("local").unwrap(),
-            authority: BoundedName::new("test").unwrap(),
-            identifier: BoundedOpaque::new("host").unwrap(),
-        },
+        target: GatewayCapabilityProfile::task_only_v1().governed_target(),
         runtime: RuntimeSelector {
-            runtime: BoundedName::new("acp").unwrap(),
-            profile: Some(BoundedName::new("cosh-core-brokered").unwrap()),
+            runtime: BoundedName::new("core").unwrap(),
+            profile: Some(BoundedName::new("gateway-brokered-v1").unwrap()),
         },
     }
 }

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/coordinator_recovery.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/coordinator_recovery.rs
@@ -105,8 +105,22 @@ impl TaskCoordinator {
         now_ms: u64,
         lease_expires_at_ms: u64,
     ) -> Result<RuntimeStartClaim, GatewayDaemonError> {
-        let Some(claim) = self.store.claim_outbox(
-            &runtime_start_delivery_kind(),
+        let delivery_kind = runtime_start_delivery_kind();
+        let Some(candidate) = self.store.peek_ready_outbox(&delivery_kind, now_ms)? else {
+            return Ok(RuntimeStartClaim::Empty);
+        };
+        let intent = decode_runtime_start_intent(
+            candidate.payload.clone(),
+            self.expected_profile,
+        )?;
+        if intent.task_id != candidate.task_id {
+            return Err(GatewayDaemonError::Protocol(
+                "runtime start Outbox identity mismatch".to_owned(),
+            ));
+        }
+        let Some(claim) = self.store.claim_outbox_candidate(
+            &delivery_kind,
+            &candidate,
             worker_id,
             now_ms,
             lease_expires_at_ms,
@@ -114,13 +128,6 @@ impl TaskCoordinator {
         else {
             return Ok(RuntimeStartClaim::Empty);
         };
-        let intent = serde_json::from_value::<RuntimeStartIntent>(claim.payload.clone())?;
-        if intent.schema_version != RUNTIME_START_SCHEMA_VERSION || intent.task_id != claim.task_id
-        {
-            return Err(GatewayDaemonError::Protocol(
-                "runtime start Outbox identity or schema mismatch".to_owned(),
-            ));
-        }
         let task = self.store.load_task(&intent.task_id)?;
         if task.owner_actor_id() != &intent.actor.actor_id
             || task.active_run_id() != Some(&intent.run_id)

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/input_tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/input_tests.rs
@@ -146,11 +146,7 @@ fn submission(key: &str) -> SubmitTask {
         request_id: RequestId::new(),
         idempotency_key: IdempotencyKey::new(key).unwrap(),
         intent: BoundedText::new("ask for input").unwrap(),
-        target: TargetRef {
-            kind: BoundedName::new("local").unwrap(),
-            authority: BoundedName::new("test").unwrap(),
-            identifier: BoundedOpaque::new("host").unwrap(),
-        },
+        target: GatewayCapabilityProfile::task_only_v1().governed_target(),
         runtime: RuntimeSelector {
             runtime: BoundedName::new("core").unwrap(),
             profile: Some(BoundedName::new("gateway-brokered-v1").unwrap()),

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/lifecycle.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/lifecycle.rs
@@ -11,10 +11,28 @@ impl<F: RuntimeFactory> TaskScheduler<F> {
         worker_id: BoundedOpaque,
         factory: F,
     ) -> Result<Self, GatewayDaemonError> {
-        Self::open_with_config(
+        Self::open_for_capability_profile(
             database_path,
             requested_installation_id,
             worker_id,
+            GatewayCapabilityProfile::task_only_v1(),
+            factory,
+        )
+    }
+
+    /// Opens durable scheduling bound to one trusted capability profile.
+    pub(crate) fn open_for_capability_profile(
+        database_path: impl AsRef<Path>,
+        requested_installation_id: Option<InstallationId>,
+        worker_id: BoundedOpaque,
+        expected_profile: GatewayCapabilityProfile,
+        factory: F,
+    ) -> Result<Self, GatewayDaemonError> {
+        Self::open_with_profile_and_config(
+            database_path,
+            requested_installation_id,
+            worker_id,
+            expected_profile,
             factory,
             TaskSchedulerConfig::default(),
         )
@@ -28,8 +46,30 @@ impl<F: RuntimeFactory> TaskScheduler<F> {
         factory: F,
         config: TaskSchedulerConfig,
     ) -> Result<Self, GatewayDaemonError> {
+        Self::open_with_profile_and_config(
+            database_path,
+            requested_installation_id,
+            worker_id,
+            GatewayCapabilityProfile::task_only_v1(),
+            factory,
+            config,
+        )
+    }
+
+    fn open_with_profile_and_config(
+        database_path: impl AsRef<Path>,
+        requested_installation_id: Option<InstallationId>,
+        worker_id: BoundedOpaque,
+        expected_profile: GatewayCapabilityProfile,
+        factory: F,
+        config: TaskSchedulerConfig,
+    ) -> Result<Self, GatewayDaemonError> {
         Ok(Self {
-            coordinator: TaskCoordinator::open(database_path, requested_installation_id)?,
+            coordinator: TaskCoordinator::open_for_capability_profile(
+                database_path,
+                requested_installation_id,
+                expected_profile,
+            )?,
             worker_id,
             config: config.validate()?,
             factory,

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/model.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/model.rs
@@ -1,4 +1,4 @@
-pub(super) const RUNTIME_START_SCHEMA_VERSION: u16 = 2;
+pub(super) const RUNTIME_START_SCHEMA_VERSION: u16 = 3;
 const DEFAULT_LEASE_DURATION_MS: u64 = 180_000;
 const DEFAULT_LEASE_RENEWAL_MARGIN_MS: u64 = 60_000;
 const DEFAULT_RUNTIME_OPERATION_TIMEOUT_MS: u64 = 70_000;
@@ -19,6 +19,95 @@ pub(super) struct RuntimeStartIntent {
     pub(super) intent: BoundedText,
     pub(super) target: TargetRef,
     pub(super) workspace: WorkspaceRef,
+    pub(super) capability_profile: GatewayCapabilityProfileIdentity,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuntimeStartIntentV2 {
+    schema_version: u16,
+    actor: ActorRef,
+    task_id: TaskId,
+    run_id: RunId,
+    runtime: RuntimeSelector,
+    intent: BoundedText,
+    target: TargetRef,
+    workspace: WorkspaceRef,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RuntimeStartIntentHeader {
+    schema_version: u16,
+}
+
+pub(super) fn decode_runtime_start_intent(
+    value: serde_json::Value,
+    expected_profile: GatewayCapabilityProfile,
+) -> Result<RuntimeStartIntent, GatewayDaemonError> {
+    let header = serde_json::from_value::<RuntimeStartIntentHeader>(value.clone()).map_err(
+        |error| {
+            GatewayDaemonError::Protocol(format!(
+                "runtime start intent has no valid schema version: {error}"
+            ))
+        },
+    )?;
+    let intent = match header.schema_version {
+        RUNTIME_START_SCHEMA_VERSION => serde_json::from_value::<RuntimeStartIntent>(value)?,
+        2 => {
+            let legacy = serde_json::from_value::<RuntimeStartIntentV2>(value)?;
+            if legacy.schema_version != 2 {
+                return Err(GatewayDaemonError::Protocol(
+                    "runtime start v2 decoder observed another schema".to_owned(),
+                ));
+            }
+            let legacy_profile = GatewayCapabilityProfile::task_only_v1();
+            if legacy.target != legacy_profile.governed_target()
+                || !is_task_only_runtime(&legacy.runtime)
+            {
+                return Err(GatewayDaemonError::Protocol(
+                    "runtime start v2 intent is compatible only with the exact task-only target and Runtime"
+                        .to_owned(),
+                ));
+            }
+            RuntimeStartIntent {
+                schema_version: RUNTIME_START_SCHEMA_VERSION,
+                actor: legacy.actor,
+                task_id: legacy.task_id,
+                run_id: legacy.run_id,
+                runtime: legacy.runtime,
+                intent: legacy.intent,
+                target: legacy.target,
+                workspace: legacy.workspace,
+                capability_profile: legacy_profile.identity(),
+            }
+        }
+        version if version > RUNTIME_START_SCHEMA_VERSION => {
+            return Err(GatewayDaemonError::Protocol(format!(
+                "runtime start intent schema {version} is newer than supported schema {RUNTIME_START_SCHEMA_VERSION}"
+            )))
+        }
+        version => {
+            return Err(GatewayDaemonError::Protocol(format!(
+                "runtime start intent schema {version} is not supported"
+            )))
+        }
+    };
+    expected_profile
+        .verify_identity(&intent.capability_profile)
+        .map_err(|error| GatewayDaemonError::Protocol(error.to_string()))?;
+    if intent.target != expected_profile.governed_target()
+        || !is_task_only_runtime(&intent.runtime)
+    {
+        return Err(GatewayDaemonError::Protocol(
+            "runtime start intent does not match the task-only capability profile".to_owned(),
+        ));
+    }
+    Ok(intent)
+}
+
+fn is_task_only_runtime(runtime: &RuntimeSelector) -> bool {
+    runtime.runtime.as_str() == "core"
+        && runtime.profile.as_ref().map(BoundedName::as_str) == Some("gateway-brokered-v1")
 }
 
 /// Immutable work description passed to an injected Runtime factory.
@@ -38,6 +127,8 @@ pub struct ScheduledRun {
     pub target: TargetRef,
     /// Trusted public projection of the canonical workspace.
     pub workspace: WorkspaceRef,
+    /// Capability identity durably selected when this Run was admitted.
+    pub capability_profile: GatewayCapabilityProfileIdentity,
     /// Current Run-lease generation.
     pub lease_generation: u64,
 }

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/tests.rs
@@ -5,13 +5,14 @@ use std::{fs, os::unix::fs::PermissionsExt};
 use cosh_gateway_contracts::capability::{CapabilityRequest, CapabilityScope, OperationDescriptor};
 use cosh_gateway_contracts::common::{
     BoundedName, BoundedOpaque, BoundedText, Digest, IdempotencyKey, RuntimeBindingRef,
-    RuntimeSelector, TargetRef,
+    RuntimeSelector,
 };
 use cosh_gateway_contracts::external::{ExternalRef, ExternalRefKind};
 use cosh_gateway_contracts::ids::{
     AgentSessionId, ApprovalId, InstallationId, RequestId, RuntimeBindingId, RuntimeInstanceId,
     TurnId,
 };
+use cosh_gateway_contracts::profile::GatewayCapabilityProfile;
 use cosh_gateway_contracts::runtime::ToolSummary;
 use tempfile::TempDir;
 
@@ -23,14 +24,10 @@ fn submission(key: &str) -> SubmitTask {
         request_id: RequestId::new(),
         idempotency_key: IdempotencyKey::new(key).unwrap(),
         intent: BoundedText::new("inspect service").unwrap(),
-        target: TargetRef {
-            kind: BoundedName::new("local").unwrap(),
-            authority: BoundedName::new("test").unwrap(),
-            identifier: BoundedOpaque::new("host").unwrap(),
-        },
+        target: GatewayCapabilityProfile::task_only_v1().governed_target(),
         runtime: RuntimeSelector {
-            runtime: BoundedName::new("acp").unwrap(),
-            profile: Some(BoundedName::new("codex").unwrap()),
+            runtime: BoundedName::new("core").unwrap(),
+            profile: Some(BoundedName::new("gateway-brokered-v1").unwrap()),
         },
     }
 }
@@ -230,6 +227,130 @@ impl RuntimeHandle for PermissionHandle {
 
 fn test_digest() -> Digest {
     Digest::parse("a".repeat(64)).unwrap()
+}
+
+#[test]
+fn invalid_start_intents_are_rejected_before_outbox_claim() {
+    for case in ["profile-drift", "v2-target", "v2-runtime", "future-schema"] {
+        let root = TempDir::new().unwrap();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let database_path = root.path().join("gateway.db");
+        let installation = InstallationId::new();
+        let mut coordinator =
+            TaskCoordinator::open(&database_path, Some(installation.clone())).unwrap();
+        let actor = actor_id_for_uid(&installation, 1000).unwrap();
+        coordinator.submit(&actor, submission(case)).unwrap();
+        let now = now_ms().unwrap().saturating_add(1);
+        let candidate = coordinator
+            .store
+            .peek_ready_outbox(&runtime_start_delivery_kind(), now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(candidate.attempt, 0, "case {case}");
+        let mut payload = candidate.payload;
+        match case {
+            "profile-drift" => {
+                payload["capability_profile"]["manifest_digest"] =
+                    serde_json::json!("b".repeat(64));
+            }
+            "v2-target" => {
+                payload["schema_version"] = serde_json::json!(2);
+                payload
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("capability_profile");
+                payload["target"]["identifier"] = serde_json::json!("another-target");
+            }
+            "v2-runtime" => {
+                payload["schema_version"] = serde_json::json!(2);
+                payload
+                    .as_object_mut()
+                    .unwrap()
+                    .remove("capability_profile");
+                payload["runtime"] = serde_json::json!({"runtime": "acp", "profile": "codex"});
+            }
+            "future-schema" => payload["schema_version"] = serde_json::json!(4),
+            _ => unreachable!(),
+        }
+        coordinator
+            .store
+            .replace_outbox_payload_for_test(&candidate.delivery_id, &payload)
+            .unwrap();
+        drop(coordinator);
+
+        let starts = Arc::new(AtomicUsize::new(0));
+        let mut scheduler = TaskScheduler::open(
+            &database_path,
+            Some(installation),
+            BoundedOpaque::new(format!("invalid-start-{case}")).unwrap(),
+            NeverStartFactory(Arc::clone(&starts)),
+        )
+        .unwrap();
+        assert!(
+            matches!(scheduler.tick(now), Err(GatewayDaemonError::Protocol(_))),
+            "case {case}"
+        );
+        let candidate = scheduler
+            .coordinator
+            .store
+            .peek_ready_outbox(&runtime_start_delivery_kind(), now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(candidate.attempt, 0, "case {case}");
+        assert_eq!(starts.load(Ordering::Relaxed), 0, "case {case}");
+    }
+}
+
+#[test]
+fn exact_task_only_v2_intent_maps_to_current_profile() {
+    let root = TempDir::new().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    let database_path = root.path().join("gateway.db");
+    let installation = InstallationId::new();
+    let mut coordinator =
+        TaskCoordinator::open(&database_path, Some(installation.clone())).unwrap();
+    let actor = actor_id_for_uid(&installation, 1000).unwrap();
+    coordinator
+        .submit(&actor, submission("compatible-v2-start"))
+        .unwrap();
+    let now = now_ms().unwrap().saturating_add(1);
+    let candidate = coordinator
+        .store
+        .peek_ready_outbox(&runtime_start_delivery_kind(), now)
+        .unwrap()
+        .unwrap();
+    let mut payload = candidate.payload;
+    payload["schema_version"] = serde_json::json!(2);
+    payload
+        .as_object_mut()
+        .unwrap()
+        .remove("capability_profile");
+    coordinator
+        .store
+        .replace_outbox_payload_for_test(&candidate.delivery_id, &payload)
+        .unwrap();
+    drop(coordinator);
+
+    let mut scheduler = TaskScheduler::open(
+        &database_path,
+        Some(installation),
+        BoundedOpaque::new("compatible-v2-worker").unwrap(),
+        UpdateFactory,
+    )
+    .unwrap();
+    assert!(matches!(
+        scheduler.tick(now).unwrap(),
+        SchedulerTick::Started(_)
+    ));
+    assert_eq!(
+        scheduler
+            .active
+            .as_ref()
+            .unwrap()
+            .scheduled
+            .capability_profile,
+        GatewayCapabilityProfile::task_only_v1().identity()
+    );
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/tick.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler/tick.rs
@@ -42,6 +42,7 @@ impl<F: RuntimeFactory> TaskScheduler<F> {
             intent: intent.intent,
             target: intent.target,
             workspace: intent.workspace,
+            capability_profile: intent.capability_profile,
             lease_generation: lease.generation,
         };
         match self.factory.open(&scheduled) {

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler_attachment.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/scheduler_attachment.rs
@@ -27,10 +27,11 @@ impl GatewayDaemon {
             ));
         }
         self.scheduler = Some(
-            TaskScheduler::open(
+            TaskScheduler::open_for_capability_profile(
                 &self.database_path,
                 Some(self.coordinator.installation_id.clone()),
                 worker_id,
+                self.capability_profile,
                 factory,
             )?
             .with_brokered_execution_driver(driver),
@@ -61,10 +62,11 @@ impl GatewayDaemon {
                 "Gateway scheduler is already attached".to_owned(),
             ));
         }
-        self.scheduler = Some(TaskScheduler::open(
+        self.scheduler = Some(TaskScheduler::open_for_capability_profile(
             &self.database_path,
             Some(self.coordinator.installation_id.clone()),
             worker_id,
+            self.capability_profile,
             factory,
         )?);
         self.runtime_containment = Some(containment);

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/server.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/server.rs
@@ -5,6 +5,7 @@ pub struct GatewayDaemon {
     socket_path: PathBuf,
     socket_identity: (u64, u64),
     owner_uid: u32,
+    capability_profile: GatewayCapabilityProfile,
     admitted_target: TargetRef,
     admitted_workspace: WorkspaceRef,
     admitted_runtime: RuntimeSelector,
@@ -20,15 +21,22 @@ impl GatewayDaemon {
     ///
     /// Returns a fail-closed path, storage, socket, or already-running error.
     pub fn bind(config: GatewayDaemonConfig) -> Result<Self, GatewayDaemonError> {
-        if !supported_daemon_runtime(&config.runtime) {
+        let admitted_target = config.capability_profile.governed_target();
+        if config.capability_profile != GatewayCapabilityProfile::task_only_v1()
+            || !supported_daemon_runtime(&config.runtime)
+        {
             return Err(GatewayDaemonError::Protocol(
-                "daemon Runtime selector is not supported".to_owned(),
+                "daemon capability profile or Runtime selector is not supported".to_owned(),
             ));
         }
         let owner_uid = Uid::effective().as_raw();
         prepare_socket_path(&config.socket_path, owner_uid)?;
         let database_path = config.database_path.clone();
-        let coordinator = TaskCoordinator::open(&database_path, config.installation_id)?;
+        let coordinator = TaskCoordinator::open_for_capability_profile(
+            &database_path,
+            config.installation_id,
+            config.capability_profile,
+        )?;
         let listener = UnixListener::bind(&config.socket_path)?;
         fs::set_permissions(&config.socket_path, fs::Permissions::from_mode(0o600))?;
         listener.set_nonblocking(true)?;
@@ -39,7 +47,8 @@ impl GatewayDaemon {
             socket_path: config.socket_path,
             socket_identity: (metadata.dev(), metadata.ino()),
             owner_uid,
-            admitted_target: config.target,
+            capability_profile: config.capability_profile,
+            admitted_target,
             admitted_workspace: config.workspace,
             admitted_runtime: config.runtime,
             database_path,

--- a/src/cosh-ng/crates/cosh-gateway/src/daemon/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/daemon/tests.rs
@@ -38,11 +38,7 @@ fn submit(key: &str) -> SubmitTask {
         request_id: RequestId::new(),
         idempotency_key: IdempotencyKey::new(key).unwrap(),
         intent: BoundedText::new("inspect the failed service").unwrap(),
-        target: TargetRef {
-            kind: BoundedName::new("local").unwrap(),
-            authority: BoundedName::new("test").unwrap(),
-            identifier: BoundedOpaque::new("host").unwrap(),
-        },
+        target: GatewayCapabilityProfile::task_only_v1().governed_target(),
         runtime: brokered_core_runtime(),
     }
 }
@@ -65,7 +61,7 @@ fn daemon_config(socket_path: PathBuf, database_path: PathBuf) -> GatewayDaemonC
         socket_path,
         database_path,
         installation_id: None,
-        target: submit("daemon-config").target,
+        capability_profile: GatewayCapabilityProfile::task_only_v1(),
         workspace: WorkspaceRef {
             scope_digest: sha256_digest(b"cosh.gateway.test.workspace.v1"),
             display_name: None,
@@ -386,6 +382,20 @@ fn retryable_failure_requires_explicit_retry_and_replays_the_new_start_intent() 
         .submit(&actor.actor_id, submit("retryable-run"))
         .unwrap();
     let previous_run_id = queued.active_run_id.clone().unwrap();
+    let submitted_candidate = coordinator
+        .store
+        .peek_ready_outbox(
+            &scheduler::runtime_start_delivery_kind(),
+            now_ms().unwrap().saturating_add(1),
+        )
+        .unwrap()
+        .unwrap();
+    let original_identity = scheduler::decode_runtime_start_intent(
+        submitted_candidate.payload,
+        GatewayCapabilityProfile::task_only_v1(),
+    )
+    .unwrap()
+    .capability_profile;
     let retryable = ContractError::new(
         "runtime_busy",
         ErrorCategory::RuntimeUnavailable,
@@ -428,7 +438,7 @@ fn retryable_failure_requires_explicit_retry_and_replays_the_new_start_intent() 
     let retried = coordinator
         .retry_admitted(
             &actor,
-            &config.target,
+            &config.capability_profile.governed_target(),
             &config.workspace,
             &config.runtime,
             retry.clone(),
@@ -437,11 +447,26 @@ fn retryable_failure_requires_explicit_retry_and_replays_the_new_start_intent() 
     assert_eq!(retried.state, TaskState::Queued);
     let next_run_id = retried.active_run_id.clone().unwrap();
     assert_ne!(next_run_id, previous_run_id);
+    let retry_candidate = coordinator
+        .store
+        .peek_ready_outbox(
+            &scheduler::runtime_start_delivery_kind(),
+            now_ms().unwrap().saturating_add(1),
+        )
+        .unwrap()
+        .unwrap();
+    let retry_intent = scheduler::decode_runtime_start_intent(
+        retry_candidate.payload,
+        GatewayCapabilityProfile::task_only_v1(),
+    )
+    .unwrap();
+    assert_eq!(retry_intent.run_id, next_run_id);
+    assert_eq!(retry_intent.capability_profile, original_identity);
     assert_eq!(
         coordinator
             .retry_admitted(
                 &actor,
-                &config.target,
+                &config.capability_profile.governed_target(),
                 &config.workspace,
                 &config.runtime,
                 retry.clone(),
@@ -455,7 +480,7 @@ fn retryable_failure_requires_explicit_retry_and_replays_the_new_start_intent() 
     assert!(matches!(
         coordinator.retry_admitted(
             &actor,
-            &config.target,
+            &config.capability_profile.governed_target(),
             &config.workspace,
             &config.runtime,
             conflicting,
@@ -547,7 +572,7 @@ fn retry_waits_for_crash_window_lease_recovery_before_queueing() {
     };
     let blocked = coordinator.retry_admitted(
         &actor,
-        &admission.target,
+        &admission.capability_profile.governed_target(),
         &admission.workspace,
         &admission.runtime,
         retry.clone(),
@@ -597,7 +622,7 @@ fn retry_waits_for_crash_window_lease_recovery_before_queueing() {
     let retried = coordinator
         .retry_admitted(
             &actor,
-            &admission.target,
+            &admission.capability_profile.governed_target(),
             &admission.workspace,
             &admission.runtime,
             retry,
@@ -648,7 +673,7 @@ fn terminal_tasks_are_never_reopened_by_retry() {
     assert!(matches!(
         coordinator.retry_admitted(
             &actor,
-            &config.target,
+            &config.capability_profile.governed_target(),
             &config.workspace,
             &config.runtime,
             RetryTask {
@@ -686,7 +711,7 @@ fn terminal_tasks_are_never_reopened_by_retry() {
     assert!(matches!(
         coordinator.retry_admitted(
             &actor,
-            &config.target,
+            &config.capability_profile.governed_target(),
             &config.workspace,
             &config.runtime,
             RetryTask {
@@ -720,7 +745,7 @@ fn terminal_tasks_are_never_reopened_by_retry() {
     assert!(matches!(
         coordinator.retry_admitted(
             &actor,
-            &config.target,
+            &config.capability_profile.governed_target(),
             &config.workspace,
             &config.runtime,
             RetryTask {

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_bridge/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_bridge/tests.rs
@@ -422,7 +422,7 @@ fn brokered_profile_rejects_checkpoint_request_before_capability() {
     let workspace = tempfile::tempdir().unwrap();
     let script = r#"
 IFS= read -r line
-printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":2,"execution_profile":"gateway_brokered_v1","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":3,"execution_profile":"gateway_brokered_v1","capability_profile":{"profile_id":"task-only-v1","manifest_digest":"2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"},"runtime_tools":["ask_user_question"],"capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-session"}'
 IFS= read -r line
 printf '%s\n' '{"type":"stream_event","event":{"type":"message_start"}}'
@@ -475,7 +475,7 @@ fn brokered_ask_user_is_exact_single_use_and_side_effect_free() {
     let workspace = tempfile::tempdir().unwrap();
     let script = r#"
 IFS= read -r line
-printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":2,"execution_profile":"gateway_brokered_v1","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":3,"execution_profile":"gateway_brokered_v1","capability_profile":{"profile_id":"task-only-v1","manifest_digest":"2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"},"runtime_tools":["ask_user_question"],"capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-session"}'
 IFS= read -r line
 printf '%s\n' '{"type":"stream_event","event":{"type":"message_start"}}'
@@ -603,7 +603,7 @@ fn brokered_ask_user_resolution_after_cancel_fails_closed() {
     let workspace = tempfile::tempdir().unwrap();
     let script = r#"
 IFS= read -r line
-printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":2,"execution_profile":"gateway_brokered_v1","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":3,"execution_profile":"gateway_brokered_v1","capability_profile":{"profile_id":"task-only-v1","manifest_digest":"2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"},"runtime_tools":["ask_user_question"],"capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-session"}'
 IFS= read -r line
 printf '%s\n' '{"type":"stream_event","event":{"type":"message_start"}}'
@@ -675,7 +675,7 @@ fn brokered_profile_rejects_generic_permission_and_unknown_intent() {
     let workspace = tempfile::tempdir().unwrap();
     let script = r#"
 IFS= read -r line
-printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":2,"execution_profile":"gateway_brokered_v1","capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
+printf '%s\n' '{"type":"control_response","response":{"subtype":"success","request_id":"__INIT_REQUEST_ID__","response":{"subtype":"initialize","protocol_version":3,"execution_profile":"gateway_brokered_v1","capability_profile":{"profile_id":"task-only-v1","manifest_digest":"2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a"},"runtime_tools":["ask_user_question"],"capabilities":{"can_handle_can_use_tool":true,"can_handle_host_executed_shell_tool_result":false,"can_handle_approval_receipt":true,"can_handle_hosted_checkpoint_create":false,"can_handle_brokered_ask_user":true}}}}'
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"provider-session"}'
 IFS= read -r line
 printf '%s\n' '{"type":"stream_event","event":{"type":"message_start"}}'

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/codec.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/codec.rs
@@ -1,5 +1,6 @@
 //! Stateful encoder and decoder for private cosh-core JSONL frames.
 
+use cosh_gateway_contracts::profile::{GatewayCapabilityProfile, GatewayCapabilityProfileIdentity};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -12,6 +13,7 @@ pub struct CoshCoreJsonlCodec {
     max_frame_bytes: usize,
     phase: CoshCoreProtocolPhase,
     profile: CoshCoreExecutionProfile,
+    capability_profile: Option<GatewayCapabilityProfileIdentity>,
 }
 
 impl CoshCoreJsonlCodec {
@@ -32,10 +34,11 @@ impl CoshCoreJsonlCodec {
             max_frame_bytes,
             phase: CoshCoreProtocolPhase::Created,
             profile: CoshCoreExecutionProfile::Legacy,
+            capability_profile: None,
         })
     }
 
-    /// Creates a codec that requires the exact brokered v2 acknowledgement.
+    /// Creates a codec that requires the exact brokered v3 acknowledgement.
     ///
     /// # Errors
     ///
@@ -46,6 +49,7 @@ impl CoshCoreJsonlCodec {
     ) -> Result<Self, CoshCoreCodecError> {
         let mut codec = Self::new(initialize_request_id, max_frame_bytes)?;
         codec.profile = CoshCoreExecutionProfile::GatewayBrokeredV1;
+        codec.capability_profile = Some(GatewayCapabilityProfile::task_only_v1().identity());
         Ok(codec)
     }
 
@@ -75,6 +79,7 @@ impl CoshCoreJsonlCodec {
                     fire_session_start,
                     protocol_version: self.profile.protocol_version(),
                     execution_profile: self.profile.wire_name(),
+                    capability_profile: self.capability_profile.as_ref(),
                 },
             },
             self.max_frame_bytes,
@@ -344,6 +349,21 @@ impl CoshCoreJsonlCodec {
         if acknowledged_profile != self.profile.wire_name() {
             return Err(CoshCoreCodecError::InitializeProfileMismatch);
         }
+        if envelope.response.response.capability_profile != self.capability_profile {
+            return Err(CoshCoreCodecError::InitializeProfileMismatch);
+        }
+        if self.profile == CoshCoreExecutionProfile::GatewayBrokeredV1 {
+            let runtime_tools = envelope
+                .response
+                .response
+                .runtime_tools
+                .as_ref()
+                .ok_or(CoshCoreCodecError::InitializeCapabilitiesMissing)?;
+            let runtime_tools = runtime_tools.iter().map(String::as_str).collect::<Vec<_>>();
+            GatewayCapabilityProfile::task_only_v1()
+                .verify_runtime_tools(&runtime_tools)
+                .map_err(|_| CoshCoreCodecError::InitializeCapabilitiesInvalid)?;
+        }
         let capabilities = envelope
             .response
             .response
@@ -471,16 +491,18 @@ struct InitializeInput<'a> {
     #[serde(rename = "type")]
     message_type: &'static str,
     request_id: &'a str,
-    request: InitializeRequest,
+    request: InitializeRequest<'a>,
 }
 
 #[derive(Serialize)]
-struct InitializeRequest {
+struct InitializeRequest<'a> {
     subtype: &'static str,
     fire_session_start: bool,
     protocol_version: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     execution_profile: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capability_profile: Option<&'a GatewayCapabilityProfileIdentity>,
 }
 
 #[derive(Serialize)]
@@ -568,6 +590,10 @@ struct WireInitializeBody {
     protocol_version: Option<u32>,
     #[serde(default)]
     execution_profile: Option<String>,
+    #[serde(default)]
+    capability_profile: Option<GatewayCapabilityProfileIdentity>,
+    #[serde(default)]
+    runtime_tools: Option<Vec<String>>,
     #[serde(default)]
     capabilities: Option<CoshCoreCapabilities>,
     #[serde(default)]

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/tests.rs
@@ -28,9 +28,9 @@ fn initialized_codec() -> CoshCoreJsonlCodec {
 
 fn initialized_brokered_codec() -> CoshCoreJsonlCodec {
     let corpus = private_wire_corpus();
-    let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v2", 4096).unwrap();
+    let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
     codec.initialize_frame(false).unwrap();
-    let response = fixture_frame(&corpus["gateway_brokered_v2"]["initialize_ack"]);
+    let response = fixture_frame(&corpus["gateway_brokered_v3"]["initialize_ack"]);
     assert!(matches!(
         codec.decode_frame(&response).unwrap(),
         CoshCoreObservation::Initialized(_)
@@ -51,23 +51,28 @@ fn initialize_is_explicitly_private_version_one() {
 }
 
 #[test]
-fn brokered_initialize_is_exact_private_v2_and_profile_bound() {
+fn brokered_initialize_is_exact_private_v3_and_profile_bound() {
     let corpus = private_wire_corpus();
-    let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v2", 4096).unwrap();
+    let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
     let frame = codec.initialize_frame(false).unwrap();
     let value: Value = serde_json::from_str(frame.trim()).unwrap();
-    assert_eq!(value, corpus["gateway_brokered_v2"]["initialize_request"]);
+    assert_eq!(value, corpus["gateway_brokered_v3"]["initialize_request"]);
 }
 
 #[test]
 fn brokered_initialize_rejects_missing_or_wrong_profile_and_capabilities() {
     let corpus = private_wire_corpus();
-    let invalid = corpus["gateway_brokered_v2"]["invalid_initialize_acks"]
+    let invalid = corpus["gateway_brokered_v3"]["invalid_initialize_acks"]
         .as_object()
         .expect("invalid initialize acknowledgement map");
 
-    for case in ["missing_profile", "wrong_profile"] {
-        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v2", 4096).unwrap();
+    for case in [
+        "missing_profile",
+        "wrong_profile",
+        "missing_capability_profile",
+        "drifted_capability_profile",
+    ] {
+        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
         codec.initialize_frame(false).unwrap();
         let response = fixture_frame(&invalid[case]);
         assert!(
@@ -85,7 +90,7 @@ fn brokered_initialize_rejects_missing_or_wrong_profile_and_capabilities() {
         ("missing_capabilities", "missing_capabilities"),
         ("wrong_capabilities", "wrong_capabilities"),
     ] {
-        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v2", 4096).unwrap();
+        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
         codec.initialize_frame(false).unwrap();
         let response = fixture_frame(&invalid[case]);
         let error = codec.decode_frame(&response).unwrap_err();
@@ -95,8 +100,8 @@ fn brokered_initialize_rejects_missing_or_wrong_profile_and_capabilities() {
                 "wrong_version" => matches!(
                     error,
                     CoshCoreCodecError::InitializeVersionMismatch {
-                        required: 2,
-                        actual: 1
+                        required: 3,
+                        actual: 2
                     }
                 ),
                 "missing_capabilities" => {
@@ -109,6 +114,39 @@ fn brokered_initialize_rejects_missing_or_wrong_profile_and_capabilities() {
             },
             "case {case}: {error:?}"
         );
+    }
+}
+
+#[test]
+fn brokered_initialize_rejects_runtime_tool_inventory_drift() {
+    let corpus = private_wire_corpus();
+    let mut missing = corpus["gateway_brokered_v3"]["initialize_ack"].clone();
+    missing["response"]["response"]
+        .as_object_mut()
+        .unwrap()
+        .remove("runtime_tools");
+    let mut null = corpus["gateway_brokered_v3"]["initialize_ack"].clone();
+    null["response"]["response"]["runtime_tools"] = serde_json::json!(null);
+    for acknowledgement in [missing, null] {
+        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
+        codec.initialize_frame(false).unwrap();
+        assert!(matches!(
+            codec.decode_frame(&fixture_frame(&acknowledgement)),
+            Err(CoshCoreCodecError::InitializeCapabilitiesMissing)
+        ));
+    }
+    for runtime_tools in [
+        serde_json::json!([]),
+        serde_json::json!(["ask_user_question", "shell"]),
+    ] {
+        let mut acknowledgement = corpus["gateway_brokered_v3"]["initialize_ack"].clone();
+        acknowledgement["response"]["response"]["runtime_tools"] = runtime_tools;
+        let mut codec = CoshCoreJsonlCodec::new_gateway_brokered("gateway-init-v3", 4096).unwrap();
+        codec.initialize_frame(false).unwrap();
+        assert!(matches!(
+            codec.decode_frame(&fixture_frame(&acknowledgement)),
+            Err(CoshCoreCodecError::InitializeCapabilitiesInvalid)
+        ));
     }
 }
 
@@ -138,14 +176,14 @@ fn brokered_callback_frames_are_closed_golden_shapes() {
             .trim(),
     )
     .unwrap();
-    assert_eq!(answer, corpus["gateway_brokered_v2"]["ask_user_answer"]);
+    assert_eq!(answer, corpus["gateway_brokered_v3"]["ask_user_answer"]);
 }
 
 #[test]
 fn brokered_ask_user_request_is_strictly_typed() {
     let corpus = private_wire_corpus();
     let mut codec = initialized_brokered_codec();
-    let request = fixture_frame(&corpus["gateway_brokered_v2"]["ask_user_request"]);
+    let request = fixture_frame(&corpus["gateway_brokered_v3"]["ask_user_request"]);
 
     assert_eq!(
         codec.decode_frame(&request).unwrap(),

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/types.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/cosh_core_jsonl/types.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 /// Exact private Shell/Core control protocol version implemented by cosh-core.
 pub const PRIVATE_COSH_CONTROL_PROTOCOL_VERSION: u32 = 1;
 /// Exact private protocol version for the Gateway-brokered Core profile.
-pub const BROKERED_COSH_CONTROL_PROTOCOL_VERSION: u32 = 2;
+pub const BROKERED_COSH_CONTROL_PROTOCOL_VERSION: u32 = 3;
 /// Exact launch and acknowledgement name for the brokered Core profile.
 pub const GATEWAY_BROKERED_EXECUTION_PROFILE: &str = "gateway_brokered_v1";
 

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_acp_factory/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_acp_factory/tests.rs
@@ -237,6 +237,8 @@ fn factory_rejects_untrusted_run_fields_before_launch() {
         intent: BoundedText::new("read status").unwrap(),
         target: expected_target,
         workspace: workspace_ref,
+        capability_profile:
+            cosh_gateway_contracts::profile::GatewayCapabilityProfile::task_only_v1().identity(),
         lease_generation: 1,
     };
     let error = match factory.create(&run) {
@@ -275,6 +277,8 @@ fn factory_launches_a_valid_explicit_adapter_without_opening_a_session() {
         intent: BoundedText::new("read status").unwrap(),
         target: expected_target,
         workspace: workspace_ref,
+        capability_profile:
+            cosh_gateway_contracts::profile::GatewayCapabilityProfile::task_only_v1().identity(),
         lease_generation: 7,
     };
 
@@ -318,6 +322,8 @@ fn factory_pins_a_symlink_target_at_admission() {
         intent: BoundedText::new("read status").unwrap(),
         target: expected_target,
         workspace: workspace_ref,
+        capability_profile:
+            cosh_gateway_contracts::profile::GatewayCapabilityProfile::task_only_v1().identity(),
         lease_generation: 7,
     };
 

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory.rs
@@ -11,6 +11,7 @@ use cosh_gateway_contracts::{
     common::{BoundedName, Digest},
     error::{ContractError, ErrorCategory},
     ids::{AgentSessionId, InstallationId, RuntimeBindingId, RuntimeInstanceId},
+    profile::GatewayCapabilityProfile,
 };
 use sha2::{Digest as _, Sha256};
 
@@ -168,7 +169,11 @@ impl InstalledBrokeredCoreRuntimePortFactory {
 
 impl AgentRuntimePortFactory for InstalledBrokeredCoreRuntimePortFactory {
     fn create(&mut self, run: &ScheduledRun) -> Result<ScheduledRuntimePort, ContractError> {
-        if run.runtime.runtime.as_str() != "core"
+        if GatewayCapabilityProfile::task_only_v1()
+            .verify_identity(&run.capability_profile)
+            .is_err()
+            || run.target != GatewayCapabilityProfile::task_only_v1().governed_target()
+            || run.runtime.runtime.as_str() != "core"
             || run.runtime.profile.as_ref().map(BoundedName::as_str)
                 != Some(GATEWAY_BROKERED_CORE_RUNTIME_PROFILE)
         {

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/installed_core_factory/tests.rs
@@ -54,7 +54,7 @@ fn admitted(
 ) -> (InstalledBrokeredCoreRuntimePortFactory, ScheduledRun) {
     let workspace = root.path().join("workspace");
     fs::create_dir(&workspace).unwrap();
-    let expected_target = target("primary");
+    let expected_target = GatewayCapabilityProfile::task_only_v1().governed_target();
     let installation = InstallationId::new();
     let actors = LocalOsActorResolver::new(installation.clone(), 1000);
     let actor = actors.actor_ref().clone();
@@ -86,6 +86,7 @@ fn admitted(
         intent: BoundedText::new("create a checkpoint").unwrap(),
         target: expected_target,
         workspace: workspace_ref,
+        capability_profile: GatewayCapabilityProfile::task_only_v1().identity(),
         lease_generation: 9,
     };
     (factory, run)
@@ -132,6 +133,12 @@ fn factory_rejects_runtime_profile_and_actor_substitution_before_launch() {
         "runtime_profile_invalid"
     );
     run.runtime.profile = Some(BoundedName::new(GATEWAY_BROKERED_CORE_RUNTIME_PROFILE).unwrap());
+    run.capability_profile.manifest_digest = Digest::parse("b".repeat(64)).unwrap();
+    assert_eq!(
+        factory.create(&run).err().unwrap().code.as_str(),
+        "runtime_profile_invalid"
+    );
+    run.capability_profile = GatewayCapabilityProfile::task_only_v1().identity();
     run.actor.actor_id = cosh_gateway_contracts::ids::ActorId::new();
     assert_eq!(
         factory.create(&run).err().unwrap().code.as_str(),

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/scheduled_adapter/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/scheduled_adapter/tests.rs
@@ -131,6 +131,9 @@ impl Fixture {
                     identifier: BoundedOpaque::new("host").unwrap(),
                 },
                 workspace: workspace.clone(),
+                capability_profile:
+                    cosh_gateway_contracts::profile::GatewayCapabilityProfile::task_only_v1()
+                        .identity(),
                 lease_generation: 1,
             },
             workspace,

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/task_store.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/task_store.rs
@@ -59,6 +59,15 @@ pub struct OutboxClaim {
     pub lease_expires_at_ms: u64,
 }
 
+/// Read-only next-delivery snapshot used to validate before taking a lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OutboxCandidate {
+    pub(crate) delivery_id: DeliveryId,
+    pub(crate) task_id: TaskId,
+    pub(crate) payload: serde_json::Value,
+    pub(crate) attempt: u64,
+}
+
 /// Complete unit of work admitted by the single Task writer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TaskCommit {

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/task_store/outbox.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/task_store/outbox.rs
@@ -1,4 +1,60 @@
 impl SqliteTaskStore {
+    /// Reads the same eligible delivery that [`Self::claim_outbox`] would lease.
+    pub(crate) fn peek_ready_outbox(
+        &self,
+        delivery_kind: &BoundedName,
+        now_ms: u64,
+    ) -> Result<Option<OutboxCandidate>, StoreError> {
+        let now = sqlite_integer(now_ms, "Outbox peek timestamp")?;
+        let candidate = self
+            .connection()
+            .query_row(
+                "SELECT delivery_id, task_id, payload_json, attempt
+                 FROM outbox
+                 WHERE delivery_kind = ?1 AND next_attempt_at_ms <= ?2
+                   AND (state = 'pending'
+                        OR (state = 'leased' AND lease_expires_at_ms <= ?2))
+                 ORDER BY next_attempt_at_ms, created_at_ms, delivery_id
+                 LIMIT 1",
+                params![delivery_kind.as_str(), now],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, i64>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((delivery_id, task_id, payload_json, attempt)) = candidate else {
+            return Ok(None);
+        };
+        Ok(Some(OutboxCandidate {
+            delivery_id: DeliveryId::parse(&delivery_id).map_err(|error| {
+                corrupt(&format!("invalid Outbox delivery identity: {error}"))
+            })?,
+            task_id: TaskId::parse(&task_id)
+                .map_err(|error| corrupt(&format!("invalid Outbox Task identity: {error}")))?,
+            payload: serde_json::from_str(&payload_json)?,
+            attempt: u64::try_from(attempt)
+                .map_err(|_| corrupt("negative Outbox attempt"))?,
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replace_outbox_payload_for_test(
+        &mut self,
+        delivery_id: &DeliveryId,
+        payload: &serde_json::Value,
+    ) -> Result<(), StoreError> {
+        let payload = serde_json::to_string(payload)?;
+        self.connection_mut().execute(
+            "UPDATE outbox SET payload_json=?2 WHERE delivery_id=?1",
+            params![delivery_id.as_str(), payload],
+        )?;
+        Ok(())
+    }
 
     /// Claims the oldest ready delivery of one kind in an immediate transaction.
     ///
@@ -16,6 +72,41 @@ impl SqliteTaskStore {
         now_ms: u64,
         lease_expires_at_ms: u64,
     ) -> Result<Option<OutboxClaim>, StoreError> {
+        self.claim_outbox_matching(
+            delivery_kind,
+            None,
+            lease_owner,
+            now_ms,
+            lease_expires_at_ms,
+        )
+    }
+
+    /// Claims only the delivery previously inspected by [`Self::peek_ready_outbox`].
+    pub(crate) fn claim_outbox_candidate(
+        &mut self,
+        delivery_kind: &BoundedName,
+        candidate: &OutboxCandidate,
+        lease_owner: &BoundedOpaque,
+        now_ms: u64,
+        lease_expires_at_ms: u64,
+    ) -> Result<Option<OutboxClaim>, StoreError> {
+        self.claim_outbox_matching(
+            delivery_kind,
+            Some(candidate),
+            lease_owner,
+            now_ms,
+            lease_expires_at_ms,
+        )
+    }
+
+    fn claim_outbox_matching(
+        &mut self,
+        delivery_kind: &BoundedName,
+        expected: Option<&OutboxCandidate>,
+        lease_owner: &BoundedOpaque,
+        now_ms: u64,
+        lease_expires_at_ms: u64,
+    ) -> Result<Option<OutboxClaim>, StoreError> {
         if lease_expires_at_ms <= now_ms {
             return Err(invalid("Outbox lease deadline must be in the future"));
         }
@@ -29,11 +120,16 @@ impl SqliteTaskStore {
                 "SELECT delivery_id, task_id, event_id, payload_json, attempt
                  FROM outbox
                  WHERE delivery_kind = ?1 AND next_attempt_at_ms <= ?2
+                   AND (?3 IS NULL OR delivery_id = ?3)
                    AND (state = 'pending'
                         OR (state = 'leased' AND lease_expires_at_ms <= ?2))
                  ORDER BY next_attempt_at_ms, created_at_ms, delivery_id
                  LIMIT 1",
-                params![delivery_kind.as_str(), now],
+                params![
+                    delivery_kind.as_str(),
+                    now,
+                    expected.map(|candidate| candidate.delivery_id.as_str()),
+                ],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,
@@ -49,6 +145,23 @@ impl SqliteTaskStore {
             transaction.commit()?;
             return Ok(None);
         };
+        let payload = serde_json::from_str(&payload_json)?;
+        if let Some(expected) = expected {
+            let attempt = u64::try_from(attempt)
+                .map_err(|_| corrupt("negative Outbox attempt"))?;
+            if delivery_id != expected.delivery_id.as_str()
+                || task_id != expected.task_id.as_str()
+                || payload != expected.payload
+            {
+                return Err(corrupt(
+                    "Outbox delivery changed after its read-only validation",
+                ));
+            }
+            if attempt != expected.attempt {
+                transaction.commit()?;
+                return Ok(None);
+            }
+        }
         let next_attempt = attempt
             .checked_add(1)
             .ok_or_else(|| corrupt("Outbox attempt overflow"))?;
@@ -79,7 +192,7 @@ impl SqliteTaskStore {
             event_id: MessageId::parse(&event_id)
                 .map_err(|error| corrupt(&format!("invalid Outbox event identity: {error}")))?,
             delivery_kind: delivery_kind.clone(),
-            payload: serde_json::from_str(&payload_json)?,
+            payload,
             attempt: u64::try_from(next_attempt).map_err(|_| corrupt("negative Outbox attempt"))?,
             lease_owner: lease_owner.clone(),
             lease_expires_at_ms,

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/task_store/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/task_store/tests.rs
@@ -744,6 +744,109 @@ fn outbox_claim_is_exclusive_and_stale_attempt_is_fenced() {
 }
 
 #[test]
+fn validated_outbox_candidate_never_falls_through_to_the_next_delivery() {
+    let root = TempDir::new().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    let path = root.path().join("gateway.db");
+    let mut validating_store = SqliteTaskStore::open(&path).unwrap();
+    let task_id = TaskId::new();
+    let actor_id = ActorId::new();
+    let event = submitted(&task_id, &actor_id);
+    validating_store
+        .commit_task(&task_commit(
+            &task_id,
+            &actor_id,
+            "candidate-race",
+            'f',
+            vec![event.clone()],
+            vec![
+                outbox(&event, DeliveryId::new()),
+                outbox(&event, DeliveryId::new()),
+            ],
+        ))
+        .unwrap();
+    let mut competing_store = SqliteTaskStore::open(&path).unwrap();
+    let kind = BoundedName::new("task_event").unwrap();
+    let validated = validating_store
+        .peek_ready_outbox(&kind, 100)
+        .unwrap()
+        .unwrap();
+
+    let competing_claim = competing_store
+        .claim_outbox(&kind, &BoundedOpaque::new("worker-b").unwrap(), 100, 200)
+        .unwrap()
+        .unwrap();
+    assert_eq!(competing_claim.delivery_id, validated.delivery_id);
+    assert!(validating_store
+        .claim_outbox_candidate(
+            &kind,
+            &validated,
+            &BoundedOpaque::new("worker-a").unwrap(),
+            100,
+            200,
+        )
+        .unwrap()
+        .is_none());
+
+    let next = validating_store
+        .peek_ready_outbox(&kind, 100)
+        .unwrap()
+        .unwrap();
+    assert_ne!(next.delivery_id, validated.delivery_id);
+    assert_eq!(next.attempt, 0);
+}
+
+#[test]
+fn stale_validated_outbox_attempt_is_normal_contention() {
+    let root = TempDir::new().unwrap();
+    fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700)).unwrap();
+    let path = root.path().join("gateway.db");
+    let mut validating_store = SqliteTaskStore::open(&path).unwrap();
+    let task_id = TaskId::new();
+    let actor_id = ActorId::new();
+    let event = submitted(&task_id, &actor_id);
+    validating_store
+        .commit_task(&task_commit(
+            &task_id,
+            &actor_id,
+            "stale-candidate-attempt",
+            '9',
+            vec![event.clone()],
+            vec![outbox(&event, DeliveryId::new())],
+        ))
+        .unwrap();
+    let mut competing_store = SqliteTaskStore::open(&path).unwrap();
+    let kind = BoundedName::new("task_event").unwrap();
+    let stale = validating_store
+        .peek_ready_outbox(&kind, 100)
+        .unwrap()
+        .unwrap();
+
+    let competing_claim = competing_store
+        .claim_outbox(&kind, &BoundedOpaque::new("worker-b").unwrap(), 100, 200)
+        .unwrap()
+        .unwrap();
+    assert_eq!(competing_claim.attempt, 1);
+    assert!(validating_store
+        .claim_outbox_candidate(
+            &kind,
+            &stale,
+            &BoundedOpaque::new("worker-a").unwrap(),
+            200,
+            300,
+        )
+        .unwrap()
+        .is_none());
+
+    let refreshed = validating_store
+        .peek_ready_outbox(&kind, 200)
+        .unwrap()
+        .unwrap();
+    assert_eq!(refreshed.delivery_id, stale.delivery_id);
+    assert_eq!(refreshed.attempt, 1);
+}
+
+#[test]
 fn outbox_retry_preserves_identity_and_increments_attempt() {
     let mut store = SqliteTaskStore::open_in_memory().unwrap();
     let task_id = TaskId::new();

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance.md
@@ -6,16 +6,19 @@
 
 **Overall: PARTIAL. Generic Broker foundations exist; Phase 1 does not pass.** The
 implementation worktree is based on
-`e90d9d9402c7fa1c8122267eb4e075c0adda51f5`.
+`a6592234341a095b2b9446601642caa87314e2c5`.
 
 The foundational Broker logic validates Capability request expiry, authoritative Task, Run, complete Actor
 provenance, target, operation descriptor, complete operation digest, and requested scope before
 policy. It separates policy decisions from permits, issues exactly bound single-use permits, and
-atomically consumes them in a process-local memory store. Eight targeted tests pass. These are
+atomically consumes them in a process-local memory store. Targeted capability tests pass. These are
 generic contract/logic foundations, not production execution evidence.
 
 This result is not a universal governance claim. The production `CoshBrokered`
-profile is task-only and exposes `ask_user_question` only. It has no production
+profile is bound to the pinned `task-only-v1` manifest and exposes
+`ask_user_question` only. The daemon, durable start intent, installed Core
+factory, and private v3 handshake verify the identity before execution or Task
+input. It has no production
 `ExecutionTarget` and no checkpoint/ws-ckpt dependency. Generic Capability,
 Permit, and Execution contracts/ledger rows remain future foundations. Shell,
 Skill, MCP, extension-tool, legacy CLI, and interactive Core mutation paths
@@ -65,6 +68,7 @@ gating, execution, and reconciliation remain future optional capability work.
 | [`memory.rs`](../../../../../crates/cosh-gateway/src/capability/memory.rs) | Holds permit validation and consumption under one mutex; mismatch, expiry, and replay fail closed |
 | [`memory/tests.rs`](../../../../../crates/cosh-gateway/src/capability/memory/tests.rs) | Covers parent and actor-provenance substitution, policy branches/failures, permit binding, mismatch, expiry/replay, and concurrent consumption |
 | [`capability.rs`](../../../../../crates/cosh-gateway-contracts/src/capability.rs) | Defines neutral request, decision, approval, and permit contracts with Actor/Task/Run/Execution/target/operation/policy/expiry bindings |
+| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | Pins the only admitted `task-only-v1` identity, canonical manifest digest, governed target, and exact `ask_user_question` Runtime inventory |
 | [`scheduler.rs`](../../../../../crates/cosh-gateway/src/daemon/scheduler.rs) | Keeps durable Task/Run/Outbox/lease/input/cancel/retry/recovery coordination separate from future execution-target adapters |
 
 The Broker source depends on contracts and its two explicit ports. It does not import Task storage,
@@ -88,30 +92,23 @@ Runtime bridges, OS operators, ACP, or network APIs.
 | CBR-012 | Typed policy has allow/deny/require-approval outcomes. | PASS | Neutral `PolicyPort` and deterministic tests cover all three outcomes plus unavailable/invalid authority. |
 | CBR-013 | Execution start in the profile requires durable security audit. | NOT IMPLEMENTED | No production execution start or target exists in the task-only profile. |
 | CBR-014 | Direct Core side-effecting tools are disabled or delegated in the profile. | PASS for task-only scope | The immutable inventory contains only `ask_user_question`; hooks, MCP, Skills, extensions, Shell, file, process, network, and checkpoint paths are disabled. |
-| CBR-015 | Production Gateway operations cannot bypass permit in governed mode. | PASS for task-only scope | `serve` and the library daemon admit only the task-only selector; no production side-effect operation can bypass a permit. ACP `doctor`/`run` and legacy CLI are explicitly outside the governed claim. |
+| CBR-015 | Production Gateway operations cannot bypass permit in governed mode. | PASS for task-only scope | `serve` and the library daemon derive the target from the pinned profile; Runtime start schema v3 and the Core handshake reject identity or inventory drift before launch/input. No production side-effect operation can bypass a permit. ACP `doctor`/`run` and legacy CLI are explicitly outside the governed claim. |
 | CBR-016 | Remote identity is disabled until a v2 attestation decision is approved. | PASS for scope decision | Phase 1 is local installation-scoped single-tenant; remote and `TenantId`/multi-tenant support are future v2. |
 
 ## Validation evidence
 
-Commands run from `src/cosh-ng`:
+Commands run from `src/cosh-ng` on the rebased candidate:
 
 ```text
-cargo fmt --package cosh-gateway -- --check
-cargo test --locked --package cosh-gateway-contracts
-result: package tests and doc-test targets passed
-
-cargo test --locked --package cosh-gateway capability::
-result: targeted capability suite passed
-
-cargo clippy --locked --package cosh-gateway-contracts --all-targets -- -D warnings
-cargo clippy --locked --package cosh-gateway --all-targets -- -D warnings
-result: passed with zero warnings
-
-cargo doc --locked --package cosh-gateway-contracts --package cosh-gateway --no-deps
-result: passed
+cargo fmt --all -- --check
+cargo test --locked -p cosh-gateway-contracts profile
+cargo test --locked -p cosh-gateway capability::
+cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
+cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts
 ```
 
-The eight tests prove:
+The targeted tests prove:
 
 - request expiry and Task, Run, Actor ID, issuer, assurance, target, operation descriptor,
   complete operation digest, and scope substitution fail closed before policy;

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance_zh.md
@@ -5,16 +5,18 @@
 ## 结果
 
 **整体结果为 PARTIAL。通用 Broker foundation 已存在，Phase 1 尚未通过。**
-实现 worktree 基于 `e90d9d9402c7fa1c8122267eb4e075c0adda51f5`。
+实现 worktree 基于 `a6592234341a095b2b9446601642caa87314e2c5`。
 
 基础 Broker logic 会在 policy 前校验 Capability request expiry，以及 authoritative Task、Run、完整 Actor
 provenance、target、operation descriptor、完整 operation digest 与 requested scope。它将 policy
 decision 与 permit 分开，为 permit 绑定准确 authority，并通过 process-local memory store atomically
-consume single-use permit。八个 targeted test 通过。这些是通用 contract/logic foundation，不是
+consume single-use permit。定向 capability test 通过。这些是通用 contract/logic foundation，不是
 production execution 证据。
 
-该结果不构成通用治理声明。Production `CoshBrokered` profile 是 task-only，只有
-`ask_user_question`，没有 production `ExecutionTarget`，也不依赖 checkpoint/ws-ckpt。通用
+该结果不构成通用治理声明。Production `CoshBrokered` profile 绑定固定 `task-only-v1` manifest，只有
+`ask_user_question`。Daemon、durable start intent、installed Core factory 与 private v3 handshake 会在
+execution 或 Task input 前校验 identity。它没有 production `ExecutionTarget`，也不依赖
+checkpoint/ws-ckpt。通用
 Capability、Permit 与 Execution contract/ledger row 作为后续基础保留。Shell、Skill、MCP、扩展工具、
 legacy CLI 与 interactive Core mutation path 仍在该边界之外。
 
@@ -59,6 +61,7 @@ capability，仍待完成。
 | [`memory.rs`](../../../../../crates/cosh-gateway/src/capability/memory.rs) | 在同一个 mutex 内校验并 consume permit；mismatch、expiry 与 replay fail closed |
 | [`memory/tests.rs`](../../../../../crates/cosh-gateway/src/capability/memory/tests.rs) | 覆盖 parent 与 actor-provenance substitution、policy branch/failure、permit binding、mismatch、expiry/replay 与 concurrent consumption |
 | [`capability.rs`](../../../../../crates/cosh-gateway-contracts/src/capability.rs) | 定义中立 request、decision、approval 与 permit contract，包含 Actor/Task/Run/Execution/target/operation/policy/expiry binding |
+| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | 固定唯一接纳的 `task-only-v1` identity、canonical manifest digest、governed target 与准确的 `ask_user_question` Runtime inventory |
 | [`scheduler.rs`](../../../../../crates/cosh-gateway/src/daemon/scheduler.rs) | 保持 durable Task/Run/Outbox/lease/input/cancel/retry/recovery coordination 与未来 execution-target adapter 分离 |
 
 Broker source 只依赖 contracts 和两个显式 port，不 import Task storage、Runtime bridge、OS operator、
@@ -82,30 +85,23 @@ ACP 或 network API。
 | CBR-012 | Typed policy 有 allow/deny/require-approval outcome。 | PASS | Neutral `PolicyPort` 与 deterministic test 覆盖三个 outcome，以及 unavailable/invalid authority。 |
 | CBR-013 | 该 profile 的 execution start 要求 durable security audit。 | NOT IMPLEMENTED | Task-only profile 没有 production execution start 或 target。 |
 | CBR-014 | 该 profile 禁用或 delegated Core direct side-effecting tool。 | Task-only scope PASS | Immutable inventory 只有 `ask_user_question`；hook、MCP、Skill、扩展、Shell、file、process、network 与 checkpoint path 均禁用。 |
-| CBR-015 | Governed mode 下 production Gateway operation 不能绕过 permit。 | Task-only scope PASS | `serve` 与 library daemon 只接纳 task-only selector；没有 production side-effect operation 可以绕过 permit。ACP `doctor`/`run` 与 legacy CLI 明确不在 governed claim 内。 |
+| CBR-015 | Governed mode 下 production Gateway operation 不能绕过 permit。 | Task-only scope PASS | `serve` 与 library daemon 从固定 profile 派生 target；Runtime start schema v3 与 Core handshake 会在 launch/input 前拒绝 identity 或 inventory drift。没有 production side-effect operation 可以绕过 permit。ACP `doctor`/`run` 与 legacy CLI 明确不在 governed claim 内。 |
 | CBR-016 | Remote identity 在 v2 attestation 决策批准前保持禁用。 | Scope decision PASS | Phase 1 是 local installation-scoped single-tenant；remote 与 `TenantId`/multi-tenant support 属未来 v2。 |
 
 ## 验证证据
 
-从 `src/cosh-ng` 运行：
+从 `src/cosh-ng` 在 rebased candidate 上运行：
 
 ```text
-cargo fmt --package cosh-gateway -- --check
-cargo test --locked --package cosh-gateway-contracts
-result: package test 与 doc-test target passed
-
-cargo test --locked --package cosh-gateway capability::
-result: targeted capability suite passed
-
-cargo clippy --locked --package cosh-gateway-contracts --all-targets -- -D warnings
-cargo clippy --locked --package cosh-gateway --all-targets -- -D warnings
-result: passed with zero warnings
-
-cargo doc --locked --package cosh-gateway-contracts --package cosh-gateway --no-deps
-result: passed
+cargo fmt --all -- --check
+cargo test --locked -p cosh-gateway-contracts profile
+cargo test --locked -p cosh-gateway capability::
+cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
+cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts
 ```
 
-八个测试证明：
+定向测试证明：
 
 - Request expiry，以及 Task、Run、Actor ID、issuer、assurance、target、operation descriptor、
   完整 operation digest 与 scope substitution 在 policy 前 fail closed；

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design.md
@@ -4,10 +4,12 @@
 
 ## Status and decision
 
-This design is based on upstream commit `e90d9d94`. Its universal Broker model remains the
+This increment is based on upstream commit `a6592234`. Its universal Broker model remains the
 architecture target, not an accepted Phase 1 claim. The accepted production scope is narrower:
 `serve` and the library daemon admit only `core` / `gateway-brokered-v1`, whose immutable inventory
-is task-only and contains `ask_user_question` only. No production `ExecutionTarget` or
+is bound to the pinned `task-only-v1` manifest and contains `ask_user_question` only. Gateway,
+durable Runtime start intent, and Core v3 negotiation verify that identity and exact inventory
+before launch or Task input. No production `ExecutionTarget` or
 checkpoint/ws-ckpt dependency is wired in this PR. Every side-effecting hook, Skill, MCP, extension,
 Shell, file, process, and network path is disabled in this profile. ACP `doctor`/`run`, legacy CLI
 commands, and standalone Shell are explicitly ungoverned interoperability/rollback paths and
@@ -381,7 +383,8 @@ output. Transport timeout is not evidence that an effect did not occur.
    production execution remains unimplemented.**
 4. Admit only `core` / `gateway-brokered-v1` with the task-only inventory in production `serve`; keep old CLI and ACP
    `doctor`/`run` explicitly ungoverned.
-5. Use private COSH brokered v2 and expose only the task-only `ask_user_question` capability.
+5. Use private COSH brokered v3, bind the pinned `task-only-v1` manifest, and expose only
+   `ask_user_question`.
 6. Keep Shell/ACP/Skills/MCP/extensions disabled until a later phase provides complete adapters.
 7. Remove or explicitly isolate legacy bypasses only after parity and recovery acceptance passes.
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design_zh.md
@@ -4,9 +4,11 @@
 
 ## 状态与决策
 
-本文基于上游提交 `e90d9d94`。通用 Broker 模型仍是目标架构，不是已验收的 Phase 1 声明。
+当前增量基于上游提交 `a6592234`。通用 Broker 模型仍是目标架构，不是已验收的 Phase 1 声明。
 已验收 production scope 更窄：`serve` 与 library daemon 只接纳 `core` / `gateway-brokered-v1`，其
-immutable inventory 是 task-only，只有 `ask_user_question`。本 PR 不接入 production
+immutable inventory 绑定固定 `task-only-v1` manifest，只有 `ask_user_question`。Gateway、durable
+Runtime start intent 与 Core v3 negotiation 会在 launch 或 Task input 前校验 identity 与准确 inventory。
+本 PR 不接入 production
 `ExecutionTarget`，也不依赖 checkpoint/ws-ckpt。该 profile 禁用其他 side-effecting hook、Skill、MCP、
 扩展、Shell、file、process 与 network path。ACP `doctor`/`run`、legacy CLI command 与 standalone Shell
 是明确 ungoverned 的 interoperability/rollback path，不能作为 governed evidence。
@@ -353,7 +355,8 @@ denial，不能回显 secret input 或无界 target output。Transport timeout �
    production execution 仍未实现。**
 4. Production `serve` 只接纳带 task-only inventory 的 `core` / `gateway-brokered-v1`；旧 CLI 与 ACP `doctor`/`run` 明确
    ungoverned。
-5. 使用 private COSH brokered v2，只暴露 task-only 的 `ask_user_question` capability。
+5. 使用 private COSH brokered v3，绑定固定 `task-only-v1` manifest，只暴露
+   `ask_user_question`。
 6. Shell/ACP/Skills/MCP/扩展保持禁用，等待后续 phase 提供完整 adapter。
 7. Parity 与 recovery acceptance 通过后，删除或显式隔离 legacy bypass。
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/acceptance.md
@@ -5,9 +5,9 @@
 ## Baseline result
 
 **Overall: PARTIAL implementation on a candidate based on upstream
-`e90d9d94`; Phase 1 remains NOT ACCEPTED.** The candidate adds a neutral
+`a6592234`; Phase 1 remains NOT ACCEPTED.** The candidate adds a neutral
 `AgentRuntimePort` and a supervised `CoshCoreBridge` over two explicitly private
-COSH profiles: legacy Shell/Core v1 and Gateway brokered v2. The bridge fences
+COSH profiles: legacy Shell/Core v1 and Gateway brokered v3. The bridge fences
 public identity and event order, bounds retained state, and settles cancellation
 through process cleanup. The contained Gateway production profile is task-only
 and exposes only `ask_user_question`. It has no production `ExecutionTarget`
@@ -28,7 +28,7 @@ validation remain unaccepted.
 
 ## Evidence inspected
 
-- Upstream source baseline: `e90d9d94`.
+- Upstream source baseline: `a6592234`.
 - [`protocol.rs`](../../../../../crates/cosh-core/src/protocol.rs) defines exact private protocol v1
   and all current message shapes.
 - [`headless.rs`](../../../../../crates/cosh-core/src/headless.rs) negotiates and runs provider turns.
@@ -44,7 +44,9 @@ validation remain unaccepted.
 - [`runtime/bounded_io.rs`](../../../../../crates/cosh-gateway/src/runtime/bounded_io.rs) implements
   bounded stdout framing and stderr-tail retention.
 - [`runtime/cosh_core_jsonl.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_jsonl.rs)
-  implements strict private v1/v2 initialization and typed wire observations without ACP naming.
+  implements strict private v1/v3 initialization and typed wire observations without ACP naming.
+- [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) pins the
+  `task-only-v1` manifest identity, governed target, and exact Runtime inventory.
 - [`runtime/port.rs`](../../../../../crates/cosh-gateway/src/runtime/port.rs) defines the
   provider-neutral, object-safe command/event boundary and redacted errors.
 - [`runtime/cosh_core_bridge.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_bridge.rs)
@@ -56,9 +58,9 @@ validation remain unaccepted.
 | ID | Criterion | Baseline | Evidence or missing artifact |
 | --- | --- | --- | --- |
 | CCB-001 | Bridge implements neutral `AgentRuntimePort`. | PASS for library slice | Object-safe port and Core implementation compile and pass focused lifecycle tests. |
-| CCB-002 | Private COSH v1/v2 are explicitly distinct from ACP v1. | PASS | The shared dual-version corpus and both codecs use COSH names and versions; neither profile is presented as ACP. |
-| CCB-003 | Exact initialization succeeds before Task input admission. | PARTIAL | Gateway negotiates brokered v2 before Prompt and requires `SessionOpened` first; the daemon persists Runtime binding before prompt, while complete Core recovery remains. |
-| CCB-004 | Gateway production rejects legacy, missing, and mismatched negotiation. | PASS | Cross-implementation negative fixtures reject wrong/missing version, profile, and capability before input; production requires exact brokered v2. |
+| CCB-002 | Private COSH v1/v3 are explicitly distinct from ACP v1. | PASS | The shared dual-version corpus and both codecs use COSH names and versions; neither profile is presented as ACP. |
+| CCB-003 | Exact initialization succeeds before Task input admission. | PARTIAL | Gateway negotiates brokered v3 before Prompt and requires `SessionOpened` first; the daemon persists Runtime binding before prompt, while complete Core recovery remains. |
+| CCB-004 | Gateway production rejects legacy, missing, and mismatched negotiation. | PASS | Cross-implementation negative fixtures reject wrong/missing version, execution profile, capability-profile identity, Runtime inventory, and capability before input; production requires exact brokered v3. |
 | CCB-005 | `RuntimeSupervisor` solely owns child process lifecycle. | PARTIAL | New supervisor owns one child/group/pipes/reap; existing Shell core owner and restart policy are not migrated. |
 | CCB-006 | Every JSONL message maps to a bounded ordered Runtime event/command. | PARTIAL | Session, text, tool observation, result, cancel, and transport failure map with monotonic sequence; question/auth/tool permission, usage, environment, durable backpressure, and full goldens remain. |
 | CCB-007 | Task/Run/runtime/Agent/provider IDs remain distinct. | PARTIAL | The daemon persists fenced Runtime binding and rejects stale generation; complete provider-session recovery remains. |
@@ -70,8 +72,8 @@ validation remain unaccepted.
 | CCB-013 | Process cancel escalates, kills the group, and reaps children. | PARTIAL | Focused tests cover interrupt, cancelled terminal, TERM/KILL/reap, and synchronous fallback cleanup; descendant and cancel/result/EOF race fixtures remain. |
 | CCB-014 | Provider session persists separately from Task storage. | PASS | Current `SessionStore` is workspace-scoped provider state. |
 | CCB-015 | Crash/restart never silently resends an uncertain prompt. | PARTIAL | Runtime binding/restart convergence is durable and fail closed; side-effect uncertainty reconciliation and complete prompt/recovery fixtures remain future work. |
-| CCB-016 | Gateway has no Rust dependency on core implementation or Shell. | PASS | `cosh-gateway` speaks mirrored private wire types and has no core/Shell crate dependency. |
-| CCB-017 | Phase 1 brokered inventory and private-protocol profile decision are frozen. | PASS for scope decision | Gateway production uses private COSH v2 and exposes only task-only `ask_user_question`. Legacy v1 stays with standalone Shell; checkpoint/ws-ckpt and Shell attachment/owner migration are future work. |
+| CCB-016 | Gateway and Core preserve the one-way process/wire boundary. | PASS | `cosh-gateway` has no core/Shell crate dependency, and `cosh-core` has no Gateway crate dependency. Each owns its private wire shape, with the shared golden corpus detecting drift. |
+| CCB-017 | Phase 1 brokered inventory and private-protocol profile decision are frozen. | PASS for scope decision | Gateway production uses private COSH v3 with the pinned `task-only-v1` identity and exposes only `ask_user_question`. Legacy v1 stays with standalone Shell; checkpoint/ws-ckpt and Shell attachment/owner migration are future work. |
 
 Legacy Shell behavior and ACP `doctor`/`run` interoperability are ungoverned compatibility paths,
 not proof of a Gateway-governed path.
@@ -80,7 +82,7 @@ not proof of a Gateway-governed path.
 
 | Artifact | Required proof |
 | --- | --- |
-| `cosh-private-wire-dual-version` canonical corpus | Legacy v1 initialize/ack, brokered v2 task/question request/ack/result, and wrong/missing version/profile/capability cases. |
+| `cosh-private-wire-dual-version` canonical corpus | Legacy v1 initialize/ack, brokered v3 task/question request/ack/result, and wrong/missing version/profile/manifest/inventory/capability cases. |
 | Cross-implementation fixture report | Core encoder, Shell mirror, and Gateway decoder agree. |
 | `runtime-supervisor-killpoints` | Spawn, negotiate, stream, cancel, EOF, wait, shutdown, restart races. |
 | `runtime-event-mapping` goldens | Bounded normalized events and ID correlation for every message. |
@@ -98,20 +100,26 @@ cargo test --package cosh-core --test jsonl_protocol
 cargo test --package cosh-gateway-contracts runtime_schema
 ```
 
-Current bridge-targeted evidence on the uncommitted candidate:
+Current scoped evidence on the rebased candidate:
 
 ```bash
-cargo +1.88.0 test --locked --package cosh-gateway cosh_core_bridge
-cargo +1.88.0 test --locked --package cosh-core --test jsonl_protocol
-cargo +1.88.0 test --locked --package cosh-gateway cosh_core_jsonl
+cargo test --locked -p cosh-gateway-contracts profile
+cargo test --locked -p cosh-core brokered_profile
+cargo test --locked -p cosh-core private_wire_dual_version_corpus_matches_core_types
+cargo test --locked -p cosh-gateway runtime_tool_inventory
+cargo test --locked -p cosh-gateway stale_validated_outbox_attempt_is_normal_contention
+cargo test --locked -p cosh-gateway invalid_start_intents_are_rejected_before_outbox_claim
+cargo test --locked -p cosh-gateway exact_task_only_v2_intent_maps_to_current_profile
+cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
+cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts
+bash scripts/check-source-layout.sh
 ```
 
-This covers identity fencing, stream and terminal mapping, single terminal delivery, open timeout,
-cross-Run rejection, SessionOpened-before-Prompt ordering, idle-cancel rejection, aggregate Prompt
-bounds, retained tool-ID bounds, process cleanup on cancellation, and the shared dual-version wire
-corpus. It does not replace the full process-tree/race, universal Broker, recovery, backpressure,
-real-provider, or PTY gates. Rustdoc and Clippy evidence are recorded only after their final scoped
-commands complete.
+This covers manifest and inventory admission, Core/Gateway dependency isolation, exact legacy-v2
+mapping, stale Outbox-attempt contention, and the shared dual-version wire corpus. It does not
+replace full package/workspace, process-tree/race, universal Broker, recovery, backpressure,
+real-provider, or PTY gates; broader coverage remains delegated to CI.
 
 ## Exit criteria
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/acceptance_zh.md
@@ -4,9 +4,9 @@
 
 ## 基线结果
 
-**整体结果：基于上游 `e90d9d94` 的候选实现为 PARTIAL，Phase 1 仍是 NOT ACCEPTED。**
+**整体结果：基于上游 `a6592234` 的候选实现为 PARTIAL，Phase 1 仍是 NOT ACCEPTED。**
 候选实现加入 neutral `AgentRuntimePort`，并在两个明确私有的 COSH profile 上实现 supervised
-`CoshCoreBridge`：legacy Shell/Core v1 与 Gateway brokered v2。Bridge 已约束 public identity 与
+`CoshCoreBridge`：legacy Shell/Core v1 与 Gateway brokered v3。Bridge 已约束 public identity 与
 event 顺序、限制 retained state，并通过 process cleanup 结算 cancel。受约束的 Gateway production
 profile 是 task-only，只有 `ask_user_question`，没有 production `ExecutionTarget`，也不依赖
 checkpoint/ws-ckpt。通用 Capability/Permit/Execution contract 属后续基础。更广的 tool execution、
@@ -24,7 +24,7 @@ resume/recovery、Shell ownership migration、real-provider evidence 与人工 T
 
 ## 已检查证据
 
-- 上游源码基线：`e90d9d94`。
+- 上游源码基线：`a6592234`。
 - [`protocol.rs`](../../../../../crates/cosh-core/src/protocol.rs) 定义 exact private protocol v1 和全部当前
   message shape。
 - [`headless.rs`](../../../../../crates/cosh-core/src/headless.rs) negotiation 并运行 provider turn。
@@ -39,7 +39,9 @@ resume/recovery、Shell ownership migration、real-provider evidence 与人工 T
 - [`runtime/bounded_io.rs`](../../../../../crates/cosh-gateway/src/runtime/bounded_io.rs) 实现 bounded
   stdout framing 与 stderr-tail retention。
 - [`runtime/cosh_core_jsonl.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_jsonl.rs) 实现严格的
-  private v1/v2 initialization 与 typed wire observation，不使用 ACP 命名。
+  private v1/v3 initialization 与 typed wire observation，不使用 ACP 命名。
+- [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) 固定
+  `task-only-v1` manifest identity、governed target 与准确 Runtime inventory。
 - [`runtime/port.rs`](../../../../../crates/cosh-gateway/src/runtime/port.rs) 定义 provider-neutral、
   object-safe command/event boundary 与脱敏 error。
 - [`runtime/cosh_core_bridge.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_bridge.rs) 绑定
@@ -51,9 +53,9 @@ resume/recovery、Shell ownership migration、real-provider evidence 与人工 T
 | ID | 验收项 | 基线 | 证据或缺失产物 |
 | --- | --- | --- | --- |
 | CCB-001 | Bridge 实现 neutral `AgentRuntimePort`。 | Library 切片 PASS | Object-safe port 与 Core implementation 可编译，并通过 focused lifecycle test。 |
-| CCB-002 | Private COSH v1/v2 与 ACP v1 显式分离。 | PASS | Shared dual-version corpus 与两侧 codec 都使用 COSH 名称和版本，两个 profile 均不冒充 ACP。 |
-| CCB-003 | Task input admission 前 exact initialization 成功。 | PARTIAL | Gateway 在 Prompt 前完成 brokered v2 negotiation 并要求先交付 `SessionOpened`；daemon 在 prompt 前持久化 Runtime binding，完整 Core recovery 仍缺。 |
-| CCB-004 | Gateway production 拒绝 legacy、missing 与 mismatched negotiation。 | PASS | Cross-implementation negative fixture 在 input 前拒绝错误或缺失的 version/profile/capability；production 要求精确 brokered v2。 |
+| CCB-002 | Private COSH v1/v3 与 ACP v1 显式分离。 | PASS | Shared dual-version corpus 与两侧 codec 都使用 COSH 名称和版本，两个 profile 均不冒充 ACP。 |
+| CCB-003 | Task input admission 前 exact initialization 成功。 | PARTIAL | Gateway 在 Prompt 前完成 brokered v3 negotiation 并要求先交付 `SessionOpened`；daemon 在 prompt 前持久化 Runtime binding，完整 Core recovery 仍缺。 |
+| CCB-004 | Gateway production 拒绝 legacy、missing 与 mismatched negotiation。 | PASS | Cross-implementation negative fixture 在 input 前拒绝错误或缺失的 version、execution profile、capability-profile identity、Runtime inventory 与 capability；production 要求精确 brokered v3。 |
 | CCB-005 | `RuntimeSupervisor` 是 child process lifecycle 唯一 owner。 | PARTIAL | 新 supervisor 独占一个 child/group/pipe/reap；现有 Shell core owner 与 restart policy 尚未迁移。 |
 | CCB-006 | 每种 JSONL message 映射成有界有序 Runtime event/command。 | PARTIAL | Session、text、tool observation、result、cancel 与 transport failure 已用 monotonic sequence 映射；question/auth/tool permission、usage、environment、durable backpressure 与完整 golden 仍缺。 |
 | CCB-007 | Task/Run/runtime/Agent/provider ID 保持独立。 | PARTIAL | Daemon 持久化 fenced Runtime binding 并拒绝 stale generation；完整 provider-session recovery 仍缺。 |
@@ -65,8 +67,8 @@ resume/recovery、Shell ownership migration、real-provider evidence 与人工 T
 | CCB-013 | Process cancel escalation、kill group 并 reap child。 | PARTIAL | Focused test 覆盖 interrupt、cancelled terminal、TERM/KILL/reap 与同步 fallback cleanup；仍缺 descendant 与 cancel/result/EOF race fixture。 |
 | CCB-014 | Provider session persistence 与 Task storage 分离。 | PASS | 当前 `SessionStore` 是 workspace-scoped provider state。 |
 | CCB-015 | Crash/restart 不会静默重发 uncertain prompt。 | PARTIAL | Runtime binding/restart convergence 已持久且 fail closed；side-effect uncertainty reconciliation 与完整 prompt/recovery fixture 属后续工作。 |
-| CCB-016 | Gateway 不通过 Rust dependency 依赖 core implementation 或 Shell。 | PASS | `cosh-gateway` mirror private wire type，不依赖 core/Shell crate。 |
-| CCB-017 | Phase 1 brokered inventory 与 private-protocol profile 决策已固化。 | Scope decision PASS | Gateway production 使用 private COSH v2，只暴露 task-only `ask_user_question`。Legacy v1 留给 standalone Shell；checkpoint/ws-ckpt 与 Shell attachment/owner migration 属后续工作。 |
+| CCB-016 | Gateway 与 Core 保持单向 process/wire boundary。 | PASS | `cosh-gateway` 不依赖 core/Shell crate，`cosh-core` 也不依赖 Gateway crate。双方各自持有 private wire shape，并通过 shared golden corpus 检测 drift。 |
+| CCB-017 | Phase 1 brokered inventory 与 private-protocol profile 决策已固化。 | Scope decision PASS | Gateway production 使用带固定 `task-only-v1` identity 的 private COSH v3，只暴露 `ask_user_question`。Legacy v1 留给 standalone Shell；checkpoint/ws-ckpt 与 Shell attachment/owner migration 属后续工作。 |
 
 Legacy Shell behavior 与 ACP `doctor`/`run` interoperability 是 ungoverned compatibility path，不证明
 Gateway-governed path 已存在。
@@ -75,7 +77,7 @@ Gateway-governed path 已存在。
 
 | 产物 | 必须提供的证明 |
 | --- | --- |
-| `cosh-private-wire-dual-version` canonical corpus | Legacy v1 initialize/ack、brokered v2 task/question request/ack/result，以及 wrong/missing version/profile/capability case。 |
+| `cosh-private-wire-dual-version` canonical corpus | Legacy v1 initialize/ack、brokered v3 task/question request/ack/result，以及 wrong/missing version/profile/manifest/inventory/capability case。 |
 | Cross-implementation fixture report | Core encoder、Shell mirror 与 Gateway decoder 一致。 |
 | `runtime-supervisor-killpoints` | Spawn、negotiate、stream、cancel、EOF、wait、shutdown 与 restart race。 |
 | `runtime-event-mapping` golden | 每种 message 的有界 normalized event 与 ID correlation。 |
@@ -93,19 +95,25 @@ cargo test --package cosh-core --test jsonl_protocol
 cargo test --package cosh-gateway-contracts runtime_schema
 ```
 
-当前未提交候选实现的 bridge-targeted evidence：
+当前 rebased candidate 的 scoped evidence：
 
 ```bash
-cargo +1.88.0 test --locked --package cosh-gateway cosh_core_bridge
-cargo +1.88.0 test --locked --package cosh-core --test jsonl_protocol
-cargo +1.88.0 test --locked --package cosh-gateway cosh_core_jsonl
+cargo test --locked -p cosh-gateway-contracts profile
+cargo test --locked -p cosh-core brokered_profile
+cargo test --locked -p cosh-core private_wire_dual_version_corpus_matches_core_types
+cargo test --locked -p cosh-gateway runtime_tool_inventory
+cargo test --locked -p cosh-gateway stale_validated_outbox_attempt_is_normal_contention
+cargo test --locked -p cosh-gateway invalid_start_intents_are_rejected_before_outbox_claim
+cargo test --locked -p cosh-gateway exact_task_only_v2_intent_maps_to_current_profile
+cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
+cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts
+bash scripts/check-source-layout.sh
 ```
 
-这覆盖 identity fencing、stream 与 terminal mapping、single terminal delivery、open timeout、cross-Run
-rejection、SessionOpened-before-Prompt ordering、idle-cancel rejection、aggregate Prompt bound、retained
-tool-ID bound、cancel 时的 process cleanup，以及 shared dual-version wire corpus。它不能替代完整
-process-tree/race、通用 Broker、recovery、backpressure、real-provider 或 PTY gate。Rustdoc 与 Clippy
-evidence 只会在最终 scoped command 完成后记录。
+这覆盖 manifest 与 inventory admission、Core/Gateway dependency isolation、exact legacy-v2 mapping、
+stale Outbox-attempt contention 和 shared dual-version wire corpus。它不能替代完整 package/workspace、
+process-tree/race、通用 Broker、recovery、backpressure、real-provider 或 PTY gate；更广覆盖交给 CI。
 
 ## Exit criteria
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/design.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/design.md
@@ -4,11 +4,11 @@
 
 ## Status and decision
 
-This Phase 1 implementation is based on upstream commit
-`e90d9d9402c7fa1c8122267eb4e075c0adda51f5`. `CoshCoreBridge` adapts the private cosh-core
+The current capability-admission increment is based on upstream commit
+`a6592234341a095b2b9446601642caa87314e2c5`. `CoshCoreBridge` adapts the private cosh-core
 newline-delimited JSONL control protocol to neutral `AgentRuntimePort`. Private COSH legacy v1
 remains the Shell/Core compatibility protocol; Gateway's closed brokered profile negotiates
-private COSH v2 and `gateway_brokered_v1`. Neither version is ACP. ACP v1 remains a separate
+private COSH v3 and `gateway_brokered_v1`. Neither version is ACP. ACP v1 remains a separate
 interoperability protocol used by ungoverned `doctor`/`run`, not production `serve`.
 
 `RuntimeSupervisor` is the only owner of cosh-core and future ACP/provider child processes. The
@@ -70,7 +70,8 @@ installed brokered Core Runtime factory used by production `serve`:
   with an explicit discarded-byte count.
 - [`cosh_core_jsonl.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_jsonl.rs) is a
   pure dual-profile codec. Legacy uses **private COSH v1**; the Gateway brokered profile requires
-  **private COSH v2**, exact `gateway_brokered_v1`, correlation, and capabilities. It permits only
+  **private COSH v3**, exact `gateway_brokered_v1`, capability-profile identity, exact Runtime
+  tool inventory, correlation, and capabilities. It permits only
   bounded auth bootstrap before readiness,
   decodes current system/stream/assistant/tool/control/registry/result shapes into runtime-local
   observations, and synthesizes EOF-without-result once.
@@ -94,7 +95,7 @@ flowchart LR
     ARP --> CCB["CoshCoreBridge"]
     CCB --> RS["RuntimeSupervisor\nsole child owner"]
     RS --> CORE["cosh-core child"]
-    CORE <--> J["private COSH JSONL\nlegacy v1 / brokered v2"]
+    CORE <--> J["private COSH JSONL\nlegacy v1 / brokered v3"]
     J <--> CCB
     CCB --> RES["RuntimeEventSink"]
     CCB --> CB["CapabilityBrokerPort"]
@@ -118,9 +119,11 @@ cosh-shell remains standalone
 
 There is no Rust dependency from `cosh-gateway` to the cosh-core implementation crate, from
 `cosh-core` back to Gateway, or between Gateway and `cosh-shell`. The bridge launches the binary
-and speaks the private JSONL contract. Canonical JSON fixtures are mirrored across core, Shell,
-and Gateway tests to detect drift. Neutral Runtime IDs/events follow the Phase 0 G0 schema-first
-decision and planned side-effect-free `cosh-gateway-contracts` leaf.
+and speaks the private JSONL contract. Core owns a narrow private v3 profile mirror while Gateway
+owns the canonical admitted profile; neither imports the other's domain crate. Canonical JSON
+fixtures are mirrored across Core, Shell, and Gateway tests to detect drift. Neutral Runtime
+IDs/events follow the Phase 0 G0 schema-first decision and planned side-effect-free
+`cosh-gateway-contracts` leaf.
 
 ## Agent Runtime Port
 
@@ -162,19 +165,20 @@ and causation/correlation IDs where applicable.
 ### Initialization
 
 Before a user message, legacy Shell/Core sends private v1. Gateway production sends a correlated
-`control_request.initialize` with `protocol_version: 2`, `execution_profile:
-gateway_brokered_v1`, and `fire_session_start: false`. It requires the matching v2 response,
-profile, and exact safe capability snapshot before input. Missing version remains compatible only
+`control_request.initialize` with `protocol_version: 3`, `execution_profile:
+gateway_brokered_v1`, the pinned `task-only-v1` manifest identity, and
+`fire_session_start: false`. It requires the matching v3 response, identical profile identity,
+exact `ask_user_question` Runtime inventory, and safe capability snapshot before input. Missing version remains compatible only
 for legacy v1 and is rejected by the brokered profile. Current headless startup may request authentication
 before it consumes initialization, so one bounded `auth_required` bootstrap exchange is allowed
 through the secret-safe credential port. No Task user turn is admitted during that exchange.
 Mismatch, malformed response, any other output before negotiation, or deadline expiry terminates
 the runtime attempt before input admission.
 
-`CONTROL_PROTOCOL_VERSION = 1` and `BROKERED_CONTROL_PROTOCOL_VERSION = 2` are private COSH
+`CONTROL_PROTOCOL_VERSION = 1` and `BROKERED_CONTROL_PROTOCOL_VERSION = 3` are private COSH
 constants. They are unrelated to ACP SDK or wire versions. One shared golden corpus is consumed by
-Core serializers/parsers and the Gateway codec for v1/v2 initialize, task/question request,
-acknowledgement, result, and negative version/profile/capability cases. Shell need not support v2.
+Core serializers/parsers and the Gateway codec for v1/v3 initialize, task/question request,
+acknowledgement, result, and negative version/profile/capability cases. Shell need not support v3.
 
 ### Input mapping
 
@@ -384,7 +388,7 @@ migration work remains.
 | --- | --- | --- |
 | Is one persistent core reused across Tasks? | Runtime owner | One active turn; reuse only after clean settlement and profile/workspace validation. |
 | Which core tools are exposed in brokered profile? | Core/Broker owners | Only audited non-effecting or host-delegated tools. |
-| Does brokered profile require private protocol v2? | Core/Bridge owners | Yes. The task/question profile and capability binding are frozen in private COSH v2; checkpoint remains future. |
+| Does brokered profile require private protocol v3? | Core/Bridge owners | Yes. The task-only profile identity and exact Runtime inventory are frozen in private COSH v3; checkpoint remains future. |
 | How are credentials supplied? | Secret/security owner | Opaque credential reference; no Task/event secret values. |
 | What is the maximum durable event lag? | Runtime/Task owners | Benchmark bounded queue; cancel safely before control-event loss. |
 | Can a failed turn resume the provider session? | Runtime/product owners | Only with validated session and explicit no-uncertain-effect policy. |

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/design_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/cosh-core-bridge/design_zh.md
@@ -4,10 +4,10 @@
 
 ## 状态与决策
 
-本文的 Phase 1 实现基于上游提交 `e90d9d9402c7fa1c8122267eb4e075c0adda51f5`。
+当前 capability admission 增量基于上游提交 `a6592234341a095b2b9446601642caa87314e2c5`。
 `CoshCoreBridge` 将 private cosh-core newline-delimited JSONL control protocol 适配到 neutral
 `AgentRuntimePort`。Private COSH legacy v1 继续用于 Shell/Core compatibility；Gateway 的封闭 brokered
-profile negotiation private COSH v2 与 `gateway_brokered_v1`。两个版本都不是 ACP。ACP v1 只用于
+profile negotiation private COSH v3 与 `gateway_brokered_v1`。两个版本都不是 ACP。ACP v1 只用于
 ungoverned `doctor`/`run` interoperability，不用于 production `serve`。
 
 `RuntimeSupervisor` 是 cosh-core 与未来 ACP/provider child process 的唯一 owner。Bridge 拥有 protocol
@@ -65,8 +65,9 @@ runtime binding 或 brokered core launch profile。
 - [`bounded_io.rs`](../../../../../crates/cosh-gateway/src/runtime/bounded_io.rs) 在整行分配前限制 stdout
   JSONL frame，并持续 drain 固定容量的 stderr tail，同时明确记录 discarded byte 数量。
 - [`cosh_core_jsonl.rs`](../../../../../crates/cosh-gateway/src/runtime/cosh_core_jsonl.rs) 是 dual-profile
-  纯 codec。Legacy 使用 **private COSH v1**；Gateway brokered profile 要求 **private COSH v2**、
-  exact `gateway_brokered_v1`、correlation 与 capability，readiness 前只允许有界 auth bootstrap，将当前
+  纯 codec。Legacy 使用 **private COSH v1**；Gateway brokered profile 要求 **private COSH v3**、
+  exact `gateway_brokered_v1`、capability-profile identity、准确 Runtime tool inventory、correlation 与
+  capability，readiness 前只允许有界 auth bootstrap，将当前
   system/stream/assistant/tool/control/registry/result shape 解码为 runtime-local observation，并且只生成
   一次 EOF-without-result。
 - Public Task、Run、Runtime 与 Agent ID/event 继续由 `cosh-gateway-contracts` 拥有。Codec 不复制这些
@@ -86,7 +87,7 @@ flowchart LR
     ARP --> CCB["CoshCoreBridge"]
     CCB --> RS["RuntimeSupervisor\nchild 唯一 owner"]
     RS --> CORE["cosh-core child"]
-    CORE <--> J["private COSH JSONL\nlegacy v1 / brokered v2"]
+    CORE <--> J["private COSH JSONL\nlegacy v1 / brokered v3"]
     J <--> CCB
     CCB --> RES["RuntimeEventSink"]
     CCB --> CB["CapabilityBrokerPort"]
@@ -110,9 +111,10 @@ cosh-shell remains standalone
 
 不存在 `cosh-gateway` 到 cosh-core implementation crate 的 Rust dependency，也不存在 `cosh-core`
 反向依赖 Gateway，或 Gateway 与 `cosh-shell` 之间的 crate dependency。Bridge 启动 binary 并使用 private
-JSONL contract。Core、Shell 与 Gateway test 通过 canonical JSON fixture mirror 检测 drift。Neutral
-Runtime ID/event 遵循 Phase 0 G0 schema-first 决策和计划中的 side-effect-free
-`cosh-gateway-contracts` leaf。
+JSONL contract。Core 只持有 private v3 profile mirror，Gateway 持有 canonical admitted profile，
+双方都不导入对方的 domain crate。Core、Shell 与 Gateway test 通过 canonical JSON fixture mirror
+检测 drift。Neutral Runtime ID/event 遵循 Phase 0 G0 schema-first 决策和计划中的
+side-effect-free `cosh-gateway-contracts` leaf。
 
 ## Agent Runtime Port
 
@@ -153,18 +155,19 @@ RuntimeProcessExited, RuntimeProtocolFailed
 ### Initialization
 
 发送 user message 前，legacy Shell/Core 使用 private v1。Gateway production 发送相关联的
-`control_request.initialize`，携带 `protocol_version: 2`、`execution_profile:
-gateway_brokered_v1` 与 `fire_session_start: false`。Bridge 在 input 前要求 matching v2 response、profile
-与准确 safe capability snapshot。Missing version 只对 legacy v1 compatibility 有效，brokered profile 会拒绝。
+`control_request.initialize`，携带 `protocol_version: 3`、`execution_profile:
+gateway_brokered_v1`、固定 `task-only-v1` manifest identity 与 `fire_session_start: false`。Bridge 在
+input 前要求 matching v3 response、相同 profile identity、准确的 `ask_user_question` Runtime inventory
+与 safe capability snapshot。Missing version 只对 legacy v1 compatibility 有效，brokered profile 会拒绝。
 当前 headless startup 可能
 在消费 initialization 前请求 authentication，因此允许通过 secret-safe credential port 完成一次有界
 `auth_required` bootstrap exchange，期间不能接收 Task user turn。Mismatch、malformed response、其他
 negotiation 前 output 或 deadline expiry 都会在 input admission 前结束 runtime attempt。
 
-`CONTROL_PROTOCOL_VERSION = 1` 与 `BROKERED_CONTROL_PROTOCOL_VERSION = 2` 都是 private COSH
+`CONTROL_PROTOCOL_VERSION = 1` 与 `BROKERED_CONTROL_PROTOCOL_VERSION = 3` 都是 private COSH
 constant，与 ACP SDK 或 wire version 无关。Core serializer/parser 与 Gateway codec 共同消费一份 golden
-corpus，覆盖 v1/v2 initialize、task/question request、ack、result，以及 version/profile/capability 负例。
-Shell 无需支持 v2。
+corpus，覆盖 v1/v3 initialize、task/question request、ack、result，以及 version/profile/capability 负例。
+Shell 无需支持 v3。
 
 ### Input mapping
 
@@ -358,7 +361,7 @@ backpressure、real-provider 与 Phase 2 Shell migration 仍待完成。
 | --- | --- | --- |
 | 是否跨 Task 复用一个 persistent core？ | Runtime owner | 单 active turn；clean settlement 且 profile/workspace validation 后才复用。 |
 | Brokered profile 暴露哪些 core tool？ | Core/Broker owner | 只暴露 audited non-effecting 或 host-delegated tool。 |
-| Brokered profile 是否要求 private protocol v2？ | Core/Bridge owner | 是。Task/question profile 与 profile/capability binding 已固化在 private COSH v2；checkpoint 属后续。 |
+| Brokered profile 是否要求 private protocol v3？ | Core/Bridge owner | 是。Task-only profile identity 与准确 Runtime inventory 已固化在 private COSH v3；checkpoint 属后续。 |
 | 如何提供 credential？ | Secret/security owner | Opaque credential reference；Task/event 不存 secret value。 |
 | 最大 durable event lag 是多少？ | Runtime/Task owner | Benchmark bounded queue；在 control-event loss 前安全 cancel。 |
 | Failed turn 能否 resume provider session？ | Runtime/product owner | 只有 validated session 且明确无 uncertain effect 时允许。 |


### PR DESCRIPTION
## Why

PR #2603 made the local Gateway-owned Task path durable and task-only, but the selected profile was not yet bound to a versioned manifest across persistence and Runtime startup. A mismatched Gateway/Core pair therefore lacked one exact identity and inventory contract to reject drift before Task input. This PR adds that admission boundary as the first slice of #2725 while deliberately keeping checkpoint/ws-ckpt out of scope.

## What changed

- Add one closed `task-only-v1` capability profile with a canonical manifest digest, governed target, and exact `ask_user_question` Runtime inventory.
- Bind the profile identity into Runtime start schema v3, retry, scheduler admission, and installed Core launch; legacy v2 can map only to the exact task-only target and Runtime.
- Upgrade only the private brokered Core control wire to v3. Gateway owns the canonical admitted profile, while Core owns a narrow private wire mirror verified by the shared golden corpus, preserving the process/wire dependency boundary.
- Treat a changed Outbox attempt after read-only validation as normal contention without relaxing immutable Task or payload checks.
- Keep production configuration closed: no profile CLI, provider registry, SQLite profile table, ws-ckpt dependency, or checkpoint operation.

## Related issue

Part of #2725. The issue remains open for the optional ws-ckpt target and governed checkpoint-create slices.

## User / Agent impact

Existing `cosh agent task` commands and the task-only user flow are unchanged. A persistent Task now starts its contained Core only when Gateway, durable start intent, installed Runtime, and Core agree on the exact `task-only-v1` contract; a mismatched or widened inventory fails before user input or side effects. This PR adds no slash command and does not enable checkpoint, file, Shell, Web, remote, or ACP-governed execution.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The library daemon configuration now accepts a closed profile instead of a caller-assembled target. The private brokered Core wire changes from v2 to v3; legacy v1 is untouched. Runtime start schema v3 reads only exact task-only v2 payloads without a SQLite migration, but old binaries cannot consume newly written v3 start intents.

No production side-effect provider is enabled. Identity, target, Runtime, schema, and inventory mismatches are rejected before child launch or Outbox claim.

## Validation

Run on Linux from `src/cosh-ng` at `19f56300d77cf4eb1b9f6d1f7054ed684a39bc5d`:

```text
cargo fmt --all -- --check
cargo test --locked -p cosh-gateway-contracts profile
cargo test --locked -p cosh-core brokered_profile
cargo test --locked -p cosh-core private_wire_dual_version_corpus_matches_core_types
cargo test --locked -p cosh-gateway runtime_tool_inventory
cargo test --locked -p cosh-gateway stale_validated_outbox_attempt_is_normal_contention
cargo test --locked -p cosh-gateway invalid_start_intents_are_rejected_before_outbox_claim
cargo test --locked -p cosh-gateway exact_task_only_v2_intent_maps_to_current_profile
cargo test --locked -p cosh-gateway capability::
cargo clippy --locked -p cosh-gateway-contracts -p cosh-core -p cosh-gateway --all-targets -- -D warnings
cargo doc --locked --no-deps -p cosh-gateway-contracts
bash scripts/check-source-layout.sh
```

Run from the repository root:

```text
bash scripts/docs-lint.sh
python3 scripts/docs-link-check.py
git diff --check
```

All scoped commands passed. Full package/workspace gates, ECS, real adapters, and manual Terminal validation are intentionally delegated to CI or later acceptance work.

Negative coverage includes profile digest drift, missing/null/empty/extra Runtime tools, target/Runtime drift, future start schemas, exact v2 compatibility, stale Outbox attempt contention, retry identity preservation, reject-before-claim, reject-before-launch, the default empty provider set, and competing Outbox workers.

## Documentation and rollback

Updated the English and Chinese Capability Broker and Cosh Core Bridge design/acceptance documents for the rebased baseline and dependency ownership. Overall Task Plane status remains **NOT ACCEPTED**, and checkpoint/ws-ckpt remains a later optional capability.

Rollback by reverting `19f56300`. Before running an older binary against a database used by this revision, stop the Gateway and either settle/cancel queued v3 Runtime starts or restore the pre-upgrade database snapshot; no SQLite schema downgrade is required.
