### PR TITLE
chore(anolisa): bump version to 0.3.6

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-08-22
+
+### Fixed
+
+- `anolisa --quiet adapter scan` and `anolisa --quiet adapter status` now
+  suppress all non-error human output, including empty-state messages and
+  result tables, while `--json` continues to emit the standard envelope.
+  Agents can rely on quiet adapter inspection producing no human output
+  ([#2752](https://github.com/alibaba/anolisa/pull/2752)).
+- `anolisa --dry-run forget <component>` now refuses a component that still
+  has enabled adapters with the same `INVALID_ARGUMENT`, exit code 2, and
+  `adapter disable` guidance as the real operation. Previews no longer report
+  that an impossible forget would succeed, while unrelated adapter receipts
+  remain ignored
+  ([#2762](https://github.com/alibaba/anolisa/pull/2762)).
+
 ## [0.3.5] - 2026-08-20
 
 ### Fixed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,20 @@
 
 ## [未发布]
 
+## [0.3.6] - 2026-08-22
+
+### 修复
+
+- `anolisa --quiet adapter scan` 和 `anolisa --quiet adapter status` 现会
+  抑制所有非错误的人类可读输出，包括空状态提示与结果表格；`--json` 仍会输出
+  标准响应封装。Agent 可依赖 quiet 模式的 adapter 检查不产生人类可读输出
+  ([#2752](https://github.com/alibaba/anolisa/pull/2752))。
+- `anolisa --dry-run forget <component>` 现会与真实执行一样，以
+  `INVALID_ARGUMENT`、退出码 2 和 `adapter disable` 指引，拒绝仍有已启用
+  adapter 的 component。预览不再误报无法执行的 forget 会成功，同时仍会忽略
+  无关 component 的 adapter receipt
+  ([#2762](https://github.com/alibaba/anolisa/pull/2762))。
+
 ## [0.3.5] - 2026-08-20
 
 ### 修复

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.88"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Thu Aug 20 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Sat Aug 22 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Quiet adapter inspection now suppresses all non-error human output.
+- Forget dry-runs now refuse components with enabled adapters.
+
+* Thu Aug 20 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.5-1
 - Component uninstall now stops every loaded systemd template instance.
 
 * Wed Aug 19 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.4-1

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.5",
-    "@anolisa/cli-linux-arm64": "0.3.5",
-    "@anolisa/cli-darwin-arm64": "0.3.5"
+    "@anolisa/cli-linux-x64": "0.3.6",
+    "@anolisa/cli-linux-arm64": "0.3.6",
+    "@anolisa/cli-darwin-arm64": "0.3.6"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA 0.3.5 predates the user-visible fixes merged in #2752 and #2762. This patch release synchronizes every active distribution version surface and records the final behavior so the publication workflows can ship coherent 0.3.6 artifacts.

## What changed

- Bump the Cargo workspace and all five workspace packages to 0.3.6.
- Bump the root npm package, its three optional native dependencies, and all three platform package templates to 0.3.6.
- Add semantically paired English and Chinese 0.3.6 notes for quiet adapter inspection and `forget --dry-run` adapter-claim refusal.
- Add the current RPM changelog placeholder row and freeze the prior row at 0.3.5.

The release notes omit the behavior-preserving install/uninstall application-layer refactors and the unrelated Tokenless catalog update. This bump adds no runtime source behavior.

## Related issue

no-issue: release aggregation for #2752 and #2762

## User / Agent impact

Published 0.3.6 artifacts include two already-merged fixes: `anolisa --quiet adapter scan` and `adapter status` suppress all non-error human output while JSON remains available, and `anolisa --dry-run forget <component>` refuses enabled adapter claims with the same guidance as execution.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low release risk: this commit changes only nine version/changelog surfaces and introduces no runtime code. The history-derived release audit, built CLI, npm tarball install, and rendered RPM all report 0.3.6. Existing callers relying on incorrect human output under `--quiet` or a false-green claimed-component forget preview receive the corrected behavior from the underlying fixes.

## Validation

Linux x86_64, Rust 1.88.0:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- focused `adapter_quiet` and `forget_dry_run_adapter` integration tests
- `cargo build --release --locked -p anolisa-cli`; built binary reports `anolisa 0.3.6`

Release and packaging checks:

- `check_release.py` passed against both the working tree and committed `HEAD` using the 0.3.5 content bump `88ac3dd0`
- npm platform tests and template validation passed
- isolated Linux x64 npm pack/install smoke passed; root and platform manifests plus installed binary report 0.3.6
- rendered RPM reports `anolisa 0.3.6-1.al8` and preserves `@VERSION@` in the template
- component metadata check and nightly raw-lifecycle harness validation passed
- docs lint and relative-link checks passed
- isolated website `npm ci`, English/Chinese build, typecheck, and 164-page link/duplicate-ID check passed with Node 20.20.2

Linux arm64 and macOS arm64 native binaries were not built on this Linux x86_64 host; their npm templates were validated.

## Documentation and rollback

The paired component changelogs and RPM changelog document the release; no README or user-guide contract changed. Before publication, revert `75262a79` to roll back the release bump. After publication, issue a new patch version rather than rewriting published 0.3.6 artifacts.