### PR TITLE
fix(tokenless): compress request tool schemas

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -80,7 +80,19 @@ Accepted item shapes (detected per item):
 - Direct schema: `{"name", "description", "parameters"}`
 - Gemini / copilot-shell wrapper: `{"functionDeclarations": [{"name", "description", "parameters" | "parametersJsonSchema"}, ...]}`; copilot-shell BeforeModel hooks deliver tool declarations in this shape (`llm_request.config.tools`). Declarations inside the wrapper are compressed individually (the parameter schema is read from `parametersJsonSchema` when present, otherwise from `parameters`); the wrapper itself and any sibling fields are preserved.
 
-An array input enables batch handling automatically. Common options:
+An array input enables batch handling automatically.
+
+A complete request object with a top-level `tools` array is also accepted. Its
+Function Calling entries may be OpenAI `{"function": {...}}` wrappers, Gemini
+`{"functionDeclarations": [...]}` tool objects, or bare
+`{name, description, parameters}` declarations. Do not pass `--batch` for this
+shape; non-function tools and fields outside `tools` are preserved.
+
+```bash
+tokenless compress-schema -f request.json
+```
+
+Common options:
 
 | Option | Description |
 |--------|-------------|

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -76,7 +76,18 @@ cat tools.json | tokenless compress-schema --batch
 - 直接 Schema：`{"name", "description", "parameters"}`
 - Gemini / copilot-shell 包装：`{"functionDeclarations": [{"name", "description", "parameters" | "parametersJsonSchema"}, ...]}`；copilot-shell 的 BeforeModel hook 以该形态下发工具声明（`llm_request.config.tools`）。包装内的声明逐个压缩（参数 schema 优先取 `parametersJsonSchema`，其次取 `parameters`），包装本身及其同级字段原样保留。
 
-输入本身是数组时会自动使用 batch 处理。常用参数：
+输入本身是数组时会自动使用 batch 处理。
+
+包含顶层 `tools` 数组的完整请求对象也受支持，其中的 Function Calling 定义可以是
+OpenAI `{"function": {...}}` Wrapper、Gemini `{"functionDeclarations": [...]}` 工具对象，
+或裸 `{name, description, parameters}` 定义。该结构不要传 `--batch`；非函数工具及
+`tools` 之外的字段会原样保留。
+
+```bash
+tokenless compress-schema -f request.json
+```
+
+常用参数：
 
 | 参数 | 说明 |
 |------|------|

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -275,6 +275,15 @@ Compress a batch of tools (JSON array):
 tokenless compress-schema -f tools.json --batch
 ```
 
+A top-level request object with a `tools` array is also accepted without
+`--batch`; OpenAI wrappers, Gemini `functionDeclarations` tool objects, and
+bare Function Calling declarations are compressed while non-function tools and
+fields outside `tools` are preserved:
+
+```bash
+tokenless compress-schema -f request.json
+```
+
 ### compress-response
 
 Compress an API response:

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -140,6 +140,24 @@ anolisa adapter enable tokenless dsh --profile <profile>
 dsh --profile <profile>
 ```
 
+### Schema 压缩 CLI
+
+`compress-schema` 支持单个工具定义、工具定义 JSON 数组，以及包含顶层
+`tools` 数组的完整请求对象。处理完整请求对象时不传 `--batch`；其中的 OpenAI
+Wrapper、Gemini `functionDeclarations` 工具对象及裸 Function Calling 定义会被压缩，
+非函数工具及 `tools` 之外的字段会原样保留。
+
+```bash
+# 单个工具定义
+tokenless compress-schema -f tool.json
+
+# 工具定义数组
+tokenless compress-schema -f tools.json --batch
+
+# 包含顶层 tools 数组的请求对象
+tokenless compress-schema -f request.json
+```
+
 从源码构建适合开发者。
 
 ```bash

--- a/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
+++ b/src/tokenless/crates/tokenless-cli/tests/cli_integration.rs
@@ -378,6 +378,68 @@ fn compress_schema_batch_gemini_function_declarations() {
 }
 
 #[test]
+fn compress_schema_tools_request_container() {
+    let input = serde_json::to_string_pretty(&serde_json::json!({
+        "model": "example-model",
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "A".repeat(2000),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "B".repeat(1000)
+                        }
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+    let output = tokenless_bin()
+        .env("TOKENLESS_COMPRESSION_ENABLED", "1")
+        .env("TOKENLESS_STATS_ENABLED", "0")
+        .args(["compress-schema", "--no-stash"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "compress-schema failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["model"], "example-model");
+    assert!(
+        result["tools"][0]["function"]["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 256
+    );
+    assert!(
+        result["tools"][0]["function"]["parameters"]["properties"]["query"]["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 160
+    );
+}
+
+#[test]
 fn compress_response_from_stdin() {
     let response =
         r#"{"data":"value","debug":"remove","trace":"remove","empty_field":"","null_field":null}"#;

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -288,7 +288,7 @@ impl TokenlessRuntime {
         Ok(result)
     }
 
-    /// Compress one OpenAI Function Calling schema with reversible markers.
+    /// Compress a Function Calling schema or top-level `tools` request with reversible markers.
     ///
     /// # Errors
     ///
@@ -422,7 +422,7 @@ impl TokenlessRuntime {
     }
 }
 
-/// Compress a schema using an optional caller-owned stash store.
+/// Compress a Function Calling schema or top-level `tools` request using an optional stash store.
 ///
 /// # Errors
 ///
@@ -1007,6 +1007,60 @@ mod tests {
         let records = recorder.records_by_session("schema-session", None).unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].operation, OperationType::CompressSchema);
+    }
+
+    #[test]
+    fn schema_compression_handles_tools_request_container() {
+        let directory = tempfile::tempdir().unwrap();
+        let runtime = TokenlessRuntime::new(RuntimeConfig {
+            data_dir: Some(directory.path().to_path_buf()),
+            ..RuntimeConfig::default()
+        })
+        .unwrap();
+        let input = serde_json::to_string(&serde_json::json!({
+            "model": "example-model",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "A".repeat(2000),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "B".repeat(1000)
+                            }
+                        }
+                    }
+                }
+            }]
+        }))
+        .unwrap();
+
+        let result = runtime
+            .compress_schema(&input, &Attribution::new("runtime-test"))
+            .unwrap();
+        assert!(result.applied());
+
+        let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(output["model"], "example-model");
+        assert!(
+            output["tools"][0]["function"]["description"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count()
+                <= 256
+        );
+        assert!(
+            output["tools"][0]["function"]["parameters"]["properties"]["query"]["description"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count()
+                <= 160
+        );
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -218,12 +218,15 @@ impl SchemaCompressor {
         self.stash_errors.set(self.stash_errors.get() + 1);
     }
 
-    /// Compress a function-calling tool declaration.
+    /// Compress a function-calling tool declaration or request envelope.
     ///
-    /// Supports three wrapper shapes:
-    /// - Gemini `{"functionDeclarations": [{name, description, parametersJsonSchema}, ...]}`
+    /// Supports these declaration and wrapper shapes:
     /// - OpenAI `{"function": {name, description, parameters}}`
-    /// - Bare schema `{name, description, parameters}`
+    /// - Gemini `{"functionDeclarations": [{name, description, parametersJsonSchema}, ...]}`
+    /// - Bare `{name, description, parameters}` declarations, optionally with
+    ///   `"type": "function"`
+    /// - Request envelopes whose top-level `tools` array contains any of the
+    ///   shapes above
     ///
     /// The Gemini SDK stores the parameter schema under `parametersJsonSchema`
     /// (JSON Schema format, used by copilot-shell's `DeclarativeTool`); the
@@ -238,9 +241,23 @@ impl SchemaCompressor {
 
         let mut result = tool.clone();
 
-        // Dispatch by wrapper shape: Gemini `functionDeclarations` array,
-        // OpenAI `function` object, or a bare schema.
-        if let Some(decls) = result.get_mut("functionDeclarations") {
+        // Dispatch by wrapper shape: a request `tools` array, Gemini
+        // `functionDeclarations`, an OpenAI `function`, or a bare declaration.
+        if let Some(tools) = result.get_mut("tools").and_then(Value::as_array_mut) {
+            for entry in tools {
+                let is_bare_declaration = entry.get("type").is_none()
+                    && entry.get("name").and_then(Value::as_str).is_some()
+                    && (entry.get("parameters").is_some()
+                        || entry.get("parametersJsonSchema").is_some());
+                let is_function = entry.get("type").and_then(Value::as_str) == Some("function")
+                    || entry.get("function").is_some()
+                    || entry.get("functionDeclarations").is_some()
+                    || is_bare_declaration;
+                if is_function {
+                    *entry = self.compress(entry);
+                }
+            }
+        } else if let Some(decls) = result.get_mut("functionDeclarations") {
             // Gemini tools format: a Tool object wraps an array of
             // declarations `{ "functionDeclarations": [{name, description,
             // parametersJsonSchema}, ...] }`. Compress each declaration in

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -33,6 +33,149 @@ fn test_compress_long_description() {
 }
 
 #[test]
+fn compress_openai_tools_request_container() {
+    let compressor = SchemaCompressor::new();
+    let schema = json!({
+        "model": "example-model",
+        "tool_choice": "auto",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "A".repeat(2000),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "B".repeat(1000)
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "type": "web_search_preview",
+                "search_context_size": "low",
+                "title": "Preserve built-in tool metadata",
+                "description": "C".repeat(400),
+                "examples": ["preserve"]
+            }
+        ]
+    });
+
+    let result = compressor.compress(&schema);
+    let function = &result["tools"][0]["function"];
+
+    assert!(
+        function["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 256
+    );
+    assert!(
+        function["parameters"]["properties"]["query"]["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 160
+    );
+    assert_eq!(result["model"], "example-model");
+    assert_eq!(result["tool_choice"], "auto");
+    assert_eq!(result["tools"][1], schema["tools"][1]);
+}
+
+#[test]
+fn compress_gemini_tools_request_container() {
+    let compressor = SchemaCompressor::new();
+    let schema = json!({
+        "model": "example-model",
+        "tools": [{
+            "functionDeclarations": [{
+                "name": "lookup",
+                "description": "A".repeat(2000),
+                "parametersJsonSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "B".repeat(1000)
+                        }
+                    }
+                }
+            }]
+        }]
+    });
+
+    let result = compressor.compress(&schema);
+    let function = &result["tools"][0]["functionDeclarations"][0];
+
+    assert!(
+        function["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 256
+    );
+    assert!(
+        function["parametersJsonSchema"]["properties"]["query"]["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 160
+    );
+    assert_eq!(result["model"], schema["model"]);
+}
+
+#[test]
+fn compress_bare_declaration_in_tools_request_container() {
+    let compressor = SchemaCompressor::new();
+    let schema = json!({
+        "model": "example-model",
+        "tools": [{
+            "name": "lookup",
+            "description": "A".repeat(2000),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "B".repeat(1000)
+                    }
+                }
+            }
+        }]
+    });
+
+    let result = compressor.compress(&schema);
+    let function = &result["tools"][0];
+
+    assert!(
+        function["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 256
+    );
+    assert!(
+        function["parameters"]["properties"]["query"]["description"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .count()
+            <= 160
+    );
+    assert_eq!(result["model"], schema["model"]);
+}
+
+#[test]
 fn test_protected_fields_preserved() {
     let compressor = SchemaCompressor::new();
     let schema = json!({

--- a/src/tokenless/docs/response-compression.md
+++ b/src/tokenless/docs/response-compression.md
@@ -362,4 +362,7 @@ tokenless stats summary
 | 含 debug/trace 的 API 响应 | ~78% | ~82-85% | 响应压缩移除冗余字段后，TOON 消除剩余 JSON 语法 |
 | 表格数据 `[{...}]` | ~5-10% | ~40-60% | 响应压缩对表格效果有限，TOON 效果显著（实测 44%） |
 | 简单扁平对象 | ~0-10% | ~15-25% | JSON 语法开销占比有限 |
-| 嵌套 Schema 定义 | ~57% | ~60-65% | Schema 压缩由专门的 SchemaCompressor 处理 |
+
+Schema 压缩不经过本表的响应压缩或 TOON 流程。Tokenless 0.7.11 在仓库参考
+fixture 上的独立 Schema 压缩结果为 47.3%；该数字不是生产范围或任意 Schema
+的保证值，实际结果取决于输入结构、description 长度和可移除字段。


### PR DESCRIPTION
## Why

`tokenless compress-schema` treated a complete request object with a top-level `tools` array as a bare schema. It compacted JSON whitespace but did not apply description limits inside Function Calling definitions, producing misleadingly small savings for otherwise compressible schemas.

## What changed

Route top-level `tools` request envelopes through the shared `SchemaCompressor`, while preserving non-function tools and request fields outside `tools`. Add core, Runtime, and CLI regression coverage, document all accepted schema shapes in English and Chinese, and replace the stale generic schema-savings claim with the measured reference-fixture result and its limitations.

## Related issue

no-issue: reported standalone schema-envelope compatibility defect

## User / Agent impact

Standalone CLI and Runtime/Python callers can now pass complete request objects and receive the same description compression as single-tool and batch inputs. Built-in non-function tools and request metadata remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: this broadens an existing input boundary without changing signatures, flags, thresholds, or the compression policy. Traversal is restricted to Function Calling entries.

## Validation

Linux x86_64, from `src/tokenless` unless noted:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `bash scripts/docs-lint.sh` from the repository root
- `python3 scripts/docs-link-check.py` from the repository root
- `git diff --check`

## Documentation and rollback

Updated the paired component READMEs and CLI references with the supported request-envelope shape, and corrected the stale schema-compression percentage in the component documentation. Revert commit `5e84ff6e` to roll back; no data or configuration migration is required.