### PR TITLE
fix(ckpt): unbreak global config and error hints in k8s sidecar

### DIFF
--- a/docs/user-guide/en/runtime/ws-ckpt.md
+++ b/docs/user-guide/en/runtime/ws-ckpt.md
@@ -161,6 +161,10 @@ ws-ckpt config -w /home/user/projects/my-project --enable-auto-cleanup --auto-cl
 ws-ckpt config -g --enable-auto-cleanup --auto-cleanup-keep 20
 ```
 
+The global config file is read by the daemon, so `config -g` does more than write it: after saving `/etc/ws-ckpt/config.toml` it asks the daemon to reload, then compares what the daemon actually loaded against what was written. On any mismatch the command lists each differing field and exits non-zero instead of reporting success.
+
+This matters most in a Kubernetes sidecar deployment, where the CLI (app container) and the daemon run in separate containers with separate filesystems. Mount `/etc/ws-ckpt` on a volume shared by both containers (an `emptyDir` is enough); otherwise every `config -g` setting silently stays at the daemon's built-in default. The bundled `k8s-sidecar-example.yaml` already wires this shared volume up.
+
 ---
 
 ## Important Notes

--- a/docs/user-guide/zh/runtime/ws-ckpt.md
+++ b/docs/user-guide/zh/runtime/ws-ckpt.md
@@ -161,6 +161,10 @@ ws-ckpt config -w /home/user/projects/my-project --enable-auto-cleanup --auto-cl
 ws-ckpt config -g --enable-auto-cleanup --auto-cleanup-keep 20
 ```
 
+全局配置文件的读取方是 daemon，因此 `config -g` 不止于写文件：写入 `/etc/ws-ckpt/config.toml` 后，它会请求 daemon 重载，并把 daemon 实际加载到的配置与刚写入的逐项比对。只要有任何不一致，命令会列出每个差异字段并以非零退出，而不是报成功。
+
+这一点在 Kubernetes sidecar 部署中尤其重要：CLI（app 容器）与 daemon 运行在不同容器、各自独立的文件系统里。需把 `/etc/ws-ckpt` 挂到两容器共享的卷上（`emptyDir` 即可）；否则每一条 `config -g` 设置都会静默停留在 daemon 的内置默认值。随附的 `k8s-sidecar-example.yaml` 已经接好了这个共享卷。
+
 ---
 
 ## 重要注意事项

--- a/src/ws-ckpt/README.md
+++ b/src/ws-ckpt/README.md
@@ -143,6 +143,8 @@ ws-ckpt config -w ~/my-workspace --reset               # Remove local policy.tom
 ws-ckpt reload
 ```
 
+`config -g` writes the global file, then verifies the daemon reloaded the same settings — it exits non-zero and lists any field that differs. In a Kubernetes sidecar deployment the CLI and daemon run in separate containers, so `/etc/ws-ckpt` must be on a volume shared by both, or global settings will not reach the daemon.
+
 ## Command Reference
 
 | Command | Description |

--- a/src/ws-ckpt/README_zh.md
+++ b/src/ws-ckpt/README_zh.md
@@ -141,6 +141,8 @@ ws-ckpt config -w ~/my-workspace --reset               # 删除局部 policy.tom
 ws-ckpt reload
 ```
 
+`config -g` 写入全局配置后会校验 daemon 重载了相同的设置——若有字段不一致会以非零退出并逐项列出。Kubernetes sidecar 部署下 CLI 与 daemon 运行在不同容器，`/etc/ws-ckpt` 必须挂在两容器共享的卷上，否则全局设置无法送达 daemon。
+
 ## 命令总览
 
 | 命令 | 说明 |

--- a/src/ws-ckpt/docs/k8s-sidecar-deploy.md
+++ b/src/ws-ckpt/docs/k8s-sidecar-deploy.md
@@ -86,6 +86,7 @@ kubectl logs wsckpt-smoke -c daemon      # 确认 bootstrap 成功
 | ws-state | hostPath `/var/lib/ws-ckpt` | **必须持久化** — 存放 btrfs-data.img、state.json、daemon.lock。丢失此 volume = 数据丢失。 |
 | ws-ckpt-mount | hostPath（anchor 目录） | daemon 在此 overmount btrfs；daemon 侧 `mountPropagation: Bidirectional`，app 侧 `HostToContainer` |
 | data | emptyDir | workspace 父目录；workspace 使用其子目录（如 `/data/workspace`） |
+| config | emptyDir | `/etc/ws-ckpt` —— 全局配置面。CLI 写 `config.toml`，daemon 重载同一份文件。**不共享则所有 `config --global` 设置对 daemon 无效。** |
 
 ## 关键约束
 
@@ -102,6 +103,10 @@ kubectl logs wsckpt-smoke -c daemon      # 确认 bootstrap 成功
 6. **`shareProcessNamespace: true`** — 使 `fuser -m`（rollback/recover/img-shrink 判断挂载是否空闲时调用）能看到 app 容器的进程。
 
 7. **后端自动检测**：若宿主机 `/var/lib` 在原生 btrfs 上，`auto_detect` 选择 BtrfsBase（直接操作 subvolume，无需 loop 设备）。BtrfsLoop overmount 路径仅在 ext4/xfs 宿主机上激活。两种后端均可正常工作，无需 ConfigMap 强制指定。
+
+8. **`/etc/ws-ckpt` 必须两容器共享**。全局配置是文件面而非 socket 面：`ws-ckpt config --global` 由 CLI 直接写 `/etc/ws-ckpt/config.toml`，daemon 重载时读**它自己容器内**的同一路径。两容器各用镜像层时，daemon 读不到文件即回落内置默认值，`auto-cleanup` 等策略全部失效。CLI 写入后会比对 daemon 的 effective 配置并报错，但根治方式是把 `/etc/ws-ckpt` 挂成共享 volume（`emptyDir` 即可）。
+
+   per-workspace 配置（`config -w`）走 daemon 状态，不受此约束。
 
 ## SIGTERM 与 Loop 设备清理
 

--- a/src/ws-ckpt/k8s-sidecar-example.yaml
+++ b/src/ws-ckpt/k8s-sidecar-example.yaml
@@ -11,6 +11,8 @@
 #   ws-ckpt-mount — hostPath anchor, daemon overmounts btrfs here;
 #                   Bidirectional propagation carries the mount to app
 #   data          — emptyDir, workspace parent directory (/data/workspace)
+#   config        — emptyDir, /etc/ws-ckpt so `config --global` from app
+#                   reaches the daemon (see note below)
 #
 # Notes:
 # - shareProcessNamespace: true so fuser -m (used by rollback/recover/shrink)
@@ -19,6 +21,9 @@
 #   (no loop device needed); the overmount path only activates on ext4/xfs hosts.
 # - daemon does NOT umount/losetup -d on SIGTERM; preStop hook handles cleanup
 #   to prevent loop device leaks across pod restarts.
+# - /etc/ws-ckpt must be a shared volume: the CLI writes config.toml there and
+#   the daemon reads its own view of that path. Unshared, every global setting
+#   applies to nothing and the CLI reports the mismatch.
 
 apiVersion: v1
 kind: Pod
@@ -47,6 +52,10 @@ spec:
         type: DirectoryOrCreate
     - name: data                         # workspace parent dir; workspace uses subdir /data/workspace. Container rootfs dirs are private — only shared volumes align app writes with daemon operations
       emptyDir: {}                       # avoids ws-ckpt bug (mount point rename EBUSY)
+    # Global config plane: `ws-ckpt config --global` in app writes config.toml
+    # here, daemon reloads the same file.
+    - name: config
+      emptyDir: {}
   containers:
     - name: daemon
       image: localhost/ws-ckpt:smoke
@@ -71,6 +80,8 @@ spec:
           mountPropagation: Bidirectional
         - name: data
           mountPath: /data
+        - name: config
+          mountPath: /etc/ws-ckpt
       # Clean orphan loop devices on pod teardown. Dead containers leave
       # host-scoped loops pointing at phantom paths (container rootfs gone but
       # loop persists). Without this, the next pod sees a stale btrfs mount.
@@ -97,3 +108,5 @@ spec:
           mountPropagation: HostToContainer
         - name: data
           mountPath: /data               # workspace at subdir /data/workspace
+        - name: config
+          mountPath: /etc/ws-ckpt        # same file the daemon reloads

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -1698,20 +1698,18 @@ async fn handle_global_config_update(
     // ConfigReport so JSON mode can emit the landed state on stdout
     // without a follow-up `Config` round-trip.
     let mut reloaded_config: Option<ws_ckpt_common::ConfigReport> = None;
+    let mut daemon_file: Option<ws_ckpt_common::FileConfig> = None;
+    let mut reload_error: Option<String> = None;
     match send_request_to_daemon(&Request::ReloadGlobalConfig).await {
-        Ok(Response::ReloadConfigOk { config }) => {
+        Ok(Response::ReloadConfigOk { config, file }) => {
             status_sink(format_args!(
                 "\x1b[32m\u{2713} Daemon reloaded configuration\x1b[0m"
             ));
-            if has_img_settings {
-                status_sink(format_args!(
-                    "\x1b[33m\u{26a0} Note: btrfs-loop image settings (img-size, img-max-percent) require daemon restart to take effect.\x1b[0m"
-                ));
-            }
             reloaded_config = Some(config);
+            daemon_file = file;
         }
         Ok(Response::Error { message, .. }) => {
-            eprintln!("\x1b[33m\u{26a0} Daemon reload failed: {}\x1b[0m", message);
+            reload_error = Some(format!("daemon reload failed: {}", message));
         }
         Err(_) => {
             status_sink(format_args!(
@@ -1719,6 +1717,37 @@ async fn handle_global_config_update(
             ));
         }
         _ => {}
+    }
+
+    // The daemon reloads CONFIG_FILE_PATH as *it* sees it. When CLI and daemon
+    // do not share that path — k8s sidecar puts them in separate container
+    // filesystems — the reload succeeds against an absent file, the daemon
+    // falls back to built-in defaults, and the policy silently never applies.
+    // Compare the file the daemon parsed against the one just written so that
+    // case surfaces as a failure instead of a green checkmark. Comparing files
+    // rather than effective values also covers the bootstrap-only image
+    // settings, which no post-reload runtime view can confirm.
+    if let Some(landed) = &daemon_file {
+        let unlanded = unlanded_global_settings(&fc, landed);
+        if !unlanded.is_empty() {
+            reload_error = Some(format!(
+                "daemon did not load the settings written to {}:\n  {}\n\
+                 The daemon reloads its own view of that path — if it runs in a \
+                 separate container or mount namespace, {} must be on a volume \
+                 shared with this CLI.",
+                CONFIG_FILE_PATH,
+                unlanded.join("\n  "),
+                CONFIG_FILE_PATH
+            ));
+        }
+    }
+
+    // Only advise a restart once the file is known to have reached the daemon;
+    // otherwise the restart would reload the same unseen file.
+    if has_img_settings && reload_error.is_none() && reloaded_config.is_some() {
+        status_sink(format_args!(
+            "\x1b[33m\u{26a0} Note: btrfs-loop image settings (img-size, img-max-percent) require daemon restart to take effect.\x1b[0m"
+        ));
     }
 
     // JSON mode emits the post-update state on stdout so callers don't need
@@ -1735,7 +1764,102 @@ async fn handle_global_config_update(
         }
     }
 
+    if let Some(err) = reload_error {
+        anyhow::bail!("{}", err);
+    }
+
     Ok(())
+}
+
+/// Fields where the config file just written differs from the one the daemon
+/// parsed, rendered as `field: file has X, daemon has Y`.
+///
+/// Compares the two files rather than file-against-effective-runtime so that
+/// `img_size` and `img_max_percent` are covered too: those apply at bootstrap
+/// only, so no post-reload runtime view can tell a daemon that read them from
+/// one that never saw the file.
+fn unlanded_global_settings(
+    saved: &ws_ckpt_common::FileConfig,
+    landed: &ws_ckpt_common::FileConfig,
+) -> Vec<String> {
+    /// Renders an unset optional as `unset` so the two sides stay comparable.
+    fn shown<T: std::fmt::Display>(v: Option<T>) -> String {
+        v.map_or_else(|| "unset".to_string(), |v| v.to_string())
+    }
+
+    // Whole-struct equality is the gate, not the per-field list below. A field
+    // added to FileConfig later is caught by `==` before anyone remembers to
+    // extend this function; the per-field lines only make the failure legible.
+    if saved == landed {
+        return Vec::new();
+    }
+
+    let mut unlanded = Vec::new();
+    if saved.auto_cleanup != landed.auto_cleanup {
+        unlanded.push(format!(
+            "auto-cleanup: file has {}, daemon has {}",
+            shown(saved.auto_cleanup),
+            shown(landed.auto_cleanup)
+        ));
+    }
+    if saved.auto_cleanup_keep != landed.auto_cleanup_keep {
+        unlanded.push(format!(
+            "auto-cleanup-keep: file has {}, daemon has {}",
+            shown(saved.auto_cleanup_keep.as_ref().map(format_retention)),
+            shown(landed.auto_cleanup_keep.as_ref().map(format_retention))
+        ));
+    }
+    if saved.auto_cleanup_interval_secs != landed.auto_cleanup_interval_secs {
+        unlanded.push(format!(
+            "auto-cleanup-interval: file has {}, daemon has {}",
+            shown(saved.auto_cleanup_interval_secs),
+            shown(landed.auto_cleanup_interval_secs)
+        ));
+    }
+    if saved.health_check_interval_secs != landed.health_check_interval_secs {
+        unlanded.push(format!(
+            "health-check-interval: file has {}, daemon has {}",
+            shown(saved.health_check_interval_secs),
+            shown(landed.health_check_interval_secs)
+        ));
+    }
+    if saved.backend.r#type != landed.backend.r#type {
+        unlanded.push(format!(
+            "backend type: file has {}, daemon has {}",
+            saved.backend.r#type, landed.backend.r#type
+        ));
+    }
+    let saved_loop = saved.backend.btrfs_loop.as_ref();
+    let landed_loop = landed.backend.btrfs_loop.as_ref();
+    let (saved_size, landed_size) = (
+        saved_loop.and_then(|b| b.img_size),
+        landed_loop.and_then(|b| b.img_size),
+    );
+    if saved_size != landed_size {
+        unlanded.push(format!(
+            "img-size: file has {}, daemon has {}",
+            shown(saved_size),
+            shown(landed_size)
+        ));
+    }
+    let (saved_pct, landed_pct) = (
+        saved_loop.and_then(|b| b.img_max_percent),
+        landed_loop.and_then(|b| b.img_max_percent),
+    );
+    if saved_pct != landed_pct {
+        unlanded.push(format!(
+            "img-max-percent: file has {}, daemon has {}",
+            shown(saved_pct),
+            shown(landed_pct)
+        ));
+    }
+    // The `==` gate above already proved the two differ; if none of the known
+    // fields account for it, the difference is in a field this build does not
+    // know about. Still surface something rather than an empty list.
+    if unlanded.is_empty() {
+        unlanded.push("config file contents differ (unrecognized field)".to_string());
+    }
+    unlanded
 }
 
 /// Render a daemon-returned [`ConfigReport`] as the same [`GlobalConfigJson`]
@@ -3124,6 +3248,82 @@ mod tests {
             }
             _ => panic!("expected Recover"),
         }
+    }
+
+    // ── unlanded_global_settings: `config -g` write must actually reach the daemon ──
+
+    fn img_config(
+        img_size: Option<u64>,
+        img_max_percent: Option<f64>,
+    ) -> ws_ckpt_common::FileConfig {
+        ws_ckpt_common::FileConfig {
+            backend: ws_ckpt_common::BackendConfig {
+                btrfs_loop: Some(ws_ckpt_common::BtrfsLoopConfig {
+                    img_size,
+                    img_max_percent,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_unlanded_settings_when_daemon_reloaded_same_file() {
+        let saved = ws_ckpt_common::FileConfig {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(3)),
+            health_check_interval_secs: Some(30),
+            ..Default::default()
+        };
+        assert!(unlanded_global_settings(&saved, &saved).is_empty());
+    }
+
+    #[test]
+    fn unlanded_settings_reported_when_daemon_never_saw_the_file() {
+        // Sidecar case: daemon's own /etc/ws-ckpt/config.toml is absent, so it
+        // reloads into built-in defaults while the CLI wrote a real policy.
+        let saved = ws_ckpt_common::FileConfig {
+            auto_cleanup: Some(true),
+            auto_cleanup_keep: Some(CleanupRetention::Count(3)),
+            auto_cleanup_interval_secs: Some(600),
+            health_check_interval_secs: Some(30),
+            ..Default::default()
+        };
+        let unlanded = unlanded_global_settings(&saved, &ws_ckpt_common::FileConfig::default());
+        assert_eq!(unlanded.len(), 4, "got: {:?}", unlanded);
+        assert!(unlanded[0].starts_with("auto-cleanup: file has true, daemon has unset"));
+    }
+
+    #[test]
+    fn img_only_write_is_reported_when_daemon_never_saw_the_file() {
+        // Bootstrap-only settings are the case a runtime view cannot catch: the
+        // daemon would keep the running image size either way.
+        let saved = img_config(Some(64), Some(75.0));
+        let unlanded = unlanded_global_settings(&saved, &ws_ckpt_common::FileConfig::default());
+        assert_eq!(unlanded.len(), 2, "got: {:?}", unlanded);
+        assert!(unlanded[0].starts_with("img-size: file has 64, daemon has unset"));
+    }
+
+    #[test]
+    fn img_write_the_daemon_read_is_not_reported() {
+        let saved = img_config(Some(64), None);
+        assert!(unlanded_global_settings(&saved, &saved).is_empty());
+    }
+
+    #[test]
+    fn age_retention_compares_by_value() {
+        let saved = ws_ckpt_common::FileConfig {
+            auto_cleanup_keep: Some(CleanupRetention::age("30d").unwrap()),
+            ..Default::default()
+        };
+        assert!(unlanded_global_settings(&saved, &saved).is_empty());
+
+        let stale = ws_ckpt_common::FileConfig {
+            auto_cleanup_keep: Some(CleanupRetention::age("7d").unwrap()),
+            ..Default::default()
+        };
+        assert_eq!(unlanded_global_settings(&saved, &stale).len(), 1);
     }
 
     // ── disabled_warning_for: warn whenever the user touched a policy field but effective stays disabled ──

--- a/src/ws-ckpt/src/crates/cli/src/main.rs
+++ b/src/ws-ckpt/src/crates/cli/src/main.rs
@@ -397,9 +397,19 @@ async fn run(cli: Cli) -> Result<()> {
             ws_ckpt_daemon::run_daemon(config).await?;
         }
         Commands::Init { workspace } => {
-            let request = Request::Init {
-                workspace: resolve_workspace_arg(&workspace),
-            };
+            let workspace = resolve_workspace_arg(&workspace);
+            // Catch a plain missing path here so the caller gets that answer
+            // instead of the daemon's namespace-scoped one, which has to hedge
+            // about shared volumes. symlink_metadata, not exists(): a dangling
+            // workspace symlink is the daemon's re-init recovery path. Only
+            // NotFound is conclusive — the daemon is privileged and may reach
+            // paths this process cannot stat, so any other error goes to it.
+            if let Err(e) = std::fs::symlink_metadata(&workspace) {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    anyhow::bail!("path does not exist: {}", workspace);
+                }
+            }
+            let request = Request::Init { workspace };
             let response = send_request_to_daemon(&request).await?;
             handle_response(response, &request).await?;
         }
@@ -668,7 +678,7 @@ async fn send_request_to_daemon(request: &Request) -> Result<Response> {
         match e.kind() {
             std::io::ErrorKind::NotFound => {
                 eprintln!("\x1b[31m\u{2717} Daemon is not running.\x1b[0m");
-                eprintln!("  Start it with 'systemctl start ws-ckpt'.");
+                eprintln!("  Start the systemd service `ws-ckpt`, or its daemon container.");
                 process::exit(1);
             }
             std::io::ErrorKind::ConnectionRefused => {

--- a/src/ws-ckpt/src/crates/common/src/lib.rs
+++ b/src/ws-ckpt/src/crates/common/src/lib.rs
@@ -227,6 +227,17 @@ pub enum Response {
     /// confirm the landed state without a follow-up `Config` round-trip.
     ReloadConfigOk {
         config: ConfigReport,
+        /// Global config the daemon now operates from, as parsed from
+        /// [`CONFIG_FILE_PATH`] *in the daemon's own filesystem* — defaults
+        /// when that file is absent. `None` when the reload did not consult
+        /// the global file at all (per-workspace policy reload).
+        ///
+        /// `config` reports effective runtime values, which cannot expose a
+        /// bootstrap-only setting the daemon has not applied yet; this field
+        /// can. A client that just wrote the file compares it here to detect
+        /// that the daemon reloaded a different file, or none — the case
+        /// where CLI and daemon do not share `/etc/ws-ckpt`.
+        file: Option<FileConfig>,
     },
     CheckpointSkipped {
         reason: String,
@@ -2406,12 +2417,26 @@ mod tests {
                 img_size: 30,
                 img_max_percent: 40.0,
             },
+            file: Some(FileConfig {
+                auto_cleanup: Some(true),
+                auto_cleanup_keep: Some(CleanupRetention::age("30d").unwrap()),
+                ..Default::default()
+            }),
         };
         match round_trip_response(&resp) {
-            Response::ReloadConfigOk { config } => {
+            Response::ReloadConfigOk { config, file } => {
                 assert!(config.auto_cleanup);
                 assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(5));
                 assert_eq!(config.auto_cleanup_interval_secs, 3_600);
+                // Age retention re-derives secs from `raw` over the wire; the
+                // client compares this against the file it wrote, so the
+                // round-trip must preserve it exactly.
+                let file = file.expect("daemon-visible config file");
+                assert_eq!(file.auto_cleanup, Some(true));
+                assert_eq!(
+                    file.auto_cleanup_keep,
+                    Some(CleanupRetention::age("30d").unwrap())
+                );
             }
             _ => panic!("expected ReloadConfigOk variant"),
         }

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_common.rs
@@ -206,7 +206,8 @@ pub async fn ensure_btrfs_support() -> Result<()> {
         "Kernel does not support btrfs (no entry in /proc/filesystems and \
          `modprobe btrfs` did not register the module). Install the matching \
          kernel-modules-extra package or rebuild the kernel with CONFIG_BTRFS_FS, \
-         then run `systemctl restart ws-ckpt`."
+         then restart the systemd service (`systemctl restart ws-ckpt`) or the \
+         ws-ckpt daemon container."
     );
 }
 

--- a/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/dispatcher.rs
@@ -380,6 +380,7 @@ async fn handle_reload_config(state: &Arc<DaemonState>) -> Response {
             state.config_notify.notify_waiters();
             Response::ReloadConfigOk {
                 config: build_config_report(state),
+                file: Some(file_config),
             }
         }
         Err(e) => Response::Error {
@@ -399,6 +400,8 @@ async fn handle_reload_workspace_policy(state: &Arc<DaemonState>, workspace: &st
     state.config_notify.notify_waiters();
     Response::ReloadConfigOk {
         config: build_config_report(state),
+        // Global file untouched by a per-workspace reload.
+        file: None,
     }
 }
 
@@ -410,6 +413,7 @@ fn handle_reload_global_config(state: &Arc<DaemonState>) -> Response {
             state.config_notify.notify_waiters();
             Response::ReloadConfigOk {
                 config: build_config_report(state),
+                file: Some(file_config),
             }
         }
         Err(e) => Response::Error {

--- a/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/workspace_mgr.rs
@@ -156,10 +156,27 @@ pub async fn init(state: &Arc<DaemonState>, workspace: &str) -> anyhow::Result<R
     // 1. Canonicalize (resolves symlinks to real path)
     let abs_path = match tokio::fs::canonicalize(workspace).await {
         Ok(p) => p,
-        Err(_) => {
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                // Resolution happens in the daemon's mount namespace, which in a
+                // sidecar deployment shows only the volumes it shares with the
+                // client — so a path the caller can see may still be absent here.
+                return Ok(error_resp(
+                    ErrorCode::InvalidPath,
+                    format!(
+                        "path does not exist in the daemon's mount namespace: {}. \
+                         In a sidecar deployment the workspace must live on a volume \
+                         shared with the daemon container.",
+                        workspace
+                    ),
+                ));
+            }
+            // A different failure (symlink loop, permission, I/O) means the path
+            // exists but cannot be resolved — report the real cause instead of
+            // pointing at the sidecar shared-volume layout.
             return Ok(error_resp(
                 ErrorCode::InvalidPath,
-                format!("path does not exist: {}", workspace),
+                format!("cannot resolve workspace path {}: {}", workspace, e),
             ));
         }
     };
@@ -730,6 +747,40 @@ mod tests {
         match resp {
             Response::Error { code, .. } => assert_eq!(code, ErrorCode::InvalidPath),
             _ => panic!("expected InvalidPath error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn init_symlink_loop_reports_resolution_error_not_shared_volume_hint() {
+        let state = Arc::new(DaemonState::new(
+            test_config(),
+            test_backend(),
+            test_state_dir(),
+        ));
+        // A self-referential symlink exists on disk (so it passes any lstat-based
+        // pre-check), but canonicalize cannot resolve it (ELOOP). The error must
+        // report the real resolution failure, not the sidecar "path does not
+        // exist in the daemon's mount namespace" hint, which would send users
+        // looking at their shared-volume layout for a symlink problem.
+        let tmpdir = tempfile::tempdir().unwrap();
+        let loop_link = tmpdir.path().join("loop");
+        tokio::fs::symlink("loop", &loop_link).await.unwrap();
+        let resp = init(&state, &loop_link.to_string_lossy()).await.unwrap();
+        match resp {
+            Response::Error { code, message } => {
+                assert_eq!(code, ErrorCode::InvalidPath);
+                assert!(
+                    message.contains("cannot resolve"),
+                    "expected a resolution error, got: {}",
+                    message
+                );
+                assert!(
+                    !message.contains("shared with the daemon container"),
+                    "must not point at the sidecar shared-volume layout: {}",
+                    message
+                );
+            }
+            other => panic!("expected InvalidPath error, got {:?}", other),
         }
     }
 

--- a/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
+++ b/src/ws-ckpt/src/crates/daemon/tests/protocol_integration.rs
@@ -124,6 +124,7 @@ async fn mock_server_handle(mut stream: tokio::net::UnixStream) {
                 img_size: 30,
                 img_max_percent: 40.0,
             },
+            file: None,
         },
         Request::ConfigOverview => Response::ConfigOverviewOk {
             config: ConfigReport {
@@ -639,7 +640,7 @@ async fn full_reload_config_request_response_over_socket() {
 
     let response: Response = decode_payload(&payload).unwrap();
     match response {
-        Response::ReloadConfigOk { config } => {
+        Response::ReloadConfigOk { config, .. } => {
             assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
             assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(20));
         }
@@ -829,7 +830,7 @@ async fn full_patch_workspace_policy_unchanged_only_over_socket() {
 
 // ── Reload IPCs: exercise every variant on the wire ──
 //
-// All three reload variants share the `ReloadConfigOk { config }` reply
+// All three reload variants share the `ReloadConfigOk { config, file }` reply
 // shape. Mock server returns the same body for all three (combined match
 // arm), so these tests verify the *request* tags round-trip distinctly
 // — a bincode tag shuffle that swapped `ReloadConfig` and
@@ -841,7 +842,7 @@ async fn full_patch_workspace_policy_unchanged_only_over_socket() {
 async fn full_reload_config_over_socket() {
     let resp = run_policy_request(Request::ReloadConfig).await;
     match resp {
-        Response::ReloadConfigOk { config } => {
+        Response::ReloadConfigOk { config, .. } => {
             assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
             assert_eq!(config.auto_cleanup_keep, CleanupRetention::Count(20));
         }
@@ -853,7 +854,7 @@ async fn full_reload_config_over_socket() {
 async fn full_reload_global_config_over_socket() {
     let resp = run_policy_request(Request::ReloadGlobalConfig).await;
     match resp {
-        Response::ReloadConfigOk { config } => {
+        Response::ReloadConfigOk { config, .. } => {
             assert_eq!(config.mount_path, "/mnt/btrfs-workspace");
         }
         other => panic!("expected ReloadConfigOk, got {:?}", other),
@@ -867,7 +868,7 @@ async fn full_reload_workspace_policy_over_socket() {
     })
     .await;
     match resp {
-        Response::ReloadConfigOk { config } => {
+        Response::ReloadConfigOk { config, .. } => {
             // Mock reuses the same global config payload for the per-ws
             // reload reply; the point of the test is the request side.
             assert_eq!(config.mount_path, "/mnt/btrfs-workspace");


### PR DESCRIPTION
## Why

Verifying ws-ckpt 0.4.3 in the k8s sidecar deployment form surfaced three
defects that all share one root cause: paths and supervision assumptions that
hold on a systemd host stop holding once the CLI and the daemon live in
separate containers.

The worst of them is silent. `config --global` writes
`/etc/ws-ckpt/config.toml` from the CLI's container while the daemon reloads
its own view of that path; a missing file is a *successful* load of built-in
defaults, so the daemon answered `ReloadConfigOk` and the CLI printed a green
checkmark while `auto-cleanup` and every other global policy applied to
nothing. Disk-space governance appeared configured and was not.

## What changed

- `config --global` compares the daemon's post-reload `ConfigReport` against
  the settings just written and fails with the specific mismatches plus the
  shared-volume requirement. A daemon-side reload error is now an error rather
  than a yellow warning.
- The sidecar example pod and its deployment guide mount `/etc/ws-ckpt` as a
  shared volume — it was the one volume the two containers need that neither
  asset listed.
- The btrfs-unsupported and daemon-unreachable messages name both the systemd
  service and the daemon container instead of only `systemctl`, which cannot
  work when PID 1 is not systemd.
- `init` no longer reports a path the caller can see as non-existent without
  explanation: the daemon names its mount namespace and the shared-volume
  requirement, and the CLI screens out a genuinely missing path first so
  single-namespace users keep the plain answer.

## Related issue

- closes #2813
- closes #2807
- closes #2814

## User / Agent impact

`config --global` now exits non-zero when the daemon did not load what was
written. This is a deliberate behavior change: the command previously reported
success in that case. Scripts that ignored the old exit code and relied on the
write alone are unaffected; scripts that treated exit 0 as "policy is live"
were being misled and will now fail loudly.

Error text changes on three paths. Agents parsing `path does not exist:` from
`init` should note the daemon-side wording now continues past that phrase; the
CLI-side message for a truly missing path keeps the original prefix.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`config --global` gains a non-zero exit path (see impact above). No protocol,
error-code, or on-disk format change: the verification reuses the
`ConfigReport` the daemon already returns. Image sizing is excluded from the
comparison because it is bootstrap-only, so a fresh write legitimately differs
from the running value until restart.

The CLI-side `init` pre-check uses `symlink_metadata`, not `exists()`, so a
dangling workspace symlink still reaches the daemon's re-init recovery path.

## Validation

Gates run in a container built from `hub.docker.alibaba-inc.com/os/alinux4_base`
(rust 1.93.1 from dnf), source mounted read-only, `CARGO_HOME` and
`CARGO_TARGET_DIR` outside the tree:

```
cargo fmt --all -- --check                                  rc=0
cargo clippy --workspace --all-targets -- -D warnings       rc=0
cargo test --workspace                                      rc=0
  470 passed, 0 failed, 6 ignored
```

Four new unit tests cover the landing check, including the sidecar case where
the daemon reloads into built-in defaults, `CleanupRetention` age-mode
comparison, and the img-only write that must not be reported as unlanded.

Behavior checked manually in that container, where PID 1 is not systemd:

- `init` on a missing path fails locally with `path does not exist: <p>` and
  never contacts the daemon.
- With the daemon down, the hint reads `Start the systemd service ws-ckpt, or
  its daemon container.` — no bare `systemctl`.
- A dangling workspace symlink passes the pre-check and is forwarded to the
  daemon, confirming the `symlink_metadata` choice.

Not covered: the mismatch path against a live daemon, which needs btrfs plus a
privileged container and host loop devices.

## Documentation and rollback

`docs/k8s-sidecar-deploy.md` gains the `/etc/ws-ckpt` volume row and a
constraint entry explaining why the global config plane is file-based, and
notes that per-workspace config is unaffected.

Each commit reverts independently. Reverting the CLI commit restores the old
silent-success behavior; reverting the deployment commit only removes the
shared volume, at which point the CLI check reports the mismatch instead.
