### PR TITLE
chore(sec-core): bump version to 0.11.0

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -2,7 +2,7 @@ manifest_version = 2
 
 [component]
 name = "sec-core"
-version = "0.10.1"
+version = "0.11.0"
 layer = "runtime"
 domain = "security"
 display_name = "Agent Security Core"

--- a/src/agent-sec-core/CHANGELOG.md
+++ b/src/agent-sec-core/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.11.0
+
+**Prompt Scanner**
+
+- Rewrote prompt scanner core in Rust for native performance. (#2409)
+- Added ATR (Agent Threat Rules) rule packs and reduced compile time. (#2531)
+- Added Warden-Gen L2 backend option for prompt scanning. (#2699)
+- Routed Rust native extension logs to Python logging framework. (#2640)
+
+**Hermes Hook Integration**
+
+- Dropped Hermes synthetic warning injection; PII and Skill Ledger policies now use native observe/block boundaries. (#2712)
+
+**PII Checker**
+
+- Refined PII detection to reduce JWT and Email false positives and aligned user notices across all host adapters. (#2443)
+
+**Skill Ledger Runtime**
+
+- Added SkillFS HMAC peer authentication for cross-container Skill Ledger deployments. (#2493)
+
+**Security Events & CLI**
+
+- Added `agent-sec-cli capabilities` subcommand for environment-based hook configuration inspection. (#2356)
+- Set observability hook timeout to 10s and CLI default timeout to 5s. (#2346)
+- Added security observability skill for structured event and session report queries. (#2245)
+
+**Documentation**
+
+- Corrected and restructured user docs to align with 0.10.x shipped behavior. (#2456)
+
 ## 0.10.1
 
 **OpenClaw & cosh Hook Integrations**

--- a/src/agent-sec-core/CHANGELOG.md
+++ b/src/agent-sec-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added ATR (Agent Threat Rules) rule packs and reduced compile time. (#2531)
 - Added Warden-Gen L2 backend option for prompt scanning. (#2699)
 - Routed Rust native extension logs to Python logging framework. (#2640)
+- Corrected warmup documentation to describe model availability checks and silenced per-invocation scan mode logging in the Codex, cosh, and Qwen Code prompt scanner hooks. (#2745)
 
 **Hermes Hook Integration**
 

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "prompt-scanner",
  "pyo3",

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -26,7 +26,7 @@ ureq = { version = "2.10", features = ["json"] }
 
 [package]
 name = "agent-sec-cli"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 description = "Agent Security Core CLI - Native Rust extensions"
 license = "Apache-2.0"

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-sec-cli"
-version = "0.10.1"
+version = "0.11.0"
 description = "Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification for AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
@@ -1,3 +1,3 @@
 """Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification."""
 
-__version__ = "0.10.1"
+__version__ = "0.11.0"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -36,7 +36,7 @@ try:
 
     __version__ = get_version("agent-sec-cli")
 except Exception:
-    __version__ = "0.10.1"  # pragma: no cover
+    __version__ = "0.11.0"  # pragma: no cover
 
 app = typer.Typer(
     name="agent-sec-cli",

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.6"
 resolution-markers = [
     "sys_platform != 'darwin'",
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -258,6 +258,9 @@ rm -rf $RPM_BUILD_ROOT
 make install-all-for-rpmbuild DESTDIR=$RPM_BUILD_ROOT
 
 %changelog
+* Fri Aug 21 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.11.0-1
+- Update version to 0.11.0
+
 * Wed Aug 12 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.10.1-1
 - Update version to 0.10.1
 

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, skill ledger integrity verification, and turn/tool observability."
 }

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "hooks": {
     "PreToolUse": [
       {

--- a/src/agent-sec-core/hermes-plugin/src/plugin.yaml
+++ b/src/agent-sec-core/hermes-plugin/src/plugin.yaml
@@ -1,5 +1,5 @@
 name: agent-sec-core-hermes-plugin
-version: 0.10.1
+version: 0.11.0
 description: "OS-level security guardrails for Hermes Agent — powered by agent-sec-cli"
 provides_hooks:
   - pre_llm_call

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-sec",
   "name": "Agent Security",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Security hooks powered by agent-sec-cli",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-sec-openclaw-plugin",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
+++ b/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Agent security core hooks for Qoder CLI."
 }

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core-qwen-code-extension",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "ANOLISA security integration for Qwen Code",
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Why

agent-sec-core 0.11.0 版本准备发布，需要统一升级各组件版本标识并补充发布材料。

## What changed

- 通过 `bump-version.sh` 将所有插件 manifest、CLI 包元数据、Cargo workspace、spec.in 和 component 声明的版本号从 0.10.1 升级到 0.11.0。
- 新增 CHANGELOG.md 0.11.0 section，按交付能力维度归类 10 个已合入 PR。
- 新增 spec.in %changelog 条目。

## Related issue

no-issue: 版本升级流程性变更。

## User / Agent impact

None。本 PR 仅更新版本标识和发布文档，不改变运行时行为。

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

版本号变更体现在 CLI `--version` 输出和插件元数据中，属于预期的发布流程行为。

## Validation

- `git --no-pager diff --cached --check` — 通过，无 whitespace 问题
- `git log upstream/main..HEAD --format=%B | awk 'length > 100'` — 通过，commit body 行长符合 commitlint 要求
- CHANGELOG 条目与 PR 列表交叉核对 — 10 个 PR 全部覆盖、编号正确

## Documentation and rollback

CHANGELOG.md 和 spec.in %changelog 已更新。回滚方式：revert 本 commit 即可恢复至 0.10.1 版本标识。