### PR TITLE
fix(cosh-ng): preserve raw entry

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -105,20 +105,21 @@ fn main() {
             stderr_tty,
         ) {
             Invocation::ExecShell(plan) => std::process::exit(exec_shell(plan)),
-            Invocation::Tui(_) => {
+            Invocation::Tui(entry) => {
                 runtime::terminal::install_terminal_recovery();
                 let cosh_config = config::load_config();
                 runtime::logging::init_logging(&cosh_config.log_level);
                 tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
-                // The allowlist only admits valid UTF-8 tokens in args[1..];
-                // argv[0] may be arbitrary bytes, so it is converted lossily
-                // (the TUI never re-parses it).
-                let args = args_os
+                // The classifier only admits valid UTF-8 launch arguments;
+                // argv[0] may be arbitrary bytes, so it never reaches the
+                // TUI parser.
+                let launch_args = entry
+                    .launch_args
                     .iter()
                     .map(|arg| arg.to_string_lossy().into_owned())
                     .collect::<Vec<_>>();
                 let (adapter_name, shell_kind, launch_options) =
-                    configured_raw_invocation(&args[1..]);
+                    configured_raw_invocation(&launch_args);
                 let status =
                     runtime::controller::run_raw(&adapter_name, shell_kind, launch_options);
                 std::process::exit(status);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
@@ -24,6 +24,8 @@ pub(crate) struct GatewayPlan {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TuiEntry {
     pub(crate) login: bool,
+    /// Arguments consumed by the TUI after any entry subcommand is removed.
+    pub(crate) launch_args: Vec<OsString>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,6 +114,20 @@ pub(crate) fn classify_invocation(
     stdout_tty: bool,
     stderr_tty: bool,
 ) -> Invocation {
+    if args.first().and_then(|arg| arg.to_str()) == Some("raw") {
+        // Keep the legacy non-interactive escape hatches (`raw -c` and
+        // `raw --`) transparent, but treat every other raw shape as the
+        // explicit TUI request that the direct cosh-shell entry accepts.
+        if let Some(args) = normalize_raw_invocation(args) {
+            return classify_invocation(argv0, &args, stdin_tty, stdout_tty, stderr_tty);
+        }
+
+        return Invocation::Tui(TuiEntry {
+            login: is_login_invocation(argv0, args),
+            launch_args: args[1..].to_vec(),
+        });
+    }
+
     let mut kept: Vec<OsString> = Vec::new();
     let mut shell_override: Option<OsString> = None;
     let mut idx = 0;
@@ -173,6 +189,7 @@ pub(crate) fn classify_invocation(
     if stdin_tty && stdout_tty && stderr_tty {
         Invocation::Tui(TuiEntry {
             login: is_login_invocation(argv0, args),
+            launch_args: args.to_vec(),
         })
     } else {
         Invocation::ExecShell(ExecPlan {
@@ -333,22 +350,13 @@ mod tests {
     }
 
     #[test]
-    fn agent_namespace_builds_gateway_plan_without_the_namespace_token() {
-        assert_eq!(
-            gateway_plan(&os(&["agent", "task", "get", "task-1"])),
-            Some(GatewayPlan {
-                args: os(&["task", "get", "task-1"]),
-            })
-        );
-        assert_eq!(gateway_plan(&os(&["agentic"])), None);
-        assert_eq!(gateway_plan(&[]), None);
-    }
-
-    #[test]
     fn classify_row_1_bare_terminal_enters_tui() {
         assert_eq!(
             classify("cosh", &[], ALL_TTY),
-            Invocation::Tui(TuiEntry { login: false })
+            Invocation::Tui(TuiEntry {
+                login: false,
+                launch_args: os(&[]),
+            })
         );
     }
 
@@ -375,7 +383,10 @@ mod tests {
     fn classify_row_3_login_argv0_sets_login_and_preserves_arg0() {
         assert_eq!(
             classify("-cosh", &[], ALL_TTY),
-            Invocation::Tui(TuiEntry { login: true })
+            Invocation::Tui(TuiEntry {
+                login: true,
+                launch_args: os(&[]),
+            })
         );
         match classify("-cosh", &["-c", "id"], ALL_TTY) {
             Invocation::ExecShell(plan) => assert_eq!(plan.arg0, OsString::from("-cosh")),
@@ -388,7 +399,10 @@ mod tests {
         for flag in ["-l", "--login"] {
             assert_eq!(
                 classify("cosh", &[flag], ALL_TTY),
-                Invocation::Tui(TuiEntry { login: true })
+                Invocation::Tui(TuiEntry {
+                    login: true,
+                    launch_args: os(&[flag]),
+                })
             );
             assert_eq!(
                 exec_args(classify("cosh", &[flag], (false, false, false))),
@@ -636,16 +650,6 @@ mod tests {
     }
 
     #[test]
-    fn cosh_entry_matches_only_the_cosh_basename() {
-        for argv0 in ["cosh", "-cosh", "/usr/bin/cosh", "./cosh"] {
-            assert!(is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
-        }
-        for argv0 in ["cosh-shell", "-cosh-shell", "/usr/libexec/cosh-shell", ""] {
-            assert!(!is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
-        }
-    }
-
-    #[test]
     fn normalize_raw_diverts_only_command_string_and_double_dash() {
         assert_eq!(
             normalize_raw_invocation(&os(&["raw", "cosh-core", "-c", "echo ok"])),
@@ -680,3 +684,7 @@ mod tests {
         assert_eq!(normalize_raw_invocation(&os(&["-c", "echo ok"])), None);
     }
 }
+
+#[cfg(test)]
+#[path = "invocation_tests.rs"]
+mod invocation_tests;

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/invocation_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/invocation_tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use std::ffi::{OsStr, OsString};
+
+const ALL_TTY: (bool, bool, bool) = (true, true, true);
+
+fn os(args: &[&str]) -> Vec<OsString> {
+    args.iter().map(OsString::from).collect()
+}
+
+fn classify(argv0: &str, args: &[&str], tty: (bool, bool, bool)) -> Invocation {
+    classify_invocation(OsStr::new(argv0), &os(args), tty.0, tty.1, tty.2)
+}
+
+fn exec_args(invocation: Invocation) -> Vec<OsString> {
+    match invocation {
+        Invocation::ExecShell(plan) => plan.args,
+        Invocation::Tui(entry) => panic!("expected ExecShell, got Tui({entry:?})"),
+    }
+}
+
+#[test]
+fn agent_namespace_builds_gateway_plan_without_the_namespace_token() {
+    assert_eq!(
+        gateway_plan(&os(&["agent", "task", "get", "task-1"])),
+        Some(GatewayPlan {
+            args: os(&["task", "get", "task-1"]),
+        })
+    );
+    assert_eq!(gateway_plan(&os(&["agentic"])), None);
+    assert_eq!(gateway_plan(&[]), None);
+}
+
+#[test]
+fn cosh_entry_matches_only_the_cosh_basename() {
+    for argv0 in ["cosh", "-cosh", "/usr/bin/cosh", "./cosh"] {
+        assert!(is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
+    }
+    for argv0 in ["cosh-shell", "-cosh-shell", "/usr/libexec/cosh-shell", ""] {
+        assert!(!is_cosh_entry(OsStr::new(argv0)), "argv0 {argv0}");
+    }
+}
+
+#[test]
+fn raw_subcommand_enters_tui_and_is_marked_for_launch_normalization() {
+    for args in [
+        vec!["raw"],
+        vec!["raw", "cosh-core"],
+        vec!["raw", "--shell", "zsh", "cosh-core", "--resume"],
+    ] {
+        assert_eq!(
+            classify("cosh", &args, ALL_TTY),
+            Invocation::Tui(TuiEntry {
+                login: false,
+                launch_args: os(&args[1..]),
+            }),
+            "args {args:?}"
+        );
+    }
+
+    assert!(matches!(
+        classify("cosh", &["raw", "cosh-core"], (false, true, true)),
+        Invocation::Tui(TuiEntry { launch_args, .. }) if launch_args == os(&["cosh-core"])
+    ));
+}
+
+#[test]
+fn raw_non_interactive_escape_hatches_keep_their_legacy_passthrough() {
+    for (args, expected) in [
+        (
+            vec!["raw", "cosh-core", "-c", "echo ok"],
+            vec!["-c", "echo ok"],
+        ),
+        (vec!["raw", "--", "echo", "ok"], vec!["--", "echo", "ok"]),
+    ] {
+        assert_eq!(
+            exec_args(classify("cosh", &args, ALL_TTY)),
+            os(&expected),
+            "args {args:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Why

The `/usr/bin/cosh` transparency classifier treated the explicit `raw` TUI subcommand as an unknown token and delegated it to bash. Bash then tried to execute `raw` as a script and exited 127.

## What changed

Route `raw` through its existing legacy invocation normalizer before the wrapper classifier. The `raw -c …` and `raw -- …` passthrough forms remain shell-transparent; all other `raw` shapes start the TUI and pass normalized launch arguments to the bootstrap.

## Related issue

closes #2739

## User / Agent impact

`/usr/bin/cosh raw <adapter>` again launches the same TUI path as the direct `cosh-shell raw <adapter>` entry instead of failing with exit 127.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Restores the pre-regression `raw` wrapper contract while retaining the non-interactive passthrough behavior.

## Validation

- `cargo test -p cosh-shell runtime::invocation` (22 passed)
- `crates/cosh-shell/scripts/check-layout.sh`
- `cargo fmt --all -- --check`
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`
- `git diff --check`

## Documentation and rollback

No documentation changes. Revert `1d3c374c5` to restore the current wrapper behavior.