### PR TITLE
refactor(anolisa): add repair application

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -30,10 +30,10 @@ use anolisa_core::domain::{
     ProviderBinding,
 };
 use anolisa_core::executor::{DelegatedExecutionTarget, RecordSink, execute_delegated_steps};
-use anolisa_core::facts::{JournalEvidence, JournalInventory, ObserveRequest, assemble_facts};
+use anolisa_core::facts::{JournalEvidence, JournalInventory};
 use anolisa_core::lock::InstallLock;
 use anolisa_core::owned_executor::{OwnedExecutionError, execute_owned_steps};
-use anolisa_core::planner::{Intent, NativeProbe, Plan, PlanError, RecordWrite, Step, plan};
+use anolisa_core::planner::{NativeProbe, PlanError, RecordWrite, Step};
 use anolisa_core::providers::{DelegatedProvider, ProviderError};
 use anolisa_core::record_sink::{DelegatedIdentity, RecordContext, StoreRecordSink};
 use anolisa_core::state::{ObjectKind, OperationRecord};
@@ -44,10 +44,10 @@ use anolisa_core::transaction::{
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
-use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
+#[cfg(test)]
+use anolisa_platform::pkg_transaction::PackageTransaction;
+use anolisa_platform::pkg_transaction::PackageTransactionError;
 use anolisa_platform::privilege;
-use anolisa_platform::rpm_query::RpmPackageQuery;
-use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use crate::color::Palette;
 use crate::commands::common;
@@ -59,10 +59,11 @@ use crate::commands::tier1::install::{
 };
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install::{self, PendingRpmInstall};
-use crate::commands::tier1::update::rpm_repo_source_for_update;
 use crate::context::CliContext;
 use crate::resolution::load_optional_component_index;
 use crate::response::{CliError, render_json};
+
+mod application;
 
 /// Command label for JSON envelopes and error routing.
 const COMMAND: &str = "repair";
@@ -109,42 +110,19 @@ struct RepairResultPayload {
 /// Returns [`CliError`] when the component is untracked, its record is
 /// unrecoverable, the native database is ambiguous, or an executor fails.
 pub fn handle(args: RepairArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let command = format!("repair {}", args.component);
-    let layout = common::resolve_layout(ctx);
-    let (resolved, view) = common::resolve_mutation_target(&args.component, ctx, &command)?;
-    let store = &view.writable.state;
-    let is_delegated = matches!(
-        store
-            .find(ObjectKind::Component, &resolved)
-            .map(|r| &r.binding),
-        Some(ProviderBinding::Delegated { .. })
-    );
-    // R4 may re-run `dnf install`; when the component is delegated and an
-    // ANOLISA rpm repo is configured, pin the transaction to it exactly like
-    // update does. Unlike update, repair must not *require* the repo: R3 and
-    // R5 only read the native db and need to work on a bare host.
-    if is_delegated
-        && let Ok(repo_config) =
-            common::load_repo_config(ctx, &layout, &command, RepoPersistPolicy::BestEffort)
-    {
-        let env = anolisa_env::EnvService::detect();
-        if let Ok(Some(repo)) = rpm_repo_source_for_update(&repo_config, &env, &command) {
-            let query = RpmPackageQuery::system_with_repo(repo.clone());
-            let txn = RpmTransaction::system_with_repo(repo);
-            return repair_with_deps(&args.component, ctx, &query, &txn, privilege::is_root());
-        }
-    }
-    repair_with_deps(
-        &args.component,
+    let outcome = application::run(
+        application::ApplicationRequest {
+            component: &args.component,
+            intent: execution_intent(ctx),
+        },
         ctx,
-        &RpmPackageQuery::system(),
-        &RpmTransaction::system(),
-        privilege::is_root(),
-    )
+    )?;
+    render_application_outcome(ctx, outcome)
 }
 
 /// Core of [`handle`] with the package backends injected so tests drive
 /// every branch without a live rpmdb/dnf or real privileges.
+#[cfg(test)]
 pub(crate) fn repair_with_deps(
     target: &str,
     ctx: &CliContext,
@@ -152,321 +130,29 @@ pub(crate) fn repair_with_deps(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<(), CliError> {
-    repair_attempt(target, ctx, query, txn, is_root, true)
+    let outcome = application::run_with_dependencies(
+        application::ApplicationRequest {
+            component: target,
+            intent: execution_intent(ctx),
+        },
+        ctx,
+        query,
+        txn,
+        is_root,
+    )?;
+    render_application_outcome(ctx, outcome)
 }
 
-/// One observe → plan → execute pass. `may_recover_journal` bounds the R1
-/// re-entry: consuming a journal replans exactly once, so two independent
-/// pending journals need two `repair` invocations instead of looping here.
-fn repair_attempt(
-    input: &str,
-    ctx: &CliContext,
-    query: &dyn PackageQuery,
-    txn: &dyn PackageTransaction,
-    is_root: bool,
-    may_recover_journal: bool,
-) -> Result<(), CliError> {
-    let command = format!("repair {input}");
-    let layout = common::resolve_layout(ctx);
-    let state_path = layout.state_dir.join("installed.toml");
-    let journal_dir = rpm_install::journal_dir(&layout);
-    let uid = privilege::effective_uid();
-    let scope = match ctx.install_mode {
-        crate::context::InstallMode::System => InstallationScope::System,
-        crate::context::InstallMode::User => InstallationScope::User { uid },
-    };
-    let now = now_iso8601();
-
-    let (resolved, view) = common::resolve_mutation_target(input, ctx, &command)?;
-    let mut store = view.writable.state;
-    common::hydrate_owned_file_contracts(&mut store, &layout);
-    let target = resolved.as_str();
-
-    // The probe target: an active delegated record's resolved package (a
-    // legacy record without one resolves through the adopt candidate chain
-    // so R3 can backfill it), a quarantined record's package metadata (its
-    // own name as a last resort — R5 checks the native authority before the
-    // file-based exit), nothing for owned or absent records.
-    let native_package: Option<String> = match store.find(ObjectKind::Component, target) {
-        Some(installation) => match &installation.binding {
-            ProviderBinding::Delegated { package, .. } => match package.resolved_name() {
-                Some(name) => Some(name.to_string()),
-                None => Some(resolve_repair_package(target, ctx, query, &command)?),
-            },
-            ProviderBinding::Owned { .. } => None,
-        },
-        None => quarantined_record(&store, target).map(|q| {
-            q.record
-                .rpm_metadata
-                .as_ref()
-                .map(|m| m.package_name.trim())
-                .filter(|n| !n.is_empty())
-                .map(str::to_string)
-                .unwrap_or_else(|| target.to_string())
-        }),
-    };
-
-    // Whether missing rpm tooling is fatal: a delegated record cannot be
-    // repaired without the native authority, and neither can a quarantined
-    // record that names a package. A quarantined record with no package
-    // metadata degrades to the file-based exit (R6) instead.
-    let record_requires_native = match store.find(ObjectKind::Component, target) {
-        Some(installation) => matches!(installation.binding, ProviderBinding::Delegated { .. }),
-        None => quarantined_record(&store, target).is_some_and(|q| {
-            q.record
-                .rpm_metadata
-                .as_ref()
-                .is_some_and(|m| !m.package_name.trim().is_empty())
-        }),
-    };
-
-    // A same-version external RPM upgrade can replace the package-owned
-    // component contract without touching ANOLISA state. Compare it with the
-    // state snapshot for active delegated records so repair heals a stale
-    // snapshot even when the record itself needs nothing.
-    let manifest_drifted = matches!(
-        store
-            .find(ObjectKind::Component, target)
-            .map(|r| &r.binding),
-        Some(ProviderBinding::Delegated { .. })
-    ) && {
-        let inspection =
-            inspect_datadir_contract_drift(&layout, target, &command, ctx.packaged_data_probe());
-        if !ctx.quiet {
-            for warning in &inspection.warnings {
-                eprintln!("warning: {warning}");
-            }
-        }
-        inspection.drifted
-    };
-    let manifest_reconciliation = manifest_drifted.then_some("component manifest drift");
-
-    let provider = DelegatedProvider::new(query, txn);
-    let observe_request = ObserveRequest {
-        kind: ObjectKind::Component,
-        name: target,
-        scope,
-        native_package: native_package.as_deref(),
-        observed_at: &now,
-        verify_owned_files: true,
-    };
-    let facts = match assemble_facts(
-        &observe_request,
-        &store,
-        Some(&provider),
-        &layout,
-        &journal_dir,
-    ) {
-        Ok(facts) => facts,
-        Err(anolisa_core::facts::FactsError::Probe(ProviderError::Query(
-            PackageQueryError::CommandMissing { command: bin },
-        ))) => {
-            if record_requires_native {
-                return Err(rpm_tooling_missing_error(&command, &bin, target));
-            }
-            assemble_facts(&observe_request, &store, None, &layout, &journal_dir).map_err(
-                |err| CliError::Runtime {
-                    command: command.clone(),
-                    reason: err.to_string(),
-                },
-            )?
-        }
-        Err(err) => {
-            return Err(CliError::Runtime {
-                command: command.clone(),
-                reason: err.to_string(),
-            });
-        }
-    };
-
-    let steps = match plan(&Intent::Repair, &facts) {
-        Ok(Plan::Execute { steps, .. }) => steps,
-        Ok(Plan::NoOp { .. }) => {
-            // Only owned records reach NoOp (a delegated record present in
-            // rpmdb always replans R3), so a drifted contract snapshot can
-            // never be stranded here.
-            return render_result(
-                ctx,
-                &RepairResultPayload {
-                    component: target.to_string(),
-                    package: native_package,
-                    action: "nothing-to-repair".to_string(),
-                    from_version: None,
-                    to_version: None,
-                    dry_run: ctx.dry_run,
-                    plan: Vec::new(),
-                    operation_id: None,
-                    manifest_reconciliation,
-                },
-            );
-        }
-        Err(err) => return Err(plan_error_to_cli(err, target, &command)),
-    };
-
-    let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
-
+fn execution_intent(ctx: &CliContext) -> anolisa_core::execution::ExecutionIntent {
     if ctx.dry_run {
-        return render_result(
-            ctx,
-            &RepairResultPayload {
-                component: target.to_string(),
-                package: native_package,
-                action: plan_action(&steps).to_string(),
-                from_version: None,
-                to_version: None,
-                dry_run: true,
-                plan: plan_labels,
-                operation_id: None,
-                manifest_reconciliation,
-            },
-        );
+        anolisa_core::execution::ExecutionIntent::Plan
+    } else {
+        anolisa_core::execution::ExecutionIntent::Apply
     }
-
-    // R1: the journal is consumed under the lock; a recovery that only
-    // clears the journal replans once with fresh facts.
-    if matches!(steps.as_slice(), [Step::RecoverJournal]) {
-        if !may_recover_journal {
-            return Err(CliError::Runtime {
-                command,
-                reason: format!(
-                    "another operation journal for '{target}' is still pending after the last recovery; run `anolisa repair {target}` again"
-                ),
-            });
-        }
-        return match recover_journal(
-            input,
-            target,
-            ctx,
-            &layout,
-            &state_path,
-            &journal_dir,
-            scope,
-            &now,
-            &provider,
-            &command,
-        )? {
-            Recovery::Recovered => Ok(()),
-            Recovery::Cleared => repair_attempt(input, ctx, query, txn, is_root, false),
-        };
-    }
-
-    // R6: restore a quarantined record whose files verified intact. The plan
-    // is a single record write; nothing touches the host.
-    if matches!(steps.as_slice(), [Step::WriteRecord(RecordWrite::Owned)]) {
-        let execution = repair_restore_quarantined(
-            target,
-            ctx,
-            &layout,
-            &state_path,
-            &journal_dir,
-            scope,
-            &now,
-            &steps,
-            &plan_labels,
-            &command,
-        )?;
-        return continue_after_locked_repair(
-            execution,
-            may_recover_journal,
-            target,
-            &command,
-            || repair_attempt(input, ctx, query, txn, is_root, true),
-        );
-    }
-
-    // R2: replay the recorded owned artifact over its damaged files.
-    if steps.iter().any(|s| matches!(s, Step::PlaceFiles)) {
-        let prior = match store
-            .find(ObjectKind::Component, target)
-            .map(|r| &r.binding)
-        {
-            Some(ProviderBinding::Owned { artifact }) => artifact.clone(),
-            _ => {
-                return Err(CliError::Runtime {
-                    command,
-                    reason: format!(
-                        "internal: planner produced an owned plan but the record for '{target}' is not owned"
-                    ),
-                });
-            }
-        };
-        let execution = repair_owned_replay(
-            target,
-            ctx,
-            &layout,
-            &state_path,
-            &journal_dir,
-            scope,
-            &now,
-            &steps,
-            &plan_labels,
-            prior,
-            &command,
-        )?;
-        return continue_after_locked_repair(
-            execution,
-            may_recover_journal,
-            target,
-            &command,
-            || repair_attempt(input, ctx, query, txn, is_root, true),
-        );
-    }
-
-    // R3/R4/R5: the delegated family.
-    let package = native_package.clone().ok_or_else(|| CliError::Runtime {
-        command: command.clone(),
-        reason: format!(
-            "internal: planner produced a delegated plan but no probe target was resolved for '{target}'"
-        ),
-    })?;
-
-    // dnf transactions (R4) need root; observation-only plans do not.
-    let needs_txn = steps
-        .iter()
-        .any(|s| matches!(s, Step::NativeTransaction { .. }));
-    if needs_txn && !is_root {
-        return Err(CliError::Runtime {
-            command,
-            reason: format!(
-                "reinstalling system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa repair {target}`"
-            ),
-        });
-    }
-
-    let from_version = match store.find(ObjectKind::Component, target) {
-        Some(installation) => match &installation.binding {
-            ProviderBinding::Delegated { last_observed, .. } => last_observed
-                .as_ref()
-                .map(|o| o.evr.clone().unwrap_or_else(|| o.version.clone())),
-            _ => None,
-        },
-        None => quarantined_record(&store, target).map(|q| q.record.version.clone()),
-    };
-    drop(store);
-
-    let execution = repair_delegated(
-        target,
-        ctx,
-        &layout,
-        &state_path,
-        &journal_dir,
-        scope,
-        &now,
-        &steps,
-        &plan_labels,
-        &package,
-        from_version,
-        &provider,
-        manifest_drifted,
-        &command,
-    )?;
-    continue_after_locked_repair(execution, may_recover_journal, target, &command, || {
-        repair_attempt(input, ctx, query, txn, is_root, true)
-    })
 }
 
 enum LockedRepairExecution {
-    Completed,
+    Completed(Box<application::ApplicationOutcome>),
     RecoveryAppeared,
 }
 
@@ -475,10 +161,10 @@ fn continue_after_locked_repair(
     may_recover_journal: bool,
     target: &str,
     command: &str,
-    retry: impl FnOnce() -> Result<(), CliError>,
-) -> Result<(), CliError> {
+    retry: impl FnOnce() -> Result<application::ApplicationOutcome, CliError>,
+) -> Result<application::ApplicationOutcome, CliError> {
     match execution {
-        LockedRepairExecution::Completed => Ok(()),
+        LockedRepairExecution::Completed(outcome) => Ok(*outcome),
         LockedRepairExecution::RecoveryAppeared if may_recover_journal => retry(),
         LockedRepairExecution::RecoveryAppeared => Err(CliError::Runtime {
             command: command.to_string(),
@@ -501,7 +187,6 @@ fn repair_delegated(
     scope: InstallationScope,
     now: &str,
     steps: &[Step],
-    plan_labels: &[String],
     package: &str,
     from_version: Option<String>,
     provider: &DelegatedProvider<'_>,
@@ -631,10 +316,22 @@ fn repair_delegated(
                 plan_action(steps)
             ),
         );
-        return Err(CliError::Runtime {
-            command: command.to_string(),
-            reason: format!("the record for '{target}' was repaired, but {reason}"),
-        });
+        return Ok(LockedRepairExecution::Completed(Box::new(
+            application::partially_applied(
+                command,
+                application::RepairSubject {
+                    component: target.to_string(),
+                    package: Some(package.to_string()),
+                    from_version,
+                    to_version,
+                },
+                plan_action(steps),
+                steps.to_vec(),
+                operation_id,
+                format!("the record for '{target}' was repaired, but {reason}"),
+                Some("component manifest drift"),
+            ),
+        )));
     }
 
     append_repair_log(
@@ -651,21 +348,22 @@ fn repair_delegated(
         ),
     );
 
-    render_result(
-        ctx,
-        &RepairResultPayload {
-            component: target.to_string(),
-            package: Some(package.to_string()),
-            action: plan_action(steps).to_string(),
-            from_version,
-            to_version,
-            dry_run: false,
-            plan: plan_labels.to_vec(),
-            operation_id: Some(operation_id),
-            manifest_reconciliation: manifest_drifted.then_some("component manifest drift"),
-        },
-    )?;
-    Ok(LockedRepairExecution::Completed)
+    Ok(LockedRepairExecution::Completed(Box::new(
+        application::applied(
+            command,
+            application::RepairSubject {
+                component: target.to_string(),
+                package: Some(package.to_string()),
+                from_version,
+                to_version,
+            },
+            plan_action(steps),
+            steps.to_vec(),
+            operation_id,
+            Vec::new(),
+            manifest_drifted.then_some("component manifest drift"),
+        ),
+    )))
 }
 
 /// Execute the quarantine-restore plan (R6) under the install lock: rebuild
@@ -680,7 +378,6 @@ fn repair_restore_quarantined(
     scope: InstallationScope,
     now: &str,
     steps: &[Step],
-    plan_labels: &[String],
     command: &str,
 ) -> Result<LockedRepairExecution, CliError> {
     let _lock = InstallLock::acquire(&layout.lock_file).map_err(|err| CliError::Runtime {
@@ -752,21 +449,22 @@ fn repair_restore_quarantined(
         format!("restored quarantined record for component {target} as owned ({version})"),
     );
 
-    render_result(
-        ctx,
-        &RepairResultPayload {
-            component: target.to_string(),
-            package: None,
-            action: "restore-owned-record".to_string(),
-            from_version: None,
-            to_version: Some(version),
-            dry_run: false,
-            plan: plan_labels.to_vec(),
-            operation_id: Some(operation_id),
-            manifest_reconciliation: None,
-        },
-    )?;
-    Ok(LockedRepairExecution::Completed)
+    Ok(LockedRepairExecution::Completed(Box::new(
+        application::applied(
+            command,
+            application::RepairSubject {
+                component: target.to_string(),
+                package: None,
+                from_version: None,
+                to_version: Some(version),
+            },
+            application::RepairAction::RestoreOwnedRecord,
+            steps.to_vec(),
+            operation_id,
+            Vec::new(),
+            None,
+        ),
+    )))
 }
 
 /// Execute an owned replay plan (R2) against the raw backend, pinned to the
@@ -785,7 +483,6 @@ fn repair_owned_replay(
     scope: InstallationScope,
     now: &str,
     steps: &[Step],
-    plan_labels: &[String],
     prior: anolisa_core::domain::OwnedArtifact,
     command: &str,
 ) -> Result<LockedRepairExecution, CliError> {
@@ -895,28 +592,29 @@ fn repair_owned_replay(
         format!("replayed owned files for component {target} at {version}"),
     );
 
-    render_result(
-        ctx,
-        &RepairResultPayload {
-            component: target.to_string(),
-            package: Some(package),
-            action: "replay-owned-files".to_string(),
-            from_version: None,
-            to_version: Some(version),
-            dry_run: false,
-            plan: plan_labels.to_vec(),
-            operation_id: Some(operation_id),
-            manifest_reconciliation: None,
-        },
-    )?;
-    Ok(LockedRepairExecution::Completed)
+    Ok(LockedRepairExecution::Completed(Box::new(
+        application::applied(
+            command,
+            application::RepairSubject {
+                component: target.to_string(),
+                package: Some(package),
+                from_version: None,
+                to_version: Some(version),
+            },
+            application::RepairAction::ReplayOwnedFiles,
+            steps.to_vec(),
+            operation_id,
+            Vec::new(),
+            None,
+        ),
+    )))
 }
 
 /// What consuming a pending journal (R1) left behind.
 enum Recovery {
     /// The interrupted operation was completed (its record committed) and
     /// the result rendered; nothing further to do.
-    Recovered,
+    Recovered(Box<application::ApplicationOutcome>),
     /// The journal was settled without a record change; the caller replans
     /// once against the now-unblocked facts.
     Cleared,
@@ -1142,12 +840,11 @@ fn recover_journal(
                     delegated_record_action_label(recovery.record_action),
                 ),
             );
-            render_result(
-                ctx,
-                &RepairResultPayload {
+            Ok(Recovery::Recovered(Box::new(application::applied(
+                command,
+                application::RepairSubject {
                     component: target.to_string(),
                     package: Some(package.to_string()),
-                    action: "recovered-journal".to_string(),
                     from_version: None,
                     to_version: Some(
                         observation
@@ -1155,13 +852,13 @@ fn recover_journal(
                             .clone()
                             .unwrap_or_else(|| observation.version.clone()),
                     ),
-                    dry_run: false,
-                    plan: Vec::new(),
-                    operation_id: Some(operation_id),
-                    manifest_reconciliation: None,
                 },
-            )?;
-            Ok(Recovery::Recovered)
+                application::RepairAction::RecoveredJournal,
+                Vec::new(),
+                operation_id,
+                Vec::new(),
+                None,
+            ))))
         }
         NativeProbe::MultipleVersions { .. } => Err(CliError::Runtime {
             command: command.to_string(),
@@ -1632,21 +1329,20 @@ fn recover_delegated_drop(
         LogStatus::Ok,
         format!("completed interrupted record removal for component {target}"),
     );
-    render_result(
-        ctx,
-        &RepairResultPayload {
+    Ok(Recovery::Recovered(Box::new(application::applied(
+        command,
+        application::RepairSubject {
             component: target.to_string(),
             package: package.map(str::to_string),
-            action: "recovered-journal".to_string(),
             from_version: None,
             to_version: None,
-            dry_run: false,
-            plan: Vec::new(),
-            operation_id: Some(operation_id),
-            manifest_reconciliation: None,
         },
-    )?;
-    Ok(Recovery::Recovered)
+        application::RepairAction::RecoveredJournal,
+        Vec::new(),
+        operation_id,
+        Vec::new(),
+        None,
+    ))))
 }
 
 fn delegated_record_action_label(action: DelegatedRecordAction) -> &'static str {
@@ -1742,12 +1438,11 @@ fn recover_legacy_rpm_install(
                     pending.component
                 ),
             );
-            render_result(
-                ctx,
-                &RepairResultPayload {
+            Ok(Recovery::Recovered(Box::new(application::applied(
+                command,
+                application::RepairSubject {
                     component: pending.component.clone(),
                     package: Some(pending.package.clone()),
-                    action: "recovered-pending-install".to_string(),
                     from_version: None,
                     to_version: Some(
                         observation
@@ -1755,13 +1450,13 @@ fn recover_legacy_rpm_install(
                             .clone()
                             .unwrap_or_else(|| observation.version.clone()),
                     ),
-                    dry_run: false,
-                    plan: Vec::new(),
-                    operation_id: Some(operation_id),
-                    manifest_reconciliation: None,
                 },
-            )?;
-            Ok(Recovery::Recovered)
+                application::RepairAction::RecoveredPendingInstall,
+                Vec::new(),
+                operation_id,
+                Vec::new(),
+                None,
+            ))))
         }
         NativeProbe::MultipleVersions { .. } => Err(CliError::Runtime {
             command: command.to_string(),
@@ -2017,29 +1712,29 @@ fn resolve_repair_package(
 }
 
 /// Human-facing name of what a repair plan does, for previews and payloads.
-fn plan_action(steps: &[Step]) -> &'static str {
+fn plan_action(steps: &[Step]) -> application::RepairAction {
     if matches!(steps, [Step::RecoverJournal]) {
-        return "recover-journal";
+        return application::RepairAction::RecoverJournal;
     }
     if matches!(steps, [Step::WriteRecord(RecordWrite::Owned)]) {
-        return "restore-owned-record";
+        return application::RepairAction::RestoreOwnedRecord;
     }
     if steps.iter().any(|s| matches!(s, Step::PlaceFiles)) {
-        return "replay-owned-files";
+        return application::RepairAction::ReplayOwnedFiles;
     }
     if steps
         .iter()
         .any(|s| matches!(s, Step::NativeTransaction { .. }))
     {
-        return "reinstall-package";
+        return application::RepairAction::ReinstallPackage;
     }
     if steps
         .iter()
         .any(|s| matches!(s, Step::WriteRecord(RecordWrite::DelegatedObserved)))
     {
-        return "restore-observed-record";
+        return application::RepairAction::RestoreObservedRecord;
     }
-    "refresh-observation"
+    application::RepairAction::RefreshObservation
 }
 
 /// Map a planning refusal to an actionable CLI error. The planner names the
@@ -2229,6 +1924,84 @@ fn append_repair_log(
 }
 
 /// Render the repair result (or its dry-run preview).
+fn render_application_outcome(
+    ctx: &CliContext,
+    application_outcome: application::ApplicationOutcome,
+) -> Result<(), CliError> {
+    let payload = match application_outcome {
+        application::ApplicationOutcome::NoOp {
+            subject,
+            manifest_reconciliation,
+        } => RepairResultPayload {
+            component: subject.component,
+            package: subject.package,
+            action: application::RepairAction::NothingToRepair
+                .as_str()
+                .to_string(),
+            from_version: subject.from_version,
+            to_version: subject.to_version,
+            dry_run: ctx.dry_run,
+            plan: Vec::new(),
+            operation_id: None,
+            manifest_reconciliation,
+        },
+        application::ApplicationOutcome::Preview {
+            subject,
+            action,
+            steps,
+            manifest_reconciliation,
+        } => RepairResultPayload {
+            component: subject.component,
+            package: subject.package,
+            action: action.as_str().to_string(),
+            from_version: subject.from_version,
+            to_version: subject.to_version,
+            dry_run: true,
+            plan: steps.iter().map(step_label).collect(),
+            operation_id: None,
+            manifest_reconciliation,
+        },
+        application::ApplicationOutcome::Applied {
+            command,
+            subject,
+            action,
+            steps,
+            outcome,
+            manifest_reconciliation,
+        } => {
+            if matches!(
+                outcome.status(),
+                anolisa_core::execution::CommandOutcomeStatus::Partial
+            ) {
+                let reason = outcome
+                    .warnings()
+                    .first()
+                    .expect("partial repair outcome carries its reconciliation failure");
+                return Err(CliError::Runtime {
+                    command,
+                    reason: reason.clone(),
+                });
+            }
+            for warning in outcome.warnings() {
+                eprintln!("warning: {warning}");
+            }
+            RepairResultPayload {
+                component: subject.component,
+                package: subject.package,
+                action: action.as_str().to_string(),
+                from_version: subject.from_version,
+                to_version: subject.to_version,
+                dry_run: false,
+                plan: steps.iter().map(step_label).collect(),
+                operation_id: outcome.operation_id().map(str::to_string),
+                manifest_reconciliation,
+            }
+        }
+    };
+    render_result(ctx, &payload)
+}
+
+/// Render the repair result (or its dry-run preview).
 fn render_result(ctx: &CliContext, payload: &RepairResultPayload) -> Result<(), CliError> {
     if ctx.json {
         return render_json(COMMAND, payload);
@@ -2332,6 +2105,18 @@ mod tests {
 
     use crate::context::InstallMode;
 
+    fn no_op_application_outcome() -> application::ApplicationOutcome {
+        application::ApplicationOutcome::NoOp {
+            subject: application::RepairSubject {
+                component: "cosh".to_string(),
+                package: None,
+                from_version: None,
+                to_version: None,
+            },
+            manifest_reconciliation: None,
+        }
+    }
+
     #[test]
     fn locked_pending_reenters_recovery_after_releasing_the_lock() {
         let retries = Cell::new(0);
@@ -2343,7 +2128,7 @@ mod tests {
             "repair cosh",
             || {
                 retries.set(retries.get() + 1);
-                Ok(())
+                Ok(no_op_application_outcome())
             },
         )
         .expect("new recovery chain should be replanned once");
@@ -2362,7 +2147,7 @@ mod tests {
             "repair cosh",
             || {
                 retries.set(retries.get() + 1);
-                Ok(())
+                Ok(no_op_application_outcome())
             },
         )
         .expect_err("one invocation must not consume two recovery chains");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair/application.rs
@@ -1,0 +1,680 @@
+//! Application orchestration for the single-component `repair` lifecycle verb.
+
+use std::fmt;
+
+use anolisa_core::component_snapshot::{ComponentSnapshotRequest, SnapshotProbe};
+use anolisa_core::domain::{InstallationScope, ProviderBinding};
+use anolisa_core::execution::{
+    CommandOutcome, CommandOutcomeStatus, ExecutionIntent, PreparedExecution,
+};
+use anolisa_core::facts::{FactsError, assemble_component_snapshot, lifecycle_facts_from_snapshot};
+use anolisa_core::planner::{Intent, RecordWrite, Step, plan};
+use anolisa_core::providers::{DelegatedProvider, ProviderError};
+use anolisa_core::state::ObjectKind;
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_transaction::PackageTransaction;
+use anolisa_platform::privilege;
+use anolisa_platform::rpm_query::RpmPackageQuery;
+use anolisa_platform::rpm_transaction::RpmTransaction;
+
+use crate::commands::common;
+use crate::commands::common::RepoPersistPolicy;
+use crate::commands::tier1::rpm_install;
+use crate::commands::tier1::update::rpm_repo_source_for_update;
+use crate::context::CliContext;
+use crate::response::CliError;
+
+use super::{
+    Recovery, continue_after_locked_repair, plan_action, plan_error_to_cli, quarantined_record,
+    recover_journal, repair_delegated, repair_owned_replay, repair_restore_quarantined,
+    resolve_repair_package, rpm_tooling_missing_error,
+};
+
+/// CLI input mapped to the lifecycle execution protocol.
+pub(super) struct ApplicationRequest<'a> {
+    pub(super) component: &'a str,
+    pub(super) intent: ExecutionIntent,
+}
+
+/// Stable repair action used by the application outcome and wire renderer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RepairAction {
+    /// Record and observed reality already agree.
+    NothingToRepair,
+    /// Refresh the recorded native-package observation.
+    RefreshObservation,
+    /// Reinstall a missing managed native package.
+    ReinstallPackage,
+    /// Replay the recorded owned artifact over damaged files.
+    ReplayOwnedFiles,
+    /// Restore a quarantined record as observed delegated state.
+    RestoreObservedRecord,
+    /// Restore a quarantined record as owned state.
+    RestoreOwnedRecord,
+    /// Preview consumption of a blocking operation journal.
+    RecoverJournal,
+    /// Complete a legacy pending native-package install.
+    RecoveredPendingInstall,
+    /// Complete or settle a subject-bound operation journal.
+    RecoveredJournal,
+}
+
+impl RepairAction {
+    /// Returns the stable action label used by existing repair output.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::NothingToRepair => "nothing-to-repair",
+            Self::RefreshObservation => "refresh-observation",
+            Self::ReinstallPackage => "reinstall-package",
+            Self::ReplayOwnedFiles => "replay-owned-files",
+            Self::RestoreObservedRecord => "restore-observed-record",
+            Self::RestoreOwnedRecord => "restore-owned-record",
+            Self::RecoverJournal => "recover-journal",
+            Self::RecoveredPendingInstall => "recovered-pending-install",
+            Self::RecoveredJournal => "recovered-journal",
+        }
+    }
+
+    fn change(self) -> RepairChange {
+        match self {
+            Self::NothingToRepair => {
+                unreachable!("a no-op repair action cannot become an applied change")
+            }
+            Self::RefreshObservation => RepairChange::ObservationRefreshed,
+            Self::ReinstallPackage => RepairChange::NativePackageReinstalled,
+            Self::ReplayOwnedFiles => RepairChange::OwnedFilesReplayed,
+            Self::RestoreObservedRecord => RepairChange::ObservedRecordRestored,
+            Self::RestoreOwnedRecord => RepairChange::OwnedRecordRestored,
+            Self::RecoverJournal | Self::RecoveredJournal => RepairChange::JournalRecovered,
+            Self::RecoveredPendingInstall => RepairChange::PendingInstallRecovered,
+        }
+    }
+}
+
+impl fmt::Display for RepairAction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Resolved component and version evidence carried to the renderer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RepairSubject {
+    /// Resolved component identity.
+    pub(super) component: String,
+    /// Native or raw package identity when one participates in the repair.
+    pub(super) package: Option<String>,
+    /// Recorded version before reconciliation.
+    pub(super) from_version: Option<String>,
+    /// Observed or replayed version after reconciliation.
+    pub(super) to_version: Option<String>,
+}
+
+/// Durable change completed by an applied repair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RepairChange {
+    /// A delegated record absorbed a fresh native observation.
+    ObservationRefreshed,
+    /// A missing managed native package was reinstalled.
+    NativePackageReinstalled,
+    /// Damaged ANOLISA-owned files were replayed.
+    OwnedFilesReplayed,
+    /// A quarantined record was restored as observed delegated state.
+    ObservedRecordRestored,
+    /// A quarantined record was restored as owned state.
+    OwnedRecordRestored,
+    /// A subject-bound journal was recovered or settled.
+    JournalRecovered,
+    /// A legacy pending package install was recovered.
+    PendingInstallRecovered,
+}
+
+/// Typed application result consumed by the command renderer.
+#[derive(Debug)]
+pub(super) enum ApplicationOutcome {
+    /// No repair work is required.
+    NoOp {
+        subject: RepairSubject,
+        manifest_reconciliation: Option<&'static str>,
+    },
+    /// Plan-only result; no lock or effect executor was acquired.
+    Preview {
+        subject: RepairSubject,
+        action: RepairAction,
+        steps: Vec<Step>,
+        manifest_reconciliation: Option<&'static str>,
+    },
+    /// Applied result with durable operation evidence.
+    Applied {
+        command: String,
+        subject: RepairSubject,
+        action: RepairAction,
+        steps: Vec<Step>,
+        outcome: CommandOutcome<RepairChange>,
+        manifest_reconciliation: Option<&'static str>,
+    },
+}
+
+/// Builds a completed typed repair outcome.
+pub(super) fn applied(
+    command: &str,
+    subject: RepairSubject,
+    action: RepairAction,
+    steps: Vec<Step>,
+    operation_id: String,
+    warnings: Vec<String>,
+    manifest_reconciliation: Option<&'static str>,
+) -> ApplicationOutcome {
+    ApplicationOutcome::Applied {
+        command: command.to_string(),
+        subject,
+        action,
+        steps,
+        outcome: CommandOutcome::new(
+            CommandOutcomeStatus::Completed,
+            Some(operation_id),
+            vec![action.change()],
+            warnings,
+        ),
+        manifest_reconciliation,
+    }
+}
+
+/// Builds a repair outcome whose durable effects need reconciliation.
+pub(super) fn partially_applied(
+    command: &str,
+    subject: RepairSubject,
+    action: RepairAction,
+    steps: Vec<Step>,
+    operation_id: String,
+    reason: String,
+    manifest_reconciliation: Option<&'static str>,
+) -> ApplicationOutcome {
+    ApplicationOutcome::Applied {
+        command: command.to_string(),
+        subject,
+        action,
+        steps,
+        outcome: CommandOutcome::new(
+            CommandOutcomeStatus::Partial,
+            Some(operation_id),
+            vec![action.change()],
+            vec![reason],
+        ),
+        manifest_reconciliation,
+    }
+}
+
+/// Run one component repair against production package backends.
+pub(super) fn run(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+) -> Result<ApplicationOutcome, CliError> {
+    let command = format!("repair {}", request.component);
+    let layout = common::resolve_layout(ctx);
+    let (resolved, view) = common::resolve_mutation_target(request.component, ctx, &command)?;
+    let is_delegated = matches!(
+        view.writable
+            .state
+            .find(ObjectKind::Component, &resolved)
+            .map(|record| &record.binding),
+        Some(ProviderBinding::Delegated { .. })
+    );
+    if is_delegated
+        && let Ok(repo_config) =
+            common::load_repo_config(ctx, &layout, &command, RepoPersistPolicy::BestEffort)
+    {
+        let env = anolisa_env::EnvService::detect();
+        if let Ok(Some(repo)) = rpm_repo_source_for_update(&repo_config, &env, &command) {
+            let query = RpmPackageQuery::system_with_repo(repo.clone());
+            let transaction = RpmTransaction::system_with_repo(repo);
+            return run_with_dependencies(request, ctx, &query, &transaction, privilege::is_root());
+        }
+    }
+    run_with_dependencies(
+        request,
+        ctx,
+        &RpmPackageQuery::system(),
+        &RpmTransaction::system(),
+        privilege::is_root(),
+    )
+}
+
+/// Run the repair application protocol with explicit package boundaries.
+pub(super) fn run_with_dependencies(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    transaction: &dyn PackageTransaction,
+    is_root: bool,
+) -> Result<ApplicationOutcome, CliError> {
+    repair_attempt(request, ctx, query, transaction, is_root, true)
+}
+
+fn repair_attempt(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    transaction: &dyn PackageTransaction,
+    is_root: bool,
+    may_recover_journal: bool,
+) -> Result<ApplicationOutcome, CliError> {
+    let input = request.component;
+    let command = format!("repair {input}");
+    let layout = common::resolve_layout(ctx);
+    let state_path = layout.state_dir.join("installed.toml");
+    let journal_dir = rpm_install::journal_dir(&layout);
+    let scope = match ctx.install_mode {
+        crate::context::InstallMode::System => InstallationScope::System,
+        crate::context::InstallMode::User => InstallationScope::User {
+            uid: privilege::effective_uid(),
+        },
+    };
+    let now = super::now_iso8601();
+
+    let (resolved, view) = common::resolve_mutation_target(input, ctx, &command)?;
+    let mut store = view.writable.state;
+    common::hydrate_owned_file_contracts(&mut store, &layout);
+    let target = resolved.as_str();
+
+    let native_package = match store.find(ObjectKind::Component, target) {
+        Some(installation) => match &installation.binding {
+            ProviderBinding::Delegated { package, .. } => match package.resolved_name() {
+                Some(name) => Some(name.to_string()),
+                None => Some(resolve_repair_package(target, ctx, query, &command)?),
+            },
+            ProviderBinding::Owned { .. } => None,
+        },
+        None => quarantined_record(&store, target).map(|quarantined| {
+            quarantined
+                .record
+                .rpm_metadata
+                .as_ref()
+                .map(|metadata| metadata.package_name.trim())
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| target.to_string())
+        }),
+    };
+    let record_requires_native = match store.find(ObjectKind::Component, target) {
+        Some(installation) => matches!(installation.binding, ProviderBinding::Delegated { .. }),
+        None => quarantined_record(&store, target).is_some_and(|quarantined| {
+            quarantined
+                .record
+                .rpm_metadata
+                .as_ref()
+                .is_some_and(|metadata| !metadata.package_name.trim().is_empty())
+        }),
+    };
+
+    let manifest_drifted = matches!(
+        store
+            .find(ObjectKind::Component, target)
+            .map(|record| &record.binding),
+        Some(ProviderBinding::Delegated { .. })
+    ) && {
+        let inspection = super::inspect_datadir_contract_drift(
+            &layout,
+            target,
+            &command,
+            ctx.packaged_data_probe(),
+        );
+        if !ctx.quiet {
+            for warning in &inspection.warnings {
+                eprintln!("warning: {warning}");
+            }
+        }
+        inspection.drifted
+    };
+    let manifest_reconciliation = manifest_drifted.then_some("component manifest drift");
+
+    let provider = DelegatedProvider::new(query, transaction);
+    let facts = match observe_repair_facts(
+        target,
+        scope,
+        native_package.as_deref(),
+        &now,
+        &store,
+        Some(&provider),
+        &layout,
+        &journal_dir,
+    ) {
+        Ok(facts) => facts,
+        Err(FactsError::Probe(ProviderError::Query(PackageQueryError::CommandMissing {
+            command: binary,
+        }))) => {
+            if record_requires_native {
+                return Err(rpm_tooling_missing_error(&command, &binary, target));
+            }
+            observe_repair_facts(
+                target,
+                scope,
+                native_package.as_deref(),
+                &now,
+                &store,
+                None,
+                &layout,
+                &journal_dir,
+            )
+            .map_err(|error| CliError::Runtime {
+                command: command.clone(),
+                reason: error.to_string(),
+            })?
+        }
+        Err(error) => {
+            return Err(CliError::Runtime {
+                command: command.clone(),
+                reason: error.to_string(),
+            });
+        }
+    };
+
+    let lifecycle_plan = plan(&Intent::Repair, &facts)
+        .map_err(|error| plan_error_to_cli(error, target, &command))?;
+    match request.intent.prepare(lifecycle_plan) {
+        PreparedExecution::NoOp { .. } => Ok(ApplicationOutcome::NoOp {
+            subject: RepairSubject {
+                component: target.to_string(),
+                package: native_package,
+                from_version: None,
+                to_version: None,
+            },
+            manifest_reconciliation,
+        }),
+        PreparedExecution::Preview { steps, .. } => Ok(ApplicationOutcome::Preview {
+            subject: RepairSubject {
+                component: target.to_string(),
+                package: native_package,
+                from_version: None,
+                to_version: None,
+            },
+            action: plan_action(&steps),
+            steps,
+            manifest_reconciliation,
+        }),
+        PreparedExecution::Apply { steps, .. } => apply_repair_plan(
+            request,
+            ctx,
+            query,
+            transaction,
+            is_root,
+            may_recover_journal,
+            &command,
+            &layout,
+            &state_path,
+            &journal_dir,
+            scope,
+            &now,
+            target,
+            native_package,
+            manifest_drifted,
+            store,
+            provider,
+            steps,
+        ),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+fn apply_repair_plan(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    transaction: &dyn PackageTransaction,
+    is_root: bool,
+    may_recover_journal: bool,
+    command: &str,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    state_path: &std::path::Path,
+    journal_dir: &std::path::Path,
+    scope: InstallationScope,
+    now: &str,
+    target: &str,
+    native_package: Option<String>,
+    manifest_drifted: bool,
+    store: anolisa_core::state_store::StateStore,
+    provider: DelegatedProvider<'_>,
+    steps: Vec<Step>,
+) -> Result<ApplicationOutcome, CliError> {
+    if matches!(steps.as_slice(), [Step::RecoverJournal]) {
+        if !may_recover_journal {
+            return Err(CliError::Runtime {
+                command: command.to_string(),
+                reason: format!(
+                    "another operation journal for '{target}' is still pending after the last recovery; run `anolisa repair {target}` again"
+                ),
+            });
+        }
+        return match recover_journal(
+            request.component,
+            target,
+            ctx,
+            layout,
+            state_path,
+            journal_dir,
+            scope,
+            now,
+            &provider,
+            command,
+        )? {
+            Recovery::Recovered(outcome) => Ok(*outcome),
+            Recovery::Cleared => repair_attempt(request, ctx, query, transaction, is_root, false),
+        };
+    }
+
+    if matches!(steps.as_slice(), [Step::WriteRecord(RecordWrite::Owned)]) {
+        let execution = repair_restore_quarantined(
+            target,
+            ctx,
+            layout,
+            state_path,
+            journal_dir,
+            scope,
+            now,
+            &steps,
+            command,
+        )?;
+        return continue_after_locked_repair(
+            execution,
+            may_recover_journal,
+            target,
+            command,
+            || repair_attempt(request, ctx, query, transaction, is_root, true),
+        );
+    }
+
+    if steps.iter().any(|step| matches!(step, Step::PlaceFiles)) {
+        let prior = match store
+            .find(ObjectKind::Component, target)
+            .map(|record| &record.binding)
+        {
+            Some(ProviderBinding::Owned { artifact }) => artifact.clone(),
+            _ => {
+                return Err(CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!(
+                        "internal: planner produced an owned plan but the record for '{target}' is not owned"
+                    ),
+                });
+            }
+        };
+        let execution = repair_owned_replay(
+            target,
+            ctx,
+            layout,
+            state_path,
+            journal_dir,
+            scope,
+            now,
+            &steps,
+            prior,
+            command,
+        )?;
+        return continue_after_locked_repair(
+            execution,
+            may_recover_journal,
+            target,
+            command,
+            || repair_attempt(request, ctx, query, transaction, is_root, true),
+        );
+    }
+
+    let package = native_package.ok_or_else(|| CliError::Runtime {
+        command: command.to_string(),
+        reason: format!(
+            "internal: planner produced a delegated plan but no probe target was resolved for '{target}'"
+        ),
+    })?;
+    let needs_transaction = steps
+        .iter()
+        .any(|step| matches!(step, Step::NativeTransaction { .. }));
+    if needs_transaction && !is_root {
+        return Err(CliError::Runtime {
+            command: command.to_string(),
+            reason: format!(
+                "reinstalling system RPM '{package}' requires root privileges; re-run with sudo: `sudo anolisa repair {target}`"
+            ),
+        });
+    }
+    let from_version = match store.find(ObjectKind::Component, target) {
+        Some(installation) => match &installation.binding {
+            ProviderBinding::Delegated { last_observed, .. } => {
+                last_observed.as_ref().map(|observation| {
+                    observation
+                        .evr
+                        .clone()
+                        .unwrap_or_else(|| observation.version.clone())
+                })
+            }
+            ProviderBinding::Owned { .. } => None,
+        },
+        None => {
+            quarantined_record(&store, target).map(|quarantined| quarantined.record.version.clone())
+        }
+    };
+    drop(store);
+
+    let execution = repair_delegated(
+        target,
+        ctx,
+        layout,
+        state_path,
+        journal_dir,
+        scope,
+        now,
+        &steps,
+        &package,
+        from_version,
+        &provider,
+        manifest_drifted,
+        command,
+    )?;
+    continue_after_locked_repair(execution, may_recover_journal, target, command, || {
+        repair_attempt(request, ctx, query, transaction, is_root, true)
+    })
+}
+
+#[expect(clippy::too_many_arguments)]
+fn observe_repair_facts(
+    component: &str,
+    scope: InstallationScope,
+    native_package: Option<&str>,
+    observed_at: &str,
+    store: &anolisa_core::state_store::StateStore,
+    provider: Option<&DelegatedProvider<'_>>,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    journal_dir: &std::path::Path,
+) -> Result<anolisa_core::planner::Facts, FactsError> {
+    let mut probes = vec![
+        SnapshotProbe::State,
+        SnapshotProbe::OwnedFiles,
+        SnapshotProbe::PendingJournal,
+    ];
+    if native_package.is_some() && provider.is_some() && matches!(scope, InstallationScope::System)
+    {
+        probes.push(SnapshotProbe::NativePackage);
+    }
+    let snapshot = assemble_component_snapshot(
+        ComponentSnapshotRequest::new(component, scope, probes),
+        native_package,
+        observed_at,
+        store,
+        provider,
+        layout,
+        journal_dir,
+    )?;
+    let active_adapter_claims = store
+        .adapter_claims
+        .iter()
+        .filter(|claim| claim.component == component)
+        .map(|claim| claim.framework.clone())
+        .collect();
+    lifecycle_facts_from_snapshot(&snapshot, active_adapter_claims, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use anolisa_core::planner::{NoOpReason, Plan};
+
+    use super::*;
+
+    #[test]
+    fn plan_intent_never_prepares_repair_effects() {
+        let plan = Plan::Execute {
+            steps: vec![Step::RecoverJournal],
+            notes: Vec::new(),
+        };
+
+        assert!(matches!(
+            ExecutionIntent::Plan.prepare(plan.clone()),
+            PreparedExecution::Preview { .. }
+        ));
+        assert!(matches!(
+            ExecutionIntent::Apply.prepare(plan),
+            PreparedExecution::Apply { .. }
+        ));
+    }
+
+    #[test]
+    fn healthy_repair_never_becomes_apply_ready() {
+        let plan = Plan::NoOp {
+            reason: NoOpReason::NothingToRepair,
+        };
+
+        for intent in [ExecutionIntent::Plan, ExecutionIntent::Apply] {
+            assert!(matches!(
+                intent.prepare(plan.clone()),
+                PreparedExecution::NoOp {
+                    reason: NoOpReason::NothingToRepair
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn reconciliation_failure_is_a_typed_partial_outcome() {
+        let result = partially_applied(
+            "repair cosh",
+            RepairSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            RepairAction::RefreshObservation,
+            vec![Step::WriteRecord(RecordWrite::RefreshObservation)],
+            "operation-1".to_string(),
+            "component manifest reconciliation did not complete".to_string(),
+            Some("component manifest drift"),
+        );
+
+        let ApplicationOutcome::Applied { outcome, .. } = result else {
+            panic!("expected applied repair outcome");
+        };
+        assert_eq!(outcome.status(), CommandOutcomeStatus::Partial);
+        assert_eq!(
+            outcome.warnings(),
+            ["component manifest reconciliation did not complete"]
+        );
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/component_snapshot.rs
+++ b/src/anolisa/crates/anolisa-core/src/component_snapshot.rs
@@ -49,6 +49,8 @@ impl<T, P> ProbeEvidence<T, P> {
 pub enum SnapshotProbe {
     /// Read the ANOLISA installation state.
     State,
+    /// Verify the files owned by the active or quarantined component record.
+    OwnedFiles,
     /// Query the native package authority. Valid only in system scope.
     NativePackage,
     /// Inspect the transaction journal directory.
@@ -114,6 +116,13 @@ pub struct NativePackageProvenance {
     pub package: String,
 }
 
+/// Source of an owned-file integrity observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedFilesProvenance {
+    /// State file whose owned-file contract selected the paths to verify.
+    pub state_path: PathBuf,
+}
+
 /// Source of a pending-journal observation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JournalProvenance {
@@ -139,6 +148,15 @@ pub enum NativePackageSnapshot {
     MultipleVersions,
 }
 
+/// Integrity of the files declared by an owned component record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnedFilesSnapshot {
+    /// Every verifiable owned path satisfies its recorded contract.
+    Verified,
+    /// At least one owned path has a decisive integrity failure.
+    Drifted,
+}
+
 /// Pending transaction selected for the requested component.
 ///
 /// A collector may inspect a multi-entry journal inventory, but each snapshot
@@ -154,6 +172,7 @@ pub struct PendingJournalSnapshot {
 pub struct ComponentSnapshot {
     request: ComponentSnapshotRequest,
     state: ProbeEvidence<StateSnapshot, StateProvenance>,
+    owned_files: ProbeEvidence<OwnedFilesSnapshot, OwnedFilesProvenance>,
     native_package: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
     pending_journal: ProbeEvidence<PendingJournalSnapshot, JournalProvenance>,
 }
@@ -172,6 +191,28 @@ impl ComponentSnapshot {
         native_package: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
         pending_journal: ProbeEvidence<PendingJournalSnapshot, JournalProvenance>,
     ) -> Result<Self, SnapshotContractError> {
+        Self::from_parts_with_owned_files(
+            request,
+            state,
+            ProbeEvidence::NotRequested,
+            native_package,
+            pending_journal,
+        )
+    }
+
+    /// Builds a snapshot that may include owned-file integrity evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SnapshotContractError`] under the same conditions as
+    /// [`Self::from_parts`], including mismatched owned-file probe evidence.
+    pub fn from_parts_with_owned_files(
+        request: ComponentSnapshotRequest,
+        state: ProbeEvidence<StateSnapshot, StateProvenance>,
+        owned_files: ProbeEvidence<OwnedFilesSnapshot, OwnedFilesProvenance>,
+        native_package: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
+        pending_journal: ProbeEvidence<PendingJournalSnapshot, JournalProvenance>,
+    ) -> Result<Self, SnapshotContractError> {
         if matches!(request.scope, InstallationScope::User { .. })
             && request.requests(SnapshotProbe::NativePackage)
         {
@@ -182,6 +223,11 @@ impl ComponentSnapshot {
         }
         validate_evidence(&request, SnapshotProbe::State, state.is_not_requested())?;
         validate_state_target(&request, &state)?;
+        validate_evidence(
+            &request,
+            SnapshotProbe::OwnedFiles,
+            owned_files.is_not_requested(),
+        )?;
         validate_evidence(
             &request,
             SnapshotProbe::NativePackage,
@@ -196,6 +242,7 @@ impl ComponentSnapshot {
         Ok(Self {
             request,
             state,
+            owned_files,
             native_package,
             pending_journal,
         })
@@ -209,6 +256,11 @@ impl ComponentSnapshot {
     /// Returns the installation-state evidence.
     pub fn state(&self) -> &ProbeEvidence<StateSnapshot, StateProvenance> {
         &self.state
+    }
+
+    /// Returns the owned-file integrity evidence.
+    pub fn owned_files(&self) -> &ProbeEvidence<OwnedFilesSnapshot, OwnedFilesProvenance> {
+        &self.owned_files
     }
 
     /// Returns the native package evidence.

--- a/src/anolisa/crates/anolisa-core/src/facts.rs
+++ b/src/anolisa/crates/anolisa-core/src/facts.rs
@@ -15,8 +15,8 @@ use thiserror::Error;
 
 use crate::component_snapshot::{
     ComponentSnapshot, ComponentSnapshotRequest, JournalProvenance, NativePackageProvenance,
-    NativePackageSnapshot, PendingJournalSnapshot, ProbeEvidence, SnapshotContractError,
-    SnapshotProbe, StateProvenance, StateSnapshot,
+    NativePackageSnapshot, OwnedFilesProvenance, OwnedFilesSnapshot, PendingJournalSnapshot,
+    ProbeEvidence, SnapshotContractError, SnapshotProbe, StateProvenance, StateSnapshot,
 };
 use crate::domain::{InstallationScope, NativePm, ProviderBinding};
 use crate::integrity::{IntegrityStatus, check_owned_file};
@@ -376,20 +376,46 @@ pub fn assemble_component_snapshot(
         .into());
     }
 
+    let record = store.record_facts(ObjectKind::Component, request.component());
     let state = if request.requests(SnapshotProbe::State) {
         let provenance = StateProvenance {
             path: layout.state_dir.join("installed.toml"),
         };
-        match store.record_facts(ObjectKind::Component, request.component()) {
+        match &record {
             RecordFacts::Absent => ProbeEvidence::Absent { provenance },
             RecordFacts::Active(installation) => ProbeEvidence::Present {
                 provenance,
-                value: StateSnapshot::Active(Box::new(installation)),
+                value: StateSnapshot::Active(Box::new(installation.clone())),
             },
             RecordFacts::Quarantined(reason) => ProbeEvidence::Present {
                 provenance,
-                value: StateSnapshot::Quarantined(reason),
+                value: StateSnapshot::Quarantined(reason.clone()),
             },
+        }
+    } else {
+        ProbeEvidence::NotRequested
+    };
+
+    let owned_files = if request.requests(SnapshotProbe::OwnedFiles) {
+        let provenance = OwnedFilesProvenance {
+            state_path: layout.state_dir.join("installed.toml"),
+        };
+        match verify_owned_files(
+            &record,
+            store,
+            ObjectKind::Component,
+            request.component(),
+            layout,
+        ) {
+            Some(true) => ProbeEvidence::Present {
+                provenance,
+                value: OwnedFilesSnapshot::Verified,
+            },
+            Some(false) => ProbeEvidence::Present {
+                provenance,
+                value: OwnedFilesSnapshot::Drifted,
+            },
+            None => ProbeEvidence::Absent { provenance },
         }
     } else {
         ProbeEvidence::NotRequested
@@ -444,8 +470,14 @@ pub fn assemble_component_snapshot(
         ProbeEvidence::NotRequested
     };
 
-    ComponentSnapshot::from_parts(request, state, native_package_evidence, pending_journal)
-        .map_err(FactsError::from)
+    ComponentSnapshot::from_parts_with_owned_files(
+        request,
+        state,
+        owned_files,
+        native_package_evidence,
+        pending_journal,
+    )
+    .map_err(FactsError::from)
 }
 
 /// Project a component snapshot into the existing lifecycle planner facts.
@@ -528,13 +560,32 @@ pub fn lifecycle_facts_from_snapshot(
         }
     };
 
+    let snapshot_owned_files_verified = match snapshot.owned_files() {
+        ProbeEvidence::NotRequested => owned_files_verified,
+        ProbeEvidence::Absent { .. } => None,
+        ProbeEvidence::Present {
+            value: OwnedFilesSnapshot::Verified,
+            ..
+        } => Some(true),
+        ProbeEvidence::Present {
+            value: OwnedFilesSnapshot::Drifted,
+            ..
+        } => Some(false),
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(FactsError::SnapshotEvidence {
+                probe: SnapshotProbe::OwnedFiles,
+                reason: reason.clone(),
+            });
+        }
+    };
+
     Ok(Facts {
         scope: snapshot.request().scope(),
         record,
         native,
         pending_journal,
         active_adapter_claims,
-        owned_files_verified,
+        owned_files_verified: snapshot_owned_files_verified,
     })
 }
 
@@ -891,6 +942,88 @@ mod tests {
                 if package == "cosh" && observation.version == "2.7.0"
         ));
         assert!(!facts.pending_journal);
+    }
+
+    #[test]
+    fn component_snapshot_projects_owned_file_integrity() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let layout = layout_under(tmp.path());
+        let file_path = layout.bin_dir.join("skillfs");
+        fs::write(&file_path, b"binary").expect("write owned file");
+        let digest = {
+            use sha2::{Digest, Sha256};
+            let hash = Sha256::digest(b"binary");
+            hash.iter().fold(String::new(), |mut digest, byte| {
+                use std::fmt::Write;
+                let _ = write!(digest, "{byte:02x}");
+                digest
+            })
+        };
+        let owned_file = OwnedFile {
+            path: file_path.clone(),
+            owner: FileOwner::Anolisa,
+            sha256: Some(digest),
+            kind: OwnedFileKind::File,
+            referent: None,
+            mode: None,
+            capabilities: Vec::new(),
+        };
+        let mut store = StateStore::empty();
+        store.upsert(owned_installation("skillfs", vec![owned_file]));
+        let request = || {
+            ComponentSnapshotRequest::new(
+                "skillfs",
+                InstallationScope::System,
+                [
+                    SnapshotProbe::State,
+                    SnapshotProbe::OwnedFiles,
+                    SnapshotProbe::PendingJournal,
+                ],
+            )
+        };
+
+        let snapshot = assemble_component_snapshot(
+            request(),
+            None,
+            NOW,
+            &store,
+            None,
+            &layout,
+            &layout.state_dir.join("journal"),
+        )
+        .expect("healthy snapshot");
+        assert!(matches!(
+            snapshot.owned_files(),
+            ProbeEvidence::Present {
+                provenance,
+                value: OwnedFilesSnapshot::Verified,
+            } if provenance.state_path == layout.state_dir.join("installed.toml")
+        ));
+        let facts =
+            lifecycle_facts_from_snapshot(&snapshot, Vec::new(), None).expect("healthy facts");
+        assert_eq!(facts.owned_files_verified, Some(true));
+
+        fs::remove_file(file_path).expect("remove owned file");
+        let snapshot = assemble_component_snapshot(
+            request(),
+            None,
+            NOW,
+            &store,
+            None,
+            &layout,
+            &layout.state_dir.join("journal"),
+        )
+        .expect("drifted snapshot");
+        assert!(matches!(
+            snapshot.owned_files(),
+            ProbeEvidence::Present {
+                value: OwnedFilesSnapshot::Drifted,
+                ..
+            }
+        ));
+        let facts =
+            lifecycle_facts_from_snapshot(&snapshot, Vec::new(), None).expect("drifted facts");
+        assert_eq!(facts.owned_files_verified, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Single-component repair still mixed observation, planning, execution, recovery, and rendering in the command layer after the other lifecycle paths gained application boundaries. This kept repair outside the shared lifecycle protocol and left owned-file integrity evidence on the legacy facts path.

## What changed

- Add a crate-private repair application layer with typed requests, subjects, actions, changes, and outcomes.
- Route no-op, preview, applied, partial, and bounded journal recovery paths through ExecutionIntent and CommandOutcome while retaining the existing locked effect implementations.
- Extend ComponentSnapshot with additive owned-file integrity evidence and project it into lifecycle facts.
- Preserve the existing command renderer, JSON schema, exit behavior, privilege checks, package behavior, and journal format.

## Related issue

closes #2785

## User / Agent impact

None. CLI text, JSON schema, dry-run behavior, exit behavior, privilege checks, and recovery semantics are preserved.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The user-facing CLI is unchanged. The shared anolisa-core ComponentSnapshot API gains additive owned-file probe types and a compatibility-preserving constructor; the existing from_parts entry point remains available.

## Validation

Host:

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-cli --locked`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- `git diff --check`

Alibaba Cloud Linux 4.0.3 official container, with the current workspace mounted read-only:

- `/work/target/debug/anolisa --version` reports `anolisa 0.3.6`
- focused repair application tests: 3 passed
- complete repair unit tests: 61 passed
- ComponentSnapshot and owned-file evidence tests: 11 passed
- real CLI scope-identity integration tests as non-root UID 1000: 13 passed

The container runs as root by default, so the user-scope integration binary was intentionally executed as UID 1000 to exercise its documented non-root contract.

## Documentation and rollback

No documentation changes are required for this behavior-preserving refactor. Roll back by reverting commit `c1774b2d`.