### PR TITLE
chore(tokenless): bump version to 0.7.13

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.12"
+version = "0.7.13"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,17 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.13] - 2026-08-25
+
+### Added
+
+- Rust callers can now use the `tokenless-protocol` and `tokenless-pipeline` crates for versioned compression requests and responses, bounded content detection, registry routing, staged execution, and fail-open arbitration ([#2783](https://github.com/alibaba/anolisa/pull/2783), [#2788](https://github.com/alibaba/anolisa/pull/2788), [#2799](https://github.com/alibaba/anolisa/pull/2799)).
+
+### Changed
+
+- The CLI `compress-response` command, `TokenlessRuntime::compress_response`, and the Python binding now route record-shaped JSON through the shared pipeline; scalar JSON roots pass through unchanged, while timeouts and rejected candidates return the original content and roll back their Stash writes ([#2816](https://github.com/alibaba/anolisa/pull/2816)).
+- Runtime and Python `disposition` values now use the protocol's snake_case forms such as `dry_run` and `no_savings`, and may report `passthrough`, `timeout`, or `error`; cleanup-only savings can now apply under `require_reversible` without a Stash when no truncation occurred ([#2816](https://github.com/alibaba/anolisa/pull/2816)).
+
 ## [0.7.12] - 2026-08-22
 
 ### Changed

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,17 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.13] - 2026-08-25
+
+### 新增
+
+- Rust 调用方现在可以使用 `tokenless-protocol` 与 `tokenless-pipeline` Crate，获得带版本的压缩 Request/Response、受限成本的内容探测、Registry 路由、分阶段执行和 fail-open 仲裁能力（[#2783](https://github.com/alibaba/anolisa/pull/2783)、[#2788](https://github.com/alibaba/anolisa/pull/2788)、[#2799](https://github.com/alibaba/anolisa/pull/2799)）。
+
+### 变更
+
+- CLI `compress-response` 命令、`TokenlessRuntime::compress_response` 与 Python Binding 现在通过共享 Pipeline 处理 Record 结构的 JSON；标量 JSON 根节点会保持原样透传，超时或被拒绝的候选结果会返回原始内容并回滚其 Stash 写入（[#2816](https://github.com/alibaba/anolisa/pull/2816)）。
+- Runtime 与 Python 的 `disposition` 值现在使用协议定义的 snake_case 形式（如 `dry_run` 和 `no_savings`），并可能返回 `passthrough`、`timeout` 或 `error`；当未发生截断时，纯清理节省现在无需 Stash 也可在 `require_reversible` 下生效（[#2816](https://github.com/alibaba/anolisa/pull/2816)）。
+
 ## [0.7.12] - 2026-08-22
 
 ### 变更

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "chrono",
  "clap",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-pipeline"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "thiserror 2.0.18",
  "tokenless-ccr",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-protocol"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "regex",
  "serde_json",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.12"
+version = "0.7.13"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.12",
-    "@anolisa/tokenless-linux-arm64": "0.7.12",
-    "@anolisa/tokenless-darwin-x64": "0.7.12",
-    "@anolisa/tokenless-darwin-arm64": "0.7.12"
+    "@anolisa/tokenless-linux-x64": "0.7.13",
+    "@anolisa/tokenless-linux-arm64": "0.7.13",
+    "@anolisa/tokenless-darwin-x64": "0.7.13",
+    "@anolisa/tokenless-darwin-arm64": "0.7.13"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -470,6 +470,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Tue Aug 25 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.13-1
+- feat(tokenless): add protocol v1 compression types
+- feat(tokenless): add content detection and registry routing
+- feat(tokenless): add staged fail-open arbitration
+- feat(tokenless): route response compression through the registry
+
 * Sat Aug 22 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.12-1
 - feat(tokenless): preserve tail items during array truncation
 - fix(tokenless): surface skipped schema compression


### PR DESCRIPTION
## Why

Release the Tokenless protocol, pipeline, and response-compression changes merged after 0.7.12 as version 0.7.13. The bump follows the established 0.7.x patch cadence and synchronizes the history-derived 14-file release contract rather than adding runtime code. Paired release notes describe the final behavior from #2783, #2788, #2799, and #2816, including the binding-visible disposition compatibility change.

## What changed

- Bump the Tokenless Cargo workspace and locks, ANOLISA component catalog, Cosh extension, npm root and four platform packages, and RPM changelog to 0.7.13.
- Add semantically equivalent English and Chinese release notes for the public protocol/pipeline APIs and final response-compression behavior.
- Keep the version bump as the branch's last and only release commit; it adds no runtime behavior beyond the already-merged range.

## Related issue

no-issue: release rollup for merged Tokenless changes

## User / Agent impact

Tokenless 0.7.13 makes the versioned Rust protocol and staged pipeline available and routes CLI, Runtime, and Python response compression through the shared fail-open arbitration path. Scalar JSON roots now pass through, cleanup-only savings can satisfy `require_reversible` without Stash when no truncation occurs, and binding-visible `disposition` values use snake_case (`dry_run`, `no_savings`) with new `passthrough`, `timeout`, and `error` outcomes.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [x] Migration or rollback guidance is needed

Runtime and Python consumers that parse disposition strings must accept the snake_case values and new variants. Response compression remains fail-open: timeout, error, reversibility rejection, and no-savings paths preserve the original content and roll back candidate Stash writes. The current-host npm smoke artifact requires GLIBC 2.32 and is not a publishable Linux baseline artifact; release CI must continue to supply the validated GLIBC 2.17 prebuilts.

## Validation

Alibaba Cloud Linux 8 compatible host, x86_64:

- Release audit passed against bump boundary `5a1c5800` in working-tree and committed `--revision HEAD` modes; `git diff --check` passed.
- `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace -- --test-threads=1` (685 passed, 2 ignored network tests); `cargo doc --workspace --no-deps`.
- `make build`, `make lint`, and built `target/release/tokenless --version` reported 0.7.13.
- `PATH="$PWD/target/release:$PWD/third_party/rtk/target/release:$PATH" make test`: 71/71 shell E2E, 98 Python hook/integration tests, adapter suites, raw packaging, four-platform npm contract packaging, and stale-TOON cleanup passed.
- `make test-python-runtime`: ABI3 wheel built as 0.7.13 and 28 Runtime/SDK tests passed.
- `make test-agentscope-integration`: AgentScope 1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.7 smoke tests passed.
- `RUST_MIN_STACK=16777216 cargo test --manifest-path benchmark/l1-compressor/Cargo.toml` (89 passed); `cargo test --manifest-path benchmark/l2-module/Cargo.toml` (42 passed).
- Real release binaries produced a verified 0.7.13 Linux x86_64 raw archive; `make npm-package` assembled the native npm package; stamped `rpmspec -P` reported version 0.7.13-1.al8 and `Provides: anolisa-component(tokenless)`.
- Root and benchmark `cargo metadata --locked` plus JSON manifest parsing passed.

## Documentation and rollback

Updated `CHANGELOG.md` and `CHANGELOG_zh.md` with equivalent 0.7.13 entries and preserved their empty Unreleased sections. Before publication, rollback by reverting commit `65487f27`; after immutable packages are published, restore compatibility through a new version rather than attempting to republish 0.7.13.
