### PR TITLE
fix(sec-core): enforce owner only access on files

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -297,6 +297,20 @@ The observability stream uses its own JSONL file, lock file, SQLite database,
 rotation limit, backup count, and 7-day SQLite retention policy; it does not
 write to `security-events.jsonl` or `security-events.db`.
 
+### Local JSONL File Permissions
+
+The local `security-events.jsonl`, `observability.jsonl`, and `cli.jsonl`
+writers create active data files and their advisory lock files with mode
+`0600`, independently of the process umask. Existing active data and lock
+files are tightened to `0600` when a writer opens them. On the first write,
+recognized timestamped backups retained from older releases are also tightened
+to `0600`; backups created by the current writer inherit the tightened mode.
+
+Unprivileged direct readers must run as the file-owning user. Operators with
+existing group/other read workflows should move those readers to the owning
+user or a controlled export path instead of broadening the source log
+permissions.
+
 ---
 
 ## Security

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/writer.py
@@ -3,8 +3,10 @@
 import fcntl
 import json
 import logging
+import os
 import re
 import shutil
+import stat
 import threading
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
@@ -44,6 +46,11 @@ DEFAULT_MAX_BYTES = 100 * 1024 * 1024
 # Default number of rotated files to keep
 DEFAULT_BACKUP_COUNT = 10
 
+# Local security-event, observability, and diagnostic streams can contain
+# request/result evidence. Keep both data files and their advisory lock files
+# owner-only, independently of the caller's umask.
+_PRIVATE_FILE_MODE = 0o600
+
 # Matches the timestamp suffix produced by _rotate():
 #   YYYYMMDD-HHMMSS.fff          (normal)
 #   YYYYMMDD-HHMMSS.fff.N        (collision-guard counter)
@@ -81,6 +88,7 @@ class JsonlEventWriter:
         self._on_error = on_error
         self._lock = threading.Lock()
         self._dir_created = False
+        self._retained_backups_secured = False
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -101,13 +109,70 @@ class JsonlEventWriter:
         self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._dir_created = True
 
-    def _needs_rotation(self, additional_bytes: int = 0) -> bool:
-        """Check if the current log file would exceed the size limit after adding additional_bytes."""
+    @staticmethod
+    def _open_private_append_fd(path: Path) -> int:
+        """Open a file for append and enforce mode ``0o600``.
+
+        The creation mode prevents a new file from starting with broader
+        permissions. ``fchmod`` tightens files created by older releases and
+        restores owner access when the process umask is unusually restrictive.
+        """
+        fd = os.open(
+            path,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            _PRIVATE_FILE_MODE,
+        )
         try:
-            st = self._path.stat()
-            return st.st_size + additional_bytes >= self._max_bytes
-        except OSError:
-            return False
+            metadata = os.fstat(fd)
+            if stat.S_IMODE(metadata.st_mode) != _PRIVATE_FILE_MODE:
+                os.fchmod(fd, _PRIVATE_FILE_MODE)
+            return fd
+        except BaseException:
+            os.close(fd)
+            raise
+
+    def _needs_rotation(self, fd: int, additional_bytes: int = 0) -> bool:
+        """Return whether appending to the opened log would cross its size limit."""
+        return os.fstat(fd).st_size + additional_bytes >= self._max_bytes
+
+    def _tighten_retained_backup(self, path: Path) -> None:
+        """Best-effort tighten one recognized retained backup without following links."""
+        try:
+            if not stat.S_ISREG(path.lstat().st_mode):
+                return
+
+            fd = os.open(
+                path,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK,
+            )
+            try:
+                metadata = os.fstat(fd)
+                if not stat.S_ISREG(metadata.st_mode):
+                    return
+                if stat.S_IMODE(metadata.st_mode) != _PRIVATE_FILE_MODE:
+                    os.fchmod(fd, _PRIVATE_FILE_MODE)
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            self._notify_error(exc)
+
+    def _secure_retained_backups_once(self) -> None:
+        """Tighten backups left by older releases on this writer's first write."""
+        if self._retained_backups_secured:
+            return
+
+        try:
+            prefix = f"{self._path.name}."
+            for entry in self._path.parent.iterdir():
+                if not entry.name.startswith(prefix):
+                    continue
+                suffix = entry.name[len(prefix) :]
+                if _BACKUP_SUFFIX_RE.match(suffix):
+                    self._tighten_retained_backup(entry)
+        except OSError as exc:
+            self._notify_error(exc)
+        finally:
+            self._retained_backups_secured = True
 
     def _rotate(self) -> None:
         """Rotate the log file by renaming it with a timestamp suffix.
@@ -153,11 +218,11 @@ class JsonlEventWriter:
         and destroyed within a single lock acquisition.
         """
         lock_path = self._path.parent / (self._path.name + ".lock")
-        lock_fd = None
+        lock_fd: int | None = None
         lock_acquired = False
         try:
             self._ensure_parent_dir()
-            lock_fd = lock_path.open("w")
+            lock_fd = self._open_private_append_fd(lock_path)
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             lock_acquired = True
         except OSError:
@@ -166,28 +231,38 @@ class JsonlEventWriter:
             # Best-effort: still write, accept small race.
             if lock_fd is not None:
                 try:
-                    lock_fd.close()
+                    os.close(lock_fd)
                 except OSError:
                     pass
                 lock_fd = None
 
         try:
-            # Check rotation under the lock
-            if self._needs_rotation(line_bytes):
-                self._rotate()
+            self._secure_retained_backups_once()
+            event_fd: int | None = self._open_private_append_fd(self._path)
+            try:
+                # Tighten an existing file before checking rotation so the
+                # resulting backup cannot retain a legacy group/world-readable
+                # mode. Reopen by path after rotation to avoid stale inodes.
+                if self._needs_rotation(event_fd, line_bytes):
+                    os.close(event_fd)
+                    event_fd = None
+                    self._rotate()
+                    event_fd = self._open_private_append_fd(self._path)
 
-            # Open the file fresh by path, write, and close.
-            # This is the key to avoiding inode-reuse: we never hold a
-            # persistent fd across lock boundaries.
-            with self._path.open("a", encoding="utf-8") as fh:
-                fh.write(line)
-                fh.flush()
+                fh = os.fdopen(event_fd, "a", encoding="utf-8")
+                event_fd = None
+                with fh:
+                    fh.write(line)
+                    fh.flush()
+            finally:
+                if event_fd is not None:
+                    os.close(event_fd)
         finally:
             if lock_fd is not None:
                 try:
                     if lock_acquired:
                         fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                    lock_fd.close()
+                    os.close(lock_fd)
                 except OSError:
                     pass
 

--- a/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_writer.py
@@ -4,6 +4,7 @@ import json
 import multiprocessing
 import os
 import re
+import stat
 import threading
 import time
 from datetime import datetime, timedelta
@@ -148,6 +149,96 @@ class TestJsonlEventWriter:
         assert observability_lock.exists()
         assert security_lock.resolve() != observability_lock.resolve()
 
+    def test_data_and_lock_files_are_created_owner_only(self, tmp_path: Path) -> None:
+        path = tmp_path / "security-events.jsonl"
+
+        JsonlEventWriter(path=path).write({"stream": "security"})
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(Path(f"{path}.lock").stat().st_mode) == 0o600
+
+    @pytest.mark.parametrize("process_umask", [0o000, 0o777])
+    def test_owner_only_mode_does_not_depend_on_process_umask(
+        self, tmp_path: Path, process_umask: int
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        previous_umask = os.umask(process_umask)
+        try:
+            JsonlEventWriter(path=path).write_or_raise({"stream": "security"})
+        finally:
+            os.umask(previous_umask)
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(Path(f"{path}.lock").stat().st_mode) == 0o600
+
+    def test_existing_owned_data_and_lock_files_are_tightened(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        lock_path = Path(f"{path}.lock")
+        path.write_text("", encoding="utf-8")
+        lock_path.write_text("", encoding="utf-8")
+        path.chmod(0o644)
+        lock_path.chmod(0o666)
+
+        JsonlEventWriter(path=path).write({"stream": "security"})
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    def test_existing_retained_backups_are_tightened_without_rotation(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        backups = [
+            tmp_path / "security-events.jsonl.20260101-120000.100",
+            tmp_path / "security-events.jsonl.20260101-120000.100.1",
+        ]
+        for backup in backups:
+            backup.write_text("legacy\n", encoding="utf-8")
+            backup.chmod(0o644)
+
+        JsonlEventWriter(path=path, max_bytes=10_000).write_or_raise(
+            {"stream": "security"}
+        )
+
+        assert all(stat.S_IMODE(backup.stat().st_mode) == 0o600 for backup in backups)
+        assert len(_backup_files(path)) == 2
+
+    def test_retained_backup_migration_does_not_follow_symlinks(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        target = tmp_path / "unrelated.txt"
+        target.write_text("unrelated\n", encoding="utf-8")
+        target.chmod(0o644)
+        backup_link = tmp_path / "security-events.jsonl.20260101-120000.100"
+        backup_link.symlink_to(target)
+
+        JsonlEventWriter(path=path).write_or_raise({"stream": "security"})
+
+        assert backup_link.is_symlink()
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+    def test_retained_backup_migration_ignores_non_backup_files(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        unrelated = [
+            tmp_path / "security-events.jsonl.old",
+            tmp_path / "security-events.jsonl.bak",
+            tmp_path / "security-events.jsonl.notes",
+        ]
+        for candidate in unrelated:
+            candidate.write_text("unrelated\n", encoding="utf-8")
+            candidate.chmod(0o644)
+
+        JsonlEventWriter(path=path).write_or_raise({"stream": "security"})
+
+        assert all(
+            stat.S_IMODE(candidate.stat().st_mode) == 0o644 for candidate in unrelated
+        )
+
     def test_generic_writer_uses_stream_specific_rotation_state(
         self, tmp_path: Path
     ) -> None:
@@ -200,6 +291,21 @@ class TestWriterAutoRotation:
         assert _backup_files(path), "At least one rotated backup file should exist"
         assert path.exists()
         assert path.stat().st_size < 600
+
+    def test_rotation_tightens_legacy_file_before_moving_it(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "security-events.jsonl"
+        path.write_text("legacy\n", encoding="utf-8")
+        path.chmod(0o644)
+        writer = JsonlEventWriter(path=path, max_bytes=1, backup_count=3)
+
+        writer.write({"stream": "security"})
+
+        backups = _backup_files(path)
+        assert len(backups) == 1
+        assert stat.S_IMODE(backups[0].stat().st_mode) == 0o600
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
     def test_backup_count_limit(self, tmp_path: Path) -> None:
         """Test that old backups are deleted when backup_count is exceeded."""

--- a/src/agent-sec-core/tests/unit-test/test_cli_logging.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli_logging.py
@@ -373,9 +373,7 @@ def test_handler_stringifies_non_json_data_values(tmp_path: Path) -> None:
     }
 
 
-def test_handler_does_not_chmod_log_file_on_emit(tmp_path: Path) -> None:
-    # Access control relies on the parent directory's 0o700 mode; the handler
-    # must not chmod the log file itself on each write.
+def test_handler_tightens_existing_log_file_on_emit(tmp_path: Path) -> None:
     init_invocation_context()
     path = tmp_path / "cli.jsonl"
     path.write_text("", encoding="utf-8")
@@ -384,9 +382,7 @@ def test_handler_does_not_chmod_log_file_on_emit(tmp_path: Path) -> None:
 
     handler.emit(_make_record())
 
-    # File mode is untouched by the handler — whatever umask/explicit chmod
-    # set it to, that's what remains.
-    assert stat.S_IMODE(path.stat().st_mode) == 0o644
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_setup_cli_logging_is_idempotent(


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->
Files created by cli are readable by other users which is unexpected. 
## What changed

<!-- Keep this focused on one logical change. -->
Enforce owner only access on cli created files.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->
fixes https://github.com/alibaba/anolisa/issues/2854
## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
