### PR TITLE
fix(cosh-ng): [gateway] allow Core openat2

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
@@ -73,6 +73,16 @@ remaining arguments unchanged.
   `cosh-gateway@.service`. It selects the contained `core` runtime with the
   `gateway-brokered-v1` profile and admits the configured canonical workspace:
 
+  The unit defaults Core `HOME` to
+  `/var/lib/cosh-gateway-%i/core-home`, below its private systemd
+  `StateDirectory`. Store the provider configuration at
+  `/var/lib/cosh-gateway-$USER/core-home/.copilot-shell/config.toml`, or use
+  `/etc/copilot-shell/config.toml` as a system configuration. Do not set
+  `HOME` to a path outside that `StateDirectory` in
+  `/etc/cosh/gateway-$USER.env`. `EnvironmentFile` values override the unit's
+  safe default, while the admitted workspace and other host paths are
+  read-only for this contained Core profile.
+
   ```bash
   sudo install -d -m 0755 /etc/cosh
   sudo install -m 0600 /dev/null "/etc/cosh/gateway-$USER.env"

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
@@ -68,6 +68,14 @@ Gateway binary；此时请替换为 `cosh-gateway doctor`、`cosh-gateway run` �
   `cosh-gateway@.service` unit。它选择 contained `core` runtime 和
   `gateway-brokered-v1` profile，并接纳配置的 canonical workspace：
 
+  Unit 默认把 Core `HOME` 设为 private systemd `StateDirectory` 下的
+  `/var/lib/cosh-gateway-%i/core-home`。Provider config 可以放在
+  `/var/lib/cosh-gateway-$USER/core-home/.copilot-shell/config.toml`，也可以使用
+  `/etc/copilot-shell/config.toml` system config。不要在
+  `/etc/cosh/gateway-$USER.env` 中把 `HOME` 设到该 `StateDirectory` 之外。
+  `EnvironmentFile` 中的值会覆盖 unit 的安全默认值，而 admitted workspace 与其他 host
+  path 对这个 contained Core profile 保持只读。
+
   ```bash
   sudo install -d -m 0755 /etc/cosh
   sudo install -m 0600 /dev/null "/etc/cosh/gateway-$USER.env"

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -137,6 +137,16 @@ side effect.
 
 Configure the workspace and start the account-named Gateway instance:
 
+The Core unit defaults `HOME` to
+`/var/lib/cosh-gateway-%i/core-home`, below its private systemd
+`StateDirectory`. Put the Core provider configuration at
+`/var/lib/cosh-gateway-$USER/core-home/.copilot-shell/config.toml`, or use the
+system configuration at `/etc/copilot-shell/config.toml`. Do not override
+`HOME` to a path outside that `StateDirectory` in
+`/etc/cosh/gateway-$USER.env`; the environment file takes precedence over the
+safe default, while the admitted workspace and other host paths are read-only
+inside this unit.
+
 ```bash
 sudo install -d -m 0755 /etc/cosh
 sudo install -m 0600 /dev/null "/etc/cosh/gateway-$USER.env"

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -126,6 +126,13 @@ slash command、Web 或 remote capability，也没有需要 approval 的 side ef
 
 配置 workspace 并启动按 account 命名的 Gateway instance。
 
+Core unit 默认把 `HOME` 设为 private systemd `StateDirectory` 下的
+`/var/lib/cosh-gateway-%i/core-home`。Core provider config 可以放在
+`/var/lib/cosh-gateway-$USER/core-home/.copilot-shell/config.toml`，也可以使用
+`/etc/copilot-shell/config.toml` system config。不要在
+`/etc/cosh/gateway-$USER.env` 中把 `HOME` 覆盖到该 `StateDirectory` 之外；environment
+file 的优先级高于安全默认值，而 admitted workspace 与其他 host path 在这个 unit 中是只读的。
+
 ```bash
 sudo install -d -m 0755 /etc/cosh
 sudo install -m 0600 /dev/null "/etc/cosh/gateway-$USER.env"

--- a/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
+++ b/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
@@ -430,6 +430,7 @@ fn packaged_base_service_is_task_only_and_free_of_ws_ckpt_dependency() {
 
     assert!(unit.contains("--core-executable=\"{libexecdir}/cosh-ng/cosh-core\""));
     assert!(unit.contains("--workspace=${COSH_GATEWAY_WORKSPACE}"));
+    assert!(unit.contains("Environment=HOME=/var/lib/cosh-gateway-%i/core-home"));
     assert!(!unit.contains("ws-ckpt.service"));
     assert!(!unit.contains("--checkpoint-socket="));
     assert!(!unit.contains("--security-audit="));
@@ -441,11 +442,19 @@ fn packaged_base_service_is_task_only_and_free_of_ws_ckpt_dependency() {
         "Delegate=no",
         "TimeoutStopSec=15",
         "Restart=on-failure",
+        "NoNewPrivileges=true",
+        "PrivateTmp=true",
+        "PrivateDevices=true",
+        "TemporaryFileSystem=/dev/shm:ro,nosuid,nodev,noexec",
+        "ProtectSystem=strict",
         "ProtectControlGroups=true",
         "InaccessiblePaths=/run/user",
+        "RestrictSUIDSGID=false",
     ] {
         assert!(unit.lines().any(|line| line == property), "{property}");
     }
+    assert!(!unit.lines().any(|line| line == "ProtectSystem=full"));
+    assert!(!unit.lines().any(|line| line == "RestrictSUIDSGID=true"));
     assert!(!unit.contains("--adapter="));
     assert!(!unit.contains("--profile="));
     assert!(!unit.contains("--runtime-backend="));

--- a/src/cosh-ng/packaging/systemd/cosh-gateway@.service.in
+++ b/src/cosh-ng/packaging/systemd/cosh-gateway@.service.in
@@ -8,6 +8,9 @@ StartLimitBurst=5
 Type=exec
 User=%i
 EnvironmentFile=/etc/cosh/gateway-%i.env
+# Brokered Core disables its own session persistence but still initializes a
+# rolling logger. Keep that private write below the systemd-managed state root.
+Environment=HOME=/var/lib/cosh-gateway-%i/core-home
 ExecStart="{libexecdir}/cosh-ng/cosh-gateway" serve --systemd-unit=cosh-gateway@%i.service --socket=/run/cosh-gateway-%i/gateway.sock --database=/var/lib/cosh-gateway-%i/gateway.sqlite --core-executable="{libexecdir}/cosh-ng/cosh-core" --workspace=${COSH_GATEWAY_WORKSPACE}
 RuntimeDirectory=cosh-gateway-%i
 RuntimeDirectoryMode=0700
@@ -26,12 +29,23 @@ RestartSec=2
 
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectSystem=full
+# Replace the host device tree, then cover the separately mounted /dev/shm
+# with an explicitly read-only private filesystem. This closes writable paths
+# outside ProtectSystem without blocking Core's openat2 confinement.
+PrivateDevices=true
+TemporaryFileSystem=/dev/shm:ro,nosuid,nodev,noexec
+# The closed Core profile has no workspace write capability. Keeping every
+# non-systemd-managed path read-only preserves the effect of SUID/SGID
+# creation hardening without blocking Core's read-only openat2 confinement.
+ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
 InaccessiblePaths=/run/user
-RestrictSUIDSGID=true
+# systemd implements this directive by rejecting every openat2 call because
+# seccomp cannot inspect its indirect mode argument. The strict read-only
+# filesystem boundary above leaves only private daemon state writable.
+RestrictSUIDSGID=false
 LockPersonality=true
 
 [Install]

--- a/src/cosh-ng/scripts/fixtures/gateway-containment-tree.sh
+++ b/src/cosh-ng/scripts/fixtures/gateway-containment-tree.sh
@@ -3,8 +3,98 @@
 set -euo pipefail
 
 usage() {
-    printf 'usage: %s {assert-clean|launch|leaf|spawn-grandchild|double-fork} ...\n' "$0" >&2
+    printf 'usage: %s {assert-core-filesystem|assert-clean|launch|leaf|spawn-grandchild|double-fork} ...\n' "$0" >&2
     exit 64
+}
+
+assert_core_filesystem() {
+    local workspace="$1" state="$2" shm_marker="$3"
+
+    python3 - "$workspace" "$state" "$shm_marker" <<'PY'
+import ctypes
+import errno
+import os
+import sys
+
+workspace, state, shm_marker = map(os.fsencode, sys.argv[1:])
+if os.path.basename(shm_marker) != shm_marker:
+    raise RuntimeError(f"invalid /dev/shm marker basename: {shm_marker!r}")
+expected_home = state + b"/core-home"
+actual_home = os.fsencode(os.environ.get("HOME", ""))
+if actual_home != expected_home:
+    raise RuntimeError(f"private Core HOME mismatch: {actual_home!r}")
+
+dev_flags = os.statvfs(b"/dev").f_flag
+if not dev_flags & os.ST_RDONLY:
+    raise RuntimeError("PrivateDevices did not mount /dev read-only")
+
+shm_flags = os.statvfs(b"/dev/shm").f_flag
+for flag, label in (
+    (os.ST_RDONLY, "read-only"),
+    (os.ST_NOSUID, "nosuid"),
+    (os.ST_NODEV, "nodev"),
+    (os.ST_NOEXEC, "noexec"),
+):
+    if not shm_flags & flag:
+        raise RuntimeError(f"private /dev/shm is not {label}")
+
+shm_probe = b"/dev/shm/" + shm_marker
+try:
+    fd = os.open(shm_probe, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o6755)
+except OSError as error:
+    if error.errno not in (errno.EROFS, errno.EACCES, errno.EPERM):
+        raise
+else:
+    os.close(fd)
+    os.unlink(shm_probe)
+    raise RuntimeError("the private /dev/shm remained writable")
+
+shm_result_path = state + b"/dev-shm-containment-result"
+fd = os.open(shm_result_path, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600)
+os.write(fd, b"creation-denied\n")
+os.close(fd)
+
+
+class OpenHow(ctypes.Structure):
+    _fields_ = [
+        ("flags", ctypes.c_uint64),
+        ("mode", ctypes.c_uint64),
+        ("resolve", ctypes.c_uint64),
+    ]
+
+
+libc = ctypes.CDLL(None, use_errno=True)
+how = OpenHow(os.O_PATH | os.O_DIRECTORY | os.O_CLOEXEC, 0, 0)
+fd = libc.syscall(437, -100, workspace, ctypes.byref(how), ctypes.sizeof(how))
+if fd < 0:
+    error = ctypes.get_errno()
+    raise OSError(error, f"openat2 workspace probe failed: {os.strerror(error)}")
+os.close(fd)
+
+forbidden = workspace + b"/must-not-create-suid"
+try:
+    fd = os.open(forbidden, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o4755)
+except OSError as error:
+    if error.errno not in (errno.EROFS, errno.EACCES, errno.EPERM):
+        raise
+else:
+    os.close(fd)
+    os.unlink(forbidden)
+    raise RuntimeError("the admitted Core workspace remained writable")
+
+marker = state + b"/private-state-probe"
+fd = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+os.close(fd)
+os.unlink(marker)
+
+log_dir = expected_home + b"/.copilot-shell/logs"
+os.makedirs(log_dir, mode=0o700, exist_ok=True)
+log_file = log_dir + b"/cosh-core.log.probe"
+fd = os.open(log_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+os.write(fd, b"private Core logging remains writable\n")
+os.close(fd)
+os.unlink(log_file)
+PY
 }
 
 process_start_time() {
@@ -191,6 +281,10 @@ launch() {
 }
 
 case "${1:-}" in
+    assert-core-filesystem)
+        [ "$#" -eq 4 ] || usage
+        assert_core_filesystem "$2" "$3" "$4"
+        ;;
     assert-clean)
         [ "$#" -eq 2 ] || usage
         assert_clean "$2"

--- a/src/cosh-ng/scripts/test-gateway-containment.sh
+++ b/src/cosh-ng/scripts/test-gateway-containment.sh
@@ -60,8 +60,14 @@ for property in \
     "Delegate=no" \
     "TimeoutStopSec=15" \
     "Restart=on-failure" \
+    "NoNewPrivileges=true" \
+    "PrivateTmp=true" \
+    "PrivateDevices=true" \
+    "TemporaryFileSystem=/dev/shm:ro,nosuid,nodev,noexec" \
+    "ProtectSystem=strict" \
     "ProtectControlGroups=true" \
-    "InaccessiblePaths=/run/user"; do
+    "InaccessiblePaths=/run/user" \
+    "RestrictSUIDSGID=false"; do
     grep -Fqx -- "$property" "$PACKAGED_UNIT" \
         || fail "packaged Gateway unit is missing containment property: $property"
 done
@@ -80,13 +86,20 @@ ENVIRONMENT_FILE="/etc/cosh/gateway-${INSTANCE}.env"
 USER_RUNTIME_DIR="/run/user/65534"
 POSITIVE_USER_UNIT="${BASE}-positive-user.service"
 FIXTURE="$WORK_DIR/tree-fixture.sh"
-STATE="$WORK_DIR/state"
+WORKSPACE_ROOT="/opt/${BASE}"
+WORKSPACE="$WORKSPACE_ROOT/workspace"
+STATE="/var/lib/cosh-gateway-${INSTANCE}"
+SHM_MARKER="${BASE}-suid-probe"
+HOST_SHM_PROBE="/dev/shm/${SHM_MARKER}"
 CONTROL_GROUP=""
 
 [ ! -e "$UNIT_FILE" ] || fail "refusing to replace an existing runtime Gateway template"
 [ ! -e "$DROP_IN_DIR" ] || fail "refusing to replace an existing Gateway drop-in"
 [ ! -e "$WS_CKPT_UNIT_FILE" ] || fail "refusing to replace an existing runtime ws-ckpt unit"
 [ ! -e "$ENVIRONMENT_FILE" ] || fail "refusing to replace an existing Gateway environment"
+[ ! -e "$WORKSPACE_ROOT" ] || fail "refusing to reuse an existing workspace root"
+[ ! -e "$STATE" ] || fail "refusing to reuse an existing Gateway state directory"
+[ ! -e "$HOST_SHM_PROBE" ] || fail "refusing to reuse an existing /dev/shm probe"
 ! systemctl is-active --quiet user@65534.service \
     || fail "refusing to reuse an active fixture user manager"
 
@@ -116,17 +129,24 @@ cleanup() {
     fi
     rm -rf -- "$DROP_IN_DIR"
     rm -f -- "$WS_CKPT_UNIT_FILE" "$ENVIRONMENT_FILE"
+    rm -f -- "$HOST_SHM_PROBE"
     systemctl daemon-reload >/dev/null 2>&1
     case "$WORK_DIR" in
         /run/cosh-gateway-containment.*) rm -rf -- "$WORK_DIR" ;;
+    esac
+    case "$WORKSPACE_ROOT" in
+        /opt/cosh-gateway-containment-*) rm -rf -- "$WORKSPACE_ROOT" ;;
+    esac
+    case "$STATE" in
+        /var/lib/cosh-gateway-containment*) rm -rf -- "$STATE" ;;
     esac
 }
 trap cleanup EXIT INT TERM
 
 install -m 0755 "$SOURCE_FIXTURE" "$FIXTURE"
-install -d -m 0770 -o 65534 -g 65534 "$STATE"
+install -d -m 0755 -o 65534 -g 65534 "$WORKSPACE"
 install -d -m 0755 /etc/cosh "$DROP_IN_DIR"
-printf 'COSH_GATEWAY_WORKSPACE=%s\n' "$STATE" > "$ENVIRONMENT_FILE"
+printf 'COSH_GATEWAY_WORKSPACE=%s\n' "$WORKSPACE" > "$ENVIRONMENT_FILE"
 chmod 0600 "$ENVIRONMENT_FILE"
 
 sed 's|{libexecdir}|/usr/libexec|g' "$PACKAGED_UNIT" > "$UNIT_FILE"
@@ -143,6 +163,7 @@ User=65534
 Group=65534
 Environment=XDG_RUNTIME_DIR=$USER_RUNTIME_DIR
 ExecStart=
+ExecStartPre="$FIXTURE" assert-core-filesystem "$WORKSPACE" "$STATE" "$SHM_MARKER"
 ExecStartPre="$FIXTURE" assert-clean "$STATE"
 ExecStart="$FIXTURE" launch "$STATE" "$TOKEN"
 EOF
@@ -170,7 +191,7 @@ run_as_fixture_user systemctl --user stop "$POSITIVE_USER_UNIT"
 systemctl start "$UNIT"
 
 EFFECTIVE_PROPERTIES="$(systemctl show "$UNIT" \
-    --property=Type,KillMode,SendSIGKILL,FinalKillSignal,Delegate,Restart,FragmentPath,DropInPaths)"
+    --property=Type,KillMode,SendSIGKILL,FinalKillSignal,Delegate,Restart,FragmentPath,DropInPaths,ProtectSystem,RestrictSUIDSGID,NoNewPrivileges,PrivateDevices,TemporaryFileSystem)"
 for property in \
     "Type=exec" \
     "KillMode=control-group" \
@@ -178,12 +199,24 @@ for property in \
     "FinalKillSignal=9" \
     "Delegate=no" \
     "Restart=on-failure" \
+    "ProtectSystem=strict" \
+    "RestrictSUIDSGID=no" \
+    "NoNewPrivileges=yes" \
+    "PrivateDevices=yes" \
+    "TemporaryFileSystem=/dev/shm:ro,nosuid,nodev,noexec" \
     "FragmentPath=$UNIT_FILE"; do
     printf '%s\n' "$EFFECTIVE_PROPERTIES" | grep -Fqx -- "$property" \
         || fail "effective Gateway unit property mismatch: $property"
 done
 printf '%s\n' "$EFFECTIVE_PROPERTIES" | grep -F -- "$DROP_IN" >/dev/null \
     || fail "systemd did not load the fixture-only ExecStart drop-in"
+systemctl show "$UNIT" --property=Environment --value \
+    | grep -F -- "HOME=/var/lib/cosh-gateway-${INSTANCE}/core-home" >/dev/null \
+    || fail "systemd did not isolate brokered Core HOME below private state"
+[ -s "$STATE/dev-shm-containment-result" ] \
+    || fail "the private /dev/shm containment probe did not complete"
+[ ! -e "$HOST_SHM_PROBE" ] \
+    || fail "the Core unit created a host-visible SUID/SGID /dev/shm artifact"
 case "$(systemctl show "$UNIT" --property=TimeoutStopUSec --value)" in
     15s | 15000000us) ;;
     *) fail "effective Gateway stop timeout differs from the packaged 15 seconds" ;;


### PR DESCRIPTION
## Why

On systemd 255, `RestrictSUIDSGID=true` rejects every `openat2` call because
seccomp cannot inspect the indirect `open_how` mode argument. The packaged
Gateway unit therefore makes brokered Core fail before its task runtime starts.

## What changed

- Disable the incompatible `RestrictSUIDSGID` filter for the closed Core unit.
- Make all non-state host paths read-only with `ProtectSystem=strict`.
- Isolate `/dev` and cover `/dev/shm` with a private read-only,
  `nosuid,nodev,noexec` filesystem.
- Keep Core logging under the systemd-managed private `StateDirectory`.
- Add static and disposable-systemd regression coverage for `openat2`, writable
  state, workspace confinement, and SUID/SGID artifact rejection.

## Related issue

Fixes #2840

## User / Agent impact

Gateway tasks launched through the packaged Core systemd unit can complete the
workspace-confinement `openat2` preflight on systemd 255 while retaining a
read-only workspace and private writable daemon state.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The unit now supplies a private default `HOME`. An operator-provided `HOME` in
`/etc/cosh/gateway-$USER.env` still takes precedence and must remain below the
Gateway `StateDirectory`; otherwise strict filesystem protection can prevent
Core logging. The ACP-specific unit keeps `RestrictSUIDSGID=true` unchanged.

## Validation

Current branch `38dccdbbdac571abfdb2e2b187cbe6ef894da167`:

- `cargo test --locked -p cosh-gateway --test cli_entrypoint packaged_base_service_is_task_only_and_free_of_ws_ckpt_dependency -- --exact` — 1 passed
- `cargo test --locked -p cosh-core --bin cosh-core bare_config_preserves_user_provider_but_ignores_project_and_runtime_extensions` — 1 passed
- `cargo clippy --locked -p cosh-gateway --test cli_entrypoint -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `bash -n scripts/test-gateway-containment.sh scripts/fixtures/gateway-containment-tree.sh` — passed
- `bash scripts/docs-lint.sh` — passed
- `python3 scripts/docs-link-check.py` — passed
- `git diff --check up/main...HEAD` — passed

The same unit and containment patch passed the destructive acceptance gate in a
disposable Alibaba Linux 4 container with systemd 255.16. That run verified
working `openat2`, a read-only workspace, writable private state, isolated
read-only `/dev/shm`, no host-visible SUID/SGID artifact, and a real brokered
Core v3 initialize/shutdown with exit code 0. The destructive gate correctly
skips on a normal host. A post-fix packaged RPM task submission on a persistent
ECS was not rerun and remains a release validation item.

## Documentation and rollback

Updated the English and Chinese component README and user guide with the private
Core `HOME` and environment-file precedence. Roll back by reverting this commit;
on systemd 255 that also restores the `openat2` failure described in #2840.
