### PR TITLE
fix(tokenless): fail RPM build when spec lacks anolisa-component Provides

### DIFF
--- a/.github/workflows/_rpm-build.yaml
+++ b/.github/workflows/_rpm-build.yaml
@@ -249,6 +249,54 @@ jobs:
           echo "SPEC_BASENAME=$(basename "$SPEC_FILE")" >> $GITHUB_ENV
           echo "EXTRACT_DIR=${EXTRACT_DIR}" >> $GITHUB_ENV
 
+      - name: Verify tokenless component contract
+        if: inputs.component == 'tokenless'
+        run: |
+          # Component contract guard for the nightly RPM path: this workflow
+          # processes the archived spec and calls rpmbuild directly, so it
+          # never runs the build_tokenless guard in scripts/rpm-build.sh.
+          # Mirror that assertion here: derive the component name from
+          # .anolisa/component.toml.in, verify it matches the RPM package
+          # name, and require an exact "Provides: anolisa-component(<name>)"
+          # line in the processed spec, so spec drift fails the build
+          # instead of publishing an RPM that silently lacks the capability
+          # used by `anolisa install tokenless` (GH-2836).
+          COMPONENT_IN=$(find "$EXTRACT_DIR" -path '*/.anolisa/component.toml.in' | head -1)
+          if [ -z "$COMPONENT_IN" ]; then
+            echo "ERROR: component contract template (.anolisa/component.toml.in) not found in source archive"
+            exit 1
+          fi
+
+          COMPONENT_NAME=$(awk '
+            $0 == "[component]" { in_component = 1; next }
+            in_component && /^\[/ { exit }
+            in_component && /^name = / {
+              value = $0
+              sub(/^name = "/, "", value)
+              sub(/"$/, "", value)
+              print value
+              exit
+            }
+          ' "$COMPONENT_IN")
+          if [ -z "$COMPONENT_NAME" ]; then
+            echo "ERROR: could not parse component name from $COMPONENT_IN"
+            exit 1
+          fi
+
+          SPEC_NAME=$(grep -E '^Name:' "$HOME/rpmbuild/SPECS/$SPEC_BASENAME" | awk '{print $2}' | tr -d ' \t')
+          if [ "$COMPONENT_NAME" != "$SPEC_NAME" ]; then
+            echo "ERROR: tokenless identity mismatch: RPM name '$SPEC_NAME', component name '$COMPONENT_NAME'"
+            exit 1
+          fi
+
+          if ! grep -Fqx "Provides:       anolisa-component($COMPONENT_NAME)" "$HOME/rpmbuild/SPECS/$SPEC_BASENAME"; then
+            echo "ERROR: tokenless spec must provide anolisa-component($COMPONENT_NAME)"
+            exit 1
+          fi
+
+          echo "TOKENLESS_COMPONENT_NAME=$COMPONENT_NAME" >> "$GITHUB_ENV"
+          echo "tokenless component contract OK: $SPEC_NAME provides anolisa-component($COMPONENT_NAME)"
+
       - name: Build RPM
         run: |
           rpmbuild -bb --nodeps \
@@ -271,6 +319,21 @@ jobs:
           if [ "${{ inputs.component }}" = "agentsight" ]; then
             while IFS= read -r rpm_path; do
               "$AGENTSIGHT_VERIFY_RPM" "$rpm_path"
+            done < <(find /tmp/rpm-output/ -maxdepth 1 -type f -name "*.rpm" -print)
+          fi
+
+          if [ "${{ inputs.component }}" = "tokenless" ]; then
+            # Verify the built artifact actually publishes the component
+            # capability; this catches cases where rpmbuild silently drops a
+            # malformed Provides line that passed the spec text guard.
+            while IFS= read -r rpm_path; do
+              echo "Verifying tokenless RPM capabilities: $rpm_path"
+              if ! rpm -qp --provides "$rpm_path" | grep -Eq "^anolisa-component\(${TOKENLESS_COMPONENT_NAME}\)([[:space:]]|$)"; then
+                echo "ERROR: $rpm_path does not provide anolisa-component(${TOKENLESS_COMPONENT_NAME})"
+                echo "Actual provides:"
+                rpm -qp --provides "$rpm_path"
+                exit 1
+              fi
             done < <(find /tmp/rpm-output/ -maxdepth 1 -type f -name "*.rpm" -print)
           fi
 

--- a/scripts/rpm-build.sh
+++ b/scripts/rpm-build.sh
@@ -463,6 +463,38 @@ build_tokenless() {
 
     local pkg_name
     pkg_name=$(parse_spec_name "$spec_in")
+
+    # Component contract guard (mirrors build_cosh_ng): the RPM must publish
+    # the anolisa-component(<name>) capability so `anolisa install tokenless`
+    # can resolve the package via Provides when the component index is
+    # unavailable. Fail the build on spec drift instead of shipping a package
+    # that silently lacks the capability (GH-2836).
+    local component_in="${TOKEN_DIR}/.anolisa/component.toml.in"
+    if [ ! -f "$component_in" ]; then
+        err "Component contract template not found: $component_in"
+        return 1
+    fi
+    local component_name
+    component_name=$(awk '
+        $0 == "[component]" { in_component = 1; next }
+        in_component && /^\[/ { exit }
+        in_component && /^name = / {
+            value = $0
+            sub(/^name = "/, "", value)
+            sub(/"$/, "", value)
+            print value
+            exit
+        }
+    ' "$component_in")
+    if [ "$component_name" != "$pkg_name" ]; then
+        err "tokenless identity mismatch: RPM name '${pkg_name}', component name '${component_name}'"
+        return 1
+    fi
+    if ! grep -Fqx "Provides:       anolisa-component(${component_name})" "$spec_in"; then
+        err "tokenless spec must provide anolisa-component(${component_name})"
+        return 1
+    fi
+
     local tarball_name="${pkg_name}-${version}.tar.gz"
 
     # Step 1: Process spec template


### PR DESCRIPTION
## Why

The released tokenless 0.7.12 RPM still lacks `Provides: anolisa-component(tokenless)` even though the spec fix (#2576) landed on `main`. The in-repo build path (`scripts/rpm-build.sh`) never asserted the capability for tokenless, so a spec baseline that drifted away from the fix could build and ship silently. `build_cosh_ng` already guards this (see its identity + Provides + manifest checks); tokenless did not. In addition, the nightly pipeline (`docker-nightly.yaml` → `_rpm-build.yaml`) never runs `scripts/rpm-build.sh` at all — it processes the archived spec and calls `rpmbuild` directly — so the in-repo script fix alone leaves the nightly artifact path unprotected.

Fixes #2836.

## What changed

### Commit `b6181ff` — in-repo build guard (`scripts/rpm-build.sh`)

Added a component-contract guard to `build_tokenless` in `scripts/rpm-build.sh`, mirroring the existing `build_cosh_ng` pattern:

- Derive the component name from `src/tokenless/.anolisa/component.toml.in`.
- Fail the build if the component name does not match the RPM package name.
- Fail the build unless `tokenless.spec.in` contains an exact `Provides: anolisa-component(<component>)` line.

No change to the shipped spec content (the `Provides:` line already exists at `src/tokenless/tokenless.spec.in`); this only makes a future regression fail loudly at build time instead of shipping.

### Commit `f359ab9` — nightly workflow guard (`.github/workflows/_rpm-build.yaml`)

The checked-in nightly pipeline produces tokenless RPMs through `docker-nightly.yaml` → `_rpm-build.yaml`, which processes the archived spec and calls `rpmbuild` directly, so the `build_tokenless` guard above never runs there: deleting the `Provides:` line would still let the nightly publish an RPM with the original defect. This commit closes the gap with the same component-contract assertion, gated on `inputs.component == 'tokenless'` so other components are unaffected:

- New `Verify tokenless component contract` step before `Build RPM` (`_rpm-build.yaml:252`): derive the component name from `.anolisa/component.toml.in` in the source archive, verify it matches the RPM `Name:` of the processed spec, and require an exact `Provides: anolisa-component(<name>)` line in the processed spec.
- Extend `Collect RPM artifacts`: for tokenless, verify every built RPM actually publishes the `anolisa-component(<name>)` capability via `rpm -qp --provides`, catching malformed Provides lines that pass the text guard but are silently dropped by rpmbuild (mirrors the existing agentsight verification hook).

Archive layout note: `package-source` ships the full `src/tokenless` tree plus the `make generate-component-contract` output, so the extracted archive contains both the `.anolisa/component.toml.in` template read by the guard and the generated `.anolisa/component.toml`; the guard's `find` pattern matches only the `.in` template.

## Validation

Environment (public info only): Linux Alibaba Cloud Linux 3, x86_64; GNU bash 4.4.20; GNU Make 4.2.1; rustc/cargo 1.96.0; node v22.21.1 / npm 10.9.4; rpmbuild 4.14.3; python3 + PyYAML (YAML syntax check only).

### Commit `b6181ff` — in-repo guard

Real runs performed (not simulated):

| Check | Command | Result |
|---|---|---|
| Syntax | `bash -n scripts/rpm-build.sh` | pass |
| Positive (guard passes on current tree) | `bash scripts/rpm-build.sh tokenless` | full RPM build succeeds |
| Built RPM carries capability | `rpm -qp --provides <built rpm>` | `anolisa-component(tokenless)` present |
| Negative (missing Provides) | removed the `Provides:` line, re-ran build | fails fast: `tokenless spec must provide anolisa-component(tokenless)`, exit 1 |
| Negative (identity drift) | renamed component to `tokenlessx`, re-ran build | fails fast: `tokenless identity mismatch: RPM name 'tokenless', component name 'tokenlessx'`, exit 1 |

Positive build output: `tokenless-0.7.13-1.al8.x86_64.rpm`; `rpm -qp --provides` returns `anolisa-component(tokenless)` as the first capability. Negative cases were run against temporary edits and reverted.

Re-run on the final tree (`f359ab9`): `bash scripts/rpm-build.sh tokenless` exits 0, writes `tokenless-0.7.13-1.al8.x86_64.rpm`, and rpmbuild reports `Provides: anolisa-component(tokenless)` — confirming the commit-1 guard still passes and commit 2 does not alter the in-repo path.

### Commit `f359ab9` — nightly workflow guard

The nightly path only executes in CI, so each new step body was extracted verbatim from the workflow YAML (only `${{ inputs.* }}` substituted, isolated `$HOME` instead of the runner home) and run against a faithful local reproduction of the nightly inputs: `.github/actions/package-source` reproduced for tokenless (copy `src/tokenless/` tree → `make generate-component-contract` → tar into `tokenless-0.7.13.nightly.tar.gz`; the rtk vendoring step was skipped because it only affects `third_party/rtk`, which the guard never reads), then `Prepare source and spec` run verbatim (extract archive, copy tarball to `SOURCES`, process `tokenless.spec.in` → `tokenless.spec` with `sed s/@VERSION@/0.7.13/`). The archive was verified to contain both `.anolisa/component.toml.in` and the generated `.anolisa/component.toml`.

| Check | Result |
|---|---|
| YAML syntax: `_rpm-build.yaml`, `docker-nightly.yaml` | pass (python3/PyYAML `safe_load`) |
| `Verify tokenless component contract`, positive (current tree) | `tokenless component contract OK: tokenless provides anolisa-component(tokenless)`, exit 0 |
| Guard, negative: `Provides:` line removed from processed spec | fails fast: `ERROR: tokenless spec must provide anolisa-component(tokenless)`, exit 1 |
| Guard, negative: component renamed to `tokenlessx` in archived `component.toml.in` | fails fast: `ERROR: tokenless identity mismatch: RPM name 'tokenless', component name 'tokenlessx'`, exit 1 |
| Guard, negative: `.anolisa/component.toml.in` deleted from archive | fails fast: `ERROR: component contract template (.anolisa/component.toml.in) not found in source archive`, exit 1 |
| `Collect RPM artifacts` capability check, positive (freshly built tokenless RPM) | `Verifying tokenless RPM capabilities: .../tokenless-0.7.13-1.al8.x86_64.rpm`, exit 0 |
| Capability check, negative (minimal dummy RPM without the capability) | fails: `ERROR: ... does not provide anolisa-component(tokenless)` and prints actual provides, exit 1 |

CI at `f359ab9`: green, no failed checks (checks for other components are skipped by design on this PR).

## Risk and compatibility

- [x] Build/packaging behavior changed (new fail-fast guards)

- The guards only add pre-build and post-build assertions; they do not alter the spec, tarball layout, or rpmbuild invocation. Builds from a correct tree behave exactly as before. No runtime or user-facing behavior changes.
- The workflow guards are gated on `inputs.component == 'tokenless'`: RPM builds for the other components (copilot-shell, cosh-ng, agent-sec-core, agentsight, os-skills, ws-ckpt, agent-memory, skillfs, anolisa) run through unchanged code paths.
- The collect-step check can only fail a build whose built RPM lacks the declared capability — exactly the defect this PR exists to stop shipping (GH-2836).

## Not run

- The full Rust test suite (`cargo test`) was not re-run here because the change touches only the shell build guard and CI workflow YAML, not Rust sources.
- The GitHub-hosted nightly pipeline (`docker-nightly.yaml`) was not triggered end-to-end as part of this validation; the new steps were validated by running them verbatim against locally reproduced nightly inputs (source archive, processed spec, built RPM) as detailed above.
