### PR TITLE
fix(sec-core): support cosh-ng skill input

### DIFF
--- a/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
+++ b/src/agent-sec-core/cosh-extension/hooks/skill_ledger_hook.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Cosh hook script for skill-ledger.
 
-Reads a cosh PreToolUse JSON from stdin, resolves the skill directory
-from the skill context or skill name, invokes ``agent-sec-cli skill-ledger show`` via
-subprocess, and writes a cosh HookOutput JSON to stdout.
+Reads a cosh PreToolUse JSON from stdin, normalizes the legacy Cosh or
+Cosh-NG skill invocation, resolves the skill directory from the skill context or
+skill name, invokes ``agent-sec-cli skill-ledger show`` via subprocess, and
+writes a cosh HookOutput JSON to stdout.
 
 Hook point: **PreToolUse** — matcher: ``skill``
 
@@ -17,6 +18,10 @@ Input schema::
         "cwd": "/path/to/project"
     }
 
+Legacy Cosh uses ``tool_input.skill``.  Cosh-NG uses
+``tool_input.action``/``tool_input.name``; a missing or non-string action means
+``invoke`` and ``action: "list"`` does not identify or execute a skill.
+
 Output mapping:
 
     summary.message is null → { "decision": "allow" }
@@ -25,7 +30,7 @@ Output mapping:
     policy "warn"            → summary.message allows with visible reason
     policy "block"           → summary.message blocks execution
 
-Optional copilot-shell settings.json configuration::
+Optional Cosh settings.json configuration::
 
     {
       "hooks": {
@@ -64,6 +69,7 @@ _INIT_TIMEOUT = 3  # seconds for key initialization
 
 _DEFAULT_POLICY = "ask"
 _HOOK_ENABLED = env_flag_enabled("SKILL_LEDGER_HOOK_ENABLED", True)
+_MISSING = object()
 
 # -- helpers -----------------------------------------------------------------
 
@@ -99,6 +105,21 @@ def _allow_or_warn(reason: str, _policy: str) -> str:
     return _allow()
 
 
+def _format_contract_error(detail: str, policy: str) -> str:
+    """Map an invalid Host invocation contract to the configured policy."""
+    reason = "\u26a0\ufe0f Skill check cannot bind the invoked identity: {}".format(
+        detail
+    )
+    if policy == "observe":
+        _debug(reason)
+        return _allow()
+    if policy == "warn":
+        return _allow_with_reason(reason)
+    if policy == "block":
+        return _block_with_reason(reason)
+    return _ask_with_reason(reason)
+
+
 def _read_policy() -> str:
     """Return the configured Skill Ledger mode."""
     raw = os.environ.get("SKILL_LEDGER_MODE")
@@ -106,6 +127,87 @@ def _read_policy() -> str:
     if "SKILL_LEDGER_MODE" in os.environ and normalize_hook_policy(raw, "") == "":
         _debug("invalid SKILL_LEDGER_MODE; using ask")
     return policy
+
+
+def _validate_identity(value: Any, field_name: str) -> tuple[str | None, str | None]:
+    """Return an exact identity value or a Host contract error."""
+    if value is _MISSING:
+        return None, "{} is empty or missing".format(field_name)
+    if not isinstance(value, str):
+        return None, "{} must be a string".format(field_name)
+    if not value.strip():
+        return None, "{} is empty or missing".format(field_name)
+    return value, None
+
+
+def _normalize_skill_call(
+    tool_input: Any,
+) -> tuple[str | None, str | None, bool]:
+    """Normalize Host input into ``(identity, error, skip)``.
+
+    The presence of ``action`` or ``name`` selects the Cosh-NG profile.  The
+    identity remains byte-for-byte equivalent to the Host value; whitespace is
+    inspected only to reject empty values.
+    """
+    if not isinstance(tool_input, dict):
+        return None, "tool_input must be an object", False
+
+    is_cosh_ng = "action" in tool_input or "name" in tool_input
+    if not is_cosh_ng:
+        skill_name, error = _validate_identity(
+            tool_input.get("skill", _MISSING), "skill"
+        )
+        return skill_name, error, False
+
+    action = tool_input.get("action")
+    if isinstance(action, str):
+        if action == "list":
+            return None, None, True
+        if action != "invoke":
+            return None, "unsupported Cosh-NG action {!r}".format(action), False
+
+    skill_name, error = _validate_identity(tool_input.get("name", _MISSING), "name")
+    if error is not None:
+        return None, error, False
+
+    if "skill" in tool_input:
+        legacy_name, legacy_error = _validate_identity(tool_input.get("skill"), "skill")
+        if legacy_error is not None:
+            return None, legacy_error, False
+        if legacy_name != skill_name:
+            return (
+                None,
+                "Cosh-NG name and legacy skill identities conflict",
+                False,
+            )
+
+    return skill_name, None, False
+
+
+def _validate_skill_context(input_data: dict[str, Any], skill_name: str) -> str | None:
+    """Validate a present context without letting it override Host identity."""
+    if "skill_context" not in input_data:
+        return None
+
+    skill_context = input_data.get("skill_context")
+    if not isinstance(skill_context, dict):
+        return "skill_context must be an object"
+
+    context_name, error = _validate_identity(
+        skill_context.get("skill_name", _MISSING), "skill_context.skill_name"
+    )
+    if error is not None:
+        return error
+
+    _file_path, error = _validate_identity(
+        skill_context.get("file_path", _MISSING), "skill_context.file_path"
+    )
+    if error is not None:
+        return error
+
+    if context_name != skill_name:
+        return "skill_context.skill_name conflicts with the invoked identity"
+    return None
 
 
 def _supported_skill_bases(cwd: str) -> list[Path]:
@@ -144,11 +246,12 @@ def _resolve_skill_dir_from_context(
 ) -> tuple[str | None, bool]:
     """Resolve the skill dir from ``skill_context.file_path`` when available.
 
+    The caller validates a present context before invoking this function.
     Returns ``(skill_dir, handled)``.  ``handled`` is True whenever a
     well-formed ``skill_context.file_path`` was present, even if the path is
     outside the supported project/user/system scope.  In that case the caller
     should fail open without falling back to name-based lookup, because the
-    context identifies the actual skill that copilot-shell resolved.
+    context identifies the actual skill that Cosh resolved.
     """
     skill_context = input_data.get("skill_context")
     if not isinstance(skill_context, dict):
@@ -292,35 +395,34 @@ def main() -> None:
         print(_allow())
         return
 
+    if not isinstance(input_data, dict):
+        print(_allow())
+        return
+
     # 2. Verify this is a skill tool call
     tool_name = input_data.get("tool_name", "")
     if tool_name != _TOOL_NAME:
         print(_allow())
         return
 
-    policy = _read_policy()
-
     tool_input = input_data.get("tool_input", {})
-    skill_name = tool_input.get("skill", "")
-    if not isinstance(skill_name, str):
-        print(
-            _allow_or_warn(
-                "\u26a0\ufe0f Skill check skipped: skill name must be a string",
-                policy,
-            )
-        )
-        return
-    skill_name = skill_name.strip()
-    if not skill_name:
-        print(
-            _allow_or_warn(
-                "\u26a0\ufe0f Skill check skipped: skill name is empty or missing",
-                policy,
-            )
-        )
+    skill_name, contract_error, skip = _normalize_skill_call(tool_input)
+    if skip:
+        print(_allow())
         return
 
-    # 3. Resolve skill directory.  Prefer copilot-shell's resolved file path
+    policy = _read_policy()
+    if contract_error is not None or skill_name is None:
+        detail = contract_error or "skill identity is empty or missing"
+        print(_format_contract_error(detail, policy))
+        return
+
+    context_error = _validate_skill_context(input_data, skill_name)
+    if context_error is not None:
+        print(_format_contract_error(context_error, policy))
+        return
+
+    # 3. Resolve skill directory.  Prefer Cosh's resolved file path
     # when present so SKILL.md names may differ from directory names, but only
     # within the current project/user/system scope.
     cwd = input_data.get("cwd", os.environ.get("COPILOT_SHELL_PROJECT_DIR", "."))

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -631,7 +631,7 @@ agent-sec-cli skill-ledger certify <skill_dir> --findings /tmp/skill-vetter-find
 
 ### 设计原则
 
-推荐部署模式是 SkillFS 捕获变更并触发 daemon activation refresh。宿主 hook/capability 作为兼容入口保留并默认挂载。除 Hermes 使用 `policy = "observe"` 外，其余支持提示或确认的宿主默认 `policy = "ask"`。OpenClaw、copilot-shell、Hermes 和 Qwen Code 根据 `skill-ledger show` 的统一 exposure summary 决定宿主动作；Codex 和 Qoder CLI 在各自的 Skill 触发边界直接消费只读 `skill-ledger check` 状态。
+推荐部署模式是 SkillFS 捕获变更并触发 daemon activation refresh。宿主 hook/capability 作为兼容入口保留并默认挂载。除 Hermes 使用 `policy = "observe"` 外，其余支持提示或确认的宿主默认 `policy = "ask"`。OpenClaw、Cosh（Legacy 与 NG）、Hermes 和 Qwen Code 根据 `skill-ledger show` 的统一 exposure summary 决定宿主动作；Codex 和 Qoder CLI 在各自的 Skill 触发边界直接消费只读 `skill-ledger check` 状态。
 
 使用 exposure summary 的宿主不直接读取 `check.status`，也不自行实现扫描状态分支：
 
@@ -655,7 +655,7 @@ Policy 语义：
 | `ask` | 默认值。`message == null` 静默放行；`message != null` 时请求用户确认或使用宿主 approval UI。 |
 | `block` | `message != null` 时直接阻断，并把 message 作为原因或告警信息。 |
 
-OpenClaw、copilot-shell、Hermes、Codex 和 Qwen Code 遇到 CLI 不可用、执行失败、超时或输出不可解析时保持 fail-open。Qoder CLI 将这些基础设施异常归一为 `error`，继续通过 `observe` / `warn` / `ask` / `block` policy 处理。`block_statuses` / `blockStatuses` 是旧配置字段，新逻辑不再按状态列表判断；旧 `enable_block` / `enableBlock` 仅适用于已有兼容实现。所有宿主都把旧值 `debug` 映射为 `observe`、把旧值 `deny` 映射为 `block`。
+OpenClaw、Cosh（Legacy 与 NG）、Hermes、Codex 和 Qwen Code 遇到 CLI 不可用、执行失败、超时或输出不可解析时保持 fail-open。Qoder CLI 将这些基础设施异常归一为 `error`，继续通过 `observe` / `warn` / `ask` / `block` policy 处理。`block_statuses` / `blockStatuses` 是旧配置字段，新逻辑不再按状态列表判断；旧 `enable_block` / `enableBlock` 仅适用于已有兼容实现。所有宿主都把旧值 `debug` 映射为 `observe`、把旧值 `deny` 映射为 `block`。
 
 ### message 触发规则
 
@@ -683,7 +683,7 @@ OpenClaw、copilot-shell、Hermes、Codex 和 Qwen Code 遇到 CLI 不可用、�
 | 宿主 | 触发与检查 | `observe` | `warn` | `ask` | `block` | 覆盖与默认值 |
 |------|------------|-----------|--------|-------|---------|------------|
 | OpenClaw | `before_tool_call` 读取 SKILL.md → `show` | debug 后放行 | logger warning 后放行 | `requireApproval` | `block` / `blockReason` | `~/.openclaw/skills/`；`enabled=true, policy="ask"` |
-| copilot-shell | `PreToolUse(skill)` → `show` | stderr 审计后放行 | `decision: "allow"` + `reason` | `decision: "ask"` | `decision: "block"` | project / user / system；默认注册且 policy 为 `ask` |
+| Cosh Legacy / Cosh-NG | `PreToolUse(skill)` → 归一化调用身份 → `show` | stderr 审计后放行 | `decision: "allow"` + `reason` | `decision: "ask"` | `decision: "block"` | project / user / system；默认注册且 policy 为 `ask` |
 | Hermes | `pre_tool_call(skill_view)` → `show` | logger 审计后放行 | 降级为 `observe` 并记录诊断 | 降级为 `observe` 并记录诊断 | `{"action": "block"}` | `~/.hermes/skills/**`；`enabled=true, policy="observe"` |
 | Qoder CLI | `PreToolUse(Skill)` → `check` | stderr 审计后放行 | `decision: "allow"` + `systemMessage` | `permissionDecision: "ask"` | `permissionDecision: "deny"` | project / user；默认注册且 policy 为 `ask` |
 | Codex | `UserPromptSubmit($skill-name)` → `check` | 静默审计后放行 | `systemMessage` 后放行 | fallback 为 `warn` | `decision: "block"` | repo / user / system；默认注册且 policy 为 `ask` |
@@ -693,9 +693,9 @@ OpenClaw、copilot-shell、Hermes、Codex 和 Qwen Code 遇到 CLI 不可用、�
 
 以 OpenClaw Plugin 形式分发，默认注册 `skill-ledger` capability，`capabilities.skill-ledger.policy` 默认为 `ask`。`before_tool_call` handler 过滤 read tool 对 `*/SKILL.md` 的访问，解析 `skill_dir` 后调用 `agent-sec-cli skill-ledger show`。`enabled=false` 时完全不注册；`policy=observe` 时只写 debug 审计并放行；`policy=warn` 时通过 `api.logger.warn` 输出告警并放行；`policy=block` 在 summary message 非空时返回 `block`。旧 `enableBlock` 仅在未配置 `policy` 时作为兼容映射，旧 `blockStatuses` 不再参与运行态判断。
 
-### 6.2 copilot-shell（Command Hook）
+### 6.2 Cosh Legacy / Cosh-NG（Command Hook）
 
-独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。默认 Cosh manifest 挂载该 hook，默认 `SKILL_LEDGER_MODE=ask`。该环境变量属于可信宿主或部署环境配置，不应由 Skill、项目脚本或不可信 shell 启动逻辑设置；若需要防止本地 shell profile 被篡改后降级策略，后续应迁移到可信宿主配置源：
+独立 Python 脚本 `cosh-extension/hooks/skill_ledger_hook.py`，专为 stdin/stdout 协议设计，不依赖 `agent_sec_cli` 包。同一 hook 同时接受 Cosh Legacy 和 Cosh-NG 的 `PreToolUse(skill)` 事件，并先把宿主输入归一化为唯一的 Skill 身份，再解析目录并调用 `agent-sec-cli skill-ledger show`。默认 Cosh manifest 挂载该 hook，默认 `SKILL_LEDGER_MODE=ask`。该环境变量属于可信宿主或部署环境配置，不应由 Skill、项目脚本或不可信 shell 启动逻辑设置；若需要防止本地 shell profile 被篡改后降级策略，后续应迁移到可信宿主配置源：
 
 配置：
 ```jsonc
@@ -715,15 +715,41 @@ OpenClaw、copilot-shell、Hermes、Codex 和 Qwen Code 遇到 CLI 不可用、�
 }
 ```
 
-**Skill 目录定位（当前版本范围）**：copilot-shell hook 仅覆盖 project → user → system 三类 skill：
+两种宿主的输入协议分别为：
+
+```jsonc
+// Cosh Legacy
+{ "tool_input": { "skill": "github" } }
+
+// Cosh-NG：显式 invoke
+{ "tool_input": { "action": "invoke", "name": "github" } }
+
+// Cosh-NG：省略 action 时仍表示 invoke
+{ "tool_input": { "name": "github" } }
+```
+
+**调用身份归一化**：只要 `tool_input` 出现 `action` 或 `name` 字段，hook 就按 Cosh-NG 协议解释，且只把 `name` 作为宿主实际执行的 canonical Skill 身份，不回退到 legacy `skill`。`action="invoke"`、缺失 action 和非字符串 action 均按 Cosh-NG 当前的 invoke 语义处理，并要求 `name` 是非空字符串；不支持的字符串 action 属于协议契约异常。若 `action/name` 均未出现，则按 Cosh Legacy 协议读取 `skill`。`name` 与 `skill` 同时出现时必须完全相同，hook 只使用 `strip()` 判断空白值，不改变身份的大小写或原始内容。
+
+`action="list"` 不执行 Skill，hook 因此立即静默放行；该分支不会读取 policy、解析 Skill 目录、初始化密钥或调用 CLI。其它缺失、空白、非字符串或互相冲突的身份，以及缺损或身份冲突的 `skill_context`，都作为协议契约异常按当前 hook policy 返回：
+
+| Policy | 协议契约异常行为 |
+|--------|------------------|
+| `observe` | 写入 stderr 诊断并放行。 |
+| `warn` | 返回 `decision: "allow"` 和用户可见的 `reason`。 |
+| `ask` | 返回 `decision: "ask"` 和确认原因。 |
+| `block` | 返回 `decision: "block"` 和阻断原因。 |
+
+**Skill 目录定位（当前版本范围）**：两种 Cosh 输入协议共用同一目录边界，hook 仅覆盖 project → user → system 三类 Skill：
 - project：`<cwd>/.copilot-shell/skills/<skill>/`
 - user：`~/.copilot-shell/skills/<skill>/`
 - system（RPM）：`/usr/share/anolisa/skills/<skill>/`
 - system（raw install）：`/usr/local/share/anolisa/skills/<skill>/`
 
-当 PreToolUse 事件包含 `skill_context.file_path` 时，hook 优先使用该路径解决 `SKILL.md` 中 `name` 与目录名不一致的问题；但该路径仍必须落在上述 project/user/system 根目录内。若路径落在 custom、extension、remote 或其他目录，当前版本不执行 skill-ledger 检查，hook fail-open，并仅写入 debug 日志说明该 skill 不在当前 hook 支持范围内。
+`skill_context` 是可选的身份佐证和路径来源，不会覆盖归一化后的调用身份。事件不含该字段时，hook 保留按名称查找目录的行为；事件包含该字段时，`skill_name` 必须与归一化身份一致，`file_path` 必须指向现有 `SKILL.md`，且 canonical path 必须落在上述 project/user/system 根目录内。若路径落在 custom、extension、remote 或其他目录，当前版本不执行 skill-ledger 检查，hook 保持既有 fail-open，并仅写入 debug 日志说明该 Skill 不在当前 hook 支持范围内。
 
-**custom / extension / remote Skills**：当前版本的 copilot-shell hook 不覆盖这些来源。未来若扩展覆盖范围，需要单独补充目录解析、信任边界和测试用例。
+**custom / extension / remote Skills**：当前版本的 Cosh hook 不覆盖这些来源。未来若扩展覆盖范围，需要单独补充目录解析、信任边界和测试用例。目录未找到、范围外路径、CLI 缺失或超时、执行失败及输出不可解析等既有基础设施路径仍保持 fail-open；这些路径与上述输入协议契约异常的 policy 映射相互独立。
+
+**检查边界**：该 hook 只保证对 sec-core 收到的原始 `PreToolUse` 快照完成身份归一化和检查，不提供端到端 fail-closed 保证。若同一轮后续 hook 通过 `tool_input_patch` 改写 `action` / `name` / `skill`，可能使最终执行身份与已检查身份不同；该 TOCTOU 问题需要宿主侧身份改写约束作为独立 follow-up 处理。
 
 ### 6.3 Hermes（Plugin Hook）
 

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -27,6 +27,7 @@ Usage::
     python3 e2e_test.py --verbose  # show CLI stdout/stderr
 """
 
+import argparse
 import hashlib
 import json
 import os
@@ -69,6 +70,7 @@ def run_skill_ledger(
     result = subprocess.run(
         cmd,
         capture_output=True,
+        check=False,
         text=True,
         env=env,
         cwd=cwd,
@@ -1113,6 +1115,7 @@ def case_passphrase_missing_env_fails(ws: Workspace):
         cmd,
         input="\n",
         capture_output=True,
+        check=False,
         text=True,
         env=env_without,
         start_new_session=True,
@@ -1130,25 +1133,37 @@ def case_passphrase_missing_env_fails(ws: Workspace):
 
 # ── G12: cosh hook integration ───────────────────────────────────────────
 
-# The cosh hook script location varies; try common paths.
-_HOOK_SEARCH_PATHS = [
-    # Relative to RPM install
-    Path("/usr/share/anolisa/extensions/agent-sec-core/hooks/skill_ledger_hook.py"),
-    # Relative to source tree (if running during development)
-    Path(__file__).resolve().parents[3]
-    / "cosh-extension"
-    / "hooks"
-    / "skill_ledger_hook.py",
-]
+# Source gates must exercise the checked-out hook, while direct RPM acceptance
+# must keep validating the installed artifact.
+_SOURCE_ROOT = Path(__file__).resolve().parents[3]
+_SOURCE_HOOK = _SOURCE_ROOT / "cosh-extension" / "hooks" / "skill_ledger_hook.py"
+_INSTALLED_HOOK = Path(
+    "/usr/share/anolisa/extensions/agent-sec-core/hooks/skill_ledger_hook.py"
+)
+_CLI_PATH = Path(CLI_BIN).resolve() if CLI_BIN else None
+_SOURCE_RUN = _CLI_PATH is not None and _CLI_PATH.is_relative_to(_SOURCE_ROOT)
+_HOOK_OVERRIDE_RAW = os.environ.get("SKILL_LEDGER_E2E_HOOK_SCRIPT")
+_HOOK_OVERRIDE = Path(_HOOK_OVERRIDE_RAW).expanduser() if _HOOK_OVERRIDE_RAW else None
+if _HOOK_OVERRIDE is not None:
+    _HOOK_SEARCH_PATHS = [_HOOK_OVERRIDE]
+elif _SOURCE_RUN:
+    _HOOK_SEARCH_PATHS = [_SOURCE_HOOK, _INSTALLED_HOOK]
+else:
+    _HOOK_SEARCH_PATHS = [_INSTALLED_HOOK, _SOURCE_HOOK]
 HOOK_SCRIPT: str | None = None
 for _p in _HOOK_SEARCH_PATHS:
     if _p.is_file():
         HOOK_SCRIPT = str(_p)
         break
+if _HOOK_OVERRIDE is not None and HOOK_SCRIPT is None:
+    raise FileNotFoundError(
+        "SKILL_LEDGER_E2E_HOOK_SCRIPT does not point to a regular file: "
+        f"{_HOOK_OVERRIDE}"
+    )
 
 
-def _run_hook(input_data, env_extra=None):
-    """Pipe cosh event JSON into the hook script, return parsed output."""
+def _run_hook_process(input_data, env_extra=None):
+    """Pipe cosh event JSON into the hook script and return the process result."""
     env = os.environ.copy()
     if env_extra:
         env.update(env_extra)
@@ -1159,6 +1174,7 @@ def _run_hook(input_data, env_extra=None):
         ),
         capture_output=True,
         text=True,
+        check=False,
         timeout=CLI_TIMEOUT_S,
         env=env,
     )
@@ -1166,6 +1182,12 @@ def _run_hook(input_data, env_extra=None):
         print(f"  hook stdout: {proc.stdout.strip()[:200]}")
         if proc.stderr.strip():
             print(f"  hook stderr: {proc.stderr.strip()[:200]}")
+    return proc
+
+
+def _run_hook(input_data, env_extra=None):
+    """Pipe cosh event JSON into the hook script, return parsed output."""
+    proc = _run_hook_process(input_data, env_extra=env_extra)
     return json.loads(proc.stdout)
 
 
@@ -1176,15 +1198,58 @@ def _hook_env(env_extra: dict | None = None, *, policy: str) -> dict:
     return env
 
 
-def _make_cosh_event(skill_name: str, cwd: str) -> dict:
-    """Build a minimal cosh PreToolUse JSON event."""
-    return {
+def _add_skill_context(event: dict, skill_name: str, skill_dir: Path | None) -> dict:
+    """Attach the Host-resolved SKILL.md path when supplied."""
+    if skill_dir is not None:
+        event["skill_context"] = {
+            "skill_name": skill_name,
+            "file_path": str(skill_dir / "SKILL.md"),
+        }
+    return event
+
+
+def _make_cosh_event(
+    skill_name: str, cwd: str, *, skill_dir: Path | None = None
+) -> dict:
+    """Build a legacy Cosh PreToolUse JSON event."""
+    event = {
         "session_id": "test-session",
         "hook_event_name": "PreToolUse",
         "tool_name": "skill",
         "tool_input": {"skill": skill_name},
         "cwd": cwd,
     }
+    return _add_skill_context(event, skill_name, skill_dir)
+
+
+def _make_cosh_ng_event(
+    skill_name: str, cwd: str, *, skill_dir: Path | None = None
+) -> dict:
+    """Build a Cosh-NG invoke PreToolUse JSON event."""
+    event = {
+        "session_id": "test-session",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "skill",
+        "tool_input": {"action": "invoke", "name": skill_name},
+        "cwd": cwd,
+    }
+    return _add_skill_context(event, skill_name, skill_dir)
+
+
+def _make_host_skill_events(
+    skill_name: str, cwd: str, skill_dir: Path
+) -> list[tuple[str, dict]]:
+    """Return equivalent legacy Cosh and Cosh-NG invoke events."""
+    return [
+        (
+            "legacy-cosh",
+            _make_cosh_event(skill_name, cwd, skill_dir=skill_dir),
+        ),
+        (
+            "cosh-ng",
+            _make_cosh_ng_event(skill_name, cwd, skill_dir=skill_dir),
+        ),
+    ]
 
 
 def case_hook_invalid_json_allows():
@@ -1206,18 +1271,16 @@ def case_hook_wrong_tool_allows():
 
 def case_hook_unknown_skill_policy_modes():
     """Skill not found before summary resolution: fail-open regardless of policy."""
-    output = _run_hook(_make_cosh_event("nonexistent-skill-xyz", "/tmp"))
-    assert output == {"decision": "allow"}
-
-    output = _run_hook(
-        _make_cosh_event("nonexistent-skill-xyz", "/tmp"),
-        env_extra=_hook_env(policy="warn"),
-    )
-    assert output == {"decision": "allow"}
+    for policy in ("observe", "warn", "ask", "block"):
+        output = _run_hook(
+            _make_cosh_event("nonexistent-skill-xyz", "/tmp"),
+            env_extra=_hook_env(policy=policy),
+        )
+        assert output == {"decision": "allow"}, f"{policy}: {output}"
 
 
 def case_hook_pass_status_silent(ws: Workspace):
-    """Hook on a pass-status skill → silent allow (no reason)."""
+    """Both Host payloads allow a pass-status skill without a reason."""
     skill = make_skill(ws.hook_skills_dir, "hook-pass", {"m.txt": "main"})
     env = ws.env()
     findings = write_findings_file(
@@ -1228,16 +1291,16 @@ def case_hook_pass_status_silent(ws: Workspace):
     run_skill_ledger(
         ["certify", str(skill), "--findings", str(findings)], env_extra=env
     )
-    output = _run_hook(
-        _make_cosh_event("hook-pass", str(ws.root)),
-        env_extra=env,
-    )
-    assert output["decision"] == "allow"
-    assert "reason" not in output, f"Expected silent allow, got reason: {output}"
+    for profile, event in _make_host_skill_events("hook-pass", str(ws.root), skill):
+        output = _run_hook(event, env_extra=env)
+        assert output["decision"] == "allow", f"{profile}: {output}"
+        assert (
+            "reason" not in output
+        ), f"{profile}: expected silent allow, got reason: {output}"
 
 
 def case_hook_drifted_policy_modes(ws: Workspace):
-    """Hook on a drifted skill: default asks, debug allows, block rejects."""
+    """Both Host payloads apply ask/debug/warn/block to a drifted skill."""
     skill = make_skill(ws.hook_skills_dir, "hook-drift", {"f.txt": "original"})
     env = ws.env()
     findings = write_findings_file(
@@ -1249,46 +1312,103 @@ def case_hook_drifted_policy_modes(ws: Workspace):
         ["certify", str(skill), "--findings", str(findings)], env_extra=env
     )
     (skill / "f.txt").write_text("MODIFIED")
-    output = _run_hook(
-        _make_cosh_event("hook-drift", str(ws.root)),
-        env_extra=env,
+    for profile, event in _make_host_skill_events("hook-drift", str(ws.root), skill):
+        output = _run_hook(event, env_extra=env)
+        assert output["decision"] == "ask", f"{profile}: {output}"
+        assert (
+            "reason" in output
+        ), f"{profile}: expected confirmation reason for drifted: {output}"
+        assert (
+            "drifted" in output["reason"].lower()
+            or "changed" in output["reason"].lower()
+        ), f"{profile}: {output}"
+
+        output = _run_hook(
+            event,
+            env_extra=_hook_env(env, policy="debug"),
+        )
+        assert output == {"decision": "allow"}, f"{profile}: {output}"
+
+        output = _run_hook(
+            event,
+            env_extra=_hook_env(env, policy="warn"),
+        )
+        assert output["decision"] == "allow", f"{profile}: {output}"
+        assert (
+            "reason" in output
+        ), f"{profile}: expected visible warning for drifted: {output}"
+        assert (
+            "drifted" in output["reason"].lower()
+            or "changed" in output["reason"].lower()
+        ), f"{profile}: {output}"
+
+        output = _run_hook(
+            event,
+            env_extra=_hook_env(env, policy="block"),
+        )
+        assert output["decision"] == "block", f"{profile}: {output}"
+        assert (
+            "reason" in output
+        ), f"{profile}: expected block reason for drifted: {output}"
+        assert (
+            "drifted" in output["reason"].lower()
+            or "changed" in output["reason"].lower()
+        ), f"{profile}: {output}"
+
+
+def case_hook_cosh_ng_list_silent_allow(ws: Workspace):
+    """Cosh-NG list skips identity checks, policy reads, keys, and CLI calls."""
+    skill = make_skill(ws.hook_skills_dir, "hook-list-probe", {"f.txt": "main"})
+    marker = ws.root / "unexpected-cli-call"
+    fake_bin = ws.root / "fake-bin"
+    fake_bin.mkdir()
+    fake_cli = fake_bin / "agent-sec-cli"
+    fake_cli.write_text(
+        '#!/bin/sh\n: > "$SKILL_LEDGER_E2E_CLI_MARKER"\nexit 97\n',
+        encoding="utf-8",
     )
-    assert output["decision"] == "ask"
-    assert "reason" in output, f"Expected confirmation reason for drifted: {output}"
-    assert (
-        "drifted" in output["reason"].lower() or "changed" in output["reason"].lower()
+    fake_cli.chmod(0o755)
+
+    event = _make_cosh_ng_event(
+        "ignored-list-name",
+        str(ws.root),
+        skill_dir=skill,
+    )
+    event["tool_input"] = {
+        "action": "list",
+        "name": "ignored-list-name",
+        "skill": "hook-list-probe",
+    }
+    result = _run_hook_process(
+        event,
+        env_extra=ws.env(
+            {
+                "PATH": str(fake_bin),
+                "SKILL_LEDGER_E2E_CLI_MARKER": str(marker),
+                "SKILL_LEDGER_MODE": "invalid-list-probe-policy",
+            }
+        ),
     )
 
-    output = _run_hook(
-        _make_cosh_event("hook-drift", str(ws.root)),
-        env_extra=_hook_env(env, policy="debug"),
-    )
-    assert output == {"decision": "allow"}
-
-    output = _run_hook(
-        _make_cosh_event("hook-drift", str(ws.root)),
-        env_extra=_hook_env(env, policy="block"),
-    )
-    assert output["decision"] == "block"
-    assert "reason" in output, f"Expected block reason for drifted: {output}"
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"decision": "allow"}
     assert (
-        "drifted" in output["reason"].lower() or "changed" in output["reason"].lower()
-    )
+        result.stderr == ""
+    ), f"list emitted identity/policy diagnostics: {result.stderr}"
+    assert not marker.exists(), "list unexpectedly invoked agent-sec-cli"
+    key_dir = ws.xdg_data / "agent-sec" / "skill-ledger"
+    assert not (key_dir / "key.pub").exists(), "list unexpectedly initialized keys"
+    assert not (key_dir / "key.enc").exists(), "list unexpectedly initialized keys"
 
 
 def case_hook_path_traversal_policy_modes(ws: Workspace):
     """Path traversal before summary resolution fails open without HookOutput reason."""
-    output = _run_hook(
-        _make_cosh_event("../../etc/passwd", "/tmp"),
-        env_extra=ws.env(),
-    )
-    assert output == {"decision": "allow"}
-
-    output = _run_hook(
-        _make_cosh_event("../../etc/passwd", "/tmp"),
-        env_extra=_hook_env(ws.env(), policy="warn"),
-    )
-    assert output == {"decision": "allow"}
+    for policy in ("observe", "warn", "ask", "block"):
+        output = _run_hook(
+            _make_cosh_event("../../etc/passwd", "/tmp"),
+            env_extra=_hook_env(ws.env(), policy=policy),
+        )
+        assert output == {"decision": "allow"}, f"{policy}: {output}"
 
 
 # ── G13: Full pipeline (vetter → ledger → hook) ─────────────────────────
@@ -1484,9 +1604,15 @@ E2E_CASES = [
         requires_hook=True,
     ),
     E2ECase(
-        "G12: hook drifted ask/debug/block",
+        "G12: hook drifted ask/debug/warn/block",
         case_hook_drifted_policy_modes,
         requires_hook=True,
+    ),
+    E2ECase(
+        "G12: Cosh-NG list → silent allow",
+        case_hook_cosh_ng_list_silent_allow,
+        requires_hook=True,
+        init_default_keys=False,
     ),
     E2ECase(
         "G12: hook path traversal fail-open",
@@ -1546,8 +1672,6 @@ def test_skill_ledger_e2e_case(case: E2ECase, ws: Workspace):
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for running this pytest module directly."""
     global VERBOSE
-
-    import argparse
 
     parser = argparse.ArgumentParser(description="skill-ledger CLI E2E tests (RPM)")
     parser.add_argument("-v", "--verbose", action="store_true", help="Show CLI output")

--- a/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
+++ b/src/agent-sec-core/tests/unit-test/cosh_hooks/test_skill_ledger_hook.py
@@ -3,12 +3,12 @@
 The hook is self-contained (no agent_sec_cli imports), so we test it
 by piping JSON via subprocess — identical to the code_scanner_hook tests.
 
-Tests are grouped into three categories:
+Tests are grouped into four categories:
 
-1. **Fail-open paths** — invalid input, wrong tool, missing skill dir.
-   These never invoke the CLI and verify the hook always returns allow.
-2. **Skill directory resolution** — project-level lookup, missing SKILL.md.
-3. **Output mapping** — exposure summary message → prompt formatting.
+1. **Early fail-open paths** — invalid input and wrong tools.
+2. **Host input compatibility** — legacy Cosh and Cosh-NG normalization.
+3. **Skill directory resolution** — project-level lookup, context binding.
+4. **Output mapping** — exposure summary message → prompt formatting.
    Uses a mock CLI script to return canned show results, verifying that only
    ``message`` controls user prompts.
 """
@@ -41,6 +41,7 @@ skill_ledger_hook = load_standalone_hook(
 )
 
 _COSH_MANIFEST = Path(_COSH_HOOK).parents[1] / "cosh-extension.json"
+_UNSET = object()
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +89,34 @@ def _make_skill_event(skill_name, cwd=".", skill_file_path=None):
     return event
 
 
+def _make_ng_skill_event(
+    skill_name,
+    cwd=".",
+    skill_file_path=None,
+    *,
+    action=_UNSET,
+    legacy_skill=_UNSET,
+):
+    """Build a Cosh-NG skill event, optionally omitting its action."""
+    tool_input = {"name": skill_name}
+    if action is not _UNSET:
+        tool_input["action"] = action
+    if legacy_skill is not _UNSET:
+        tool_input["skill"] = legacy_skill
+    event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "skill",
+        "tool_input": tool_input,
+        "cwd": cwd,
+    }
+    if skill_file_path is not None:
+        event["skill_context"] = {
+            "skill_name": skill_name,
+            "file_path": str(skill_file_path),
+        }
+    return event
+
+
 def _create_skill_dir(parent, name="test-skill", manifest_name=None):
     """Create a minimal skill directory with a SKILL.md file.
 
@@ -125,7 +154,18 @@ def test_missing_or_invalid_enabled_value_defaults_to_true(monkeypatch, value):
     assert skill_ledger_hook.env_flag_enabled("SKILL_LEDGER_HOOK_ENABLED", True)
 
 
-def test_injects_trace_context_into_skill_ledger_show_command(monkeypatch, capsys):
+@pytest.mark.parametrize(
+    "tool_input",
+    [
+        {"skill": "test-skill"},
+        {"action": "invoke", "name": "test-skill"},
+        {"name": "test-skill"},
+    ],
+    ids=["legacy", "ng-explicit-invoke", "ng-implicit-invoke"],
+)
+def test_injects_trace_context_into_skill_ledger_show_command(
+    monkeypatch, capsys, tool_input
+):
     captured = {}
 
     def fake_run(args, **kwargs):
@@ -153,7 +193,7 @@ def test_injects_trace_context_into_skill_ledger_show_command(monkeypatch, capsy
                 {
                     "hook_event_name": "PreToolUse",
                     "tool_name": "skill",
-                    "tool_input": {"skill": "test-skill"},
+                    "tool_input": tool_input,
                     "cwd": "/project",
                     "trace_id": "trace-1",
                     "session_id": "session-1",
@@ -191,12 +231,12 @@ def test_injects_trace_context_into_skill_ledger_show_command(monkeypatch, capsy
 
 
 # ---------------------------------------------------------------------------
-# Fail-open tests — these never invoke the real CLI
+# Early exits and infrastructure fail-open tests
 # ---------------------------------------------------------------------------
 
 
 class TestFailOpen:
-    """Every error / unrecognized input must produce ``{"decision": "allow"}``."""
+    """Infrastructure errors and unrelated inputs remain fail-open."""
 
     def test_hook_disabled_short_circuits_before_work(self, monkeypatch, capsys):
         monkeypatch.setattr(skill_ledger_hook, "_HOOK_ENABLED", False)
@@ -247,42 +287,6 @@ class TestFailOpen:
         output = _run_hook({"tool_input": {"skill": "test"}})
         assert output == {"decision": "allow"}
 
-    def test_missing_skill_name_allows(self):
-        output, stderr = _run_hook(
-            {"tool_name": "skill", "tool_input": {}},
-            return_stderr=True,
-        )
-        assert output == {"decision": "allow"}
-        assert "reason" not in output
-        assert "empty or missing" in stderr
-
-    def test_empty_skill_name_allows(self):
-        output, stderr = _run_hook(
-            {"tool_name": "skill", "tool_input": {"skill": ""}},
-            return_stderr=True,
-        )
-        assert output == {"decision": "allow"}
-        assert "reason" not in output
-        assert "empty or missing" in stderr
-
-    def test_whitespace_skill_name_allows(self):
-        output, stderr = _run_hook(
-            {"tool_name": "skill", "tool_input": {"skill": "   "}},
-            return_stderr=True,
-        )
-        assert output == {"decision": "allow"}
-        assert "reason" not in output
-        assert "empty or missing" in stderr
-
-    def test_nonstring_skill_name_allows(self):
-        output, stderr = _run_hook(
-            {"tool_name": "skill", "tool_input": {"skill": 42}},
-            return_stderr=True,
-        )
-        assert output == {"decision": "allow"}
-        assert "reason" not in output
-        assert "must be a string" in stderr
-
     def test_skill_dir_not_found_allows(self):
         """Skill name that resolves to no on-disk directory → fail-open."""
         output, stderr = _run_hook(
@@ -322,6 +326,196 @@ class TestFailOpen:
 
 
 # ---------------------------------------------------------------------------
+# Host input compatibility and contract validation
+# ---------------------------------------------------------------------------
+
+
+class TestHostInputCompatibility:
+    """Bind Ledger checks to the identity each Cosh generation executes."""
+
+    @pytest.mark.parametrize(
+        "action",
+        [_UNSET, None, 42, {}],
+        ids=["missing", "null", "number", "object"],
+    )
+    def test_ng_missing_or_nonstring_action_is_implicit_invoke(
+        self, mock_cli_env, action
+    ):
+        env = mock_cli_env["make_env"](
+            json.dumps({"latestStatus": "drifted", "message": "drifted latest"})
+        )
+        output = _run_hook(
+            _make_ng_skill_event(
+                "test-skill",
+                mock_cli_env["cwd"],
+                action=action,
+            ),
+            env_override=env,
+        )
+
+        assert output["decision"] == "ask"
+        assert "drifted latest" in output["reason"]
+
+    @pytest.mark.parametrize(
+        "tool_input",
+        [
+            {"action": "list"},
+            {
+                "action": "list",
+                "name": "ignored-name",
+                "skill": "conflicting-name",
+            },
+        ],
+        ids=["missing-identity", "conflicting-identities"],
+    )
+    def test_ng_list_is_a_silent_side_effect_free_allow(
+        self, monkeypatch, capsys, tool_input
+    ):
+        monkeypatch.setattr(
+            skill_ledger_hook,
+            "_read_policy",
+            lambda: pytest.fail("policy should not be read"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook,
+            "_validate_skill_context",
+            lambda *_args: pytest.fail("context should not be validated"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook,
+            "_resolve_skill_dir_from_context",
+            lambda *_args: pytest.fail("skills should not be resolved"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook,
+            "_resolve_skill_dir",
+            lambda *_args: pytest.fail("skills should not be resolved by name"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook,
+            "_ensure_keys",
+            lambda *_args: pytest.fail("keys should not be initialized"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook.subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail("CLI should not be called"),
+        )
+        monkeypatch.setattr(
+            skill_ledger_hook.sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "tool_name": "skill",
+                        "tool_input": tool_input,
+                        "skill_context": None,
+                    }
+                )
+            ),
+        )
+
+        skill_ledger_hook.main()
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == {"decision": "allow"}
+        assert captured.err == ""
+
+    def test_matching_ng_and_legacy_identities_are_accepted(self, mock_cli_env):
+        env = mock_cli_env["make_env"](
+            json.dumps({"latestStatus": "drifted", "message": "drifted latest"})
+        )
+        output = _run_hook(
+            _make_ng_skill_event(
+                "test-skill",
+                mock_cli_env["cwd"],
+                action="invoke",
+                legacy_skill="test-skill",
+            ),
+            env_override=env,
+        )
+
+        assert output["decision"] == "ask"
+        assert "test-skill" in output["reason"]
+
+    def test_conflicting_ng_and_legacy_identities_are_rejected(self):
+        output = _run_hook(
+            _make_ng_skill_event(
+                "canonical-name",
+                action="invoke",
+                legacy_skill="other-name",
+            ),
+            env_override={"SKILL_LEDGER_MODE": "block"},
+        )
+
+        assert output["decision"] == "block"
+        assert "identities conflict" in output["reason"]
+
+    def test_identity_whitespace_is_not_normalized(self):
+        assert skill_ledger_hook._normalize_skill_call({"name": " test-skill "}) == (
+            " test-skill ",
+            None,
+            False,
+        )
+
+    @pytest.mark.parametrize(
+        ("tool_input", "expected_detail"),
+        [
+            ({}, "skill is empty or missing"),
+            ({"skill": "   "}, "skill is empty or missing"),
+            ({"skill": 42}, "skill must be a string"),
+            ({"action": "invoke"}, "name is empty or missing"),
+            ({"name": "   "}, "name is empty or missing"),
+            ({"name": 42}, "name must be a string"),
+            ({"action": "inspect", "name": "test-skill"}, "unsupported Cosh-NG action"),
+        ],
+        ids=[
+            "legacy-missing",
+            "legacy-blank",
+            "legacy-nonstring",
+            "ng-missing",
+            "ng-blank",
+            "ng-nonstring",
+            "ng-unknown-action",
+        ],
+    )
+    def test_invalid_invocations_are_contract_errors(self, tool_input, expected_detail):
+        output = _run_hook(
+            {"tool_name": "skill", "tool_input": tool_input},
+            env_override={"SKILL_LEDGER_MODE": "block"},
+        )
+
+        assert output["decision"] == "block"
+        assert expected_detail in output["reason"]
+
+    @pytest.mark.parametrize(
+        ("policy", "expected_decision", "visible_reason", "debug_stderr"),
+        [
+            ("observe", "allow", False, True),
+            ("warn", "allow", True, False),
+            ("ask", "ask", True, False),
+            ("block", "block", True, False),
+        ],
+    )
+    def test_contract_errors_follow_policy(
+        self,
+        policy,
+        expected_decision,
+        visible_reason,
+        debug_stderr,
+    ):
+        output, stderr = _run_hook(
+            {"tool_name": "skill", "tool_input": {"action": "invoke"}},
+            env_override={"SKILL_LEDGER_MODE": policy},
+            return_stderr=True,
+        )
+
+        assert output["decision"] == expected_decision
+        assert ("reason" in output) is visible_reason
+        assert ("cannot bind the invoked identity" in stderr) is debug_stderr
+
+
+# ---------------------------------------------------------------------------
 # Skill directory resolution tests
 # ---------------------------------------------------------------------------
 
@@ -347,7 +541,10 @@ class TestSkillDirResolution:
         assert output["decision"] == "ask"
         assert "reason" in output, "Skill dir not found — CLI was never called"
 
-    def test_skill_context_resolves_name_directory_mismatch(self, mock_cli_env):
+    @pytest.mark.parametrize("profile", ["legacy", "ng"])
+    def test_skill_context_resolves_name_directory_mismatch(
+        self, mock_cli_env, profile
+    ):
         """skill_context.file_path should locate project skills by real path.
 
         This covers the case where the Skill tool receives the frontmatter
@@ -361,8 +558,9 @@ class TestSkillDirResolution:
         env = mock_cli_env["make_env"](
             json.dumps({"latestStatus": "drifted", "message": "drifted latest"})
         )
+        make_event = _make_skill_event if profile == "legacy" else _make_ng_skill_event
         output = _run_hook(
-            _make_skill_event(
+            make_event(
                 "frontmatter-name",
                 mock_cli_env["cwd"],
                 Path(skill_dir) / "SKILL.md",
@@ -371,6 +569,59 @@ class TestSkillDirResolution:
         )
         assert output["decision"] == "ask"
         assert "drifted latest" in output["reason"]
+
+    @pytest.mark.parametrize(
+        "skill_context",
+        [
+            None,
+            [],
+            {},
+            {"skill_name": "test-skill"},
+            {"file_path": "/project/SKILL.md"},
+            {"skill_name": 42, "file_path": "/project/SKILL.md"},
+            {"skill_name": "test-skill", "file_path": "   "},
+        ],
+        ids=[
+            "null",
+            "array",
+            "empty",
+            "missing-path",
+            "missing-name",
+            "nonstring-name",
+            "blank-path",
+        ],
+    )
+    def test_present_malformed_context_is_a_contract_error(self, skill_context):
+        event = _make_skill_event("test-skill")
+        event["skill_context"] = skill_context
+
+        output = _run_hook(
+            event,
+            env_override={"SKILL_LEDGER_MODE": "block"},
+        )
+
+        assert output["decision"] == "block"
+        assert "skill_context" in output["reason"]
+
+    def test_context_identity_cannot_override_invoked_identity(self, tmp_path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text("---\nname: context-name\n---\n")
+        event = _make_ng_skill_event(
+            "invoked-name",
+            action="invoke",
+        )
+        event["skill_context"] = {
+            "skill_name": "context-name",
+            "file_path": str(skill_file),
+        }
+
+        output = _run_hook(
+            event,
+            env_override={"SKILL_LEDGER_MODE": "block"},
+        )
+
+        assert output["decision"] == "block"
+        assert "conflicts with the invoked identity" in output["reason"]
 
     def test_skill_context_skips_only_unresolvable_supported_base(self, mock_cli_env):
         """A bad project base should not discard user/system base checks."""


### PR DESCRIPTION
## Why

Cosh-NG changed Skill invocations from the legacy `tool_input.skill` field to
`tool_input.action` and `tool_input.name`. The Cosh Skill Ledger hook still read
only the legacy field, so Cosh-NG invocations could bypass the expected Ledger
event and policy decision.

## What changed

Normalize both legacy Cosh and Cosh-NG Skill payloads before resolving the
checked Skill. Cosh-NG `list` calls now exit without side effects, while missing,
malformed, or contradictory invocation identities and `skill_context` values
follow the configured Hook policy. Existing filesystem, CLI, timeout, and
invalid-output failures remain fail-open.

The change also adds legacy/Cosh-NG unit and E2E coverage, ensures source E2E
runs select the checked-out Hook instead of a stale installed copy, and documents
the compatibility and original PreToolUse snapshot boundary.

## Related issue

Fixes #2815

## User / Agent impact

Cosh-NG Skill invocations now run the same Skill Ledger checks as legacy Cosh.
A valid registered Skill remains silently allowed, while a drifted Skill can
warn, ask, or block according to `SKILL_LEDGER_MODE`. Cosh-NG `list` behavior and
legacy Cosh behavior remain unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change is scoped to the Cosh Hook adapter and does not modify either Host
schema or any CLI/configuration schema. Malformed Host identity contracts now
follow the configured policy instead of silently bypassing the check; existing
infrastructure failures remain fail-open. Rewrites by a later `tool_input_patch`
remain outside the original PreToolUse snapshot boundary and are not addressed
by this change.

## Validation

Local validation on Darwin arm64 with the repository-pinned Python 3.11.6:

- `make python-code-pretty` — passed; 363 files unchanged
- `uv run --project agent-sec-cli ruff check cosh-extension/hooks/skill_ledger_hook.py tests/unit-test/cosh_hooks/test_skill_ledger_hook.py tests/e2e/skill-ledger/e2e_test.py` — passed
- `uv run --project agent-sec-cli pytest -q tests/unit-test/cosh_hooks/test_skill_ledger_hook.py` — 61 passed
- `uv run --project agent-sec-cli pytest -q tests/e2e/skill-ledger/e2e_test.py` — 51 passed
- `make test-python` — passed before the final rebase; all four changed blobs are byte-identical after rebase
- `git diff --check upstream/main...HEAD` — clean

Real-host acceptance used Cosh-NG 0.16.1 and agent-sec-core 0.11.0 with the
exact candidate Hook blob. The side-effect-free `list` case passed; an
`action/name` invocation produced a correlated pass event and completed; and a
drifted invocation surfaced the native approval flow, where denial prevented
execution and produced the correlated drifted event. Final run cleanup was
clean.

Full Linux `make test` and remote pytest were not run because that host lacked
`uv`, `cargo`, `rustc`, and `pytest`; no dependencies were installed or
transferred. The retained acceptance record also preserves an earlier npm-cache
preflight deviation and an invalid approval-navigation attempt; neither was
used as product-pass evidence.

## Documentation and rollback

Updated `src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md` with the legacy and
Cosh-NG input contracts, policy behavior, supported directory boundary, and the
remaining Host-side identity-rewrite limitation. Rollback is a revert of this
commit; no data or configuration migration is required.
