### PR TITLE
fix(cosh-ng): swap remaining chunks_exact uses

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/tool/grep.rs
+++ b/src/cosh-ng/crates/cosh-core/src/tool/grep.rs
@@ -508,7 +508,9 @@ fn decode_utf16(raw: &[u8], little_endian: bool) -> (Vec<u8>, u64) {
 
 fn decode_utf16_bytes(bytes: &[u8], little_endian: bool) -> String {
     let units = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|bytes| read_utf16_unit([bytes[0], bytes[1]], little_endian))
         .collect::<Vec<_>>();
     let has_partial_unit = bytes.len() & 1 == 1;

--- a/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_crypto.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/recommendation/personal_crypto.rs
@@ -256,7 +256,9 @@ mod tests {
     fn decode_hex(value: &str) -> Vec<u8> {
         value
             .as_bytes()
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| {
                 let text = std::str::from_utf8(pair).unwrap();
                 u8::from_str_radix(text, 16).unwrap()


### PR DESCRIPTION
## Why

Clippy 1.98 (rolling stable) ships the new `chunks_exact_to_as_chunks` lint. Beyond the `decode_hex` site fixed in #2742, the same lint fires on two more `chunks_exact(2)` sites. This PR delivers the follow-up promised in the #2742 review discussion (KaiLongZhou's non-blocking observations).

## What changed

Swapped `.chunks_exact(2)` for `.as_chunks::<2>().0.iter()` (the exact form clippy suggests) in:

- `cosh-core/src/tool/grep.rs` — `decode_utf16_bytes`: both forms iterate full 2-byte units and drop the tail remainder; the odd tail is handled separately via `has_partial_unit`, unchanged.
- `cosh-shell/src/recommendation/personal_crypto.rs` — test-only `decode_hex` helper; `std::str::from_utf8(pair)` accepts the `&[u8; 2]` items via unsize coercion.

Note on the other half of the promised follow-up: the MSRV alignment (observation 1) is already done — 77c4e8bb5 ("feat(cosh-ng): [gateway] add ACP v1 foundation") set `rust-version = "1.88"` on main, matching the 1.88.0 pinned CI jobs, so no Cargo.toml change is needed here.

## Related issue

no-issue: pre-existing code flagged by a new clippy lint, not a user-visible bug. Attribution per repo convention in the commit body: `Fixes: c818e11876a3 ("fix(cosh-ng): [core] confine read tools")` and `Fixes: 8d4d74c12e70 ("feat(cosh-ng): add shell prompt recommendations")`.

## User / Agent impact

None. Semantics-preserving internal refactor; no public API, CLI, or behavior change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: `as_chunks` stabilized in Rust 1.88; cosh-ng CI pins 1.88.0 (integration/release-build) and 1.97.1 (fast checks) — neither toolchain carries this lint, so the pinned jobs compile and lint unchanged.

## Validation

- Discriminating lint evidence (ECS Linux, stable 1.98 clippy, `-p cosh-core -p cosh-shell --all-targets --keep-going`):
  - pre-fix on the main baseline (with query.rs temporarily mirroring the #2742 patch so cosh-platform compiles and cosh-core gets reached): the lint fires at `grep.rs:511` and `personal_crypto.rs:259`
  - post-fix (this PR): both target sites disappear from the lint output; exit code still non-zero only because of the out-of-scope sites below
- ECS, `RUSTUP_TOOLCHAIN=1.89.0`: `cargo clippy -p cosh-core -p cosh-shell --all-targets -- -D warnings` — exit 0
- ECS, `RUSTUP_TOOLCHAIN=1.88.0`: `cargo check -p cosh-core -p cosh-shell` — exit 0 (MSRV floor confirmed; the two pre-existing fs2 `unlock()` future-incompat warnings in `extension/` are unrelated to this change)
- ECS, 1.89.0: `cargo test -p cosh-core --lib` — 124 passed / 0 failed; `cargo test -p cosh-shell --lib` — 1347 passed / 0 failed
- Local `cargo fmt --all -- --check` with both 1.89.0 and stable 1.98 — clean
- Known out-of-scope remainder: `personal_crypto.rs:66` (`SHA256_BLOCK_BYTES`) and `:172` (`chunks_exact(4)`) also trip the same lint on clippy 1.98; they are not the `chunks_exact(2)` sites called out in the review and the pinned CI toolchains do not carry the lint. Left for a later pass if fast checks ever move to a lint-carrying toolchain (same for `query.rs`, owned by #2742).

## Documentation and rollback

None. Revert the single commit to restore the previous form.
