### PR TITLE
feat(cosh-ng): add checkpoint profile contract

### DIFF
--- a/src/cosh-ng/crates/cosh-gateway-contracts/src/profile.rs
+++ b/src/cosh-ng/crates/cosh-gateway-contracts/src/profile.rs
@@ -10,8 +10,14 @@ use crate::common::{BoundedName, BoundedOpaque, Digest, TargetRef};
 
 /// Canonical wire and configuration name of the portable Task-only profile.
 pub const TASK_ONLY_V1_PROFILE: &str = "task-only-v1";
+/// Canonical wire and configuration name of the workspace-checkpoint profile.
+pub const WORKSPACE_CHECKPOINT_V1_PROFILE: &str = "workspace-checkpoint-v1";
 /// Runtime tool resolved by the Gateway without a host side effect.
 pub const ASK_USER_QUESTION_TOOL: &str = "ask_user_question";
+/// Runtime tool whose side effect must cross a governed checkpoint target.
+pub const WORKSPACE_CHECKPOINT_CREATE_TOOL: &str = "workspace_checkpoint_create";
+/// Canonical name of the only checkpoint provider admitted by this contract.
+pub const WS_CKPT_PROVIDER: &str = "ws-ckpt";
 /// Domain separator for the first capability-profile manifest format.
 pub const CAPABILITY_PROFILE_MANIFEST_DOMAIN: &str = "cosh.gateway.capability-profile.v1";
 /// Canonical manifest of the portable Task-only profile.
@@ -26,13 +32,76 @@ pub const TASK_ONLY_V1_CANONICAL_MANIFEST: &str = concat!(
 /// Pinned SHA-256 digest of [`TASK_ONLY_V1_CANONICAL_MANIFEST`].
 pub const TASK_ONLY_V1_MANIFEST_DIGEST: &str =
     "2b95e0f3e28df8eb2b7930f2dec3650ffe399f971671c971865e4663c382c94a";
+/// Canonical manifest of the optional workspace-checkpoint profile.
+///
+/// Each profile manifest is an opaque pinned constant compared by digest, never
+/// a parsed structure. A profile without providers therefore omits the trailing
+/// `providers:` section entirely, which keeps
+/// [`TASK_ONLY_V1_CANONICAL_MANIFEST`] byte-identical to its original revision.
+pub const WORKSPACE_CHECKPOINT_V1_CANONICAL_MANIFEST: &str = concat!(
+    "cosh.gateway.capability-profile.v1\n",
+    "profile:workspace-checkpoint-v1\n",
+    "target:\n",
+    "workspace/cosh/workspace-checkpoint-v1\n",
+    "runtime-tools:\n",
+    "ask_user_question\n",
+    "workspace_checkpoint_create\n",
+    "providers:\n",
+    "ws-ckpt\n",
+);
+/// Pinned SHA-256 digest of [`WORKSPACE_CHECKPOINT_V1_CANONICAL_MANIFEST`].
+pub const WORKSPACE_CHECKPOINT_V1_MANIFEST_DIGEST: &str =
+    "6b3e7093e7b8656d4a7cf21faa85b9eed761ef415d002623cfc442f3ef3c8ae1";
 
 const TASK_ONLY_V1_RUNTIME_TOOLS: &[&str] = &[ASK_USER_QUESTION_TOOL];
+const WORKSPACE_CHECKPOINT_V1_RUNTIME_TOOLS: &[&str] =
+    &[ASK_USER_QUESTION_TOOL, WORKSPACE_CHECKPOINT_CREATE_TOOL];
+const NO_PROVIDERS: &[CapabilityProviderId] = &[];
+const WS_CKPT_PROVIDER_SET: &[CapabilityProviderId] = &[CapabilityProviderId::WsCkpt];
 
 /// Failure returned when a profile name is not an admitted production profile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("unsupported capability profile; expected `task-only-v1`")]
+#[error("unsupported capability profile; expected `task-only-v1` or `workspace-checkpoint-v1`")]
 pub struct CapabilityProfileParseError;
+
+/// Failure returned when a provider name is not an admitted production provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("unsupported capability provider; expected `ws-ckpt`")]
+pub struct CapabilityProviderParseError;
+
+/// Versioned identity of a side-effect provider sealed into a capability profile.
+///
+/// Providers are selected only by the profile a trusted Gateway configuration
+/// admits. Task input, Runtime tool names, and ACP payloads never widen this set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityProviderId {
+    /// Workspace checkpoint provider backed by the local `ws-ckpt` daemon.
+    WsCkpt,
+}
+
+impl CapabilityProviderId {
+    /// Returns the canonical wire and configuration name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WsCkpt => WS_CKPT_PROVIDER,
+        }
+    }
+
+    /// Parses an exact canonical production provider name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CapabilityProviderParseError`] for every unknown name. Unknown
+    /// names never fall back to an admitted provider.
+    pub fn parse(value: &str) -> Result<Self, CapabilityProviderParseError> {
+        match value {
+            WS_CKPT_PROVIDER => Ok(Self::WsCkpt),
+            _ => Err(CapabilityProviderParseError),
+        }
+    }
+}
 
 /// Failure returned when advertised profile state differs from its closed contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
@@ -46,6 +115,9 @@ pub enum CapabilityProfileVerificationError {
     /// The Runtime tool inventory differs from the profile's closed inventory.
     #[error("Runtime tool inventory does not match the configured capability profile")]
     RuntimeToolInventoryMismatch,
+    /// The admitted provider set differs from the profile's sealed provider set.
+    #[error("capability provider set does not match the configured capability profile")]
+    ProviderSetMismatch,
 }
 
 /// Versioned identity of an admitted Gateway capability profile.
@@ -54,6 +126,8 @@ pub enum CapabilityProfileVerificationError {
 pub enum GatewayCapabilityProfileId {
     /// Portable profile whose only Runtime tool asks the user a question.
     TaskOnlyV1,
+    /// Optional profile that additionally admits one governed checkpoint target.
+    WorkspaceCheckpointV1,
 }
 
 impl GatewayCapabilityProfileId {
@@ -62,6 +136,7 @@ impl GatewayCapabilityProfileId {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::TaskOnlyV1 => TASK_ONLY_V1_PROFILE,
+            Self::WorkspaceCheckpointV1 => WORKSPACE_CHECKPOINT_V1_PROFILE,
         }
     }
 
@@ -74,6 +149,7 @@ impl GatewayCapabilityProfileId {
     pub fn parse(value: &str) -> Result<Self, CapabilityProfileParseError> {
         match value {
             TASK_ONLY_V1_PROFILE => Ok(Self::TaskOnlyV1),
+            WORKSPACE_CHECKPOINT_V1_PROFILE => Ok(Self::WorkspaceCheckpointV1),
             _ => Err(CapabilityProfileParseError),
         }
     }
@@ -83,6 +159,7 @@ impl GatewayCapabilityProfileId {
     pub const fn profile(self) -> GatewayCapabilityProfile {
         match self {
             Self::TaskOnlyV1 => GatewayCapabilityProfile::task_only_v1(),
+            Self::WorkspaceCheckpointV1 => GatewayCapabilityProfile::workspace_checkpoint_v1(),
         }
     }
 }
@@ -104,11 +181,23 @@ pub struct GatewayCapabilityProfile {
 }
 
 impl GatewayCapabilityProfile {
-    /// Returns the only production profile currently admitted by this contract.
+    /// Returns the portable profile that admits no side-effect provider.
     #[must_use]
     pub const fn task_only_v1() -> Self {
         Self {
             id: GatewayCapabilityProfileId::TaskOnlyV1,
+        }
+    }
+
+    /// Returns the optional profile that admits exactly one checkpoint provider.
+    ///
+    /// Selecting this profile does not make a checkpoint reachable on its own. A
+    /// trusted Gateway configuration must additionally admit the sealed provider
+    /// set as a real, identity-bound execution target.
+    #[must_use]
+    pub const fn workspace_checkpoint_v1() -> Self {
+        Self {
+            id: GatewayCapabilityProfileId::WorkspaceCheckpointV1,
         }
     }
 
@@ -123,6 +212,9 @@ impl GatewayCapabilityProfile {
     pub const fn canonical_manifest(self) -> &'static str {
         match self.id {
             GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_CANONICAL_MANIFEST,
+            GatewayCapabilityProfileId::WorkspaceCheckpointV1 => {
+                WORKSPACE_CHECKPOINT_V1_CANONICAL_MANIFEST
+            }
         }
     }
 
@@ -131,6 +223,9 @@ impl GatewayCapabilityProfile {
     pub fn manifest_digest(self) -> Digest {
         let digest = match self.id {
             GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_MANIFEST_DIGEST,
+            GatewayCapabilityProfileId::WorkspaceCheckpointV1 => {
+                WORKSPACE_CHECKPOINT_V1_MANIFEST_DIGEST
+            }
         };
         Digest::parse(digest)
             .unwrap_or_else(|_| unreachable!("reviewed static profile digests are canonical"))
@@ -148,15 +243,13 @@ impl GatewayCapabilityProfile {
     /// Returns the single governed target bound into the profile manifest.
     #[must_use]
     pub fn governed_target(self) -> TargetRef {
-        match self.id {
-            GatewayCapabilityProfileId::TaskOnlyV1 => TargetRef {
-                kind: BoundedName::new("workspace")
-                    .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
-                authority: BoundedName::new("cosh")
-                    .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
-                identifier: BoundedOpaque::new(TASK_ONLY_V1_PROFILE)
-                    .unwrap_or_else(|_| unreachable!("static profile target IDs are bounded")),
-            },
+        TargetRef {
+            kind: BoundedName::new("workspace")
+                .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
+            authority: BoundedName::new("cosh")
+                .unwrap_or_else(|_| unreachable!("static profile target names are bounded")),
+            identifier: BoundedOpaque::new(self.id.as_str())
+                .unwrap_or_else(|_| unreachable!("static profile target IDs are bounded")),
         }
     }
 
@@ -165,6 +258,21 @@ impl GatewayCapabilityProfile {
     pub const fn runtime_tools(self) -> &'static [&'static str] {
         match self.id {
             GatewayCapabilityProfileId::TaskOnlyV1 => TASK_ONLY_V1_RUNTIME_TOOLS,
+            GatewayCapabilityProfileId::WorkspaceCheckpointV1 => {
+                WORKSPACE_CHECKPOINT_V1_RUNTIME_TOOLS
+            }
+        }
+    }
+
+    /// Returns the exact ordered side-effect provider set sealed into the profile.
+    ///
+    /// The Task-only profile returns an empty set, so a Task-only instance can
+    /// never reach a side-effect provider even when one is installed on the host.
+    #[must_use]
+    pub const fn providers(self) -> &'static [CapabilityProviderId] {
+        match self.id {
+            GatewayCapabilityProfileId::TaskOnlyV1 => NO_PROVIDERS,
+            GatewayCapabilityProfileId::WorkspaceCheckpointV1 => WS_CKPT_PROVIDER_SET,
         }
     }
 
@@ -200,6 +308,23 @@ impl GatewayCapabilityProfile {
             Ok(())
         } else {
             Err(CapabilityProfileVerificationError::RuntimeToolInventoryMismatch)
+        }
+    }
+
+    /// Verifies that trusted configuration admitted exactly the sealed provider set.
+    ///
+    /// # Errors
+    ///
+    /// Returns a mismatch for missing, additional, reordered, or substituted
+    /// providers. A Task-only instance therefore rejects any admitted provider.
+    pub fn verify_providers(
+        self,
+        actual: &[CapabilityProviderId],
+    ) -> Result<(), CapabilityProfileVerificationError> {
+        if actual == self.providers() {
+            Ok(())
+        } else {
+            Err(CapabilityProfileVerificationError::ProviderSetMismatch)
         }
     }
 }
@@ -243,6 +368,116 @@ mod tests {
     }
 
     #[test]
+    fn workspace_checkpoint_manifest_and_digest_are_pinned() {
+        let profile = GatewayCapabilityProfile::workspace_checkpoint_v1();
+        let actual_digest = format!("{:x}", Sha256::digest(profile.canonical_manifest()));
+
+        assert_eq!(profile.id().as_str(), WORKSPACE_CHECKPOINT_V1_PROFILE);
+        assert!(profile
+            .canonical_manifest()
+            .starts_with(CAPABILITY_PROFILE_MANIFEST_DOMAIN));
+        assert_eq!(
+            profile.canonical_manifest(),
+            WORKSPACE_CHECKPOINT_V1_CANONICAL_MANIFEST
+        );
+        assert_eq!(
+            profile.manifest_digest().as_str(),
+            WORKSPACE_CHECKPOINT_V1_MANIFEST_DIGEST
+        );
+        assert_eq!(actual_digest, WORKSPACE_CHECKPOINT_V1_MANIFEST_DIGEST);
+        assert_eq!(
+            profile.runtime_tools(),
+            [ASK_USER_QUESTION_TOOL, WORKSPACE_CHECKPOINT_CREATE_TOOL]
+        );
+        assert_eq!(profile.providers(), [CapabilityProviderId::WsCkpt]);
+        assert_eq!(profile.verify_identity(&profile.identity()), Ok(()));
+        let target = profile.governed_target();
+        assert_eq!(target.kind.as_str(), "workspace");
+        assert_eq!(target.authority.as_str(), "cosh");
+        assert_eq!(target.identifier.as_str(), WORKSPACE_CHECKPOINT_V1_PROFILE);
+        assert!(profile.canonical_manifest().contains(&format!(
+            "target:\n{}/{}/{}\n",
+            target.kind.as_str(),
+            target.authority.as_str(),
+            target.identifier.as_str(),
+        )));
+        assert!(profile
+            .canonical_manifest()
+            .ends_with(&format!("providers:\n{WS_CKPT_PROVIDER}\n")));
+    }
+
+    #[test]
+    fn optional_profile_never_alters_the_task_only_contract() {
+        let task_only = GatewayCapabilityProfile::task_only_v1();
+        let checkpoint = GatewayCapabilityProfile::workspace_checkpoint_v1();
+
+        // The Task-only manifest is byte-identical to its original revision, so
+        // the private Core v3 wire mirror keeps verifying the pinned digest.
+        assert_eq!(
+            task_only.manifest_digest().as_str(),
+            TASK_ONLY_V1_MANIFEST_DIGEST
+        );
+        assert!(!task_only.canonical_manifest().contains("providers:"));
+        assert_eq!(task_only.providers(), []);
+        assert_eq!(task_only.verify_providers(&[]), Ok(()));
+        assert_ne!(task_only.governed_target(), checkpoint.governed_target());
+        assert_ne!(task_only.manifest_digest(), checkpoint.manifest_digest());
+        assert_eq!(
+            task_only.verify_identity(&checkpoint.identity()),
+            Err(CapabilityProfileVerificationError::ProfileMismatch)
+        );
+        assert_eq!(
+            checkpoint.verify_identity(&task_only.identity()),
+            Err(CapabilityProfileVerificationError::ProfileMismatch)
+        );
+    }
+
+    #[test]
+    fn provider_sets_are_exact_and_never_widened_by_installation() {
+        let task_only = GatewayCapabilityProfile::task_only_v1();
+        let checkpoint = GatewayCapabilityProfile::workspace_checkpoint_v1();
+
+        // A host that happens to run ws-ckpt is not authority for a Task-only
+        // instance; the empty sealed set rejects the installed provider.
+        assert_eq!(
+            task_only.verify_providers(&[CapabilityProviderId::WsCkpt]),
+            Err(CapabilityProfileVerificationError::ProviderSetMismatch)
+        );
+        assert_eq!(
+            checkpoint.verify_providers(&[CapabilityProviderId::WsCkpt]),
+            Ok(())
+        );
+        assert_eq!(
+            checkpoint.verify_providers(&[]),
+            Err(CapabilityProfileVerificationError::ProviderSetMismatch)
+        );
+        assert_eq!(
+            checkpoint
+                .verify_providers(&[CapabilityProviderId::WsCkpt, CapabilityProviderId::WsCkpt]),
+            Err(CapabilityProfileVerificationError::ProviderSetMismatch)
+        );
+    }
+
+    #[test]
+    fn provider_names_are_exact_and_fail_closed() {
+        assert_eq!(
+            CapabilityProviderId::parse(WS_CKPT_PROVIDER),
+            Ok(CapabilityProviderId::WsCkpt)
+        );
+        assert_eq!(CapabilityProviderId::WsCkpt.as_str(), "ws-ckpt");
+        for unknown in ["", "ws_ckpt", "WS-CKPT", "ws-ckpt-v1", "shell"] {
+            assert_eq!(
+                CapabilityProviderId::parse(unknown),
+                Err(CapabilityProviderParseError)
+            );
+        }
+        assert_eq!(
+            serde_json::to_value(CapabilityProviderId::WsCkpt).expect("provider ID serializes"),
+            serde_json::json!(WS_CKPT_PROVIDER)
+        );
+    }
+
+    #[test]
     fn profile_names_are_exact_and_fail_closed() {
         assert_eq!(
             GatewayCapabilityProfileId::parse(TASK_ONLY_V1_PROFILE),
@@ -252,12 +487,26 @@ mod tests {
             GatewayCapabilityProfileId::TaskOnlyV1.profile(),
             GatewayCapabilityProfile::task_only_v1()
         );
+        assert_eq!(
+            GatewayCapabilityProfileId::parse(WORKSPACE_CHECKPOINT_V1_PROFILE),
+            Ok(GatewayCapabilityProfileId::WorkspaceCheckpointV1)
+        );
+        assert_eq!(
+            GatewayCapabilityProfileId::WorkspaceCheckpointV1.profile(),
+            GatewayCapabilityProfile::workspace_checkpoint_v1()
+        );
         for unknown in [
             "",
             "task-only",
             "task-only-v2",
             "TASK-ONLY-V1",
+            // The contract rejected this provider-shaped name; it must not be
+            // revived as an alias for the capability-shaped profile name.
             "ws-ckpt-v1",
+            "ws-ckpt",
+            "workspace-checkpoint",
+            "workspace-checkpoint-v2",
+            "WORKSPACE-CHECKPOINT-V1",
         ] {
             assert_eq!(
                 GatewayCapabilityProfileId::parse(unknown),
@@ -290,7 +539,7 @@ mod tests {
         );
         for drifted in [
             &[][..],
-            &[ASK_USER_QUESTION_TOOL, "workspace_checkpoint_create"][..],
+            &[ASK_USER_QUESTION_TOOL, WORKSPACE_CHECKPOINT_CREATE_TOOL][..],
             &["ask_user"][..],
         ] {
             assert_eq!(
@@ -301,16 +550,57 @@ mod tests {
     }
 
     #[test]
-    fn profile_identity_uses_canonical_wire_names() {
-        let identity = GatewayCapabilityProfile::task_only_v1().identity();
-        let encoded = serde_json::to_value(&identity).expect("profile identity serializes");
+    fn checkpoint_inventory_rejects_missing_extra_and_reordered_tools() {
+        let profile = GatewayCapabilityProfile::workspace_checkpoint_v1();
 
-        assert_eq!(encoded["profile_id"], TASK_ONLY_V1_PROFILE);
-        assert_eq!(encoded["manifest_digest"], TASK_ONLY_V1_MANIFEST_DIGEST);
         assert_eq!(
-            serde_json::from_value::<GatewayCapabilityProfileIdentity>(encoded)
-                .expect("profile identity deserializes"),
-            identity
+            profile
+                .verify_runtime_tools(&[ASK_USER_QUESTION_TOOL, WORKSPACE_CHECKPOINT_CREATE_TOOL]),
+            Ok(())
         );
+        for drifted in [
+            &[][..],
+            &[ASK_USER_QUESTION_TOOL][..],
+            &[WORKSPACE_CHECKPOINT_CREATE_TOOL][..],
+            &[WORKSPACE_CHECKPOINT_CREATE_TOOL, ASK_USER_QUESTION_TOOL][..],
+            &[
+                ASK_USER_QUESTION_TOOL,
+                WORKSPACE_CHECKPOINT_CREATE_TOOL,
+                "workspace_checkpoint_rollback",
+            ][..],
+            &[ASK_USER_QUESTION_TOOL, "workspace_checkpoint"][..],
+        ] {
+            assert_eq!(
+                profile.verify_runtime_tools(drifted),
+                Err(CapabilityProfileVerificationError::RuntimeToolInventoryMismatch)
+            );
+        }
+    }
+
+    #[test]
+    fn profile_identity_uses_canonical_wire_names() {
+        for (profile, name, digest) in [
+            (
+                GatewayCapabilityProfile::task_only_v1(),
+                TASK_ONLY_V1_PROFILE,
+                TASK_ONLY_V1_MANIFEST_DIGEST,
+            ),
+            (
+                GatewayCapabilityProfile::workspace_checkpoint_v1(),
+                WORKSPACE_CHECKPOINT_V1_PROFILE,
+                WORKSPACE_CHECKPOINT_V1_MANIFEST_DIGEST,
+            ),
+        ] {
+            let identity = profile.identity();
+            let encoded = serde_json::to_value(&identity).expect("profile identity serializes");
+
+            assert_eq!(encoded["profile_id"], name);
+            assert_eq!(encoded["manifest_digest"], digest);
+            assert_eq!(
+                serde_json::from_value::<GatewayCapabilityProfileIdentity>(encoded)
+                    .expect("profile identity deserializes"),
+                identity
+            );
+        }
     }
 }

--- a/src/cosh-ng/crates/cosh-gateway/src/capability.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/capability.rs
@@ -4,6 +4,7 @@ mod approval;
 mod broker;
 mod execution;
 mod memory;
+mod provider;
 
 pub use approval::{
     BrokeredApprovalBinding, DurableApprovalCoordinator, DurableApprovalError,
@@ -20,3 +21,4 @@ pub use execution::{
     SecurityAuditError, SecurityAuditGate,
 };
 pub use memory::MemoryPermitStore;
+pub use provider::{SealedCapabilityProviderRegistry, SealedProviderAdmissionError};

--- a/src/cosh-ng/crates/cosh-gateway/src/capability/provider.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/capability/provider.rs
@@ -1,0 +1,115 @@
+//! Sealed side-effect provider registry admitted by trusted configuration.
+//!
+//! The registry is the single place where an admitted capability profile is
+//! matched against the real execution targets an instance owns, and therefore the
+//! only boundary at which an instance gains side-effect authority.
+//!
+//! Production configuration reaches exactly one shape: an instance with no
+//! provider. No execution target exists here yet, so this registry is where a
+//! requested provider is refused rather than resolved.
+
+use cosh_gateway_contracts::profile::{
+    CapabilityProfileVerificationError, CapabilityProviderId, GatewayCapabilityProfile,
+};
+use thiserror::Error;
+
+/// Fail-closed failure raised before an instance owns any side-effect authority.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SealedProviderAdmissionError {
+    /// Configuration admitted a provider set the profile does not seal.
+    #[error(transparent)]
+    ProviderSet(#[from] CapabilityProfileVerificationError),
+    /// The checkpoint provider cannot yet be granted side-effect authority.
+    ///
+    /// The ws-ckpt checkpoint request is not identity-only: its dispatch path
+    /// unconditionally runs workspace auto-initialization first, and the
+    /// workspace identity a request carries is resolved as a relative path when
+    /// its registration has disappeared. A checkpoint-create permit could
+    /// therefore cause workspace registration, subvolume adoption, a directory
+    /// move, or a symlink removal — none of which that permit grants, and none of
+    /// which the Gateway can undo or bound after the fact.
+    #[error("ws-ckpt checkpoint requests are not identity-only; provider admission is withheld")]
+    CheckpointProviderWithheld,
+}
+
+/// Complete set of side-effect providers one Gateway instance may reach.
+pub struct SealedCapabilityProviderRegistry {
+    profile: GatewayCapabilityProfile,
+    providers: Vec<CapabilityProviderId>,
+}
+
+impl SealedCapabilityProviderRegistry {
+    /// Admits the exact provider set sealed into one capability profile.
+    ///
+    /// `requested` is the provider set trusted per-instance configuration asks
+    /// for. A Task-only instance that requests a provider is rejected instead of
+    /// widened: an installed ws-ckpt daemon is never authority on its own.
+    ///
+    /// Checkpoint provider admission is **withheld** for every profile, and no
+    /// checkpoint execution target exists in this crate. The ws-ckpt protocol has
+    /// no identity-only checkpoint request, so issuing one can make the daemon
+    /// mutate the host outside the authority a checkpoint-create permit grants.
+    /// Admission is refused here, at the boundary where an instance would gain that
+    /// authority. Lifting it requires a checkpoint request that resolves a workspace
+    /// identity strictly and never auto-initializes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a provider-set mismatch when the requested set differs from the set
+    /// the profile seals, and
+    /// [`SealedProviderAdmissionError::CheckpointProviderWithheld`] whenever a
+    /// checkpoint provider is requested by a profile that seals it.
+    pub fn admit(
+        profile: GatewayCapabilityProfile,
+        requested: &[CapabilityProviderId],
+    ) -> Result<Self, SealedProviderAdmissionError> {
+        // Verify the sealed set first so a Task-only instance reports the narrower
+        // provider-set mismatch rather than the withheld decision.
+        profile.verify_providers(requested)?;
+        if requested.contains(&CapabilityProviderId::WsCkpt) {
+            return Err(SealedProviderAdmissionError::CheckpointProviderWithheld);
+        }
+
+        Ok(Self {
+            profile,
+            providers: requested.to_vec(),
+        })
+    }
+
+    /// Admits the empty provider set required by a portable Task-only instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns a provider-set mismatch when the profile seals a provider.
+    pub fn task_only(
+        profile: GatewayCapabilityProfile,
+    ) -> Result<Self, SealedProviderAdmissionError> {
+        Self::admit(profile, &[])
+    }
+
+    /// Returns the canonical admitted capability profile.
+    #[must_use]
+    pub const fn profile(&self) -> GatewayCapabilityProfile {
+        self.profile
+    }
+
+    /// Returns the exact ordered provider set admitted for this instance.
+    #[must_use]
+    pub fn providers(&self) -> &[CapabilityProviderId] {
+        &self.providers
+    }
+}
+
+impl std::fmt::Debug for SealedCapabilityProviderRegistry {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SealedCapabilityProviderRegistry")
+            .field("profile", &self.profile.id())
+            .field("providers", &self.providers)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+#[path = "provider/tests.rs"]
+mod tests;

--- a/src/cosh-ng/crates/cosh-gateway/src/capability/provider/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/capability/provider/tests.rs
@@ -1,0 +1,112 @@
+use cosh_gateway_contracts::profile::GatewayCapabilityProfileId;
+
+use super::*;
+
+/// Every profile an instance may configure, with the provider set it seals.
+fn profiles() -> [(GatewayCapabilityProfile, &'static [CapabilityProviderId]); 2] {
+    [
+        (GatewayCapabilityProfile::task_only_v1(), &[]),
+        (
+            GatewayCapabilityProfile::workspace_checkpoint_v1(),
+            &[CapabilityProviderId::WsCkpt],
+        ),
+    ]
+}
+
+#[test]
+fn task_only_instance_admits_an_empty_provider_set() {
+    let registry =
+        SealedCapabilityProviderRegistry::task_only(GatewayCapabilityProfile::task_only_v1())
+            .expect("a Task-only instance needs no provider");
+
+    assert_eq!(registry.profile(), GatewayCapabilityProfile::task_only_v1());
+    assert_eq!(registry.providers(), []);
+}
+
+#[test]
+fn task_only_instance_starts_without_any_ws_ckpt_configuration() {
+    // Nothing about ws-ckpt is consulted here, which is exactly the portable
+    // Task-only deployment: no socket, no directory, no daemon.
+    let registry =
+        SealedCapabilityProviderRegistry::admit(GatewayCapabilityProfile::task_only_v1(), &[])
+            .expect("a Task-only instance starts with no checkpoint dependency");
+
+    assert_eq!(registry.providers(), []);
+}
+
+#[test]
+fn task_only_instance_rejects_a_requested_checkpoint_provider() {
+    let error = SealedCapabilityProviderRegistry::admit(
+        GatewayCapabilityProfile::task_only_v1(),
+        &[CapabilityProviderId::WsCkpt],
+    )
+    .expect_err("an installed provider is not authority for a Task-only instance");
+
+    // The narrower sealed-set mismatch is reported before the withheld decision.
+    assert_eq!(
+        error,
+        SealedProviderAdmissionError::ProviderSet(
+            CapabilityProfileVerificationError::ProviderSetMismatch
+        )
+    );
+}
+
+/// The checkpoint provider is withheld even for the profile that seals it.
+///
+/// ws-ckpt has no identity-only checkpoint request, so a checkpoint-create permit
+/// could cause workspace registration. Admission is refused at this boundary
+/// rather than letting an adapter attempt to bound an effect it cannot undo.
+#[test]
+fn checkpoint_provider_admission_is_withheld_until_requests_are_identity_only() {
+    let error = SealedCapabilityProviderRegistry::admit(
+        GatewayCapabilityProfile::workspace_checkpoint_v1(),
+        &[CapabilityProviderId::WsCkpt],
+    )
+    .expect_err("checkpoint side-effect authority is not granted yet");
+
+    assert_eq!(
+        error,
+        SealedProviderAdmissionError::CheckpointProviderWithheld
+    );
+}
+
+#[test]
+fn checkpoint_instance_rejects_a_missing_provider() {
+    let error = SealedCapabilityProviderRegistry::admit(
+        GatewayCapabilityProfile::workspace_checkpoint_v1(),
+        &[],
+    )
+    .expect_err("an unavailable provider must refuse admission");
+
+    assert_eq!(
+        error,
+        SealedProviderAdmissionError::ProviderSet(
+            CapabilityProfileVerificationError::ProviderSetMismatch
+        )
+    );
+}
+
+/// No profile and no requested set yields side-effect authority.
+///
+/// This enumerates every reachable admission outcome. No checkpoint execution
+/// target exists in this crate, so there is no other path to cover.
+#[test]
+fn no_instance_can_obtain_checkpoint_side_effect_authority() {
+    for (profile, sealed) in profiles() {
+        for requested in [&[][..], &[CapabilityProviderId::WsCkpt][..]] {
+            match SealedCapabilityProviderRegistry::admit(profile, requested) {
+                Ok(registry) => {
+                    assert_eq!(profile.id(), GatewayCapabilityProfileId::TaskOnlyV1);
+                    assert_eq!(registry.providers(), []);
+                }
+                Err(SealedProviderAdmissionError::CheckpointProviderWithheld) => {
+                    assert_eq!(sealed, [CapabilityProviderId::WsCkpt]);
+                    assert_eq!(requested, [CapabilityProviderId::WsCkpt]);
+                }
+                Err(SealedProviderAdmissionError::ProviderSet(_)) => {
+                    assert_ne!(requested, sealed);
+                }
+            }
+        }
+    }
+}

--- a/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
+++ b/src/cosh-ng/crates/cosh-platform/src/checkpoint.rs
@@ -2,7 +2,7 @@
 //!
 //! Wire format: [4-byte LE length prefix][bincode payload]
 
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::Duration;
@@ -36,10 +36,59 @@ enum ProtocolFailure {
     UnexpectedResponse,
 }
 
+/// Whether a failed ws-ckpt request may already have changed daemon state.
+///
+/// A governed caller must never retry a `PossiblyApplied` request. It has to
+/// reconcile against durable daemon evidence or record an uncertain outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CkptRequestEffect {
+    /// The daemon provably did not apply the request.
+    KnownNoEffect,
+    /// The request may have been applied, but its result cannot be proven.
+    PossiblyApplied,
+}
+
+/// Failed ws-ckpt request together with its side-effect classification.
+#[derive(Debug)]
+pub struct CkptRequestFailure {
+    /// Whether daemon state may already have changed.
+    pub effect: CkptRequestEffect,
+    /// Redacted failure suitable for audit and presentation.
+    pub error: CoshError,
+}
+
+impl CkptRequestFailure {
+    fn known_no_effect(error: CoshError) -> Self {
+        Self {
+            effect: CkptRequestEffect::KnownNoEffect,
+            error,
+        }
+    }
+
+    fn possibly_applied(error: CoshError) -> Self {
+        Self {
+            effect: CkptRequestEffect::PossiblyApplied,
+            error,
+        }
+    }
+}
+
+/// Exact durable evidence for one snapshot identity in one workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CkptSnapshotEvidence {
+    /// Snapshot identity reported by the daemon index.
+    pub snapshot_id: String,
+    /// Workspace registration path reported verbatim by the daemon.
+    pub workspace: String,
+    /// Whether the daemon index knows the snapshot data is no longer present.
+    pub missing: bool,
+}
+
 /// Client for ws-ckpt daemon IPC.
 pub struct CkptClient {
     socket_path: String,
     timeout_ms: u64,
+    trusted_peer_uid: Option<u32>,
 }
 
 impl CkptClient {
@@ -48,6 +97,7 @@ impl CkptClient {
         Self {
             socket_path: socket_path.to_string(),
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            trusted_peer_uid: None,
         }
     }
 
@@ -56,12 +106,28 @@ impl CkptClient {
         Self {
             socket_path: socket_path.to_string(),
             timeout_ms,
+            trusted_peer_uid: None,
         }
     }
 
     /// Create a new client using the default socket path.
     pub fn default_path() -> Self {
         Self::new(DEFAULT_SOCKET_PATH)
+    }
+
+    /// Require every connection to authenticate as root or `owner_uid`.
+    ///
+    /// Path metadata alone cannot secure a socket: another principal may swap a
+    /// verified directory between the check and `connect`. Kernel peer
+    /// credentials are read after connecting and before any request byte is
+    /// written, so an impostor listener is rejected with no possible effect.
+    /// [`Self::create_classified`] and [`Self::find_snapshot`] reject the client
+    /// before socket access unless this configuration is present; legacy
+    /// operations retain their existing optional-authentication behavior.
+    #[must_use]
+    pub fn require_trusted_peer(mut self, owner_uid: u32) -> Self {
+        self.trusted_peer_uid = Some(owner_uid);
+        self
     }
 
     /// Check if the daemon socket exists (basic health check).
@@ -127,6 +193,110 @@ impl CkptClient {
                 reason: Some(reason),
             }),
             WsCkptResponse::Error { code, message } => Err(ws_error_to_cosh(code, message)),
+            _ => Err(unexpected_response()),
+        }
+    }
+
+    /// Create a workspace checkpoint, classifying failures by possible effect.
+    ///
+    /// Governed callers use this instead of [`Self::create`] because a lost
+    /// response must not be replayed. Only a failure raised before any request
+    /// byte reaches the kernel is `KnownNoEffect`. Every failure after that,
+    /// including a daemon-reported error code, is `PossiblyApplied` so the caller
+    /// reconciles or records an uncertain outcome.
+    ///
+    /// # Errors
+    ///
+    /// Returns `KnownNoEffect` when trusted-peer authentication was not
+    /// configured, or a classified transport, protocol, or daemon failure.
+    pub fn create_classified(
+        &self,
+        workspace: &str,
+        id: &str,
+        message: Option<&str>,
+        metadata: Option<&str>,
+        pin: bool,
+    ) -> Result<CkptCreated, CkptRequestFailure> {
+        let owner_uid = self
+            .governed_peer_uid()
+            .map_err(CkptRequestFailure::known_no_effect)?;
+        let req = WsCkptRequest::Checkpoint {
+            workspace: workspace.to_string(),
+            id: id.to_string(),
+            message: message.map(|s| s.to_string()),
+            metadata: metadata.map(|s| s.to_string()),
+            pin,
+        };
+        match self.send_request_classified_with_peer(&req, Some(owner_uid))? {
+            WsCkptResponse::CheckpointOk { snapshot_id } => Ok(CkptCreated {
+                snapshot_id: Some(snapshot_id),
+                workspace: workspace.to_string(),
+                skipped: false,
+                reason: None,
+            }),
+            WsCkptResponse::CheckpointSkipped { reason } => Ok(CkptCreated {
+                snapshot_id: None,
+                workspace: workspace.to_string(),
+                skipped: true,
+                reason: Some(reason),
+            }),
+            // A daemon error proves no snapshot was created, but not that daemon
+            // state is unchanged. The checkpoint dispatch path auto-initializes
+            // the workspace first, so registration, subvolume adoption, or a
+            // broken-symlink removal may already have happened before the code
+            // was produced. No response code is treated as proven no-effect
+            // until the protocol supplies an explicit pre-effect guarantee.
+            WsCkptResponse::Error { code, message: _ } => {
+                Err(CkptRequestFailure::possibly_applied(ws_error_to_cosh(
+                    code,
+                    "ws-ckpt daemon rejected the checkpoint request".to_owned(),
+                )))
+            }
+            // An unexpected variant means this client's model of the daemon is
+            // wrong, so no-effect cannot be claimed.
+            _ => Err(CkptRequestFailure::possibly_applied(unexpected_response())),
+        }
+    }
+
+    /// Look up exact durable evidence for one snapshot ID in one workspace.
+    ///
+    /// This is the read-only reconcile query for a checkpoint whose response was
+    /// lost. It reuses the existing workspace-scoped listing and matches the
+    /// snapshot identity exactly, so it never probes by creating a second
+    /// snapshot. `Ok(None)` means the daemon index does not list the identity,
+    /// which is not proof that no snapshot exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns a permission error when trusted-peer authentication was not
+    /// configured, or a transport, protocol, or daemon-reported failure. Any
+    /// error leaves the reconciled outcome unproven.
+    pub fn find_snapshot(
+        &self,
+        workspace: &str,
+        id: &str,
+    ) -> Result<Option<CkptSnapshotEvidence>, CoshError> {
+        let owner_uid = self.governed_peer_uid()?;
+        let req = WsCkptRequest::List {
+            workspace: Some(workspace.to_string()),
+            format: None,
+        };
+        match self
+            .send_request_classified_with_peer(&req, Some(owner_uid))
+            .map_err(|failure| failure.error)?
+        {
+            WsCkptResponse::ListOk { snapshots } => Ok(snapshots
+                .into_iter()
+                .find(|entry| entry.id == id)
+                .map(|entry| CkptSnapshotEvidence {
+                    snapshot_id: entry.id,
+                    workspace: entry.workspace,
+                    missing: entry.meta.missing,
+                })),
+            WsCkptResponse::Error { code, message: _ } => Err(ws_error_to_cosh(
+                code,
+                "ws-ckpt daemon rejected the checkpoint evidence query".to_owned(),
+            )),
             _ => Err(unexpected_response()),
         }
     }
@@ -248,60 +418,165 @@ impl CkptClient {
     /// Send a request and receive a response over the Unix socket.
     /// Wire format: [4-byte LE length prefix][bincode payload]
     fn send_request(&self, req: &WsCkptRequest) -> Result<WsCkptResponse, CoshError> {
+        self.send_request_classified(req)
+            .map_err(|failure| failure.error)
+    }
+
+    /// Send a request, reporting whether a failure may already have taken effect.
+    ///
+    /// Only failures raised strictly before any request byte reaches the kernel
+    /// are `KnownNoEffect`. Once a byte is handed over, this client does not
+    /// assume the daemon discards a truncated frame, so the outcome is
+    /// `PossiblyApplied` until the caller proves otherwise.
+    fn send_request_classified(
+        &self,
+        req: &WsCkptRequest,
+    ) -> Result<WsCkptResponse, CkptRequestFailure> {
+        self.send_request_classified_with_peer(req, self.trusted_peer_uid)
+    }
+
+    fn governed_peer_uid(&self) -> Result<u32, CoshError> {
+        self.trusted_peer_uid
+            .ok_or_else(trusted_peer_configuration_error)
+    }
+
+    fn send_request_classified_with_peer(
+        &self,
+        req: &WsCkptRequest,
+        trusted_peer_uid: Option<u32>,
+    ) -> Result<WsCkptResponse, CkptRequestFailure> {
         // 1. Socket existence check — fast fail before attempting connection.
         if !Path::new(&self.socket_path).exists() {
-            return Err(CoshError::new(
-                ErrorCode::CheckpointDaemonUnavailable,
-                "ws-ckpt daemon socket is unavailable",
-                "checkpoint",
-            )
-            .with_hint("Start daemon with: systemctl start ws-ckpt")
-            .recoverable(true));
+            return Err(CkptRequestFailure::known_no_effect(
+                CoshError::new(
+                    ErrorCode::CheckpointDaemonUnavailable,
+                    "ws-ckpt daemon socket is unavailable",
+                    "checkpoint",
+                )
+                .with_hint("Start daemon with: systemctl start ws-ckpt")
+                .recoverable(true),
+            ));
         }
 
         // 2. Connect to Unix socket.
-        let mut stream = UnixStream::connect(&self.socket_path)
-            .map_err(|error| classify_io_error(error, IoPhase::Connect))?;
+        let mut stream = UnixStream::connect(&self.socket_path).map_err(|error| {
+            CkptRequestFailure::known_no_effect(classify_io_error(error, IoPhase::Connect))
+        })?;
+
+        // 2a. Authenticate the connected peer before writing anything. This is
+        //     what actually defeats a directory or socket swap racing the
+        //     caller's path checks.
+        if let Some(owner_uid) = trusted_peer_uid {
+            verify_peer_credentials(&stream, owner_uid)
+                .map_err(CkptRequestFailure::known_no_effect)?;
+        }
 
         // 3. Apply configurable timeout to both read and write.
         let timeout = Duration::from_millis(self.timeout_ms);
         stream.set_read_timeout(Some(timeout)).ok();
         stream.set_write_timeout(Some(timeout)).ok();
 
-        // 4. Encode and send the request frame.
-        let frame = encode_frame(req)?;
-        stream
-            .write_all(&frame)
-            .map_err(|error| classify_io_error(error, IoPhase::WriteRequest))?;
+        // 4. Encode and send the request frame, tracking how much was handed over.
+        let frame = encode_frame(req).map_err(CkptRequestFailure::known_no_effect)?;
+        write_request_frame(&mut stream, &frame)?;
 
         // 5. Read response length prefix (4 bytes, little-endian).
         let mut len_buf = [0u8; 4];
         stream.read_exact(&mut len_buf).map_err(|error| {
-            if error.kind() == std::io::ErrorKind::UnexpectedEof {
+            CkptRequestFailure::possibly_applied(if error.kind() == ErrorKind::UnexpectedEof {
                 protocol_error(ProtocolFailure::TruncatedLength)
             } else {
                 classify_io_error(error, IoPhase::ReadResponseLength)
-            }
+            })
         })?;
         let resp_len = u32::from_le_bytes(len_buf) as usize;
 
         if resp_len > MAX_RESPONSE_LEN {
-            return Err(protocol_error(ProtocolFailure::OversizedLength));
+            return Err(CkptRequestFailure::possibly_applied(protocol_error(
+                ProtocolFailure::OversizedLength,
+            )));
         }
 
         // 6. Read response payload.
         let mut resp_buf = vec![0u8; resp_len];
         stream.read_exact(&mut resp_buf).map_err(|error| {
-            if error.kind() == std::io::ErrorKind::UnexpectedEof {
+            CkptRequestFailure::possibly_applied(if error.kind() == ErrorKind::UnexpectedEof {
                 protocol_error(ProtocolFailure::TruncatedPayload)
             } else {
                 classify_io_error(error, IoPhase::ReadResponsePayload)
-            }
+            })
         })?;
 
         // 7. Decode response.
-        decode_response(&resp_buf)
+        decode_response(&resp_buf).map_err(CkptRequestFailure::possibly_applied)
     }
+}
+
+/// Writes the complete request frame, classifying a partial write as applied.
+fn write_request_frame(stream: &mut UnixStream, frame: &[u8]) -> Result<(), CkptRequestFailure> {
+    let mut written = 0;
+    while written < frame.len() {
+        // A partial write leaves the peer holding an undecodable prefix. This
+        // client does not depend on the daemon's framing to discard it, so any
+        // transferred byte forfeits the known-no-effect classification.
+        let classify = |error| {
+            if written == 0 {
+                CkptRequestFailure::known_no_effect(error)
+            } else {
+                CkptRequestFailure::possibly_applied(error)
+            }
+        };
+        match stream.write(&frame[written..]) {
+            Ok(0) => {
+                return Err(classify(classify_io_error(
+                    std::io::Error::from(ErrorKind::WriteZero),
+                    IoPhase::WriteRequest,
+                )))
+            }
+            Ok(count) => written = written.saturating_add(count),
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) => return Err(classify(classify_io_error(error, IoPhase::WriteRequest))),
+        }
+    }
+    Ok(())
+}
+
+/// Rejects a connected peer that is neither root nor the expected owner.
+#[cfg(target_os = "linux")]
+fn verify_peer_credentials(stream: &UnixStream, owner_uid: u32) -> Result<(), CoshError> {
+    use nix::sys::socket::{getsockopt, sockopt::PeerCredentials};
+
+    let credentials = getsockopt(stream, PeerCredentials).map_err(|_| peer_error())?;
+    if credentials.uid() == 0 || credentials.uid() == owner_uid {
+        Ok(())
+    } else {
+        Err(peer_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn verify_peer_credentials(_stream: &UnixStream, _owner_uid: u32) -> Result<(), CoshError> {
+    // Without kernel peer credentials a governed caller cannot authenticate the
+    // daemon, so requiring a trusted peer fails closed instead of degrading.
+    Err(peer_error())
+}
+
+fn peer_error() -> CoshError {
+    CoshError::new(
+        ErrorCode::PermissionDenied,
+        "ws-ckpt daemon peer is not a trusted principal",
+        "checkpoint",
+    )
+    .with_hint("Verify that ws-ckpt is running as root or as the Gateway owner")
+}
+
+fn trusted_peer_configuration_error() -> CoshError {
+    CoshError::new(
+        ErrorCode::PermissionDenied,
+        "governed checkpoint request requires trusted peer authentication",
+        "checkpoint",
+    )
+    .with_hint("Configure the client with require_trusted_peer(owner_uid)")
 }
 
 // ---------------------------------------------------------------------------
@@ -446,7 +721,22 @@ mod tests {
     use std::os::unix::net::UnixListener;
     use std::thread;
 
+    #[cfg(target_os = "linux")]
+    use std::fs;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::process::CommandExt;
+    #[cfg(target_os = "linux")]
+    use std::process::{Command, Stdio};
+    #[cfg(target_os = "linux")]
+    use std::time::Duration;
+
     use super::*;
+
+    fn trusted_client(socket_path: &str) -> CkptClient {
+        CkptClient::new(socket_path).require_trusted_peer(nix::unistd::Uid::effective().as_raw())
+    }
 
     fn send_fake_response(response: Vec<u8>) -> (CoshError, String) {
         let directory = tempfile::tempdir().unwrap();
@@ -603,6 +893,357 @@ mod tests {
                 "skipped": false,
                 "reason": null,
             })
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn spawn_silent_daemon() -> (tempfile::TempDir, String, thread::JoinHandle<()>) {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("ws-ckpt.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut len_buf = [0_u8; 4];
+            stream.read_exact(&mut len_buf).unwrap();
+            let mut request = vec![0_u8; u32::from_le_bytes(len_buf) as usize];
+            stream.read_exact(&mut request).unwrap();
+            // Accept the complete request and then vanish without answering.
+            drop(stream);
+        });
+
+        let socket_path = socket_path.to_string_lossy().into_owned();
+        (dir, socket_path, handle)
+    }
+
+    #[test]
+    fn missing_socket_create_is_known_no_effect() {
+        let client = trusted_client("/tmp/absent-ws-ckpt-classified.sock");
+
+        let failure = client
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+
+        assert_eq!(failure.effect, CkptRequestEffect::KnownNoEffect);
+        assert_eq!(failure.error.code, ErrorCode::CheckpointDaemonUnavailable);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn lost_response_after_full_write_is_possibly_applied() {
+        let (_dir, socket_path, daemon) = spawn_silent_daemon();
+        let client = trusted_client(&socket_path);
+
+        let failure = client
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+        daemon.join().unwrap();
+
+        assert_eq!(failure.effect, CkptRequestEffect::PossiblyApplied);
+        assert_eq!(failure.error.code, ErrorCode::CheckpointProtocolError);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn truncated_response_payload_is_possibly_applied() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("ws-ckpt.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let daemon = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut len_buf = [0_u8; 4];
+            stream.read_exact(&mut len_buf).unwrap();
+            let mut request = vec![0_u8; u32::from_le_bytes(len_buf) as usize];
+            stream.read_exact(&mut request).unwrap();
+            stream.write_all(&64_u32.to_le_bytes()).unwrap();
+            stream.write_all(&[1, 2, 3]).unwrap();
+        });
+        let socket_path = socket_path.to_string_lossy().into_owned();
+
+        let failure = trusted_client(&socket_path)
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+        daemon.join().unwrap();
+
+        assert_eq!(failure.effect, CkptRequestEffect::PossiblyApplied);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unexpected_response_variant_is_possibly_applied() {
+        let (_dir, socket_path, daemon) = spawn_one_shot_daemon(WsCkptResponse::RecoverOk {
+            workspace: "/tmp/ws".into(),
+        });
+
+        let failure = trusted_client(&socket_path)
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+        daemon.join().unwrap();
+
+        assert_eq!(failure.effect, CkptRequestEffect::PossiblyApplied);
+        assert_eq!(failure.error.code, ErrorCode::CheckpointProtocolError);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn every_daemon_reported_error_is_possibly_applied() {
+        // The checkpoint dispatch path auto-initializes the workspace before it
+        // attempts a snapshot, so registration, subvolume adoption, or a
+        // broken-symlink removal may precede any of these codes. None of them
+        // proves daemon state is unchanged.
+        for code in [
+            WsCkptErrorCode::WorkspaceNotFound,
+            WsCkptErrorCode::SnapshotAlreadyExists,
+            WsCkptErrorCode::WriteLockConflict,
+            WsCkptErrorCode::InvalidPath,
+            WsCkptErrorCode::IoError,
+            WsCkptErrorCode::BtrfsError,
+            WsCkptErrorCode::InternalError,
+            WsCkptErrorCode::DiskSpaceInsufficient,
+            WsCkptErrorCode::SnapshotNotFound,
+            WsCkptErrorCode::AlreadyInitialized,
+            WsCkptErrorCode::ConfirmationRequired,
+            WsCkptErrorCode::CwdOccupied,
+            WsCkptErrorCode::CwdScanFailed,
+        ] {
+            let daemon_message = format!(
+                "/secret/workspace\n\u{1b}[31m{}",
+                "daemon-controlled-data".repeat(4096)
+            );
+            let (_dir, socket_path, daemon) = spawn_one_shot_daemon(WsCkptResponse::Error {
+                code: code.clone(),
+                message: daemon_message,
+            });
+
+            let failure = trusted_client(&socket_path)
+                .create_classified("/tmp/ws", "ckp_1", None, None, false)
+                .unwrap_err();
+            daemon.join().unwrap();
+
+            assert_eq!(
+                failure.effect,
+                CkptRequestEffect::PossiblyApplied,
+                "{code:?} must fail closed"
+            );
+            assert_eq!(
+                failure.error.message,
+                "ws-ckpt daemon rejected the checkpoint request"
+            );
+            assert!(failure.error.message.len() < 128);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_untrusted_peer_is_rejected_as_known_no_effect() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o777)).unwrap();
+        let socket_path = directory.path().join("untrusted.sock");
+
+        // A root peer is always trusted in production, regardless of the
+        // configured owner. Run the listener under a different kernel UID so
+        // this remains a real negative test when the suite itself runs as root.
+        let helper_exe = directory.path().join("untrusted-peer-helper");
+        fs::copy(std::env::current_exe().unwrap(), &helper_exe).unwrap();
+        fs::set_permissions(&helper_exe, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut command = Command::new(&helper_exe);
+        command
+            .arg("--exact")
+            .arg("checkpoint::tests::untrusted_peer_daemon_helper")
+            .arg("--nocapture")
+            .env("COSH_TEST_UNTRUSTED_PEER_SOCKET", &socket_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let test_uid = nix::unistd::Uid::effective().as_raw();
+        if test_uid == 0 {
+            command.uid(65_534);
+        }
+        let mut daemon = command.spawn().unwrap();
+        for _ in 0..100 {
+            if socket_path.exists() {
+                break;
+            }
+            assert!(daemon.try_wait().unwrap().is_none());
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(socket_path.exists());
+
+        let trusted_owner = if test_uid == 0 {
+            0
+        } else {
+            test_uid.wrapping_add(1)
+        };
+
+        let socket_path_string = socket_path.to_string_lossy().into_owned();
+        let failure = CkptClient::new(&socket_path_string)
+            .require_trusted_peer(trusted_owner)
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+
+        assert_eq!(failure.effect, CkptRequestEffect::KnownNoEffect);
+        assert_eq!(failure.error.code, ErrorCode::PermissionDenied);
+        assert!(daemon.wait().unwrap().success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn untrusted_peer_daemon_helper() {
+        let Ok(socket_path) = std::env::var("COSH_TEST_UNTRUSTED_PEER_SOCKET") else {
+            return;
+        };
+        let listener = UnixListener::bind(socket_path).unwrap();
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut byte = [0_u8; 1];
+        assert_eq!(stream.read(&mut byte).unwrap(), 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_trusted_peer_is_accepted() {
+        let (_dir, socket_path, daemon) = spawn_one_shot_daemon(WsCkptResponse::CheckpointOk {
+            snapshot_id: "snap-1".into(),
+        });
+        let owner = nix::unistd::Uid::effective().as_raw();
+
+        let created = CkptClient::new(&socket_path)
+            .require_trusted_peer(owner)
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap();
+        daemon.join().unwrap();
+
+        assert_eq!(created.snapshot_id.as_deref(), Some("snap-1"));
+    }
+
+    #[test]
+    fn missing_auth_create_refuses_before_socket_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("ws-ckpt.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+
+        let failure = CkptClient::new(socket_path.to_str().unwrap())
+            .create_classified("/tmp/ws", "ckp_1", None, None, false)
+            .unwrap_err();
+
+        assert_eq!(failure.effect, CkptRequestEffect::KnownNoEffect);
+        assert_eq!(failure.error.code, ErrorCode::PermissionDenied);
+        assert!(failure.error.message.contains("requires trusted peer"));
+        assert_eq!(listener.accept().unwrap_err().kind(), ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn missing_auth_find_refuses_before_socket_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("ws-ckpt.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+
+        let error = CkptClient::new(socket_path.to_str().unwrap())
+            .find_snapshot("/tmp/ws", "ckp_1")
+            .unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::PermissionDenied);
+        assert!(error.message.contains("requires trusted peer"));
+        assert_eq!(listener.accept().unwrap_err().kind(), ErrorKind::WouldBlock);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn governed_operations_fail_closed_when_peer_authentication_is_unavailable() {
+        let exercise = |operation: fn(&CkptClient) -> Result<(), CoshError>| {
+            let dir = tempfile::tempdir().unwrap();
+            let socket_path = dir.path().join("ws-ckpt.sock");
+            let listener = UnixListener::bind(&socket_path).unwrap();
+            let daemon = thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut byte = [0_u8; 1];
+                assert_eq!(stream.read(&mut byte).unwrap(), 0);
+            });
+            let client = CkptClient::new(socket_path.to_str().unwrap()).require_trusted_peer(0);
+
+            let error = operation(&client).unwrap_err();
+            daemon.join().unwrap();
+
+            assert_eq!(error.code, ErrorCode::PermissionDenied);
+        };
+
+        exercise(|client| {
+            client
+                .create_classified("/tmp/ws", "ckp_1", None, None, false)
+                .map(|_| ())
+                .map_err(|failure| {
+                    assert_eq!(failure.effect, CkptRequestEffect::KnownNoEffect);
+                    failure.error
+                })
+        });
+        exercise(|client| client.find_snapshot("/tmp/ws", "ckp_1").map(|_| ()));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_snapshot_preserves_reported_workspace_and_matches_exact_identity() {
+        let entry = |id: &str, missing: bool| SnapshotEntry {
+            id: id.to_owned(),
+            workspace: "/registered/../workspace".to_owned(),
+            meta: SnapshotMeta {
+                message: None,
+                metadata: None,
+                pinned: false,
+                created_at: chrono::Utc::now(),
+                missing,
+                parent_id: None,
+                child_ids: Vec::new(),
+            },
+        };
+        let (_dir, socket_path, daemon) = spawn_one_shot_daemon(WsCkptResponse::ListOk {
+            snapshots: vec![entry("ckp_other", false), entry("ckp_wanted", true)],
+        });
+
+        let evidence = trusted_client(&socket_path)
+            .find_snapshot("/tmp/ws", "ckp_wanted")
+            .unwrap();
+        daemon.join().unwrap();
+
+        assert_eq!(
+            evidence,
+            Some(CkptSnapshotEvidence {
+                snapshot_id: "ckp_wanted".to_owned(),
+                workspace: "/registered/../workspace".to_owned(),
+                missing: true,
+            })
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_snapshot_reports_absent_identity_without_error() {
+        let (_dir, socket_path, daemon) =
+            spawn_one_shot_daemon(WsCkptResponse::ListOk { snapshots: vec![] });
+
+        let evidence = trusted_client(&socket_path)
+            .find_snapshot("/tmp/ws", "ckp_wanted")
+            .unwrap();
+        daemon.join().unwrap();
+
+        assert_eq!(evidence, None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_snapshot_propagates_a_daemon_error() {
+        let (_dir, socket_path, daemon) = spawn_one_shot_daemon(WsCkptResponse::Error {
+            code: WsCkptErrorCode::WorkspaceNotFound,
+            message: "/secret/workspace\n\u{1b}[31mdaemon rejection".into(),
+        });
+
+        let error = trusted_client(&socket_path)
+            .find_snapshot("/tmp/ws", "ckp_wanted")
+            .unwrap_err();
+        daemon.join().unwrap();
+
+        assert_eq!(error.code, ErrorCode::CheckpointNotFound);
+        assert_eq!(
+            error.message,
+            "ws-ckpt daemon rejected the checkpoint evidence query"
         );
     }
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance.md
@@ -4,9 +4,9 @@
 
 ## Result
 
-**Overall: PARTIAL. Generic Broker foundations exist; Phase 1 does not pass.** The
-implementation worktree is based on
-`a6592234341a095b2b9446601642caa87314e2c5`.
+**Overall: PARTIAL. Generic Broker foundations exist, but no checkpoint execution target or
+ledger-side reconciliation ships; Phase 1 does not pass.** The implementation worktree is based on
+`a43ab81738d3f39721a425cef717a6147276fae9`.
 
 The foundational Broker logic validates Capability request expiry, authoritative Task, Run, complete Actor
 provenance, target, operation descriptor, complete operation digest, and requested scope before
@@ -18,11 +18,38 @@ This result is not a universal governance claim. The production `CoshBrokered`
 profile is bound to the pinned `task-only-v1` manifest and exposes
 `ask_user_question` only. The daemon, durable start intent, installed Core
 factory, and private v3 handshake verify the identity before execution or Task
-input. It has no production
-`ExecutionTarget` and no checkpoint/ws-ckpt dependency. Generic Capability,
+input, and that profile has no checkpoint/ws-ckpt dependency. Generic Capability,
 Permit, and Execution contracts/ledger rows remain future foundations. Shell,
 Skill, MCP, extension-tool, legacy CLI, and interactive Core mutation paths
 remain outside this boundary.
+
+## Optional profile and deferred checkpoint target result
+
+**Overall: CLOSED PROFILE AND SEALED PROVIDER SET VERIFIED; CHECKPOINT PROVIDER AUTHORITY WITHHELD;
+CHECKPOINT EXECUTION TARGET DEFERRED.** The Gateway owns a closed `workspace-checkpoint-v1` profile with
+a pinned canonical manifest and digest, a sealed one-provider set, and a `SealedCapabilityProviderRegistry`
+that refuses every requested checkpoint provider. `CkptClient` additionally gained effect classification, a
+read-only evidence query, and peer authentication.
+
+**No checkpoint execution target exists in this increment.** A `workspace_checkpoint_create` permit must
+authorize exactly one snapshot creation, and the ws-ckpt checkpoint request cannot be constrained to that:
+dispatch unconditionally runs workspace auto-initialization first, and a workspace identity whose
+registration disappeared between any pre-request query and the request is resolved as a relative path.
+Auto-initialization registers a workspace, can adopt a subvolume, moves a directory aside, creates a
+symlink, and removes a broken symlink. A checkpoint-create permit grants none of that; the Gateway cannot
+prevent it, because the query and the request are separate round trips, and cannot undo it. The target is
+therefore deferred rather than shipped behind a gate, which also keeps `cosh-gateway` depending only on the
+side-effect-free `cosh-gateway-contracts` leaf among internal crates.
+
+Two ws-ckpt protocol prerequisites are recorded for the deferred slice: a checkpoint request that resolves
+a workspace identity strictly and never auto-initializes, and a non-reusable workspace generation token
+validated atomically with checkpoint creation. The design document additionally records the socket-trust,
+workspace-representation, btrfs volume-identity, and generation constraints established while prototyping,
+so they do not have to be rediscovered.
+
+`serve`, the packaged systemd unit, the installed Core factory, the private Core v3 mirror, and the
+brokered execution driver are unchanged, so no Runtime can request or obtain a checkpoint. A
+checkpoint-enabled instance is not startable end to end, and no release may advertise governed checkpoints.
 
 The owner scope decision is therefore: Phase 1 criteria below apply to the enabled Gateway
 production profile only. Production `serve` and the library daemon admit only `core` /
@@ -45,9 +72,10 @@ stale-lease, cross-Task Run, generation-skip,
 approval-deadline widening, integer-overflow, idempotency-namespace, receipt-corruption, and atomic
 rollback fixtures.
 
-No checkpoint driver, ws-ckpt resolver, production target, or pre-effect
-execution loop is wired. Target resolution, durable permit issuance, audit
-gating, execution, and reconciliation remain future optional capability work.
+No checkpoint driver or pre-effect execution loop is wired to the durable ledger.
+Durable permit issuance, audit gating, and Runtime-visible checkpoint execution
+remain future work. No trusted configuration admits a checkpoint execution
+target, and no Task can reach one.
 
 ## Result vocabulary
 
@@ -68,7 +96,9 @@ gating, execution, and reconciliation remain future optional capability work.
 | [`memory.rs`](../../../../../crates/cosh-gateway/src/capability/memory.rs) | Holds permit validation and consumption under one mutex; mismatch, expiry, and replay fail closed |
 | [`memory/tests.rs`](../../../../../crates/cosh-gateway/src/capability/memory/tests.rs) | Covers parent and actor-provenance substitution, policy branches/failures, permit binding, mismatch, expiry/replay, and concurrent consumption |
 | [`capability.rs`](../../../../../crates/cosh-gateway-contracts/src/capability.rs) | Defines neutral request, decision, approval, and permit contracts with Actor/Task/Run/Execution/target/operation/policy/expiry bindings |
-| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | Pins the only admitted `task-only-v1` identity, canonical manifest digest, governed target, and exact `ask_user_question` Runtime inventory |
+| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | Pins the `task-only-v1` and `workspace-checkpoint-v1` identities, canonical manifest digests, governed targets, exact Runtime inventories, and sealed provider sets |
+| [`provider.rs`](../../../../../crates/cosh-gateway/src/capability/provider.rs) | Admits exactly the provider set a profile seals; rejects a requested provider on a Task-only instance and a missing provider on a checkpoint-enabled instance, and withholds the checkpoint provider for every profile |
+| [`checkpoint.rs`](../../../../../crates/cosh-platform/src/checkpoint.rs) | Authenticates the connected peer before any write, returns proven no-effect or `PossiblyApplied` according to the request phase, and provides an exact read-only evidence query. No Gateway caller exists yet; these are transport primitives for a future target and ledger-side reconciler |
 | [`scheduler.rs`](../../../../../crates/cosh-gateway/src/daemon/scheduler.rs) | Keeps durable Task/Run/Outbox/lease/input/cancel/retry/recovery coordination separate from future execution-target adapters |
 
 The Broker source depends on contracts and its two explicit ports. It does not import Task storage,
@@ -79,15 +109,15 @@ Runtime bridges, OS operators, ACP, or network APIs.
 | ID | Criterion | Result | Evidence or remaining gap |
 | --- | --- | --- | --- |
 | CBR-001 | Every side effect enabled in the Gateway production profile uses typed `CapabilityRequest`. | PASS for task-only scope | The immutable inventory exposes only side-effect-free `ask_user_question`; no production side effect is enabled. |
-| CBR-002 | Its target resolves to an immutable authenticated local identity. | NOT IMPLEMENTED | No production `ExecutionTarget` or target resolver is wired; checkpoint/ws-ckpt identity is future work. |
+| CBR-002 | Its target resolves to an immutable authenticated local identity. | NOT IMPLEMENTED | No checkpoint execution target exists. The identity requirements established while prototyping — socket path chain plus peer authentication, both workspace representations, and a `(filesystem ID, subvolume ID, inode)` btrfs volume identity — are recorded in the design document as prerequisites for the deferred slice. |
 | CBR-003 | Policy result, approval, and permit are distinct types in that path. | PARTIAL | Generic contracts and in-memory logic distinguish the types; no production side-effect path issues them. |
 | CBR-004 | Every permitted effect in that profile has one `ExecutionId`. | NOT IMPLEMENTED | The task-only inventory has no permitted OS effect or production execution target. |
 | CBR-005 | Its permit binds actor, Task, Run, target, operation digest, policy, fence, expiry, and one use. | PARTIAL | Generic permit validation covers the binding in logic tests; durable production issuance remains future work. |
-| CBR-006 | Its target verifies and consumes the permit immediately before execution. | NOT IMPLEMENTED | No production target is wired, so no target-side consume or execution loop is claimed. |
+| CBR-006 | Its target verifies and consumes the permit immediately before execution. | NOT IMPLEMENTED | No production target exists, so no target-side consume or execution loop is claimed. |
 | CBR-007 | Its approval is durable Task state and cannot widen authority. | PARTIAL | Durable Task approval state exists; approval-to-permit and target binding remain future work. |
 | CBR-008 | Broker never writes the Task aggregate. | PASS | Broker has no Task aggregate or storage dependency and returns decisions only. |
-| CBR-009 | Repeated execute in the profile cannot produce a second effect. | NOT IMPLEMENTED | No production effect or execution target is enabled in the task-only profile. |
-| CBR-010 | Crash uncertainty triggers typed reconciliation, never automatic retry. | PARTIAL | Task/Run restart recovery and fail-closed retry boundaries exist; typed side-effect reconciliation is future work. |
+| CBR-009 | Repeated execute in the profile cannot produce a second effect. | PARTIAL | No admitted provider enables an effect. The transport supplies a read-only evidence primitive that a future target could use instead of issuing a second create after a lost response, but no execution target or permit loop exists. |
+| CBR-010 | Crash uncertainty triggers typed reconciliation, never automatic retry. | PARTIAL | Task/Run restart recovery and fail-closed retry boundaries exist. After the first request byte, the checkpoint transport returns `PossiblyApplied` for every failure, including a daemon-reported error code, and exposes a read-only evidence primitive. Target-side and ledger-side reconciliation are future work. |
 | CBR-011 | No opaque Shell fallback is enabled in the governed profile. | PASS for task-only scope | The accepted inventory contains no Shell or other side-effecting operation. Legacy parser behavior is compatibility evidence only. |
 | CBR-012 | Typed policy has allow/deny/require-approval outcomes. | PASS | Neutral `PolicyPort` and deterministic tests cover all three outcomes plus unavailable/invalid authority. |
 | CBR-013 | Execution start in the profile requires durable security audit. | NOT IMPLEMENTED | No production execution start or target exists in the task-only profile. |
@@ -101,11 +131,11 @@ Commands run from `src/cosh-ng` on the rebased candidate:
 
 ```text
 cargo fmt --all -- --check
-cargo test --locked -p cosh-gateway-contracts profile
-cargo test --locked -p cosh-gateway capability::
-cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
-cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
-cargo doc --locked --no-deps -p cosh-gateway-contracts
+cargo test --locked -p cosh-gateway-contracts profile::
+cargo test --locked -p cosh-platform checkpoint::
+cargo test --locked -p cosh-gateway
+cargo clippy --locked -p cosh-gateway-contracts -p cosh-platform -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts -p cosh-gateway
 ```
 
 The targeted tests prove:
@@ -121,12 +151,33 @@ The targeted tests prove:
 - expired and repeated consumption fail closed;
 - exactly one of eight simultaneous claims succeeds.
 
-Generic contract/ledger and scheduler suites were exercised. No checkpoint
-adapter/driver, ws-ckpt resolver, production target, or side-effect execution
-loop is claimed. The destructive packaged-unit containment fixture passed on
-disposable Ubuntu 24.04 arm64/systemd 255. No
-accepted real Codex/Claude, manual Terminal, ECS, network, or universal tool
-validation is claimed.
+The optional profile and withheld provider tests additionally prove:
+
+- the `task-only-v1` canonical manifest and pinned digest are unchanged and contain no provider
+  section, so the private Core v3 mirror still verifies the same identity;
+- the second profile's manifest, digest, exact two-tool inventory, and one-provider set reject every
+  missing, additional, reordered, renamed, or substituted value, including the rejected `ws-ckpt-v1`
+  name;
+- a Task-only instance admits an empty provider set with no ws-ckpt socket, directory, or daemon
+  present, and rejects a configured checkpoint provider instead of widening;
+- a checkpoint-enabled instance refuses admission when no provider is requested;
+- the checkpoint provider is withheld for the profile that seals it, and an exhaustive test over every
+  profile and requested-provider combination shows no admission outcome yields checkpoint side-effect
+  authority;
+- every transport phase returns proven no-effect or `PossiblyApplied`, including all thirteen daemon
+  error codes, plus peer authentication and the exact read-only evidence query.
+
+Generic contract/ledger and scheduler suites were exercised. The destructive
+packaged-unit containment fixture passed on disposable Ubuntu 24.04
+arm64/systemd 255. Checkpoint evidence comes from a fake Unix daemon only; no
+real ws-ckpt daemon, accepted real Codex/Claude, manual Terminal, ECS, network,
+or universal tool validation is claimed.
+
+No btrfs behaviour is validated, because no code in this increment reads it. The
+btrfs volume-identity requirement is recorded in the design document rather than
+implemented, and the prototype that established it is preserved outside the
+delivery branch. Validating it needs a privileged btrfs environment and belongs to
+the deferred slice.
 
 ## Required remaining artifacts
 
@@ -159,7 +210,45 @@ formal universal Broker exit additionally requires:
 
 - `MemoryPermitStore` remains test-only; production authority for any future
   target path is not yet wired.
-- Target identity and execution coverage, including checkpoint/ws-ckpt, remain
-  future optional capabilities rather than current production evidence.
+- No checkpoint execution target is implemented or Runtime-reachable. The
+  checkpoint profile and withheld provider must not be read as governed
+  checkpoint support.
+- The transport supplies only a read-only, workspace-scoped evidence primitive.
+  A future ledger-side reconciler would need a narrow exact-query protocol if
+  that evidence becomes ambiguous or unbounded before recording a conclusive
+  outcome.
+- No ws-ckpt response code is accepted as pre-effect evidence, so an ordinary
+  daemon rejection makes the transport return `PossiblyApplied`. No durable
+  uncertain receipt is recorded today; a future target and ledger would have to
+  persist that uncertainty until reconciliation. Reducing it requires an explicit
+  pre-effect guarantee in the protocol, not a classification table maintained
+  against daemon internals.
+- The daemon remains the trust anchor for its own workspace registry. A
+  compromised daemon is outside this boundary.
+- **Checkpoint requests are not identity-only.** ws-ckpt runs workspace
+  auto-initialization before every checkpoint, and resolves an unregistered
+  workspace identity as a relative path, so a checkpoint-create permit could cause
+  workspace registration or symlink removal outside its authority. Provider
+  admission is withheld and the execution target is deferred until the protocol
+  offers a strict identity-only request. This is an authority gap, not a reporting
+  gap, and no Gateway-side check closes it.
+- **A Gateway-side checkpoint transport has no admitted home.** Among internal
+  crates `cosh-gateway` depends only on `cosh-gateway-contracts`. Reusing
+  `CkptClient` from a Gateway target would add `cosh-platform` and `cosh-types`
+  edges, so the deferred slice must first decide where that transport may live.
+- **Generation attribution is not fenced.** The ws-ckpt workspace identity is
+  derived from the workspace path and is reusable after an unregister, and
+  `rollback` to the current DAG head replaces the live subvolume while leaving the
+  workspace ID, the registration path, and `index.head` unchanged. A future target
+  would need to compare the registered path, workspace volume identity, and daemon
+  mapping against admission both before and after every request. The prototype
+  established that a btrfs filesystem identifier plus the non-reused subvolume ID
+  would detect a rollback that persists through either comparison, while a rollback
+  confined entirely to the create window would remain invisible because no protocol
+  value can be validated atomically. A future ledger therefore must not bind a
+  conclusive receipt to the workspace-content generation until the ws-ckpt protocol
+  provides a non-reusable workspace generation token validated atomically with
+  checkpoint creation; the same prerequisite applies to any immutable workspace
+  fence claim.
 - Ungoverned Shell, ACP interoperability, Skill, MCP, extension, and legacy effects remain outside
   the closed production profile and must never be advertised as governed.

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/acceptance_zh.md
@@ -4,8 +4,9 @@
 
 ## 结果
 
-**整体结果为 PARTIAL。通用 Broker foundation 已存在，Phase 1 尚未通过。**
-实现 worktree 基于 `a6592234341a095b2b9446601642caa87314e2c5`。
+**整体结果为 PARTIAL。通用 Broker foundation 已存在，但本次没有交付 checkpoint execution target 或
+ledger-side reconciliation，Phase 1 尚未通过。**
+实现 worktree 基于 `a43ab81738d3f39721a425cef717a6147276fae9`。
 
 基础 Broker logic 会在 policy 前校验 Capability request expiry，以及 authoritative Task、Run、完整 Actor
 provenance、target、operation descriptor、完整 operation digest 与 requested scope。它将 policy
@@ -15,10 +16,31 @@ production execution 证据。
 
 该结果不构成通用治理声明。Production `CoshBrokered` profile 绑定固定 `task-only-v1` manifest，只有
 `ask_user_question`。Daemon、durable start intent、installed Core factory 与 private v3 handshake 会在
-execution 或 Task input 前校验 identity。它没有 production `ExecutionTarget`，也不依赖
-checkpoint/ws-ckpt。通用
+execution 或 Task input 前校验 identity，且该 profile 不依赖 checkpoint/ws-ckpt。通用
 Capability、Permit 与 Execution contract/ledger row 作为后续基础保留。Shell、Skill、MCP、扩展工具、
 legacy CLI 与 interactive Core mutation path 仍在该边界之外。
+
+## 可选 profile 与被推迟的 checkpoint target 结果
+
+**整体结果为：封闭 profile 与 sealed provider set 已验证；checkpoint provider authority 被 withheld；
+checkpoint execution target 被推迟。** Gateway 拥有封闭的 `workspace-checkpoint-v1` profile（含固定 canonical
+manifest 与 digest）、sealed 单 provider 集合，以及会拒绝任何被请求的 checkpoint provider 的
+`SealedCapabilityProviderRegistry`。`CkptClient` 另外获得了 effect 分类、只读 evidence 查询与 peer 认证。
+
+**本增量中不存在 checkpoint execution target。** 一个 `workspace_checkpoint_create` permit 必须只授权创建一个
+快照，而 ws-ckpt 的 checkpoint 请求无法被约束到该范围：dispatch 会无条件先跑 workspace auto-init，且在任何前置
+查询与请求之间注册消失的 workspace identity 会被当作相对路径解析。Auto-init 会注册 workspace、可能收养
+subvolume、把目录改名移开、创建 symlink，并删除损坏的 symlink。checkpoint-create permit 不授予其中任何一项；
+Gateway 无法阻止（查询与请求是两次独立往返），也无法撤销。因此该 target 被推迟，而不是加个门之后照样交付——这也让
+`cosh-gateway` 在内部 crate 中继续只依赖无副作用的 `cosh-gateway-contracts` 叶子。
+
+为被推迟的 slice 记录了两个 ws-ckpt 协议前置条件：严格解析 workspace identity 且绝不 auto-init 的 checkpoint
+请求，以及与 checkpoint 创建原子校验的不可复用 workspace generation token。设计文档另外记录了原型阶段确立的
+socket 可信性、workspace 双表示、btrfs volume identity 与 generation 约束，避免重新踩坑。
+
+`serve`、打包的 systemd unit、installed Core factory、private Core v3 mirror 与 brokered execution driver 均未
+改动，因此没有 Runtime 能请求或获得 checkpoint。checkpoint-enabled instance 不能端到端启动，任何 release 都不得
+宣传 governed checkpoint。
 
 Owner scope decision 如下：下表 Phase 1 criterion 只适用于 enabled Gateway production profile。
 Production `serve` 与 library daemon 只接纳 `core` / `gateway-brokered-v1`。ACP `doctor`/`run`
@@ -38,9 +60,9 @@ Durable ledger suite 使用
 cross-Task Run、generation skip、扩大
 approval deadline、integer overflow、idempotency namespace、receipt corruption 与 atomic rollback。
 
-本 PR 没有 checkpoint driver、ws-ckpt resolver、production target 或 pre-effect execution loop。
-Target resolution、durable permit issuance、audit gate、execution 与 reconciliation 属后续可选
-capability，仍待完成。
+本 PR 没有把 checkpoint driver 或 pre-effect execution loop 接入 durable ledger。Durable permit
+issuance、audit gate 与 Runtime 可见的 checkpoint execution 属后续工作。Trusted config 不会接纳任何
+checkpoint execution target，Task 也无法触达这类 target。
 
 ## 结果口径
 
@@ -61,7 +83,9 @@ capability，仍待完成。
 | [`memory.rs`](../../../../../crates/cosh-gateway/src/capability/memory.rs) | 在同一个 mutex 内校验并 consume permit；mismatch、expiry 与 replay fail closed |
 | [`memory/tests.rs`](../../../../../crates/cosh-gateway/src/capability/memory/tests.rs) | 覆盖 parent 与 actor-provenance substitution、policy branch/failure、permit binding、mismatch、expiry/replay 与 concurrent consumption |
 | [`capability.rs`](../../../../../crates/cosh-gateway-contracts/src/capability.rs) | 定义中立 request、decision、approval 与 permit contract，包含 Actor/Task/Run/Execution/target/operation/policy/expiry binding |
-| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | 固定唯一接纳的 `task-only-v1` identity、canonical manifest digest、governed target 与准确的 `ask_user_question` Runtime inventory |
+| [`profile.rs`](../../../../../crates/cosh-gateway-contracts/src/profile.rs) | 固定 `task-only-v1` 与 `workspace-checkpoint-v1` identity、canonical manifest digest、governed target、准确 Runtime inventory 与 sealed provider set |
+| [`provider.rs`](../../../../../crates/cosh-gateway/src/capability/provider.rs) | 只接纳 profile 固化的 provider 集合；拒绝 task-only instance 上被请求的 provider 与 checkpoint-enabled instance 上缺失的 provider，并对所有 profile withhold checkpoint provider |
+| [`checkpoint.rs`](../../../../../crates/cosh-platform/src/checkpoint.rs) | 在任何写入之前认证已连接的 peer，根据请求阶段返回可证明无副作用或 `PossiblyApplied`，并提供准确的只读 evidence 查询。目前还没有 Gateway 调用方；这些是未来 target 与 ledger-side reconciler 所需的 transport 原语 |
 | [`scheduler.rs`](../../../../../crates/cosh-gateway/src/daemon/scheduler.rs) | 保持 durable Task/Run/Outbox/lease/input/cancel/retry/recovery coordination 与未来 execution-target adapter 分离 |
 
 Broker source 只依赖 contracts 和两个显式 port，不 import Task storage、Runtime bridge、OS operator、
@@ -72,15 +96,15 @@ ACP 或 network API。
 | ID | 验收项 | 结果 | 证据或剩余缺口 |
 | --- | --- | --- | --- |
 | CBR-001 | Gateway production profile 启用的每个 side effect 使用 typed `CapabilityRequest`。 | Task-only scope PASS | Immutable inventory 只有无 side effect 的 `ask_user_question`；production 没有 enabled side effect。 |
-| CBR-002 | 其 target 解析成 immutable authenticated local identity。 | NOT IMPLEMENTED | 没有 production `ExecutionTarget` 或 target resolver；checkpoint/ws-ckpt identity 属后续工作。 |
+| CBR-002 | 其 target 解析成 immutable authenticated local identity。 | NOT IMPLEMENTED | 不存在 checkpoint execution target。原型阶段确立的 identity 要求——socket 路径链加 peer 认证、workspace 的两种表示、`(filesystem ID, subvolume ID, inode)` 形式的 btrfs volume identity——已记录在设计文档中，作为被推迟 slice 的前置条件。 |
 | CBR-003 | 该 path 的 policy result、approval 与 permit 是不同类型。 | PARTIAL | 通用 contract 与 in-memory logic 区分这些类型；production 没有 side-effect path 签发它们。 |
 | CBR-004 | 该 profile 每个 permitted effect 有一个 `ExecutionId`。 | NOT IMPLEMENTED | Task-only inventory 没有 permitted OS effect 或 production execution target。 |
 | CBR-005 | 其 permit 绑定 actor、Task、Run、target、operation digest、policy、fence、expiry 与一次使用。 | PARTIAL | 通用 permit validation 在 logic test 中覆盖 binding；durable production issuance 属后续工作。 |
-| CBR-006 | 其 target 在执行前立即校验并 consume permit。 | NOT IMPLEMENTED | 没有 production target，因此不声称 target-side consume 或 execution loop。 |
+| CBR-006 | 其 target 在执行前立即校验并 consume permit。 | NOT IMPLEMENTED | 不存在 production target，因此不声称 target-side consume 或 execution loop。 |
 | CBR-007 | 其 approval 是 durable Task state 且不能扩大 authority。 | PARTIAL | Durable Task approval state 已有；approval-to-permit 与 target binding 属后续工作。 |
 | CBR-008 | Broker 不写 Task aggregate。 | PASS | Broker 不依赖 Task aggregate 或 storage，只返回 decision。 |
-| CBR-009 | 该 profile 重复 execute 不能产生第二个 effect。 | NOT IMPLEMENTED | Task-only profile 没有 enabled production effect 或 execution target。 |
-| CBR-010 | Crash uncertainty 进入 typed reconciliation，不自动 retry。 | PARTIAL | Task/Run restart recovery 与 fail-closed retry boundary 已有；typed side-effect reconciliation 属后续工作。 |
+| CBR-009 | 该 profile 重复 execute 不能产生第二个 effect。 | PARTIAL | 没有已准入 provider 会启用 effect。Transport 提供只读 evidence 原语，未来 target 可在响应丢失后用它代替再次 create，但当前不存在 execution target 或 permit loop。 |
+| CBR-010 | Crash uncertainty 进入 typed reconciliation，不自动 retry。 | PARTIAL | Task/Run restart recovery 与 fail-closed retry boundary 已有。第一个请求字节之后发生任何失败时，checkpoint transport 都返回 `PossiblyApplied`，包括 daemon 报告错误码的情况，并公开只读 evidence 原语。Target 侧与 ledger 侧 reconcile 属后续工作。 |
 | CBR-011 | Governed profile 不启用 opaque Shell fallback。 | Task-only scope PASS | Accepted inventory 不含 Shell 或其他 side-effect operation；legacy parser behavior 只算 compatibility evidence。 |
 | CBR-012 | Typed policy 有 allow/deny/require-approval outcome。 | PASS | Neutral `PolicyPort` 与 deterministic test 覆盖三个 outcome，以及 unavailable/invalid authority。 |
 | CBR-013 | 该 profile 的 execution start 要求 durable security audit。 | NOT IMPLEMENTED | Task-only profile 没有 production execution start 或 target。 |
@@ -94,11 +118,11 @@ ACP 或 network API。
 
 ```text
 cargo fmt --all -- --check
-cargo test --locked -p cosh-gateway-contracts profile
-cargo test --locked -p cosh-gateway capability::
-cargo clippy --locked -p cosh-gateway-contracts --all-targets -- -D warnings
-cargo clippy --locked -p cosh-core -p cosh-gateway --all-targets -- -D warnings
-cargo doc --locked --no-deps -p cosh-gateway-contracts
+cargo test --locked -p cosh-gateway-contracts profile::
+cargo test --locked -p cosh-platform checkpoint::
+cargo test --locked -p cosh-gateway
+cargo clippy --locked -p cosh-gateway-contracts -p cosh-platform -p cosh-gateway --all-targets -- -D warnings
+cargo doc --locked --no-deps -p cosh-gateway-contracts -p cosh-gateway
 ```
 
 定向测试证明：
@@ -113,10 +137,26 @@ cargo doc --locked --no-deps -p cosh-gateway-contracts
 - Expired 与重复 consume fail closed；
 - 八个同时 claim 只有一个成功。
 
-通用 contract/ledger 与 scheduler suite 已执行。不声称 checkpoint adapter/driver、ws-ckpt resolver、
-production target 或 side-effect execution loop。Destructive package-unit containment fixture 已在
-disposable Ubuntu 24.04 arm64/systemd 255 上通过。
-不声称已验收真实 Codex/Claude、人工 Terminal、ECS、network 或通用工具验证。
+可选 profile 与被 withhold 的 provider 测试另外证明：
+
+- `task-only-v1` canonical manifest 与固定 digest 未变且不含 provider 段，因此 private Core v3 mirror
+  仍校验同一个 identity；
+- 第二个 profile 的 manifest、digest、准确两项 tool inventory 与单 provider 集合会拒绝任何缺失、额外、
+  重排、改名或替换的取值，含已被拒绝的 `ws-ckpt-v1` 名称；
+- Task-only instance 在没有 ws-ckpt socket、目录与 daemon 时接纳空 provider 集合，并拒绝已配置的
+  checkpoint provider 而不是扩权；
+- Checkpoint-enabled instance 在没有请求 provider 时拒绝准入；
+- 固化该 provider 的 profile 同样被 withhold，且穷举 (profile × requested provider) 全部组合的 test 表明没有任何
+  准入结果会产生 checkpoint 副作用 authority；
+- 每个 transport 阶段都返回可证明无副作用或 `PossiblyApplied`，覆盖全部十三个 daemon 错误码，并覆盖 peer
+  认证与准确的只读 evidence 查询。
+
+通用 contract/ledger 与 scheduler suite 已执行。Destructive package-unit containment fixture 已在
+disposable Ubuntu 24.04 arm64/systemd 255 上通过。Checkpoint 证据只来自 fake Unix daemon；不声称已验收
+真实 ws-ckpt daemon、真实 Codex/Claude、人工 Terminal、ECS、network 或通用工具验证。
+
+本增量没有验证任何 btrfs 行为，因为没有任何代码读取它。btrfs volume identity 要求被记录在设计文档中而非实现，
+确立该要求的原型保存在交付分支之外。验证它需要特权 btrfs 环境，属于被推迟的 slice。
 
 ## 必要的剩余产物
 
@@ -146,7 +186,28 @@ execution 尚未实现，已记录的 real-provider/manual release gate 也仍�
 ## 剩余风险
 
 - `MemoryPermitStore` 仍只用于测试；任何 future target path 的 production authority 尚未接入。
-- Target identity 与 execution coverage（包括 checkpoint/ws-ckpt）属于后续可选 capability，不是当前
-  production evidence。
+- 当前没有实现 checkpoint execution target，Runtime 也无法触达这类 target。不得把 checkpoint profile 与
+  withheld provider 解读为 governed checkpoint 支持。
+- Transport 只提供按 workspace 查询的只读 evidence 原语。如果该证据变得有歧义或无界，未来 ledger-side
+  reconciler 必须先获得窄的 exact-query 协议，才能记录确定结论。
+- 任何 ws-ckpt 响应码都不被当作 pre-effect 证据，因此普通的 daemon 拒绝会让 transport 返回
+  `PossiblyApplied`。当前不会记录 durable uncertain receipt；未来 target 与 ledger 必须持久化这种不确定性，
+  直到 reconciliation 完成。要减少这种不确定性，需要协议提供明确的 pre-effect 保证，而不是维护一张对着
+  daemon 内部实现的分类表。
+- Daemon 仍是其自身 workspace registry 的信任锚，被攻陷的 daemon 在该边界之外。
+- **Checkpoint 请求不是 identity-only。** ws-ckpt 在每次 checkpoint 之前都会跑 workspace auto-init，并把未注册的
+  workspace identity 当相对路径解析，因此 checkpoint-create permit 可能在其 authority 之外导致 workspace 注册或
+  symlink 删除。Provider 准入将一直 withheld、execution target 一直推迟，直到协议提供严格 identity-only 的请求。
+  这是 authority 缺口而非上报缺口，Gateway 侧没有任何检查能关闭它。
+- **Gateway 侧 checkpoint transport 还没有合法归属。** 在内部 crate 中 `cosh-gateway` 只依赖
+  `cosh-gateway-contracts`。从 Gateway target 复用 `CkptClient` 会新增 `cosh-platform` 与 `cosh-types` 两条边，
+  因此被推迟的 slice 必须先决定该 transport 应该放在哪里。
+- **Generation 归因未被 fence。** ws-ckpt workspace identity 由 workspace 路径派生，unregister 之后可被复用；
+  `rollback` 到当前 DAG head 会替换 live subvolume，同时保持 workspace ID、注册路径与 `index.head` 不变。未来
+  target 必须在每次请求前后都把注册路径、workspace volume identity 与 daemon 映射同准入状态比较。原型表明，
+  使用 btrfs 文件系统标识加不被复用的 subvolume ID，可以检出持续到任一次比较时的 rollback；完全落在 create
+  窗口内的 rollback 仍不可见，因为没有协议取值可被原子校验。因此在 ws-ckpt 协议提供与 checkpoint 创建原子
+  校验的不可复用 workspace generation token 之前，未来 ledger 不得把确定性 receipt 绑定到 workspace 内容的
+  generation，也不得声称存在 immutable workspace fence。
 - Ungoverned Shell、ACP interoperability、Skill、MCP、扩展与 legacy effect 仍在封闭 production
   profile 之外，绝不能宣传为 governed。

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design.md
@@ -4,16 +4,24 @@
 
 ## Status and decision
 
-This increment is based on upstream commit `a6592234`. Its universal Broker model remains the
+This increment is based on upstream commit `a43ab817`. Its universal Broker model remains the
 architecture target, not an accepted Phase 1 claim. The accepted production scope is narrower:
 `serve` and the library daemon admit only `core` / `gateway-brokered-v1`, whose immutable inventory
 is bound to the pinned `task-only-v1` manifest and contains `ask_user_question` only. Gateway,
 durable Runtime start intent, and Core v3 negotiation verify that identity and exact inventory
-before launch or Task input. No production `ExecutionTarget` or
-checkpoint/ws-ckpt dependency is wired in this PR. Every side-effecting hook, Skill, MCP, extension,
+before launch or Task input. Every side-effecting hook, Skill, MCP, extension,
 Shell, file, process, and network path is disabled in this profile. ACP `doctor`/`run`, legacy CLI
 commands, and standalone Shell are explicitly ungoverned interoperability/rollback paths and
 cannot be cited as governed evidence.
+
+The Gateway now additionally owns an optional `workspace-checkpoint-v1` capability profile and a sealed
+capability provider registry that **withholds** the checkpoint provider for every profile. **No checkpoint
+execution target exists**: it is deferred until the ws-ckpt protocol offers an identity-only checkpoint
+request and a non-reusable workspace generation token, because without them a checkpoint-create permit
+could make the daemon mutate the host outside the authority it grants. `serve`, the packaged systemd unit,
+and the brokered execution driver are unchanged as well. The accepted claim is "the closed profile and the
+sealed provider set exist and fail closed, and the checkpoint transport classifies effects correctly", not
+"a ws-ckpt target exists" and not "checkpoints are governed end to end".
 
 The universal target still requires `CapabilityBroker` as the mandatory policy enforcement and
 permit authority for every enabled OS side effect, regardless of origin. An execution target
@@ -45,16 +53,132 @@ fields and marks a permit consumed under one mutex, so exactly one concurrent ca
 A failed binding check does not consume authority.
 
 `MemoryPermitStore` remains a process-local logic fixture and is not production authority. Generic
-durable approval/permit/execution ledger contracts may be retained as reusable foundations, but this
-PR does not wire them to a production execution target. The task-only production profile has no
-side-effecting operation beyond `ask_user_question`; it does not invoke a checkpoint provider and has
-no ws-ckpt dependency. Checkpoint/ws-ckpt support, target resolution, pre-effect audit, result
-reconciliation, and any production permit loop are follow-up optional capability work, not accepted
-evidence here.
+durable approval/permit/execution ledger contracts may be retained as reusable foundations. The
+task-only production profile has no side-effecting operation beyond `ask_user_question`; it does not
+invoke a checkpoint provider and has no ws-ckpt dependency.
 
 Phase 1 is installation-scoped and single-tenant. `InstallationId` plus authenticated local peer
 credentials form the v1 boundary. `TenantId`, remote peers, and cross-tenant isolation are future
 v2 work and are not claimed here.
+
+## Optional sealed provider set and the deferred checkpoint target
+
+A capability profile seals the exact ordered set of side-effect providers an instance may reach.
+[`GatewayCapabilityProfile::providers`](../../../../../crates/cosh-gateway-contracts/src/profile.rs)
+returns an empty set for `task-only-v1` and exactly `ws-ckpt` for `workspace-checkpoint-v1`, and
+`verify_providers` rejects a missing, additional, reordered, or substituted provider. A host that
+happens to run the ws-ckpt daemon is therefore never authority on its own.
+
+[`SealedCapabilityProviderRegistry`](../../../../../crates/cosh-gateway/src/capability/provider.rs)
+is the single boundary at which an instance would gain side-effect authority. A Task-only instance that
+requests a provider is rejected rather than widened, and the sealed set is verified before anything else.
+
+That boundary **withholds** the checkpoint provider for every profile, so the only shape an instance can
+reach is the empty provider set. **No checkpoint execution target exists in this crate.** The target is
+deferred, not merely unwired: the constraints below are prerequisites any future implementation must
+satisfy, and two of them require ws-ckpt protocol changes that no Gateway-side code can substitute for.
+
+Keeping `cosh-gateway` free of a checkpoint adapter also preserves its dependency direction. Among
+internal crates it depends only on the side-effect-free `cosh-gateway-contracts` leaf. A Gateway-side
+target that reused the existing `CkptClient` would add `cosh-platform` and `cosh-types` edges, so the
+deferred slice must first decide where a checkpoint transport may live.
+
+### Why checkpoint authority is withheld
+
+A `workspace_checkpoint_create` permit must authorize exactly one snapshot creation on one admitted
+workspace. The ws-ckpt checkpoint request cannot be constrained to that.
+
+Checkpoint dispatch unconditionally runs workspace auto-initialization before it attempts a snapshot.
+Auto-initialization resolves the request's workspace field, and that resolution falls through to treating
+the value as a relative path when no registration matches it. Workspace initialization is a real host
+mutation: it registers a workspace, can adopt an existing subvolume, moves the original directory aside,
+creates a symlink, and removes a broken symlink before reporting an invalid path.
+
+Naming the daemon-owned workspace identity instead of a pathname removes the ordinary trigger, because a
+registered identity resolves without auto-initialization. It does not remove the window. Any pre-request
+identity query and the checkpoint request are separate round trips, so a `recover` that unregisters the
+workspace in between leaves the daemon resolving a stale identity string as a relative path. What it then
+touches depends on the daemon's working directory, which the Gateway neither controls nor verifies.
+
+No Gateway-side check closes this. A post-request comparison can only downgrade the reported outcome to
+indeterminate; it cannot prevent or undo a registration the daemon already performed. Bounding the window
+is not a security property either.
+
+**Prerequisite.** A ws-ckpt checkpoint request that resolves a workspace identity strictly and never
+auto-initializes.
+
+### Established constraints for the deferred target
+
+These were derived while prototyping the target and are recorded so the deferred slice does not rediscover
+them. Each is a requirement, not a description of shipped behaviour.
+
+**Socket trust cannot rest on path metadata.** The daemon publishes a world-connectable socket on purpose,
+so the socket's mode is not evidence. Trust requires the socket owner to be root or the Gateway owner and
+**every** ancestor directory up to the root to be owned by root or the Gateway owner and not writable by
+other principals unless it carries the sticky bit; checking only the immediate parent leaves that parent's
+own directory entry replaceable. Even then, path checks cannot close the window between a check and
+`connect`. The connected peer must be authenticated with kernel credentials after connecting and before
+any request byte is written. Pinning the socket device, inode, and owner remains useful for detecting
+replacement, but authentication is what secures the request.
+
+**A workspace has two representations that are not the same string.** After initialization the daemon moves
+the original directory into its backend and leaves a symlink at the user-facing path, then keeps reporting
+that registered path in its registry, `Status`, and `List`. A descriptor-pinned open of the same path
+resolves through the symlink to the backend directory. Requiring the two to be equal rejects every normally
+initialized workspace, so both must be bound: the registered path verbatim for daemon queries and evidence
+comparison, and the pinned directory for local identity.
+
+**Device and inode do not identify a btrfs subvolume.** Every subvolume root carries inode 256, and a
+subvolume's anonymous device number is allocated at first access and may be reused once the subvolume is
+deleted. Rollback renames the live subvolume aside, creates a new writable snapshot at the same path, and
+deletes the old one, so device and inode can compare equal across two different subvolumes. The containing
+subvolume ID from `BTRFS_IOC_INO_LOOKUP` comes from a persistent increasing counter and is not reused, but
+it is unique only inside one filesystem, so the filesystem identifier from `BTRFS_IOC_FS_INFO` must scope
+it. The identity is therefore `(filesystem ID, subvolume ID, inode)`, with the scheme tag bound so a
+workspace cannot silently move to a device-and-inode identity.
+
+**Workspace identity is not a generation fence.** The daemon derives its workspace ID from the workspace
+path, so it is reused when the same path is registered again after an unregister, and `rollback` to the
+current DAG head replaces the live subvolume while leaving the workspace ID, the registration path, and
+`index.head` unchanged. Comparing the volume identity before and after a request detects every rollback
+that persists past either comparison, but a rollback confined entirely to the create window is invisible,
+and no observable protocol value could be validated atomically with creation. A conclusive receipt could
+therefore attest the registered workspace, the checkpoint identity, and the reported snapshot — never the
+generation of the workspace contents.
+
+**Prerequisite.** A non-reusable workspace generation token in the ws-ckpt protocol, validated atomically
+with checkpoint creation, before any checkpoint receipt may bind workspace contents.
+
+### Effect classification and reconciliation
+
+The transport primitives for this are implemented in
+[`CkptClient`](../../../../../crates/cosh-platform/src/checkpoint.rs) and are the one part of the
+checkpoint work that ships in this increment, because they are self-contained and correct independently of
+the target.
+
+The governed primitives `create_classified` and `find_snapshot` structurally require peer
+authentication: the caller must configure `require_trusted_peer(owner_uid)`. Without that configuration,
+both reject before inspecting or accessing the socket. `create_classified` reports this rejection as
+`KnownNoEffect`, while `find_snapshot` returns a permission error. This fail-closed requirement is scoped
+to these two governed primitives; legacy `CkptClient` operations retain their existing optional-peer-auth
+behavior.
+
+`create_classified` reports whether a failed request may already have changed daemon state. Only failures
+raised strictly before any request byte reaches the kernel are proven `KnownNoEffect`: missing trusted-peer
+configuration, a missing socket, a refused connection, an untrusted peer, or a write that transferred
+nothing. Everything after that is `PossiblyApplied` — a partial write, a lost or truncated response, an
+undecodable payload, an unexpected response variant, **and every daemon-reported error code**.
+
+No response code is treated as pre-effect evidence. The checkpoint dispatch path auto-initializes the
+workspace before it attempts a snapshot, so registration, subvolume adoption, or removal of a broken
+workspace symlink may already have happened before a code such as `WriteLockConflict`,
+`SnapshotAlreadyExists`, or `InvalidPath` is produced. Those codes prove that no snapshot was created; they
+do not prove that daemon state is unchanged.
+
+`find_snapshot` is the read-only evidence primitive: it matches one workspace and one exact checkpoint
+identity and reports whether the daemon still lists the snapshot as present. A future target and ledger-side
+reconciler can use that evidence after a `PossiblyApplied` failure instead of creating a second snapshot,
+but this increment does not turn it into a conclusive or durable uncertain outcome.
 
 ## Goals
 
@@ -385,8 +509,19 @@ output. Transport timeout is not evidence that an effect did not occur.
    `doctor`/`run` explicitly ungoverned.
 5. Use private COSH brokered v3, bind the pinned `task-only-v1` manifest, and expose only
    `ask_user_question`.
-6. Keep Shell/ACP/Skills/MCP/extensions disabled until a later phase provides complete adapters.
-7. Remove or explicitly isolate legacy bypasses only after parity and recovery acceptance passes.
+6. Add the optional `workspace-checkpoint-v1` profile, its sealed provider set, and the checkpoint
+   transport's effect classification. **Provider admission withheld; no execution target.**
+7. Land the ws-ckpt protocol prerequisites, then implement the checkpoint execution target, wire the
+   Runtime checkpoint request through durable approval and a single-use permit, and mirror the second
+   profile on the private Core wire. **Not implemented.**
+8. Keep Shell/ACP/Skills/MCP/extensions disabled until a later phase provides complete adapters.
+9. Remove or explicitly isolate legacy bypasses only after parity and recovery acceptance passes.
+
+The optional profile never changes the portable one. The `task-only-v1` canonical manifest stays
+byte-identical to its original revision, so the private Core v3 mirror keeps verifying the same pinned
+digest, and a Task-only instance keeps starting with no ws-ckpt package, socket, service, or provider.
+An unavailable ws-ckpt daemon can only make a checkpoint-enabled instance refuse admission; it can
+never block a Task-only instance.
 
 Rollback preserves standalone Shell and legacy binaries. Production `serve` remains fail-closed;
 it cannot fall back to ACP or a legacy mutation backend. A release may advertise only the
@@ -435,9 +570,22 @@ consumption, expiry/replay, and eight-way concurrent claim. The broader security
 - Concurrent consume tests proving one permit produces at most one claimed Execution ID.
 - Kill-point tests before/after claim, audit start, OS invocation, result capture, and Task callback.
 - Reconciliation tests for typed success, typed failure, in-progress, and unknown effects.
-- Bypass tests proving the current production inventory is task-only with no
-  `ExecutionTarget`, plus future tests for each Gateway/Core/Shell/ACP/Skill/MCP
-  mutation path before it may be enabled.
+- Bypass tests proving the packaged production service stays task-only with no ws-ckpt dependency,
+  plus future tests for each Gateway/Core/Shell/ACP/Skill/MCP mutation path before it may be enabled.
+
+The optional profile and its withheld provider add deterministic coverage, with no real ws-ckpt daemon,
+btrfs filesystem, ECS instance, or manual terminal involved:
+
+- Profile tests pinning the second canonical manifest and digest, and rejecting a missing, extra,
+  reordered, or renamed tool and any provider-set drift, including the previously rejected
+  `ws-ckpt-v1` name.
+- Registry tests proving a Task-only instance admits an empty provider set with no ws-ckpt configuration
+  present and rejects a requested provider, that a checkpoint-enabled instance refuses admission without
+  one, and that the checkpoint provider is withheld for the profile that seals it.
+- An exhaustive test over every profile and requested-provider combination proving no admission outcome
+  yields checkpoint side-effect authority.
+- Transport tests classifying every request phase as proven no-effect or possibly applied, including all
+  thirteen daemon error codes, and covering peer authentication and the exact read-only reconcile query.
 
 ## Open questions
 

--- a/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design_zh.md
+++ b/src/cosh-ng/docs/design/acp-task-platform/task-plane/capability-broker/design_zh.md
@@ -4,14 +4,20 @@
 
 ## 状态与决策
 
-当前增量基于上游提交 `a6592234`。通用 Broker 模型仍是目标架构，不是已验收的 Phase 1 声明。
+当前增量基于上游提交 `a43ab817`。通用 Broker 模型仍是目标架构，不是已验收的 Phase 1 声明。
 已验收 production scope 更窄：`serve` 与 library daemon 只接纳 `core` / `gateway-brokered-v1`，其
 immutable inventory 绑定固定 `task-only-v1` manifest，只有 `ask_user_question`。Gateway、durable
 Runtime start intent 与 Core v3 negotiation 会在 launch 或 Task input 前校验 identity 与准确 inventory。
-本 PR 不接入 production
-`ExecutionTarget`，也不依赖 checkpoint/ws-ckpt。该 profile 禁用其他 side-effecting hook、Skill、MCP、
+该 profile 禁用其他 side-effecting hook、Skill、MCP、
 扩展、Shell、file、process 与 network path。ACP `doctor`/`run`、legacy CLI command 与 standalone Shell
 是明确 ungoverned 的 interoperability/rollback path，不能作为 governed evidence。
+
+Gateway 现在额外拥有可选的 `workspace-checkpoint-v1` capability profile，以及对所有 profile 都 **withhold**
+checkpoint provider 的 sealed capability provider registry。**不存在 checkpoint execution target**：它被推迟到
+ws-ckpt 协议提供 identity-only checkpoint 请求与不可复用的 workspace generation token 之后——没有这两者，
+checkpoint-create permit 可能让 daemon 在其授予范围之外改动主机。`serve`、打包的 systemd unit 与 brokered
+execution driver 同样未改动。已验收声明是“封闭 profile 与 sealed provider set 已存在且 fail closed，checkpoint
+transport 的 effect 分类正确”，不是“存在 ws-ckpt target”，也不是“checkpoint 已端到端 governed”。
 
 通用目标仍要求每个 enabled OS side effect 都把 `CapabilityBroker` 作为 mandatory policy
 enforcement 与 permit authority。Execution target 只有收到绑定 target 和 operation 的有效 permit 才能
@@ -41,14 +47,106 @@ authority。Process-local
 authority。
 
 `MemoryPermitStore` 仍是 process-local logic fixture，不承载 production authority。通用 durable
-approval/permit/execution ledger contract 可以作为可复用基础保留，但本 PR 不把它们接入 production
-execution target。Task-only production profile 没有 side-effecting operation，只有 `ask_user_question`；
-不调用 checkpoint provider，也不依赖 ws-ckpt。Checkpoint/ws-ckpt support、target resolution、
-pre-effect audit、result reconciliation 与 production permit loop 都属于后续可选 capability，不能作为
-本 PR 的验收证据。
+approval/permit/execution ledger contract 可以作为可复用基础保留。Task-only production profile 没有
+side-effecting operation，只有 `ask_user_question`；不调用 checkpoint provider，也不依赖 ws-ckpt。
 
 Phase 1 是 installation-scoped single-tenant。`InstallationId` 与 authenticated local peer credential
 构成 v1 boundary。`TenantId`、remote peer 与 cross-tenant isolation 属未来 v2，本文不作相关声明。
+
+## 可选 sealed provider set 与被推迟的 checkpoint target
+
+Capability profile 固化 instance 可触达的准确有序 side-effect provider 集合。
+[`GatewayCapabilityProfile::providers`](../../../../../crates/cosh-gateway-contracts/src/profile.rs)
+对 `task-only-v1` 返回空集，对 `workspace-checkpoint-v1` 精确返回 `ws-ckpt`；`verify_providers` 拒绝
+缺失、额外、重排或替换的 provider。因此“主机上恰好运行 ws-ckpt daemon”本身永远不是 authority。
+
+[`SealedCapabilityProviderRegistry`](../../../../../crates/cosh-gateway/src/capability/provider.rs)
+是 instance 获得副作用 authority 的唯一边界。请求 provider 的 task-only instance 会被拒绝而不是被扩权，
+且 sealed set 在其他一切之前先完成校验。
+
+该边界对**所有** profile 都 withhold checkpoint provider，因此 instance 唯一能达到的形态是空 provider 集合。
+**本 crate 中不存在 checkpoint execution target。** 该 target 是被推迟，而不只是未接线：下文的约束是任何未来
+实现都必须满足的前置条件，其中两条需要 ws-ckpt 协议变更，任何 Gateway 侧代码都无法替代。
+
+让 `cosh-gateway` 不含 checkpoint adapter 也保持了它的依赖方向。在内部 crate 中它只依赖无副作用的
+`cosh-gateway-contracts` 叶子；复用既有 `CkptClient` 的 Gateway 侧 target 会新增 `cosh-platform` 与
+`cosh-types` 两条边，因此被推迟的 slice 必须先决定 checkpoint transport 应该放在哪里。
+
+### 为什么 withhold checkpoint authority
+
+一个 `workspace_checkpoint_create` permit 必须只授权在一个被准入的 workspace 上创建一个快照。ws-ckpt 的
+checkpoint 请求无法被约束到这个范围。
+
+Checkpoint dispatch 会在尝试快照之前无条件先跑 workspace auto-init。Auto-init 解析请求里的 workspace 字段，而
+该解析在没有任何注册匹配时会继续把该值当作**相对路径**处理。Workspace 初始化是真实的主机变更：它会注册
+workspace、可能收养已存在的 subvolume、把原目录改名移开、创建 symlink，并在报告 invalid path 之前删除损坏的
+symlink。
+
+用 daemon 拥有的 workspace identity 而不是路径名，可以消除常规触发条件——已注册的 identity 会直接解析成功、不进
+auto-init。但它消除不了那个窗口：任何前置 identity 查询与 checkpoint 请求都是两次独立往返，因此期间发生的
+`recover` 把 workspace unregister 之后，daemon 会把失效 identity 字符串当相对路径解析。它究竟会碰到什么，取决于
+daemon 的工作目录——而这既不由 Gateway 控制，也未被 Gateway 校验。
+
+Gateway 侧没有任何检查能关闭它。副作用后的比较只能把上报结果降级为不确定，无法阻止或撤销 daemon 已经完成的注册；
+“把窗口缩小”也不是安全属性。
+
+**前置条件**：ws-ckpt 提供严格解析 workspace identity、绝不 auto-init 的 checkpoint 请求。
+
+### 为被推迟的 target 已确立的约束
+
+以下结论来自 target 原型阶段，记录在此以免被推迟的 slice 重新踩一遍。每一条都是要求，而不是已交付行为的描述。
+
+**Socket 可信性不能建立在路径元数据上。** daemon 故意发布可被任意进程连接的 socket，因此其 mode 不是证据。
+可信性要求 socket owner 为 root 或 Gateway owner，且**每一级**上级目录直到根都由 root 或 Gateway owner 拥有、
+并且除带 sticky bit 外不对其他 principal 可写——只检查直接父目录会让该父目录自身的目录项仍可被替换。即便如此，
+路径检查也关不掉“检查到 `connect`”之间的窗口：必须在连接之后、写出任何请求字节之前用 kernel peer credentials
+认证对端。Pin socket 的 device、inode 与 owner 仍可用于检出替换，但真正保护请求的是认证。
+
+**一个 workspace 有两种并不相同的表示。** 初始化之后 daemon 会把原目录搬进 backend 并在 user-facing 路径留下
+symlink，随后其 registry、`Status` 与 `List` 始终报告那个注册路径；而对同一路径做 descriptor-pinned open 会穿过
+symlink 得到 backend 目录。要求二者相等会拒绝所有正常初始化过的 workspace，因此必须同时绑定：逐字用于 daemon
+查询与证据比较的注册路径，以及作为本地 identity 的 pinned directory。
+
+**device 与 inode 无法标识 btrfs subvolume。** 每个 subvolume 根的 inode 恒为 256，而 subvolume 的 anonymous
+device number 在首次访问时分配、在 subvolume 被删除后可被复用。Rollback 会把 live subvolume 改名移开、在同一路径
+创建新的 writable snapshot、再删除旧的，因此两个不同 subvolume 的 device 与 inode 可能完全相等。
+`BTRFS_IOC_INO_LOOKUP` 给出的所属 subvolume ID 来自持久递增计数器且不被复用，但它只在单个文件系统内唯一，因此
+必须用 `BTRFS_IOC_FS_INFO` 的文件系统标识为其定作用域。identity 因此是 `(filesystem ID, subvolume ID, inode)`，
+且 scheme 标记也要参与绑定，使 workspace 无法静默退回 device/inode identity。
+
+**Workspace identity 不是 generation fence。** daemon 由 workspace 路径派生其 workspace ID，因此同一路径在
+unregister 之后再次注册会复用它；`rollback` 到当前 DAG head 会替换 live subvolume，同时保持 workspace ID、注册
+路径与 `index.head` 不变。在请求前后比较 volume identity 能检出所有持续到某次比较之后的 rollback，但完全落在
+create 窗口内的 rollback 不可见，也没有任何可观测协议取值能与创建原子校验。因此确定性 receipt 最多只能证明被注册
+的 workspace、checkpoint identity 与被报告的快照，**绝不能**证明 workspace 内容的 generation。
+
+**前置条件**：ws-ckpt 协议提供不可复用的 workspace generation token 并与 checkpoint 创建原子校验，然后 checkpoint
+receipt 才可能绑定 workspace 内容。
+
+### Effect 分类与 reconcile
+
+这部分的 transport 原语实现在
+[`CkptClient`](../../../../../crates/cosh-platform/src/checkpoint.rs)，也是本增量中唯一交付的 checkpoint 相关
+代码——因为它自成一体，且其正确性不依赖 target。
+
+Governed 原语 `create_classified` 与 `find_snapshot` 在结构上强制要求 peer 认证：caller 必须配置
+`require_trusted_peer(owner_uid)`。缺少该配置时，两者都会在检查或访问 socket 之前拒绝请求。
+`create_classified` 将这种拒绝报告为 `KnownNoEffect`，`find_snapshot` 则返回 permission error。该 fail-closed
+要求只适用于这两个 governed 原语；legacy `CkptClient` operation 保留现有的 optional peer-auth 行为。
+
+`create_classified` 报告失败请求是否可能已经改变 daemon 状态。只有在任何请求字节进入 kernel 之前发生的失败才是
+可证明的 `KnownNoEffect`：缺少 trusted-peer 配置、socket 缺失、连接被拒绝、peer 不可信、零字节写入。其后的
+一切都是 `PossiblyApplied`——部分写入、响应丢失或截断、payload 无法解码、意外响应 variant，**以及每一个
+daemon 报告的错误码**。
+
+任何响应码都不被当作 pre-effect 证据。Checkpoint dispatch 路径会先 auto-init workspace 再尝试快照，因此在产生
+`WriteLockConflict`、`SnapshotAlreadyExists` 或 `InvalidPath` 之类错误码之前，注册、subvolume 收养或删除损坏的
+workspace symlink 可能已经发生。这些错误码只证明没有创建快照，不证明 daemon 状态未变化。
+
+`find_snapshot` 是只读 evidence 原语：它按一个 workspace 与一个准确 checkpoint identity 精确匹配，
+报告 daemon 是否仍把该快照列为存在。未来 target 与 ledger-side reconciler 可在
+`PossiblyApplied` 失败后使用该证据，而不是再创建一个快照；本增量不会把它转成
+确定结果或 durable uncertain outcome。
 
 ## 目标
 
@@ -357,8 +455,17 @@ denial，不能回显 secret input 或无界 target output。Transport timeout �
    ungoverned。
 5. 使用 private COSH brokered v3，绑定固定 `task-only-v1` manifest，只暴露
    `ask_user_question`。
-6. Shell/ACP/Skills/MCP/扩展保持禁用，等待后续 phase 提供完整 adapter。
-7. Parity 与 recovery acceptance 通过后，删除或显式隔离 legacy bypass。
+6. 增加可选 `workspace-checkpoint-v1` profile、其 sealed provider set，以及 checkpoint transport 的 effect
+   分类。**Provider 准入被 withheld；不存在 execution target。**
+7. 先落地 ws-ckpt 协议前置条件，再实现 checkpoint execution target、把 Runtime checkpoint request 经
+   durable approval 与 single-use permit 接入，并在 private Core wire 上镜像第二个 profile。**未实现。**
+8. Shell/ACP/Skills/MCP/扩展保持禁用，等待后续 phase 提供完整 adapter。
+9. Parity 与 recovery acceptance 通过后，删除或显式隔离 legacy bypass。
+
+可选 profile 从不改变可移植 profile。`task-only-v1` canonical manifest 与原始版本逐字节一致，因此
+private Core v3 mirror 继续校验同一个固定 digest，task-only instance 也继续在没有 ws-ckpt package、
+socket、service 与 provider 的情况下启动。ws-ckpt daemon 不可用只能使 checkpoint-enabled instance 拒绝
+准入，绝不能阻塞 task-only instance。
 
 Rollback 保留 standalone Shell 与 legacy binary。Production `serve` 继续 fail closed，不能 fallback 到
 ACP 或 legacy mutation backend。Release 只能宣传 task-only `ask_user_question` profile，不能宣传“all
@@ -405,8 +512,19 @@ claim。仍需更广的 security suite：
 - Concurrent consume test 证明一个 permit 最多产生一个 claimed Execution ID。
 - 在 claim、audit start、OS invocation、result capture 和 Task callback 前后执行 kill-point test。
 - Typed success、typed failure、in-progress 与 unknown effect 的 reconciliation test。
-- Bypass test 证明当前 production inventory 是 task-only 且没有 `ExecutionTarget`；每个未来
+- Bypass test 证明打包的 production service 仍是 task-only 且不依赖 ws-ckpt；每个未来
   Gateway/Core/Shell/ACP/Skill/MCP mutation path 都必须先补相应测试才能启用。
+
+可选 profile 与被 withhold 的 provider 补充确定性覆盖，不涉及真实 ws-ckpt daemon、btrfs 文件系统、ECS 实例或
+人工终端：
+
+- Profile test 固定第二个 canonical manifest 与 digest，并拒绝缺失、额外、重排或改名的 tool 以及任何
+  provider set 漂移，包含此前已被拒绝的 `ws-ckpt-v1` 名称。
+- Registry test 证明 task-only instance 在没有任何 ws-ckpt 配置时接纳空 provider set 并拒绝被请求的 provider、
+  checkpoint-enabled instance 在缺少 provider 时拒绝准入，以及固化该 provider 的 profile 同样被 withhold。
+- 穷举 (profile × requested provider) 全部组合的 test 证明没有任何准入结果会产生 checkpoint 副作用 authority。
+- Transport test 把每个请求阶段分类为可证明无副作用或可能已应用，覆盖全部十三个 daemon 错误码，并覆盖 peer
+  认证与准确的只读 reconcile 查询。
 
 ## 开放问题
 


### PR DESCRIPTION
## Why

Slice B needs a closed checkpoint capability contract without granting authority that the current ws-ckpt protocol and Gateway dependency graph cannot safely enforce. This change makes the contract and transport semantics reviewable while keeping production checkpoint execution fail-closed.

## What changed

- Add the closed `workspace-checkpoint-v1` profile with an exact ordered tool inventory, exact `ws-ckpt` provider inventory, and a pinned manifest digest.
- Add a sealed Gateway provider registry. Task-only instances admit the empty provider set, while every request for checkpoint provider authority is explicitly withheld.
- Add peer-authenticated checkpoint transport primitives that classify failures as `KnownNoEffect` or `PossiblyApplied` and support a read-only snapshot evidence lookup.
- Preserve the `task-only-v1` manifest byte-for-byte and avoid adding Gateway dependencies on `cosh-platform` or `cosh-types`.
- Update the English and Chinese capability-broker design and acceptance documents with the delivered boundary and deferred prerequisites.

## Related issue

Related to #2725. This is Slice B and does not close the governed checkpoint delivery tracked by that issue.

## User / Agent impact

The current code supports these scenarios:

- A trusted caller can select `workspace-checkpoint-v1` and reject any drift in profile name, manifest digest, ordered tool inventory, or provider set.
- A production Gateway can continue to admit the portable task-only profile without a ws-ckpt socket or daemon.
- Any attempt to grant ws-ckpt side-effect authority fails before an execution target can be obtained.
- A lower-level platform caller can authenticate the Unix peer, classify a checkpoint-create failure by possible side effect, and perform one read-only evidence lookup instead of replaying an uncertain create.

The current code does not expose a Gateway checkpoint execution target, advertise the tool from Runtime, add a `serve` checkpoint-socket option, persist target receipts, or execute an end-to-end governed checkpoint Task. The PR remains Draft until the ws-ckpt protocol gains identity-only requests and an atomic generation witness, and checkpoint transport ownership is resolved without violating the Gateway dependency rule.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The public Rust contract and transport APIs expand, but existing task-only manifest bytes and legacy optional-authentication transport calls remain unchanged. Governed calls map daemon error codes to bounded local messages and never expose daemon-controlled text. Checkpoint provider authority is withheld, so this change does not enable new host side effects through Gateway.

## Validation

- `cargo test --locked -p cosh-gateway-contracts profile::` — 10 passed
- `cargo test --locked -p cosh-gateway capability::provider::` — 6 passed
- `cargo test --locked -p cosh-platform checkpoint::` — 34 passed
- `cargo clippy --locked -p cosh-platform --all-targets -- -D warnings`
- `cargo clippy --locked -p cosh-platform --tests --target aarch64-apple-darwin -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/docs-lint.sh`
- `scripts/docs-link-check.py`
- `git diff --check`

The three targeted suites also ran on a persistent x86_64 Linux ECS before review. That run exposed a root-only false-negative fixture: a root fake daemon is trusted by design. The corrected UID 65534 subprocess fixture passed the real negative `SO_PEERCRED` case as root. The review revision also cross-compiled the cosh-platform test target for `aarch64-apple-darwin` with warnings denied.

Not run on the final candidate: full workspace gates, release build, `run-test-gates.sh all`, a real ws-ckpt daemon, Btrfs behavior, or manual Terminal validation.

## Documentation and rollback

Updated the bilingual capability-broker design and acceptance documents. Revert commit `66912084` to remove Slice B; no runtime checkpoint configuration needs disabling because provider authority is not admitted.
