### PR TITLE
ci(ci): build tokenless prebuilt packages

### DIFF
--- a/.github/actions/build-cosh-ng-prebuilt/test.sh
+++ b/.github/actions/build-cosh-ng-prebuilt/test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
 REPO_ROOT="$(git -C "$ACTION_DIR" rev-parse --show-toplevel)"
 COMPONENT_ROOT="$REPO_ROOT/src/cosh-ng"
 TEMPORARY="$(mktemp -d)"
@@ -37,7 +38,7 @@ EMPTY_CARGO_HOME="$TEMPORARY/empty-cargo-home"
 DELEGATED_MARKER="$TEMPORARY/delegated-command"
 install -d -m 0755 "$EMPTY_CARGO_HOME"
 CARGO_HOME="$EMPTY_CARGO_HOME" \
-    python3 "$ACTION_DIR/reproducible-build.py" \
+    python3 "$COMMON_DIR/reproducible-build.py" \
         --source-root "$COMPONENT_ROOT" \
         --source-date-epoch 0 \
         -- sh -c "test \"\$SOURCE_DATE_EPOCH\" = 0; touch \"\$1\"" \
@@ -97,16 +98,18 @@ for platform in linux macos; do
     )
 done
 
-python3 "$ACTION_DIR/generate-sbom.py" \
+python3 "$COMMON_DIR/generate-sbom.py" \
     --artifact "$TEMPORARY/linux.tar.gz" \
+    --component cosh-ng \
     --version "$VERSION" \
     --os linux \
     --arch x86_64 \
     --target x86_64-unknown-linux-gnu \
     --project-dir "$COMPONENT_ROOT" \
     --source-date-epoch 0 >/dev/null
-python3 "$ACTION_DIR/generate-sbom.py" \
+python3 "$COMMON_DIR/generate-sbom.py" \
     --artifact "$TEMPORARY/macos.tar.gz" \
+    --component cosh-ng \
     --version "$VERSION" \
     --os macos \
     --arch aarch64 \

--- a/.github/actions/build-tokenless-prebuilt/action.yaml
+++ b/.github/actions/build-tokenless-prebuilt/action.yaml
@@ -1,0 +1,59 @@
+name: Build Tokenless prebuilt package
+description: Build and package one Tokenless release target on the release Cross runner.
+
+inputs:
+  version:
+    description: Component version without the v prefix.
+    required: true
+  target-os:
+    description: Package target operating system.
+    required: true
+  target-arch:
+    description: Package target architecture.
+    required: true
+  profile:
+    description: Prepared Cross release profile.
+    required: true
+  tag:
+    description: Release tag to bind to the checked-out commit. Empty for previews.
+    required: false
+    default: ''
+
+outputs:
+  artifact-directory:
+    description: Directory containing the tar, checksums, and CycloneDX SBOM.
+    value: ${{ steps.build.outputs.artifact-directory }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Select Node.js 22
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.23.2'
+
+    - name: Build precompiled package
+      id: build
+      shell: bash
+      env:
+        TOKENLESS_OUTPUT_DIR: ${{ runner.temp }}/tokenless-prebuilt-${{ inputs.target-os }}-${{ inputs.target-arch }}
+        TOKENLESS_VERSION: ${{ inputs.version }}
+        TOKENLESS_TARGET_OS: ${{ inputs.target-os }}
+        TOKENLESS_TARGET_ARCH: ${{ inputs.target-arch }}
+        TOKENLESS_PROFILE: ${{ inputs.profile }}
+        TOKENLESS_TAG: ${{ inputs.tag }}
+      run: |
+        "$GITHUB_ACTION_PATH/build.sh" \
+          --source-repo "$GITHUB_WORKSPACE" \
+          --output-dir "$TOKENLESS_OUTPUT_DIR" \
+          --version "$TOKENLESS_VERSION" \
+          --target-os "$TOKENLESS_TARGET_OS" \
+          --target-arch "$TOKENLESS_TARGET_ARCH" \
+          --profile "$TOKENLESS_PROFILE" \
+          --tag "$TOKENLESS_TAG"
+        echo "artifact-directory=$TOKENLESS_OUTPUT_DIR" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-tokenless-prebuilt/build.sh
+++ b/.github/actions/build-tokenless-prebuilt/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Build and package one reproducible cosh-ng precompiled release target.
+# Build and package one reproducible Tokenless precompiled release target.
 set -euo pipefail
 
 ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
-FIXED_WORKTREE="${COSH_NG_SOURCE_WORKTREE:-/tmp/anolisa-raw-release-source-worktrees/cosh-ng}"
+FIXED_WORKTREE="${TOKENLESS_SOURCE_WORKTREE:-/tmp/anolisa-raw-release-source-worktrees/tokenless}"
 VERSION=""
 TARGET_OS=""
 TARGET_ARCH=""
@@ -23,7 +23,7 @@ usage() {
     cat <<'EOF'
 Usage: build.sh --source-repo PATH --output-dir PATH --version X.Y.Z \
   --target-os {linux|macos} --target-arch {x86_64|aarch64} \
-  --profile PROFILE [--tag cosh-ng/vX.Y.Z]
+  --profile PROFILE [--tag tokenless/vX.Y.Z]
 EOF
 }
 
@@ -46,19 +46,14 @@ done
 [ -n "$PROFILE" ] || die '--profile is required'
 [ -n "$SOURCE_REPO" ] || die '--source-repo is required'
 [ -n "$OUTPUT_DIR" ] || die '--output-dir is required'
-
-for command in cargo flock git install python3 sha256sum; do
-    command -v "$command" >/dev/null || die "missing required command: $command"
-done
-SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
-    die "source-repo is not a Git worktree"
-SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || \
+    die "invalid Tokenless version: $VERSION"
 
 case "$TARGET_OS/$TARGET_ARCH/$PROFILE" in
-    linux/x86_64/gnu2.28-x86_64)
+    linux/x86_64/gnu2.17-x86_64)
         RUST_TARGET=x86_64-unknown-linux-gnu
         ;;
-    linux/aarch64/gnu2.28-aarch64)
+    linux/aarch64/gnu2.17-aarch64)
         RUST_TARGET=aarch64-unknown-linux-gnu
         ;;
     macos/aarch64/darwin11-aarch64)
@@ -69,9 +64,17 @@ case "$TARGET_OS/$TARGET_ARCH/$PROFILE" in
         ;;
 esac
 
+if [ -n "$TAG" ] && [ "$TAG" != "tokenless/v$VERSION" ]; then
+    die "release tag $TAG does not match requested version $VERSION"
+fi
+for command in cargo flock git install just make node npm patch python3 sha256sum; do
+    command -v "$command" >/dev/null || die "missing required command: $command"
+done
+SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
+    die "source-repo is not a Git worktree"
+SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+
 if [ -n "$TAG" ]; then
-    [ "$TAG" = "cosh-ng/v$VERSION" ] || \
-        die "release tag $TAG does not match requested version $VERSION"
     TAG_COMMIT="$(git -C "$SOURCE_REPO" rev-parse --verify "refs/tags/$TAG^{commit}")" || \
         die "release tag is unavailable in the checkout: $TAG"
     [ "$TAG_COMMIT" = "$SOURCE_COMMIT" ] || \
@@ -80,7 +83,7 @@ fi
 
 install -d -m 0755 "$(dirname "$FIXED_WORKTREE")"
 exec 9>"${FIXED_WORKTREE}.lock"
-flock -n 9 || die "cosh-ng source worktree is already in use"
+flock -n 9 || die "Tokenless source worktree is already in use"
 
 worktree_registered() {
     git -C "$SOURCE_REPO" worktree list --porcelain | \
@@ -108,24 +111,30 @@ elif [ -e "$FIXED_WORKTREE" ]; then
 fi
 git -C "$SOURCE_REPO" worktree add --detach "$FIXED_WORKTREE" "$SOURCE_COMMIT"
 WORKTREE_READY=1
-git -C "$SOURCE_REPO" worktree lock --reason 'cosh-ng prebuilt package build' \
+git -C "$SOURCE_REPO" worktree lock --reason 'Tokenless prebuilt package build' \
     "$FIXED_WORKTREE"
 
-COMPONENT_ROOT="$FIXED_WORKTREE/src/cosh-ng"
-LINUX_VERSION="$(
+COMPONENT_ROOT="$FIXED_WORKTREE/src/tokenless"
+(
+    cd "$COMPONENT_ROOT"
+    make -B stamp-adapter-templates
+)
+CONTRACT="$COMPONENT_ROOT/.anolisa/component.toml"
+SOURCE_VERSION="$(
     python3 "$COMPONENT_ROOT/packaging/raw/verify-release.py" \
-        "$COMPONENT_ROOT" "$COMPONENT_ROOT/.anolisa/component.toml" \
-        --os linux --arch x86_64
+        "$COMPONENT_ROOT" "$CONTRACT"
 )"
-MACOS_VERSION="$(
-    python3 "$COMPONENT_ROOT/packaging/raw/verify-release.py" \
-        "$COMPONENT_ROOT" "$COMPONENT_ROOT/.anolisa/component.macos.toml" \
-        --os macos --arch aarch64
-)"
-[ "$LINUX_VERSION" = "$MACOS_VERSION" ] || \
-    die "Linux and macOS contracts do not have one version"
-[ "$VERSION" = "$LINUX_VERSION" ] || \
-    die "requested version $VERSION does not match cosh-ng $LINUX_VERSION"
+[ "$VERSION" = "$SOURCE_VERSION" ] || \
+    die "requested version $VERSION does not match Tokenless $SOURCE_VERSION"
+(
+    cd "$COMPONENT_ROOT"
+    make build-openclaw-plugin build-dsh-plugin
+    just setup-rtk
+)
+RTK_ROOT="$COMPONENT_ROOT/third_party/rtk"
+# RTK is excluded from Tokenless's workspace; make its cloned source an explicit
+# workspace root so Cargo never searches the persistent /tmp parent hierarchy.
+printf '\n[workspace]\n' >> "$RTK_ROOT/Cargo.toml"
 
 if [ -e "$OUTPUT_DIR" ] && [ -n "$(find "$OUTPUT_DIR" -mindepth 1 -print -quit)" ]; then
     die "output directory must be empty: $OUTPUT_DIR"
@@ -138,11 +147,13 @@ esac
 export RUSTUP_TOOLCHAIN=1.93.0-x86_64-unknown-linux-gnu
 export SOURCE_DATE_EPOCH
 
-cargo metadata \
-    --format-version 1 \
-    --locked \
-    --filter-platform "$RUST_TARGET" \
-    --manifest-path "$COMPONENT_ROOT/Cargo.toml" >/dev/null
+for manifest in "$COMPONENT_ROOT/Cargo.toml" "$RTK_ROOT/Cargo.toml"; do
+    cargo metadata \
+        --format-version 1 \
+        --locked \
+        --filter-platform "$RUST_TARGET" \
+        --manifest-path "$manifest" >/dev/null
+done
 
 (
     cd "$FIXED_WORKTREE"
@@ -151,73 +162,64 @@ cargo metadata \
         --source-date-epoch "$SOURCE_DATE_EPOCH" \
         -- "$COMMON_DIR/cross-profile.sh" "$PROFILE" build \
         --release \
-        --workspace \
         --locked \
-        --manifest-path src/cosh-ng/Cargo.toml
+        --manifest-path src/tokenless/Cargo.toml
+    python3 "$COMMON_DIR/reproducible-build.py" \
+        --source-root "$COMPONENT_ROOT" \
+        --source-date-epoch "$SOURCE_DATE_EPOCH" \
+        -- "$COMMON_DIR/cross-profile.sh" "$PROFILE" build \
+        --release \
+        --locked \
+        --manifest-path src/tokenless/third_party/rtk/Cargo.toml
 )
 
-BIN_DIR="$COMPONENT_ROOT/target/release"
-TARGET_BIN_DIR="$COMPONENT_ROOT/target/$RUST_TARGET/release"
+BIN_DIR="$COMPONENT_ROOT/target/raw-prebuilt/$RUST_TARGET"
 install -d -m 0755 "$BIN_DIR"
-for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
-    [ -x "$TARGET_BIN_DIR/$binary" ] || \
-        die "Cross build did not produce $TARGET_BIN_DIR/$binary"
-    install -p -m 0755 "$TARGET_BIN_DIR/$binary" "$BIN_DIR/$binary"
+install -p -m 0755 \
+    "$COMPONENT_ROOT/target/$RUST_TARGET/release/tokenless" \
+    "$BIN_DIR/tokenless"
+install -p -m 0755 \
+    "$RTK_ROOT/target/$RUST_TARGET/release/rtk" \
+    "$BIN_DIR/rtk"
+for binary in tokenless rtk; do
     if [ "$TARGET_OS" = macos ]; then
         python3 "$COMMON_DIR/verify-macho.py" --min 11.0 "$BIN_DIR/$binary"
     else
         python3 "$COMMON_DIR/verify-glibc.py" \
-            --arch "$TARGET_ARCH" --max 2.28 "$BIN_DIR/$binary"
+            --arch "$TARGET_ARCH" --max 2.17 "$BIN_DIR/$binary"
     fi
 done
 
-METADATA="$BIN_DIR/cosh-ng-build.toml"
-{
-    printf 'version = "%s"\n' "$VERSION"
-    printf 'target_os = "%s"\n' "$TARGET_OS"
-    printf 'target_arch = "%s"\n\n' "$TARGET_ARCH"
-    printf '[binaries]\n'
-    for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
-        printf '%s = "%s"\n' \
-            "$binary" "$(sha256sum "$BIN_DIR/$binary" | awk '{print $1}')"
-    done
-} > "$METADATA"
-
-if [ "$TARGET_OS" = macos ]; then
-    CONTRACT="$COMPONENT_ROOT/.anolisa/component.macos.toml"
-else
-    CONTRACT="$COMPONENT_ROOT/.anolisa/component.toml"
-fi
-COSH_NG_SOURCE_DIR="$COMPONENT_ROOT" \
+TOKENLESS_SOURCE_DIR="$COMPONENT_ROOT" \
 RAW_CONTRACT="$CONTRACT" \
 BIN_DIR="$BIN_DIR" \
-COSH_NG_BUILD_METADATA="$METADATA" \
 OUTPUT_DIR="$OUTPUT_DIR" \
 TARGET_OS="$TARGET_OS" \
 TARGET_ARCH="$TARGET_ARCH" \
 SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
     "$COMPONENT_ROOT/packaging/raw/package.sh" package >/dev/null
 
-ARCHIVE="cosh-ng-$VERSION-$TARGET_OS-$TARGET_ARCH.tar.gz"
+ARCHIVE="tokenless-$VERSION-$TARGET_OS-$TARGET_ARCH.tar.gz"
 (
     cd "$OUTPUT_DIR"
     sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
 )
 python3 "$COMMON_DIR/generate-sbom.py" \
     --artifact "$OUTPUT_DIR/$ARCHIVE" \
-    --component cosh-ng \
+    --component tokenless \
     --version "$VERSION" \
     --os "$TARGET_OS" \
     --arch "$TARGET_ARCH" \
     --target "$RUST_TARGET" \
     --project-dir "$COMPONENT_ROOT" \
+    --project-dir "$RTK_ROOT" \
     --source-date-epoch "$SOURCE_DATE_EPOCH" >/dev/null
 python3 "$COMMON_DIR/verify-artifacts.py" \
     --directory "$OUTPUT_DIR" \
-    --component cosh-ng \
+    --component tokenless \
     --version "$VERSION" \
     --layout flat \
     --os "$TARGET_OS" \
     --arch "$TARGET_ARCH"
-printf 'Built cosh-ng %s for %s/%s at %s\n' \
+printf 'Built Tokenless %s for %s/%s at %s\n' \
     "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$OUTPUT_DIR"

--- a/.github/actions/build-tokenless-prebuilt/test.sh
+++ b/.github/actions/build-tokenless-prebuilt/test.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Exercise Tokenless action input binding and shared multi-project SBOM generation.
+set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
+REPO_ROOT="$(git -C "$ACTION_DIR" rev-parse --show-toplevel)"
+TEMPORARY="$(mktemp -d)"
+trap 'rm -rf -- "$TEMPORARY"' EXIT
+
+python3 - "$ACTION_DIR/action.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+
+action = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected_bindings = (
+    "TOKENLESS_VERSION: ${{ inputs.version }}",
+    "TOKENLESS_TARGET_OS: ${{ inputs.target-os }}",
+    "TOKENLESS_TARGET_ARCH: ${{ inputs.target-arch }}",
+    "TOKENLESS_PROFILE: ${{ inputs.profile }}",
+    "TOKENLESS_TAG: ${{ inputs.tag }}",
+)
+for binding in expected_bindings:
+    if binding not in action:
+        raise SystemExit(f"composite action is missing environment binding: {binding}")
+
+marker = "      run: |\n"
+if marker not in action:
+    raise SystemExit("composite action is missing its Bash run block")
+run_block = action.split(marker, 1)[1]
+if "${{ inputs." in run_block:
+    raise SystemExit("composite action interpolates an input directly into Bash")
+PY
+
+python3 - "$REPO_ROOT/.github/actions/package-source/action.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+
+action = Path(sys.argv[1]).read_text(encoding="utf-8")
+if "bash scripts/setup-rtk.sh third_party/rtk" not in action:
+    raise SystemExit("source packaging does not use the pinned RTK setup script")
+if "RTK_TAG=" in action or "git clone --depth 1 --branch" in action:
+    raise SystemExit("source packaging still resolves RTK through a mutable tag")
+PY
+
+RTK_SETUP="$REPO_ROOT/src/tokenless/scripts/setup-rtk.sh"
+PINNED_RTK_COMMIT="$(
+    sed -n 's/^RTK_COMMIT="\([0-9a-f]\{40\}\)"$/\1/p' "$RTK_SETUP"
+)"
+[ -n "$PINNED_RTK_COMMIT" ] || {
+    printf 'ERROR: RTK setup script has no pinned 40-character commit\n' >&2
+    exit 1
+}
+RTK_DRIFT="$TEMPORARY/rtk-drift"
+install -d -m 0755 "$RTK_DRIFT"
+printf '[package]\nname = "rtk"\nversion = "0.0.0"\n' > "$RTK_DRIFT/Cargo.toml"
+printf '%040d\n' 0 > "$RTK_DRIFT/.anolisa-rtk-commit"
+if bash "$RTK_SETUP" "$RTK_DRIFT" >"$TEMPORARY/rtk-drift.log" 2>&1; then
+    printf 'ERROR: mismatched RTK revision marker was accepted\n' >&2
+    exit 1
+fi
+grep -Fq "does not match pinned commit $PINNED_RTK_COMMIT" \
+    "$TEMPORARY/rtk-drift.log"
+
+OPENCLAW_ROOT="$REPO_ROOT/src/tokenless/adapters/tokenless/openclaw"
+OPENCLAW_FIXTURE="$TEMPORARY/openclaw"
+TOKENLESS_VERSION="$(python3 - "$REPO_ROOT/src/tokenless/Cargo.toml" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+
+manifest = tomllib.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(manifest["workspace"]["package"]["version"])
+PY
+)"
+python3 - "$OPENCLAW_ROOT/package-lock.json" "$TOKENLESS_VERSION" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+lockfile = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected = sys.argv[2]
+versions = {
+    lockfile.get("version"),
+    lockfile.get("packages", {}).get("", {}).get("version"),
+}
+if versions != {expected}:
+    raise SystemExit(f"OpenClaw lockfile version does not match Tokenless {expected}")
+PY
+install -d -m 0755 "$OPENCLAW_FIXTURE"
+sed "s/@VERSION@/$TOKENLESS_VERSION/g" "$OPENCLAW_ROOT/package.json.in" \
+    > "$OPENCLAW_FIXTURE/package.json"
+cp "$OPENCLAW_ROOT/package-lock.json" "$OPENCLAW_FIXTURE/package-lock.json"
+(
+    cd "$OPENCLAW_FIXTURE"
+    npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund >/dev/null
+)
+sed -i 's/"typescript": "\^5.8.0"/"typescript": "0.0.1"/' \
+    "$OPENCLAW_FIXTURE/package.json"
+if (
+    cd "$OPENCLAW_FIXTURE"
+    npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund \
+        >"$TEMPORARY/npm-drift.log" 2>&1
+); then
+    printf 'ERROR: npm lockfile drift was accepted\n' >&2
+    exit 1
+fi
+
+MARKER="$TEMPORARY/injected"
+if TOKENLESS_SOURCE_WORKTREE="$TEMPORARY/version-worktree/tokenless" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/version-output" \
+        --version "0.7.12\$(touch ${MARKER})" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag '' >"$TEMPORARY/version.log" 2>&1; then
+    printf 'ERROR: malicious version input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious version input executed a command\n' >&2
+    exit 1
+}
+
+if TOKENLESS_SOURCE_WORKTREE="$TEMPORARY/tag-worktree/tokenless" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/tag-output" \
+        --version 0.7.12 \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag "tokenless/v0.7.12\$(touch ${MARKER})" \
+        >"$TEMPORARY/tag.log" 2>&1; then
+    printf 'ERROR: malicious tag input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious tag input executed a command\n' >&2
+    exit 1
+}
+
+for project in tokenless-fixture rtk-fixture; do
+    install -d -m 0755 "$TEMPORARY/$project/src"
+    printf 'fn main() {}\n' > "$TEMPORARY/$project/src/main.rs"
+    sed "s/@NAME@/$project/" > "$TEMPORARY/$project/Cargo.toml" <<'EOF'
+[workspace]
+
+[package]
+name = "@NAME@"
+version = "1.0.0"
+edition = "2021"
+EOF
+    cargo generate-lockfile --manifest-path "$TEMPORARY/$project/Cargo.toml"
+done
+
+printf 'Tokenless SBOM fixture\n' > "$TEMPORARY/payload.txt"
+ARTIFACT_ROOT="$TEMPORARY/artifacts"
+for target in \
+    'linux x86_64 x86_64-unknown-linux-gnu' \
+    'linux aarch64 aarch64-unknown-linux-gnu' \
+    'macos aarch64 aarch64-apple-darwin'; do
+    read -r target_os target_arch target_triple <<<"$target"
+    artifact_dir="$ARTIFACT_ROOT/tokenless-prebuilt-1.0.0-$target_os-$target_arch"
+    archive="$artifact_dir/tokenless-1.0.0-$target_os-$target_arch.tar.gz"
+    install -d -m 0755 "$artifact_dir"
+    tar -C "$TEMPORARY" -czf "$archive" payload.txt
+    (
+        cd "$artifact_dir"
+        sha256sum "${archive##*/}" > "${archive##*/}.sha256"
+    )
+    python3 "$COMMON_DIR/generate-sbom.py" \
+        --artifact "$archive" \
+        --component tokenless \
+        --version 1.0.0 \
+        --os "$target_os" \
+        --arch "$target_arch" \
+        --target "$target_triple" \
+        --project-dir "$TEMPORARY/tokenless-fixture" \
+        --project-dir "$TEMPORARY/rtk-fixture" \
+        --source-date-epoch 0 >/dev/null
+    python3 "$COMMON_DIR/verify-artifacts.py" \
+        --directory "$artifact_dir" \
+        --component tokenless \
+        --version 1.0.0 \
+        --layout flat \
+        --os "$target_os" \
+        --arch "$target_arch"
+done
+
+python3 "$COMMON_DIR/verify-artifacts.py" \
+    --directory "$ARTIFACT_ROOT" \
+    --component tokenless \
+    --version 1.0.0 \
+    --layout actions
+
+python3 - "$ARTIFACT_ROOT/tokenless-prebuilt-1.0.0-linux-x86_64/tokenless-1.0.0-linux-x86_64.tar.gz.cdx.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+document = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+components = list(document["components"])
+components.extend(document["metadata"]["component"].get("components", []))
+names = {component["name"] for component in components}
+expected = {"tokenless-fixture", "rtk-fixture"}
+missing = expected - names
+if missing:
+    raise SystemExit(f"multi-project SBOM is missing components: {sorted(missing)}")
+PY
+
+MISSING_ROOT="$TEMPORARY/missing-artifacts"
+cp -a "$ARTIFACT_ROOT" "$MISSING_ROOT"
+rm "$MISSING_ROOT/tokenless-prebuilt-1.0.0-linux-x86_64/"*.sha256
+if python3 "$COMMON_DIR/verify-artifacts.py" \
+    --directory "$MISSING_ROOT" \
+    --component tokenless \
+    --version 1.0.0 \
+    --layout actions >/dev/null 2>&1; then
+    printf 'ERROR: incomplete Actions Artifact set was accepted\n' >&2
+    exit 1
+fi
+
+EXTRA_ROOT="$TEMPORARY/extra-artifacts"
+cp -a "$ARTIFACT_ROOT" "$EXTRA_ROOT"
+touch "$EXTRA_ROOT/tokenless-prebuilt-1.0.0-linux-x86_64/unexpected"
+if python3 "$COMMON_DIR/verify-artifacts.py" \
+    --directory "$EXTRA_ROOT" \
+    --component tokenless \
+    --version 1.0.0 \
+    --layout actions >/dev/null 2>&1; then
+    printf 'ERROR: Actions Artifact set with an extra file was accepted\n' >&2
+    exit 1
+fi
+
+printf 'Tokenless prebuilt action tests passed\n'

--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -156,21 +156,8 @@ runs:
         set -euo pipefail
         cd /tmp/build/${ARCHIVE_NAME}
 
-        RTK_TAG="$(sed -n 's/^rtk_tag[[:space:]]*:=[[:space:]]*"\(.*\)"/\1/p' justfile)"
-        if [ -z "$RTK_TAG" ]; then
-          echo "ERROR: Could not resolve rtk_tag from justfile"
-          exit 1
-        fi
-
         rm -rf third_party/rtk
-        git clone --depth 1 --branch "$RTK_TAG" \
-          https://github.com/rtk-ai/rtk.git third_party/rtk
-
-        patch --forward -p1 --no-backup-if-mismatch \
-          -d third_party/rtk < third_party/patches/rtk-tokenless-stats.patch
-        patch --forward -p1 --no-backup-if-mismatch \
-          -d third_party/rtk < third_party/patches/rtk-pytest-error-report.patch
-
+        bash scripts/setup-rtk.sh third_party/rtk
         rm -rf third_party/rtk/.git
 
     - name: Generate tokenless component contract

--- a/.github/actions/prebuilt-rust-common/cross-profile.sh
+++ b/.github/actions/prebuilt-rust-common/cross-profile.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Run one Cargo command with a prepared cosh-ng release Cross profile.
+# Run one Cargo command with a prepared ANOLISA release Cross profile.
 set -euo pipefail
 
 RUST_VERSION=1.93.0
 RUST_TOOLCHAIN=1.93.0-x86_64-unknown-linux-gnu
 SCCACHE_VERSION=0.17.0
 SCCACHE_CACHE_SIZE=20G
+GNU217_X86_BASE="docker.io/dockcross/manylinux2014-x64@sha256:ab5968050aa67592ef8fde28f3d304881bf2a394f160010d0bb13e98b4ed1b3b"
+GNU217_X86_IMAGE="anolisa/rust-release-builder:gnu2.17-x86_64"
+GNU217_X86_IMAGE_ID="sha256:72b3599de7e2406e6d0b3d1fd803cf4f613486868972f83c73b1fa4e145ea42a"
+GNU217_ARM_BASE="docker.io/dockcross/manylinux2014-aarch64@sha256:86fb00cdd7f386dd13458ad6c55699ee78586da237087b14d0f94e1ea417ff54"
+GNU217_ARM_IMAGE="anolisa/rust-release-builder:gnu2.17-aarch64"
+GNU217_ARM_IMAGE_ID="sha256:4cec3c91665c86a79bb02aa4940eccbd40542bb3367bbaa4e24cced78aeb4421"
 GNU228_X86_BASE="docker.io/dockcross/manylinux_2_28-x64@sha256:263b776c5dc6ae7e50942c5fbb82eb24a1ec64016cd6dd10831d51c2201923cf"
 GNU228_X86_IMAGE="anolisa/rust-release-builder:gnu2.28-x86_64"
 GNU228_X86_IMAGE_ID="sha256:0a5c24bde830394d0fb585a4c7c2021b315e394bf3a3e3abb22401b70e4b35db"
@@ -24,33 +30,43 @@ die() {
 
 profile_target() {
     case "$1" in
-        gnu2.28-x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
-        gnu2.28-aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
+        gnu2.17-x86_64|gnu2.28-x86_64) printf 'x86_64-unknown-linux-gnu\n' ;;
+        gnu2.17-aarch64|gnu2.28-aarch64) printf 'aarch64-unknown-linux-gnu\n' ;;
         darwin11-aarch64) printf 'aarch64-apple-darwin\n' ;;
-        *) die "unsupported cosh-ng Cross profile: $1" ;;
+        *) die "unsupported release Cross profile: $1" ;;
     esac
 }
 
 profile_image() {
     case "$1" in
+        gnu2.17-x86_64) printf '%s\n' "$GNU217_X86_IMAGE" ;;
+        gnu2.17-aarch64) printf '%s\n' "$GNU217_ARM_IMAGE" ;;
         gnu2.28-x86_64) printf '%s\n' "$GNU228_X86_IMAGE" ;;
         gnu2.28-aarch64) printf '%s\n' "$GNU228_ARM_IMAGE" ;;
         darwin11-aarch64) printf '%s\n' "$DARWIN_IMAGE" ;;
-        *) die "unsupported cosh-ng Cross profile: $1" ;;
+        *) die "unsupported release Cross profile: $1" ;;
     esac
 }
 
 profile_image_id() {
     case "$1" in
+        gnu2.17-x86_64) printf '%s\n' "$GNU217_X86_IMAGE_ID" ;;
+        gnu2.17-aarch64) printf '%s\n' "$GNU217_ARM_IMAGE_ID" ;;
         gnu2.28-x86_64) printf '%s\n' "$GNU228_X86_IMAGE_ID" ;;
         gnu2.28-aarch64) printf '%s\n' "$GNU228_ARM_IMAGE_ID" ;;
         darwin11-aarch64) printf '%s\n' "$DARWIN_IMAGE_ID" ;;
-        *) die "unsupported cosh-ng Cross profile: $1" ;;
+        *) die "unsupported release Cross profile: $1" ;;
     esac
 }
 
 profile_path() {
     case "$1" in
+        gnu2.17-x86_64)
+            printf '/opt/rh/devtoolset-10/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+            ;;
+        gnu2.17-aarch64)
+            printf '/usr/xcc/aarch64-unknown-linux-gnu/bin:/opt/rh/devtoolset-10/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
+            ;;
         gnu2.28-x86_64)
             printf '/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
             ;;
@@ -60,7 +76,7 @@ profile_path() {
         darwin11-aarch64)
             printf '/opt/osxcross/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n'
             ;;
-        *) die "unsupported cosh-ng Cross profile: $1" ;;
+        *) die "unsupported release Cross profile: $1" ;;
     esac
 }
 
@@ -88,29 +104,39 @@ verify_common_tools() {
 verify_linux_profile() {
     local profile="$1"
     local image="$2"
-    local base
+    local base glibc
 
     case "$profile" in
+        gnu2.17-x86_64)
+            base="$GNU217_X86_BASE"
+            glibc=2.17
+            ;;
+        gnu2.17-aarch64)
+            base="$GNU217_ARM_BASE"
+            glibc=2.17
+            ;;
         gnu2.28-x86_64)
             base="$GNU228_X86_BASE"
+            glibc=2.28
             ;;
         gnu2.28-aarch64)
             base="$GNU228_ARM_BASE"
+            glibc=2.28
             ;;
     esac
     [ "$(image_label "$image" org.anolisa.release-builder.profile)" = "$profile" ] || \
         die "$image does not identify profile $profile"
     [ "${base##*@}" = "$(image_label "$image" org.anolisa.release-builder.base-image | sed 's/^.*@//')" ] || \
         die "$image does not bind the pinned base image digest"
-    [ "$(docker run --rm --entrypoint getconf "$image" GNU_LIBC_VERSION)" = 'glibc 2.28' ] || \
-        die "$image is not a glibc 2.28 profile"
+    [ "$(docker run --rm --entrypoint getconf "$image" GNU_LIBC_VERSION)" = "glibc $glibc" ] || \
+        die "$image is not a glibc $glibc profile"
 
     if [ "$profile" = gnu2.28-x86_64 ]; then
         docker run --rm --entrypoint rpm "$image" -q \
             clang-devel llvm-devel elfutils-libelf-devel systemd-devel \
             fuse3-devel openssl-devel zlib-devel libzstd-devel \
             pkgconf-pkg-config >/dev/null
-    else
+    elif [ "$profile" = gnu2.28-aarch64 ]; then
         docker run --rm --entrypoint sh "$image" -c '
             set -eu
             sysroot="$(aarch64-unknown-linux-gnu-gcc --print-sysroot)"
@@ -120,6 +146,12 @@ verify_linux_profile() {
                 PKG_CONFIG_LIBDIR="$sysroot/usr/lib64/pkgconfig:$sysroot/usr/share/pkgconfig" \
                 pkg-config --exists openssl
         '
+    elif [ "$profile" = gnu2.17-x86_64 ]; then
+        docker run --rm --entrypoint sh "$image" -c \
+            'test "$(gcc -dumpmachine)" = x86_64-redhat-linux'
+    else
+        docker run --rm --entrypoint sh "$image" -c \
+            'test -x /usr/xcc/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc'
     fi
 }
 
@@ -191,8 +223,8 @@ run_profile() {
     cargo_home="${CARGO_HOME:-$HOME/.cargo}"
     install -d -m 0755 "$cargo_home/sccache"
     case "$profile" in
-        gnu2.28-x86_64) linker=gcc; archiver='ar' ;;
-        gnu2.28-aarch64)
+        gnu2.17-x86_64|gnu2.28-x86_64) linker=gcc; archiver='ar' ;;
+        gnu2.17-aarch64|gnu2.28-aarch64)
             linker=aarch64-unknown-linux-gnu-gcc
             archiver=aarch64-unknown-linux-gnu-ar
             ;;
@@ -234,7 +266,7 @@ run_profile() {
             "CXXFLAGS_${target//-/_}=-mmacosx-version-min=$deployment" \
             cross "$@" --target "$target"
     else
-        if [ "$profile" = gnu2.28-aarch64 ]; then
+        if [ "$profile" = gnu2.17-aarch64 ] || [ "$profile" = gnu2.28-aarch64 ]; then
             local sysroot=/usr/xcc/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
             container_opts+=" --env=PKG_CONFIG_SYSROOT_DIR=$sysroot"
             container_opts+=" --env=PKG_CONFIG_LIBDIR=$sysroot/usr/lib64/pkgconfig:$sysroot/usr/share/pkgconfig"

--- a/.github/actions/prebuilt-rust-common/generate-sbom.py
+++ b/.github/actions/prebuilt-rust-common/generate-sbom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a deterministic CycloneDX 1.6 sidecar for a cosh-ng archive."""
+"""Generate a deterministic CycloneDX 1.6 sidecar for a Rust archive."""
 
 from __future__ import annotations
 
@@ -103,13 +103,16 @@ def cargo_metadata(project_dir: Path, target: str) -> dict[str, Any]:
 
 
 def resolved_package_identities(data: dict[str, Any]) -> set[tuple[str, str]]:
-    """Return normal dependencies reachable from every workspace member."""
+    """Return normal dependencies reachable from default workspace members."""
     packages = data.get("packages")
     workspace_members = data.get("workspace_members")
+    workspace_default_members = data.get("workspace_default_members")
     resolve = data.get("resolve")
     nodes = resolve.get("nodes") if isinstance(resolve, dict) else None
     if not isinstance(packages, list) or not isinstance(workspace_members, list):
         die("cargo metadata is missing packages or workspace_members")
+    if not isinstance(workspace_default_members, list):
+        workspace_default_members = workspace_members
     if not isinstance(nodes, list):
         die("cargo metadata is missing the resolved dependency graph")
 
@@ -124,7 +127,7 @@ def resolved_package_identities(data: dict[str, Any]) -> set[tuple[str, str]]:
             die("cargo metadata contains an invalid resolve node")
         nodes_by_id[node["id"]] = node
 
-    pending = list(workspace_members)
+    pending = list(workspace_default_members)
     reachable: set[str] = set()
     while pending:
         package_id = pending.pop()
@@ -310,9 +313,46 @@ def deduplicate_component_tree(component: dict[str, Any], seen: set[str]) -> Non
     component["components"] = unique
 
 
+def merge_sboms(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge filtered cargo-sbom documents for every shipped Rust project."""
+    if not documents:
+        die("at least one cargo-sbom document is required")
+    merged = documents[0]
+    metadata = merged.get("metadata")
+    root = metadata.get("component") if isinstance(metadata, dict) else None
+    root_components = root.get("components") if isinstance(root, dict) else None
+    components = merged.get("components")
+    dependencies = merged.get("dependencies")
+    if not all(isinstance(value, list) for value in (root_components, components, dependencies)):
+        die("cargo-sbom output is missing mergeable component collections")
+
+    for document in documents[1:]:
+        other_metadata = document.get("metadata")
+        other_root = (
+            other_metadata.get("component")
+            if isinstance(other_metadata, dict)
+            else None
+        )
+        other_root_components = (
+            other_root.get("components") if isinstance(other_root, dict) else None
+        )
+        other_components = document.get("components")
+        other_dependencies = document.get("dependencies")
+        if not all(
+            isinstance(value, list)
+            for value in (other_root_components, other_components, other_dependencies)
+        ):
+            die("cargo-sbom output is missing mergeable component collections")
+        root_components.extend(other_root_components)
+        components.extend(other_components)
+        dependencies.extend(other_dependencies)
+    return merged
+
+
 def normalize_sbom(
     data: dict[str, Any],
     *,
+    component_name: str,
     version: str,
     target_os: str,
     target_arch: str,
@@ -328,11 +368,11 @@ def normalize_sbom(
     if not isinstance(metadata, dict) or not isinstance(root, dict):
         die("cargo-sbom output is missing metadata.component")
 
-    artifact_id = f"cosh-ng-{version}-{target_os}-{target_arch}-tar"
+    artifact_id = f"{component_name}-{version}-{target_os}-{target_arch}-tar"
     root.update(
         {
             "type": "application",
-            "name": "cosh-ng",
+            "name": component_name,
             "version": version,
             "bom-ref": artifact_id,
             "hashes": [{"alg": "SHA-256", "content": artifact_sha256}],
@@ -359,7 +399,8 @@ def normalize_sbom(
     )
     metadata["authors"] = [{"name": "ANOLISA Release Pipeline"}]
     serial_seed = (
-        f"anolisa:cosh-ng:{version}:{target_os}:{target_arch}:sha256:{artifact_sha256}"
+        f"anolisa:{component_name}:{version}:{target_os}:{target_arch}:"
+        f"sha256:{artifact_sha256}"
     )
     data["serialNumber"] = f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, serial_seed)}"
     data["version"] = 1
@@ -386,13 +427,23 @@ def normalize_sbom(
         deduplicate_component_tree(component, seen)
         unique.append(component)
     data["components"] = unique
+    merged_dependencies: dict[str, set[str]] = {}
     for dependency in dependencies:
         if not isinstance(dependency, dict):
             die("cargo-sbom output contains an invalid dependency")
+        reference = dependency.get("ref")
         depends_on = dependency.get("dependsOn")
-        if isinstance(depends_on, list):
-            dependency["dependsOn"] = sorted(set(depends_on))
-    dependencies.sort(key=lambda item: str(item.get("ref", "")))
+        if not isinstance(reference, str) or not isinstance(depends_on, list):
+            die("cargo-sbom output contains an invalid dependency edge")
+        targets = merged_dependencies.setdefault(reference, set())
+        for target in depends_on:
+            if not isinstance(target, str):
+                die("cargo-sbom output contains an invalid dependency target")
+            targets.add(target)
+    data["dependencies"] = [
+        {"ref": reference, "dependsOn": sorted(targets)}
+        for reference, targets in sorted(merged_dependencies.items())
+    ]
     return data
 
 
@@ -414,19 +465,26 @@ def main() -> int:
     """Generate the normalized SBOM and its checksum sidecar."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--artifact", required=True, type=Path)
+    parser.add_argument("--component", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--os", dest="target_os", required=True)
     parser.add_argument("--arch", dest="target_arch", required=True)
     parser.add_argument("--target", required=True)
-    parser.add_argument("--project-dir", required=True, type=Path)
+    parser.add_argument(
+        "--project-dir", required=True, action="append", type=Path
+    )
     parser.add_argument("--source-date-epoch", required=True, type=int)
     parser.add_argument("--tool", default="cargo-sbom")
     args = parser.parse_args()
 
     artifact = args.artifact.resolve()
-    project_dir = args.project_dir.resolve()
-    if not artifact.is_file() or not project_dir.is_dir():
-        die("artifact must be a file and project-dir must be a directory")
+    project_dirs = [project_dir.resolve() for project_dir in args.project_dir]
+    if not artifact.is_file() or any(
+        not project_dir.is_dir() for project_dir in project_dirs
+    ):
+        die("artifact must be a file and every project-dir must be a directory")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", args.component):
+        die("component must be a lowercase release component name")
     if args.source_date_epoch < 0:
         die("source-date-epoch must not be negative")
     expected_target = {
@@ -443,37 +501,43 @@ def main() -> int:
     if read_sidecar(Path(f"{artifact}.sha256"), artifact.name) != artifact_sha256:
         die(f"artifact checksum sidecar does not match {artifact}")
 
-    try:
-        result = subprocess.run(
-            [
-                args.tool,
-                "--output-format",
-                "cyclone_dx_json_1_6",
-                "--project-directory",
-                str(project_dir),
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+    documents: list[dict[str, Any]] = []
+    for project_dir in project_dirs:
+        try:
+            result = subprocess.run(
+                [
+                    args.tool,
+                    "--output-format",
+                    "cyclone_dx_json_1_6",
+                    "--project-directory",
+                    str(project_dir),
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except FileNotFoundError:
+            die(f"cargo-sbom command not found: {args.tool}")
+        except subprocess.CalledProcessError as error:
+            detail = (error.stderr or error.stdout or "").strip()
+            die(f"cargo-sbom failed: {detail or error.returncode}")
+        try:
+            raw = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            die(f"cargo-sbom returned invalid JSON: {error}")
+        if not isinstance(raw, dict):
+            die("cargo-sbom output must be a JSON object")
+        documents.append(
+            filter_sbom_for_target(
+                raw,
+                resolved_package_identities(cargo_metadata(project_dir, args.target)),
+            )
         )
-    except FileNotFoundError:
-        die(f"cargo-sbom command not found: {args.tool}")
-    except subprocess.CalledProcessError as error:
-        detail = (error.stderr or error.stdout or "").strip()
-        die(f"cargo-sbom failed: {detail or error.returncode}")
-    try:
-        raw = json.loads(result.stdout)
-    except json.JSONDecodeError as error:
-        die(f"cargo-sbom returned invalid JSON: {error}")
-    if not isinstance(raw, dict):
-        die("cargo-sbom output must be a JSON object")
-    raw = filter_sbom_for_target(
-        raw,
-        resolved_package_identities(cargo_metadata(project_dir, args.target)),
-    )
+    raw = merge_sboms(documents)
     normalized = normalize_sbom(
         raw,
+        component_name=args.component,
         version=args.version,
         target_os=args.target_os,
         target_arch=args.target_arch,

--- a/.github/actions/prebuilt-rust-common/plan_matrix.py
+++ b/.github/actions/prebuilt-rust-common/plan_matrix.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Plan the target matrix for components with prebuilt release packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from targets import TARGETS
+
+
+def build_matrix(component: str) -> dict[str, list[dict[str, str]]]:
+    """Return the matrix rows supported by the selected component."""
+    return {
+        "include": [
+            {"component": component, **target}
+            for target in TARGETS.get(component, ())
+        ]
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--component", required=True)
+    args = parser.parse_args()
+
+    matrix = build_matrix(args.component)
+    print(f"enabled={'true' if matrix['include'] else 'false'}")
+    print(f"matrix={json.dumps(matrix, separators=(',', ':'), sort_keys=True)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/prebuilt-rust-common/reproducible-build.py
+++ b/.github/actions/prebuilt-rust-common/reproducible-build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a build command with stable Rust source paths and timestamps."""
+"""Run a Rust build command with stable source paths and timestamps."""
 
 from __future__ import annotations
 

--- a/.github/actions/prebuilt-rust-common/targets.py
+++ b/.github/actions/prebuilt-rust-common/targets.py
@@ -1,0 +1,41 @@
+"""Shared target definitions for prebuilt release packages."""
+
+from __future__ import annotations
+
+
+TARGETS = {
+    "cosh-ng": (
+        {
+            "target-os": "linux",
+            "target-arch": "x86_64",
+            "profile": "gnu2.28-x86_64",
+        },
+        {
+            "target-os": "linux",
+            "target-arch": "aarch64",
+            "profile": "gnu2.28-aarch64",
+        },
+        {
+            "target-os": "macos",
+            "target-arch": "aarch64",
+            "profile": "darwin11-aarch64",
+        },
+    ),
+    "tokenless": (
+        {
+            "target-os": "linux",
+            "target-arch": "x86_64",
+            "profile": "gnu2.17-x86_64",
+        },
+        {
+            "target-os": "linux",
+            "target-arch": "aarch64",
+            "profile": "gnu2.17-aarch64",
+        },
+        {
+            "target-os": "macos",
+            "target-arch": "aarch64",
+            "profile": "darwin11-aarch64",
+        },
+    ),
+}

--- a/.github/actions/prebuilt-rust-common/test_plan_matrix.py
+++ b/.github/actions/prebuilt-rust-common/test_plan_matrix.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Regression tests for the prebuilt release matrix planner."""
+
+from __future__ import annotations
+
+import unittest
+
+import plan_matrix
+
+
+class PlanMatrixTests(unittest.TestCase):
+    def test_cosh_ng_targets(self) -> None:
+        matrix = plan_matrix.build_matrix("cosh-ng")
+
+        self.assertEqual(
+            [(row["target-os"], row["target-arch"], row["profile"]) for row in matrix["include"]],
+            [
+                ("linux", "x86_64", "gnu2.28-x86_64"),
+                ("linux", "aarch64", "gnu2.28-aarch64"),
+                ("macos", "aarch64", "darwin11-aarch64"),
+            ],
+        )
+        self.assertTrue(all(row["component"] == "cosh-ng" for row in matrix["include"]))
+
+    def test_tokenless_targets(self) -> None:
+        matrix = plan_matrix.build_matrix("tokenless")
+
+        self.assertEqual(
+            [(row["target-os"], row["target-arch"], row["profile"]) for row in matrix["include"]],
+            [
+                ("linux", "x86_64", "gnu2.17-x86_64"),
+                ("linux", "aarch64", "gnu2.17-aarch64"),
+                ("macos", "aarch64", "darwin11-aarch64"),
+            ],
+        )
+        self.assertTrue(all(row["component"] == "tokenless" for row in matrix["include"]))
+
+    def test_component_without_prebuilt_targets(self) -> None:
+        self.assertEqual(plan_matrix.build_matrix("anolisa"), {"include": []})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/actions/prebuilt-rust-common/verify-artifacts.py
+++ b/.github/actions/prebuilt-rust-common/verify-artifacts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify one flat cosh-ng package or a complete Actions Artifact download."""
+"""Verify one flat prebuilt package or a complete Actions Artifact download."""
 
 from __future__ import annotations
 
@@ -12,12 +12,7 @@ import tarfile
 from pathlib import Path
 from typing import Any
 
-
-TARGETS = (
-    ("linux", "x86_64"),
-    ("linux", "aarch64"),
-    ("macos", "aarch64"),
-)
+from targets import TARGETS
 
 
 def die(message: str) -> None:
@@ -81,9 +76,11 @@ def component_refs(component: dict[str, Any]) -> list[str]:
     return references
 
 
-def expected_files(version: str, target_os: str, target_arch: str) -> set[str]:
+def expected_files(
+    component_name: str, version: str, target_os: str, target_arch: str
+) -> set[str]:
     """Return the exact four release asset names for one target."""
-    archive = f"cosh-ng-{version}-{target_os}-{target_arch}.tar.gz"
+    archive = f"{component_name}-{version}-{target_os}-{target_arch}.tar.gz"
     return {
         archive,
         f"{archive}.sha256",
@@ -92,9 +89,15 @@ def expected_files(version: str, target_os: str, target_arch: str) -> set[str]:
     }
 
 
-def validate_directory(directory: Path, version: str, target_os: str, target_arch: str) -> None:
+def validate_directory(
+    directory: Path,
+    component_name: str,
+    version: str,
+    target_os: str,
+    target_arch: str,
+) -> None:
     """Validate one target's exact four-file output directory."""
-    expected = expected_files(version, target_os, target_arch)
+    expected = expected_files(component_name, version, target_os, target_arch)
     try:
         entries = list(directory.iterdir())
     except OSError as error:
@@ -108,7 +111,7 @@ def validate_directory(directory: Path, version: str, target_os: str, target_arc
             f"missing={missing or 'none'} extra={extra or 'none'}"
         )
 
-    archive_name = f"cosh-ng-{version}-{target_os}-{target_arch}.tar.gz"
+    archive_name = f"{component_name}-{version}-{target_os}-{target_arch}.tar.gz"
     archive = directory / archive_name
     archive_sha = sha256_file(archive)
     if read_sidecar(Path(f"{archive}.sha256"), archive.name) != archive_sha:
@@ -134,11 +137,11 @@ def validate_directory(directory: Path, version: str, target_os: str, target_arc
         die(f"SBOM is not CycloneDX 1.6: {sbom}")
     metadata = data.get("metadata")
     component = metadata.get("component") if isinstance(metadata, dict) else None
-    artifact_id = f"cosh-ng-{version}-{target_os}-{target_arch}-tar"
+    artifact_id = f"{component_name}-{version}-{target_os}-{target_arch}-tar"
     if not isinstance(metadata, dict) or not isinstance(component, dict):
         die(f"SBOM is missing metadata.component: {sbom}")
     if (
-        component.get("name") != "cosh-ng"
+        component.get("name") != component_name
         or component.get("version") != version
         or component.get("bom-ref") != artifact_id
     ):
@@ -202,23 +205,36 @@ def main() -> int:
     """Validate flat or downloaded Actions Artifact layout."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--directory", required=True, type=Path)
+    parser.add_argument("--component", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--layout", choices=("flat", "actions"), required=True)
     parser.add_argument("--os", dest="target_os")
     parser.add_argument("--arch", dest="target_arch")
     args = parser.parse_args()
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", args.component):
+        parser.error("component must be a lowercase release component name")
     root = args.directory.resolve()
     if args.layout == "flat":
         if not args.target_os or not args.target_arch:
             parser.error("flat layout requires --os and --arch")
-        validate_directory(root, args.version, args.target_os, args.target_arch)
+        validate_directory(
+            root,
+            args.component,
+            args.version,
+            args.target_os,
+            args.target_arch,
+        )
         return 0
     if args.target_os or args.target_arch:
         parser.error("actions layout does not accept --os or --arch")
 
+    component_targets = TARGETS.get(args.component)
+    if component_targets is None:
+        parser.error(f"component has no prebuilt target matrix: {args.component}")
     expected_directories = {
-        f"cosh-ng-prebuilt-{args.version}-{target_os}-{target_arch}"
-        for target_os, target_arch in TARGETS
+        f"{args.component}-prebuilt-{args.version}-"
+        f"{target['target-os']}-{target['target-arch']}"
+        for target in component_targets
     }
     try:
         entries = list(root.iterdir())
@@ -232,10 +248,17 @@ def main() -> int:
             "unexpected Actions Artifacts; "
             f"missing={missing or 'none'} extra={extra or 'none'}"
         )
-    for target_os, target_arch in TARGETS:
-        directory = root / f"cosh-ng-prebuilt-{args.version}-{target_os}-{target_arch}"
-        validate_directory(directory, args.version, target_os, target_arch)
-    print(f"Verified 12 cosh-ng prebuilt release assets under {root}")
+    for target in component_targets:
+        target_os = target["target-os"]
+        target_arch = target["target-arch"]
+        directory = (
+            root
+            / f"{args.component}-prebuilt-{args.version}-{target_os}-{target_arch}"
+        )
+        validate_directory(
+            directory, args.component, args.version, target_os, target_arch
+        )
+    print(f"Verified 12 {args.component} prebuilt release assets under {root}")
     return 0
 
 

--- a/.github/actions/prebuilt-rust-common/verify-glibc.py
+++ b/.github/actions/prebuilt-rust-common/verify-glibc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify an internal release binary's architecture and glibc ceiling."""
+"""Verify a release binary's architecture and glibc ceiling."""
 
 from __future__ import annotations
 

--- a/.github/actions/prebuilt-rust-common/verify-macho.py
+++ b/.github/actions/prebuilt-rust-common/verify-macho.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate an arm64 macOS executable and its deployment target."""
+"""Validate an arm64 macOS release executable and its deployment target."""
 
 from __future__ import annotations
 

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -45,8 +45,19 @@ jobs:
   package-preview:
     name: Packaging Preview ${{ inputs.component }}-${{ inputs.version }}
     runs-on: anolisa-k8s-amd-release
+    outputs:
+      prebuilt-enabled: ${{ steps.plan-prebuilt.outputs.enabled }}
+      prebuilt-matrix: ${{ steps.plan-prebuilt.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Plan precompiled packages
+        id: plan-prebuilt
+        env:
+          COMPONENT: ${{ inputs.component }}
+        run: |
+          python3 .github/actions/prebuilt-rust-common/plan_matrix.py \
+            --component "$COMPONENT" >> "$GITHUB_OUTPUT"
 
       - name: Package source archive
         uses: ./.github/actions/package-source
@@ -66,34 +77,26 @@ jobs:
           artifact-suffix: '.preview'
           retention-days: 14
 
-  build-cosh-ng-prebuilt-preview:
-    name: Preview cosh-ng ${{ matrix.target-os }}-${{ matrix.target-arch }}
-    if: inputs.component == 'cosh-ng'
+  build-prebuilt-preview:
+    name: Preview precompiled packages
+    needs: package-preview
+    if: needs.package-preview.outputs.prebuilt-enabled == 'true'
     permissions:
       contents: read
     runs-on: [self-hosted, Linux, X64, anolisa-release-cross-x64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target-os: linux
-            target-arch: x86_64
-            profile: gnu2.28-x86_64
-          - target-os: linux
-            target-arch: aarch64
-            profile: gnu2.28-aarch64
-          - target-os: macos
-            target-arch: aarch64
-            profile: darwin11-aarch64
+      matrix: ${{ fromJSON(needs.package-preview.outputs.prebuilt-matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Build precompiled package
-        id: prebuilt
+      - name: Build cosh-ng precompiled package
+        id: cosh-ng-prebuilt
+        if: matrix.component == 'cosh-ng'
         uses: ./.github/actions/build-cosh-ng-prebuilt
         with:
           version: ${{ inputs.version }}
@@ -101,18 +104,49 @@ jobs:
           target-arch: ${{ matrix.target-arch }}
           profile: ${{ matrix.profile }}
 
+      - name: Build Tokenless precompiled package
+        id: tokenless-prebuilt
+        if: matrix.component == 'tokenless'
+        uses: ./.github/actions/build-tokenless-prebuilt
+        with:
+          version: ${{ inputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+
+      - name: Select precompiled package output
+        id: prebuilt
+        shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
+          COSH_NG_DIRECTORY: ${{ steps.cosh-ng-prebuilt.outputs.artifact-directory }}
+          TOKENLESS_DIRECTORY: ${{ steps.tokenless-prebuilt.outputs.artifact-directory }}
+        run: |
+          case "$COMPONENT" in
+            cosh-ng) ARTIFACT_DIRECTORY="$COSH_NG_DIRECTORY" ;;
+            tokenless) ARTIFACT_DIRECTORY="$TOKENLESS_DIRECTORY" ;;
+            *) echo "::error::Unsupported prebuilt component: $COMPONENT"; exit 1 ;;
+          esac
+          if [ -z "$ARTIFACT_DIRECTORY" ]; then
+            echo "::error::Missing prebuilt output for $COMPONENT"
+            exit 1
+          fi
+          echo "artifact-directory=$ARTIFACT_DIRECTORY" >> "$GITHUB_OUTPUT"
+
       - name: Upload precompiled package
         uses: actions/upload-artifact@v4
         with:
-          name: cosh-ng-prebuilt-${{ inputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          name: ${{ matrix.component }}-prebuilt-${{ inputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
           path: ${{ steps.prebuilt.outputs.artifact-directory }}/*
           if-no-files-found: error
           retention-days: 14
 
-  verify-cosh-ng-prebuilt-preview:
-    name: Verify preview cosh-ng artifacts
-    needs: build-cosh-ng-prebuilt-preview
-    if: inputs.component == 'cosh-ng'
+  verify-prebuilt-preview:
+    name: Verify preview ${{ inputs.component }} artifacts
+    needs: build-prebuilt-preview
+    if: >-
+      always() &&
+      needs.build-prebuilt-preview.result == 'success'
     permissions:
       actions: read
       contents: read
@@ -122,17 +156,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download cosh-ng precompiled packages
+      - name: Download precompiled packages
         uses: actions/download-artifact@v4
         with:
-          pattern: cosh-ng-prebuilt-${{ inputs.version }}-*
-          path: /tmp/cosh-ng-prebuilt-preview
+          pattern: ${{ inputs.component }}-prebuilt-${{ inputs.version }}-*
+          path: /tmp/prebuilt-preview
 
-      - name: Verify cosh-ng precompiled packages
+      - name: Verify precompiled packages
         env:
-          COSH_NG_VERSION: ${{ inputs.version }}
+          COMPONENT: ${{ inputs.component }}
+          VERSION: ${{ inputs.version }}
         run: |
-          python3 .github/actions/build-cosh-ng-prebuilt/verify-artifacts.py \
-            --directory /tmp/cosh-ng-prebuilt-preview \
-            --version "$COSH_NG_VERSION" \
+          python3 .github/actions/prebuilt-rust-common/verify-artifacts.py \
+            --directory /tmp/prebuilt-preview \
+            --component "$COMPONENT" \
+            --version "$VERSION" \
             --layout actions

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,8 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       tag: ${{ steps.parse.outputs.tag }}
       archive-sha256: ${{ steps.package-source.outputs.archive-sha256 }}
+      prebuilt-enabled: ${{ steps.plan-prebuilt.outputs.enabled }}
+      prebuilt-matrix: ${{ steps.plan-prebuilt.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,6 +78,14 @@ jobs:
           echo "| Component | \`$COMPONENT\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Version | \`$VERSION\` |" >> $GITHUB_STEP_SUMMARY
 
+      - name: Plan precompiled packages
+        id: plan-prebuilt
+        env:
+          COMPONENT: ${{ steps.parse.outputs.component }}
+        run: |
+          python3 .github/actions/prebuilt-rust-common/plan_matrix.py \
+            --component "$COMPONENT" >> "$GITHUB_OUTPUT"
+
       - name: Package source archive
         id: package-source
         uses: ./.github/actions/package-source
@@ -95,27 +105,17 @@ jobs:
           artifact-suffix: ''
           retention-days: 28
 
-  build_cosh_ng_prebuilt:
-    name: Build cosh-ng ${{ matrix.target-os }}-${{ matrix.target-arch }}
+  build_prebuilt:
+    name: Build precompiled packages
     needs: package
-    if: needs.package.outputs.component == 'cosh-ng'
+    if: needs.package.outputs.prebuilt-enabled == 'true'
     permissions:
       contents: read
     runs-on: [self-hosted, Linux, X64, anolisa-release-cross-x64]
     timeout-minutes: 90
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target-os: linux
-            target-arch: x86_64
-            profile: gnu2.28-x86_64
-          - target-os: linux
-            target-arch: aarch64
-            profile: gnu2.28-aarch64
-          - target-os: macos
-            target-arch: aarch64
-            profile: darwin11-aarch64
+      matrix: ${{ fromJSON(needs.package.outputs.prebuilt-matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,8 +123,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Build precompiled package
-        id: prebuilt
+      - name: Build cosh-ng precompiled package
+        id: cosh-ng-prebuilt
+        if: matrix.component == 'cosh-ng'
         uses: ./.github/actions/build-cosh-ng-prebuilt
         with:
           version: ${{ needs.package.outputs.version }}
@@ -133,10 +134,40 @@ jobs:
           profile: ${{ matrix.profile }}
           tag: ${{ needs.package.outputs.tag }}
 
+      - name: Build Tokenless precompiled package
+        id: tokenless-prebuilt
+        if: matrix.component == 'tokenless'
+        uses: ./.github/actions/build-tokenless-prebuilt
+        with:
+          version: ${{ needs.package.outputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+          tag: ${{ needs.package.outputs.tag }}
+
+      - name: Select precompiled package output
+        id: prebuilt
+        shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
+          COSH_NG_DIRECTORY: ${{ steps.cosh-ng-prebuilt.outputs.artifact-directory }}
+          TOKENLESS_DIRECTORY: ${{ steps.tokenless-prebuilt.outputs.artifact-directory }}
+        run: |
+          case "$COMPONENT" in
+            cosh-ng) ARTIFACT_DIRECTORY="$COSH_NG_DIRECTORY" ;;
+            tokenless) ARTIFACT_DIRECTORY="$TOKENLESS_DIRECTORY" ;;
+            *) echo "::error::Unsupported prebuilt component: $COMPONENT"; exit 1 ;;
+          esac
+          if [ -z "$ARTIFACT_DIRECTORY" ]; then
+            echo "::error::Missing prebuilt output for $COMPONENT"
+            exit 1
+          fi
+          echo "artifact-directory=$ARTIFACT_DIRECTORY" >> "$GITHUB_OUTPUT"
+
       - name: Upload precompiled package
         uses: actions/upload-artifact@v4
         with:
-          name: cosh-ng-prebuilt-${{ needs.package.outputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          name: ${{ matrix.component }}-prebuilt-${{ needs.package.outputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
           path: ${{ steps.prebuilt.outputs.artifact-directory }}/*
           if-no-files-found: error
           retention-days: 28
@@ -148,12 +179,12 @@ jobs:
   # =========================================================================
   publish:
     name: Publish ${{ needs.package.outputs.tag }}
-    needs: [package, build_cosh_ng_prebuilt]
+    needs: [package, build_prebuilt]
     if: >-
       always() &&
       needs.package.result == 'success' &&
-      (needs.package.outputs.component != 'cosh-ng' ||
-       needs.build_cosh_ng_prebuilt.result == 'success')
+      (needs.package.outputs.prebuilt-enabled != 'true' ||
+       needs.build_prebuilt.result == 'success')
     permissions:
       contents: write
       actions: read
@@ -195,26 +226,29 @@ jobs:
           name: ${{ needs.package.outputs.component }}-${{ needs.package.outputs.version }}-vendor
           path: /tmp/archives
 
-      - name: Download cosh-ng precompiled packages
-        if: needs.package.outputs.component == 'cosh-ng'
+      - name: Download precompiled packages
+        if: needs.package.outputs.prebuilt-enabled == 'true'
         uses: actions/download-artifact@v4
         with:
-          pattern: cosh-ng-prebuilt-${{ needs.package.outputs.version }}-*
-          path: /tmp/cosh-ng-prebuilt
+          pattern: ${{ needs.package.outputs.component }}-prebuilt-${{ needs.package.outputs.version }}-*
+          path: /tmp/prebuilt
 
-      - name: Verify cosh-ng precompiled packages
-        if: needs.package.outputs.component == 'cosh-ng'
+      - name: Verify precompiled packages
+        if: needs.package.outputs.prebuilt-enabled == 'true'
         env:
-          COSH_NG_VERSION: ${{ needs.package.outputs.version }}
+          COMPONENT: ${{ needs.package.outputs.component }}
+          VERSION: ${{ needs.package.outputs.version }}
         run: |
-          python3 .github/actions/build-cosh-ng-prebuilt/verify-artifacts.py \
-            --directory /tmp/cosh-ng-prebuilt \
-            --version "$COSH_NG_VERSION" \
+          python3 .github/actions/prebuilt-rust-common/verify-artifacts.py \
+            --directory /tmp/prebuilt \
+            --component "$COMPONENT" \
+            --version "$VERSION" \
             --layout actions
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PREBUILT_ENABLED: ${{ needs.package.outputs.prebuilt-enabled }}
         run: |
           COMPONENT="${{ needs.package.outputs.component }}"
           VERSION="${{ needs.package.outputs.version }}"
@@ -249,11 +283,11 @@ jobs:
           if [ -f "$VENDOR_ARCHIVE" ]; then
             ASSETS+=("$VENDOR_ARCHIVE")
           fi
-          if [ "$COMPONENT" = "cosh-ng" ]; then
+          if [ "$PREBUILT_ENABLED" = "true" ]; then
             while IFS= read -r asset; do
               ASSETS+=("$asset")
             done < <(
-              find /tmp/cosh-ng-prebuilt -mindepth 2 -maxdepth 2 -type f -print |
+              find /tmp/prebuilt -mindepth 2 -maxdepth 2 -type f -print |
                 LC_ALL=C sort
             )
           fi

--- a/.github/workflows/tokenless-prebuilt-ci.yaml
+++ b/.github/workflows/tokenless-prebuilt-ci.yaml
@@ -1,24 +1,26 @@
-name: CI / cosh-ng prebuilt action
+name: CI / Tokenless prebuilt action
 
 on:
   push:
     branches: [main, 'release/**']
     paths:
-      - '.github/actions/build-cosh-ng-prebuilt/**'
+      - '.github/actions/build-tokenless-prebuilt/**'
+      - '.github/actions/package-source/**'
       - '.github/actions/prebuilt-rust-common/**'
-      - '.github/workflows/cosh-ng-prebuilt-ci.yaml'
+      - '.github/workflows/tokenless-prebuilt-ci.yaml'
       - '.github/workflows/release.yaml'
       - '.github/workflows/release-preview.yaml'
-      - 'src/cosh-ng/**'
+      - 'src/tokenless/**'
   pull_request:
     branches: [main, 'release/**']
     paths:
-      - '.github/actions/build-cosh-ng-prebuilt/**'
+      - '.github/actions/build-tokenless-prebuilt/**'
+      - '.github/actions/package-source/**'
       - '.github/actions/prebuilt-rust-common/**'
-      - '.github/workflows/cosh-ng-prebuilt-ci.yaml'
+      - '.github/workflows/tokenless-prebuilt-ci.yaml'
       - '.github/workflows/release.yaml'
       - '.github/workflows/release-preview.yaml'
-      - 'src/cosh-ng/**'
+      - 'src/tokenless/**'
   workflow_dispatch:
 
 permissions:
@@ -31,7 +33,7 @@ env:
 
 jobs:
   test:
-    name: Test cosh-ng prebuilt action
+    name: Test Tokenless prebuilt action
     runs-on: anolisa-k8s-general-ci-x64
     timeout-minutes: 10
     steps:
@@ -41,13 +43,20 @@ jobs:
         with:
           python-version: '3.11'
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.2'
+
       - uses: dtolnay/rust-toolchain@1.93.0
 
       - name: Install cargo-sbom
         run: cargo install cargo-sbom --version 0.10.0 --locked
 
       - name: Run prebuilt action regression tests
-        run: .github/actions/build-cosh-ng-prebuilt/test.sh
+        run: .github/actions/build-tokenless-prebuilt/test.sh
 
       - name: Run prebuilt matrix planner tests
         run: python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py
+
+      - name: Run Tokenless raw package tests
+        run: src/tokenless/tests/test-package-raw.sh

--- a/src/tokenless/Makefile
+++ b/src/tokenless/Makefile
@@ -141,7 +141,7 @@ $(AGENTSCOPE_PACKAGE_DIR)/pyproject.toml: \
 # for `openclaw plugins install` to succeed.
 build-openclaw-plugin: stamp-adapter-templates
 	@echo "==> Building tokenless OpenClaw plugin..."
-	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm install --legacy-peer-deps --no-audit --no-fund --package-lock=false
+	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm ci --legacy-peer-deps --ignore-scripts --no-audit --no-fund
 	cd $(OPENCLAW_PLUGIN_SRC_DIR) && npm run build
 	@test -f $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js \
 	    || { echo "ERROR: $(OPENCLAW_PLUGIN_SRC_DIR)/dist/index.js was not produced"; exit 1; }
@@ -347,7 +347,6 @@ clean:
 	cargo clean --release --manifest-path third_party/rtk/Cargo.toml 2>/dev/null || true
 	rm -rf $(OPENCLAW_PLUGIN_SRC_DIR)/dist $(OPENCLAW_PLUGIN_SRC_DIR)/node_modules
 	rm -rf $(ADAPTER_SRC_DIR)/agentscope
-	rm -f  $(OPENCLAW_PLUGIN_SRC_DIR)/package-lock.json
 	rm -f  $(ADAPTER_TEMPLATES) $(COMPONENT_CONTRACT)
 	rm -f  $(AGENTSCOPE_PACKAGE_DIR)/pyproject.toml
 

--- a/src/tokenless/adapters/tokenless/openclaw/.gitignore
+++ b/src/tokenless/adapters/tokenless/openclaw/.gitignore
@@ -1,3 +1,2 @@
 dist/
 node_modules/
-package-lock.json

--- a/src/tokenless/adapters/tokenless/openclaw/package-lock.json
+++ b/src/tokenless/adapters/tokenless/openclaw/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "@tokenless/openclaw-plugin",
+  "version": "0.7.13",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tokenless/openclaw-plugin",
+      "version": "0.7.13",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": ">=22",
+        "typescript": "^5.8.0"
+      },
+      "peerDependencies": {
+        "rtk": ">=0.35.0",
+        "tokenless": ">=0.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/tokenless/justfile
+++ b/src/tokenless/justfile
@@ -2,30 +2,15 @@
 # Usage: just build       (setup rtk + build all)
 #        just setup-rtk   (clone + patch rtk only)
 
-rtk_tag   := "v0.43.0"
 rtk_dir   := "third_party/rtk"
-patch_dir := "third_party/patches"
 
 # Default: list available recipes
 default:
     @just --list
 
-# Clone rtk from GitHub and apply tokenless patches
+# Fetch the pinned RTK commit and apply Tokenless patches
 setup-rtk:
-    @if [ ! -f {{rtk_dir}}/Cargo.toml ]; then \
-        echo "Cloning rtk {{rtk_tag}} from GitHub..."; \
-        git clone --depth 1 --branch {{rtk_tag}} \
-            https://github.com/rtk-ai/rtk.git {{rtk_dir}}; \
-        echo "Applying tokenless stats patch..."; \
-        patch --forward -p1 --no-backup-if-mismatch \
-            -d {{rtk_dir}} < {{patch_dir}}/rtk-tokenless-stats.patch && \
-        echo "Applying pytest error report patch..."; \
-        patch --forward -p1 --no-backup-if-mismatch \
-            -d {{rtk_dir}} < {{patch_dir}}/rtk-pytest-error-report.patch && \
-        echo "rtk setup complete."; \
-    else \
-        echo "rtk already set up ({{rtk_dir}}/Cargo.toml exists)."; \
-    fi
+    bash scripts/setup-rtk.sh {{rtk_dir}}
 
 # Remove cloned rtk directory (use when switching versions or re-patching)
 clean-rtk:

--- a/src/tokenless/scripts/setup-rtk.sh
+++ b/src/tokenless/scripts/setup-rtk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Fetch and patch the immutable RTK source used by Tokenless builds.
+set -euo pipefail
+
+COMPONENT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RTK_REPOSITORY="https://github.com/rtk-ai/rtk.git"
+RTK_RELEASE="v0.43.0"
+RTK_COMMIT="5a7880d404db8364d602f2ecdc41dd790f64013f"
+RTK_DIR="${1:-$COMPONENT_ROOT/third_party/rtk}"
+PATCH_DIR="$COMPONENT_ROOT/third_party/patches"
+REVISION_MARKER="$RTK_DIR/.anolisa-rtk-commit"
+TEMPORARY=""
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$TEMPORARY" ] && [ -d "$TEMPORARY" ]; then
+        rm -rf -- "$TEMPORARY"
+    fi
+}
+trap cleanup EXIT
+
+[ "$#" -le 1 ] || die 'usage: setup-rtk.sh [destination]'
+
+if [ -e "$RTK_DIR" ]; then
+    [ -f "$RTK_DIR/Cargo.toml" ] || \
+        die "RTK destination is incomplete: $RTK_DIR"
+    [ -f "$REVISION_MARKER" ] || \
+        die "RTK revision marker is missing; run just clean-rtk and retry"
+    [ "$(cat "$REVISION_MARKER")" = "$RTK_COMMIT" ] || \
+        die "RTK checkout does not match pinned commit $RTK_COMMIT"
+    if [ -d "$RTK_DIR/.git" ]; then
+        [ "$(git -C "$RTK_DIR" rev-parse HEAD)" = "$RTK_COMMIT" ] || \
+            die "RTK HEAD does not match pinned commit $RTK_COMMIT"
+    fi
+    printf 'RTK %s is already set up at %s\n' "$RTK_RELEASE" "$RTK_COMMIT"
+    exit 0
+fi
+
+install -d -m 0755 "$(dirname "$RTK_DIR")"
+TEMPORARY="$(mktemp -d "${RTK_DIR}.tmp.XXXXXX")"
+git init --quiet "$TEMPORARY"
+git -C "$TEMPORARY" remote add origin "$RTK_REPOSITORY"
+git -C "$TEMPORARY" fetch --quiet --depth 1 origin "$RTK_COMMIT"
+git -C "$TEMPORARY" checkout --quiet --detach "$RTK_COMMIT"
+[ "$(git -C "$TEMPORARY" rev-parse HEAD)" = "$RTK_COMMIT" ] || \
+    die "fetched RTK does not match pinned commit $RTK_COMMIT"
+
+patch --forward -p1 --no-backup-if-mismatch \
+    -d "$TEMPORARY" < "$PATCH_DIR/rtk-tokenless-stats.patch"
+patch --forward -p1 --no-backup-if-mismatch \
+    -d "$TEMPORARY" < "$PATCH_DIR/rtk-pytest-error-report.patch"
+printf '%s\n' "$RTK_COMMIT" > "$TEMPORARY/.anolisa-rtk-commit"
+
+mv "$TEMPORARY" "$RTK_DIR"
+TEMPORARY=""
+printf 'RTK %s setup complete at %s\n' "$RTK_RELEASE" "$RTK_COMMIT"

--- a/src/tokenless/tests/test-package-raw.sh
+++ b/src/tokenless/tests/test-package-raw.sh
@@ -45,6 +45,7 @@ write_json_version() {
 write_json_version "$ADAPTERS/manifest.json"
 write_json_version "$ADAPTERS/openclaw/package.json"
 write_json_version "$ADAPTERS/openclaw/openclaw.plugin.json"
+printf '{"lockfileVersion":3}\n' > "$ADAPTERS/openclaw/package-lock.json"
 write_json_version "$ADAPTERS/dsh/package.json"
 write_json_version "$ADAPTERS/qoder/.qoder-plugin/plugin.json"
 write_json_version "$ADAPTERS/claude-code/.claude-plugin/plugin.json"
@@ -174,6 +175,7 @@ test ! -e "$EXTRACTED/adapters/agentscope"
 test -z "$(find "$EXTRACTED" -type l -print -quit)"
 test -z "$(find "$EXTRACTED" \( \
     -name '*.in' -o \
+    -name package-lock.json -o \
     -name node_modules -o \
     -name build -o \
     -name '*.egg-info' -o \


### PR DESCRIPTION
## Why

Tokenless tags currently publish source and vendor packages but do not compile the
component's distributable binaries in GitHub CI. Add the three supported release targets
while leaving OSS publication, public readback, remote smoke tests, and registry metadata
outside this workflow.

## What changed

- Move the proven Cross, reproducibility, ABI, SBOM, and Artifact validators from the
  cosh-ng action into a shared Rust prebuilt layer; cosh-ng retains its component-owned
  build and packaging script.
- Add a Tokenless composite action that stamps adapter manifests, builds the OpenClaw and
  dsh payloads, prepares pinned RTK v0.43.0, cross-compiles `tokenless` and `rtk`, calls the
  component-owned Raw packer, and emits tar, SHA-256, and CycloneDX 1.6 SBOM assets.
- Add glibc 2.17 Linux x86_64/aarch64 profiles and reuse the existing macOS arm64 profile.
  Each prepared Linux image contains sccache 0.17.0 compiled against its native glibc and
  is bound by an exact image ID.
- Route cosh-ng and Tokenless through one component-planned prebuilt matrix in tag
  Release and manual Preview workflows. Release waits for the selected matrix, validates
  the complete 12-file inventory, and attaches the assets to the existing GitHub Release;
  Preview only uploads and validates Actions Artifacts.
- Add path-filtered ordinary CI regression coverage without executing pull-request code on
  the persistent release Runner.

## Related issue

no-issue: migrate the existing Tokenless precompiled package build into GitHub CI

## User / Agent impact

Tagged Tokenless releases gain Linux x86_64, Linux aarch64, and macOS aarch64 precompiled
archives with checksum and SBOM sidecars. Other components retain their existing release
behavior.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The new matrix uses the persistent self-hosted release Runner only for release tags and
manual upstream previews. Build jobs have `contents: read`; the existing `release`
Environment remains the publication gate. The ordinary pull-request regression job uses
the existing general CI Runner. Tokenless output stays limited to the component's existing
Raw package targets and layout.

## Validation

- actionlint 1.7.12, ShellCheck 0.11.0, Python compile, prebuilt matrix planner
  tests, and `git diff --check`
- Rebased onto the latest main Tokenless 0.7.13 bump; the prebuilt regression and full
  Tokenless CI suites pass without rerunning the three real Cross targets
- `.github/actions/build-tokenless-prebuilt/test.sh`: input binding, command-injection
  rejection, two-project SBOM merge, flat and 12-file Actions Artifact validation, and
  missing/extra file rejection
- `.github/actions/build-cosh-ng-prebuilt/test.sh` after moving the shared implementation
- `src/tokenless/tests/test-package-raw.sh`, including byte-identical repeated Raw packages
- Runner image checks:
  - `gnu2.17-x86_64` image
    `sha256:72b3599de7e2406e6d0b3d1fd803cf4f613486868972f83c73b1fa4e145ea42a`
  - `gnu2.17-aarch64` image
    `sha256:4cec3c91665c86a79bb02aa4940eccbd40542bb3367bbaa4e24cced78aeb4421`
  - both images identify glibc 2.17 and dynamically linked sccache 0.17.0; a real Rust
    cache miss followed by a cache hit completed without cache errors
- self-hosted Runner builds from commit `74c35fc4` produced and verified all three
  Tokenless 0.7.12 targets; no second local full build was run:
  - Linux x86_64: maximum GLIBC 2.16; tar
    `96b1e27dd9c3e76b17d260b5bca930330b59c6fec4b3c1904306f34d9587418c`, SBOM
    `d11b429989113118880764e2782e8459383232cd8c53799fe0f364d51cf76572`
  - Linux aarch64: maximum GLIBC 2.17; tar
    `c0173f1ed3804f6e6e6779061ea4101c11e87f85f1aafa389c4805d708e4c111`, SBOM
    `bd234483ee52ba5e65b78ba22ef0b9b9cf91a34945dbb36e2f842d811fadd151`
  - macOS aarch64: arm64 Mach-O, minimum macOS 11.0; tar
    `a97f2cb3d963ba3203561d6152257497c9ae2e9ad3515ca6664d6607e19f1ca4`, SBOM
    `ba59dd8696672937eef72cee0a189993f61f9ce4861102ec1ea8d5f17d0c1896`
- a second Runner Linux x86_64 build produced byte-identical tar, checksum, SBOM, and SBOM
  checksum files; the real 12-file download layout passed the publish-job validator

## Documentation and rollback

No user documentation changes are required. Revert the commit to restore the previous
workflows. The two Tokenless builder images are additive and can be removed independently
after rollback; no existing image tag, Docker data, or release artifact was deleted.


