### PR TITLE
refactor(anolisa): use snapshots in doctor

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1.rs
@@ -2,6 +2,7 @@
 
 pub mod adopt;
 pub mod bug;
+pub(crate) mod component_observation;
 pub mod doctor;
 pub mod env;
 pub mod forget;

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
@@ -1,0 +1,585 @@
+//! Shared read-only component evidence for status and diagnostics.
+//!
+//! This module owns snapshot assembly and source-level classification only;
+//! command-specific records, findings, fix suggestions, and rendering stay
+//! with their consumers.
+
+use anolisa_core::domain::{Installation, InstallationScope, NativePm, Observation};
+use anolisa_core::{
+    AdapterObservation, AdapterProvenance, ComponentSnapshot, ComponentSnapshotObservations,
+    ComponentSnapshotRequest, ManifestHealthProvenance, ManifestHealthSnapshot,
+    NativePackageProvenance, NativePackageSnapshot, OwnedFilesProvenance, OwnedFilesSnapshot,
+    PendingJournalSnapshot, ProbeEvidence, SnapshotContractError, SnapshotProbe, StateProvenance,
+    StateRootScope, StateSnapshot, StateVisibilitySnapshot,
+};
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use thiserror::Error;
+
+use crate::commands::common;
+use crate::commands::state_view::{ScopedInstalledObject, StateScope, StateView};
+
+/// Selects which visible state records a read-only consumer observes.
+#[derive(Clone, Copy)]
+pub(crate) enum AggregateSelection {
+    /// Select only the effective record for each component name.
+    ActiveOnly,
+    /// Select every readable scope record, including shadowed records.
+    AllVisible,
+}
+
+/// Failure while assembling a component snapshot from read-only evidence.
+#[derive(Debug, Error)]
+pub(crate) enum ComponentObservationError {
+    /// Collected evidence violated the shared snapshot contract.
+    #[error("component snapshot contract failed for {component:?}: {source}")]
+    Contract {
+        /// Component whose request and evidence disagreed.
+        component: String,
+        /// Underlying request/evidence contract violation.
+        #[source]
+        source: SnapshotContractError,
+    },
+}
+
+/// Live native-package drift relative to the recorded component state.
+pub(crate) enum RpmDrift {
+    /// The native authority disagrees with the recorded package version.
+    Drifted { reason: String },
+    /// The recorded native package is absent.
+    Missing,
+}
+
+/// Apply the read-only state normalization shared by status and doctor.
+pub(crate) fn normalize_view_states(view: &mut StateView) {
+    for root in &mut view.visible_roots {
+        common::migrate_v3_symlinks(&mut root.state, &root.layout);
+        common::hydrate_owned_file_contracts(&mut root.state, &root.layout);
+    }
+    if let Some(root) = view.visible_roots.iter().find(|root| root.writable) {
+        view.writable = root.clone();
+    }
+}
+
+/// Select visible component records without projecting command output.
+pub(crate) fn select_visible_components<'a>(
+    view: &'a StateView,
+    name: Option<&str>,
+    aggregate_selection: AggregateSelection,
+) -> Vec<ScopedInstalledObject<'a>> {
+    let visible_components = view.visible_components();
+    match name {
+        None => visible_components
+            .into_iter()
+            .filter(|record| {
+                record.active || matches!(aggregate_selection, AggregateSelection::AllVisible)
+            })
+            .collect(),
+        Some(target) => visible_components
+            .into_iter()
+            .filter(|record| record.object.name == target)
+            .collect(),
+    }
+}
+
+/// Assemble one installed component snapshot from consumer-selected probes.
+pub(crate) fn snapshot_from_record(
+    record: &ScopedInstalledObject<'_>,
+    owned_files: ProbeEvidence<OwnedFilesSnapshot, OwnedFilesProvenance>,
+    native_package: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
+    manifest_health: ProbeEvidence<ManifestHealthSnapshot, ManifestHealthProvenance>,
+    adapters: ProbeEvidence<Vec<AdapterObservation>, AdapterProvenance>,
+    pending_journal: ProbeEvidence<PendingJournalSnapshot, anolisa_core::JournalProvenance>,
+) -> Result<ComponentSnapshot, ComponentObservationError> {
+    let state = ProbeEvidence::Present {
+        provenance: StateProvenance {
+            path: record.root.state_path.clone(),
+        },
+        value: StateSnapshot::Active(Box::new(record.object.clone())),
+    };
+    let state_visibility = StateVisibilitySnapshot {
+        root_scope: snapshot_scope(record.scope()),
+        active: record.active,
+        mutable_by_current_invocation: record.mutable_by_current_invocation,
+        shadowed_by: record.shadowed_by.map(snapshot_scope),
+    };
+    let mut probes = vec![SnapshotProbe::State, SnapshotProbe::OwnedFiles];
+    push_requested_probe(&mut probes, SnapshotProbe::NativePackage, &native_package);
+    push_requested_probe(&mut probes, SnapshotProbe::ManifestHealth, &manifest_health);
+    push_requested_probe(&mut probes, SnapshotProbe::Adapters, &adapters);
+    push_requested_probe(&mut probes, SnapshotProbe::PendingJournal, &pending_journal);
+    let request =
+        ComponentSnapshotRequest::new(record.object.name.clone(), record.object.scope, probes);
+
+    ComponentSnapshot::from_observations(
+        request,
+        ComponentSnapshotObservations {
+            state,
+            state_visibility: Some(state_visibility),
+            owned_files,
+            native_package,
+            manifest_health,
+            adapters,
+            pending_journal,
+        },
+    )
+    .map_err(|source| ComponentObservationError::Contract {
+        component: record.object.name.clone(),
+        source,
+    })
+}
+
+/// Observe the owned-file contract selected by one state record.
+pub(crate) fn owned_files_evidence(
+    record: &ScopedInstalledObject<'_>,
+) -> ProbeEvidence<OwnedFilesSnapshot, OwnedFilesProvenance> {
+    match anolisa_core::facts::observe_owned_files(record.object, &record.root.layout) {
+        Some(value) => ProbeEvidence::Present {
+            provenance: OwnedFilesProvenance {
+                state_path: record.root.state_path.clone(),
+            },
+            value,
+        },
+        None => ProbeEvidence::Absent {
+            provenance: OwnedFilesProvenance {
+                state_path: record.root.state_path.clone(),
+            },
+        },
+    }
+}
+
+/// Assemble state-absent evidence for a named component query.
+pub(crate) fn absent_snapshot(
+    component: &str,
+    scope: InstallationScope,
+    state_path: std::path::PathBuf,
+) -> Result<ComponentSnapshot, ComponentObservationError> {
+    let request = ComponentSnapshotRequest::new(component, scope, [SnapshotProbe::State]);
+    ComponentSnapshot::from_observations(
+        request,
+        ComponentSnapshotObservations {
+            state: ProbeEvidence::Absent {
+                provenance: StateProvenance { path: state_path },
+            },
+            state_visibility: None,
+            owned_files: ProbeEvidence::NotRequested,
+            native_package: ProbeEvidence::NotRequested,
+            manifest_health: ProbeEvidence::NotRequested,
+            adapters: ProbeEvidence::NotRequested,
+            pending_journal: ProbeEvidence::NotRequested,
+        },
+    )
+    .map_err(|source| ComponentObservationError::Contract {
+        component: component.to_string(),
+        source,
+    })
+}
+
+fn push_requested_probe<T, P>(
+    probes: &mut Vec<SnapshotProbe>,
+    probe: SnapshotProbe,
+    evidence: &ProbeEvidence<T, P>,
+) {
+    if !matches!(evidence, ProbeEvidence::NotRequested) {
+        probes.push(probe);
+    }
+}
+
+fn snapshot_scope(scope: StateScope) -> StateRootScope {
+    match scope {
+        StateScope::User => StateRootScope::User,
+        StateScope::System => StateRootScope::System,
+    }
+}
+
+/// Query one resolved native package while preserving source failure detail.
+pub(crate) fn native_package_evidence(
+    manager: NativePm,
+    package: &str,
+    query: &dyn PackageQuery,
+    observed_at: &str,
+) -> ProbeEvidence<NativePackageSnapshot, NativePackageProvenance> {
+    let provenance = NativePackageProvenance {
+        manager,
+        package: package.to_string(),
+    };
+    match query.query_installed(package) {
+        Ok(Some(info)) => ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::Installed(Observation {
+                version: info.version.version.clone(),
+                evr: Some(info.version.to_string()),
+                arch: Some(info.arch),
+                source_repo: info.origin,
+                observed_at: observed_at.to_string(),
+            }),
+        },
+        Ok(None) => ProbeEvidence::Absent { provenance },
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::UnexpectedOutput { detail },
+        },
+        Err(error) => ProbeEvidence::Unavailable {
+            provenance,
+            reason: error.to_string(),
+        },
+    }
+}
+
+/// Return the resolved package identity and recorded EVR for drift checks.
+pub(crate) fn drift_probe_identity(installation: &Installation) -> Option<(&str, Option<&str>)> {
+    match &installation.binding {
+        anolisa_core::domain::ProviderBinding::Delegated {
+            package,
+            last_observed,
+            ..
+        } => package
+            .resolved_name()
+            .map(|name| (name, last_observed.as_ref().and_then(|o| o.evr.as_deref()))),
+        anolisa_core::domain::ProviderBinding::Owned { .. } => None,
+    }
+}
+
+/// Version displayed by read-only component consumers.
+pub(crate) fn record_version(installation: &Installation) -> Option<String> {
+    match &installation.binding {
+        anolisa_core::domain::ProviderBinding::Owned { artifact } => Some(artifact.version.clone()),
+        anolisa_core::domain::ProviderBinding::Delegated { last_observed, .. } => {
+            last_observed.as_ref().map(|observation| {
+                observation
+                    .evr
+                    .clone()
+                    .unwrap_or_else(|| observation.version.clone())
+            })
+        }
+    }
+}
+
+/// Classify native package evidence relative to the recorded EVR.
+pub(crate) fn rpm_drift_from_evidence(
+    evidence: &ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
+    recorded_evr: Option<&str>,
+) -> Option<RpmDrift> {
+    match evidence {
+        ProbeEvidence::Absent { .. } => Some(RpmDrift::Missing),
+        ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::Installed(observation),
+        } => match (recorded_evr, observation.evr.as_deref()) {
+            (Some(recorded), Some(live)) if recorded != live => Some(RpmDrift::Drifted {
+                reason: format!(
+                    "rpmdb reports {live} for package {} but ANOLISA state records {recorded}",
+                    provenance.package
+                ),
+            }),
+            _ => None,
+        },
+        ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::MultipleVersions,
+        } => Some(RpmDrift::Drifted {
+            reason: format!(
+                "rpmdb reports multiple installed versions for package {}",
+                provenance.package
+            ),
+        }),
+        ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::UnexpectedOutput { detail },
+        } => Some(RpmDrift::Drifted {
+            reason: format!(
+                "rpmdb returned unexpected output for package {}: {detail}",
+                provenance.package
+            ),
+        }),
+        ProbeEvidence::NotRequested | ProbeEvidence::Unavailable { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anolisa_core::domain::{
+        LifecycleStatus, ManagementRelation, OwnedArtifact, PackageIdentity, ProviderBinding,
+    };
+    use anolisa_core::state::{FileOwner, OwnedFile, OwnedFileKind};
+    use anolisa_core::state_store::StateStore;
+    use anolisa_core::{IntegrityStatus, ObjectKind, SubscriptionScope};
+    use anolisa_platform::fs_layout::FsLayout;
+    use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
+
+    fn installation(scope: InstallationScope) -> Installation {
+        Installation {
+            kind: ObjectKind::Component,
+            name: "tokenless".to_string(),
+            scope,
+            binding: ProviderBinding::Delegated {
+                pm: NativePm::Rpm,
+                package: PackageIdentity::Resolved {
+                    name: "tokenless".to_string(),
+                },
+                relation: ManagementRelation::Observed,
+                last_observed: None,
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-08-25T00:00:00Z".to_string(),
+            last_operation_id: None,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn selection_preserves_active_and_shadowed_records() {
+        let mut user = StateStore::empty();
+        user.installations
+            .push(installation(InstallationScope::User { uid: 1000 }));
+        let mut system = StateStore::empty();
+        system
+            .installations
+            .push(installation(InstallationScope::System));
+        let user_root = crate::commands::state_view::ScopedStateRoot {
+            scope: StateScope::User,
+            layout: FsLayout::user_with_overrides(
+                "/tmp/home".into(),
+                None,
+                None,
+                Some("/tmp/user-state".into()),
+                None,
+                None,
+            ),
+            state_path: "/tmp/user-state/installed.toml".into(),
+            writable: true,
+            state: user,
+        };
+        let system_root = crate::commands::state_view::ScopedStateRoot {
+            scope: StateScope::System,
+            layout: FsLayout::system(Some("/tmp/system".into())),
+            state_path: "/tmp/system-state/installed.toml".into(),
+            writable: false,
+            state: system,
+        };
+        let view = StateView {
+            writable: user_root.clone(),
+            visible_roots: vec![user_root, system_root],
+            unavailable_roots: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let active = select_visible_components(&view, None, AggregateSelection::ActiveOnly);
+        assert_eq!(active.len(), 1);
+        assert!(active[0].active);
+        let named =
+            select_visible_components(&view, Some("tokenless"), AggregateSelection::ActiveOnly);
+        assert_eq!(named.len(), 2);
+        assert!(named[0].active);
+        assert_eq!(named[1].shadowed_by, Some(StateScope::User));
+    }
+
+    #[test]
+    fn absent_snapshot_requests_only_state() {
+        let snapshot = absent_snapshot(
+            "ghost",
+            InstallationScope::System,
+            "/var/lib/anolisa/installed.toml".into(),
+        )
+        .expect("absent snapshot");
+
+        assert!(matches!(snapshot.state(), ProbeEvidence::Absent { .. }));
+        assert_eq!(snapshot.owned_files(), &ProbeEvidence::NotRequested);
+        assert_eq!(snapshot.native_package(), &ProbeEvidence::NotRequested);
+    }
+
+    #[test]
+    fn snapshot_preserves_scope_visibility_and_owned_file_evidence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let binary = layout.bin_dir.join("tokenless");
+        std::fs::create_dir_all(binary.parent().expect("binary parent")).expect("binary dir");
+        std::fs::write(&binary, b"tokenless").expect("binary fixture");
+        let mut store = StateStore::empty();
+        store.installations.push(Installation {
+            kind: ObjectKind::Component,
+            name: "tokenless".to_string(),
+            scope: InstallationScope::System,
+            binding: ProviderBinding::Owned {
+                artifact: OwnedArtifact {
+                    version: "1.0.0".to_string(),
+                    distribution_source: None,
+                    raw_package: None,
+                    manifest_digest: None,
+                    files: vec![OwnedFile {
+                        path: binary.clone(),
+                        owner: FileOwner::Anolisa,
+                        sha256: None,
+                        kind: OwnedFileKind::File,
+                        referent: None,
+                        mode: None,
+                        capabilities: Vec::new(),
+                    }],
+                    services: Vec::new(),
+                    external_modified_files: Vec::new(),
+                    provisioned_packages: Vec::new(),
+                },
+            },
+            status: LifecycleStatus::Installed,
+            installed_at: "2026-08-25T00:00:00Z".to_string(),
+            last_operation_id: None,
+            subscription_scope: SubscriptionScope::None,
+            enabled_features: Vec::new(),
+            health: Vec::new(),
+        });
+        let root = crate::commands::state_view::ScopedStateRoot {
+            scope: StateScope::System,
+            layout,
+            state_path: tmp.path().join("state/installed.toml"),
+            writable: true,
+            state: store,
+        };
+        let view = StateView {
+            writable: root.clone(),
+            visible_roots: vec![root],
+            unavailable_roots: Vec::new(),
+            warnings: Vec::new(),
+        };
+        let selected = select_visible_components(&view, None, AggregateSelection::ActiveOnly);
+        let owned_files = owned_files_evidence(&selected[0]);
+        let snapshot = snapshot_from_record(
+            &selected[0],
+            owned_files,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+        )
+        .expect("component snapshot");
+
+        let visibility = snapshot.state_visibility().expect("state visibility");
+        assert_eq!(visibility.root_scope, StateRootScope::System);
+        assert!(visibility.active);
+        assert!(visibility.mutable_by_current_invocation);
+        assert!(matches!(
+            snapshot.owned_files(),
+            ProbeEvidence::Present { value, .. }
+                if value.files.len() == 1
+                    && value.files[0].path == binary
+                    && value.files[0].status == IntegrityStatus::Unverified
+        ));
+    }
+
+    #[derive(Clone, Copy)]
+    enum InstalledReply {
+        Present,
+        Absent,
+        Unavailable,
+        Unexpected,
+    }
+
+    struct ScriptedQuery(InstalledReply);
+
+    impl PackageQuery for ScriptedQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            match self.0 {
+                InstalledReply::Present => Ok(Some(PackageInfo {
+                    name: package.to_string(),
+                    version: PackageVersion {
+                        epoch: None,
+                        version: "1.2.3".to_string(),
+                        release: Some("1.al4".to_string()),
+                    },
+                    arch: "x86_64".to_string(),
+                    origin: Some("@System".to_string()),
+                })),
+                InstalledReply::Absent => Ok(None),
+                InstalledReply::Unavailable => Err(PackageQueryError::CommandMissing {
+                    command: "rpm".to_string(),
+                }),
+                InstalledReply::Unexpected => Err(PackageQueryError::UnexpectedOutput {
+                    command: "rpm".to_string(),
+                    detail: "malformed row".to_string(),
+                }),
+            }
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn native_package_evidence_preserves_query_outcomes() {
+        let present = native_package_evidence(
+            NativePm::Rpm,
+            "tokenless",
+            &ScriptedQuery(InstalledReply::Present),
+            "2026-08-25T00:00:00Z",
+        );
+        assert!(matches!(
+            present,
+            ProbeEvidence::Present {
+                value: NativePackageSnapshot::Installed(Observation { evr: Some(evr), .. }),
+                ..
+            } if evr == "1.2.3-1.al4"
+        ));
+
+        let absent = native_package_evidence(
+            NativePm::Rpm,
+            "tokenless",
+            &ScriptedQuery(InstalledReply::Absent),
+            "2026-08-25T00:00:00Z",
+        );
+        assert!(matches!(absent, ProbeEvidence::Absent { .. }));
+
+        let unavailable = native_package_evidence(
+            NativePm::Rpm,
+            "tokenless",
+            &ScriptedQuery(InstalledReply::Unavailable),
+            "2026-08-25T00:00:00Z",
+        );
+        assert!(matches!(
+            unavailable,
+            ProbeEvidence::Unavailable { reason, .. } if reason == "command not found: rpm"
+        ));
+
+        let unexpected = native_package_evidence(
+            NativePm::Rpm,
+            "tokenless",
+            &ScriptedQuery(InstalledReply::Unexpected),
+            "2026-08-25T00:00:00Z",
+        );
+        assert!(matches!(
+            unexpected,
+            ProbeEvidence::Present {
+                value: NativePackageSnapshot::UnexpectedOutput { detail },
+                ..
+            } if detail == "malformed row"
+        ));
+    }
+
+    #[test]
+    fn rpm_drift_classifies_multiple_and_unexpected_output() {
+        let provenance = NativePackageProvenance {
+            manager: NativePm::Rpm,
+            package: "tokenless".to_string(),
+        };
+        let multiple = ProbeEvidence::Present {
+            provenance: provenance.clone(),
+            value: NativePackageSnapshot::MultipleVersions,
+        };
+        assert!(matches!(
+            rpm_drift_from_evidence(&multiple, Some("1.2.3-1.al4")),
+            Some(RpmDrift::Drifted { reason }) if reason.contains("multiple installed versions")
+        ));
+
+        let unexpected = ProbeEvidence::Present {
+            provenance,
+            value: NativePackageSnapshot::UnexpectedOutput {
+                detail: "malformed row".to_string(),
+            },
+        };
+        assert!(matches!(
+            rpm_drift_from_evidence(&unexpected, Some("1.2.3-1.al4")),
+            Some(RpmDrift::Drifted { reason }) if reason.contains("malformed row")
+        ));
+    }
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/doctor.rs
@@ -8,25 +8,33 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use anolisa_core::domain::{Installation, LifecycleStatus, ManagementRelation, ProviderBinding};
+use anolisa_core::domain::{
+    Installation, InstallationScope, LifecycleStatus, ManagementRelation, ProviderBinding,
+};
 use anolisa_core::facts::{FactsError, JournalEvidence, JournalInventory};
 use anolisa_core::{
-    CheckEnv, CheckOutcome, CheckSpec, CheckStatus, ComponentManifest, DependencyKind,
-    DependencyResolution, DependencyResolver, DependencyStatus, HealthEntry, ObjectKind,
-    ResolverEnv, ServiceManager, ServiceRef, ServiceScope, ServiceState, check_owned_file,
-    run_check, service_for_install_mode, user_service_for_install_mode,
+    CheckEnv, CheckOutcome, CheckSpec, CheckStatus, ComponentManifest, ComponentSnapshot,
+    DependencyKind, DependencyResolution, DependencyResolver, DependencyStatus, HealthEntry,
+    IntegrityStatus, ManifestHealthProvenance, ManifestHealthSnapshot, NativePackageProvenance,
+    NativePackageSnapshot, ProbeEvidence, ResolverEnv, ServiceManager, ServiceRef, ServiceScope,
+    ServiceState, StateRootScope, StateSnapshot, check_owned_file, run_check,
+    service_for_install_mode, user_service_for_install_mode,
 };
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::privilege;
 use anolisa_platform::rpm_query::RpmPackageQuery;
+use chrono::{SecondsFormat, Utc};
 use clap::Parser;
 use serde::Serialize;
 
 use crate::color::Palette;
 use crate::commands::common;
 use crate::commands::state_view::{ScopedStateRoot, StateScope, StateView, StateVisibility};
+use crate::commands::tier1::component_observation::{
+    self, AggregateSelection, RpmDrift, drift_probe_identity, rpm_drift_from_evidence,
+};
 use crate::commands::tier1::rpm_install;
-use crate::commands::tier1::status::{self, AggregateRecordSelection, ComponentRecord, RpmDrift};
 use crate::context::{CliContext, InstallMode};
 use crate::response::{CliError, render_json_with_status};
 
@@ -239,7 +247,7 @@ fn payload_has_issues(payload: &DoctorPayload) -> bool {
 
 fn diagnose(component: Option<&str>, ctx: &CliContext) -> Result<DoctorPayload, CliError> {
     let mut view = StateView::load(ctx, COMMAND, StateVisibility::UserPlusSystem)?;
-    status::migrate_view_states(&mut view);
+    component_observation::normalize_view_states(&mut view);
     let rpm_query = RpmPackageQuery::system();
     let component = component
         .map(|name| lookup_component_name_from_view(name, &view, ctx))
@@ -266,60 +274,80 @@ fn diagnose_from_view(
     component: Option<&str>,
     view_ctx: &DoctorViewContext<'_>,
 ) -> Result<DoctorPayload, CliError> {
-    // `None` keeps the projection from executing manifest health checks:
-    // doctor runs the same structured checks itself below (honoring
-    // dry-run), and a second executor here would double every probe.
-    let records = status::select_components_from_view(
+    let records = component_observation::select_visible_components(
         view,
         component,
-        AggregateRecordSelection::ActiveOnly,
-        None,
-        None,
-        None,
-    )
-    .map_err(|error| CliError::Runtime {
-        command: COMMAND.to_string(),
-        reason: format!("failed to assemble component status snapshot: {error}"),
-    })?;
+        AggregateSelection::ActiveOnly,
+    );
     let warnings = view.warnings.clone();
     let mut components = Vec::new();
     let journal_roots = scan_journal_roots(view);
     let mut claimed_journals = BTreeSet::new();
+    let checked_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
 
-    for mut record in records {
-        let root = root_for_record(view, &record);
-        let remediation_scope = root.map_or(view.writable.scope, |root| root.scope);
-        let object =
-            root.and_then(|root| root.state.find(ObjectKind::Component, record.name.as_str()));
-        normalize_rpm_record(&mut record, object);
-        let layout = root
-            .map(|root| &root.layout)
-            .unwrap_or(&view.writable.layout);
-        let (manifest, manifest_warning) = if object.is_some() {
-            resolve_component_manifest(layout, &record.name)
-        } else {
-            (None, None)
-        };
+    for record in records {
+        let root = record.root;
+        let remediation_scope = root.scope;
+        let layout = &root.layout;
+        let (manifest, manifest_warning) = resolve_component_manifest(layout, &record.object.name);
         let probe_ctx = DoctorProbeContext {
             layout,
             resolver_env: view_ctx.resolver_env,
             rpm_query: view_ctx.rpm_query,
-            system_service: view_ctx.system_service_for_root(root),
+            system_service: view_ctx.system_service_for_root(Some(root)),
             user_service: view_ctx.user_service,
             dry_run: view_ctx.dry_run,
         };
-        let mut component = diagnose_component(
+        let snapshot = collect_doctor_snapshot(
             &record,
+            manifest.as_ref(),
+            manifest_warning.as_deref(),
+            &probe_ctx,
+            &checked_at,
+        )?;
+        let mut diagnosed = diagnose_component(
+            &snapshot,
             remediation_scope,
-            object,
             manifest.as_ref(),
             manifest_warning,
             &probe_ctx,
-        );
-        apply_component_journal_guard(&journal_roots, &mut component, &mut claimed_journals);
-        dedupe_fix_plan(&mut component.fix_plan);
-        component.status = component_status(&component);
-        components.push(component);
+            &checked_at,
+        )?;
+        apply_component_journal_guard(&journal_roots, &mut diagnosed, &mut claimed_journals);
+        dedupe_fix_plan(&mut diagnosed.fix_plan);
+        diagnosed.status = component_status(&diagnosed);
+        components.push(diagnosed);
+    }
+
+    if components.is_empty()
+        && let Some(component) = component
+    {
+        let scope = installation_scope_for_root(view.writable.scope);
+        let snapshot = component_observation::absent_snapshot(
+            component,
+            scope,
+            view.writable.state_path.clone(),
+        )
+        .map_err(snapshot_cli_error)?;
+        let probe_ctx = DoctorProbeContext {
+            layout: &view.writable.layout,
+            resolver_env: view_ctx.resolver_env,
+            rpm_query: view_ctx.rpm_query,
+            system_service: view_ctx.system_service_for_root(None),
+            user_service: view_ctx.user_service,
+            dry_run: view_ctx.dry_run,
+        };
+        let mut diagnosed = diagnose_component(
+            &snapshot,
+            view.writable.scope,
+            None,
+            None,
+            &probe_ctx,
+            &checked_at,
+        )?;
+        dedupe_fix_plan(&mut diagnosed.fix_plan);
+        diagnosed.status = component_status(&diagnosed);
+        components.push(diagnosed);
     }
 
     let recovery_roots = collect_root_recovery(&journal_roots, &claimed_journals, component);
@@ -333,6 +361,121 @@ fn diagnose_from_view(
     })
 }
 
+fn snapshot_cli_error(error: component_observation::ComponentObservationError) -> CliError {
+    CliError::Runtime {
+        command: COMMAND.to_string(),
+        reason: format!("failed to assemble component status snapshot: {error}"),
+    }
+}
+
+fn installation_scope_for_root(scope: StateScope) -> InstallationScope {
+    match scope {
+        StateScope::System => InstallationScope::System,
+        StateScope::User => InstallationScope::User {
+            uid: privilege::effective_uid(),
+        },
+    }
+}
+
+fn collect_doctor_snapshot(
+    record: &crate::commands::state_view::ScopedInstalledObject<'_>,
+    manifest: Option<&ComponentManifest>,
+    manifest_warning: Option<&str>,
+    probe_ctx: &DoctorProbeContext<'_>,
+    observed_at: &str,
+) -> Result<ComponentSnapshot, CliError> {
+    let owned_files = component_observation::owned_files_evidence(record);
+    let native_package =
+        collect_doctor_native_package(record.object, probe_ctx.rpm_query, observed_at);
+    let manifest_health =
+        collect_doctor_manifest_health(record.object, manifest, manifest_warning, probe_ctx);
+    component_observation::snapshot_from_record(
+        record,
+        owned_files,
+        native_package,
+        manifest_health,
+        ProbeEvidence::NotRequested,
+        ProbeEvidence::NotRequested,
+    )
+    .map_err(snapshot_cli_error)
+}
+
+fn collect_doctor_native_package(
+    installation: &Installation,
+    query: &dyn PackageQuery,
+    observed_at: &str,
+) -> ProbeEvidence<NativePackageSnapshot, NativePackageProvenance> {
+    let ProviderBinding::Delegated { pm, package, .. } = &installation.binding else {
+        return ProbeEvidence::NotRequested;
+    };
+    if !matches!(installation.scope, InstallationScope::System) {
+        return ProbeEvidence::NotRequested;
+    }
+    let Some(package) = package.resolved_name() else {
+        return ProbeEvidence::NotRequested;
+    };
+    component_observation::native_package_evidence(*pm, package, query, observed_at)
+}
+
+fn collect_doctor_manifest_health(
+    installation: &Installation,
+    manifest: Option<&ComponentManifest>,
+    manifest_warning: Option<&str>,
+    probe_ctx: &DoctorProbeContext<'_>,
+) -> ProbeEvidence<ManifestHealthSnapshot, ManifestHealthProvenance> {
+    let provenance = ManifestHealthProvenance {
+        path: common::installed_component_manifest_path(
+            probe_ctx.layout,
+            &installation.name,
+            COMMAND,
+        )
+        .unwrap_or_else(|_| {
+            probe_ctx
+                .layout
+                .state_dir
+                .join("component-manifests")
+                .join(&installation.name)
+                .join("component.toml")
+        }),
+    };
+    let Some(manifest) = manifest else {
+        return match manifest_warning {
+            Some(reason) if !reason.starts_with("component contract unavailable") => {
+                ProbeEvidence::Unavailable {
+                    provenance,
+                    reason: reason.to_string(),
+                }
+            }
+            _ => ProbeEvidence::Absent { provenance },
+        };
+    };
+    if installation.binding.is_delegated() {
+        return ProbeEvidence::Present {
+            provenance,
+            value: ManifestHealthSnapshot {
+                outcome: CheckOutcome {
+                    spec_label: "component.health_check".to_string(),
+                    status: CheckStatus::Skipped,
+                    detail: Some(
+                        "RPM components are verified through rpmdb; raw-layout health probes are skipped"
+                            .to_string(),
+                    ),
+                    children: Vec::new(),
+                },
+            },
+        };
+    }
+    let Some(spec) = manifest.health_spec() else {
+        return ProbeEvidence::Absent { provenance };
+    };
+    let skip_active_service_probe = installation.status == LifecycleStatus::Disabled;
+    let outcome = run_doctor_check(&spec, Some(manifest), probe_ctx, skip_active_service_probe);
+    ProbeEvidence::Present {
+        provenance,
+        value: ManifestHealthSnapshot { outcome },
+    }
+}
+
 fn lookup_component_name_from_view(
     input: &str,
     view: &StateView,
@@ -344,49 +487,89 @@ fn lookup_component_name_from_view(
     common::lookup_component_name_in_store(input, &view.writable.state, ctx, COMMAND)
 }
 
-fn root_for_record<'a>(
-    view: &'a StateView,
-    record: &ComponentRecord,
-) -> Option<&'a ScopedStateRoot> {
-    let state_path = record.state_path.as_deref()?;
-    view.visible_roots
-        .iter()
-        .find(|root| root.state_path.display().to_string() == state_path)
-}
-
 fn diagnose_component(
-    record: &ComponentRecord,
+    snapshot: &ComponentSnapshot,
     remediation_scope: StateScope,
-    object: Option<&Installation>,
     manifest: Option<&ComponentManifest>,
     manifest_warning: Option<String>,
     probe_ctx: &DoctorProbeContext<'_>,
-) -> DoctorComponent {
-    let mut out = DoctorComponent {
-        name: record.name.clone(),
-        status: "ok".to_string(),
-        scope: record.scope.clone(),
-        remediation_scope,
-        active: record.active,
-        mutable_by_current_invocation: record.mutable_by_current_invocation,
-        shadowed_by: record.shadowed_by.clone(),
-        state_path: record.state_path.clone(),
-        state_status: Some(
-            object
-                .map(|object| common::installation_status_str(object).to_string())
-                .unwrap_or_else(|| record.status.clone()),
+    checked_at: &str,
+) -> Result<DoctorComponent, CliError> {
+    let (object, state_path) = match snapshot.state() {
+        ProbeEvidence::Absent { .. } => (None, None),
+        ProbeEvidence::Present {
+            provenance,
+            value: StateSnapshot::Active(installation),
+        } => (
+            Some(installation.as_ref()),
+            Some(provenance.path.display().to_string()),
         ),
-        version: record.version.clone(),
+        ProbeEvidence::Present {
+            value: StateSnapshot::Quarantined(_),
+            ..
+        } => {
+            return Err(CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component snapshot for '{}' contains quarantined state",
+                    snapshot.request().component()
+                ),
+            });
+        }
+        ProbeEvidence::Unavailable { reason, .. } => {
+            return Err(CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: reason.clone(),
+            });
+        }
+        ProbeEvidence::NotRequested => {
+            return Err(CliError::Runtime {
+                command: COMMAND.to_string(),
+                reason: format!(
+                    "component snapshot for '{}' did not request state",
+                    snapshot.request().component()
+                ),
+            });
+        }
+    };
+    let visibility = snapshot.state_visibility();
+    let state_status = object
+        .map(common::installation_status_str)
+        .unwrap_or("not_installed");
+    let mut out = DoctorComponent {
+        name: snapshot.request().component().to_string(),
+        status: "ok".to_string(),
+        scope: object.map_or_else(
+            || "none".to_string(),
+            |_| {
+                visibility.map_or_else(
+                    || installation_scope_label(snapshot.request().scope()).to_string(),
+                    |metadata| state_root_scope_label(metadata.root_scope).to_string(),
+                )
+            },
+        ),
+        remediation_scope,
+        active: visibility.is_some_and(|metadata| metadata.active),
+        mutable_by_current_invocation: visibility
+            .is_some_and(|metadata| metadata.mutable_by_current_invocation),
+        shadowed_by: visibility
+            .and_then(|metadata| metadata.shadowed_by)
+            .map(state_root_scope_label)
+            .map(str::to_string),
+        state_path,
+        state_status: Some(state_status.to_string()),
+        version: object.and_then(component_observation::record_version),
         findings: Vec::new(),
         health_checks: Vec::new(),
         dependencies: Vec::new(),
         fix_plan: Vec::new(),
     };
 
-    add_state_finding(record, object, &mut out);
-    add_health_entries(record, object, probe_ctx.layout, &mut out);
+    add_state_finding(state_status, &mut out);
+    add_persisted_health(object, probe_ctx.layout, &mut out);
+    add_owned_file_health(snapshot, object, probe_ctx.layout, checked_at, &mut out);
     add_manifest_warning(manifest_warning, object, probe_ctx.layout, &mut out);
-    add_structured_health(manifest, object, probe_ctx, &mut out);
+    add_snapshot_manifest_health(snapshot, object, probe_ctx.layout, &mut out);
     add_service_refs(manifest, object, probe_ctx, &mut out);
     add_runtime_dependencies(
         manifest,
@@ -395,42 +578,32 @@ fn diagnose_component(
         probe_ctx.dry_run,
         &mut out,
     );
-    add_rpm_drift(object, probe_ctx.rpm_query, &mut out);
-    out
+    add_rpm_drift(snapshot, object, &mut out);
+    Ok(out)
 }
 
-fn normalize_rpm_record(record: &mut ComponentRecord, object: Option<&Installation>) {
-    let Some(object) = object else {
-        return;
-    };
-    if !object.binding.is_delegated() {
-        return;
+fn installation_scope_label(scope: InstallationScope) -> &'static str {
+    match scope {
+        InstallationScope::System => "system",
+        InstallationScope::User { .. } => "user",
     }
-    // `status`' legacy manifest probes expand `{bindir}` through the raw
-    // `/usr/local` layout. Delegated packages own their files under distro
-    // paths, so doctor must not treat those raw-layout probe results as
-    // package health.
-    record
-        .health
-        .retain(|entry| !entry.name.starts_with(&format!("{}:", record.name)));
-    record.status = crate::commands::common::installation_status_str(object).to_string();
 }
 
-fn add_state_finding(
-    record: &ComponentRecord,
-    object: Option<&Installation>,
-    out: &mut DoctorComponent,
-) {
-    let status = object
-        .map(common::installation_status_str)
-        .unwrap_or(record.status.as_str());
+fn state_root_scope_label(scope: StateRootScope) -> &'static str {
+    match scope {
+        StateRootScope::User => "user",
+        StateRootScope::System => "system",
+    }
+}
+
+fn add_state_finding(status: &str, out: &mut DoctorComponent) {
     match status {
         "installed" | "adopted" | "observed" | "disabled" => {}
         "not_installed" => {
             out.findings.push(finding(
                 FindingSeverity::Error,
                 "component_not_installed",
-                format!("component '{}' is not installed", record.name),
+                format!("component '{}' is not installed", out.name),
                 "state",
                 None,
             ));
@@ -438,7 +611,7 @@ fn add_state_finding(
                 out.remediation_scope,
                 "install_component",
                 "install",
-                &record.name,
+                &out.name,
                 "install the component before running component-level diagnostics",
             ));
         }
@@ -447,7 +620,7 @@ fn add_state_finding(
             "component_degraded",
             format!(
                 "component '{}' is marked degraded in ANOLISA state",
-                record.name
+                out.name
             ),
             "state",
             None,
@@ -455,50 +628,100 @@ fn add_state_finding(
         "failed" => out.findings.push(finding(
             FindingSeverity::Error,
             "component_failed",
-            format!(
-                "component '{}' is marked failed in ANOLISA state",
-                record.name
-            ),
+            format!("component '{}' is marked failed in ANOLISA state", out.name),
             "state",
             None,
         )),
         other => out.findings.push(finding(
             FindingSeverity::Warning,
             "component_status_attention",
-            format!("component '{}' has status '{other}'", record.name),
+            format!("component '{}' has status '{other}'", out.name),
             "state",
             None,
         )),
     }
 }
 
-fn add_health_entries(
-    record: &ComponentRecord,
+fn add_persisted_health(
     object: Option<&Installation>,
     layout: &FsLayout,
     out: &mut DoctorComponent,
 ) {
-    for entry in &record.health {
-        out.health_checks.push(health_from_entry(entry));
-        let Some(severity) = severity_for_health_status(&entry.status) else {
+    let Some(object) = object else {
+        return;
+    };
+    let manifest_prefix = format!("{}:", object.name);
+    for entry in &object.health {
+        // Delegated packages are verified through rpmdb. Persisted raw-layout
+        // manifest probes expand paths under /usr/local and do not describe
+        // the files owned by the package manager.
+        if object.binding.is_delegated() && entry.name.starts_with(&manifest_prefix) {
             continue;
+        }
+        add_health_entry(entry, Some(object), layout, out);
+    }
+}
+
+fn add_owned_file_health(
+    snapshot: &ComponentSnapshot,
+    object: Option<&Installation>,
+    layout: &FsLayout,
+    checked_at: &str,
+    out: &mut DoctorComponent,
+) {
+    let ProbeEvidence::Present { value, .. } = snapshot.owned_files() else {
+        return;
+    };
+    for observation in &value.files {
+        if observation.status == IntegrityStatus::Skipped {
+            continue;
+        }
+        let reason = match &observation.status {
+            IntegrityStatus::ProbeLimitExceeded { size, limit } => Some(format!(
+                "file size {size} exceeds the {limit}-byte integrity probe ceiling; \
+                 the recorded digest was not re-checked this run"
+            )),
+            _ => None,
         };
-        out.findings.push(finding(
-            severity,
-            format!("health_{}", sanitize_code(&entry.status)),
-            format!("health check '{}' reported '{}'", entry.name, entry.status),
-            "health",
-            entry.reason.clone(),
-        ));
-        out.fix_plan.extend(suggestions_for_health(
-            out.remediation_scope,
-            &record.name,
-            &entry.name,
-            &entry.status,
+        add_health_entry(
+            &HealthEntry {
+                name: format!("integrity:{}", observation.path.display()),
+                status: observation.status.label().to_string(),
+                checked_at: checked_at.to_string(),
+                reason,
+            },
             object,
             layout,
-        ));
+            out,
+        );
     }
+}
+
+fn add_health_entry(
+    entry: &HealthEntry,
+    object: Option<&Installation>,
+    layout: &FsLayout,
+    out: &mut DoctorComponent,
+) {
+    out.health_checks.push(health_from_entry(entry));
+    let Some(severity) = severity_for_health_status(&entry.status) else {
+        return;
+    };
+    out.findings.push(finding(
+        severity,
+        format!("health_{}", sanitize_code(&entry.status)),
+        format!("health check '{}' reported '{}'", entry.name, entry.status),
+        "health",
+        entry.reason.clone(),
+    ));
+    out.fix_plan.extend(suggestions_for_health(
+        out.remediation_scope,
+        &out.name,
+        &entry.name,
+        &entry.status,
+        object,
+        layout,
+    ));
 }
 
 fn add_manifest_warning(
@@ -544,38 +767,20 @@ fn add_manifest_warning(
     out.fix_plan.extend(fixes);
 }
 
-fn add_structured_health(
-    manifest: Option<&ComponentManifest>,
+fn add_snapshot_manifest_health(
+    snapshot: &ComponentSnapshot,
     object: Option<&Installation>,
-    probe_ctx: &DoctorProbeContext<'_>,
+    layout: &FsLayout,
     out: &mut DoctorComponent,
 ) {
     let Some(object) = object else {
         return;
     };
-    let Some(manifest) = manifest else {
+    let ProbeEvidence::Present { value, .. } = snapshot.manifest_health() else {
         return;
     };
-    if object.binding.is_delegated() {
-        out.health_checks.push(DoctorHealthCheck {
-            name: "component.health_check".to_string(),
-            status: "skipped".to_string(),
-            source: "structured_health".to_string(),
-            detail: Some(
-                "RPM components are verified through rpmdb; raw-layout health probes are skipped"
-                    .to_string(),
-            ),
-            checked_at: None,
-        });
-        return;
-    }
-    let Some(spec) = manifest.health_spec() else {
-        return;
-    };
-    let skip_active_service_probe = object.status == LifecycleStatus::Disabled;
-    let outcome = run_doctor_check(&spec, Some(manifest), probe_ctx, skip_active_service_probe);
     let component = out.name.clone();
-    add_check_outcome(&component, object, probe_ctx.layout, &outcome, out);
+    add_check_outcome(&component, object, layout, &value.outcome, out);
 }
 
 fn run_doctor_check(
@@ -1238,8 +1443,8 @@ fn add_dependency_resolution(resolution: &DependencyResolution, out: &mut Doctor
 }
 
 fn add_rpm_drift(
+    snapshot: &ComponentSnapshot,
     object: Option<&Installation>,
-    rpm_query: &dyn PackageQuery,
     out: &mut DoctorComponent,
 ) {
     let Some(object) = object else {
@@ -1248,7 +1453,7 @@ fn add_rpm_drift(
     if !object.binding.is_delegated() {
         return;
     }
-    let Some((package, recorded_evr)) = status::drift_probe_identity(object) else {
+    let Some((package, recorded_evr)) = drift_probe_identity(object) else {
         out.health_checks.push(DoctorHealthCheck {
             name: "rpmdb".to_string(),
             status: "unverified".to_string(),
@@ -1275,7 +1480,7 @@ fn add_rpm_drift(
         ));
         return;
     };
-    match status::probe_rpm_drift(package, recorded_evr, rpm_query) {
+    match rpm_drift_from_evidence(snapshot.native_package(), recorded_evr) {
         Some(RpmDrift::Drifted { reason }) => {
             out.health_checks.push(DoctorHealthCheck {
                 name: format!("rpmdb:{package}"),
@@ -2151,9 +2356,11 @@ mod tests {
     use anolisa_core::state_store::StateStore;
     use anolisa_core::transaction::Transaction;
     use anolisa_core::{
-        DependencyStatus, FakeServiceManager, HealthEntry, NotSupportedServiceManager, ServiceOp,
+        DependencyStatus, FakeServiceManager, HealthEntry, NotSupportedServiceManager, ObjectKind,
+        ServiceOp,
     };
-    use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError};
+    use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError, PackageVersion};
+    use std::cell::Cell;
     use std::path::PathBuf;
 
     struct MissingPackageQuery;
@@ -2171,25 +2378,27 @@ mod tests {
         }
     }
 
-    fn record(name: &str, status: &str) -> ComponentRecord {
-        ComponentRecord {
-            name: name.to_string(),
-            status: status.to_string(),
-            scope: "system".to_string(),
-            active: true,
-            mutable_by_current_invocation: true,
-            shadowed_by: None,
-            state_path: Some("/tmp/anolisa-system-state/installed.toml".to_string()),
-            version: Some("1.0.0".to_string()),
-            installed_at: None,
-            last_operation_id: None,
-            enabled_features: Vec::new(),
-            health: Vec::new(),
-            adapters: Vec::new(),
-            rpm_package: None,
-            rpm_evr: None,
-            rpm_source_repo: None,
-            provisioned_packages: Vec::new(),
+    struct CountingPackageQuery {
+        calls: Cell<usize>,
+    }
+
+    impl PackageQuery for CountingPackageQuery {
+        fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(Some(PackageInfo {
+                name: package.to_string(),
+                version: PackageVersion {
+                    epoch: None,
+                    version: "1.0.0".to_string(),
+                    release: Some("1.al4".to_string()),
+                },
+                arch: "x86_64".to_string(),
+                origin: None,
+            }))
+        }
+
+        fn query_available(&self, _package: &str) -> Result<Vec<PackageInfo>, PackageQueryError> {
+            Ok(Vec::new())
         }
     }
 
@@ -2632,6 +2841,104 @@ mod tests {
     }
 
     #[test]
+    fn named_missing_component_uses_state_absent_snapshot() {
+        let view = system_only_doctor_view(StateStore::empty());
+
+        let payload = diagnose_test_view(&view, Some("ghost"));
+
+        assert_eq!(payload.components.len(), 1);
+        let component = &payload.components[0];
+        assert_eq!(component.name, "ghost");
+        assert_eq!(component.scope, "none");
+        assert!(!component.active);
+        assert!(!component.mutable_by_current_invocation);
+        assert_eq!(component.state_path, None);
+        assert_eq!(component.state_status.as_deref(), Some("not_installed"));
+        assert_eq!(component.status, "not_installed");
+    }
+
+    #[test]
+    fn doctor_queries_native_package_exactly_once() {
+        let object =
+            resolved_delegated_object("cosh", "copilot-shell", ManagementRelation::Observed);
+        let view = system_only_doctor_view(state_with_component(object));
+        let resolver_env = ResolverEnv::default();
+        let query = CountingPackageQuery {
+            calls: Cell::new(0),
+        };
+        let system_service = FakeServiceManager::new();
+        let user_service = FakeServiceManager::with_scope(ServiceScope::User);
+        let view_ctx = DoctorViewContext {
+            resolver_env: &resolver_env,
+            rpm_query: &query,
+            current_system_service: &system_service,
+            system_scope_service: &system_service,
+            user_service: &user_service,
+            dry_run: false,
+        };
+
+        let payload =
+            diagnose_from_view(&view, Some("cosh"), &view_ctx).expect("diagnose test view");
+
+        assert_eq!(query.calls.get(), 1);
+        assert!(
+            payload.components[0]
+                .health_checks
+                .iter()
+                .any(|check| check.name == "rpmdb:copilot-shell" && check.status == "ok")
+        );
+    }
+
+    #[test]
+    fn doctor_projects_owned_file_evidence_from_snapshot() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        let missing = layout.bin_dir.join("agentsight");
+        let mut object = owned_object("agentsight", LifecycleStatus::Installed);
+        push_owned_file(&mut object, missing.clone());
+        let view = system_view_with_layout(layout, state_with_component(object));
+
+        let payload = diagnose_test_view(&view, Some("agentsight"));
+
+        let component = &payload.components[0];
+        assert!(component.health_checks.iter().any(|check| {
+            check.name == format!("integrity:{}", missing.display())
+                && check.status == "missing_file"
+        }));
+        assert!(
+            component
+                .findings
+                .iter()
+                .any(|finding| finding.code == "health_missing_file")
+        );
+    }
+
+    #[test]
+    fn doctor_reports_installed_manifest_parse_failure_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+        write_manifest_snapshot(&layout, "agentsight", "invalid = [");
+        let view = system_view_with_layout(
+            layout,
+            state_with_component(owned_object("agentsight", LifecycleStatus::Installed)),
+        );
+
+        let payload = diagnose_test_view(&view, Some("agentsight"));
+
+        let manifest_findings = payload.components[0]
+            .findings
+            .iter()
+            .filter(|finding| finding.code == "manifest_unavailable")
+            .collect::<Vec<_>>();
+        assert_eq!(manifest_findings.len(), 1);
+        assert!(
+            manifest_findings[0].detail.as_deref().is_some_and(
+                |detail| detail.contains("failed to parse installed manifest snapshot")
+            )
+        );
+    }
+
+    #[test]
     fn system_doctor_view_uses_only_visible_system_root() {
         let view = system_only_doctor_view(state_with_component(delegated_object(
             "system-tool",
@@ -2876,7 +3183,7 @@ mod tests {
     #[test]
     fn missing_component_recommends_install() {
         let mut component = empty_component("ghost");
-        add_state_finding(&record("ghost", "not_installed"), None, &mut component);
+        add_state_finding("not_installed", &mut component);
 
         assert_eq!(component.findings[0].code, "component_not_installed");
         assert_eq!(
@@ -2890,17 +3197,16 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
         let missing = layout.bin_dir.join("agentsight");
-        let mut rec = record("agentsight", "installed");
-        rec.health.push(HealthEntry {
+        let entry = HealthEntry {
             name: format!("integrity:{}", missing.display()),
             status: "missing_file".to_string(),
             checked_at: "2026-06-01T00:00:00Z".to_string(),
             reason: Some("missing file".to_string()),
-        });
+        };
         let mut obj = owned_object("agentsight", LifecycleStatus::Installed);
         push_owned_file(&mut obj, missing);
-        let mut component = empty_component(&rec.name);
-        add_health_entries(&rec, Some(&obj), &layout, &mut component);
+        let mut component = empty_component("agentsight");
+        add_health_entry(&entry, Some(&obj), &layout, &mut component);
 
         assert_eq!(component.findings[0].severity, FindingSeverity::Error);
         assert_eq!(
@@ -3674,26 +3980,26 @@ mod tests {
 
     #[test]
     fn rpm_record_discards_raw_layout_manifest_health() {
-        let mut rec = record("agentsight", "failed");
-        rec.health.push(HealthEntry {
+        let mut obj = delegated_object("agentsight", LifecycleStatus::Installed);
+        obj.health.push(HealthEntry {
             name: "agentsight:command:launcher".to_string(),
             status: "command_error".to_string(),
             checked_at: "2026-06-01T00:00:00Z".to_string(),
             reason: Some("raw bindir probe failed".to_string()),
         });
-        rec.health.push(HealthEntry {
+        obj.health.push(HealthEntry {
             name: "persisted:last".to_string(),
             status: "ok".to_string(),
             checked_at: "2026-06-01T00:00:00Z".to_string(),
             reason: None,
         });
-        let obj = delegated_object("agentsight", LifecycleStatus::Installed);
+        let layout = FsLayout::system(None);
+        let mut component = empty_component("agentsight");
 
-        normalize_rpm_record(&mut rec, Some(&obj));
+        add_persisted_health(Some(&obj), &layout, &mut component);
 
-        assert_eq!(rec.status, "installed");
-        assert_eq!(rec.health.len(), 1);
-        assert_eq!(rec.health[0].name, "persisted:last");
+        assert_eq!(component.health_checks.len(), 1);
+        assert_eq!(component.health_checks[0].name, "persisted:last");
     }
 
     #[test]
@@ -3718,20 +4024,19 @@ mod tests {
 
     #[test]
     fn unverified_health_is_informational_when_state_is_clean() {
-        let mut rec = record("agent-memory", "degraded");
-        rec.health.push(HealthEntry {
+        let entry = HealthEntry {
             name: "integrity:/var/lib/anolisa/component-manifests/agent-memory/component.toml"
                 .to_string(),
             status: "unverified".to_string(),
             checked_at: "2026-06-01T00:00:00Z".to_string(),
             reason: None,
-        });
+        };
         let obj = owned_object("agent-memory", LifecycleStatus::Installed);
         let layout = FsLayout::system(None);
-        let mut component = empty_component(&rec.name);
+        let mut component = empty_component("agent-memory");
 
-        add_state_finding(&rec, Some(&obj), &mut component);
-        add_health_entries(&rec, Some(&obj), &layout, &mut component);
+        add_state_finding("installed", &mut component);
+        add_health_entry(&entry, Some(&obj), &layout, &mut component);
 
         assert!(component.findings.is_empty());
         assert!(component.fix_plan.is_empty());

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/status.rs
@@ -23,35 +23,41 @@ use clap::Parser;
 use serde::Serialize;
 use thiserror::Error;
 
+#[cfg(test)]
+use anolisa_core::SnapshotProbe;
 use anolisa_core::adapter::claim::ClaimStatus;
 use anolisa_core::adapter::manager::{AdapterSourceStatus, ScanEntry};
-use anolisa_core::domain::{
-    Installation, InstallationScope, NativePm, Observation, ProviderBinding,
-};
-use anolisa_core::facts::observe_owned_files;
+#[cfg(test)]
+use anolisa_core::domain::NativePm;
+use anolisa_core::domain::{Installation, InstallationScope, ProviderBinding};
 use anolisa_core::state::ObjectKind;
 use anolisa_core::state_migration::QuarantineReason;
 #[cfg(test)]
 use anolisa_core::state_store::StateStore;
 use anolisa_core::{
     AdapterObservation, AdapterProvenance, AdapterSourceSnapshot, CheckEnv, CheckOutcome,
-    CheckStatus, ComponentManifest, ComponentSnapshot, ComponentSnapshotObservations,
-    ComponentSnapshotRequest, HealthEntry, IntegrityStatus, ManifestHealthProvenance,
-    ManifestHealthSnapshot, NativePackageProvenance, NativePackageSnapshot, OwnedFilesProvenance,
-    ProbeEvidence, ServiceManager, ServiceProbes, SnapshotContractError, SnapshotProbe,
-    StateProvenance, StateRootScope, StateSnapshot, StateVisibilitySnapshot, run_check,
+    CheckStatus, ComponentManifest, ComponentSnapshot, HealthEntry, IntegrityStatus,
+    ManifestHealthProvenance, ManifestHealthSnapshot, NativePackageProvenance,
+    NativePackageSnapshot, OwnedFilesProvenance, ProbeEvidence, ServiceManager, ServiceProbes,
+    SnapshotContractError, StateRootScope, StateSnapshot, run_check,
     service_for_install_mode as service_factory, user_service_for_install_mode,
 };
 use anolisa_env::EnvService;
 use anolisa_platform::fs_layout::FsLayout;
-use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use crate::color::{Palette, pad_right};
 use crate::commands::common;
 use crate::commands::common::RepoPersistPolicy;
-use crate::commands::state_view::{StateScope, StateView, StateVisibility};
+#[cfg(test)]
+use crate::commands::state_view::StateScope;
+use crate::commands::state_view::{StateView, StateVisibility};
 use crate::commands::telemetry::status_command_for_service_target;
+use crate::commands::tier1::component_observation::{
+    self, AggregateSelection, ComponentObservationError, RpmDrift, drift_probe_identity,
+    rpm_drift_from_evidence,
+};
 use crate::commands::tier1::install::rpm_package_candidates_with_index;
 use crate::context::{CliContext, InstallMode};
 use crate::repo_config::BackendConfig;
@@ -178,14 +184,8 @@ struct StatusPayload {
     warnings: Vec<String>,
 }
 
-/// Selects which records an aggregate read-only view should project.
-#[derive(Clone, Copy)]
-pub(crate) enum AggregateRecordSelection {
-    /// Project only the effective record for each component name.
-    ActiveOnly,
-    /// Project every readable scope record, including shadowed records.
-    AllVisible,
-}
+#[cfg(test)]
+pub(crate) type AggregateRecordSelection = AggregateSelection;
 
 /// Internal failure while constructing or projecting a status snapshot.
 #[derive(Debug, Error)]
@@ -204,7 +204,18 @@ pub(crate) enum StatusSnapshotError {
     MissingActiveState { component: String },
 }
 
+impl From<ComponentObservationError> for StatusSnapshotError {
+    fn from(error: ComponentObservationError) -> Self {
+        match error {
+            ComponentObservationError::Contract { component, source } => {
+                Self::Contract { component, source }
+            }
+        }
+    }
+}
+
 enum AdapterScanEvidence<'a> {
+    #[cfg(test)]
     NotRequested,
     Available(&'a [ScanEntry]),
     Unavailable(String),
@@ -212,7 +223,7 @@ enum AdapterScanEvidence<'a> {
 
 pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     let mut view = StateView::load(ctx, COMMAND, StateVisibility::UserPlusSystem)?;
-    migrate_view_states(&mut view);
+    component_observation::normalize_view_states(&mut view);
     let layout = common::resolve_layout(ctx);
     let adapter_scan = common::build_adapter_manager(ctx).scan();
 
@@ -254,7 +265,7 @@ pub fn handle(args: StatusArgs, ctx: &CliContext) -> Result<(), CliError> {
     let mut records = select_components_from_view_with_adapter_evidence(
         &view,
         selected_component.as_deref(),
-        AggregateRecordSelection::AllVisible,
+        AggregateSelection::AllVisible,
         adapter_evidence,
         Some(&service_backends),
         Some(&query),
@@ -397,16 +408,6 @@ fn quarantine_reason_text(reason: &QuarantineReason) -> String {
     }
 }
 
-pub(crate) fn migrate_view_states(view: &mut StateView) {
-    for root in &mut view.visible_roots {
-        common::migrate_v3_symlinks(&mut root.state, &root.layout);
-        common::hydrate_owned_file_contracts(&mut root.state, &root.layout);
-    }
-    if let Some(root) = view.visible_roots.iter().find(|root| root.writable) {
-        view.writable = root.clone();
-    }
-}
-
 /// Scope-routed service managers for the manifest health probe, built once
 /// per invocation. Mirrors doctor's routing: system units on a system-scope
 /// record probe through the real system manager regardless of invocation
@@ -491,10 +492,9 @@ pub(crate) fn select_components(
     .expect("test snapshot evidence must satisfy its request")
 }
 
-/// `manifest_probe` controls whether the projection executes each record's
-/// snapshot-declared health check: status passes its scope-routed backends,
-/// doctor passes `None` because it runs the same structured checks itself
-/// (with its own dry-run semantics) — there must be exactly one executor.
+/// `manifest_probe` lets selector tests choose whether the status projection
+/// executes each record's snapshot-declared health check.
+#[cfg(test)]
 pub(crate) fn select_components_from_view(
     view: &StateView,
     name: Option<&str>,
@@ -520,26 +520,13 @@ pub(crate) fn select_components_from_view(
 fn select_components_from_view_with_adapter_evidence(
     view: &StateView,
     name: Option<&str>,
-    aggregate_selection: AggregateRecordSelection,
+    aggregate_selection: AggregateSelection,
     adapter_scan: AdapterScanEvidence<'_>,
     manifest_probe: Option<&ServiceProbeBackends<'_>>,
     rpm_query: Option<&dyn PackageQuery>,
 ) -> Result<Vec<ComponentRecord>, StatusSnapshotError> {
-    let visible_components = view.visible_components();
-    let selected: Vec<_> = match name {
-        None => visible_components
-            .iter()
-            .copied()
-            .filter(|record| {
-                record.active || matches!(aggregate_selection, AggregateRecordSelection::AllVisible)
-            })
-            .collect(),
-        Some(target) => visible_components
-            .iter()
-            .copied()
-            .filter(|record| record.object.name == target)
-            .collect(),
-    };
+    let selected =
+        component_observation::select_visible_components(view, name, aggregate_selection);
 
     let Some(target_records) = (!selected.is_empty()).then_some(selected) else {
         return Ok(name
@@ -577,37 +564,13 @@ fn collect_status_snapshot(
     rpm_query: Option<&dyn PackageQuery>,
     observed_at: &str,
 ) -> Result<ComponentSnapshot, StatusSnapshotError> {
-    let state = ProbeEvidence::Present {
-        provenance: StateProvenance {
-            path: record.root.state_path.clone(),
-        },
-        value: StateSnapshot::Active(Box::new(record.object.clone())),
-    };
-    let state_visibility = StateVisibilitySnapshot {
-        root_scope: snapshot_scope(record.scope()),
-        active: record.active,
-        mutable_by_current_invocation: record.mutable_by_current_invocation,
-        shadowed_by: record.shadowed_by.map(snapshot_scope),
-    };
-    let owned_files = match observe_owned_files(record.object, &record.root.layout) {
-        Some(value) => ProbeEvidence::Present {
-            provenance: OwnedFilesProvenance {
-                state_path: record.root.state_path.clone(),
-            },
-            value,
-        },
-        None => ProbeEvidence::Absent {
-            provenance: OwnedFilesProvenance {
-                state_path: record.root.state_path.clone(),
-            },
-        },
-    };
     let manifest_health = collect_manifest_health(
         &record.root.layout,
         record.scope().label(),
         manifest_probe,
         record.object,
     );
+    let owned_files = component_observation::owned_files_evidence(record);
     let pre_native_status = projected_health_status(
         common::installation_status_str(record.object),
         &owned_files,
@@ -618,42 +581,15 @@ fn collect_status_snapshot(
     let adapters =
         collect_adapter_observations(&record.object.name, adapter_scan, adapter_state_paths);
 
-    let mut probes = vec![SnapshotProbe::State, SnapshotProbe::OwnedFiles];
-    if !matches!(&native_package, ProbeEvidence::NotRequested) {
-        probes.push(SnapshotProbe::NativePackage);
-    }
-    if !matches!(&manifest_health, ProbeEvidence::NotRequested) {
-        probes.push(SnapshotProbe::ManifestHealth);
-    }
-    if !matches!(&adapters, ProbeEvidence::NotRequested) {
-        probes.push(SnapshotProbe::Adapters);
-    }
-    let request =
-        ComponentSnapshotRequest::new(record.object.name.clone(), record.object.scope, probes);
-
-    ComponentSnapshot::from_observations(
-        request,
-        ComponentSnapshotObservations {
-            state,
-            state_visibility: Some(state_visibility),
-            owned_files,
-            native_package,
-            manifest_health,
-            adapters,
-            pending_journal: ProbeEvidence::NotRequested,
-        },
+    component_observation::snapshot_from_record(
+        record,
+        owned_files,
+        native_package,
+        manifest_health,
+        adapters,
+        ProbeEvidence::NotRequested,
     )
-    .map_err(|source| StatusSnapshotError::Contract {
-        component: record.object.name.clone(),
-        source,
-    })
-}
-
-fn snapshot_scope(scope: StateScope) -> StateRootScope {
-    match scope {
-        StateScope::User => StateRootScope::User,
-        StateScope::System => StateRootScope::System,
-    }
+    .map_err(StatusSnapshotError::from)
 }
 
 fn collect_native_package(
@@ -677,40 +613,7 @@ fn collect_native_package(
         return ProbeEvidence::NotRequested;
     };
 
-    native_package_evidence(*pm, package, query, observed_at)
-}
-
-fn native_package_evidence(
-    manager: NativePm,
-    package: &str,
-    query: &dyn PackageQuery,
-    observed_at: &str,
-) -> ProbeEvidence<NativePackageSnapshot, NativePackageProvenance> {
-    let provenance = NativePackageProvenance {
-        manager,
-        package: package.to_string(),
-    };
-    match query.query_installed(package) {
-        Ok(Some(info)) => ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::Installed(Observation {
-                version: info.version.version.clone(),
-                evr: Some(info.version.to_string()),
-                arch: Some(info.arch),
-                source_repo: info.origin,
-                observed_at: observed_at.to_string(),
-            }),
-        },
-        Ok(None) => ProbeEvidence::Absent { provenance },
-        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::UnexpectedOutput { detail },
-        },
-        Err(error) => ProbeEvidence::Unavailable {
-            provenance,
-            reason: error.to_string(),
-        },
-    }
+    component_observation::native_package_evidence(*pm, package, query, observed_at)
 }
 
 fn collect_manifest_health(
@@ -780,6 +683,7 @@ fn collect_adapter_observations(
         state_paths: state_paths.to_vec(),
     };
     match scan {
+        #[cfg(test)]
         AdapterScanEvidence::NotRequested => ProbeEvidence::NotRequested,
         AdapterScanEvidence::Unavailable(reason) => ProbeEvidence::Unavailable {
             provenance,
@@ -937,22 +841,6 @@ fn observed_record(
     None
 }
 
-/// Live rpmdb-drift classification for an in-state RPM component (#960).
-///
-/// `None` (from [`probe_rpm_drift`]) means "no drift to report" — the recorded
-/// status stands. The two variants are the manual-mutation cases the proposal
-/// calls out: a `dnf update`/`downgrade` (or a same-name multi-version rpmdb)
-/// surfaces as [`Drifted`](RpmDrift::Drifted); an `rpm -e` surfaces as
-/// [`Missing`](RpmDrift::Missing).
-// pub(crate): the cross-command MVP lifecycle test (#963) asserts on these variants.
-pub(crate) enum RpmDrift {
-    /// rpmdb holds the package at a different version than ANOLISA recorded, or
-    /// holds several versions at once. `reason` explains which.
-    Drifted { reason: String },
-    /// rpmdb no longer holds the package at all.
-    Missing,
-}
-
 /// Compare an RPM component's recorded EVR against live rpmdb reality.
 ///
 /// `status` is read-only and best-effort: an unrunnable or anomalous query
@@ -960,69 +848,15 @@ pub(crate) enum RpmDrift {
 /// than crying drift on a read we cannot trust. A same-name multi-version rpmdb
 /// is a genuine divergence from the single recorded version, so it classifies
 /// as drift. `query` is injected so tests drive this without a live rpmdb.
-// pub(crate): driven by the cross-command MVP lifecycle test (#963).
+#[cfg(test)]
 pub(crate) fn probe_rpm_drift(
     package: &str,
     recorded_evr: Option<&str>,
     query: &dyn PackageQuery,
 ) -> Option<RpmDrift> {
-    let evidence = native_package_evidence(NativePm::Rpm, package, query, "");
+    let evidence =
+        component_observation::native_package_evidence(NativePm::Rpm, package, query, "");
     rpm_drift_from_evidence(&evidence, recorded_evr)
-}
-
-/// The (package, recorded EVR) pair the drift probe compares against rpmdb,
-/// when the installation is delegated with a resolved package.
-pub(crate) fn drift_probe_identity(installation: &Installation) -> Option<(&str, Option<&str>)> {
-    match &installation.binding {
-        ProviderBinding::Delegated {
-            package,
-            last_observed,
-            ..
-        } => package
-            .resolved_name()
-            .map(|name| (name, last_observed.as_ref().and_then(|o| o.evr.as_deref()))),
-        ProviderBinding::Owned { .. } => None,
-    }
-}
-
-fn rpm_drift_from_evidence(
-    evidence: &ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
-    recorded_evr: Option<&str>,
-) -> Option<RpmDrift> {
-    match evidence {
-        ProbeEvidence::Absent { .. } => Some(RpmDrift::Missing),
-        ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::Installed(observation),
-        } => match (recorded_evr, observation.evr.as_deref()) {
-            (Some(recorded), Some(live)) if recorded != live => Some(RpmDrift::Drifted {
-                reason: format!(
-                    "rpmdb reports {live} for package {} but ANOLISA state records {recorded}",
-                    provenance.package
-                ),
-            }),
-            _ => None,
-        },
-        ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::MultipleVersions,
-        } => Some(RpmDrift::Drifted {
-            reason: format!(
-                "rpmdb reports multiple installed versions for package {}",
-                provenance.package
-            ),
-        }),
-        ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::UnexpectedOutput { detail },
-        } => Some(RpmDrift::Drifted {
-            reason: format!(
-                "rpmdb returned unexpected output for package {}: {detail}",
-                provenance.package
-            ),
-        }),
-        ProbeEvidence::NotRequested | ProbeEvidence::Unavailable { .. } => None,
-    }
 }
 
 fn apply_native_package_to_record(
@@ -1113,7 +947,7 @@ fn record_from_snapshot(
             .map(state_root_scope_label)
             .map(str::to_string),
         state_path: Some(state_provenance.path.display().to_string()),
-        version: record_version(installation),
+        version: component_observation::record_version(installation),
         installed_at: Some(installation.installed_at.clone()),
         last_operation_id: installation.last_operation_id.clone(),
         enabled_features: installation.enabled_features.clone(),
@@ -1178,17 +1012,6 @@ fn adapter_summaries_from_snapshot(
             source_reason: observation.source_reason.clone(),
         })
         .collect()
-}
-
-/// Displayed version: authoritative for owned artifacts; the last observed
-/// EVR (full EVR preferred, matching the legacy wire) for delegated rows.
-fn record_version(installation: &Installation) -> Option<String> {
-    match &installation.binding {
-        ProviderBinding::Owned { artifact } => Some(artifact.version.clone()),
-        ProviderBinding::Delegated { last_observed, .. } => last_observed
-            .as_ref()
-            .map(|o| o.evr.clone().unwrap_or_else(|| o.version.clone())),
-    }
 }
 
 /// Project typed owned-file observations into the existing health-entry wire.


### PR DESCRIPTION
## Why

Doctor still depended on the status command projection even though component evidence is now modeled by request-scoped snapshots. This slice moves shared observation behind a CLI-private boundary so doctor can diagnose directly from `ComponentSnapshot`.

## What changed

- Add a neutral component-observation module for state visibility, owned files, native packages, and RPM drift classification.
- Keep status responsible for adapter and manifest-health collection plus its existing `ComponentRecord` projection.
- Build doctor snapshots directly from selected state records, including state-absent snapshots for named missing components.
- Preserve doctor-owned journal recovery, service references, runtime dependency checks, and exactly-once probes.

## Related issue

closes #2828

## User / Agent impact

None. Human and JSON output, exit codes, dry-run behavior, disabled-service handling, and remediation suggestions are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This is an internal projection refactor with regression coverage for existing behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test -p anolisa-cli --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps`
- ALinux 4 disposable container: targeted doctor and observation tests
- ALinux 4 isolated user state: healthy, named-missing, and degraded human/JSON scenarios with expected exit codes 0/2/2

## Documentation and rollback

No tracked documentation changes. The local Chinese refactoring roadmap remains untracked and is intentionally excluded from this PR. Roll back by reverting commit `cffa2feb`.