### PR TITLE
fix(sec-core): correct warmup claim and hook noise

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/crates/prompt-scanner/src/detectors.rs
+++ b/src/agent-sec-core/agent-sec-cli/crates/prompt-scanner/src/detectors.rs
@@ -65,7 +65,10 @@ pub trait DetectionLayer: Send + Sync {
         true
     }
 
-    /// Prepare the layer so the first scan pays no cold-start cost.
+    /// Check the layer's prerequisites before the first scan.
+    ///
+    /// Availability only: a layer reported ready may still pay a cold-start
+    /// cost on its first scan.
     ///
     /// # Errors
     ///

--- a/src/agent-sec-core/agent-sec-cli/crates/prompt-scanner/src/scanner.rs
+++ b/src/agent-sec-core/agent-sec-cli/crates/prompt-scanner/src/scanner.rs
@@ -125,7 +125,11 @@ impl PromptScanner {
         PromptScanner::new(ScanConfig::preset(mode))
     }
 
-    /// Prepare every layer so the first scan pays no cold-start cost.
+    /// Check every layer's prerequisites before the first scan.
+    ///
+    /// Availability only: an L2 model that Ollama can serve is reported ready
+    /// without being loaded into memory, so the first scan still pays the
+    /// model's cold-start cost.
     ///
     /// # Errors
     ///

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/prompt_scanner/cli.py
@@ -22,6 +22,10 @@ _L2_MODEL_ENV = "PROMPT_SCANNER_L2_MODEL"
 # Modes whose pipeline includes the L2 ml_classifier layer; an L2 model
 # override is inert in every other mode.
 _L2_MODES = frozenset({"standard", "strict"})
+# Modes whose warmup actually reaches Ollama: standard/strict probe the L2
+# model, multi_turn the fixed L4 one.  fast is L1-only, so its warmup builds
+# the rule engine and nothing else.
+_MODEL_BACKED_MODES = _L2_MODES | {_MULTITURN_MODE}
 
 # Selectable L2 backends, listed in the help epilog rather than in the
 # ``--model`` help text: the option column is ~45 chars wide, so these 46-50
@@ -163,17 +167,23 @@ def warmup_model(
     mode: str = typer.Option(
         "standard",
         "--mode",
-        help="Detection mode to warm up: fast, standard, strict, multi_turn",
+        help="Detection mode to check: fast, standard, strict, multi_turn",
         case_sensitive=False,
     ),
     model: str | None = typer.Option(
         None,
         "--model",
-        help="L2 backend model to warm up; see the backend list below. "
+        help="L2 backend model to check; see the backend list below. "
         f"Overrides {_L2_MODEL_ENV}.",
     ),
 ) -> None:
-    """Verify required models are served and load them to avoid cold-start latency.
+    """Check that Ollama can serve the models the selected mode requires.
+
+    fast requires none, so there the check only covers the rule engine.
+
+    Availability only: a model Ollama can serve is reported ready without
+    being loaded into memory, so the first scan still pays the model's
+    cold-start cost.
 
     Models are never downloaded automatically; pull them into Ollama first
     (e.g. ``ollama pull <model>``).
@@ -194,10 +204,15 @@ def warmup_model(
         native = _load_native()
         native.warmup_scanner(mode=mode, model=resolved_model)
     except Exception as exc:  # noqa: BLE001 - CLI error surface
-        typer.echo(f"Warmup failed: {exc}", err=True)
+        typer.echo(f"Model check failed: {exc}", err=True)
         raise typer.Exit(code=1)
 
-    typer.echo("Warmup complete. Model is ready.")
+    if mode in _MODEL_BACKED_MODES:
+        typer.echo("Check complete. Ollama can serve the model.")
+    else:
+        typer.echo(
+            f"Check complete. {mode} mode runs rules only; no model was checked."
+        )
 
 
 @scanner_app.callback(invoke_without_command=True)

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/hooks/prompt_scanner_hook.py
@@ -45,15 +45,27 @@ _RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().
 _DEFAULT_SCAN_MODE = _RAW_SCAN_MODE
 if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_SCAN_MODE = "standard"
-print(
-    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
-    f"effective={_DEFAULT_SCAN_MODE!r}",
-    file=sys.stderr,
-)
 _DEFAULT_SOURCE = "user_input"
 
 
 # -- output helpers --------------------------------------------------------
+
+
+def _warn_invalid_scan_mode() -> None:
+    """Report a PROMPT_SCANNER_SCAN_MODE value that silently fell back.
+
+    Mirrors the pii-checker and skill-ledger hooks: only the misconfiguration
+    is surfaced, so a correctly configured hook stays silent.
+    """
+    if (
+        "PROMPT_SCANNER_SCAN_MODE" in os.environ
+        and _RAW_SCAN_MODE != _DEFAULT_SCAN_MODE
+    ):
+        print(
+            f"[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE {_RAW_SCAN_MODE!r}; "
+            f"using {_DEFAULT_SCAN_MODE!r}",
+            file=sys.stderr,
+        )
 
 
 def _block(scan_result: dict) -> None:
@@ -84,6 +96,8 @@ def _block(scan_result: dict) -> None:
 def main() -> None:
     if not _HOOK_ENABLED:
         return
+
+    _warn_invalid_scan_mode()
 
     # 1. Read stdin JSON (fail-open: empty stdout = allow in Codex)
     try:

--- a/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/prompt_scanner_hook.py
@@ -45,12 +45,21 @@ _RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().
 _DEFAULT_MODE = _RAW_SCAN_MODE
 if _DEFAULT_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_MODE = "standard"
-print(
-    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
-    f"effective={_DEFAULT_MODE!r}",
-    file=sys.stderr,
-)
 _DEFAULT_SOURCE = "user_input"
+
+
+def _warn_invalid_scan_mode() -> None:
+    """Report a PROMPT_SCANNER_SCAN_MODE value that silently fell back.
+
+    Mirrors the pii-checker and skill-ledger hooks: only the misconfiguration
+    is surfaced, so a correctly configured hook stays silent.
+    """
+    if "PROMPT_SCANNER_SCAN_MODE" in os.environ and _RAW_SCAN_MODE != _DEFAULT_MODE:
+        print(
+            f"[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE {_RAW_SCAN_MODE!r}; "
+            f"using {_DEFAULT_MODE!r}",
+            file=sys.stderr,
+        )
 
 
 # -- helpers ---------------------------------------------------------------
@@ -121,6 +130,8 @@ def main() -> None:
     if not _HOOK_ENABLED:
         print(_allow())
         return
+
+    _warn_invalid_scan_mode()
 
     # 1. Read stdin JSON (UserPromptSubmit event)
     try:

--- a/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
+++ b/src/agent-sec-core/qwen-code-extension/hooks/prompt_scanner_hook.py
@@ -52,15 +52,27 @@ _RAW_SCAN_MODE = os.environ.get("PROMPT_SCANNER_SCAN_MODE", "standard").strip().
 _DEFAULT_SCAN_MODE = _RAW_SCAN_MODE
 if _DEFAULT_SCAN_MODE not in {"fast", "standard", "strict"}:
     _DEFAULT_SCAN_MODE = "standard"
-print(
-    f"[prompt-scanner] scan mode configured: raw={_RAW_SCAN_MODE!r}, "
-    f"effective={_DEFAULT_SCAN_MODE!r}",
-    file=sys.stderr,
-)
 _DEFAULT_SOURCE = "user_input"
 
 
 # -- helpers ---------------------------------------------------------------
+
+
+def _warn_invalid_scan_mode() -> None:
+    """Report a PROMPT_SCANNER_SCAN_MODE value that silently fell back.
+
+    Mirrors the pii-checker and skill-ledger hooks: only the misconfiguration
+    is surfaced, so a correctly configured hook stays silent.
+    """
+    if (
+        "PROMPT_SCANNER_SCAN_MODE" in os.environ
+        and _RAW_SCAN_MODE != _DEFAULT_SCAN_MODE
+    ):
+        print(
+            f"[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE {_RAW_SCAN_MODE!r}; "
+            f"using {_DEFAULT_SCAN_MODE!r}",
+            file=sys.stderr,
+        )
 
 
 def _noop() -> str:
@@ -116,6 +128,8 @@ def main() -> None:
     if not _HOOK_ENABLED:
         print(_noop())
         return
+
+    _warn_invalid_scan_mode()
 
     # 1. Read stdin JSON (fail-open)
     try:

--- a/src/agent-sec-core/skills/prompt-scanner/SKILL.md
+++ b/src/agent-sec-core/skills/prompt-scanner/SKILL.md
@@ -136,4 +136,4 @@ agent-sec-cli scan-prompt --text "hello, how are you?" --format text
 
 - 退出码 `0` 表示扫描器正常运行（包括检测到威胁），退出码 `1` 表示参数错误。判断是否有威胁应解析 JSON 中的 `verdict` 字段，而非依赖退出码。
 - 如果 ML 依赖未安装（未执行 `uv sync --extra ml`），scanner 会自动降级为仅 L1 模式并输出 WARNING 日志，不会报错。此时 `--mode standard` 实际只执行 L1。
-- 首次使用 `standard` / `strict` 模式会触发模型下载（约 1 GB），可提前执行 `agent-sec-cli scan-prompt warmup` 预热以避免冷启动延迟。
+- `standard` / `strict` 模式依赖 L2 模型，模型不会自动下载，需先执行 `ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF`。`agent-sec-cli scan-prompt warmup` 只检查 Ollama 能否提供该模型，不会把模型加载进内存，因此首次扫描仍会有秒级冷启动开销。

--- a/src/agent-sec-core/tests/unit-test/codex_hooks/test_prompt_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/codex_hooks/test_prompt_scanner_hook.py
@@ -43,8 +43,12 @@ _HOOK_SCRIPT = os.path.join(_HOOKS_DIR, "prompt_scanner_hook.py")
 # ---------------------------------------------------------------------------
 
 
-def _run_hook(input_data, *, env_override=None):
-    """Run prompt_scanner_hook.py as subprocess and return parsed JSON output."""
+def _run_hook_process(input_data, *, env_override=None):
+    """Run prompt_scanner_hook.py as subprocess and return the raw process.
+
+    Kept separate from :func:`_run_hook` so diagnostics on stderr stay
+    assertable instead of being discarded with the JSON decision.
+    """
     env = os.environ.copy()
     if env_override:
         env.update(env_override)
@@ -59,6 +63,12 @@ def _run_hook(input_data, *, env_override=None):
         env=env,
     )
     assert proc.returncode == 0, f"Hook crashed: stderr={proc.stderr}"
+    return proc
+
+
+def _run_hook(input_data, *, env_override=None):
+    """Run prompt_scanner_hook.py as subprocess and return parsed JSON output."""
+    proc = _run_hook_process(input_data, env_override=env_override)
     if not proc.stdout.strip():
         return {}
     return json.loads(proc.stdout)
@@ -313,6 +323,47 @@ class TestDenyMode:
         )
         assert output["decision"] == "block"
         assert "置信度" not in output["reason"]
+
+
+class TestScanModeDiagnostics:
+    """Only a misconfigured PROMPT_SCANNER_SCAN_MODE may reach stderr.
+
+    The empty prompt returns before the CLI call, so stderr carries the
+    configuration diagnostic alone.
+    """
+
+    def test_invalid_scan_mode_reports_fallback(self):
+        proc = _run_hook_process(
+            {"prompt": ""},
+            env_override={"PROMPT_SCANNER_SCAN_MODE": "banana"},
+        )
+        assert (
+            "[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE 'banana'; "
+            "using 'standard'" in proc.stderr
+        )
+
+    @pytest.mark.parametrize("scan_mode", ["fast", "standard", "strict", "  STRICT "])
+    def test_valid_scan_mode_stays_silent(self, scan_mode):
+        proc = _run_hook_process(
+            {"prompt": ""},
+            env_override={"PROMPT_SCANNER_SCAN_MODE": scan_mode},
+        )
+        assert proc.stderr == ""
+
+    def test_unset_scan_mode_stays_silent(self):
+        env = os.environ.copy()
+        env.pop("PROMPT_SCANNER_SCAN_MODE", None)
+        proc = subprocess.run(
+            [sys.executable, _HOOK_SCRIPT],
+            input=json.dumps({"prompt": ""}),
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert proc.returncode == 0
+        assert proc.stderr == ""
 
 
 class TestUnknownMode:

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_prompt_scanner_hook.py
@@ -292,3 +292,50 @@ class TestCoshHookSubprocess:
         assert "sensitive data here" not in captured["args"]
         # Must be piped via stdin
         assert captured["input"] == "sensitive data here"
+
+
+# ---------------------------------------------------------------------------
+# Scan mode configuration diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _run_hook_process(scan_mode: str | None) -> subprocess.CompletedProcess[str]:
+    """Run the hook with one PROMPT_SCANNER_SCAN_MODE value and keep stderr.
+
+    The empty prompt short-circuits before the CLI call, so stderr carries the
+    configuration diagnostic alone.
+    """
+    env = os.environ.copy()
+    if scan_mode is None:
+        env.pop("PROMPT_SCANNER_SCAN_MODE", None)
+    else:
+        env["PROMPT_SCANNER_SCAN_MODE"] = scan_mode
+    proc = subprocess.run(
+        [sys.executable, _COSH_HOOK],
+        input=json.dumps({"prompt": ""}),
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+    assert proc.returncode == 0, f"Hook stderr: {proc.stderr}"
+    return proc
+
+
+class TestScanModeDiagnostics:
+    """Only a misconfigured PROMPT_SCANNER_SCAN_MODE may reach stderr."""
+
+    def test_invalid_scan_mode_reports_fallback(self):
+        proc = _run_hook_process("banana")
+        assert (
+            "[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE 'banana'; "
+            "using 'standard'" in proc.stderr
+        )
+
+    @pytest.mark.parametrize("scan_mode", ["fast", "standard", "strict", "  STRICT "])
+    def test_valid_scan_mode_stays_silent(self, scan_mode):
+        assert _run_hook_process(scan_mode).stderr == ""
+
+    def test_unset_scan_mode_stays_silent(self):
+        assert _run_hook_process(None).stderr == ""

--- a/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/prompt_scanner/test_cli.py
@@ -370,8 +370,21 @@ def test_scan_prompt_warmup_subcommand(monkeypatch):
     with patch("agent_sec_cli.prompt_scanner.cli._load_native", return_value=native):
         rv = runner.invoke(scanner_app, ["warmup", "--mode", "standard"])
     assert rv.exit_code == 0
-    assert "Warmup complete" in rv.output
+    assert "Check complete" in rv.output
+    assert "Ollama can serve the model" in rv.output
     native.warmup_scanner.assert_called_once_with(mode="standard", model=None)
+
+
+def test_scan_prompt_warmup_fast_mode_claims_no_model_check(monkeypatch):
+    """fast builds no model-backed layer, so success must not name Ollama."""
+    monkeypatch.delenv("PROMPT_SCANNER_L2_MODEL", raising=False)
+    native = MagicMock()
+    with patch("agent_sec_cli.prompt_scanner.cli._load_native", return_value=native):
+        rv = runner.invoke(scanner_app, ["warmup", "--mode", "fast"])
+    assert rv.exit_code == 0
+    assert "Check complete" in rv.output
+    assert "Ollama" not in rv.output
+    assert "no model was checked" in rv.output
 
 
 def test_scan_prompt_forwards_l2_model_from_env(monkeypatch):

--- a/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_prompt_scanner_hook.py
+++ b/src/agent-sec-core/tests/unit-test/qwen-code-extension/test_prompt_scanner_hook.py
@@ -279,3 +279,41 @@ def test_invalid_mode_warns_and_allows(mock_cli) -> None:
     assert output["decision"] == "allow"
     assert "systemMessage" in output
     assert "Invalid PROMPT_SCANNER_MODE" in output["systemMessage"]
+
+
+def _run_with_scan_mode(
+    mock_cli, scan_mode: str | None
+) -> subprocess.CompletedProcess[str]:
+    """Run the hook with one PROMPT_SCANNER_SCAN_MODE value and keep stderr.
+
+    The empty prompt short-circuits before the CLI call, so stderr carries the
+    configuration diagnostic alone.
+    """
+    extra = {} if scan_mode is None else {"PROMPT_SCANNER_SCAN_MODE": scan_mode}
+    env, _capture = mock_cli(extra=extra)
+
+    proc = _run_hook(
+        {"hook_event_name": "UserPromptSubmit", "prompt": ""},
+        env,
+    )
+
+    assert proc.returncode == 0
+    return proc
+
+
+def test_invalid_scan_mode_reports_fallback(mock_cli) -> None:
+    proc = _run_with_scan_mode(mock_cli, "banana")
+
+    assert (
+        "[prompt-scanner] invalid PROMPT_SCANNER_SCAN_MODE 'banana'; "
+        "using 'standard'" in proc.stderr
+    )
+
+
+@pytest.mark.parametrize("scan_mode", ["fast", "standard", "strict", "  STRICT "])
+def test_valid_scan_mode_stays_silent(mock_cli, scan_mode: str) -> None:
+    assert _run_with_scan_mode(mock_cli, scan_mode).stderr == ""
+
+
+def test_unset_scan_mode_stays_silent(mock_cli) -> None:
+    assert _run_with_scan_mode(mock_cli, None).stderr == ""


### PR DESCRIPTION
warmup only asks Ollama whether it can serve the model; it never loads the weights, so the first scan still pays the cold-start cost. The Rust doc comments, the CLI help/output strings and SKILL.md all promised the opposite. Reword them to describe an availability check and point users at `ollama pull` for the model that is never fetched automatically.

The three prompt_scanner_hook.py copies also printed the resolved scan mode to stderr on every import, which surfaces on each prompt in a correctly configured setup. Replace it with _warn_invalid_scan_mode(), matching the pii-checker and skill-ledger hooks: only report when PROMPT_SCANNER_SCAN_MODE was set to a value that silently fell back.

Trade-off: the hook logic is duplicated across the codex, cosh and qwen-code copies because they have no shared module.

Assisted-by: Qoder:1.22.1

<img width="1710" height="1044" alt="image" src="https://github.com/user-attachments/assets/6105b8ac-a34b-4b1b-9e50-aec4c8cce8bf" />

受影响的只有cosh，qwen, codex，所以其他的code agent hook不需要修改，只修改这三个即可

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
