### PR TITLE
ci(ci): build cosh-ng prebuilt packages

### DIFF
--- a/.github/actions/build-cosh-ng-prebuilt/action.yaml
+++ b/.github/actions/build-cosh-ng-prebuilt/action.yaml
@@ -1,0 +1,54 @@
+name: Build cosh-ng prebuilt package
+description: Build and package one cosh-ng release target on the release Cross runner.
+
+inputs:
+  version:
+    description: Component version without the v prefix.
+    required: true
+  target-os:
+    description: Package target operating system.
+    required: true
+  target-arch:
+    description: Package target architecture.
+    required: true
+  profile:
+    description: Prepared Cross release profile.
+    required: true
+  tag:
+    description: Release tag to bind to the checked-out commit. Empty for previews.
+    required: false
+    default: ''
+
+outputs:
+  artifact-directory:
+    description: Directory containing the tar, checksums, and CycloneDX SBOM.
+    value: ${{ steps.build.outputs.artifact-directory }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Build precompiled package
+      id: build
+      shell: bash
+      env:
+        COSH_NG_OUTPUT_DIR: ${{ runner.temp }}/cosh-ng-prebuilt-${{ inputs.target-os }}-${{ inputs.target-arch }}
+        COSH_NG_VERSION: ${{ inputs.version }}
+        COSH_NG_TARGET_OS: ${{ inputs.target-os }}
+        COSH_NG_TARGET_ARCH: ${{ inputs.target-arch }}
+        COSH_NG_PROFILE: ${{ inputs.profile }}
+        COSH_NG_TAG: ${{ inputs.tag }}
+      run: |
+        "$GITHUB_ACTION_PATH/build.sh" \
+          --source-repo "$GITHUB_WORKSPACE" \
+          --output-dir "$COSH_NG_OUTPUT_DIR" \
+          --version "$COSH_NG_VERSION" \
+          --target-os "$COSH_NG_TARGET_OS" \
+          --target-arch "$COSH_NG_TARGET_ARCH" \
+          --profile "$COSH_NG_PROFILE" \
+          --tag "$COSH_NG_TAG"
+        echo "artifact-directory=$COSH_NG_OUTPUT_DIR" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-cosh-ng-prebuilt/build.sh
+++ b/.github/actions/build-cosh-ng-prebuilt/build.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Build and package one reproducible cosh-ng precompiled release target.
+set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXED_WORKTREE="${COSH_NG_SOURCE_WORKTREE:-/tmp/anolisa-raw-release-source-worktrees/cosh-ng}"
+VERSION=""
+TARGET_OS=""
+TARGET_ARCH=""
+PROFILE=""
+TAG=""
+SOURCE_REPO=""
+OUTPUT_DIR=""
+WORKTREE_READY=0
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: build.sh --source-repo PATH --output-dir PATH --version X.Y.Z \
+  --target-os {linux|macos} --target-arch {x86_64|aarch64} \
+  --profile PROFILE [--tag cosh-ng/vX.Y.Z]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --source-repo) SOURCE_REPO="${2:-}"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+        --version) VERSION="${2:-}"; shift 2 ;;
+        --target-os) TARGET_OS="${2:-}"; shift 2 ;;
+        --target-arch) TARGET_ARCH="${2:-}"; shift 2 ;;
+        --profile) PROFILE="${2:-}"; shift 2 ;;
+        --tag) TAG="${2:-}"; shift 2 ;;
+        --help | -h) usage; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+[ -n "$VERSION" ] || die '--version is required'
+[ -n "$TARGET_OS" ] || die '--target-os is required'
+[ -n "$TARGET_ARCH" ] || die '--target-arch is required'
+[ -n "$PROFILE" ] || die '--profile is required'
+[ -n "$SOURCE_REPO" ] || die '--source-repo is required'
+[ -n "$OUTPUT_DIR" ] || die '--output-dir is required'
+
+for command in cargo flock git install python3 sha256sum; do
+    command -v "$command" >/dev/null || die "missing required command: $command"
+done
+SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
+    die "source-repo is not a Git worktree"
+SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+
+case "$TARGET_OS/$TARGET_ARCH/$PROFILE" in
+    linux/x86_64/gnu2.28-x86_64)
+        RUST_TARGET=x86_64-unknown-linux-gnu
+        ;;
+    linux/aarch64/gnu2.28-aarch64)
+        RUST_TARGET=aarch64-unknown-linux-gnu
+        ;;
+    macos/aarch64/darwin11-aarch64)
+        RUST_TARGET=aarch64-apple-darwin
+        ;;
+    *)
+        die "profile $PROFILE does not match target $TARGET_OS/$TARGET_ARCH"
+        ;;
+esac
+
+if [ -n "$TAG" ]; then
+    [ "$TAG" = "cosh-ng/v$VERSION" ] || \
+        die "release tag $TAG does not match requested version $VERSION"
+    TAG_COMMIT="$(git -C "$SOURCE_REPO" rev-parse --verify "refs/tags/$TAG^{commit}")" || \
+        die "release tag is unavailable in the checkout: $TAG"
+    [ "$TAG_COMMIT" = "$SOURCE_COMMIT" ] || \
+        die "release tag $TAG does not point at checked-out commit $SOURCE_COMMIT"
+fi
+
+install -d -m 0755 "$(dirname "$FIXED_WORKTREE")"
+exec 9>"${FIXED_WORKTREE%/cosh-ng}.lock"
+flock -n 9 || die "cosh-ng source worktree is already in use"
+
+worktree_registered() {
+    git -C "$SOURCE_REPO" worktree list --porcelain | \
+        grep -Fxq "worktree $FIXED_WORKTREE"
+}
+
+cleanup() {
+    if [ "$WORKTREE_READY" -eq 1 ] && worktree_registered; then
+        git -C "$SOURCE_REPO" worktree unlock "$FIXED_WORKTREE" >/dev/null 2>&1 || true
+        git -C "$SOURCE_REPO" worktree remove --force "$FIXED_WORKTREE" >/dev/null 2>&1 || \
+            printf 'WARN: failed to remove source worktree: %s\n' "$FIXED_WORKTREE" >&2
+    fi
+}
+trap cleanup EXIT
+
+[ ! -L "$FIXED_WORKTREE" ] || die "fixed worktree path must not be a symbolic link"
+if worktree_registered; then
+    git -C "$SOURCE_REPO" worktree unlock "$FIXED_WORKTREE" >/dev/null 2>&1 || true
+    git -C "$SOURCE_REPO" worktree remove --force "$FIXED_WORKTREE" || \
+        die "cannot remove the previous registered worktree: $FIXED_WORKTREE"
+elif [ -e "$FIXED_WORKTREE" ]; then
+    [ -d "$FIXED_WORKTREE" ] || die "fixed worktree path is not a directory"
+    rmdir "$FIXED_WORKTREE" 2>/dev/null || \
+        die "refusing to delete a non-empty unregistered path: $FIXED_WORKTREE"
+fi
+git -C "$SOURCE_REPO" worktree add --detach "$FIXED_WORKTREE" "$SOURCE_COMMIT"
+WORKTREE_READY=1
+git -C "$SOURCE_REPO" worktree lock --reason 'cosh-ng prebuilt package build' \
+    "$FIXED_WORKTREE"
+
+COMPONENT_ROOT="$FIXED_WORKTREE/src/cosh-ng"
+LINUX_VERSION="$(
+    python3 "$COMPONENT_ROOT/packaging/raw/verify-release.py" \
+        "$COMPONENT_ROOT" "$COMPONENT_ROOT/.anolisa/component.toml" \
+        --os linux --arch x86_64
+)"
+MACOS_VERSION="$(
+    python3 "$COMPONENT_ROOT/packaging/raw/verify-release.py" \
+        "$COMPONENT_ROOT" "$COMPONENT_ROOT/.anolisa/component.macos.toml" \
+        --os macos --arch aarch64
+)"
+[ "$LINUX_VERSION" = "$MACOS_VERSION" ] || \
+    die "Linux and macOS contracts do not have one version"
+[ "$VERSION" = "$LINUX_VERSION" ] || \
+    die "requested version $VERSION does not match cosh-ng $LINUX_VERSION"
+
+if [ -e "$OUTPUT_DIR" ] && [ -n "$(find "$OUTPUT_DIR" -mindepth 1 -print -quit)" ]; then
+    die "output directory must be empty: $OUTPUT_DIR"
+fi
+install -d -m 0755 "$OUTPUT_DIR"
+SOURCE_DATE_EPOCH="$(git -C "$FIXED_WORKTREE" show -s --format=%ct HEAD)"
+case "$SOURCE_DATE_EPOCH" in
+    '' | *[!0-9]*) die 'source commit timestamp is not numeric' ;;
+esac
+export RUSTUP_TOOLCHAIN=1.93.0-x86_64-unknown-linux-gnu
+export SOURCE_DATE_EPOCH
+
+cargo metadata \
+    --format-version 1 \
+    --locked \
+    --filter-platform "$RUST_TARGET" \
+    --manifest-path "$COMPONENT_ROOT/Cargo.toml" >/dev/null
+
+(
+    cd "$FIXED_WORKTREE"
+    python3 "$ACTION_DIR/reproducible-build.py" \
+        --source-root "$COMPONENT_ROOT" \
+        --source-date-epoch "$SOURCE_DATE_EPOCH" \
+        -- "$ACTION_DIR/cross-profile.sh" "$PROFILE" build \
+        --release \
+        --workspace \
+        --locked \
+        --manifest-path src/cosh-ng/Cargo.toml
+)
+
+BIN_DIR="$COMPONENT_ROOT/target/release"
+TARGET_BIN_DIR="$COMPONENT_ROOT/target/$RUST_TARGET/release"
+install -d -m 0755 "$BIN_DIR"
+for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
+    [ -x "$TARGET_BIN_DIR/$binary" ] || \
+        die "Cross build did not produce $TARGET_BIN_DIR/$binary"
+    install -p -m 0755 "$TARGET_BIN_DIR/$binary" "$BIN_DIR/$binary"
+    if [ "$TARGET_OS" = macos ]; then
+        python3 "$ACTION_DIR/verify-macho.py" --min 11.0 "$BIN_DIR/$binary"
+    else
+        python3 "$ACTION_DIR/verify-glibc.py" \
+            --arch "$TARGET_ARCH" --max 2.28 "$BIN_DIR/$binary"
+    fi
+done
+
+METADATA="$BIN_DIR/cosh-ng-build.toml"
+{
+    printf 'version = "%s"\n' "$VERSION"
+    printf 'target_os = "%s"\n' "$TARGET_OS"
+    printf 'target_arch = "%s"\n\n' "$TARGET_ARCH"
+    printf '[binaries]\n'
+    for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
+        printf '%s = "%s"\n' \
+            "$binary" "$(sha256sum "$BIN_DIR/$binary" | awk '{print $1}')"
+    done
+} > "$METADATA"
+
+if [ "$TARGET_OS" = macos ]; then
+    CONTRACT="$COMPONENT_ROOT/.anolisa/component.macos.toml"
+else
+    CONTRACT="$COMPONENT_ROOT/.anolisa/component.toml"
+fi
+COSH_NG_SOURCE_DIR="$COMPONENT_ROOT" \
+RAW_CONTRACT="$CONTRACT" \
+BIN_DIR="$BIN_DIR" \
+COSH_NG_BUILD_METADATA="$METADATA" \
+OUTPUT_DIR="$OUTPUT_DIR" \
+TARGET_OS="$TARGET_OS" \
+TARGET_ARCH="$TARGET_ARCH" \
+SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+    "$COMPONENT_ROOT/packaging/raw/package.sh" package >/dev/null
+
+ARCHIVE="cosh-ng-$VERSION-$TARGET_OS-$TARGET_ARCH.tar.gz"
+(
+    cd "$OUTPUT_DIR"
+    sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+)
+python3 "$ACTION_DIR/generate-sbom.py" \
+    --artifact "$OUTPUT_DIR/$ARCHIVE" \
+    --version "$VERSION" \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH" \
+    --target "$RUST_TARGET" \
+    --project-dir "$COMPONENT_ROOT" \
+    --source-date-epoch "$SOURCE_DATE_EPOCH" >/dev/null
+python3 "$ACTION_DIR/verify-artifacts.py" \
+    --directory "$OUTPUT_DIR" \
+    --version "$VERSION" \
+    --layout flat \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH"
+printf 'Built cosh-ng %s for %s/%s at %s\n' \
+    "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$OUTPUT_DIR"

--- a/.github/actions/build-cosh-ng-prebuilt/cross-profile.sh
+++ b/.github/actions/build-cosh-ng-prebuilt/cross-profile.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Run one Cargo command with a prepared cosh-ng release Cross profile.
+set -euo pipefail
+
+RUST_VERSION=1.93.0
+RUST_TOOLCHAIN=1.93.0-x86_64-unknown-linux-gnu
+SCCACHE_VERSION=0.17.0
+SCCACHE_CACHE_SIZE=20G
+GNU228_X86_BASE="docker.io/dockcross/manylinux_2_28-x64@sha256:263b776c5dc6ae7e50942c5fbb82eb24a1ec64016cd6dd10831d51c2201923cf"
+GNU228_X86_IMAGE="anolisa/rust-release-builder:gnu2.28-x86_64"
+GNU228_X86_IMAGE_ID="sha256:0a5c24bde830394d0fb585a4c7c2021b315e394bf3a3e3abb22401b70e4b35db"
+GNU228_ARM_BASE="docker.io/dockcross/manylinux_2_28-aarch64@sha256:63d09e1726a914c85b0087aa00b966df896fac962095310b915332f0135bfd74"
+GNU228_ARM_IMAGE="anolisa/rust-release-builder:gnu2.28-aarch64"
+GNU228_ARM_IMAGE_ID="sha256:8c0788e130476253259a838d7ddad7d04a34778d60ab391f6fabaf007639a2dd"
+DARWIN_IMAGE="anolisa/rust-release-builder:darwin11-aarch64"
+DARWIN_IMAGE_ID="sha256:f43abc5ea60980fe1a452607ebc481ea0636bb6e6f0acbd03f7ed1f5064459e1"
+DARWIN_SDK_SHA256="71ebe09d97f45d48c9814e69b524ee3577dddfe7393aa4eac8615f07d6f7e0f5"
+DARWIN_OSXCROSS_REF="27d21e4977c9751d01199c7a226a6faf494c3dd9"
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+profile_target() {
+    case "$1" in
+        gnu2.28-x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
+        gnu2.28-aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
+        darwin11-aarch64) printf 'aarch64-apple-darwin\n' ;;
+        *) die "unsupported cosh-ng Cross profile: $1" ;;
+    esac
+}
+
+profile_image() {
+    case "$1" in
+        gnu2.28-x86_64) printf '%s\n' "$GNU228_X86_IMAGE" ;;
+        gnu2.28-aarch64) printf '%s\n' "$GNU228_ARM_IMAGE" ;;
+        darwin11-aarch64) printf '%s\n' "$DARWIN_IMAGE" ;;
+        *) die "unsupported cosh-ng Cross profile: $1" ;;
+    esac
+}
+
+profile_image_id() {
+    case "$1" in
+        gnu2.28-x86_64) printf '%s\n' "$GNU228_X86_IMAGE_ID" ;;
+        gnu2.28-aarch64) printf '%s\n' "$GNU228_ARM_IMAGE_ID" ;;
+        darwin11-aarch64) printf '%s\n' "$DARWIN_IMAGE_ID" ;;
+        *) die "unsupported cosh-ng Cross profile: $1" ;;
+    esac
+}
+
+profile_path() {
+    case "$1" in
+        gnu2.28-x86_64)
+            printf '/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+            ;;
+        gnu2.28-aarch64)
+            printf '/usr/xcc/aarch64-unknown-linux-gnu/bin:/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+            ;;
+        darwin11-aarch64)
+            printf '/opt/osxcross/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+            ;;
+        *) die "unsupported cosh-ng Cross profile: $1" ;;
+    esac
+}
+
+image_label() {
+    docker image inspect --format "{{ index .Config.Labels \"$2\" }}" "$1"
+}
+
+verify_common_tools() {
+    local actual
+    local target="$1"
+
+    for command in cross docker rustc rustup; do
+        command -v "$command" >/dev/null || die "missing required command: $command"
+    done
+    actual="$(RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN" rustc --version | awk '{print $2}')"
+    [ "$actual" = "$RUST_VERSION" ] || \
+        die "rustc $RUST_VERSION is required, got $actual"
+    rustup target list --installed --toolchain "$RUST_TOOLCHAIN" | grep -Fxq "$target" || \
+        die "Rust target $target is not installed for $RUST_TOOLCHAIN"
+    actual="$(RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN" cross --version | \
+        sed -nE 's/^cross[[:space:]]+([^[:space:]]+).*$/\1/p')"
+    [ "$actual" = 0.2.5 ] || die "Cross 0.2.5 is required, got ${actual:-unknown}"
+}
+
+verify_linux_profile() {
+    local profile="$1"
+    local image="$2"
+    local base
+
+    case "$profile" in
+        gnu2.28-x86_64)
+            base="$GNU228_X86_BASE"
+            ;;
+        gnu2.28-aarch64)
+            base="$GNU228_ARM_BASE"
+            ;;
+    esac
+    [ "$(image_label "$image" org.anolisa.release-builder.profile)" = "$profile" ] || \
+        die "$image does not identify profile $profile"
+    [ "${base##*@}" = "$(image_label "$image" org.anolisa.release-builder.base-image | sed 's/^.*@//')" ] || \
+        die "$image does not bind the pinned base image digest"
+    [ "$(docker run --rm --entrypoint getconf "$image" GNU_LIBC_VERSION)" = 'glibc 2.28' ] || \
+        die "$image is not a glibc 2.28 profile"
+
+    if [ "$profile" = gnu2.28-x86_64 ]; then
+        docker run --rm --entrypoint rpm "$image" -q \
+            clang-devel llvm-devel elfutils-libelf-devel systemd-devel \
+            fuse3-devel openssl-devel zlib-devel libzstd-devel \
+            pkgconf-pkg-config >/dev/null
+    else
+        docker run --rm --entrypoint sh "$image" -c '
+            set -eu
+            sysroot="$(aarch64-unknown-linux-gnu-gcc --print-sysroot)"
+            test -f "$sysroot/usr/include/openssl/ssl.h"
+            readelf -h "$sysroot/usr/lib64/libssl.so.1.1" | grep -Fq AArch64
+            PKG_CONFIG_SYSROOT_DIR="$sysroot" \
+                PKG_CONFIG_LIBDIR="$sysroot/usr/lib64/pkgconfig:$sysroot/usr/share/pkgconfig" \
+                pkg-config --exists openssl
+        '
+    fi
+}
+
+verify_darwin_profile() {
+    local image="$1"
+
+    [ "$(image_label "$image" org.anolisa.release-builder.profile)" = darwin11-aarch64 ] || \
+        die "$image does not identify profile darwin11-aarch64"
+    [ "$(image_label "$image" org.anolisa.release-builder.target)" = aarch64-apple-darwin ] || \
+        die "$image target label is invalid"
+    [ "$(image_label "$image" org.anolisa.release-builder.macos-deployment-target)" = 11.0 ] || \
+        die "$image deployment target label is invalid"
+    [ "$(image_label "$image" org.anolisa.release-builder.macos-sdk-version)" = 15.5 ] || \
+        die "$image SDK version label is invalid"
+    [ "$(image_label "$image" org.anolisa.release-builder.macos-sdk-sha256)" = "$DARWIN_SDK_SHA256" ] || \
+        die "$image SDK checksum label is invalid"
+    [ "$(image_label "$image" org.anolisa.release-builder.osxcross-ref)" = "$DARWIN_OSXCROSS_REF" ] || \
+        die "$image osxcross revision label is invalid"
+    docker run --rm --entrypoint sh "$image" -c '
+        set -eu
+        test -x /usr/local/bin/aarch64-apple-darwin-clang
+        test -x /usr/local/bin/aarch64-apple-darwin-ar
+        test -d /opt/osxcross/SDK/MacOSX15.5.sdk
+        /usr/local/bin/aarch64-apple-darwin-clang --version >/dev/null
+    '
+}
+
+verify_profile() {
+    local profile="$1"
+    local actual image image_id target safe_path
+
+    target="$(profile_target "$profile")"
+    image="$(profile_image "$profile")"
+    image_id="$(profile_image_id "$profile")"
+    safe_path="$(profile_path "$profile")"
+    verify_common_tools "$target"
+    docker image inspect "$image" >/dev/null 2>&1 || \
+        die "Runner profile image is not prepared: $image"
+    actual="$(docker image inspect --format '{{.Id}}' "$image")"
+    [ "$actual" = "$image_id" ] || \
+        die "$image does not match pinned image ID $image_id"
+    image="$image_id"
+    actual="$(docker run --rm --entrypoint /usr/local/bin/sccache "$image" --version)"
+    [ "$actual" = "sccache $SCCACHE_VERSION" ] || \
+        die "$image cannot run sccache $SCCACHE_VERSION"
+    if [ "$profile" = darwin11-aarch64 ]; then
+        verify_darwin_profile "$image"
+    else
+        verify_linux_profile "$profile" "$image"
+    fi
+    if docker run --rm --entrypoint env "$image" \
+        "PATH=$safe_path" sh -c 'command -v cargo' >/dev/null 2>&1; then
+        die "profile PATH exposes image-provided Cargo: $profile"
+    fi
+}
+
+run_profile() {
+    local profile="$1"
+    shift
+    local image target target_env image_env safe_path linker archiver
+    local cargo_home container_opts deployment encoded
+
+    target="$(profile_target "$profile")"
+    image="$(profile_image_id "$profile")"
+    target_env="${target^^}"
+    target_env="${target_env//-/_}"
+    image_env="CROSS_TARGET_${target_env}_IMAGE"
+    safe_path="$(profile_path "$profile")"
+    cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+    install -d -m 0755 "$cargo_home/sccache"
+    case "$profile" in
+        gnu2.28-x86_64) linker=gcc; archiver='ar' ;;
+        gnu2.28-aarch64)
+            linker=aarch64-unknown-linux-gnu-gcc
+            archiver=aarch64-unknown-linux-gnu-ar
+            ;;
+        darwin11-aarch64)
+            linker=aarch64-apple-darwin-clang
+            archiver=aarch64-apple-darwin-ar
+            ;;
+    esac
+
+    container_opts="${CROSS_CONTAINER_OPTS:-}"
+    [ -z "$container_opts" ] || container_opts+=' '
+    container_opts+="--env=PATH=$safe_path --env=LD_LIBRARY_PATH=/rust/lib"
+    container_opts+=" --env=RUSTC_WRAPPER=/usr/local/bin/sccache"
+    container_opts+=" --env=SCCACHE_DIR=/cargo/sccache"
+    container_opts+=" --env=SCCACHE_CACHE_SIZE=$SCCACHE_CACHE_SIZE"
+    container_opts+=" --env=SCCACHE_CLIENT_SIDE=1 --env=CARGO_INCREMENTAL=0"
+    if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+        container_opts+=" --env=SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+    fi
+    if [ "$profile" = darwin11-aarch64 ]; then
+        deployment=11.0
+        container_opts+=" --env=MACOSX_DEPLOYMENT_TARGET=$deployment"
+        container_opts+=" --env=SDKROOT=/opt/osxcross/SDK/MacOSX.sdk"
+        encoded="${CARGO_ENCODED_RUSTFLAGS:-}"
+        if [[ "$encoded" != *'link-arg=-Wl,-no_uuid'* ]]; then
+            [ -z "$encoded" ] || encoded+=$'\x1f'
+            encoded+="-C"$'\x1f'"link-arg=-Wl,-no_uuid"
+        fi
+        env RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN" \
+            "$image_env=$image" \
+            "CROSS_CONTAINER_OPTS=$container_opts" \
+            "MACOSX_DEPLOYMENT_TARGET=$deployment" \
+            "CARGO_ENCODED_RUSTFLAGS=$encoded" \
+            "CARGO_TARGET_${target_env}_LINKER=$linker" \
+            "CC_${target//-/_}=$linker" \
+            "CXX_${target//-/_}=aarch64-apple-darwin-clang++" \
+            "AR_${target//-/_}=$archiver" \
+            "CFLAGS_${target//-/_}=-mmacosx-version-min=$deployment" \
+            "CXXFLAGS_${target//-/_}=-mmacosx-version-min=$deployment" \
+            cross "$@" --target "$target"
+    else
+        if [ "$profile" = gnu2.28-aarch64 ]; then
+            local sysroot=/usr/xcc/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
+            container_opts+=" --env=PKG_CONFIG_SYSROOT_DIR=$sysroot"
+            container_opts+=" --env=PKG_CONFIG_LIBDIR=$sysroot/usr/lib64/pkgconfig:$sysroot/usr/share/pkgconfig"
+        fi
+        env RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN" \
+            "$image_env=$image" \
+            "CROSS_CONTAINER_OPTS=$container_opts" \
+            "CARGO_TARGET_${target_env}_LINKER=$linker" \
+            "CC_${target//-/_}=$linker" \
+            "AR_${target//-/_}=$archiver" \
+            cross "$@" --target "$target"
+    fi
+}
+
+PROFILE="${1:?usage: cross-profile.sh PROFILE --check|CROSS_ARGS...}"
+shift
+verify_profile "$PROFILE"
+if [ "${1:-}" = --check ]; then
+    [ "$#" -eq 1 ] || die '--check does not accept additional arguments'
+    printf 'Cross profile verified: %s\n' "$PROFILE"
+    exit 0
+fi
+[ "$#" -gt 0 ] || die 'a Cross command is required'
+run_profile "$PROFILE" "$@"

--- a/.github/actions/build-cosh-ng-prebuilt/generate-sbom.py
+++ b/.github/actions/build-cosh-ng-prebuilt/generate-sbom.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Generate a deterministic CycloneDX 1.6 sidecar for a cosh-ng archive."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+def die(message: str) -> None:
+    """Exit with one actionable diagnostic."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def sha256_file(path: Path) -> str:
+    """Return a file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_sidecar(path: Path, filename: str) -> str:
+    """Read a strict sha256sum sidecar for one adjacent file."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        die(f"cannot read checksum sidecar {path}: {error}")
+    if len(lines) != 1:
+        die(f"checksum sidecar must contain exactly one line: {path}")
+    match = re.fullmatch(r"([0-9a-fA-F]{64})  ([^/]+)", lines[0])
+    if match is None or match.group(2) != filename:
+        die(f"checksum sidecar does not identify {filename}: {path}")
+    return match.group(1).lower()
+
+
+def cargo_sbom_version(tool: str) -> str:
+    """Return the installed cargo-sbom version."""
+    try:
+        result = subprocess.run(
+            [tool, "--version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        die(f"cargo-sbom command not found: {tool}")
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        die(f"failed to query cargo-sbom version: {detail or error.returncode}")
+    output = result.stdout.strip() or result.stderr.strip()
+    match = re.search(r"(?:^|\s)cargo-sbom\s+([^\s]+)", output)
+    if match is None:
+        die(f"unexpected cargo-sbom --version output: {output!r}")
+    return match.group(1)
+
+
+def cargo_metadata(project_dir: Path, target: str) -> dict[str, Any]:
+    """Return Cargo's default-feature dependency graph for one target."""
+    try:
+        result = subprocess.run(
+            [
+                "cargo",
+                "metadata",
+                "--format-version",
+                "1",
+                "--locked",
+                "--filter-platform",
+                target,
+                "--manifest-path",
+                str(project_dir / "Cargo.toml"),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        die("cargo command not found")
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        die(f"cargo metadata failed: {detail or error.returncode}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        die(f"cargo metadata returned invalid JSON: {error}")
+    if not isinstance(data, dict):
+        die("cargo metadata output must be a JSON object")
+    return data
+
+
+def resolved_package_identities(data: dict[str, Any]) -> set[tuple[str, str]]:
+    """Return normal dependencies reachable from every workspace member."""
+    packages = data.get("packages")
+    workspace_members = data.get("workspace_members")
+    resolve = data.get("resolve")
+    nodes = resolve.get("nodes") if isinstance(resolve, dict) else None
+    if not isinstance(packages, list) or not isinstance(workspace_members, list):
+        die("cargo metadata is missing packages or workspace_members")
+    if not isinstance(nodes, list):
+        die("cargo metadata is missing the resolved dependency graph")
+
+    packages_by_id: dict[str, dict[str, Any]] = {}
+    for package in packages:
+        if not isinstance(package, dict) or not isinstance(package.get("id"), str):
+            die("cargo metadata contains an invalid package")
+        packages_by_id[package["id"]] = package
+    nodes_by_id: dict[str, dict[str, Any]] = {}
+    for node in nodes:
+        if not isinstance(node, dict) or not isinstance(node.get("id"), str):
+            die("cargo metadata contains an invalid resolve node")
+        nodes_by_id[node["id"]] = node
+
+    pending = list(workspace_members)
+    reachable: set[str] = set()
+    while pending:
+        package_id = pending.pop()
+        if not isinstance(package_id, str) or package_id in reachable:
+            continue
+        package = packages_by_id.get(package_id)
+        node = nodes_by_id.get(package_id)
+        if package is None or node is None:
+            die(f"cargo metadata cannot resolve package {package_id}")
+        reachable.add(package_id)
+        dependencies = node.get("deps")
+        if not isinstance(dependencies, list):
+            die(f"cargo metadata package has invalid dependencies: {package_id}")
+        for dependency in dependencies:
+            if not isinstance(dependency, dict):
+                die(f"cargo metadata package has an invalid dependency: {package_id}")
+            dependency_id = dependency.get("pkg")
+            kinds = dependency.get("dep_kinds")
+            if not isinstance(dependency_id, str) or not isinstance(kinds, list):
+                die(f"cargo metadata package has an invalid dependency: {package_id}")
+            if any(
+                isinstance(kind, dict) and kind.get("kind") is None
+                for kind in kinds
+            ):
+                pending.append(dependency_id)
+
+    identities: set[tuple[str, str]] = set()
+    for package_id in reachable:
+        package = packages_by_id[package_id]
+        name = package.get("name")
+        version = package.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            die(f"cargo metadata package has no name or version: {package_id}")
+        identities.add((name, version))
+    return identities
+
+
+def component_identity(component: dict[str, Any]) -> tuple[str, str] | None:
+    """Return the Cargo name/version identity represented by a component."""
+    name = component.get("name")
+    version = component.get("version")
+    if isinstance(name, str) and isinstance(version, str):
+        return (name, version)
+    return None
+
+
+def component_identities(components: list[Any]) -> set[tuple[str, str]]:
+    """Collect identities from a nested component list."""
+    identities: set[tuple[str, str]] = set()
+    for component in components:
+        if not isinstance(component, dict):
+            die("cargo-sbom output contains an invalid component")
+        identity = component_identity(component)
+        if identity is not None:
+            identities.add(identity)
+        nested = component.get("components")
+        if isinstance(nested, list):
+            identities.update(component_identities(nested))
+    return identities
+
+
+def filter_components(
+    components: list[Any], allowed: set[tuple[str, str]]
+) -> list[dict[str, Any]]:
+    """Keep only components in the resolved target dependency graph."""
+    retained: list[dict[str, Any]] = []
+    for component in components:
+        if not isinstance(component, dict):
+            die("cargo-sbom output contains an invalid component")
+        identity = component_identity(component)
+        if identity not in allowed:
+            continue
+        nested = component.get("components")
+        if isinstance(nested, list):
+            component["components"] = filter_components(nested, allowed)
+        retained.append(component)
+    return retained
+
+
+def component_refs(components: list[Any]) -> set[str]:
+    """Collect bom-ref values from a nested component list."""
+    refs: set[str] = set()
+    for component in components:
+        if not isinstance(component, dict):
+            die("cargo-sbom output contains an invalid component")
+        bom_ref = component.get("bom-ref")
+        if isinstance(bom_ref, str) and bom_ref:
+            refs.add(bom_ref)
+        nested = component.get("components")
+        if isinstance(nested, list):
+            refs.update(component_refs(nested))
+    return refs
+
+
+def filter_sbom_for_target(
+    data: dict[str, Any], allowed: set[tuple[str, str]]
+) -> dict[str, Any]:
+    """Remove packages and edges not used by the selected Cargo target."""
+    metadata = data.get("metadata")
+    root = metadata.get("component") if isinstance(metadata, dict) else None
+    components = data.get("components")
+    dependencies = data.get("dependencies")
+    root_components = root.get("components") if isinstance(root, dict) else None
+    if not isinstance(root_components, list) or not isinstance(components, list):
+        die("cargo-sbom output is missing component collections")
+    if not isinstance(dependencies, list):
+        die("cargo-sbom output is missing dependencies")
+
+    represented = component_identities(root_components)
+    represented.update(component_identities(components))
+    missing = sorted(allowed - represented)
+    if missing:
+        name, version = missing[0]
+        die(f"cargo-sbom omitted resolved package {name} {version}")
+
+    root["components"] = filter_components(root_components, allowed)
+    data["components"] = filter_components(components, allowed)
+    refs = component_refs(root["components"])
+    refs.update(component_refs(data["components"]))
+    retained_dependencies: list[dict[str, Any]] = []
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            die("cargo-sbom output contains an invalid dependency")
+        dependency_ref = dependency.get("ref")
+        if dependency_ref not in refs:
+            continue
+        depends_on = dependency.get("dependsOn")
+        if isinstance(depends_on, list):
+            dependency["dependsOn"] = [value for value in depends_on if value in refs]
+        retained_dependencies.append(dependency)
+    data["dependencies"] = retained_dependencies
+    return data
+
+
+def canonical_key(value: Any) -> str:
+    """Render a stable sort key for arbitrary JSON values."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def component_key(component: Any) -> tuple[str, str, str]:
+    """Return a stable identity-first component sort key."""
+    if not isinstance(component, dict):
+        return ("", "", canonical_key(component))
+    return (
+        str(component.get("bom-ref", "")),
+        str(component.get("name", "")),
+        f"{component.get('version', '')}\0{canonical_key(component)}",
+    )
+
+
+def normalize_component(component: dict[str, Any]) -> None:
+    """Sort nested component collections in place."""
+    nested = component.get("components")
+    if isinstance(nested, list):
+        for item in nested:
+            if isinstance(item, dict):
+                normalize_component(item)
+        nested.sort(key=component_key)
+    for key in ("externalReferences", "hashes", "licenses", "properties"):
+        values = component.get(key)
+        if isinstance(values, list):
+            values.sort(key=canonical_key)
+
+
+def deduplicate_component_tree(component: dict[str, Any], seen: set[str]) -> None:
+    """Remove repeated bom-ref values while retaining first occurrence order."""
+    bom_ref = component.get("bom-ref")
+    if isinstance(bom_ref, str) and bom_ref:
+        seen.add(bom_ref)
+    nested = component.get("components")
+    if not isinstance(nested, list):
+        return
+    unique: list[Any] = []
+    for item in nested:
+        if not isinstance(item, dict):
+            unique.append(item)
+            continue
+        item_ref = item.get("bom-ref")
+        if isinstance(item_ref, str) and item_ref and item_ref in seen:
+            continue
+        deduplicate_component_tree(item, seen)
+        unique.append(item)
+    component["components"] = unique
+
+
+def normalize_sbom(
+    data: dict[str, Any],
+    *,
+    version: str,
+    target_os: str,
+    target_arch: str,
+    artifact_name: str,
+    artifact_sha256: str,
+    epoch: int,
+) -> dict[str, Any]:
+    """Bind cargo-sbom output to the immutable release archive."""
+    if data.get("bomFormat") != "CycloneDX" or data.get("specVersion") != "1.6":
+        die("cargo-sbom did not produce CycloneDX 1.6 JSON")
+    metadata = data.get("metadata")
+    root = metadata.get("component") if isinstance(metadata, dict) else None
+    if not isinstance(metadata, dict) or not isinstance(root, dict):
+        die("cargo-sbom output is missing metadata.component")
+
+    artifact_id = f"cosh-ng-{version}-{target_os}-{target_arch}-tar"
+    root.update(
+        {
+            "type": "application",
+            "name": "cosh-ng",
+            "version": version,
+            "bom-ref": artifact_id,
+            "hashes": [{"alg": "SHA-256", "content": artifact_sha256}],
+        }
+    )
+    properties = [
+        value
+        for value in root.get("properties", [])
+        if isinstance(value, dict)
+        and not str(value.get("name", "")).startswith("anolisa:")
+    ]
+    properties.extend(
+        [
+            {"name": "anolisa:artifact:id", "value": artifact_id},
+            {"name": "anolisa:artifact:name", "value": artifact_name},
+            {"name": "anolisa:target:arch", "value": target_arch},
+            {"name": "anolisa:target:os", "value": target_os},
+        ]
+    )
+    root["properties"] = properties
+    timestamp = dt.datetime.fromtimestamp(epoch, tz=dt.timezone.utc)
+    metadata["timestamp"] = timestamp.isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+    metadata["authors"] = [{"name": "ANOLISA Release Pipeline"}]
+    serial_seed = (
+        f"anolisa:cosh-ng:{version}:{target_os}:{target_arch}:sha256:{artifact_sha256}"
+    )
+    data["serialNumber"] = f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, serial_seed)}"
+    data["version"] = 1
+
+    normalize_component(root)
+    seen: set[str] = set()
+    deduplicate_component_tree(root, seen)
+    components = data.get("components")
+    dependencies = data.get("dependencies")
+    if not isinstance(components, list) or not isinstance(dependencies, list):
+        die("cargo-sbom components and dependencies must be arrays")
+    for component in components:
+        if isinstance(component, dict):
+            normalize_component(component)
+    components.sort(key=component_key)
+    unique: list[Any] = []
+    for component in components:
+        if not isinstance(component, dict):
+            unique.append(component)
+            continue
+        bom_ref = component.get("bom-ref")
+        if isinstance(bom_ref, str) and bom_ref and bom_ref in seen:
+            continue
+        deduplicate_component_tree(component, seen)
+        unique.append(component)
+    data["components"] = unique
+    for dependency in dependencies:
+        if not isinstance(dependency, dict):
+            die("cargo-sbom output contains an invalid dependency")
+        depends_on = dependency.get("dependsOn")
+        if isinstance(depends_on, list):
+            dependency["dependsOn"] = sorted(set(depends_on))
+    dependencies.sort(key=lambda item: str(item.get("ref", "")))
+    return data
+
+
+def atomic_write(path: Path, payload: bytes) -> None:
+    """Atomically replace one generated sidecar."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=path.parent, prefix=f".{path.name}.", delete=False
+    ) as stream:
+        temporary = Path(stream.name)
+        stream.write(payload)
+    try:
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    """Generate the normalized SBOM and its checksum sidecar."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--os", dest="target_os", required=True)
+    parser.add_argument("--arch", dest="target_arch", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--project-dir", required=True, type=Path)
+    parser.add_argument("--source-date-epoch", required=True, type=int)
+    parser.add_argument("--tool", default="cargo-sbom")
+    args = parser.parse_args()
+
+    artifact = args.artifact.resolve()
+    project_dir = args.project_dir.resolve()
+    if not artifact.is_file() or not project_dir.is_dir():
+        die("artifact must be a file and project-dir must be a directory")
+    if args.source_date_epoch < 0:
+        die("source-date-epoch must not be negative")
+    expected_target = {
+        ("linux", "x86_64"): "x86_64-unknown-linux-gnu",
+        ("linux", "aarch64"): "aarch64-unknown-linux-gnu",
+        ("macos", "aarch64"): "aarch64-apple-darwin",
+    }.get((args.target_os, args.target_arch))
+    if expected_target is None or args.target != expected_target:
+        die("target triple does not match the requested OS and architecture")
+    actual_tool_version = cargo_sbom_version(args.tool)
+    if actual_tool_version != "0.10.0":
+        die(f"cargo-sbom 0.10.0 is required, got {actual_tool_version}")
+    artifact_sha256 = sha256_file(artifact)
+    if read_sidecar(Path(f"{artifact}.sha256"), artifact.name) != artifact_sha256:
+        die(f"artifact checksum sidecar does not match {artifact}")
+
+    try:
+        result = subprocess.run(
+            [
+                args.tool,
+                "--output-format",
+                "cyclone_dx_json_1_6",
+                "--project-directory",
+                str(project_dir),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        die(f"cargo-sbom command not found: {args.tool}")
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        die(f"cargo-sbom failed: {detail or error.returncode}")
+    try:
+        raw = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        die(f"cargo-sbom returned invalid JSON: {error}")
+    if not isinstance(raw, dict):
+        die("cargo-sbom output must be a JSON object")
+    raw = filter_sbom_for_target(
+        raw,
+        resolved_package_identities(cargo_metadata(project_dir, args.target)),
+    )
+    normalized = normalize_sbom(
+        raw,
+        version=args.version,
+        target_os=args.target_os,
+        target_arch=args.target_arch,
+        artifact_name=artifact.name,
+        artifact_sha256=artifact_sha256,
+        epoch=args.source_date_epoch,
+    )
+    output = Path(f"{artifact}.cdx.json")
+    payload = (
+        json.dumps(normalized, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    ).encode()
+    atomic_write(output, payload)
+    digest = hashlib.sha256(payload).hexdigest()
+    atomic_write(Path(f"{output}.sha256"), f"{digest}  {output.name}\n".encode())
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/build-cosh-ng-prebuilt/reproducible-build.py
+++ b/.github/actions/build-cosh-ng-prebuilt/reproducible-build.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run a build command with stable Rust source paths and timestamps."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ENCODED_SEPARATOR = "\x1f"
+
+
+def rustflags_from_environment(env: dict[str, str]) -> list[str]:
+    """Return the Rust flags Cargo would use before reproducibility flags."""
+    encoded = env.get("CARGO_ENCODED_RUSTFLAGS")
+    if encoded is not None:
+        return [item for item in encoded.split(ENCODED_SEPARATOR) if item]
+    return env.get("RUSTFLAGS", "").split()
+
+
+def rust_sysroot(env: dict[str, str]) -> Path:
+    """Resolve the active host toolchain root for path remapping."""
+    try:
+        result = subprocess.run(
+            ["rustc", "--print", "sysroot"],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", "") or str(error)
+        raise RuntimeError(f"failed to query rustc sysroot: {detail.strip()}") from error
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError("rustc returned an empty sysroot")
+    return Path(value).resolve()
+
+
+def reproducible_environment(
+    source_root: Path,
+    source_date_epoch: str,
+    base_env: dict[str, str],
+) -> dict[str, str]:
+    """Build an environment that removes host-specific Rust source prefixes."""
+    env = base_env.copy()
+    flags = rustflags_from_environment(env)
+    cargo_home = Path(env.get("CARGO_HOME", str(Path.home() / ".cargo"))).resolve()
+    registry_sources = cargo_home / "registry" / "src"
+    try:
+        source_ids = sorted(path.name for path in registry_sources.iterdir() if path.is_dir())
+    except FileNotFoundError:
+        source_ids = []
+    except OSError as error:
+        raise RuntimeError(f"cannot list Cargo registry sources: {error}") from error
+    mappings = []
+    for source_id in source_ids:
+        canonical = "/cargo/registry/src/canonical"
+        mappings.extend(
+            [
+                (registry_sources / source_id, canonical),
+                (Path("/cargo/registry/src") / source_id, canonical),
+            ]
+        )
+    mappings.extend(
+        [
+            (source_root.resolve(), "/workspace"),
+            (Path("/project"), "/workspace"),
+            (cargo_home, "/cargo"),
+            (rust_sysroot(env), "/rust-toolchain"),
+        ]
+    )
+    for source, destination in mappings:
+        flag = f"--remap-path-prefix={source}={destination}"
+        if flag not in flags:
+            flags.append(flag)
+    env["CARGO_ENCODED_RUSTFLAGS"] = ENCODED_SEPARATOR.join(flags)
+    env.pop("RUSTFLAGS", None)
+    env["SOURCE_DATE_EPOCH"] = source_date_epoch
+    return env
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the fixed source root, epoch, and delegated command."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-root", required=True, type=Path)
+    parser.add_argument("--source-date-epoch", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a command is required after --")
+    if not args.source_date_epoch.isdigit():
+        parser.error("--source-date-epoch must be a non-negative integer")
+    if not args.source_root.is_dir():
+        parser.error(f"--source-root is not a directory: {args.source_root}")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    """Replace this process with the delegated reproducible build command."""
+    args = parse_args(argv)
+    try:
+        env = reproducible_environment(
+            args.source_root,
+            args.source_date_epoch,
+            os.environ,
+        )
+    except RuntimeError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    try:
+        os.execvpe(args.command[0], args.command, env)
+    except OSError as error:
+        print(f"ERROR: failed to execute {args.command[0]}: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/actions/build-cosh-ng-prebuilt/test.sh
+++ b/.github/actions/build-cosh-ng-prebuilt/test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Exercise action input binding, untrusted inputs, and target-specific SBOM filtering.
+set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$ACTION_DIR" rev-parse --show-toplevel)"
+COMPONENT_ROOT="$REPO_ROOT/src/cosh-ng"
+TEMPORARY="$(mktemp -d)"
+trap 'rm -rf -- "$TEMPORARY"' EXIT
+
+python3 - "$ACTION_DIR/action.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+
+action = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected_bindings = (
+    "COSH_NG_VERSION: ${{ inputs.version }}",
+    "COSH_NG_TARGET_OS: ${{ inputs.target-os }}",
+    "COSH_NG_TARGET_ARCH: ${{ inputs.target-arch }}",
+    "COSH_NG_PROFILE: ${{ inputs.profile }}",
+    "COSH_NG_TAG: ${{ inputs.tag }}",
+)
+for binding in expected_bindings:
+    if binding not in action:
+        raise SystemExit(f"composite action is missing environment binding: {binding}")
+
+marker = "      run: |\n"
+if marker not in action:
+    raise SystemExit("composite action is missing its Bash run block")
+run_block = action.split(marker, 1)[1]
+if "${{ inputs." in run_block:
+    raise SystemExit("composite action interpolates an input directly into Bash")
+PY
+
+EMPTY_CARGO_HOME="$TEMPORARY/empty-cargo-home"
+DELEGATED_MARKER="$TEMPORARY/delegated-command"
+install -d -m 0755 "$EMPTY_CARGO_HOME"
+CARGO_HOME="$EMPTY_CARGO_HOME" \
+    python3 "$ACTION_DIR/reproducible-build.py" \
+        --source-root "$COMPONENT_ROOT" \
+        --source-date-epoch 0 \
+        -- sh -c "test \"\$SOURCE_DATE_EPOCH\" = 0; touch \"\$1\"" \
+        sh "$DELEGATED_MARKER"
+[ -f "$DELEGATED_MARKER" ] || {
+    printf 'ERROR: empty Cargo home prevented delegated command execution\n' >&2
+    exit 1
+}
+
+VERSION="$(
+    python3 "$COMPONENT_ROOT/packaging/raw/verify-release.py" \
+        "$COMPONENT_ROOT" "$COMPONENT_ROOT/.anolisa/component.toml" \
+        --os linux --arch x86_64
+)"
+MARKER="$TEMPORARY/injected"
+MALICIOUS_VERSION="${VERSION}\$(touch ${MARKER})"
+if COSH_NG_SOURCE_WORKTREE="$TEMPORARY/version-worktree/cosh-ng" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/version-output" \
+        --version "$MALICIOUS_VERSION" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.28-x86_64 \
+        --tag '' >"$TEMPORARY/version.log" 2>&1; then
+    printf 'ERROR: malicious version input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious version input executed a command\n' >&2
+    exit 1
+}
+
+MALICIOUS_TAG="cosh-ng/v${VERSION}\$(touch ${MARKER})"
+if COSH_NG_SOURCE_WORKTREE="$TEMPORARY/tag-worktree/cosh-ng" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/tag-output" \
+        --version "$VERSION" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.28-x86_64 \
+        --tag "$MALICIOUS_TAG" >"$TEMPORARY/tag.log" 2>&1; then
+    printf 'ERROR: malicious tag input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious tag input executed a command\n' >&2
+    exit 1
+}
+
+for platform in linux macos; do
+    printf 'SBOM fixture for %s\n' "$platform" >"$TEMPORARY/$platform.tar.gz"
+    (
+        cd "$TEMPORARY"
+        sha256sum "$platform.tar.gz" >"$platform.tar.gz.sha256"
+    )
+done
+
+python3 "$ACTION_DIR/generate-sbom.py" \
+    --artifact "$TEMPORARY/linux.tar.gz" \
+    --version "$VERSION" \
+    --os linux \
+    --arch x86_64 \
+    --target x86_64-unknown-linux-gnu \
+    --project-dir "$COMPONENT_ROOT" \
+    --source-date-epoch 0 >/dev/null
+python3 "$ACTION_DIR/generate-sbom.py" \
+    --artifact "$TEMPORARY/macos.tar.gz" \
+    --version "$VERSION" \
+    --os macos \
+    --arch aarch64 \
+    --target aarch64-apple-darwin \
+    --project-dir "$COMPONENT_ROOT" \
+    --source-date-epoch 0 >/dev/null
+
+python3 - "$TEMPORARY/linux.tar.gz.cdx.json" \
+    "$TEMPORARY/macos.tar.gz.cdx.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+def names(path: str) -> set[str]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    components = list(data["components"])
+    components.extend(data["metadata"]["component"].get("components", []))
+    return {component["name"] for component in components}
+
+
+linux = names(sys.argv[1])
+macos = names(sys.argv[2])
+for platform, packages in (("linux", linux), ("macos", macos)):
+    windows = sorted(name for name in packages if name.startswith("windows"))
+    if windows:
+        raise SystemExit(f"{platform} SBOM contains Windows-only packages: {windows}")
+if "core-foundation" in linux:
+    raise SystemExit("Linux SBOM contains a macOS-only package")
+if "core-foundation" not in macos:
+    raise SystemExit("macOS SBOM is missing a target dependency")
+PY
+
+printf 'cosh-ng prebuilt action tests passed\n'

--- a/.github/actions/build-cosh-ng-prebuilt/verify-artifacts.py
+++ b/.github/actions/build-cosh-ng-prebuilt/verify-artifacts.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Verify one flat cosh-ng package or a complete Actions Artifact download."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+
+
+TARGETS = (
+    ("linux", "x86_64"),
+    ("linux", "aarch64"),
+    ("macos", "aarch64"),
+)
+
+
+def die(message: str) -> None:
+    """Exit with one actionable diagnostic."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def sha256_file(path: Path) -> str:
+    """Return a file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_sidecar(path: Path, filename: str) -> str:
+    """Read a strict sha256sum sidecar for one adjacent file."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        die(f"cannot read checksum sidecar {path}: {error}")
+    if len(lines) != 1:
+        die(f"checksum sidecar must contain exactly one line: {path}")
+    match = re.fullmatch(r"([0-9a-fA-F]{64})  ([^/]+)", lines[0])
+    if match is None or match.group(2) != filename:
+        die(f"checksum sidecar does not identify {filename}: {path}")
+    return match.group(1).lower()
+
+
+def cargo_sbom_tool_present(metadata: dict[str, Any]) -> bool:
+    """Accept both CycloneDX list and object representations of metadata.tools."""
+    tools = metadata.get("tools")
+    candidates: list[Any] = []
+    if isinstance(tools, list):
+        candidates.extend(tools)
+    elif isinstance(tools, dict):
+        for value in tools.values():
+            if isinstance(value, list):
+                candidates.extend(value)
+    return any(
+        isinstance(tool, dict)
+        and tool.get("name") == "cargo-sbom"
+        and tool.get("version") == "0.10.0"
+        for tool in candidates
+    )
+
+
+def component_refs(component: dict[str, Any]) -> list[str]:
+    """Collect non-empty bom-ref values from one nested component tree."""
+    references: list[str] = []
+    bom_ref = component.get("bom-ref")
+    if isinstance(bom_ref, str) and bom_ref:
+        references.append(bom_ref)
+    nested = component.get("components")
+    if isinstance(nested, list):
+        for item in nested:
+            if isinstance(item, dict):
+                references.extend(component_refs(item))
+    return references
+
+
+def expected_files(version: str, target_os: str, target_arch: str) -> set[str]:
+    """Return the exact four release asset names for one target."""
+    archive = f"cosh-ng-{version}-{target_os}-{target_arch}.tar.gz"
+    return {
+        archive,
+        f"{archive}.sha256",
+        f"{archive}.cdx.json",
+        f"{archive}.cdx.json.sha256",
+    }
+
+
+def validate_directory(directory: Path, version: str, target_os: str, target_arch: str) -> None:
+    """Validate one target's exact four-file output directory."""
+    expected = expected_files(version, target_os, target_arch)
+    try:
+        entries = list(directory.iterdir())
+    except OSError as error:
+        die(f"cannot list artifact directory {directory}: {error}")
+    actual = {entry.name for entry in entries}
+    if any(not entry.is_file() for entry in entries) or actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        die(
+            f"unexpected files for {target_os}/{target_arch}; "
+            f"missing={missing or 'none'} extra={extra or 'none'}"
+        )
+
+    archive_name = f"cosh-ng-{version}-{target_os}-{target_arch}.tar.gz"
+    archive = directory / archive_name
+    archive_sha = sha256_file(archive)
+    if read_sidecar(Path(f"{archive}.sha256"), archive.name) != archive_sha:
+        die(f"archive checksum mismatch: {archive}")
+    try:
+        with tarfile.open(archive, "r:gz") as package:
+            if not package.getmembers():
+                die(f"archive is empty: {archive}")
+    except (OSError, tarfile.TarError) as error:
+        die(f"cannot read archive {archive}: {error}")
+
+    sbom = Path(f"{archive}.cdx.json")
+    sbom_sha = sha256_file(sbom)
+    if read_sidecar(Path(f"{sbom}.sha256"), sbom.name) != sbom_sha:
+        die(f"SBOM checksum mismatch: {sbom}")
+    try:
+        data = json.loads(sbom.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        die(f"cannot read SBOM {sbom}: {error}")
+    if not isinstance(data, dict):
+        die(f"SBOM must contain a JSON object: {sbom}")
+    if data.get("bomFormat") != "CycloneDX" or data.get("specVersion") != "1.6":
+        die(f"SBOM is not CycloneDX 1.6: {sbom}")
+    metadata = data.get("metadata")
+    component = metadata.get("component") if isinstance(metadata, dict) else None
+    artifact_id = f"cosh-ng-{version}-{target_os}-{target_arch}-tar"
+    if not isinstance(metadata, dict) or not isinstance(component, dict):
+        die(f"SBOM is missing metadata.component: {sbom}")
+    if (
+        component.get("name") != "cosh-ng"
+        or component.get("version") != version
+        or component.get("bom-ref") != artifact_id
+    ):
+        die(f"SBOM component identity mismatch: {sbom}")
+    hashes = component.get("hashes")
+    if not isinstance(hashes, list) or not any(
+        isinstance(item, dict)
+        and item.get("alg") == "SHA-256"
+        and item.get("content") == archive_sha
+        for item in hashes
+    ):
+        die(f"SBOM does not bind the archive checksum: {sbom}")
+    properties = component.get("properties")
+    property_map = {
+        item.get("name"): item.get("value")
+        for item in properties or []
+        if isinstance(item, dict)
+    }
+    if (
+        property_map.get("anolisa:artifact:name") != archive.name
+        or property_map.get("anolisa:target:os") != target_os
+        or property_map.get("anolisa:target:arch") != target_arch
+    ):
+        die(f"SBOM target properties mismatch: {sbom}")
+    if not cargo_sbom_tool_present(metadata):
+        die(f"SBOM does not identify cargo-sbom 0.10.0: {sbom}")
+
+    components = data.get("components")
+    dependencies = data.get("dependencies")
+    if not isinstance(components, list) or not isinstance(dependencies, list):
+        die(f"SBOM components and dependencies must be arrays: {sbom}")
+    references = component_refs(component)
+    for item in components:
+        if not isinstance(item, dict):
+            die(f"SBOM contains an invalid component: {sbom}")
+        references.extend(component_refs(item))
+    if len(references) != len(set(references)):
+        die(f"SBOM contains duplicate component bom-ref values: {sbom}")
+    dependency_refs = [
+        item.get("ref") for item in dependencies if isinstance(item, dict)
+    ]
+    if (
+        len(dependency_refs) != len(dependencies)
+        or any(not isinstance(value, str) or not value for value in dependency_refs)
+        or len(dependency_refs) != len(set(dependency_refs))
+    ):
+        die(f"SBOM contains invalid or duplicate dependency refs: {sbom}")
+    known_refs = set(references)
+    for dependency in dependencies:
+        depends_on = dependency.get("dependsOn")
+        if dependency.get("ref") not in known_refs:
+            die(f"SBOM dependency ref does not resolve to a component: {sbom}")
+        if not isinstance(depends_on, list) or any(
+            not isinstance(value, str) or value not in known_refs
+            for value in depends_on
+        ):
+            die(f"SBOM dependency target does not resolve to a component: {sbom}")
+
+
+def main() -> int:
+    """Validate flat or downloaded Actions Artifact layout."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--directory", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--layout", choices=("flat", "actions"), required=True)
+    parser.add_argument("--os", dest="target_os")
+    parser.add_argument("--arch", dest="target_arch")
+    args = parser.parse_args()
+    root = args.directory.resolve()
+    if args.layout == "flat":
+        if not args.target_os or not args.target_arch:
+            parser.error("flat layout requires --os and --arch")
+        validate_directory(root, args.version, args.target_os, args.target_arch)
+        return 0
+    if args.target_os or args.target_arch:
+        parser.error("actions layout does not accept --os or --arch")
+
+    expected_directories = {
+        f"cosh-ng-prebuilt-{args.version}-{target_os}-{target_arch}"
+        for target_os, target_arch in TARGETS
+    }
+    try:
+        entries = list(root.iterdir())
+    except OSError as error:
+        die(f"cannot list Actions Artifact root {root}: {error}")
+    actual_directories = {entry.name for entry in entries}
+    if any(not entry.is_dir() for entry in entries) or actual_directories != expected_directories:
+        missing = sorted(expected_directories - actual_directories)
+        extra = sorted(actual_directories - expected_directories)
+        die(
+            "unexpected Actions Artifacts; "
+            f"missing={missing or 'none'} extra={extra or 'none'}"
+        )
+    for target_os, target_arch in TARGETS:
+        directory = root / f"cosh-ng-prebuilt-{args.version}-{target_os}-{target_arch}"
+        validate_directory(directory, args.version, target_os, target_arch)
+    print(f"Verified 12 cosh-ng prebuilt release assets under {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/build-cosh-ng-prebuilt/verify-glibc.py
+++ b/.github/actions/build-cosh-ng-prebuilt/verify-glibc.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Verify an internal release binary's architecture and glibc ceiling."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+GLIBC_RE = re.compile(r"\bGLIBC_(\d+)\.(\d+)(?:\.(\d+))?\b")
+MACHINES = {
+    "x86_64": "Advanced Micro Devices X86-64",
+    "aarch64": "AArch64",
+}
+
+
+def version(value: str) -> tuple[int, ...]:
+    """Parse a dotted numeric version."""
+    try:
+        return tuple(int(item) for item in value.split("."))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"invalid numeric version: {value}") from error
+
+
+def format_version(value: tuple[int, ...]) -> str:
+    """Format a symbol version without a redundant patch zero."""
+    items = list(value)
+    while len(items) > 2 and items[-1] == 0:
+        items.pop()
+    return ".".join(str(item) for item in items)
+
+
+def readelf(binary: Path, *args: str) -> str:
+    """Run readelf and return its standard output."""
+    try:
+        result = subprocess.run(
+            ["readelf", *args, str(binary)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError:
+        raise RuntimeError("readelf is required to verify release binaries") from None
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        raise RuntimeError(f"readelf failed for {binary}: {detail}") from error
+    return result.stdout
+
+
+def main() -> int:
+    """Validate one ELF binary."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--arch", choices=sorted(MACHINES), required=True)
+    parser.add_argument("--max", dest="maximum", type=version, required=True)
+    args = parser.parse_args()
+
+    if not args.binary.is_file():
+        print(f"ERROR: binary does not exist: {args.binary}", file=sys.stderr)
+        return 1
+    try:
+        header = readelf(args.binary, "-h")
+        symbols = readelf(args.binary, "--version-info")
+    except RuntimeError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    machine = re.search(r"^\s*Machine:\s*(.+?)\s*$", header, re.MULTILINE)
+    actual_machine = machine.group(1) if machine is not None else ""
+    if actual_machine != MACHINES[args.arch]:
+        print(
+            f"ERROR: {args.binary} machine is {actual_machine!r}, "
+            f"expected {MACHINES[args.arch]!r}",
+            file=sys.stderr,
+        )
+        return 1
+    required = {
+        tuple(int(item) for item in match.groups(default="0"))
+        for match in GLIBC_RE.finditer(symbols)
+    }
+    if not required:
+        print(f"ERROR: no GLIBC symbol versions found in {args.binary}", file=sys.stderr)
+        return 1
+    maximum = max(required)
+    padded_limit = args.maximum + (0,) * (len(maximum) - len(args.maximum))
+    if maximum > padded_limit:
+        print(
+            f"ERROR: {args.binary} requires GLIBC_{format_version(maximum)}, "
+            f"above GLIBC_{format_version(args.maximum)}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{args.binary}: arch={args.arch} max_glibc=GLIBC_{format_version(maximum)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/build-cosh-ng-prebuilt/verify-macho.py
+++ b/.github/actions/build-cosh-ng-prebuilt/verify-macho.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate an arm64 macOS executable and its deployment target."""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+
+MH_MAGIC_64 = 0xFEEDFACF
+CPU_TYPE_ARM64 = 0x0100000C
+MH_EXECUTE = 2
+LC_LOAD_DYLIB = 0xC
+LC_LOAD_WEAK_DYLIB = 0x80000018
+LC_REEXPORT_DYLIB = 0x8000001F
+LC_LOAD_UPWARD_DYLIB = 0x80000023
+LC_VERSION_MIN_MACOSX = 0x24
+LC_BUILD_VERSION = 0x32
+PLATFORM_MACOS = 1
+
+
+class MachOError(RuntimeError):
+    """The input is not the expected deployable Mach-O executable."""
+
+
+def decode_version(value: int) -> tuple[int, int, int]:
+    """Decode Apple's packed X.Y.Z version integer."""
+    return value >> 16, (value >> 8) & 0xFF, value & 0xFF
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    """Parse an X[.Y[.Z]] version supplied by the release profile."""
+    try:
+        parts = tuple(int(part) for part in value.split("."))
+    except ValueError as error:
+        raise MachOError(f"invalid version: {value}") from error
+    if not 1 <= len(parts) <= 3 or any(part < 0 or part > 255 for part in parts):
+        raise MachOError(f"invalid version: {value}")
+    return (*parts, *(0 for _ in range(3 - len(parts))))
+
+
+def c_string(data: bytes, offset: int, end: int) -> str:
+    """Decode a bounded Mach-O load-command string."""
+    if offset < 0 or offset >= end:
+        raise MachOError("invalid dylib name offset")
+    terminator = data.find(b"\0", offset, end)
+    if terminator < 0:
+        raise MachOError("unterminated dylib name")
+    try:
+        return data[offset:terminator].decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise MachOError("non-UTF-8 dylib name") from error
+
+
+def validate(data: bytes, expected_minimum: tuple[int, int, int]) -> None:
+    """Validate architecture, deployment target, and dynamic library paths."""
+    if len(data) < 32:
+        raise MachOError("file is too small for a Mach-O 64-bit header")
+    (
+        magic,
+        cpu_type,
+        _cpu_subtype,
+        file_type,
+        command_count,
+        commands_size,
+        _flags,
+        _reserved,
+    ) = struct.unpack_from("<IiiIIIII", data)
+    if magic != MH_MAGIC_64:
+        raise MachOError("expected a little-endian Mach-O 64-bit executable")
+    if cpu_type != CPU_TYPE_ARM64:
+        raise MachOError(f"expected arm64 CPU type, got 0x{cpu_type:08x}")
+    if file_type != MH_EXECUTE:
+        raise MachOError(f"expected MH_EXECUTE, got file type {file_type}")
+    if 32 + commands_size > len(data):
+        raise MachOError("load command table extends beyond the file")
+
+    minimums: list[tuple[int, int, int]] = []
+    dylibs: list[str] = []
+    cursor = 32
+    commands_end = 32 + commands_size
+    for _ in range(command_count):
+        if cursor + 8 > commands_end:
+            raise MachOError("truncated load command")
+        command, size = struct.unpack_from("<II", data, cursor)
+        if size < 8 or cursor + size > commands_end:
+            raise MachOError("invalid load command size")
+        if command == LC_BUILD_VERSION:
+            if size < 24:
+                raise MachOError("truncated LC_BUILD_VERSION")
+            platform, minimum, _sdk, _tools = struct.unpack_from(
+                "<IIII", data, cursor + 8
+            )
+            if platform != PLATFORM_MACOS:
+                raise MachOError(f"expected macOS build platform, got {platform}")
+            minimums.append(decode_version(minimum))
+        elif command == LC_VERSION_MIN_MACOSX:
+            if size < 16:
+                raise MachOError("truncated LC_VERSION_MIN_MACOSX")
+            minimum, _sdk = struct.unpack_from("<II", data, cursor + 8)
+            minimums.append(decode_version(minimum))
+        elif command in {
+            LC_LOAD_DYLIB,
+            LC_LOAD_WEAK_DYLIB,
+            LC_REEXPORT_DYLIB,
+            LC_LOAD_UPWARD_DYLIB,
+        }:
+            if size < 24:
+                raise MachOError("truncated dylib load command")
+            name_offset = struct.unpack_from("<I", data, cursor + 8)[0]
+            dylibs.append(c_string(data, cursor + name_offset, cursor + size))
+        cursor += size
+    if cursor != commands_end:
+        raise MachOError("load commands do not consume the declared command table")
+    if set(minimums) != {expected_minimum}:
+        rendered = ", ".join(
+            ".".join(map(str, value)) for value in sorted(set(minimums))
+        ) or "missing"
+        expected = ".".join(map(str, expected_minimum))
+        raise MachOError(f"deployment target is {rendered}, expected {expected}")
+    allowed = ("/usr/lib/", "/System/Library/Frameworks/")
+    unsupported = sorted(name for name in dylibs if not name.startswith(allowed))
+    if unsupported:
+        raise MachOError(
+            "non-system dynamic library reference(s): " + ", ".join(unsupported)
+        )
+
+
+def main() -> int:
+    """Validate one executable without running it."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min", dest="minimum", required=True)
+    parser.add_argument("binary", type=Path)
+    args = parser.parse_args()
+    try:
+        validate(args.binary.read_bytes(), parse_version(args.minimum))
+    except (OSError, MachOError) as error:
+        print(f"ERROR: {args.binary}: {error}", file=sys.stderr)
+        return 1
+    print(f"{args.binary}: arch=aarch64 min_macos={args.minimum}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cosh-ng-prebuilt-ci.yaml
+++ b/.github/workflows/cosh-ng-prebuilt-ci.yaml
@@ -1,0 +1,48 @@
+name: CI / cosh-ng prebuilt action
+
+on:
+  push:
+    branches: [main, 'release/**']
+    paths:
+      - '.github/actions/build-cosh-ng-prebuilt/**'
+      - '.github/workflows/cosh-ng-prebuilt-ci.yaml'
+      - '.github/workflows/release.yaml'
+      - '.github/workflows/release-preview.yaml'
+      - 'src/cosh-ng/**'
+  pull_request:
+    branches: [main, 'release/**']
+    paths:
+      - '.github/actions/build-cosh-ng-prebuilt/**'
+      - '.github/workflows/cosh-ng-prebuilt-ci.yaml'
+      - '.github/workflows/release.yaml'
+      - '.github/workflows/release-preview.yaml'
+      - 'src/cosh-ng/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  RUSTUP_DIST_SERVER: https://static.rust-lang.org
+  RUSTUP_UPDATE_ROOT: https://static.rust-lang.org/rustup
+  RUSTUP_TOOLCHAIN: '1.93.0'
+
+jobs:
+  test:
+    name: Test cosh-ng prebuilt action
+    runs-on: anolisa-k8s-general-ci-x64
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: dtolnay/rust-toolchain@1.93.0
+
+      - name: Install cargo-sbom
+        run: cargo install cargo-sbom --version 0.10.0 --locked
+
+      - name: Run prebuilt action regression tests
+        run: .github/actions/build-cosh-ng-prebuilt/test.sh

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -65,3 +65,74 @@ jobs:
           version: ${{ inputs.version }}
           artifact-suffix: '.preview'
           retention-days: 14
+
+  build-cosh-ng-prebuilt-preview:
+    name: Preview cosh-ng ${{ matrix.target-os }}-${{ matrix.target-arch }}
+    if: inputs.component == 'cosh-ng'
+    permissions:
+      contents: read
+    runs-on: [self-hosted, Linux, X64, anolisa-release-cross-x64]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target-os: linux
+            target-arch: x86_64
+            profile: gnu2.28-x86_64
+          - target-os: linux
+            target-arch: aarch64
+            profile: gnu2.28-aarch64
+          - target-os: macos
+            target-arch: aarch64
+            profile: darwin11-aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build precompiled package
+        id: prebuilt
+        uses: ./.github/actions/build-cosh-ng-prebuilt
+        with:
+          version: ${{ inputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+
+      - name: Upload precompiled package
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosh-ng-prebuilt-${{ inputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          path: ${{ steps.prebuilt.outputs.artifact-directory }}/*
+          if-no-files-found: error
+          retention-days: 14
+
+  verify-cosh-ng-prebuilt-preview:
+    name: Verify preview cosh-ng artifacts
+    needs: build-cosh-ng-prebuilt-preview
+    if: inputs.component == 'cosh-ng'
+    permissions:
+      actions: read
+      contents: read
+    runs-on: anolisa-k8s-amd-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download cosh-ng precompiled packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cosh-ng-prebuilt-${{ inputs.version }}-*
+          path: /tmp/cosh-ng-prebuilt-preview
+
+      - name: Verify cosh-ng precompiled packages
+        env:
+          COSH_NG_VERSION: ${{ inputs.version }}
+        run: |
+          python3 .github/actions/build-cosh-ng-prebuilt/verify-artifacts.py \
+            --directory /tmp/cosh-ng-prebuilt-preview \
+            --version "$COSH_NG_VERSION" \
+            --layout actions

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,52 @@ jobs:
           artifact-suffix: ''
           retention-days: 28
 
+  build_cosh_ng_prebuilt:
+    name: Build cosh-ng ${{ matrix.target-os }}-${{ matrix.target-arch }}
+    needs: package
+    if: needs.package.outputs.component == 'cosh-ng'
+    permissions:
+      contents: read
+    runs-on: [self-hosted, Linux, X64, anolisa-release-cross-x64]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target-os: linux
+            target-arch: x86_64
+            profile: gnu2.28-x86_64
+          - target-os: linux
+            target-arch: aarch64
+            profile: gnu2.28-aarch64
+          - target-os: macos
+            target-arch: aarch64
+            profile: darwin11-aarch64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build precompiled package
+        id: prebuilt
+        uses: ./.github/actions/build-cosh-ng-prebuilt
+        with:
+          version: ${{ needs.package.outputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+          tag: ${{ needs.package.outputs.tag }}
+
+      - name: Upload precompiled package
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosh-ng-prebuilt-${{ needs.package.outputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          path: ${{ steps.prebuilt.outputs.artifact-directory }}/*
+          if-no-files-found: error
+          retention-days: 28
+
   # =========================================================================
   # Step 2: Publish (requires manual approval via GitHub Environment)
   #
@@ -102,13 +148,23 @@ jobs:
   # =========================================================================
   publish:
     name: Publish ${{ needs.package.outputs.tag }}
-    needs: package
+    needs: [package, build_cosh_ng_prebuilt]
+    if: >-
+      always() &&
+      needs.package.result == 'success' &&
+      (needs.package.outputs.component != 'cosh-ng' ||
+       needs.build_cosh_ng_prebuilt.result == 'success')
+    permissions:
+      contents: write
+      actions: read
     environment: release
     runs-on: anolisa-k8s-amd-release
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download official artifact
         uses: actions/download-artifact@v4
@@ -138,6 +194,23 @@ jobs:
         with:
           name: ${{ needs.package.outputs.component }}-${{ needs.package.outputs.version }}-vendor
           path: /tmp/archives
+
+      - name: Download cosh-ng precompiled packages
+        if: needs.package.outputs.component == 'cosh-ng'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cosh-ng-prebuilt-${{ needs.package.outputs.version }}-*
+          path: /tmp/cosh-ng-prebuilt
+
+      - name: Verify cosh-ng precompiled packages
+        if: needs.package.outputs.component == 'cosh-ng'
+        env:
+          COSH_NG_VERSION: ${{ needs.package.outputs.version }}
+        run: |
+          python3 .github/actions/build-cosh-ng-prebuilt/verify-artifacts.py \
+            --directory /tmp/cosh-ng-prebuilt \
+            --version "$COSH_NG_VERSION" \
+            --layout actions
 
       - name: Create GitHub Release
         env:
@@ -175,6 +248,14 @@ jobs:
           VENDOR_ARCHIVE="/tmp/archives/${COMPONENT}-${VERSION}-vendor.tar.gz"
           if [ -f "$VENDOR_ARCHIVE" ]; then
             ASSETS+=("$VENDOR_ARCHIVE")
+          fi
+          if [ "$COMPONENT" = "cosh-ng" ]; then
+            while IFS= read -r asset; do
+              ASSETS+=("$asset")
+            done < <(
+              find /tmp/cosh-ng-prebuilt -mindepth 2 -maxdepth 2 -type f -print |
+                LC_ALL=C sort
+            )
           fi
 
           if gh release view "$TAG" > /dev/null 2>&1; then


### PR DESCRIPTION
## Why

The cosh-ng tag workflow currently publishes source and vendor packages but does not
compile the component's distributable binaries. Build the three supported release
targets in GitHub CI while leaving OSS publication, public readback, remote smoke tests,
and registry metadata outside this workflow.

## What changed

- Add a reusable composite action and directly callable script that validate one release
  version, build four cosh-ng binaries with fixed cross profiles, verify their target
  contracts, and emit deterministic tar, SHA-256, and CycloneDX 1.6 SBOM assets.
- Build sccache 0.17.0 with Rust 1.93 inside each prepared Cross image against that
  image's native glibc, and retain a bounded 20 GB compiler cache under the runner user's
  Cargo home; jobs reuse the images and cache instead of rebuilding images.
- Bind every builder to its prepared Runner image ID, require sccache 0.17.0 to run, pass
  untrusted workflow values through step environments, and filter SBOM dependencies with
  Cargo's selected target and default-feature graph. The sccache libc implementation stays
  a Runner provisioning detail rather than a CI contract.
- Add a three-target cosh-ng matrix to the tag workflow, retain each target as an
  independent Actions Artifact for 28 days, validate the complete 12-file inventory,
  and attach it to the existing GitHub Release only after the full matrix succeeds.
- Add the same matrix to the manually triggered preview workflow without creating a
  Release or enabling self-hosted execution for fork pull requests; a follow-up job
  downloads the three Actions Artifacts and validates the complete 12-file inventory.

## Related issue

no-issue: migrate the existing cosh-ng precompiled package build into GitHub CI

## User / Agent impact

Tagged cosh-ng releases gain Linux x86_64, Linux aarch64, and macOS aarch64 precompiled
archives with checksum and SBOM sidecars. Other components retain their existing release
behavior.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The new jobs use a persistent self-hosted runner, so they are restricted to cosh-ng tags
and manual upstream previews; no pull-request trigger runs untrusted fork code. Build jobs
have `contents: read`, and the existing Release environment remains the publication gate.
The `anolisa-release-cross-x64` runner label must be assigned by a repository administrator
before the first upstream preview. The prepared runner requires the three Cross images
at their pinned image IDs; the host sccache executable is not part of the CI runtime
contract.

## Validation

- actionlint 1.7.12, ShellCheck, Python bytecode/YAML parsing, and `git diff --check`
- `src/cosh-ng/tests/test-package-raw.sh`
- `.github/actions/build-cosh-ng-prebuilt/test.sh` locally and on the Runner; a static
  composite-action assertion rejects direct input interpolation, malicious version/tag
  values remain data, Linux/macOS SBOMs exclude Windows-only packages, and macOS retains
  its target-only dependencies. The test is also wired into ordinary PR CI without using
  the self-hosted release Runner.
- empty `CARGO_HOME` regression locally and on the release Runner: locked target metadata
  initializes the registry source cache before remap generation, then the delegated
  reproducible command executes successfully
- strict aggregate validation for all 12 assets; missing, duplicate, and extra inputs fail
- negative checks for version/tag/profile mismatch, wrong ELF architecture, and binary
  digest drift
- crates.io sccache 0.17.0 crate SHA-256
  `191bf7f2451d7dbfd7d50e2822b831a1b1058d7dfa17fa370306d905f8b4d4cf`; all three
  images build it from source with Rust 1.93 and `--locked --no-default-features`
- both manylinux sccache binaries are dynamically linked to glibc 2.28 with maximum
  required GLIBC 2.28; the Darwin builder sccache is dynamically linked to its Ubuntu
  24.04 glibc 2.39 with maximum required GLIBC 2.39
- each final image produced a real Rust cache miss followed by a cache hit after removing
  Cargo target output; there were no cache read, write, or compilation errors
- self-hosted Runner builds produced cosh-ng 0.20.0 outputs; no second local full build
  was run:
  - Linux x86_64: tar `3f454c4dcdeb738979edaace8312db484d34e543edc60ff362845461f0446716`,
    SBOM `02f0ad4c6e4245b04f5037a676fa5efc1718ef0572260b1ec3c90767951362e6`
  - Linux aarch64: tar `f753a453f5bda1945a5166dfd2bcc5d35262c5aad7253656eab79d63fdb7a9f1`,
    SBOM `9ab2dc649790cde18c723fea81d817853dce0302fe3be7b127cd205e8f6fdf9a`
  - macOS aarch64: tar `7defe12a6e15c3850bb39cf8043124275e40cb00ecfd93c7612d5887fc06d39c`,
    SBOM `1f8604cae32a53e77b68e9a45a1ce7672cb63e7b604e3eddea9b7f2b145b1aed`
- all 12 rebuilt files are byte-identical to the previously validated musl-sccache outputs;
  all Linux binaries have the requested ELF architecture and maximum GLIBC 2.28, and all
  macOS binaries are arm64 Mach-O with minimum macOS 11.0

## Documentation and rollback

No user documentation changes are required. Revert this commit to restore the previous
GitHub workflows. The runner retains the prepared image layers and the original root-disk
Docker/containerd data until the first upstream preview succeeds, so image and host
migrations can be rolled back independently.
