### PR TITLE
fix(sight): re-attach stale SSL uprobes

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -245,7 +245,7 @@ React + TypeScript + Webpack + Tailwind CSS，位于 `dashboard/`。开发: `npm
 
 ## 10. Configuration
 
-`AgentsightConfig`（`src/config.rs`），关键环境变量：SLS_*（阿里云日志服务导出）、`AGENTSIGHT_TOKENIZER_PATH`、`AGENTSIGHT_CHROME_TRACE`、`RUST_LOG`。
+`AgentsightConfig`（`src/config.rs`），关键环境变量：SLS_*（阿里云日志服务导出）、`AGENTSIGHT_TOKENIZER_PATH`、`AGENTSIGHT_CHROME_TRACE`、`RUST_LOG`、`AGENTSIGHT_SSL_REATTACH_TTL_SECS`（SSL uprobe 陈旧重挂载 TTL，默认 300 秒；用于内核静默注销 uprobe consumer 的 serverless/overlayfs 场景，如 ACS；设为 `0` 表示每次匹配进程都强制重挂载，仅供测试）。
 
 ### 配置文件加载语义
 

--- a/src/agentsight/CHANGELOG.md
+++ b/src/agentsight/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.1
 
 ### Fixes
+- Re-attach stale SSL uprobes after kernel-side consumer deregistration so capture self-heals without a restart. (#2791)
 - Keep null-session interruptions in breakdowns so per-session and per-conversation counts always sum to the total. (#2796)
 - Add Bun SSL_do_handshake prologue pattern so Claude Code (Bun builds >= 2.1.113) LLM traffic is captured. (#2782)
 

--- a/src/agentsight/CHANGELOG_zh.md
+++ b/src/agentsight/CHANGELOG_zh.md
@@ -3,6 +3,7 @@
 ## 0.11.1
 
 ### 修复
+- SSL uprobe 被内核静默注销后按 TTL 自动重挂载，抓包可自愈，无需重启。(#2791)
 - 中断事件按 session/conversation 拆分时保留无 session 的记录，保证分组计数与总数一致。(#2796)
 - 新增 Bun SSL_do_handshake prologue 模式，支持捕获 Claude Code（Bun 构建，>= 2.1.113）的 LLM 流量。(#2782)
 

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -25,7 +25,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 // ─── Generated skeleton ───────────────────────────────────────────────────────
@@ -44,6 +44,43 @@ use bpf::*;
 // ─── Constants ────────────────────────────────────────────────────────────────
 const MAX_BUF_SIZE: usize = bpf::MAX_BUF_SIZE as usize;
 const POLL_TIMEOUT_MS: u64 = 100;
+
+/// How long a global uprobe attachment is trusted before the next matching
+/// process triggers a re-attach. The kernel can deregister uprobe consumers
+/// without any userspace-visible error (observed on serverless/overlayfs
+/// hosts), leaving the `Link` objects alive but the probes silent. Userspace
+/// cannot query liveness, so re-attach on TTL expiry is the recovery path.
+const STALE_REATTACH_TTL: Duration = Duration::from_secs(300);
+
+/// Effective stale re-attach TTL, resolved once per `SslSniff` at
+/// construction. `AGENTSIGHT_SSL_REATTACH_TTL_SECS` overrides the default
+/// (0 forces a re-attach on every matching exec; used by tests).
+fn stale_reattach_ttl() -> Duration {
+    std::env::var("AGENTSIGHT_SSL_REATTACH_TTL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(STALE_REATTACH_TTL)
+}
+
+/// Per-inode uprobe attachment state used for stale re-attach.
+struct InodeAttach {
+    /// Held for Drop (detaches the uprobes); never read directly.
+    _links: Vec<Link>,
+    attached_at: Instant,
+}
+
+/// Outcome of a single uprobe attach attempt for one library.
+enum AttachOutcome {
+    /// Probes attached successfully.
+    Attached(Vec<Link>),
+    /// No known SSL entry points in this binary; retrying is pointless, so
+    /// the inode stays marked in `traced_files` without an attachment.
+    Untraceable,
+    /// Transient attach failure; the caller unmarks the inode so a later
+    /// sweep can retry.
+    Failed,
+}
 
 /// User-space SslEvent - lightweight version of BPF probe_SSL_data_t
 ///
@@ -235,11 +272,17 @@ pub struct SslSniff {
     // OpenObject allocation that the skeleton borrows from.
     _open_object: Box<MaybeUninit<libbpf_rs::OpenObject>>,
     skel: Box<SslsniffSkel<'static>>,
-    _links: Vec<Link>,
+    /// Per-inode uprobe links with attach metadata (for stale re-attach).
+    attachments: HashMap<u64, InodeAttach>,
     traced_files: HashSet<u64>,
     /// Maps pid -> inodes that were attached for this pid.
     /// Used to clean up traced_files when the process exits.
     pid_inodes: HashMap<u32, Vec<u64>>,
+    /// Stale re-attach TTL, resolved once at construction from the
+    /// `AGENTSIGHT_SSL_REATTACH_TTL_SECS` override (or the default).
+    reattach_ttl: Duration,
+    /// How many stale attachments have been re-attached (diagnostics/tests).
+    stale_reattachs: u64,
     // Channel for user-space SslEvent (lightweight, no need for Box)
     tx: crossbeam_channel::Sender<SslEvent>,
     rx: crossbeam_channel::Receiver<SslEvent>,
@@ -290,9 +333,11 @@ impl SslSniff {
         Ok(Self {
             _open_object: open_object,
             skel,
-            _links: Vec::new(),
+            attachments: HashMap::default(),
             traced_files: HashSet::default(),
             pid_inodes: HashMap::default(),
+            reattach_ttl: stale_reattach_ttl(),
+            stale_reattachs: 0,
             tx,
             rx,
         })
@@ -302,7 +347,10 @@ impl SslSniff {
     ///
     /// Detects which SSL libraries the process has mapped (OpenSSL, GnuTLS, NSS,
     /// or statically-linked SSL — BoringSSL/OpenSSL), attaches uprobes, and skips any
-    /// library whose inode has already been traced (dedup via `traced_files`).
+    /// library whose inode has already been traced (dedup via `traced_files`) —
+    /// unless that attachment is stale (older than the re-attach TTL), in
+    /// which case the probes are re-attached and the old links are dropped
+    /// only after the replacement succeeds.
     pub fn attach_process(&mut self, pid: i32) -> Result<()> {
         let libs = ssl_libs_from_maps(pid)?;
         if libs.is_empty() {
@@ -319,93 +367,70 @@ impl SslSniff {
                 .collect::<Vec<_>>()
         );
 
+        let now = Instant::now();
         let mut attached_inodes: Vec<u64> = Vec::new();
         for (path, inode, kind) in libs {
-            // Skip libraries whose inode we already traced.
-            // Uprobes are attached globally (pid=-1), and the kernel's
-            // uprobe_mmap mechanism automatically installs breakpoints for
-            // new processes that map an already-registered inode, so each
-            // library only needs to be attached once — including statically-linked
-            // SSL binaries (codex, node, etc).
+            // Dedup by inode: with pid=-1 global attach each library only needs
+            // to be attached once — the kernel's uprobe_mmap mechanism installs
+            // breakpoints for new processes that map an already-registered
+            // inode, including statically-linked SSL binaries (codex, node,
+            // etc). But the kernel can also silently deregister uprobe
+            // consumers (observed on serverless/overlayfs hosts), leaving the
+            // probes silent with no error. Userspace cannot query liveness, so
+            // treat attachments older than the TTL as stale and re-attach.
             if !self.traced_files.insert(inode) {
-                log::debug!("[attach_process] pid={pid}: skipping already-traced {path}");
-                // Still record the pid→inode association so detach_process
-                // can track all pids referencing this inode.
-                attached_inodes.push(inode);
+                let stale = match self.attachments.get(&inode) {
+                    Some(a) => now.duration_since(a.attached_at) >= self.reattach_ttl,
+                    // Marked but never attached: an Untraceable binary. Nothing
+                    // to re-attach; rescanning it every sweep is wasted work.
+                    None => false,
+                };
+                if !stale {
+                    log::debug!("[attach_process] pid={pid}: skipping already-traced {path}");
+                    // Still record the pid→inode association so detach_process
+                    // can track all pids referencing this inode.
+                    attached_inodes.push(inode);
+                    continue;
+                }
+                let age_secs = self
+                    .attachments
+                    .get(&inode)
+                    .map(|a| now.duration_since(a.attached_at).as_secs());
+                // Build the replacement BEFORE dropping the old links: if the
+                // re-attach fails, the previous (possibly still working) probes
+                // stay active instead of leaving the library untraced.
+                match self.build_attach(pid, &path, kind) {
+                    AttachOutcome::Attached(links) => {
+                        log::warn!(
+                            "[attach_process] pid={pid}: re-attached stale {kind:?} uprobe on {path} ({}s old)",
+                            age_secs.unwrap_or(0)
+                        );
+                        self.record_attach(inode, links);
+                        self.stale_reattachs += 1;
+                        attached_inodes.push(inode);
+                    }
+                    AttachOutcome::Untraceable | AttachOutcome::Failed => {
+                        log::warn!(
+                            "[attach_process] pid={pid}: stale re-attach failed for {path}; keeping previous links"
+                        );
+                        attached_inodes.push(inode);
+                    }
+                }
                 continue;
             }
 
-            log::debug!("[attach_process] pid={pid}: attaching {kind:?} → {path}");
-
-            let result = match kind {
-                // Use pid=-1 for global attach (all processes), avoiding per-process duplicate attaches
-                SslLibKind::OpenSsl => attach_openssl(&mut self.skel, &path, -1),
-                SslLibKind::GnuTls => attach_gnutls(&mut self.skel, &path, -1),
-                SslLibKind::Nss => attach_nss(&mut self.skel, &path, -1),
-                SslLibKind::Static => {
-                    match attach_static_ssl_by_symbol(&mut self.skel, &path, -1) {
-                        Ok(ls) => Ok(ls),
-                        Err(sym_err) => {
-                            log::debug!(
-                                "[attach_process] pid={pid}: Static SSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
-                            );
-                            match find_static_ssl_offsets(&path) {
-                                Some(off) => attach_static_ssl_by_offset(
-                                    &mut self.skel,
-                                    &path,
-                                    &off,
-                                    false,
-                                    -1,
-                                ),
-                                None => {
-                                    // Tier 3: codex offset table lookup (for static-pie binaries
-                                    // like Codex CLI that statically link OpenSSL/BoringSSL without symbols)
-                                    if let Some(ref table) = *CODEX_OFFSET_TABLE {
-                                        if let Some(off) = table.lookup(&path) {
-                                            log::info!(
-                                                "[attach_process] pid={pid}: codex offset table matched for {path} \
-                                             (write=0x{:x}, read=0x{:x}, handshake=0x{:x})",
-                                                off.ssl_write,
-                                                off.ssl_read,
-                                                off.ssl_do_handshake
-                                            );
-                                            attach_static_ssl_by_offset(
-                                                &mut self.skel,
-                                                &path,
-                                                &off,
-                                                true,
-                                                -1,
-                                            )
-                                        } else {
-                                            log::warn!(
-                                                "[attach_process] pid={pid}: SSL detection failed for {path} \
-                                             (no SSL_* in .dynsym, no byte-pattern match, and not in codex offset table), skipping"
-                                            );
-                                            continue;
-                                        }
-                                    } else {
-                                        log::warn!(
-                                            "[attach_process] pid={pid}: SSL detection failed for {path} \
-                                         (no SSL_* in .dynsym and no byte-pattern match), skipping"
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
-            match result {
-                Ok(ls) => {
-                    self._links.extend(ls);
+            match self.build_attach(pid, &path, kind) {
+                AttachOutcome::Attached(links) => {
+                    self.record_attach(inode, links);
                     attached_inodes.push(inode);
                 }
-                Err(e) => {
-                    // Attach failed: remove inode from traced_files so retries can succeed
+                AttachOutcome::Untraceable => {
+                    // Not traceable on this host; leave the inode marked so we
+                    // do not repeat the (expensive) detection on every sweep.
+                }
+                AttachOutcome::Failed => {
+                    // Attach failed: drop the inode so a later retry can succeed.
                     self.traced_files.remove(&inode);
-                    eprintln!("Warning: attach_process pid={pid} {path}: {e:#}");
                 }
             }
         }
@@ -418,14 +443,111 @@ impl SslSniff {
         Ok(())
     }
 
+    /// Number of SSL library inodes with live uprobe attachments (diagnostics).
+    pub fn traced_inode_count(&self) -> usize {
+        self.attachments.len()
+    }
+
+    /// How many stale attachments have been replaced by a re-attach
+    /// (diagnostics/tests).
+    pub fn stale_reattach_count(&self) -> u64 {
+        self.stale_reattachs
+    }
+
+    /// Record a successful attach for `inode`, replacing any prior entry
+    /// (whose links are dropped, detaching the old probes).
+    fn record_attach(&mut self, inode: u64, links: Vec<Link>) {
+        self.attachments.insert(
+            inode,
+            InodeAttach {
+                _links: links,
+                attached_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Attach uprobes for a single SSL library.
+    ///
+    /// Does not touch `traced_files` or `attachments`; the caller decides how
+    /// to record or retry the outcome.
+    fn build_attach(&mut self, pid: i32, path: &str, kind: SslLibKind) -> AttachOutcome {
+        log::debug!("[attach_process] pid={pid}: attaching {kind:?} → {path}");
+
+        // Use pid=-1 for global attach (all processes), avoiding per-process duplicate attaches
+        let result = match kind {
+            SslLibKind::OpenSsl => attach_openssl(&mut self.skel, path, -1),
+            SslLibKind::GnuTls => attach_gnutls(&mut self.skel, path, -1),
+            SslLibKind::Nss => attach_nss(&mut self.skel, path, -1),
+            SslLibKind::Static => {
+                match attach_static_ssl_by_symbol(&mut self.skel, path, -1) {
+                    Ok(ls) => Ok(ls),
+                    Err(sym_err) => {
+                        log::debug!(
+                            "[attach_process] pid={pid}: Static SSL symbol attach failed for {path} ({sym_err:#}), falling back to byte-pattern"
+                        );
+                        match find_static_ssl_offsets(path) {
+                            Some(off) => {
+                                attach_static_ssl_by_offset(&mut self.skel, path, &off, false, -1)
+                            }
+                            None => {
+                                // Tier 3: codex offset table lookup (for static-pie binaries
+                                // like Codex CLI that statically link OpenSSL/BoringSSL without symbols)
+                                if let Some(ref table) = *CODEX_OFFSET_TABLE {
+                                    if let Some(off) = table.lookup(path) {
+                                        log::info!(
+                                            "[attach_process] pid={pid}: codex offset table matched for {path} \
+                                         (write=0x{:x}, read=0x{:x}, handshake=0x{:x})",
+                                            off.ssl_write,
+                                            off.ssl_read,
+                                            off.ssl_do_handshake
+                                        );
+                                        return match attach_static_ssl_by_offset(
+                                            &mut self.skel,
+                                            path,
+                                            &off,
+                                            true,
+                                            -1,
+                                        ) {
+                                            Ok(links) => AttachOutcome::Attached(links),
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "[attach_process] pid={pid}: attach failed for {path}: {e:#}"
+                                                );
+                                                AttachOutcome::Failed
+                                            }
+                                        };
+                                    }
+                                }
+                                log::warn!(
+                                    "[attach_process] pid={pid}: SSL detection failed for {path} \
+                                 (no SSL_* in .dynsym, no byte-pattern match, and not in codex offset table), skipping"
+                                );
+                                return AttachOutcome::Untraceable;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        match result {
+            Ok(links) => AttachOutcome::Attached(links),
+            Err(e) => {
+                log::warn!("[attach_process] pid={pid}: attach failed for {path}: {e:#}");
+                AttachOutcome::Failed
+            }
+        }
+    }
+
     /// Detach SSL probes for a process and clean up traced inodes.
     ///
-    /// When a process exits, its inodes are removed from `traced_files` **only
-    /// if no other traced pid still references the same inode**.  Uprobes are
-    /// attached globally (`pid=-1`), so the link remains valid for other
-    /// processes using the same library; removing the inode prematurely would
-    /// cause the scanner to re-attach on the next sweep, producing duplicate
-    /// uprobe fds.
+    /// When a process exits, its inodes are removed from `traced_files` (and
+    /// their `attachments` entries dropped, detaching the global uprobes)
+    /// **only if no other traced pid still references the same inode**.
+    /// Uprobes are attached globally (`pid=-1`), so the link remains valid
+    /// for other processes using the same library; removing the inode
+    /// prematurely would cause the scanner to re-attach on the next sweep,
+    /// producing duplicate uprobe fds.
     pub fn detach_process(&mut self, pid: u32) {
         if let Some(inodes) = self.pid_inodes.remove(&pid) {
             let mut removed = 0;
@@ -438,6 +560,11 @@ impl SslSniff {
                     .any(|other_inode| other_inode == inode);
                 if !still_used {
                     self.traced_files.remove(inode);
+                    // Drop the attachment too: releasing the Links detaches the
+                    // (now unneeded) global uprobes and keeps `attachments`
+                    // consistent with `traced_files`. A later process mapping
+                    // this inode re-attaches through the fresh-attach path.
+                    self.attachments.remove(inode);
                     removed += 1;
                 }
             }

--- a/src/agentsight/tests/bpf_load.rs
+++ b/src/agentsight/tests/bpf_load.rs
@@ -83,3 +83,148 @@ fn all_probes_load() {
     Probes::new(&[], None, true, true, &[])
         .expect("unified Probes (all BPF programs) should load on this kernel");
 }
+
+/// Serializes the `AGENTSIGHT_SSL_REATTACH_TTL_SECS` override + sniffer
+/// construction across the sslsniff TTL tests: the TTL is cached at
+/// construction, so only the set_var → `SslSniff::new` window must not race.
+static TTL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Stale re-attach lifecycle: with the TTL forced to 0, a second
+/// `attach_process` for the same library must replace the existing
+/// attachment (drop old links, attach new ones) instead of skipping,
+/// and the traced-inode count must stay stable across the swap.
+#[test]
+#[ignore]
+fn sslsniff_stale_reattach_replaces_expired_links() {
+    use std::process::{Command, Stdio};
+
+    if unsafe { libc::geteuid() } != 0 {
+        eprintln!("skipping: uprobe attach requires root");
+        return;
+    }
+    let guard = TTL_ENV_LOCK.lock().unwrap();
+    // SAFETY: single-threaded window guarded by TTL_ENV_LOCK; the value is
+    // cached by SslSniff::new before the guard is released.
+    unsafe { std::env::set_var("AGENTSIGHT_SSL_REATTACH_TTL_SECS", "0") };
+
+    // Spawn a long-lived process that maps libssl.so dynamically.
+    let mut child = match Command::new("python3")
+        .args(["-c", "import ssl, time; time.sleep(60)"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skipping: cannot spawn python3: {e}");
+            return;
+        }
+    };
+    let mut sniffer = SslSniff::new().expect("sslsniff BPF should load on this kernel");
+    drop(guard);
+    // Interpreter startup varies; poll until the libssl mapping appears.
+    // The TTL=0 override makes every call a real attach attempt, so polling
+    // is safe and idempotent.
+    let mut before = 0;
+    for _ in 0..25 {
+        sniffer
+            .attach_process(child.id() as i32)
+            .expect("attach_process on python3 child");
+        before = sniffer.traced_inode_count();
+        if before > 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    if before == 0 {
+        let _ = child.kill();
+        eprintln!("skipping: python3 child mapped no detectable SSL library");
+        return;
+    }
+    // TTL=0 marks the attachment stale immediately; the second call must
+    // rebuild and swap the links rather than skip.
+    let reattaches_before = sniffer.stale_reattach_count();
+    sniffer
+        .attach_process(child.id() as i32)
+        .expect("stale re-attach should succeed");
+    assert_eq!(
+        sniffer.traced_inode_count(),
+        before,
+        "re-attach must preserve the set of traced inodes"
+    );
+    assert_eq!(
+        sniffer.stale_reattach_count(),
+        reattaches_before + 1,
+        "expired attachment must be rebuilt, not skipped"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// TTL regression guard: while an attachment is younger than the TTL, a
+/// repeated `attach_process` must skip (dedup), not rebuild the probes.
+/// Would fail if the staleness check were inverted or removed.
+#[test]
+#[ignore]
+fn sslsniff_fresh_attach_not_rebuilt_before_ttl() {
+    use std::process::{Command, Stdio};
+
+    if unsafe { libc::geteuid() } != 0 {
+        eprintln!("skipping: uprobe attach requires root");
+        return;
+    }
+    let guard = TTL_ENV_LOCK.lock().unwrap();
+    // SAFETY: single-threaded window guarded by TTL_ENV_LOCK; the value is
+    // cached by SslSniff::new before the guard is released.
+    unsafe { std::env::set_var("AGENTSIGHT_SSL_REATTACH_TTL_SECS", "3600") };
+
+    let mut child = match Command::new("python3")
+        .args(["-c", "import ssl, time; time.sleep(60)"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skipping: cannot spawn python3: {e}");
+            return;
+        }
+    };
+    let mut sniffer = SslSniff::new().expect("sslsniff BPF should load on this kernel");
+    drop(guard);
+    let mut before = 0;
+    for _ in 0..25 {
+        sniffer
+            .attach_process(child.id() as i32)
+            .expect("attach_process on python3 child");
+        before = sniffer.traced_inode_count();
+        if before > 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    if before == 0 {
+        let _ = child.kill();
+        eprintln!("skipping: python3 child mapped no detectable SSL library");
+        return;
+    }
+    // With a 1-hour TTL the attachment is fresh: the second call must dedup.
+    let reattaches_before = sniffer.stale_reattach_count();
+    sniffer
+        .attach_process(child.id() as i32)
+        .expect("second attach_process should succeed");
+    assert_eq!(
+        sniffer.traced_inode_count(),
+        before,
+        "fresh re-attach must not change the traced-inode set"
+    );
+    assert_eq!(
+        sniffer.stale_reattach_count(),
+        reattaches_before,
+        "fresh attachment must be skipped, not rebuilt"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Description

On ACS serverless hosts (lifsea kernel / overlayfs), the kernel can deregister uprobe consumers without any userspace-visible error, leaving the libbpf `Link` objects alive while SSL capture goes silently dead. Once that happened, the `traced_files` inode dedup made every subsequent `attach_process` skip the library at debug level, so capture never recovered until `agentsight trace` was restarted.

This PR tracks attach time per inode and treats attachments older than a TTL as stale: on the next matching process the probes are rebuilt, and the old links are swapped out only after the replacement attaches successfully (a failed re-attach keeps the previous probes alive). The TTL defaults to 5 minutes and is overridable via `AGENTSIGHT_SSL_REATTACH_TTL_SECS` (0 forces a re-attach on every matching exec). Attach-failure logging is also promoted from `eprintln` to `log::warn`.

## Related Issue

closes #2791

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` (831 passed) in `src/agentsight`.
- New root-gated integration test `sslsniff_stale_reattach_replaces_expired_links` (tests/bpf_load.rs, `#[ignore]` like the other BPF tests): spawns a python3 child mapping libssl.so, forces TTL to 0, and asserts the second `attach_process` replaces the attachment while preserving the traced-inode set. Verified locally on kernel 5.10: passes.
- Verified on the affected ACS cluster: restarting `agentsight trace` immediately restored QwenCode capture, confirming the failure mode is dead attachments rather than discovery; with this change the same recovery happens automatically on the next matching process after TTL expiry.

## Risk and compatibility

- No BPF program, map, FFI, or config-file changes; userspace-only bookkeeping in `sslsniff` plus one opt-in env var.
- Re-attach swaps links only after the replacement succeeds, so no capture gap is introduced by a failed refresh. Worst case of a false-positive TTL refresh is a cheap re-attach bounded by process-exec frequency.

## Additional Notes

No documentation or rollback procedure changes; revert is a single commit.