### PR TITLE
feat(tokenless): add protocol v1 request/response types

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -857,6 +857,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenless-protocol"
+version = "0.7.12"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tokenless-python"
 version = "0.7.12"
 dependencies = [

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/tokenless-ccr",
+    "crates/tokenless-protocol",
     "crates/tokenless-schema",
     "crates/tokenless-runtime",
     "crates/tokenless-cli",
@@ -10,6 +11,7 @@ members = [
 ]
 default-members = [
     "crates/tokenless-ccr",
+    "crates/tokenless-protocol",
     "crates/tokenless-schema",
     "crates/tokenless-runtime",
     "crates/tokenless-cli",

--- a/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/backends/sqlite.rs
@@ -137,8 +137,7 @@ impl SqliteStore {
     fn lock_conn(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().unwrap_or_else(|poisoned| {
             eprintln!(
-                "[tokenless-ccr] WARNING: sqlite mutex poisoned by a previous panic; recovering: {}",
-                poisoned
+                "[tokenless-ccr] WARNING: sqlite mutex poisoned by a previous panic; recovering: {poisoned}"
             );
             self.conn.clear_poison();
             poisoned.into_inner()
@@ -256,7 +255,7 @@ impl StashStore for SqliteStore {
         // `SqliteCcrStore::get`. Best-effort — a purge failure must not block
         // the lookup; it falls through to the SELECT below.
         if let Err(e) = conn.execute("DELETE FROM stash WHERE expires_at < ?", [now as i64]) {
-            eprintln!("[tokenless-ccr] WARNING: stash lazy-purge failed: {}", e);
+            eprintln!("[tokenless-ccr] WARNING: stash lazy-purge failed: {e}");
         }
         match conn.query_row(
             "SELECT payload FROM stash WHERE hash = ? AND expires_at >= ?",

--- a/src/tokenless/crates/tokenless-ccr/src/key.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/key.rs
@@ -51,9 +51,9 @@ mod tests {
     fn no_collisions_across_many_payloads() {
         let mut seen = std::collections::HashSet::new();
         for i in 0..100_000u64 {
-            let payload = format!("collision-probe-{}", i);
+            let payload = format!("collision-probe-{i}");
             let key = compute_key(payload.as_bytes());
-            assert!(seen.insert(key), "collision at i={}", i);
+            assert!(seen.insert(key), "collision at i={i}");
         }
     }
 }

--- a/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
+++ b/src/tokenless/crates/tokenless-ccr/src/tests/store_tests.rs
@@ -11,7 +11,7 @@ fn is_empty_default_trait_method() {
 #[test]
 fn stash_error_display() {
     let e = StashError::Backend("test error".to_string());
-    assert!(format!("{}", e).contains("test error"));
+    assert!(format!("{e}").contains("test error"));
 }
 
 #[test]
@@ -32,6 +32,6 @@ fn stash_error_from_rusqlite() {
         Some("test error".to_string()),
     );
     let stash_err: StashError = StashError::from(rusqlite_err);
-    let msg = format!("{}", stash_err);
+    let msg = format!("{stash_err}");
     assert!(msg.contains("test error"));
 }

--- a/src/tokenless/crates/tokenless-cli/src/env_check.rs
+++ b/src/tokenless/crates/tokenless-cli/src/env_check.rs
@@ -709,9 +709,9 @@ fn load_spec(
     spec_path: &PathBuf,
 ) -> Result<std::collections::HashMap<String, ToolDepSpec>, String> {
     let content =
-        fs::read_to_string(spec_path).map_err(|e| format!("Failed to read spec file: {}", e))?;
+        fs::read_to_string(spec_path).map_err(|e| format!("Failed to read spec file: {e}"))?;
     let value: Value =
-        serde_json::from_str(&content).map_err(|e| format!("Failed to parse spec JSON: {}", e))?;
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse spec JSON: {e}"))?;
 
     let mut specs = std::collections::HashMap::new();
     // Skip _comment key
@@ -855,7 +855,7 @@ fn format_dep_status(status: &DepStatus) -> String {
             installed,
             required,
         } => {
-            format!("version low ({} < {})", installed, required)
+            format!("version low ({installed} < {required})")
         }
     }
 }
@@ -869,7 +869,7 @@ fn format_dep_status_label(status: &DepStatus) -> String {
             installed,
             required,
         } => {
-            format!("OUTDATED ({}/{})", installed, required)
+            format!("OUTDATED ({installed}/{required})")
         }
     }
 }
@@ -906,15 +906,15 @@ fn generate_checklist(results: &[ToolReadyResult]) -> String {
         }
         for (cfg, ok) in &result.config_results {
             let label = if *ok { "INSTALLED" } else { "MISSING" };
-            output.push_str(&format!("  config:     {:12} {}\n", cfg, label));
+            output.push_str(&format!("  config:     {cfg:12} {label}\n"));
         }
         for (perm, ok) in &result.permission_results {
             let label = if *ok { "GRANTED" } else { "DENIED" };
-            output.push_str(&format!("  permission: {:12} {}\n", perm, label));
+            output.push_str(&format!("  permission: {perm:12} {label}\n"));
         }
         for (net, ok) in &result.network_results {
             let label = if *ok { "OK" } else { "FAIL" };
-            output.push_str(&format!("  network:    {:12} {}\n", net, label));
+            output.push_str(&format!("  network:    {net:12} {label}\n"));
         }
         if !result.required_results.is_empty()
             || !result.recommended_results.is_empty()
@@ -944,11 +944,10 @@ fn generate_checklist(results: &[ToolReadyResult]) -> String {
         .count();
 
     let mut summary = format!(
-        "Summary: {} ready, {} partial, {} not ready",
-        ready_count, partial_count, not_ready_count
+        "Summary: {ready_count} ready, {partial_count} partial, {not_ready_count} not ready"
     );
     if unknown_count > 0 {
-        summary.push_str(&format!(", {} unknown", unknown_count));
+        summary.push_str(&format!(", {unknown_count} unknown"));
     }
     summary.push_str(&format!(" (total: {})\n", results.len()));
     output.push_str(&summary);
@@ -1176,8 +1175,8 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
         })
         .collect();
 
-    let json_str = serde_json::to_string(&deps_json)
-        .map_err(|e| format!("Failed to serialize deps: {}", e))?;
+    let json_str =
+        serde_json::to_string(&deps_json).map_err(|e| format!("Failed to serialize deps: {e}"))?;
 
     // Use timeout if available (coreutils procps), otherwise run without timeout
     let has_timeout = Command::new("sh")
@@ -1196,7 +1195,7 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
-            .map_err(|e| format!("Failed to run env-fix: {}", e))?
+            .map_err(|e| format!("Failed to run env-fix: {e}"))?
     } else {
         Command::new("bash")
             .arg(&fix_script)
@@ -1205,7 +1204,7 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()
-            .map_err(|e| format!("Failed to run env-fix: {}", e))?
+            .map_err(|e| format!("Failed to run env-fix: {e}"))?
     };
 
     let mut stdin_handle = child
@@ -1214,12 +1213,12 @@ fn auto_fix(missing_deps: &[DepEntry]) -> Result<String, String> {
         .ok_or_else(|| "Failed to open stdin for env-fix process".to_string())?;
     stdin_handle
         .write_all(json_str.as_bytes())
-        .map_err(|e| format!("Failed to write deps to env-fix stdin: {}", e))?;
+        .map_err(|e| format!("Failed to write deps to env-fix stdin: {e}"))?;
     drop(stdin_handle);
 
     let output = child
         .wait_with_output()
-        .map_err(|e| format!("Failed to wait for env-fix: {}", e))?;
+        .map_err(|e| format!("Failed to wait for env-fix: {e}"))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     if !output.status.success() {
@@ -1309,7 +1308,7 @@ fn build_json_result(
     if *status == ReadyStatus::NotReady {
         let diag_parts: Vec<String> = missing
             .iter()
-            .map(|m| format!("required dependency missing: {}", m))
+            .map(|m| format!("required dependency missing: {m}"))
             .collect();
         obj.insert(
             "diagnostic".to_string(),
@@ -1369,8 +1368,8 @@ pub fn run(
             .collect();
         if json {
             let json_value = serde_json::to_string(&generate_checklist_json(&results))
-                .map_err(|e| (format!("Failed to serialize checklist JSON: {}", e), 1))?;
-            println!("{}", json_value);
+                .map_err(|e| (format!("Failed to serialize checklist JSON: {e}"), 1))?;
+            println!("{json_value}");
         } else {
             println!("{}", generate_checklist(&results));
         }
@@ -1448,7 +1447,7 @@ pub fn run(
             let fix_output = auto_fix(&fixable_deps).map_err(|e| (e, 1))?;
             if !json {
                 for line in fix_output.lines() {
-                    println!("  {}", line);
+                    println!("  {line}");
                 }
             }
 

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -281,10 +281,10 @@ fn read_input(file: &Option<String>) -> Result<String, String> {
         Some(path) => {
             let mut content = String::new();
             fs::File::open(path)
-                .map_err(|e| format!("Failed to open file '{}': {}", path, e))?
+                .map_err(|e| format!("Failed to open file '{path}': {e}"))?
                 .take(limit)
                 .read_to_string(&mut content)
-                .map_err(|e| format!("Failed to read file '{}': {}", path, e))?;
+                .map_err(|e| format!("Failed to read file '{path}': {e}"))?;
             if content.len() > MAX_INPUT_BYTES {
                 return Err(too_large());
             }
@@ -300,7 +300,7 @@ fn read_input(file: &Option<String>) -> Result<String, String> {
                 .lock()
                 .take(limit)
                 .read_to_string(&mut buf)
-                .map_err(|e| format!("Failed to read stdin: {}", e))?;
+                .map_err(|e| format!("Failed to read stdin: {e}"))?;
             if buf.len() > MAX_INPUT_BYTES {
                 return Err(too_large());
             }
@@ -365,7 +365,7 @@ fn get_db_path_with(paths: &DatabasePathResolver) -> Result<PathBuf, String> {
         Ok(env_path) if !env_path.is_empty() => {
             match validate_db_path(Path::new(&env_path), home, data_dir.ok()) {
                 Ok(path) => return Ok(path),
-                Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {}", reason),
+                Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STATS_DB: {reason}"),
             }
         }
         _ => {}
@@ -390,7 +390,7 @@ fn validate_db_path(path: &Path, home: &str, data_dir: Option<&Path>) -> Result<
 fn ensure_db_dir(db_path: &Path) -> Result<(), (String, i32)> {
     if let Some(parent) = db_path.parent() {
         ensure_state_dir(parent)
-            .map_err(|e| (format!("Failed to create database directory: {}", e), 1))?;
+            .map_err(|e| (format!("Failed to create database directory: {e}"), 1))?;
     }
     Ok(())
 }
@@ -401,9 +401,9 @@ fn open_recorder() -> Result<StatsRecorder, (String, i32)> {
 
 fn open_recorder_with(paths: &DatabasePathResolver) -> Result<StatsRecorder, (String, i32)> {
     let db_path = get_db_path_with(paths)
-        .map_err(|error| (format!("Stats database unavailable: {}", error), 1))?;
+        .map_err(|error| (format!("Stats database unavailable: {error}"), 1))?;
     ensure_db_dir(&db_path)?;
-    StatsRecorder::new(db_path).map_err(|e| (format!("Failed to open database: {}", e), 1))
+    StatsRecorder::new(db_path).map_err(|e| (format!("Failed to open database: {e}"), 1))
 }
 
 /// Resolve the stash database path under a trusted state root.
@@ -424,7 +424,7 @@ fn get_stash_db_path_with(
     if let Some(p) = override_path.filter(|s| !s.is_empty()) {
         match validate_db_path(Path::new(p), home, data_dir.ok()) {
             Ok(valid) => return Ok(valid),
-            Err(reason) => eprintln!("[tokenless] rejecting --stash-db {}: {}", p, reason),
+            Err(reason) => eprintln!("[tokenless] rejecting --stash-db {p}: {reason}"),
         }
     }
     if let Ok(env_path) = std::env::var("TOKENLESS_STASH_DB")
@@ -432,7 +432,7 @@ fn get_stash_db_path_with(
     {
         match validate_db_path(Path::new(&env_path), home, data_dir.ok()) {
             Ok(path) => return Ok(path),
-            Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {}", reason),
+            Err(reason) => eprintln!("[tokenless] ignoring TOKENLESS_STASH_DB: {reason}"),
         }
     }
     let data_dir = data_dir.map_err(str::to_string)?;
@@ -472,7 +472,7 @@ fn open_stash_store_with(
     match open_stash_store_or_err_with(paths, override_path) {
         Ok(store) => Some(store),
         Err(e) => {
-            eprintln!("[tokenless] stash disabled: {}", e);
+            eprintln!("[tokenless] stash disabled: {e}");
             None
         }
     }
@@ -495,8 +495,8 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             stash_db,
         } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
-            let value: serde_json::Value = serde_json::from_str(&input)
-                .map_err(|e| (format!("JSON parse error: {}", e), 2))?;
+            let value: serde_json::Value =
+                serde_json::from_str(&input).map_err(|e| (format!("JSON parse error: {e}"), 2))?;
 
             // Load config before deciding on the stash so we can skip it
             // entirely when compression is disabled (dry-run). Attaching the
@@ -532,8 +532,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             let after_tokens = estimate_tokens(&after_compact);
             let output_text = if after_tokens >= before_tokens {
                 eprintln!(
-                    "tokenless: schema compression did not reduce size ({} -> {} est. tokens), outputting original",
-                    before_tokens, after_tokens
+                    "tokenless: schema compression did not reduce size ({before_tokens} -> {after_tokens} est. tokens), outputting original"
                 );
                 // Discarded compressed output never reaches the LLM, so roll
                 // back stash keys created during this compress — otherwise
@@ -560,7 +559,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             } else {
                 input.clone()
             };
-            println!("{}", emit_text);
+            println!("{emit_text}");
 
             record_compression_stats(
                 &config,
@@ -676,7 +675,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             let store = match open_stash_store_or_err(stash_db.as_deref()) {
                 Ok(s) => s,
                 Err(e) => {
-                    return Err((format!("stash unavailable: {}", e), 1));
+                    return Err((format!("stash unavailable: {e}"), 1));
                 }
             };
             let payload = retrieve_from_store(store.as_ref(), &hash)
@@ -701,10 +700,10 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         let tokenless_sid = sessions[1].as_str();
                         let baseline = recorder
                             .records_by_session(baseline_sid, limit)
-                            .map_err(|e| (format!("Failed to query baseline: {}", e), 1))?;
+                            .map_err(|e| (format!("Failed to query baseline: {e}"), 1))?;
                         let tokenless = recorder
                             .records_by_session(tokenless_sid, limit)
-                            .map_err(|e| (format!("Failed to query tokenless: {}", e), 1))?;
+                            .map_err(|e| (format!("Failed to query tokenless: {e}"), 1))?;
                         if let Some(message) = missing_compare_sessions(
                             baseline_sid,
                             tokenless_sid,
@@ -726,7 +725,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     }
                     let records = recorder
                         .all_records(limit)
-                        .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
+                        .map_err(|e| (format!("Failed to query records: {e}"), 1))?;
                     if json {
                         println!("{}", tokenless_stats::format_summary_json(&records, None));
                     } else {
@@ -740,15 +739,15 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     let recorder = open_recorder()?;
                     let records = recorder
                         .all_records(Some(limit))
-                        .map_err(|e| (format!("Failed to query records: {}", e), 1))?;
+                        .map_err(|e| (format!("Failed to query records: {e}"), 1))?;
                     println!("{}", format_list(&records, limit));
                 }
                 StatsCommands::Show { id } => {
                     let recorder = open_recorder()?;
                     let record = recorder
                         .record_by_id(id)
-                        .map_err(|e| (format!("Failed to query record: {}", e), 1))?
-                        .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
+                        .map_err(|e| (format!("Failed to query record: {e}"), 1))?
+                        .ok_or_else(|| (format!("Record not found: {id}"), 1))?;
                     println!("{}", format_show(&record));
                 }
                 StatsCommands::Diff {
@@ -766,20 +765,20 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                         (Some(id), None) => {
                             let record = recorder
                                 .record_by_id(id)
-                                .map_err(|e| (format!("Failed to query record: {}", e), 1))?
-                                .ok_or_else(|| (format!("Record not found: {}", id), 1))?;
+                                .map_err(|e| (format!("Failed to query record: {e}"), 1))?
+                                .ok_or_else(|| (format!("Record not found: {id}"), 1))?;
                             record_report(&record, context)
                         }
                         (None, Some(session_id)) => {
                             let records = recorder
                                 .records_for_diff(&session_id, tool_use_id.as_deref())
-                                .map_err(|e| (format!("Failed to query diff records: {}", e), 1))?;
+                                .map_err(|e| (format!("Failed to query diff records: {e}"), 1))?;
                             if records.is_empty() {
                                 let scope = tool_use_id.as_deref().map_or_else(
                                     || format!("session {session_id:?}"),
                                     |tool| format!("tool use {tool:?} in session {session_id:?}"),
                                 );
-                                return Err((format!("No records found for {}", scope), 1));
+                                return Err((format!("No records found for {scope}"), 1));
                             }
                             if let Some(tool_use_id) = tool_use_id {
                                 tool_use_report(&records, &session_id, &tool_use_id, context)
@@ -801,8 +800,8 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     };
                     if json {
                         let output = serde_json::to_string_pretty(&report)
-                            .map_err(|e| (format!("Failed to serialize diff report: {}", e), 1))?;
-                        println!("{}", output);
+                            .map_err(|e| (format!("Failed to serialize diff report: {e}"), 1))?;
+                        println!("{output}");
                     } else {
                         let color = !no_color
                             && std::env::var_os("NO_COLOR").is_none()
@@ -827,7 +826,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     }
                     recorder
                         .clear()
-                        .map_err(|e| (format!("Failed to clear: {}", e), 1))?;
+                        .map_err(|e| (format!("Failed to clear: {e}"), 1))?;
                     println!("Statistics cleared.");
                 }
                 StatsCommands::Status => {
@@ -852,7 +851,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     } else {
                         "default"
                     };
-                    println!("Stats recording: {} (via {})", stats_state, stats_source);
+                    println!("Stats recording: {stats_state} (via {stats_source})");
 
                     let sls_state = if config.is_sls_enabled() {
                         "ENABLED"
@@ -866,7 +865,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     } else {
                         "default"
                     };
-                    println!("SLS recording:   {} (via {})", sls_state, sls_source);
+                    println!("SLS recording:   {sls_state} (via {sls_source})");
                 }
                 StatsCommands::Enable => {
                     persist_stats_enabled(true)?;
@@ -941,12 +940,12 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
         Commands::DecompressToon { file } => {
             let input = read_input(&file).map_err(|e| (e, 2))?;
             let value: serde_json::Value = toon_format::decode_default(&input)
-                .map_err(|e| (format!("toon decode failed: {}", e), 2))?;
+                .map_err(|e| (format!("toon decode failed: {e}"), 2))?;
             let output = serde_json::to_string_pretty(&value)
-                .map_err(|e| (format!("Serialization error: {}", e), 2))?;
+                .map_err(|e| (format!("Serialization error: {e}"), 2))?;
             let output = output.trim_end().to_string();
             if !output.is_empty() {
-                println!("{}", output);
+                println!("{output}");
             }
         }
         Commands::EnvCheck {
@@ -981,8 +980,7 @@ fn resolve_mode(
         CompressionMode::Active
     } else {
         eprintln!(
-            "tokenless: dry-run mode (compression disabled) — emitted original, predicted {} -> {} est. tokens",
-            before_tokens, after_tokens
+            "tokenless: dry-run mode (compression disabled) — emitted original, predicted {before_tokens} -> {after_tokens} est. tokens"
         );
         CompressionMode::DryRun
     }
@@ -1037,7 +1035,7 @@ fn persist_stats_enabled(enabled: bool) -> Result<(), (String, i32)> {
     let config = stats_persist_snapshot(TokenlessConfig::load_from_file(), enabled);
     config
         .save()
-        .map_err(|e| (format!("Failed to save config: {}", e), 1))?;
+        .map_err(|e| (format!("Failed to save config: {e}"), 1))?;
     Ok(())
 }
 
@@ -1128,7 +1126,7 @@ fn record_compression_stats(
 
 fn main() {
     if let Err((msg, code)) = run() {
-        eprintln!("Error: {}", msg);
+        eprintln!("Error: {msg}");
         process::exit(code);
     }
 }

--- a/src/tokenless/crates/tokenless-cli/src/mcp.rs
+++ b/src/tokenless/crates/tokenless-cli/src/mcp.rs
@@ -153,8 +153,7 @@ fn retrieve(args: Value, store: &Option<Arc<dyn StashStore>>) -> Value {
         None if is_valid_hash(hash) => hash,
         None => {
             return tool_error(&format!(
-                "invalid stash hash: {:?} (expected 24 hex chars or a <<tokenless:HASH>> marker)",
-                hash
+                "invalid stash hash: {hash:?} (expected 24 hex chars or a <<tokenless:HASH>> marker)"
             ));
         }
     };

--- a/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/env_check_tests.rs
@@ -307,7 +307,7 @@ fn format_dep_status_all() {
 fn expand_path_home() {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     let expanded = expand_path("~/.copilot-shell/settings.json");
-    assert_eq!(expanded, format!("{}/.copilot-shell/settings.json", home));
+    assert_eq!(expanded, format!("{home}/.copilot-shell/settings.json"));
 }
 
 #[test]
@@ -1111,7 +1111,7 @@ fn expand_path_tilde_subdir() {
         return;
     }
     let expanded = expand_path("~/.config");
-    assert_eq!(expanded, format!("{}/.config", home));
+    assert_eq!(expanded, format!("{home}/.config"));
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -30,22 +30,22 @@ impl TempDbGuard {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let test_dir = format!("{}/.tokenless-test-{}", home, nanos);
-        let sls_dir = format!("/tmp/tokenless-sls-test-{}", nanos);
+        let test_dir = format!("{home}/.tokenless-test-{nanos}");
+        let sls_dir = format!("/tmp/tokenless-sls-test-{nanos}");
         std::fs::create_dir_all(&test_dir).unwrap();
         std::fs::create_dir_all(&sls_dir).unwrap();
-        let sls_path = format!("{}/tokenless.jsonl", sls_dir);
+        let sls_path = format!("{sls_dir}/tokenless.jsonl");
         // Pre-create the JSONL file so SlsWriter::write can open it.
         std::fs::write(&sls_path, "").unwrap();
         let prev_stats_db = std::env::var_os("TOKENLESS_STATS_DB");
         let prev_stash_db = std::env::var_os("TOKENLESS_STASH_DB");
         let prev_sls_path = std::env::var_os("TOKENLESS_SLS_PATH");
         unsafe {
-            std::env::set_var("TOKENLESS_STATS_DB", format!("{}/stats.db", test_dir));
-            std::env::set_var("TOKENLESS_STASH_DB", format!("{}/stash.db", test_dir));
+            std::env::set_var("TOKENLESS_STATS_DB", format!("{test_dir}/stats.db"));
+            std::env::set_var("TOKENLESS_STASH_DB", format!("{test_dir}/stash.db"));
             std::env::set_var("TOKENLESS_SLS_PATH", &sls_path);
         }
-        let stash_db_path = format!("{}/stash.db", test_dir);
+        let stash_db_path = format!("{test_dir}/stash.db");
         Some(TempDbGuard {
             _lock: lock,
             test_dir,
@@ -238,8 +238,7 @@ fn validate_db_path_canonicalizes_home_with_symlink_prefix() {
     let result = validate_db_path(&inner, home.to_str().unwrap(), None);
     assert!(
         result.is_ok(),
-        "raw (non-canonical) home should be accepted after internal canonicalization: {:?}",
-        result
+        "raw (non-canonical) home should be accepted after internal canonicalization: {result:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -259,8 +258,7 @@ fn validate_db_path_rejects_parent_dir_bypass_with_nonexistent_parent() {
     );
     assert!(
         result.is_err(),
-        "ParentDir bypass via nonexistent intermediate must be rejected; got {:?}",
-        result
+        "ParentDir bypass via nonexistent intermediate must be rejected; got {result:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -785,7 +783,7 @@ fn run_command_retrieve_with_marker() {
     }
     let store = store.unwrap();
     let key = store.stash("hello world").unwrap().key;
-    let marker = format!("<<tokenless:{}>>", key);
+    let marker = format!("<<tokenless:{key}>>");
     let result = run_command(Commands::Retrieve {
         hash: marker,
         stash_db: None,

--- a/src/tokenless/crates/tokenless-protocol/Cargo.toml
+++ b/src/tokenless/crates/tokenless-protocol/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tokenless-protocol"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Versioned compression request/response protocol shared by all tokenless frontends"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -1,0 +1,376 @@
+//! Versioned compression protocol shared by every tokenless frontend.
+//!
+//! This crate defines protocol v1 (evolution roadmap §4.1): the compatibility
+//! boundary between agent-specific adapters and the shared compression
+//! pipeline. It is deliberately not an OpenAI or Anthropic request shape —
+//! [`CompressionRequest`] carries only the model-visible content plus the
+//! attribution and capability facts the pipeline needs, and
+//! [`CompressionResponse`] carries the final content plus the decision the
+//! adapter needs to build its host-specific envelope.
+//!
+//! The roadmap section numbers cited throughout this crate (§4.1, §4.5,
+//! §5.1, §5.6, …) refer to the tokenless evolution roadmap, which has not
+//! landed in this repository yet. Until it does, the JSON examples and
+//! contract tests in this crate are the authoritative wire contract.
+//!
+//! # Compatibility rules
+//!
+//! - Readers ignore unknown fields within a supported major protocol version,
+//!   so optional fields may be added without a version bump.
+//! - An incompatible shape requires a new `protocol_version`, never a
+//!   parallel adapter-specific payload.
+//! - [`CompressionRequest::from_json`] / [`CompressionResponse::from_json`]
+//!   check the version before the full parse, so a future version is reported
+//!   as [`ProtocolError::UnsupportedVersion`] rather than a shape error.
+//!
+//! # Fail-open contract
+//!
+//! `CompressionResponse::output` always holds exactly what the adapter must
+//! emit. On every non-[`Disposition::Applied`] disposition it is the original
+//! model-visible content, so adapters never need fallback logic of their own
+//! (roadmap principle 6).
+//!
+//! # Token counter identity
+//!
+//! All token counts in protocol v1 use the counter recorded in
+//! [`TOKENIZER_ID`]. The choice is the measured §5.1 decision (see the note
+//! in `docs/roadmap/evolution-roadmap.md`): the character-class heuristic
+//! `heuristic-v1`, not a provider tokenizer. Counts are normalized tokens for
+//! arbitration and attribution, not billing estimates.
+
+use serde::{Deserialize, Serialize};
+
+/// The protocol version this crate implements.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Identity of the normalized token counter used for every count in
+/// protocol v1: the character-class heuristic implemented by
+/// `tokenless-stats` (CJK ≈ 1 token per char, other ≈ 1 token per 4 chars).
+///
+/// Any change to the estimator's character classes or ratios requires a new
+/// ID; rows and responses produced under different IDs must never be merged
+/// into one series without an explicit per-counter breakdown.
+pub const TOKENIZER_ID: &str = "heuristic-v1";
+
+/// Upper bound, in bytes, for [`CompressionResponse::diagnostic`]. Writers
+/// truncate to this limit on a char boundary before emitting, so a failing
+/// pipeline can never bloat the response payload it is supposed to shrink
+/// (roadmap principle 6: diagnostics stay bounded).
+pub const DIAGNOSTIC_MAX_BYTES: usize = 4096;
+
+/// Error returned when a protocol payload cannot be accepted or produced.
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    /// The payload declares a protocol version this build does not support.
+    #[error("unsupported protocol_version {found} (supported: {PROTOCOL_VERSION})")]
+    UnsupportedVersion {
+        /// The version the payload declared.
+        found: u32,
+    },
+    /// The payload is not valid JSON for the declared version's shape.
+    #[error("malformed protocol payload: {0}")]
+    Malformed(#[from] serde_json::Error),
+    /// A value could not be serialized to the wire format. Unreachable for
+    /// the derived v1 shapes; kept so `to_json` stays honest if a future
+    /// field gains a fallible serializer.
+    #[error("protocol serialization failed: {0}")]
+    Serialize(#[source] serde_json::Error),
+}
+
+/// Where in the agent loop the content was intercepted (roadmap §4.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Seam {
+    /// Content headed into a model request (e.g. schema publication).
+    BeforeModel,
+    /// Tool input before execution (e.g. command rewrite).
+    PreTool,
+    /// Tool output after execution — the primary compression seam.
+    PostTool,
+    /// A proxy frontend observing model traffic.
+    Proxy,
+}
+
+/// What the requesting adapter's host can actually do with the result.
+///
+/// The pipeline intersects compressor candidates with these capabilities
+/// (roadmap principle 2): a response compressor must not run when the host
+/// cannot replace the original model-visible output. Every capability
+/// defaults to `false`, so an adapter that declares nothing gets passthrough
+/// rather than an unemittable candidate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capabilities {
+    /// The host can replace the model-visible tool output with
+    /// [`CompressionResponse::output`].
+    #[serde(default)]
+    pub replace_output: bool,
+    /// The host exposes a retrieval tool (`tokenless_retrieve` or an
+    /// equivalent), so retrievable-lossy markers are actually recoverable.
+    #[serde(default)]
+    pub publish_retrieve_tool: bool,
+}
+
+/// A compression request: the model-visible content plus attribution.
+///
+/// Adapters own their private host contracts (roadmap §4.5); only the
+/// model-visible value is copied here. UI or business objects that must
+/// remain unmodified never enter the protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompressionRequest {
+    /// Must equal [`PROTOCOL_VERSION`]. Enforced on every deserialization
+    /// path, including direct `serde_json::from_str`.
+    #[serde(deserialize_with = "version_must_match")]
+    pub protocol_version: u32,
+    /// The model-visible content to consider for compression.
+    pub content: String,
+    /// Stable identifier of the requesting agent frontend
+    /// (e.g. `claude-code`).
+    pub agent_id: String,
+    /// Session attribution, when the host provides one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Tool-use attribution, when the host provides one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    /// Name of the tool that produced the content, when one exists.
+    /// Absent for non-tool seams such as schema publication.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    /// Where in the agent loop this content was intercepted.
+    pub seam: Seam,
+    /// What the host can do with the result. Missing fields are `false`.
+    #[serde(default)]
+    pub capabilities: Capabilities,
+}
+
+impl CompressionRequest {
+    /// Creates a v1 request with the required fields; optional attribution
+    /// and capabilities are set directly on the public fields.
+    pub fn new(content: impl Into<String>, agent_id: impl Into<String>, seam: Seam) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            content: content.into(),
+            agent_id: agent_id.into(),
+            session_id: None,
+            tool_use_id: None,
+            tool_name: None,
+            seam,
+            capabilities: Capabilities::default(),
+        }
+    }
+
+    /// Parses a request, rejecting unsupported versions before shape errors.
+    ///
+    /// # Errors
+    ///
+    /// [`ProtocolError::UnsupportedVersion`] when `protocol_version` differs
+    /// from [`PROTOCOL_VERSION`]; [`ProtocolError::Malformed`] when the JSON
+    /// does not match the v1 shape.
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        check_version(json)?;
+        Ok(serde_json::from_str(json)?)
+    }
+
+    /// Serializes to the wire format.
+    ///
+    /// # Errors
+    ///
+    /// [`ProtocolError::Serialize`] — unreachable for the current derived
+    /// shape, surfaced instead of a panic per library error policy.
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        serde_json::to_string(self).map_err(ProtocolError::Serialize)
+    }
+}
+
+/// The pipeline's verdict on one request.
+///
+/// Only [`Disposition::Applied`] means [`CompressionResponse::output`]
+/// differs from the request content; every other disposition returns the
+/// original so the adapter can emit unconditionally. These names are the
+/// shared vocabulary the M1 exit gate requires CLI and Runtime to agree on
+/// (roadmap §5.6).
+///
+/// The Runtime's pre-protocol `CompressionDisposition::as_str` still prints
+/// kebab-case (`dry-run`, `no-savings`); the Runtime-integration change is
+/// expected to align those user-visible strings to these snake_case wire
+/// values rather than fork the vocabulary further.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Disposition {
+    /// A compressed candidate was accepted; `output` replaces the original.
+    Applied,
+    /// Dry-run mode: a candidate was produced and measured, but `output` is
+    /// the original content. `before_tokens`/`after_tokens` carry the
+    /// predicted delta; dry-run results are never mixed into applied
+    /// savings. Mirrors the Runtime's existing dry-run disposition.
+    DryRun,
+    /// The pipeline chose not to touch the content (skip rule, missing
+    /// capability, or unrecognized content routed to passthrough).
+    Passthrough,
+    /// A candidate was produced but rejected because it did not remove
+    /// normalized tokens; no active savings are recorded.
+    NoSavings,
+    /// Required-reversible mode rejected a candidate whose removed content
+    /// would not be retrievable.
+    ReversibilityUnavailable,
+    /// The pipeline exceeded its overall timeout budget; the original is
+    /// preserved.
+    Timeout,
+    /// An optional compression step failed; the original is preserved and
+    /// a bounded diagnostic is recorded (roadmap principle 6).
+    Error,
+}
+
+/// Recovery state of an applied transformation (roadmap principle 5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Reversibility {
+    /// Nothing task-relevant was removed; no recovery needed.
+    Lossless,
+    /// Removed content is stored in the Stash and referenced by emitted
+    /// markers; retrieval restores it byte-exactly.
+    Retrievable,
+    /// Content was removed without a recovery path. Rejected outright in
+    /// required-reversible mode.
+    Unrecoverable,
+}
+
+/// A compression response: the content to emit plus the decision facts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompressionResponse {
+    /// Must equal [`PROTOCOL_VERSION`]. Enforced on every deserialization
+    /// path, including direct `serde_json::from_str`.
+    #[serde(deserialize_with = "version_must_match")]
+    pub protocol_version: u32,
+    /// Exactly what the adapter must emit — compressed on
+    /// [`Disposition::Applied`], the original otherwise.
+    pub output: String,
+    /// The pipeline's verdict.
+    pub disposition: Disposition,
+    /// Detected content taxonomy value (e.g. `build_log`), once a detector
+    /// classified the content. Wire values are stable strings; the Rust
+    /// taxonomy type arrives with the detector and registry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    /// Stable IDs of the compressors that shaped `output`, in order.
+    /// Empty on non-applied dispositions.
+    #[serde(default)]
+    pub compressor_chain: Vec<String>,
+    /// Recovery state of `output`. [`Reversibility::Lossless`] whenever the
+    /// original was returned unchanged.
+    pub reversibility: Reversibility,
+    /// Normalized tokens of the request content, counted by `tokenizer_id`.
+    pub before_tokens: u64,
+    /// Normalized tokens of `output`, counted by `tokenizer_id`.
+    pub after_tokens: u64,
+    /// Stash keys committed by this response. Only keys present in an
+    /// applied, emitted result appear here; rolled-back candidates never
+    /// leak keys (roadmap §4.6).
+    #[serde(default)]
+    pub stash_keys: Vec<String>,
+    /// Identity of the counter behind both token counts. Writers set
+    /// [`TOKENIZER_ID`]. A payload missing the field reads as
+    /// [`TOKENIZER_ID`] too: the heuristic estimator is the only counter
+    /// that ever shipped before the field existed, so the default is the
+    /// factual legacy identity rather than an ambiguous empty string.
+    #[serde(default = "default_tokenizer_id")]
+    pub tokenizer_id: String,
+    /// Bounded diagnostic accompanying [`Disposition::Error`]: at most
+    /// [`DIAGNOSTIC_MAX_BYTES`] bytes. The pipeline, as the only writer,
+    /// truncates before setting it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+}
+
+impl CompressionResponse {
+    /// The canonical passthrough response: the original content, unchanged
+    /// counts, and no artifacts. Every frontend must produce this same shape
+    /// so dispositions stay comparable across CLI and Runtime (§5.6).
+    #[must_use]
+    pub fn passthrough(request: &CompressionRequest, before_tokens: u64) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            output: request.content.clone(),
+            disposition: Disposition::Passthrough,
+            content_type: None,
+            compressor_chain: Vec::new(),
+            reversibility: Reversibility::Lossless,
+            before_tokens,
+            after_tokens: before_tokens,
+            stash_keys: Vec::new(),
+            tokenizer_id: TOKENIZER_ID.to_owned(),
+            diagnostic: None,
+        }
+    }
+
+    /// True when `output` replaced the original content.
+    #[must_use]
+    pub fn is_applied(&self) -> bool {
+        self.disposition == Disposition::Applied
+    }
+
+    /// Parses a response, rejecting unsupported versions before shape errors.
+    ///
+    /// # Errors
+    ///
+    /// [`ProtocolError::UnsupportedVersion`] when `protocol_version` differs
+    /// from [`PROTOCOL_VERSION`]; [`ProtocolError::Malformed`] when the JSON
+    /// does not match the v1 shape.
+    pub fn from_json(json: &str) -> Result<Self, ProtocolError> {
+        check_version(json)?;
+        Ok(serde_json::from_str(json)?)
+    }
+
+    /// Serializes to the wire format.
+    ///
+    /// # Errors
+    ///
+    /// [`ProtocolError::Serialize`] — unreachable for the current derived
+    /// shape, surfaced instead of a panic per library error policy.
+    pub fn to_json(&self) -> Result<String, ProtocolError> {
+        serde_json::to_string(self).map_err(ProtocolError::Serialize)
+    }
+}
+
+/// Extracts and checks `protocol_version` without depending on the rest of
+/// the shape, so a future version's payload reports as unsupported rather
+/// than malformed.
+fn check_version(json: &str) -> Result<(), ProtocolError> {
+    #[derive(Deserialize)]
+    struct VersionOnly {
+        protocol_version: u32,
+    }
+    let v: VersionOnly = serde_json::from_str(json)?;
+    if v.protocol_version != PROTOCOL_VERSION {
+        return Err(ProtocolError::UnsupportedVersion {
+            found: v.protocol_version,
+        });
+    }
+    Ok(())
+}
+
+/// Field-level guard used by the derived `Deserialize` impls, so the version
+/// gate cannot be bypassed by deserializing the structs directly instead of
+/// going through `from_json`.
+fn version_must_match<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = u32::deserialize(deserializer)?;
+    if v != PROTOCOL_VERSION {
+        return Err(serde::de::Error::custom(format!(
+            "unsupported protocol_version {v} (supported: {PROTOCOL_VERSION})"
+        )));
+    }
+    Ok(v)
+}
+
+fn default_tokenizer_id() -> String {
+    TOKENIZER_ID.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/protocol_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
@@ -1,0 +1,219 @@
+// Contract tests for protocol v1. The two *_roadmap_example tests pin the
+// §4.1 JSON examples from the evolution roadmap draft. That document has not
+// landed in-repo yet, so until it does the JSON here is the authoritative
+// wire contract; once it lands, these tests become the drift guard between
+// the document and the types.
+
+#[test]
+fn request_roadmap_example_parses() {
+    let json = r#"{
+  "protocol_version": 1,
+  "content": "...",
+  "agent_id": "claude-code",
+  "session_id": "...",
+  "tool_use_id": "...",
+  "tool_name": "Bash",
+  "seam": "post_tool",
+  "capabilities": {
+    "replace_output": true,
+    "publish_retrieve_tool": true
+  }
+}"#;
+    let req = CompressionRequest::from_json(json).expect("roadmap request example must parse");
+    assert_eq!(req.protocol_version, PROTOCOL_VERSION);
+    assert_eq!(req.agent_id, "claude-code");
+    assert_eq!(req.tool_name.as_deref(), Some("Bash"));
+    assert_eq!(req.seam, Seam::PostTool);
+    assert!(req.capabilities.replace_output);
+    assert!(req.capabilities.publish_retrieve_tool);
+}
+
+#[test]
+fn response_roadmap_example_parses() {
+    let json = r#"{
+  "protocol_version": 1,
+  "output": "...",
+  "disposition": "applied",
+  "content_type": "build_log",
+  "compressor_chain": ["terminal-cleanup", "build-log"],
+  "reversibility": "retrievable",
+  "before_tokens": 1200,
+  "after_tokens": 340,
+  "stash_keys": ["0123456789abcdef01234567"]
+}"#;
+    let resp = CompressionResponse::from_json(json).expect("roadmap response example must parse");
+    assert!(resp.is_applied());
+    assert_eq!(resp.content_type.as_deref(), Some("build_log"));
+    assert_eq!(resp.compressor_chain, ["terminal-cleanup", "build-log"]);
+    assert_eq!(resp.reversibility, Reversibility::Retrievable);
+    assert_eq!((resp.before_tokens, resp.after_tokens), (1200, 340));
+    assert_eq!(resp.stash_keys, ["0123456789abcdef01234567"]);
+    // The example predates the field; absence reads as the heuristic
+    // estimator, the only counter that ever shipped before the field.
+    assert_eq!(resp.tokenizer_id, TOKENIZER_ID);
+}
+
+#[test]
+fn request_round_trips() {
+    let mut req = CompressionRequest::new("hello world", "codex", Seam::PostTool);
+    req.session_id = Some("s-1".into());
+    req.tool_use_id = Some("tu-1".into());
+    req.tool_name = Some("Bash".into());
+    req.capabilities.replace_output = true;
+    let parsed = CompressionRequest::from_json(&req.to_json().unwrap()).unwrap();
+    assert_eq!(parsed, req);
+}
+
+#[test]
+fn response_round_trips() {
+    let req = CompressionRequest::new("payload", "claude-code", Seam::PreTool);
+    let resp = CompressionResponse::passthrough(&req, 42);
+    let parsed = CompressionResponse::from_json(&resp.to_json().unwrap()).unwrap();
+    assert_eq!(parsed, resp);
+}
+
+#[test]
+fn unknown_fields_are_ignored() {
+    let json = r#"{
+  "protocol_version": 1,
+  "content": "x",
+  "agent_id": "a",
+  "seam": "post_tool",
+  "future_optional_field": {"nested": [1, 2, 3]}
+}"#;
+    let req = CompressionRequest::from_json(json).expect("unknown optional fields are ignored");
+    assert_eq!(req.content, "x");
+}
+
+#[test]
+fn missing_optionals_take_defaults() {
+    let json = r#"{"protocol_version":1,"content":"x","agent_id":"a","seam":"before_model"}"#;
+    let req = CompressionRequest::from_json(json).unwrap();
+    assert_eq!(req.session_id, None);
+    assert_eq!(req.tool_use_id, None);
+    assert_eq!(req.tool_name, None);
+    assert!(!req.capabilities.replace_output);
+    assert!(!req.capabilities.publish_retrieve_tool);
+}
+
+#[test]
+fn unsupported_version_beats_shape_errors() {
+    // A v2 payload with a shape v1 cannot parse must still be reported as a
+    // version problem, not a malformed payload.
+    let json = r#"{"protocol_version":2,"body":{"parts":["..."]}}"#;
+    match CompressionRequest::from_json(json) {
+        Err(ProtocolError::UnsupportedVersion { found: 2 }) => {}
+        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    }
+    match CompressionResponse::from_json(json) {
+        Err(ProtocolError::UnsupportedVersion { found: 2 }) => {}
+        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    }
+}
+
+#[test]
+fn malformed_payload_is_reported() {
+    let err = CompressionRequest::from_json("not json").unwrap_err();
+    assert!(matches!(err, ProtocolError::Malformed(_)));
+    // The structured serde error stays reachable through the source chain.
+    assert!(std::error::Error::source(&err).is_some());
+    // Valid version, wrong shape for the rest.
+    assert!(matches!(
+        CompressionRequest::from_json(r#"{"protocol_version":1,"content":7}"#),
+        Err(ProtocolError::Malformed(_))
+    ));
+}
+
+#[test]
+fn direct_deserialization_cannot_bypass_the_version_gate() {
+    // A v2 payload whose remaining fields happen to fit the v1 shape must
+    // fail even through plain serde, not only through from_json.
+    let json = r#"{"protocol_version":2,"content":"x","agent_id":"a","seam":"post_tool"}"#;
+    let err = serde_json::from_str::<CompressionRequest>(json).unwrap_err();
+    assert!(err.to_string().contains("unsupported protocol_version 2"));
+
+    let json = r#"{"protocol_version":2,"output":"o","disposition":"applied","reversibility":"lossless","before_tokens":1,"after_tokens":1}"#;
+    let err = serde_json::from_str::<CompressionResponse>(json).unwrap_err();
+    assert!(err.to_string().contains("unsupported protocol_version 2"));
+}
+
+#[test]
+fn passthrough_is_canonical() {
+    let req = CompressionRequest::new("original", "qoder-cli", Seam::PostTool);
+    let resp = CompressionResponse::passthrough(&req, 9);
+    assert_eq!(resp.output, "original");
+    assert_eq!(resp.disposition, Disposition::Passthrough);
+    assert_eq!(resp.reversibility, Reversibility::Lossless);
+    assert_eq!((resp.before_tokens, resp.after_tokens), (9, 9));
+    assert!(resp.compressor_chain.is_empty());
+    assert!(resp.stash_keys.is_empty());
+    assert_eq!(resp.tokenizer_id, TOKENIZER_ID);
+    assert!(!resp.is_applied());
+}
+
+#[test]
+fn wire_format_is_stable() {
+    // Locks field names and enum wire values. A failure here is a protocol
+    // change and requires either a compatible optional field or a new
+    // protocol_version — never a silent rename.
+    let mut req = CompressionRequest::new("c", "a", Seam::PostTool);
+    req.capabilities.replace_output = true;
+    assert_eq!(
+        req.to_json().unwrap(),
+        r#"{"protocol_version":1,"content":"c","agent_id":"a","seam":"post_tool","capabilities":{"replace_output":true,"publish_retrieve_tool":false}}"#
+    );
+
+    let resp = CompressionResponse {
+        protocol_version: PROTOCOL_VERSION,
+        output: "o".into(),
+        disposition: Disposition::NoSavings,
+        content_type: Some("search_results".into()),
+        compressor_chain: vec!["search".into()],
+        reversibility: Reversibility::Unrecoverable,
+        before_tokens: 10,
+        after_tokens: 10,
+        stash_keys: vec!["k".into()],
+        tokenizer_id: TOKENIZER_ID.into(),
+        diagnostic: Some("d".into()),
+    };
+    assert_eq!(
+        resp.to_json().unwrap(),
+        r#"{"protocol_version":1,"output":"o","disposition":"no_savings","content_type":"search_results","compressor_chain":["search"],"reversibility":"unrecoverable","before_tokens":10,"after_tokens":10,"stash_keys":["k"],"tokenizer_id":"heuristic-v1","diagnostic":"d"}"#
+    );
+}
+
+#[test]
+fn all_seams_and_dispositions_round_trip() {
+    for (seam, wire) in [
+        (Seam::BeforeModel, "\"before_model\""),
+        (Seam::PreTool, "\"pre_tool\""),
+        (Seam::PostTool, "\"post_tool\""),
+        (Seam::Proxy, "\"proxy\""),
+    ] {
+        assert_eq!(serde_json::to_string(&seam).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<Seam>(wire).unwrap(), seam);
+    }
+    for (disp, wire) in [
+        (Disposition::Applied, "\"applied\""),
+        (Disposition::DryRun, "\"dry_run\""),
+        (Disposition::Passthrough, "\"passthrough\""),
+        (Disposition::NoSavings, "\"no_savings\""),
+        (
+            Disposition::ReversibilityUnavailable,
+            "\"reversibility_unavailable\"",
+        ),
+        (Disposition::Timeout, "\"timeout\""),
+        (Disposition::Error, "\"error\""),
+    ] {
+        assert_eq!(serde_json::to_string(&disp).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<Disposition>(wire).unwrap(), disp);
+    }
+    for (rev, wire) in [
+        (Reversibility::Lossless, "\"lossless\""),
+        (Reversibility::Retrievable, "\"retrievable\""),
+        (Reversibility::Unrecoverable, "\"unrecoverable\""),
+    ] {
+        assert_eq!(serde_json::to_string(&rev).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<Reversibility>(wire).unwrap(), rev);
+    }
+}

--- a/src/tokenless/crates/tokenless-schema/examples/bench.rs
+++ b/src/tokenless/crates/tokenless-schema/examples/bench.rs
@@ -11,7 +11,7 @@ use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 
 fn load_fixture(dir: &str, name: &str) -> Value {
     let manifest = env!("CARGO_MANIFEST_DIR");
-    let path = format!("{}/tests/fixtures/{}/{}", manifest, dir, name);
+    let path = format!("{manifest}/tests/fixtures/{dir}/{name}");
     let content = std::fs::read_to_string(&path).expect("load fixture");
     serde_json::from_str(&content).expect("parse fixture")
 }
@@ -130,21 +130,17 @@ fn main() {
     .map(|(name, _)| (*name, load_fixture("responses", name)))
     .collect();
 
-    println!("Tokenless Benchmark ({} iterations per test)\n", ITERATIONS);
+    println!("Tokenless Benchmark ({ITERATIONS} iterations per test)\n");
 
     println!("L1 — SchemaCompressor (no stash)");
     for (name, fixture) in &schema_fixtures {
-        print_result(&run_schema_bench(
-            &format!("schema/{}", name),
-            fixture,
-            false,
-        ));
+        print_result(&run_schema_bench(&format!("schema/{name}"), fixture, false));
     }
 
     println!("\nL1 — SchemaCompressor + Stash (reversible)");
     for (name, fixture) in &schema_fixtures {
         print_result(&run_schema_bench(
-            &format!("schema+stash/{}", name),
+            &format!("schema+stash/{name}"),
             fixture,
             true,
         ));

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -236,10 +236,7 @@ impl ResponseCompressor {
                     // surface the failure — a silent orphan is worse than a
                     // loud warning (AGENTS.md: do not swallow operational errors).
                     self.record_stash_error();
-                    eprintln!(
-                        "[tokenless] stash: rollback delete failed for key {}: {e}",
-                        key
-                    );
+                    eprintln!("[tokenless] stash: rollback delete failed for key {key}: {e}");
                 }
             }
         }
@@ -385,7 +382,7 @@ impl ResponseCompressor {
         let truncated = &s[..truncate_pos];
 
         if attach_marker {
-            Value::String(format!("{}{}", truncated, LOSSY_MARKER))
+            Value::String(format!("{truncated}{LOSSY_MARKER}"))
         } else {
             Value::String(truncated.to_string())
         }
@@ -441,7 +438,7 @@ impl ResponseCompressor {
                     remaining,
                     marker_for(&key)
                 ),
-                None => format!("<... {} more items truncated, not stashed>", remaining),
+                None => format!("<... {remaining} more items truncated, not stashed>"),
             };
             result.push(Value::String(marker));
         } else if truncate && self.stash_store.is_some() {

--- a/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/schema_compressor.rs
@@ -165,10 +165,7 @@ impl SchemaCompressor {
                 Ok(false) => {}
                 Err(e) => {
                     self.record_stash_error();
-                    eprintln!(
-                        "[tokenless] stash: rollback delete failed for key {}: {e}",
-                        key
-                    );
+                    eprintln!("[tokenless] stash: rollback delete failed for key {key}: {e}");
                 }
             }
         }

--- a/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/schema_compressor_tests.rs
@@ -554,8 +554,7 @@ fn test_truncate_at_sentence_boundary() {
     // Should truncate at a sentence boundary
     assert!(
         result.ends_with('.'),
-        "Result '{}' should end with '.'",
-        result
+        "Result '{result}' should end with '.'"
     );
     assert!(result.len() <= 60);
 }

--- a/src/tokenless/crates/tokenless-schema/tests/integration_test.rs
+++ b/src/tokenless/crates/tokenless-schema/tests/integration_test.rs
@@ -19,7 +19,7 @@ fn fixtures_dir() -> String {
 fn load_schema(name: &str) -> Value {
     let path = format!("{}/{}", fixtures_dir(), name);
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to load schema {}: {}", path, e));
+        .unwrap_or_else(|e| panic!("Failed to load schema {path}: {e}"));
     serde_json::from_str(&content).unwrap()
 }
 
@@ -30,7 +30,7 @@ fn response_fixtures_dir() -> String {
 fn load_response(name: &str) -> Value {
     let path = format!("{}/{}", response_fixtures_dir(), name);
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to load response {}: {}", path, e));
+        .unwrap_or_else(|e| panic!("Failed to load response {path}: {e}"));
     serde_json::from_str(&content).unwrap()
 }
 
@@ -410,9 +410,7 @@ fn test_fixture_hubspot_contact() {
     let comp_len = serde_json::to_string(&compressed).unwrap().len();
     assert!(
         comp_len < orig_len,
-        "Should compress: original={}, compressed={}",
-        orig_len,
-        comp_len
+        "Should compress: original={orig_len}, compressed={comp_len}"
     );
 
     // Enum preserved on lifecyclestage
@@ -436,9 +434,7 @@ fn test_fixture_stripe_payment() {
     let comp_len = serde_json::to_string(&compressed).unwrap().len();
     assert!(
         comp_len < orig_len,
-        "Should compress: original={}, compressed={}",
-        orig_len,
-        comp_len
+        "Should compress: original={orig_len}, compressed={comp_len}"
     );
 }
 
@@ -459,22 +455,19 @@ fn test_all_fixtures_produce_valid_json() {
         let compressed = compressor.compress(&schema);
 
         // Must be valid JSON object
-        assert!(compressed.is_object(), "{} should compress to object", name);
+        assert!(compressed.is_object(), "{name} should compress to object");
 
         // Serialization round-trip must succeed
         let json_str = serde_json::to_string(&compressed).unwrap();
         let reparsed: Value = serde_json::from_str(&json_str).unwrap();
-        assert!(reparsed.is_object(), "{} round-trip failed", name);
+        assert!(reparsed.is_object(), "{name} round-trip failed");
 
         // Compression ratio > 0
         let orig_len = serde_json::to_string(&schema).unwrap().len();
         let comp_len = json_str.len();
         assert!(
             comp_len <= orig_len,
-            "{}: compressed ({}) should be <= original ({})",
-            name,
-            comp_len,
-            orig_len
+            "{name}: compressed ({comp_len}) should be <= original ({orig_len})"
         );
 
         // The top-level "type": "function" discriminant must be preserved when present.
@@ -482,8 +475,7 @@ fn test_all_fixtures_produce_valid_json() {
             assert_eq!(
                 compressed.get("type"),
                 schema.get("type"),
-                "{}: top-level \"type\" field must survive compression",
-                name
+                "{name}: top-level \"type\" field must survive compression"
             );
         }
     }
@@ -512,25 +504,18 @@ fn test_fixture_compression_ratio_benchmark() {
         let comp = serde_json::to_string(&compressed).unwrap().len();
 
         let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
-        println!(
-            "{:<30} {} -> {} bytes ({:.1}% saved)",
-            name, orig, comp, saved
-        );
+        println!("{name:<30} {orig} -> {comp} bytes ({saved:.1}% saved)");
 
         total_orig += orig;
         total_comp += comp;
     }
 
     let avg_saved = (1.0 - total_comp as f64 / total_orig as f64) * 100.0;
-    println!(
-        "TOTAL: {} -> {} ({:.1}% saved)",
-        total_orig, total_comp, avg_saved
-    );
+    println!("TOTAL: {total_orig} -> {total_comp} ({avg_saved:.1}% saved)");
 
     assert!(
         avg_saved >= 5.0,
-        "Average compression should be >= 5%, got {:.1}%",
-        avg_saved
+        "Average compression should be >= 5%, got {avg_saved:.1}%"
     );
 }
 
@@ -577,10 +562,7 @@ fn bench_l1_schema_compressor() {
         let orig = byte_len(&schema);
         let comp = byte_len(&compressed);
         let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
-        println!(
-            "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
-            name, orig, comp, saved
-        );
+        println!("  {name:<35} {orig:>6} -> {comp:>6} ({saved:.1}% saved)");
         total_orig += orig;
         total_comp += comp;
     }
@@ -593,8 +575,7 @@ fn bench_l1_schema_compressor() {
 
     assert!(
         overall >= 5.0,
-        "L1 schema: expected >= 5% savings, got {:.1}%",
-        overall
+        "L1 schema: expected >= 5% savings, got {overall:.1}%"
     );
 }
 
@@ -612,10 +593,7 @@ fn bench_l1_response_compressor() {
         let orig = byte_len(&response);
         let comp = byte_len(&compressed);
         let saved = (1.0 - comp as f64 / orig as f64) * 100.0;
-        println!(
-            "  {:<35} {:>6} -> {:>6} ({:.1}% saved)",
-            name, orig, comp, saved
-        );
+        println!("  {name:<35} {orig:>6} -> {comp:>6} ({saved:.1}% saved)");
         total_orig += orig;
         total_comp += comp;
     }
@@ -628,8 +606,7 @@ fn bench_l1_response_compressor() {
 
     assert!(
         overall > 0.0,
-        "L1 response: expected some savings, got {:.1}%",
-        overall
+        "L1 response: expected some savings, got {overall:.1}%"
     );
 }
 
@@ -734,8 +711,7 @@ fn bench_l1_stash_response() {
         serde_json::from_str(&retrieved).expect("stashed payload must be valid JSON");
     assert!(
         tail.is_array(),
-        "stashed payload must be an array of the dropped items, got: {:?}",
-        tail
+        "stashed payload must be an array of the dropped items, got: {tail:?}"
     );
     assert!(
         !tail.as_array().unwrap().is_empty(),
@@ -770,14 +746,7 @@ fn bench_l2_schema_response_pipeline() {
             let combined_saved = (1.0 - combined_comp as f64 / combined_orig as f64) * 100.0;
 
             println!(
-                "  {} + {}: schema {:.1}% | response {:.1}% | combined {:.1}% ({} -> {})",
-                schema_name,
-                resp_name,
-                schema_saved,
-                resp_saved,
-                combined_saved,
-                combined_orig,
-                combined_comp
+                "  {schema_name} + {resp_name}: schema {schema_saved:.1}% | response {resp_saved:.1}% | combined {combined_saved:.1}% ({combined_orig} -> {combined_comp})"
             );
         }
     }
@@ -870,10 +839,7 @@ fn bench_l4_full_pipeline_aggregate() {
     }
 
     let overall = (1.0 - grand_comp as f64 / grand_orig as f64) * 100.0;
-    println!(
-        "\n  GRAND TOTAL: {} -> {} bytes ({:.1}% saved)",
-        grand_orig, grand_comp, overall
-    );
+    println!("\n  GRAND TOTAL: {grand_orig} -> {grand_comp} bytes ({overall:.1}% saved)");
     println!(
         "  Stash entries: {} (schema fields stashed reversibly; response savings include lossy field removal)",
         store.len()

--- a/src/tokenless/crates/tokenless-stats/src/home.rs
+++ b/src/tokenless/crates/tokenless-stats/src/home.rs
@@ -96,7 +96,7 @@ mod tests {
             "must not read $HOME as a fallback",
         );
         if !h.is_empty() {
-            assert!(h.starts_with('/'), "passwd home must be absolute: {}", h);
+            assert!(h.starts_with('/'), "passwd home must be absolute: {h}");
         }
         // Restore previous HOME (or unset it) so we don't pollute sibling tests.
         unsafe {

--- a/src/tokenless/crates/tokenless-stats/src/query.rs
+++ b/src/tokenless/crates/tokenless-stats/src/query.rs
@@ -350,10 +350,7 @@ pub fn format_compare(baseline: &[StatsRecord], tokenless: &[StatsRecord]) -> St
         } else {
             0.0
         };
-        output.push_str(&format!(
-            "{:<22}{:>12}{:>14}{:>10}{:>11.1}%\n",
-            op, b, t, saved, pct
-        ));
+        output.push_str(&format!("{op:<22}{b:>12}{t:>14}{saved:>10}{pct:>11.1}%\n"));
     }
 
     output.push_str(&"-".repeat(68));

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -41,7 +41,7 @@ impl FromStr for OperationType {
             "compress-response" => Ok(OperationType::CompressResponse),
             "rewrite-command" => Ok(OperationType::RewriteCommand),
             "compress-toon" => Ok(OperationType::CompressToon),
-            other => Err(format!("unknown operation type: {}", other)),
+            other => Err(format!("unknown operation type: {other}")),
         }
     }
 }
@@ -260,7 +260,7 @@ impl StatsRecord {
     pub fn format_summary_line(&self) -> String {
         let pid = self
             .source_pid
-            .map(|p| format!(" pid:{}", p))
+            .map(|p| format!(" pid:{p}"))
             .unwrap_or_default();
         let session = self.session_id.as_deref().unwrap_or("-");
         let tool = self.tool_use_id.as_deref().unwrap_or("-");

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -117,7 +117,7 @@ impl StatsRecorder {
                 .unwrap_or(false);
             if !exists {
                 conn.execute(
-                    &format!("ALTER TABLE stats ADD COLUMN {} {}", col, col_type),
+                    &format!("ALTER TABLE stats ADD COLUMN {col} {col_type}"),
                     [],
                 )?;
             }
@@ -139,8 +139,7 @@ impl StatsRecorder {
     fn lock_conn(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().unwrap_or_else(|poisoned| {
             eprintln!(
-                "[tokenless-stats] WARNING: mutex was poisoned by a previous panic; recovering: {}",
-                poisoned
+                "[tokenless-stats] WARNING: mutex was poisoned by a previous panic; recovering: {poisoned}"
             );
             self.conn.clear_poison();
             poisoned.into_inner()
@@ -218,9 +217,8 @@ impl StatsRecorder {
                     static CORRUPT_LOGGED: AtomicBool = AtomicBool::new(false);
                     if !CORRUPT_LOGGED.swap(true, Ordering::Relaxed) {
                         eprintln!(
-                            "[tokenless-stats] skipping corrupt row(s): {} \
-                             (further corrupt rows suppressed)",
-                            e
+                            "[tokenless-stats] skipping corrupt row(s): {e} \
+                             (further corrupt rows suppressed)"
                         );
                     }
                     None
@@ -433,10 +431,7 @@ impl StatsRecorder {
             timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(1)?)
                 .map(|dt| dt.with_timezone(&chrono::Local))
                 .unwrap_or_else(|e| {
-                    eprintln!(
-                        "[tokenless-stats] corrupt timestamp, using current time: {}",
-                        e
-                    );
+                    eprintln!("[tokenless-stats] corrupt timestamp, using current time: {e}");
                     chrono::Local::now()
                 }),
             operation: OperationType::from_str(&row.get::<_, String>(2)?).map_err(|e| {
@@ -445,7 +440,7 @@ impl StatsRecorder {
                     rusqlite::types::Type::Text,
                     Box::new(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        format!("unknown operation type: {}", e),
+                        format!("unknown operation type: {e}"),
                     )),
                 )
             })?,

--- a/src/tokenless/crates/tokenless-stats/src/sls.rs
+++ b/src/tokenless/crates/tokenless-stats/src/sls.rs
@@ -122,8 +122,7 @@ fn resolve_sls_path(env_val: Option<&str>) -> PathBuf {
                 eprintln!(
                     "tokenless-sls: TOKENLESS_SLS_PATH rejected (must be under \
                      /var/log/ or /tmp/, and must not contain '..'), \
-                     falling back to default: {}",
-                    DEFAULT_SLS_PATH
+                     falling back to default: {DEFAULT_SLS_PATH}"
                 );
                 None
             }
@@ -246,7 +245,7 @@ impl SlsWriter {
         let line = match serde_json::to_string(&sls_record) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("tokenless-sls: serialization error: {}", e);
+                eprintln!("tokenless-sls: serialization error: {e}");
                 return;
             }
         };
@@ -374,7 +373,7 @@ mod tests {
             "tokenless.compression.tokens_saved_percent",
         ];
         for expected in &expected_keys {
-            assert!(keys.contains(expected), "missing key: {}", expected);
+            assert!(keys.contains(expected), "missing key: {expected}");
         }
         assert_eq!(keys.len(), expected_keys.len());
     }
@@ -389,8 +388,7 @@ mod tests {
         for key in obj.as_object().unwrap().keys() {
             assert!(
                 !key.chars().any(|c| c.is_ascii_uppercase()),
-                "key contains uppercase: {}",
-                key
+                "key contains uppercase: {key}"
             );
         }
     }
@@ -410,9 +408,7 @@ mod tests {
                         || c == '.'
                         || c == '_'
                         || c == '-',
-                    "invalid char '{}' in key: {}",
-                    c,
-                    key
+                    "invalid char '{c}' in key: {key}"
                 );
             }
         }


### PR DESCRIPTION
## Why

The evolution direction for tokenless is one shared Rust compression pipeline serving CLI hooks, the in-process Runtime, and framework adapters. That needs a single versioned compatibility boundary instead of adapter-specific payloads: adapters copy only the model-visible value into a request and get back the final content plus the decision facts required to build their host envelope.

This PR pins that boundary — the protocol v1 types and their serialization contract — as a standalone crate with exhaustive wire-format tests, so the follow-up detector/registry/pipeline work builds against a reviewed contract. Nothing consumes the crate yet; it is intentionally the first, independently buildable slice.

It also clears the workspace's clippy debt: on current stable Rust (1.88+), `uninlined_format_args` is warn-by-default, so `cargo clippy --workspace --all-targets -- -D warnings` fails on `main` across four crates. The cleanup is included here so the workspace gates pass again.

## What changed

- **New crate `tokenless-protocol`** (workspace + default member), depending only on `serde`/`serde_json`/`thiserror`:
  - `CompressionRequest` / `CompressionResponse` with `protocol_version`;
  - `Seam` (`before_model` / `pre_tool` / `post_tool` / `proxy`);
  - `Capabilities` — every capability defaults to `false`, so an adapter that declares nothing gets passthrough rather than an unemittable candidate;
  - `Disposition` (`applied` / `dry_run` / `passthrough` / `no_savings` / `reversibility_unavailable` / `timeout` / `error`, matching the Runtime's existing dry-run semantics) — the shared vocabulary CLI and Runtime must agree on;
  - `Reversibility` (`lossless` / `retrievable` / `unrecoverable`).
- **Version-checked parsing** — `from_json` validates `protocol_version` before the shape, so a future v2 payload reports `UnsupportedVersion` instead of a misleading shape error; the gate is also enforced inside the derived `Deserialize` impls, so direct `serde_json::from_str` cannot bypass it. Unknown optional fields are ignored within a supported major version.
- **Error policy per AGENTS.md §3.4** — `Malformed` wraps the `serde_json::Error` via `#[from]` (source chain preserved); `to_json` returns `Result` instead of `expect`ing.
- **Fail-open by construction** — `output` always carries the emittable content (the original on every non-`applied` disposition), and `CompressionResponse::passthrough` is the canonical constructor, so adapters need no local fallback logic.
- **Token counter identity** — responses carry `tokenizer_id`; the `TOKENIZER_ID = "heuristic-v1"` constant names the existing CJK-aware character estimator in `tokenless-stats`. Counts produced under different counter IDs must not be merged into one series.
- **Contract tests** — 12 tests covering exact wire-format locks (byte-for-byte JSON), round trips, version rejection on both parse paths, unknown-field tolerance, missing-optional defaults, and every enum wire value.
- **Clippy cleanup** — mechanically inlined `format!` arguments across `tokenless-ccr`, `tokenless-stats`, `tokenless-schema`, and `tokenless-cli` (applied via `cargo clippy --fix`, then `cargo fmt`). No behavior change.

## User / Agent impact

None at runtime. No CLI, hook, configuration, or adapter behavior changes; the new crate is not yet referenced by any binary.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change is additive: a new public Rust API (`tokenless-protocol`) with no consumers yet, so nothing existing changes shape. The wire format is locked by tests; extending it later means adding optional fields (readers ignore unknowns) or bumping `protocol_version`. The lint cleanup only rewrites format strings and is covered by the existing test suite.

## Validation

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo doc --workspace --no-deps
```

All four pass; `cargo test --workspace` reports 15 green test targets including the 12 protocol contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
