### PR TITLE
fix(cosh-ng): route Han prompts

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/input_intent.sh
@@ -203,7 +203,7 @@ _cosh_command_veto() {
 
   if (( top_han_status == 0 )); then
     case "$scan" in
-      *'|'*|*'&'*|*';'*|*'<'*|*'>'*|*'$'*|*'`'*|*[[:cntrl:]]*)
+      *[[:cntrl:]]*)
         return 0
         ;;
     esac
@@ -236,6 +236,30 @@ _cosh_command_veto() {
           ;;
         '('|')')
           [[ -z "$quote" ]] && return 0
+          ;;
+        '|'|'&'|';'|'<'|'>')
+          # command-not-found runs after parsing. A successful intercept
+          # would otherwise alter the status of an executable shell list.
+          [[ -z "$quote" ]] && return 0
+          ;;
+        '`')
+          # Backticks expand inside double quotes, but are literal in single
+          # quotes. Never let command substitution reach the shell.
+          [[ "$quote" != "'" ]] && return 0
+          ;;
+        '$')
+          # Only simple parameter references are safe to quote for the Agent.
+          # Shell-specific expansion operators can evaluate their value before
+          # command-not-found runs, so they remain shell-owned.
+          if [[ "$quote" != "'" ]]; then
+            case "${scan:$index:1}" in
+              [A-Za-z_]) ;;
+              '{')
+                [[ "${scan:$index}" =~ ^\{[A-Za-z_][A-Za-z0-9_]*\} ]] || return 0
+                ;;
+              *) return 0 ;;
+            esac
+          fi
           ;;
       esac
     done

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/input_intent.rs
@@ -333,10 +333,6 @@ fn command_veto_matrix_is_consistent() {
             "./\u{4e2d}\u{6587}\u{811a}\u{672c}",
             "./\u{4e2d}\u{6587}\u{811a}\u{672c}",
         ),
-        (
-            "\u{5e2e}\u{6211}\u{770b} \"$PATH\"",
-            "\u{5e2e}\u{6211}\u{770b}",
-        ),
         ("review --all", "review"),
         ("review FOO=bar", "review"),
         ("review this | cat", "review"),
@@ -345,6 +341,7 @@ fn command_veto_matrix_is_consistent() {
     ] {
         assert_bash_zsh(input, top_token, "command");
     }
+    assert_bash_zsh("帮我看 \"$PATH\"", "帮我看", "natural_language");
 }
 
 #[test]
@@ -480,8 +477,10 @@ fn missing_path_context_keeps_conservative_vetoes() {
             "https://example.com/foo",
             "ambiguous",
         ),
-        // pipe metacharacter still vetoes
+        // A pipeline is still executable after command-not-found returns.
         ("打开./config.toml | cat", "打开./config.toml", "command"),
+        // The missing-path context never broadens the ASCII command path.
+        ("open ./config.toml | cat", "open", "command"),
         // option token still vetoes
         ("./run.sh --all", "./run.sh", "command"),
         // Han-leading assignment syntax is Tier A.
@@ -534,8 +533,14 @@ fn routing_c1_classifier_han_tier_matrix() {
         ("解释 ps aux | grep java", "解释", "command"),
         ("解释 true && touch x", "解释", "command"),
         ("解释 false || touch x", "解释", "command"),
-        ("解释 \"$HOME\"", "解释", "command"),
-        ("解释 'a>b'", "解释", "command"),
+        ("解释 \"$HOME\"", "解释", "natural_language"),
+        ("解释 'a>b'", "解释", "natural_language"),
+        ("解释 $HOME", "解释", "natural_language"),
+        ("解释 \"${evil@P}\"", "解释", "command"),
+        ("解释 \"${(e)evil}\"", "解释", "command"),
+        ("解释 foo; bar", "解释", "command"),
+        ("解释 input < file", "解释", "command"),
+        ("解释 output > file", "解释", "command"),
         ("解释 $((1 + 1))", "解释", "command"),
         ("解释 <(printf x)", "解释", "command"),
         ("解释 `printf x`", "解释", "command"),

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -371,6 +371,125 @@ fn shell_host_zsh_missing_natural_language_closes_started_command() {
 }
 
 #[test]
+fn shell_host_han_parameter_expansion_routes_to_agent() {
+    let inputs = ["帮我解释 $HOME 变量"];
+    for shell in ["bash", "zsh"] {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-han-metachar-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let mut config = ShellHostConfig::new(format!("han-metachar-{shell}"), &work_dir);
+        config.native_mode = false;
+        for input in inputs {
+            let output = if shell == "bash" {
+                run_scripted_bash(&config, &[ScriptedInput::user_line(input)])
+            } else {
+                run_scripted_zsh(&config, &[ScriptedInput::user_line(input)])
+            }
+            .unwrap_or_else(|error| panic!("{shell}: {input:?}: {error}"));
+            assert!(
+                output.events.iter().any(|event| {
+                    event.kind == ShellEventKind::UserInputIntercepted
+                        && event.input.as_deref() == Some(input)
+                        && event.component.as_deref() == Some("natural_language")
+                }),
+                "{shell}: {input:?}: {:?}",
+                output.events
+            );
+        }
+    }
+}
+
+#[test]
+fn shell_host_han_re_evaluated_parameter_expansion_stays_shell_owned() {
+    for (shell, expansion) in [("bash", "${evil@P}"), ("zsh", "${(e)evil}")] {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-han-re-eval-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let input = format!("解释 \"{expansion}\"");
+        let mut config = ShellHostConfig::new(format!("han-re-eval-{shell}"), &work_dir);
+        config.native_mode = false;
+        let steps = [
+            ScriptedInput::command("evil='$(printf __han_re_eval__)'"),
+            ScriptedInput::user_line(&input),
+        ];
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &steps)
+        } else {
+            run_scripted_zsh(&config, &steps)
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input.as_str())
+            }),
+            "{shell}: {:?}",
+            output.events
+        );
+    }
+}
+
+#[test]
+fn shell_host_han_control_operator_stays_shell_owned() {
+    for shell in ["bash", "zsh"] {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        if shell == "bash" && !bash_supports_command_not_found_handler() {
+            continue;
+        }
+
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-han-control-operator-{shell}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let side_effect = work_dir.join("must-not-exist");
+        let input = format!("解释 false && touch {}", side_effect.display());
+        let mut config = ShellHostConfig::new(format!("han-control-operator-{shell}"), &work_dir);
+        config.native_mode = false;
+        let output = if shell == "bash" {
+            run_scripted_bash(&config, &[ScriptedInput::user_line(&input)])
+        } else {
+            run_scripted_zsh(&config, &[ScriptedInput::user_line(&input)])
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::UserInputIntercepted
+                    && event.input.as_deref() == Some(input.as_str())
+            }),
+            "{shell}: {:?}",
+            output.events
+        );
+        assert!(
+            !side_effect.exists(),
+            "{shell}: command-not-found must not enable the && branch"
+        );
+    }
+}
+
+#[test]
 fn shell_host_zsh_ambiguous_phrase_stays_in_shell() {
     if Command::new("zsh").arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
## Why

Han-leading natural-language prompts that reference parameter expansions can bypass NL interception and fall through to the shell. Compound shell syntax cannot safely be intercepted from command-not-found: a successful handler status can change sibling-command execution.

## What changed

Allow Han Tier-A prompts containing simple parameter references such as `$HOME` and `${HOME}`. Keep shell-specific parameter-expansion operators, unquoted control operators, redirects, command substitution, malformed quoting, unquoted parentheses/process substitution, and control bytes shell-owned.

## Related issue

closes #1990

## User / Agent impact

Prompts such as `帮我解释 $HOME 变量` route to the Agent in bash and zsh. Executable shell structures remain native so an intercept cannot run or suppress adjacent commands.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The command-not-found handler no longer changes the execution status of compound shell lines.

## Validation

- `cargo test -p cosh-shell --test shell_host input_intent::` (19 passed)
- `cargo test -p cosh-shell --test shell_host marker::shell_host_han_` (bash/zsh PTY positive and re-evaluation/control-operator counterproof)
- `cargo clippy -p cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- layout/test-inventory/diff checks

## Documentation and rollback

No documentation change is required. Revert `e4e410b08` to restore the prior classifier behavior.