### PR TITLE
fix(ckpt): preserve interrupted rollback

### DIFF
--- a/src/ws-ckpt/docs/ws-ckpt-design.md
+++ b/src/ws-ckpt/docs/ws-ckpt-design.md
@@ -535,7 +535,8 @@ pub struct DaemonState {
 2. 初始化 `tracing_subscriber`
 3. 创建 `/var/lib/ws-ckpt/indexes/`
 4. `lockfile::acquire` 单实例守卫
-5. `startup::resolve_state`：加载 `state.json` → 创建 backend → bootstrap → 重建 in-memory state
+5. `startup::resolve_state`：加载 `state.json` → 创建 backend → bootstrap；bootstrap 在 backend
+   mount/data root 就绪后同步恢复可证明的 interrupted rollback，再重建 in-memory state 和 watcher
 6. `save_manifest`：持久化初始状态（bootstrap 可能改了 backend 选择）
 7. `util::ensure_symlinks`：重启后修复工作区 symlink
 8. `seccomp::apply_seccomp_filter`
@@ -548,15 +549,36 @@ pub struct DaemonState {
 
 ## 后台调度
 
-`scheduler::start_scheduler` 启动三个后台任务，全部通过 `config_notify` push 唤醒（不轮询）：
+`scheduler::start_scheduler` 启动两个后台任务，全部通过 `config_notify` push 唤醒（不轮询）：
 
 | 任务 | 触发 | 行为 |
 |------|------|------|
 | **Auto-cleanup** | 每 `auto_cleanup_interval_secs` 或 config reload 唤醒 | 遍历所有 ws，按各自 effective policy 的 `Count(N)` 或 `Age(duration)` 删除过期快照。任一 ws 有局部 override 启用 cleanup 即运行，全部 disabled 时 park |
 | **Health-check** | 每 `health_check_interval_secs` 或 config reload 唤醒 | 上报 fs 使用率 + 快照超限告警（>1000 / >90%），结果缓存供 CLI `HealthAdvisory` 拉取 |
-| **Orphan recovery** | 启动时一次性 | 扫描 mount path 下 `.rollback-tmp` 残留目录并清理 |
 
 config reload（`notify_waiters()`）会立即打断 sleep，让 loop 重读配置。`Notified` 在读 config 之前就 `enable()` 注册，避免 notify 丢失。
+
+### Rollback 崩溃恢复
+
+`.rollback-tmp` 是 rollback 把旧 live subvolume 移开后留下的中间状态，不能按文件名当作
+可删除的 orphan。恢复由各 Btrfs backend 的 `bootstrap` 在 state rebuild、watcher、scheduler
+和 listener 之前同步完成，并扫描 backend 自己的 data root：BtrfsBase 使用
+`<btrfs-mount>/ws-ckpt-data`，BtrfsLoop 使用 loop image 的 mount root。
+
+- tmp 是已验证的 Btrfs subvolume、live 不存在：使用 `RENAME_NOREPLACE` 恢复旧 live。
+- tmp 不存在：幂等 no-op。
+- live 与 tmp 同时存在，或任一路径是 symlink、普通目录、文件或无法验证：保留所有路径并
+  阻止 backend bootstrap。没有 durable rollback commit evidence 时，daemon 不能证明应该
+  保留哪一个 subvolume。
+- recovery 只接管在 `snapshots/<workspace-id>/` 中有对应 ownership marker 的
+  `.rollback-tmp`。该证据同时覆盖当前 ID 和 migration 保留的 legacy ID；没有 marker 的
+  foreign path 只告警并保留。
+
+当前 fail-closed 粒度是整个 daemon：一个 workspace 的 ambiguous rollback 会阻止其他
+workspace 一同启动。这是缺少 per-workspace quarantine 时的安全取舍。该恢复也不能关闭
+“新 live 已创建或旧 tmp 已删除，但 `index.head` 尚未持久化”的逻辑提交窗口；完整自动恢复
+需要 durable rollback journal/commit record。真实 Btrfs crash injection 与断电持久性仍需
+在隔离的特权环境验证。
 
 ---
 

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_base.rs
@@ -11,6 +11,7 @@ use ws_ckpt_common::backend::*;
 use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
+use super::rollback_recovery;
 use btrfs_common::{backup_path_for, recover_orphan_backup, resolve_symlink_path};
 
 /// Deployment scenario for BtrfsBase backend.
@@ -40,6 +41,12 @@ impl BtrfsBaseBackend {
             snapshots_dir,
             scenario,
         }
+    }
+
+    async fn recover_interrupted_rollbacks(&self) -> anyhow::Result<()> {
+        rollback_recovery::recover_interrupted_rollbacks(&self.data_root)
+            .await
+            .context("failed to recover interrupted BtrfsBase rollback")
     }
 
     /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 3.
@@ -513,6 +520,8 @@ impl StorageBackend for BtrfsBaseBackend {
                 .await
                 .with_context(|| format!("Failed to ensure directory exists: {:?}", dir))?;
         }
+        // Startup awaits bootstrap before rebuilding workspace watchers.
+        self.recover_interrupted_rollbacks().await?;
         Ok(())
     }
 }
@@ -521,7 +530,7 @@ impl StorageBackend for BtrfsBaseBackend {
 mod tests {
     use super::{BtrfsBaseBackend, BtrfsBaseScenario};
     use ws_ckpt_common::backend::StorageBackend;
-    use ws_ckpt_common::{CleanupRetention, DaemonConfig};
+    use ws_ckpt_common::{CleanupRetention, DaemonConfig, SNAPSHOTS_DIR};
 
     fn dummy_config() -> DaemonConfig {
         DaemonConfig {
@@ -561,5 +570,23 @@ mod tests {
         backend.bootstrap(&dummy_config()).await.unwrap();
         // A second call on existing directories must succeed.
         backend.bootstrap(&dummy_config()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bootstrap_recovery_scans_backend_data_root_not_config_mount_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = BtrfsBaseBackend::new(tmp.path().to_path_buf(), BtrfsBaseScenario::InPlace);
+        let data_root = tmp.path().join("ws-ckpt-data");
+        tokio::fs::create_dir_all(&data_root).await.unwrap();
+        let candidate = data_root.join("ws-abc123.rollback-tmp");
+        tokio::fs::write(&candidate, b"foreign").await.unwrap();
+        tokio::fs::create_dir_all(data_root.join(SNAPSHOTS_DIR).join("ws-abc123"))
+            .await
+            .unwrap();
+
+        let error = backend.bootstrap(&dummy_config()).await.unwrap_err();
+
+        assert!(format!("{error:#}").contains("ambiguous interrupted rollback"));
+        assert!(candidate.exists(), "unsafe candidate must be preserved");
     }
 }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -12,6 +12,7 @@ use ws_ckpt_common::persist::LoopImgState;
 use ws_ckpt_common::{DaemonConfig, DiffEntry, WorkspaceInfo, SNAPSHOTS_DIR};
 
 use super::btrfs_common;
+use super::rollback_recovery;
 use crate::util::{is_mounted, run_command, run_command_checked};
 use btrfs_common::{backup_path_for, recover_orphan_backup, resolve_symlink_path};
 
@@ -29,6 +30,12 @@ impl BtrfsLoopBackend {
             img_path,
             snapshots_dir,
         }
+    }
+
+    async fn recover_interrupted_rollbacks(&self) -> anyhow::Result<()> {
+        rollback_recovery::recover_interrupted_rollbacks(&self.mount_path)
+            .await
+            .context("failed to recover interrupted BtrfsLoop rollback")
     }
 
     /// Internal init implementation; caller wraps with cleanup-on-failure. Sets `*backup_owned` after step 3.
@@ -527,6 +534,9 @@ impl StorageBackend for BtrfsLoopBackend {
         tokio::fs::create_dir_all(&snapshots_dir)
             .await
             .context("Failed to create snapshots directory")?;
+
+        // Startup awaits bootstrap before rebuilding workspace watchers.
+        self.recover_interrupted_rollbacks().await?;
 
         info!("BtrfsLoop bootstrap complete (img={:?})", self.img_path);
         Ok(())
@@ -1219,9 +1229,29 @@ fn parse_df_total(output: &str) -> anyhow::Result<u64> {
 mod tests {
     use super::{
         compute_target_size, derive_img_dir, parse_df_available, parse_df_total, parse_losetup_j,
+        BtrfsLoopBackend,
     };
+    use ws_ckpt_common::SNAPSHOTS_DIR;
 
     const GB: u64 = 1024 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn recovery_scans_loop_mount_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mount_path = tmp.path().join("mount");
+        tokio::fs::create_dir_all(&mount_path).await.unwrap();
+        let candidate = mount_path.join("ws-abc123.rollback-tmp");
+        tokio::fs::write(&candidate, b"foreign").await.unwrap();
+        tokio::fs::create_dir_all(mount_path.join(SNAPSHOTS_DIR).join("ws-abc123"))
+            .await
+            .unwrap();
+        let backend = BtrfsLoopBackend::new(mount_path, tmp.path().join("image"));
+
+        let error = backend.recover_interrupted_rollbacks().await.unwrap_err();
+
+        assert!(format!("{error:#}").contains("ambiguous interrupted rollback"));
+        assert!(candidate.exists(), "unsafe candidate must be preserved");
+    }
 
     #[test]
     fn parses_available_column_from_df_b1() {

--- a/src/ws-ckpt/src/crates/daemon/src/backends/mod.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/mod.rs
@@ -1,3 +1,4 @@
 pub mod btrfs_base;
 pub mod btrfs_common;
 pub mod btrfs_loop;
+pub(crate) mod rollback_recovery;

--- a/src/ws-ckpt/src/crates/daemon/src/backends/rollback_recovery.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/rollback_recovery.rs
@@ -1,0 +1,556 @@
+//! Startup recovery for Btrfs rollback temporary subvolumes.
+//!
+//! Ambiguous state stops backend bootstrap because ws-ckpt has no durable
+//! rollback commit record with which to choose between two live candidates.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use nix::fcntl::{renameat2, RenameFlags};
+use tokio::process::Command;
+use tracing::{info, warn};
+use ws_ckpt_common::SNAPSHOTS_DIR;
+
+const ROLLBACK_TMP_SUFFIX: &str = ".rollback-tmp";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RollbackPathState {
+    Missing,
+    Subvolume,
+    Unsafe(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RollbackRecoveryOutcome {
+    Noop,
+    RestoredLive,
+}
+
+#[async_trait]
+trait RollbackRecoveryOps: Sync {
+    async fn inspect(&self, path: &Path) -> Result<RollbackPathState>;
+    async fn rename_noreplace(&self, from: &Path, to: &Path) -> Result<()>;
+}
+
+struct BtrfsRollbackRecoveryOps;
+
+#[async_trait]
+impl RollbackRecoveryOps for BtrfsRollbackRecoveryOps {
+    async fn inspect(&self, path: &Path) -> Result<RollbackPathState> {
+        let metadata = match tokio::fs::symlink_metadata(path).await {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(RollbackPathState::Missing)
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("failed to inspect {}", path.display()))
+            }
+        };
+
+        if metadata.file_type().is_symlink() {
+            return Ok(RollbackPathState::Unsafe("a symlink".to_string()));
+        }
+        if !metadata.is_dir() {
+            return Ok(RollbackPathState::Unsafe(
+                "not a directory or Btrfs subvolume".to_string(),
+            ));
+        }
+
+        let output = Command::new("btrfs")
+            .args(["subvolume", "show"])
+            .arg(path)
+            .output()
+            .await
+            .with_context(|| format!("failed to verify Btrfs subvolume {}", path.display()))?;
+        if output.status.success() {
+            return Ok(RollbackPathState::Subvolume);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Ok(RollbackPathState::Unsafe(format!(
+            "not a verified Btrfs subvolume (btrfs exited with {}: {})",
+            output.status,
+            stderr.trim()
+        )))
+    }
+
+    async fn rename_noreplace(&self, from: &Path, to: &Path) -> Result<()> {
+        rename_noreplace(from, to).await
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RollbackTmpName {
+    NotCandidate,
+    Workspace(OsString),
+    Malformed,
+}
+
+fn classify_rollback_tmp_name(name: &OsStr) -> RollbackTmpName {
+    let Some(ws_id) = name.as_bytes().strip_suffix(ROLLBACK_TMP_SUFFIX.as_bytes()) else {
+        return RollbackTmpName::NotCandidate;
+    };
+    if ws_id.is_empty() || ws_id == b"." || ws_id == b".." {
+        return RollbackTmpName::Malformed;
+    }
+    RollbackTmpName::Workspace(OsString::from_vec(ws_id.to_vec()))
+}
+
+async fn has_workspace_ownership_marker(data_root: &Path, ws_id: &OsStr) -> Result<bool> {
+    let marker = data_root.join(SNAPSHOTS_DIR).join(ws_id);
+    match tokio::fs::symlink_metadata(&marker).await {
+        Ok(metadata) => Ok(metadata.is_dir() && !metadata.file_type().is_symlink()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "failed to inspect rollback ownership marker {}",
+                marker.display()
+            )
+        }),
+    }
+}
+
+async fn recover_interrupted_rollback_with<O: RollbackRecoveryOps>(
+    data_root: &Path,
+    ws_id: &OsStr,
+    ops: &O,
+) -> Result<RollbackRecoveryOutcome> {
+    let live_path = data_root.join(ws_id);
+    let mut tmp_name = ws_id.to_os_string();
+    tmp_name.push(ROLLBACK_TMP_SUFFIX);
+    let tmp_path = data_root.join(tmp_name);
+
+    let tmp_state = ops
+        .inspect(&tmp_path)
+        .await
+        .with_context(|| format!("failed to inspect rollback temporary path {tmp_path:?}"))?;
+    if tmp_state == RollbackPathState::Missing {
+        return Ok(RollbackRecoveryOutcome::Noop);
+    }
+
+    let live_state = ops
+        .inspect(&live_path)
+        .await
+        .with_context(|| format!("failed to inspect live workspace path {live_path:?}"))?;
+
+    match (live_state, tmp_state) {
+        (RollbackPathState::Missing, RollbackPathState::Subvolume) => {
+            ops.rename_noreplace(&tmp_path, &live_path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to restore interrupted rollback {tmp_path:?} -> {live_path:?}; \
+                         temporary subvolume was retained"
+                    )
+                })?;
+            info!(
+                "Restored live workspace from interrupted rollback: {:?} -> {:?}",
+                tmp_path, live_path
+            );
+            Ok(RollbackRecoveryOutcome::RestoredLive)
+        }
+        (live_state, tmp_state) => bail!(
+            "ambiguous interrupted rollback for workspace {ws_id:?}: live path {live_path:?} is \
+             {live_state:?}, temporary path {tmp_path:?} is {tmp_state:?}; refusing to rename or \
+             delete either path"
+        ),
+    }
+}
+
+/// Resolves all interrupted rollbacks before workspace state is rebuilt.
+///
+/// Any owned but ambiguous entry fails the whole backend bootstrap. This is a
+/// deliberate coarse fail-closed boundary until per-workspace quarantine and
+/// durable rollback commit evidence exist.
+pub(crate) async fn recover_interrupted_rollbacks(data_root: &Path) -> Result<()> {
+    recover_interrupted_rollbacks_with(data_root, &BtrfsRollbackRecoveryOps).await
+}
+
+async fn recover_interrupted_rollbacks_with<O: RollbackRecoveryOps>(
+    data_root: &Path,
+    ops: &O,
+) -> Result<()> {
+    let mut entries = match tokio::fs::read_dir(data_root).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("failed to scan backend data root {data_root:?}"))
+        }
+    };
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| format!("failed to scan backend data root {data_root:?}"))?
+    {
+        let name = entry.file_name();
+        match classify_rollback_tmp_name(&name) {
+            RollbackTmpName::NotCandidate => {}
+            RollbackTmpName::Workspace(ws_id) => {
+                if has_workspace_ownership_marker(data_root, &ws_id).await? {
+                    recover_interrupted_rollback_with(data_root, &ws_id, ops).await?;
+                } else {
+                    warn!(
+                        "Leaving unowned rollback temporary entry untouched: {:?}",
+                        entry.path()
+                    );
+                }
+            }
+            RollbackTmpName::Malformed => warn!(
+                "Leaving malformed rollback temporary entry untouched: {:?}",
+                entry.path()
+            ),
+        }
+    }
+
+    Ok(())
+}
+
+async fn rename_noreplace(from: &Path, to: &Path) -> Result<()> {
+    if !from.is_absolute() || !to.is_absolute() {
+        bail!("rollback recovery rename requires absolute paths: from={from:?}, to={to:?}");
+    }
+
+    let from = from.to_path_buf();
+    let to = to.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        renameat2(
+            None,
+            from.as_path(),
+            None,
+            to.as_path(),
+            RenameFlags::RENAME_NOREPLACE,
+        )
+        .with_context(|| format!("failed to rename {from:?} to {to:?} without replacement"))
+    })
+    .await
+    .context("rollback recovery rename task failed")??;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeRollbackOps {
+        states: Mutex<HashMap<PathBuf, RollbackPathState>>,
+        calls: Mutex<Vec<String>>,
+        fail_rename: bool,
+    }
+
+    impl FakeRollbackOps {
+        fn with_states(states: impl IntoIterator<Item = (PathBuf, RollbackPathState)>) -> Self {
+            Self {
+                states: Mutex::new(states.into_iter().collect()),
+                ..Self::default()
+            }
+        }
+
+        fn state(&self, path: &Path) -> RollbackPathState {
+            self.states
+                .lock()
+                .unwrap()
+                .get(path)
+                .cloned()
+                .unwrap_or(RollbackPathState::Missing)
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl RollbackRecoveryOps for FakeRollbackOps {
+        async fn inspect(&self, path: &Path) -> Result<RollbackPathState> {
+            Ok(self.state(path))
+        }
+
+        async fn rename_noreplace(&self, from: &Path, to: &Path) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("rename:{}->{}", from.display(), to.display()));
+            if self.fail_rename {
+                bail!("injected rename failure");
+            }
+
+            let mut states = self.states.lock().unwrap();
+            if states.contains_key(to) {
+                bail!("destination exists");
+            }
+            let state = states
+                .remove(from)
+                .ok_or_else(|| anyhow::anyhow!("source missing"))?;
+            states.insert(to.to_path_buf(), state);
+            Ok(())
+        }
+    }
+
+    fn rollback_paths(root: &Path) -> (PathBuf, PathBuf) {
+        (root.join("ws-abc123"), root.join("ws-abc123.rollback-tmp"))
+    }
+
+    #[test]
+    fn rollback_tmp_name_accepts_current_and_legacy_workspace_ids() {
+        for name in [
+            "ws-abc123.rollback-tmp",
+            "ws-012def-2.rollback-tmp",
+            "ws-abc.rollback-tmp",
+            "legacy-project.rollback-tmp",
+        ] {
+            assert!(matches!(
+                classify_rollback_tmp_name(std::ffi::OsStr::new(name)),
+                RollbackTmpName::Workspace(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn rollback_tmp_name_rejects_unsafe_and_unrelated_names() {
+        for name in [".rollback-tmp", "..rollback-tmp", "...rollback-tmp"] {
+            assert_eq!(
+                classify_rollback_tmp_name(std::ffi::OsStr::new(name)),
+                RollbackTmpName::Malformed,
+                "{name}"
+            );
+        }
+        assert_eq!(
+            classify_rollback_tmp_name(std::ffi::OsStr::new("ws-abc123")),
+            RollbackTmpName::NotCandidate
+        );
+        let non_utf8 = std::ffi::OsString::from_vec(
+            [b"ws-abc12\xff".as_slice(), ROLLBACK_TMP_SUFFIX.as_bytes()].concat(),
+        );
+        assert_eq!(
+            classify_rollback_tmp_name(&non_utf8),
+            RollbackTmpName::Workspace(std::ffi::OsString::from_vec(b"ws-abc12\xff".to_vec()))
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_rollback_restores_tmp_when_live_is_missing() {
+        let root = Path::new("/backend");
+        let (live, tmp) = rollback_paths(root);
+        let ops = FakeRollbackOps::with_states([(tmp.clone(), RollbackPathState::Subvolume)]);
+
+        let outcome = recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &ops)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, RollbackRecoveryOutcome::RestoredLive);
+        assert_eq!(ops.state(&live), RollbackPathState::Subvolume);
+        assert_eq!(ops.state(&tmp), RollbackPathState::Missing);
+        assert_eq!(
+            ops.calls(),
+            vec![format!("rename:{}->{}", tmp.display(), live.display())]
+        );
+    }
+
+    #[tokio::test]
+    async fn both_valid_subvolumes_fail_closed_without_commit_evidence() {
+        let root = Path::new("/backend");
+        let (live, tmp) = rollback_paths(root);
+        let ops = FakeRollbackOps::with_states([
+            (live.clone(), RollbackPathState::Subvolume),
+            (tmp.clone(), RollbackPathState::Subvolume),
+        ]);
+
+        let error = recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &ops)
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("ambiguous interrupted rollback"));
+        assert_eq!(ops.state(&live), RollbackPathState::Subvolume);
+        assert_eq!(ops.state(&tmp), RollbackPathState::Subvolume);
+        assert!(ops.calls().is_empty(), "neither subvolume may be deleted");
+    }
+
+    #[tokio::test]
+    async fn recovery_is_idempotent_after_restore() {
+        let root = Path::new("/backend");
+        let (_, tmp) = rollback_paths(root);
+        let restore_ops = FakeRollbackOps::with_states([(tmp, RollbackPathState::Subvolume)]);
+        recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &restore_ops)
+            .await
+            .unwrap();
+        assert_eq!(
+            recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &restore_ops)
+                .await
+                .unwrap(),
+            RollbackRecoveryOutcome::Noop
+        );
+    }
+
+    #[tokio::test]
+    async fn ambiguous_rollback_states_fail_closed() {
+        let root = Path::new("/backend");
+        let (live, tmp) = rollback_paths(root);
+        let unsafe_states = [
+            (
+                RollbackPathState::Unsafe("a symlink".to_string()),
+                RollbackPathState::Subvolume,
+            ),
+            (
+                RollbackPathState::Unsafe("not a subvolume".to_string()),
+                RollbackPathState::Subvolume,
+            ),
+            (
+                RollbackPathState::Missing,
+                RollbackPathState::Unsafe("a symlink".to_string()),
+            ),
+            (
+                RollbackPathState::Subvolume,
+                RollbackPathState::Unsafe("not a subvolume".to_string()),
+            ),
+        ];
+
+        for (live_state, tmp_state) in unsafe_states {
+            let ops = FakeRollbackOps::with_states([
+                (live.clone(), live_state.clone()),
+                (tmp.clone(), tmp_state.clone()),
+            ]);
+            let error = recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &ops)
+                .await
+                .unwrap_err();
+
+            assert!(format!("{error:#}").contains("refusing to rename or delete"));
+            assert_eq!(ops.state(&live), live_state);
+            assert_eq!(ops.state(&tmp), tmp_state);
+            assert!(ops.calls().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_rename_failure_preserves_retryable_state() {
+        let root = Path::new("/backend");
+        let (live, tmp) = rollback_paths(root);
+        let rename_ops = FakeRollbackOps {
+            fail_rename: true,
+            ..FakeRollbackOps::with_states([(tmp.clone(), RollbackPathState::Subvolume)])
+        };
+
+        assert!(
+            recover_interrupted_rollback_with(root, OsStr::new("ws-abc123"), &rename_ops)
+                .await
+                .is_err()
+        );
+        assert_eq!(rename_ops.state(&live), RollbackPathState::Missing);
+        assert_eq!(rename_ops.state(&tmp), RollbackPathState::Subvolume);
+    }
+
+    #[tokio::test]
+    async fn rename_noreplace_never_overwrites_a_concurrent_live_path() {
+        let root = tempfile::tempdir().unwrap();
+        let from = root.path().join("from");
+        let to = root.path().join("to");
+        tokio::fs::write(&from, b"preserved").await.unwrap();
+        tokio::fs::write(&to, b"concurrent").await.unwrap();
+
+        assert!(rename_noreplace(&from, &to).await.is_err());
+        assert_eq!(tokio::fs::read(&from).await.unwrap(), b"preserved");
+        assert_eq!(tokio::fs::read(&to).await.unwrap(), b"concurrent");
+    }
+
+    #[tokio::test]
+    async fn rename_noreplace_rejects_relative_paths() {
+        let error = rename_noreplace(Path::new("from"), Path::new("to"))
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("requires absolute paths"));
+    }
+
+    #[tokio::test]
+    async fn scanner_preserves_malformed_and_non_subvolume_entries() {
+        let root = tempfile::tempdir().unwrap();
+        let malformed = root.path().join("foreign.rollback-tmp");
+        let regular_dir = root.path().join("ws-abc123.rollback-tmp");
+        tokio::fs::create_dir(&malformed).await.unwrap();
+        tokio::fs::create_dir(&regular_dir).await.unwrap();
+        tokio::fs::create_dir_all(root.path().join(SNAPSHOTS_DIR).join("ws-abc123"))
+            .await
+            .unwrap();
+
+        let ops = FakeRollbackOps::with_states([(
+            regular_dir.clone(),
+            RollbackPathState::Unsafe("not a subvolume".to_string()),
+        )]);
+        let error = recover_interrupted_rollbacks_with(root.path(), &ops)
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("ambiguous interrupted rollback"));
+        assert!(malformed.exists(), "malformed candidate must be preserved");
+        assert!(
+            regular_dir.exists(),
+            "ordinary directory must never be remove_dir_all'ed"
+        );
+    }
+
+    #[tokio::test]
+    async fn unowned_entry_is_preserved_without_blocking_startup() {
+        let root = tempfile::tempdir().unwrap();
+        let malformed = root.path().join("foreign.rollback-tmp");
+        tokio::fs::create_dir(&malformed).await.unwrap();
+
+        recover_interrupted_rollbacks_with(root.path(), &FakeRollbackOps::default())
+            .await
+            .unwrap();
+
+        assert!(malformed.exists());
+    }
+
+    #[tokio::test]
+    async fn scanner_restores_owned_legacy_workspace_id() {
+        let root = tempfile::tempdir().unwrap();
+        let ws_id = OsStr::new("ws-abc");
+        let live = root.path().join(ws_id);
+        let tmp = root.path().join("ws-abc.rollback-tmp");
+        tokio::fs::create_dir(&tmp).await.unwrap();
+        tokio::fs::create_dir_all(root.path().join(SNAPSHOTS_DIR).join(ws_id))
+            .await
+            .unwrap();
+        let ops = FakeRollbackOps::with_states([(tmp.clone(), RollbackPathState::Subvolume)]);
+
+        recover_interrupted_rollbacks_with(root.path(), &ops)
+            .await
+            .unwrap();
+
+        assert_eq!(ops.state(&live), RollbackPathState::Subvolume);
+        assert_eq!(ops.state(&tmp), RollbackPathState::Missing);
+        assert_eq!(
+            ops.calls(),
+            vec![format!("rename:{}->{}", tmp.display(), live.display())]
+        );
+    }
+
+    #[tokio::test]
+    async fn real_path_inspection_rejects_symlink_without_following_it() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        let candidate = root.path().join("ws-abc123.rollback-tmp");
+        tokio::fs::create_dir(&target).await.unwrap();
+        tokio::fs::symlink(&target, &candidate).await.unwrap();
+
+        let state = BtrfsRollbackRecoveryOps.inspect(&candidate).await.unwrap();
+        assert_eq!(state, RollbackPathState::Unsafe("a symlink".to_string()));
+        assert!(
+            tokio::fs::symlink_metadata(&candidate)
+                .await
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "symlink candidate must be preserved"
+        );
+    }
+}

--- a/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/scheduler.rs
@@ -1,18 +1,15 @@
-//! Background scheduler: auto-cleanup, health check, and orphan recovery.
+//! Background scheduler: auto-cleanup and health checks.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use tokio::time::Duration;
 use tracing::{debug, error, info, warn};
 
-use crate::backends::btrfs_common;
 use crate::snapshot_mgr::{delete_snapshots_locked, ensure_index_dir, persist_index_after_cleanup};
 use crate::state::DaemonState;
 use ws_ckpt_common::{CleanupRetention, EffectivePolicy};
 
-/// Start background scheduler tasks: orphan cleanup on boot, periodic auto-cleanup,
-/// and periodic health checks.
+/// Start background scheduler tasks: periodic auto-cleanup and health checks.
 ///
 /// Config hot-reload is **push-based**: the dispatcher calls
 /// `state.config_notify.notify_waiters()` after updating `state.config`, and
@@ -21,14 +18,6 @@ use ws_ckpt_common::{CleanupRetention, EffectivePolicy};
 /// (`auto_cleanup = false` or `*_interval_secs == 0`) blocks on the notify
 /// at zero CPU cost until a reload re-enables it.
 pub fn start_scheduler(state: Arc<DaemonState>) {
-    // Startup orphan cleanup
-    let mount_path = state.mount_path.clone();
-    tokio::spawn(async move {
-        if let Err(e) = cleanup_orphans(&mount_path).await {
-            error!("Failed to cleanup orphans: {}", e);
-        }
-    });
-
     // Periodic auto-cleanup: reacts to `ReloadConfig` via `config_notify`.
     let state_clone = state.clone();
     tokio::spawn(async move {
@@ -101,60 +90,6 @@ async fn health_check_loop(state: Arc<DaemonState>) {
             _ = notified.as_mut() => {}
         }
     }
-}
-
-/// Orphan recovery: clean up `.rollback-tmp` residual directories.
-///
-/// Scans the mount path for directories ending with `.rollback-tmp`
-/// and removes them. Returns the list of cleaned-up paths.
-pub async fn cleanup_orphans(mount_path: &Path) -> Result<Vec<String>, anyhow::Error> {
-    let mut cleaned = Vec::new();
-
-    let read_dir = match std::fs::read_dir(mount_path) {
-        Ok(rd) => rd,
-        Err(e) => {
-            warn!("Cannot read mount path for orphan cleanup: {}", e);
-            return Ok(cleaned);
-        }
-    };
-
-    for entry in read_dir {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy().to_string();
-        let path = entry.path();
-
-        if name_str.ends_with(".rollback-tmp") {
-            info!("Cleaning up orphan directory: {:?}", path);
-
-            // Try btrfs subvolume delete first, fall back to remove_dir_all
-            match btrfs_common::delete_subvolume(&path).await {
-                Ok(()) => {
-                    info!("Deleted orphan subvolume: {:?}", path);
-                }
-                Err(_) => {
-                    // Fallback: try regular directory removal
-                    if let Err(e) = tokio::fs::remove_dir_all(&path).await {
-                        warn!("Failed to remove orphan directory {:?}: {}", path, e);
-                        continue;
-                    }
-                    info!("Removed orphan directory: {:?}", path);
-                }
-            }
-
-            cleaned.push(path.to_string_lossy().to_string());
-        }
-    }
-
-    if !cleaned.is_empty() {
-        info!("Orphan cleanup complete: {} items removed", cleaned.len());
-    }
-
-    Ok(cleaned)
 }
 
 /// Auto-cleanup: purge non-pinned snapshots per `CleanupRetention` (pinned always kept).
@@ -297,48 +232,6 @@ async fn health_check(state: &DaemonState) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn cleanup_orphans_removes_rollback_tmp() {
-        let dir = tempfile::tempdir().unwrap();
-        let orphan1 = dir.path().join("ws-abc123.rollback-tmp");
-        let normal = dir.path().join("ws-normal");
-
-        std::fs::create_dir(&orphan1).unwrap();
-        std::fs::create_dir(&normal).unwrap();
-
-        let cleaned = cleanup_orphans(dir.path()).await.unwrap();
-
-        assert_eq!(cleaned.len(), 1);
-        assert!(!orphan1.exists(), "rollback-tmp should be removed");
-        assert!(normal.exists(), "normal directory should remain");
-    }
-
-    #[tokio::test]
-    async fn cleanup_orphans_empty_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let cleaned = cleanup_orphans(dir.path()).await.unwrap();
-        assert!(cleaned.is_empty());
-    }
-
-    #[tokio::test]
-    async fn cleanup_orphans_nonexistent_path() {
-        let result = cleanup_orphans(Path::new("/nonexistent/path/12345")).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn cleanup_orphans_only_normal_dirs() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir(dir.path().join("ws-abc")).unwrap();
-        std::fs::create_dir(dir.path().join("snapshots")).unwrap();
-
-        let cleaned = cleanup_orphans(dir.path()).await.unwrap();
-        assert!(cleaned.is_empty());
-    }
-
     // ── Per-workspace effective policy invariants ──
     // Backend-free: only assert the routing rules `auto_cleanup_loop` relies on.
     use ws_ckpt_common::{CleanupRetention, DaemonConfig, WorkspacePolicy};


### PR DESCRIPTION
## Why

A daemon or host crash after rollback renames the live workspace to `.rollback-tmp` can leave that temporary subvolume as the only preserved live state. The old BtrfsLoop startup task deleted every matching path by suffix, while BtrfsBase scanned the wrong directory level and left the workspace unrecovered. This is a pre-existing ws-ckpt defect from the component's initial merge and is independent of cosh-ng checkpoint-provider work.

## What changed

- Recover rollback temporary state synchronously from each Btrfs backend bootstrap, after storage is ready and before state rebuild creates workspace watchers.
- Restore only the provable state where a verified temporary Btrfs subvolume exists and the live path is absent, using `RENAME_NOREPLACE`; the rename helper rejects relative paths before entering the blocking task.
- Preserve both paths and fail closed when live and temporary subvolumes both exist or either path is unsafe; no commit evidence exists to choose one automatically.
- Remove the scheduler's detached suffix-based cleanup and its `remove_dir_all` fallback.
- Scan the actual backend data root for both BtrfsBase and BtrfsLoop, and require a `snapshots/<workspace-id>/` ownership marker so current and migrated legacy IDs are recovered while foreign candidates are preserved.
- Keep the online rollback implementation unchanged.

## Related issue

Closes #2771.

## User / Agent impact

After an interrupted pre-replacement rollback, daemon restart restores the preserved old live subvolume before watchers or the listener start. Ambiguous rollback state is never deleted automatically; it now blocks backend bootstrap so an operator can inspect both candidates. This coarse fail-closed behavior can make all workspaces unavailable because per-workspace quarantine does not exist yet. No CLI, configuration, or wire contract changes.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Migration or rollback guidance is needed

The documented startup architecture changes from detached scheduler cleanup to synchronous backend recovery. A valid owned but ambiguous candidate stops the whole daemon, including after a successful rollback whose old-subvolume cleanup failed. Foreign or malformed names are retained with a warning and do not block startup.

This PR does not close the crash window after a new live subvolume is created or the old temporary subvolume is deleted but before `index.head` is persisted. Complete automatic recovery needs a durable rollback journal/commit record and per-workspace quarantine.

## Validation

- `cargo test --locked -p ws-ckpt-daemon rollback_recovery` — 13 passed
- `cargo test --locked -p ws-ckpt-daemon bootstrap_recovery_scans_backend_data_root_not_config_mount_path` — 1 passed
- `cargo test --locked -p ws-ckpt-daemon recovery_scans_loop_mount_path` — 1 passed
- `cargo test --locked -p ws-ckpt-daemon scheduler::tests` — 3 passed
- `cargo clippy --locked -p ws-ckpt-daemon --all-targets -- -D warnings`
- `cargo fmt --all --manifest-path src/ws-ckpt/src/Cargo.toml -- --check`
- `scripts/docs-lint.sh`
- `scripts/docs-link-check.py`
- `git diff --check`

Not run: real Btrfs subvolume crash injection, power-loss durability, release build, ECS, or full workspace gates.

## Documentation and rollback

Updated the ws-ckpt design document with the synchronous recovery state machine, backend roots, global fail-closed blast radius, and journal limitation. Roll back by reverting `eee0c3b7`; before running an older daemon, manually inspect any remaining `.rollback-tmp` path because the old scheduler may delete it by suffix.
