### PR TITLE
feat(tokenless): move response compression behind the registry

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -889,10 +889,13 @@ dependencies = [
 name = "tokenless-runtime"
 version = "0.7.12"
 dependencies = [
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokenless-ccr",
+ "tokenless-pipeline",
+ "tokenless-protocol",
  "tokenless-schema",
  "tokenless-stats",
  "toon-format",

--- a/src/tokenless/crates/tokenless-cli/src/main.rs
+++ b/src/tokenless/crates/tokenless-cli/src/main.rs
@@ -10,7 +10,7 @@ use std::process;
 use std::sync::Arc;
 use tokenless_ccr::{SqliteStore, StashStore};
 use tokenless_runtime::{
-    CompressOptions, CompressionDisposition, MAX_INPUT_BYTES, compress_response_with_store,
+    CompressOptions, CompressResult, Disposition, MAX_INPUT_BYTES, compress_response_with_store,
     compress_toon, retrieve_from_store,
 };
 use tokenless_schema::SchemaCompressor;
@@ -641,7 +641,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                     result.stash_errors.expect("checked Some above")
                 );
             }
-            if result.disposition == CompressionDisposition::NoSavings {
+            if result.disposition == Disposition::NoSavings {
                 eprintln!(
                     "tokenless: response compression did not reduce size ({} -> {} est. tokens), outputting original",
                     result.before_tokens, result.after_tokens
@@ -649,11 +649,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
             }
 
             let mode = resolve_mode(compression_on, result.before_tokens, result.after_tokens);
-            let output_text = if result.disposition == CompressionDisposition::NoSavings {
-                input.clone()
-            } else {
-                result.compressed_output.clone()
-            };
+            let output_text = stats_after_text(&result, &input);
             println!("{}", result.output);
 
             record_compression_stats(
@@ -904,7 +900,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
                 };
                 (error.to_string(), code)
             })?;
-            if result.disposition == CompressionDisposition::NoSavings {
+            if result.disposition == Disposition::NoSavings {
                 eprintln!(
                     "tokenless: TOON encoding did not reduce size ({} -> {} est. tokens), outputting original JSON",
                     result.before_tokens, result.after_tokens
@@ -916,11 +912,7 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
 
             // Recorded `after` = the predicted TOON result (or original when
             // TOON did not reduce size), so dry-run captures the prediction.
-            let record_after = if result.disposition == CompressionDisposition::NoSavings {
-                input.clone()
-            } else {
-                result.compressed_output
-            };
+            let record_after = stats_after_text(&result, &input);
             let database_paths = DatabasePathResolver::default();
             record_compression_stats(
                 &config,
@@ -963,6 +955,21 @@ fn run_command(command: Commands) -> Result<(), (String, i32)> {
     }
 
     Ok(())
+}
+
+/// Text recorded as the statistics "after" side for one compression result.
+///
+/// Only `Applied` and `DryRun` measure the candidate. Every other
+/// disposition (no-savings, timeout, passthrough, reversibility, error)
+/// emitted the original, so recording the discarded candidate would book
+/// savings that never reached the model. Mirrors the Runtime's
+/// `record_stats` selection; `record_compression_stats` then skips records
+/// whose after side is not smaller.
+fn stats_after_text(result: &CompressResult, input: &str) -> String {
+    match result.disposition {
+        Disposition::Applied | Disposition::DryRun => result.compressed_output.clone(),
+        _ => input.to_string(),
+    }
 }
 
 /// Resolve the recording mode from the compression toggle.

--- a/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
+++ b/src/tokenless/crates/tokenless-cli/src/tests/main_tests.rs
@@ -1672,3 +1672,43 @@ fn run_command_compress_response_with_stash_truncation() {
     // Compression with stash enabled and aggressive truncation succeeds.
     assert!(result.is_ok());
 }
+
+#[test]
+fn stats_after_text_records_the_candidate_only_when_it_was_measured() {
+    let result_with = |disposition: Disposition| CompressResult {
+        output: "original".to_string(),
+        compressed_output: "candidate".to_string(),
+        disposition,
+        before_tokens: 10,
+        after_tokens: 4,
+        stash_writes: None,
+        stash_errors: None,
+        unrecoverable_truncations: None,
+        stash_size: None,
+    };
+
+    // Applied and dry-run measured the candidate; dry-run is what keeps
+    // A/B prediction records alive.
+    for disposition in [Disposition::Applied, Disposition::DryRun] {
+        assert_eq!(
+            stats_after_text(&result_with(disposition), "original"),
+            "candidate"
+        );
+    }
+    // Every rejection emitted the original: recording the discarded
+    // candidate would book savings that never reached the model. Timeout
+    // is the regression case — the pipeline keeps the candidate text for
+    // the legacy measurement channel even though the output fell back.
+    for disposition in [
+        Disposition::NoSavings,
+        Disposition::Timeout,
+        Disposition::Passthrough,
+        Disposition::ReversibilityUnavailable,
+        Disposition::Error,
+    ] {
+        assert_eq!(
+            stats_after_text(&result_with(disposition), "original"),
+            "original"
+        );
+    }
+}

--- a/src/tokenless/crates/tokenless-pipeline/src/lib.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/lib.rs
@@ -12,10 +12,11 @@
 //! - [`Compressor`] and [`run`]: the executable compressor interface and
 //!   the staged escalation engine with end-to-end arbitration.
 //!
-//! Until existing compressors move behind the registry, [`REGISTRY`] is
-//! empty and nothing routes through this crate. The roadmap section numbers
-//! refer to the tokenless evolution roadmap, which has not landed in this
-//! repository yet.
+//! [`REGISTRY`] lists the production compressors; the first entry is the
+//! existing JSON response cleanup ([`RESPONSE_CLEANUP`]), whose executable
+//! implementation lives with the Runtime that owns its stash and per-call
+//! configuration. The roadmap section numbers refer to the tokenless
+//! evolution roadmap, which has not landed in this repository yet.
 
 mod content;
 mod pipeline;
@@ -23,4 +24,4 @@ mod registry;
 
 pub use content::{ContentType, detect};
 pub use pipeline::{CompressError, CompressOutcome, Compressor, PipelineConfig, run};
-pub use registry::{CompressorSpec, CostClass, REGISTRY, Stage, candidates};
+pub use registry::{CompressorSpec, CostClass, REGISTRY, RESPONSE_CLEANUP, Stage, candidates};

--- a/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
@@ -31,9 +31,10 @@ use crate::content::{ContentType, detect};
 use crate::registry::{CompressorSpec, Stage};
 
 /// One executable compression step. [`crate::CompressorSpec`] is the routing
-/// metadata; this trait is the behavior behind it. Existing compressors
-/// migrate onto it starting with the response cleanup (roadmap §5.3); until
-/// then only test doubles implement it.
+/// metadata; this trait is the behavior behind it. The first production
+/// implementation is the response cleanup (roadmap §5.3), registered as
+/// [`crate::RESPONSE_CLEANUP`] and implemented where the Runtime owns its
+/// stash and per-call configuration.
 pub trait Compressor {
     /// The routing spec this compressor registers under.
     fn spec(&self) -> &CompressorSpec;
@@ -43,7 +44,11 @@ pub trait Compressor {
     /// `stash` is present when the host can actually retrieve stashed
     /// payloads. A retrievable-lossy compressor records every write in
     /// [`CompressOutcome::stash_writes`], which is what lets the pipeline
-    /// roll them back when the end-to-end candidate is rejected.
+    /// roll them back when the end-to-end candidate is rejected. Every
+    /// reported write must target the store [`run`] was given — rollback
+    /// and marker-presence commits go through that store, so writes routed
+    /// anywhere else (e.g. a store attached at construction that differs
+    /// from the caller's) would leak on rejection.
     ///
     /// # Errors
     ///

--- a/src/tokenless/crates/tokenless-pipeline/src/registry.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/registry.rs
@@ -76,10 +76,33 @@ impl CompressorSpec {
     }
 }
 
-/// The production registry. Empty until existing compressors move behind
-/// the registry interface; entries are appended with the compressor that
+/// Routing spec of the existing JSON response cleanup (roadmap §5.3): the
+/// structural cleanup and truncation pass that predates the pipeline. Its
+/// [`Compressor`](crate::Compressor) implementation lives with the Runtime,
+/// which owns the stash and per-call configuration; its `spec()` returns a
+/// reference to this spec so the registry entry and the implementation
+/// cannot drift.
+///
+/// Registered as retrievable-lossy: truncated content is stashed and
+/// marker-referenced when a stash store is attached. Only `replace_output`
+/// is required — the compressor degrades to a lossless-only claim or an
+/// unrecoverable one depending on what it actually removed, and required
+/// reversibility is enforced by arbitration, not by routing.
+pub const RESPONSE_CLEANUP: CompressorSpec = CompressorSpec {
+    id: "response-cleanup",
+    content_types: &[ContentType::JsonRecords],
+    seams: &[Seam::PostTool],
+    required_capabilities: Capabilities {
+        replace_output: true,
+        publish_retrieve_tool: false,
+    },
+    stage: Stage::RetrievableLossy,
+    cost_class: CostClass::Moderate,
+};
+
+/// The production registry. Entries are appended with the compressor that
 /// implements them, never speculatively.
-pub const REGISTRY: &[CompressorSpec] = &[];
+pub const REGISTRY: &[CompressorSpec] = &[RESPONSE_CLEANUP];
 
 /// Filters `registry` down to the candidates for one request, preserving
 /// registration order (the pipeline groups by [`Stage`] on top of it).

--- a/src/tokenless/crates/tokenless-pipeline/src/tests/registry_tests.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/tests/registry_tests.rs
@@ -110,12 +110,24 @@ fn stage_and_cost_orderings_match_the_escalation_ladder() {
 }
 
 #[test]
-// The emptiness is exactly what this test locks in, so the "always true"
-// lint is expected until the first compressor migrates behind the registry.
-#[allow(clippy::const_is_empty)]
-fn production_registry_starts_empty() {
+fn production_registry_lists_exactly_the_implemented_compressors() {
     // Entries land together with the compressor that implements them, never
-    // speculatively. This assertion is updated by the change that migrates
-    // the first compressor behind the registry.
-    assert!(REGISTRY.is_empty());
+    // speculatively. The response cleanup (roadmap §5.3) is the first one.
+    assert_eq!(
+        REGISTRY.iter().map(|spec| spec.id).collect::<Vec<_>>(),
+        ["response-cleanup"]
+    );
+    assert_eq!(RESPONSE_CLEANUP.stage, Stage::RetrievableLossy);
+    // Routing requires only output replacement: without a stash the cleanup
+    // degrades (and arbitration enforces required reversibility), so a
+    // missing retrieve tool must not filter it out.
+    assert!(RESPONSE_CLEANUP.matches(
+        ContentType::JsonRecords,
+        Seam::PostTool,
+        Capabilities {
+            replace_output: true,
+            publish_retrieve_tool: false,
+        },
+    ));
+    assert!(!RESPONSE_CLEANUP.matches(ContentType::JsonRecords, Seam::PostTool, NONE));
 }

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -190,10 +190,10 @@ impl CompressionRequest {
 /// shared vocabulary the M1 exit gate requires CLI and Runtime to agree on
 /// (roadmap §5.6).
 ///
-/// The Runtime's pre-protocol `CompressionDisposition::as_str` still prints
-/// kebab-case (`dry-run`, `no-savings`); the Runtime-integration change is
-/// expected to align those user-visible strings to these snake_case wire
-/// values rather than fork the vocabulary further.
+/// The Runtime shares this enum directly (its pre-protocol
+/// `CompressionDisposition` retired when response compression moved behind
+/// the registry), so user-visible strings come from [`Disposition::wire_str`]
+/// and cannot fork from the wire values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Disposition {
@@ -219,6 +219,23 @@ pub enum Disposition {
     /// An optional compression step failed; the original is preserved and
     /// a bounded diagnostic is recorded (roadmap principle 6).
     Error,
+}
+
+impl Disposition {
+    /// The `snake_case` wire name, identical to this enum's serde encoding.
+    /// The stable vocabulary for language bindings, logs, and statistics.
+    #[must_use]
+    pub fn wire_str(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::DryRun => "dry_run",
+            Self::Passthrough => "passthrough",
+            Self::NoSavings => "no_savings",
+            Self::ReversibilityUnavailable => "reversibility_unavailable",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
 }
 
 /// Recovery state of an applied transformation (roadmap principle 5).

--- a/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
@@ -207,6 +207,7 @@ fn all_seams_and_dispositions_round_trip() {
     ] {
         assert_eq!(serde_json::to_string(&disp).unwrap(), wire);
         assert_eq!(serde_json::from_str::<Disposition>(wire).unwrap(), disp);
+        assert_eq!(format!("\"{}\"", disp.wire_str()), wire);
     }
     for (rev, wire) in [
         (Reversibility::Lossless, "\"lossless\""),

--- a/src/tokenless/crates/tokenless-runtime/Cargo.toml
+++ b/src/tokenless/crates/tokenless-runtime/Cargo.toml
@@ -6,10 +6,13 @@ license.workspace = true
 description = "Application runtime for Tokenless compression and retrieval"
 
 [dependencies]
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toon-format.workspace = true
 tokenless-ccr = { path = "../tokenless-ccr" }
+tokenless-pipeline = { path = "../tokenless-pipeline" }
+tokenless-protocol = { path = "../tokenless-protocol" }
 tokenless-schema = { path = "../tokenless-schema" }
 tokenless-stats = { path = "../tokenless-stats" }
 

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -1,18 +1,34 @@
 //! Stateful application API shared by Tokenless frontends.
 //!
-//! The runtime composes response compression, reversible SQLite stash, and
-//! statistics without depending on a command-line or language-binding layer.
+//! The runtime composes the shared compression pipeline, reversible SQLite
+//! stash, and statistics without depending on a command-line or
+//! language-binding layer. Response compression routes through
+//! [`tokenless_pipeline::run`], with the existing cleanup registered as the
+//! first entry of the production registry (roadmap §5.3).
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use thiserror::Error;
-use tokenless_ccr::{SqliteStore, StashStore, extract_hash, is_valid_hash};
+use tokenless_ccr::{SqliteStore, StashError, StashStore, StashWrite, extract_hash, is_valid_hash};
+use tokenless_pipeline::PipelineConfig;
+use tokenless_protocol::{Capabilities, CompressionRequest, Seam};
 use tokenless_schema::{ResponseCompressor, SchemaCompressor};
 use tokenless_stats::{
     CompressionMode, OperationType, SlsWriter, StatsRecord, StatsRecorder, ensure_state_dir,
     estimate_tokens, get_home_dir, resolve_data_dir, validate_data_dir, validate_database_path,
 };
+
+mod response_cleanup;
+
+use response_cleanup::ResponseCleanup;
+
+/// Why a compression attempt did or did not replace the input: the protocol
+/// disposition vocabulary, re-exported verbatim so CLI, Runtime, and
+/// language bindings share one set of names and wire strings (roadmap §5.6).
+pub use tokenless_protocol::Disposition;
 
 /// Maximum accepted response size, matching the standalone CLI input limit.
 pub const MAX_INPUT_BYTES: usize = 64 * 1024 * 1024;
@@ -100,40 +116,19 @@ impl Attribution {
     }
 }
 
-/// Why a compression attempt did or did not replace the input.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompressionDisposition {
-    /// The compressed response is returned to the caller.
-    Applied,
-    /// Compression was calculated for measurement but the original is returned.
-    DryRun,
-    /// The candidate did not reduce the estimated token count.
-    NoSavings,
-    /// Reversible output was required but stash was unavailable or failed.
-    ReversibilityUnavailable,
-}
-
-impl CompressionDisposition {
-    /// Stable lowercase name suitable for language bindings and logs.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Applied => "applied",
-            Self::DryRun => "dry-run",
-            Self::NoSavings => "no-savings",
-            Self::ReversibilityUnavailable => "reversibility-unavailable",
-        }
-    }
-}
-
 /// Structured response from one compression attempt.
 #[derive(Debug, Clone)]
 pub struct CompressResult {
     /// Text that the caller should pass to the model.
     pub output: String,
-    /// Compact candidate calculated before dry-run or fail-open policy.
+    /// Compact candidate calculated before dry-run or fail-open policy; the
+    /// original input when no candidate ran (passthrough, timeout, error).
+    /// Retained as the legacy measurement channel — dry-run statistics
+    /// record the predicted candidate from it — and scheduled for removal
+    /// with the statistics migration (roadmap §5.5).
     pub compressed_output: String,
     /// Policy decision applied to the candidate.
-    pub disposition: CompressionDisposition,
+    pub disposition: Disposition,
     /// Estimated tokens in the original input.
     pub before_tokens: usize,
     /// Estimated tokens in `compressed_output`.
@@ -152,7 +147,7 @@ pub struct CompressResult {
 impl CompressResult {
     /// Whether the caller-visible output is the compressed candidate.
     pub fn applied(&self) -> bool {
-        self.disposition == CompressionDisposition::Applied
+        self.disposition == Disposition::Applied
     }
 }
 
@@ -277,8 +272,7 @@ impl TokenlessRuntime {
     ///
     /// # Errors
     ///
-    /// Returns [`RuntimeError`] for oversized or invalid JSON input, or if the
-    /// compact response cannot be serialized.
+    /// Returns [`RuntimeError`] for oversized or invalid JSON input.
     pub fn compress_response(
         &self,
         input: &str,
@@ -384,11 +378,10 @@ impl TokenlessRuntime {
             return;
         }
         let (after, after_tokens) = match result.disposition {
-            CompressionDisposition::Applied | CompressionDisposition::DryRun => {
+            Disposition::Applied | Disposition::DryRun => {
                 (result.compressed_output.as_str(), result.after_tokens)
             }
-            CompressionDisposition::NoSavings
-            | CompressionDisposition::ReversibilityUnavailable => (input, result.before_tokens),
+            _ => (input, result.before_tokens),
         };
         let before_tokens = result.before_tokens;
         if after_tokens >= before_tokens {
@@ -457,15 +450,15 @@ pub fn compress_schema_with_store(
     let after_tokens = estimate_tokens(&compressed_output);
     let compression_stash_errors = attached_store.map(|_| compressor.stash_errors());
     let disposition = if after_tokens >= before_tokens {
-        CompressionDisposition::NoSavings
+        Disposition::NoSavings
     } else if !compression_enabled {
-        CompressionDisposition::DryRun
+        Disposition::DryRun
     } else if attached_store.is_none() || compression_stash_errors.is_some_and(|count| count > 0) {
-        CompressionDisposition::ReversibilityUnavailable
+        Disposition::ReversibilityUnavailable
     } else {
-        CompressionDisposition::Applied
+        Disposition::Applied
     };
-    let (stash_writes, stash_errors) = if disposition != CompressionDisposition::Applied {
+    let (stash_writes, stash_errors) = if disposition != Disposition::Applied {
         compressor.rollback_stash_writes();
         (
             attached_store.map(|_| compressor.stash_writes()),
@@ -480,7 +473,7 @@ pub fn compress_schema_with_store(
         metrics
     };
     let stash_size = attached_store.map(|store| store.len());
-    let output = if disposition == CompressionDisposition::Applied {
+    let output = if disposition == Disposition::Applied {
         compressed_output.clone()
     } else {
         input.to_string()
@@ -517,13 +510,13 @@ pub fn compress_toon(
     let before_tokens = estimate_tokens(input);
     let after_tokens = estimate_tokens(&compressed_output);
     let disposition = if compressed_output.is_empty() || after_tokens >= before_tokens {
-        CompressionDisposition::NoSavings
+        Disposition::NoSavings
     } else if !compression_enabled {
-        CompressionDisposition::DryRun
+        Disposition::DryRun
     } else {
-        CompressionDisposition::Applied
+        Disposition::Applied
     };
-    let output = if disposition == CompressionDisposition::Applied {
+    let output = if disposition == Disposition::Applied {
         compressed_output.clone()
     } else {
         input.to_string()
@@ -550,15 +543,71 @@ fn validate_input_size(input: &str) -> Result<(), RuntimeError> {
     Ok(())
 }
 
+/// Overall pipeline budget for one response compression. The pre-pipeline
+/// path had no timeout; this bound honors the one-budget contract (roadmap
+/// §5.3) while sitting far above any observed in-process compression time,
+/// so it only fires on pathological input. Timeout is fail-open: the
+/// original content is returned.
+const RESPONSE_PIPELINE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Forwards to the caller's store while counting the pipeline ledger's
+/// deletes, which is what keeps `CompressResult`'s legacy stash metrics on
+/// their pre-pipeline semantics: `stash_writes` reports the rows still live
+/// after a rollback, and a failed rollback delete surfaces in
+/// `stash_errors` so the CLI's stash-health warning still fires on orphaned
+/// rows.
+struct DeleteTracking<'a> {
+    inner: &'a dyn StashStore,
+    // Atomics because `StashStore` is `Sync`; this tracker never actually
+    // crosses threads within one compress call.
+    removed: AtomicUsize,
+    failed: AtomicUsize,
+}
+
+impl StashStore for DeleteTracking<'_> {
+    fn stash(&self, payload: &str) -> Result<StashWrite, StashError> {
+        self.inner.stash(payload)
+    }
+
+    fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
+        self.inner.retrieve(hash)
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn evict_expired(&self) -> Result<usize, StashError> {
+        self.inner.evict_expired()
+    }
+
+    fn delete(&self, hash: &str, generation: u64) -> Result<bool, StashError> {
+        let result = self.inner.delete(hash, generation);
+        match &result {
+            Ok(true) => {
+                self.removed.fetch_add(1, Ordering::Relaxed);
+            }
+            Ok(false) => {}
+            Err(_) => {
+                self.failed.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        result
+    }
+}
+
 /// Compress a response using an optional caller-owned stash store.
 ///
-/// CLI and embedded frontends use this function to share candidate selection,
-/// no-savings fallback, dry-run behavior, and reversible fail-open policy.
+/// CLI and embedded frontends use this function to share the pipeline's
+/// routing, staged execution, and end-to-end arbitration (roadmap §4.3):
+/// no-savings fallback, dry-run behavior, reversibility policy, timeout,
+/// and stash rollback all come from [`tokenless_pipeline::run`]. A failing
+/// compression step is fail-open and reported through the disposition, not
+/// as an error.
 ///
 /// # Errors
 ///
-/// Returns [`RuntimeError`] for oversized or invalid JSON input, or if the
-/// compact response cannot be serialized.
+/// Returns [`RuntimeError`] for oversized or invalid JSON input.
 pub fn compress_response_with_store(
     input: &str,
     options: &CompressOptions,
@@ -566,7 +615,11 @@ pub fn compress_response_with_store(
     stash_store: Option<&Arc<dyn StashStore>>,
 ) -> Result<CompressResult, RuntimeError> {
     validate_input_size(input)?;
-    let value: serde_json::Value = serde_json::from_str(input)?;
+    // Boundary contract: response input must be JSON. The pipeline itself
+    // routes non-JSON content to passthrough, so this validation is what
+    // keeps invalid input a structured error for the CLI and bindings.
+    serde_json::from_str::<serde::de::IgnoredAny>(input)?;
+
     let mut compressor = ResponseCompressor::new();
     if let Some(value) = options.truncate_strings_at {
         compressor = compressor.with_truncate_strings_at(value);
@@ -581,6 +634,9 @@ pub fn compress_response_with_store(
         compressor = compressor.with_max_depth(value);
     }
 
+    // In dry-run no store is attached at all — the measured candidate is
+    // never emitted, so writing stash rows (even rolled-back ones) would be
+    // pure churn.
     let attached_store = if options.stash_enabled && compression_enabled {
         stash_store
     } else {
@@ -589,45 +645,65 @@ pub fn compress_response_with_store(
     if let Some(store) = attached_store {
         compressor = compressor.with_stash_store(Arc::clone(store));
     }
+    let adapter = ResponseCleanup::new(compressor, attached_store.is_some());
 
-    let compressed_value = compressor.compress(&value);
-    let compressed_output =
-        serde_json::to_string(&compressed_value).map_err(RuntimeError::Serialize)?;
+    // Attribution reaches statistics separately until the §5.5 migration;
+    // the in-process request carries no frontend identity.
+    let mut request = CompressionRequest::new(input, "", Seam::PostTool);
+    request.capabilities = Capabilities {
+        replace_output: true,
+        publish_retrieve_tool: attached_store.is_some(),
+    };
+    let config = PipelineConfig {
+        timeout: RESPONSE_PIPELINE_TIMEOUT,
+        // The pre-pipeline policy is "always try to shrink": a permanently
+        // unmet size target keeps the cleanup's retrievable-lossy stage on.
+        max_tokens: Some(0),
+        // Reversibility is enforced only when something would be emitted;
+        // in dry-run the pre-pipeline precedence (dry-run wins) applies.
+        require_reversibility: options.require_reversible
+            && options.stash_enabled
+            && compression_enabled,
+        dry_run: !compression_enabled,
+    };
+    let tracker = attached_store.map(|store| DeleteTracking {
+        inner: store.as_ref(),
+        removed: AtomicUsize::new(0),
+        failed: AtomicUsize::new(0),
+    });
+    let response = tokenless_pipeline::run(
+        &request,
+        &[&adapter],
+        tracker.as_ref().map(|tracker| tracker as &dyn StashStore),
+        &config,
+    );
+
+    // Legacy measurement channel (see `CompressResult::compressed_output`):
+    // the candidate the adapter produced, or the original when none ran.
+    let compressed_output = adapter
+        .take_candidate()
+        .unwrap_or_else(|| input.to_string());
+    // Both counts run the shared estimator locally, mirroring each other;
+    // this also avoids converting the response's u64 counts back to usize.
     let before_tokens = estimate_tokens(input);
     let after_tokens = estimate_tokens(&compressed_output);
-    let unrecoverable_truncations = attached_store.map(|_| compressor.unrecoverable_truncations());
-
-    let disposition = if after_tokens >= before_tokens {
-        CompressionDisposition::NoSavings
-    } else if !compression_enabled {
-        CompressionDisposition::DryRun
-    } else if options.require_reversible
-        && options.stash_enabled
-        && (attached_store.is_none() || unrecoverable_truncations.is_some_and(|count| count > 0))
-    {
-        CompressionDisposition::ReversibilityUnavailable
-    } else {
-        CompressionDisposition::Applied
-    };
-    // Discarded compressed output never reaches the LLM, so roll back stash
-    // keys created during this compress — otherwise markers live only in
-    // `compressed_output` and orphan stash rows.
-    if disposition != CompressionDisposition::Applied {
-        compressor.rollback_stash_writes();
-    }
-    let stash_writes = attached_store.map(|_| compressor.stash_writes());
-    let stash_errors = attached_store.map(|_| compressor.stash_errors());
+    // Rows still live after the ledger's rollback and orphan-commit deletes,
+    // and write/delete failures combined — the pre-pipeline metric contract.
+    let stash_writes = tracker.as_ref().map(|tracker| {
+        adapter
+            .stash_writes()
+            .saturating_sub(tracker.removed.load(Ordering::Relaxed))
+    });
+    let stash_errors = tracker
+        .as_ref()
+        .map(|tracker| adapter.stash_errors() + tracker.failed.load(Ordering::Relaxed));
+    let unrecoverable_truncations = attached_store.map(|_| adapter.unrecoverable_truncations());
     let stash_size = attached_store.map(|store| store.len());
-    let output = if disposition == CompressionDisposition::Applied {
-        compressed_output.clone()
-    } else {
-        input.to_string()
-    };
 
     Ok(CompressResult {
-        output,
+        output: response.output,
         compressed_output,
-        disposition,
+        disposition: response.disposition,
         before_tokens,
         after_tokens,
         stash_writes,
@@ -752,16 +828,13 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(
-            result.disposition,
-            CompressionDisposition::ReversibilityUnavailable,
-        );
+        assert_eq!(result.disposition, Disposition::ReversibilityUnavailable);
         assert_eq!(result.output, input);
     }
 
     #[test]
     fn reversible_policy_preserves_input_after_string_stash_failure() {
-        let input = serde_json::to_string(&"x".repeat(400)).unwrap();
+        let input = serde_json::to_string(&serde_json::json!({ "tail": "x".repeat(400) })).unwrap();
         let store = Arc::new(AlwaysFail) as Arc<dyn StashStore>;
         let result = compress_response_with_store(
             &input,
@@ -775,10 +848,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            result.disposition,
-            CompressionDisposition::ReversibilityUnavailable,
-        );
+        assert_eq!(result.disposition, Disposition::ReversibilityUnavailable);
         assert_eq!(result.output, input);
         assert_eq!(result.stash_errors, Some(1));
         assert_eq!(result.unrecoverable_truncations, Some(1));
@@ -803,10 +873,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            result.disposition,
-            CompressionDisposition::ReversibilityUnavailable,
-        );
+        assert_eq!(result.disposition, Disposition::ReversibilityUnavailable);
         assert_eq!(result.output, input);
         assert_eq!(result.stash_errors, Some(1));
         assert_eq!(result.unrecoverable_truncations, Some(1));
@@ -814,7 +881,7 @@ mod tests {
 
     #[test]
     fn reversible_policy_preserves_input_when_string_marker_cannot_fit() {
-        let input = serde_json::to_string(&"x".repeat(400)).unwrap();
+        let input = serde_json::to_string(&serde_json::json!({ "tail": "x".repeat(400) })).unwrap();
         let store = Arc::new(InMemoryStore::new()) as Arc<dyn StashStore>;
         let result = compress_response_with_store(
             &input,
@@ -828,10 +895,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            result.disposition,
-            CompressionDisposition::ReversibilityUnavailable,
-        );
+        assert_eq!(result.disposition, Disposition::ReversibilityUnavailable);
         assert_eq!(result.output, input);
         assert_eq!(result.stash_errors, Some(0));
         assert_eq!(result.unrecoverable_truncations, Some(1));
@@ -869,7 +933,7 @@ mod tests {
             Some(&store),
         )
         .unwrap();
-        assert_eq!(result.disposition, CompressionDisposition::DryRun);
+        assert_eq!(result.disposition, Disposition::DryRun);
         assert_eq!(result.output, input);
         assert_eq!(store.len(), 0);
         assert_eq!(result.stash_writes, None);
@@ -880,7 +944,7 @@ mod tests {
         let input = r#"{"value":1}"#;
         let result =
             compress_response_with_store(input, &CompressOptions::default(), true, None).unwrap();
-        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.disposition, Disposition::NoSavings);
         assert_eq!(result.output, input);
     }
 
@@ -898,10 +962,61 @@ mod tests {
             Some(&store),
         )
         .unwrap();
-        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.disposition, Disposition::NoSavings);
         assert_eq!(result.output, input);
         assert_eq!(store.len(), 0);
         assert_eq!(result.stash_writes, Some(0));
+    }
+
+    #[test]
+    fn rollback_delete_failures_surface_in_stash_errors() {
+        struct StashOkDeleteFails(InMemoryStore);
+
+        impl StashStore for StashOkDeleteFails {
+            fn stash(&self, payload: &str) -> Result<StashWrite, StashError> {
+                self.0.stash(payload)
+            }
+
+            fn retrieve(&self, hash: &str) -> Result<Option<String>, StashError> {
+                self.0.retrieve(hash)
+            }
+
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+
+            fn evict_expired(&self) -> Result<usize, StashError> {
+                self.0.evict_expired()
+            }
+
+            fn delete(&self, _hash: &str, _generation: u64) -> Result<bool, StashError> {
+                Err(StashError::Backend("simulated delete failure".to_string()))
+            }
+        }
+
+        // Twelve short items: the truncation marker outgrows the removed
+        // tail, so the candidate is rejected as no-savings after stashing.
+        let input = r#"["a","b","c","d","e","f","g","h","i","j","k","l"]"#;
+        let store = Arc::new(StashOkDeleteFails(InMemoryStore::new())) as Arc<dyn StashStore>;
+        let result = compress_response_with_store(
+            input,
+            &CompressOptions {
+                truncate_arrays_at: Some(1),
+                array_tail_preserve: Some(0),
+                ..CompressOptions::default()
+            },
+            true,
+            Some(&store),
+        )
+        .unwrap();
+
+        assert_eq!(result.disposition, Disposition::NoSavings);
+        assert_eq!(result.output, input);
+        // The rollback delete failed: the orphaned row is still live and the
+        // failure is visible, so the CLI's stash-health warning fires.
+        assert_eq!(result.stash_writes, Some(1));
+        assert_eq!(result.stash_errors, Some(1));
+        assert_eq!(store.len(), 1);
     }
 
     #[test]
@@ -910,6 +1025,74 @@ mod tests {
             compress_response_with_store("not json", &CompressOptions::default(), true, None)
                 .unwrap_err();
         assert!(matches!(error, RuntimeError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn non_record_json_passes_through_untouched() {
+        // Detection routes only record-shaped JSON ({...}/[...]) to the
+        // cleanup; a scalar root passes through, where the pre-pipeline path
+        // would truncate it. Deliberate: routing by detected content is the
+        // §4.2 contract, and non-record roots wait for their own compressor.
+        let input = serde_json::to_string(&"x".repeat(400)).unwrap();
+        let result = compress_response_with_store(
+            &input,
+            &CompressOptions {
+                truncate_strings_at: Some(80),
+                ..CompressOptions::default()
+            },
+            true,
+            None,
+        )
+        .unwrap();
+        assert_eq!(result.disposition, Disposition::Passthrough);
+        assert_eq!(result.output, input);
+        assert_eq!(result.after_tokens, result.before_tokens);
+    }
+
+    #[test]
+    fn pure_cleanup_savings_are_lossless_and_pass_required_reversibility() {
+        // Dropped debug fields, nulls, and empties keep the pre-pipeline
+        // judgment that they are cleanup, not content loss: with no
+        // truncation the candidate is lossless and applies even where
+        // reversible output is required and no stash exists. (The
+        // pre-pipeline path rejected exactly this combination.)
+        let input = serde_json::to_string(&serde_json::json!({
+            "value": 1,
+            "noise": null,
+            "debug": "x".repeat(200),
+        }))
+        .unwrap();
+        let result = compress_response_with_store(
+            &input,
+            &CompressOptions {
+                require_reversible: true,
+                ..CompressOptions::default()
+            },
+            true,
+            None,
+        )
+        .unwrap();
+        assert!(result.applied());
+        assert!(!result.output.contains("debug"));
+    }
+
+    #[test]
+    fn dry_run_wins_over_required_reversibility() {
+        let input = long_response();
+        let result = compress_response_with_store(
+            &input,
+            &CompressOptions {
+                truncate_arrays_at: Some(2),
+                require_reversible: true,
+                ..CompressOptions::default()
+            },
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(result.disposition, Disposition::DryRun);
+        assert_eq!(result.output, input);
+        assert!(result.after_tokens < result.before_tokens);
     }
 
     #[test]
@@ -1078,7 +1261,7 @@ mod tests {
         let input = r#"{"type":"function","function":{"name":"small","parameters":{}}}"#;
         let store = Arc::new(InMemoryStore::new()) as Arc<dyn StashStore>;
         let result = compress_schema_with_store(input, true, Some(&store)).unwrap();
-        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.disposition, Disposition::NoSavings);
         assert_eq!(result.output, input);
         assert_eq!(store.len(), 0);
     }
@@ -1097,7 +1280,7 @@ mod tests {
 
         let tiny = "null";
         let result = compress_toon(tiny, true).unwrap();
-        assert_eq!(result.disposition, CompressionDisposition::NoSavings);
+        assert_eq!(result.disposition, Disposition::NoSavings);
         assert_eq!(result.output, tiny);
     }
 

--- a/src/tokenless/crates/tokenless-runtime/src/response_cleanup.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/response_cleanup.rs
@@ -1,0 +1,166 @@
+//! Pipeline adapter for the existing JSON response cleanup.
+//!
+//! [`ResponseCleanup`] puts [`ResponseCompressor`] behind the pipeline's
+//! [`Compressor`] trait (roadmap §5.3: move existing response cleanup behind
+//! the new compressor interface), registered as
+//! [`tokenless_pipeline::RESPONSE_CLEANUP`]. It lives here rather than in
+//! the pipeline crate because the Runtime owns the stash store and the
+//! per-call configuration the compressor is built from.
+
+use std::cell::RefCell;
+
+use tokenless_ccr::StashStore;
+use tokenless_pipeline::{
+    CompressError, CompressOutcome, Compressor, CompressorSpec, RESPONSE_CLEANUP,
+};
+use tokenless_protocol::Reversibility;
+use tokenless_schema::ResponseCompressor;
+
+/// One-shot adapter: built per request from [`crate::CompressOptions`], with
+/// the stash already attached (the [`ResponseCompressor`] API takes an
+/// `Arc`-owned store at construction, not per call).
+pub(crate) struct ResponseCleanup {
+    inner: ResponseCompressor,
+    /// Whether `inner` was built with a stash store. Without one, every
+    /// truncation is unrecoverable no matter what the counters say.
+    stash_attached: bool,
+    /// The serialized candidate of the last `compress` call. The legacy
+    /// measurement channel for [`crate::CompressResult::compressed_output`]
+    /// (dry-run statistics record the predicted candidate); removed with the
+    /// statistics migration (roadmap §5.5).
+    candidate: RefCell<Option<String>>,
+}
+
+impl ResponseCleanup {
+    pub(crate) fn new(inner: ResponseCompressor, stash_attached: bool) -> Self {
+        Self {
+            inner,
+            stash_attached,
+            candidate: RefCell::new(None),
+        }
+    }
+
+    /// Failed stash operations of the last `compress` call.
+    pub(crate) fn stash_errors(&self) -> usize {
+        self.inner.stash_errors()
+    }
+
+    /// Successful stash writes of the last `compress` call: unique created
+    /// rows plus every refresh of a pre-existing key, matching the metric
+    /// documented for [`ResponseCompressor::stash_writes`].
+    pub(crate) fn stash_writes(&self) -> usize {
+        self.inner.stash_writes()
+    }
+
+    /// Truncations without a retrievable marker in the last `compress` call.
+    pub(crate) fn unrecoverable_truncations(&self) -> usize {
+        self.inner.unrecoverable_truncations()
+    }
+
+    /// Takes the retained candidate of the last `compress` call.
+    pub(crate) fn take_candidate(&self) -> Option<String> {
+        self.candidate.take()
+    }
+}
+
+impl Compressor for ResponseCleanup {
+    fn spec(&self) -> &CompressorSpec {
+        &RESPONSE_CLEANUP
+    }
+
+    // `_stash` is deliberately unused: the store is attached at construction
+    // (see the struct doc), and the caller passes that same store to
+    // `tokenless_pipeline::run`, so the ledger's rollback targets exactly
+    // the rows these writes created.
+    fn compress(
+        &self,
+        content: &str,
+        _stash: Option<&dyn StashStore>,
+    ) -> Result<CompressOutcome, CompressError> {
+        let value: serde_json::Value = serde_json::from_str(content)
+            .map_err(|error| CompressError::Failed(format!("JSON parse error: {error}")))?;
+        let compressed = self.inner.compress(&value);
+        let output = serde_json::to_string(&compressed)
+            .map_err(|error| CompressError::Failed(format!("serialize failed: {error}")))?;
+
+        // Dropped fields, nulls, and empties keep the pre-pipeline judgment
+        // that they are structural cleanup, not content loss: only actual
+        // truncation degrades the claim. Truncation is retrievable exactly
+        // when a store is attached and every truncated payload landed in it.
+        let reversibility = if self.inner.truncations() == 0 {
+            Reversibility::Lossless
+        } else if !self.stash_attached || self.inner.unrecoverable_truncations() > 0 {
+            Reversibility::Unrecoverable
+        } else {
+            Reversibility::Retrievable
+        };
+
+        self.candidate.replace(Some(output.clone()));
+        Ok(CompressOutcome {
+            output,
+            reversibility,
+            stash_writes: self.inner.take_stash_writes(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokenless_ccr::InMemoryStore;
+
+    use super::*;
+
+    fn compress(adapter: &ResponseCleanup, content: &str) -> CompressOutcome {
+        match adapter.compress(content, None) {
+            Ok(outcome) => outcome,
+            Err(error) => panic!("adapter failed: {error}"),
+        }
+    }
+
+    #[test]
+    fn cleanup_without_truncation_claims_lossless() {
+        let adapter = ResponseCleanup::new(ResponseCompressor::new(), false);
+        let outcome = compress(&adapter, r#"{"value":1,"noise":null,"debug":"x"}"#);
+        assert_eq!(outcome.output, r#"{"value":1}"#);
+        assert_eq!(outcome.reversibility, Reversibility::Lossless);
+        assert!(outcome.stash_writes.is_empty());
+        assert_eq!(adapter.take_candidate().as_deref(), Some(r#"{"value":1}"#));
+    }
+
+    #[test]
+    fn truncation_without_a_store_claims_unrecoverable() {
+        let compressor = ResponseCompressor::new().with_truncate_strings_at(20);
+        let adapter = ResponseCleanup::new(compressor, false);
+        let input = format!(r#"{{"tail":"{}"}}"#, "x".repeat(200));
+        let outcome = compress(&adapter, &input);
+        assert_eq!(outcome.reversibility, Reversibility::Unrecoverable);
+        assert!(outcome.stash_writes.is_empty());
+    }
+
+    #[test]
+    fn stashed_truncation_claims_retrievable_and_reports_its_writes() {
+        let store = Arc::new(InMemoryStore::new());
+        let compressor = ResponseCompressor::new()
+            .with_truncate_strings_at(80)
+            .with_stash_store(store.clone());
+        let adapter = ResponseCleanup::new(compressor, true);
+        let input = format!(r#"{{"tail":"{}"}}"#, "x".repeat(400));
+        let outcome = compress(&adapter, &input);
+        assert_eq!(outcome.reversibility, Reversibility::Retrievable);
+        assert_eq!(outcome.stash_writes.len(), 1);
+        assert!(outcome.stash_writes[0].created);
+        assert!(
+            outcome
+                .output
+                .contains(&tokenless_ccr::marker_for(&outcome.stash_writes[0].key))
+        );
+    }
+
+    #[test]
+    fn non_json_content_is_a_compressor_error() {
+        let adapter = ResponseCleanup::new(ResponseCompressor::new(), false);
+        assert!(adapter.compress("not json", None).is_err());
+    }
+}

--- a/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
+++ b/src/tokenless/crates/tokenless-schema/src/response_compressor.rs
@@ -57,6 +57,14 @@ pub struct ResponseCompressor {
     /// the last `compress()` call. Includes backend failures and marker-budget
     /// limits without conflating the two causes.
     unrecoverable_truncations: Cell<usize>,
+    /// Total truncation events (string, array, depth) during the last
+    /// `compress()` call, counted whether or not a stash store is attached.
+    /// Zero means the call removed no content beyond dropped fields/nulls,
+    /// which lets callers report the candidate as lossless.
+    truncations: Cell<usize>,
+    /// Every successful stash write of the last `compress()` call, in order.
+    /// The pipeline's ledger consumes these to own rollback end-to-end.
+    stash_write_events: RefCell<Vec<StashWrite>>,
     /// Keys created during the last `compress()` call, mapped to the latest
     /// generation this call still owns. An in-compress refresh updates the
     /// generation only when `StashWrite::previous_generation` matches, so a
@@ -101,6 +109,8 @@ impl Default for ResponseCompressor {
             stash_writes: Cell::new(0),
             stash_errors: Cell::new(0),
             unrecoverable_truncations: Cell::new(0),
+            truncations: Cell::new(0),
+            stash_write_events: RefCell::new(Vec::new()),
             stash_keys_created: RefCell::new(HashMap::new()),
         }
     }
@@ -180,6 +190,8 @@ impl ResponseCompressor {
         self.stash_writes.set(0);
         self.stash_errors.set(0);
         self.unrecoverable_truncations.set(0);
+        self.truncations.set(0);
+        self.stash_write_events.borrow_mut().clear();
         self.stash_keys_created.borrow_mut().clear();
         let original_text = serde_json::to_string(response).unwrap_or_default();
         let result = self.compress_value(response, 0);
@@ -216,6 +228,21 @@ impl ResponseCompressor {
         self.unrecoverable_truncations.get()
     }
 
+    /// Total truncation events (string, array, depth) during the last
+    /// `compress()` call, with or without an attached stash. Zero means the
+    /// call removed nothing beyond dropped fields, nulls, and empty values.
+    pub fn truncations(&self) -> usize {
+        self.truncations.get()
+    }
+
+    /// Takes every successful stash write of the last `compress()` call, in
+    /// order. Callers that hand rollback to the pipeline's ledger consume
+    /// these instead of calling [`Self::rollback_stash_writes`]; taking them
+    /// does not affect this compressor's own rollback bookkeeping.
+    pub fn take_stash_writes(&self) -> Vec<StashWrite> {
+        std::mem::take(&mut *self.stash_write_events.borrow_mut())
+    }
+
     /// Delete stash entries created during the last `compress()` call.
     ///
     /// Call this when the compressed output (and its embedded markers) will
@@ -247,6 +274,7 @@ impl ResponseCompressor {
     }
 
     fn record_stash_success(&self, write: &StashWrite) {
+        self.stash_write_events.borrow_mut().push(write.clone());
         let mut pending = self.stash_keys_created.borrow_mut();
         if write.created {
             self.stash_writes.set(self.stash_writes.get() + 1);
@@ -278,6 +306,7 @@ impl ResponseCompressor {
     fn compress_value(&self, value: &Value, depth: usize) -> Value {
         // Check depth limit
         if depth > self.max_depth {
+            self.truncations.set(self.truncations.get() + 1);
             let type_name = match value {
                 Value::Null => "null",
                 Value::Bool(_) => "bool",
@@ -335,6 +364,7 @@ impl ResponseCompressor {
         if char_count <= self.truncate_strings_at {
             return Value::String(s.to_string());
         }
+        self.truncations.set(self.truncations.get() + 1);
 
         const LOSSY_MARKER: &str = "… (truncated)";
         let lossy_marker_len = LOSSY_MARKER.chars().count();
@@ -406,6 +436,9 @@ impl ResponseCompressor {
         // every index derived below stays within `arr`.
         let head_tail_budget = head_limit.saturating_add(self.array_tail_preserve);
         let truncate = arr.len() > head_limit && arr.len() > head_tail_budget;
+        if truncate {
+            self.truncations.set(self.truncations.get() + 1);
+        }
         // Tail preserves items from the end: the configured count when
         // truncation drops middle items, or the overflow beyond head_limit
         // when head+tail covers the array (no items lost).
@@ -477,7 +510,14 @@ impl ResponseCompressor {
         if dropped.is_empty() {
             return None;
         }
-        let payload = serde_json::to_string(dropped).ok()?;
+        let Ok(payload) = serde_json::to_string(dropped) else {
+            // Nothing was stashed, so the truncation is lossy despite the
+            // attached store — count it like the depth path does.
+            if self.stash_store.is_some() {
+                self.mark_unrecoverable_truncation();
+            }
+            return None;
+        };
         if payload.is_empty() {
             return None;
         }

--- a/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
+++ b/src/tokenless/crates/tokenless-schema/src/tests/response_compressor_tests.rs
@@ -930,3 +930,43 @@ fn test_array_tail_preserve_budget_wrapping_by_one_keeps_all() {
     assert_eq!(r[0].as_str().unwrap(), "a");
     assert_eq!(r[4].as_str().unwrap(), "e");
 }
+
+#[test]
+fn truncations_count_events_with_or_without_a_store() {
+    let compressor = ResponseCompressor::new()
+        .with_truncate_strings_at(10)
+        .with_truncate_arrays_at(1)
+        .with_array_tail_preserve(0);
+    compressor.compress(&json!({ "text": "x".repeat(40) }));
+    assert_eq!(compressor.truncations(), 1);
+    compressor.compress(&json!({ "items": ["a", "b", "c"] }));
+    assert_eq!(compressor.truncations(), 1);
+    // Dropped fields, nulls, and empties are cleanup, not truncation; the
+    // counter resets per call.
+    compressor.compress(&json!({ "keep": 1, "drop": null, "debug": "x" }));
+    assert_eq!(compressor.truncations(), 0);
+
+    let depth_limited = ResponseCompressor::new().with_max_depth(0);
+    depth_limited.compress(&json!({ "deep": { "leaf": 1 } }));
+    assert_eq!(depth_limited.truncations(), 1);
+}
+
+#[test]
+fn take_stash_writes_exposes_the_raw_events_without_breaking_rollback() {
+    use tokenless_ccr::InMemoryStore;
+
+    let store = Arc::new(InMemoryStore::new());
+    let compressor = ResponseCompressor::new()
+        .with_truncate_strings_at(80)
+        .with_stash_store(store.clone());
+    compressor.compress(&json!({ "tail": "x".repeat(400) }));
+
+    let writes = compressor.take_stash_writes();
+    assert_eq!(writes.len(), 1);
+    assert!(writes[0].created);
+    // Taking drains the events but leaves this compressor's own rollback
+    // bookkeeping intact.
+    assert!(compressor.take_stash_writes().is_empty());
+    assert_eq!(compressor.rollback_stash_writes(), 1);
+    assert_eq!(store.len(), 0);
+}

--- a/src/tokenless/python/tokenless/src/lib.rs
+++ b/src/tokenless/python/tokenless/src/lib.rs
@@ -33,7 +33,7 @@ struct PyCompressionResult {
 
 impl From<CompressResult> for PyCompressionResult {
     fn from(result: CompressResult) -> Self {
-        let disposition = result.disposition.as_str().to_string();
+        let disposition = result.disposition.wire_str().to_string();
         let applied = result.applied();
         Self {
             output: result.output,

--- a/src/tokenless/python/tokenless/tests/test_runtime.py
+++ b/src/tokenless/python/tokenless/tests/test_runtime.py
@@ -201,7 +201,7 @@ class TokenlessRuntimeTests(unittest.TestCase):
             session_id="baseline-session",
             tool_use_id="tool-baseline",
         )
-        self.assertEqual(baseline_result.disposition, "dry-run")
+        self.assertEqual(baseline_result.disposition, "dry_run")
         del baseline
 
         active = TokenlessRuntime(data_dir, stats_enabled=True)
@@ -337,14 +337,14 @@ class TokenlessRuntimeTests(unittest.TestCase):
                 truncate_arrays_at=2,
                 agent_id="python-test",
             )
-            self.assertEqual(result.disposition, "reversibility-unavailable")
+            self.assertEqual(result.disposition, "reversibility_unavailable")
             self.assertEqual(result.output, original)
 
     def test_short_string_limit_is_reversible_fail_open(self) -> None:
-        original = json.dumps("x" * 400)
+        original = json.dumps({"tail": "x" * 400})
         result = self.runtime.compress_response(original, truncate_strings_at=10)
 
-        self.assertEqual(result.disposition, "reversibility-unavailable")
+        self.assertEqual(result.disposition, "reversibility_unavailable")
         self.assertEqual(result.output, original)
         self.assertEqual(result.stash_errors, 0)
         self.assertEqual(result.unrecoverable_truncations, 1)
@@ -357,9 +357,9 @@ class TokenlessRuntimeTests(unittest.TestCase):
             with sqlite3.connect(Path(directory, "stash.db")) as connection:
                 connection.execute("DROP TABLE stash")
 
-            original = json.dumps("x" * 400)
+            original = json.dumps({"tail": "x" * 400})
             result = runtime.compress_response(original, truncate_strings_at=80)
-            self.assertEqual(result.disposition, "reversibility-unavailable")
+            self.assertEqual(result.disposition, "reversibility_unavailable")
             self.assertEqual(result.output, original)
             self.assertEqual(result.stash_errors, 1)
             self.assertEqual(result.unrecoverable_truncations, 1)
@@ -374,7 +374,7 @@ class TokenlessRuntimeTests(unittest.TestCase):
 
             original = json.dumps({"nested": {"payload": "x" * 400}})
             result = runtime.compress_response(original, max_depth=0)
-            self.assertEqual(result.disposition, "reversibility-unavailable")
+            self.assertEqual(result.disposition, "reversibility_unavailable")
             self.assertEqual(result.output, original)
             self.assertEqual(result.stash_errors, 1)
             self.assertEqual(result.unrecoverable_truncations, 1)


### PR DESCRIPTION
## What

Registers the existing JSON response cleanup (`ResponseCompressor`) as the first production entry of the compressor registry, and routes `compress_response_with_store` — the shared path behind the CLI `compress-response` command, `TokenlessRuntime::compress_response`, and the Python binding — through `tokenless_pipeline::run`. The Runtime's hand-rolled arbitration (before/after comparison, disposition precedence, rejection rollback) is deleted: the pipeline engine is now the single arbitration point in the workspace.

## How

- **tokenless-pipeline**: `RESPONSE_CLEANUP` spec (content `json_records`, seam `post_tool`, stage retrievable-lossy, cost moderate) becomes `REGISTRY`'s first entry. Routing requires only `replace_output`: without a stash the cleanup degrades to an unrecoverable claim and *arbitration* enforces required reversibility, so a missing retrieve tool must not filter the candidate out.
- **tokenless-runtime**: new `ResponseCleanup` adapter implements the pipeline's `Compressor` trait over `ResponseCompressor`. It reports reversibility from what actually happened: no truncation → lossless (dropped `debug`/null/empty fields keep their pre-pipeline "cleanup, not content loss" status), all truncations stashed → retrievable, otherwise → unrecoverable. Stash rollback moves from `ResponseCompressor`'s internal bookkeeping to the pipeline's ownership-chain ledger.
- **tokenless-schema**: `ResponseCompressor` now exposes its raw `StashWrite` events (for the ledger) and a `truncations()` counter that works with or without a store; a truncation whose dropped payload cannot be serialized for stashing now counts as unrecoverable.
- **tokenless-protocol**: `Disposition::wire_str()` added. The Runtime's pre-protocol `CompressionDisposition` is retired — Runtime, CLI, and the Python binding now share the protocol enum, as the protocol docs anticipated.

## Behavior changes (all fail-open to the original content)

1. **Non-record JSON roots pass through.** A scalar root (`"…"`, `42`, `true`) is no longer truncated; detection routes only `{...}`/`[...]` to the JSON cleanup (§4.2 routing contract; §5.2 "route unknown or ambiguous content to passthrough"). Record-shaped responses — the actual tool-output shape — are unaffected.
2. **Pure-cleanup savings now apply under `require_reversible` without a stash.** Previously savings from dropped fields/nulls alone were rejected as reversibility-unavailable when no store was attached, while the same input *with* a store applied — inconsistent. Now the claim is computed from what was removed: no truncation → lossless → applies.
3. **Disposition vocabulary and precedence.** Binding-visible strings are now the snake_case wire values (`dry-run` → `dry_run`, `no-savings` → `no_savings`); new `passthrough` / `timeout` / `error` dispositions can appear. Required-reversibility rejection now outranks no-savings (protocol precedence); dry-run still wins over reversibility, as before.
4. **One timeout budget (10s)** now guards detection and all stages (§5.3). Far above any observed in-process time; on expiry the original is returned and stash writes are rolled back.
5. **Serialization failure is fail-open.** A candidate that cannot be re-serialized reports `error` with a bounded diagnostic instead of failing the request (practically unreachable for `serde_json::Value`).

`CompressResult.compressed_output` stays for now as the dry-run measurement channel (dry-run A/B stats record the predicted candidate text); it is scheduled for removal with the statistics migration (§5.5), which replaces the text channel with measured numbers.

## Out of scope

New compressors (§6 pack), the single external-hook entry point and adapter contract fixtures (§5.4, next PR — the default-off runtime toggle for new routing behavior lands there), stats attribution columns (§5.5), `SchemaCompressor` (schema seam, later).

## Validation

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (all suites green, including the 64 CLI integration tests exercising the binary end-to-end through the new path), `cargo doc --workspace --no-deps`.
