### PR TITLE
chore(anolisa): raise toolchain and msrv to 1.93

### DIFF
--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -117,7 +117,7 @@ jobs:
         if: inputs.component == 'anolisa'
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.88.0'
+          toolchain: '1.93.1'
 
       - name: "Setup Python + uv (agent-sec-core)"
         if: inputs.component == 'agent-sec-core'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1054,7 +1054,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.88.0'
+          toolchain: '1.93.1'
           components: 'rustfmt, clippy, llvm-tools-preview'
 
       - name: Install cargo-llvm-cov

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -55,7 +55,7 @@ component.
 |------|-----------------|
 | Node.js | `src/copilot-shell/package.json` requires Node.js `>=20.0.0`; npm is also used by the agentsight, agent-sec-core, tokenless, and ws-ckpt plugin builds. |
 | Python and uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` requires Python `==3.11.6`; use `uv` for that project. Do not replace this with a repository-wide Python minimum. |
-| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` pins `1.93.0`; `src/anolisa/rust-toolchain.toml` and `src/blaze/rust-toolchain.toml` pin `1.88.0`; `src/cosh-ng/rust-toolchain.toml` follows `stable`. Other components use the `rust-version` in their `Cargo.toml` when one is declared. |
+| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` pins `1.93.0`; `src/anolisa/rust-toolchain.toml` pins `1.93.1`; `src/blaze/rust-toolchain.toml` pins `1.88.0`; `src/cosh-ng/rust-toolchain.toml` follows `stable`. Other components use the `rust-version` in their `Cargo.toml` when one is declared. |
 | cosh-ng | Linux source builds need `pkg-config` and OpenSSL development files. |
 | agent-sec-core | Linux sandbox runtime and integration checks may need bubblewrap, GnuPG, and `jq`. |
 | agentsight | Linux eBPF builds need clang, LLVM, libbpf and ELF development headers, kernel headers, and a BTF-enabled kernel. `make build-mac` builds the macOS local viewer without eBPF. |

--- a/docs/BUILDING_zh.md
+++ b/docs/BUILDING_zh.md
@@ -49,7 +49,7 @@ Linux-only 组件。
 |------|------|
 | Node.js | `src/copilot-shell/package.json` 要求 Node.js `>=20.0.0`。agentsight、agent-sec-core、tokenless 和 ws-ckpt 的插件构建也会使用 npm。 |
 | Python 和 uv | `src/agent-sec-core/agent-sec-cli/pyproject.toml` 要求 Python `==3.11.6`，该项目使用 `uv`。不要把它扩展成仓库级 Python 最低版本。 |
-| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` 固定 `1.93.0`；`src/anolisa/rust-toolchain.toml` 和 `src/blaze/rust-toolchain.toml` 固定 `1.88.0`；`src/cosh-ng/rust-toolchain.toml` 跟随 `stable`。其他组件有 `rust-version` 时以各自 `Cargo.toml` 为准。 |
+| Rust | `src/agent-sec-core/linux-sandbox/rust-toolchain.toml` 固定 `1.93.0`；`src/anolisa/rust-toolchain.toml` 固定 `1.93.1`；`src/blaze/rust-toolchain.toml` 固定 `1.88.0`；`src/cosh-ng/rust-toolchain.toml` 跟随 `stable`。其他组件有 `rust-version` 时以各自 `Cargo.toml` 为准。 |
 | cosh-ng | Linux 源码构建需要 `pkg-config` 和 OpenSSL 开发文件。 |
 | agent-sec-core | Linux sandbox 运行和集成检查可能需要 bubblewrap、GnuPG 以及 `jq`。 |
 | agentsight | Linux eBPF 构建需要 clang、LLVM、libbpf 和 ELF 开发头文件、内核头文件，以及启用 BTF 的内核。`make build-mac` 构建不含 eBPF 的 macOS local viewer。 |

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
-resolver = "2"
+# MSRV-aware resolution: dependency versions are held back to what
+# `rust-version` below can still compile. RPM source builds use the
+# distro's rustc, so a dependency release that outruns the MSRV must not
+# be picked up silently by `cargo update`.
+resolver = "3"
 members = [
     "crates/anolisa-cli",
     "crates/anolisa-core",
@@ -12,7 +16,7 @@ members = [
 version = "0.3.6"
 edition = "2024"
 license = "Apache-2.0"
-rust-version = "1.88"
+rust-version = "1.93"
 publish = false
 
 [workspace.dependencies]

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -100,7 +100,7 @@ metadata is declared through `component.toml`.
 ## Requirements
 
 - Linux (x86_64 / aarch64) or macOS (arm64, limited)
-- Rust ≥ 1.88 (for source build)
+- Rust ≥ 1.93 (for source build)
 
 ## License
 

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -98,7 +98,7 @@ planner 区分 ANOLISA 自有文件与 native package authority，并在副作�
 ## 环境要求
 
 - Linux（x86_64 / aarch64）或 macOS（arm64，功能受限）
-- 从源码构建需要 Rust ≥ 1.88
+- 从源码构建需要 Rust ≥ 1.93
 
 ## 许可证
 

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -16,8 +16,8 @@ URL:            https://github.com/alibaba/anolisa
 Source0:        %{name}-%{version}.tar.gz
 Source1:        %{name}-%{version}-vendor.tar.gz
 
-BuildRequires:  rust >= 1.88
-BuildRequires:  cargo >= 1.88
+BuildRequires:  rust >= 1.93
+BuildRequires:  cargo >= 1.93
 BuildRequires:  gcc
 BuildRequires:  make
 
@@ -60,7 +60,7 @@ EOF
 
 %build
 # `rust-toolchain.toml` is rustup-only metadata; the system cargo (dnf-installed
-# rust-1.88) ignores it and uses the system rustc directly.
+# rust-1.93) ignores it and uses the system rustc directly.
 export CARGO_HOME=$(pwd)/.cargo-home
 mkdir -p "$CARGO_HOME"
 cp .cargo/config.toml "$CARGO_HOME/config.toml"

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/restart.rs
@@ -277,15 +277,17 @@ fn execute_restart_units(
     // reload the manager) aren't loadable until the manager reloads its unit
     // database, so restart would otherwise fail "unit not found". Reload once
     // per in-play scope, best-effort — a reload failure only adds a warning.
-    if used_sys && sys_manager.supported() {
-        if let Err(err) = sys_manager.daemon_reload() {
-            warnings.push(format!("daemon-reload (system scope) failed: {err}"));
-        }
+    if used_sys
+        && sys_manager.supported()
+        && let Err(err) = sys_manager.daemon_reload()
+    {
+        warnings.push(format!("daemon-reload (system scope) failed: {err}"));
     }
-    if used_user && user_manager.supported() {
-        if let Err(err) = user_manager.daemon_reload() {
-            warnings.push(format!("daemon-reload (user scope) failed: {err}"));
-        }
+    if used_user
+        && user_manager.supported()
+        && let Err(err) = user_manager.daemon_reload()
+    {
+        warnings.push(format!("daemon-reload (user scope) failed: {err}"));
     }
 
     let mut results: Vec<RestartResult> = Vec::with_capacity(units.len());

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -233,12 +233,10 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
         && ctx.install_mode == InstallMode::System
         && records.len() == 1
         && records[0].status == "not_installed"
-    {
-        if let Some(observed) =
+        && let Some(observed) =
             observed_record(target, rpm_backend, component_index.as_ref(), &query)
-        {
-            records = vec![observed];
-        }
+    {
+        records = vec![observed];
     }
 
     let quarantined = select_quarantined_from_view(&view, selected_component.as_deref());

--- a/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/contract.rs
@@ -93,13 +93,12 @@ pub fn infer_contract_datadir_root(
     }
 
     // Snapshot hit — try provenance sidecar.
-    if let Some(prov) = read_snapshot_provenance(contract_path) {
-        if prov.source_kind == ContractSourceKind::Datadir
-            && scoped_datadir_roots.contains(&prov.datadir_root)
-            && FsLayout::component_contract_path(&prov.datadir_root, component) == prov.source_path
-        {
-            return Some(prov.datadir_root);
-        }
+    if let Some(prov) = read_snapshot_provenance(contract_path)
+        && prov.source_kind == ContractSourceKind::Datadir
+        && scoped_datadir_roots.contains(&prov.datadir_root)
+        && FsLayout::component_contract_path(&prov.datadir_root, component) == prov.source_path
+    {
+        return Some(prov.datadir_root);
     }
 
     // Fallback: content match against scoped datadir contracts.
@@ -515,7 +514,8 @@ layer = "runtime"
 
         let snapshot_path = FsLayout::component_manifest_snapshot_path(&state, "sec-core");
 
-        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        let root =
+            infer_contract_datadir_root("sec-core", &snapshot_path, std::slice::from_ref(&data));
         assert_eq!(
             root.as_ref(),
             Some(&data),
@@ -543,7 +543,8 @@ layer = "runtime"
         };
         write_snapshot_provenance(&snapshot_path, &prov).expect("write prov");
 
-        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        let root =
+            infer_contract_datadir_root("sec-core", &snapshot_path, std::slice::from_ref(&data));
         assert_eq!(
             root.as_ref(),
             Some(&data),
@@ -566,7 +567,8 @@ layer = "runtime"
         let bad = FsLayout::provenance_path_for_snapshot(&snapshot_path);
         fs::write(&bad, "this is not valid toml [[[").expect("write bad");
 
-        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        let root =
+            infer_contract_datadir_root("sec-core", &snapshot_path, std::slice::from_ref(&data));
         assert_eq!(
             root.as_ref(),
             Some(&data),
@@ -594,7 +596,8 @@ layer = "runtime"
         };
         write_snapshot_provenance(&snapshot_path, &prov).expect("write prov");
 
-        let root = infer_contract_datadir_root("sec-core", &snapshot_path, &[data.clone()]);
+        let root =
+            infer_contract_datadir_root("sec-core", &snapshot_path, std::slice::from_ref(&data));
         assert_eq!(
             root.as_ref(),
             Some(&data),
@@ -611,7 +614,8 @@ layer = "runtime"
         write_datadir(&data, "mycomp", &valid_toml("mycomp"));
         let datadir_path = FsLayout::component_contract_path(&data, "mycomp");
 
-        let root = infer_contract_datadir_root("mycomp", &datadir_path, &[data.clone()]);
+        let root =
+            infer_contract_datadir_root("mycomp", &datadir_path, std::slice::from_ref(&data));
         assert_eq!(root.as_ref(), Some(&data));
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/hermes.rs
@@ -459,20 +459,20 @@ impl FrameworkDriver for HermesDriver {
 
         if let DriverPayload::Hermes(ref hermes) = claim.driver_payload {
             for skill_res_id in &hermes.skill_resources {
-                if let Some(resource) = claim.resource(skill_res_id) {
-                    if let ClaimResourceKind::ExternalPath { path } = &resource.kind {
-                        match ctx.ops.remove_tree(path) {
-                            Ok(true) => {
-                                messages.push(format!("removed skill dir {}", path.display()));
-                            }
-                            Ok(false) => {} // already gone
-                            Err(err) => {
-                                cleanup_complete = false;
-                                messages.push(format!(
-                                    "failed to remove skill dir {}: {err}",
-                                    path.display()
-                                ));
-                            }
+                if let Some(resource) = claim.resource(skill_res_id)
+                    && let ClaimResourceKind::ExternalPath { path } = &resource.kind
+                {
+                    match ctx.ops.remove_tree(path) {
+                        Ok(true) => {
+                            messages.push(format!("removed skill dir {}", path.display()));
+                        }
+                        Ok(false) => {} // already gone
+                        Err(err) => {
+                            cleanup_complete = false;
+                            messages.push(format!(
+                                "failed to remove skill dir {}: {err}",
+                                path.display()
+                            ));
                         }
                     }
                 }

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -994,10 +994,10 @@ impl AdapterManager {
         // `{datadir}/skills/<name>/`) must also be readable by the
         // Manager's controlled IO.
         for skill in &skills {
-            if let Some(ref src) = skill.source {
-                if !allowed_roots.iter().any(|r| src.starts_with(r)) {
-                    allowed_roots.push(src.clone());
-                }
+            if let Some(ref src) = skill.source
+                && !allowed_roots.iter().any(|r| src.starts_with(r))
+            {
+                allowed_roots.push(src.clone());
             }
         }
         drop(probe_ctx);
@@ -2400,10 +2400,10 @@ impl AdapterManager {
         scoped_datadir_roots: &[PathBuf],
     ) -> Option<PathBuf> {
         for datadir in scoped_datadir_roots {
-            if let Ok(path) = self.expand_dest_template(dest_template, component, datadir) {
-                if self.bundle_root_valid(framework, declared_entry, &path) {
-                    return Some(path);
-                }
+            if let Ok(path) = self.expand_dest_template(dest_template, component, datadir)
+                && self.bundle_root_valid(framework, declared_entry, &path)
+            {
+                return Some(path);
             }
         }
         None
@@ -3754,17 +3754,17 @@ fn declared_skills(
     // Framework-specific section takes precedence.
     match framework {
         "openclaw" => {
-            if let Some(ref oc) = adapter.openclaw {
-                if !oc.skills.is_empty() {
-                    return oc.skills.clone();
-                }
+            if let Some(ref oc) = adapter.openclaw
+                && !oc.skills.is_empty()
+            {
+                return oc.skills.clone();
             }
         }
         "hermes" => {
-            if let Some(ref h) = adapter.hermes {
-                if !h.skills.is_empty() {
-                    return h.skills.clone();
-                }
+            if let Some(ref h) = adapter.hermes
+                && !h.skills.is_empty()
+            {
+                return h.skills.clone();
             }
         }
         _ => {}
@@ -3856,12 +3856,11 @@ fn declared_config(
         None => return Vec::new(),
     };
     // Framework-specific section takes precedence.
-    if framework == "openclaw" {
-        if let Some(ref oc) = adapter.openclaw {
-            if !oc.config.is_empty() {
-                return oc.config.clone();
-            }
-        }
+    if framework == "openclaw"
+        && let Some(ref oc) = adapter.openclaw
+        && !oc.config.is_empty()
+    {
+        return oc.config.clone();
     }
     adapter.config.clone()
 }
@@ -3948,17 +3947,17 @@ fn declared_bundle_entry(manifest: &ComponentManifest, framework: &str) -> Optio
         .find(|a| a.framework.as_deref().map(str::trim) == Some(framework))?;
     match framework {
         "openclaw" => {
-            if let Some(ref oc) = adapter.openclaw {
-                if let Some(ref entry) = oc.bundle.entry {
-                    return Some(entry.clone());
-                }
+            if let Some(ref oc) = adapter.openclaw
+                && let Some(ref entry) = oc.bundle.entry
+            {
+                return Some(entry.clone());
             }
         }
         "hermes" => {
-            if let Some(ref h) = adapter.hermes {
-                if let Some(ref entry) = h.bundle.entry {
-                    return Some(entry.clone());
-                }
+            if let Some(ref h) = adapter.hermes
+                && let Some(ref entry) = h.bundle.entry
+            {
+                return Some(entry.clone());
             }
         }
         _ => {}

--- a/src/anolisa/crates/anolisa-core/src/telemetry/common.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/common.rs
@@ -141,24 +141,24 @@ pub fn detect_product_type(release_path: &Path) -> ProductType {
 /// (metadata-unreachable) is shared across all probes.
 pub fn probe_product_type(release_path: &Path, client: &MetadataClient) -> String {
     // 1. /etc/anolisa-release PRODUCT_TYPE field
-    if let Ok(content) = fs::read_to_string(release_path) {
-        if let Some(pt) = find_product_type_in_release(&content) {
-            return pt;
-        }
+    if let Ok(content) = fs::read_to_string(release_path)
+        && let Some(pt) = find_product_type_in_release(&content)
+    {
+        return pt;
     }
 
     // 2. EDS detection: desktop-id starts with "ecd"
-    if let Some(desktop_id) = client.query("desktop-id") {
-        if desktop_id.starts_with("ecd") {
-            return "eds".to_string();
-        }
+    if let Some(desktop_id) = client.query("desktop-id")
+        && desktop_id.starts_with("ecd")
+    {
+        return "eds".to_string();
     }
 
     // 3. ECS detection: instance-type starts with "ecs"
-    if let Some(instance_type) = client.query("instance/instance-type") {
-        if instance_type.starts_with("ecs") {
-            return "ecs".to_string();
-        }
+    if let Some(instance_type) = client.query("instance/instance-type")
+        && instance_type.starts_with("ecs")
+    {
+        return "ecs".to_string();
     }
 
     "unknown".to_string()

--- a/src/anolisa/crates/anolisa-core/src/telemetry/instance.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/instance.rs
@@ -221,13 +221,13 @@ impl InstanceProber {
     }
 
     fn write_cached_id(&self, id: &str) {
-        if let Some(parent) = self.instance_id_cache_path.parent() {
-            if let Err(e) = fs::create_dir_all(parent) {
-                eprintln!(
-                    "[anolisa] warn: cannot create instance-id cache dir {}: {e}",
-                    parent.display()
-                );
-            }
+        if let Some(parent) = self.instance_id_cache_path.parent()
+            && let Err(e) = fs::create_dir_all(parent)
+        {
+            eprintln!(
+                "[anolisa] warn: cannot create instance-id cache dir {}: {e}",
+                parent.display()
+            );
         }
         if let Err(e) = fs::write(&self.instance_id_cache_path, id) {
             eprintln!(
@@ -286,10 +286,10 @@ impl InstanceProber {
 
     fn probe_image_id(&self) -> Option<String> {
         // 1. /etc/image-id (image_id="...")
-        if let Ok(content) = fs::read_to_string(&self.image_id_path) {
-            if let Some(id) = parse_image_id(&content) {
-                return Some(id);
-            }
+        if let Ok(content) = fs::read_to_string(&self.image_id_path)
+            && let Some(id) = parse_image_id(&content)
+        {
+            return Some(id);
         }
         // 2. Metadata API fallback
         self.client.query_metadata("image-id")
@@ -307,15 +307,15 @@ impl InstanceProber {
         let mut version: Option<String> = None;
 
         for line in content.lines() {
-            if id.is_none() {
-                if let Some(val) = line.strip_prefix("ID=") {
-                    id = Some(unquote(val));
-                }
+            if id.is_none()
+                && let Some(val) = line.strip_prefix("ID=")
+            {
+                id = Some(unquote(val));
             }
-            if version.is_none() {
-                if let Some(val) = line.strip_prefix("VERSION_ID=") {
-                    version = Some(unquote(val));
-                }
+            if version.is_none()
+                && let Some(val) = line.strip_prefix("VERSION_ID=")
+            {
+                version = Some(unquote(val));
             }
             if id.is_some() && version.is_some() {
                 break;

--- a/src/anolisa/crates/anolisa-core/src/telemetry/metadata.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/metadata.rs
@@ -137,10 +137,10 @@ impl MetadataClient {
     ///    in the cloud-init datasource.
     fn query_cloud_init(&self, key: &str) -> Option<String> {
         // 1. Mapped path (e.g. instance/instance-type).
-        if let Some(path) = cloud_init_path_for_metadata_key(key) {
-            if let Some(v) = self.cloud_init_query_path(path) {
-                return Some(v);
-            }
+        if let Some(path) = cloud_init_path_for_metadata_key(key)
+            && let Some(v) = self.cloud_init_query_path(path)
+        {
+            return Some(v);
         }
 
         // 2. Direct ds.meta_data.<key> query.
@@ -179,10 +179,10 @@ impl MetadataClient {
         }
 
         // For slash-containing keys (e.g. "instance/instance-type"), try the last segment.
-        if let Some(short_key) = key.rsplit('/').next() {
-            if short_key != key {
-                return find_string_by_key(meta_data, short_key);
-            }
+        if let Some(short_key) = key.rsplit('/').next()
+            && short_key != key
+        {
+            return find_string_by_key(meta_data, short_key);
         }
         None
     }

--- a/src/anolisa/crates/anolisa-core/src/telemetry/uploader.rs
+++ b/src/anolisa/crates/anolisa-core/src/telemetry/uploader.rs
@@ -350,10 +350,10 @@ impl Uploader {
         if let Ok(entries) = fs::read_dir(&self.config.ops_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        names.push(stem.to_string());
-                    }
+                if path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+                    && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+                {
+                    names.push(stem.to_string());
                 }
             }
         }
@@ -411,23 +411,22 @@ impl Uploader {
                 // limit and retry forever. When the cap is hit the offset stays
                 // on the rotated file so the remainder drains next round.
                 let rotated = self.rotated_path(component);
-                if rotated.exists() {
-                    if let Ok((mut residue, res_consumed)) =
+                if rotated.exists()
+                    && let Ok((mut residue, res_consumed)) =
                         read_from(&rotated, o.offset, MAX_LINES_PER_ROUND)
-                    {
-                        lines.append(&mut residue);
-                        if lines.len() >= MAX_LINES_PER_ROUND {
-                            // Cap hit: keep the offset on the rotated file so
-                            // the remainder is drained next round instead of
-                            // being skipped.
-                            return Ok(Some((
-                                lines,
-                                FileOffset {
-                                    inode: o.inode,
-                                    offset: o.offset + res_consumed,
-                                },
-                            )));
-                        }
+                {
+                    lines.append(&mut residue);
+                    if lines.len() >= MAX_LINES_PER_ROUND {
+                        // Cap hit: keep the offset on the rotated file so
+                        // the remainder is drained next round instead of
+                        // being skipped.
+                        return Ok(Some((
+                            lines,
+                            FileOffset {
+                                inode: o.inode,
+                                offset: o.offset + res_consumed,
+                            },
+                        )));
                     }
                 }
                 0

--- a/src/anolisa/crates/anolisa-core/src/transaction.rs
+++ b/src/anolisa/crates/anolisa-core/src/transaction.rs
@@ -596,13 +596,13 @@ impl Transaction {
                 self.operation_id
             )));
         }
-        if let Some(existing) = &self.delegated_recovery {
-            if existing != &context {
-                return Err(TransactionError::Failed(format!(
-                    "refused to replace delegated recovery context for operation {}",
-                    self.operation_id
-                )));
-            }
+        if let Some(existing) = &self.delegated_recovery
+            && existing != &context
+        {
+            return Err(TransactionError::Failed(format!(
+                "refused to replace delegated recovery context for operation {}",
+                self.operation_id
+            )));
         }
         let previous_context = self.delegated_recovery.clone();
         let previous_step_count = self.steps.len();

--- a/src/anolisa/docs/BUILD.md
+++ b/src/anolisa/docs/BUILD.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-- Rust >= 1.88 (project uses edition 2024)
+- Rust >= 1.93 (project uses edition 2024)
 - Working directory: `src/anolisa/` (Cargo workspace root)
 
 ```bash
@@ -13,8 +13,9 @@ cd src/anolisa
 
 ### Rustup Toolchain Source
 
-This workspace pins Rust `1.88.0` via `rust-toolchain.toml`. When using
-rustup-managed `cargo`, the required toolchain is selected automatically
+This workspace pins Rust `1.93.1` via `rust-toolchain.toml` — the newest
+Rust that Alibaba Cloud Linux 4 packages, so source and RPM builds agree.
+When using rustup-managed `cargo`, the toolchain is selected automatically
 and downloaded if missing.
 
 Before building, verify that `cargo`, `rustc`, and `rustdoc` come from the
@@ -27,7 +28,7 @@ rustc -Vv
 rustdoc -Vv
 ```
 
-If your configured rustup source cannot provide Rust `1.88.0`, configure a
+If your configured rustup source cannot provide Rust `1.93.1`, configure a
 working source or preinstall the toolchain on the build machine.
 
 For bash/zsh:

--- a/src/anolisa/docs/BUILD_zh.md
+++ b/src/anolisa/docs/BUILD_zh.md
@@ -4,7 +4,7 @@
 
 ## 前置条件
 
-- Rust >= 1.88（项目使用 edition 2024）
+- Rust >= 1.93（项目使用 edition 2024）
 - 工作目录：`src/anolisa/`（即 Cargo workspace 根）
 
 ```bash
@@ -13,7 +13,8 @@ cd src/anolisa
 
 ### Rustup 工具链源
 
-本 workspace 通过 `rust-toolchain.toml` 固定 Rust `1.88.0`。
+本 workspace 通过 `rust-toolchain.toml` 固定 Rust `1.93.1`——这是
+Alibaba Cloud Linux 4 打包的最新 Rust，以保证源码构建与 RPM 构建一致。
 使用 rustup 管理的 `cargo` 时，所需工具链会被自动选择；如果本机未安装，
 rustup 会自动尝试下载。
 
@@ -26,7 +27,7 @@ rustc -Vv
 rustdoc -Vv
 ```
 
-如果当前 rustup 工具链源无法提供 Rust `1.88.0`，请切换到可用源，
+如果当前 rustup 工具链源无法提供 Rust `1.93.1`，请切换到可用源，
 或在构建机上预装该工具链。
 
 bash/zsh:

--- a/src/anolisa/rust-toolchain.toml
+++ b/src/anolisa/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.93.1"
 components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
## Why

Alibaba Cloud Linux 4 packages Rust up to **1.93.1**, while `src/anolisa`
pinned `1.88.0` and declared the same MSRV. Five usable releases were
unavailable for no reason.

Verified against the distro repository metadata (both arches; `devel`,
`plus`, `agentic-os` and `lifsea` carry no rust package):

```bash
B="https://mirrors.aliyun.com/alinux/4/updates/x86_64/os"
P=$(curl -s "$B/repodata/repomd.xml" | grep -oE 'repodata/[a-f0-9]+-primary\.xml\.gz' | head -1)
curl -s "$B/$P" | gunzip | grep -oE '<name>rust</name>.{0,200}' | grep -oE 'ver="[0-9.]+"' | sort -u
# -> 1.84.1 … 1.93.1
```

## What changed

| File | Change |
|---|---|
| `src/anolisa/rust-toolchain.toml` | `channel` `1.88.0` → `1.93.1` |
| `src/anolisa/Cargo.toml` | `rust-version` `1.88` → `1.93`; `resolver` `2` → `3` |
| `src/anolisa/anolisa.spec.in` | `BuildRequires: rust/cargo >= 1.93` |
| `README{,_zh}.md`, `docs/BUILD{,_zh}.md`, `docs/BUILDING{,_zh}.md` | prerequisite `1.88` → `1.93` |
| `.github/workflows/ci.yaml`, `_rpm-build.yaml` | anolisa toolchain pin → `1.93.1` |
| 10 `.rs` files | 27 clippy findings the newer toolchain reports |

The pinned toolchain is kept **equal** to the MSRV rather than following
`stable`, so development, CI and every RPM build path run the same
compiler. Following `stable` would need a separate MSRV job: clippy gates
its own suggestions on `rust-version`, but nothing rejects hand-written
syntax newer than the MSRV, so a lint-clean change could still fail the
distro source build.

`resolver = "3"` makes dependency selection respect `rust-version`. Under
the inherited `resolver = "2"` a `cargo update` can pull a release
requiring a newer rustc and break the offline RPM build — the highest
dependency MSRV in the current graph is already 1.86.

## Related issue

`no-issue: toolchain maintenance, no behaviour change`

## User / Agent impact

No runtime or CLI behaviour change. The 27 clippy fixes are
behaviour-neutral rewrites (`collapsible_if` collapsed into let-chains,
`cloned_ref_to_slice_refs` in test code).

Source builds now require Rust ≥ 1.93 instead of ≥ 1.88. Alibaba Cloud
Linux 4 satisfies this from the `updates` repository.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Only the documented build prerequisite and the RPM `BuildRequires` moved.
No CLI, API or on-disk format change. Other components are untouched —
`src/blaze` keeps `1.88.0` and `src/cosh-ng` keeps `stable`.

## Validation

All on the new pin, 1.93.1:

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --workspace --locked` — 2260 passed, 0 failed, 1 ignored
- `Cargo.lock` unchanged by the resolver switch

## Documentation and rollback

`README{,_zh}.md`, `docs/BUILD{,_zh}.md` and the repository-level
`docs/BUILDING{,_zh}.md` toolchain table are updated in the same commit.

Rollback is a single `git revert`; nothing persists outside the working
tree.
