### PR TITLE
fix(cosh-ng): keep debug trap on bash 4.2 prompts

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -882,7 +882,13 @@ _cosh_prompt_command() {
   _cosh_precmd_marker "$status"
   _cosh_run_user_prompt_command "$status"
   _cosh_maybe_emit_native_history_file_marker
-  if [[ -n "${_COSH_USER_PROMPT_COMMAND+x}" ]]; then
+  # bash < 5 suspends the DEBUG trap while PROMPT_COMMAND runs (#2736):
+  # `trap -p DEBUG` prints nothing inside the hook, and the empty snapshot
+  # read would poison _COSH_ACTIVE_DEBUG_TRAP, permanently dropping the
+  # trap after the first command. Suspension guarantees the trap is
+  # untouched during the hook, so only bash >= 5 — where `trap -p DEBUG`
+  # stays truthful — needs the snapshot.
+  if (( BASH_VERSINFO[0] >= 5 )) && [[ -n "${_COSH_USER_PROMPT_COMMAND+x}" ]]; then
     local trap_snapshot_file="${COSH_RECOVERY_REQUEST_FILE:-/tmp/cosh-recovery}.debug-trap"
     _COSH_SNAPSHOT_DEBUG_TRAP=1
     trap -p DEBUG > "$trap_snapshot_file" 2>/dev/null || true


### PR DESCRIPTION
## Why

On bash 4.2.x (e.g. Alibaba Group Enterprise Linux 7 line) the bash marker script permanently loses its DEBUG trap after the first prompt whenever PROMPT_COMMAND is set, so no `preexec` OSC markers are emitted from the second command on — silently losing the command audit trail. Closes #2736.

Mechanism: bash 4.x suspends the DEBUG trap while PROMPT_COMMAND runs, so `trap -p DEBUG` prints nothing inside the hook. The snapshot block in `_cosh_prompt_command` read that empty output and cleared `_COSH_ACTIVE_DEBUG_TRAP`; the subsequent `eval "$active_debug_trap"` in the preexec handler then re-installed nothing, and the freshly restored trap was permanently dropped.

## What changed

- `cosh-shell/src/shell_host/marker/bash.rs` (`_cosh_prompt_command`): the trap-snapshot block is now gated on `(( BASH_VERSINFO[0] >= 5 ))`. On bash < 5 the snapshot is skipped entirely — suspension guarantees the trap cannot change while the hook runs, so the snapshot is meaningless there and its empty read is actively harmful. The bash 5.x execution path is byte-identical (the gate only short-circuits the 4.x branch); the snapshot block body itself is unchanged.

## Related issue

closes #2736

## User / Agent impact

On bash 4.2 hosts with PROMPT_COMMAND set (e.g. the AGL7 audit-hook default), command-level OSC markers, command blocks, and exit codes are captured again from the very first command instead of silently disappearing after the first prompt. bash >= 5 hosts see no change.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: the change is a version gate in front of one snapshot block; on bash >= 5 the gate is always true. One trade-off: on bash < 5, a user hook that itself installs a new DEBUG trap would no longer be re-snapshotted — but bash < 5 suspends the trap during the hook anyway, so any trap swap could only take effect after the hook returns, which is exactly the window the preexec re-arm path already owns.

## Validation

- Discriminating bidirectional evidence on the failing test (local machine, bash 4.2.46 — the unique repro environment):
  - pre-fix on a clean main baseline: `cargo test -p cosh-shell --test shell_host shell_host_runs_bash_pty_and_emits_command_events` **FAILED** (`assertion failed: ledger.blocks.iter().any(...)` at `marker.rs:73` — no command block, matching #2736)
  - post-fix (this PR): the same test **passes**
  - full marker module on the same bash 4.2 box: baseline 43 passed / 15 failed → fixed 53 passed / 5 failed; the remaining 5 failures are a strict subset of the baseline 15 (pre-existing bash 4.2 issues out of scope here), so the fix strictly reduces failures with zero regressions
- ECS (Linux, bash 5.2.15, `RUSTUP_TOOLCHAIN=1.89.0`): `cargo test -p cosh-shell --lib` — 1347 passed / 0 failed; `cargo test -p cosh-shell --test shell_host` (full suite) — 160 passed / 0 failed / 1 ignored; `cargo fmt --all -- --check` — clean; `cargo clippy -p cosh-shell --all-targets -- -D warnings` — exit 0
- Known limitation, stated plainly: the GitHub Actions runners run bash 5.x, so CI cannot exercise the bash 4.2 code path; the local bash 4.2.46 fail→pass evidence above is the substitute for that coverage.

## Documentation and rollback

None. Revert the single commit to restore the previous behavior on bash 4.2 (bash 5.x behavior is identical either way).
