### PR TITLE
chore(skillfs): bump version to 0.4.1

### DIFF
--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -19,7 +19,7 @@ FUSE mount; the workload stays non-privileged and receives the propagated view.
 Build for the target node architecture:
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
 export PLATFORM=linux/amd64
 
 docker buildx build \

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -19,7 +19,7 @@ source。
 请为目标节点架构构建镜像：
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
 export PLATFORM=linux/amd64
 
 docker buildx build \

--- a/src/skillfs/CHANGELOG.md
+++ b/src/skillfs/CHANGELOG.md
@@ -1,11 +1,46 @@
 # Changelog
 
+[中文版](CHANGELOG_zh.md)
+
 All notable changes to SkillFS are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.1] - 2026-08-21
+
+### Added
+
+- A Kubernetes sidecar deployment now lets a privileged SkillFS container
+  expose its FUSE view to a non-privileged workload, including readable paths
+  advertised by `skill-discover`
+  ([#2057](https://github.com/alibaba/anolisa/pull/2057)).
+- Optional mutual HMAC-SHA256 authentication now protects control and notify
+  sockets across container namespaces through `--trusted-peer-key-file` and
+  `--notify-auth-key-file`, while existing host authentication remains
+  unchanged ([#2449](https://github.com/alibaba/anolisa/pull/2449)).
+
+### Changed
+
+- The reference Kubernetes deployment now marks the Pod unready after one
+  failed FUSE read and restarts only the SkillFS sidecar after two liveness
+  failures, allowing workloads to recover without restarting
+  ([#2705](https://github.com/alibaba/anolisa/pull/2705)).
+
+### Fixed
+
+- Nested Hermes skills can now update activation state through the control
+  socket with layout-relative identifiers such as `category/skill`
+  ([#2407](https://github.com/alibaba/anolisa/pull/2407)).
+- Activation metadata permissions, in-place backing aliases, and control
+  listener startup now fail closed instead of exposing metadata, accepting an
+  unsafe source, or leaving an unusable endpoint
+  ([#2407](https://github.com/alibaba/anolisa/pull/2407)).
+- The bundled `skillfs-mount` skill now names the shipped analysis scripts and
+  accurately describes managed mounts and writable source behavior
+  ([#1798](https://github.com/alibaba/anolisa/pull/1798)).
 
 ## [0.4.0] - 2026-07-24
 

--- a/src/skillfs/CHANGELOG_zh.md
+++ b/src/skillfs/CHANGELOG_zh.md
@@ -1,0 +1,229 @@
+# 更新日志
+
+[English](CHANGELOG.md)
+
+本文档记录 SkillFS 的所有重要变更。
+
+格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，
+项目遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
+
+## [未发布]
+
+## [0.4.1] - 2026-08-21
+
+### 新增
+
+- 新增 Kubernetes Sidecar 部署方式，由特权 SkillFS 容器向非特权工作负载提供
+  FUSE view，工作负载也可读取 `skill-discover` 提供的路径
+  ([#2057](https://github.com/alibaba/anolisa/pull/2057))。
+- 新增可选的双向 HMAC-SHA256 认证，通过 `--trusted-peer-key-file` 和
+  `--notify-auth-key-file` 保护跨容器 namespace 的 control socket 与 notify
+  socket，同时保持既有宿主机认证方式不变
+  ([#2449](https://github.com/alibaba/anolisa/pull/2449))。
+
+### 变更
+
+- Kubernetes 参考部署现在会在一次 FUSE read 失败后将 Pod 标记为 NotReady，
+  在连续两次 liveness 失败后仅重启 SkillFS Sidecar，使工作负载无需重启即可恢复
+  ([#2705](https://github.com/alibaba/anolisa/pull/2705))。
+
+### 修复
+
+- Hermes 嵌套 Skill 现在可通过 control socket 使用 `category/skill` 这类
+  layout-relative 标识更新 activation 状态
+  ([#2407](https://github.com/alibaba/anolisa/pull/2407))。
+- Activation metadata 权限、in-place backing alias 和 control listener 启动过程
+  现在会 fail closed，避免暴露 metadata、接受不安全 source 或遗留不可用 endpoint
+  ([#2407](https://github.com/alibaba/anolisa/pull/2407))。
+- 随包分发的 `skillfs-mount` Skill 现在使用实际存在的分析脚本名称，并准确说明
+  managed mount 与可写 source 行为
+  ([#1798](https://github.com/alibaba/anolisa/pull/1798))。
+
+## [0.4.0] - 2026-07-24
+
+### 新增
+
+- 可配置的 read-time transform 现在默认保持 directive compilation 启用，
+  并新增可选 OS adapter，内置 Ubuntu/Alinux 规则且支持外部 catalog 覆盖
+  ([#1484](https://github.com/alibaba/anolisa/pull/1484))。
+- 新增 authenticated live-source resolver 和 notify v2 protocol，使 Skill Ledger
+  可获得规范的 flat 或 Hermes Skill identity、event kind 和 changed path，
+  同时不暴露 backing-root 细节
+  ([#1517](https://github.com/alibaba/anolisa/pull/1517))。
+
+### 变更
+
+- Agent 可见访问检查现在遵循 activated snapshot 权限，live-source 权限继续控制写入
+  ([#1517](https://github.com/alibaba/anolisa/pull/1517))。
+
+### 修复
+
+- SLS telemetry writer 现在会动态遵循 `/etc/anolisa/.telemetry_disabled`，
+  且无法检查该 gate 时会 fail closed
+  ([#1584](https://github.com/alibaba/anolisa/pull/1584))。
+- Hermes symlink boundary、resolver path、socket ownership 和 peer authentication
+  现在会在 discovery、read 和 mutation 过程中 fail closed
+  ([#1517](https://github.com/alibaba/anolisa/pull/1517))。
+- Control socket 前置条件诊断现在会统一显示公开参数名 `--control-socket`
+  ([#1739](https://github.com/alibaba/anolisa/pull/1739))。
+
+## [0.3.4] - 2026-07-16
+
+### 修复
+
+- CLI output pipe 提前关闭并触发 panic unwind 时，SLS ops logging 现在仍会准确保留
+  一条 command record。
+
+## [0.3.3] - 2026-07-10
+
+### 新增
+
+- 新增 Hermes workspace layout 兼容能力。SkillFS 现在可以识别 Hermes hub marker、
+  保留 management path，并同时暴露嵌套的 `category/skill/SKILL.md` Skill 与顶层 Skill。
+- Hermes 嵌套 Skill 现在支持 activation state、installer lifecycle write、
+  notification、audit attribution、fallback snapshot 和 hidden visibility。
+
+### 修复
+
+- `skillfs validate --json` 现在会在 warning 和 error 中包含 source path，
+  便于自动化流程定位无效 Skill。
+- FUSE teardown 现在会限制 unmount 失败后的 cleanup，避免泄漏的测试 mount
+  影响后续 session。
+
+## [0.3.2] - 2026-07-03
+
+### 修复
+
+- CLI SLS ops logging 现在会记录 SkillFS mount 和 runtime operation。
+- Runtime metric 现在会向 SLS consumer 发送实时 delta。
+
+## [0.3.1] - 2026-07-03
+
+### 新增
+
+- Managed mount supervision 现在可以恢复 stale FUSE mount，并限制重复启动时的
+  recovery retry。
+
+### 变更
+
+- 中英文 README 现在包含 managed mount、in-place operation、security boundary
+  和 troubleshooting 指南。
+
+### 修复
+
+- Installer 完成后，post-publish grace read 会从 source path 读取 fallback Skill file。
+- `skillfs validate` 现在会在 status summary 中报告 parse failure。
+- In-place authoring 现在支持新 Skill 和 pending-install ownership change。
+- Managed stop 和 runtime-dir 处理现在可避免 stale ownership 与无限 recovery retry。
+- PrivateTmp 下 daemon-facing backing root 会在 mount 启动前被拒绝。
+- FUSE smoke cleanup 现在能更可靠地处理残留 mount 和临时 path。
+
+## [0.3.0] - 2026-06-26
+
+### 新增
+
+- 新增 agent Skill directory 的 runtime security integration。SkillFS 现在可从
+  `.skill-meta/activation.json` 或 `user.agent_sec.skill_ledger.activation` xattr
+  读取 activation decision，并将每个 Skill 显示为 current、hidden 或可信
+  fallback snapshot。
+- 新增面向外部 security daemon 的 file-change notification。通过
+  `--activation-mode file`、`--notify-socket`、`--activation-events-log` 和
+  `--activation-reload-mode poll`，SkillFS 可报告 Skill mutation、重新加载
+  activation decision，并让已打开的 file handle 保持指向原 target。
+- 新增用于写入 activation 的 trusted control socket。通过 `SO_PEERCRED`、
+  executable identity 和 start-time check 验证的 daemon，可通过受限 request API
+  更新 activation JSON 或 activation xattr，无需通过 agent-visible mount path
+  写入 `.skill-meta`。
+- 新增对常见 Skill 安装流程的 installer compatibility。Staging directory、
+  direct write、quiet-timeout completion 和 post-publish grace window
+  允许 installer 完成 Skill 写入后，再由 SkillFS 请求 security provider 扫描并激活。
+- 新增面向 security daemon 的 in-place mount 支持。Ledger backing root 会以
+  private bind 方式挂载并在启动时校验，使 scanner 读取真实 source tree，
+  不经过 agent-facing FUSE view。
+- Skill 的 canonical identity 现在基于 directory basename。Frontmatter `name:`
+  继续作为 display metadata，不再改变 SkillFS store key 或 daemon-facing Skill ID。
+
+### 变更
+
+- `.skill-meta/**` 对普通 agent 隐藏，只能通过 trusted metadata path 或
+  control socket 访问。
+- Skill mutation notify 现在使用普通 filesystem event kind，包括 `create`、
+  `write`、`rename`、`unlink`、`rmdir` 和 truncate event，不再使用单独的
+  install-complete protocol event。
+- POSIX passthrough 扩展了 symlink、hardlink、FIFO、path-length fallback、
+  open-after-unlink、xattr 和 inode consistency 行为。
+
+### 修复
+
+- 结合 notify-triggered reload、polling 和 activation watcher convergence，
+  避免 stale activation view。
+- 通过 start-time 与 file-identity validation 加固 trusted-writer 和
+  trusted-peer check，防止 process reuse 与 executable replacement。
+- 修复 hidden Skill、fallback snapshot、staging path 和 backing-root propagation
+  周边的 installer 与 daemon visibility 问题。
+
+## [0.2.0] - 2026-05-09
+
+### 新增
+
+- 新增 Skill directory 上 `write`、`create`、`mkdir`、`rename`、`unlink`、
+  `rmdir` 和 `setattr(size)` operation 的 FUSE write passthrough。
+- 新增 background sync worker，在写入后重新解析 `SKILL.md`，并将 entry
+  `upsert` 回 `SharedSkillStore`。
+- 新建 Skill directory 现在会立即可见。`mkdir` 会先插入
+  `ParseStatus::Degraded` placeholder，写入 `SKILL.md` 后由 sync worker
+  替换为真实 entry。
+- 新增通过 `/proc/self/fd/{n}` 访问底层 source 的 in-place mount mode，
+  避免 over-mount self-loop。
+- 新增 integration suite `crates/skillfs-fuse/tests/write_guard_tests.rs`，
+  覆盖 normal 与 in-place write path。
+
+### 变更
+
+- Directory name 现在是权威 store key。`rename` 后，stale frontmatter `name:`
+  不会再恢复旧 key。
+- 读取 `SKILL.md` 时仍返回 compiled result，raw file 只用于 write 和 parse。
+- Architecture doc 重构到 `docs/specs/skillfs-spec.md`、
+  `docs/specs/core-spec.md` 和 `docs/specs/fuse-spec.md`。
+
+### 移除
+
+- 移除 `skillfs-core` 中 workspace 相关 code path 和未使用的 workspace config
+  support（commit 6d604c7）。
+- 移除旧的临时 test script，仅保留 `scripts/build.sh` 和 `scripts/test.sh`。
+
+### 修复
+
+- CLI tracing timestamp 现在使用本地 timezone，不再使用 UTC。
+
+## [0.1.2] - 2026-04-29
+
+### 新增
+
+- 新增 read-only mount write protection，`mknod`、`symlink`、`link` 和 write
+  callback 都会返回 `EROFS`。
+
+### 修复
+
+- Parser summary 截断现在遵循 multi-byte character boundary。
+
+## [0.1.1] - 2026-04-29
+
+### 新增
+
+- 新增 `docs/skills/` 下的 `skillfs-mount` agent Skill，帮助用户设置、挂载和
+  卸载 SkillFS instance。
+
+## [0.1.0] - 2026-04-25
+
+### 新增
+
+- 首次发布 SkillFS workspace。
+- `skillfs-core` 提供 `SKILL.md` parser、带 flat 与 categorized directory layout
+  的 in-memory `SkillStore`、`skillfs-views.toml` configuration、条件式
+  `compiler::compile` 和 environment probing。Parser status 包括 `Ok`、
+  `Degraded` 与 `Error`。
+- `skillfs-fuse` 提供 read-only FUSE filesystem，在 `/skills` 暴露配置的
+  default view、始终可用的 virtual `skill-discover`，并在读取时编译 `SKILL.md`。
+  Skill directory 中的其他 file 会透传到 physical source。
+- `skillfs` CLI 提供 `mount`、`classify`、`validate` 和 `list` subcommand。

--- a/src/skillfs/Cargo.lock
+++ b/src/skillfs/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "libc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "notify",
  "parking_lot",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs-fuse"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "fuser",

--- a/src/skillfs/Cargo.toml
+++ b/src/skillfs/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.86"
 license = "Apache-2.0"

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -427,7 +427,7 @@ sidecar as privileged.
 
 ```bash
 cd src/skillfs
-IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
 docker build -f container/Dockerfile -t "$IMAGE" .
 docker push "$IMAGE"
 kubectl apply -f deploy/kubernetes/00-namespace.yaml

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -387,7 +387,7 @@ Kubernetes 1.29+、`/dev/fuse`，并允许 Sidecar 使用特权模式。
 
 ```bash
 cd src/skillfs
-IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
 docker build -f container/Dockerfile -t "$IMAGE" .
 docker push "$IMAGE"
 kubectl apply -f deploy/kubernetes/00-namespace.yaml

--- a/src/skillfs/component.toml
+++ b/src/skillfs/component.toml
@@ -3,7 +3,7 @@ anolisa_min_version = "0.1.0"
 
 [component]
 name = "skillfs"
-version = "0.4.0"
+version = "0.4.1"
 layer = "runtime"
 domain = "tools"
 description = "AI agent skill management via virtual filesystem"

--- a/src/skillfs/deploy/kubernetes/README.md
+++ b/src/skillfs/deploy/kubernetes/README.md
@@ -26,7 +26,7 @@ for the complete workflow.
 ## Deploy
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.0
+export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
 export NS=skillfs-container-example
 
 kubectl apply -f 00-namespace.yaml

--- a/src/skillfs/skillfs.spec.in
+++ b/src/skillfs/skillfs.spec.in
@@ -62,6 +62,11 @@ cp -rp docs/skills/skillfs-mount/. \
 %{_datadir}/anolisa/runtime/skills/skillfs/
 
 %changelog
+* Fri Aug 21 2026 kongche-jbw <kongche.jbw@alibaba-inc.com> - 0.4.1-1
+- Add Kubernetes sidecar deployment and authenticated container peers.
+- Fix nested Hermes activation and harden metadata and backing aliases.
+- Tighten sidecar health recovery without restarting the workload.
+
 * Fri Jul 24 2026 Kongche <kongche.jbw@alibaba-inc.com> - 0.4.0-1
 - Release read-time OS transforms and live Skill Ledger integration.
 


### PR DESCRIPTION
## Why

Prepare the reviewed SkillFS changes merged since v0.4.0 for the v0.4.1
source release. This keeps source, RPM, component, and documented container
versions aligned before the release tag is created.

## What changed

- Bump the SkillFS Cargo workspace, component metadata, RPM changelog, and
  Kubernetes example image references to 0.4.1.
- Add v0.4.1 release notes covering the Kubernetes sidecar, optional peer
  authentication, security fixes, and health-probe recovery.
- Add the required Chinese changelog and cross-link it with the English file.

The anolisa CLI binary-artifact manifest remains unchanged because it requires
the separately published binary bundle, SBOM, size, and checksum; the GitHub
source release workflow only creates source and vendored-dependency archives.

## Related issue

no-issue: SkillFS v0.4.1 release preparation

## User / Agent impact

The v0.4.1 release will expose the already-merged Kubernetes sidecar workflow,
optional authenticated container peers, nested Hermes activation fixes, and
more responsive sidecar recovery. Existing host authentication and deployments
that do not configure peer key files remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The release includes new optional peer-key flags and a privileged Kubernetes
sidecar contract. Both are opt-in; existing host-mode behavior remains
compatible, and the peer must implement the same HMAC handshake when enabled.

## Validation

- `git diff --check`
- `python3 scripts/check-component-versions.py`
- `./scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.86.0 test --workspace --locked`
- `cargo +1.86.0 doc --workspace --no-deps --locked` (passes with existing
  rustdoc link warnings)
- `scripts/test.sh` with `/dev/fuse` available, including managed remount and
  circuit-breaker recovery

## Documentation and rollback

Updated the English and Chinese changelogs plus all published sidecar image
examples. Before tagging, revert this release commit to roll back; after a tag
is published, issue a follow-up patch release rather than moving the tag.
