### PR TITLE
fix(cosh-ng): swap chunks_exact for as_chunks

### DIFF
--- a/src/cosh-ng/crates/cosh-platform/src/audit/query.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/audit/query.rs
@@ -626,7 +626,9 @@ fn decode_hex(value: &str) -> Option<Vec<u8>> {
     }
     value
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let high = (pair[0] as char).to_digit(16)?;
             let low = (pair[1] as char).to_digit(16)?;


### PR DESCRIPTION
## Why

Clippy 1.98 (rolling stable toolchain) ships the new `chunks_exact_to_as_chunks` lint. It fires on pre-existing `decode_hex` code in `cosh-platform`, turning the fast-checks job red on PRs that run stable clippy (e.g. #2708).

## What changed

Swapped `.chunks_exact(2)` for `.as_chunks::<2>().0.iter()` in `decode_hex` — the exact form clippy suggests. Semantics-preserving: both iterate full 2-byte chunks and drop the tail remainder; the length-parity check above guarantees the remainder is always empty here.

## Related issue

no-issue: pre-existing code flagged by a new clippy lint, not a user-visible bug. Unblocks the #2708 fast-checks job. Attribution: `Fixes: 1a935895a391e9714e000fab00c3602a6580cd79` ("feat(cosh-ng): [core,shell] add audit log") in the commit body per repo convention.

## User / Agent impact

None. Internal API-equivalent refactor of a private hex decoder.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: `as_chunks` stabilized in Rust 1.88 and cosh-ng CI pins 1.89, so the pinned-toolchain job compiles unchanged.

## Validation

- Reproduced pre-fix: stable 1.98 `cargo clippy -p cosh-platform --all-targets -- -D warnings` fails at `query.rs:629`; post-fix exit 0
- ECS (Linux, `RUSTUP_TOOLCHAIN=1.89.0`): `cargo clippy -p cosh-platform --all-targets -- -D warnings` clean; `cargo test -p cosh-platform` 311 passed / 0 failed
- `cargo fmt --all --check` clean under both 1.89 and stable 1.98
- Equivalence harness (rustc 1.89, not committed): old and new `decode_hex` agree on all 484 hex-pair inputs plus 10 boundary inputs (empty, odd-length, non-hex)

## Documentation and rollback

No docs change. Rollback = revert the single commit.