### PR TITLE
feat(tokenless): add staged pipeline and end-to-end arbitration

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -860,7 +860,10 @@ dependencies = [
 name = "tokenless-pipeline"
 version = "0.7.12"
 dependencies = [
+ "thiserror 2.0.18",
+ "tokenless-ccr",
  "tokenless-protocol",
+ "tokenless-stats",
 ]
 
 [[package]]

--- a/src/tokenless/crates/tokenless-pipeline/Cargo.toml
+++ b/src/tokenless/crates/tokenless-pipeline/Cargo.toml
@@ -3,7 +3,10 @@ name = "tokenless-pipeline"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Content taxonomy, deterministic detection, and the compile-time compressor registry"
+description = "Shared compression pipeline: content routing, staged execution, and arbitration"
 
 [dependencies]
+thiserror.workspace = true
+tokenless-ccr = { path = "../tokenless-ccr", default-features = false }
 tokenless-protocol = { path = "../tokenless-protocol" }
+tokenless-stats = { path = "../tokenless-stats" }

--- a/src/tokenless/crates/tokenless-pipeline/src/lib.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/lib.rs
@@ -1,22 +1,26 @@
-//! Content routing for the shared compression pipeline.
+//! The shared compression pipeline: content routing, staged execution, and
+//! end-to-end arbitration.
 //!
-//! This crate carries the pieces of roadmap §4.2 / §5.2 that sit between the
-//! protocol boundary and the compressors themselves:
+//! This crate carries the pieces of roadmap §4.2–§4.3 / §5.2–§5.3 that sit
+//! between the protocol boundary and the compressors themselves:
 //!
 //! - [`ContentType`]: the first content taxonomy;
 //! - [`detect`]: deterministic, bounded-cost content detection;
 //! - [`CompressorSpec`] and [`candidates`]: the compile-time registry and
 //!   the seam/capability filter (roadmap principle 2: route by content,
-//!   constrain by seam).
+//!   constrain by seam);
+//! - [`Compressor`] and [`run`]: the executable compressor interface and
+//!   the staged escalation engine with end-to-end arbitration.
 //!
-//! The staged pipeline and end-to-end arbitration that consume these types
-//! arrive separately; until existing compressors move behind the registry,
-//! [`REGISTRY`] is empty and nothing routes through this crate. The roadmap
-//! section numbers refer to the tokenless evolution roadmap, which has not
-//! landed in this repository yet.
+//! Until existing compressors move behind the registry, [`REGISTRY`] is
+//! empty and nothing routes through this crate. The roadmap section numbers
+//! refer to the tokenless evolution roadmap, which has not landed in this
+//! repository yet.
 
 mod content;
+mod pipeline;
 mod registry;
 
 pub use content::{ContentType, detect};
+pub use pipeline::{CompressError, CompressOutcome, Compressor, PipelineConfig, run};
 pub use registry::{CompressorSpec, CostClass, REGISTRY, Stage, candidates};

--- a/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
@@ -1,0 +1,402 @@
+//! Staged pipeline execution and end-to-end arbitration (roadmap §4.3).
+//!
+//! [`run`] takes a request through detection, routing, and the escalation
+//! ladder: every applicable lossless transformation, then at most one
+//! content-specific retrievable-lossy compressor, then at most one bounded
+//! truncation — escalating only while the configured size policy is unmet.
+//! A specialized lossy decision is final: no second lossy compressor and no
+//! generic lossy fallback runs after it. Only the bounded truncation stage,
+//! the ladder's last resort (§4.3 step 4), may still follow — and a stash
+//! write whose marker a later stage cuts out of the output is rolled back
+//! rather than committed.
+//!
+//! Arbitration is end-to-end: the original and the final candidate are
+//! compared once. A candidate that does not remove normalized tokens,
+//! violates required reversibility, or exceeds the overall timeout budget is
+//! rejected as a whole — its newly created Stash keys are rolled back and
+//! the original content is emitted unchanged. Compression stays an optional
+//! optimization throughout: a failing compressor never fails the request;
+//! the first failure is kept as a bounded diagnostic (roadmap principle 6).
+
+use std::time::{Duration, Instant};
+
+use tokenless_ccr::{StashError, StashStore, StashWrite, marker_for};
+use tokenless_protocol::{
+    CompressionRequest, CompressionResponse, DIAGNOSTIC_MAX_BYTES, Disposition, PROTOCOL_VERSION,
+    Reversibility, TOKENIZER_ID,
+};
+use tokenless_stats::estimate_tokens;
+
+use crate::content::{ContentType, detect};
+use crate::registry::{CompressorSpec, Stage};
+
+/// One executable compression step. [`crate::CompressorSpec`] is the routing
+/// metadata; this trait is the behavior behind it. Existing compressors
+/// migrate onto it starting with the response cleanup (roadmap §5.3); until
+/// then only test doubles implement it.
+pub trait Compressor {
+    /// The routing spec this compressor registers under.
+    fn spec(&self) -> &CompressorSpec;
+
+    /// Produces a transformed candidate for `content`.
+    ///
+    /// `stash` is present when the host can actually retrieve stashed
+    /// payloads. A retrievable-lossy compressor records every write in
+    /// [`CompressOutcome::stash_writes`], which is what lets the pipeline
+    /// roll them back when the end-to-end candidate is rejected.
+    ///
+    /// # Errors
+    ///
+    /// An error never fails the request: the pipeline records the first
+    /// failure as a bounded diagnostic and continues with the unchanged
+    /// input.
+    fn compress(
+        &self,
+        content: &str,
+        stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError>;
+}
+
+/// A successful compressor result.
+#[derive(Debug)]
+pub struct CompressOutcome {
+    /// The transformed content.
+    pub output: String,
+    /// Recovery state of `output` relative to the input.
+    pub reversibility: Reversibility,
+    /// Stash writes performed while producing `output`, in order. The
+    /// pipeline deletes exactly these on rollback; their keys become
+    /// [`CompressionResponse::stash_keys`] when the candidate is emitted.
+    pub stash_writes: Vec<StashWrite>,
+}
+
+/// Errors a compressor can surface.
+#[derive(Debug, thiserror::Error)]
+pub enum CompressError {
+    /// The stash backend failed while storing removed content.
+    #[error(transparent)]
+    Stash(#[from] StashError),
+    /// The compressor could not produce a candidate from this input.
+    #[error("{0}")]
+    Failed(String),
+}
+
+/// Arbitration policy for one [`run`] call.
+#[derive(Debug, Clone)]
+pub struct PipelineConfig {
+    /// Overall budget across detection and all stages. When exceeded, the
+    /// pipeline stops at the next stage boundary, rolls back, and returns
+    /// [`Disposition::Timeout`].
+    pub timeout: Duration,
+    /// The size policy: escalate beyond the lossless stage only while the
+    /// candidate exceeds this many normalized tokens. `None` never
+    /// escalates — only lossless transformations run.
+    pub max_tokens: Option<u64>,
+    /// Reject a candidate whose removed content would be unrecoverable
+    /// ([`Disposition::ReversibilityUnavailable`]).
+    pub require_reversibility: bool,
+    /// Measure the candidate but emit the original
+    /// ([`Disposition::DryRun`]); its stash writes are rolled back.
+    pub dry_run: bool,
+}
+
+/// Runs one request through detection, routing, the escalation ladder, and
+/// end-to-end arbitration.
+///
+/// The response is always emittable: on every non-applied disposition
+/// `output` is the original request content (fail-open contract of protocol
+/// v1). `compressors` is the executable registry — callers pass the
+/// compressor set matching their build; filtering by content type, seam,
+/// and declared capabilities happens here.
+#[must_use]
+pub fn run(
+    request: &CompressionRequest,
+    compressors: &[&dyn Compressor],
+    stash: Option<&dyn StashStore>,
+    config: &PipelineConfig,
+) -> CompressionResponse {
+    let deadline = Instant::now() + config.timeout;
+    let before_tokens = tokens(&request.content);
+    let content_type = detect(&request.content);
+
+    let mut lossless: Vec<&dyn Compressor> = Vec::new();
+    let mut lossy: Vec<&dyn Compressor> = Vec::new();
+    let mut truncation: Vec<&dyn Compressor> = Vec::new();
+    for &compressor in compressors {
+        let spec = compressor.spec();
+        if !spec.matches(content_type, request.seam, request.capabilities) {
+            continue;
+        }
+        match spec.stage {
+            Stage::Lossless => lossless.push(compressor),
+            Stage::RetrievableLossy => lossy.push(compressor),
+            Stage::Truncation => truncation.push(compressor),
+        }
+    }
+
+    let mut arb = Arbitration {
+        request,
+        stash,
+        content_type,
+        before_tokens,
+        current: request.content.clone(),
+        chain: Vec::new(),
+        ledger: StashLedger::default(),
+        reversibility: Reversibility::Lossless,
+        ran_any: false,
+        first_error: None,
+    };
+
+    // §4.3 steps 1–2: all applicable lossless transformations produce x1,
+    // which is dropped outright if it did not remove normalized tokens.
+    for &compressor in &lossless {
+        if Instant::now() > deadline {
+            return arb.rejected(Disposition::Timeout);
+        }
+        arb.step(compressor);
+    }
+    if !arb.chain.is_empty() && tokens(&arb.current) >= before_tokens {
+        arb.revert();
+    }
+
+    // §4.3 steps 3–4: escalate only while the size policy is unmet, one
+    // compressor per stage — the first registered candidate decides.
+    for stage in [&lossy, &truncation] {
+        let Some(&compressor) = stage.first() else {
+            continue;
+        };
+        let policy_met = config
+            .max_tokens
+            .is_none_or(|max| tokens(&arb.current) <= max);
+        if policy_met {
+            break;
+        }
+        if Instant::now() > deadline {
+            return arb.rejected(Disposition::Timeout);
+        }
+        arb.step(compressor);
+    }
+
+    if Instant::now() > deadline {
+        return arb.rejected(Disposition::Timeout);
+    }
+    arb.judge(config)
+}
+
+/// Normalized token count under the protocol's `heuristic-v1` counter.
+fn tokens(text: &str) -> u64 {
+    estimate_tokens(text) as u64
+}
+
+/// The in-flight candidate and everything needed to emit or undo it.
+struct Arbitration<'a> {
+    request: &'a CompressionRequest,
+    stash: Option<&'a dyn StashStore>,
+    content_type: ContentType,
+    before_tokens: u64,
+    current: String,
+    chain: Vec<String>,
+    ledger: StashLedger,
+    reversibility: Reversibility,
+    ran_any: bool,
+    first_error: Option<String>,
+}
+
+impl Arbitration<'_> {
+    /// Runs one compressor over the current candidate and adopts its
+    /// outcome. A failure leaves the candidate unchanged and is kept as the
+    /// diagnostic if it is the first.
+    fn step(&mut self, compressor: &dyn Compressor) {
+        match compressor.compress(&self.current, self.stash) {
+            Ok(outcome) => {
+                self.ran_any = true;
+                self.current = outcome.output;
+                self.chain.push(compressor.spec().id.to_owned());
+                for write in outcome.stash_writes {
+                    self.ledger.record(write);
+                }
+                self.reversibility = worst(self.reversibility, outcome.reversibility);
+            }
+            Err(error) => {
+                if self.first_error.is_none() {
+                    self.first_error = Some(truncate_diagnostic(&format!(
+                        "{}: {error}",
+                        compressor.spec().id
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Drops everything adopted so far: rows this run created are deleted
+    /// (their markers never reach the model) and the candidate returns to
+    /// the original content.
+    fn revert(&mut self) {
+        self.ledger.rollback(self.stash);
+        self.current.clone_from(&self.request.content);
+        self.chain.clear();
+        self.reversibility = Reversibility::Lossless;
+    }
+
+    /// A non-applied verdict: rolled back, original content, unchanged
+    /// counts.
+    fn rejected(&mut self, disposition: Disposition) -> CompressionResponse {
+        self.revert();
+        let mut response = CompressionResponse::passthrough(self.request, self.before_tokens);
+        response.disposition = disposition;
+        response.content_type = Some(self.content_type.wire_str().to_owned());
+        if disposition == Disposition::Error {
+            response.diagnostic = self.first_error.take();
+        }
+        response
+    }
+
+    /// §4.3 steps 5–6: the single end-to-end comparison of `tokens(x0)`
+    /// against the final candidate, and the explicit rejection dispositions.
+    fn judge(&mut self, config: &PipelineConfig) -> CompressionResponse {
+        if self.chain.is_empty() {
+            let disposition = if self.ran_any {
+                Disposition::NoSavings
+            } else if self.first_error.is_some() {
+                Disposition::Error
+            } else {
+                Disposition::Passthrough
+            };
+            return self.rejected(disposition);
+        }
+        if config.require_reversibility && self.reversibility == Reversibility::Unrecoverable {
+            return self.rejected(Disposition::ReversibilityUnavailable);
+        }
+        let after_tokens = tokens(&self.current);
+        if after_tokens >= self.before_tokens {
+            return self.rejected(Disposition::NoSavings);
+        }
+        if config.dry_run {
+            let mut response = self.rejected(Disposition::DryRun);
+            response.after_tokens = after_tokens;
+            return response;
+        }
+        let output = std::mem::take(&mut self.current);
+        let stash_keys = self.ledger.commit(&output, self.stash);
+        CompressionResponse {
+            protocol_version: PROTOCOL_VERSION,
+            output,
+            disposition: Disposition::Applied,
+            content_type: Some(self.content_type.wire_str().to_owned()),
+            compressor_chain: std::mem::take(&mut self.chain),
+            reversibility: self.reversibility,
+            before_tokens: self.before_tokens,
+            after_tokens,
+            stash_keys,
+            tokenizer_id: TOKENIZER_ID.to_owned(),
+            diagnostic: None,
+        }
+    }
+}
+
+/// Stash bookkeeping for one arbitration: which keys the candidate's output
+/// references, and which rows this run brought into existence and therefore
+/// owns for rollback purposes.
+#[derive(Default)]
+struct StashLedger {
+    /// Keys written while producing the candidate, in emission order,
+    /// deduplicated.
+    keys: Vec<String>,
+    /// `(key, generation)` ownership chains for rows this run *created*.
+    /// A pre-existing row (`created == false` on first sight) is never
+    /// tracked: this run only refreshed its expiry, and deleting it would
+    /// strand markers emitted by earlier requests.
+    owned: Vec<(String, u64)>,
+}
+
+impl StashLedger {
+    /// Records one stash write, maintaining the ownership chain per the
+    /// [`StashStore`] contract: a re-stash of an owned key re-adopts the new
+    /// generation only while `previous_generation` matches the one recorded
+    /// here; a mismatch means a foreign writer refreshed in between, and the
+    /// key is dropped from the rollback list so that refresh stays live.
+    fn record(&mut self, write: StashWrite) {
+        if !self.keys.contains(&write.key) {
+            self.keys.push(write.key.clone());
+        }
+        if write.created {
+            self.owned.push((write.key, write.generation));
+            return;
+        }
+        let Some(index) = self.owned.iter().position(|(key, _)| *key == write.key) else {
+            return;
+        };
+        if write.previous_generation == Some(self.owned[index].1) {
+            self.owned[index].1 = write.generation;
+        } else {
+            self.owned.swap_remove(index);
+        }
+    }
+
+    /// Deletes every row this run created. Best-effort: a row that survives
+    /// a backend error is unreachable and evicted by expiry, and the
+    /// generation guard keeps concurrently refreshed rows alive.
+    fn rollback(&mut self, stash: Option<&dyn StashStore>) {
+        self.keys.clear();
+        for (key, generation) in self.owned.drain(..) {
+            if let Some(stash) = stash {
+                let _ = stash.delete(&key, generation);
+            }
+        }
+    }
+
+    /// Commits the ledger against the final output: only keys whose marker
+    /// actually appears in it are emitted (the protocol's `stash_keys` are
+    /// the keys *present in* the applied result), while a write whose marker
+    /// a later stage cut out is rolled back instead of leaking as an
+    /// unreachable row.
+    fn commit(&mut self, output: &str, stash: Option<&dyn StashStore>) -> Vec<String> {
+        let (kept, orphaned): (Vec<String>, Vec<String>) = std::mem::take(&mut self.keys)
+            .into_iter()
+            .partition(|key| output.contains(&marker_for(key)));
+        for key in &orphaned {
+            if let Some(index) = self.owned.iter().position(|(owned, _)| owned == key) {
+                let (key, generation) = self.owned.swap_remove(index);
+                if let Some(stash) = stash {
+                    let _ = stash.delete(&key, generation);
+                }
+            }
+        }
+        self.owned.clear();
+        kept
+    }
+}
+
+/// Reversibility of a chain is its weakest link.
+fn worst(a: Reversibility, b: Reversibility) -> Reversibility {
+    use Reversibility::{Lossless, Retrievable, Unrecoverable};
+    match (a, b) {
+        (Unrecoverable, _) | (_, Unrecoverable) => Unrecoverable,
+        (Retrievable, _) | (_, Retrievable) => Retrievable,
+        (Lossless, Lossless) => Lossless,
+    }
+}
+
+/// Marker appended to a truncated diagnostic so readers can tell a clipped
+/// message from a complete one.
+const TRUNCATION_SUFFIX: &str = " [truncated]";
+
+/// Truncates to [`DIAGNOSTIC_MAX_BYTES`] on a char boundary, marking the
+/// cut. The marker fits inside the limit — the bound is a protocol
+/// contract, so it is never exceeded on top.
+fn truncate_diagnostic(message: &str) -> String {
+    if message.len() <= DIAGNOSTIC_MAX_BYTES {
+        return message.to_owned();
+    }
+    let mut end = DIAGNOSTIC_MAX_BYTES - TRUNCATION_SUFFIX.len();
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{TRUNCATION_SUFFIX}", &message[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    include!("tests/pipeline_tests.rs");
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/registry.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/registry.rs
@@ -57,6 +57,25 @@ pub struct CompressorSpec {
     pub cost_class: CostClass,
 }
 
+impl CompressorSpec {
+    /// The routing rule from principle 2: a spec matches when it supports
+    /// the detected content type, runs at the request's seam, and every
+    /// capability it requires is declared by the adapter.
+    #[must_use]
+    pub fn matches(
+        &self,
+        content_type: ContentType,
+        seam: Seam,
+        capabilities: Capabilities,
+    ) -> bool {
+        self.content_types.contains(&content_type)
+            && self.seams.contains(&seam)
+            && (!self.required_capabilities.replace_output || capabilities.replace_output)
+            && (!self.required_capabilities.publish_retrieve_tool
+                || capabilities.publish_retrieve_tool)
+    }
+}
+
 /// The production registry. Empty until existing compressors move behind
 /// the registry interface; entries are appended with the compressor that
 /// implements them, never speculatively.
@@ -70,13 +89,9 @@ pub fn candidates(
     seam: Seam,
     capabilities: Capabilities,
 ) -> impl Iterator<Item = &CompressorSpec> {
-    registry.iter().filter(move |spec| {
-        spec.content_types.contains(&content_type)
-            && spec.seams.contains(&seam)
-            && (!spec.required_capabilities.replace_output || capabilities.replace_output)
-            && (!spec.required_capabilities.publish_retrieve_tool
-                || capabilities.publish_retrieve_tool)
-    })
+    registry
+        .iter()
+        .filter(move |spec| spec.matches(content_type, seam, capabilities))
 }
 
 #[cfg(test)]

--- a/src/tokenless/crates/tokenless-pipeline/src/tests/pipeline_tests.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/tests/pipeline_tests.rs
@@ -1,0 +1,576 @@
+// Arbitration contract tests (§4.3): the escalation ladder, the single
+// end-to-end comparison, every explicit rejection disposition, and the
+// rollback of stash writes whose markers never reach the model. Compressors
+// here are test doubles — real ones migrate behind the interface starting
+// with the response cleanup.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokenless_ccr::InMemoryStore;
+use tokenless_protocol::{Capabilities, Seam};
+
+use crate::registry::CostClass;
+
+const REPLACE_ONLY: Capabilities = Capabilities {
+    replace_output: true,
+    publish_retrieve_tool: false,
+};
+const FULL: Capabilities = Capabilities {
+    replace_output: true,
+    publish_retrieve_tool: true,
+};
+
+const fn test_spec(id: &'static str, stage: Stage, capabilities: Capabilities) -> CompressorSpec {
+    CompressorSpec {
+        id,
+        content_types: &[ContentType::PlainText],
+        seams: &[Seam::PostTool],
+        required_capabilities: capabilities,
+        stage,
+        cost_class: CostClass::Cheap,
+    }
+}
+
+fn request(content: &str, capabilities: Capabilities) -> CompressionRequest {
+    let mut request = CompressionRequest::new(content, "test-agent", Seam::PostTool);
+    request.capabilities = capabilities;
+    request
+}
+
+fn config() -> PipelineConfig {
+    PipelineConfig {
+        timeout: Duration::from_secs(5),
+        max_tokens: None,
+        require_reversibility: false,
+        dry_run: false,
+    }
+}
+
+const SPACEY: &str = "alpha   beta   gamma   delta   epsilon   zeta";
+const MULTILINE: &str = "keep this head line\n\
+                        the rest of this content is a long tail\n\
+                        that the stasher moves into the stash\n\
+                        line after line of plain prose\n\
+                        with enough weight to make stashing save tokens";
+const SPACEY_MULTILINE: &str = "keep   this   head\n\
+                               and   stash   this   long   tail   of   prose\n\
+                               spread   over   several   lines   of   filler";
+
+/// Lossless: collapses runs of spaces.
+struct SpaceSquisher;
+
+static SQUISHER_SPEC: CompressorSpec = test_spec("space-squisher", Stage::Lossless, REPLACE_ONLY);
+
+impl Compressor for SpaceSquisher {
+    fn spec(&self) -> &CompressorSpec {
+        &SQUISHER_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let mut output = String::with_capacity(content.len());
+        let mut previous_space = false;
+        for ch in content.chars() {
+            if ch == ' ' && previous_space {
+                continue;
+            }
+            previous_space = ch == ' ';
+            output.push(ch);
+        }
+        Ok(CompressOutcome {
+            output,
+            reversibility: Reversibility::Lossless,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+/// Lossless that grows its input: must be rejected by arbitration.
+struct Bloater;
+
+static BLOATER_SPEC: CompressorSpec = test_spec("bloater", Stage::Lossless, REPLACE_ONLY);
+
+impl Compressor for Bloater {
+    fn spec(&self) -> &CompressorSpec {
+        &BLOATER_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        Ok(CompressOutcome {
+            output: format!("{content}{content}"),
+            reversibility: Reversibility::Lossless,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+/// Retrievable-lossy: keeps the first line, stashes the rest behind a marker.
+struct TailStasher;
+
+static TAIL_STASHER_SPEC: CompressorSpec =
+    test_spec("tail-stasher", Stage::RetrievableLossy, FULL);
+
+impl Compressor for TailStasher {
+    fn spec(&self) -> &CompressorSpec {
+        &TAIL_STASHER_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let stash = stash.ok_or_else(|| CompressError::Failed("stash unavailable".to_owned()))?;
+        let (head, tail) = content
+            .split_once('\n')
+            .ok_or_else(|| CompressError::Failed("nothing to stash".to_owned()))?;
+        let write = stash.stash(tail)?;
+        let output = format!("{head}\n{}", marker_for(&write.key));
+        Ok(CompressOutcome {
+            output,
+            reversibility: Reversibility::Retrievable,
+            stash_writes: vec![write],
+        })
+    }
+}
+
+/// Lossy double that stashes the tail twice: the second write refreshes the
+/// first, exercising the unbroken ownership chain on rollback.
+struct DoubleStasher;
+
+static DOUBLE_STASHER_SPEC: CompressorSpec =
+    test_spec("double-stasher", Stage::RetrievableLossy, FULL);
+
+impl Compressor for DoubleStasher {
+    fn spec(&self) -> &CompressorSpec {
+        &DOUBLE_STASHER_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let stash = stash.ok_or_else(|| CompressError::Failed("stash unavailable".to_owned()))?;
+        let (head, tail) = content
+            .split_once('\n')
+            .ok_or_else(|| CompressError::Failed("nothing to stash".to_owned()))?;
+        let first = stash.stash(tail)?;
+        let second = stash.stash(tail)?;
+        let output = format!("{head}\n{}", marker_for(&second.key));
+        Ok(CompressOutcome {
+            output,
+            reversibility: Reversibility::Retrievable,
+            stash_writes: vec![first, second],
+        })
+    }
+}
+
+/// Lossy double with a foreign refresh interleaved between its two reported
+/// writes, breaking the ownership chain.
+struct ForeignRefreshStasher;
+
+static FOREIGN_REFRESH_SPEC: CompressorSpec =
+    test_spec("foreign-refresh", Stage::RetrievableLossy, FULL);
+
+impl Compressor for ForeignRefreshStasher {
+    fn spec(&self) -> &CompressorSpec {
+        &FOREIGN_REFRESH_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let stash = stash.ok_or_else(|| CompressError::Failed("stash unavailable".to_owned()))?;
+        let (head, tail) = content
+            .split_once('\n')
+            .ok_or_else(|| CompressError::Failed("nothing to stash".to_owned()))?;
+        let first = stash.stash(tail)?;
+        // Another writer refreshes the row between this run's two writes.
+        stash.stash(tail)?;
+        let third = stash.stash(tail)?;
+        let output = format!("{head}\n{}", marker_for(&third.key));
+        Ok(CompressOutcome {
+            output,
+            reversibility: Reversibility::Retrievable,
+            stash_writes: vec![first, third],
+        })
+    }
+}
+
+/// Lossy without a recovery path: drops the second half of the content.
+struct HalfDropper;
+
+static HALF_DROPPER_SPEC: CompressorSpec =
+    test_spec("half-dropper", Stage::RetrievableLossy, REPLACE_ONLY);
+
+impl Compressor for HalfDropper {
+    fn spec(&self) -> &CompressorSpec {
+        &HALF_DROPPER_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let mut end = content.len() / 2;
+        while !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        Ok(CompressOutcome {
+            output: content[..end].to_owned(),
+            reversibility: Reversibility::Unrecoverable,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+/// Lossy double that must never be reached behind another lossy candidate.
+struct CountingLossy;
+
+static COUNTING_LOSSY_SPEC: CompressorSpec =
+    test_spec("counting-lossy", Stage::RetrievableLossy, FULL);
+static SECOND_LOSSY_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+impl Compressor for CountingLossy {
+    fn spec(&self) -> &CompressorSpec {
+        &COUNTING_LOSSY_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        SECOND_LOSSY_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(CompressOutcome {
+            output: content.to_owned(),
+            reversibility: Reversibility::Unrecoverable,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+/// Truncation: keeps the first 8 bytes.
+struct HeadTrunc;
+
+static HEAD_TRUNC_SPEC: CompressorSpec = test_spec("head-trunc", Stage::Truncation, REPLACE_ONLY);
+
+impl Compressor for HeadTrunc {
+    fn spec(&self) -> &CompressorSpec {
+        &HEAD_TRUNC_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let mut end = content.len().min(8);
+        while !content.is_char_boundary(end) {
+            end -= 1;
+        }
+        Ok(CompressOutcome {
+            output: content[..end].to_owned(),
+            reversibility: Reversibility::Unrecoverable,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+/// Optional step that always fails, with an oversized message.
+struct Failing;
+
+static FAILING_SPEC: CompressorSpec = test_spec("failing", Stage::Lossless, REPLACE_ONLY);
+
+impl Compressor for Failing {
+    fn spec(&self) -> &CompressorSpec {
+        &FAILING_SPEC
+    }
+
+    fn compress(
+        &self,
+        _content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        Err(CompressError::Failed("b".repeat(2 * DIAGNOSTIC_MAX_BYTES)))
+    }
+}
+
+/// Lossless that would save tokens but overruns any small budget.
+struct Slow;
+
+static SLOW_SPEC: CompressorSpec = test_spec("slow-squisher", Stage::Lossless, REPLACE_ONLY);
+
+impl Compressor for Slow {
+    fn spec(&self) -> &CompressorSpec {
+        &SLOW_SPEC
+    }
+
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        std::thread::sleep(Duration::from_millis(30));
+        Ok(CompressOutcome {
+            output: content.replace(' ', ""),
+            reversibility: Reversibility::Lossless,
+            stash_writes: Vec::new(),
+        })
+    }
+}
+
+#[test]
+fn lossless_savings_are_applied() {
+    let request = request(SPACEY, REPLACE_ONLY);
+    let response = run(&request, &[&SpaceSquisher], None, &config());
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.output, "alpha beta gamma delta epsilon zeta");
+    assert_eq!(response.compressor_chain, ["space-squisher"]);
+    assert!(response.after_tokens < response.before_tokens);
+    assert_eq!(response.reversibility, Reversibility::Lossless);
+    assert_eq!(response.content_type.as_deref(), Some("plain_text"));
+    assert_eq!(response.tokenizer_id, TOKENIZER_ID);
+    assert!(response.stash_keys.is_empty());
+}
+
+#[test]
+fn no_candidates_is_passthrough() {
+    let request = request(SPACEY, REPLACE_ONLY);
+    let response = run(&request, &[], None, &config());
+    assert_eq!(response.disposition, Disposition::Passthrough);
+    assert_eq!(response.output, SPACEY);
+    assert_eq!(response.after_tokens, response.before_tokens);
+    assert_eq!(response.content_type.as_deref(), Some("plain_text"));
+}
+
+#[test]
+fn undeclared_capabilities_filter_out_candidates() {
+    let request = request(SPACEY, Capabilities::default());
+    let response = run(&request, &[&SpaceSquisher], None, &config());
+    assert_eq!(response.disposition, Disposition::Passthrough);
+    assert_eq!(response.output, SPACEY);
+}
+
+#[test]
+fn growth_is_rejected_as_no_savings() {
+    let request = request(SPACEY, REPLACE_ONLY);
+    let response = run(&request, &[&Bloater], None, &config());
+    assert_eq!(response.disposition, Disposition::NoSavings);
+    assert_eq!(response.output, SPACEY);
+    assert_eq!(response.after_tokens, response.before_tokens);
+    assert!(response.compressor_chain.is_empty());
+}
+
+#[test]
+fn size_policy_gates_escalation() {
+    let store = InMemoryStore::new();
+    let request = request(MULTILINE, FULL);
+    // No size policy: the lossy stage never runs, nothing is stashed.
+    let response = run(&request, &[&TailStasher], Some(&store), &config());
+    assert_eq!(response.disposition, Disposition::Passthrough);
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn lossy_stage_stashes_and_applies() {
+    let store = InMemoryStore::new();
+    let request = request(MULTILINE, FULL);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    let response = run(&request, &[&TailStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.reversibility, Reversibility::Retrievable);
+    assert_eq!(response.compressor_chain, ["tail-stasher"]);
+    assert_eq!(response.stash_keys.len(), 1);
+    assert!(response.output.starts_with("keep this head line\n<<tokenless:"));
+    let tail = &MULTILINE[MULTILINE.find('\n').unwrap() + 1..];
+    let stashed = store.retrieve(&response.stash_keys[0]).unwrap();
+    assert_eq!(stashed.as_deref(), Some(tail));
+}
+
+#[test]
+fn rejected_candidates_roll_back_stash_writes() {
+    let store = InMemoryStore::new();
+    // The marker is longer than the stashed tail: a produced-but-worse
+    // candidate must disappear completely, stash entry included.
+    let request = request("ab\ncd", FULL);
+    let mut config = config();
+    config.max_tokens = Some(1);
+    let response = run(&request, &[&TailStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::NoSavings);
+    assert_eq!(response.output, "ab\ncd");
+    assert!(response.stash_keys.is_empty());
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn rollback_preserves_rows_that_predate_the_run() {
+    let store = InMemoryStore::new();
+    let preexisting = store.stash("cd").expect("seed row");
+    let request = request("ab\ncd", FULL);
+    let mut config = config();
+    config.max_tokens = Some(1);
+    let response = run(&request, &[&TailStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::NoSavings);
+    // The run only refreshed a row it did not create: it must survive, or
+    // markers emitted by earlier requests would go dead.
+    assert_eq!(store.len(), 1);
+    let stashed = store.retrieve(&preexisting.key).expect("retrieve");
+    assert_eq!(stashed.as_deref(), Some("cd"));
+}
+
+#[test]
+fn an_unbroken_refresh_chain_is_rolled_back_wholly() {
+    let store = InMemoryStore::new();
+    let request = request("ab\ncd", FULL);
+    let mut config = config();
+    config.max_tokens = Some(1);
+    let response = run(&request, &[&DoubleStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::NoSavings);
+    // Both writes belong to this run's chain; rollback re-adopted the
+    // second generation, so the row created here is gone.
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn a_foreign_refresh_keeps_the_row_alive() {
+    let store = InMemoryStore::new();
+    let request = request("ab\ncd", FULL);
+    let mut config = config();
+    config.max_tokens = Some(1);
+    let response = run(&request, &[&ForeignRefreshStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::NoSavings);
+    // The interleaved foreign refresh broke the ownership chain: the key
+    // leaves the rollback list and the row stays live.
+    assert_eq!(store.len(), 1);
+}
+
+#[test]
+fn truncation_that_cuts_a_marker_rolls_back_its_stash_write() {
+    let store = InMemoryStore::new();
+    let request = request(MULTILINE, FULL);
+    let mut config = config();
+    config.max_tokens = Some(2);
+    let compressors: [&dyn Compressor; 2] = [&TailStasher, &HeadTrunc];
+    let response = run(&request, &compressors, Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.compressor_chain, ["tail-stasher", "head-trunc"]);
+    assert_eq!(response.reversibility, Reversibility::Unrecoverable);
+    assert_eq!(response.output, "keep thi");
+    // The truncated output no longer references the stash write: the key is
+    // not committed and the row is rolled back instead of leaking.
+    assert!(response.stash_keys.is_empty());
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn required_reversibility_rejects_unrecoverable_candidates() {
+    let request = request(MULTILINE, REPLACE_ONLY);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    config.require_reversibility = true;
+    let response = run(&request, &[&HalfDropper], None, &config);
+    assert_eq!(response.disposition, Disposition::ReversibilityUnavailable);
+    assert_eq!(response.output, MULTILINE);
+    assert!(response.compressor_chain.is_empty());
+
+    config.require_reversibility = false;
+    let response = run(&request, &[&HalfDropper], None, &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.reversibility, Reversibility::Unrecoverable);
+}
+
+#[test]
+fn only_the_first_lossy_candidate_runs() {
+    let store = InMemoryStore::new();
+    let request = request(MULTILINE, FULL);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    let compressors: [&dyn Compressor; 2] = [&TailStasher, &CountingLossy];
+    let response = run(&request, &compressors, Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.compressor_chain, ["tail-stasher"]);
+    assert_eq!(SECOND_LOSSY_CALLS.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn truncation_is_the_last_resort() {
+    let request = request(MULTILINE, REPLACE_ONLY);
+    let mut config = config();
+    config.max_tokens = Some(4);
+    let response = run(&request, &[&HeadTrunc], None, &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.compressor_chain, ["head-trunc"]);
+    assert_eq!(response.reversibility, Reversibility::Unrecoverable);
+    assert_eq!(response.output, &MULTILINE[..8]);
+}
+
+#[test]
+fn the_ladder_composes_lossless_then_lossy() {
+    let store = InMemoryStore::new();
+    let request = request(SPACEY_MULTILINE, FULL);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    let compressors: [&dyn Compressor; 2] = [&SpaceSquisher, &TailStasher];
+    let response = run(&request, &compressors, Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert_eq!(response.compressor_chain, ["space-squisher", "tail-stasher"]);
+    assert_eq!(response.reversibility, Reversibility::Retrievable);
+    assert!(response.output.starts_with("keep this head\n<<tokenless:"));
+}
+
+#[test]
+fn dry_run_measures_without_emitting() {
+    let store = InMemoryStore::new();
+    let request = request(MULTILINE, FULL);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    config.dry_run = true;
+    let response = run(&request, &[&TailStasher], Some(&store), &config);
+    assert_eq!(response.disposition, Disposition::DryRun);
+    assert_eq!(response.output, MULTILINE);
+    assert!(response.after_tokens < response.before_tokens);
+    assert!(response.compressor_chain.is_empty());
+    assert!(response.stash_keys.is_empty());
+    assert_eq!(store.len(), 0);
+}
+
+#[test]
+fn failures_are_fail_open_with_a_bounded_diagnostic() {
+    let request = request(SPACEY, REPLACE_ONLY);
+    let response = run(&request, &[&Failing], None, &config());
+    assert_eq!(response.disposition, Disposition::Error);
+    assert_eq!(response.output, SPACEY);
+    let diagnostic = response.diagnostic.expect("Error carries a diagnostic");
+    assert!(diagnostic.len() <= DIAGNOSTIC_MAX_BYTES);
+    assert!(diagnostic.starts_with("failing: "));
+    assert!(diagnostic.ends_with(TRUNCATION_SUFFIX));
+
+    // A failing optional step does not poison a successful sibling.
+    let response = run(&request, &[&Failing, &SpaceSquisher], None, &config());
+    assert_eq!(response.disposition, Disposition::Applied);
+    assert!(response.diagnostic.is_none());
+}
+
+#[test]
+fn timeout_rolls_back_and_preserves_the_original() {
+    let request = request(SPACEY, REPLACE_ONLY);
+    let mut config = config();
+    config.timeout = Duration::from_millis(5);
+    let response = run(&request, &[&Slow], None, &config);
+    assert_eq!(response.disposition, Disposition::Timeout);
+    assert_eq!(response.output, SPACEY);
+    assert!(response.compressor_chain.is_empty());
+}


### PR DESCRIPTION
## Why

Follow-up to #2788. The routing layer (taxonomy, detector, registry) exists, but nothing can execute compressors or arbitrate their results. This PR adds the staged pipeline and end-to-end arbitration from roadmap §4.3 — the last shared-foundation piece before existing compressors migrate behind the interface and the hooks converge on one entry point.

## What changed

- **`Compressor` trait + `CompressOutcome`/`CompressError`** — the executable interface behind the registry's `CompressorSpec`. Outcomes record their stash writes, which is what makes rejected candidates fully undoable.
- **`run(request, compressors, stash, config)`** — detection → seam/capability routing (via `CompressorSpec::matches`, extracted from `candidates()`) → the escalation ladder → one end-to-end comparison:
  - all applicable lossless transformations produce `x1`, dropped outright if it does not remove normalized tokens (§4.3 step 2);
  - escalation to retrievable-lossy and truncation happens only while `PipelineConfig::max_tokens` is unmet, and runs **at most one compressor per stage** — a specialized lossy decision is final, no second lossy compressor or generic fallback follows it;
  - `tokens(x0)` is compared with the final candidate **once**; rejection paths return explicit dispositions (`no_savings`, `reversibility_unavailable`, `timeout`, `error`, `dry_run`, `passthrough`) with the original content as `output` — the protocol's fail-open contract;
  - rollback deletes exactly the recorded stash writes via `delete(key, generation)`, so generation matching keeps concurrently refreshed entries alive and rejected/dry-run candidates never leak markers or keys;
  - one overall timeout budget across detection and all stages, checked at stage boundaries; the first compressor failure is kept as a diagnostic bounded to `DIAGNOSTIC_MAX_BYTES`.
- **Shared counter**: all counts go through `tokenless-stats`' `estimate_tokens` (`heuristic-v1`), keeping CLI and Runtime arbitration on identical numbers (§5.6). New path deps: `tokenless-ccr` (default features off — only the `StashStore` contract) and `tokenless-stats`.
- **14 arbitration contract tests** with test-double compressors: ladder composition (lossless→lossy chain), size-policy gating, the one-lossy rule, stash rollback on rejection and on dry-run, reversibility enforcement in both modes, bounded diagnostics, fail-open sibling behavior, and the timeout budget.

## User / Agent impact

None at runtime. Nothing calls `run()` yet; wiring lands with the adapter/hook PRs behind the runtime configuration toggle (default off) noted in #2788.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Additive Rust API with no consumers. The engine is deterministic apart from the timeout boundary, and every non-applied path returns the original content unchanged, so a misbehaving compressor cannot corrupt model-visible output once wired.

## Validation

```bash
cd src/tokenless
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo doc --workspace --no-deps
```

All four pass; `tokenless-pipeline` now runs 35 tests (14 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
