### PR TITLE
fix(sight): drop hardcoded minus on savings

### DIFF
--- a/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
+++ b/src/agentsight/dashboard/src/pages/AtifViewerPage.tsx
@@ -1033,7 +1033,7 @@ export const AtifViewerPage: React.FC = () => {
                   <div>
                     <span className="text-xs text-gray-500">{t('atif.savedLabel')}</span>
                     <p className="text-xl font-bold text-green-600">
-                      -{fmtTokens(savingsDetail.total_compounded_saved)}
+                      {fmtTokens(savingsDetail.total_compounded_saved)}
                       <span className="text-sm font-normal text-gray-400 ml-1">
                         ({(savingsDetail.savings_rate * 100).toFixed(1)}%)
                       </span>


### PR DESCRIPTION
## Why

The ATIF viewer "Token Savings Comparison" card renders `total_compounded_saved` with a hardcoded `-` prefix in JSX. The value is already positive (`total_original_tokens - total_actual_tokens`), so the UI read as negative savings — the same data shows `11` on the Token Savings page and `-11` here. Reported in #2749.

## What changed

- `src/agentsight/dashboard/src/pages/AtifViewerPage.tsx`: dropped the hardcoded `-` before `fmtTokens(savingsDetail.total_compounded_saved)`. Styling (green, size, rate suffix) untouched; the leftover sat next to the #2732 rate rescale on the same line.

## Related issue

closes #2749

## User / Agent impact

The "Saved" value on the ATIF viewer savings card now displays as a positive number, matching the Token Savings page and the API contract.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: one-line display-only change; no API, data, or i18n changes.

## Validation

Mirrors #2732's dashboard validation (no component-render test harness exists in `dashboard/`; display changes there are covered by typecheck + regression scripts, per that precedent):

- `npm run typecheck` — pass
- `npm run test:api-client` — 24/24 pass
- `npm run test:i18n` — 5/5 pass
- `npm run build` — webpack compiled successfully

Environment: node v22.22.0 / npm 10.9.4 on the ECS test machine; source synced via rsync (md5-verified).

## Documentation and rollback

No docs describe this display detail. Rollback: revert the single commit.
