### PR TITLE
chore(tokenless): bump version to 0.7.11

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.10"
+version = "0.7.11"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.11] - 2026-08-20
+
 ### Fixed
 
 - `tokenless compress-toon` now scores TOON savings with the same CJK-aware character estimator as `stats summary` and the Python/SDK path, so dry-run stderr predicted counts match recorded `before_tokens`/`after_tokens`. JSON parse, oversized input, and TOON encode failures still exit 2 ([#2681](https://github.com/alibaba/anolisa/pull/2681)).

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,8 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.11] - 2026-08-20
+
 ### 修复
 
 - `tokenless compress-toon` 现在用与 `stats summary` 以及 Python/SDK 路径相同的 CJK 感知字符估算器计算 TOON 节省，因此 dry-run 的 stderr 预测计数与记录的 `before_tokens`/`after_tokens` 一致。JSON 解析、超限输入和 TOON 编码失败仍以退出码 2 结束（[#2681](https://github.com/alibaba/anolisa/pull/2681)）。

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "regex",
  "serde_json",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.10"
+version = "0.7.11"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.10",
-    "@anolisa/tokenless-linux-arm64": "0.7.10",
-    "@anolisa/tokenless-darwin-x64": "0.7.10",
-    "@anolisa/tokenless-darwin-arm64": "0.7.10"
+    "@anolisa/tokenless-linux-x64": "0.7.11",
+    "@anolisa/tokenless-linux-arm64": "0.7.11",
+    "@anolisa/tokenless-darwin-x64": "0.7.11",
+    "@anolisa/tokenless-darwin-arm64": "0.7.11"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -470,6 +470,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Thu Aug 20 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.11-1
+- fix(tokenless): align TOON CLI token scoring and exit codes
+
 * Wed Aug 19 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.10-1
 - feat(tokenless): compress Gemini tool schemas
 - feat(tokenless): expose Python stats queries


### PR DESCRIPTION
## Why

Tokenless 0.7.10 predates the merged TOON CLI estimator and exit-code fix in #2681. This release synchronizes every active version surface so the fix can move through the Raw, npm, Python, and RPM publication workflows as one patch release.

## What changed

- Bumped all 14 history-derived Tokenless release surfaces from 0.7.10 to 0.7.11.
- Finalized the paired English and Chinese changelog entry for the CJK-aware TOON estimate and exit-code contract.
- Added the matching RPM changelog boundary; no new runtime code is introduced by this bump.

## Related issue

no-issue: release bump for merged PR #2681

## User / Agent impact

The 0.7.11 artifacts will expose the already-merged behavior: `tokenless compress-toon` uses the same CJK-aware estimator as Runtime and Stats, while invalid JSON, oversized input, and TOON encode failures retain exit code 2.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low runtime risk: the release commit changes only version metadata and release documentation. The public CLI behavior comes from merged #2681, and the ANOLISA catalog change updates only the Tokenless version coordinate without changing its schema or minimum ANOLISA version.

## Validation

Linux x86_64 validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `PATH="$PWD/target/release:$PATH" make test` (exit 0; includes Rust, CLI, hooks, adapters, 71/71 E2E, Raw/npm package tests, and TOON cleanup)
- `make build` and `./target/release/tokenless --version` (`tokenless 0.7.11`)
- `cargo doc --workspace --no-deps`
- Release audit with previous bump `98ac992414271e95e8965102e6b9915390d7c2d8` (14 surfaces, pass)
- `make npm-package` and native package metadata validation
- `BIN_DIR="$PWD/target/npm-prebuilt/linux-x64" TARGET_OS=linux TARGET_ARCH=x86_64 make package-raw`
- Stamped `rpmspec -P` validation for 0.7.11
- `RUSTUP_TOOLCHAIN=1.91.0 make test-python-runtime test-agentscope-integration` (28 Python tests; AgentScope 1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.6 smoke tests)
- `bash scripts/docs-lint.sh`, `python3 scripts/docs-link-check.py`, and `python3 scripts/check-component-versions.py`
- `git diff --check`

The locally built native npm binaries require GLIBC 2.32, so that run validates package structure only; release CI must produce the supported GLIBC 2.17-compatible binaries.

## Documentation and rollback

`CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog now record the 0.7.11 patch boundary. Before publication, rollback is a revert of this atomic bump; after any registry publishes 0.7.11, use a forward patch release rather than attempting to republish the version.
