### PR TITLE
chore(ci): simplify cosh-ng matrix job name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,6 @@ jobs:
           retention-days: 28
 
   build_cosh_ng_prebuilt:
-    name: Build cosh-ng ${{ matrix.target-os }}-${{ matrix.target-arch }}
     needs: package
     if: needs.package.outputs.component == 'cosh-ng'
     permissions:


### PR DESCRIPTION
## Why

Skipped non-cosh-ng releases display the literal matrix expression from the custom job name, which is confusing in the Actions UI.

## What changed

Removed the custom name from the conditional cosh-ng prebuilt matrix job. GitHub will use its default matrix job names for real cosh-ng builds, while the skipped node no longer contains an unexpanded expression.

## Related issue

no-issue: cosmetic GitHub Actions display cleanup

## User / Agent impact

The Actions job label changes only. Packaging, matrix execution, runner selection, and publish gating are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This removes one display-only job name.

## Validation

- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/release.yaml")'`
- `git diff --check`
- Verified the diff only removes the custom name and preserves the package, prebuilt, and publish conditions.

## Documentation and rollback

No documentation change is needed. Revert the single commit to restore the previous label.