### PR TITLE
fix(skillfs): retry startup reconcile

### DIFF
--- a/src/skillfs/README.md
+++ b/src/skillfs/README.md
@@ -530,8 +530,13 @@ Related security surfaces:
 - `--activation-events-log <PATH>` writes activation protocol events as JSONL.
 - `--activation-reload-mode poll` re-reads activation state after notify events
   and updates the resolver without a remount.
-- Startup reconcile sends best-effort notifications for known skills after
-  mount startup.
+- Startup reconcile queues known skills through the notify worker and retries
+  temporary delivery failures until the daemon acknowledges, so SkillFS can
+  start before the daemon and still converge. Non-retryable failures are
+  reported, while inconclusive authentication uses a shared bounded endpoint
+  budget to prevent retry storms. See
+  [Reconcile Delivery Durability](docs/security/runtime-activation-implementation-plan.md#reconcile-delivery-durability)
+  for retry and observability details.
 - `--ledger-backing-root <PATH>` provides a daemon-visible source view for
   in-place activation/notify mounts, because the public source path is a FUSE
   over-mount. Use `/run/user/$UID/skillfs-ledger/...` or

--- a/src/skillfs/README_zh.md
+++ b/src/skillfs/README_zh.md
@@ -479,7 +479,11 @@ SkillFS 不在文件系统核心中执行扫描、签名校验或风险判断。
 - `--activation-events-log <PATH>` 将 activation protocol events 写成 JSONL。
 - `--activation-reload-mode poll` 在 notify events 后重读 activation state，
   无需 remount 即可更新 resolver。
-- startup reconcile 会在挂载启动后对已知 skills 发送 best-effort 通知。
+- startup reconcile 会通过 notify worker 为已知 skill 入队，并在暂时性投递失败时
+  重试直至 daemon 确认，因此 SkillFS 先于 daemon 启动时仍能自行收敛。不可重试的
+  错误会被报告，认证结果不确定时则使用所有 skill 共享的有界 endpoint 预算，避免
+  重试风暴。重试与可观测性细节见
+  [Reconcile Delivery Durability](docs/security/runtime-activation-implementation-plan.md#reconcile-delivery-durability)。
 - `--ledger-backing-root <PATH>` 为 in-place activation/notify mount 提供
   daemon 可见的 source 视图，因为公开 source path 已经是 FUSE over-mount。
   推荐使用 `/run/user/$UID/skillfs-ledger/...` 或

--- a/src/skillfs/crates/skillfs-cli/src/main.rs
+++ b/src/skillfs/crates/skillfs-cli/src/main.rs
@@ -2582,15 +2582,18 @@ async fn cmd_mount(
         watcher.start();
     }
 
-    // A4: fire startup reconcile after mount is spawned. Runs on a
-    // background thread so daemon socket latency cannot block startup.
+    // A4: queue startup reconcile after mount is spawned. Delivery is owned
+    // by the notify worker, which retries transient failures (daemon socket
+    // not created yet, connection refused) with exponential backoff, so a
+    // SkillFS-before-daemon start order still converges. Enqueueing is
+    // non-blocking and cannot delay startup.
     // A5: after reconcile, schedule an immediate watcher check so
     // daemon-written activation is picked up without waiting for the
     // periodic interval.
     if let (Some(ctrl), Some(names)) = (reconcile_notify, &reconcile_skill_names) {
         let names_owned = names.clone();
         let watcher_for_reconcile = activation_watcher.clone();
-        ctrl.spawn_startup_reconcile(names_owned.clone());
+        ctrl.enqueue_startup_reconcile(&names_owned);
         if let Some(ref w) = watcher_for_reconcile {
             w.schedule_immediate_check(names_owned);
         }

--- a/src/skillfs/crates/skillfs-fuse/src/security.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security.rs
@@ -184,7 +184,9 @@ pub use mode::{SecurityModeConfig, SecurityModeError};
 pub use notify::{
     CapturedNotify, DEFAULT_NOTIFY_DEBOUNCE_MS, DEFAULT_NOTIFY_TIMEOUT_MS, FailingNotifyClient,
     InMemoryNotifyClient, MAX_NOTIFY_PATHS, NOTIFY_METHOD, NOTIFY_SCHEMA_VERSION, NoopNotifyClient,
-    NotifyChangeEvent, NotifyClient, NotifyController, NotifyError, NotifyEventKind, NotifyParams,
+    NotifyChangeEvent, NotifyClient, NotifyController, NotifyError, NotifyEventKind,
+    NotifyMetricsSnapshot, NotifyParams, NotifyRetryClass, RECONCILE_AMBIGUOUS_RETRY_LIMIT,
+    RECONCILE_RETRY_BASE_MS, RECONCILE_RETRY_MAX_MS, ScriptedNotifyClient, ScriptedNotifyFailure,
     SlowNotifyClient, UnixSocketNotifyClient,
 };
 pub use path::{SKILL_META_DIR, is_skill_meta_path};

--- a/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/security/notify.rs
@@ -24,7 +24,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
@@ -59,6 +59,26 @@ pub const MAX_NOTIFY_PATHS: usize = 64;
 /// Responses exceeding this limit are rejected as `InvalidResponse`
 /// to prevent unbounded memory allocation on a malicious/buggy peer.
 const MAX_RESPONSE_BYTES: u64 = 64 * 1024;
+
+/// Delay before the first retry of a transiently failed reconcile.
+pub const RECONCILE_RETRY_BASE_MS: u64 = 250;
+/// Ceiling on the reconcile retry interval. Transient retries continue at
+/// this interval for as long as the daemon stays unreachable, so a mount
+/// that starts before the daemon still converges without operator action.
+pub const RECONCILE_RETRY_MAX_MS: u64 = 30_000;
+/// Attempt limit for [`NotifyRetryClass::Ambiguous`] failures, where the
+/// wire cannot distinguish a daemon restart from a refused authentication
+/// proof. Eight attempts span roughly 32 seconds of backoff, covering slower
+/// container recovery while ensuring that a permanently wrong key still has
+/// a fixed, endpoint-wide cost instead of causing a retry storm.
+pub const RECONCILE_AMBIGUOUS_RETRY_LIMIT: u32 = 8;
+/// Jitter amplitude as a percentage of the un-jittered interval. Spreads
+/// retries from many concurrently converging skills across the window
+/// instead of aligning them on one instant.
+const RECONCILE_RETRY_JITTER_PCT: u64 = 25;
+/// Exponent cap. `RECONCILE_RETRY_BASE_MS << 8` already exceeds
+/// `RECONCILE_RETRY_MAX_MS`; the cap only keeps the shift well-defined.
+const RECONCILE_RETRY_MAX_SHIFT: u32 = 16;
 
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -175,9 +195,36 @@ pub enum NotifyError {
     Write(std::io::Error),
     Read(std::io::Error),
     Timeout,
-    InvalidResponse { body: String },
-    Rejected { body: String },
-    Authentication(String),
+    InvalidResponse {
+        body: String,
+    },
+    Rejected {
+        body: String,
+    },
+    /// The endpoint is not usable *yet*: the parent directory or the socket
+    /// file does not exist, or the socket is being recreated. This is the
+    /// SkillFS-started-before-the-daemon case and is retryable.
+    EndpointUnavailable(String),
+    /// The endpoint exists but its ownership, mode, or file type is unsafe.
+    /// A misconfiguration or an active spoofing attempt; retrying cannot
+    /// turn an untrusted endpoint into a trusted one.
+    EndpointUntrusted(String),
+    /// Authentication or framing transport failure: handshake I/O error or
+    /// handshake timeout. Retryable.
+    AuthTransport(String),
+    /// The handshake ended without a verdict — the peer closed the
+    /// connection or sent an unparseable frame while SkillFS was waiting
+    /// for `auth.ok`.
+    ///
+    /// This is deliberately its own variant because the wire cannot
+    /// distinguish the two causes: the daemon closes the connection *both*
+    /// when it is restarting mid-handshake *and* when it has refused the
+    /// client proof. See [`NotifyRetryClass::Ambiguous`].
+    AuthInconclusive(String),
+    /// Authentication was answered and refused: HMAC proof mismatch,
+    /// wrong key material, or an oversized frame. Retrying with the same
+    /// key would only produce the same refusal.
+    AuthRejected(String),
 }
 
 impl std::fmt::Display for NotifyError {
@@ -193,12 +240,160 @@ impl std::fmt::Display for NotifyError {
             Self::Rejected { body } => {
                 write!(f, "notify: rejected: {body}")
             }
-            Self::Authentication(message) => write!(f, "notify: authentication failed: {message}"),
+            Self::EndpointUnavailable(message) => {
+                write!(f, "notify: endpoint unavailable: {message}")
+            }
+            Self::EndpointUntrusted(message) => {
+                write!(f, "notify: endpoint is not trusted: {message}")
+            }
+            Self::AuthTransport(message) => {
+                write!(f, "notify: authentication transport failed: {message}")
+            }
+            Self::AuthInconclusive(message) => {
+                write!(f, "notify: authentication inconclusive: {message}")
+            }
+            Self::AuthRejected(message) => {
+                write!(f, "notify: authentication rejected: {message}")
+            }
         }
     }
 }
 
 impl std::error::Error for NotifyError {}
+
+/// Whether a failed notify delivery is worth attempting again.
+///
+/// Only reconcile deliveries act on this: ordinary FUSE mutations keep
+/// their best-effort, single-attempt semantics (see
+/// [`NotifyController::observe`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotifyRetryClass {
+    /// The peer or the endpoint may become healthy on its own — retry with
+    /// backoff until it does.
+    Transient,
+    /// The failure cannot be told apart from a permanent one on the wire.
+    /// Retry through the controller-wide endpoint gate, but allow only
+    /// [`RECONCILE_AMBIGUOUS_RETRY_LIMIT`] probes across all pending Skills.
+    ///
+    /// The motivating case is a wrong notify authentication key: the daemon
+    /// refuses the client proof by closing the connection, which is
+    /// byte-for-byte what a daemon restarting mid-handshake looks like.
+    /// Treating it as `Transient` would retry a wrong key forever; treating
+    /// it as `Permanent` would silently drop a reconcile lost to a genuine
+    /// restart. A bounded retry converges in the restart case and turns the
+    /// wrong-key case into a handful of attempts instead of a storm.
+    Ambiguous,
+    /// The failure is a configuration, trust, or protocol mismatch — an
+    /// identical retry produces an identical failure.
+    Permanent,
+}
+
+impl NotifyError {
+    /// Classify this failure for the reconcile retry loop.
+    pub fn retry_class(&self) -> NotifyRetryClass {
+        match self {
+            Self::Connect(e) | Self::Write(e) | Self::Read(e) => io_retry_class(e.kind()),
+            Self::Timeout | Self::EndpointUnavailable(_) | Self::AuthTransport(_) => {
+                NotifyRetryClass::Transient
+            }
+            Self::AuthInconclusive(_) => NotifyRetryClass::Ambiguous,
+            Self::InvalidResponse { .. }
+            | Self::Rejected { .. }
+            | Self::EndpointUntrusted(_)
+            | Self::AuthRejected(_) => NotifyRetryClass::Permanent,
+        }
+    }
+
+    /// Whether this failure is retried at all — either indefinitely
+    /// ([`NotifyRetryClass::Transient`]) or through the controller-wide,
+    /// bounded endpoint gate ([`NotifyRetryClass::Ambiguous`]).
+    pub fn is_retryable(&self) -> bool {
+        self.retry_class() != NotifyRetryClass::Permanent
+    }
+
+    /// Whether this failure is retried without an attempt limit.
+    pub fn is_transient(&self) -> bool {
+        self.retry_class() == NotifyRetryClass::Transient
+    }
+
+    /// Whether the failure proves the business request was never sent.
+    ///
+    /// Authentication and response errors are deliberately excluded: the
+    /// public error variant does not always identify which protocol phase
+    /// failed, so the activation watcher remains the conservative fallback.
+    fn business_request_not_sent(&self) -> bool {
+        matches!(
+            self,
+            Self::Connect(_) | Self::EndpointUnavailable(_) | Self::EndpointUntrusted(_)
+        )
+    }
+}
+
+/// Classify a raw I/O failure kind.
+///
+/// The transient set is exactly the socket lifecycle: the daemon has not
+/// bound the socket yet (`NotFound`, `ConnectionRefused`), the daemon
+/// restarted mid-exchange (`ConnectionReset`, `ConnectionAborted`,
+/// `BrokenPipe`, `NotConnected`, `UnexpectedEof`), or the transfer hit a
+/// timeout (`TimedOut`, `WouldBlock`, `Interrupted`).
+///
+/// Everything else — including `PermissionDenied` on the socket and the
+/// `Other` kind used to wrap serialization failures — is permanent. An
+/// unrecognized kind is treated as permanent so an unknown failure mode
+/// cannot turn into an unbounded retry loop.
+fn io_retry_class(kind: std::io::ErrorKind) -> NotifyRetryClass {
+    use std::io::ErrorKind as Kind;
+    match kind {
+        Kind::NotFound
+        | Kind::ConnectionRefused
+        | Kind::ConnectionReset
+        | Kind::ConnectionAborted
+        | Kind::NotConnected
+        | Kind::BrokenPipe
+        | Kind::UnexpectedEof
+        | Kind::AddrNotAvailable
+        | Kind::TimedOut
+        | Kind::WouldBlock
+        | Kind::Interrupted => NotifyRetryClass::Transient,
+        _ => NotifyRetryClass::Permanent,
+    }
+}
+
+/// Map an authentication/framing failure onto a typed [`NotifyError`].
+///
+/// The mapping is by `AuthError` variant, not by rendered message, so the
+/// retry loop never has to pattern-match on strings.
+fn auth_error_to_notify(error: super::auth::AuthError) -> NotifyError {
+    use super::auth::AuthError as Auth;
+    let message = error.to_string();
+    match error {
+        // Transport-level: the daemon may simply be restarting.
+        Auth::Io(io) => match io_retry_class(io.kind()) {
+            NotifyRetryClass::Permanent => NotifyError::AuthRejected(message),
+            _ => NotifyError::AuthTransport(message),
+        },
+        Auth::Timeout => NotifyError::AuthTransport(message),
+        // `InvalidFrame` is what the client observes when the peer closes
+        // the connection before answering — `read_frame` maps `Ok(0)` to it.
+        // The daemon does exactly that both when it is restarting and when
+        // it has rejected our client proof, so a wrong key surfaces here
+        // rather than as `VerificationFailed`. Bounded retry is the only
+        // safe reading of an ambiguous signal.
+        Auth::InvalidFrame => NotifyError::AuthInconclusive(message),
+        // Entropy is an environment condition, not a trust decision; the
+        // capped retry interval bounds the cost of retrying.
+        Auth::Entropy(_) => NotifyError::AuthTransport(message),
+        // Proof mismatch, unusable key material, or a protocol violation.
+        Auth::VerificationFailed
+        | Auth::FrameTooLarge(_)
+        | Auth::RelativePath
+        | Auth::Open(_)
+        | Auth::NotRegular
+        | Auth::InsecurePermissions
+        | Auth::WrongOwner
+        | Auth::InvalidLength => NotifyError::AuthRejected(message),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Client trait + implementations
@@ -262,7 +457,7 @@ impl NotifyClient for UnixSocketNotifyClient {
                     NOTIFY_CLIENT_DOMAIN,
                     NOTIFY_SERVER_DOMAIN,
                 )
-                .map_err(|error| NotifyError::Authentication(error.to_string()))?,
+                .map_err(auth_error_to_notify)?,
             )
         } else {
             None
@@ -273,7 +468,7 @@ impl NotifyClient for UnixSocketNotifyClient {
         if let Some(session) = &authenticated_session {
             session
                 .write_frame(&mut stream, FrameSender::Client, &request)
-                .map_err(|error| NotifyError::Authentication(error.to_string()))?;
+                .map_err(auth_error_to_notify)?;
         } else {
             let mut writer = std::io::BufWriter::new(&stream);
             writer.write_all(&request).map_err(NotifyError::Write)?;
@@ -288,7 +483,7 @@ impl NotifyClient for UnixSocketNotifyClient {
                     FrameSender::Server,
                     MAX_RESPONSE_BYTES as usize,
                 )
-                .map_err(|error| NotifyError::Authentication(error.to_string()))?;
+                .map_err(auth_error_to_notify)?;
             String::from_utf8(response).map_err(|error| NotifyError::InvalidResponse {
                 body: format!("response is not UTF-8: {error}"),
             })?
@@ -298,14 +493,21 @@ impl NotifyClient for UnixSocketNotifyClient {
             let mut line = String::new();
             match limited.read_line(&mut line) {
                 Ok(0) => {
-                    return Err(NotifyError::InvalidResponse {
-                        body: "empty response".to_string(),
-                    });
+                    return Err(NotifyError::Read(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "notify acknowledgement ended before any response",
+                    )));
                 }
                 Ok(n) if n as u64 > MAX_RESPONSE_BYTES => {
                     return Err(NotifyError::InvalidResponse {
                         body: format!("response exceeds {MAX_RESPONSE_BYTES} byte limit"),
                     });
+                }
+                Ok(_) if !line.ends_with('\n') => {
+                    return Err(NotifyError::Read(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "notify acknowledgement ended before newline",
+                    )));
                 }
                 Ok(_) => {}
                 Err(e)
@@ -328,52 +530,52 @@ fn validate_authenticated_notify_endpoint(socket_path: &Path) -> Result<(), Noti
     let parent = socket_path
         .parent()
         .filter(|path| !path.as_os_str().is_empty())
-        .ok_or_else(|| endpoint_authentication_error("socket path has no parent directory"))?;
+        .ok_or_else(|| endpoint_untrusted_error("socket path has no parent directory"))?;
     let parent_metadata = std::fs::symlink_metadata(parent).map_err(|error| {
-        endpoint_authentication_error(format!(
-            "cannot inspect parent '{}': {error}",
-            parent.display()
-        ))
+        endpoint_stat_error(
+            format!("cannot inspect parent '{}': {error}", parent.display()),
+            &error,
+        )
     })?;
     if !parent_metadata.file_type().is_dir() {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "parent '{}' is not a directory",
             parent.display()
         )));
     }
     if parent_metadata.uid() != expected_uid {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "parent '{}' is not owned by the effective uid",
             parent.display()
         )));
     }
     if parent_metadata.mode() & 0o077 != 0 {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "parent '{}' must not grant group or other permissions",
             parent.display()
         )));
     }
 
     let socket_metadata = std::fs::symlink_metadata(socket_path).map_err(|error| {
-        endpoint_authentication_error(format!(
-            "cannot inspect socket '{}': {error}",
-            socket_path.display()
-        ))
+        endpoint_stat_error(
+            format!("cannot inspect socket '{}': {error}", socket_path.display()),
+            &error,
+        )
     })?;
     if !socket_metadata.file_type().is_socket() {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "endpoint '{}' is not a Unix socket",
             socket_path.display()
         )));
     }
     if socket_metadata.uid() != expected_uid {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "socket '{}' is not owned by the effective uid",
             socket_path.display()
         )));
     }
     if socket_metadata.mode() & 0o077 != 0 {
-        return Err(endpoint_authentication_error(format!(
+        return Err(endpoint_untrusted_error(format!(
             "socket '{}' must not grant group or other permissions",
             socket_path.display()
         )));
@@ -381,8 +583,22 @@ fn validate_authenticated_notify_endpoint(socket_path: &Path) -> Result<(), Noti
     Ok(())
 }
 
-fn endpoint_authentication_error(message: impl Into<String>) -> NotifyError {
-    NotifyError::Authentication(format!(
+/// A `stat` failure on the parent directory or the socket itself.
+///
+/// `NotFound` means the daemon has not created the endpoint yet — that is
+/// a startup ordering condition, not a trust violation, so it must stay
+/// retryable. Any other `stat` failure (notably `PermissionDenied`) means
+/// SkillFS cannot establish that the endpoint is safe and is permanent.
+fn endpoint_stat_error(message: impl Into<String>, error: &std::io::Error) -> NotifyError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        NotifyError::EndpointUnavailable(message.into())
+    } else {
+        endpoint_untrusted_error(message)
+    }
+}
+
+fn endpoint_untrusted_error(message: impl Into<String>) -> NotifyError {
+    NotifyError::EndpointUntrusted(format!(
         "notify socket endpoint is not trusted: {}",
         message.into()
     ))
@@ -521,6 +737,197 @@ impl NotifyClient for FailingNotifyClient {
     }
 }
 
+/// Failure mode injected by [`ScriptedNotifyClient`]. One representative
+/// error per retry class so tests assert on classification, not wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScriptedNotifyFailure {
+    /// `Connect(ConnectionRefused)` — daemon has not bound the socket.
+    /// Transient.
+    ConnectionRefused,
+    /// `EndpointUnavailable` — socket file does not exist yet. Transient.
+    SocketMissing,
+    /// `EndpointUntrusted` — socket mode or owner is unsafe. Permanent.
+    UntrustedEndpoint,
+    /// `AuthInconclusive` — the peer closed the connection while SkillFS
+    /// waited for `auth.ok`, which is what both a daemon restart and a
+    /// refused client proof look like. Ambiguous (bounded retry).
+    HandshakeEof,
+    /// `AuthRejected` — HMAC proof mismatch reported explicitly. Permanent.
+    AuthRejected,
+    /// `Rejected` — daemon answered but refused the request. Permanent.
+    DaemonRejected,
+}
+
+impl ScriptedNotifyFailure {
+    fn to_error(self) -> NotifyError {
+        match self {
+            Self::ConnectionRefused => NotifyError::Connect(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                "test: daemon not listening",
+            )),
+            Self::SocketMissing => {
+                NotifyError::EndpointUnavailable("test: socket not created yet".to_string())
+            }
+            Self::UntrustedEndpoint => NotifyError::EndpointUntrusted(
+                "test: socket must not grant group or other permissions".to_string(),
+            ),
+            Self::HandshakeEof => {
+                // Exactly what auth_error_to_notify produces for the EOF
+                // that read_frame reports as AuthError::InvalidFrame.
+                auth_error_to_notify(super::auth::AuthError::InvalidFrame)
+            }
+            Self::AuthRejected => NotifyError::AuthRejected(
+                "test: authentication proof verification failed".to_string(),
+            ),
+            Self::DaemonRejected => NotifyError::Rejected {
+                body: r#"{"ok":false,"error":{"code":"unknown_skill"}}"#.to_string(),
+            },
+        }
+    }
+}
+
+/// Test client that fails its first `failures` attempts with a chosen error
+/// and acknowledges every attempt after that. Records attempt count and
+/// accepted events so tests can assert both retry cadence and convergence.
+#[derive(Debug)]
+pub struct ScriptedNotifyClient {
+    failure: ScriptedNotifyFailure,
+    failures: u32,
+    attempts: AtomicU64,
+    events: Mutex<Vec<CapturedNotify>>,
+}
+
+impl ScriptedNotifyClient {
+    /// Fail the first `failures` attempts, then succeed.
+    pub fn new(failure: ScriptedNotifyFailure, failures: u32) -> Self {
+        Self {
+            failure,
+            failures,
+            attempts: AtomicU64::new(0),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Never succeed.
+    pub fn always_failing(failure: ScriptedNotifyFailure) -> Self {
+        Self::new(failure, u32::MAX)
+    }
+
+    /// Total `send` calls received, including failed ones.
+    pub fn attempts(&self) -> u64 {
+        self.attempts.load(Ordering::Relaxed)
+    }
+
+    /// Events from the attempts that succeeded.
+    pub fn events(&self) -> Vec<CapturedNotify> {
+        self.events.lock().clone()
+    }
+}
+
+impl NotifyClient for ScriptedNotifyClient {
+    fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+        let attempt = self.attempts.fetch_add(1, Ordering::Relaxed);
+        if attempt < u64::from(self.failures) {
+            return Err(self.failure.to_error());
+        }
+        self.events.lock().push(CapturedNotify {
+            schema_version: event.params.schema_version,
+            skill_id: event.params.skill_id.clone(),
+            event_kind: event.params.event_kind.clone(),
+            paths: event.params.paths.clone(),
+            canonical_skill_dir: event.params.canonical_skill_dir.clone(),
+        });
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile retry scheduling
+// ---------------------------------------------------------------------------
+
+/// Exponential backoff with jitter for reconcile retries.
+///
+/// `attempts` is the number of failed deliveries so far, so the first
+/// retry passes `1`. The un-jittered interval is
+/// `RECONCILE_RETRY_BASE_MS * 2^(attempts - 1)` capped at
+/// `RECONCILE_RETRY_MAX_MS`; `jitter_permille` in `[0, 1000)` then spreads
+/// the result uniformly over `±RECONCILE_RETRY_JITTER_PCT` of that
+/// interval. The jitter source is a parameter so the schedule is
+/// deterministically testable.
+///
+/// The final clamp keeps the result inside `[1, RECONCILE_RETRY_MAX_MS]`,
+/// so once the interval saturates the cap the jitter becomes one-sided
+/// (downward only). That still decorrelates many skills retrying against
+/// one daemon, which is the point of the jitter.
+fn reconcile_retry_delay(attempts: u32, jitter_permille: u64) -> Duration {
+    let shift = attempts.saturating_sub(1).min(RECONCILE_RETRY_MAX_SHIFT);
+    let base = RECONCILE_RETRY_BASE_MS
+        .saturating_mul(1_u64 << shift)
+        .min(RECONCILE_RETRY_MAX_MS);
+    let span = base * RECONCILE_RETRY_JITTER_PCT / 100;
+    // Map [0, 1000) onto [-span, +span) without signed arithmetic.
+    let offset = span * 2 * jitter_permille.min(999) / 1000;
+    let jittered = base + offset - span;
+    Duration::from_millis(jittered.clamp(1, RECONCILE_RETRY_MAX_MS))
+}
+
+/// Uniform jitter draw in `[0, 1000)`.
+///
+/// An entropy failure degrades to the midpoint (no jitter) rather than
+/// failing the retry — losing jitter is strictly better than losing
+/// convergence.
+fn random_permille() -> u64 {
+    let mut bytes = [0_u8; 2];
+    if getrandom::fill(&mut bytes).is_err() {
+        return 500;
+    }
+    u64::from(u16::from_le_bytes(bytes)) % 1000
+}
+
+/// Cumulative notify delivery counters plus the current pending gauge.
+///
+/// `attempted`, `succeeded`, and `failed` are monotonic counters over the
+/// controller's lifetime; `pending` is a gauge sampled at snapshot time.
+///
+/// A skill whose reconcile fails transiently increments `failed` **and**
+/// remains counted in `pending`, because it is still queued for another
+/// attempt. So `attempted != succeeded + failed` only while an attempt is
+/// in flight, and `pending` is not derivable from the counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct NotifyMetricsSnapshot {
+    /// Delivery attempts made, counting every retry separately.
+    pub attempted: u64,
+    /// Attempts the daemon acknowledged.
+    pub succeeded: u64,
+    /// Attempts that failed, counting every retry separately.
+    pub failed: u64,
+    /// Skills currently *queued* for a delivery attempt.
+    ///
+    /// A skill whose attempt is in flight right now is not counted: the
+    /// worker drains an entry out of the queue before dispatching it and
+    /// only puts it back if the attempt failed retryably. So this reads 0
+    /// during the send window of the last unconverged skill. Alert on it
+    /// being non-zero over a window, not on a single sample.
+    pub pending: u64,
+}
+
+/// What the worker should do with an entry after one delivery attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendOutcome {
+    /// The daemon acknowledged; the entry is done.
+    Delivered,
+    /// Transient failure; a reconcile entry should be requeued with
+    /// backoff, without an attempt limit. Ordinary mutations are still
+    /// dropped.
+    Retry,
+    /// Ambiguous failure; a reconcile entry should be requeued only while
+    /// the shared endpoint budget is under
+    /// [`RECONCILE_AMBIGUOUS_RETRY_LIMIT`].
+    RetryBounded,
+    /// Permanent failure; requeueing cannot help.
+    Failed,
+}
+
 // ---------------------------------------------------------------------------
 // NotifyController (debounce + dispatch)
 // ---------------------------------------------------------------------------
@@ -540,7 +947,21 @@ struct NotifyInner {
     protocol_event_root: PathBuf,
     debounce: Duration,
     timeout_ms: u64,
+    /// Keyed by canonical Skill identity (`skill_id`), so an entry that is
+    /// requeued after a failed reconcile deduplicates against any
+    /// mutation queued in the meantime.
     pending: Mutex<HashMap<String, NotifyPendingState>>,
+    /// Authentication ambiguity is an endpoint property: every Skill uses
+    /// the same socket and key. This gate ensures only one Skill probes the
+    /// endpoint per backoff round instead of multiplying retries by the
+    /// number of pending Skills.
+    endpoint_retry: Mutex<EndpointRetryState>,
+    /// Set before the shutdown command is sent. Blocks requeues so a
+    /// permanently unreachable daemon cannot keep the worker alive.
+    shutdown: AtomicBool,
+    attempted: AtomicU64,
+    succeeded: AtomicU64,
+    failed: AtomicU64,
     notify: TokioNotify,
     sender: mpsc::UnboundedSender<NotifyCommand>,
 }
@@ -551,6 +972,41 @@ struct NotifyPendingState {
     event_kind: NotifyEventKind,
     paths: HashSet<String>,
     fire_at: Instant,
+    /// Failed delivery attempts already made for this entry. Only
+    /// reconcile entries are requeued, so this stays `0` for ordinary
+    /// FUSE mutations.
+    attempts: u32,
+    /// Endpoint retry cycle that owns this entry. An older drained batch
+    /// must not resume after a later explicit enqueue reopens an exhausted
+    /// authentication gate.
+    reconcile_generation: u64,
+}
+
+#[derive(Debug, Default)]
+struct EndpointRetryState {
+    ambiguous_failures: u32,
+    retry_at: Option<Instant>,
+    exhausted: bool,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointGateAction {
+    Attempt,
+    DeferUntil(Instant),
+    Abandon,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AmbiguousFailureAction {
+    RetryAt {
+        retry_at: Instant,
+        ambiguous_failures: u32,
+    },
+    Exhausted {
+        ambiguous_failures: u32,
+    },
+    Stale,
 }
 
 #[derive(Debug)]
@@ -616,6 +1072,41 @@ impl NotifyController {
         )
     }
 
+    /// Build a controller with **no background worker**, for unit tests that
+    /// need to own dispatch timing.
+    ///
+    /// The `flush_*_for_testing` helpers drain the same `pending` map the
+    /// worker does, so with a live worker present both race for entries —
+    /// and `enqueue_startup_reconcile` makes that race easy to lose,
+    /// because it queues at `fire_at = now` and wakes the worker
+    /// immediately regardless of the debounce. A test that asserts on
+    /// `pending_len`, attempt counts, or backoff state must therefore be
+    /// the only thing draining the map.
+    ///
+    /// Tests covering the production dispatch path should use a normal
+    /// constructor instead and assert only on eventual convergence.
+    #[cfg(test)]
+    fn new_for_testing_without_worker(
+        client: Arc<dyn NotifyClient>,
+        canonical_root: impl Into<PathBuf>,
+        protocol_event_root: impl Into<PathBuf>,
+        debounce: Duration,
+        timeout_ms: u64,
+        protocol_event_writer: Arc<dyn ProtocolEventWriter>,
+        reload_controller: Option<Arc<ActivationReloadController>>,
+    ) -> Arc<Self> {
+        Self::build(
+            client,
+            canonical_root,
+            protocol_event_root,
+            debounce,
+            timeout_ms,
+            protocol_event_writer,
+            reload_controller,
+            false,
+        )
+    }
+
     fn new_full(
         client: Arc<dyn NotifyClient>,
         canonical_root: impl Into<PathBuf>,
@@ -624,6 +1115,29 @@ impl NotifyController {
         timeout_ms: u64,
         protocol_event_writer: Arc<dyn ProtocolEventWriter>,
         reload_controller: Option<Arc<ActivationReloadController>>,
+    ) -> Arc<Self> {
+        Self::build(
+            client,
+            canonical_root,
+            protocol_event_root,
+            debounce,
+            timeout_ms,
+            protocol_event_writer,
+            reload_controller,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        client: Arc<dyn NotifyClient>,
+        canonical_root: impl Into<PathBuf>,
+        protocol_event_root: impl Into<PathBuf>,
+        debounce: Duration,
+        timeout_ms: u64,
+        protocol_event_writer: Arc<dyn ProtocolEventWriter>,
+        reload_controller: Option<Arc<ActivationReloadController>>,
+        spawn_worker: bool,
     ) -> Arc<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
         let inner = Arc::new(NotifyInner {
@@ -636,9 +1150,17 @@ impl NotifyController {
             debounce,
             timeout_ms,
             pending: Mutex::new(HashMap::new()),
+            endpoint_retry: Mutex::new(EndpointRetryState::default()),
+            shutdown: AtomicBool::new(false),
+            attempted: AtomicU64::new(0),
+            succeeded: AtomicU64::new(0),
+            failed: AtomicU64::new(0),
             notify: TokioNotify::new(),
             sender: tx,
         });
+        if !spawn_worker {
+            return Arc::new(Self { inner });
+        }
         let worker_inner = inner.clone();
         match Handle::try_current() {
             Ok(handle) => {
@@ -678,6 +1200,11 @@ impl NotifyController {
 
     /// Record a FUSE mutation observation. Returns `true` when accepted,
     /// `false` when filtered (skill-discover, `.skill-meta/**`, lifecycle).
+    ///
+    /// Mutation delivery stays best-effort and single-attempt: unlike
+    /// reconcile, a failed mutation notify is not requeued. The daemon
+    /// re-derives the same state from the next reconcile or the next
+    /// mutation in the same skill.
     pub fn observe(
         &self,
         skill_id: &str,
@@ -696,6 +1223,7 @@ impl NotifyController {
         let event_kind = NotifyEventKind::from_mutation_kind(kind);
         let now = Instant::now();
         let fire_at = now + self.inner.debounce;
+        let reconcile_generation = self.inner.endpoint_retry.lock().generation;
         {
             let mut pending = self.inner.pending.lock();
             let entry = pending
@@ -705,13 +1233,27 @@ impl NotifyController {
                     event_kind,
                     paths: HashSet::new(),
                     fire_at,
+                    attempts: 0,
+                    reconcile_generation,
                 });
-            entry.fire_at = fire_at;
-            entry.event_kind = event_kind;
-            if let Some(rel) = relative_path {
-                let path_str = rel.to_string_lossy().to_string();
-                if !path_str.is_empty() {
-                    entry.paths.insert(path_str);
+            // A queued reconcile is a full rescan with empty `paths`, so it
+            // already subsumes this single-path mutation. Leave the entry
+            // completely alone: overwriting `event_kind` would downgrade the
+            // rescan into a partial notify and discard its retry state, and
+            // touching `fire_at` would either defeat the reconcile backoff
+            // or delay the reconcile. Nothing is lost — whenever the
+            // reconcile does fire, it covers this mutation too.
+            if entry.event_kind != NotifyEventKind::Reconcile {
+                // Trailing-edge debounce: every mutation pushes the deadline
+                // out, so a continuous write burst dispatches once after it
+                // goes quiet rather than mid-write.
+                entry.fire_at = fire_at;
+                entry.event_kind = event_kind;
+                if let Some(rel) = relative_path {
+                    let path_str = rel.to_string_lossy().to_string();
+                    if !path_str.is_empty() {
+                        entry.paths.insert(path_str);
+                    }
                 }
             }
         }
@@ -731,16 +1273,66 @@ impl NotifyController {
     }
 
     /// Drain and send all pending notifications synchronously. Test helper.
+    ///
+    /// Mirrors the worker: a transiently failed reconcile is requeued with
+    /// backoff, so the returned count is the number of *attempts* made,
+    /// not the number of skills that converged. Use
+    /// [`Self::flush_until_delivered_for_testing`] to drive retries to
+    /// completion.
     pub fn flush_for_testing(&self) -> usize {
+        let attempted_before = self.inner.attempted.load(Ordering::Relaxed);
         let drained = self
             .inner
             .drain_due(Instant::now() + self.inner.debounce * 2);
-        let mut count = 0;
         for state in drained {
-            self.inner.send_one(state);
-            count += 1;
+            self.inner.dispatch_one(state);
         }
-        count
+        self.inner
+            .attempted
+            .load(Ordering::Relaxed)
+            .saturating_sub(attempted_before) as usize
+    }
+
+    /// Repeatedly drain and send every pending entry, ignoring backoff
+    /// deadlines, until nothing is pending or `max_rounds` is exhausted.
+    /// Test helper for retry convergence; returns the total number of
+    /// delivery attempts made.
+    pub fn flush_until_delivered_for_testing(&self, max_rounds: usize) -> usize {
+        let attempted_before = self.inner.attempted.load(Ordering::Relaxed);
+        for _ in 0..max_rounds {
+            // A far-future deadline sweeps up entries still inside their
+            // backoff window so tests do not have to sleep.
+            let drained = self
+                .inner
+                .drain_due(Instant::now() + Duration::from_secs(86_400));
+            if drained.is_empty() {
+                break;
+            }
+            for state in drained {
+                self.inner.dispatch_one(state);
+            }
+        }
+        self.inner
+            .attempted
+            .load(Ordering::Relaxed)
+            .saturating_sub(attempted_before) as usize
+    }
+
+    /// Number of skills currently queued and awaiting a successful
+    /// delivery.
+    pub fn pending_len(&self) -> usize {
+        self.inner.pending.lock().len()
+    }
+
+    /// Snapshot the delivery counters and the pending gauge. See
+    /// [`NotifyMetricsSnapshot`] for how the four values relate.
+    pub fn metrics(&self) -> NotifyMetricsSnapshot {
+        NotifyMetricsSnapshot {
+            attempted: self.inner.attempted.load(Ordering::Relaxed),
+            succeeded: self.inner.succeeded.load(Ordering::Relaxed),
+            failed: self.inner.failed.load(Ordering::Relaxed),
+            pending: self.inner.pending.lock().len() as u64,
+        }
     }
 
     /// Emit startup reconcile events for all given skills. Bypasses
@@ -748,12 +1340,15 @@ impl NotifyController {
     /// `eventKind="reconcile"` protocol event and one notify. Filtered
     /// skills (skill-discover, lifecycle roots) are skipped.
     ///
-    /// **Blocking**: each `client.send()` may wait up to `timeout_ms`
-    /// per skill. Production callers should use
-    /// [`Self::spawn_startup_reconcile`] to avoid blocking the startup
-    /// path.
+    /// **Blocking and single-attempt**: each `client.send()` may wait up
+    /// to `timeout_ms` per skill, and a failed send is only logged. The
+    /// returned count is the number of skills *attempted*, not the number
+    /// the daemon acknowledged.
     ///
-    /// Returns the number of reconcile events emitted.
+    /// Production mount startup must use
+    /// [`Self::enqueue_startup_reconcile`] instead: it neither blocks the
+    /// caller nor drops a delivery that failed because the daemon socket
+    /// was not ready yet.
     pub fn emit_startup_reconcile(&self, skill_ids: &[String]) -> usize {
         let mut count = 0;
         for skill_id in skill_ids {
@@ -781,13 +1376,17 @@ impl NotifyController {
                 self.inner.timeout_ms,
             );
 
+            self.inner.attempted.fetch_add(1, Ordering::Relaxed);
             if let Err(e) = self.inner.client.send(&event) {
+                self.inner.failed.fetch_add(1, Ordering::Relaxed);
                 warn!(
                     skill = %skill_id,
                     error = %e,
+                    retry_class = ?e.retry_class(),
                     "reconcile: failed to send reconcile notification"
                 );
             } else {
+                self.inner.succeeded.fetch_add(1, Ordering::Relaxed);
                 debug!(
                     skill = %skill_id,
                     "reconcile: startup reconcile notification sent"
@@ -800,25 +1399,69 @@ impl NotifyController {
         count
     }
 
-    /// Non-blocking variant of [`Self::emit_startup_reconcile`].
+    /// Queue a startup reconcile for every eligible skill and let the
+    /// background worker own delivery.
     ///
-    /// Spawns a background thread that sends reconcile events for each
-    /// eligible skill. The caller is not blocked by daemon socket
-    /// latency. The thread is detached — its lifetime is bounded by the
-    /// `Arc<NotifyController>` it holds.
-    pub fn spawn_startup_reconcile(self: &Arc<Self>, skill_names: Vec<String>) {
-        let ctrl = self.clone();
-        let spawn_result = std::thread::Builder::new()
-            .name("skillfs-reconcile".to_string())
-            .spawn(move || {
-                ctrl.emit_startup_reconcile(&skill_names);
-            });
-        if let Err(e) = spawn_result {
-            warn!(
-                error = %e,
-                "reconcile: failed to spawn startup reconcile thread"
-            );
+    /// Each eligible skill is written into the shared pending map as an
+    /// immediately due `eventKind="reconcile"` entry with empty `paths`,
+    /// deduplicated by canonical Skill identity. The worker then keeps
+    /// retrying entries with exponential backoff and jitter for as long as
+    /// delivery fails transiently — daemon socket not created yet,
+    /// connection refused, socket recreated mid-handshake — so a mount
+    /// that starts before the daemon still converges without an external
+    /// trigger. An inconclusive authentication handshake is retried through
+    /// a controller-wide endpoint gate: one Skill probes per backoff round,
+    /// and the current reconcile set is abandoned after the bounded budget
+    /// is exhausted. Permanent failures (untrusted endpoint, explicit
+    /// authentication refusal, daemon rejection, malformed response) are
+    /// logged at `error` and dropped because an identical retry can only
+    /// fail identically.
+    ///
+    /// This replaces the previous detached one-shot thread. Enqueueing
+    /// touches no socket and spawns no thread, so it neither blocks mount
+    /// startup nor holds an `Arc<NotifyController>` that would stop `Drop`
+    /// from triggering shutdown.
+    ///
+    /// Returns the number of newly inserted pending entries after identity
+    /// deduplication. Existing entries may still be upgraded to reconcile,
+    /// so the return value is not the total queue depth or a delivery count.
+    /// Read [`Self::metrics`] for the current depth and delivery outcomes.
+    pub fn enqueue_startup_reconcile(&self, skill_ids: &[String]) -> usize {
+        let now = Instant::now();
+        let has_eligible = skill_ids
+            .iter()
+            .any(|skill_id| is_notify_eligible(skill_id));
+        let reconcile_generation = has_eligible
+            .then(|| self.inner.start_new_reconcile_cycle_if_exhausted())
+            .unwrap_or_default();
+
+        let mut newly_queued = 0;
+        let mut accepted = 0;
+        for skill_id in skill_ids {
+            if !is_notify_eligible(skill_id) {
+                continue;
+            }
+            accepted += 1;
+            if self.inner.merge_pending(NotifyPendingState {
+                skill_id: skill_id.clone(),
+                event_kind: NotifyEventKind::Reconcile,
+                paths: HashSet::new(),
+                fire_at: now,
+                attempts: 0,
+                reconcile_generation,
+            }) {
+                newly_queued += 1;
+            }
         }
+        if accepted > 0 {
+            let _ = self.inner.sender.send(NotifyCommand::Wakeup);
+            self.inner.notify.notify_one();
+        }
+        info!(
+            accepted,
+            newly_queued, "reconcile: startup reconcile queued for retrying delivery"
+        );
+        newly_queued
     }
 
     /// A5: inject an activation watcher registrar so that skills observed
@@ -835,21 +1478,23 @@ impl NotifyController {
     /// The worker picks it up on its next iteration.
     pub fn enqueue_immediate(&self, skill_id: &str, kind: MutationKind, paths: Vec<String>) {
         let event_kind = NotifyEventKind::from_mutation_kind(kind);
-        let state = NotifyPendingState {
+        let reconcile_generation = self.inner.endpoint_retry.lock().generation;
+        self.inner.merge_pending(NotifyPendingState {
             skill_id: skill_id.to_string(),
             event_kind,
             paths: paths.into_iter().collect(),
             fire_at: Instant::now(),
-        };
-        self.inner
-            .pending
-            .lock()
-            .insert(skill_id.to_string(), state);
+            attempts: 0,
+            reconcile_generation,
+        });
         let _ = self.inner.sender.send(NotifyCommand::Wakeup);
         self.inner.notify.notify_one();
     }
 
     pub fn shutdown(&self) {
+        // Set the flag before signalling so an in-flight attempt that
+        // fails during shutdown cannot requeue itself.
+        self.inner.shutdown.store(true, Ordering::Release);
         let _ = self.inner.sender.send(NotifyCommand::Shutdown);
         self.inner.notify.notify_waiters();
     }
@@ -866,6 +1511,21 @@ impl Drop for NotifyController {
 }
 
 impl NotifyInner {
+    /// A later explicit startup reconcile is a new operator-visible cycle.
+    /// Re-open only an exhausted gate; repeated enqueues during an active
+    /// retry cycle must not replenish the wrong-key budget.
+    fn start_new_reconcile_cycle_if_exhausted(&self) -> u64 {
+        let mut endpoint_retry = self.endpoint_retry.lock();
+        if endpoint_retry.exhausted {
+            endpoint_retry.ambiguous_failures = 0;
+            endpoint_retry.retry_at = None;
+            endpoint_retry.exhausted = false;
+            endpoint_retry.generation = endpoint_retry.generation.saturating_add(1);
+            info!("reconcile: reopening exhausted authentication retry gate for a new cycle");
+        }
+        endpoint_retry.generation
+    }
+
     fn drain_due(&self, deadline: Instant) -> Vec<NotifyPendingState> {
         let mut due = Vec::new();
         let mut guard = self.pending.lock();
@@ -886,7 +1546,312 @@ impl NotifyInner {
         self.pending.lock().values().map(|s| s.fire_at).min()
     }
 
-    fn send_one(&self, state: NotifyPendingState) {
+    /// Merge an incoming entry into the pending map, deduplicated by
+    /// canonical Skill identity.
+    ///
+    /// Reconcile dominates: if either side is a reconcile the merged entry
+    /// stays a reconcile with empty `paths`, because a reconcile is a full
+    /// rescan of the current on-disk state and so already covers any path
+    /// list. That is what makes requeueing a failed reconcile safe when a
+    /// mutation landed on the same skill while the reconcile was in
+    /// flight — the requeue merges instead of overwriting, and neither
+    /// request is lost.
+    ///
+    /// `fire_at` takes the incoming entry's deadline, matching the
+    /// overwrite semantics this had before it became a merge. For a
+    /// reconcile requeue that is the backoff deadline, so the backoff is
+    /// honoured rather than being short-circuited by whatever mutation
+    /// happened to be queued. Delaying that mutation costs nothing: the
+    /// backoff only exists because the daemon is unreachable, so an earlier
+    /// attempt would fail anyway. `attempts` takes the larger so backoff
+    /// keeps growing across a merge instead of restarting at zero.
+    ///
+    /// Returns `true` only when the Skill identity was newly inserted.
+    fn merge_pending(&self, incoming: NotifyPendingState) -> bool {
+        let mut pending = self.pending.lock();
+        match pending.get_mut(&incoming.skill_id) {
+            Some(existing) => {
+                if incoming.reconcile_generation < existing.reconcile_generation {
+                    return false;
+                }
+                if incoming.reconcile_generation > existing.reconcile_generation {
+                    *existing = incoming;
+                    return false;
+                }
+                existing.fire_at = incoming.fire_at;
+                existing.attempts = existing.attempts.max(incoming.attempts);
+                if existing.event_kind == NotifyEventKind::Reconcile
+                    || incoming.event_kind == NotifyEventKind::Reconcile
+                {
+                    existing.event_kind = NotifyEventKind::Reconcile;
+                    existing.paths.clear();
+                } else {
+                    existing.event_kind = incoming.event_kind;
+                    existing.paths.extend(incoming.paths);
+                }
+                false
+            }
+            None => {
+                pending.insert(incoming.skill_id.clone(), incoming);
+                true
+            }
+        }
+    }
+
+    /// Decide whether this scheduled reconcile may probe the endpoint.
+    ///
+    /// Comparing scheduled deadlines rather than wall-clock time keeps the
+    /// test drain helpers deterministic while preserving production timing:
+    /// an entry from the previous batch has an older deadline and therefore
+    /// cannot bypass a gate advanced by the first ambiguous failure.
+    fn endpoint_gate_action(&self, generation: u64, scheduled_at: Instant) -> EndpointGateAction {
+        let endpoint_retry = self.endpoint_retry.lock();
+        if generation != endpoint_retry.generation || endpoint_retry.exhausted {
+            return EndpointGateAction::Abandon;
+        }
+        match endpoint_retry.retry_at {
+            Some(retry_at) if scheduled_at < retry_at => EndpointGateAction::DeferUntil(retry_at),
+            _ => EndpointGateAction::Attempt,
+        }
+    }
+
+    /// Record one endpoint-wide ambiguous authentication result.
+    fn record_ambiguous_failure(&self, generation: u64) -> AmbiguousFailureAction {
+        let mut endpoint_retry = self.endpoint_retry.lock();
+        if generation != endpoint_retry.generation || endpoint_retry.exhausted {
+            return AmbiguousFailureAction::Stale;
+        }
+        endpoint_retry.ambiguous_failures = endpoint_retry.ambiguous_failures.saturating_add(1);
+        let ambiguous_failures = endpoint_retry.ambiguous_failures;
+        if ambiguous_failures >= RECONCILE_AMBIGUOUS_RETRY_LIMIT {
+            endpoint_retry.retry_at = None;
+            endpoint_retry.exhausted = true;
+            drop(endpoint_retry);
+
+            // Entries already drained by the worker observe `exhausted` in
+            // `endpoint_gate_action`; entries not yet drained are removed
+            // here. Together those paths stop the whole endpoint without
+            // performing one extra handshake per Skill.
+            self.abandon_reconcile_generation(generation);
+            AmbiguousFailureAction::Exhausted { ambiguous_failures }
+        } else {
+            let delay = reconcile_retry_delay(ambiguous_failures, random_permille());
+            let retry_at = Instant::now() + delay;
+            endpoint_retry.retry_at = Some(retry_at);
+            AmbiguousFailureAction::RetryAt {
+                retry_at,
+                ambiguous_failures,
+            }
+        }
+    }
+
+    /// Remove only reconciles owned by the exhausted retry cycle.
+    ///
+    /// The endpoint lock is intentionally released before taking `pending`.
+    /// A concurrent explicit enqueue may reopen the gate in that interval,
+    /// so deleting every reconcile would erase the new generation too.
+    fn abandon_reconcile_generation(&self, generation: u64) {
+        self.pending.lock().retain(|_, state| {
+            state.event_kind != NotifyEventKind::Reconcile
+                || state.reconcile_generation != generation
+        });
+    }
+
+    /// Any daemon acknowledgement proves that the shared endpoint and key
+    /// are healthy, so the next pending Skill need not wait behind the gate.
+    fn reset_endpoint_retry_after_ack(&self) {
+        let mut endpoint_retry = self.endpoint_retry.lock();
+        if endpoint_retry.ambiguous_failures != 0
+            || endpoint_retry.retry_at.is_some()
+            || endpoint_retry.exhausted
+        {
+            if endpoint_retry.exhausted {
+                // The exhausted cycle already abandoned its drained batch.
+                // A later mutation ACK may prove the endpoint recovered,
+                // but must not resurrect those obsolete entries.
+                endpoint_retry.generation = endpoint_retry.generation.saturating_add(1);
+            }
+            endpoint_retry.ambiguous_failures = 0;
+            endpoint_retry.retry_at = None;
+            endpoint_retry.exhausted = false;
+            debug!("reconcile: daemon acknowledgement cleared authentication retry gate");
+        }
+    }
+
+    /// Put a reconcile back without recording another send attempt.
+    fn defer_reconcile_until(&self, mut state: NotifyPendingState, retry_at: Instant) {
+        if self.shutdown.load(Ordering::Acquire) {
+            return;
+        }
+        state.fire_at = retry_at;
+        self.merge_pending(state);
+        let _ = self.sender.send(NotifyCommand::Wakeup);
+        self.notify.notify_one();
+    }
+
+    /// Requeue a reconcile whose delivery failed transiently.
+    ///
+    /// `attempts` is the running failure count including the attempt that
+    /// just failed. No-op once shutdown has been signalled, so an
+    /// unreachable daemon cannot keep the worker — and with it the
+    /// controller's private runtime thread — alive indefinitely.
+    fn requeue_reconcile(&self, skill_id: &str, attempts: u32, reconcile_generation: u64) {
+        if self.shutdown.load(Ordering::Acquire) {
+            debug!(
+                skill = %skill_id,
+                "reconcile: shutdown in progress; not requeueing"
+            );
+            return;
+        }
+        if self.endpoint_retry.lock().generation != reconcile_generation {
+            debug!(
+                skill = %skill_id,
+                reconcile_generation,
+                "reconcile: not requeueing an obsolete retry cycle"
+            );
+            return;
+        }
+        let delay = reconcile_retry_delay(attempts, random_permille());
+        self.merge_pending(NotifyPendingState {
+            skill_id: skill_id.to_string(),
+            event_kind: NotifyEventKind::Reconcile,
+            paths: HashSet::new(),
+            fire_at: Instant::now() + delay,
+            attempts,
+            reconcile_generation,
+        });
+        warn!(
+            skill = %skill_id,
+            attempts,
+            retry_in_ms = delay.as_millis() as u64,
+            "reconcile: delivery failed transiently; skill stays degraded \
+             until the daemon acknowledges a reconcile"
+        );
+        let _ = self.sender.send(NotifyCommand::Wakeup);
+        self.notify.notify_one();
+    }
+
+    /// Requeue the single endpoint probe at the shared authentication
+    /// deadline. Other Skills are deferred to the same deadline without a
+    /// send attempt when the worker reaches them.
+    fn requeue_ambiguous_probe(
+        &self,
+        skill_id: &str,
+        attempts: u32,
+        retry_at: Instant,
+        ambiguous_failures: u32,
+        reconcile_generation: u64,
+    ) {
+        if self.shutdown.load(Ordering::Acquire) {
+            return;
+        }
+        self.merge_pending(NotifyPendingState {
+            skill_id: skill_id.to_string(),
+            event_kind: NotifyEventKind::Reconcile,
+            paths: HashSet::new(),
+            fire_at: retry_at,
+            attempts,
+            reconcile_generation,
+        });
+        warn!(
+            skill = %skill_id,
+            ambiguous_failures,
+            limit = RECONCILE_AMBIGUOUS_RETRY_LIMIT,
+            retry_in_ms = retry_at.saturating_duration_since(Instant::now()).as_millis() as u64,
+            "reconcile: authentication outcome inconclusive; endpoint probe queued"
+        );
+        let _ = self.sender.send(NotifyCommand::Wakeup);
+        self.notify.notify_one();
+    }
+
+    /// Deliver one drained entry and apply the retry policy to the result.
+    ///
+    /// Retry is deliberately scoped to reconcile. Ordinary FUSE mutations
+    /// keep their best-effort, single-attempt semantics: the daemon
+    /// re-derives the same state from the next reconcile or the next
+    /// mutation, and requeueing them would change the latency and
+    /// ordering guarantees of the hot write path.
+    fn dispatch_one(&self, state: NotifyPendingState) {
+        let skill_id = state.skill_id.clone();
+        let is_reconcile = state.event_kind == NotifyEventKind::Reconcile;
+        let attempts = state.attempts;
+        let reconcile_generation = state.reconcile_generation;
+        if !is_reconcile {
+            // Mutations are best-effort and single-attempt regardless of
+            // outcome.
+            if self.send_one(state) == SendOutcome::Delivered {
+                self.reset_endpoint_retry_after_ack();
+            }
+            return;
+        }
+
+        match self.endpoint_gate_action(reconcile_generation, state.fire_at) {
+            EndpointGateAction::Attempt => {}
+            EndpointGateAction::DeferUntil(retry_at) => {
+                self.defer_reconcile_until(state, retry_at);
+                return;
+            }
+            EndpointGateAction::Abandon => {
+                debug!(
+                    skill = %skill_id,
+                    "reconcile: authentication retry gate exhausted; abandoning queued skill"
+                );
+                return;
+            }
+        }
+
+        let attempted = attempts + 1;
+        match self.send_one(state) {
+            SendOutcome::Delivered => self.reset_endpoint_retry_after_ack(),
+            SendOutcome::Retry => {
+                self.requeue_reconcile(&skill_id, attempted, reconcile_generation)
+            }
+            SendOutcome::RetryBounded => {
+                match self.record_ambiguous_failure(reconcile_generation) {
+                    AmbiguousFailureAction::RetryAt {
+                        retry_at,
+                        ambiguous_failures,
+                    } => self.requeue_ambiguous_probe(
+                        &skill_id,
+                        attempted,
+                        retry_at,
+                        ambiguous_failures,
+                        reconcile_generation,
+                    ),
+                    AmbiguousFailureAction::Exhausted { ambiguous_failures } => {
+                        tracing::error!(
+                            skill = %skill_id,
+                            attempts = attempted,
+                            ambiguous_failures,
+                            limit = RECONCILE_AMBIGUOUS_RETRY_LIMIT,
+                            "reconcile: endpoint authentication retry budget exhausted; \
+                             check the notify authentication key — pending startup \
+                            reconciles will not converge"
+                        );
+                    }
+                    AmbiguousFailureAction::Stale => {
+                        debug!(
+                            skill = %skill_id,
+                            reconcile_generation,
+                            "reconcile: ignoring ambiguous result from an obsolete retry cycle"
+                        );
+                    }
+                }
+            }
+            SendOutcome::Failed => {
+                // Deliberately not requeued: an identical retry would
+                // reproduce the same refusal, so this needs an operator.
+                tracing::error!(
+                    skill = %skill_id,
+                    attempts = attempted,
+                    "reconcile: delivery failed permanently; skill will not \
+                     converge until the notify endpoint or daemon is repaired"
+                );
+            }
+        }
+    }
+
+    fn send_one(&self, state: NotifyPendingState) -> SendOutcome {
         let canonical_skill_dir = self.canonical_root.join(&state.skill_id);
         let canonical_skill_dir = canonical_skill_dir.to_string_lossy().to_string();
         let protocol_skill_dir = self.protocol_event_root.join(&state.skill_id);
@@ -925,43 +1890,75 @@ impl NotifyInner {
             self.timeout_ms,
         );
 
-        if let Err(e) = self.client.send(&event) {
-            warn!(
-                skill = %state.skill_id,
-                error = %e,
-                "notify: failed to send change notification; \
-                 current activation mapping unchanged"
-            );
-            // A5: daemon unreachable — register for watcher convergence
-            // so a later daemon repair can still be observed.
-            self.register_with_watcher(&state.skill_id);
-        } else {
-            debug!(
-                skill = %state.skill_id,
-                event_kind = state.event_kind.as_str(),
-                "notify: change notification accepted"
-            );
-        }
+        self.attempted.fetch_add(1, Ordering::Relaxed);
+        let (outcome, business_request_not_sent) = match self.client.send(&event) {
+            Err(e) => {
+                self.failed.fetch_add(1, Ordering::Relaxed);
+                let business_request_not_sent = e.business_request_not_sent();
+                let retry_class = e.retry_class();
+                warn!(
+                    skill = %state.skill_id,
+                    error = %e,
+                    ?retry_class,
+                    "notify: failed to send change notification; \
+                     current activation mapping unchanged"
+                );
+                // A5: daemon unreachable — register for watcher convergence
+                // so a later daemon repair can still be observed.
+                self.register_with_watcher(&state.skill_id);
+                let outcome = match retry_class {
+                    NotifyRetryClass::Transient => SendOutcome::Retry,
+                    NotifyRetryClass::Ambiguous => SendOutcome::RetryBounded,
+                    NotifyRetryClass::Permanent => SendOutcome::Failed,
+                };
+                (outcome, business_request_not_sent)
+            }
+            Ok(()) => {
+                self.succeeded.fetch_add(1, Ordering::Relaxed);
+                debug!(
+                    skill = %state.skill_id,
+                    event_kind = state.event_kind.as_str(),
+                    "notify: change notification accepted"
+                );
+                (SendOutcome::Delivered, false)
+            }
+        };
+
+        // A retryable reconcile failure, or a permanent failure that proves
+        // the business request was never sent, cannot produce an activation
+        // write. Skipping the poll keeps the serial worker from paying one
+        // full reload timeout per Skill. Post-delivery failures still poll,
+        // and watcher registration above covers conservative late repair.
+        let skip_reload_poll = state.event_kind == NotifyEventKind::Reconcile
+            && (matches!(outcome, SendOutcome::Retry | SendOutcome::RetryBounded)
+                || business_request_not_sent);
 
         // A3: poll-after-notify activation reload.
-        if let Some(ref reload) = self.reload_controller {
+        if let Some(reload) = self
+            .reload_controller
+            .as_ref()
+            .filter(|_| !skip_reload_poll)
+        {
             let baseline = pre_notify_freshness
                 .expect("reload_controller presence implies freshness was captured");
             debug!(
                 skill = %state.skill_id,
                 "notify: starting activation reload poll"
             );
-            let outcome = reload.poll_reload_skill(&state.skill_id, baseline);
+            let reload_outcome = reload.poll_reload_skill(&state.skill_id, baseline);
             debug!(
                 skill = %state.skill_id,
-                outcome = ?outcome,
+                outcome = ?reload_outcome,
                 "notify: activation reload poll completed"
             );
 
             // A5: on poll timeout, register the skill with the watcher
             // so late activation writes are still caught by the
             // background convergence loop.
-            if matches!(outcome, super::activation_reload::ReloadOutcome::Timeout) {
+            if matches!(
+                reload_outcome,
+                super::activation_reload::ReloadOutcome::Timeout
+            ) {
                 self.register_with_watcher(&state.skill_id);
             }
 
@@ -969,10 +1966,12 @@ impl NotifyInner {
             let reload_event = ProtocolEvent::with_reload_outcome(
                 &protocol_skill_dir,
                 &state.skill_id,
-                outcome.as_protocol_label(),
+                reload_outcome.as_protocol_label(),
             );
             self.protocol_event_writer.emit(&reload_event);
         }
+
+        outcome
     }
 
     /// A5: register a skill with the activation watcher (if set).
@@ -1023,15 +2022,39 @@ async fn notify_worker_loop(
             _ = tokio::time::sleep(sleep_for) => {}
         }
 
+        // Re-check after the select: a Shutdown may have been queued behind
+        // a Wakeup, and a requeue after this point would never be drained.
+        if inner.shutdown.load(Ordering::Acquire) {
+            debug!("notify worker shutting down");
+            return;
+        }
+
         let due = inner.drain_due(Instant::now());
         if due.is_empty() {
             continue;
         }
         for state in due {
+            // Each dispatch can block for a full socket timeout plus an
+            // activation reload poll, so a shutdown arriving mid-batch must
+            // abandon the rest of the batch instead of paying that cost per
+            // remaining skill.
+            if inner.shutdown.load(Ordering::Acquire) {
+                debug!("notify worker shutting down; abandoning the rest of the batch");
+                return;
+            }
             let inner_clone = inner.clone();
-            let join = tokio::task::spawn_blocking(move || inner_clone.send_one(state)).await;
+            let skill_id = state.skill_id.clone();
+            let is_reconcile = state.event_kind == NotifyEventKind::Reconcile;
+            let attempts = state.attempts;
+            let reconcile_generation = state.reconcile_generation;
+            let join = tokio::task::spawn_blocking(move || inner_clone.dispatch_one(state)).await;
             if let Err(e) = join {
                 warn!(error = %e, "notify: blocking task join failed");
+                // The attempt never reported an outcome, so treat a
+                // reconcile as transiently failed rather than losing it.
+                if is_reconcile {
+                    inner.requeue_reconcile(&skill_id, attempts + 1, reconcile_generation);
+                }
             }
         }
     }
@@ -1983,6 +3006,1086 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // Reconcile retry: error classification
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn io_kinds_that_mean_the_socket_is_not_ready_are_transient() {
+        use std::io::ErrorKind as Kind;
+        for kind in [
+            Kind::NotFound,
+            Kind::ConnectionRefused,
+            Kind::ConnectionReset,
+            Kind::ConnectionAborted,
+            Kind::NotConnected,
+            Kind::BrokenPipe,
+            Kind::UnexpectedEof,
+            Kind::AddrNotAvailable,
+            Kind::TimedOut,
+            Kind::WouldBlock,
+            Kind::Interrupted,
+        ] {
+            assert_eq!(
+                io_retry_class(kind),
+                NotifyRetryClass::Transient,
+                "{kind:?} must be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn io_kinds_that_mean_misconfiguration_are_permanent() {
+        use std::io::ErrorKind as Kind;
+        for kind in [
+            Kind::PermissionDenied,
+            Kind::InvalidData,
+            Kind::InvalidInput,
+            Kind::Other,
+        ] {
+            assert_eq!(
+                io_retry_class(kind),
+                NotifyRetryClass::Permanent,
+                "{kind:?} must not be retried"
+            );
+        }
+    }
+
+    #[test]
+    fn notify_error_retry_classification_table() {
+        let transient: Vec<NotifyError> = vec![
+            NotifyError::Timeout,
+            NotifyError::EndpointUnavailable("socket missing".to_string()),
+            NotifyError::AuthTransport("handshake io".to_string()),
+            NotifyError::Connect(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            NotifyError::Connect(std::io::Error::from(std::io::ErrorKind::ConnectionRefused)),
+            NotifyError::Write(std::io::Error::from(std::io::ErrorKind::BrokenPipe)),
+            NotifyError::Read(std::io::Error::from(std::io::ErrorKind::ConnectionReset)),
+        ];
+        for error in &transient {
+            assert!(error.is_transient(), "must be transient: {error}");
+        }
+
+        let permanent: Vec<NotifyError> = vec![
+            NotifyError::EndpointUntrusted("bad mode".to_string()),
+            NotifyError::AuthRejected("proof mismatch".to_string()),
+            NotifyError::InvalidResponse {
+                body: "not json".to_string(),
+            },
+            NotifyError::Rejected {
+                body: r#"{"ok":false}"#.to_string(),
+            },
+            NotifyError::Connect(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            NotifyError::Write(std::io::Error::other("serialize failed")),
+        ];
+        for error in &permanent {
+            assert!(!error.is_transient(), "must be permanent: {error}");
+        }
+    }
+
+    #[test]
+    fn auth_errors_map_by_variant_not_by_message() {
+        use super::super::auth::AuthError;
+
+        // Handshake transport problems: the daemon may be restarting, and
+        // the failure is distinguishable from a trust decision.
+        for error in [
+            AuthError::Timeout,
+            AuthError::Io(std::io::Error::from(std::io::ErrorKind::ConnectionReset)),
+        ] {
+            let mapped = auth_error_to_notify(error);
+            assert!(
+                matches!(mapped, NotifyError::AuthTransport(_)),
+                "expected AuthTransport, got {mapped:?}"
+            );
+            assert!(mapped.is_transient());
+        }
+
+        // Trust decisions and protocol violations: retrying is pointless.
+        for error in [
+            AuthError::VerificationFailed,
+            AuthError::FrameTooLarge(64),
+            AuthError::InsecurePermissions,
+            AuthError::WrongOwner,
+            AuthError::InvalidLength,
+            AuthError::NotRegular,
+            AuthError::RelativePath,
+            AuthError::Io(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        ] {
+            let mapped = auth_error_to_notify(error);
+            assert!(
+                matches!(mapped, NotifyError::AuthRejected(_)),
+                "expected AuthRejected, got {mapped:?}"
+            );
+            assert!(!mapped.is_transient());
+        }
+    }
+
+    #[test]
+    fn missing_socket_is_unavailable_but_bad_mode_is_untrusted() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let sock_path = dir.path().join("absent.sock");
+
+        // The daemon has not created the socket yet.
+        let result = validate_authenticated_notify_endpoint(&sock_path);
+        assert!(
+            matches!(result, Err(NotifyError::EndpointUnavailable(_))),
+            "absent socket must be retryable, got {result:?}"
+        );
+        assert!(result.unwrap_err().is_transient());
+
+        // A socket that exists but is world-writable is a trust failure.
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let result = validate_authenticated_notify_endpoint(&sock_path);
+        assert!(
+            matches!(result, Err(NotifyError::EndpointUntrusted(_))),
+            "permissive socket must be permanent, got {result:?}"
+        );
+        assert!(!result.unwrap_err().is_transient());
+        drop(listener);
+    }
+
+    #[test]
+    fn missing_parent_directory_is_unavailable() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("not-created-yet").join("notify.sock");
+        let result = validate_authenticated_notify_endpoint(&sock_path);
+        assert!(
+            matches!(result, Err(NotifyError::EndpointUnavailable(_))),
+            "absent parent directory must be retryable, got {result:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Reconcile retry: backoff schedule
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn retry_delay_grows_exponentially_from_the_base() {
+        // jitter_permille = 500 is the midpoint, i.e. no offset.
+        assert_eq!(
+            reconcile_retry_delay(1, 500),
+            Duration::from_millis(RECONCILE_RETRY_BASE_MS)
+        );
+        assert_eq!(
+            reconcile_retry_delay(2, 500),
+            Duration::from_millis(RECONCILE_RETRY_BASE_MS * 2)
+        );
+        assert_eq!(
+            reconcile_retry_delay(3, 500),
+            Duration::from_millis(RECONCILE_RETRY_BASE_MS * 4)
+        );
+    }
+
+    #[test]
+    fn ambiguous_retry_budget_spans_about_thirty_seconds() {
+        let total = (1..RECONCILE_AMBIGUOUS_RETRY_LIMIT)
+            .map(|attempts| reconcile_retry_delay(attempts, 500))
+            .sum::<Duration>();
+
+        assert_eq!(total, Duration::from_millis(31_750));
+    }
+
+    #[test]
+    fn retry_delay_is_capped_at_the_maximum_interval() {
+        for attempts in [8_u32, 16, 64, 1_000, u32::MAX] {
+            let delay = reconcile_retry_delay(attempts, 999);
+            assert!(
+                delay <= Duration::from_millis(RECONCILE_RETRY_MAX_MS),
+                "attempt {attempts} produced {delay:?}, above the cap"
+            );
+        }
+        // Once capped the interval stops growing, so retries continue
+        // forever at a bounded rate rather than backing off to never.
+        assert_eq!(
+            reconcile_retry_delay(1_000, 500),
+            Duration::from_millis(RECONCILE_RETRY_MAX_MS)
+        );
+    }
+
+    #[test]
+    fn retry_delay_jitter_stays_within_the_configured_band() {
+        // Attempts 1..=7 stay strictly below RECONCILE_RETRY_MAX_MS, so
+        // jitter spreads in both directions there.
+        for attempts in 1..=7_u32 {
+            let center = reconcile_retry_delay(attempts, 500).as_millis() as u64;
+            assert!(
+                center < RECONCILE_RETRY_MAX_MS,
+                "attempt {attempts} is expected to be below the cap"
+            );
+            let span = center * RECONCILE_RETRY_JITTER_PCT / 100;
+            let low = reconcile_retry_delay(attempts, 0).as_millis() as u64;
+            let high = reconcile_retry_delay(attempts, 999).as_millis() as u64;
+            assert!(low < center, "attempt {attempts}: no spread downward");
+            assert!(high > center, "attempt {attempts}: no spread upward");
+            assert!(
+                low >= center - span && high <= center + span,
+                "attempt {attempts}: [{low}, {high}] escapes ±{span} around {center}"
+            );
+            assert!(low >= 1, "delay must never be zero");
+        }
+    }
+
+    #[test]
+    fn retry_delay_jitter_is_one_sided_at_the_cap() {
+        // At the cap the final clamp removes the upward half of the band.
+        // Spread survives downward, which is all jitter needs to decorrelate
+        // many skills retrying against one daemon.
+        let center = reconcile_retry_delay(32, 500).as_millis() as u64;
+        assert_eq!(center, RECONCILE_RETRY_MAX_MS);
+        let low = reconcile_retry_delay(32, 0).as_millis() as u64;
+        let high = reconcile_retry_delay(32, 999).as_millis() as u64;
+        let span = RECONCILE_RETRY_MAX_MS * RECONCILE_RETRY_JITTER_PCT / 100;
+        assert_eq!(low, RECONCILE_RETRY_MAX_MS - span);
+        assert_eq!(high, RECONCILE_RETRY_MAX_MS, "never exceeds the cap");
+    }
+
+    #[test]
+    fn retry_delay_never_zero_even_with_extreme_jitter() {
+        for jitter in [0_u64, 1, 499, 500, 501, 999, 5_000] {
+            assert!(reconcile_retry_delay(1, jitter) >= Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn random_permille_stays_in_range() {
+        for _ in 0..64 {
+            assert!(random_permille() < 1000);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Reconcile retry: convergence
+    // -------------------------------------------------------------------
+
+    /// Worker-free controller: these tests assert on `pending_len`, attempt
+    /// counts, and backoff state, so they must be the only thing draining
+    /// the pending map. A live worker would race every one of them.
+    fn retry_controller(client: Arc<dyn NotifyClient>) -> Arc<NotifyController> {
+        NotifyController::new_for_testing_without_worker(
+            client,
+            "/srv/skills",
+            "/srv/skills",
+            Duration::from_millis(50),
+            5000,
+            Arc::new(NoopProtocolEventWriter),
+            None,
+        )
+    }
+
+    struct SequencedNotifyClient {
+        failures: Mutex<std::collections::VecDeque<ScriptedNotifyFailure>>,
+        attempts: AtomicU64,
+        events: Mutex<Vec<CapturedNotify>>,
+    }
+
+    impl SequencedNotifyClient {
+        fn new(failures: impl IntoIterator<Item = ScriptedNotifyFailure>) -> Self {
+            Self {
+                failures: Mutex::new(failures.into_iter().collect()),
+                attempts: AtomicU64::new(0),
+                events: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn attempts(&self) -> u64 {
+            self.attempts.load(Ordering::Relaxed)
+        }
+    }
+
+    impl NotifyClient for SequencedNotifyClient {
+        fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+            self.attempts.fetch_add(1, Ordering::Relaxed);
+            if let Some(failure) = self.failures.lock().pop_front() {
+                return Err(failure.to_error());
+            }
+            self.events.lock().push(CapturedNotify {
+                schema_version: event.params.schema_version,
+                skill_id: event.params.skill_id.clone(),
+                event_kind: event.params.event_kind.clone(),
+                paths: event.params.paths.clone(),
+                canonical_skill_dir: event.params.canonical_skill_dir.clone(),
+            });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn reconcile_retries_until_the_daemon_acks() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            2,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        assert_eq!(ctrl.enqueue_startup_reconcile(&["alpha".to_string()]), 1);
+        assert_eq!(ctrl.pending_len(), 1, "reconcile must be queued, not sent");
+
+        let attempts = ctrl.flush_until_delivered_for_testing(8);
+
+        assert_eq!(attempts, 3, "two failures then one success");
+        assert_eq!(client.attempts(), 3);
+        assert_eq!(
+            ctrl.pending_len(),
+            0,
+            "pending must drain once the daemon ACKs"
+        );
+
+        let delivered = client.events();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].skill_id, "alpha");
+        assert_eq!(delivered[0].event_kind, "reconcile");
+        assert!(
+            delivered[0].paths.is_empty(),
+            "reconcile is a full rescan and carries no paths"
+        );
+
+        let metrics = ctrl.metrics();
+        assert_eq!(metrics.attempted, 3);
+        assert_eq!(metrics.succeeded, 1);
+        assert_eq!(metrics.failed, 2);
+        assert_eq!(metrics.pending, 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn reconcile_retries_when_the_socket_appears_only_later() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::SocketMissing,
+            3,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        let attempts = ctrl.flush_until_delivered_for_testing(8);
+
+        assert_eq!(attempts, 4);
+        assert_eq!(ctrl.pending_len(), 0);
+        assert_eq!(client.events().len(), 1);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn transient_failure_keeps_the_skill_pending_while_counting_a_failure() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::ConnectionRefused,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_for_testing();
+
+        // A transiently failed skill contributes to `failed` *and* is still
+        // counted in `pending` — the two are independent by design.
+        let metrics = ctrl.metrics();
+        assert_eq!(metrics.attempted, 1);
+        assert_eq!(metrics.succeeded, 0);
+        assert_eq!(metrics.failed, 1);
+        assert_eq!(metrics.pending, 1);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn multiple_skills_converge_independently() {
+        // beta needs three attempts; alpha and gamma succeed at once. The
+        // shared client counter makes the total attempt count the sum.
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            2,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        let names = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        assert_eq!(ctrl.enqueue_startup_reconcile(&names), 3);
+        assert_eq!(ctrl.pending_len(), 3);
+
+        ctrl.flush_until_delivered_for_testing(16);
+
+        assert_eq!(ctrl.pending_len(), 0, "every skill must converge");
+        let mut delivered: Vec<String> = client
+            .events()
+            .into_iter()
+            .map(|event| event.skill_id)
+            .collect();
+        delivered.sort();
+        assert_eq!(delivered, vec!["alpha", "beta", "gamma"]);
+        assert_eq!(ctrl.metrics().succeeded, 3);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn repeated_reconcile_enqueue_dedups_by_skill_identity() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            0,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        assert_eq!(
+            ctrl.enqueue_startup_reconcile(&["category/alpha".to_string()]),
+            1
+        );
+        for _ in 0..4 {
+            assert_eq!(
+                ctrl.enqueue_startup_reconcile(&["category/alpha".to_string()]),
+                0,
+                "an existing identity is merged rather than newly queued"
+            );
+        }
+        assert_eq!(
+            ctrl.pending_len(),
+            1,
+            "five enqueues of the same identity must collapse to one entry"
+        );
+
+        let attempts = ctrl.flush_until_delivered_for_testing(4);
+        assert_eq!(attempts, 1, "dedup must yield a single delivery");
+        assert_eq!(client.events()[0].skill_id, "category/alpha");
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn untrusted_endpoint_is_attempted_exactly_once() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::UntrustedEndpoint,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        let attempts = ctrl.flush_until_delivered_for_testing(16);
+
+        assert_eq!(attempts, 1, "a trust failure must not be retried");
+        assert_eq!(client.attempts(), 1);
+        assert_eq!(
+            ctrl.pending_len(),
+            0,
+            "a permanently failed reconcile must not linger in pending"
+        );
+        let metrics = ctrl.metrics();
+        assert_eq!(metrics.attempted, 1);
+        assert_eq!(metrics.failed, 1);
+        assert_eq!(metrics.succeeded, 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn pre_delivery_reconcile_failure_skips_reload_poll() {
+        use super::super::activation_reload::ActivationReloadController;
+
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = Arc::new(super::super::active::ActiveSkillResolver::new(dir.path()));
+        let reload = Arc::new(ActivationReloadController::new(
+            dir.path(),
+            resolver,
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+        ));
+        let writer = Arc::new(InMemoryProtocolEventWriter::new());
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::UntrustedEndpoint,
+        ));
+        let ctrl = NotifyController::new_for_testing_without_worker(
+            client,
+            dir.path(),
+            dir.path(),
+            Duration::from_millis(5),
+            20,
+            writer.clone(),
+            Some(reload),
+        );
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(1);
+
+        let events = writer.events();
+        assert_eq!(events.len(), 1, "only the reconcile event is emitted");
+        assert_eq!(events[0].event_kind, "reconcile");
+        assert!(
+            events.iter().all(|event| event.event_kind != "reload"),
+            "a request rejected before delivery cannot trigger activation"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn post_delivery_reconcile_failure_keeps_reload_poll() {
+        use super::super::activation_reload::ActivationReloadController;
+
+        let dir = tempfile::tempdir().unwrap();
+        let resolver = Arc::new(super::super::active::ActiveSkillResolver::new(dir.path()));
+        let reload = Arc::new(ActivationReloadController::new(
+            dir.path(),
+            resolver,
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+        ));
+        let writer = Arc::new(InMemoryProtocolEventWriter::new());
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::DaemonRejected,
+        ));
+        let ctrl = NotifyController::new_for_testing_without_worker(
+            client,
+            dir.path(),
+            dir.path(),
+            Duration::from_millis(5),
+            20,
+            writer.clone(),
+            Some(reload),
+        );
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(1);
+
+        assert!(
+            writer
+                .events()
+                .iter()
+                .any(|event| event.event_kind == "reload"),
+            "a daemon response proves the request arrived, so reload still polls"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn wrong_hmac_key_does_not_produce_a_retry_storm() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::AuthRejected,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "beta".to_string()]);
+        ctrl.flush_until_delivered_for_testing(32);
+
+        assert_eq!(
+            client.attempts(),
+            2,
+            "one attempt per skill, no retries on a rejected proof"
+        );
+        assert_eq!(ctrl.pending_len(), 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn daemon_rejection_is_not_retried() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::DaemonRejected,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(16);
+
+        assert_eq!(client.attempts(), 1);
+        assert_eq!(ctrl.pending_len(), 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn shutdown_stops_further_reconcile_attempts() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::ConnectionRefused,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_for_testing();
+        assert_eq!(client.attempts(), 1);
+        assert_eq!(ctrl.pending_len(), 1, "requeued for another try");
+
+        ctrl.shutdown();
+
+        // After shutdown a failed delivery must not be requeued, so the
+        // next drain empties the map instead of refilling it.
+        let attempts = ctrl.flush_until_delivered_for_testing(16);
+        assert_eq!(attempts, 1, "exactly the already-queued entry, then stop");
+        assert_eq!(client.attempts(), 2);
+        assert_eq!(
+            ctrl.pending_len(),
+            0,
+            "shutdown must forbid requeueing failed requests"
+        );
+    }
+
+    #[test]
+    fn a_worker_that_never_reaches_the_daemon_still_lets_the_controller_drop() {
+        // The retry loop must not hold an Arc<NotifyController>, otherwise
+        // Drop could never fire and the private runtime thread would leak.
+        let start = std::time::Instant::now();
+        for _ in 0..4 {
+            let client = Arc::new(ScriptedNotifyClient::always_failing(
+                ScriptedNotifyFailure::ConnectionRefused,
+            ));
+            let ctrl = NotifyController::new(client, "/srv/skills", Duration::from_millis(5), 5000);
+            ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+            std::thread::sleep(Duration::from_millis(30));
+            drop(ctrl);
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "a leaked retry loop would have blocked teardown"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Reconcile retry: dedup against a concurrent mutation
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn requeued_reconcile_does_not_overwrite_a_concurrent_mutation() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::ConnectionRefused,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        // Reconcile is drained and fails...
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        // ...and a mutation for the same skill lands before the requeue.
+        ctrl.observe("alpha", Some(Path::new("SKILL.md")), MutationKind::Write);
+        ctrl.flush_for_testing();
+
+        // Neither request may be lost: the merged entry stays a reconcile,
+        // which is a full rescan and therefore already covers SKILL.md.
+        assert_eq!(ctrl.pending_len(), 1, "merged into one entry, not dropped");
+        let pending = ctrl.inner.pending.lock();
+        let entry = pending.get("alpha").expect("alpha still pending");
+        assert_eq!(entry.event_kind, NotifyEventKind::Reconcile);
+        assert!(
+            entry.paths.is_empty(),
+            "a reconcile carries no paths; it rescans the whole skill"
+        );
+        assert_eq!(entry.attempts, 1, "retry state must survive the merge");
+        drop(pending);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn a_mutation_must_not_downgrade_a_queued_reconcile() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            0,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.observe("alpha", Some(Path::new("SKILL.md")), MutationKind::Write);
+        ctrl.observe(
+            "alpha",
+            Some(Path::new("scripts/run.sh")),
+            MutationKind::Create,
+        );
+
+        assert_eq!(ctrl.pending_len(), 1);
+        assert_eq!(ctrl.flush_until_delivered_for_testing(4), 1);
+
+        let delivered = client.events();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(
+            delivered[0].event_kind, "reconcile",
+            "the queued reconcile must win over later mutation kinds"
+        );
+        assert!(delivered[0].paths.is_empty());
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn a_mutation_does_not_disturb_a_backed_off_reconcile_deadline() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::ConnectionRefused,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_for_testing();
+        let backed_off = ctrl.inner.pending.lock().get("alpha").unwrap().fire_at;
+
+        ctrl.observe("alpha", Some(Path::new("SKILL.md")), MutationKind::Write);
+        let after_mutation = ctrl.inner.pending.lock().get("alpha").unwrap().fire_at;
+
+        // Pulling the deadline forward would defeat the backoff, and pushing
+        // it out would delay the reconcile. The backoff exists because the
+        // daemon is unreachable, so an earlier attempt would fail anyway.
+        assert_eq!(
+            after_mutation, backed_off,
+            "a mutation must leave a backed-off reconcile deadline alone"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn mutation_debounce_stays_trailing_edge() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            0,
+        ));
+        let debounce = Duration::from_millis(200);
+        let ctrl = NotifyController::new_for_testing_without_worker(
+            client.clone(),
+            "/srv/skills",
+            "/srv/skills",
+            debounce,
+            5000,
+            Arc::new(NoopProtocolEventWriter),
+            None,
+        );
+
+        ctrl.observe("alpha", Some(Path::new("a.txt")), MutationKind::Write);
+        let first = ctrl.inner.pending.lock().get("alpha").unwrap().fire_at;
+
+        // A second mutation must push the deadline out, so a continuous
+        // write burst dispatches once after it goes quiet rather than
+        // firing on a deadline anchored at the first write.
+        std::thread::sleep(Duration::from_millis(20));
+        ctrl.observe("alpha", Some(Path::new("b.txt")), MutationKind::Write);
+        let second = ctrl.inner.pending.lock().get("alpha").unwrap().fire_at;
+
+        assert!(
+            second > first,
+            "each mutation must reset the debounce deadline (trailing edge)"
+        );
+        ctrl.shutdown();
+    }
+
+    // -------------------------------------------------------------------
+    // Reconcile retry: ambiguous authentication outcome
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn handshake_eof_is_ambiguous_not_transient() {
+        use super::super::auth::AuthError;
+
+        // The daemon closes the connection both when it is restarting and
+        // when it has refused our client proof; `read_frame` maps that EOF
+        // to `InvalidFrame`. It must be bounded-retry, not infinite-retry.
+        let mapped = auth_error_to_notify(AuthError::InvalidFrame);
+        assert!(
+            matches!(mapped, NotifyError::AuthInconclusive(_)),
+            "expected AuthInconclusive, got {mapped:?}"
+        );
+        assert_eq!(mapped.retry_class(), NotifyRetryClass::Ambiguous);
+        assert!(
+            mapped.is_retryable(),
+            "a daemon restart must still converge"
+        );
+        assert!(
+            !mapped.is_transient(),
+            "a wrong key must not retry without a limit"
+        );
+    }
+
+    #[test]
+    fn an_inconclusive_handshake_retries_but_gives_up_at_the_limit() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::HandshakeEof,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        let attempts = ctrl.flush_until_delivered_for_testing(64);
+
+        assert_eq!(
+            attempts, RECONCILE_AMBIGUOUS_RETRY_LIMIT as usize,
+            "an ambiguous failure must retry, but only up to the limit"
+        );
+        assert_eq!(
+            client.attempts(),
+            u64::from(RECONCILE_AMBIGUOUS_RETRY_LIMIT)
+        );
+        assert_eq!(
+            ctrl.pending_len(),
+            0,
+            "the entry must be dropped once the limit is reached"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn a_wrong_key_that_recovers_before_the_limit_still_converges() {
+        // A daemon restarting mid-handshake looks identical to a wrong key,
+        // so the bounded retry must be enough to ride the restart out.
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::HandshakeEof,
+            RECONCILE_AMBIGUOUS_RETRY_LIMIT - 1,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(64);
+
+        assert_eq!(ctrl.pending_len(), 0);
+        assert_eq!(
+            ctrl.metrics().succeeded,
+            1,
+            "must converge before the limit"
+        );
+        assert_eq!(client.events().len(), 1);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn transient_failures_do_not_consume_the_ambiguous_budget() {
+        let failures = std::iter::repeat_n(ScriptedNotifyFailure::ConnectionRefused, 6).chain(
+            std::iter::repeat_n(
+                ScriptedNotifyFailure::HandshakeEof,
+                RECONCILE_AMBIGUOUS_RETRY_LIMIT as usize - 1,
+            ),
+        );
+        let client = Arc::new(SequencedNotifyClient::new(failures));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(64);
+
+        assert_eq!(
+            client.attempts(),
+            6 + u64::from(RECONCILE_AMBIGUOUS_RETRY_LIMIT),
+            "transient failures, the bounded ambiguous budget, then ACK"
+        );
+        assert_eq!(ctrl.metrics().succeeded, 1);
+        assert_eq!(ctrl.pending_len(), 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn an_inconclusive_handshake_uses_one_endpoint_wide_budget() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::HandshakeEof,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&[
+            "alpha".to_string(),
+            "beta".to_string(),
+            "gamma".to_string(),
+        ]);
+        ctrl.flush_until_delivered_for_testing(256);
+
+        assert_eq!(
+            client.attempts(),
+            u64::from(RECONCILE_AMBIGUOUS_RETRY_LIMIT),
+            "the shared endpoint budget must not scale with Skill count"
+        );
+        assert_eq!(ctrl.pending_len(), 0);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn endpoint_ack_releases_every_deferred_skill() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::HandshakeEof,
+            RECONCILE_AMBIGUOUS_RETRY_LIMIT - 1,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "beta".to_string()]);
+        ctrl.flush_until_delivered_for_testing(64);
+
+        assert_eq!(client.events().len(), 2);
+        assert_eq!(ctrl.metrics().succeeded, 2);
+        assert_eq!(ctrl.pending_len(), 0);
+        assert_eq!(
+            ctrl.inner.endpoint_retry.lock().ambiguous_failures,
+            0,
+            "an ACK proves the shared endpoint is healthy"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn a_new_reconcile_cycle_can_probe_after_exhaustion() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::HandshakeEof,
+            RECONCILE_AMBIGUOUS_RETRY_LIMIT,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "beta".to_string()]);
+        ctrl.flush_until_delivered_for_testing(64);
+        assert_eq!(ctrl.pending_len(), 0);
+        assert!(ctrl.inner.endpoint_retry.lock().exhausted);
+
+        assert_eq!(ctrl.enqueue_startup_reconcile(&["alpha".to_string()]), 1);
+        ctrl.flush_until_delivered_for_testing(4);
+
+        assert_eq!(ctrl.metrics().succeeded, 1);
+        assert!(!ctrl.inner.endpoint_retry.lock().exhausted);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn reopening_the_gate_cannot_resume_an_abandoned_drained_batch() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::HandshakeEof,
+            RECONCILE_AMBIGUOUS_RETRY_LIMIT,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "beta".to_string()]);
+        let mut initial_batch = ctrl
+            .inner
+            .drain_due(Instant::now() + Duration::from_secs(1));
+        let old_beta = initial_batch
+            .iter()
+            .position(|state| state.skill_id == "beta")
+            .map(|index| initial_batch.swap_remove(index))
+            .expect("beta was drained into the old batch");
+        let alpha = initial_batch.pop().expect("alpha was drained");
+
+        // Hold beta outside `pending` while alpha consumes the shared
+        // endpoint budget, matching a worker batch drained before the gate
+        // was exhausted.
+        ctrl.inner.dispatch_one(alpha);
+        for _ in 1..RECONCILE_AMBIGUOUS_RETRY_LIMIT {
+            let probe = ctrl
+                .inner
+                .drain_due(Instant::now() + Duration::from_secs(86_400))
+                .pop()
+                .expect("the next endpoint probe was requeued");
+            ctrl.inner.dispatch_one(probe);
+        }
+        assert_eq!(
+            client.attempts(),
+            u64::from(RECONCILE_AMBIGUOUS_RETRY_LIMIT)
+        );
+
+        // A new cycle reopens the gate, but beta still belongs to the old
+        // generation and must not become an extra authentication attempt.
+        ctrl.enqueue_startup_reconcile(&["gamma".to_string()]);
+        ctrl.inner.dispatch_one(old_beta);
+        assert_eq!(
+            client.attempts(),
+            u64::from(RECONCILE_AMBIGUOUS_RETRY_LIMIT)
+        );
+
+        ctrl.flush_until_delivered_for_testing(4);
+        assert_eq!(client.events().len(), 1);
+        assert_eq!(client.events()[0].skill_id, "gamma");
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn exhausting_an_old_cycle_does_not_delete_a_new_cycles_pending_work() {
+        let ctrl = retry_controller(Arc::new(InMemoryNotifyClient::new()));
+        ctrl.inner.merge_pending(NotifyPendingState {
+            skill_id: "old".to_string(),
+            event_kind: NotifyEventKind::Reconcile,
+            paths: HashSet::new(),
+            fire_at: Instant::now(),
+            attempts: 4,
+            reconcile_generation: 0,
+        });
+        ctrl.inner.merge_pending(NotifyPendingState {
+            skill_id: "new".to_string(),
+            event_kind: NotifyEventKind::Reconcile,
+            paths: HashSet::new(),
+            fire_at: Instant::now(),
+            attempts: 0,
+            reconcile_generation: 1,
+        });
+
+        // Models a new enqueue landing after the old generation marks the
+        // gate exhausted but before its pending-map cleanup acquires the
+        // lock. Cleanup must be scoped to the exhausted generation.
+        ctrl.inner.abandon_reconcile_generation(0);
+
+        let pending = ctrl.inner.pending.lock();
+        assert!(!pending.contains_key("old"));
+        assert_eq!(pending.get("new").unwrap().reconcile_generation, 1);
+        drop(pending);
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn mutation_failures_are_still_best_effort_and_never_requeued() {
+        let client = Arc::new(ScriptedNotifyClient::always_failing(
+            ScriptedNotifyFailure::ConnectionRefused,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        ctrl.observe("alpha", Some(Path::new("SKILL.md")), MutationKind::Write);
+        assert_eq!(ctrl.flush_for_testing(), 1);
+
+        assert_eq!(client.attempts(), 1);
+        assert_eq!(
+            ctrl.pending_len(),
+            0,
+            "retry is scoped to reconcile; mutations keep best-effort semantics"
+        );
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn enqueue_startup_reconcile_filters_ineligible_skills() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            0,
+        ));
+        let ctrl = retry_controller(client.clone());
+
+        let names = vec![
+            "alpha".to_string(),
+            "skill-discover".to_string(),
+            ".staging".to_string(),
+            ".certified".to_string(),
+            ".quarantine".to_string(),
+            ".archive".to_string(),
+            String::new(),
+        ];
+        assert_eq!(ctrl.enqueue_startup_reconcile(&names), 1);
+        assert_eq!(ctrl.pending_len(), 1);
+
+        ctrl.flush_until_delivered_for_testing(4);
+        let delivered = client.events();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0].skill_id, "alpha");
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn enqueue_startup_reconcile_empty_list_queues_nothing() {
+        let client = Arc::new(InMemoryNotifyClient::new());
+        let ctrl = retry_controller(client.clone());
+        assert_eq!(ctrl.enqueue_startup_reconcile(&[]), 0);
+        assert_eq!(ctrl.pending_len(), 0);
+        assert_eq!(ctrl.metrics(), NotifyMetricsSnapshot::default());
+        ctrl.shutdown();
+    }
+
+    #[test]
+    fn queued_reconcile_writes_a_protocol_event_per_attempt() {
+        let client = Arc::new(ScriptedNotifyClient::new(
+            ScriptedNotifyFailure::ConnectionRefused,
+            2,
+        ));
+        let writer = Arc::new(InMemoryProtocolEventWriter::new());
+        let ctrl = NotifyController::new_with_protocol_writer(
+            client,
+            "/srv/skills",
+            "/srv/skills",
+            Duration::from_secs(3600),
+            5000,
+            writer.clone(),
+        );
+
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+        ctrl.flush_until_delivered_for_testing(8);
+
+        // The protocol event log is append-only and records every attempt,
+        // so an operator can see the two failures before the ACK.
+        assert_eq!(writer.len(), 3);
+        for event in writer.events() {
+            assert_eq!(event.event_kind, "reconcile");
+            assert_eq!(event.skill_name, "alpha");
+            assert!(event.paths.is_empty());
+            assert_eq!(event.skill_dir, "/srv/skills/alpha");
+        }
+        ctrl.shutdown();
+    }
+
+    // -------------------------------------------------------------------
     // A4 Reload outcome protocol event tests
     // -------------------------------------------------------------------
 
@@ -2026,6 +4129,110 @@ mod tests {
         assert!(
             result.is_ok(),
             "normal response must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unauthenticated_notify_eof_before_ack_is_transient() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Reconcile,
+            vec![],
+            5000,
+        );
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(&stream).read_line(&mut request).unwrap();
+        });
+
+        let result = client.send(&event);
+        handle.join().unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(NotifyError::Read(ref error))
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof
+            ),
+            "EOF before an acknowledgement must be retryable: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unauthenticated_notify_truncated_ack_is_transient() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Reconcile,
+            vec![],
+            5000,
+        );
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(&stream).read_line(&mut request).unwrap();
+            let mut writer = std::io::BufWriter::new(&stream);
+            writer.write_all(br#"{"ok":true"#).unwrap();
+            writer.flush().unwrap();
+        });
+
+        let result = client.send(&event);
+        handle.join().unwrap();
+        assert!(
+            matches!(
+                result,
+                Err(NotifyError::Read(ref error))
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof
+            ),
+            "a truncated acknowledgement must be retryable: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unauthenticated_notify_complete_malformed_ack_is_permanent() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock_path = dir.path().join("test.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
+        let event = NotifyChangeEvent::new(
+            "/srv/skills/alpha",
+            "alpha",
+            NotifyEventKind::Reconcile,
+            vec![],
+            5000,
+        );
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut request = String::new();
+            BufReader::new(&stream).read_line(&mut request).unwrap();
+            let mut writer = std::io::BufWriter::new(&stream);
+            writer.write_all(b"not-json\n").unwrap();
+            writer.flush().unwrap();
+        });
+
+        let result = client.send(&event);
+        handle.join().unwrap();
+        assert!(
+            matches!(result, Err(NotifyError::InvalidResponse { .. })),
+            "a complete malformed acknowledgement remains permanent: {result:?}"
         );
     }
 
@@ -2119,7 +4326,7 @@ mod tests {
         let result = client.send(&event);
         assert!(matches!(
             result,
-            Err(NotifyError::Authentication(message))
+            Err(NotifyError::EndpointUntrusted(message))
                 if message.contains("group or other permissions")
         ));
     }
@@ -2154,7 +4361,7 @@ mod tests {
         let result = client.send(&event);
         assert!(matches!(
             result,
-            Err(NotifyError::Authentication(message))
+            Err(NotifyError::EndpointUntrusted(message))
                 if message.contains("group or other permissions")
         ));
     }
@@ -2209,7 +4416,7 @@ mod tests {
         let result = client.send(&event);
         assert!(matches!(
             result,
-            Err(NotifyError::Authentication(message)) if message.contains("not a Unix socket")
+            Err(NotifyError::EndpointUntrusted(message)) if message.contains("not a Unix socket")
         ));
     }
 

--- a/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/notify_fuse_tests.rs
@@ -655,12 +655,12 @@ fn fuse_write_triggers_reload_and_refreshes_resolver() {
 // A4: Startup reconcile produces protocol events
 // ---------------------------------------------------------------------------
 
-/// Mirrors the `main.rs` wiring: `spawn_startup_reconcile` fires on a
-/// background thread after mount, skill names are derived from the store
-/// with `skill-discover` filtered out. Verifies the async path delivers
-/// both protocol events and notify events.
+/// Mirrors the `main.rs` wiring: `enqueue_startup_reconcile` queues each
+/// skill on the notify worker after mount, skill names are derived from the
+/// store with `skill-discover` filtered out. Verifies the queued path
+/// delivers both protocol events and notify events.
 #[test]
-fn startup_reconcile_spawn_produces_events() {
+fn startup_reconcile_enqueue_produces_events() {
     skip_if_no_fuse!();
 
     let source = tempfile::tempdir().unwrap();
@@ -710,10 +710,10 @@ fn startup_reconcile_spawn_produces_events() {
 
     std::thread::sleep(Duration::from_millis(300));
 
-    // Use the production path: spawn_startup_reconcile (non-blocking).
-    ctrl.spawn_startup_reconcile(skill_names);
+    // Use the production path: enqueue_startup_reconcile (non-blocking).
+    ctrl.enqueue_startup_reconcile(&skill_names);
 
-    // Wait for background thread to complete.
+    // Wait for the notify worker to drain the queue.
     let deadline = std::time::Instant::now() + Duration::from_secs(3);
     loop {
         if writer.len() >= 2 {

--- a/src/skillfs/crates/skillfs-fuse/tests/notify_reconcile_retry_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/notify_reconcile_retry_tests.rs
@@ -1,0 +1,928 @@
+//! Startup reconcile retry integration tests.
+//!
+//! Regression coverage for the startup race between SkillFS and sec-core:
+//! SkillFS mounts, enumerates its skills, and queues one reconcile per
+//! skill *before* the daemon has necessarily created its notify socket.
+//! The reconcile delivery must survive that window, because nothing else
+//! can recover it — the activation watcher only consumes activation state
+//! the daemon has already written, so a skill the daemon has never scanned
+//! stays hidden indefinitely until some reconcile actually lands.
+//!
+//! These tests drive the real `UnixSocketNotifyClient` against a socket
+//! that appears late or is recreated mid-flight, and the real
+//! `ActivationReloadController` for the hidden-to-visible transition.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use skillfs_fuse::security::{
+    ActivationReloadController, ActiveSkillResolver, ActiveTarget, CapturedNotify,
+    InMemoryProtocolEventWriter, NotifyChangeEvent, NotifyClient, NotifyController, NotifyError,
+    NotifyEventKind, UnixSocketNotifyClient,
+};
+
+const ACK: &[u8] = br#"{"ok":true,"data":{"schemaVersion":2,"accepted":true}}"#;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Accept exactly `count` notify requests, ACK each, and return the
+/// `skillId` values seen. Runs on the caller's thread.
+fn serve_acks(listener: &UnixListener, count: usize) -> Vec<String> {
+    let mut seen = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(20);
+    listener
+        .set_nonblocking(true)
+        .expect("set notify listener nonblocking");
+    while seen.len() < count && Instant::now() < deadline {
+        let stream = match listener.accept() {
+            Ok((stream, _)) => stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(20));
+                continue;
+            }
+            Err(error) => panic!("accept notify connection: {error}"),
+        };
+        let mut request = String::new();
+        BufReader::new(&stream)
+            .read_line(&mut request)
+            .expect("read notify request");
+        let parsed: serde_json::Value =
+            serde_json::from_str(request.trim()).expect("notify request is JSON");
+        seen.push(parsed["params"]["skillId"].as_str().unwrap().to_string());
+        let mut writer = std::io::BufWriter::new(&stream);
+        writer.write_all(ACK).unwrap();
+        writer.write_all(b"\n").unwrap();
+        writer.flush().unwrap();
+    }
+    assert_eq!(seen.len(), count, "timed out waiting for notify requests");
+    seen
+}
+
+/// Bind a listener at `path`, removing any stale socket first.
+fn bind(path: &Path) -> UnixListener {
+    let _ = std::fs::remove_file(path);
+    UnixListener::bind(path).expect("bind notify socket")
+}
+
+/// Controller with the real background worker, for tests that exercise the
+/// production dispatch path end to end.
+fn reconcile_controller(socket_path: &Path, canonical_root: &Path) -> Arc<NotifyController> {
+    NotifyController::new(
+        Arc::new(UnixSocketNotifyClient::new(
+            socket_path,
+            Duration::from_millis(500),
+        )),
+        canonical_root.to_path_buf(),
+        Duration::from_millis(20),
+        500,
+    )
+}
+
+/// Wait for `predicate` to hold, polling until `timeout` elapses.
+fn wait_for(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    predicate()
+}
+
+fn seed_skill(root: &Path, skill: &str) {
+    std::fs::create_dir_all(
+        root.join(skill)
+            .join(".skill-meta/versions/v000001.snapshot"),
+    )
+    .expect("create snapshot dir");
+}
+
+/// Write `<root>/<skill>/.skill-meta/activation.json` and keep rewriting
+/// until its mtime observably advances, so the reload poll cannot miss it
+/// on a coarse-granularity filesystem.
+fn write_activation_fresh(root: &Path, skill: &str) {
+    let meta = root.join(skill).join(".skill-meta");
+    std::fs::create_dir_all(&meta).unwrap();
+    let path = meta.join("activation.json");
+    let before = std::fs::metadata(&path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok());
+    for _ in 0..100 {
+        std::thread::sleep(Duration::from_millis(15));
+        std::fs::write(
+            &path,
+            r#"{"schemaVersion": 1, "target": ".skill-meta/versions/v000001.snapshot"}"#,
+        )
+        .expect("write activation.json");
+        let after = std::fs::metadata(&path)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok());
+        if before.map_or(after.is_some(), |before| {
+            after.is_some_and(|after| after > before)
+        }) {
+            return;
+        }
+    }
+    panic!("activation.json mtime did not advance");
+}
+
+// ---------------------------------------------------------------------------
+// Late socket
+// ---------------------------------------------------------------------------
+
+/// The regression case from the issue: SkillFS wins the startup race, so
+/// the notify socket does not exist when the reconcile is queued. The
+/// reconcile must not be dropped — it must keep retrying until the daemon
+/// binds the socket and acknowledges.
+#[test]
+fn reconcile_survives_a_socket_that_does_not_exist_yet() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    assert_eq!(ctrl.enqueue_startup_reconcile(&["alpha".to_string()]), 1);
+
+    // No socket yet: the attempt fails as `Connect(NotFound)`, which is
+    // transient, so the skill stays queued.
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().failed >= 1),
+        "the live worker must attempt delivery while the socket is absent"
+    );
+    let metrics = ctrl.metrics();
+    assert!(metrics.attempted >= 1);
+    assert!(metrics.failed >= 1);
+    assert_eq!(metrics.succeeded, 0);
+
+    // The daemon starts up and binds its socket.
+    let listener = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&listener, 1));
+
+    let seen = server.join().expect("server thread");
+    assert_eq!(seen, vec!["alpha"], "daemon must receive the reconcile");
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().succeeded == 1),
+        "ACK must be reflected in delivery metrics"
+    );
+    ctrl.shutdown();
+}
+
+/// A socket that exists but has no listener yet (`ConnectionRefused`) is
+/// the other half of the same startup race.
+#[test]
+fn reconcile_survives_a_socket_with_no_listener() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+
+    // Bind then drop: the socket file remains, nothing is accepting.
+    drop(bind(&sock_path));
+    assert!(sock_path.exists());
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().failed >= 1),
+        "connection refused must be retried"
+    );
+
+    let listener = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&listener, 1));
+
+    assert_eq!(server.join().unwrap(), vec!["alpha"]);
+    assert!(wait_for(Duration::from_secs(5), || ctrl
+        .metrics()
+        .succeeded
+        == 1));
+    ctrl.shutdown();
+}
+
+/// The daemon can accept the business request and restart before writing its
+/// newline-delimited acknowledgement. EOF in that window is transport churn,
+/// not a complete malformed response, so the startup reconcile must retry.
+#[test]
+fn reconcile_survives_eof_before_an_unauthenticated_ack() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+    let listener = bind(&sock_path);
+
+    let server = std::thread::spawn(move || {
+        listener.set_nonblocking(true).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut dropped_first = false;
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    let mut request = String::new();
+                    BufReader::new(&stream).read_line(&mut request).unwrap();
+                    dropped_first = true;
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) => panic!("accept first notify request: {error}"),
+            }
+        }
+        assert!(dropped_first, "timed out waiting for the first request");
+        serve_acks(&listener, 1)
+    });
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+
+    assert_eq!(server.join().unwrap(), vec!["alpha"]);
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().succeeded == 1),
+        "the retry must converge after the daemon starts acknowledging"
+    );
+    let metrics = ctrl.metrics();
+    assert_eq!(metrics.attempted, 2);
+    assert_eq!(metrics.failed, 1);
+    ctrl.shutdown();
+}
+
+/// The daemon restarts during the startup window: its socket is unlinked
+/// and re-bound between two reconcile attempts. Convergence must not
+/// depend on catching the socket in a single instant.
+#[test]
+fn reconcile_survives_a_socket_deleted_and_recreated() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+
+    let first = bind(&sock_path);
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+
+    // Daemon goes away mid-startup, taking its socket with it.
+    drop(first);
+    std::fs::remove_file(&sock_path).unwrap();
+
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().failed >= 1),
+        "a reconcile lost to a socket teardown must be retried"
+    );
+
+    // Daemon comes back with a fresh socket at the same path.
+    let second = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&second, 1));
+
+    assert_eq!(server.join().unwrap(), vec!["alpha"]);
+    assert!(wait_for(Duration::from_secs(5), || ctrl
+        .metrics()
+        .succeeded
+        == 1));
+    ctrl.shutdown();
+}
+
+/// Each skill converges on its own and is deduplicated by canonical Skill
+/// identity, including nested Hermes-style ids.
+#[test]
+fn multiple_skills_converge_independently_over_a_real_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    let names = vec![
+        "alpha".to_string(),
+        "category/beta".to_string(),
+        "category/gamma".to_string(),
+    ];
+    // Enqueue twice: identity dedup must not double the work.
+    ctrl.enqueue_startup_reconcile(&names);
+    ctrl.enqueue_startup_reconcile(&names);
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().failed >= 3),
+        "all three skills must be attempted while the endpoint is absent"
+    );
+
+    let listener = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&listener, 3));
+
+    let mut seen = server.join().unwrap();
+    seen.sort();
+    assert_eq!(seen, vec!["alpha", "category/beta", "category/gamma"]);
+    assert!(wait_for(Duration::from_secs(5), || ctrl
+        .metrics()
+        .succeeded
+        == 3));
+    ctrl.shutdown();
+}
+
+/// A daemon that answers `ok:false` has made a decision. Retrying cannot
+/// change it, so the attempt happens exactly once and does not linger.
+#[test]
+fn a_rejecting_daemon_is_not_retried_over_a_real_socket() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+    let listener = bind(&sock_path);
+
+    let server = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let mut request = String::new();
+        BufReader::new(&stream).read_line(&mut request).unwrap();
+        let mut writer = std::io::BufWriter::new(&stream);
+        writer
+            .write_all(br#"{"ok":false,"error":{"code":"unknown_skill"}}"#)
+            .unwrap();
+        writer.write_all(b"\n").unwrap();
+        writer.flush().unwrap();
+    });
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+    server.join().unwrap();
+
+    assert!(wait_for(Duration::from_secs(5), || ctrl.metrics().failed == 1));
+    let attempted = ctrl.metrics().attempted;
+    std::thread::sleep(Duration::from_millis(500));
+    assert_eq!(attempted, 1, "a daemon rejection is permanent");
+    assert_eq!(ctrl.metrics().attempted, attempted, "must not retry");
+    ctrl.shutdown();
+}
+
+/// Client that exposes a transport outage first, then inconclusive
+/// authentication, and finally recovers.
+struct PhasedRetryNotifyClient {
+    transient_failures: u64,
+    ambiguous_failures: u64,
+    attempts: AtomicU64,
+    events: Mutex<Vec<CapturedNotify>>,
+}
+
+impl PhasedRetryNotifyClient {
+    fn new(transient_failures: u64, ambiguous_failures: u64) -> Self {
+        Self {
+            transient_failures,
+            ambiguous_failures,
+            attempts: AtomicU64::new(0),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn attempts(&self) -> u64 {
+        self.attempts.load(Ordering::Relaxed)
+    }
+}
+
+impl NotifyClient for PhasedRetryNotifyClient {
+    fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+        let attempt = self.attempts.fetch_add(1, Ordering::Relaxed);
+        if attempt < self.transient_failures {
+            return Err(NotifyError::EndpointUnavailable(
+                "test: endpoint is not listening".to_string(),
+            ));
+        }
+        if attempt < self.transient_failures + self.ambiguous_failures {
+            return Err(NotifyError::AuthInconclusive(
+                "test: endpoint closed during authentication".to_string(),
+            ));
+        }
+        self.events.lock().push(CapturedNotify {
+            schema_version: event.params.schema_version,
+            skill_id: event.params.skill_id.clone(),
+            event_kind: event.params.event_kind.clone(),
+            paths: event.params.paths.clone(),
+            canonical_skill_dir: event.params.canonical_skill_dir.clone(),
+        });
+        Ok(())
+    }
+}
+
+/// The live worker must preserve convergence when transport recovery is
+/// followed by inconclusive authentication. The deterministic unit suite
+/// separately drives the full endpoint budget without production sleeps.
+#[test]
+fn transient_then_ambiguous_failures_still_converge() {
+    let root = tempfile::tempdir().unwrap();
+    // Keep transport retry depth independent of the ambiguous-auth budget:
+    // changing one policy must not silently lengthen this test or alter the
+    // other policy's coverage.
+    let transient_failures = 4;
+    let ambiguous_failures = 2;
+    let client = Arc::new(PhasedRetryNotifyClient::new(
+        transient_failures,
+        ambiguous_failures,
+    ));
+    let ctrl = NotifyController::new(
+        client.clone(),
+        root.path().to_path_buf(),
+        Duration::from_millis(20),
+        500,
+    );
+
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+
+    assert!(
+        wait_for(Duration::from_secs(20), || ctrl.metrics().succeeded == 1),
+        "reconcile must survive transport failures followed by ambiguous auth; metrics: {:?}",
+        ctrl.metrics()
+    );
+    assert_eq!(
+        client.attempts(),
+        transient_failures + ambiguous_failures + 1
+    );
+    ctrl.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Convergence of the mounted view
+// ---------------------------------------------------------------------------
+
+/// Notify client that fails its first `failures` attempts and, on the
+/// first success, writes `activation.json` for the notified skill — the
+/// daemon's side of a reconcile.
+struct LateDaemonNotifyClient {
+    daemon_root: PathBuf,
+    failures: u32,
+    attempts: AtomicU64,
+    events: Mutex<Vec<CapturedNotify>>,
+}
+
+impl LateDaemonNotifyClient {
+    fn new(daemon_root: &Path, failures: u32) -> Self {
+        Self {
+            daemon_root: daemon_root.to_path_buf(),
+            failures,
+            attempts: AtomicU64::new(0),
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn attempts(&self) -> u64 {
+        self.attempts.load(Ordering::Relaxed)
+    }
+
+    fn events(&self) -> Vec<CapturedNotify> {
+        self.events.lock().clone()
+    }
+}
+
+impl NotifyClient for LateDaemonNotifyClient {
+    fn send(&self, event: &NotifyChangeEvent) -> Result<(), NotifyError> {
+        let attempt = self.attempts.fetch_add(1, Ordering::Relaxed);
+        if attempt < u64::from(self.failures) {
+            return Err(NotifyError::EndpointUnavailable(
+                "test: daemon socket not created yet".to_string(),
+            ));
+        }
+        self.events.lock().push(CapturedNotify {
+            schema_version: event.params.schema_version,
+            skill_id: event.params.skill_id.clone(),
+            event_kind: event.params.event_kind.clone(),
+            paths: event.params.paths.clone(),
+            canonical_skill_dir: event.params.canonical_skill_dir.clone(),
+        });
+        write_activation_fresh(&self.daemon_root, &event.params.skill_id);
+        Ok(())
+    }
+}
+
+/// End-to-end: a skill with no activation is hidden at mount time. The
+/// daemon is not up yet, so the first reconcile attempts fail. Once the
+/// retried reconcile lands and the daemon writes activation, the mounted
+/// view flips to visible — with no further filesystem event to trigger it.
+///
+/// This is the property the old one-shot reconcile lost: the activation
+/// watcher can only observe activation the daemon has already written, so
+/// without a surviving reconcile there is nothing to make the daemon scan
+/// a skill it has never seen.
+#[test]
+fn a_new_skill_becomes_visible_without_any_extra_filesystem_event() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_skill(dir.path(), "alpha");
+
+    let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
+    let reload = Arc::new(ActivationReloadController::new(
+        dir.path(),
+        resolver.clone(),
+        Duration::from_millis(20),
+        Duration::from_secs(2),
+    ));
+    let writer = Arc::new(InMemoryProtocolEventWriter::new());
+    let client = Arc::new(LateDaemonNotifyClient::new(dir.path(), 2));
+    let ctrl = NotifyController::new_with_reload(
+        client.clone(),
+        dir.path().to_path_buf(),
+        dir.path().to_path_buf(),
+        Duration::from_millis(50),
+        500,
+        writer.clone(),
+        reload,
+    );
+
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+
+    // First attempt: daemon unreachable, so the skill is still unknown to
+    // it and must remain fail-safe hidden.
+    assert!(wait_for(Duration::from_secs(5), || client.attempts() >= 1));
+    assert!(
+        matches!(
+            resolver.get("alpha"),
+            None | Some(ActiveTarget::Hidden { .. })
+        ),
+        "a skill the daemon has never scanned must stay hidden, got {:?}",
+        resolver.get("alpha")
+    );
+
+    // The worker retries; the third attempt reaches the daemon, which writes
+    // activation.json.
+    assert!(
+        wait_for(Duration::from_secs(10), || ctrl.metrics().succeeded == 1),
+        "the live worker must deliver after the daemon recovers"
+    );
+
+    assert_eq!(client.attempts(), 3, "two failures then the delivery");
+    assert_eq!(client.events().len(), 1);
+    assert_eq!(client.events()[0].event_kind, "reconcile");
+
+    match resolver.get("alpha") {
+        Some(ActiveTarget::Snapshot { version, .. }) => {
+            assert_eq!(version, "v000001.snapshot")
+        }
+        other => panic!("skill must become visible after the retried reconcile, got {other:?}"),
+    }
+    ctrl.shutdown();
+}
+
+/// A skill that already has valid activation keeps serving that activation
+/// for the whole time its reconcile sits pending. Retry must not make the
+/// existing trusted view worse than the pre-fix behaviour, where a dropped
+/// reconcile simply left the stale-but-valid mapping in place.
+#[test]
+fn an_activated_skill_stays_readable_while_its_reconcile_is_pending() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_skill(dir.path(), "alpha");
+    write_activation_fresh(dir.path(), "alpha");
+
+    let resolver = Arc::new(ActiveSkillResolver::new(dir.path()));
+    let reload = Arc::new(ActivationReloadController::new(
+        dir.path(),
+        resolver.clone(),
+        Duration::from_millis(20),
+        Duration::from_millis(200),
+    ));
+    // Prime the resolver from the on-disk activation, as mount bootstrap
+    // does.
+    reload.reload_skill_once("alpha");
+    let primed = resolver.get("alpha");
+    assert!(
+        matches!(primed, Some(ActiveTarget::Snapshot { .. })),
+        "precondition: skill must start visible, got {primed:?}"
+    );
+
+    let writer = Arc::new(InMemoryProtocolEventWriter::new());
+    // Never reachable: the reconcile stays pending for the whole test.
+    let client = Arc::new(LateDaemonNotifyClient::new(dir.path(), u32::MAX));
+    let ctrl = NotifyController::new_with_reload(
+        client.clone(),
+        dir.path().to_path_buf(),
+        dir.path().to_path_buf(),
+        Duration::from_millis(50),
+        500,
+        writer.clone(),
+        reload,
+    );
+
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string()]);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while client.attempts() < 4 && Instant::now() < deadline {
+        assert_eq!(
+            resolver.get("alpha").map(|t| t.as_label()),
+            primed.as_ref().map(|t| t.as_label()),
+            "a pending reconcile must not disturb the existing trusted view"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    assert!(client.attempts() >= 4);
+    assert_eq!(ctrl.metrics().succeeded, 0);
+    ctrl.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// Production dispatch path (real background worker)
+// ---------------------------------------------------------------------------
+
+/// The same regression, driven entirely by the production worker with no
+/// test-side flushing: SkillFS queues the reconcile against a socket that
+/// does not exist, the daemon starts later, and the worker's own retry loop
+/// delivers it. This is the test that would have failed before the fix.
+#[test]
+fn the_live_worker_retries_until_a_late_daemon_answers() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+
+    let ctrl = reconcile_controller(&sock_path, root.path());
+    ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "category/beta".to_string()]);
+
+    // Let the worker fail against the absent socket a few times.
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().failed >= 2),
+        "worker must retry while the socket is absent, metrics: {:?}",
+        ctrl.metrics()
+    );
+    assert_eq!(
+        ctrl.metrics().succeeded,
+        0,
+        "nothing can be delivered before the daemon exists"
+    );
+
+    // Daemon starts.
+    let listener = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&listener, 2));
+
+    let mut seen = server.join().expect("daemon must receive both reconciles");
+    seen.sort();
+    assert_eq!(seen, vec!["alpha", "category/beta"]);
+
+    // Wait on `succeeded`, not `pending_len`: an in-flight entry is already
+    // out of the queue, so pending can read 0 before the ACK is recorded.
+    assert!(
+        wait_for(Duration::from_secs(5), || ctrl.metrics().succeeded == 2),
+        "both reconciles must be recorded as delivered, metrics: {:?}",
+        ctrl.metrics()
+    );
+    assert_eq!(ctrl.pending_len(), 0, "nothing left to retry");
+    ctrl.shutdown();
+}
+
+/// A refused authentication handshake must enter the shared endpoint gate,
+/// rather than multiplying immediate attempts by the number of Skills.
+///
+/// This drives the real authenticated client. A daemon that closes during
+/// the handshake and sec-core refusing a bad client proof both reach the
+/// same EOF/InvalidFrame classification. Deterministic unit tests exercise
+/// full budget exhaustion and generation reopening without sleeping through
+/// the production backoff window; this integration test pins the real wire
+/// classification and verifies that its first retry is endpoint-gated.
+#[test]
+fn refused_authentication_is_retried_through_the_endpoint_gate() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    // The authenticated client requires an owner-only parent and socket.
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+    let key_path = dir.path().join("notify.key");
+    std::fs::write(&key_path, [7_u8; 32]).unwrap();
+    std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    let listener = bind(&sock_path);
+    std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    // Read the client hello, then close before sending a challenge. A wrong
+    // key closes later in the handshake, but both wire paths surface as the
+    // same EOF/InvalidFrame classification to the client.
+    let accepted = Arc::new(AtomicU64::new(0));
+    let accepted_for_server = accepted.clone();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_for_server = stop.clone();
+    let server = std::thread::spawn(move || {
+        listener.set_nonblocking(true).unwrap();
+        while !stop_for_server.load(Ordering::Acquire) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    let mut hello = String::new();
+                    let _ = BufReader::new(&stream).read_line(&mut hello);
+                    accepted_for_server.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("accept authenticated notify client: {error}"),
+            }
+        }
+    });
+
+    let client = Arc::new(
+        UnixSocketNotifyClient::new_authenticated(
+            &sock_path,
+            Duration::from_millis(300),
+            &key_path,
+        )
+        .expect("build authenticated notify client"),
+    );
+    let ctrl = NotifyController::new(
+        client,
+        root.path().to_path_buf(),
+        Duration::from_millis(20),
+        300,
+    );
+    let skills: Vec<String> = (0..12).map(|index| format!("skill-{index}")).collect();
+    ctrl.enqueue_startup_reconcile(&skills);
+
+    // Watch `attempted`, not `pending_len`: the worker drains an entry out
+    // of the queue before dispatching it, so pending reads 0 during every
+    // send window and would signal "finished" after the first attempt.
+    assert!(
+        wait_for(Duration::from_secs(2), || ctrl.metrics().attempted >= 1),
+        "the real handshake EOF must produce one delivery attempt; metrics: {:?}",
+        ctrl.metrics()
+    );
+
+    // The first retry cannot be multiplied by the other eleven due Skills.
+    // Even the minimum jittered first backoff is 188 ms.
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(
+        ctrl.metrics().attempted,
+        1,
+        "all Skills must share the first endpoint backoff"
+    );
+
+    // EOF must still be retried rather than classified as permanent.
+    assert!(
+        wait_for(Duration::from_secs(2), || ctrl.metrics().attempted >= 2),
+        "the endpoint gate must schedule a later probe; metrics: {:?}",
+        ctrl.metrics()
+    );
+    ctrl.shutdown();
+    assert_eq!(ctrl.metrics().attempted, 2);
+    assert_eq!(ctrl.metrics().succeeded, 0);
+    assert!(
+        wait_for(Duration::from_secs(2), || accepted.load(Ordering::Relaxed)
+            == 2),
+        "the server must observe exactly the real send attempts"
+    );
+    stop.store(true, Ordering::Release);
+    server.join().unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+/// Shutdown must abandon the remainder of an already-drained batch, not
+/// walk it entry by entry paying a socket timeout each time.
+///
+/// The daemon here accepts connections and never answers, so every send
+/// blocks for the full client timeout. With a batch of many skills, a
+/// shutdown arriving during the first send must not cost one timeout per
+/// remaining skill.
+#[test]
+fn shutdown_abandons_the_rest_of_a_drained_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+    let listener = bind(&sock_path);
+
+    // Hold every accepted connection open without replying, so each send
+    // burns its full read timeout.
+    let held = Arc::new(Mutex::new(Vec::new()));
+    let held_for_server = held.clone();
+    std::thread::spawn(move || {
+        while let Ok((stream, _)) = listener.accept() {
+            held_for_server.lock().push(stream);
+        }
+    });
+
+    const SEND_TIMEOUT: Duration = Duration::from_millis(400);
+    const SKILLS: usize = 12;
+
+    let ctrl = NotifyController::new(
+        Arc::new(UnixSocketNotifyClient::new(&sock_path, SEND_TIMEOUT)),
+        root.path().to_path_buf(),
+        Duration::from_millis(5),
+        SEND_TIMEOUT.as_millis() as u64,
+    );
+    let names: Vec<String> = (0..SKILLS).map(|i| format!("skill-{i}")).collect();
+    ctrl.enqueue_startup_reconcile(&names);
+
+    // Wait until the worker is inside the first blocking send.
+    assert!(
+        wait_for(Duration::from_secs(3), || ctrl.metrics().attempted >= 1),
+        "worker must have started a send"
+    );
+
+    let start = Instant::now();
+    ctrl.shutdown();
+    // Give the worker room to finish the in-flight send and notice the flag.
+    std::thread::sleep(SEND_TIMEOUT * 3);
+    let elapsed = start.elapsed();
+    let attempted_after_shutdown = ctrl.metrics().attempted;
+
+    // Walking the whole batch would cost SKILLS * SEND_TIMEOUT.
+    assert!(
+        attempted_after_shutdown < SKILLS as u64,
+        "shutdown must abandon the batch, but {attempted_after_shutdown} of \
+         {SKILLS} skills were attempted"
+    );
+    assert!(
+        elapsed < SEND_TIMEOUT * (SKILLS as u32),
+        "teardown took {elapsed:?}, close to a full serial batch"
+    );
+
+    // And no further attempts happen at all after shutdown settles.
+    let settled = ctrl.metrics().attempted;
+    std::thread::sleep(Duration::from_millis(300));
+    assert_eq!(
+        ctrl.metrics().attempted,
+        settled,
+        "no new attempts may start after shutdown"
+    );
+    drop(ctrl);
+}
+
+/// Shutdown must both wake the worker and forbid requeueing, so an
+/// unreachable daemon cannot keep the retry loop — and the controller's
+/// private runtime thread — alive past teardown.
+#[test]
+fn shutdown_ends_the_retry_loop_promptly() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = tempfile::tempdir().unwrap();
+    // Never created, so every attempt fails transiently.
+    let sock_path = dir.path().join("never-bound.sock");
+
+    let start = Instant::now();
+    for _ in 0..4 {
+        let ctrl = NotifyController::new(
+            Arc::new(UnixSocketNotifyClient::new(
+                &sock_path,
+                Duration::from_millis(50),
+            )),
+            root.path().to_path_buf(),
+            // Short debounce so the live worker actually runs the retries.
+            Duration::from_millis(5),
+            50,
+        );
+        ctrl.enqueue_startup_reconcile(&["alpha".to_string(), "beta".to_string()]);
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(ctrl.metrics().attempted > 0, "worker must have tried");
+        // Dropping the last Arc triggers shutdown via Drop.
+        drop(ctrl);
+    }
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "an unbounded retry loop would have blocked teardown; took {:?}",
+        start.elapsed()
+    );
+}
+
+/// Sanity check that the ACK helper and the wire shape agree, so a failing
+/// retry test above is a retry bug and not a protocol mismatch.
+#[test]
+fn ack_helper_matches_the_notify_v2_wire_contract() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("notify.sock");
+    let listener = bind(&sock_path);
+    let server = std::thread::spawn(move || serve_acks(&listener, 1));
+
+    let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_secs(5));
+    let event = NotifyChangeEvent::new(
+        "/srv/skills/alpha",
+        "alpha",
+        NotifyEventKind::Reconcile,
+        Vec::new(),
+        5000,
+    );
+    let result = client.send(&event);
+    assert_eq!(server.join().unwrap(), vec!["alpha"]);
+    assert!(result.is_ok(), "reconcile ACK must be accepted: {result:?}");
+}
+
+/// Connecting to a path that was never created reports a transient error,
+/// not a permanent one. This is the classification the retry loop depends
+/// on, verified against the real client rather than a stub.
+#[test]
+fn real_client_reports_a_missing_socket_as_transient() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("absent.sock");
+    let client = UnixSocketNotifyClient::new(&sock_path, Duration::from_millis(100));
+    let event = NotifyChangeEvent::new(
+        "/srv/skills/alpha",
+        "alpha",
+        NotifyEventKind::Reconcile,
+        Vec::new(),
+        100,
+    );
+
+    let error = client.send(&event).expect_err("no socket at that path");
+    assert!(
+        error.is_transient(),
+        "a missing socket must be retryable, got {error}"
+    );
+
+    // And a socket file with no listener behaves the same way.
+    drop(bind(&sock_path));
+    let error = UnixStream::connect(&sock_path).expect_err("nothing is listening");
+    assert_eq!(error.kind(), std::io::ErrorKind::ConnectionRefused);
+    let error = client.send(&event).expect_err("nothing is listening");
+    assert!(
+        error.is_transient(),
+        "connection refused must be retryable, got {error}"
+    );
+}

--- a/src/skillfs/docs/security/runtime-activation-implementation-plan.md
+++ b/src/skillfs/docs/security/runtime-activation-implementation-plan.md
@@ -219,16 +219,148 @@ event log.
 
 Scope:
 
-- Emit best-effort startup reconcile notifications for known skills after the
-  mount is ready.
-- Run reconcile on a background thread so mount startup is not blocked by a
-  slow or unavailable daemon.
+- Queue one startup reconcile notification per known skill after the mount is
+  ready, and let the shared notify worker own delivery.
+- Do not block mount startup on the daemon: enqueueing touches no socket, so a
+  slow or unavailable daemon cannot delay startup.
+- Retry a reconcile whose delivery failed transiently, with exponential
+  backoff, jitter, and a capped maximum interval, until the daemon
+  acknowledges it. See "Reconcile delivery durability" below.
 - Add `reloadOutcome` to protocol events for activation reload results:
   `activation_updated`, `activation_unchanged`, `activation_timeout`, and
   `activation_invalid_hidden`.
 - Provide explicit runtime reload helpers for one skill or known skills.
 - Preserve fd-pinned read consistency: old file handles keep their open-time
   target; new opens observe the updated active mapping.
+
+#### Reconcile Delivery Durability
+
+The first A4 implementation sent each reconcile exactly once from a detached
+thread and only logged a failed send. That lost the notification whenever
+SkillFS won the startup race against the daemon, and nothing recovered it: the
+A5 activation watcher consumes activation state the daemon has *already*
+written, so it cannot make the daemon scan a skill it has never seen. A skill
+absent from the daemon's `managedSkillDirs` would therefore stay fail-safe
+hidden until an unrelated filesystem event or a manual reconcile arrived.
+
+Reconcile delivery is therefore durable:
+
+- Each skill enters the notify worker's `pending` map as an immediately due
+  `eventKind="reconcile"` entry with empty `paths`, deduplicated by canonical
+  Skill identity.
+- A transient failure requeues the entry with exponential backoff, jitter, and
+  a capped maximum interval. Retries continue at the capped rate for as long as
+  the failure persists, so convergence does not depend on an attempt limit.
+- An ambiguous authentication failure retries under one endpoint/controller
+  budget shared by every skill. Transient transport failures do not consume
+  this budget. See "Ambiguous handshake outcomes" below.
+- A permanent failure is logged at `error` and dropped. Retrying an untrusted
+  endpoint, a rejected authentication proof, or a daemon rejection can only
+  reproduce the same result, so it needs an operator, not another attempt.
+- A reconcile failure that proves the business request was never sent skips
+  activation reload polling. Post-delivery failures retain the poll, while the
+  activation watcher remains the fallback for late repair in either case.
+- Shutdown forbids requeueing, and also abandons the remainder of an
+  already-drained batch rather than walking it entry by entry — each entry can
+  cost a full socket timeout plus an activation reload poll. The retry loop
+  lives in the worker rather than in a thread holding an
+  `Arc<NotifyController>`, so `Drop` still triggers shutdown even while a skill
+  is unconverged.
+
+Failures are classified by error variant, never by rendered message:
+
+| Condition | Class |
+| --- | --- |
+| Parent directory or socket not created yet (`NotFound`) | retry |
+| `ConnectionRefused`, `ConnectionReset`, `ConnectionAborted`, `BrokenPipe`, `NotConnected`, `UnexpectedEof` | retry |
+| Read/write timeout, `WouldBlock`, `Interrupted` | retry |
+| Authentication handshake I/O error, handshake timeout | retry |
+| Peer closed the connection or sent an unparseable frame during authentication | endpoint-scoped bounded retry |
+| Endpoint owner, mode, or file type unsafe (including `PermissionDenied` on stat) | permanent |
+| Authentication proof verification reported failed, unusable key material | permanent |
+| Complete malformed notify acknowledgement, notify schema mismatch, oversized authentication frame, daemon rejection | permanent |
+
+##### Ambiguous Handshake Outcomes
+
+One condition cannot be classified from the wire. sec-core refuses a bad
+client proof by **closing the connection**, so the SkillFS client observes EOF
+while waiting for `auth.ok`; `read_frame` maps that `Ok(0)` to
+`AuthError::InvalidFrame`. A daemon restarting at any handshake phase produces
+the same error variant. The client therefore never sees `VerificationFailed`
+for a wrong notify authentication key — that variant only covers proofs the
+peer explicitly answered.
+
+Neither pure classification is acceptable: treating it as transient retries a
+permanently wrong key forever, and treating it as permanent silently drops a
+reconcile lost to a genuine restart — the exact failure mode this section
+exists to remove. It is therefore its own class, retried with the normal
+backoff under an endpoint/controller-level budget of eight inconclusive
+handshakes, a nominal 31.75-second window before jitter. The budget is shared
+by every startup reconcile that uses the same notify client, rather than being
+multiplied by the number of skills. Another immediately due skill cannot bypass
+the endpoint backoff and consume the budget in a tight loop.
+
+Only an actual inconclusive authentication handshake consumes the ambiguous
+budget. Socket lifecycle and other transient transport failures retain their
+normal retry state but neither consume nor reset it. An acknowledged delivery
+proves that authentication is working and resets the budget. If the budget is
+exhausted, the worker emits one endpoint-level `error` naming the notify key as
+the thing to check and abandons the current and remaining queued startup
+reconciles without making one more authentication attempt per skill. This caps
+the total wrong-key handshake cost for the controller, independent of skill
+count, while still giving a daemon restart a bounded convergence window.
+The exhausted gate applies to that reconcile generation rather than disabling
+the controller forever: a later explicit startup-reconcile enqueue starts a
+new generation and clears the gate and its ambiguous count. Any acknowledged
+delivery also clears the gate and count; after exhaustion it advances the
+generation so entries already drained from the abandoned cycle remain stale.
+
+Retry is scoped to reconcile. Ordinary FUSE mutations keep their best-effort,
+single-attempt semantics, because the daemon re-derives the same state from the
+next reconcile or the next mutation in the same skill, and requeueing them
+would change the latency behaviour of the hot write path.
+
+Dedup handles the in-flight race. If a mutation for the same skill arrives
+while its reconcile is being delivered, the requeue merges rather than
+overwrites: the merged entry stays a reconcile with empty `paths`, because a
+reconcile is a full rescan of current on-disk state and already covers any path
+list.
+
+Ordinary mutation scheduling is untouched by all of this. A mutation landing on
+a queued reconcile leaves the entry completely alone — it neither downgrades
+`eventKind` nor moves `fireAt`, because the reconcile already covers it.
+Mutation-on-mutation keeps its original trailing-edge debounce, where each
+mutation pushes the deadline out so a continuous write burst dispatches once
+after it goes quiet rather than mid-write.
+
+Delivery observability replaces the previous single emitted-event count:
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `attempted` | counter | Delivery attempts, counting every retry separately. |
+| `succeeded` | counter | Attempts the daemon acknowledged. |
+| `failed` | counter | Attempts that failed, counting every retry separately. |
+| `pending` | gauge | Skills currently queued for a delivery attempt. |
+
+`pending` is not derivable from the counters. A skill whose reconcile fails
+transiently increments `failed` **and** goes back into `pending`, because it is
+queued for another attempt.
+
+`pending` counts the queue, not in-flight work: the worker drains an entry
+before dispatching it and only requeues it if the attempt failed retryably, so
+`pending` reads 0 during the send window even when the skill has not converged.
+Alert on it being non-zero across a window rather than on a single sample.
+
+The counters describe actual delivery attempts. An inconclusive handshake
+increments both `attempted` and `failed` once, regardless of which skill was
+selected for that endpoint attempt. Reconciles abandoned after the shared
+authentication budget is exhausted are not additional attempts and therefore
+do not increment either counter; removing them from the queue updates
+`pending`. The endpoint-level terminal `error` is the signal that those queued
+skills were abandoned.
+
+The daemon wire protocol is unchanged, and no Kubernetes startup ordering
+constraint is introduced: SkillFS may start before or after the daemon.
 
 ### A5: Activation State Watcher And Continuous Convergence
 

--- a/src/skillfs/docs/skillfs-filesystem-capability-record.md
+++ b/src/skillfs/docs/skillfs-filesystem-capability-record.md
@@ -102,7 +102,7 @@ and write the resulting activation state.
 | Notify change client | Supported | Sends debounced change notifications over Unix socket. |
 | Protocol event log | Supported | Writes activation protocol JSONL events. |
 | Runtime activation reload | Supported | Polls activation after notify and refreshes the active resolver. |
-| Startup reconcile | Supported | Emits best-effort reconcile notifications after mount startup. |
+| Startup reconcile | Supported | Queues known skills through the notify worker, retries transient delivery until ACK, and bounds inconclusive authentication retries per endpoint. Exposes delivery counters and pending queue depth; see [Reconcile Delivery Durability](security/runtime-activation-implementation-plan.md#reconcile-delivery-durability). |
 | Ledger backing root | Supported | Private source-side work path for external daemons, especially under in-place mounts. Bind mounts are marked `MS_PRIVATE\|MS_REC` to isolate propagation and prevent the FUSE over-mount from leaking into the backing root. |
 | Control socket activation write | Supported | Trusted peers can write `activation.json` and activation xattr through the control socket instead of the FUSE mount path. Validates skill name, activation payload, writes atomically, and triggers reload. |
 | Direct final-skill pending install | Supported | Newly created, not-yet-activated skill directories are tracked as pending installs: hidden from listing, writable via exact path, intermediate mutations suppressed. After a quiet window, completeness check (parseable `SKILL.md`) gates the aggregated mutation notification. Activation still determines visibility. |


### PR DESCRIPTION
## Why

Startup reconcile was delivered once from a detached thread. If SkillFS won
the startup race against the daemon socket, that notification was dropped and
the affected Skill could remain fail-safe hidden until an unrelated mutation
or manual reconcile occurred.

## What changed

Startup reconciles now enter the existing notify worker pending map, where
transient endpoint failures retry with capped exponential backoff and jitter.
Authentication failures are classified by typed error variants, and ambiguous
handshake failures share one bounded endpoint-wide probe budget across all
pending Skills. Retry generations isolate drained batches from later recovery
cycles, while ordinary mutation delivery and trailing-edge debounce remain
unchanged. Empty or truncated unauthenticated acknowledgements are treated as
transport EOF, and pre-delivery reconcile failures skip activation polling.
Delivery counters, queue-depth metrics, tests, and documentation were updated
with the new semantics.

## Related issue

closes #2784

## User / Agent impact

SkillFS mounts now converge automatically when the notify daemon starts late,
rebinds its socket, or restarts before acknowledging a request. A wrong HMAC
key produces a bounded number of endpoint probes instead of retries multiplied
by the number of Skills, with an explicit error directing operators to the key.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The notify wire protocol and configuration format are unchanged. Retry remains
limited to startup reconcile; normal FUSE mutation notifications retain their
single-attempt behavior. Ambiguous authentication retries are bounded to eight
endpoint probes, a nominal 31.75-second window before jitter, and a later
explicit reconcile starts a fresh recovery cycle.

## Validation

Linux, Rust 1.86:

- `cargo +1.86.0 fmt --all -- --check`
- `cargo +1.86.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.86.0 test --workspace`
- `cargo +1.86.0 test -p skillfs-fuse --test notify_reconcile_retry_tests`
  (15/15; repeated five times after the retry-budget adjustment)
- `cargo +1.86.0 doc --workspace --no-deps`
  (passes with 23 pre-existing rustdoc warnings)
- `scripts/test.sh`

Coverage includes a missing socket, connection refusal, socket recreation,
EOF before an unauthenticated acknowledgement, transient-to-ambiguous
sequencing, multi-Skill endpoint gating, deterministic full-budget exhaustion,
repair followed by a fresh reconcile generation, hidden-to-visible convergence,
pre-delivery reload-poll suppression, and shutdown during a drained batch.

## Documentation and rollback

Updated the English and Chinese SkillFS README, filesystem capability record,
and runtime activation implementation plan. README keeps only the user-facing
behavior and links to the design document for retry and metric details. Roll
back by reverting the commit; there is no data migration or wire-protocol
downgrade.
