### PR TITLE
chore(skill): bump version to 0.6.3

### DIFF
--- a/src/os-skills/CHANGELOG.md
+++ b/src/os-skills/CHANGELOG.md
@@ -1,17 +1,35 @@
 # Changelog
 
-## 0.6.2
+[中文版](CHANGELOG_zh.md)
+
+All notable changes to OS Skills are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.3] - 2026-08-21
+
+### Fixed
+
+- The RPM now provides `anolisa-component(os-skills)`, allowing
+  `anolisa upgrade` to resolve the OS Skills package from RPM metadata for an
+  existing component when the repository-side component index is unavailable
+  ([#2576](https://github.com/alibaba/anolisa/pull/2576)).
+
+## [0.6.2] - 2026-08-07
 
 - Added the `ktuner` skill for deterministic kernel diagnosis, tuning, and rollback. (#1278)
 - Removed legacy OpenClaw and Hermes adapter scripts from source and RPM installs. (#1172)
 - Updated `anolisa-guide` with authenticated Skill Ledger recovery and tamper detection. (#2185)
 
-## 0.6.1
+## [0.6.1] - 2026-07-03
 
 - Rewrote `sysom-diagnosis` skill and removed legacy CLI. (#1241)
 - Fixed OpenClaw gateway write scope verification in `install-openclaw` skill. (#1205)
 
-## 0.6.0
+## [0.6.0] - 2026-06-29
 
 - Added anolisa component contract (component.toml, Makefile, RPM spec). (#1159)
 - Added OpenClaw bootstrap guidance to `install-openclaw` skill. (#1051)
@@ -22,11 +40,11 @@
 - Fixed dashscope proxy URL to new Anthropic endpoint in `install-claude-code` skill. (#858)
 - Renamed `copaw` to `qwenpaw` across os-skills. (#968)
 
-## 0.5.0
+## [0.5.0] - 2026-06-11
 
 - Added `anolisa-register` skill. (#829)
 
-## 0.4.0
+## [0.4.0] - 2026-06-08
 
 - Added auto-install tokenless plugin support for agent install skills. (#731)
 - Added OpenClaw dependency precheck. (#719)
@@ -36,7 +54,7 @@
 - Fixed OpenClaw state dir handling normalization. (#641)
 - Improved Makefile install paths and contract. (#541)
 
-## 0.3.0
+## [0.3.0] - 2026-04-26
 
 - Added `hermes-agent-install` skill. (#353)
 - Added `clawhub-skill-mng` skill with npm install support and YAML description matching. (#315)
@@ -44,16 +62,16 @@
 - Fixed AgentSight token savings query support. (#355)
 - Fixed AgentSight interruption CLI and aligned `conversation_id` naming. (#334)
 
-## 0.2.2
+## [0.2.2] - 2026-04-15
 
 - Support enable AgentSight dashboard in `agentsight` skill. (#222)
 
-## 0.2.1
+## [0.2.1] - 2026-04-14
 
 - Upgraded `xlsx` skill with MiniMax open-source implementation. (#218)
 - Updated skill descriptions from "suitable for alinux4" to "rpm-base linux". (#182)
 
-## 0.2
+## [0.2] - 2026-04-12
 
 - Added `humanizer`, `image-gen`, `pdf-reader`, and `xlsx` skills. (#178)
 - Added `cosh-guide` skill. (#23)

--- a/src/os-skills/CHANGELOG_zh.md
+++ b/src/os-skills/CHANGELOG_zh.md
@@ -1,0 +1,78 @@
+# 更新日志
+
+[English](CHANGELOG.md)
+
+本文档记录 OS Skills 的所有重要变更。
+
+格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，
+项目遵循 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
+
+## [未发布]
+
+## [0.6.3] - 2026-08-21
+
+### 修复
+
+- RPM 现在提供 `anolisa-component(os-skills)`，当仓库侧组件索引不可用时，
+  `anolisa upgrade` 可通过 RPM metadata 为已有 OS Skills 组件解析软件包
+  ([#2576](https://github.com/alibaba/anolisa/pull/2576))。
+
+## [0.6.2] - 2026-08-07
+
+- 新增 `ktuner` Skill，支持确定性的内核诊断、调优和回滚。（#1278）
+- 从源码和 RPM 安装内容中移除旧版 OpenClaw 与 Hermes adapter 脚本。（#1172）
+- 更新 `anolisa-guide`，补充带认证的 Skill Ledger 恢复与篡改检测说明。（#2185）
+
+## [0.6.1] - 2026-07-03
+
+- 重写 `sysom-diagnosis` Skill，并移除旧版 CLI。（#1241）
+- 修复 `install-openclaw` Skill 对 OpenClaw gateway 写入范围的验证。（#1205）
+
+## [0.6.0] - 2026-06-29
+
+- 新增 anolisa 组件契约，包括 component.toml、Makefile 和 RPM spec。（#1159）
+- 为 `install-openclaw` Skill 新增 OpenClaw bootstrap 指引。（#1051）
+- 在启动 gateway 前为 `install-openclaw` Skill 新增模型 endpoint 预检。（#1031）
+- 为 `anolisa-guide` Skill 新增静态知识库更新脚本。（#1010）
+- 新增 `anolisa-guide` Skill。（#849）
+- 修复 uv 和 qwenpaw 安装过程中的阿里云镜像 fallback。（#968）
+- 将 `install-claude-code` Skill 的 DashScope proxy URL 更新为新的 Anthropic
+  endpoint。（#858）
+- 在 OS Skills 中将 `copaw` 重命名为 `qwenpaw`。（#968）
+
+## [0.5.0] - 2026-06-11
+
+- 新增 `anolisa-register` Skill。（#829）
+
+## [0.4.0] - 2026-06-08
+
+- 新增 Agent 安装 Skill 自动安装 Tokenless plugin 的能力。（#731）
+- 新增 OpenClaw 依赖项预检。（#719）
+- 改进 OpenClaw 非交互式配置流程。（#687）
+- 新增 Hermes adapter runner。（#617）
+- 新增独立的 ANOLISA adapter 入口。（#549）
+- 修复 OpenClaw state dir 路径规范化。（#641）
+- 改进 Makefile 安装路径与组件契约。（#541）
+
+## [0.3.0] - 2026-04-26
+
+- 新增 `hermes-agent-install` Skill。（#353）
+- 新增 `clawhub-skill-mng` Skill，支持 npm 安装和 YAML 描述匹配。（#315）
+- 修复 AgentSight 自定义数据库路径问题，改用默认路径。（#366）
+- 修复 AgentSight Token 节省量查询支持。（#355）
+- 修复 AgentSight 中断 CLI，并统一使用 `conversation_id` 命名。（#334）
+
+## [0.2.2] - 2026-04-15
+
+- 支持通过 `agentsight` Skill 启用 AgentSight dashboard。（#222）
+
+## [0.2.1] - 2026-04-14
+
+- 使用 MiniMax 开源实现升级 `xlsx` Skill。（#218）
+- 将 Skill 描述中的“适用于 alinux4”更新为“适用于 RPM-based Linux”。（#182）
+
+## [0.2] - 2026-04-12
+
+- 新增 `humanizer`、`image-gen`、`pdf-reader` 和 `xlsx` Skill。（#178）
+- 新增 `cosh-guide` Skill。（#23）
+- 为 `sysom-diagnosis` Skill 新增网络、I/O 和系统负载诊断能力。（#163）

--- a/src/os-skills/component.toml
+++ b/src/os-skills/component.toml
@@ -3,7 +3,7 @@ anolisa_min_version = "0.1.15"
 
 [component]
 name = "os-skills"
-version = "0.6.2"
+version = "0.6.3"
 layer = "runtime"
 domain = "tools"
 description = "Curated OS Skill library for agent runtimes"

--- a/src/os-skills/cosh-extension.json
+++ b/src/os-skills/cosh-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "anolisa-os-skills",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "skills": "."
 }

--- a/src/os-skills/os-skills.spec.in
+++ b/src/os-skills/os-skills.spec.in
@@ -54,5 +54,8 @@ find %{buildroot}%{_datadir}/anolisa/skills -type f \
 %{_datadir}/anolisa/skills/*
 
 %changelog
+* Fri Aug 21 2026 kongche-jbw <kongche.jbw@alibaba-inc.com> - 0.6.3-1
+- Let anolisa upgrade resolve existing OS Skills through RPM metadata.
+
 * Wed Mar 18 2026 Shenglong Zhu <shenglongzhu@linux.alibaba.com> - 0.0.1-1
 - Initial RPM package


### PR DESCRIPTION
## Why

Prepare the reviewed OS Skills packaging fix merged since v0.6.2 for the
v0.6.3 source release. This keeps source, extension, RPM, and documented
release versions aligned before the release tag is created.

## What changed

- Bump the OS Skills component contract, root extension manifest, and RPM
  changelog to v0.6.3.
- Add v0.6.3 release notes for existing-component RPM resolution through
  `anolisa-component(os-skills)`.
- Add the required Chinese changelog, cross-link both languages, and align
  historical headings with Keep a Changelog.

The anolisa CLI repository manifest snapshot remains unchanged because it is
refreshed separately with the repository-side component index; this source
release uses `src/os-skills/component.toml` as its authoritative contract.

## Related issue

no-issue: OS Skills v0.6.3 release preparation

## User / Agent impact

When the repository-side component index is unavailable, `anolisa upgrade` can
resolve the OS Skills package for an existing component through RPM metadata.
A fresh install still requires the component index. Skill contents and
framework adapter behavior are unchanged.

## Risk and compatibility

- [x] Cross-component contract changed

Low risk. The release adds an RPM virtual provide without changing package
contents, installation paths, Skill behavior, or existing consumers.

## Validation

- `git diff --check`
- `make -C src/os-skills build`
- Parsed every `cosh-extension.json` with `jq`
- Parsed `component.toml` with Python `tomllib`
- Verified OpenClaw and Hermes each declare 27 unique packaged skills
- `python3 scripts/check-component-versions.py`
- `./scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- Static RPM spec checks passed; `rpmspec` is unavailable in the local
  environment, so macro expansion is left to CI/package validation

## Documentation and rollback

Updated the English and Chinese component changelogs. Before tagging, revert
this release commit to roll back; after a tag is published, issue a follow-up
patch release rather than moving the tag.
