### PR TITLE
fix(sight): return savings rates as fractions

### DIFF
--- a/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
+++ b/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
@@ -1035,7 +1035,7 @@ export const AtifViewerPage: React.FC = () => {
                     <p className="text-xl font-bold text-green-600">
                       -{fmtTokens(savingsDetail.total_compounded_saved)}
                       <span className="text-sm font-normal text-gray-400 ml-1">
-                        ({savingsDetail.savings_rate.toFixed(1)}%)
+                        ({(savingsDetail.savings_rate * 100).toFixed(1)}%)
                       </span>
                     </p>
                   </div>

--- a/src/agentsight/dashboard/src/pages/TokenSavingsPage.tsx
+++ b/src/agentsight/dashboard/src/pages/TokenSavingsPage.tsx
@@ -428,11 +428,11 @@ const SessionRow: React.FC<{
             <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden max-w-[80px]">
               <div
                 className="h-full bg-green-500 rounded-full"
-                style={{ width: `${Math.min(session.compounded_savings_rate, 100)}%` }}
+                style={{ width: `${Math.min(session.compounded_savings_rate * 100, 100)}%` }}
               />
             </div>
             <span className="text-xs font-semibold text-green-600">
-              {session.compounded_savings_rate.toFixed(1)}%
+              {(session.compounded_savings_rate * 100).toFixed(1)}%
             </span>
           </div>
         </td>
@@ -565,7 +565,6 @@ export const TokenSavingsPage: React.FC = () => {
   const totalCompoundedSaved = summary?.total_compounded_saved ?? 0;
   const totalCompoundedToolSaved = summary?.total_compounded_tool_saved ?? 0;
   const totalCompoundedMcpSaved = summary?.total_compounded_mcp_saved ?? 0;
-  const compoundedSavingsRate = summary?.compounded_savings_rate ?? 0;
   const savingsRate = baselineTokens > 0 ? (totalCompoundedSaved / baselineTokens) * 100 : 0;
 
   return (

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -648,7 +648,9 @@ export interface SessionSavings {
   baseline_tokens: number;
   saved_tokens: number;
   compounded_saved: number;
+  /** Fraction of tokens saved, in [0, 1] (not a percentage). */
   savings_rate: number;
+  /** Fraction saved including compounding, in [0, 1] (not a percentage). */
   compounded_savings_rate: number;
   request_count: number;
   tool_saved: number;
@@ -670,7 +672,9 @@ export interface SavingsSummary {
   baseline_tokens: number;
   total_saved_tokens: number;
   total_compounded_saved: number;
+  /** Fraction of tokens saved, in [0, 1] (not a percentage). */
   savings_rate: number;
+  /** Fraction saved including compounding, in [0, 1] (not a percentage). */
   compounded_savings_rate: number;
   total_tool_saved: number;
   total_mcp_saved: number;
@@ -716,6 +720,7 @@ export interface SessionSavingsDetail {
   total_actual_tokens: number;
   total_compounded_saved: number;
   total_original_tokens: number;
+  /** Fraction of tokens saved, in [0, 1] (not a percentage). */
   savings_rate: number;
   items: OptimizationItem[];
 }

--- a/src/agentsight/src/server/token_savings.rs
+++ b/src/agentsight/src/server/token_savings.rs
@@ -40,7 +40,9 @@ pub struct SavingsSummary {
     pub baseline_tokens: i64,
     pub total_saved_tokens: i64,
     pub total_compounded_saved: i64,
+    /// Fraction of tokens saved: `total_saved_tokens / total_tokens`, in [0.0, 1.0].
     pub savings_rate: f64,
+    /// Fraction saved including the compounding effect, in [0.0, 1.0].
     pub compounded_savings_rate: f64,
     pub total_tool_saved: i64,
     pub total_mcp_saved: i64,
@@ -91,7 +93,9 @@ pub struct SessionSavingsDto {
     pub baseline_tokens: i64,
     pub saved_tokens: i64,
     pub compounded_saved: i64,
+    /// Fraction of tokens saved: `saved_tokens / total_tokens`, in [0.0, 1.0].
     pub savings_rate: f64,
+    /// Fraction saved including the compounding effect, in [0.0, 1.0].
     pub compounded_savings_rate: f64,
     pub request_count: i64,
     pub tool_saved: i64,
@@ -124,6 +128,7 @@ pub struct SessionSavingsDetail {
     pub total_actual_tokens: i64,
     pub total_compounded_saved: i64,
     pub total_original_tokens: i64,
+    /// Fraction of tokens saved: `total_compounded_saved / total_actual_tokens`, in [0.0, 1.0].
     pub savings_rate: f64,
     pub items: Vec<OptimizationItemDto>,
 }
@@ -363,6 +368,8 @@ pub(crate) fn build_explanation(
 }
 
 /// Generate optimization tips based on aggregated savings data.
+///
+/// `grand_compounded_rate` is a fraction in [0.0, 1.0] (not a percentage).
 pub(crate) fn generate_optimization_tips(
     stats_available: bool,
     grand_total: i64,
@@ -379,7 +386,7 @@ pub(crate) fn generate_optimization_tips(
             title: "Tokenless component not detected".to_string(),
             description: "stats.db not found. Make sure the tokenless component is installed and enabled; it automatically compresses tool output and MCP responses, significantly cutting token consumption.".to_string(),
         });
-    } else if grand_compounded_rate < 15.0 && grand_total > 0 {
+    } else if grand_compounded_rate < 0.15 && grand_total > 0 {
         tips.push(OptimizationTip {
             level: "warning".to_string(),
             title: "Savings rate is low".to_string(),
@@ -419,22 +426,22 @@ pub(crate) fn generate_optimization_tips(
         });
     }
 
-    if grand_compounded_rate >= 30.0 {
+    if grand_compounded_rate >= 0.30 {
         tips.push(OptimizationTip {
             level: "success".to_string(),
             title: "Excellent savings".to_string(),
             description: format!(
                 "Current compounded savings rate is {:.1}% — excellent! Keep the current configuration.",
-                grand_compounded_rate
+                grand_compounded_rate * 100.0
             ),
         });
-    } else if grand_compounded_rate >= 15.0 {
+    } else if grand_compounded_rate >= 0.15 {
         tips.push(OptimizationTip {
             level: "success".to_string(),
             title: "Good savings".to_string(),
             description: format!(
                 "Current compounded savings rate is {:.1}% — a good level. Try tuning compression strategies to improve further.",
-                grand_compounded_rate
+                grand_compounded_rate * 100.0
             ),
         });
     }
@@ -622,12 +629,12 @@ pub async fn get_token_savings(
 
         // FIX(#1): use compounded/total_tokens for both list and detail pages
         let savings_rate = if total_tokens > 0 {
-            session_saved as f64 / total_tokens as f64 * 100.0
+            session_saved as f64 / total_tokens as f64
         } else {
             0.0
         };
         let compounded_savings_rate = if total_tokens > 0 {
-            session_compounded_saved as f64 / total_tokens as f64 * 100.0
+            session_compounded_saved as f64 / total_tokens as f64
         } else {
             0.0
         };
@@ -661,12 +668,12 @@ pub async fn get_token_savings(
 
     let grand_total = grand_input + grand_output;
     let grand_rate = if grand_total > 0 {
-        grand_saved as f64 / grand_total as f64 * 100.0
+        grand_saved as f64 / grand_total as f64
     } else {
         0.0
     };
     let grand_compounded_rate = if grand_total > 0 {
-        grand_compounded_saved as f64 / grand_total as f64 * 100.0
+        grand_compounded_saved as f64 / grand_total as f64
     } else {
         0.0
     };
@@ -842,7 +849,7 @@ pub async fn get_session_savings(
 
     // FIX(#1): use compounded/total_tokens — consistent with get_token_savings
     let savings_rate = if total_tokens > 0 {
-        total_compounded_saved as f64 / total_tokens as f64 * 100.0
+        total_compounded_saved as f64 / total_tokens as f64
     } else {
         0.0
     };
@@ -1088,6 +1095,21 @@ mod tests {
         let total_saved = body["summary"]["total_saved_tokens"].as_i64().unwrap();
         assert!(total_saved > 0);
 
+        // Rates are fractions in [0.0, 1.0]: 2200 saved / 2700 total tokens
+        let expected_rate = 2200.0 / 2700.0;
+        let rate = body["summary"]["savings_rate"].as_f64().unwrap();
+        assert!((rate - expected_rate).abs() < 1e-9, "got {rate}");
+        let compounded_rate = body["summary"]["compounded_savings_rate"].as_f64().unwrap();
+        assert!(
+            (compounded_rate - expected_rate).abs() < 1e-9,
+            "got {compounded_rate}"
+        );
+        let session_rate = body["sessions"][0]["savings_rate"].as_f64().unwrap();
+        assert!(
+            (session_rate - expected_rate).abs() < 1e-9,
+            "got {session_rate}"
+        );
+
         // Restore HOME
         match orig_home {
             Some(v) => unsafe { std::env::set_var("HOME", v) },
@@ -1172,6 +1194,9 @@ mod tests {
         assert!(items[0]["strategy_label"].as_str().is_some());
         let compounded = body["total_compounded_saved"].as_i64().unwrap();
         assert!(compounded > 0);
+        // Rate is a fraction in [0.0, 1.0]: 2200 compounded saved / 2700 total tokens
+        let rate = body["savings_rate"].as_f64().unwrap();
+        assert!((rate - 2200.0 / 2700.0).abs() < 1e-9, "got {rate}");
 
         // Restore HOME
         match orig_home {
@@ -1384,7 +1409,7 @@ mod tests {
 
     #[test]
     fn test_tips_low_savings_rate() {
-        let tips = generate_optimization_tips(true, 10000, 10.0, 100, 200, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.10, 100, 200, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "warning" && t.title.contains("Savings rate"))
@@ -1431,7 +1456,7 @@ mod tests {
 
     #[test]
     fn test_tips_boundary_at_15_no_warning() {
-        let tips = generate_optimization_tips(true, 10000, 15.0, 1000, 500, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.15, 1000, 500, &[]);
         assert!(
             !tips
                 .iter()
@@ -1442,7 +1467,7 @@ mod tests {
 
     #[test]
     fn test_tips_boundary_at_30_excellent() {
-        let tips = generate_optimization_tips(true, 10000, 30.0, 2000, 1000, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.30, 2000, 1000, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "success" && t.title.contains("Excellent"))
@@ -1451,7 +1476,7 @@ mod tests {
 
     #[test]
     fn test_tips_boundary_just_below_15_warning() {
-        let tips = generate_optimization_tips(true, 10000, 14.9, 500, 500, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.149, 500, 500, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "warning" && t.title.contains("Savings rate"))
@@ -1460,7 +1485,7 @@ mod tests {
 
     #[test]
     fn test_tips_only_tool_saved_suggest_mcp() {
-        let tips = generate_optimization_tips(true, 10000, 10.0, 500, 0, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.10, 500, 0, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "info" && t.title.contains("MCP"))
@@ -1469,7 +1494,7 @@ mod tests {
 
     #[test]
     fn test_tips_only_mcp_saved_suggest_tool() {
-        let tips = generate_optimization_tips(true, 10000, 10.0, 0, 500, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.10, 0, 500, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "info" && t.title.contains("tool-output"))
@@ -1482,13 +1507,13 @@ mod tests {
             make_session_for_tips(0, 5000),
             make_session_for_tips(200, 3000),
         ];
-        let tips = generate_optimization_tips(true, 8000, 10.0, 100, 100, &sessions);
+        let tips = generate_optimization_tips(true, 8000, 0.10, 100, 100, &sessions);
         assert!(tips.iter().any(|t| t.title.contains("1")));
     }
 
     #[test]
     fn test_tips_excellent_rate() {
-        let tips = generate_optimization_tips(true, 10000, 35.0, 2000, 1500, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.35, 2000, 1500, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "success" && t.title.contains("Excellent"))
@@ -1497,7 +1522,7 @@ mod tests {
 
     #[test]
     fn test_tips_good_rate() {
-        let tips = generate_optimization_tips(true, 10000, 20.0, 1000, 1000, &[]);
+        let tips = generate_optimization_tips(true, 10000, 0.20, 1000, 1000, &[]);
         assert!(
             tips.iter()
                 .any(|t| t.level == "success" && t.title.contains("Good"))


### PR DESCRIPTION
## Why

`/api/token-savings` returned `savings_rate` / `compounded_savings_rate` scaled by 100 (percent values, e.g. `0.269` meaning 0.269%) while the field names imply a ratio. Consumers naturally read `savings_rate: 0.269` as 26.9% — a 100x overstatement. Reported feedback: actual ratio is 6,594 / 2,448,188 = 0.00269, not 0.269.

## What changed

- Backend (`src/server/token_savings.rs`): both `/api/token-savings` and `/api/token-savings/session/{id}` now return true fractions in [0.0, 1.0] for `savings_rate` and `compounded_savings_rate` (session-level, grand summary, session detail). DTO doc comments state the contract.
- Optimization tips: thresholds moved from percent (15.0 / 30.0) to fraction scale (0.15 / 0.30); displayed percentage strings multiply by 100.
- Dashboard: display sites convert fraction → percent (session table bar + label on TokenSavingsPage, saved-label on AtifViewerPage); rendered UI is unchanged. Removed an unused `compoundedSavingsRate` variable; TS interfaces document the [0, 1] range.
- Tests: exact fraction assertions (2200/2700 ≈ 0.8148) added to both handler integration tests; tips unit tests rescaled to fractions.

## Related issue

no-issue: user feedback on API field semantics (no GitHub issue filed)

## User / Agent impact

Dashboard UI renders identically. Direct API consumers of the two rate fields see a value-scale change (percent number → fraction).

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

API value-scale change: `savings_rate` / `compounded_savings_rate` on the two token-savings endpoints now return fractions in [0.0, 1.0] instead of percent values. The only in-repo consumer (embedded dashboard) is adapted in the same commit; a monorepo-wide grep confirms no other consumers. Field names and response shapes are unchanged. Renaming to `*_pct` was considered and rejected: it breaks the response shape for the same audience without fixing the name/value mismatch.

## Validation

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass (excluding the pre-existing `question_mark` error in `src/analyzer/message/openai.rs`; verified identical on main)
- `cargo test token_savings` — 40/40 pass
- `cargo test --no-fail-fast --workspace --lib --tests` — 27 test binaries, all green (one earlier run hit a transient `/tmp` fstat I/O flake in test setup; re-ran clean twice)
- `dashboard/`: `npm run typecheck`, `npm run test:api-client`, `npm run test:i18n` — pass
- Known pre-existing failures on main, unrelated to this change: clippy `question_mark` in `analyzer/message/openai.rs`, doctest in `genai/helpers.rs` (both fail with the local toolchain)

Environment: Linux x86_64, kernel 5.10.

## Documentation and rollback

No existing docs describe these field semantics (checked `docs/` and the AGENTS.md endpoint table — the endpoint is listed without field details); the new rustdoc and TS interface comments serve as the contract. Rollback: revert the single commit — backend and dashboard changes are coupled in one commit and revert atomically.