### PR TITLE
feat(tokenless): add content taxonomy, detector, and static registry

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -857,6 +857,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokenless-pipeline"
+version = "0.7.12"
+dependencies = [
+ "tokenless-protocol",
+]
+
+[[package]]
 name = "tokenless-protocol"
 version = "0.7.12"
 dependencies = [

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/tokenless-ccr",
     "crates/tokenless-protocol",
+    "crates/tokenless-pipeline",
     "crates/tokenless-schema",
     "crates/tokenless-runtime",
     "crates/tokenless-cli",
@@ -12,6 +13,7 @@ members = [
 default-members = [
     "crates/tokenless-ccr",
     "crates/tokenless-protocol",
+    "crates/tokenless-pipeline",
     "crates/tokenless-schema",
     "crates/tokenless-runtime",
     "crates/tokenless-cli",

--- a/src/tokenless/crates/tokenless-pipeline/Cargo.toml
+++ b/src/tokenless/crates/tokenless-pipeline/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tokenless-pipeline"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Content taxonomy, deterministic detection, and the compile-time compressor registry"
+
+[dependencies]
+tokenless-protocol = { path = "../tokenless-protocol" }

--- a/src/tokenless/crates/tokenless-pipeline/src/content.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content.rs
@@ -1,0 +1,156 @@
+//! Content taxonomy and deterministic detection (roadmap §4.2).
+//!
+//! Detection is a pure function of the content with bounded work: only the
+//! first [`MAX_SCAN_BYTES`] bytes / [`MAX_SCAN_LINES`] lines are inspected
+//! (plus, for the JSON sniff alone, at most [`MAX_SCAN_BYTES`] trailing
+//! bytes), and no format is fully parsed — expensive parsing belongs inside the
+//! selected compressor, not in a detector that runs on every input. When no
+//! cheap signal is decisive the detector prefers the more general class, and
+//! ultimately [`ContentType::PlainText`] or [`ContentType::Unknown`]; the
+//! pipeline routes those to passthrough until a conservative fallback
+//! compressor exists.
+
+mod build_log;
+mod diff;
+mod html;
+mod json;
+mod search_results;
+mod source_code;
+mod stack_trace;
+mod tabular;
+
+/// The first content taxonomy (roadmap §4.2).
+///
+/// Wire values (see [`ContentType::wire_str`]) are the stable strings the
+/// protocol's `content_type` response field carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContentType {
+    /// JSON documents, typically arrays of records or nested objects.
+    JsonRecords,
+    /// grep/ripgrep-style `path:line[:col]:text` match listings.
+    SearchResults,
+    /// Compiler, package-manager, or test-runner terminal output.
+    BuildLog,
+    /// A stack trace or panic report, starting as one.
+    StackTrace,
+    /// Unified diff / patch output.
+    Diff,
+    /// A complete HTML document. Ambiguous fragments are not classified.
+    Html,
+    /// Delimiter-consistent tables (CSV, TSV, Markdown tables).
+    Tabular,
+    /// Program source code. Detected only on strong signals.
+    SourceCode,
+    /// Readable text with no more specific classification.
+    PlainText,
+    /// Empty, binary-like, or otherwise unclassifiable content.
+    Unknown,
+}
+
+impl ContentType {
+    /// The stable wire value used by the protocol's `content_type` field.
+    #[must_use]
+    pub fn wire_str(self) -> &'static str {
+        match self {
+            Self::JsonRecords => "json_records",
+            Self::SearchResults => "search_results",
+            Self::BuildLog => "build_log",
+            Self::StackTrace => "stack_trace",
+            Self::Diff => "diff",
+            Self::Html => "html",
+            Self::Tabular => "tabular",
+            Self::SourceCode => "source_code",
+            Self::PlainText => "plain_text",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Detection inspects at most this many leading bytes.
+pub const MAX_SCAN_BYTES: usize = 64 * 1024;
+/// Detection inspects at most this many leading lines.
+pub const MAX_SCAN_LINES: usize = 200;
+
+/// Classifies content into the taxonomy. Deterministic: identical input
+/// always produces the identical class.
+///
+/// Checks run from the most distinctive shape to the most general one, so a
+/// build log that merely *contains* a traceback stays [`ContentType::BuildLog`]
+/// while content that *starts as* a traceback is [`ContentType::StackTrace`].
+#[must_use]
+pub fn detect(content: &str) -> ContentType {
+    let scan = scan_prefix(content);
+    if scan.trim().is_empty() {
+        return ContentType::Unknown;
+    }
+    if !mostly_text(scan) {
+        return ContentType::Unknown;
+    }
+    if diff::is_diff(scan) {
+        return ContentType::Diff;
+    }
+    if stack_trace::is_stack_trace(scan) {
+        return ContentType::StackTrace;
+    }
+    // Bracket sniff on the content's head and bounded tail: the JSON
+    // compressor is the authority — it parses, and non-record JSON passes
+    // through there.
+    if json::is_json_like(content) {
+        return ContentType::JsonRecords;
+    }
+    if html::is_html_document(scan) {
+        return ContentType::Html;
+    }
+    if search_results::is_search_results(scan) {
+        return ContentType::SearchResults;
+    }
+    if tabular::is_tabular(scan) {
+        return ContentType::Tabular;
+    }
+    if build_log::is_build_log(scan) {
+        return ContentType::BuildLog;
+    }
+    if source_code::is_source_code(scan) {
+        return ContentType::SourceCode;
+    }
+    ContentType::PlainText
+}
+
+/// The bounded slice all line-based checks operate on, cut at a char
+/// boundary at most [`MAX_SCAN_BYTES`] into the content.
+fn scan_prefix(content: &str) -> &str {
+    if content.len() <= MAX_SCAN_BYTES {
+        return content;
+    }
+    let mut end = MAX_SCAN_BYTES;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    &content[..end]
+}
+
+fn scan_lines(scan: &str) -> impl Iterator<Item = &str> {
+    scan.lines().take(MAX_SCAN_LINES)
+}
+
+fn non_empty_lines(scan: &str) -> impl Iterator<Item = &str> {
+    scan_lines(scan).filter(|l| !l.trim().is_empty())
+}
+
+/// Rejects binary-like input: more than 5% of the leading bytes are control
+/// characters other than the whitespace family and ESC (ANSI sequences are
+/// legitimate in terminal output).
+fn mostly_text(scan: &str) -> bool {
+    let sample = &scan.as_bytes()[..scan.len().min(4096)];
+    let control = sample
+        .iter()
+        .filter(|b| b.is_ascii_control() && !matches!(b, b'\n' | b'\r' | b'\t' | 0x1b))
+        .count();
+    control * 20 <= sample.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/content_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/build_log.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/build_log.rs
@@ -1,0 +1,42 @@
+const BUILD_LOG_MARKERS: &[&str] = &[
+    "Compiling ",
+    "Finished ",
+    "Downloading ",
+    "Installing ",
+    "warning:",
+    "error:",
+    "error[",
+    "FAILED",
+    " passed",
+    " failed",
+    "npm ",
+    "make[",
+    "$ ",
+];
+
+/// Terminal build/test output: ANSI sequences, progress redraws, or at least
+/// two distinct marker kinds.
+pub(super) fn is_build_log(scan: &str) -> bool {
+    let mut score = 0usize;
+    if scan.contains('\u{1b}') {
+        score += 1;
+    }
+    if has_bare_carriage_return(scan) {
+        score += 1;
+    }
+    score += BUILD_LOG_MARKERS
+        .iter()
+        .filter(|m| scan.contains(**m))
+        .count();
+    score >= 2
+}
+
+/// A `\r` not followed by `\n` is a progress-bar redraw, not a Windows line
+/// ending.
+fn has_bare_carriage_return(scan: &str) -> bool {
+    let bytes = scan.as_bytes();
+    bytes
+        .iter()
+        .enumerate()
+        .any(|(i, b)| *b == b'\r' && bytes.get(i + 1) != Some(&b'\n'))
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/diff.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/diff.rs
@@ -1,0 +1,22 @@
+use super::scan_lines;
+
+pub(super) fn is_diff(scan: &str) -> bool {
+    if scan.starts_with("diff --git ") || scan.contains("\ndiff --git ") {
+        return true;
+    }
+    // Unified diff without git framing: a ---/+++ header pair followed by at
+    // least one hunk header.
+    let mut minus_header = false;
+    let mut plus_header = false;
+    let mut hunks = 0;
+    for line in scan_lines(scan) {
+        if line.starts_with("--- ") {
+            minus_header = true;
+        } else if line.starts_with("+++ ") {
+            plus_header = true;
+        } else if line.starts_with("@@ -") {
+            hunks += 1;
+        }
+    }
+    minus_header && plus_header && hunks >= 1
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/html.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/html.rs
@@ -1,0 +1,9 @@
+pub(super) fn is_html_document(scan: &str) -> bool {
+    let head = scan.trim_start().as_bytes();
+    starts_with_ignore_ascii_case(head, b"<!doctype html")
+        || starts_with_ignore_ascii_case(head, b"<html")
+}
+
+fn starts_with_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len() && haystack[..needle.len()].eq_ignore_ascii_case(needle)
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/json.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/json.rs
@@ -1,0 +1,31 @@
+use super::MAX_SCAN_BYTES;
+
+/// Bracket sniff on the first and last non-whitespace bytes. Deliberately
+/// consults the content's tail, not just the leading scan window: the closing
+/// bracket of a JSON document larger than the window lies beyond it, and a
+/// misroute degrades to passthrough because the JSON compressor is the
+/// authority that parses. Cost stays bounded: the leading trim is covered by
+/// `detect()`'s emptiness check on the scan prefix, and the trailing trim
+/// inspects at most [`MAX_SCAN_BYTES`] final bytes — deeper whitespace
+/// padding is not JSON.
+pub(super) fn is_json_like(content: &str) -> bool {
+    let first = content.trim_start().as_bytes().first();
+    let last = tail_window(content).trim_end().as_bytes().last();
+    matches!(
+        (first, last),
+        (Some(b'{'), Some(b'}')) | (Some(b'['), Some(b']'))
+    )
+}
+
+/// The trailing counterpart of `scan_prefix`: at most [`MAX_SCAN_BYTES`]
+/// final bytes, cut at a char boundary.
+fn tail_window(content: &str) -> &str {
+    if content.len() <= MAX_SCAN_BYTES {
+        return content;
+    }
+    let mut start = content.len() - MAX_SCAN_BYTES;
+    while !content.is_char_boundary(start) {
+        start += 1;
+    }
+    &content[start..]
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/search_results.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/search_results.rs
@@ -1,0 +1,29 @@
+use super::non_empty_lines;
+
+/// `path:line[:col]:text` listings: at least 3 non-empty lines, and at least
+/// 80% of the inspected ones carry a path-like prefix and a line number.
+pub(super) fn is_search_results(scan: &str) -> bool {
+    let mut total = 0usize;
+    let mut hits = 0usize;
+    for line in non_empty_lines(scan).take(50) {
+        total += 1;
+        if line_is_search_hit(line) {
+            hits += 1;
+        }
+    }
+    total >= 3 && hits * 10 >= total * 8
+}
+
+fn line_is_search_hit(line: &str) -> bool {
+    let Some(colon) = line.find(':') else {
+        return false;
+    };
+    let path = &line[..colon];
+    // Require a path-looking prefix so `12:30:00` timestamps do not match.
+    if path.is_empty() || !(path.contains('/') || path.contains('.')) {
+        return false;
+    }
+    let rest = &line[colon + 1..];
+    let digits = rest.bytes().take_while(u8::is_ascii_digit).count();
+    digits >= 1 && rest.as_bytes().get(digits) == Some(&b':')
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/source_code.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/source_code.rs
@@ -1,0 +1,31 @@
+use super::non_empty_lines;
+
+const SOURCE_MARKERS: &[&str] = &[
+    "fn ",
+    "pub ",
+    "def ",
+    "class ",
+    "#include",
+    "import ",
+    "use ",
+    "impl ",
+    "function ",
+    "package ",
+];
+
+/// Source code needs strong signals: a shebang, or several lines opening
+/// with declaration keywords. Weak matches fall through to plain text —
+/// misclassifying prose as code is worse than the reverse while the
+/// source-code compressor is experimental and Read stays skipped.
+pub(super) fn is_source_code(scan: &str) -> bool {
+    if scan.starts_with("#!") {
+        return true;
+    }
+    non_empty_lines(scan)
+        .filter(|l| {
+            let t = l.trim_start();
+            SOURCE_MARKERS.iter().any(|m| t.starts_with(m))
+        })
+        .count()
+        >= 5
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/stack_trace.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/stack_trace.rs
@@ -1,0 +1,23 @@
+use super::non_empty_lines;
+
+pub(super) fn is_stack_trace(scan: &str) -> bool {
+    let mut lines = non_empty_lines(scan);
+    let Some(first) = lines.next() else {
+        return false;
+    };
+    if first.starts_with("Traceback (most recent call last") {
+        return true;
+    }
+    if first.starts_with("thread '") && first.contains("panicked at") {
+        return true;
+    }
+    if first.starts_with("panic:") || first.starts_with("goroutine ") {
+        return true;
+    }
+    // Java/JS style: an exception line followed by indented `at` frames.
+    let Some(second) = lines.next() else {
+        return false;
+    };
+    (first.contains("Exception") || first.contains("Error"))
+        && second.trim_start().starts_with("at ")
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/content/tabular.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/content/tabular.rs
@@ -1,0 +1,21 @@
+use super::non_empty_lines;
+
+/// Markdown tables, or CSV/TSV with a consistent delimiter count across the
+/// first non-empty lines.
+pub(super) fn is_tabular(scan: &str) -> bool {
+    let lines: Vec<&str> = non_empty_lines(scan).take(10).collect();
+    if lines.len() < 3 {
+        return false;
+    }
+    let markdown = lines[0].starts_with('|')
+        && lines[0].ends_with('|')
+        && lines[1].chars().all(|c| matches!(c, '|' | '-' | ':' | ' '));
+    if markdown {
+        return true;
+    }
+    let consistent = |delim: char, min: usize| {
+        let first = lines[0].matches(delim).count();
+        first >= min && lines.iter().all(|l| l.matches(delim).count() == first)
+    };
+    consistent('\t', 1) || consistent(',', 2)
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/lib.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/lib.rs
@@ -1,0 +1,22 @@
+//! Content routing for the shared compression pipeline.
+//!
+//! This crate carries the pieces of roadmap §4.2 / §5.2 that sit between the
+//! protocol boundary and the compressors themselves:
+//!
+//! - [`ContentType`]: the first content taxonomy;
+//! - [`detect`]: deterministic, bounded-cost content detection;
+//! - [`CompressorSpec`] and [`candidates`]: the compile-time registry and
+//!   the seam/capability filter (roadmap principle 2: route by content,
+//!   constrain by seam).
+//!
+//! The staged pipeline and end-to-end arbitration that consume these types
+//! arrive separately; until existing compressors move behind the registry,
+//! [`REGISTRY`] is empty and nothing routes through this crate. The roadmap
+//! section numbers refer to the tokenless evolution roadmap, which has not
+//! landed in this repository yet.
+
+mod content;
+mod registry;
+
+pub use content::{ContentType, detect};
+pub use registry::{CompressorSpec, CostClass, REGISTRY, Stage, candidates};

--- a/src/tokenless/crates/tokenless-pipeline/src/registry.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/registry.rs
@@ -1,0 +1,86 @@
+//! Compile-time compressor registry and candidate filtering (roadmap §4.2).
+//!
+//! Registration is static (roadmap principle 7): the registry is a `const`
+//! slice assembled at compile time; dynamic plugins and configuration-driven
+//! loading are out of scope. [`candidates`] applies the routing rule from
+//! principle 2 — a compressor is only a candidate when it supports the
+//! detected content type, runs at the request's seam, and every capability
+//! it requires is declared by the adapter.
+
+use crate::content::ContentType;
+use tokenless_protocol::{Capabilities, Seam};
+
+/// Escalation stage a compressor belongs to (roadmap principle 3). The
+/// ordering matches the escalation ladder: lossless runs before
+/// retrievable-lossy runs before truncation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Stage {
+    /// Removes nothing task-relevant; always safe to apply.
+    Lossless,
+    /// Removes content that is stashed and retrievable by marker.
+    RetrievableLossy,
+    /// Bounded truncation; the last resort.
+    Truncation,
+}
+
+/// Bounded cost class used for timeout-aware selection: the pipeline skips
+/// classes whose per-class budget does not fit in the remaining overall
+/// timeout budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CostClass {
+    /// Single-pass scanning, no allocation proportional to input.
+    Cheap,
+    /// Parsing or restructuring proportional to input size.
+    Moderate,
+    /// Multi-pass analysis; only selected when the budget is generous.
+    Expensive,
+}
+
+/// One registered compressor's routing metadata.
+#[derive(Debug, Clone, Copy)]
+pub struct CompressorSpec {
+    /// Stable ID reported in `compressor_chain` and persisted in stats.
+    pub id: &'static str,
+    /// Content types this compressor understands.
+    pub content_types: &'static [ContentType],
+    /// Seams this compressor may run at.
+    pub seams: &'static [Seam],
+    /// Capabilities the adapter must declare for this compressor to be a
+    /// candidate. A required `replace_output` keeps response-shaping
+    /// compressors away from hosts that cannot replace model-visible
+    /// output; a required `publish_retrieve_tool` keeps retrievable-lossy
+    /// compressors away from hosts where markers would be dead ends.
+    pub required_capabilities: Capabilities,
+    /// Escalation stage this compressor runs in.
+    pub stage: Stage,
+    /// Cost class for timeout-aware selection.
+    pub cost_class: CostClass,
+}
+
+/// The production registry. Empty until existing compressors move behind
+/// the registry interface; entries are appended with the compressor that
+/// implements them, never speculatively.
+pub const REGISTRY: &[CompressorSpec] = &[];
+
+/// Filters `registry` down to the candidates for one request, preserving
+/// registration order (the pipeline groups by [`Stage`] on top of it).
+pub fn candidates(
+    registry: &[CompressorSpec],
+    content_type: ContentType,
+    seam: Seam,
+    capabilities: Capabilities,
+) -> impl Iterator<Item = &CompressorSpec> {
+    registry.iter().filter(move |spec| {
+        spec.content_types.contains(&content_type)
+            && spec.seams.contains(&seam)
+            && (!spec.required_capabilities.replace_output || capabilities.replace_output)
+            && (!spec.required_capabilities.publish_retrieve_tool
+                || capabilities.publish_retrieve_tool)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/registry_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/tests/content_tests.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/tests/content_tests.rs
@@ -1,0 +1,190 @@
+// Detector contract tests: one positive case per taxonomy class, plus the
+// adversarial orderings the detector documents (a log containing a traceback
+// stays a build log; a diff full of error lines stays a diff).
+
+#[test]
+fn detects_json_records() {
+    assert_eq!(
+        detect(r#"[{"id": 1, "state": "open"}, {"id": 2, "state": "closed"}]"#),
+        ContentType::JsonRecords
+    );
+    assert_eq!(
+        detect("{\n  \"items\": [1, 2, 3],\n  \"total\": 3\n}"),
+        ContentType::JsonRecords
+    );
+}
+
+#[test]
+fn detects_search_results() {
+    let grep = "src/main.rs:10:fn main() {\n\
+                src/lib.rs:42:    let value = compute();\n\
+                tests/it.rs:7:fn it_works() {\n\
+                src/main.rs:11:    run();";
+    assert_eq!(detect(grep), ContentType::SearchResults);
+}
+
+#[test]
+fn detects_build_log() {
+    let cargo = "   \u{1b}[1m\u{1b}[32mCompiling\u{1b}[0m serde v1.0.229\n\
+                 warning: unused variable: `seam`\n\
+                     Finished `release` profile [optimized] target(s) in 42.18s";
+    assert_eq!(detect(cargo), ContentType::BuildLog);
+}
+
+#[test]
+fn log_containing_a_traceback_stays_build_log() {
+    let pytest = "$ pytest -q\n\
+                  ...F\n\
+                  =================================== FAILURES ===================================\n\
+                  Traceback (most recent call last):\n\
+                    File \"test_hooks.py\", line 118, in test_threshold\n\
+                  AssertionError: assert 2048 == 4096\n\
+                  1 failed, 74 passed in 6.41s";
+    assert_eq!(detect(pytest), ContentType::BuildLog);
+}
+
+#[test]
+fn detects_stack_traces_that_start_as_one() {
+    let python = "Traceback (most recent call last):\n\
+                  \x20 File \"app.py\", line 3, in <module>\n\
+                  ValueError: bad input";
+    assert_eq!(detect(python), ContentType::StackTrace);
+
+    let rust = "thread 'main' panicked at src/main.rs:4:5:\nindex out of bounds";
+    assert_eq!(detect(rust), ContentType::StackTrace);
+
+    let java = "Exception in thread \"main\" java.lang.NullPointerException\n\
+                \tat com.example.Main.main(Main.java:14)";
+    assert_eq!(detect(java), ContentType::StackTrace);
+
+    let go = "panic: runtime error: invalid memory address\n\ngoroutine 1 [running]:";
+    assert_eq!(detect(go), ContentType::StackTrace);
+}
+
+#[test]
+fn detects_diffs_over_their_own_error_lines() {
+    let git = "commit 585fbdb9\nAuthor: dev <d@example.com>\n\n    fix\n\n\
+               diff --git a/src/lib.rs b/src/lib.rs\n\
+               --- a/src/lib.rs\n\
+               +++ b/src/lib.rs\n\
+               @@ -1,3 +1,3 @@\n\
+               -    error: old\n\
+               +    error: new";
+    assert_eq!(detect(git), ContentType::Diff);
+
+    let bare = "--- before.txt\n+++ after.txt\n@@ -1 +1 @@\n-old\n+new";
+    assert_eq!(detect(bare), ContentType::Diff);
+}
+
+#[test]
+fn detects_html_documents_but_not_fragments() {
+    assert_eq!(
+        detect("<!DOCTYPE html>\n<html><body>hi</body></html>"),
+        ContentType::Html
+    );
+    // Ambiguous fragments are not classified as HTML (roadmap M4 policy).
+    assert_ne!(detect("<div>partial</div>"), ContentType::Html);
+}
+
+#[test]
+fn detects_tabular_content() {
+    assert_eq!(
+        detect("name,age,city\nalice,30,berlin\nbob,25,tokyo"),
+        ContentType::Tabular
+    );
+    assert_eq!(
+        detect("a\tb\nc\td\ne\tf"),
+        ContentType::Tabular
+    );
+    assert_eq!(
+        detect("| col | n |\n|---|---:|\n| x | 1 |"),
+        ContentType::Tabular
+    );
+}
+
+#[test]
+fn detects_source_code_on_strong_signals_only() {
+    assert_eq!(detect("#!/usr/bin/env bash\necho hi"), ContentType::SourceCode);
+    let rust = "use std::fs;\n\
+                pub struct Config;\n\
+                impl Config {\n\
+                fn load() {}\n\
+                pub fn save() {}\n\
+                use std::io;";
+    assert_eq!(detect(rust), ContentType::SourceCode);
+    // One keyword in prose is not code.
+    assert_eq!(
+        detect("please use the new API for this import step"),
+        ContentType::PlainText
+    );
+}
+
+#[test]
+fn readable_prose_is_plain_text() {
+    assert_eq!(
+        detect("压缩按无损、可取回有损、截断三级阶梯递进。检测器必须廉价且确定。"),
+        ContentType::PlainText
+    );
+    assert_eq!(detect("just a short sentence"), ContentType::PlainText);
+}
+
+#[test]
+fn empty_and_binary_are_unknown() {
+    assert_eq!(detect(""), ContentType::Unknown);
+    assert_eq!(detect("   \n\t  "), ContentType::Unknown);
+    let binary = "\u{0}\u{1}\u{2}abc".repeat(50);
+    assert_eq!(detect(&binary), ContentType::Unknown);
+}
+
+#[test]
+fn large_json_beyond_the_scan_window_stays_json() {
+    let mut big = String::from("[\n");
+    while big.len() <= MAX_SCAN_BYTES {
+        big.push_str("  {\"id\": 1, \"state\": \"open\"},\n");
+    }
+    big.push_str("  {\"id\": 2}\n]");
+    assert_eq!(detect(&big), ContentType::JsonRecords);
+}
+
+#[test]
+fn whitespace_padding_beyond_the_tail_window_is_not_json() {
+    let padded = format!("{{\"k\": 1}}{}", " ".repeat(MAX_SCAN_BYTES + 1));
+    assert_ne!(detect(&padded), ContentType::JsonRecords);
+}
+
+#[test]
+fn timestamped_logs_are_not_search_results() {
+    let log = "12:30:00 starting worker\n12:30:01 ready\n12:30:05 done";
+    assert_ne!(detect(log), ContentType::SearchResults);
+}
+
+#[test]
+fn detection_is_deterministic_and_bounded() {
+    let large = "some plain prose line about nothing in particular\n".repeat(100_000);
+    let first = detect(&large);
+    assert_eq!(first, detect(&large));
+    assert_eq!(first, ContentType::PlainText);
+}
+
+#[test]
+fn wire_values_are_stable_and_unique() {
+    let all = [
+        (ContentType::JsonRecords, "json_records"),
+        (ContentType::SearchResults, "search_results"),
+        (ContentType::BuildLog, "build_log"),
+        (ContentType::StackTrace, "stack_trace"),
+        (ContentType::Diff, "diff"),
+        (ContentType::Html, "html"),
+        (ContentType::Tabular, "tabular"),
+        (ContentType::SourceCode, "source_code"),
+        (ContentType::PlainText, "plain_text"),
+        (ContentType::Unknown, "unknown"),
+    ];
+    for (ty, wire) in all {
+        assert_eq!(ty.wire_str(), wire);
+    }
+    let mut wires: Vec<&str> = all.iter().map(|(ty, _)| ty.wire_str()).collect();
+    wires.sort_unstable();
+    wires.dedup();
+    assert_eq!(wires.len(), all.len());
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/tests/registry_tests.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/tests/registry_tests.rs
@@ -1,0 +1,121 @@
+// Registry filtering contract: candidates must match content type and seam,
+// and every capability a spec requires must be declared by the adapter.
+
+const FULL: Capabilities = Capabilities {
+    replace_output: true,
+    publish_retrieve_tool: true,
+};
+const NONE: Capabilities = Capabilities {
+    replace_output: false,
+    publish_retrieve_tool: false,
+};
+
+const TEST_REGISTRY: &[CompressorSpec] = &[
+    CompressorSpec {
+        id: "response-cleanup",
+        content_types: &[ContentType::JsonRecords],
+        seams: &[Seam::PostTool],
+        required_capabilities: Capabilities {
+            replace_output: true,
+            publish_retrieve_tool: false,
+        },
+        stage: Stage::Lossless,
+        cost_class: CostClass::Cheap,
+    },
+    CompressorSpec {
+        id: "build-log",
+        content_types: &[ContentType::BuildLog],
+        seams: &[Seam::PostTool],
+        required_capabilities: FULL,
+        stage: Stage::RetrievableLossy,
+        cost_class: CostClass::Moderate,
+    },
+    CompressorSpec {
+        id: "schema",
+        content_types: &[ContentType::JsonRecords],
+        seams: &[Seam::BeforeModel],
+        required_capabilities: NONE,
+        stage: Stage::Lossless,
+        cost_class: CostClass::Cheap,
+    },
+    CompressorSpec {
+        id: "json-truncate",
+        content_types: &[ContentType::JsonRecords],
+        seams: &[Seam::PostTool],
+        required_capabilities: Capabilities {
+            replace_output: true,
+            publish_retrieve_tool: false,
+        },
+        stage: Stage::Truncation,
+        cost_class: CostClass::Cheap,
+    },
+];
+
+fn ids(
+    content_type: ContentType,
+    seam: Seam,
+    capabilities: Capabilities,
+) -> Vec<&'static str> {
+    candidates(TEST_REGISTRY, content_type, seam, capabilities)
+        .map(|spec| spec.id)
+        .collect()
+}
+
+#[test]
+fn filters_by_content_type_and_seam() {
+    assert_eq!(
+        ids(ContentType::JsonRecords, Seam::PostTool, FULL),
+        ["response-cleanup", "json-truncate"]
+    );
+    assert_eq!(ids(ContentType::JsonRecords, Seam::BeforeModel, FULL), ["schema"]);
+    assert_eq!(ids(ContentType::BuildLog, Seam::PostTool, FULL), ["build-log"]);
+    assert!(ids(ContentType::Diff, Seam::PostTool, FULL).is_empty());
+}
+
+#[test]
+fn required_capabilities_must_be_declared() {
+    // No replace_output: response-shaping candidates disappear entirely.
+    assert!(ids(ContentType::JsonRecords, Seam::PostTool, NONE).is_empty());
+    // replace_output alone is not enough for a retrievable-lossy compressor
+    // that needs a reachable retrieve tool.
+    let replace_only = Capabilities {
+        replace_output: true,
+        publish_retrieve_tool: false,
+    };
+    assert!(ids(ContentType::BuildLog, Seam::PostTool, replace_only).is_empty());
+    // A spec requiring nothing is a candidate for a capability-less adapter.
+    assert_eq!(ids(ContentType::JsonRecords, Seam::BeforeModel, NONE), ["schema"]);
+}
+
+#[test]
+fn registration_order_is_preserved() {
+    let order = ids(ContentType::JsonRecords, Seam::PostTool, FULL);
+    assert_eq!(order, ["response-cleanup", "json-truncate"]);
+}
+
+#[test]
+fn stage_and_cost_orderings_match_the_escalation_ladder() {
+    let mut stages = [Stage::Truncation, Stage::Lossless, Stage::RetrievableLossy];
+    stages.sort_unstable();
+    assert_eq!(
+        stages,
+        [Stage::Lossless, Stage::RetrievableLossy, Stage::Truncation]
+    );
+    let mut costs = [CostClass::Expensive, CostClass::Cheap, CostClass::Moderate];
+    costs.sort_unstable();
+    assert_eq!(
+        costs,
+        [CostClass::Cheap, CostClass::Moderate, CostClass::Expensive]
+    );
+}
+
+#[test]
+// The emptiness is exactly what this test locks in, so the "always true"
+// lint is expected until the first compressor migrates behind the registry.
+#[allow(clippy::const_is_empty)]
+fn production_registry_starts_empty() {
+    // Entries land together with the compressor that implements them, never
+    // speculatively. This assertion is updated by the change that migrates
+    // the first compressor behind the registry.
+    assert!(REGISTRY.is_empty());
+}


### PR DESCRIPTION
## Why

Follow-up to #2783. The shared pipeline routes by content and constrains by seam: it needs a content taxonomy, a detector, and a registry that knows which compressor may run where — before the staged pipeline and arbitration can exist. This PR adds that routing layer as the next independently buildable slice. Nothing consumes it yet; the production registry is intentionally empty, because entries land together with the compressor that implements them, never speculatively.

On the "gate the evolution behind a switch" question that naturally arises here: new-pipeline behavior will be controlled by a runtime configuration toggle (default off) introduced when the wiring changes land, not by a Cargo feature — the shipped artifact is a single binary, and a compile-time feature would fork it while leaving users unable to toggle. Until that wiring exists, crates like this one are inert by construction.

## What changed

- **New crate `tokenless-pipeline`** (workspace + default member), depending only on `tokenless-protocol`:
  - `ContentType` — the first taxonomy (`json_records`, `search_results`, `build_log`, `stack_trace`, `diff`, `html`, `tabular`, `source_code`, `plain_text`, `unknown`) with stable wire values matching the protocol's `content_type` field;
  - `detect()` — deterministic, bounded-cost detection: a pure function of the content, inspecting at most 64 KiB / 200 lines, with no format fully parsed (expensive parsing stays inside the selected compressor). Checks run from the most distinctive shape to the most general: a build log that merely contains a traceback stays `build_log`, while content that starts as a traceback is `stack_trace`; git and bare unified diffs win over their own `error:` lines; ambiguous content falls through to `plain_text`/`unknown`, which the pipeline will route to passthrough;
  - `CompressorSpec`, `Stage` (lossless < retrievable-lossy < truncation), `CostClass` (cheap/moderate/expensive, for timeout-aware selection), and `candidates()` — the compile-time registry and the routing filter: a compressor is a candidate only when it supports the detected content type, runs at the request's seam, and every capability it requires is declared by the adapter (so response-shaping compressors never reach hosts that cannot replace output, and retrievable-lossy compressors never reach hosts without a retrieve tool).
- **Conservative-by-design detection**: HTML is only a document that starts as one (fragments are not classified); source code needs a shebang or several declaration-keyword lines (misclassifying prose as code is worse than the reverse while Read stays skipped); timestamped log lines do not count as `path:line:` search hits; binary-like input is `unknown`.
- **19 contract tests**: one positive case per taxonomy class, the adversarial orderings above, CJK prose staying `plain_text` (this also pins a multi-byte-safe scan boundary), determinism on large input, wire-value stability/uniqueness, and the registry filter rules including the capability-implication cases and preserved registration order.

## User / Agent impact

None at runtime. No CLI, hook, configuration, or adapter behavior changes; the new crate is not referenced by any binary yet.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Additive only: a new public Rust API with no consumers. Detector misclassification cannot affect behavior today (nothing calls it), and once wired, a wrong class degrades to the fail-open passthrough path by design.

## Validation

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo doc --workspace --no-deps
```

All four pass; `cargo test --workspace` reports 17 green test targets including the 19 new detector/registry tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
