### PR TITLE
chore(tokenless): bump version to 0.7.12

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.11"
+version = "0.7.12"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,21 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.12] - 2026-08-22
+
+### Changed
+
+- Response compression now keeps a configurable tail window after the retained array head (8 items by default, controlled by `--array-tail-preserve` and the Runtime API), so final statuses and error details remain inline while Stash stores only the omitted middle segment ([#2433](https://github.com/alibaba/anolisa/pull/2433)).
+- The `BeforeModel` schema hook now warns once per session when a payload is malformed or carries no tool declarations, making a skipped hook distinguishable from a successful run that produced no savings; explicitly empty tool arrays still pass through silently ([#2606](https://github.com/alibaba/anolisa/pull/2606)).
+- L2 benchmark JSON, Markdown, and semantic-gate findings now identify the missing ground-truth items behind retention failures instead of reporting counts alone ([#2433](https://github.com/alibaba/anolisa/pull/2433)).
+
+### Fixed
+
+- `tokenless stats enable` and `stats disable` now persist only the Stats toggle from the on-disk configuration, so temporary compression and SLS environment overrides are not copied into `config.json` ([#2592](https://github.com/alibaba/anolisa/pull/2592)).
+- `tokenless stats summary --compare` now fails when either Session has no records, and `--limit 0` is rejected, preventing typos or empty samples from appearing as successful 0% comparisons ([#2674](https://github.com/alibaba/anolisa/pull/2674)).
+- Schema compression now handles complete request objects with a top-level `tools` array, compressing Function Calling entries while preserving non-function tools and fields outside the array ([#2758](https://github.com/alibaba/anolisa/pull/2758)).
+- Lossy array truncation markers now survive TOON round trips intact, and extremely large tail-preservation values keep the full array instead of overflowing ([#2433](https://github.com/alibaba/anolisa/pull/2433)).
+
 ## [0.7.11] - 2026-08-20
 
 ### Fixed

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,21 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.12] - 2026-08-22
+
+### 变更
+
+- Response 压缩现在会在保留数组头部后继续保留可配置的尾部窗口（默认 8 项，可通过 `--array-tail-preserve` 和 Runtime API 控制），使最终状态与错误细节继续内联，而 Stash 只存储被省略的中间段（[#2433](https://github.com/alibaba/anolisa/pull/2433)）。
+- 当 `BeforeModel` Payload 格式错误或未携带工具声明时，Schema Hook 现在会每个 Session 警告一次，使 Hook 被跳过与正常执行但未产生节省可以区分；显式空工具数组仍会静默透传（[#2606](https://github.com/alibaba/anolisa/pull/2606)）。
+- L2 Benchmark 的 JSON、Markdown 与 Semantic Gate Finding 现在会列出保真失败时缺失的 Ground Truth 项，不再只报告计数（[#2433](https://github.com/alibaba/anolisa/pull/2433)）。
+
+### 修复
+
+- `tokenless stats enable` 与 `stats disable` 现在只基于磁盘配置持久化 Stats 开关，因此临时的压缩与 SLS 环境变量覆盖不会被写入 `config.json`（[#2592](https://github.com/alibaba/anolisa/pull/2592)）。
+- 当任一 Session 没有记录时，`tokenless stats summary --compare` 现在会失败，并且 `--limit 0` 会被拒绝，避免拼写错误或空样本显示为成功的 0% 对比（[#2674](https://github.com/alibaba/anolisa/pull/2674)）。
+- Schema 压缩现在支持包含顶层 `tools` 数组的完整请求对象，在保留非 Function 工具与数组外字段的同时压缩 Function Calling 条目（[#2758](https://github.com/alibaba/anolisa/pull/2758)）。
+- 无 Stash 的数组截断 Marker 现在可以完整通过 TOON 往返，极大的尾部保留值也会保留完整数组而不再溢出（[#2433](https://github.com/alibaba/anolisa/pull/2433)）。
+
 ## [0.7.11] - 2026-08-20
 
 ### 修复

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "regex",
  "serde_json",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.11"
+version = "0.7.12"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.11",
-    "@anolisa/tokenless-linux-arm64": "0.7.11",
-    "@anolisa/tokenless-darwin-x64": "0.7.11",
-    "@anolisa/tokenless-darwin-arm64": "0.7.11"
+    "@anolisa/tokenless-linux-x64": "0.7.12",
+    "@anolisa/tokenless-linux-arm64": "0.7.12",
+    "@anolisa/tokenless-darwin-x64": "0.7.12",
+    "@anolisa/tokenless-darwin-arm64": "0.7.12"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -470,6 +470,15 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Sat Aug 22 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.12-1
+- feat(tokenless): preserve tail items during array truncation
+- fix(tokenless): surface skipped schema compression
+- fix(tokenless): persist stats without environment overrides
+- fix(tokenless): reject invalid stats comparisons
+- fix(tokenless): compress top-level request tool schemas
+- fix(tokenless): report missing L2 retention items
+- fix(tokenless): keep plain truncation markers TOON-safe
+
 * Thu Aug 20 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.11-1
 - fix(tokenless): align TOON CLI token scoring and exit codes
 


### PR DESCRIPTION
## Why

Tokenless has accumulated backward-compatible array-retention, schema-compression, statistics,
and benchmark-reporting changes since 0.7.11. The release metadata and bilingual notes need one
atomic patch bump so every distribution channel publishes the same component version.

## What changed

- Bumped all 14 history-derived Tokenless release surfaces from 0.7.11 to 0.7.12.
- Added semantically paired English and Chinese notes for the final user-visible behavior in
  #2433, #2592, #2606, #2674, and #2758.
- Added the matching RPM changelog boundary. This version-only commit adds no runtime behavior.

## Related issue

no-issue: patch release aggregating already merged Tokenless changes

## User / Agent impact

After the release workflows publish 0.7.12, users receive configurable array-tail retention,
clearer schema-hook skip diagnostics, top-level request `tools` compression, safer Stats config and
comparison behavior, and more actionable L2 retention reports. This PR only synchronizes version
metadata and release documentation for those merged changes.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The released changes are backward-compatible within the 0.7.x line. The ANOLISA component catalog
version is synchronized, but its schema and minimum-version contract are unchanged. No migration is
required.

## Validation

Environment: Linux x86_64, rustc/cargo 1.97.1, CPython 3.12.13; the runtime wheel is abi3 for
CPython 3.11+.

- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo doc --workspace --no-deps --locked`
- `make build`
- `make lint`
- `make test` (all passed; two network tests remained explicitly ignored)
- `PATH="$PWD/target/release:$PWD/third_party/rtk/target/release:$PATH" bash tests/run-all-tests.sh`
  (71/71 against `tokenless 0.7.12`)
- `make test-python-runtime test-agentscope-integration` (0.7.12 wheels; AgentScope 1.0.11,
  1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.6)
- `cargo test --manifest-path benchmark/l2-module/Cargo.toml --locked`
- `RUST_MIN_STACK=16777216 cargo test --manifest-path benchmark/l1-compressor/Cargo.toml --locked`
- `python3 /home/jiawa.syx/.codex/skills/release-anolisa-component/scripts/check_release.py --repo
  /home/jiawa.syx/Code/Opensource/anolisa-tokenless --component tokenless --scope tokenless
  --version 0.7.12 --previous 0.7.11 --bump-commit 45306960e1dc6f1958055e97fc962b923fefb4da
  --revision HEAD`
- JSON/TOML version consistency, stamped `rpmspec -P`, built CLI/Wheel version readback, and
  `git diff --check`

The standalone L1 suite initially overflowed the default Rust test-thread stack in its pre-existing
500-level JSON destruction case. The complete suite passed with a 16 MiB `RUST_MIN_STACK`; the test
file predates this release range and is unchanged here.

## Documentation and rollback

`CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog were updated together from the actual
0.7.11-to-main diff. Before publication, rollback is a revert of this version-only commit. After any
0.7.12 artifact is public, use a forward patch release instead of moving or overwriting the version.
