### PR TITLE
refactor(anolisa): extract update batch app

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -508,6 +508,7 @@ pub(crate) enum PlannedUpdateRoute {
 /// A committed update also reports the adapters it left with a stale
 /// resource bundle (issue #1885); no-op, dry-run, and failed updates report
 /// none.
+#[cfg(test)]
 pub(crate) fn update_component_with_deps(
     input: &str,
     ctx: &CliContext,
@@ -1136,6 +1137,7 @@ fn render_application_outcome(
     ctx: &CliContext,
     application_outcome: application::ApplicationOutcome,
 ) -> ComponentUpdateResult {
+    let batch_outcome = application_outcome.batch_outcome()?;
     match application_outcome {
         application::ApplicationOutcome::NoOp { subject } => {
             render_result(
@@ -1150,7 +1152,7 @@ fn render_application_outcome(
                 None,
                 &[],
             )?;
-            Ok((UpdateOutcome::AlreadyCurrent, Vec::new()))
+            Ok((batch_outcome, Vec::new()))
         }
         application::ApplicationOutcome::Preview { subject, steps } => {
             let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
@@ -1166,35 +1168,19 @@ fn render_application_outcome(
                 None,
                 &[],
             )?;
-            Ok((UpdateOutcome::Updated, Vec::new()))
+            Ok((batch_outcome, Vec::new()))
         }
         application::ApplicationOutcome::Applied {
-            command,
+            command: _,
             subject,
             steps,
             outcome,
             adapter_actions,
         } => {
-            if matches!(
-                outcome.status(),
-                anolisa_core::execution::CommandOutcomeStatus::Partial
-            ) {
-                let reason = outcome
-                    .warnings()
-                    .first()
-                    .expect("partial update outcome carries its reconciliation failure");
-                return Err(CliError::Runtime {
-                    command,
-                    reason: format!(
-                        "the update of '{}' committed, but {reason}; run `anolisa repair {}` to reconcile",
-                        subject.component, subject.component
-                    ),
-                });
-            }
             for warning in outcome.warnings() {
                 eprintln!("warning: {warning}");
             }
-            let updated = !outcome.changes().is_empty();
+            let updated = matches!(batch_outcome, UpdateOutcome::Updated);
             let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
             render_result(
                 ctx,
@@ -1208,14 +1194,7 @@ fn render_application_outcome(
                 outcome.operation_id(),
                 &adapter_actions,
             )?;
-            Ok((
-                if updated {
-                    UpdateOutcome::Updated
-                } else {
-                    UpdateOutcome::AlreadyCurrent
-                },
-                adapter_actions,
-            ))
+            Ok((batch_outcome, adapter_actions))
         }
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use serde::Serialize;
 
 use anolisa_core::domain::NativePm;
+use anolisa_core::execution::ExecutionIntent;
 use anolisa_core::executor::{
     DelegatedExecutionTarget, PHASE_NATIVE_TXN, delegated_recovery_context,
     execute_delegated_steps_resumed,
@@ -41,11 +42,16 @@ use crate::context::CliContext;
 use crate::response::{CliError, render_json, render_json_with_status};
 
 use super::{
-    AdapterAction, AdapterRevisionSnapshot, COMMAND, ComponentUpdateResult, PlannedComponentUpdate,
-    PlannedUpdateRoute, UpdateOutcome, adapter_actions_after_update, adapter_revision_snapshot,
-    append_update_log, complete_delegated_update, native_update_authorized, now_iso8601,
-    plan_component_update, render_adapter_action_notices, step_label, update_backends,
-    update_component_with_deps,
+    AdapterAction, AdapterRevisionSnapshot, COMMAND, PlannedComponentUpdate, PlannedUpdateRoute,
+    adapter_actions_after_update, adapter_revision_snapshot, append_update_log,
+    complete_delegated_update, native_update_authorized, now_iso8601,
+    render_adapter_action_notices, step_label, update_backends,
+};
+
+mod application;
+use application::{
+    BatchApplicationOutcome, BatchEffectOutcome, BatchMemberOutcome, BatchMemberStatus,
+    BatchOutputEvent, MemberApplicationOutcome, batch_status, failed_item,
 };
 
 const BATCH_COMMAND: &str = "update all";
@@ -84,22 +90,23 @@ struct UpdateAllPayload {
 }
 
 pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
-    let layout = common::resolve_layout(ctx);
-    let state_path = layout.state_dir.join("installed.toml");
-    let store = StateStore::load_for_layout(&state_path, privilege::effective_uid(), &layout)
-        .map_err(|err| CliError::Runtime {
-            command: BATCH_COMMAND.to_string(),
-            reason: format!("failed to load installed state: {err}"),
-        })?;
-    let names: Vec<String> = store
-        .installations
-        .iter()
-        .filter(|installation| installation.kind == ObjectKind::Component)
-        .map(|installation| installation.name.clone())
-        .collect();
-    drop(store);
+    let mut output = |event| render_batch_event(ctx, event);
+    let outcome = application::run(
+        application::BatchRequest {
+            intent: super::execution_intent(ctx),
+        },
+        ctx,
+        &mut output,
+    )?;
+    render_application_outcome(ctx, outcome)
+}
 
-    if names.is_empty() {
+fn render_application_outcome(
+    ctx: &CliContext,
+    outcome: BatchApplicationOutcome,
+) -> Result<(), CliError> {
+    let dry_run = outcome.is_preview();
+    if outcome.items.is_empty() {
         if !ctx.quiet && !ctx.json {
             let color = Palette::new(ctx.no_color);
             println!(
@@ -116,7 +123,7 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
                     planned: 0,
                     already_current: 0,
                     failed: 0,
-                    dry_run: ctx.dry_run,
+                    dry_run,
                     merged_transaction: None,
                     items: Vec::new(),
                 },
@@ -125,139 +132,41 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
         return Ok(());
     }
 
-    // Suppress per-component rendering: the batch owns the final output.
-    let mut suppressed_ctx = ctx.clone();
-    suppressed_ctx.json = false;
-    suppressed_ctx.quiet = true;
-
-    // Peek phase: plan every component read-only and classify. Delegated
-    // refreshes (U5) merge into one native transaction; everything else
-    // (owned plans, NoOps, planning errors) re-plans through the per-item
-    // pipeline, which reproduces the same outcome — the extra probe is
-    // cheap next to a dnf run.
-    let mut merged: Vec<MergedUpdate> = Vec::new();
-    let mut per_item: Vec<String> = Vec::new();
-    for name in &names {
-        let candidate = update_backends(name, &suppressed_ctx)
-            .and_then(|(query, txn)| plan_component_update(name, &suppressed_ctx, &query, &txn))
-            .ok()
-            .and_then(|planned| {
-                merged_update_package(&planned).map(|package| MergedUpdate {
-                    name: name.clone(),
-                    package,
-                    planned,
-                })
-            });
-        match candidate {
-            Some(item) => merged.push(item),
-            None => per_item.push(name.clone()),
-        }
-    }
-
-    // A single delegated refresh gains nothing from merging; keep it on the
-    // per-item pipeline.
-    if merged.len() < 2 {
-        per_item = names.clone();
-        merged.clear();
-    }
-    let merged_transaction: Option<Vec<String>> =
-        (!merged.is_empty()).then(|| merged.iter().map(|item| item.package.clone()).collect());
-
-    let mut results: HashMap<String, UpdateAllItem> = HashMap::with_capacity(names.len());
-
-    if !merged.is_empty() {
-        if !ctx.quiet && !ctx.json {
-            let color = Palette::new(ctx.no_color);
-            let members = merged
-                .iter()
-                .map(|item| item.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            println!("{} {members} (one rpm transaction)", color.label("==>"));
-        }
-        if ctx.dry_run {
-            // Each member previews its own plan in the single-component
-            // format; the group header above already announced that the
-            // native transactions will merge into one dnf run.
-            for item in &merged {
-                let steps = match &item.planned.route {
-                    PlannedUpdateRoute::Delegated { steps } => steps.as_slice(),
-                    _ => &[],
-                };
-                let labels: Vec<String> = steps.iter().map(step_label).collect();
-                if !ctx.quiet && !ctx.json {
-                    let color = Palette::new(ctx.no_color);
-                    println!(
-                        "{} {} {}",
-                        color.command("update"),
-                        item.name,
-                        color.muted("(dry-run — nothing updated)"),
-                    );
-                    if let Some(from) = &item.planned.native_from {
-                        println!("{} {from}", color.label("current:"));
-                    }
-                    for label in &labels {
-                        println!("  - {label}");
-                    }
-                }
-                results.insert(
-                    item.name.clone(),
-                    UpdateAllItem {
-                        component: item.name.clone(),
-                        status: "planned",
-                        reason: None,
-                        plan: Some(labels),
-                        adapter_actions: Vec::new(),
-                    },
-                );
-            }
-        } else {
-            for item in execute_merged_updates(merged, ctx) {
-                results.insert(item.component.clone(), item);
-            }
-        }
-    }
-
-    for name in &per_item {
-        if !ctx.quiet && !ctx.json {
-            let color = Palette::new(ctx.no_color);
-            println!("{} {name}", color.label("==>"));
-        }
-        let outcome = update_backends(name, &suppressed_ctx).and_then(|(query, txn)| {
-            update_component_with_deps(name, &suppressed_ctx, &query, &txn, privilege::is_root())
-        });
-        let item = match outcome {
-            Ok((outcome, adapter_actions)) => UpdateAllItem {
-                component: name.clone(),
-                status: item_status(outcome, ctx.dry_run),
-                reason: None,
-                plan: None,
-                adapter_actions,
-            },
-            Err(err) => UpdateAllItem {
-                component: name.clone(),
-                status: "failed",
-                reason: Some(err.reason().to_string()),
-                plan: None,
-                adapter_actions: Vec::new(),
-            },
-        };
-        results.insert(name.clone(), item);
-    }
-
-    // Rebuild the summary in the original record order.
-    let items: Vec<UpdateAllItem> = names
+    let total = outcome.items.len();
+    let updated = outcome
+        .items
         .iter()
-        .filter_map(|name| results.remove(name))
-        .collect();
-
-    let updated = items.iter().filter(|i| i.status == "updated").count();
-    let planned = items.iter().filter(|i| i.status == "planned").count();
-    let already_current = items
-        .iter()
-        .filter(|i| i.status == "already-current")
+        .filter(|item| item.status == BatchMemberStatus::Updated)
         .count();
-    let failed = items.iter().filter(|i| i.status == "failed").count();
+    let planned = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::Planned)
+        .count();
+    let already_current = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::AlreadyCurrent)
+        .count();
+    let failed = outcome
+        .items
+        .iter()
+        .filter(|item| item.status == BatchMemberStatus::Failed)
+        .count();
+    debug_assert_eq!(outcome.has_failures(), failed > 0);
+    let items = outcome
+        .items
+        .into_iter()
+        .map(|item| UpdateAllItem {
+            component: item.component,
+            status: item.status.as_str(),
+            reason: item.reason,
+            plan: item
+                .plan
+                .map(|steps| steps.iter().map(step_label).collect()),
+            adapter_actions: item.adapter_actions,
+        })
+        .collect::<Vec<_>>();
 
     if ctx.json {
         // The batch summary is the single, complete JSON response; a partial
@@ -267,13 +176,13 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
             BATCH_COMMAND,
             failed == 0,
             UpdateAllPayload {
-                total: names.len(),
+                total,
                 updated,
                 planned,
                 already_current,
                 failed,
-                dry_run: ctx.dry_run,
-                merged_transaction,
+                dry_run,
+                merged_transaction: outcome.merged_transaction,
                 items,
             },
         )?;
@@ -289,8 +198,8 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
     if !ctx.quiet {
         let color = Palette::new(ctx.no_color);
         println!();
-        let ok_word = if ctx.dry_run { "planned" } else { "updated" };
-        let ok_count = if ctx.dry_run { planned } else { updated };
+        let ok_word = if dry_run { "planned" } else { "updated" };
+        let ok_count = if dry_run { planned } else { updated };
         let current_segment = if already_current > 0 {
             format!("  already-current={already_current}")
         } else {
@@ -300,7 +209,7 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
             println!(
                 "{} total={}  {ok_word}={ok_count}{current_segment}",
                 color.label("summary:"),
-                names.len(),
+                total,
             );
         } else {
             let failed_names: Vec<&str> = items
@@ -311,7 +220,7 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
             println!(
                 "{} total={}  {ok_word}={ok_count}{current_segment}  failed={failed} ({})",
                 color.label("summary:"),
-                names.len(),
+                total,
                 failed_names.join(", "),
             );
             for item in items.iter().filter(|i| i.status == "failed") {
@@ -341,14 +250,39 @@ pub(crate) fn handle_update_all(ctx: &CliContext) -> Result<(), CliError> {
     }
 }
 
-/// Batch status string for a successful per-item update, combining the
-/// outcome with dry-run: nothing is written on dry-run, so a would-be update
-/// reads "planned" while an idempotent NoOp reads the same either way.
-fn item_status(outcome: UpdateOutcome, dry_run: bool) -> &'static str {
-    match (outcome, dry_run) {
-        (UpdateOutcome::Updated, false) => "updated",
-        (UpdateOutcome::Updated, true) => "planned",
-        (UpdateOutcome::AlreadyCurrent, _) => "already-current",
+fn render_batch_event(ctx: &CliContext, event: BatchOutputEvent) {
+    let color = Palette::new(ctx.no_color);
+    match event {
+        BatchOutputEvent::Warning(warning) => {
+            eprintln!("warning: {warning}");
+        }
+        BatchOutputEvent::MergedGroup { members } if !ctx.quiet && !ctx.json => {
+            println!("{} {members} (one rpm transaction)", color.label("==>"));
+        }
+        BatchOutputEvent::PreviewPlan {
+            component,
+            from_version,
+            steps,
+        } if !ctx.quiet && !ctx.json => {
+            println!(
+                "{} {} {}",
+                color.command("update"),
+                component,
+                color.muted("(dry-run — nothing updated)"),
+            );
+            if let Some(from) = from_version {
+                println!("{} {from}", color.label("current:"));
+            }
+            for step in &steps {
+                println!("  - {}", step_label(step));
+            }
+        }
+        BatchOutputEvent::Member { component } if !ctx.quiet && !ctx.json => {
+            println!("{} {component}", color.label("==>"));
+        }
+        BatchOutputEvent::MergedGroup { .. }
+        | BatchOutputEvent::PreviewPlan { .. }
+        | BatchOutputEvent::Member { .. } => {}
     }
 }
 
@@ -387,7 +321,11 @@ fn merged_update_package(planned: &PlannedComponentUpdate) -> Option<String> {
 /// Execute the merged group against the live host: real backends pointed at
 /// the configured ANOLISA repo, degrade re-plans through the per-item
 /// pipeline.
-fn execute_merged_updates(group: Vec<MergedUpdate>, ctx: &CliContext) -> Vec<UpdateAllItem> {
+fn execute_merged_updates(
+    group: Vec<MergedUpdate>,
+    ctx: &CliContext,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> BatchEffectOutcome {
     let mut suppressed_ctx = ctx.clone();
     suppressed_ctx.json = false;
     suppressed_ctx.quiet = true;
@@ -395,17 +333,33 @@ fn execute_merged_updates(group: Vec<MergedUpdate>, ctx: &CliContext) -> Vec<Upd
         Ok(backends) => backends,
         Err(err) => {
             let reason = err.reason().to_string();
-            return group
-                .iter()
-                .map(|item| failed_item(&item.name, reason.clone()))
-                .collect();
+            return BatchEffectOutcome {
+                items: group
+                    .iter()
+                    .map(|item| failed_item(&item.name, reason.clone()))
+                    .collect(),
+            };
         }
     };
     let mut degrade = |name: &str| {
-        let (query, txn) = update_backends(name, &suppressed_ctx)?;
-        update_component_with_deps(name, &suppressed_ctx, &query, &txn, privilege::is_root())
+        let outcome = super::application::run(
+            super::application::ApplicationRequest {
+                component: name,
+                intent: ExecutionIntent::Apply,
+            },
+            &suppressed_ctx,
+        )?;
+        application::member_application_outcome(outcome)
     };
-    execute_merged_updates_with_deps(group, ctx, &query, &txn, privilege::is_root(), &mut degrade)
+    execute_merged_updates_with_deps(
+        group,
+        ctx,
+        &query,
+        &txn,
+        privilege::is_root(),
+        &mut degrade,
+        output,
+    )
 }
 
 /// Core of the merged execution with the backends and the degrade pipeline
@@ -426,13 +380,16 @@ fn execute_merged_updates_with_deps(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
-    degrade: &mut dyn FnMut(&str) -> ComponentUpdateResult,
-) -> Vec<UpdateAllItem> {
-    let all_failed = |group: &[MergedUpdate], reason: &str| -> Vec<UpdateAllItem> {
-        group
-            .iter()
-            .map(|item| failed_item(&item.name, reason.to_string()))
-            .collect()
+    degrade: &mut dyn FnMut(&str) -> Result<MemberApplicationOutcome, CliError>,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> BatchEffectOutcome {
+    let all_failed = |group: &[MergedUpdate], reason: &str| -> BatchEffectOutcome {
+        BatchEffectOutcome {
+            items: group
+                .iter()
+                .map(|item| failed_item(&item.name, reason.to_string()))
+                .collect(),
+        }
     };
 
     if !is_root {
@@ -466,7 +423,7 @@ fn execute_merged_updates_with_deps(
 
     // Re-validate each member's authority under the lock and open its
     // journal, mirroring the single-component race check.
-    let mut items: Vec<UpdateAllItem> = Vec::with_capacity(group.len());
+    let mut items: Vec<BatchMemberOutcome> = Vec::with_capacity(group.len());
     let mut active: Vec<(MergedUpdate, Transaction)> = Vec::with_capacity(group.len());
     for item in group {
         let target = item.planned.target.as_str();
@@ -485,7 +442,7 @@ fn execute_merged_updates_with_deps(
         }
     }
     if active.is_empty() {
-        return items;
+        return BatchEffectOutcome { items };
     }
     let prior_adapter_revisions: HashMap<String, AdapterRevisionSnapshot> = active
         .iter()
@@ -541,7 +498,7 @@ fn execute_merged_updates_with_deps(
                 let _ = journal.finish(TransactionOutcomeStatus::Failed);
                 items.push(failed_item(&member.name, reason.clone()));
             }
-            return items;
+            return BatchEffectOutcome { items };
         }
     }
 
@@ -567,7 +524,9 @@ fn execute_merged_updates_with_deps(
                 parent_operation_id: None,
             });
             if let Err(err) = store.save(&state_path) {
-                eprintln!("warning: failed to record operation history: {err}");
+                output(BatchOutputEvent::Warning(format!(
+                    "failed to record operation history: {err}"
+                )));
             }
             for (item, mut journal) in active {
                 let target = item.planned.target.clone();
@@ -676,9 +635,13 @@ fn execute_merged_updates_with_deps(
                         } else {
                             Vec::new()
                         };
-                        items.push(UpdateAllItem {
+                        items.push(BatchMemberOutcome {
                             component: item.name.clone(),
-                            status: if moved { "updated" } else { "already-current" },
+                            status: if moved {
+                                BatchMemberStatus::Updated
+                            } else {
+                                BatchMemberStatus::AlreadyCurrent
+                            },
                             reason: None,
                             plan: None,
                             adapter_actions,
@@ -697,7 +660,7 @@ fn execute_merged_updates_with_deps(
             // history reads the same as the members' journals.
             let any_member_failed = items[members_start..]
                 .iter()
-                .any(|item| item.status == "failed");
+                .any(|item| item.status == BatchMemberStatus::Failed);
             if let Some(parent) = store
                 .operations
                 .iter_mut()
@@ -710,9 +673,11 @@ fn execute_merged_updates_with_deps(
             // committed record refreshes, exactly like the single-component
             // path.
             if let Err(err) = store.save(&state_path) {
-                eprintln!("warning: failed to record operation history: {err}");
+                output(BatchOutputEvent::Warning(format!(
+                    "failed to record operation history: {err}"
+                )));
             }
-            items
+            BatchEffectOutcome { items }
         }
         Err(source) => {
             // Forward-only classification: only the exact pre-transaction
@@ -759,46 +724,41 @@ fn execute_merged_updates_with_deps(
                     .mark_failed(0, &reason)
                     .and_then(|()| journal.finish(journal_outcome))
                 {
-                    eprintln!(
-                        "warning: failed to journal the merged transaction outcome for '{}': {err}",
+                    output(BatchOutputEvent::Warning(format!(
+                        "failed to journal the merged transaction outcome for '{}': {err}",
                         item.name
-                    );
+                    )));
                 }
             }
             drop(store);
             drop(_lock);
 
             if clean.is_empty() {
-                return items;
+                return BatchEffectOutcome { items };
             }
-            eprintln!(
-                "warning: merged rpm transaction failed ({reason}); retrying {} component(s) individually",
+            output(BatchOutputEvent::Warning(format!(
+                "merged rpm transaction failed ({reason}); retrying {} component(s) individually",
                 clean.len()
-            );
+            )));
             for name in clean {
                 match degrade(&name) {
-                    Ok((outcome, adapter_actions)) => items.push(UpdateAllItem {
-                        component: name,
-                        status: item_status(outcome, false),
-                        reason: None,
-                        plan: None,
-                        adapter_actions,
-                    }),
+                    Ok(outcome) => {
+                        for warning in outcome.warnings {
+                            output(BatchOutputEvent::Warning(warning));
+                        }
+                        items.push(BatchMemberOutcome {
+                            component: name,
+                            status: batch_status(outcome.outcome, ExecutionIntent::Apply),
+                            reason: None,
+                            plan: None,
+                            adapter_actions: outcome.adapter_actions,
+                        });
+                    }
                     Err(err) => items.push(failed_item(&name, err.reason().to_string())),
                 }
             }
-            items
+            BatchEffectOutcome { items }
         }
-    }
-}
-
-fn failed_item(name: &str, reason: String) -> UpdateAllItem {
-    UpdateAllItem {
-        component: name.to_string(),
-        status: "failed",
-        reason: Some(reason),
-        plan: None,
-        adapter_actions: Vec::new(),
     }
 }
 
@@ -819,6 +779,7 @@ mod tests {
     use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError};
     use anolisa_platform::pkg_transaction::PackageTransactionError;
 
+    use super::super::UpdateOutcome;
     use super::super::tests::{
         ctx, load_store, pkg_info, raw_manifest_with_adapter, rpm_object,
         seed_package_contract_and_stale_snapshot,
@@ -991,11 +952,19 @@ mod tests {
         }
     }
 
-    fn find<'a>(items: &'a [UpdateAllItem], name: &str) -> &'a UpdateAllItem {
+    fn find<'a>(items: &'a [BatchMemberOutcome], name: &str) -> &'a BatchMemberOutcome {
         items
             .iter()
             .find(|item| item.component == name)
             .unwrap_or_else(|| panic!("no summary item for {name}"))
+    }
+
+    fn applied_member(outcome: UpdateOutcome) -> MemberApplicationOutcome {
+        MemberApplicationOutcome {
+            outcome,
+            warnings: Vec::new(),
+            adapter_actions: Vec::new(),
+        }
     }
 
     #[test]
@@ -1052,9 +1021,10 @@ mod tests {
             ],
             false,
         );
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a committed merged transaction must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1066,7 +1036,9 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         assert_eq!(
             host.calls.borrow().as_slice(),
@@ -1076,8 +1048,8 @@ mod tests {
             )],
             "both packages must share one dnf update"
         );
-        assert_eq!(find(&items, "cosh").status, "updated");
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "cosh").status, BatchMemberStatus::Updated);
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
 
         // Each record absorbed its own fresh observation.
         let store = load_store(&c);
@@ -1152,9 +1124,10 @@ mod tests {
             ],
             false,
         );
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a committed merged transaction must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1166,10 +1139,12 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
-        assert_eq!(find(&items, "cosh").status, "updated");
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "cosh").status, BatchMemberStatus::Updated);
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
         for snapshot in [&cosh_snapshot, &sec_snapshot] {
             assert_eq!(
                 std::fs::read_to_string(snapshot).expect("read snapshot"),
@@ -1222,9 +1197,10 @@ mod tests {
             ],
             false,
         );
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a committed merged transaction must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1236,16 +1212,18 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         let cosh_item = find(&items, "cosh");
-        assert_eq!(cosh_item.status, "failed");
+        assert_eq!(cosh_item.status, BatchMemberStatus::Failed);
         let reason = cosh_item.reason.as_deref().expect("failure reason");
         assert!(
             reason.contains("committed") && reason.contains("repair"),
             "reason must state the update committed and point at repair: {reason}"
         );
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
         assert_eq!(
             std::fs::read_to_string(&sec_snapshot).expect("read snapshot"),
             "framework = \"new\"\n",
@@ -1299,9 +1277,10 @@ mod tests {
             )],
             false,
         );
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a recovery-blocked member must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![u5_item("cosh", "copilot-shell", "1.0.0-1.al4")],
@@ -1310,11 +1289,13 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         assert!(host.calls.borrow().is_empty(), "dnf must not run");
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].status, "failed");
+        assert_eq!(items[0].status, BatchMemberStatus::Failed);
         assert!(
             items[0]
                 .reason
@@ -1355,15 +1336,22 @@ mod tests {
             true,
         );
         let degraded = RefCell::new(Vec::new());
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let events = RefCell::new(Vec::new());
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             degraded.borrow_mut().push(name.to_string());
+            events.borrow_mut().push(format!("degrade:{name}"));
             if name == "cosh" {
                 Err(CliError::Runtime {
                     command: "update cosh".to_string(),
                     reason: "repo unreachable for copilot-shell".to_string(),
                 })
             } else {
-                Ok((UpdateOutcome::Updated, Vec::new()))
+                Ok(applied_member(UpdateOutcome::Updated))
+            }
+        };
+        let mut output = |event| {
+            if let BatchOutputEvent::Warning(warning) = event {
+                events.borrow_mut().push(format!("warning:{warning}"));
             }
         };
 
@@ -1377,13 +1365,18 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
+        let events = events.borrow();
+        assert!(events[0].contains("retrying 2 component(s) individually"));
+        assert_eq!(events[1..], ["degrade:cosh", "degrade:sec-core"]);
         assert_eq!(degraded.borrow().as_slice(), ["cosh", "sec-core"]);
         let cosh = find(&items, "cosh");
-        assert_eq!(cosh.status, "failed");
+        assert_eq!(cosh.status, BatchMemberStatus::Failed);
         assert!(cosh.reason.as_deref().unwrap().contains("repo unreachable"));
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
 
         // Clean failure journals never stay pending.
         let layout = common::resolve_layout(&c);
@@ -1418,10 +1411,11 @@ mod tests {
             true,
         );
         let degraded = RefCell::new(Vec::new());
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             degraded.borrow_mut().push(name.to_string());
-            Ok((UpdateOutcome::Updated, Vec::new()))
+            Ok(applied_member(UpdateOutcome::Updated))
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1433,16 +1427,18 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         // Forward-only for the moved member: no retry, repair reconciles.
         assert_eq!(degraded.borrow().as_slice(), ["sec-core"]);
         let cosh = find(&items, "cosh");
-        assert_eq!(cosh.status, "failed");
+        assert_eq!(cosh.status, BatchMemberStatus::Failed);
         let reason = cosh.reason.as_deref().unwrap();
         assert!(reason.contains("changed in the rpmdb"), "got: {reason}");
         assert!(reason.contains("anolisa repair cosh"), "got: {reason}");
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
 
         let layout = common::resolve_layout(&c);
         let journal_dir = rpm_install::journal_dir(&layout);
@@ -1482,10 +1478,11 @@ mod tests {
         );
         let host = FakeHost::new(&[], true).with_multiple_versions(&["copilot-shell"]);
         let degraded = RefCell::new(Vec::new());
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             degraded.borrow_mut().push(name.to_string());
-            Ok((UpdateOutcome::Updated, Vec::new()))
+            Ok(applied_member(UpdateOutcome::Updated))
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![u5_item("cosh", "copilot-shell", "1.0.0-1.al4")],
@@ -1494,7 +1491,9 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         assert_eq!(host.calls.borrow().len(), 1, "dnf must run only once");
         assert!(
@@ -1502,7 +1501,7 @@ mod tests {
             "an indeterminate rpmdb state must not trigger a second update"
         );
         let cosh = find(&items, "cosh");
-        assert_eq!(cosh.status, "failed");
+        assert_eq!(cosh.status, BatchMemberStatus::Failed);
         assert!(
             cosh.reason
                 .as_deref()
@@ -1525,9 +1524,10 @@ mod tests {
         let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
         managed_pair(&c);
         let host = FakeHost::new(&[], false);
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a refused merged group must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1539,12 +1539,14 @@ mod tests {
             &host,
             false,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         assert!(host.calls.borrow().is_empty(), "dnf must not run");
         for component in ["cosh", "sec-core"] {
             let item = find(&items, component);
-            assert_eq!(item.status, "failed");
+            assert_eq!(item.status, BatchMemberStatus::Failed);
             assert!(item.reason.as_deref().unwrap().contains("requires root"));
         }
     }
@@ -1573,9 +1575,10 @@ mod tests {
             )],
             false,
         );
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1587,17 +1590,19 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
         let sec = find(&items, "sec-core");
-        assert_eq!(sec.status, "failed");
+        assert_eq!(sec.status, BatchMemberStatus::Failed);
         assert!(
             sec.reason
                 .as_deref()
                 .unwrap()
                 .contains("changed while this update was planning")
         );
-        assert_eq!(find(&items, "cosh").status, "updated");
+        assert_eq!(find(&items, "cosh").status, BatchMemberStatus::Updated);
         // The refused member never entered the transaction.
         assert_eq!(
             host.calls.borrow().as_slice(),
@@ -1647,9 +1652,10 @@ mod tests {
             std::fs::write(changed_cosh_root.join("plugin.json"), b"v2")
                 .expect("replace cosh bundle");
         }));
-        let mut degrade = |name: &str| -> ComponentUpdateResult {
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
             panic!("a committed merged transaction must not degrade ({name})");
         };
+        let mut output = |_: BatchOutputEvent| {};
 
         let items = execute_merged_updates_with_deps(
             vec![
@@ -1661,10 +1667,12 @@ mod tests {
             &host,
             true,
             &mut degrade,
-        );
+            &mut output,
+        )
+        .items;
 
-        assert_eq!(find(&items, "cosh").status, "updated");
-        assert_eq!(find(&items, "sec-core").status, "updated");
+        assert_eq!(find(&items, "cosh").status, BatchMemberStatus::Updated);
+        assert_eq!(find(&items, "sec-core").status, BatchMemberStatus::Updated);
         assert!(
             find(&items, "cosh").adapter_actions.is_empty()
                 && find(&items, "sec-core").adapter_actions.is_empty(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
@@ -1,0 +1,326 @@
+//! Application orchestration for `update all`.
+
+use std::collections::HashMap;
+
+use anolisa_core::execution::ExecutionIntent;
+use anolisa_core::planner::Step;
+use anolisa_core::state::ObjectKind;
+use anolisa_core::state_store::StateStore;
+use anolisa_platform::privilege;
+
+use crate::commands::common;
+use crate::context::CliContext;
+use crate::response::CliError;
+
+use super::super::application as update_application;
+use super::super::{
+    AdapterAction, PlannedUpdateRoute, UpdateOutcome, plan_component_update, update_backends,
+};
+use super::{MergedUpdate, execute_merged_updates, merged_update_package};
+
+const BATCH_COMMAND: &str = "update all";
+
+/// Batch command input plus whether the caller requested preview or apply.
+pub(super) struct BatchRequest {
+    pub(super) intent: ExecutionIntent,
+}
+
+/// Typed disposition of one batch member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BatchMemberStatus {
+    /// Effects completed for this member.
+    Updated,
+    /// The member has an executable plan, but no effects ran.
+    Planned,
+    /// Existing state already covers the latest version.
+    AlreadyCurrent,
+    /// Planning or execution failed for this member.
+    Failed,
+}
+
+impl BatchMemberStatus {
+    /// Returns the stable label used by the existing batch wire format.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Updated => "updated",
+            Self::Planned => "planned",
+            Self::AlreadyCurrent => "already-current",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Typed result for one recorded component in state order.
+#[derive(Debug)]
+pub(super) struct BatchMemberOutcome {
+    pub(super) component: String,
+    pub(super) status: BatchMemberStatus,
+    pub(super) reason: Option<String>,
+    /// Only merged preview members expose their existing per-member plan.
+    pub(super) plan: Option<Vec<Step>>,
+    pub(super) adapter_actions: Vec<AdapterAction>,
+}
+
+/// Complete batch result consumed by the command renderer.
+#[derive(Debug)]
+pub(super) struct BatchApplicationOutcome {
+    pub(super) intent: ExecutionIntent,
+    pub(super) merged_transaction: Option<Vec<String>>,
+    pub(super) items: Vec<BatchMemberOutcome>,
+}
+
+/// Ordered presentation facts consumed by the command renderer.
+#[derive(Debug)]
+pub(super) enum BatchOutputEvent {
+    /// Announces members sharing one native transaction.
+    MergedGroup { members: String },
+    /// Shows one merged member's plan in the legacy human format.
+    PreviewPlan {
+        component: String,
+        from_version: Option<String>,
+        steps: Vec<Step>,
+    },
+    /// Announces a member using the single-component application path.
+    Member { component: String },
+    /// Surfaces a non-fatal application warning.
+    Warning(String),
+}
+
+/// Effects returned by the merged transaction boundary.
+pub(super) struct BatchEffectOutcome {
+    pub(super) items: Vec<BatchMemberOutcome>,
+}
+
+/// Per-member fallback result returned to merged transaction orchestration.
+pub(super) struct MemberApplicationOutcome {
+    pub(super) outcome: UpdateOutcome,
+    pub(super) warnings: Vec<String>,
+    pub(super) adapter_actions: Vec<AdapterAction>,
+}
+
+impl BatchApplicationOutcome {
+    /// Returns whether any member failed.
+    pub(super) fn has_failures(&self) -> bool {
+        self.items
+            .iter()
+            .any(|item| item.status == BatchMemberStatus::Failed)
+    }
+
+    /// Returns whether this batch was prepared without applying effects.
+    pub(super) fn is_preview(&self) -> bool {
+        matches!(self.intent, ExecutionIntent::Plan)
+    }
+}
+
+/// Run the batch application against production host dependencies.
+pub(super) fn run(
+    request: BatchRequest,
+    ctx: &CliContext,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> Result<BatchApplicationOutcome, CliError> {
+    let layout = common::resolve_layout(ctx);
+    let state_path = layout.state_dir.join("installed.toml");
+    let store = StateStore::load_for_layout(&state_path, privilege::effective_uid(), &layout)
+        .map_err(|err| CliError::Runtime {
+            command: BATCH_COMMAND.to_string(),
+            reason: format!("failed to load installed state: {err}"),
+        })?;
+    let names: Vec<String> = store
+        .installations
+        .iter()
+        .filter(|installation| installation.kind == ObjectKind::Component)
+        .map(|installation| installation.name.clone())
+        .collect();
+    drop(store);
+
+    if names.is_empty() {
+        return Ok(BatchApplicationOutcome {
+            intent: request.intent,
+            merged_transaction: None,
+            items: Vec::new(),
+        });
+    }
+
+    // Per-member applications return typed outcomes; batch owns the only
+    // final renderer, so their human and JSON output stays suppressed.
+    let mut suppressed_ctx = ctx.clone();
+    suppressed_ctx.json = false;
+    suppressed_ctx.quiet = true;
+    suppressed_ctx.dry_run = matches!(request.intent, ExecutionIntent::Plan);
+
+    // Preserve the existing read-only peek. Delegated U5 refreshes merge;
+    // every other route re-plans through the single-component application.
+    let mut merged: Vec<MergedUpdate> = Vec::new();
+    let mut per_item: Vec<String> = Vec::new();
+    for name in &names {
+        let candidate = update_backends(name, &suppressed_ctx)
+            .and_then(|(query, txn)| plan_component_update(name, &suppressed_ctx, &query, &txn))
+            .ok()
+            .and_then(|planned| {
+                merged_update_package(&planned).map(|package| MergedUpdate {
+                    name: name.clone(),
+                    package,
+                    planned,
+                })
+            });
+        match candidate {
+            Some(item) => merged.push(item),
+            None => per_item.push(name.clone()),
+        }
+    }
+
+    if merged.len() < 2 {
+        per_item.clone_from(&names);
+        merged.clear();
+    }
+    let merged_transaction =
+        (!merged.is_empty()).then(|| merged.iter().map(|item| item.package.clone()).collect());
+
+    let preview = matches!(request.intent, ExecutionIntent::Plan);
+    let mut results: HashMap<String, BatchMemberOutcome> = HashMap::with_capacity(names.len());
+
+    if !merged.is_empty() {
+        let members = merged
+            .iter()
+            .map(|item| item.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        output(BatchOutputEvent::MergedGroup { members });
+        if preview {
+            for item in &merged {
+                let PlannedUpdateRoute::Delegated { steps } = &item.planned.route else {
+                    unreachable!("merged updates are classified as delegated")
+                };
+                let steps = steps.clone();
+                output(BatchOutputEvent::PreviewPlan {
+                    component: item.name.clone(),
+                    from_version: item.planned.native_from.clone(),
+                    steps: steps.clone(),
+                });
+                results.insert(
+                    item.name.clone(),
+                    BatchMemberOutcome {
+                        component: item.name.clone(),
+                        status: BatchMemberStatus::Planned,
+                        reason: None,
+                        plan: Some(steps),
+                        adapter_actions: Vec::new(),
+                    },
+                );
+            }
+        } else {
+            for item in execute_merged_updates(merged, ctx, output).items {
+                results.insert(item.component.clone(), item);
+            }
+        }
+    }
+
+    for name in &per_item {
+        output(BatchOutputEvent::Member {
+            component: name.clone(),
+        });
+        let member = update_application::run(
+            update_application::ApplicationRequest {
+                component: name,
+                intent: request.intent,
+            },
+            &suppressed_ctx,
+        )
+        .and_then(member_application_outcome);
+        let item = match member {
+            Ok(member) => {
+                for warning in member.warnings {
+                    output(BatchOutputEvent::Warning(warning));
+                }
+                BatchMemberOutcome {
+                    component: name.clone(),
+                    status: batch_status(member.outcome, request.intent),
+                    reason: None,
+                    plan: None,
+                    adapter_actions: member.adapter_actions,
+                }
+            }
+            Err(error) => failed_item(name, error.reason().to_string()),
+        };
+        results.insert(name.clone(), item);
+    }
+
+    let items = names
+        .into_iter()
+        .map(|name| {
+            results
+                .remove(&name)
+                .expect("every recorded component receives one batch outcome")
+        })
+        .collect();
+
+    Ok(BatchApplicationOutcome {
+        intent: request.intent,
+        merged_transaction,
+        items,
+    })
+}
+
+pub(super) fn member_application_outcome(
+    outcome: update_application::ApplicationOutcome,
+) -> Result<MemberApplicationOutcome, CliError> {
+    let batch_outcome = outcome.batch_outcome()?;
+    Ok(MemberApplicationOutcome {
+        outcome: batch_outcome,
+        warnings: outcome.warnings().to_vec(),
+        adapter_actions: outcome.adapter_actions().to_vec(),
+    })
+}
+
+pub(super) fn failed_item(name: &str, reason: String) -> BatchMemberOutcome {
+    BatchMemberOutcome {
+        component: name.to_string(),
+        status: BatchMemberStatus::Failed,
+        reason: Some(reason),
+        plan: None,
+        adapter_actions: Vec::new(),
+    }
+}
+
+pub(super) fn batch_status(outcome: UpdateOutcome, intent: ExecutionIntent) -> BatchMemberStatus {
+    match (outcome, intent) {
+        (UpdateOutcome::Updated, ExecutionIntent::Apply) => BatchMemberStatus::Updated,
+        (UpdateOutcome::Updated, ExecutionIntent::Plan) => BatchMemberStatus::Planned,
+        (UpdateOutcome::AlreadyCurrent, _) => BatchMemberStatus::AlreadyCurrent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_status_is_driven_by_execution_intent() {
+        assert_eq!(
+            batch_status(UpdateOutcome::Updated, ExecutionIntent::Apply),
+            BatchMemberStatus::Updated
+        );
+        assert_eq!(
+            batch_status(UpdateOutcome::Updated, ExecutionIntent::Plan),
+            BatchMemberStatus::Planned
+        );
+        for intent in [ExecutionIntent::Plan, ExecutionIntent::Apply] {
+            assert_eq!(
+                batch_status(UpdateOutcome::AlreadyCurrent, intent),
+                BatchMemberStatus::AlreadyCurrent
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_failure_is_typed() {
+        let outcome = BatchApplicationOutcome {
+            intent: ExecutionIntent::Apply,
+            merged_transaction: None,
+            items: vec![failed_item("cosh", "failed".to_string())],
+        };
+
+        assert!(outcome.has_failures());
+        assert!(!outcome.is_preview());
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
@@ -78,6 +78,60 @@ pub(super) enum ApplicationOutcome {
     },
 }
 
+impl ApplicationOutcome {
+    /// Collapse the typed result to the legacy batch-member classification.
+    pub(super) fn batch_outcome(&self) -> Result<super::UpdateOutcome, CliError> {
+        match self {
+            Self::NoOp { .. } => Ok(super::UpdateOutcome::AlreadyCurrent),
+            Self::Preview { .. } => Ok(super::UpdateOutcome::Updated),
+            Self::Applied {
+                command,
+                subject,
+                outcome,
+                ..
+            } => {
+                if matches!(outcome.status(), CommandOutcomeStatus::Partial) {
+                    let reason = outcome
+                        .warnings()
+                        .first()
+                        .expect("partial update outcome carries its reconciliation failure");
+                    return Err(CliError::Runtime {
+                        command: command.clone(),
+                        reason: format!(
+                            "the update of '{}' committed, but {reason}; run `anolisa repair {}` to reconcile",
+                            subject.component, subject.component
+                        ),
+                    });
+                }
+                Ok(if outcome.changes().is_empty() {
+                    super::UpdateOutcome::AlreadyCurrent
+                } else {
+                    super::UpdateOutcome::Updated
+                })
+            }
+        }
+    }
+
+    /// Returns warnings that a batch caller must surface without rendering a
+    /// per-component result envelope.
+    pub(super) fn warnings(&self) -> &[String] {
+        match self {
+            Self::NoOp { .. } | Self::Preview { .. } => &[],
+            Self::Applied { outcome, .. } => outcome.warnings(),
+        }
+    }
+
+    /// Returns adapter follow-up actions produced by an applied update.
+    pub(super) fn adapter_actions(&self) -> &[AdapterAction] {
+        match self {
+            Self::Applied {
+                adapter_actions, ..
+            } => adapter_actions,
+            Self::NoOp { .. } | Self::Preview { .. } => &[],
+        }
+    }
+}
+
 /// Run one component update against production package backends.
 pub(super) fn run(
     request: ApplicationRequest<'_>,


### PR DESCRIPTION
## Why

`update all` still mixed state enumeration, batch planning, merged RPM execution, per-member fallback, and CLI rendering in one command module. This left the final R1 batch path outside the lifecycle application boundary established by the single-component update flow.

## What changed

Added a crate-private typed batch application with request, member outcome, aggregate outcome, and ordered output events. Per-item execution and clean merged-transaction degradation now consume the single-component update application directly, while the command handler only maps the execution intent and renders the existing output contract. The existing read-only peek plus per-item re-planning, merged U5 transaction, journal/recovery behavior, adapter actions, and output ordering remain unchanged.

## Related issue

Closes #2797

## User / Agent impact

None. CLI arguments, human output, JSON schema, exit codes, package-manager behavior, and recovery semantics are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This is an internal application-boundary refactor; injected merged-transaction tests continue to cover privileged execution, lock-time revalidation, partial recovery, adapter follow-up, and warning order.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p anolisa-cli --locked`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- Targeted `update all` tests cover typed plan/apply status, merged success, clean degradation, moved and indeterminate members, lock-time drift, contract refresh failure, adapter actions, and warning-before-degrade ordering.

## Documentation and rollback

No documentation changes are required because public behavior is unchanged. Roll back by reverting commit `17baead4`.
