### PR TITLE
fix(sight): keep binding API state consistent

### DIFF
--- a/src/agentsight/src/enforcement/coordinator.rs
+++ b/src/agentsight/src/enforcement/coordinator.rs
@@ -360,6 +360,20 @@ pub enum EnforcementCoordinatorError {
     /// Desired state or evidence persistence failed.
     #[error(transparent)]
     Store(#[from] EnforcementStoreError),
+    /// Desired state was persisted, but the enforcer did not acknowledge it.
+    ///
+    /// Distinguishes persisted-but-unacknowledged applies from failures that
+    /// happened before persistence, so callers can report store truth.
+    #[error("binding {binding_id} persisted as {state:?}: {source}")]
+    PersistedUnacknowledged {
+        /// Persisted binding identifier.
+        binding_id: Uuid,
+        /// Terminal persisted state at failure time.
+        state: BindingState,
+        /// Underlying apply failure.
+        #[source]
+        source: Box<EnforcementCoordinatorError>,
+    },
     /// The ingestion worker could not be created.
     #[error("start enforcement ingestion: {0}")]
     Thread(#[from] std::io::Error),
@@ -397,7 +411,10 @@ impl EnforcementCoordinator {
     ///
     /// Returns a persistence error or the enforcer rejection after recording a
     /// sanitized failed state. Returns an availability error before persisting
-    /// when combined backend and violation-ingestion health is not ready.
+    /// when combined backend and violation-ingestion health is not ready. Once
+    /// the pending state is persisted, later failures return
+    /// [`EnforcementCoordinatorError::PersistedUnacknowledged`] so callers can
+    /// see that the binding remains in the store.
     pub fn apply(&self, request: ApplyPolicy) -> Result<Binding, EnforcementCoordinatorError> {
         let _lifecycle = self.lifecycle();
         if let Some(existing) = self.store.binding(request.binding_id)?
@@ -453,22 +470,35 @@ impl EnforcementCoordinator {
                         } else {
                             let message =
                                 "violation ingestion readiness changed during policy apply";
+                            let binding_id = binding.request.binding_id;
                             self.persist_degraded_binding(binding, message)?;
-                            Err(EnforcementCoordinatorError::EnforcementUnavailable(
-                                message.into(),
+                            Err(persisted_unacknowledged(
+                                binding_id,
+                                BindingState::Degraded,
+                                EnforcementCoordinatorError::EnforcementUnavailable(message.into()),
                             ))
                         }
                     }
                     Ok(health) => {
                         let detail = health_message(&health);
                         log::error!("enforcement became unavailable after policy apply: {detail}");
+                        let binding_id = binding.request.binding_id;
                         self.persist_degraded_binding(binding, &detail)?;
-                        Err(EnforcementCoordinatorError::EnforcementUnavailable(detail))
+                        Err(persisted_unacknowledged(
+                            binding_id,
+                            BindingState::Degraded,
+                            EnforcementCoordinatorError::EnforcementUnavailable(detail),
+                        ))
                     }
                     Err(error) => {
                         log::error!("enforcement health check failed after policy apply: {error}");
+                        let binding_id = binding.request.binding_id;
                         self.persist_degraded_binding(binding, DEGRADED_BINDING_MESSAGE)?;
-                        Err(error.into())
+                        Err(persisted_unacknowledged(
+                            binding_id,
+                            BindingState::Degraded,
+                            error.into(),
+                        ))
                     }
                 }
             }
@@ -478,25 +508,35 @@ impl EnforcementCoordinator {
                 log::error!("required violation subscription unavailable: {message}");
                 self.ingestion_readiness
                     .invalidate_lease(&lease, INGESTION_UNAVAILABLE_MESSAGE.into());
+                let binding_id = request.binding_id;
                 self.store.upsert_binding(&Binding {
                     request,
                     state: BindingState::Degraded,
                     message: Some(DEGRADED_BINDING_MESSAGE.into()),
                     domain_id: None,
                 })?;
-                Err(EnforcementCoordinatorError::EnforcementUnavailable(
-                    INGESTION_UNAVAILABLE_MESSAGE.into(),
+                Err(persisted_unacknowledged(
+                    binding_id,
+                    BindingState::Degraded,
+                    EnforcementCoordinatorError::EnforcementUnavailable(
+                        INGESTION_UNAVAILABLE_MESSAGE.into(),
+                    ),
                 ))
             }
             Err(error) => {
                 log::error!("enforcement policy apply failed: {error}");
+                let binding_id = request.binding_id;
                 self.store.upsert_binding(&Binding {
                     request,
                     state: BindingState::Failed,
                     message: Some(FAILED_BINDING_MESSAGE.into()),
                     domain_id: None,
                 })?;
-                Err(error.into())
+                Err(persisted_unacknowledged(
+                    binding_id,
+                    BindingState::Failed,
+                    error.into(),
+                ))
             }
         }
     }
@@ -669,11 +709,32 @@ impl EnforcementCoordinator {
 
     /// Lists persisted binding state.
     ///
+    /// Returns every persisted binding, including detached terminal state;
+    /// containment and reconciliation rely on the full snapshot.
+    ///
     /// # Errors
     ///
     /// Returns a persistence error.
     pub fn bindings(&self) -> Result<Vec<Binding>, EnforcementCoordinatorError> {
         Ok(self.store.bindings()?)
+    }
+
+    /// Lists persisted bindings for API consumers, hiding detached bindings.
+    ///
+    /// Detached bindings acknowledge successful deletion and would otherwise
+    /// resurface as zombie rows in the bindings list. Failed and degraded
+    /// bindings stay visible so operators can still inspect them.
+    ///
+    /// # Errors
+    ///
+    /// Returns a persistence error.
+    pub fn active_bindings(&self) -> Result<Vec<Binding>, EnforcementCoordinatorError> {
+        Ok(self
+            .store
+            .bindings()?
+            .into_iter()
+            .filter(|binding| binding.state != BindingState::Detached)
+            .collect())
     }
 
     /// Reads immutable structured provenance for one credential binding.
@@ -820,6 +881,18 @@ impl EnforcementCoordinator {
 
 fn unavailable_from_health(health: HealthStatus) -> EnforcementCoordinatorError {
     EnforcementCoordinatorError::EnforcementUnavailable(health_message(&health))
+}
+
+fn persisted_unacknowledged(
+    binding_id: Uuid,
+    state: BindingState,
+    source: EnforcementCoordinatorError,
+) -> EnforcementCoordinatorError {
+    EnforcementCoordinatorError::PersistedUnacknowledged {
+        binding_id,
+        state,
+        source: Box::new(source),
+    }
 }
 
 fn health_message(health: &HealthStatus) -> String {
@@ -1025,6 +1098,14 @@ fn sleep_until_superseded(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    use agentsight_enforcement_protocol::{
+        PROTOCOL_VERSION, RemoteError, Request, Response, ResponseBody, read_frame, write_frame,
+    };
+
     use super::*;
 
     #[test]
@@ -1234,5 +1315,204 @@ mod tests {
                 "violation event buffer overflow: dropped_events=1; violation persistence failed: database is locked"
             )
         );
+    }
+
+    fn fixture_policy(binding_id: Uuid) -> ApplyPolicy {
+        ApplyPolicy {
+            binding_id,
+            agent_id: "agent-1".into(),
+            session_id: None,
+            root_pid: 42,
+            process_start_time: 7,
+            policy_id: "policy-1".into(),
+            policy_revision: "revision-1".into(),
+            policy_dsl: "label AGENT".into(),
+            policy_mode: None,
+        }
+    }
+
+    fn fixture_health(ready: bool, message: Option<&str>) -> HealthStatus {
+        HealthStatus {
+            ready,
+            backend: "fixture".into(),
+            capabilities:
+                agentsight_enforcement_protocol::EnforcementCapabilities::mock_development(),
+            message: message.map(str::to_string),
+        }
+    }
+
+    /// Serves one response per client connection, mirroring the request-reply UDS protocol.
+    fn fixture_enforcer(
+        responses: Vec<Result<ResponseBody, RemoteError>>,
+    ) -> (EnforcementClient, thread::JoinHandle<()>, PathBuf) {
+        let socket_path =
+            std::env::temp_dir().join(format!("enforcement-coordinator-{}.sock", Uuid::new_v4()));
+        let listener = UnixListener::bind(&socket_path).expect("fixture listener should bind");
+        let server = thread::spawn(move || {
+            for result in responses {
+                let (mut stream, _) = listener.accept().expect("fixture client should connect");
+                let request: Request = read_frame(&mut BufReader::new(
+                    stream
+                        .try_clone()
+                        .expect("fixture stream should clone for reading"),
+                ))
+                .expect("fixture request should decode")
+                .expect("fixture request should exist");
+                let response = Response {
+                    protocol_version: PROTOCOL_VERSION,
+                    request_id: request.request_id,
+                    result,
+                };
+                let mut bytes = Vec::new();
+                write_frame(&mut bytes, &response).expect("fixture response should encode");
+                stream
+                    .write_all(&bytes)
+                    .expect("fixture response should write");
+                stream.flush().expect("fixture response should flush");
+            }
+        });
+        (EnforcementClient::new(&socket_path), server, socket_path)
+    }
+
+    #[test]
+    fn active_bindings_hide_detached_terminal_state_only() {
+        let coordinator = EnforcementCoordinator::new(
+            EnforcementClient::new("/tmp/unused-enforcement.sock"),
+            EnforcementStore::open(":memory:").expect("test store should open"),
+        );
+        let states = [
+            BindingState::Pending,
+            BindingState::Enforced,
+            BindingState::Failed,
+            BindingState::Degraded,
+            BindingState::Detaching,
+            BindingState::Detached,
+        ];
+        for state in states {
+            let binding = Binding {
+                request: fixture_policy(Uuid::new_v4()),
+                state,
+                message: None,
+                domain_id: None,
+            };
+            coordinator
+                .store
+                .upsert_binding(&binding)
+                .expect("fixture binding should persist");
+        }
+
+        let listed = coordinator
+            .active_bindings()
+            .expect("active bindings should list");
+        assert_eq!(listed.len(), 5);
+        assert!(
+            listed
+                .iter()
+                .all(|binding| binding.state != BindingState::Detached)
+        );
+
+        // The store keeps detached rows: containment and reconciliation
+        // consume the full snapshot through `bindings`.
+        assert_eq!(
+            coordinator
+                .store
+                .bindings()
+                .expect("store bindings should list")
+                .len(),
+            6
+        );
+    }
+
+    #[test]
+    fn apply_rejection_persists_failed_state_and_reports_it() {
+        let (client, server, socket_path) = fixture_enforcer(vec![
+            Ok(ResponseBody::Health(fixture_health(true, None))),
+            Err(RemoteError {
+                code: "internal_error".into(),
+                message: "fixture apply rejection".into(),
+            }),
+        ]);
+        let coordinator = EnforcementCoordinator::new(
+            client,
+            EnforcementStore::open(":memory:").expect("test store should open"),
+        );
+        let worker = coordinator.ingestion_readiness.candidate();
+        coordinator.ingestion_readiness.install(Arc::clone(&worker));
+        make_ready(&coordinator.ingestion_readiness, &worker);
+
+        let binding_id = Uuid::new_v4();
+        let result = coordinator.apply(fixture_policy(binding_id));
+        server.join().expect("fixture server should join");
+        std::fs::remove_file(&socket_path).expect("fixture socket should be removed");
+
+        match result {
+            Err(EnforcementCoordinatorError::PersistedUnacknowledged {
+                binding_id: persisted_id,
+                state,
+                ..
+            }) => {
+                assert_eq!(persisted_id, binding_id);
+                assert_eq!(state, BindingState::Failed);
+            }
+            other => panic!("expected persisted-unacknowledged failure, got {other:?}"),
+        }
+        let stored = coordinator
+            .store
+            .binding(binding_id)
+            .expect("store read should succeed")
+            .expect("rejected binding should stay persisted");
+        assert_eq!(stored.state, BindingState::Failed);
+        assert!(
+            coordinator
+                .active_bindings()
+                .expect("active bindings should list")
+                .iter()
+                .any(|binding| binding.request.binding_id == binding_id)
+        );
+    }
+
+    #[test]
+    fn apply_degraded_after_backend_loss_reports_persisted_state() {
+        let request = fixture_policy(Uuid::new_v4());
+        let applied = Binding {
+            request: request.clone(),
+            state: BindingState::Enforced,
+            message: None,
+            domain_id: None,
+        };
+        let (client, server, socket_path) = fixture_enforcer(vec![
+            Ok(ResponseBody::Health(fixture_health(true, None))),
+            Ok(ResponseBody::Applied(applied)),
+            Ok(ResponseBody::Health(fixture_health(
+                false,
+                Some("fixture backend lost"),
+            ))),
+        ]);
+        let coordinator = EnforcementCoordinator::new(
+            client,
+            EnforcementStore::open(":memory:").expect("test store should open"),
+        );
+        let worker = coordinator.ingestion_readiness.candidate();
+        coordinator.ingestion_readiness.install(Arc::clone(&worker));
+        make_ready(&coordinator.ingestion_readiness, &worker);
+
+        let result = coordinator.apply(request);
+        server.join().expect("fixture server should join");
+        std::fs::remove_file(&socket_path).expect("fixture socket should be removed");
+
+        match result {
+            Err(EnforcementCoordinatorError::PersistedUnacknowledged {
+                binding_id, state, ..
+            }) => {
+                assert_eq!(state, BindingState::Degraded);
+                let stored = coordinator
+                    .store
+                    .binding(binding_id)
+                    .expect("store read should succeed")
+                    .expect("degraded binding should stay persisted");
+                assert_eq!(stored.state, BindingState::Degraded);
+            }
+            other => panic!("expected persisted-unacknowledged failure, got {other:?}"),
+        }
     }
 }

--- a/src/agentsight/src/server/enforcement.rs
+++ b/src/agentsight/src/server/enforcement.rs
@@ -168,12 +168,16 @@ fn unix_epoch_ns() -> u64 {
 }
 
 /// Lists AgentSight's persisted desired binding states.
+///
+/// Detached bindings acknowledge successful deletion and are hidden so the
+/// list reflects the bindings an operator can still act on. Each item keeps
+/// its `state` field so failed or degraded bindings remain distinguishable.
 #[get("/enforcement/bindings")]
 pub(super) async fn list_bindings(data: web::Data<AppState>) -> HttpResponse {
     let Some(coordinator) = data.enforcement.clone() else {
         return unavailable();
     };
-    match web::block(move || coordinator.bindings()).await {
+    match web::block(move || coordinator.active_bindings()).await {
         Ok(Ok(bindings)) => HttpResponse::Ok().json(json!({
             "bindings": bindings.into_iter().map(public_binding).collect::<Vec<_>>()
         })),
@@ -367,6 +371,15 @@ fn build_credential_binding(
 }
 
 fn coordinator_error(error: EnforcementCoordinatorError) -> HttpResponse {
+    log::error!("enforcement coordinator request failed: {error}");
+    let (error, persisted) = match error {
+        EnforcementCoordinatorError::PersistedUnacknowledged {
+            binding_id,
+            state,
+            source,
+        } => (*source, Some((binding_id, state))),
+        error => (error, None),
+    };
     let (status, code, message, retryable) = match &error {
         EnforcementCoordinatorError::IngestionUnavailable => (
             actix_web::http::StatusCode::SERVICE_UNAVAILABLE,
@@ -428,7 +441,11 @@ fn coordinator_error(error: EnforcementCoordinatorError) -> HttpResponse {
             false,
         ),
     };
-    log::error!("enforcement coordinator request failed: {error}");
+    if let Some((binding_id, state)) = persisted
+        && status == actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+    {
+        return persisted_error_response(status, code, message, retryable, binding_id, state);
+    }
     error_response(status, code, message, retryable)
 }
 
@@ -459,6 +476,30 @@ fn error_response(
 ) -> HttpResponse {
     HttpResponse::build(status).json(json!({
         "error": { "code": code, "message": message, "retryable": retryable }
+    }))
+}
+
+/// Marks a 503 as "the desired state was persisted anyway".
+///
+/// Callers receiving this error can look up `binding_id` in the bindings list
+/// instead of assuming the failed request left no trace.
+fn persisted_error_response(
+    status: actix_web::http::StatusCode,
+    code: &str,
+    message: &str,
+    retryable: bool,
+    binding_id: Uuid,
+    state: BindingState,
+) -> HttpResponse {
+    HttpResponse::build(status).json(json!({
+        "error": {
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+            "persisted": true,
+            "binding_id": binding_id,
+            "state": state,
+        }
     }))
 }
 
@@ -724,6 +765,8 @@ mod tests {
             serde_json::Value::String("enforcement_unavailable".into())
         );
         assert_eq!(value["error"]["retryable"], serde_json::Value::Bool(true));
+        // Health failures happen before persistence and must not claim otherwise.
+        assert!(value["error"].get("persisted").is_none());
     }
 
     #[actix_web::test]
@@ -785,5 +828,87 @@ mod tests {
             status.message.as_deref(),
             Some("enforcement backend is not ready")
         );
+    }
+
+    #[actix_web::test]
+    async fn persisted_apply_failures_expose_persisted_state_on_503() {
+        let binding_id = Uuid::new_v4();
+        let response = coordinator_error(EnforcementCoordinatorError::PersistedUnacknowledged {
+            binding_id,
+            state: BindingState::Failed,
+            source: Box::new(EnforcementCoordinatorError::Client(
+                crate::enforcement::EnforcementError::Remote {
+                    code: "internal_error".into(),
+                    message: "fixture apply rejection".into(),
+                },
+            )),
+        });
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("error response body should load");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("error response should be JSON");
+        assert_eq!(value["error"]["code"], "enforcer_unavailable");
+        assert_eq!(value["error"]["persisted"], serde_json::Value::Bool(true));
+        assert_eq!(value["error"]["state"], "failed");
+        assert_eq!(
+            value["error"]["binding_id"],
+            serde_json::Value::String(binding_id.to_string())
+        );
+    }
+
+    #[actix_web::test]
+    async fn persisted_degraded_apply_failures_expose_state_on_503() {
+        let response = coordinator_error(EnforcementCoordinatorError::PersistedUnacknowledged {
+            binding_id: Uuid::new_v4(),
+            state: BindingState::Degraded,
+            source: Box::new(EnforcementCoordinatorError::EnforcementUnavailable(
+                "fixture backend lost".into(),
+            )),
+        });
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("error response body should load");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("error response should be JSON");
+        assert_eq!(value["error"]["code"], "enforcement_unavailable");
+        assert_eq!(value["error"]["persisted"], serde_json::Value::Bool(true));
+        assert_eq!(value["error"]["state"], "degraded");
+    }
+
+    #[actix_web::test]
+    async fn persisted_policy_rejections_keep_actionable_status_without_state_detail() {
+        let response = coordinator_error(EnforcementCoordinatorError::PersistedUnacknowledged {
+            binding_id: Uuid::new_v4(),
+            state: BindingState::Failed,
+            source: Box::new(EnforcementCoordinatorError::Client(
+                crate::enforcement::EnforcementError::Remote {
+                    code: "compile_failure".into(),
+                    message: "fixture compile rejection".into(),
+                },
+            )),
+        });
+
+        assert_eq!(
+            response.status(),
+            actix_web::http::StatusCode::UNPROCESSABLE_ENTITY
+        );
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .expect("error response body should load");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("error response should be JSON");
+        assert_eq!(value["error"]["code"], "compile_failure");
+        assert!(value["error"].get("persisted").is_none());
     }
 }

--- a/src/agentsight/tests/enforcement_pipeline.rs
+++ b/src/agentsight/tests/enforcement_pipeline.rs
@@ -873,8 +873,15 @@ fn remote_subscription_rejection_precedes_local_disconnect_observation() {
 
     assert!(matches!(
         &result,
-        Err(EnforcementCoordinatorError::EnforcementUnavailable(message))
-            if message.contains("violation ingestion is not subscribed")
+        Err(EnforcementCoordinatorError::PersistedUnacknowledged {
+            state: BindingState::Degraded,
+            source,
+            ..
+        }) if matches!(
+            source.as_ref(),
+            EnforcementCoordinatorError::EnforcementUnavailable(message)
+                if message.contains("violation ingestion is not subscribed")
+        )
     ));
     assert_eq!(fixture.apply_attempts(), 1);
     assert!(fixture.bindings().is_empty());
@@ -1002,8 +1009,15 @@ fn disconnect_during_apply_never_reports_enforced_state() {
     assert!(
         matches!(
             &result,
-            Err(EnforcementCoordinatorError::EnforcementUnavailable(message))
-                if message.contains("violation ingestion is not subscribed")
+            Err(EnforcementCoordinatorError::PersistedUnacknowledged {
+                state: BindingState::Degraded,
+                source,
+                ..
+            }) if matches!(
+                source.as_ref(),
+                EnforcementCoordinatorError::EnforcementUnavailable(message)
+                    if message.contains("violation ingestion is not subscribed")
+            )
         ),
         "unexpected apply result after disconnect: {result:?}"
     );


### PR DESCRIPTION
## Why

Enforcement binding write operations reported state that contradicted the store (#2779):

- `POST /api/enforcement/file-bindings` returned `503 enforcer_unavailable` while the binding **was already persisted** (coordinator persists `Pending` first, then upserts `Failed`/`Degraded` on failure — `src/agentsight/src/enforcement/coordinator.rs` apply, upsert at ~L426/493), so clients retried blind and zombie rows accumulated.
- `DELETE /api/enforcement/bindings/{id}` returned `204` but the `Detached` row stayed in `GET /api/enforcement/bindings` forever, because `store.bindings()` (`src/agentsight/src/enforcement/store.rs` ~L260) selects all rows with no state filter and no code path ever deletes rows.

## What changed

- **List hides detached bindings**: `EnforcementCoordinator::active_bindings()` filters `BindingState::Detached`; `GET /enforcement/bindings` now uses it. Each item already carries its `state` field, so failed/degraded bindings remain visible and distinguishable. `bindings()` keeps returning the full snapshot because containment (`security/containment/enforcer.rs`) and reconciliation (`enforcement/coordinator/reconciliation.rs` ~L129) depend on it.
- **503 now tells the truth about persistence**: apply failures that happen *after* the desired state is persisted return the new `EnforcementCoordinatorError::PersistedUnacknowledged { binding_id, state }`; the HTTP layer keeps the 503 status but extends the error body with `persisted: true`, `binding_id`, and `state` (e.g. `{"error":{"code":"enforcer_unavailable",...,"persisted":true,"binding_id":"…","state":"failed"}}`). Availability failures raised *before* persistence (ingestion lease, pre-apply health) keep the plain 503 body.
- **Deliberately out of scope** (terminal REST semantics belong to the #2017 atomic-handoff design): hard-deleting rows or a purge endpoint for `DELETE`, switching POST to 202, filtering `Failed` from the list, aligning `/health` readiness with apply availability, and the credential-bindings POST path. Today `DELETE` on a `Failed` binding still works as the cleanup path (detach's `missing_binding` branch lands it in `Detached`, which is then hidden).

## Related issue

Closes #2779

## User / Agent impact

- The dashboard "Policy bindings" table no longer shows already-deleted bindings.
- Clients receiving a 503 on apply can now check `error.persisted` and look up `error.binding_id` instead of assuming nothing happened.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The bindings list response shrinks (detached rows hidden) and 503 bodies gain additive fields; both are backward-compatible for clients that ignore unknown fields. Pre-persist 503s and all non-503 statuses keep byte-identical bodies. `EnforcementCoordinatorError` gains one variant; the only non-exhaustive match (`containment_enforcer_error`) still compiles because apply is not called from containment.

## Validation

On a Linux ECS host, Rust toolchain 1.89.0, `src/agentsight`:

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p agentsight --lib --all-targets -- -D warnings` — pass, zero warnings
- `cargo test -p agentsight --lib enforcement` — 65 passed, 0 failed (targeted suite; full lib suite not run, compile+clippy cover all targets)

New discriminating tests (verified to fail with the fix logic disabled, pass with it enabled):

- `enforcement::coordinator::tests::active_bindings_hide_detached_terminal_state_only` — all six states persisted; list shows 5, store keeps 6
- `enforcement::coordinator::tests::apply_rejection_persists_failed_state_and_reports_it` — fixture UDS enforcer rejects apply; error carries `PersistedUnacknowledged{state: Failed}` and the store keeps the `Failed` row
- `enforcement::coordinator::tests::apply_degraded_after_backend_loss_reports_persisted_state` — apply acknowledged then backend health drops; `Degraded` reported and persisted
- `server::enforcement::tests::persisted_apply_failures_expose_persisted_state_on_503` / `persisted_degraded_apply_failures_expose_state_on_503` — 503 body contains `persisted`/`binding_id`/`state`
- `server::enforcement::tests::persisted_policy_rejections_keep_actionable_status_without_state_detail` — wrapped `compile_failure` stays 422 without the extra fields
- existing `maps_combined_health_failure_to_retryable_service_unavailable` now also asserts pre-persist 503s do **not** claim `persisted`

## Documentation and rollback

No doc changes: the API reference for these endpoints is the code-owned error envelope, and the added fields are additive. Rollback is a single-commit revert; persisted `Detached` rows simply reappear in the list.
