### PR TITLE
chore(anolisa): bump version to 0.3.7

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-08-25
+
+### Changed
+
+- Source and RPM builds now require Rust 1.93, with the rustup toolchain pinned
+  to 1.93.1 and Cargo dependency resolution constrained by the declared MSRV.
+  Builders can use the newest compiler packaged by Alibaba Cloud Linux 4
+  without Cargo selecting dependencies that exceed the supported compiler;
+  older Rust toolchains must be upgraded
+  ([#2810](https://github.com/alibaba/anolisa/pull/2810)).
+
+### Fixed
+
+- `anolisa --dry-run restart <component>` now lists the units that would be
+  restarted without invoking `systemctl daemon-reload` or `systemctl restart`.
+  System-mode previews read recorded state without taking the exclusive install
+  lock, so they no longer require write access to the state root
+  ([#2774](https://github.com/alibaba/anolisa/pull/2774)).
+
 ## [0.3.6] - 2026-08-22
 
 ### Fixed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,23 @@
 
 ## [未发布]
 
+## [0.3.7] - 2026-08-25
+
+### 变更
+
+- 源码构建与 RPM 构建现要求 Rust 1.93，rustup toolchain 固定为 1.93.1，
+  Cargo dependency resolution 同时受声明的 MSRV 约束。构建者可使用
+  Alibaba Cloud Linux 4 打包的最新 compiler，且 Cargo 不会选择超出受支持
+  compiler 的 dependency；更早的 Rust toolchain 需要升级
+  ([#2810](https://github.com/alibaba/anolisa/pull/2810))。
+
+### 修复
+
+- `anolisa --dry-run restart <component>` 现会列出将要重启的 unit，但不会调用
+  `systemctl daemon-reload` 或 `systemctl restart`。System mode 预览会读取已记录
+  状态而不获取 exclusive install lock，因此不再要求对 state root 拥有写权限
+  ([#2774](https://github.com/alibaba/anolisa/pull/2774))。
+
 ## [0.3.6] - 2026-08-22
 
 ### 修复

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Sat Aug 22 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Tue Aug 25 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Restart dry-runs now remain read-only and never invoke systemd.
+- Source and RPM builds now require Rust 1.93.
+
+* Sat Aug 22 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.6-1
 - Quiet adapter inspection now suppresses all non-error human output.
 - Forget dry-runs now refuse components with enabled adapters.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.6",
-    "@anolisa/cli-linux-arm64": "0.3.6",
-    "@anolisa/cli-darwin-arm64": "0.3.6"
+    "@anolisa/cli-linux-x64": "0.3.7",
+    "@anolisa/cli-linux-arm64": "0.3.7",
+    "@anolisa/cli-darwin-arm64": "0.3.7"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

ANOLISA has accumulated a user-visible restart-preview fix and a documented build-floor change since 0.3.6. This release cut synchronizes every active Cargo, npm, and RPM version surface so the release workflows build one coherent 0.3.7 artifact set.

## What changed

- Bump the Cargo workspace, root npm package, and three native npm package templates to 0.3.7.
- Add equivalent English and Chinese release notes for #2774 and #2810.
- Start the 0.3.7 RPM changelog boundary while freezing the prior template row at 0.3.6-1.

## Related issue

no-issue: scheduled ANOLISA component release; included user-visible changes are tracked by #2774 and #2810.

## User / Agent impact

The 0.3.7 packages keep `anolisa --dry-run restart <component>` read-only: previews list units without invoking systemd and system-mode previews no longer need state-root write access. Source and RPM builders must use Rust 1.93 or newer; the pinned rustup toolchain is 1.93.1.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The bump itself contains no runtime implementation change. Runtime compatibility is unchanged; the only compatibility boundary is the already-documented Rust 1.93 minimum for source and RPM builds. Linux arm64 and macOS arm64 package templates were validated, but their native artifacts cannot be built on this Linux x86_64 host.

## Validation

Host: Alibaba Cloud Linux 8, x86_64; Rust 1.93.1; Node.js 20.20.2 for website checks.

- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/scripts/package-npm.js --validate`
- `node --test npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --target linux-x64`
- Installed the generated root and Linux x64 tarballs together; `anolisa --version` reported 0.3.7.
- `sed 's/@VERSION@/0.3.7/g' anolisa.spec.in | rpmspec -P /dev/stdin`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- Node 20 temporary-worktree checks: website production build, typecheck, Agent index validation, and static link/duplicate-ID validation.
- `check_release.py` passed for both the working tree and committed `HEAD` against the 0.3.6 content bump `3b7f6ebc`.
- `git diff --cached --check`

The initial RPM stdin attempt used `rpmspec -P -`, which this host treats as a filename. Re-running the same rendered spec through `/dev/stdin` passed.

## Documentation and rollback

`CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM changelog describe the final user-visible range. Before publication, rollback is a revert of this atomic bump; after any 0.3.7 artifact is published, do not reuse the version and publish a corrective higher version instead.
