### PR TITLE
fix(anolisa): honor dry-run on restart

### DIFF
--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -134,7 +134,9 @@ sudo anolisa --install-mode system restart <component>
 ```
 
 `--dry-run` lists the units that would restart and does not run
-`systemctl daemon-reload` or `systemctl restart`.
+`systemctl daemon-reload` or `systemctl restart`. System-mode preview
+reads recorded state without taking the exclusive install lock, so it
+does not need write access to the state root.
 
 ### upgrade
 

--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -127,9 +127,14 @@ explicitly.
 Restart services recorded for an installation in the selected scope:
 
 ```bash
+anolisa --dry-run --install-mode user restart <component>
 anolisa --install-mode user restart <component>
+anolisa --dry-run --install-mode system restart <component>
 sudo anolisa --install-mode system restart <component>
 ```
+
+`--dry-run` lists the units that would restart and does not run
+`systemctl daemon-reload` or `systemctl restart`.
 
 ### upgrade
 

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -119,9 +119,14 @@ system root 时，它会在修复建议中补全
 重启所选 scope 安装记录中的 service：
 
 ```bash
+anolisa --dry-run --install-mode user restart <component>
 anolisa --install-mode user restart <component>
+anolisa --dry-run --install-mode system restart <component>
 sudo anolisa --install-mode system restart <component>
 ```
+
+`--dry-run` 只列出将要重启的 unit，不会执行 `systemctl daemon-reload`
+或 `systemctl restart`。
 
 ### upgrade
 

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -126,7 +126,8 @@ sudo anolisa --install-mode system restart <component>
 ```
 
 `--dry-run` 只列出将要重启的 unit，不会执行 `systemctl daemon-reload`
-或 `systemctl restart`。
+或 `systemctl restart`。system 模式预览只读已记录状态，不获取排他安装锁，
+因此不需要 state root 的写权限。
 
 ### upgrade
 

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -34,7 +34,7 @@ anolisa update all
 | `status` | Show component health |
 | `doctor` | Diagnose issues and suggest fixes |
 | `logs` | Query component logs (`--severity`, alias `--level`) |
-| `restart` | Restart a component service |
+| `restart` | Restart a component service (`--dry-run` lists units without dispatching) |
 | `repair` | Reconcile state after manual RPM changes |
 | `adopt` | Record an existing system RPM as adopted without default removal authority |
 | `forget` | Drop state record without package operations |

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -34,7 +34,7 @@ anolisa update all
 | `status` | 显示组件健康状态 |
 | `doctor` | 诊断问题并给出修复建议 |
 | `logs` | 查询组件日志（`--severity`，别名 `--level`） |
-| `restart` | 重启组件服务 |
+| `restart` | 重启组件服务（`--dry-run` 仅列出 unit，不执行重启） |
 | `repair` | 手工修改 RPM 后协调 ANOLISA 状态与 rpmdb |
 | `adopt` | 将已有 system RPM 记录为已采纳安装 |
 | `forget` | 仅删除状态记录，不执行包操作 |

--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -398,8 +398,8 @@ fn command_policy(command: &Commands) -> CommandPolicy {
             ComponentCommands::Doctor(_) => CommandPolicy::new("doctor", CommandScope::ReadOnly),
             ComponentCommands::Logs(_) => CommandPolicy::new("logs", CommandScope::ReadOnly),
             // Preview lists recorded/discovered units and does not
-            // daemon-reload or restart, so `--dry-run` can waive root
-            // like install/uninstall/repair/forget.
+            // daemon-reload, restart, or take the exclusive install lock,
+            // so `--dry-run` can waive root like install/uninstall/repair/forget.
             ComponentCommands::Restart(_) => mode_scoped("restart", true),
             // `update --check` is read-only upgrade detection: it only runs
             // read-only rpm/dnf queries (no package transaction, no state

--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -397,7 +397,10 @@ fn command_policy(command: &Commands) -> CommandPolicy {
             ComponentCommands::Status(_) => CommandPolicy::new("status", CommandScope::ReadOnly),
             ComponentCommands::Doctor(_) => CommandPolicy::new("doctor", CommandScope::ReadOnly),
             ComponentCommands::Logs(_) => CommandPolicy::new("logs", CommandScope::ReadOnly),
-            ComponentCommands::Restart(_) => mode_scoped("restart", false),
+            // Preview lists recorded/discovered units and does not
+            // daemon-reload or restart, so `--dry-run` can waive root
+            // like install/uninstall/repair/forget.
+            ComponentCommands::Restart(_) => mode_scoped("restart", true),
             // `update --check` is read-only upgrade detection: it only runs
             // read-only rpm/dnf queries (no package transaction, no state
             // writes), so it must not be gated behind the mutating-update root
@@ -609,6 +612,28 @@ mod tests {
 
         validate_global_args_with_euid(&ctx, mode_scoped("install", true), 1000, true)
             .expect("non-root system dry-run should reach preview-capable handlers");
+    }
+
+    #[test]
+    fn restart_policy_allows_system_dry_run_without_root() {
+        let command =
+            Commands::Component(ComponentCommands::Restart(tier1::restart::RestartArgs {
+                component: "cosh".to_string(),
+            }));
+        let policy = command_policy(&command);
+        let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+        ctx.dry_run = true;
+
+        validate_global_args_with_euid(&ctx, policy, 1000, true)
+            .expect("non-root system restart dry-run should reach the preview handler");
+        let err = validate_global_args_with_euid(
+            &ctx_with_prefix(PathBuf::from("/")),
+            policy,
+            1000,
+            true,
+        )
+        .expect_err("a real system restart still requires root");
+        assert_eq!(err.code(), "PERMISSION_DENIED");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/recovery.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/recovery.rs
@@ -110,7 +110,7 @@ impl<'lock> LockedJournalGate<'lock> {
     }
 }
 
-fn pending_operation_error(command: &str, subject: &str, path: &Path) -> CliError {
+pub(crate) fn pending_operation_error(command: &str, subject: &str, path: &Path) -> CliError {
     CliError::Runtime {
         command: command.to_string(),
         reason: format!(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -64,7 +64,18 @@ pub struct RestartArgs {
 }
 
 pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let command = format!("restart {}", args.component);
+    let payload = compute_restart(&args.component, ctx)?;
+    render_restart(&payload, ctx)
+}
+
+/// Resolve units and either preview or dispatch the restart.
+///
+/// `--dry-run` must not `daemon-reload` or `restart_service`. Those are live
+/// systemd mutations; a preview that still dispatched would bounce units
+/// while the operator asked only for the plan. Unsupported scopes stay
+/// `not_supported` so the preview names the same units execute would skip.
+fn compute_restart(input: &str, ctx: &CliContext) -> Result<RestartPayload, CliError> {
+    let command = format!("restart {input}");
 
     let install_mode = ctx.install_mode.as_str();
     let layout = common::resolve_layout(ctx);
@@ -72,7 +83,7 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         command: command.clone(),
         reason: format!("failed to acquire install lock: {err}"),
     })?;
-    let (resolved, view) = common::resolve_mutation_target(&args.component, ctx, &command)?;
+    let (resolved, view) = common::resolve_mutation_target(input, ctx, &command)?;
     let journal_dir = rpm_install::journal_dir(&layout);
     let journal_gate = LockedJournalGate::load(
         &_lock,
@@ -108,7 +119,12 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         // Ships only template units whose instances are per-user runtime state
         // restart cannot choose. Not an error: the package is fine,
         // so exit 0 and surface the per-user guidance already collected.
-        return render_guidance_only(&resolved, install_mode, warnings, ctx);
+        return Ok(guidance_only_payload(
+            &resolved,
+            install_mode,
+            warnings,
+            ctx.dry_run,
+        ));
     }
 
     let env = EnvService::detect();
@@ -137,6 +153,88 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
         (false, false) => unreachable!("restartable units present but no scope flagged"),
     };
 
+    let results = if ctx.dry_run {
+        preview_restart_results(&units, sys_manager.as_ref(), user_manager.as_ref())
+    } else {
+        execute_restart_units(
+            &units,
+            sys_manager.as_ref(),
+            user_manager.as_ref(),
+            used_sys,
+            used_user,
+            &mut warnings,
+        )
+    };
+
+    Ok(RestartPayload {
+        component: resolved,
+        install_mode: install_mode.to_string(),
+        manager: manager_label,
+        supported,
+        dry_run: ctx.dry_run,
+        units: results,
+        warnings,
+    })
+}
+
+fn render_restart(payload: &RestartPayload, ctx: &CliContext) -> Result<(), CliError> {
+    if ctx.json {
+        return render_json(COMMAND, payload);
+    }
+
+    if !ctx.quiet {
+        if payload.units.is_empty() {
+            let color = Palette::new(ctx.no_color);
+            println!(
+                "{} {} {}",
+                color.command("restart"),
+                payload.component,
+                color.warn("no instances to restart")
+            );
+            for warning in &payload.warnings {
+                eprintln!("{} {}", color.warn("guidance:"), warning);
+            }
+        } else {
+            render_human(payload, ctx.no_color);
+        }
+    }
+    Ok(())
+}
+
+/// Describe units execute would touch without contacting systemd.
+fn preview_restart_results(
+    units: &[RestartUnit],
+    sys_manager: &dyn ServiceManager,
+    user_manager: &dyn ServiceManager,
+) -> Vec<RestartResult> {
+    units
+        .iter()
+        .map(|unit| {
+            let manager = manager_for_scope(unit.scope, sys_manager, user_manager);
+            if !manager.supported() {
+                unsupported_restart_result(unit, manager)
+            } else {
+                RestartResult {
+                    component: unit.component.clone(),
+                    unit: unit.unit.clone(),
+                    state: PLANNED_STATE.to_string(),
+                    changed: false,
+                    manager: manager.manager().to_string(),
+                    message: format!("dry-run: would restart {}", unit.unit),
+                }
+            }
+        })
+        .collect()
+}
+
+fn execute_restart_units(
+    units: &[RestartUnit],
+    sys_manager: &dyn ServiceManager,
+    user_manager: &dyn ServiceManager,
+    used_sys: bool,
+    used_user: bool,
+    warnings: &mut Vec<String>,
+) -> Vec<RestartResult> {
     // Freshly-placed units (a place-only install, or an RPM whose %post did not
     // reload the manager) aren't loadable until the manager reloads its unit
     // database, so restart would otherwise fail "unit not found". Reload once
@@ -153,36 +251,21 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
     }
 
     let mut results: Vec<RestartResult> = Vec::with_capacity(units.len());
-
-    for u in &units {
-        let manager: &dyn ServiceManager = match u.scope {
-            ServiceScope::System => sys_manager.as_ref(),
-            ServiceScope::User => user_manager.as_ref(),
-        };
+    for unit in units {
+        let manager = manager_for_scope(unit.scope, sys_manager, user_manager);
         if !manager.supported() {
             // Quiet skip: this unit's scope has no driver here (a user unit
             // in a system-mode restart, container, non-Linux). Reported
             // `not_supported` per unit so the boundary is explicit and the
             // unit is never mis-driven through another namespace.
-            let reason = manager
-                .unsupported_reason()
-                .unwrap_or("service manager not supported in this environment")
-                .to_string();
-            results.push(RestartResult {
-                component: u.component.clone(),
-                unit: u.unit.clone(),
-                state: "not_supported".to_string(),
-                changed: false,
-                manager: manager.manager().to_string(),
-                message: reason,
-            });
+            results.push(unsupported_restart_result(unit, manager));
             continue;
         }
-        match manager.restart_service(&u.unit) {
+        match manager.restart_service(&unit.unit) {
             Ok(outcome) => {
                 results.push(RestartResult {
-                    component: u.component.clone(),
-                    unit: u.unit.clone(),
+                    component: unit.component.clone(),
+                    unit: unit.unit.clone(),
                     state: outcome.state.as_str().to_string(),
                     changed: outcome.changed,
                     manager: outcome.manager,
@@ -191,8 +274,8 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
                 if matches!(outcome.state, ServiceState::Failed | ServiceState::Unknown) {
                     warnings.push(format!(
                         "{}/{} reports state '{}' after restart",
-                        u.component,
-                        u.unit,
+                        unit.component,
+                        unit.unit,
                         outcome.state.as_str()
                     ));
                 }
@@ -201,11 +284,11 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
                 let msg = format!("{err}");
                 warnings.push(format!(
                     "service restart skipped for {}/{}: {msg}",
-                    u.component, u.unit
+                    unit.component, unit.unit
                 ));
                 results.push(RestartResult {
-                    component: u.component.clone(),
-                    unit: u.unit.clone(),
+                    component: unit.component.clone(),
+                    unit: unit.unit.clone(),
                     state: "unknown".to_string(),
                     changed: false,
                     manager: manager.manager().to_string(),
@@ -214,30 +297,32 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
             }
         }
     }
+    results
+}
 
-    if ctx.json {
-        let payload = RestartPayload {
-            component: resolved.clone(),
-            install_mode: install_mode.to_string(),
-            manager: manager_label.clone(),
-            supported,
-            units: results.clone(),
-            warnings: warnings.clone(),
-        };
-        return render_json(COMMAND, &payload);
+fn manager_for_scope<'a>(
+    scope: ServiceScope,
+    sys_manager: &'a dyn ServiceManager,
+    user_manager: &'a dyn ServiceManager,
+) -> &'a dyn ServiceManager {
+    match scope {
+        ServiceScope::System => sys_manager,
+        ServiceScope::User => user_manager,
     }
+}
 
-    if !ctx.quiet {
-        render_human(
-            &resolved,
-            &manager_label,
-            supported,
-            &results,
-            &warnings,
-            ctx.no_color,
-        );
+fn unsupported_restart_result(unit: &RestartUnit, manager: &dyn ServiceManager) -> RestartResult {
+    RestartResult {
+        component: unit.component.clone(),
+        unit: unit.unit.clone(),
+        state: "not_supported".to_string(),
+        changed: false,
+        manager: manager.manager().to_string(),
+        message: manager
+            .unsupported_reason()
+            .unwrap_or("service manager not supported in this environment")
+            .to_string(),
     }
-    Ok(())
 }
 
 /// Absolute directories systemd searches for **system** unit files. A `.service`
@@ -376,43 +461,17 @@ fn guidance_only_payload(
     component: &str,
     install_mode: &str,
     warnings: Vec<String>,
+    dry_run: bool,
 ) -> RestartPayload {
     RestartPayload {
         component: component.to_string(),
         install_mode: install_mode.to_string(),
         manager: GUIDANCE_MANAGER.to_string(),
         supported: true,
+        dry_run,
         units: Vec::new(),
         warnings,
     }
-}
-
-/// Successful guidance-only outcome: the component ships only
-/// template units restart cannot expand, so there is nothing to drive but the
-/// package is healthy. Exits 0 with the per-user guidance as warnings.
-fn render_guidance_only(
-    component: &str,
-    install_mode: &str,
-    warnings: Vec<String>,
-    ctx: &CliContext,
-) -> Result<(), CliError> {
-    if ctx.json {
-        let payload = guidance_only_payload(component, install_mode, warnings);
-        return render_json(COMMAND, &payload);
-    }
-    if !ctx.quiet {
-        let color = Palette::new(ctx.no_color);
-        println!(
-            "{} {} {}",
-            color.command("restart"),
-            component,
-            color.warn("no instances to restart")
-        );
-        for w in &warnings {
-            eprintln!("{} {}", color.warn("guidance:"), w);
-        }
-    }
-    Ok(())
 }
 
 /// Keep the `.service` files that sit **directly** in a known systemd unit
@@ -482,45 +541,49 @@ struct RestartResult {
     message: String,
 }
 
-#[derive(serde::Serialize)]
+/// Wire state for a dry-run unit that execute would restart.
+const PLANNED_STATE: &str = "planned";
+
+#[derive(Debug, serde::Serialize)]
 struct RestartPayload {
     component: String,
     install_mode: String,
     manager: String,
     supported: bool,
+    dry_run: bool,
     units: Vec<RestartResult>,
     warnings: Vec<String>,
 }
 
-fn render_human(
-    component: &str,
-    manager_label: &str,
-    supported: bool,
-    results: &[RestartResult],
-    warnings: &[String],
-    no_color: bool,
-) {
+fn render_human(payload: &RestartPayload, no_color: bool) {
     let color = Palette::new(no_color);
-    if supported {
+    if payload.dry_run {
         println!(
             "{} {} {}",
             color.command("restart"),
-            component,
+            payload.component,
+            color.ok("planned")
+        );
+    } else if payload.supported {
+        println!(
+            "{} {} {}",
+            color.command("restart"),
+            payload.component,
             color.ok("dispatched")
         );
     } else {
         println!(
             "{} {} {} {}",
             color.command("restart"),
-            component,
+            payload.component,
             color.warn("skipped"),
-            color.muted(format!("(manager={manager_label} unsupported)"))
+            color.muted(format!("(manager={} unsupported)", payload.manager))
         );
     }
-    println!("{} {}", color.label("manager:"), manager_label);
-    if !results.is_empty() {
+    println!("{} {}", color.label("manager:"), payload.manager);
+    if !payload.units.is_empty() {
         println!("{}", color.header("units:"));
-        for r in results {
+        for r in &payload.units {
             println!(
                 "  - {}/{} {} (changed={})",
                 r.component,
@@ -530,7 +593,7 @@ fn render_human(
             );
         }
     }
-    for w in warnings {
+    for w in &payload.warnings {
         eprintln!("{} {}", color.warn("warning:"), w);
     }
 }
@@ -572,6 +635,60 @@ mod tests {
             prefix.clone(),
             Default::default(),
         )
+    }
+
+    fn ctx_with_options(
+        install_mode: InstallMode,
+        prefix: Option<PathBuf>,
+        options: crate::test_support::TestContextOptions,
+    ) -> CliContext {
+        let root = prefix
+            .as_deref()
+            .unwrap_or_else(|| std::path::Path::new("/tmp/anolisa-restart-validation"));
+        if install_mode == InstallMode::System
+            && let Some(prefix) = prefix.as_ref()
+        {
+            crate::commands::tier1::install::tests::seed_repo_config_with_index(
+                &anolisa_platform::fs_layout::FsLayout::system(Some(prefix.clone())),
+                crate::commands::tier1::install::tests::TEST_INDEX_COMPONENTS,
+            );
+        }
+        crate::test_support::context_for_root(root, install_mode, prefix.clone(), options)
+    }
+
+    fn plant_owned_restartable(layout: &FsLayout, name: &str, unit: &str, scope: ServiceScope) {
+        let state_path = layout.state_dir.join("installed.toml");
+        let mut store = StateStore::empty_for_layout(layout);
+        store.upsert(Installation {
+            kind: ObjectKind::Component,
+            name: name.to_string(),
+            scope: InstallationScope::System,
+            binding: ProviderBinding::Owned {
+                artifact: OwnedArtifact {
+                    version: "1.0.0".to_string(),
+                    distribution_source: None,
+                    raw_package: None,
+                    manifest_digest: None,
+                    files: Vec::new(),
+                    services: vec![ServiceRef {
+                        name: unit.to_string(),
+                        manager: "systemd".to_string(),
+                        restartable: true,
+                        enabled: true,
+                        scope,
+                    }],
+                    external_modified_files: Vec::new(),
+                    provisioned_packages: Vec::new(),
+                },
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-07-21T00:00:00Z".to_string(),
+            last_operation_id: None,
+            subscription_scope: Default::default(),
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        });
+        store.save(&state_path).expect("save state");
     }
 
     /// Fake `CommandRunner` returning a canned `rpm -ql` listing (or a spawn
@@ -752,7 +869,10 @@ mod tests {
             "anolisa-memory@.service",
             ServiceScope::User,
         )];
-        let res = render_guidance_only("agent-memory", "system", warnings, &ctx);
+        let res = render_restart(
+            &guidance_only_payload("agent-memory", "system", warnings, ctx.dry_run),
+            &ctx,
+        );
         assert!(
             res.is_ok(),
             "templates-only restart must succeed, got {res:?}"
@@ -767,9 +887,10 @@ mod tests {
             "anolisa-memory@.service",
             ServiceScope::User,
         )];
-        let payload = guidance_only_payload("agent-memory", "system", warnings);
+        let payload = guidance_only_payload("agent-memory", "system", warnings, false);
         assert_eq!(payload.manager, "none");
         assert!(payload.supported);
+        assert!(!payload.dry_run);
         assert!(payload.units.is_empty());
         assert_eq!(payload.warnings.len(), 1);
         assert!(
@@ -832,5 +953,131 @@ mod tests {
             "{}",
             err.reason()
         );
+    }
+
+    #[test]
+    fn dry_run_lists_recorded_units_without_dispatching() {
+        // A planted unit that does not exist on the host. Execute would
+        // daemon-reload and call systemctl; dry-run must stay at `planned`
+        // with changed=false so the preview cannot bounce live services.
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        plant_owned_restartable(
+            &layout,
+            "agentsight",
+            "anolisa-restart-dry-run-probe.service",
+            ServiceScope::System,
+        );
+        let ctx = ctx_with_options(
+            InstallMode::System,
+            Some(prefix),
+            crate::test_support::TestContextOptions {
+                dry_run: true,
+                quiet: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        let payload = compute_restart("agentsight", &ctx).expect("dry-run preview");
+
+        assert!(payload.dry_run, "preview must mark dry_run");
+        assert_eq!(payload.units.len(), 1, "{:?}", payload.units);
+        assert_eq!(
+            payload.units[0].unit,
+            "anolisa-restart-dry-run-probe.service"
+        );
+        assert!(!payload.units[0].changed);
+        // Hosts that can drive systemd preview as `planned`. Container/user
+        // CI still reports `not_supported` — never a live restart state.
+        assert!(
+            payload.units[0].state == PLANNED_STATE || payload.units[0].state == "not_supported",
+            "dry-run must not dispatch, got {}",
+            payload.units[0].state
+        );
+        if payload.units[0].state == PLANNED_STATE {
+            assert!(
+                payload.units[0].message.contains("dry-run: would restart"),
+                "{}",
+                payload.units[0].message
+            );
+        }
+        assert!(
+            payload
+                .warnings
+                .iter()
+                .all(|w| !w.contains("daemon-reload")),
+            "dry-run must not daemon-reload: {:?}",
+            payload.warnings
+        );
+    }
+
+    #[test]
+    fn dry_run_still_refuses_an_absent_component() {
+        let tmp = tempdir().expect("tmpdir");
+        let ctx = ctx_with_options(
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+            crate::test_support::TestContextOptions {
+                dry_run: true,
+                quiet: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+        let err = compute_restart("agentsight", &ctx).expect_err("absent target must fail");
+        assert_eq!(err.code(), "NOT_INSTALLED");
+    }
+
+    #[test]
+    fn dry_run_still_refuses_a_pending_lifecycle() {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        plant_owned_restartable(
+            &layout,
+            "agentsight",
+            "anolisa-restart-dry-run-probe.service",
+            ServiceScope::System,
+        );
+        let _pending = Transaction::begin_with_subject(
+            "uninstall",
+            Some("agentsight"),
+            layout.state_dir.join("installed.toml"),
+            &rpm_install::journal_dir(&layout),
+        )
+        .expect("begin pending uninstall");
+        let ctx = ctx_with_options(
+            InstallMode::System,
+            Some(prefix),
+            crate::test_support::TestContextOptions {
+                dry_run: true,
+                quiet: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+
+        let err = compute_restart("agentsight", &ctx)
+            .expect_err("pending lifecycle must block the preview too");
+        assert!(err.reason().contains("pending operation journal"), "{err}");
+    }
+
+    #[test]
+    fn preview_marks_unsupported_scopes_without_planned() {
+        let units = [RestartUnit {
+            component: "agentsight".to_string(),
+            unit: "agentsight.service".to_string(),
+            scope: ServiceScope::System,
+        }];
+        let manager = anolisa_core::NotSupportedServiceManager::new(
+            "container runtime detected — refusing to drive systemctl".to_string(),
+        );
+        let results = preview_restart_results(&units, &manager, &manager);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].state, "not_supported");
+        assert!(!results[0].changed);
+        assert_ne!(results[0].state, PLANNED_STATE);
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -29,14 +29,17 @@
 //!   6. Calls `restart_service(unit)` per unit. Per-unit failures are collected
 //!      as warnings; a unit systemctl refuses does NOT abort the whole op.
 //!
-//! The selected state-root lock covers lookup through service dispatch. This
-//! prevents restart from racing teardown and makes the same pending-recovery
-//! gate used by other lifecycle mutations authoritative here as well.
+//! The execute path holds the exclusive state-root lock from lookup through
+//! service dispatch so restart cannot race teardown and the pending-recovery
+//! gate stays authoritative. `--dry-run` reads the same state and journals
+//! without creating or exclusively locking that root, matching
+//! forget/repair previews, so a non-root system preview can render a plan
+//! on a root-owned install.
 
 use clap::Parser;
 
 use anolisa_core::domain::{Installation, ProviderBinding};
-use anolisa_core::facts::JournalEvidence;
+use anolisa_core::facts::{JournalEvidence, pending_journal_for};
 use anolisa_core::lock::InstallLock;
 use anolisa_core::{
     ObjectKind, ServiceManager, ServiceScope, ServiceState,
@@ -50,7 +53,7 @@ use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::Palette;
 use crate::commands::common;
-use crate::commands::tier1::recovery::LockedJournalGate;
+use crate::commands::tier1::recovery::{LockedJournalGate, pending_operation_error};
 use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::response::{CliError, render_json};
@@ -91,18 +94,33 @@ fn compute_restart_with(
 
     let install_mode = ctx.install_mode.as_str();
     let layout = common::resolve_layout(ctx);
-    let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
-        command: command.clone(),
-        reason: format!("failed to acquire install lock: {err}"),
-    })?;
+    // Preview only reads recorded units and journals. Creating or exclusively
+    // locking `/var/lib/anolisa/lock` would fail on a root-owned install
+    // before a non-root `--dry-run` could print the plan.
+    let exclusive_lock = if ctx.dry_run {
+        None
+    } else {
+        Some(
+            InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
+                command: command.clone(),
+                reason: format!("failed to acquire install lock: {err}"),
+            })?,
+        )
+    };
     let (resolved, view) = common::resolve_mutation_target(input, ctx, &command)?;
     let journal_dir = rpm_install::journal_dir(&layout);
-    let journal_gate = LockedJournalGate::load(
-        &_lock,
-        JournalEvidence::new(&journal_dir, &view.writable.state.operations),
-        &command,
-    )?;
-    journal_gate.ensure_clear(&resolved, &command)?;
+    let evidence = JournalEvidence::new(&journal_dir, &view.writable.state.operations);
+    if let Some(ref lock) = exclusive_lock {
+        let journal_gate = LockedJournalGate::load(lock, evidence, &command)?;
+        journal_gate.ensure_clear(&resolved, &command)?;
+    } else if let Some(path) =
+        pending_journal_for(evidence, &resolved).map_err(|err| CliError::Runtime {
+            command: command.clone(),
+            reason: format!("failed to inspect operation journals: {err}"),
+        })?
+    {
+        return Err(pending_operation_error(&command, &resolved, &path));
+    }
     let comp = view
         .writable
         .state
@@ -1163,6 +1181,102 @@ mod tests {
         let err = compute_restart("agentsight", &ctx)
             .expect_err("pending lifecycle must block the preview too");
         assert!(err.reason().contains("pending operation journal"), "{err}");
+    }
+
+    #[test]
+    fn dry_run_does_not_create_the_exclusive_lock() {
+        let (_tmp, ctx) = planted_restart_ctx(true);
+        let layout = FsLayout::system(Some(ctx.prefix.clone().expect("planted prefix")));
+        assert!(
+            !layout.lock_file.exists(),
+            "fixture must start without a lock file"
+        );
+
+        let sys = FakeServiceManager::new();
+        let user = FakeServiceManager::with_scope(ServiceScope::User);
+        let payload =
+            compute_restart_with("agentsight", &ctx, Some((&sys, &user))).expect("dry-run preview");
+
+        assert!(payload.dry_run);
+        assert_eq!(payload.units[0].state, PLANNED_STATE);
+        assert!(
+            !layout.lock_file.exists(),
+            "preview must not create {}",
+            layout.lock_file.display()
+        );
+    }
+
+    #[test]
+    fn dry_run_previews_from_a_non_writable_system_state_root() {
+        // Root ignores directory mode bits, so this models a normal
+        // unprivileged preview against a root-owned `/var/lib/anolisa`.
+        if anolisa_platform::privilege::effective_uid() == 0 {
+            return;
+        }
+
+        let (tmp, dry_ctx) = planted_restart_ctx(true);
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let exec_ctx = ctx_with_options(
+            InstallMode::System,
+            Some(tmp.path().to_path_buf()),
+            crate::test_support::TestContextOptions {
+                dry_run: false,
+                quiet: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+        let _restore = RestorePermissions::dir_mode(&layout.state_dir, 0o555, 0o755);
+
+        let sys = FakeServiceManager::new();
+        let user = FakeServiceManager::with_scope(ServiceScope::User);
+        let payload = compute_restart_with("agentsight", &dry_ctx, Some((&sys, &user)))
+            .expect("non-writable preview must still list units");
+        assert!(payload.dry_run);
+        assert_eq!(payload.units[0].unit, PROBE_UNIT);
+        assert_eq!(payload.units[0].state, PLANNED_STATE);
+        assert!(
+            !layout.lock_file.exists(),
+            "preview must not create the exclusive lock"
+        );
+
+        let err = compute_restart("agentsight", &exec_ctx)
+            .expect_err("execute still needs a writable exclusive lock");
+        assert!(
+            err.reason().contains("failed to acquire install lock"),
+            "{err}"
+        );
+    }
+
+    struct RestorePermissions {
+        path: PathBuf,
+        restore: u32,
+    }
+
+    impl RestorePermissions {
+        fn dir_mode(path: &std::path::Path, restrict: u32, restore: u32) -> Self {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path)
+                .expect("state dir metadata")
+                .permissions();
+            perms.set_mode(restrict);
+            std::fs::set_permissions(path, perms).expect("restrict state dir");
+            Self {
+                path: path.to_path_buf(),
+                restore,
+            }
+        }
+    }
+
+    impl Drop for RestorePermissions {
+        fn drop(&mut self) {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = std::fs::metadata(&self.path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(self.restore);
+                let _ = std::fs::set_permissions(&self.path, perms);
+            }
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -75,6 +75,18 @@ pub fn handle(args: RestartArgs, ctx: &CliContext) -> Result<(), CliError> {
 /// while the operator asked only for the plan. Unsupported scopes stay
 /// `not_supported` so the preview names the same units execute would skip.
 fn compute_restart(input: &str, ctx: &CliContext) -> Result<RestartPayload, CliError> {
+    compute_restart_with(input, ctx, None)
+}
+
+/// Resolve units and either preview or dispatch using the given managers.
+///
+/// Tests inject recording managers so a supported backend cannot hide a
+/// dry-run dispatch behind the host's `not_supported` skip.
+fn compute_restart_with(
+    input: &str,
+    ctx: &CliContext,
+    managers: Option<(&dyn ServiceManager, &dyn ServiceManager)>,
+) -> Result<RestartPayload, CliError> {
     let command = format!("restart {input}");
 
     let install_mode = ctx.install_mode.as_str();
@@ -127,15 +139,23 @@ fn compute_restart(input: &str, ctx: &CliContext) -> Result<RestartPayload, CliE
         ));
     }
 
-    let env = EnvService::detect();
     // Restart routes each unit through the manager for its own scope — the
     // same per-scope partitioning uninstall uses. System units drive
     // `systemctl`, user units drive `systemctl --user`, so a mixed-scope
     // component never mis-drives a user unit through the system manager (or
     // vice versa): a unit whose scope has no driver here is a per-unit
     // `not_supported` skip rather than a wrong-namespace call.
-    let sys_manager = service_factory(install_mode, &env);
-    let user_manager = user_service_factory(install_mode, &env);
+    let detected_sys;
+    let detected_user;
+    let (sys_manager, user_manager) = match managers {
+        Some(pair) => pair,
+        None => {
+            let env = EnvService::detect();
+            detected_sys = service_factory(install_mode, &env);
+            detected_user = user_service_factory(install_mode, &env);
+            (detected_sys.as_ref(), detected_user.as_ref())
+        }
+    };
 
     // Summary fields describe the set of scopes actually present. The op is
     // "supported" if at least one unit's manager can drive it, and the label
@@ -154,12 +174,12 @@ fn compute_restart(input: &str, ctx: &CliContext) -> Result<RestartPayload, CliE
     };
 
     let results = if ctx.dry_run {
-        preview_restart_results(&units, sys_manager.as_ref(), user_manager.as_ref())
+        preview_restart_results(&units, sys_manager, user_manager)
     } else {
         execute_restart_units(
             &units,
-            sys_manager.as_ref(),
-            user_manager.as_ref(),
+            sys_manager,
+            user_manager,
             used_sys,
             used_user,
             &mut warnings,
@@ -555,29 +575,36 @@ struct RestartPayload {
     warnings: Vec<String>,
 }
 
+/// Banner verb for the human summary. Unsupported scopes keep `skipped`
+/// even on `--dry-run`, so a preview does not look successful when every
+/// unit would be refused.
+fn human_banner_status(payload: &RestartPayload) -> &'static str {
+    if !payload.supported {
+        "skipped"
+    } else if payload.dry_run {
+        "planned"
+    } else {
+        "dispatched"
+    }
+}
+
 fn render_human(payload: &RestartPayload, no_color: bool) {
     let color = Palette::new(no_color);
-    if payload.dry_run {
-        println!(
-            "{} {} {}",
-            color.command("restart"),
-            payload.component,
-            color.ok("planned")
-        );
-    } else if payload.supported {
-        println!(
-            "{} {} {}",
-            color.command("restart"),
-            payload.component,
-            color.ok("dispatched")
-        );
-    } else {
+    let status = human_banner_status(payload);
+    if status == "skipped" {
         println!(
             "{} {} {} {}",
             color.command("restart"),
             payload.component,
-            color.warn("skipped"),
+            color.warn(status),
             color.muted(format!("(manager={} unsupported)", payload.manager))
+        );
+    } else {
+        println!(
+            "{} {} {}",
+            color.command("restart"),
+            payload.component,
+            color.ok(status)
         );
     }
     println!("{} {}", color.label("manager:"), payload.manager);
@@ -610,6 +637,7 @@ mod tests {
     use anolisa_core::state::ServiceRef;
     use anolisa_core::state_store::StateStore;
     use anolisa_core::transaction::Transaction;
+    use anolisa_core::{FakeServiceManager, ServiceOp};
     use anolisa_platform::command::CommandOutput;
     use anolisa_platform::fs_layout::FsLayout;
     use std::path::PathBuf;
@@ -654,6 +682,26 @@ mod tests {
             );
         }
         crate::test_support::context_for_root(root, install_mode, prefix.clone(), options)
+    }
+
+    const PROBE_UNIT: &str = "anolisa-restart-dry-run-probe.service";
+
+    fn planted_restart_ctx(dry_run: bool) -> (tempfile::TempDir, CliContext) {
+        let tmp = tempdir().expect("tmpdir");
+        let prefix = tmp.path().to_path_buf();
+        let layout = FsLayout::system(Some(prefix.clone()));
+        plant_owned_restartable(&layout, "agentsight", PROBE_UNIT, ServiceScope::System);
+        let ctx = ctx_with_options(
+            InstallMode::System,
+            Some(prefix),
+            crate::test_support::TestContextOptions {
+                dry_run,
+                quiet: true,
+                no_color: true,
+                ..Default::default()
+            },
+        );
+        (tmp, ctx)
     }
 
     fn plant_owned_restartable(layout: &FsLayout, name: &str, unit: &str, scope: ServiceScope) {
@@ -957,52 +1005,37 @@ mod tests {
 
     #[test]
     fn dry_run_lists_recorded_units_without_dispatching() {
-        // A planted unit that does not exist on the host. Execute would
-        // daemon-reload and call systemctl; dry-run must stay at `planned`
-        // with changed=false so the preview cannot bounce live services.
-        let tmp = tempdir().expect("tmpdir");
-        let prefix = tmp.path().to_path_buf();
-        let layout = FsLayout::system(Some(prefix.clone()));
-        plant_owned_restartable(
-            &layout,
-            "agentsight",
-            "anolisa-restart-dry-run-probe.service",
-            ServiceScope::System,
-        );
-        let ctx = ctx_with_options(
-            InstallMode::System,
-            Some(prefix),
-            crate::test_support::TestContextOptions {
-                dry_run: true,
-                quiet: true,
-                no_color: true,
-                ..Default::default()
-            },
-        );
+        // Inject supported recording managers so this cannot go green on a
+        // host whose real manager is `not_supported` and therefore never
+        // calls reload/restart even on the execute path.
+        let (_tmp, ctx) = planted_restart_ctx(true);
+        let sys = FakeServiceManager::new();
+        let user = FakeServiceManager::with_scope(ServiceScope::User);
 
-        let payload = compute_restart("agentsight", &ctx).expect("dry-run preview");
+        let payload =
+            compute_restart_with("agentsight", &ctx, Some((&sys, &user))).expect("dry-run preview");
 
         assert!(payload.dry_run, "preview must mark dry_run");
+        assert!(payload.supported);
         assert_eq!(payload.units.len(), 1, "{:?}", payload.units);
-        assert_eq!(
-            payload.units[0].unit,
-            "anolisa-restart-dry-run-probe.service"
-        );
+        assert_eq!(payload.units[0].unit, PROBE_UNIT);
+        assert_eq!(payload.units[0].state, PLANNED_STATE);
         assert!(!payload.units[0].changed);
-        // Hosts that can drive systemd preview as `planned`. Container/user
-        // CI still reports `not_supported` — never a live restart state.
         assert!(
-            payload.units[0].state == PLANNED_STATE || payload.units[0].state == "not_supported",
-            "dry-run must not dispatch, got {}",
-            payload.units[0].state
+            payload.units[0].message.contains("dry-run: would restart"),
+            "{}",
+            payload.units[0].message
         );
-        if payload.units[0].state == PLANNED_STATE {
-            assert!(
-                payload.units[0].message.contains("dry-run: would restart"),
-                "{}",
-                payload.units[0].message
-            );
-        }
+        assert!(
+            sys.calls().is_empty(),
+            "dry-run must not reload or restart: {:?}",
+            sys.calls()
+        );
+        assert!(
+            user.calls().is_empty(),
+            "dry-run must not touch the user manager: {:?}",
+            user.calls()
+        );
         assert!(
             payload
                 .warnings
@@ -1011,6 +1044,74 @@ mod tests {
             "dry-run must not daemon-reload: {:?}",
             payload.warnings
         );
+    }
+
+    #[test]
+    fn execute_records_reload_and_restart_when_manager_is_supported() {
+        let (_tmp, ctx) = planted_restart_ctx(false);
+        let sys = FakeServiceManager::new();
+        let user = FakeServiceManager::with_scope(ServiceScope::User);
+
+        let payload =
+            compute_restart_with("agentsight", &ctx, Some((&sys, &user))).expect("execute restart");
+
+        assert!(!payload.dry_run);
+        assert!(payload.supported);
+        assert_eq!(payload.units.len(), 1, "{:?}", payload.units);
+        assert_eq!(payload.units[0].unit, PROBE_UNIT);
+        assert_ne!(payload.units[0].state, PLANNED_STATE);
+        assert_eq!(
+            sys.calls(),
+            vec![
+                (ServiceOp::DaemonReload, String::new()),
+                (ServiceOp::Restart, PROBE_UNIT.to_string()),
+            ]
+        );
+        assert!(
+            user.calls().is_empty(),
+            "system-only execute must not drive the user manager: {:?}",
+            user.calls()
+        );
+    }
+
+    #[test]
+    fn dry_run_human_banner_stays_skipped_when_unsupported() {
+        let unsupported = RestartPayload {
+            component: "agentsight".to_string(),
+            install_mode: "system".to_string(),
+            manager: "not-supported".to_string(),
+            supported: false,
+            dry_run: true,
+            units: vec![RestartResult {
+                component: "agentsight".to_string(),
+                unit: PROBE_UNIT.to_string(),
+                state: "not_supported".to_string(),
+                changed: false,
+                manager: "not-supported".to_string(),
+                message: "container".to_string(),
+            }],
+            warnings: Vec::new(),
+        };
+        assert_eq!(human_banner_status(&unsupported), "skipped");
+
+        let planned = RestartPayload {
+            supported: true,
+            manager: "fake".to_string(),
+            units: vec![RestartResult {
+                manager: "fake".to_string(),
+                state: PLANNED_STATE.to_string(),
+                message: "dry-run: would restart".to_string(),
+                ..unsupported.units[0].clone()
+            }],
+            ..unsupported
+        };
+        assert_eq!(human_banner_status(&planned), "planned");
+
+        let dispatched = RestartPayload {
+            dry_run: false,
+            ..planned
+        };
+        assert_eq!(human_banner_status(&dispatched), "dispatched");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/tests/restart_dry_run_lock.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/restart_dry_run_lock.rs
@@ -186,9 +186,13 @@ fn restart_dry_run_json_previews_from_a_non_writable_system_state_root() {
         .expect("units array");
     assert_eq!(units.len(), 1, "{value}");
     assert_eq!(units[0].get("unit").and_then(Value::as_str), Some(UNIT));
-    assert_eq!(
-        units[0].get("state").and_then(Value::as_str),
-        Some("planned")
+    // The subprocess uses the real EnvService factory. Container hosts
+    // return an unsupported manager, so the unit is `not_supported`
+    // even when the non-writable preview itself is correct.
+    let state = units[0].get("state").and_then(Value::as_str);
+    assert!(
+        matches!(state, Some("planned") | Some("not_supported")),
+        "preview must keep the host-appropriate unit state, got {state:?}: {value}"
     );
     assert_eq!(units[0].get("changed"), Some(&Value::Bool(false)));
     assert!(

--- a/src/anolisa/crates/anolisa-cli/tests/restart_dry_run_lock.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/restart_dry_run_lock.rs
@@ -1,0 +1,199 @@
+//! CLI coverage: system `--dry-run restart` must preview on a non-writable
+//! state root.
+//!
+//! Policy already lets a non-root system preview reach the handler. The
+//! handler must not then create or exclusively lock the state-root file, or
+//! a normal root-owned `/var/lib/anolisa` exits with permission denied
+//! before listing units. Subprocesses stay on `--dry-run` with
+//! `--install-mode system` and a temporary `--prefix`.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Output;
+
+use anolisa_core::domain::{
+    Installation, InstallationScope, LifecycleStatus, OwnedArtifact, ProviderBinding,
+};
+use anolisa_core::state::{ObjectKind, ServiceRef};
+use anolisa_core::{ServiceScope, state_store::StateStore};
+use anolisa_platform::fs_layout::FsLayout;
+use anolisa_platform::privilege;
+use serde_json::Value;
+
+mod common;
+
+const TARGET: &str = "agentsight";
+const UNIT: &str = "anolisa-restart-dry-run-probe.service";
+
+struct RestartFixture {
+    _tmp: tempfile::TempDir,
+    prefix: PathBuf,
+    state_dir: PathBuf,
+}
+
+impl RestartFixture {
+    fn planted() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prefix = tmp.path().join("system");
+        seed_index(&prefix);
+        let layout = plant_restartable(&prefix);
+        Self {
+            _tmp: tmp,
+            prefix,
+            state_dir: layout.state_dir,
+        }
+    }
+
+    fn run_dry_run(&self) -> Output {
+        let prefix = self.prefix.to_string_lossy().into_owned();
+        common::run(&[
+            "--json",
+            "--no-color",
+            "--dry-run",
+            "--install-mode",
+            "system",
+            "--prefix",
+            prefix.as_str(),
+            "restart",
+            TARGET,
+        ])
+    }
+}
+
+struct RestorePermissions {
+    path: PathBuf,
+    restore: u32,
+}
+
+impl RestorePermissions {
+    fn dir_mode(path: &std::path::Path, restrict: u32, restore: u32) -> Self {
+        let mut perms = std::fs::metadata(path)
+            .expect("state dir metadata")
+            .permissions();
+        perms.set_mode(restrict);
+        std::fs::set_permissions(path, perms).expect("restrict state dir");
+        Self {
+            path: path.to_path_buf(),
+            restore,
+        }
+    }
+}
+
+impl Drop for RestorePermissions {
+    fn drop(&mut self) {
+        if let Ok(metadata) = std::fs::metadata(&self.path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(self.restore);
+            let _ = std::fs::set_permissions(&self.path, perms);
+        }
+    }
+}
+
+fn seed_index(prefix: &std::path::Path) {
+    let repo_v1 = prefix.join("repo/v1");
+    std::fs::create_dir_all(&repo_v1).expect("local repo");
+    std::fs::write(
+        repo_v1.join("components-v2.toml"),
+        format!(
+            "schema_version = 2\n\n[[components]]\nname = \"{TARGET}\"\ntargets = [{{ os = \"{os}\", arch = \"{arch}\" }}]\n",
+            os = std::env::consts::OS,
+            arch = std::env::consts::ARCH,
+        ),
+    )
+    .expect("component index");
+    let etc = prefix.join("etc/anolisa");
+    std::fs::create_dir_all(&etc).expect("config dir");
+    std::fs::write(
+        etc.join("repo.toml"),
+        format!(
+            "schema_version = 1\ndefault_backend = \"raw\"\n\n[backends.raw]\nbase_url = \"file://{}\"\n",
+            repo_v1.display()
+        ),
+    )
+    .expect("repo config");
+}
+
+fn plant_restartable(prefix: &std::path::Path) -> FsLayout {
+    let layout = FsLayout::system(Some(prefix.to_path_buf()));
+    let state_path = layout.state_dir.join("installed.toml");
+    let mut store = StateStore::empty_for_layout(&layout);
+    store.upsert(Installation {
+        kind: ObjectKind::Component,
+        name: TARGET.to_string(),
+        scope: InstallationScope::System,
+        binding: ProviderBinding::Owned {
+            artifact: OwnedArtifact {
+                version: "1.0.0".to_string(),
+                distribution_source: None,
+                raw_package: None,
+                manifest_digest: None,
+                files: Vec::new(),
+                services: vec![ServiceRef {
+                    name: UNIT.to_string(),
+                    manager: "systemd".to_string(),
+                    restartable: true,
+                    enabled: true,
+                    scope: ServiceScope::System,
+                }],
+                external_modified_files: Vec::new(),
+                provisioned_packages: Vec::new(),
+            },
+        },
+        status: LifecycleStatus::Installed,
+        installed_at: "2026-07-21T00:00:00Z".to_string(),
+        last_operation_id: None,
+        subscription_scope: Default::default(),
+        enabled_features: Vec::new(),
+        health: Vec::new(),
+    });
+    store.save(&state_path).expect("save state");
+    layout
+}
+
+#[test]
+fn restart_dry_run_json_previews_from_a_non_writable_system_state_root() {
+    // Root ignores directory mode bits, so this cannot model a root-owned
+    // system state root. Run the anolisa crate gates as anolisa-ci.
+    if privilege::effective_uid() == 0 {
+        return;
+    }
+
+    let fixture = RestartFixture::planted();
+    let lock_file = fixture.state_dir.join("lock");
+    assert!(
+        !lock_file.exists(),
+        "fixture must start without a lock file"
+    );
+    let _restore = RestorePermissions::dir_mode(&fixture.state_dir, 0o555, 0o755);
+
+    let output = fixture.run_dry_run();
+    assert_eq!(
+        Some(0),
+        output.status.code(),
+        "non-writable system preview must succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let value: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be a JSON envelope");
+    assert_eq!(value.get("ok"), Some(&Value::Bool(true)), "{value}");
+    let data = value.get("data").expect("data");
+    assert_eq!(data.get("dry_run"), Some(&Value::Bool(true)));
+    assert_eq!(data.get("component").and_then(Value::as_str), Some(TARGET));
+    let units = data
+        .get("units")
+        .and_then(Value::as_array)
+        .expect("units array");
+    assert_eq!(units.len(), 1, "{value}");
+    assert_eq!(units[0].get("unit").and_then(Value::as_str), Some(UNIT));
+    assert_eq!(
+        units[0].get("state").and_then(Value::as_str),
+        Some("planned")
+    );
+    assert_eq!(units[0].get("changed"), Some(&Value::Bool(false)));
+    assert!(
+        !lock_file.exists(),
+        "preview must not create {}",
+        lock_file.display()
+    );
+}


### PR DESCRIPTION
## Why

`anolisa --dry-run restart <component>` is advertised as a preview (global `--dry-run`: "Print the plan without executing"), but the restart handler never read `ctx.dry_run`. On a host that can drive systemd it still ran `daemon-reload` and `systemctl restart`. Sibling lifecycle verbs already treat `--dry-run` as a no-mutation preview.

This head also keeps the no-dispatch proof independent of host systemd support, keeps the human summary `skipped` when the manager is unsupported, and lets a non-root system preview read recorded state without taking the exclusive install lock. The CLI lock regression asserts that preview contract without requiring the host factory to report a supported manager.

## What changed

**Dry-run does not dispatch**
- `restart` computes the same unit plan as execute, then either renders a preview (`state: "planned"`, `changed: false`, JSON `dry_run: true`) or dispatches systemd.
- Tests inject supported recording managers through `compute_restart`: dry-run records zero reload/restart calls; execute records both.

**Preview does not take the exclusive lock**
- Dry-run reads `installed.toml` and journals without creating or exclusively locking the selected state root, so `anolisa --install-mode system --dry-run restart` works on a root-owned `/var/lib/anolisa`.
- Execute still acquires the writable lock and the locked pending-journal gate.
- CLI regression `restart_dry_run_json_previews_from_a_non_writable_system_state_root` plants a system prefix, makes the state directory `0555`, and asserts a successful envelope, unit discovery, `changed: false`, and no lock file. Unit state is the host-appropriate `planned` or `not_supported`; injected-manager unit tests already prove the supported `planned` path.

**Unsupported stays skipped**
- Per-unit `not_supported` is unchanged.
- The human banner is `skipped (manager=... unsupported)` whenever `supported` is false, including `--dry-run`.

**Policy and docs**
- `command_policy` allows a system-mode dry-run without root; a real restart still requires it.
- Component README (en/zh) and the user-guide `anolisa restart` examples document the preview, including that system-mode dry-run does not need write access to the state root.

## Related issue

fixes #2773

## User / Agent impact

- `--dry-run restart` no longer reloads or restarts units.
- Dry-run JSON includes `data.dry_run: true` and planned unit results.
- Non-root system-mode policy can reach the preview handler; the handler no longer requires write access to the install lock.
- Human output says `skipped` when the manager is unsupported, including during dry-run.
- Absent component, pending journal, and unsupported-scope skip behavior are unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`--dry-run` on `restart` now matches the documented global meaning. Live `restart` without `--dry-run` is unchanged. JSON grows an additive `dry_run` field.

## Validation

```bash
cd src/anolisa
cargo fmt --all --check
cargo clippy --all-targets --locked -- -D warnings
# cargo test --locked must run as a non-root user (anolisa-ci);
# root euid 0 fails adapter --install-mode user tests.
runuser -u anolisa-ci -- env HOME=/tmp/anolisa-ci-home \
  CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup \
  cargo test --locked
```

Focused coverage: `dry_run_lists_recorded_units_without_dispatching`, `execute_records_reload_and_restart_when_manager_is_supported`, `dry_run_human_banner_stays_skipped_when_unsupported`, `dry_run_still_refuses_an_absent_component`, `dry_run_still_refuses_a_pending_lifecycle`, `preview_marks_unsupported_scopes_without_planned`, `restart_policy_allows_system_dry_run_without_root`, `dry_run_does_not_create_the_exclusive_lock`, `dry_run_previews_from_a_non_writable_system_state_root`, `restart_dry_run_json_previews_from_a_non_writable_system_state_root`.

Head: `fa18ac3cc84c93ac56c5c540aa3ad0c643d4d7cf`

## Documentation and rollback

`src/anolisa/README.md`, `README_zh.md`, `docs/user-guide/en/user-entrypoint/anolisa-cli.md` and the zh sibling document `--dry-run restart`. Revert these commits to restore the old always-dispatch behavior.
