### PR TITLE
docs(tokenless): qualify compression rates

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/en/token-saving/tokenless/measuring-savings.md
@@ -130,6 +130,43 @@ anolisa adapter status tokenless
 
 Then see [No statistics appear after enabling the adapter](troubleshooting.md#no-statistics-appear-after-enabling-the-adapter).
 
+## Run the repository reference workload
+
+The source tree includes deterministic fixtures for comparing compressor
+behavior across Tokenless revisions. On Linux, run the following command from
+`src/tokenless/benchmark/l1-compressor` in an ANOLISA source checkout:
+
+```bash
+cargo run --release --bin compression_rate -- --json
+```
+
+The report uses the committed
+`src/tokenless/benchmark/l1-compressor/fixtures/tool_response.json` and
+`src/tokenless/benchmark/l1-compressor/fixtures/schema_search.json` with the
+checked-out compressor defaults. Tokenless 0.7.11 produces this reference
+snapshot:
+
+| JSON field | Isolated stage and input | Saving |
+|---|---|---:|
+| `canonical.response.savings_pct` | Response compression on the canonical response | 65.8% |
+| `canonical.schema.savings_pct` | Schema compression on the canonical schema | 47.3% |
+| `canonical.response.toon_only_savings_pct` | TOON encoding of the uncompressed canonical response | 17.0% |
+| `canonical.schema.toon_only_savings_pct` | TOON encoding of the uncompressed canonical schema | -2.3% |
+
+A negative isolated TOON result means that encoding made this input larger. In
+active mode, the runtime emits the original JSON whenever a candidate does not
+reduce the estimated token count.
+
+This is a regression workload, not a promised production range. The response
+fixture is synthetic and compression-friendly, the suite uses one response and
+one schema, and token counts use the approximate `ceil(bytes / 4)` rule rather
+than a model tokenizer. It also excludes adapter behavior and the share of tool
+data in a complete session. Use the snapshot only to check that the same source
+revision behaves comparably; use your own representative payloads and the
+dry-run comparison below to evaluate an actual workload. See the
+[benchmark methodology and limitations](../../../../../src/tokenless/benchmark/l1-compressor/README.md#methodology)
+for details.
+
 ## Run a dry-run comparison
 
 Dry-run computes the compressed result and predicted savings but returns the original to its caller. A minimal reproducible comparison for the same input is:

--- a/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
+++ b/docs/user-guide/zh/token-saving/tokenless/measuring-savings.md
@@ -130,6 +130,37 @@ anolisa adapter status tokenless
 
 继续参阅[启用后没有产生统计记录](troubleshooting.md#启用后没有产生统计记录)。
 
+## 运行仓库参考负载
+
+源码树提供了确定性的 fixture，用于比较不同 Tokenless 版本的压缩行为。在 Linux 上，
+进入 ANOLISA 源码中的 `src/tokenless/benchmark/l1-compressor` 后运行：
+
+```bash
+cargo run --release --bin compression_rate -- --json
+```
+
+报告使用仓库内置的
+`src/tokenless/benchmark/l1-compressor/fixtures/tool_response.json` 和
+`src/tokenless/benchmark/l1-compressor/fixtures/schema_search.json`，并应用当前检出源码的
+默认压缩配置。Tokenless 0.7.11 的参考结果如下：
+
+| JSON 字段 | 独立测试阶段与输入 | 节省率 |
+|---|---|---:|
+| `canonical.response.savings_pct` | 对 canonical 响应执行响应压缩 | 65.8% |
+| `canonical.schema.savings_pct` | 对 canonical Schema 执行 Schema 压缩 | 47.3% |
+| `canonical.response.toon_only_savings_pct` | 对未压缩的 canonical 响应执行 TOON 编码 | 17.0% |
+| `canonical.schema.toon_only_savings_pct` | 对未压缩的 canonical Schema 执行 TOON 编码 | -2.3% |
+
+TOON 独立测试出现负数，表示编码后反而变大。Active 模式下，Runtime 会在候选结果
+没有减少估算 Token 数时输出原始 JSON。
+
+这是一组回归参考负载，不是承诺的生产压缩率范围。响应 fixture 是特意构造的、易于
+压缩的合成数据；测试只使用一个响应和一个 Schema，并以近似 `ceil(bytes / 4)` 规则
+估算 Token，而不调用模型 Tokenizer。测试也不包含 Adapter 行为以及工具数据在完整
+会话中的占比。因此，这组结果只用于确认同一源码版本的行为是否相近；评估真实工作
+负载时，应使用有代表性的自有 Payload，并执行下文的 dry-run 双跑。详细口径见
+[benchmark 方法与限制](../../../../../src/tokenless/benchmark/l1-compressor/README.md#methodology)。
+
 ## 用 dry-run 做双跑对比
 
 dry-run 会计算压缩结果和预测节省，但向调用方返回原文。要对同一输入做最小可重复对比：

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -7,7 +7,7 @@
 Token-Less combines complementary strategies to minimize LLM token consumption:
 
 - **Schema & Response Compression** — Compresses OpenAI Function Calling tool definitions and API responses via the `tokenless-schema` library, cutting structural overhead before tokens ever reach the context window.
-- **TOON Context Compression** — Encodes JSON responses to TOON (Token-Oriented Object Notation) format via the `toon-format` library linked into `tokenless`, reducing token usage by 15-40% for structured data.
+- **TOON Context Compression** — Encodes JSON responses to TOON (Token-Oriented Object Notation) format via the `toon-format` library linked into `tokenless`, reducing syntax overhead for suitable structured data.
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
 - **Tool Ready (legacy, hard-disabled)** — Its pre-call dependency checks are retained in source but unconditionally bypassed while the readiness model is redesigned.
 
@@ -27,12 +27,12 @@ cover schema compression, RTK rewriting, response compression, TOON, retrieval, 
 
 ## Features
 
-| Capability | Token Savings | Details |
+| Capability | Savings indicator | Details |
 |---|---|---|
-| Schema compression | ~57% | Compresses OpenAI Function Calling tool schemas |
-| Response compression | ~26–78% | Compresses API / tool responses (varies by content type) |
+| Schema compression | 47.3% on reference fixture | Compresses OpenAI Function Calling tool schemas |
+| Response compression | 65.8% on reference fixture | Compresses API / tool responses |
 | Reversible compression (stash) | — | Dropped array items are stashed and retrievable via `<<tokenless:KEY>>` markers |
-| TOON context compression | 15–40% | Encodes JSON to TOON format for LLMs |
+| TOON context compression | 17.0% on reference response | Encodes JSON to TOON format for LLMs |
 | Command rewriting | 60–90% | Filters CLI output via RTK (70+ commands supported) |
 | Tool Ready | reduces retry waste | Legacy pre-call check, auto-fix, and blocking; hard-disabled |
 | OpenClaw plugin | — | Command rewriting ✅, Response compression ✅, Schema compression ✅ |
@@ -46,17 +46,28 @@ cover schema compression, RTK rewriting, response compression, TOON, retrieval, 
 | AgentScope framework integration | — | Schema ✅, RTK ✅, Response ✅, TOON ✅, Retrieval ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
 
+The schema, response, and TOON figures above are isolated Tokenless 0.7.11
+results on the repository's committed reference fixtures; they are neither a
+production range nor additive. Compression depends on payload size and shape,
+removable fields, configured thresholds, and the share of tool data in the
+session. Short or already compact payloads may save only a few percent or pass
+through unchanged. See [Measuring Tokenless Savings](../../docs/user-guide/en/token-saving/tokenless/measuring-savings.md#run-the-repository-reference-workload)
+for the exact inputs, command, full output, and limitations.
+
 ## Applicable Scenarios & Expected Effects
 
-tokenless only removes redundancy from **tool call responses** before they enter the LLM context; it does not touch model reasoning or conversation history. The payoff depends heavily on the share and shape of tool responses in the session.
+tokenless optimizes the tool-related content it handles—tool schemas, tool/API
+responses, and supported shell output—before it enters the LLM context. It does
+not touch model reasoning or conversation history. The payoff depends heavily
+on the share and shape of that content in the session.
 
 ### Where it pays off
 
 | Workload | Primary strategy | Why |
 |----------|-----------------|-----|
 | Shell-heavy (build/test/triage) | Command rewriting (RTK) | `cargo`/`npm`/`go`/`pytest` output carries lots of progress/warning noise; RTK cuts 60–90% |
-| API/fetch-heavy (REST, web_fetch) | Response compression + TOON | JSON carries debug/null/empty and syntax overhead; 26–78% compression, TOON adds 15–40% |
-| Agents with many tools | Schema compression | Many Function Calling definitions carry verbose descriptions; ~57% |
+| API/fetch-heavy (REST, web_fetch) | Response compression + TOON | JSON may carry removable debug/null/empty fields; sufficiently large, regular structures also have reducible syntax overhead |
+| Agents with many tools | Schema compression | Many Function Calling definitions carry verbose descriptions and removable metadata |
 | Long responses that must stay faithful | Reversible compression (Stash) | Truncated content is `retrieve`-able end-to-end lossless; thresholds can be tightened safely |
 
 ### Where it pays little or doesn't apply

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -6,13 +6,19 @@ LLM Token 优化工具包——Schema/响应压缩 + 命令重写 + 工具环境
 
 ## 核心能力
 
-| 能力 | Token 节省 | 说明 |
+| 能力 | 节省率示例 | 说明 |
 |------|-----------|------|
-| Schema 压缩 | ~57% | 压缩 OpenAI Function Calling 工具定义 |
-| 响应压缩 | ~26–78% | 压缩 API/工具响应（因内容类型而异） |
-| TOON 上下文压缩 | 15–40% | 将 JSON 编码为 TOON 格式 |
+| Schema 压缩 | 参考 fixture 47.3% | 压缩 OpenAI Function Calling 工具定义 |
+| 响应压缩 | 参考 fixture 65.8% | 压缩 API/工具响应 |
+| TOON 上下文压缩 | 参考响应 17.0% | 将 JSON 编码为 TOON 格式 |
 | 命令重写 | 60–90% | 通过 RTK 过滤 CLI 输出（支持 70+ 命令） |
 | Tool Ready | 减少重试浪费 | 旧版调用前预检、自动修复与阻断；当前硬关闭 |
+
+表中 Schema、响应和 TOON 数字是 Tokenless 0.7.11 对仓库内置参考 fixture 的独立测试
+结果，既不是生产范围，也不能相加。实际压缩率取决于 Payload 的大小和结构、可移除字段、
+配置阈值，以及工具数据在会话中的占比。短小或已经紧凑的 Payload 可能只节省几个百分
+点，也可能直接原样透传。精确输入、命令、完整结果和限制见
+[Tokenless 效果度量](../../docs/user-guide/zh/token-saving/tokenless/measuring-savings.md#运行仓库参考负载)。
 
 Tool Ready 当前在所有 Adapter 中无条件硬旁路，不会读取依赖规范、执行调用前检查、自动修复环境或阻止工具调用。任何环境变量都无法恢复旧行为；重新启用必须修改源码并重新发布。
 
@@ -20,15 +26,17 @@ Tool Ready 当前在所有 Adapter 中无条件硬旁路，不会读取依赖规
 
 ## 适用场景与预期效果
 
-tokenless 只优化**工具调用响应**进入 LLM 上下文前的冗余，不触及模型推理与对话历史。收益高度取决于会话中工具响应的占比与形态。
+tokenless 优化进入 LLM 上下文前、由它实际处理的工具相关内容，包括工具 Schema、
+工具/API 响应和受支持的 Shell 输出；它不触及模型推理与对话历史。收益高度取决于
+这些内容在会话中的占比与形态。
 
 ### 哪些场景收益高
 
 | 工作负载 | 主要受益策略 | 原因 |
 |----------|-------------|------|
 | Shell 密集（编译/测试/排查） | 命令重写（RTK） | `cargo`/`npm`/`go`/`pytest` 等输出含大量进度/警告噪声，RTK 削减 60–90% |
-| API/抓取密集（REST、web_fetch） | 响应压缩 + TOON | JSON 含 debug/null/空值与语法开销，压缩 26–78%，TOON 再省 15–40% |
-| 工具数量多的 Agent | Schema 压缩 | 大量 Function Calling 定义冗余描述，~57% |
+| API/抓取密集（REST、web_fetch） | 响应压缩 + TOON | JSON 可能含可移除的 debug/null/空值；足够大且结构规则的数据也有可削减的语法开销 |
+| 工具数量多的 Agent | Schema 压缩 | 大量 Function Calling 定义可能含冗长描述和可移除元数据 |
 | 长响应需保真 | 可逆压缩（Stash） | 截断后可 `retrieve` 原文，端到端无损，可放心收紧阈值 |
 
 ### 哪些场景收益低或不适用


### PR DESCRIPTION
## Why

The Tokenless READMEs presented schema, response, and TOON compression percentages as broad expectations even though savings vary with payload shape, thresholds, and session composition. This could make short or already compact workloads look like product regressions when they are outside the reference workload.

## What changed

- Replace unsupported headline ranges with reproducible Tokenless 0.7.11 fixture results.
- Qualify the figures next to the capability table as isolated, non-additive reference values.
- Add bilingual reference-workload instructions with exact fixtures, command, JSON fields, expected output, and limitations.
- Clarify that Tokenless optimizes only the tool-related content it actually handles.

## Related issue

no-issue: documentation clarification requested from user feedback

## User / Agent impact

Users retain quick numeric indicators while gaining a reproducible comparison point and clear guidance that production savings are workload-dependent.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Documentation claims changed; runtime behavior, CLI contracts, configuration, and stored data are unchanged. Risk is low.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `npm run build --prefix website`
- `npm run check:links --prefix website`
- `git diff --check`
- `cargo run --release --bin compression_rate -- --json`
- Verified the documented 65.8%, 47.3%, 17.0%, and -2.3% reference fields with `jq -e`.

## Documentation and rollback

Updated the English and Chinese Tokenless READMEs and savings-measurement guides. Revert commit `555012a2` to restore the previous wording.