### PR TITLE
feat(skillfs): add alinux4 container image

### DIFF
--- a/src/skillfs/container/Dockerfile.alinux4
+++ b/src/skillfs/container/Dockerfile.alinux4
@@ -1,0 +1,148 @@
+# Dedicated SkillFS FUSE sidecar image for Alibaba Cloud Linux 4.
+#
+# This image runs ONE process: `skillfs mount ... --foreground --allow-other`.
+# It deliberately does not include or start any other ANOLISA service, and it
+# does not depend on systemd or the SkillFS managed-mount supervisor.
+#
+# Build context: the `src/skillfs` component directory.
+#   docker build -f container/Dockerfile.alinux4 .
+
+# ---------------------------------------------------------------------------
+# Stage 1 — builder
+# ---------------------------------------------------------------------------
+# The builder and the runtime share the same base image so the produced binary
+# links against the runtime glibc and fuse3 ABI. Do not swap one side only.
+ARG BASE_IMAGE=alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
+
+FROM ${BASE_IMAGE} AS builder
+
+# Alibaba Cloud Linux 4 ships a Rust toolchain newer than the minimum 1.86
+# declared by Cargo.toml, so use the distro-tested compiler and package manager.
+RUN set -eux; \
+    sed -i \
+        's#mirrors\.cloud\.aliyuncs\.com#mirrors.aliyun.com#g' \
+        /etc/yum.repos.d/*.repo; \
+    dnf install -y --setopt=install_weak_deps=False \
+        gcc \
+        make \
+        binutils \
+        pkgconf-pkg-config \
+        fuse3-devel \
+        rust \
+        cargo \
+        ca-certificates; \
+    dnf clean all; \
+    rm -rf /var/cache/dnf; \
+    rustc --version; \
+    cargo --version
+
+WORKDIR /build
+
+# Use the public Aliyun sparse registry by default for reliable builds in China.
+# Set this argument to an empty value to use Cargo's official crates.io source.
+ARG SKILLFS_CARGO_REGISTRY_INDEX=sparse+https://mirrors.aliyun.com/crates.io-index/
+
+# Source replacement keeps Cargo.lock identities and checksums while routing
+# both the sparse index and crate downloads through the selected mirror.
+RUN set -eux; \
+    if [ -n "${SKILLFS_CARGO_REGISTRY_INDEX}" ]; then \
+        mkdir -p /root/.cargo; \
+        printf '%s\n' \
+            '[source.crates-io]' \
+            'replace-with = "mirror"' \
+            '[source.mirror]' \
+            "registry = \"${SKILLFS_CARGO_REGISTRY_INDEX}\"" \
+            > /root/.cargo/config.toml; \
+    fi
+
+# Copy the whole component. `.dockerignore` keeps `target/` and local mount
+# scratch out of the context so the image does not embed host build artifacts.
+COPY . /build
+
+# `--locked` makes the dependency set exactly Cargo.lock, which is what makes
+# repeated builds of the same commit produce the same dependency tree.
+RUN set -eux; \
+    RUSTFLAGS="-C opt-level=3 -C codegen-units=1" \
+        cargo build --release --locked -p skillfs; \
+    strip target/release/skillfs; \
+    target/release/skillfs --version
+
+# ---------------------------------------------------------------------------
+# Stage 2 — runtime
+# ---------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS runtime
+
+ARG VERSION=unknown
+ARG REVISION=unknown
+ARG SOURCE_URL=https://github.com/alibaba/anolisa
+
+# fuse3 provides the fusermount3 helper and libfuse3 runtime. The remaining
+# packages provide the exact utilities used by the entrypoint, preflight, probe,
+# and example seeding scripts.
+RUN set -eux; \
+    sed -i \
+        's#mirrors\.cloud\.aliyuncs\.com#mirrors.aliyun.com#g' \
+        /etc/yum.repos.d/*.repo; \
+    dnf install -y --setopt=install_weak_deps=False \
+        fuse3 \
+        bash \
+        coreutils \
+        grep \
+        gawk \
+        sed \
+        findutils \
+        util-linux; \
+    dnf clean all; \
+    rm -rf /var/cache/dnf
+
+# `--allow-other` requires user_allow_other in /etc/fuse.conf. The sidecar runs
+# as root today, where libfuse skips the check, but the flag is written
+# unconditionally so a future non-root sidecar UID does not silently regress,
+# and so the preflight check has something real to assert.
+RUN set -eux; \
+    touch /etc/fuse.conf; \
+    if ! grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf; then \
+        printf 'user_allow_other\n' >> /etc/fuse.conf; \
+    fi; \
+    chmod 0644 /etc/fuse.conf; \
+    grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf
+
+COPY --from=builder /build/target/release/skillfs /usr/local/bin/skillfs
+COPY container/entrypoint.sh /usr/local/bin/skillfs-sidecar-entrypoint
+COPY container/preflight.sh /usr/local/bin/skillfs-preflight
+COPY container/mount-probe.sh /usr/local/bin/skillfs-mount-probe
+
+RUN set -eux; \
+    chmod 0755 /usr/local/bin/skillfs \
+        /usr/local/bin/skillfs-sidecar-entrypoint \
+        /usr/local/bin/skillfs-preflight \
+        /usr/local/bin/skillfs-mount-probe; \
+    skillfs --version
+
+# Defaults match src/skillfs/deploy/kubernetes. Override per deployment.
+#
+# SKILLFS_MOUNTPOINT is a *subdirectory* of the shared volume, not the volume
+# root: mount propagation carries a mount created inside the shared volume, and
+# over-mounting the volume root itself is not the supported topology.
+#
+# SKILLFS_PROBE_FILE is relative to the mountpoint. SkillFS exposes the view
+# under `<mountpoint>/skills/<skill-name>/`, so the probe path includes `skills/`.
+ENV SKILLFS_SOURCE=/var/lib/skillfs/source \
+    SKILLFS_MOUNTPOINT=/var/lib/skillfs/shared/mount \
+    SKILLFS_DISCOVER_ROOT=/var/lib/skillfs/shared/mount/skills \
+    SKILLFS_EXTRA_ARGS="" \
+    SKILLFS_PROBE_FILE=skills/skillfs-container-example/SKILL.md \
+    SKILLFS_PROBE_TIMEOUT=5 \
+    RUST_LOG=info
+
+LABEL org.opencontainers.image.title="SkillFS FUSE sidecar for Alibaba Cloud Linux 4" \
+      org.opencontainers.image.description="SkillFS foreground FUSE mount sidecar for Kubernetes" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.source="${SOURCE_URL}" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="The Anolisa Authors"
+
+# The entrypoint runs preflight and then `exec`s skillfs, so skillfs becomes
+# PID 1 and receives SIGTERM directly from the kubelet.
+ENTRYPOINT ["/usr/local/bin/skillfs-sidecar-entrypoint"]


### PR DESCRIPTION
## Why

SkillFS provides a Debian-based FUSE sidecar image, but users also need a
reproducible Alibaba Cloud Linux 4 build for platform validation and deployment.

## What changed

- Add `container/Dockerfile.alinux4` as a standalone two-stage sidecar build.
- Use the public Alibaba Cloud Linux RPM mirror and native FUSE packages.
- Keep the existing Debian Dockerfile and its behavior unchanged.

## Related issue

no-issue: requested Alibaba Cloud Linux 4 test image

## User / Agent impact

Users can build the optional image with
`docker build -f container/Dockerfile.alinux4 .`. Existing image builds are
unchanged.

## Risk and compatibility

Low risk. The new file is opt-in, uses the existing entrypoint and probe
contract, and does not change CLI, configuration, or the Debian image.

## Validation

- `docker build -f container/Dockerfile.alinux4 -t skillfs:alinux4-pr-test .`
- Privileged arm64 container test with `/dev/fuse`: mount, readiness probe,
  FUSE reads, write passthrough, SIGTERM unmount, and exit code 0.
- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `scripts/test.sh`

## Documentation and rollback

No public documentation changed. Roll back by removing the optional Dockerfile;
the existing Debian image remains available throughout.