### PR TITLE
fix(anolisa): fail forget dry-run on adapters

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/forget.rs
@@ -93,10 +93,10 @@ pub fn handle(args: ForgetArgs, ctx: &CliContext) -> Result<(), CliError> {
     // silently orphaning a registered plugin is worse than refusing. This guard
     // is a fast-fail and the dry-run preview; `persist_forget` re-checks
     // authoritatively under the lock. Mirrors `uninstall`, pointing at
-    // `adapter disable`.
-    if !ctx.dry_run {
-        ensure_no_adapter_claims(&store, target, &command)?;
-    }
+    // `adapter disable`. Dry-run must refuse here too — the pending-journal
+    // check above already previews execute refusals, and a success preview
+    // would tell the operator to proceed when the real forget cannot.
+    ensure_no_adapter_claims(&store, target, &command)?;
 
     if ctx.dry_run {
         let payload = ForgetPayload {
@@ -740,6 +740,89 @@ mod tests {
             load_store(&c)
                 .find(ObjectKind::Component, "copilot-shell")
                 .is_some(),
+        );
+    }
+
+    /// Dry-run must preview the same adapter-claim refusal as a real run.
+    /// A success preview would tell the operator the drop is clear, then the
+    /// real forget would fail and leave adapters still claiming the record.
+    #[test]
+    fn forget_dry_run_refuses_with_enabled_adapter_claim() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            vec![rpm_observed_object(
+                "copilot-shell",
+                "copilot-shell",
+                "2.2.0-1.al8",
+            )],
+            vec![sample_claim("copilot-shell", "openclaw")],
+        );
+        let snapshot_dir = seed_manifest_snapshot(&c, "copilot-shell");
+        let err = handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect_err("dry-run must preview the same adapter refusal as execute");
+        assert_eq!(err.code(), "INVALID_ARGUMENT");
+        assert_eq!(err.exit_code(), 2);
+        assert!(
+            err.reason().contains("adapter disable"),
+            "reason must point at adapter disable: {}",
+            err.reason()
+        );
+        assert!(
+            err.reason().contains("openclaw"),
+            "reason must name the blocking framework: {}",
+            err.reason()
+        );
+        assert!(
+            load_store(&c)
+                .find(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "dry-run refusal must leave the state record",
+        );
+        assert!(
+            snapshot_dir.exists(),
+            "dry-run refusal must leave the manifest snapshot",
+        );
+    }
+
+    /// A receipt on a different component must not block this forget, including
+    /// on dry-run. The preview still succeeds and still leaves this record.
+    #[test]
+    fn forget_dry_run_ignores_unrelated_adapter_claim() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, true);
+        seed(
+            &c,
+            vec![
+                rpm_observed_object("copilot-shell", "copilot-shell", "2.2.0-1.al8"),
+                rpm_observed_object("tokenless", "tokenless", "1.0.0-1.al8"),
+            ],
+            vec![sample_claim("tokenless", "openclaw")],
+        );
+        handle(
+            ForgetArgs {
+                component: "copilot-shell".to_string(),
+            },
+            &c,
+        )
+        .expect("unrelated adapter receipt must not block this dry-run");
+        assert!(
+            load_store(&c)
+                .find(ObjectKind::Component, "copilot-shell")
+                .is_some(),
+            "dry-run must not drop the targeted record",
+        );
+        assert!(
+            load_store(&c)
+                .find(ObjectKind::Component, "tokenless")
+                .is_some(),
+            "dry-run must not touch the unrelated record",
         );
     }
 

--- a/src/anolisa/crates/anolisa-cli/tests/forget_dry_run_adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/forget_dry_run_adapter.rs
@@ -3,8 +3,13 @@
 //! Execute already refuses a component that still has enabled adapters.
 //! Dry-run must preview that same refusal (error envelope, exit 2) instead
 //! of a successful "would forget" payload. An unrelated receipt must not
-//! block this component. Subprocesses pin `--install-mode system` and a
-//! temporary `--prefix` so host state cannot change the assertions.
+//! block this component.
+//!
+//! Subprocesses stay on `--dry-run` with `--install-mode system` and a
+//! temporary `--prefix`. A real system-mode forget is a ModeScopedMutation
+//! and needs root; the privilege gate would hide the adapter envelope on
+//! non-root runners. In-process `forget_refuses_with_enabled_adapter_claim`
+//! covers the execute path.
 
 use std::path::PathBuf;
 use std::process::Output;
@@ -40,21 +45,19 @@ impl ForgetFixture {
         Self { _tmp: tmp, prefix }
     }
 
-    fn run(&self, dry_run: bool) -> Output {
+    fn run_dry_run(&self) -> Output {
         let prefix = self.prefix.to_string_lossy().into_owned();
-        let mut args = vec![
+        common::run(&[
             "--json",
             "--no-color",
+            "--dry-run",
             "--install-mode",
             "system",
             "--prefix",
             prefix.as_str(),
-        ];
-        if dry_run {
-            args.push("--dry-run");
-        }
-        args.extend_from_slice(&["forget", TARGET]);
-        common::run(&args)
+            "forget",
+            TARGET,
+        ])
     }
 }
 
@@ -188,21 +191,15 @@ fn parse_error(output: &Output) -> Value {
 }
 
 #[test]
-fn forget_dry_run_json_refuses_enabled_adapter_like_execute() {
+fn forget_dry_run_json_refuses_enabled_adapter() {
     let fixture = ForgetFixture::with_claim_on(TARGET);
-    let dry = parse_error(&fixture.run(true));
-    let real = parse_error(&fixture.run(false));
-    assert_eq!(
-        dry.get("error"),
-        real.get("error"),
-        "dry-run must preview the same adapter refusal as execute"
-    );
+    parse_error(&fixture.run_dry_run());
 }
 
 #[test]
 fn forget_dry_run_json_ignores_unrelated_adapter_claim() {
     let fixture = ForgetFixture::with_claim_on(OTHER);
-    let output = fixture.run(true);
+    let output = fixture.run_dry_run();
     assert_eq!(
         Some(0),
         output.status.code(),

--- a/src/anolisa/crates/anolisa-cli/tests/forget_dry_run_adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/forget_dry_run_adapter.rs
@@ -1,0 +1,220 @@
+//! Subprocess coverage for `forget --dry-run` when adapter receipts exist.
+//!
+//! Execute already refuses a component that still has enabled adapters.
+//! Dry-run must preview that same refusal (error envelope, exit 2) instead
+//! of a successful "would forget" payload. An unrelated receipt must not
+//! block this component. Subprocesses pin `--install-mode system` and a
+//! temporary `--prefix` so host state cannot change the assertions.
+
+use std::path::PathBuf;
+use std::process::Output;
+
+use anolisa_core::adapter::claim::{
+    AdapterClaim, CLAIM_SCHEMA_VERSION, ClaimStatus, DRIVER_SCHEMA_VERSION, DriverPayload,
+    OpenClawClaim,
+};
+use anolisa_core::{
+    InstallMode as StateInstallMode, InstalledObject, InstalledState, ObjectKind, ObjectStatus,
+    Ownership, RpmMetadata, SubscriptionScope,
+};
+use anolisa_platform::fs_layout::FsLayout;
+use serde_json::Value;
+
+mod common;
+
+const TARGET: &str = "copilot-shell";
+const OTHER: &str = "tokenless";
+const FRAMEWORK: &str = "openclaw";
+
+struct ForgetFixture {
+    _tmp: tempfile::TempDir,
+    prefix: PathBuf,
+}
+
+impl ForgetFixture {
+    fn with_claim_on(component: &str) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prefix = tmp.path().join("system");
+        seed_index(&prefix, &[TARGET, OTHER]);
+        plant_state(&prefix, component);
+        Self { _tmp: tmp, prefix }
+    }
+
+    fn run(&self, dry_run: bool) -> Output {
+        let prefix = self.prefix.to_string_lossy().into_owned();
+        let mut args = vec![
+            "--json",
+            "--no-color",
+            "--install-mode",
+            "system",
+            "--prefix",
+            prefix.as_str(),
+        ];
+        if dry_run {
+            args.push("--dry-run");
+        }
+        args.extend_from_slice(&["forget", TARGET]);
+        common::run(&args)
+    }
+}
+
+fn seed_index(prefix: &std::path::Path, components: &[&str]) {
+    let repo_v1 = prefix.join("repo/v1");
+    std::fs::create_dir_all(&repo_v1).expect("local repo");
+    let mut index = String::from("schema_version = 2\n");
+    for component in components {
+        index.push_str(&format!(
+            "\n[[components]]\nname = \"{component}\"\ntargets = [{{ os = \"{os}\", arch = \"{arch}\" }}]\n",
+            os = std::env::consts::OS,
+            arch = std::env::consts::ARCH,
+        ));
+    }
+    std::fs::write(repo_v1.join("components-v2.toml"), index).expect("component index");
+    let etc = prefix.join("etc/anolisa");
+    std::fs::create_dir_all(&etc).expect("config dir");
+    std::fs::write(
+        etc.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            repo_v1.display()
+        ),
+    )
+    .expect("repo config");
+}
+
+fn plant_state(prefix: &std::path::Path, claimed_component: &str) {
+    let layout = FsLayout::system(Some(prefix.to_path_buf()));
+    std::fs::create_dir_all(&layout.state_dir).expect("state dir");
+    InstalledState {
+        install_mode: StateInstallMode::System,
+        prefix: layout.prefix.clone(),
+        objects: vec![rpm_object(TARGET), rpm_object(OTHER)],
+        adapter_claims: vec![sample_claim(claimed_component)],
+        ..InstalledState::default()
+    }
+    .save(&layout.state_dir.join("installed.toml"))
+    .expect("state");
+}
+
+fn rpm_object(component: &str) -> InstalledObject {
+    InstalledObject {
+        kind: ObjectKind::Component,
+        name: component.to_string(),
+        version: "1.0.0-1".to_string(),
+        status: ObjectStatus::Adopted,
+        manifest_digest: None,
+        distribution_source: None,
+        raw_package: None,
+        install_backend: Some("rpm".to_string()),
+        ownership: Some(Ownership::RpmObserved),
+        rpm_metadata: Some(RpmMetadata {
+            package_name: component.to_string(),
+            evr: Some("1.0.0-1".to_string()),
+            arch: Some("x86_64".to_string()),
+            source_repo: Some("@System".to_string()),
+        }),
+        installed_at: "2026-01-01T00:00:00Z".to_string(),
+        last_operation_id: None,
+        managed: false,
+        adopted: true,
+        subscription_scope: SubscriptionScope::None,
+        enabled_features: Vec::new(),
+        component_refs: Vec::new(),
+        files: Vec::new(),
+        external_modified_files: Vec::new(),
+        services: Vec::new(),
+        health: Vec::new(),
+        provisioned_packages: Vec::new(),
+    }
+}
+
+fn sample_claim(component: &str) -> AdapterClaim {
+    AdapterClaim {
+        claim_schema: CLAIM_SCHEMA_VERSION,
+        component: component.to_string(),
+        framework: FRAMEWORK.to_string(),
+        plugin_id: None,
+        adapter_type: None,
+        enabled_at: "2026-01-01T00:00:00Z".to_string(),
+        resource_root: PathBuf::from("/tmp/anolisa-forget-dry-run"),
+        bundle_digest: None,
+        source_revision: None,
+        materialized_files: Vec::new(),
+        driver_schema: DRIVER_SCHEMA_VERSION,
+        status: ClaimStatus::Enabled,
+        notices: Vec::new(),
+        resources: Vec::new(),
+        driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+            state_dir_resource: "state".to_string(),
+            plugin_resource: "plugin".to_string(),
+            skill_resources: Vec::new(),
+            config_resources: Vec::new(),
+        }),
+    }
+}
+
+fn parse_error(output: &Output) -> Value {
+    assert_eq!(
+        Some(2),
+        output.status.code(),
+        "adapter refusal must exit 2; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be a JSON envelope");
+    assert_eq!(value.get("ok"), Some(&Value::Bool(false)), "{value}");
+    let command = format!("forget {TARGET}");
+    assert_eq!(
+        value.get("command").and_then(Value::as_str),
+        Some(command.as_str()),
+        "{value}"
+    );
+    let error = value.get("error").expect("error object").clone();
+    assert_eq!(
+        error.get("code").and_then(Value::as_str),
+        Some("INVALID_ARGUMENT"),
+        "{value}"
+    );
+    let reason = error
+        .get("reason")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        reason.contains("adapter disable") && reason.contains(FRAMEWORK),
+        "reason must name adapter disable and {FRAMEWORK}: {value}"
+    );
+    value
+}
+
+#[test]
+fn forget_dry_run_json_refuses_enabled_adapter_like_execute() {
+    let fixture = ForgetFixture::with_claim_on(TARGET);
+    let dry = parse_error(&fixture.run(true));
+    let real = parse_error(&fixture.run(false));
+    assert_eq!(
+        dry.get("error"),
+        real.get("error"),
+        "dry-run must preview the same adapter refusal as execute"
+    );
+}
+
+#[test]
+fn forget_dry_run_json_ignores_unrelated_adapter_claim() {
+    let fixture = ForgetFixture::with_claim_on(OTHER);
+    let output = fixture.run(true);
+    assert_eq!(
+        Some(0),
+        output.status.code(),
+        "unrelated receipt must not block this dry-run; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be a JSON envelope");
+    assert_eq!(value.get("ok"), Some(&Value::Bool(true)), "{value}");
+    let data = value.get("data").expect("data");
+    assert_eq!(data.get("component").and_then(Value::as_str), Some(TARGET));
+    assert_eq!(data.get("dry_run"), Some(&Value::Bool(true)));
+    assert_eq!(data.get("forgotten"), Some(&Value::Bool(false)));
+}


### PR DESCRIPTION
## Why

`anolisa forget --dry-run` skipped the adapter-claim guard that a real forget enforces. A preview could print a successful "would forget" payload while `anolisa forget` then exits 2 and asks for `adapter disable`. The pending-journal check in the same function already previews execute refusals, and `uninstall --dry-run` already refuses enabled adapters. Dry-run must not tell the operator to proceed when the real drop cannot.

The subprocess that pinned that wire envelope also ran a real `--install-mode system` forget. On non-root runners that mutation is rejected as `PERMISSION_DENIED` before the adapter guard, so CI never saw the intended error.

## What changed

- **Dry-run adapter guard:** `handle` always calls `ensure_no_adapter_claims` before the dry-run success payload. Execute still re-checks under the lock in `persist_forget`.
- **Adjacent refusals:** dry-run with an enabled receipt on the target fails like execute (`INVALID_ARGUMENT`, exit 2, `adapter disable` + framework name). A receipt on a different component still previews successfully and leaves both records.
- **Regression tests:** in-process coverage in `forget.rs` still owns execute and the locked re-check. The `forget_dry_run_adapter` subprocess only asserts the dry-run JSON envelope under `--install-mode system --prefix`, which is allowed without root.

## Related issue

fixes #2761

## User / Agent impact

`anolisa forget --dry-run <component>` now refuses when that component still has enabled adapters, matching the real command and `uninstall --dry-run`. Unrelated receipts and the no-claim dry-run preview are unchanged. JSON error envelopes keep the existing schema and exit 2.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Dry-run success for a claimed component becomes a refusal. Callers that treated the previous false-green preview as authorization will now see the same error execute already returned. Execute behavior, pending-journal dry-run, and no-claim dry-run are unchanged.

## Validation

```bash
cd src/anolisa
cargo fmt --all -- --check
cargo clippy --all-targets --locked -- -D warnings
cargo test --locked --workspace --lib --bins
cargo test --locked --package anolisa-cli --bin anolisa forget
cargo test --locked --package anolisa-cli --test forget_dry_run_adapter
cargo test --locked --package anolisa-cli --test uninstall_dry_run_json
```

Environment: Linux. Head `ff03cf15d1a87431ab83afa5bb630acb9edcf0c8`. Focused subprocess tests also passed as uid 1000 (`anolisa-ci`). In-process execute refusal, dry-run refusal, unrelated-claim dry-run, and the locked re-check remain in `forget.rs`. Full `cargo test --locked` as root still hits pre-existing `--install-mode user` integration failures unrelated to this change.

## Documentation and rollback

No documentation change: dry-run is already a preview of the mutation, and the adapter guard comment already described this check as the dry-run preview. Revert this PR to restore the previous false-green `forget --dry-run` when adapters are enabled.
