### PR TITLE
fix(ci): pin Rust toolchains

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -943,7 +943,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         with:
           components: 'rustfmt, clippy'
 
@@ -974,7 +974,7 @@ jobs:
       # ── Rust coverage gate ──────────────────────────────────────────────
       - name: Rust coverage gate (≥45%)
         run: |
-          cargo install cargo-tarpaulin --locked
+          cargo install cargo-tarpaulin --version 0.37.2 --locked
           cd src/ws-ckpt/src
           cargo tarpaulin --workspace --out Stdout --fail-under 45
 
@@ -1240,6 +1240,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.cosh_ng == 'true'
     runs-on: anolisa-k8s-general-ci-x64
+    env:
+      # Keep lint upgrades explicit; this overrides the workspace's `stable` channel.
+      RUSTUP_TOOLCHAIN: '1.97.1'
     steps:
       - uses: actions/checkout@v4
 
@@ -1247,7 +1250,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: 'rustfmt, clippy'
 


### PR DESCRIPTION
## Description

Pins ws-ckpt CI to the verified Rust 1.98.0 toolchain and cargo-tarpaulin
0.37.2. Pins the cosh-ng fast lint job to its last known-good Rust 1.97.1
toolchain while preserving the separate Rust 1.88 MSRV integration and release
jobs. This prevents a floating `stable` promotion from changing required lint
behavior without an explicit review.

## Related Issue

no-issue: follow-up to CI failures caused by floating Rust toolchains

## Type of Change

- [x] CI/CD or build changes

## Scope

- [x] `cosh-ng` (cosh-ng)
- [x] `ckpt` (ws-ckpt)

## Checklist

- [x] My code follows the project's code style
- [x] Lock files are up to date (`package-lock.json` / `Cargo.lock`)

## Testing

- Parsed `.github/workflows/ci.yaml` with Ruby YAML and asserted both toolchain
  pins plus the tarpaulin version.
- Ran `python3 .github/scripts/validate-repository-metadata.py`.
- Ran `python3 .github/scripts/test_validate_repository_metadata.py` (22 tests).
- Ran `git diff --check`.
- ws-ckpt Rust 1.98.0 and tarpaulin 0.37.2 completed successfully in
  https://github.com/alibaba/anolisa/actions/runs/32441082877/job/96651885524.
- cosh-ng fast checks completed successfully with Rust 1.97.1 in
  https://github.com/alibaba/anolisa/actions/runs/32383033189/job/96471138815.

## Additional Notes

The cosh-ng Rust 1.88 toolchain remains the compatibility baseline for its
integration and release jobs. It is not suitable for the current all-target
Clippy gate because the existing tree has `uninlined_format_args` lint debt on
that Clippy version. Rust 1.98.0 is also not used for this lint job yet because
it introduces `chunks_exact_to_as_chunks`; that upgrade should be handled in a
separate explicit PR.

Because this PR only changes the workflow file, path detection does not
automatically select the two component jobs. They can be forced through
`workflow_dispatch` with `run_ws_ckpt=true` and `run_cosh_ng=true` after the
branch is available in the base repository.
