### PR TITLE
feat(skillfs): document container images

### DIFF
--- a/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/en/runtime/skillfs-kubernetes-sidecar.md
@@ -6,6 +6,10 @@ Run SkillFS beside a Kubernetes workload so the workload reads the SkillFS
 view without mounting the physical skill source. The SkillFS container owns the
 FUSE mount; the workload stays non-privileged and receives the propagated view.
 
+The repository does not currently publish a dedicated SkillFS sidecar image.
+Build the image from the source revision you plan to deploy, verify it locally,
+and push it to a registry that the cluster can pull from.
+
 ## Prerequisites
 
 - Kubernetes 1.29 or later.
@@ -14,23 +18,90 @@ FUSE mount; the workload stays non-privileged and receives the propagated view.
 - `docker buildx` and `kubectl`.
 - A registry that the cluster can pull from.
 
-## Build and push the image
+## Choose the image base
 
-Build for the target node architecture:
+SkillFS provides two equivalent sidecar image definitions. They use the same
+entrypoint, probes, default paths, and Kubernetes manifest.
+
+| Dockerfile | Runtime base | Use when |
+| --- | --- | --- |
+| `src/skillfs/container/Dockerfile` | Debian Bookworm | You want the general-purpose image with the pinned Rust 1.86 build toolchain |
+| `src/skillfs/container/Dockerfile.alinux4` | Alibaba Cloud Linux 4 | Your deployment standardizes on Alibaba Cloud Linux 4 or builds through the public Aliyun RPM and Cargo mirrors |
+
+The Alibaba Cloud Linux 4 build uses the Aliyun Cargo mirror by default. Pass
+an empty `SKILLFS_CARGO_REGISTRY_INDEX` build argument when the build
+environment should use crates.io directly. Both image definitions accept a
+`BASE_IMAGE` build argument when production builds need a pinned base tag or
+digest.
+
+## Build, verify, and push the image
+
+Run the following commands from the repository root. The example builds the
+Debian image for AMD64 and tags it with the source commit so an operator can
+trace the deployed image back to its inputs.
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
+export REVISION="$(git rev-parse HEAD)"
+export VERSION="$(git describe --tags --match 'skillfs/v*' --always)"
+export IMAGE="registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)"
 export PLATFORM=linux/amd64
+export DOCKERFILE=src/skillfs/container/Dockerfile
 
 docker buildx build \
   --platform "$PLATFORM" \
-  -f src/skillfs/container/Dockerfile \
+  --build-arg VERSION="$VERSION" \
+  --build-arg REVISION="$REVISION" \
+  -f "$DOCKERFILE" \
   -t "$IMAGE" \
-  --push \
+  --load \
   src/skillfs
+
+docker run --rm --platform "$PLATFORM" "$IMAGE" skillfs --version
+docker push "$IMAGE"
 ```
 
-Use `linux/arm64` for ARM64 nodes.
+Set `DOCKERFILE=src/skillfs/container/Dockerfile.alinux4` to build the Alibaba
+Cloud Linux 4 variant. Set `PLATFORM` to the target node architecture and run
+the smoke check on every platform before publishing a multi-platform tag. The
+repository CI does not currently build or test these dedicated sidecar images.
+
+The `docker run` command above only verifies the binary and runtime libraries.
+Serving a FUSE view still requires the device, privilege, volumes, and mount
+propagation described below.
+
+## How the image starts
+
+With no command arguments, the image runs its preflight checks and then starts
+this fixed container lifecycle:
+
+```text
+skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" \
+  --foreground --allow-other
+```
+
+`SKILLFS_DISCOVER_ROOT` and `SKILLFS_EXTRA_ARGS` add optional mount arguments.
+Do not add `--managed`; the foreground SkillFS process must remain PID 1 so the
+kubelet can restart it and deliver `SIGTERM` directly. Passing command arguments
+to the image replaces the mount command completely, which is why the version
+smoke check works without `/dev/fuse`.
+
+## Required Pod topology
+
+The reference Pod keeps the physical source away from the workload and shares
+only the propagated FUSE view.
+
+| Volume | Sidecar mount | Workload mount | Requirement |
+| --- | --- | --- | --- |
+| `skill-source` | `/var/lib/skillfs/source` | Not mounted | Must be writable; use a PVC when skill changes must survive Pod recreation |
+| `skill-shared` | `/var/lib/skillfs/shared` with `Bidirectional` | The same path with `HostToContainer` | Keep the FUSE mountpoint in a subdirectory such as `shared/mount`, never over the volume root |
+| `fuse-device` | `/dev/fuse` | Not mounted | Use a `/dev/fuse` `hostPath` with type `CharDevice` |
+
+Only the SkillFS sidecar runs as root with `privileged` enabled. The workload
+can run as a different non-root UID because the image always adds
+`--allow-other`. The manifest uses a native Kubernetes sidecar by setting the
+SkillFS init container's `restartPolicy` to `Always`, so Kubernetes waits for
+the FUSE startup probe before starting the workload and stops the sidecar after
+the workload exits.
 
 ## Deploy
 
@@ -108,6 +179,31 @@ workload intentionally has no liveness probe. After an `EIO` or `ENOTCONN`, a
 consumer must close the failed file descriptor and reopen the file after the
 Pod becomes Ready again.
 
+## Image configuration
+
+The image defaults match the reference manifest. Override them in the Pod when
+your volume paths or probe skill differ.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SKILLFS_SOURCE` | `/var/lib/skillfs/source` | Writable physical skill source root |
+| `SKILLFS_MOUNTPOINT` | `/var/lib/skillfs/shared/mount` | FUSE mountpoint inside the shared volume |
+| `SKILLFS_DISCOVER_ROOT` | `/var/lib/skillfs/shared/mount/skills` | Reader-visible root advertised by `skill-discover` |
+| `SKILLFS_EXTRA_ARGS` | Empty | Additional whitespace-separated `skillfs mount` arguments |
+| `SKILLFS_PROBE_FILE` | `skills/skillfs-container-example/SKILL.md` | Stable, non-empty file read through FUSE by the health probe |
+| `SKILLFS_PROBE_TIMEOUT` | `5` | Per-read health probe timeout in seconds |
+| `RUST_LOG` | `info` | SkillFS log filter |
+
+The preflight check requires distinct absolute source and mountpoint paths, a
+writable source, an openable `/dev/fuse`, `fusermount3`, and
+`user_allow_other` in `/etc/fuse.conf`. `SKILLFS_SKIP_PREFLIGHT=1` is a debugging
+escape hatch and should not be used in a normal deployment.
+
+On shutdown, SkillFS receives `SIGTERM` as PID 1 and unmounts the FUSE view. If
+a previous process was killed before cleanup, the next preflight removes a
+residual FUSE mount at the configured mountpoint. It refuses to unmount any
+non-FUSE filesystem found there, which protects a misconfigured volume path.
+
 ## Troubleshoot
 
 ```bash
@@ -119,6 +215,11 @@ kubectl -n "$NS" get events --sort-by=.lastTimestamp
 
 Common causes are blocked privileged containers, missing `/dev/fuse`, incorrect
 mount propagation, an unreadable probe file, or a read-only source volume.
+
+Preflight failures include a stable numeric code in the container log. Codes
+10 through 16 cover invalid configuration, the FUSE device, `fusermount3`, the
+source root, the mountpoint, `fuse.conf`, and residual mount cleanup in that
+order.
 
 ## Cleanup
 

--- a/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
+++ b/docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md
@@ -6,6 +6,9 @@
 mount，工作负载保持非特权，只读取传播后的 SkillFS view，不直接挂载物理 Skill
 source。
 
+仓库目前没有发布可直接拉取的 SkillFS Sidecar 专用镜像。请从准备部署的源码
+revision 构建镜像，完成本地验证后，再推送到集群可以访问的 registry。
+
 ## 前提条件
 
 - Kubernetes 1.29 或更高版本。
@@ -14,23 +17,83 @@ source。
 - 可使用 `docker buildx` 和 `kubectl`。
 - 集群能够拉取目标 registry 中的镜像。
 
-## 构建并推送镜像
+## 选择基础镜像
 
-请为目标节点架构构建镜像：
+SkillFS 提供两份功能相同的 Sidecar 镜像定义。它们使用相同的 entrypoint、probe、
+默认路径和 Kubernetes manifest。
+
+| Dockerfile | Runtime 基础镜像 | 适用场景 |
+| --- | --- | --- |
+| `src/skillfs/container/Dockerfile` | Debian Bookworm | 使用通用镜像，并由固定的 Rust 1.86 toolchain 完成构建 |
+| `src/skillfs/container/Dockerfile.alinux4` | Alibaba Cloud Linux 4 | 部署环境统一使用 Alibaba Cloud Linux 4，或需要通过公开 Aliyun RPM 与 Cargo 镜像完成构建 |
+
+Alibaba Cloud Linux 4 构建默认使用 Aliyun Cargo 镜像。构建环境需要直接访问
+crates.io 时，把 `SKILLFS_CARGO_REGISTRY_INDEX` build argument 设为空值。生产构建
+需要固定基础镜像 tag 或 digest 时，两份定义都可以通过 `BASE_IMAGE` build
+argument 覆盖默认值。
+
+## 构建、验证并推送镜像
+
+下面的命令从仓库根目录运行。示例为 AMD64 构建 Debian 镜像，并用源码 commit
+作为镜像 tag，方便部署后追溯构建输入。
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
+export REVISION="$(git rev-parse HEAD)"
+export VERSION="$(git describe --tags --match 'skillfs/v*' --always)"
+export IMAGE="registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)"
 export PLATFORM=linux/amd64
+export DOCKERFILE=src/skillfs/container/Dockerfile
 
 docker buildx build \
   --platform "$PLATFORM" \
-  -f src/skillfs/container/Dockerfile \
+  --build-arg VERSION="$VERSION" \
+  --build-arg REVISION="$REVISION" \
+  -f "$DOCKERFILE" \
   -t "$IMAGE" \
-  --push \
+  --load \
   src/skillfs
+
+docker run --rm --platform "$PLATFORM" "$IMAGE" skillfs --version
+docker push "$IMAGE"
 ```
 
-ARM64 节点使用 `linux/arm64`。
+构建 Alibaba Cloud Linux 4 镜像时，将 `DOCKERFILE` 设为
+`src/skillfs/container/Dockerfile.alinux4`。`PLATFORM` 应与目标节点架构一致。
+发布 multi-platform tag 前，需要逐一构建并运行 smoke check。仓库 CI 目前不会构建
+或测试这两份专用 Sidecar 镜像。
+
+上面的 `docker run` 只验证二进制和 runtime library。提供 FUSE view 还需要下文所列
+的设备、权限、Volume 和 mount propagation 配置。
+
+## 镜像启动方式
+
+没有传入 command argument 时，镜像先运行 preflight，然后按下面的固定方式启动。
+
+```text
+skillfs mount "$SKILLFS_SOURCE" "$SKILLFS_MOUNTPOINT" \
+  --foreground --allow-other
+```
+
+`SKILLFS_DISCOVER_ROOT` 和 `SKILLFS_EXTRA_ARGS` 可以追加可选 mount argument。不要
+加入 `--managed`。前台 SkillFS 进程需要保持为 PID 1，让 kubelet 可以重启它，并把
+`SIGTERM` 直接交给进程。给镜像传入 command argument 会完全替换 mount 命令，因此
+版本 smoke check 不需要 `/dev/fuse`。
+
+## Pod 必需结构
+
+参考 Pod 不向工作负载暴露物理 source，只共享传播后的 FUSE view。
+
+| Volume | Sidecar mount | 工作负载 mount | 要求 |
+| --- | --- | --- | --- |
+| `skill-source` | `/var/lib/skillfs/source` | 不挂载 | 必须可写。Skill 变更需要跨 Pod 保留时使用 PVC |
+| `skill-shared` | `/var/lib/skillfs/shared`，使用 `Bidirectional` | 相同路径，使用 `HostToContainer` | FUSE mountpoint 必须是 `shared/mount` 这样的子目录，不能覆盖 Volume 根目录 |
+| `fuse-device` | `/dev/fuse` | 不挂载 | 使用 `/dev/fuse` `hostPath`，类型设为 `CharDevice` |
+
+只有 SkillFS Sidecar 以 root 身份运行并启用 `privileged`。镜像固定加入
+`--allow-other`，工作负载可以使用另一个非 root UID。Manifest 将 SkillFS init
+container 的 `restartPolicy` 设为 `Always`，从而使用原生 Kubernetes Sidecar。
+Kubernetes 会等 FUSE startup probe 通过再启动工作负载，并在工作负载退出后停止
+Sidecar。
 
 ## 部署
 
@@ -51,7 +114,7 @@ kubectl -n "$NS" wait \
 
 ## 验证挂载视图
 
-从非特权工作负载容器读取 SkillFS view：
+在非特权工作负载容器中读取 SkillFS view。
 
 ```bash
 export POD=skillfs-sidecar-example
@@ -85,7 +148,7 @@ Pod 恢复 Ready 后，重新执行挂载视图验证命令。
 
 ## 使用自己的工作负载
 
-修改 `src/skillfs/deploy/kubernetes/20-pod.yaml`：
+按下面的步骤修改 `src/skillfs/deploy/kubernetes/20-pod.yaml`。
 
 1. 将 `skill-source` 替换为自己的 PVC；
 2. 删除示例 ConfigMap 和 `seed-example` init container；
@@ -104,6 +167,29 @@ liveness 失败后只重启 SkillFS Sidecar。单次失败阈值意味着偶发 
 probe。消费方遇到 `EIO` 或 `ENOTCONN` 后必须关闭失败的文件描述符，并在 Pod 恢复
 Ready 后重新打开文件。
 
+## 镜像配置
+
+镜像默认值与参考 manifest 一致。Volume 路径或 probe Skill 不同时，在 Pod 中覆盖
+对应配置。
+
+| 变量 | 默认值 | 用途 |
+| --- | --- | --- |
+| `SKILLFS_SOURCE` | `/var/lib/skillfs/source` | 可写的物理 Skill source 根目录 |
+| `SKILLFS_MOUNTPOINT` | `/var/lib/skillfs/shared/mount` | 共享 Volume 内的 FUSE mountpoint |
+| `SKILLFS_DISCOVER_ROOT` | `/var/lib/skillfs/shared/mount/skills` | `skill-discover` 提供给读取方的可见根目录 |
+| `SKILLFS_EXTRA_ARGS` | 空 | 追加给 `skillfs mount` 的参数，以空白字符分隔 |
+| `SKILLFS_PROBE_FILE` | `skills/skillfs-container-example/SKILL.md` | Health probe 通过 FUSE 读取的稳定非空文件 |
+| `SKILLFS_PROBE_TIMEOUT` | `5` | 每次 probe 读取的超时时间，单位为秒 |
+| `RUST_LOG` | `info` | SkillFS 日志过滤规则 |
+
+Preflight 要求 source 与 mountpoint 是两个不同的绝对路径，source 可写，
+`/dev/fuse` 可以打开，同时能找到 `fusermount3`，并且 `/etc/fuse.conf` 含有
+`user_allow_other`。`SKILLFS_SKIP_PREFLIGHT=1` 只用于调试，正常部署不要启用。
+
+退出时，PID 1 形式的 SkillFS 直接收到 `SIGTERM` 并卸载 FUSE view。上一个进程没能
+完成清理时，下一次 preflight 会删除配置 mountpoint 上残留的 FUSE mount。发现其他
+文件系统时，preflight 会拒绝卸载，避免错误的 Volume 路径影响已有 mount。
+
 ## 故障排查
 
 ```bash
@@ -115,6 +201,10 @@ kubectl -n "$NS" get events --sort-by=.lastTimestamp
 
 常见原因包括特权容器被策略阻止、`/dev/fuse` 缺失、mount propagation 配置错误、
 probe 文件不可读或 source volume 为只读。
+
+Preflight 失败时，容器日志会包含稳定的数字代码。代码 10 到 16 依次表示配置错误、
+FUSE device、`fusermount3`、source 根目录、mountpoint、`fuse.conf` 和残留 mount
+清理失败。
 
 ## 清理
 

--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -427,8 +427,11 @@ sidecar as privileged.
 
 ```bash
 cd src/skillfs
-IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
-docker build -f container/Dockerfile -t "$IMAGE" .
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)
+DOCKERFILE=container/Dockerfile
+# Use container/Dockerfile.alinux4 for Alibaba Cloud Linux 4.
+docker build -f "$DOCKERFILE" -t "$IMAGE" .
+docker run --rm "$IMAGE" skillfs --version
 docker push "$IMAGE"
 kubectl apply -f deploy/kubernetes/00-namespace.yaml
 kubectl apply -f deploy/kubernetes/10-example-configmap.yaml

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -387,8 +387,11 @@ Kubernetes 1.29+、`/dev/fuse`，并允许 Sidecar 使用特权模式。
 
 ```bash
 cd src/skillfs
-IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
-docker build -f container/Dockerfile -t "$IMAGE" .
+IMAGE=registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)
+DOCKERFILE=container/Dockerfile
+# Alibaba Cloud Linux 4 使用 container/Dockerfile.alinux4。
+docker build -f "$DOCKERFILE" -t "$IMAGE" .
+docker run --rm "$IMAGE" skillfs --version
 docker push "$IMAGE"
 kubectl apply -f deploy/kubernetes/00-namespace.yaml
 kubectl apply -f deploy/kubernetes/10-example-configmap.yaml

--- a/src/skillfs/deploy/kubernetes/README.md
+++ b/src/skillfs/deploy/kubernetes/README.md
@@ -13,7 +13,8 @@ for the complete workflow.
 - Kubernetes 1.29 or later.
 - Privileged containers and the `/dev/fuse` hostPath are allowed.
 - The target nodes provide `/dev/fuse`.
-- The SkillFS image is available to the cluster.
+- A self-built SkillFS image is available to the cluster. The repository does
+  not currently publish a dedicated sidecar image.
 
 ## Files
 
@@ -26,7 +27,7 @@ for the complete workflow.
 ## Deploy
 
 ```bash
-export IMAGE=registry.example.com/anolisa/skillfs-sidecar:0.4.1
+export IMAGE="registry.example.com/anolisa/skillfs-sidecar:$(git rev-parse --short=12 HEAD)"
 export NS=skillfs-container-example
 
 kubectl apply -f 00-namespace.yaml
@@ -36,6 +37,10 @@ kubectl -n "$NS" wait \
   --for=condition=Ready pod/skillfs-sidecar-example \
   --timeout=300s
 ```
+
+Build and verify the image with `container/Dockerfile`, or use
+`container/Dockerfile.alinux4` for an Alibaba Cloud Linux 4 runtime. The linked
+user guide documents both variants and their runtime configuration.
 
 The workload readiness probe reads the transformed default skill and the
 virtual `skill-discover/SKILL.md`. It also opens a secondary skill through the


### PR DESCRIPTION
## Why

The Alibaba Cloud Linux 4 sidecar Dockerfile was added after the existing
container guide, which still showed only the Debian build and a release-like
placeholder tag. Operators also had to read the entrypoint and Pod manifest to
learn the required volumes, environment variables, and restart behavior.

## What changed

- Document the Debian and Alibaba Cloud Linux 4 image variants.
- Build traceable commit-tagged images, run a binary smoke check, and push them.
- Describe the Pod topology, image configuration, lifecycle, and preflight errors.
- Keep the English and Chinese user guides and component quick starts aligned.

## Related issue

no-issue: documentation follow-up for the Alibaba Cloud Linux 4 image

## User / Agent impact

Operators can choose the intended image base and deploy the SkillFS sidecar
without inferring its runtime contract from shell scripts and YAML comments.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Documentation now exposes existing image settings and operational behavior.
Runtime code, defaults, and manifests are unchanged, so compatibility risk is low.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `python3 /Users/kongche/.codex/skills/human-writing/scripts/check_prose.py docs/user-guide/zh/runtime/skillfs-kubernetes-sidecar.md`
- English and Chinese fenced command blocks compared byte for byte
- Documented environment defaults compared with both Dockerfiles
- Repository pre-commit hook
- `git diff --check`

Rust, FUSE, and container smoke tests were not run because this is a docs-only
change on macOS and Docker is unavailable.

## Documentation and rollback

The bilingual Sidecar guides, component READMEs, and manifest README were
updated together. Revert commit `7e41b059` to roll back the documentation.