### PR TITLE
fix(blaze): accept nsfs mount roots

### DIFF
--- a/src/blaze/crates/blazed/src/sandbox/template.rs
+++ b/src/blaze/crates/blazed/src/sandbox/template.rs
@@ -2819,18 +2819,35 @@ impl MountTable {
                     "mountinfo entry has fewer than six fields",
                 ));
             }
+            let separator = fields
+                .iter()
+                .enumerate()
+                .skip(6)
+                .find_map(|(index, field)| (*field == b"-").then_some(index))
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "mountinfo entry lacks field separator",
+                    )
+                })?;
+            let filesystem_type = fields.get(separator + 1).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "mountinfo entry lacks filesystem type",
+                )
+            })?;
             let device = parse_mount_device(fields[2])?;
             let root = decode_mount_path(fields[3])?;
             let mount_point = decode_mount_path(fields[4])?;
-            if !root.is_absolute() || !mount_point.is_absolute() {
+            if !mount_point.is_absolute() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "mountinfo root and mount point must be absolute",
+                    "mountinfo mount point must be absolute",
                 ));
             }
             entries.push(MountEntry {
                 device,
-                root: normalize_absolute_path(&root)?,
+                root: normalize_mount_root(&root, filesystem_type)?,
                 mount_point: normalize_absolute_path(&mount_point)?,
             });
         }
@@ -2900,6 +2917,35 @@ fn decode_mount_path(value: &[u8]) -> io::Result<PathBuf> {
         ));
     }
     Ok(PathBuf::from(OsString::from_vec(decoded)))
+}
+
+#[cfg(any(test, target_os = "linux"))]
+fn normalize_mount_root(root: &Path, filesystem_type: &[u8]) -> io::Result<PathBuf> {
+    if root.is_absolute() {
+        return normalize_absolute_path(root);
+    }
+    if filesystem_type != b"nsfs" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "mountinfo root must be absolute for non-nsfs filesystems",
+        ));
+    }
+
+    let mut components = root.components();
+    let Some(Component::Normal(namespace)) = components.next() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "mountinfo nsfs root must identify one namespace",
+        ));
+    };
+    if components.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "mountinfo nsfs root must identify one namespace",
+        ));
+    }
+
+    Ok(Path::new("/").join(namespace))
 }
 
 fn normalize_absolute_path(path: &Path) -> io::Result<PathBuf> {
@@ -5068,6 +5114,39 @@ mod tests {
                 .expect("mounted location")
                 .path,
             Path::new("/srv/runtime templates/base")
+        );
+    }
+
+    #[test]
+    fn mount_table_accepts_nsfs_namespace_roots() {
+        let mounts = MountTable::parse(
+            b"1062 592 0:4 net:[4026539640] /run/netns/blz-ns-0-e0fe3133-49ee-471a-ac53-6233df618010 rw shared:681 - nsfs nsfs rw\n",
+        )
+        .expect("nsfs mount table");
+
+        assert_eq!(
+            mounts
+                .location(Path::new(
+                    "/run/netns/blz-ns-0-e0fe3133-49ee-471a-ac53-6233df618010",
+                ))
+                .expect("location")
+                .expect("mounted location")
+                .path,
+            Path::new("/net:[4026539640]")
+        );
+    }
+
+    #[test]
+    fn mount_table_rejects_relative_regular_filesystem_roots() {
+        let error =
+            MountTable::parse(b"25 24 8:1 srv/storage /mnt/catalog rw - ext4 /dev/root rw\n")
+                .expect_err("relative ext4 root must be rejected");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            error
+                .to_string()
+                .contains("root must be absolute for non-nsfs filesystems")
         );
     }
 


### PR DESCRIPTION
## Description

Linux represents a persistent network namespace bind mount with an `nsfs`
mountinfo root such as `net:[4026539640]`. Blaze treated every mount root as a
host pathname, so template boundary validation rejected that valid record and
prevented `blazed` from starting or restarting while a named network namespace
existed.

This change reads the filesystem type from the mountinfo record and accepts a
non-absolute root only when it is one opaque component on `nsfs`. The namespace
identifier is normalized into the mount table's internal comparison key.
Mount points remain absolute for every filesystem, and roots remain absolute
for every non-`nsfs` filesystem.

Before: one valid `nsfs` record could reject the complete mount table and abort
daemon startup.

After: named network namespaces coexist with startup boundary validation,
without weakening the ordinary filesystem path checks used to reject unsafe
template storage aliases.

This is an internal parser correction. It changes no HTTP API, configuration,
persisted format, or user-facing design contract, so no product documentation
is changed.

## Related Issue

closes #2729

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional change)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [ ] `cosh` (copilot-shell)
- [ ] `cosh-ng` (cosh-ng)
- [ ] `sec-core` (agent-sec-core)
- [ ] `skill` (os-skills)
- [ ] `sight` (agentsight)
- [ ] `tokenless` (tokenless)
- [ ] `ckpt` (ws-ckpt)
- [ ] `memory` (agent-memory)
- [ ] `anolisa` (anolisa-cli)
- [ ] `skillfs` (SkillFS)
- [x] `blaze` (blaze)
- [ ] Multiple / Project-wide

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] For `cosh`: Lint passes, type check passes, and tests pass
- [ ] For `cosh-ng`: `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Rust): `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `sec-core` (Python): Ruff format and pytest pass
- [ ] For `skill`: Skill directory structure is valid and shell scripts pass syntax check
- [ ] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `tokenless`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [ ] For `memory` (Linux only): `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --check`, and `cargo test` pass
- [ ] For `anolisa`: `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, and `cargo test --locked` pass
- [ ] For `skillfs`: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

Validated commit `3fc9d7f824f211694a2d744c3ad489c1ee7a7a2b` on Linux x86_64 with the repository-pinned Rust 1.88.0 toolchain:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 69 `blaze-core` and 345 `blazed` tests passed
- `cargo doc --workspace --no-deps`

Focused coverage includes the exact `nsfs` mountinfo field layout emitted for a
named network namespace and a regression assertion that a relative `ext4` root
is still rejected.

## Additional Notes

- This correction unblocks daemon-restart validation for #2678; it does not include any hibernate or resume implementation.
- No public API or durable design document changes are included.
