### PR TITLE
fix(sight): classify analyzer calls as internal

### DIFF
--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -92,6 +92,12 @@ pub(super) fn classify_call_kind(request: &LLMRequest) -> CallKind {
         {
             return CallKind::Recap;
         }
+        // Cosh-shell personal analyzer background summary (#2750): fixed
+        // prompt from cosh-ng recommendation/personal_analyzer.rs; runs in a
+        // setsid child process, must not surface as a user session.
+        if text.starts_with("Summarize only grounded work into the supplied JSON schema") {
+            return CallKind::Recap;
+        }
         // QwenCode memory extraction subagent
         if text.starts_with("Managed memory has TWO directories") {
             return CallKind::Recap;
@@ -165,6 +171,8 @@ pub(super) fn classify_call_kind_from_raw(
             && first_user_text.contains("Do NOT call any tools"))
         || first_user_text.starts_with("Managed memory has TWO directories")
         || first_user_text.starts_with("[SUGGESTION MODE:")
+        // Cosh-shell personal analyzer background summary (#2750)
+        || first_user_text.starts_with("Summarize only grounded work into the supplied JSON schema")
     {
         "recap"
     } else if first_user_text.contains("Perform a web search for the query:") {
@@ -706,6 +714,35 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_cosh_personal_analyzer_recap() {
+        // cosh-shell personal analyzer background summary: fixed prompt from
+        // cosh-ng recommendation/personal_analyzer.rs build_fixed_prompt (#2750).
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "Summarize only grounded work into the supplied JSON schema. List every business entity mentioned by a summary or prompt in that item's entities field.\nSCHEMA:\n{}".to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Recap);
+    }
+
+    #[test]
+    fn test_classify_similar_analyzer_wording_stays_main() {
+        // Similar summarize wording without the analyzer's fixed prefix must
+        // not be misclassified (#2750).
+        let req = make_llm_request(vec![InputMessage {
+            role: "user".to_string(),
+            parts: vec![MessagePart::Text {
+                content: "Please summarize only grounded work into a JSON report for me"
+                    .to_string(),
+            }],
+            name: None,
+        }]);
+        assert_eq!(classify_call_kind(&req), CallKind::Main);
+    }
+
+    #[test]
     fn test_classify_claude_web_search() {
         let req = make_llm_request(vec![InputMessage {
             role: "user".to_string(),
@@ -1204,6 +1241,18 @@ mod tests {
     fn test_raw_classify_recap_claude_code() {
         let first_user = "Your task is to create a detailed summary of the conversation so far. Please Do NOT call any tools in this turn.";
         assert_eq!(classify_call_kind_from_raw(&None, first_user), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_recap_cosh_personal_analyzer() {
+        let first_user = "Summarize only grounded work into the supplied JSON schema. List every business entity mentioned by a summary or prompt in that item's entities field.\nSCHEMA:\n{}";
+        assert_eq!(classify_call_kind_from_raw(&None, first_user), "recap");
+    }
+
+    #[test]
+    fn test_raw_classify_similar_analyzer_wording_stays_main() {
+        let first_user = "Please summarize only grounded work into a JSON report for me";
+        assert_eq!(classify_call_kind_from_raw(&None, first_user), "main");
     }
 
     #[test]


### PR DESCRIPTION
## Why

cosh-shell's personalization analyzer (not a recap — root cause corrected in the issue comment) spawns a `setsid()` cosh-core child after 3s foreground idle with a fixed prompt ("Summarize only grounded work…", `personal_analyzer.rs build_fixed_prompt`). agentsight's id_resolver keys sessions by `(agent_name, pid, first user text)`, so the child PID lands in a new bucket → new `session_id`; the prompt matched no internal-call marker in `classify_call_kind` → `call_kind=main` → the call passes the session list's `call_kind = 'main' OR NULL` filter and surfaces as a phantom 0-token session (#2750).

## What changed

- `src/agentsight/src/genai/helpers.rs`: add the analyzer's stable prompt prefix (`starts_with "Summarize only grounded work into the supplied JSON schema"`) to both classification paths — `classify_call_kind` (structured) and `classify_call_kind_from_raw` (pending-write). Such calls now classify as `recap` (the existing bucket for compaction/summary-style internal traffic) and stay out of the session list.
- Discriminating tests for both paths: the exact prefix classifies as recap; similar-but-different summarize wording stays main. Verified red-on-unpatched before the fix (both new positive cases failed with `main != recap`), green after.

Full root-cause chain with file:line references: [issue comment](https://github.com/alibaba/anolisa/issues/2750#issuecomment-5369497742).

## Related issue

Refs #2750

Does **not** close it: the report also asks for merging analyzer calls into the parent session. That requires cross-process session injection (cosh-ng env passthrough or an agentsight merge strategy) and is proposed as a separate follow-up discussion in the issue comment. This PR implements layer ① (stop the session-list pollution); layer ② (parent-session attribution) is out of scope by design.

## User / Agent impact

The 0-token "CoshNG" phantom sessions disappear from the dashboard session list and `/api/sessions`. Analyzer events remain in the event store under their own session_id with `call_kind=recap`.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: classification-only change behind a conservative `starts_with` marker tied to a fixed prompt string; the marker follows the existing best-effort pattern documented on `classify_call_kind`. If cosh-ng ever changes that prompt, the call degrades back to `main` (today's behavior), nothing breaks.

## Validation

On the ECS test machine (rustc/cargo 1.89.0, matching the repo toolchain):

- `cargo test -p agentsight --lib genai::helpers::tests` — 71/71 pass (was 69 pass + 2 fail before the fix; the 2 failures are the new positive cases)
- `cargo fmt --all -- --check` — pass
- `cargo clippy -p agentsight --lib -- -D warnings` — pass, zero warnings

Note: the repo's CI "Test agentsight" job runs `@stable`, which may differ from the pinned 1.89.0 toolchain used above; full-workspace tests were not run locally (agentsight compile weight) — targeted `genai::helpers` suite covers this change.

## Documentation and rollback

No docs describe call-kind markers. Rollback: revert the single commit — classification reverts to today's behavior.
