### PR TITLE
refactor(anolisa): extract batch application

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install.rs
@@ -134,27 +134,6 @@ pub(crate) fn handle_one(
     Ok(batch_outcome)
 }
 
-/// Run one batch member while preserving batch-owned conflict context.
-pub(crate) fn handle_one_with_planned_components(
-    component: String,
-    args: InstallArgs,
-    ctx: &CliContext,
-    planned_components: &std::collections::HashSet<String>,
-) -> Result<InstallOutcome, CliError> {
-    let outcome = application::run_with_planned_components(
-        application::InstallRequest {
-            component: &component,
-            args: &args,
-            intent: execution_intent(ctx),
-        },
-        ctx,
-        planned_components,
-    )?;
-    let batch_outcome = outcome.batch_outcome();
-    render_outcome(ctx, outcome)?;
-    Ok(batch_outcome)
-}
-
 fn execution_intent(ctx: &CliContext) -> ExecutionIntent {
     if ctx.dry_run {
         ExecutionIntent::Plan

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/application.rs
@@ -81,6 +81,16 @@ impl InstallApplicationOutcome {
             Self::Preview { .. } | Self::Applied { .. } => InstallOutcome::Installed,
         }
     }
+
+    /// Returns warnings that a batch caller must surface without rendering a
+    /// per-component result envelope.
+    pub(super) fn warnings(&self) -> &[String] {
+        match self {
+            Self::NoOp { .. } => &[],
+            Self::Preview { warnings, .. } => warnings,
+            Self::Applied { outcome, .. } => outcome.warnings(),
+        }
+    }
 }
 
 /// Run one component against production host dependencies.

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -10,11 +10,10 @@
 //! Everything that is not a fresh delegated install keeps the per-item
 //! pipeline unchanged.
 
-use std::collections::{HashMap, HashSet};
-
 use serde::Serialize;
 
 use anolisa_core::domain::NativePm;
+use anolisa_core::execution::ExecutionIntent;
 use anolisa_core::executor::{
     DelegatedExecutionTarget, PHASE_NATIVE_TXN, delegated_recovery_context,
     execute_delegated_steps_resumed,
@@ -39,22 +38,25 @@ use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::recovery::LockedJournalGate;
 use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
-use crate::progress::{self, Activity};
+use crate::progress;
 use crate::repo_config::RepoConfig;
 use crate::resolution::ComponentIndex;
 use crate::response::{CliError, render_json, render_json_with_status};
 
-use super::types::InstallOutcome;
 use super::{COMMAND, InstallArgs};
 
-// Dispatch pieces re-exported from the parent module: the per-item pipeline
-// (`handle_one`), the read-only planning prefix (`plan_component`), and the
-// shared guards it mirrors.
+// Dispatch pieces re-exported from the parent module for merged transaction
+// effects and their shared guards.
 use super::io_util::now_iso8601;
 use super::{
-    PlannedComponent, PlannedRoute, RpmdbProbe, handle_one, handle_one_with_planned_components,
-    host_backends, normalized_repo_override, plan_component, quarantined,
+    PlannedComponent, PlannedRoute, host_backends, normalized_repo_override, quarantined,
     require_configured_rpm_backend, revalidate_native_absence, step_label,
+};
+
+mod application;
+use application::{
+    BatchApplicationOutcome, BatchEffectOutcome, BatchMemberOutcome, BatchMemberStatus,
+    BatchOutputEvent, MemberApplicationOutcome, failed_item,
 };
 // ── --all support ───────────────────────────────────────────────────
 
@@ -90,15 +92,24 @@ pub(crate) struct AllSummaryPayload {
 }
 
 pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliError> {
-    let mut activity = Activity::start(
-        progress::feedback_for_stderr(ctx.json, ctx.quiet),
-        "Preparing batch installation...",
-    );
-    let index_base_override = normalized_repo_override(&args)?;
-    let names =
-        resolve_all_components(ctx, args.backend.as_deref(), index_base_override.as_deref())?;
-    if names.is_empty() {
-        activity.finish();
+    let mut output = |event| render_batch_event(ctx, event);
+    let outcome = application::run(
+        application::BatchRequest {
+            args: &args,
+            intent: super::execution_intent(ctx),
+        },
+        ctx,
+        &mut output,
+    )?;
+    render_application_outcome(ctx, outcome)
+}
+
+fn render_application_outcome(
+    ctx: &CliContext,
+    outcome: BatchApplicationOutcome,
+) -> Result<(), CliError> {
+    let dry_run = outcome.is_preview();
+    if outcome.items.is_empty() {
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
             println!(
@@ -116,7 +127,7 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
                     already_installed: 0,
                     failed: 0,
                     skipped: 0,
-                    dry_run: ctx.dry_run,
+                    dry_run,
                     merged_transaction: None,
                     items: Vec::new(),
                 },
@@ -125,215 +136,59 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         return Ok(());
     }
 
-    // Suppress per-component rendering: handle_all owns the final output.
-    // Each handle_one call runs in quiet mode so it doesn't print individual
-    // JSON envelopes or human-mode messages — only the batch summary at the
-    // end goes to stdout.
-    let mut suppressed_ctx = ctx.clone();
-    suppressed_ctx.json = false;
-    suppressed_ctx.quiet = true;
-
-    // Peek phase: plan every component read-only and classify. Fresh
-    // delegated installs merge into one native transaction; everything else
-    // (owned plans, existing records, planning errors) re-plans through the
-    // per-item pipeline, which reproduces the same outcome — the extra probe
-    // is cheap next to a dnf run.
-    let mut merged: Vec<MergedItem> = Vec::new();
-    let mut per_item: Vec<String> = Vec::new();
-    for (index, name) in names.iter().enumerate() {
-        activity.set_message(&format!(
-            "Planning {name} ({}/{})...",
-            index + 1,
-            names.len()
-        ));
-        let per_args = per_component_args(name, &args);
-        let env = anolisa_env::EnvService::detect();
-        let rpmdb = RpmdbProbe::for_host(&env);
-        let candidate = host_backends(name, &per_args, &suppressed_ctx)
-            .and_then(|(query, txn)| {
-                plan_component(name, &per_args, &suppressed_ctx, &env, &rpmdb, &query, &txn)
-            })
-            .ok()
-            .and_then(|planned| {
-                merged_package(&planned).map(|package| MergedItem {
-                    name: name.clone(),
-                    package,
-                    planned,
-                })
-            });
-        match candidate {
-            Some(item) => merged.push(item),
-            None => per_item.push(name.clone()),
-        }
-    }
-
-    // A single fresh delegated install gains nothing from merging; keep it
-    // on the per-item pipeline.
-    if merged.len() < 2 {
-        per_item = names.clone();
-        merged.clear();
-    }
-    let merged_transaction: Option<Vec<String>> =
-        (!merged.is_empty()).then(|| merged.iter().map(|item| item.package.clone()).collect());
-
-    let mut results: HashMap<String, AllSummaryItem> = HashMap::with_capacity(names.len());
-    // Dry-run does not persist each successful member, so carry the batch's
-    // simulated state forward to keep later raw conflict checks aligned with
-    // the sequential real execution order.
-    let mut planned_components: HashSet<String> = HashSet::new();
-    let mut fail_fast_tripped = false;
-
-    if !merged.is_empty() {
-        let members = merged
-            .iter()
-            .map(|item| item.name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
-        if ctx.dry_run {
-            activity.set_message(&format!("Preparing install plan for {members}..."));
-        } else {
-            activity.set_message(&format!("Installing {members}..."));
-        }
-        if !ctx.quiet && !ctx.json {
-            let color = Palette::new(ctx.no_color);
-            progress::suspend_output(|| {
-                println!("{} {members} (one rpm transaction)", color.label("==>"))
-            });
-        }
-        if ctx.dry_run {
-            // Each member previews its own plan in the single-component
-            // format; the group header above already announced that the
-            // native transactions will merge into one dnf run.
-            for item in &merged {
-                let labels: Vec<String> =
-                    item.planned.route.steps().iter().map(step_label).collect();
-                if !ctx.quiet && !ctx.json {
-                    progress::suspend_output(|| {
-                        println!("install {} (dry-run):", item.name);
-                        for label in &labels {
-                            println!("  - {label}");
-                        }
-                    });
-                }
-                results.insert(
-                    item.name.clone(),
-                    AllSummaryItem {
-                        component: item.name.clone(),
-                        status: "planned",
-                        reason: None,
-                        plan: Some(labels),
-                    },
-                );
-                planned_components.insert(item.name.clone());
-            }
-        } else {
-            let statuses = execute_merged_group(merged, &args, ctx);
-            let any_failed = statuses.iter().any(|item| item.status == "failed");
-            for item in statuses {
-                results.insert(item.component.clone(), item);
-            }
-            if args.fail_fast && any_failed {
-                fail_fast_tripped = true;
-            }
-        }
-    }
-
-    for name in &per_item {
-        if fail_fast_tripped {
-            break;
-        }
-        if ctx.dry_run {
-            activity.set_message(&format!("Preparing install plan for {name}..."));
-        } else {
-            activity.set_message(&format!("Installing {name}..."));
-        }
-        if !ctx.quiet && !ctx.json {
-            let color = Palette::new(ctx.no_color);
-            progress::suspend_output(|| println!("{} {name}", color.label("==>")));
-        }
-        let per_args = per_component_args(name, &args);
-        match handle_one_with_planned_components(
-            name.clone(),
-            per_args,
-            &suppressed_ctx,
-            &planned_components,
-        ) {
-            // Map (outcome, dry-run) to a batch status string (§7.5).
-            // Dry-run successes are "planned": nothing was written.
-            Ok(outcome) => {
-                if ctx.dry_run && outcome == InstallOutcome::Installed {
-                    planned_components.insert(name.clone());
-                }
-                results.insert(
-                    name.clone(),
-                    AllSummaryItem {
-                        component: name.clone(),
-                        status: batch_status(outcome, ctx.dry_run),
-                        reason: None,
-                        plan: None,
-                    },
-                );
-            }
-            Err(err) => {
-                results.insert(
-                    name.clone(),
-                    AllSummaryItem {
-                        component: name.clone(),
-                        status: "failed",
-                        reason: Some(err.reason().to_string()),
-                        plan: None,
-                    },
-                );
-                if args.fail_fast {
-                    fail_fast_tripped = true;
-                }
-            }
-        }
-    }
-
-    // Rebuild the summary in the original component order; anything without
-    // a result was left unattempted by --fail-fast, so `total` always equals
-    // the full target set.
-    let items: Vec<AllSummaryItem> = names
+    let total = outcome.items.len();
+    let installed = outcome
+        .items
         .iter()
-        .map(|name| {
-            results.remove(name).unwrap_or_else(|| AllSummaryItem {
-                component: name.clone(),
-                status: "skipped",
-                reason: Some("--fail-fast: not attempted".to_string()),
-                plan: None,
-            })
-        })
-        .collect();
-
-    let installed = items.iter().filter(|i| i.status == "installed").count();
-    let planned = items.iter().filter(|i| i.status == "planned").count();
-    let already_installed = items
-        .iter()
-        .filter(|i| i.status == "already-installed")
+        .filter(|item| item.status == BatchMemberStatus::Installed)
         .count();
-    let failed = items.iter().filter(|i| i.status == "failed").count();
-    let skipped = items.iter().filter(|i| i.status == "skipped").count();
-
-    activity.finish();
+    let planned = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::Planned)
+        .count();
+    let already_installed = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::AlreadyInstalled)
+        .count();
+    let failed = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::Failed)
+        .count();
+    let skipped = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::Skipped)
+        .count();
+    debug_assert_eq!(outcome.has_failures(), failed > 0);
+    let items = outcome
+        .items
+        .into_iter()
+        .map(|item| AllSummaryItem {
+            component: item.component,
+            status: item.status.as_str(),
+            reason: item.reason,
+            plan: item
+                .plan
+                .map(|steps| steps.iter().map(step_label).collect()),
+        })
+        .collect::<Vec<_>>();
 
     if ctx.json {
-        // The batch summary is the single, complete JSON response.  We
-        // return BatchPartial (not Ok) so that main's render_error still
-        // sets a non-zero exit code — but render_error recognises
-        // BatchPartial and skips the second JSON render.
         render_json_with_status(
             "install --all",
             failed == 0,
             AllSummaryPayload {
-                total: names.len(),
+                total,
                 installed,
                 planned,
                 already_installed,
                 failed,
                 skipped,
-                dry_run: ctx.dry_run,
-                merged_transaction,
+                dry_run,
+                merged_transaction: outcome.merged_transaction,
                 items,
             },
         )?;
@@ -354,10 +209,8 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
             .filter(|i| i.status == "failed")
             .map(|i| i.component.as_str())
             .collect();
-        let ok_word = if ctx.dry_run { "planned" } else { "installed" };
-        let ok_count = if ctx.dry_run { planned } else { installed };
-        // Idempotent NoOps read the same either way — dry-run or real,
-        // nothing would be written.
+        let ok_word = if dry_run { "planned" } else { "installed" };
+        let ok_count = if dry_run { planned } else { installed };
         let already_segment = if already_installed > 0 {
             format!("  already-installed={already_installed}")
         } else {
@@ -367,7 +220,7 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
             println!(
                 "{} total={}  {ok_word}={}{already_segment}  skipped={}",
                 color.label("summary:"),
-                names.len(),
+                total,
                 ok_count,
                 skipped,
             );
@@ -375,7 +228,7 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
             println!(
                 "{} total={}  {ok_word}={}{already_segment}  failed={} ({})  skipped={}",
                 color.label("summary:"),
-                names.len(),
+                total,
                 ok_count,
                 failed,
                 failed_names.join(", "),
@@ -389,13 +242,40 @@ pub(crate) fn handle_all(args: InstallArgs, ctx: &CliContext) -> Result<(), CliE
         }
     }
 
-    // Human mode: preserve non-zero exit code on failure.
     if failed > 0 {
         Err(CliError::BatchPartial {
             command: "install --all".to_string(),
         })
     } else {
         Ok(())
+    }
+}
+
+fn render_batch_event(ctx: &CliContext, event: BatchOutputEvent) {
+    let color = Palette::new(ctx.no_color);
+    match event {
+        BatchOutputEvent::Warning(warning) => {
+            progress::suspend_output(|| eprintln!("warning: {warning}"));
+        }
+        BatchOutputEvent::MergedGroup { members } if !ctx.quiet && !ctx.json => {
+            progress::suspend_output(|| {
+                println!("{} {members} (one rpm transaction)", color.label("==>"));
+            });
+        }
+        BatchOutputEvent::PreviewPlan { component, steps } if !ctx.quiet && !ctx.json => {
+            progress::suspend_output(|| {
+                println!("install {component} (dry-run):");
+                for step in &steps {
+                    println!("  - {}", step_label(step));
+                }
+            });
+        }
+        BatchOutputEvent::Member { component } if !ctx.quiet && !ctx.json => {
+            progress::suspend_output(|| println!("{} {component}", color.label("==>")));
+        }
+        BatchOutputEvent::MergedGroup { .. }
+        | BatchOutputEvent::PreviewPlan { .. }
+        | BatchOutputEvent::Member { .. } => {}
     }
 }
 
@@ -446,12 +326,13 @@ fn merged_package(planned: &PlannedComponent) -> Option<String> {
 }
 
 /// Execute the merged group against the live host: real backends pointed at
-/// the configured ANOLISA repo, degrade re-plans through [`handle_one`].
+/// the configured ANOLISA repo, with clean failures re-planned per member.
 fn execute_merged_group(
     group: Vec<MergedItem>,
     args: &InstallArgs,
     ctx: &CliContext,
-) -> Vec<AllSummaryItem> {
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> BatchEffectOutcome {
     let per_args = per_component_args(&group[0].name, args);
     let mut suppressed_ctx = ctx.clone();
     suppressed_ctx.json = false;
@@ -460,18 +341,28 @@ fn execute_merged_group(
         Ok(backends) => backends,
         Err(err) => {
             let reason = err.reason().to_string();
-            return group
-                .iter()
-                .map(|item| failed_item(&item.name, reason.clone()))
-                .collect();
+            return BatchEffectOutcome {
+                items: group
+                    .iter()
+                    .map(|item| failed_item(&item.name, reason.clone()))
+                    .collect(),
+            };
         }
     };
     let mut degrade = |name: &str| {
-        handle_one(
-            name.to_string(),
-            per_component_args(name, args),
+        let per_args = per_component_args(name, args);
+        let outcome = super::application::run(
+            super::application::InstallRequest {
+                component: name,
+                args: &per_args,
+                intent: ExecutionIntent::Apply,
+            },
             &suppressed_ctx,
-        )
+        )?;
+        Ok(MemberApplicationOutcome {
+            outcome: outcome.batch_outcome(),
+            warnings: outcome.warnings().to_vec(),
+        })
     };
     execute_merged_group_with_deps(
         group,
@@ -481,6 +372,7 @@ fn execute_merged_group(
         &txn,
         privilege::is_root(),
         &mut degrade,
+        output,
     )
 }
 
@@ -495,6 +387,9 @@ fn execute_merged_group(
 /// members whose package is absent re-plan individually through `degrade`
 /// (no side effects for them — D9), members whose package landed anyway get
 /// a `Partial` journal and a repair hint (forward-only, never retried).
+// Keep host effects explicit so tests can independently script transaction,
+// privilege, fallback, and output ordering at this boundary.
+#[allow(clippy::too_many_arguments)]
 fn execute_merged_group_with_deps(
     group: Vec<MergedItem>,
     args: &InstallArgs,
@@ -502,14 +397,17 @@ fn execute_merged_group_with_deps(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
-    degrade: &mut dyn FnMut(&str) -> Result<InstallOutcome, CliError>,
-) -> Vec<AllSummaryItem> {
+    degrade: &mut dyn FnMut(&str) -> Result<MemberApplicationOutcome, CliError>,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> BatchEffectOutcome {
     const BATCH_COMMAND: &str = "install --all";
-    let all_failed = |group: &[MergedItem], reason: &str| -> Vec<AllSummaryItem> {
-        group
-            .iter()
-            .map(|item| failed_item(&item.name, reason.to_string()))
-            .collect()
+    let all_failed = |group: &[MergedItem], reason: &str| -> BatchEffectOutcome {
+        BatchEffectOutcome {
+            items: group
+                .iter()
+                .map(|item| failed_item(&item.name, reason.to_string()))
+                .collect(),
+        }
     };
 
     // Environment preflight, mirroring the single-component delegated path:
@@ -561,7 +459,7 @@ fn execute_merged_group_with_deps(
 
     // Re-validate each slot under the lock and open its journal, mirroring
     // the single-component race check.
-    let mut items: Vec<AllSummaryItem> = Vec::with_capacity(group.len());
+    let mut items: Vec<BatchMemberOutcome> = Vec::with_capacity(group.len());
     let mut active: Vec<(MergedItem, Transaction)> = Vec::with_capacity(group.len());
     for item in group {
         let target = &item.planned.component;
@@ -591,7 +489,7 @@ fn execute_merged_group_with_deps(
         }
     }
     if active.is_empty() {
-        return items;
+        return BatchEffectOutcome { items };
     }
 
     // Journal the shared transaction step in every member's journal before
@@ -633,7 +531,7 @@ fn execute_merged_group_with_deps(
                 let _ = journal.finish(TransactionOutcomeStatus::Failed);
                 items.push(failed_item(&member.name, reason.clone()));
             }
-            return items;
+            return BatchEffectOutcome { items };
         }
     }
 
@@ -700,11 +598,11 @@ fn execute_merged_group_with_deps(
                             COMMAND,
                             ctx.packaged_data_probe(),
                         ) {
-                            progress::suspend_output(|| eprintln!("warning: {warning}"));
+                            output(BatchOutputEvent::Warning(warning));
                         }
-                        items.push(AllSummaryItem {
+                        items.push(BatchMemberOutcome {
                             component: item.name.clone(),
-                            status: "installed",
+                            status: BatchMemberStatus::Installed,
                             reason: None,
                             plan: None,
                         });
@@ -722,7 +620,7 @@ fn execute_merged_group_with_deps(
             // reads the same as the members' journals.
             let any_member_failed = items[members_start..]
                 .iter()
-                .any(|item| item.status == "failed");
+                .any(|item| item.status == BatchMemberStatus::Failed);
             store.operations.push(OperationRecord {
                 id: batch_operation_id,
                 command: BATCH_COMMAND.to_string(),
@@ -734,11 +632,11 @@ fn execute_merged_group_with_deps(
             // Operation history is best-effort bookkeeping on top of the
             // committed records, exactly like the single-component path.
             if let Err(err) = store.save(&state_path) {
-                progress::suspend_output(|| {
-                    eprintln!("warning: failed to record operation history: {err}")
-                });
+                output(BatchOutputEvent::Warning(format!(
+                    "failed to record operation history: {err}"
+                )));
             }
-            items
+            BatchEffectOutcome { items }
         }
         Err(source) => {
             // Forward-only classification: re-observe each member and let
@@ -770,44 +668,48 @@ fn execute_merged_group_with_deps(
                     .mark_failed(0, &reason)
                     .and_then(|()| journal.finish(journal_outcome))
                 {
-                    progress::suspend_output(|| {
-                        eprintln!(
-                            "warning: failed to journal the merged transaction outcome for '{}': {err}",
-                            item.name
-                        )
-                    });
+                    output(BatchOutputEvent::Warning(format!(
+                        "failed to journal the merged transaction outcome for '{}': {err}",
+                        item.name
+                    )));
                 }
             }
             drop(store);
             drop(_lock);
 
             if clean.is_empty() {
-                return items;
+                return BatchEffectOutcome { items };
             }
-            progress::suspend_output(|| {
-                eprintln!(
-                    "warning: merged rpm transaction failed ({reason}); retrying {} component(s) individually",
-                    clean.len()
-                )
-            });
+            output(BatchOutputEvent::Warning(format!(
+                "merged rpm transaction failed ({reason}); retrying {} component(s) individually",
+                clean.len()
+            )));
             let mut fail_fast_tripped = false;
             for name in clean {
                 if fail_fast_tripped {
-                    items.push(AllSummaryItem {
+                    items.push(BatchMemberOutcome {
                         component: name,
-                        status: "skipped",
+                        status: BatchMemberStatus::Skipped,
                         reason: Some("--fail-fast: not attempted".to_string()),
                         plan: None,
                     });
                     continue;
                 }
                 match degrade(&name) {
-                    Ok(outcome) => items.push(AllSummaryItem {
-                        component: name,
-                        status: batch_status(outcome, false),
-                        reason: None,
-                        plan: None,
-                    }),
+                    Ok(outcome) => {
+                        for warning in outcome.warnings {
+                            output(BatchOutputEvent::Warning(warning));
+                        }
+                        items.push(BatchMemberOutcome {
+                            component: name,
+                            status: application::batch_status(
+                                outcome.outcome,
+                                ExecutionIntent::Apply,
+                            ),
+                            reason: None,
+                            plan: None,
+                        });
+                    }
                     Err(err) => {
                         items.push(failed_item(&name, err.reason().to_string()));
                         if args.fail_fast {
@@ -816,29 +718,8 @@ fn execute_merged_group_with_deps(
                     }
                 }
             }
-            items
+            BatchEffectOutcome { items }
         }
-    }
-}
-
-fn failed_item(name: &str, reason: String) -> AllSummaryItem {
-    AllSummaryItem {
-        component: name.to_string(),
-        status: "failed",
-        reason: Some(reason),
-        plan: None,
-    }
-}
-
-/// Batch status string for a successful `handle_one`, combining the outcome
-/// with dry-run. Kept aligned with the `filter`-by-string counting in
-/// [`handle_all`] (§7.5): a new string here must be matched there too.
-pub(crate) fn batch_status(outcome: InstallOutcome, dry_run: bool) -> &'static str {
-    match (outcome, dry_run) {
-        (InstallOutcome::Installed, false) => "installed",
-        (InstallOutcome::Installed, true) => "planned",
-        // Idempotent either way: nothing would be written even for real.
-        (InstallOutcome::AlreadyInstalled, _) => "already-installed",
     }
 }
 
@@ -926,22 +807,9 @@ mod tests {
     use super::super::tests::{
         FakeInstaller, FakeQuery, load_store, pkg_info, system_ctx_with_configured_rpm_repo,
     };
+    use super::super::types::InstallOutcome;
 
     const NOW: &str = "2026-07-17T00:00:00Z";
-
-    #[test]
-    fn batch_status_maps_outcome_and_dry_run() {
-        assert_eq!(batch_status(InstallOutcome::Installed, false), "installed");
-        assert_eq!(batch_status(InstallOutcome::Installed, true), "planned");
-        assert_eq!(
-            batch_status(InstallOutcome::AlreadyInstalled, false),
-            "already-installed"
-        );
-        assert_eq!(
-            batch_status(InstallOutcome::AlreadyInstalled, true),
-            "already-installed"
-        );
-    }
 
     #[test]
     fn batch_component_selection_uses_host_target() {
@@ -1095,11 +963,18 @@ mod tests {
         }
     }
 
-    fn item_status<'a>(items: &'a [AllSummaryItem], name: &str) -> &'a AllSummaryItem {
+    fn item_status<'a>(items: &'a [BatchMemberOutcome], name: &str) -> &'a BatchMemberOutcome {
         items
             .iter()
             .find(|item| item.component == name)
             .unwrap_or_else(|| panic!("no summary item for {name}"))
+    }
+
+    fn applied_member() -> MemberApplicationOutcome {
+        MemberApplicationOutcome {
+            outcome: InstallOutcome::Installed,
+            warnings: Vec::new(),
+        }
     }
 
     #[test]
@@ -1147,11 +1022,11 @@ mod tests {
                 pkg_info("pkg-b", "2.0.0", Some("1.al4"), "x86_64"),
             ),
         ]);
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a committed merged transaction must not degrade ({name})");
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1159,7 +1034,9 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
 
         // One dnf invocation carried both packages — the whole point of D9.
         assert_eq!(
@@ -1170,7 +1047,9 @@ mod tests {
             )]
         );
         assert!(
-            items.iter().all(|item| item.status == "installed"),
+            items
+                .iter()
+                .all(|item| item.status == BatchMemberStatus::Installed),
             "expected both installed, got {:?}",
             items
                 .iter()
@@ -1252,11 +1131,11 @@ mod tests {
             .count();
         let query = FakeQuery::default();
         let txn = BatchTxn::new(false);
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a recovery-blocked member must not degrade ({name})");
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a")],
             &batch_args(),
             &ctx,
@@ -1264,11 +1143,13 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
 
         assert!(txn.calls.borrow().is_empty(), "dnf must not run");
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].status, "failed");
+        assert_eq!(items[0].status, BatchMemberStatus::Failed);
         assert!(
             items[0]
                 .reason
@@ -1296,19 +1177,26 @@ mod tests {
         let query = FakeQuery::default();
         let txn = BatchTxn::new(true);
         let degraded = RefCell::new(Vec::new());
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let events = RefCell::new(Vec::new());
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             degraded.borrow_mut().push(name.to_string());
+            events.borrow_mut().push(format!("degrade:{name}"));
             if name == "a" {
                 Err(CliError::Runtime {
                     command: "install a".to_string(),
                     reason: "no match for pkg-a".to_string(),
                 })
             } else {
-                Ok(InstallOutcome::Installed)
+                Ok(applied_member())
+            }
+        };
+        let mut output = |event| {
+            if let BatchOutputEvent::Warning(warning) = event {
+                events.borrow_mut().push(format!("warning:{warning}"));
             }
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1316,14 +1204,22 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut output,
         );
+        let events = events.borrow();
+        assert!(events[0].contains("retrying 2 component(s) individually"));
+        assert_eq!(events[1..], ["degrade:a", "degrade:b"]);
+        let items = effect.items;
 
         // The offender fails with its own error; the innocent member lands.
         assert_eq!(degraded.borrow().as_slice(), ["a", "b"]);
         let a = item_status(&items, "a");
-        assert_eq!(a.status, "failed");
+        assert_eq!(a.status, BatchMemberStatus::Failed);
         assert!(a.reason.as_deref().unwrap().contains("no match for pkg-a"));
-        assert_eq!(item_status(&items, "b").status, "installed");
+        assert_eq!(
+            item_status(&items, "b").status,
+            BatchMemberStatus::Installed
+        );
 
         // Clean failure: no record was written and no pending journal blocks
         // the per-item retry or any later intent.
@@ -1352,12 +1248,12 @@ mod tests {
             pkg_info("pkg-a", "1.0.0", Some("1.al4"), "x86_64"),
         )]);
         let degraded = RefCell::new(Vec::new());
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             degraded.borrow_mut().push(name.to_string());
-            Ok(InstallOutcome::Installed)
+            Ok(applied_member())
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1365,16 +1261,21 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
 
         // Forward-only for the landed member: no retry, repair reconciles.
         assert_eq!(degraded.borrow().as_slice(), ["b"]);
         let a = item_status(&items, "a");
-        assert_eq!(a.status, "failed");
+        assert_eq!(a.status, BatchMemberStatus::Failed);
         let reason = a.reason.as_deref().unwrap();
         assert!(reason.contains("reached the rpmdb"), "got: {reason}");
         assert!(reason.contains("anolisa repair a"), "got: {reason}");
-        assert_eq!(item_status(&items, "b").status, "installed");
+        assert_eq!(
+            item_status(&items, "b").status,
+            BatchMemberStatus::Installed
+        );
 
         // The landed member's journal stays pending (Partial) so the next
         // intent routes to repair; the clean member's does not.
@@ -1405,11 +1306,11 @@ mod tests {
         let (_tmp, ctx) = system_ctx_with_configured_rpm_repo(false);
         let query = FakeQuery::default();
         let txn = BatchTxn::new(false);
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a refused merged group must not degrade ({name})");
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1417,12 +1318,14 @@ mod tests {
             &txn,
             false,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
 
         assert!(txn.calls.borrow().is_empty(), "dnf must not run");
         for component in ["a", "b"] {
             let item = item_status(&items, component);
-            assert_eq!(item.status, "failed");
+            assert_eq!(item.status, BatchMemberStatus::Failed);
             assert!(item.reason.as_deref().unwrap().contains("requires root"));
         }
     }
@@ -1441,12 +1344,12 @@ mod tests {
                 pkg_info("pkg-b", "2.0.0", Some("1.al4"), "x86_64"),
             ),
         ]);
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("must not degrade ({name})");
         };
 
         // First merged run records both members.
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1454,14 +1357,20 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut |_| {},
         );
-        assert!(items.iter().all(|item| item.status == "installed"));
+        let items = effect.items;
+        assert!(
+            items
+                .iter()
+                .all(|item| item.status == BatchMemberStatus::Installed)
+        );
 
         // A second merged run over the same members must notice the records
         // that appeared since its (stale) planning and refuse each slot —
         // without running dnf again.
         let txn = BatchTxn::new(false);
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a"), i2_item("b", "pkg-b")],
             &batch_args(),
             &ctx,
@@ -1469,11 +1378,13 @@ mod tests {
             &txn,
             true,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
         assert!(txn.calls.borrow().is_empty(), "dnf must not run twice");
         for component in ["a", "b"] {
             let item = item_status(&items, component);
-            assert_eq!(item.status, "failed");
+            assert_eq!(item.status, BatchMemberStatus::Failed);
             assert!(
                 item.reason
                     .as_deref()
@@ -1489,11 +1400,11 @@ mod tests {
         let layout = common::resolve_layout(&ctx);
         let fake = FakeInstaller::new("pkg-a", pkg_info("pkg-a", "1.0.0", Some("1.al4"), "x86_64"))
             .package_appears_under_lock(layout.lock_file.clone());
-        let mut degrade = |name: &str| -> Result<InstallOutcome, CliError> {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a stale merged plan must not degrade ({name})");
         };
 
-        let items = execute_merged_group_with_deps(
+        let effect = execute_merged_group_with_deps(
             vec![i2_item("a", "pkg-a")],
             &batch_args(),
             &ctx,
@@ -1501,11 +1412,13 @@ mod tests {
             &fake,
             true,
             &mut degrade,
+            &mut |_| {},
         );
+        let items = effect.items;
 
         assert_eq!(fake.install_calls.get(), 0, "dnf must not run");
         let item = item_status(&items, "a");
-        assert_eq!(item.status, "failed");
+        assert_eq!(item.status, BatchMemberStatus::Failed);
         assert!(
             item.reason
                 .as_deref()

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
@@ -1,0 +1,353 @@
+//! Application orchestration for `install --all`.
+
+use std::collections::{HashMap, HashSet};
+
+use anolisa_core::execution::ExecutionIntent;
+use anolisa_core::planner::Step;
+
+use crate::context::CliContext;
+use crate::progress::{self, Activity};
+use crate::response::CliError;
+
+use super::super::application as install_application;
+use super::super::{
+    InstallArgs, InstallOutcome, RpmdbProbe, host_backends, normalized_repo_override,
+    plan_component,
+};
+use super::{
+    MergedItem, execute_merged_group, merged_package, per_component_args, resolve_all_components,
+};
+
+/// Batch command input plus whether the caller requested preview or apply.
+pub(super) struct BatchRequest<'a> {
+    pub(super) args: &'a InstallArgs,
+    pub(super) intent: ExecutionIntent,
+}
+
+/// Typed disposition of one batch member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BatchMemberStatus {
+    /// Effects completed for this member.
+    Installed,
+    /// The member has an executable plan, but no effects ran.
+    Planned,
+    /// Existing state already covers the requested install.
+    AlreadyInstalled,
+    /// Planning or execution failed for this member.
+    Failed,
+    /// Fail-fast prevented this member from being attempted.
+    Skipped,
+}
+
+impl BatchMemberStatus {
+    /// Returns the stable label used by the existing batch wire format.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Installed => "installed",
+            Self::Planned => "planned",
+            Self::AlreadyInstalled => "already-installed",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+/// Typed result for one component in index order.
+#[derive(Debug)]
+pub(super) struct BatchMemberOutcome {
+    pub(super) component: String,
+    pub(super) status: BatchMemberStatus,
+    pub(super) reason: Option<String>,
+    /// Only merged preview members expose their existing per-member plan.
+    pub(super) plan: Option<Vec<Step>>,
+}
+
+/// Complete batch result consumed by the command renderer.
+#[derive(Debug)]
+pub(super) struct BatchApplicationOutcome {
+    pub(super) intent: ExecutionIntent,
+    pub(super) merged_transaction: Option<Vec<String>>,
+    pub(super) items: Vec<BatchMemberOutcome>,
+}
+
+/// Ordered presentation facts consumed by the command renderer.
+#[derive(Debug)]
+pub(super) enum BatchOutputEvent {
+    /// Announces members sharing one native transaction.
+    MergedGroup { members: String },
+    /// Shows one merged member's plan in the legacy human format.
+    PreviewPlan { component: String, steps: Vec<Step> },
+    /// Announces a member using the single-component application path.
+    Member { component: String },
+    /// Surfaces a non-fatal application warning.
+    Warning(String),
+}
+
+/// Effects returned by the merged transaction boundary.
+pub(super) struct BatchEffectOutcome {
+    pub(super) items: Vec<BatchMemberOutcome>,
+}
+
+/// Per-member fallback result returned to merged transaction orchestration.
+pub(super) struct MemberApplicationOutcome {
+    pub(super) outcome: InstallOutcome,
+    pub(super) warnings: Vec<String>,
+}
+
+impl BatchApplicationOutcome {
+    /// Returns whether any member failed.
+    pub(super) fn has_failures(&self) -> bool {
+        self.items
+            .iter()
+            .any(|item| item.status == BatchMemberStatus::Failed)
+    }
+
+    /// Returns whether this batch was prepared without applying effects.
+    pub(super) fn is_preview(&self) -> bool {
+        matches!(self.intent, ExecutionIntent::Plan)
+    }
+}
+
+/// Run the batch application against production host dependencies.
+pub(super) fn run(
+    request: BatchRequest<'_>,
+    ctx: &CliContext,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> Result<BatchApplicationOutcome, CliError> {
+    let mut activity = Activity::start(
+        progress::feedback_for_stderr(ctx.json, ctx.quiet),
+        "Preparing batch installation...",
+    );
+    let index_base_override = normalized_repo_override(request.args)?;
+    let names = resolve_all_components(
+        ctx,
+        request.args.backend.as_deref(),
+        index_base_override.as_deref(),
+    )?;
+    if names.is_empty() {
+        activity.finish();
+        return Ok(BatchApplicationOutcome {
+            intent: request.intent,
+            merged_transaction: None,
+            items: Vec::new(),
+        });
+    }
+
+    // Per-member applications return typed outcomes; batch owns the only
+    // final renderer, so their human and JSON output stays suppressed.
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
+    suppressed_ctx.dry_run = matches!(request.intent, ExecutionIntent::Plan);
+
+    let mut merged: Vec<MergedItem> = Vec::new();
+    let mut per_item: Vec<String> = Vec::new();
+    for (index, name) in names.iter().enumerate() {
+        activity.set_message(&format!(
+            "Planning {name} ({}/{})...",
+            index + 1,
+            names.len()
+        ));
+        let per_args = per_component_args(name, request.args);
+        let env = anolisa_env::EnvService::detect();
+        let rpmdb = RpmdbProbe::for_host(&env);
+        let candidate = host_backends(name, &per_args, &suppressed_ctx)
+            .and_then(|(query, txn)| {
+                plan_component(name, &per_args, &suppressed_ctx, &env, &rpmdb, &query, &txn)
+            })
+            .ok()
+            .and_then(|planned| {
+                merged_package(&planned).map(|package| MergedItem {
+                    name: name.clone(),
+                    package,
+                    planned,
+                })
+            });
+        match candidate {
+            Some(item) => merged.push(item),
+            None => per_item.push(name.clone()),
+        }
+    }
+
+    if merged.len() < 2 {
+        per_item.clone_from(&names);
+        merged.clear();
+    }
+    let merged_transaction =
+        (!merged.is_empty()).then(|| merged.iter().map(|item| item.package.clone()).collect());
+
+    let mut results: HashMap<String, BatchMemberOutcome> = HashMap::with_capacity(names.len());
+    let mut planned_components: HashSet<String> = HashSet::new();
+    let mut fail_fast_tripped = false;
+    let preview = matches!(request.intent, ExecutionIntent::Plan);
+
+    if !merged.is_empty() {
+        let members = merged
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let message = if preview {
+            format!("Preparing install plan for {members}...")
+        } else {
+            format!("Installing {members}...")
+        };
+        activity.set_message(&message);
+        output(BatchOutputEvent::MergedGroup {
+            members: members.clone(),
+        });
+        if preview {
+            for item in &merged {
+                let steps = item.planned.route.steps().to_vec();
+                output(BatchOutputEvent::PreviewPlan {
+                    component: item.name.clone(),
+                    steps: steps.clone(),
+                });
+                results.insert(
+                    item.name.clone(),
+                    BatchMemberOutcome {
+                        component: item.name.clone(),
+                        status: BatchMemberStatus::Planned,
+                        reason: None,
+                        plan: Some(steps),
+                    },
+                );
+                planned_components.insert(item.name.clone());
+            }
+        } else {
+            let effect = execute_merged_group(merged, request.args, ctx, output);
+            let any_failed = effect
+                .items
+                .iter()
+                .any(|item| item.status == BatchMemberStatus::Failed);
+            for item in effect.items {
+                results.insert(item.component.clone(), item);
+            }
+            if request.args.fail_fast && any_failed {
+                fail_fast_tripped = true;
+            }
+        }
+    }
+
+    for name in &per_item {
+        if fail_fast_tripped {
+            break;
+        }
+        let message = if preview {
+            format!("Preparing install plan for {name}...")
+        } else {
+            format!("Installing {name}...")
+        };
+        activity.set_message(&message);
+        output(BatchOutputEvent::Member {
+            component: name.clone(),
+        });
+        let per_args = per_component_args(name, request.args);
+        let member = install_application::run_with_planned_components(
+            install_application::InstallRequest {
+                component: name,
+                args: &per_args,
+                intent: request.intent,
+            },
+            &suppressed_ctx,
+            &planned_components,
+        );
+        match member {
+            Ok(outcome) => {
+                for warning in outcome.warnings() {
+                    output(BatchOutputEvent::Warning(warning.clone()));
+                }
+                let legacy = outcome.batch_outcome();
+                if preview && legacy == InstallOutcome::Installed {
+                    planned_components.insert(name.clone());
+                }
+                results.insert(
+                    name.clone(),
+                    BatchMemberOutcome {
+                        component: name.clone(),
+                        status: batch_status(legacy, request.intent),
+                        reason: None,
+                        plan: None,
+                    },
+                );
+            }
+            Err(error) => {
+                results.insert(name.clone(), failed_item(name, error.reason().to_string()));
+                if request.args.fail_fast {
+                    fail_fast_tripped = true;
+                }
+            }
+        }
+    }
+
+    let items = names
+        .iter()
+        .map(|name| {
+            results.remove(name).unwrap_or_else(|| BatchMemberOutcome {
+                component: name.clone(),
+                status: BatchMemberStatus::Skipped,
+                reason: Some("--fail-fast: not attempted".to_string()),
+                plan: None,
+            })
+        })
+        .collect();
+    activity.finish();
+
+    Ok(BatchApplicationOutcome {
+        intent: request.intent,
+        merged_transaction,
+        items,
+    })
+}
+
+pub(super) fn failed_item(name: &str, reason: String) -> BatchMemberOutcome {
+    BatchMemberOutcome {
+        component: name.to_string(),
+        status: BatchMemberStatus::Failed,
+        reason: Some(reason),
+        plan: None,
+    }
+}
+
+pub(super) fn batch_status(outcome: InstallOutcome, intent: ExecutionIntent) -> BatchMemberStatus {
+    match (outcome, intent) {
+        (InstallOutcome::Installed, ExecutionIntent::Apply) => BatchMemberStatus::Installed,
+        (InstallOutcome::Installed, ExecutionIntent::Plan) => BatchMemberStatus::Planned,
+        (InstallOutcome::AlreadyInstalled, _) => BatchMemberStatus::AlreadyInstalled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_status_is_driven_by_execution_intent() {
+        assert_eq!(
+            batch_status(InstallOutcome::Installed, ExecutionIntent::Apply),
+            BatchMemberStatus::Installed
+        );
+        assert_eq!(
+            batch_status(InstallOutcome::Installed, ExecutionIntent::Plan),
+            BatchMemberStatus::Planned
+        );
+        for intent in [ExecutionIntent::Plan, ExecutionIntent::Apply] {
+            assert_eq!(
+                batch_status(InstallOutcome::AlreadyInstalled, intent),
+                BatchMemberStatus::AlreadyInstalled
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_failure_is_typed() {
+        let outcome = BatchApplicationOutcome {
+            intent: ExecutionIntent::Apply,
+            merged_transaction: None,
+            items: vec![failed_item("cosh", "failed".to_string())],
+        };
+
+        assert!(outcome.has_failures());
+        assert!(!outcome.is_preview());
+    }
+}


### PR DESCRIPTION
## Why

`install --all` still mixed batch orchestration, host effects, and output rendering in the command module after single-component install gained an application boundary. This change completes the matching batch boundary so later lifecycle work does not add more command-layer coupling.

## What changed

Added a crate-private batch application module with typed requests, member/aggregate outcomes, execution intent, and output events. The command handler now maps arguments, invokes the application, and renders the existing human and JSON contracts, while merged RPM effects and single-component fallback behavior remain unchanged.

## Related issue

closes #2789

## User / Agent impact

None. CLI arguments, output schema, progress ordering, exit codes, package selection, fail-fast behavior, and recovery semantics are preserved.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This is an internal boundary extraction; existing merged-transaction and per-component effect implementations are reused.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Rebased-head checks:
  - `cargo test -p anolisa-cli --locked`
  - `cargo clippy -p anolisa-cli --all-targets --locked -- -D warnings`
- Alibaba Cloud Linux 4 container:
  - release build completed successfully
  - batch module tests: 12 passed
  - `install_all` regression tests: 7 passed
  - manual raw batch scenarios covered empty, apply, idempotent rerun, dry-run,
    partial failure, and fail-fast skip outcomes

## Documentation and rollback

No documentation change is required because behavior and public contracts are unchanged. Roll back by reverting this commit.
