### PR TITLE
fix(sec-core): repair asset verification

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -57,6 +57,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 | [Code Scanner Hook Configuration](agent-security/agent-sec-core/code-scanner.md) | agent-sec-core | Per-agent hook modes, environment variables, and fallback behavior |
 | [Prompt Scanner](agent-security/agent-sec-core/prompt-scanner.md) | agent-sec-core | Prompt injection / jailbreak detection, modes, and verdicts |
 | [PII Checker](agent-security/agent-sec-core/pii-checker.md) | agent-sec-core | Personal data / credential detection and redaction |
+| [Asset Verification](agent-security/agent-sec-core/asset-verification.md) | agent-sec-core | GPG-signed skill distribution verification and discovery outcomes |
 | [Skill Ledger User Guide](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | Skill integrity chain and signing workflow |
 | [OpenClaw Deployment & Upgrade](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw plugin deployment and upgrade guide |
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/asset-verification.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/asset-verification.md
@@ -1,0 +1,130 @@
+# Asset Verification
+
+[中文版](../../../zh/agent-security/agent-sec-core/asset-verification.md)
+
+Asset Verification checks the distribution integrity of Skill directories. It verifies a
+GPG-signed manifest, checks the SHA-256 digest of every manifest entry, and rejects additional
+non-hidden regular files that the manifest does not cover.
+
+This command validates release or deployment signatures. It is separate from
+[Skill Ledger](skill-ledger.md), which uses Ed25519 signatures to maintain a local runtime history.
+
+## Installation
+
+```bash
+# Recommended: install the standard ANOLISA raw component in system mode
+sudo anolisa --install-mode system install sec-core
+
+# Alternative for Alinux systems with the YUM repository configured
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
+
+# Source build for developers
+./scripts/build-all.sh --component sec-core
+```
+
+Asset Verification requires GnuPG 2.0 or later. The component package includes the verifier
+configuration and trusted public keys.
+
+## Verify Skills
+
+Run batch discovery with no option, or bypass discovery and verify one Skill explicitly:
+
+```bash
+# Scan the default installation roots
+agent-sec-cli verify
+
+# Verify exactly one Skill directory
+agent-sec-cli verify --skill /path/to/skill
+```
+
+Each candidate must contain:
+
+| Path | Purpose |
+|------|---------|
+| `.skill-meta/Manifest.json` | Lists the expected SHA-256 digest for each signed file |
+| `.skill-meta/.skill.sig` | GPG detached signature for `Manifest.json` |
+
+The verifier loads trusted `.asc` public keys from the packaged
+`agent_sec_cli/asset_verify/trusted-keys/` directory. A missing manifest or signature, an untrusted
+or invalid signature, a missing or modified manifest entry, or an additional unsigned regular file
+fails that candidate.
+
+## Default Discovery Roots
+
+`agent-sec-cli verify` reads the packaged `asset_verify/config.conf`. The default configuration has
+two optional discovery roots:
+
+| Installation topology | Discovery root |
+|-----------------------|----------------|
+| RPM | `/usr/share/anolisa/skills` |
+| Standard ANOLISA raw package | `/usr/local/share/anolisa/skills` |
+
+Every immediate, non-hidden child directory is a candidate Skill. Discovery follows these rules:
+
+- A missing root is skipped silently.
+- An empty root, or one containing no immediate visible directories, contributes no candidates.
+- Roots that resolve to the same canonical path are scanned once.
+- An existing non-directory root or a root that cannot be enumerated is an operation error.
+- An unreadable candidate, like a candidate with an invalid signature or hash, is a verification
+  failure.
+
+The two default roots are fixed package data. They are not rendered from an arbitrary installation
+prefix. For a relocated or custom Skill, use `agent-sec-cli verify --skill /path/to/skill`.
+
+## Outcomes and Exit Codes
+
+Every completed run prints `CHECKED`, `PASSED`, and `FAILED` counts, followed by one exact final
+status line:
+
+| Outcome | Meaning | Final status line | Exit code |
+|---------|---------|-------------------|-----------|
+| `verified` | At least one candidate was checked and every candidate passed | `VERIFICATION PASSED` | `0` |
+| `failed` | At least one candidate failed verification | `VERIFICATION FAILED` | `1` |
+| `no_candidates` | Discovery completed normally but found no candidates | `VERIFICATION SKIPPED: NO CANDIDATE SKILLS` | `0` |
+
+`no_candidates` is a successful best-effort discovery result. It does not mean that any asset was
+verified. Missing and empty default roots therefore do not turn an installation with no Skills into
+a verification failure.
+
+`--skill` names exactly one candidate. A nonexistent path, non-directory path, unreadable Skill, or
+invalid Skill is therefore always `failed` with exit code `1`; explicit verification never maps
+that input to `no_candidates`.
+
+Configuration parsing, trusted-key loading, canonicalization, and root-enumeration failures are
+operation errors and exit `1`. Because no stable verification result exists in that case, telemetry
+may omit the asset outcome. The CLI reports these operation errors on standard error.
+
+For completed runs, telemetry records `seccore.asset_outcome` as `verified`, `failed`, or
+`no_candidates`, together with passed and failed counts. Discovery roots and Skill paths are not
+uploaded.
+
+## Sign Skills in Self-Managed Deployments
+
+Release packages should retain their release signatures. For a self-managed deployment, use the
+source-tree signing helper to create a local signing key, export its public key to the verifier trust
+directory, and sign Skills:
+
+```bash
+cd src/agent-sec-core
+tools/sign-skill.sh --check
+tools/sign-skill.sh --init
+tools/sign-skill.sh /path/to/skill --force
+```
+
+Re-sign a Skill after changing any covered file. See the
+[Skill Signing Guide](../../../../../src/agent-sec-core/tools/SIGNING_GUIDE.md) for key management,
+batch signing, and CI/CD usage.
+
+## Troubleshooting
+
+- `no_candidates`: check whether Skills are installed below either default root, or pass `--skill`
+  for a custom location.
+- `ERR_MANIFEST_MISSING` or `ERR_SIG_MISSING`: the discovered directory is a candidate but is not
+  signed with the Asset Verification format.
+- `ERR_SIG_INVALID`: verify that the signing public key is installed in the packaged
+  `trusted-keys/` directory and re-sign if the manifest changed.
+- `ERR_HASH_MISMATCH` or `ERR_UNEXPECTED_FILE`: inspect the Skill contents, then restore the signed
+  release or deliberately re-sign the reviewed content.
+- An operation error before an outcome: check `config.conf`, the trusted-key directory, and the type
+  and permissions of every existing discovery root.

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -57,6 +57,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 | [Code Scanner Hook 配置](agent-security/agent-sec-core/code-scanner.md) | agent-sec-core | 各 Agent 的 hook 模式、环境变量与 fallback 行为 |
 | [Prompt Scanner](agent-security/agent-sec-core/prompt-scanner.md) | agent-sec-core | 提示词注入 / 越狱检测、模式与 verdict |
 | [PII 检测](agent-security/agent-sec-core/pii-checker.md) | agent-sec-core | 个人数据/凭证检测与脱敏 |
+| [资产验证](agent-security/agent-sec-core/asset-verification.md) | agent-sec-core | GPG 签名的 Skill 分发验证与发现结果 |
 | [Skill Ledger 用户指南](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | 技能账本完整性链与签名工作流 |
 | [OpenClaw 兼容部署与升级](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw 插件部署与升级指南 |
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/asset-verification.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/asset-verification.md
@@ -1,0 +1,116 @@
+# 资产验证
+
+[English](../../../en/agent-security/agent-sec-core/asset-verification.md)
+
+资产验证用于检查 Skill 目录的分发完整性。它会验证 GPG 签名的 manifest，检查每个
+manifest 条目的 SHA-256 摘要，并拒绝 manifest 未覆盖的额外非隐藏普通文件。
+
+该命令验证发布或部署签名。它不同于 [Skill Ledger](skill-ledger.md)：后者使用 Ed25519
+签名维护本地运行时历史。
+
+## 安装
+
+```bash
+# 首选：以 system mode 安装标准 ANOLISA raw 组件
+sudo anolisa --install-mode system install sec-core
+
+# 备选：已配置 YUM 源的 Alinux 系统
+sudo yum install anolisa agent-sec-core
+sudo anolisa --install-mode system adopt sec-core
+
+# 源码构建（仅开发者）
+./scripts/build-all.sh --component sec-core
+```
+
+资产验证要求 GnuPG 2.0 或更高版本。组件包中包含 verifier 配置和受信公钥。
+
+## 验证 Skill
+
+不带参数时执行批量发现；也可以绕过发现逻辑，显式验证单个 Skill。
+
+```bash
+# 扫描默认安装根目录
+agent-sec-cli verify
+
+# 只验证一个 Skill 目录
+agent-sec-cli verify --skill /path/to/skill
+```
+
+每个候选 Skill 必须包含：
+
+| 路径 | 用途 |
+|------|------|
+| `.skill-meta/Manifest.json` | 记录每个已签名文件的预期 SHA-256 摘要 |
+| `.skill-meta/.skill.sig` | `Manifest.json` 的 GPG 分离签名 |
+
+verifier 从包内 `agent_sec_cli/asset_verify/trusted-keys/` 目录加载受信 `.asc` 公钥。
+manifest 或签名缺失、签名不受信或无效、manifest 条目缺失或被修改，以及出现额外未签名的
+普通文件，都会使该候选验证失败。
+
+## 默认发现根目录
+
+`agent-sec-cli verify` 读取包内 `asset_verify/config.conf`。默认配置包含两个可选发现根目录：
+
+| 安装拓扑 | 发现根目录 |
+|----------|------------|
+| RPM | `/usr/share/anolisa/skills` |
+| 标准 ANOLISA raw 包 | `/usr/local/share/anolisa/skills` |
+
+每个直接、非隐藏的子目录都是候选 Skill。发现过程遵循以下规则：
+
+- 缺失的根目录会被静默跳过。
+- 空根目录，或不含直接、可见子目录的根目录，不会贡献候选。
+- 解析到同一 canonical path 的重复根目录只扫描一次。
+- 已存在但不是目录的根路径，或无法枚举的根目录，属于操作错误。
+- 无法读取的候选 Skill 与签名或哈希无效的候选一样，属于验证失败。
+
+两个默认根目录是固定的包数据，不会从任意安装 prefix 动态渲染。对于重定位或自定义
+Skill，请使用 `agent-sec-cli verify --skill /path/to/skill`。
+
+## Outcome 与退出码
+
+每次正常完成的运行都会先输出 `CHECKED`、`PASSED` 和 `FAILED` 计数，再输出一行精确的
+最终状态：
+
+| Outcome | 含义 | 最终状态行 | 退出码 |
+|---------|------|------------|--------|
+| `verified` | 至少检查了一个候选，且所有候选均通过 | `VERIFICATION PASSED` | `0` |
+| `failed` | 至少一个候选验证失败 | `VERIFICATION FAILED` | `1` |
+| `no_candidates` | 发现流程正常完成，但没有找到候选 | `VERIFICATION SKIPPED: NO CANDIDATE SKILLS` | `0` |
+
+`no_candidates` 是成功的 best-effort 发现结果，不代表已验证任何资产。因此，默认根目录
+缺失或为空，不会让未安装 Skill 的环境产生验证失败。
+
+`--skill` 只指定一个候选。路径不存在、路径不是目录、Skill 不可读或内容无效时，结果
+始终为 `failed`，退出码为 `1`；显式验证不会把这种输入映射为 `no_candidates`。
+
+配置解析、受信密钥加载、canonicalization 或根目录枚举失败属于操作错误，退出码为 `1`。
+此时不存在稳定验证结果，telemetry 可以省略资产 outcome；CLI 会把操作错误写入标准错误。
+
+对于正常完成的运行，telemetry 会记录 `seccore.asset_outcome`，值为 `verified`、`failed`
+或 `no_candidates`，并同时记录通过与失败计数。发现根目录和 Skill 路径不会上传。
+
+## 自管理部署中的 Skill 签名
+
+发布包应保留其发布签名。自行管理部署时，可以使用源码树中的签名工具生成本地签名密钥、
+把公钥导出到 verifier 信任目录，并为 Skill 签名：
+
+```bash
+cd src/agent-sec-core
+tools/sign-skill.sh --check
+tools/sign-skill.sh --init
+tools/sign-skill.sh /path/to/skill --force
+```
+
+修改任何受覆盖文件后都要重新签名。密钥管理、批量签名和 CI/CD 用法见
+[Skill 签名指南](../../../../../src/agent-sec-core/tools/SIGNING_GUIDE_zh.md)。
+
+## 故障排查
+
+- `no_candidates`：检查 Skill 是否安装在两个默认根目录中；自定义位置请传入 `--skill`。
+- `ERR_MANIFEST_MISSING` 或 `ERR_SIG_MISSING`：被发现的目录是候选，但未使用资产验证格式签名。
+- `ERR_SIG_INVALID`：确认签名公钥已安装到包内 `trusted-keys/` 目录；manifest 变化后需重新签名。
+- `ERR_HASH_MISMATCH` 或 `ERR_UNEXPECTED_FILE`：检查 Skill 内容，然后恢复已签名发布版本，
+  或对已审查的内容有意重新签名。
+- outcome 产生前的操作错误：检查 `config.conf`、受信密钥目录，以及每个现存发现根路径的
+  类型和权限。

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -230,6 +230,9 @@ agent-sec-cli scan-prompt --mode standard --text "ignore previous instructions"
 # PII detection
 agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
 
+# Verify release-signed skills in the default installation roots
+agent-sec-cli verify
+
 # Skill integrity check
 agent-sec-cli skill-ledger check /path/to/skill
 
@@ -239,6 +242,30 @@ agent-sec-cli events --summary
 
 Full CLI reference and per-host integration steps:
 [AgentSecCore User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/QUICKSTART.md).
+
+### Asset Verification
+
+`agent-sec-cli verify` checks GPG-signed distribution manifests and SHA-256
+file coverage. It is separate from Skill Ledger: `verify` validates release or
+deployment signatures, while `skill-ledger` maintains the local Ed25519 runtime
+integrity history.
+
+Batch verification discovers immediate, non-hidden Skill directories from two
+optional system roots: `/usr/share/anolisa/skills` for RPM installations and
+`/usr/local/share/anolisa/skills` for standard ANOLISA raw installations.
+Missing or empty roots are skipped, and canonical duplicate roots are scanned
+once. A completed scan reports `verified` when at least one candidate passes and
+none fail, `failed` when any candidate fails, or `no_candidates` when no
+candidate is found. `no_candidates` exits successfully but does not claim that
+an asset was verified.
+
+The two roots are fixed package defaults and are not derived from an arbitrary
+installation prefix. Use `agent-sec-cli verify --skill /path/to/skill` for a
+relocated or custom Skill. Configuration, trust-key, and root-enumeration errors
+remain operation failures; candidate signature, manifest, hash, unexpected-file,
+or access failures produce the `failed` outcome.
+
+Details: [Asset Verification User Guide](../../docs/user-guide/en/agent-security/agent-sec-core/asset-verification.md).
 
 ## Prompt Scanner
 

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -220,6 +220,9 @@ agent-sec-cli scan-prompt --mode standard --text "ignore previous instructions"
 # PII 检测
 agent-sec-cli scan-pii --text "contact alice@example.com" --source manual
 
+# 验证默认安装根目录中的发布签名 Skill
+agent-sec-cli verify
+
 # Skill 完整性检查
 agent-sec-cli skill-ledger check /path/to/skill
 
@@ -229,6 +232,26 @@ agent-sec-cli events --summary
 
 完整 CLI 说明与各宿主集成步骤见
 [AgentSecCore 用户指南](../../docs/user-guide/zh/agent-security/agent-sec-core/QUICKSTART.md)。
+
+### 资产验证
+
+`agent-sec-cli verify` 用于检查 GPG 签名的分发 manifest 和 SHA-256 文件覆盖。它与
+Skill Ledger 职责不同：`verify` 验证发布或部署签名，`skill-ledger` 维护本地 Ed25519
+运行时完整性历史。
+
+批量验证会从两个可选系统根目录发现直接、非隐藏的 Skill 子目录：RPM 安装使用
+`/usr/share/anolisa/skills`，标准 ANOLISA raw 安装使用
+`/usr/local/share/anolisa/skills`。缺失或为空的根目录会被跳过，指向同一 canonical path
+的重复根目录只扫描一次。至少找到一个候选且全部通过时 outcome 为 `verified`；任何候选
+失败时为 `failed`；没有发现候选时为 `no_candidates`。`no_candidates` 会成功退出，
+但不代表已验证任何资产。
+
+这两个根目录是固定的包默认值，不会从任意安装 prefix 动态推导。对于重定位或自定义
+Skill，请使用 `agent-sec-cli verify --skill /path/to/skill`。配置、受信密钥和根目录枚举
+异常仍属于操作失败；候选 Skill 的签名、manifest、哈希、未签名文件或访问失败会产生
+`failed` outcome。
+
+详见 [资产验证用户指南](../../docs/user-guide/zh/agent-security/agent-sec-core/asset-verification.md)。
 
 ## Prompt Scanner
 

--- a/src/agent-sec-core/agent-sec-cli/README.md
+++ b/src/agent-sec-core/agent-sec-cli/README.md
@@ -263,14 +263,30 @@ uv run maturin build --release
 
 ### Asset Verification
 
-Edit `asset_verify/config.conf`:
+The packaged `asset_verify/config.conf` contains both supported system discovery roots:
 
 ```ini
 skills_dir = [
     /usr/share/anolisa/skills
-    /opt/custom-skills
+    /usr/local/share/anolisa/skills
 ]
 ```
+
+The first path is used by RPM installations; the second is used by standard ANOLISA raw
+installations. Both are optional. Missing or empty roots are skipped, and roots that resolve to the
+same canonical path are scanned once. The defaults are not derived from a custom installation
+prefix; use `agent-sec-cli verify --skill /path/to/skill` for a relocated Skill.
+
+Normal runs report `verified` when at least one candidate passes and none fail, `failed` when any
+candidate fails, or `no_candidates` when discovery completes without finding a candidate.
+`no_candidates` exits `0` but does not claim that an asset was verified. Configuration, trusted-key,
+canonicalization, and root-enumeration errors exit `1` as operation failures and may omit the
+outcome; the CLI writes those operation errors to standard error. Completed runs print
+`CHECKED`/`PASSED`/`FAILED` counts and finish with `VERIFICATION PASSED`, `VERIFICATION FAILED`, or
+`VERIFICATION SKIPPED: NO CANDIDATE SKILLS`.
+
+Full behavior and topology reference:
+[Asset Verification User Guide](../../../docs/user-guide/en/agent-security/agent-sec-core/asset-verification.md).
 
 ### Security Events
 
@@ -309,6 +325,9 @@ sign-skill.sh /path/to/skill
 
 # Sign all skills in batch
 sign-skill.sh --batch /usr/share/anolisa/skills --force
+
+# Standard ANOLISA raw installation root
+sign-skill.sh --batch /usr/local/share/anolisa/skills --force
 ```
 
 ### Verifying Skills
@@ -317,9 +336,17 @@ sign-skill.sh --batch /usr/share/anolisa/skills --force
 # Verify all configured skills
 agent-sec-cli verify
 
-# Verify with detailed output
-python -m agent_sec_cli.asset_verify.verifier --skill /path/to/skill
+# Verify one Skill without default-root discovery
+agent-sec-cli verify --skill /path/to/skill
 ```
+
+Batch discovery treats each immediate, non-hidden child directory as a candidate. Candidate
+manifest, signature, hash, unexpected-file, and access failures produce the `failed` outcome and
+exit `1`. An existing discovery root that is not a directory or cannot be enumerated is an operation
+error instead. An explicit `--skill` always represents one candidate, so a nonexistent, non-directory,
+unreadable, or invalid path is `failed` with exit `1`, never `no_candidates`. Completed runs expose
+`seccore.asset_outcome = verified|failed|no_candidates` to the sanitized telemetry projection;
+paths are not uploaded.
 
 ---
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/__init__.py
@@ -1,6 +1,7 @@
 """Asset verification module for skill integrity checking."""
 
 from agent_sec_cli.asset_verify.errors import (
+    ErrConfigInvalid,
     ErrConfigMissing,
     ErrHashMismatch,
     ErrManifestMissing,
@@ -10,7 +11,9 @@ from agent_sec_cli.asset_verify.errors import (
     ErrUnexpectedFile,
 )
 from agent_sec_cli.asset_verify.verifier import (
+    VerificationResult,
     compute_file_hash,
+    format_verification_result,
     load_config,
     load_trusted_keys,
     run_verification,
@@ -20,6 +23,7 @@ from agent_sec_cli.asset_verify.verifier import (
 )
 
 __all__ = [
+    "ErrConfigInvalid",
     "ErrConfigMissing",
     "ErrHashMismatch",
     "ErrManifestMissing",
@@ -27,7 +31,9 @@ __all__ = [
     "ErrSigInvalid",
     "ErrSigMissing",
     "ErrUnexpectedFile",
+    "VerificationResult",
     "compute_file_hash",
+    "format_verification_result",
     "load_config",
     "load_trusted_keys",
     "verify_manifest_hashes",

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf
@@ -5,4 +5,5 @@
 # Skills directories to verify (one per line)
 skills_dir = [
     /usr/share/anolisa/skills
+    /usr/local/share/anolisa/skills
 ]

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/errors.py
@@ -63,6 +63,13 @@ class ErrConfigMissing(SkillVerifyError):
         super().__init__(f"ERR_CONFIG_MISSING: Config file not found: {path}")
 
 
+class ErrConfigInvalid(SkillVerifyError):
+    code = 22
+
+    def __init__(self, path: str, detail: str) -> None:
+        super().__init__(f"ERR_CONFIG_INVALID: Invalid config file '{path}': {detail}")
+
+
 class ErrNoTrustedKeys(SkillVerifyError):
     code = 21
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/asset_verify/verifier.py
@@ -9,7 +9,9 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+from typing import Literal, NotRequired, TypedDict
 
 try:
     import pgpy
@@ -17,6 +19,7 @@ except ImportError:
     pgpy = None
 
 from agent_sec_cli.asset_verify.errors import (
+    ErrConfigInvalid,
     ErrConfigMissing,
     ErrHashMismatch,
     ErrManifestMissing,
@@ -37,16 +40,50 @@ GPG_BIN = shutil.which("gpg") or shutil.which("gpg2")
 SIGNING_DIR = ".skill-meta"
 
 
-def load_config(config_path: Path) -> dict[str, list[str] | str]:
-    """Load verification config file"""
+VerificationOutcome = Literal["verified", "failed", "no_candidates"]
+
+
+class VerificationConfig(TypedDict):
+    """Parsed asset-verification configuration."""
+
+    skills_dirs: list[str]
+    trusted_keys_dir: NotRequired[str]
+
+
+class VerificationFailure(TypedDict):
+    """One skill that failed verification."""
+
+    name: str
+    error: str
+
+
+class SkillsDirectoryResult(TypedDict):
+    """Verification result for one configured skills root."""
+
+    checked: int
+    passed: list[str]
+    failed: list[VerificationFailure]
+
+
+class VerificationResult(TypedDict):
+    """Structured verification result shared by all entry points."""
+
+    outcome: VerificationOutcome
+    checked: int
+    passed: list[str]
+    failed: list[VerificationFailure]
+
+
+def load_config(config_path: Path) -> VerificationConfig:
+    """Load verification config file."""
     if not config_path.exists():
         raise ErrConfigMissing(str(config_path))
 
-    config = {"skills_dirs": []}
+    config: VerificationConfig = {"skills_dirs": []}
     in_list = False
 
-    with open(config_path, "r") as f:
-        for line in f:
+    with open(config_path, "r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
@@ -55,17 +92,49 @@ def load_config(config_path: Path) -> dict[str, list[str] | str]:
                 if line == "]":
                     in_list = False
                 else:
-                    config["skills_dirs"].append(line.rstrip(","))
+                    value = line.rstrip(",").strip()
+                    if not value:
+                        raise ErrConfigInvalid(
+                            str(config_path), "empty skills_dir entry"
+                        )
+                    config["skills_dirs"].append(value)
             elif "=" in line:
                 key, val = line.split("=", 1)
                 key, val = key.strip(), val.strip()
                 if key == "skills_dir":
                     if val == "[":
                         in_list = True
+                    elif val == "[]":
+                        continue
+                    elif not val:
+                        raise ErrConfigInvalid(
+                            str(config_path), "empty skills_dir value"
+                        )
+                    elif val.startswith("[") or val.endswith("]"):
+                        raise ErrConfigInvalid(
+                            str(config_path),
+                            f"unsupported skills_dir list syntax on line {line_number}",
+                        )
                     else:
                         config["skills_dirs"].append(val)
                 elif key == "trusted_keys_dir":
+                    if not val:
+                        raise ErrConfigInvalid(
+                            str(config_path), "empty trusted_keys_dir value"
+                        )
                     config["trusted_keys_dir"] = val
+                else:
+                    raise ErrConfigInvalid(
+                        str(config_path),
+                        f"unknown config key '{key}' on line {line_number}",
+                    )
+            else:
+                raise ErrConfigInvalid(
+                    str(config_path), f"malformed entry on line {line_number}"
+                )
+
+    if in_list:
+        raise ErrConfigInvalid(str(config_path), "unterminated skills_dir list")
     return config
 
 
@@ -149,8 +218,6 @@ def verify_signature_gpg(
             skill_name, "Neither pgpy nor gpg available for signature verification"
         )
 
-    import tempfile
-
     with tempfile.TemporaryDirectory() as gnupg_home:
         # Set proper permissions for GNUPGHOME (GPG requires 700)
         os.chmod(gnupg_home, 0o700)
@@ -165,6 +232,7 @@ def verify_signature_gpg(
             result = subprocess.run(
                 [GPG_BIN, "--batch", "--yes", "--import", key_file],
                 capture_output=True,
+                check=False,
                 env=env,
             )
             if result.returncode != 0:
@@ -186,6 +254,7 @@ def verify_signature_gpg(
                 manifest_path,
             ],
             capture_output=True,
+            check=False,
             env=env,
         )
 
@@ -267,29 +336,58 @@ def verify_skill(skill_dir: str, trusted_keys: list) -> tuple[bool, str]:
     return True, skill_name
 
 
-def verify_skills_dir(skills_dir: str, trusted_keys: list) -> dict[str, list]:
-    """Verify all skills in a directory"""
-    results = {"passed": [], "failed": []}
+def verify_skills_dir(skills_dir: str, trusted_keys: list) -> SkillsDirectoryResult:
+    """Verify all candidate skills in one best-effort search root.
 
-    if not os.path.isdir(skills_dir):
-        print(f"[WARN] Skills directory not found: {skills_dir}")
-        return results
+    Missing roots are valid because packaged and raw installations use different
+    locations. Existing roots that cannot be enumerated still raise an error.
+    """
+    root = Path(skills_dir)
+    try:
+        entries = sorted(root.iterdir(), key=lambda entry: entry.name)
+    except FileNotFoundError:
+        return {
+            "checked": 0,
+            "passed": [],
+            "failed": [],
+        }
 
-    for entry in sorted(os.listdir(skills_dir)):
-        skill_path = os.path.join(skills_dir, entry)
-        if not os.path.isdir(skill_path) or entry.startswith("."):
+    passed: list[str] = []
+    failed: list[VerificationFailure] = []
+    checked = 0
+
+    for entry in entries:
+        if entry.name.startswith("."):
+            continue
+        if not stat.S_ISDIR(entry.stat().st_mode):
             continue
 
+        checked += 1
         try:
-            _, skill_name = verify_skill(skill_path, trusted_keys)
-            results["passed"].append(skill_name)
+            _, skill_name = verify_skill(str(entry), trusted_keys)
+            passed.append(skill_name)
         except Exception as e:
-            results["failed"].append({"name": entry, "error": str(e)})
+            failed.append({"name": entry.name, "error": str(e)})
 
-    return results
+    return {
+        "checked": checked,
+        "passed": passed,
+        "failed": failed,
+    }
 
 
-def run_verification(skill: str | None = None) -> dict[str, list]:
+def _verification_outcome(
+    checked: int, failed: list[VerificationFailure]
+) -> VerificationOutcome:
+    """Return the semantic outcome for a completed verification run."""
+    if failed:
+        return "failed"
+    if checked == 0:
+        return "no_candidates"
+    return "verified"
+
+
+def run_verification(skill: str | None = None) -> VerificationResult:
     """Run verification and return structured results.
 
     Handles the full workflow: load trusted keys, verify single skill or
@@ -300,30 +398,81 @@ def run_verification(skill: str | None = None) -> dict[str, list]:
                all directories listed in ``config.conf`` are scanned.
 
     Returns:
-        dict with ``passed`` (list[str]) and ``failed`` (list[dict]) keys.
+        Structured outcome, checked count, and per-skill results.
     """
     trusted_keys = load_trusted_keys(DEFAULT_TRUSTED_KEYS_DIR)
 
     if skill is not None:
         try:
             verify_skill(skill, trusted_keys)
-            return {"passed": [os.path.basename(skill)], "failed": []}
-        except Exception as e:
             return {
+                "outcome": "verified",
+                "checked": 1,
+                "passed": [os.path.basename(os.path.normpath(skill))],
+                "failed": [],
+            }
+        except Exception as e:
+            failed: list[VerificationFailure] = [
+                {
+                    "name": os.path.basename(os.path.normpath(skill)),
+                    "error": str(e),
+                }
+            ]
+            return {
+                "outcome": "failed",
+                "checked": 1,
                 "passed": [],
-                "failed": [{"name": os.path.basename(skill), "error": str(e)}],
+                "failed": failed,
             }
 
     config = load_config(DEFAULT_CONFIG)
     all_passed: list[str] = []
-    all_failed: list[dict] = []
+    all_failed: list[VerificationFailure] = []
+    checked = 0
+    seen_roots: set[Path] = set()
 
     for skills_dir in config.get("skills_dirs", []):
+        canonical_root = Path(skills_dir).resolve(strict=False)
+        if canonical_root in seen_roots:
+            continue
+        seen_roots.add(canonical_root)
+
         results = verify_skills_dir(skills_dir, trusted_keys)
+        checked += results["checked"]
         all_passed.extend(results["passed"])
         all_failed.extend(results["failed"])
 
-    return {"passed": all_passed, "failed": all_failed}
+    return {
+        "outcome": _verification_outcome(checked, all_failed),
+        "checked": checked,
+        "passed": all_passed,
+        "failed": all_failed,
+    }
+
+
+def format_verification_result(results: VerificationResult) -> str:
+    """Render the canonical human-readable verification result."""
+    output_lines: list[str] = []
+    for name in results["passed"]:
+        output_lines.append(f"[OK] {name}")
+    for item in results["failed"]:
+        output_lines.append(f"[ERROR] {item['name']}")
+        output_lines.append(f"  {item['error']}")
+
+    output_lines.append("")
+    output_lines.append("=" * 50)
+    output_lines.append(f"CHECKED: {results['checked']}")
+    output_lines.append(f"PASSED: {len(results['passed'])}")
+    output_lines.append(f"FAILED: {len(results['failed'])}")
+    output_lines.append("=" * 50)
+
+    status = {
+        "verified": "VERIFICATION PASSED",
+        "failed": "VERIFICATION FAILED",
+        "no_candidates": "VERIFICATION SKIPPED: NO CANDIDATE SKILLS",
+    }[results["outcome"]]
+    output_lines.append(status)
+    return "\n".join(output_lines) + "\n"
 
 
 def main() -> int:
@@ -335,28 +484,11 @@ def main() -> int:
 
     try:
         results = run_verification(args.skill)
-
-        for name in results["passed"]:
-            print(f"[OK] {name}")
-
-        for item in results["failed"]:
-            print(f"[ERROR] {item['name']}")
-            print(f"  {item['error']}")
-
-        print(f"\n{'=' * 50}")
-        print(f"PASSED: {len(results['passed'])}")
-        print(f"FAILED: {len(results['failed'])}")
-        print(f"{'=' * 50}")
-
-        if results["failed"]:
-            print("VERIFICATION FAILED")
-            return 1
-        else:
-            print("VERIFICATION PASSED")
-            return 0
+        print(format_verification_result(results), end="")
+        return 1 if results["outcome"] == "failed" else 0
 
     except Exception as e:
-        print(f"[ERROR] {e}")
+        print(f"[ERROR] {e}", file=sys.stderr)
         return 1
 
 

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -284,7 +284,7 @@ def verify(
     """Skill integrity verification."""
     result = invoke("verify", skill=skill)
     if result.stdout:
-        typer.echo(result.stdout)
+        typer.echo(result.stdout, nl=False)
     if result.error:
         typer.echo(result.error, err=True)
     raise typer.Exit(code=result.exit_code)

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_events/summary_formatter.py
@@ -124,6 +124,25 @@ def _is_full_verify(event: SecurityEvent) -> bool:
     return request.get("skill") is None
 
 
+def _asset_verify_outcome(event: SecurityEvent) -> str:
+    """Return the semantic verification outcome, including for legacy events."""
+    result = _get_result(event)
+    outcome = result.get("outcome")
+    if outcome in {"verified", "failed", "no_candidates"}:
+        return str(outcome)
+
+    if event.result == "failed":
+        return "failed"
+
+    passed = result.get("passed", 0)
+    failed = result.get("failed", 0)
+    if isinstance(failed, int) and failed > 0:
+        return "failed"
+    if passed == 0 and failed == 0:
+        return "no_candidates"
+    return "verified"
+
+
 def _get_mode(event: SecurityEvent) -> str:
     """Extract hardening mode from details.result, fallback to parsing request.args.
 
@@ -267,32 +286,34 @@ def _summarize_asset_verify(events: list[SecurityEvent]) -> str:
     """Summarize asset_verify category events."""
     lines = ["--- Asset Verification ---"]
 
-    ok_count = 0
-    latest: SecurityEvent | None = None
-    for e in events:
-        if e.result == "succeeded":
-            ok_count += 1
-            if latest is None:
-                latest = e
-    fail_count = len(events) - ok_count
+    outcomes = [_asset_verify_outcome(event) for event in events]
+    verified_count = outcomes.count("verified")
+    skipped_count = outcomes.count("no_candidates")
+    failed_count = outcomes.count("failed")
     lines.append(
         f"  Verifications performed: {len(events)} "
-        f"(succeeded: {ok_count}, failed: {fail_count})"
+        f"(verified: {verified_count}, skipped: {skipped_count}, failed: {failed_count})"
     )
 
-    # Latest successful result
-    if latest:
-        result = _get_result(latest)
-        passed = result.get("passed", 0)
-        failed = result.get("failed", 0)
-        lines.append("")
-        lines.append("  Latest result:")
-        lines.append(f"    {passed} passed, {failed} failed")
-        if failed == 0:
-            lines.append("    Integrity status: ALL CLEAR")
-        else:
-            lines.append("    Integrity status: FAILURES DETECTED")
-            lines.append("    Check details using `agent-sec-cli verify`")
+    latest = events[0]
+    result = _get_result(latest)
+    passed = result.get("passed", 0)
+    failed = result.get("failed", 0)
+    checked = result.get("checked", passed + failed)
+    outcome = _asset_verify_outcome(latest)
+    lines.append("")
+    lines.append("  Latest result:")
+    lines.append(f"    {checked} checked, {passed} passed, {failed} failed")
+    if outcome == "verified":
+        lines.append("    Integrity status: ALL CLEAR")
+    elif outcome == "no_candidates":
+        lines.append("    Integrity status: NOT ASSESSED (no candidate skills)")
+    else:
+        lines.append("    Integrity status: FAILURES DETECTED")
+        error_msg = _safe_details(latest).get("error")
+        if error_msg:
+            lines.append(f"    Latest error: {error_msg}")
+        lines.append("    Check details using `agent-sec-cli verify`")
 
     return "\n".join(lines)
 
@@ -562,21 +583,20 @@ def _compute_posture(
             if failures:
                 needs_attention = True
 
-    # --- Asset Verification (latest FULL verify event) ---
+    # --- Asset Verification (latest conclusive FULL verify event) ---
     # Only consider full-skill verifications (skill=None) for posture calculation
-    # Single-skill verifications should not affect overall system status
-    if verify_events:
-        # Find the latest full verify event
-        latest_full_verify = next(
-            (e for e in verify_events if _is_full_verify(e)), None
-        )
-        if latest_full_verify:
-            if latest_full_verify.result == "failed":
-                needs_attention = True
-            elif latest_full_verify.result == "succeeded":
-                result = _get_result(latest_full_verify)
-                if result.get("failed", 0) > 0:
-                    needs_attention = True
+    # Single-skill and no-candidate runs must not change the prior system status.
+    latest_full_verify = next(
+        (
+            event
+            for event in verify_events
+            if _is_full_verify(event)
+            and _asset_verify_outcome(event) != "no_candidates"
+        ),
+        None,
+    )
+    if latest_full_verify and _asset_verify_outcome(latest_full_verify) == "failed":
+        needs_attention = True
 
     # --- Prompt Scan (any DENY verdict) ---
     for e in prompt_scan_events:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/asset_verify.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/security_middleware/backends/asset_verify.py
@@ -2,7 +2,10 @@
 
 from typing import Any
 
-from agent_sec_cli.asset_verify import run_verification
+from agent_sec_cli.asset_verify import (
+    format_verification_result,
+    run_verification,
+)
 from agent_sec_cli.security_middleware.backends.base import BaseBackend
 from agent_sec_cli.security_middleware.context import RequestContext
 from agent_sec_cli.security_middleware.result import ActionResult
@@ -34,30 +37,16 @@ class AssetVerifyBackend(BaseBackend):
                 error_type=type(exc).__name__,
             )
 
-        passed = results["passed"]
-        failed = results["failed"]
-
-        # Build human-readable output
-        output_lines: list[str] = []
-        for name in passed:
-            output_lines.append(f"[OK] {name}")
-        for item in failed:
-            output_lines.append(f"[ERROR] {item['name']}")
-            output_lines.append(f"  {item['error']}")
-
-        output_lines.append("")
-        output_lines.append("=" * 50)
-        output_lines.append(f"PASSED: {len(passed)}")
-        output_lines.append(f"FAILED: {len(failed)}")
-        output_lines.append("=" * 50)
-        status = "VERIFICATION PASSED" if not failed else "VERIFICATION FAILED"
-        output_lines.append(status)
-
-        has_failures = len(failed) > 0
+        has_failures = results["outcome"] == "failed"
 
         return ActionResult(
             success=(not has_failures),
-            stdout="\n".join(output_lines) + "\n",
-            data={"passed": len(passed), "failed": len(failed)},
+            stdout=format_verification_result(results),
+            data={
+                "outcome": results["outcome"],
+                "checked": results["checked"],
+                "passed": len(results["passed"]),
+                "failed": len(results["failed"]),
+            },
             exit_code=1 if has_failures else 0,
         )

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/schema.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/telemetry/schema.py
@@ -19,6 +19,7 @@ from agent_sec_cli.telemetry.sanitizer import (
 
 _VERDICTS = frozenset({"pass", "warn", "deny", "error"})
 _RESULTS = frozenset({"succeeded", "failed"})
+_ASSET_OUTCOMES = frozenset({"verified", "failed", "no_candidates"})
 _BASELINE_ACTION = "harden"
 _ASSET_VERIFY_ACTION = "verify"
 _SCAN_ACTIONS = frozenset({"code_scan", "prompt_scan", "pii_scan"})
@@ -70,6 +71,11 @@ def _build_seccore_record(
         )
 
     if event.event_type == _ASSET_VERIFY_ACTION:
+        _add_optional(
+            record,
+            "seccore.asset_outcome",
+            enum_value(result.get("outcome"), _ASSET_OUTCOMES),
+        )
         _add_optional(
             record,
             "seccore.asset_passed_count",

--- a/src/agent-sec-core/docs/design/telemetry-security-event-sync.md
+++ b/src/agent-sec-core/docs/design/telemetry-security-event-sync.md
@@ -169,7 +169,7 @@ L1 字段。
 | `code_scan` | `seccore.verdict`、`seccore.elapsed_ms`、可选错误字段 |
 | `prompt_scan` | `seccore.verdict`、`seccore.elapsed_ms`、可选错误字段 |
 | `pii_scan` | `seccore.verdict`、`seccore.elapsed_ms`、可选错误字段 |
-| `verify` | `seccore.asset_passed_count`、`seccore.asset_failed_count`、可选错误字段 |
+| `verify` | `seccore.asset_outcome`、`seccore.asset_passed_count`、`seccore.asset_failed_count`、可选错误字段 |
 | `harden` | baseline result/timestamp/counts、可选错误字段 |
 | 其他或新增 action | 无额外字段，仅公共 L1 envelope 和可选错误字段 |
 
@@ -182,6 +182,21 @@ pass / warn / deny / error
 ```
 
 耗时必须是非负有限数值。计数必须是非负整数；布尔值不能作为整数接受。
+
+`seccore.asset_outcome` 仅接受：
+
+```text
+verified / failed / no_candidates
+```
+
+- `verified`：至少检查了一个候选 Skill，且所有候选均通过。
+- `failed`：至少一个候选 Skill 验证失败。
+- `no_candidates`：可选发现根目录的扫描正常完成，但没有找到候选 Skill。缺失或为空的
+  `/usr/share/anolisa/skills` 与 `/usr/local/share/anolisa/skills` 不属于产品失败。
+
+配置、受信密钥、canonicalization 或根目录枚举异常属于操作错误；此时 backend 没有稳定
+的资产结果，允许省略 `seccore.asset_outcome` 和资产计数。Telemetry 不投影配置根目录、
+候选 Skill 路径或其他文件系统路径。
 
 ### 5.3 示例
 
@@ -198,6 +213,23 @@ Code Scanner 成功记录：
   "seccore.timestamp": "2026-07-16T08:00:00+00:00",
   "seccore.verdict": "pass",
   "seccore.elapsed_ms": 3
+}
+```
+
+Asset Verification 未发现候选的成功记录：
+
+```json
+{
+  "component.name": "agent-sec-core",
+  "component.version": "<package-version>",
+  "component.agent_name": "codex",
+  "seccore.event_type": "verify",
+  "seccore.category": "asset_verify",
+  "seccore.result": "succeeded",
+  "seccore.timestamp": "2026-07-16T08:00:30+00:00",
+  "seccore.asset_outcome": "no_candidates",
+  "seccore.asset_passed_count": 0,
+  "seccore.asset_failed_count": 0
 }
 ```
 
@@ -259,7 +291,7 @@ def build_telemetry_security_event(
 
 Telemetry 直接消费 middleware 已写入的 `event_type` 和 `category`，只用 `_SCAN_ACTIONS`、
 `_BASELINE_ACTION` 和 `_ASSET_VERIFY_ACTION` 表达特殊字段投影。公共 envelope、扫描指标、
-资产计数、baseline 计数和错误字段分别复用小型 scalar projector。
+资产 outcome 与计数、baseline 计数和错误字段分别复用小型 scalar projector。
 
 Telemetry sanitizer 不提供通用递归 JSON 转换，不调用未知对象的 `model_dump()` 或
 `str()`，也不自动展开 dict/list。新增字段必须修改显式映射和精确字段测试，不能仅由 backend
@@ -275,6 +307,7 @@ Telemetry sanitizer 不提供通用递归 JSON 转换，不调用未知对象的
 - 新增 action 无需修改 Telemetry 即可输出公共 L1 envelope，且不会获得特殊字段。
 - `AgentName` 枚举中的 6 个产品名可输出，未知值和客户标识统一降为空字符串。
 - PII request/summary 完全缺席。
+- Asset Verification 三种 outcome、对应计数组合及操作错误省略 outcome 的契约。
 - 原始 Prompt、代码、命令、路径、错误消息和所有 ID 的 canary 无法进入 JSON。
 - 未知对象不会被字符串化。
 - error type 格式、失败状态和 exit code 的组合约束。

--- a/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
+++ b/src/agent-sec-core/tests/integration-test/asset-verify/test_verifier.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Integration tests for skill verifier"""
 
+import errno
 import json
 import os
 import shutil
@@ -8,6 +9,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 # Add agent-sec-cli/src to path so the full package is importable
 sys.path.insert(
@@ -20,6 +23,7 @@ sys.path.insert(
 )
 
 from agent_sec_cli.asset_verify.errors import (
+    ErrConfigInvalid,
     ErrConfigMissing,
     ErrHashMismatch,
     ErrManifestMissing,
@@ -172,6 +176,7 @@ class TestVerifySkillsDir(unittest.TestCase):
     def test_nonexistent_dir(self):
         missing_dir = os.path.join(self.tmpdir, "missing_skills")
         results = verify_skills_dir(missing_dir, [])
+        self.assertEqual(results["checked"], 0)
         self.assertEqual(results["passed"], [])
         self.assertEqual(results["failed"], [])
 
@@ -179,8 +184,63 @@ class TestVerifySkillsDir(unittest.TestCase):
         empty_dir = os.path.join(self.tmpdir, "empty_skills")
         os.makedirs(empty_dir)
         results = verify_skills_dir(empty_dir, [])
+        self.assertEqual(results["checked"], 0)
         self.assertEqual(results["passed"], [])
         self.assertEqual(results["failed"], [])
+
+    def test_root_files_and_hidden_directories_are_not_candidates(self):
+        root = os.path.join(self.tmpdir, "skills")
+        os.makedirs(os.path.join(root, ".hidden-skill"))
+        with open(os.path.join(root, "README.md"), "w") as f:
+            f.write("not a skill directory")
+
+        results = verify_skills_dir(root, [])
+
+        self.assertEqual(results["checked"], 0)
+        self.assertEqual(results["passed"], [])
+        self.assertEqual(results["failed"], [])
+
+    def test_existing_non_directory_is_an_error(self):
+        file_path = os.path.join(self.tmpdir, "not-a-directory")
+        with open(file_path, "w") as f:
+            f.write("x")
+
+        with self.assertRaises(NotADirectoryError):
+            verify_skills_dir(file_path, [])
+
+    def test_unreadable_root_is_an_error(self):
+        root = Path(self.tmpdir) / "skills"
+        root.mkdir()
+
+        with patch.object(Path, "iterdir", side_effect=PermissionError("denied")):
+            with self.assertRaisesRegex(PermissionError, "denied"):
+                verify_skills_dir(str(root), [])
+
+    def test_visible_entry_stat_io_error_is_an_operation_error(self):
+        root = Path(self.tmpdir) / "skills"
+        (root / "candidate").mkdir(parents=True)
+
+        with patch.object(
+            Path,
+            "stat",
+            side_effect=OSError(errno.EIO, "Input/output error"),
+        ):
+            with self.assertRaisesRegex(OSError, "Input/output error"):
+                verify_skills_dir(str(root), [])
+
+    @patch(
+        "agent_sec_cli.asset_verify.verifier.verify_skill",
+        side_effect=ErrManifestMissing("bad-skill"),
+    )
+    def test_candidate_failure_counts_as_checked(self, _mock_verify_skill):
+        root = os.path.join(self.tmpdir, "skills")
+        os.makedirs(os.path.join(root, "bad-skill"))
+
+        results = verify_skills_dir(root, [])
+
+        self.assertEqual(results["checked"], 1)
+        self.assertEqual(results["passed"], [])
+        self.assertEqual(len(results["failed"]), 1)
 
 
 class TestLoadConfig(unittest.TestCase):
@@ -191,15 +251,11 @@ class TestLoadConfig(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_missing_config(self):
-        from pathlib import Path
-
         missing_config = Path(self.tmpdir) / "missing.conf"
         with self.assertRaises(ErrConfigMissing):
             load_config(missing_config)
 
     def test_single_skills_dir(self):
-        from pathlib import Path
-
         config_path = os.path.join(self.tmpdir, "config.conf")
         with open(config_path, "w") as f:
             f.write("skills_dir = /opt/skills\n")
@@ -208,8 +264,6 @@ class TestLoadConfig(unittest.TestCase):
         self.assertEqual(config["skills_dirs"], ["/opt/skills"])
 
     def test_list_skills_dir(self):
-        from pathlib import Path
-
         config_path = os.path.join(self.tmpdir, "config.conf")
         with open(config_path, "w") as f:
             f.write("skills_dir = [\n")
@@ -220,6 +274,50 @@ class TestLoadConfig(unittest.TestCase):
         config = load_config(Path(config_path))
         self.assertEqual(config["skills_dirs"], ["/opt/skills1", "/opt/skills2"])
 
+    def test_empty_list_is_valid(self):
+        config_path = Path(self.tmpdir) / "config.conf"
+        with open(config_path, "w") as f:
+            f.write("skills_dir = []\n")
+
+        config = load_config(config_path)
+
+        self.assertEqual(config["skills_dirs"], [])
+
+    def test_unterminated_list_is_invalid(self):
+        config_path = Path(self.tmpdir) / "config.conf"
+        with open(config_path, "w") as f:
+            f.write("skills_dir = [\n")
+            f.write("    /opt/skills\n")
+
+        with self.assertRaises(ErrConfigInvalid):
+            load_config(config_path)
+
+    def test_malformed_entry_is_invalid(self):
+        config_path = Path(self.tmpdir) / "config.conf"
+        with open(config_path, "w") as f:
+            f.write("skills_dir /opt/skills\n")
+
+        with self.assertRaises(ErrConfigInvalid):
+            load_config(config_path)
+
+    def test_unknown_key_is_invalid(self):
+        config_path = Path(self.tmpdir) / "config.conf"
+        with open(config_path, "w") as f:
+            f.write("skill_dirs = /opt/skills\n")
+
+        with self.assertRaisesRegex(
+            ErrConfigInvalid, "unknown config key 'skill_dirs' on line 1"
+        ):
+            load_config(config_path)
+
+    def test_unsupported_inline_list_is_invalid(self):
+        config_path = Path(self.tmpdir) / "config.conf"
+        with open(config_path, "w") as f:
+            f.write("skills_dir = [/opt/skills, /usr/local/skills]\n")
+
+        with self.assertRaises(ErrConfigInvalid):
+            load_config(config_path)
+
 
 class TestLoadTrustedKeys(unittest.TestCase):
     def setUp(self):
@@ -229,15 +327,11 @@ class TestLoadTrustedKeys(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_nonexistent_dir(self):
-        from pathlib import Path
-
         missing_dir = Path(self.tmpdir) / "missing_keys"
         with self.assertRaises(ErrNoTrustedKeys):
             load_trusted_keys(missing_dir)
 
     def test_empty_keys_dir(self):
-        from pathlib import Path
-
         with self.assertRaises(ErrNoTrustedKeys):
             load_trusted_keys(Path(self.tmpdir))
 
@@ -275,6 +369,7 @@ Expire-Date: 0
             ["gpg", "--homedir", cls.gpg_home, "--batch", "--gen-key"],
             input=key_params.encode(),
             capture_output=True,
+            check=False,
         )
 
         # Export public key
@@ -290,6 +385,7 @@ Expire-Date: 0
                     "test@test.com",
                 ],
                 stdout=f,
+                check=False,
             )
 
         # Create test skill files
@@ -298,8 +394,6 @@ Expire-Date: 0
             f.write("print('hello')")
 
         # Create .skill-meta directory and manifest
-        from agent_sec_cli.asset_verify.verifier import compute_file_hash
-
         cls.meta_dir = os.path.join(cls.skill_dir, ".skill-meta")
         os.makedirs(cls.meta_dir)
 
@@ -327,6 +421,7 @@ Expire-Date: 0
                 cls.manifest_path,
             ],
             capture_output=True,
+            check=False,
         )
 
     @classmethod
@@ -338,8 +433,6 @@ Expire-Date: 0
         if not self.gpg_available:
             self.skipTest("gpg not available")
 
-        from pathlib import Path
-
         keys = load_trusted_keys(Path(self.keys_dir))
         self.assertTrue(len(keys) > 0)
 
@@ -350,8 +443,6 @@ Expire-Date: 0
     def test_batch_verification(self):
         if not self.gpg_available:
             self.skipTest("gpg not available")
-
-        from pathlib import Path
 
         keys = load_trusted_keys(Path(self.keys_dir))
 

--- a/src/agent-sec-core/tests/packaging/test-package-raw.sh
+++ b/src/agent-sec-core/tests/packaging/test-package-raw.sh
@@ -9,8 +9,19 @@ trap 'rm -rf "$TMP"' EXIT
 BUILD="$TMP/build"
 VERSION="$(python3 "$ROOT/packaging/raw/verify_release.py" \
     "$ROOT" "$ROOT/.anolisa/component.toml")"
+ASSET_VERIFY_SOURCE_CONFIG="$ROOT/agent-sec-cli/src/agent_sec_cli/asset_verify/config.conf"
+ASSET_VERIFY_PACKAGE_PATH="lib/anolisa/sec-core/python3.11/site-packages/agent_sec_cli/asset_verify/config.conf"
+
+assert_asset_verify_config() {
+    local config="$1"
+
+    cmp "$ASSET_VERIFY_SOURCE_CONFIG" "$config"
+    test "$(grep -Fc '/usr/share/anolisa/skills' "$config")" = "1"
+    test "$(grep -Fc '/usr/local/share/anolisa/skills' "$config")" = "1"
+}
 
 install -d -m 0755 \
+    "$BUILD/site-packages/agent_sec_cli/asset_verify" \
     "$BUILD/site-packages/agent_sec_cli/daemon" \
     "$BUILD/site-packages/agent_sec_cli/__pycache__" \
     "$BUILD/python-runtime/bin" \
@@ -37,6 +48,8 @@ printf 'def main():\n    return 0\n' > \
     "$BUILD/site-packages/agent_sec_cli/cli.py"
 printf 'def main():\n    return 0\n' > \
     "$BUILD/site-packages/agent_sec_cli/daemon/server.py"
+cp "$ASSET_VERIFY_SOURCE_CONFIG" \
+    "$BUILD/site-packages/agent_sec_cli/asset_verify/config.conf"
 printf 'host-specific bytecode\n' > \
     "$BUILD/site-packages/agent_sec_cli/__pycache__/cli.cpython-311.pyc"
 
@@ -148,6 +161,7 @@ test "$(stat -c '%a' \
 test "$(stat -c '%a' "$STAGE/.anolisa/component.toml")" = "644"
 test -z "$(find "$STAGE" -type l -print -quit)"
 cmp "$ROOT/.anolisa/component.toml" "$STAGE/.anolisa/component.toml"
+assert_asset_verify_config "$STAGE/$ASSET_VERIFY_PACKAGE_PATH"
 
 RPM_STAGE="$TMP/rpm-stage"
 MANIFEST_STAGE="$TMP/manifest-stage"
@@ -261,6 +275,7 @@ for expected in \
     "./lib/anolisa/sec-core/python3.11/runtime/lib/libpython3.11.so.1.0" \
     "./lib/anolisa/sec-core/python3.11/runtime/lib/python3.11/LICENSE.txt" \
     "./lib/anolisa/sec-core/python3.11/runtime/lib/tk8.6/demos/license.terms" \
+    "./$ASSET_VERIFY_PACKAGE_PATH" \
     "./lib/anolisa/sec-core/python3.11/site-packages/agent_sec_cli/cli.py" \
     "./adapters/sec-core/openclaw/openclaw.plugin.json" \
     "./adapters/sec-core/hermes/plugin.yaml" \
@@ -291,6 +306,9 @@ fi
 
 tar -xzOf "$OUT_ONE/$ARTIFACT" ./.anolisa/component.toml > "$TMP/contract.toml"
 cmp "$ROOT/.anolisa/component.toml" "$TMP/contract.toml"
+tar -xzOf "$OUT_ONE/$ARTIFACT" "./$ASSET_VERIFY_PACKAGE_PATH" \
+    > "$TMP/asset-verify-config.conf"
+assert_asset_verify_config "$TMP/asset-verify-config.conf"
 tar -xzOf "$OUT_ONE/$ARTIFACT" ./bin/agent-sec-cli > "$TMP/agent-sec-cli"
 tar -xzOf "$OUT_ONE/$ARTIFACT" ./bin/agent-sec-python > "$TMP/agent-sec-python"
 tar -xzOf "$OUT_ONE/$ARTIFACT" \

--- a/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
+++ b/src/agent-sec-core/tests/unit-test/security_events/test_summary_formatter.py
@@ -399,8 +399,10 @@ class TestAssetVerifySummary:
         output = format_summary(events, "last 24 hours")
 
         assert "--- Asset Verification ---" in output
-        assert "Verifications performed: 2 (succeeded: 2, failed: 0)" in output
-        assert "5 passed, 0 failed" in output
+        assert (
+            "Verifications performed: 2 (verified: 1, skipped: 0, failed: 1)" in output
+        )
+        assert "5 checked, 5 passed, 0 failed" in output
         assert "ALL CLEAR" in output
 
     def test_failed_verification(self):
@@ -418,7 +420,7 @@ class TestAssetVerifySummary:
         ]
         output = format_summary(events, "last 24 hours")
         assert "FAILURES DETECTED" in output
-        assert "3 passed, 2 failed" in output
+        assert "5 checked, 3 passed, 2 failed" in output
 
     def test_single_skill_verify_after_full_verify(self):
         """After full verify + single skill verify, summary shows latest result.
@@ -461,10 +463,156 @@ class TestAssetVerifySummary:
         # (single-skill verify should not affect posture)
         assert "Needs attention" in output
         assert "--- Asset Verification ---" in output
-        assert "Verifications performed: 2 (succeeded: 2, failed: 0)" in output
+        assert (
+            "Verifications performed: 2 (verified: 1, skipped: 0, failed: 1)" in output
+        )
         # Latest result shows single skill result (1 passed, 0 failed)
         assert "Latest result:" in output
-        assert "1 passed, 0 failed" in output
+        assert "1 checked, 1 passed, 0 failed" in output
+
+    def test_no_candidates_is_reported_as_not_assessed(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {
+                        "outcome": "no_candidates",
+                        "checked": 0,
+                        "passed": 0,
+                        "failed": 0,
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert (
+            "Verifications performed: 1 (verified: 0, skipped: 1, failed: 0)" in output
+        )
+        assert "0 checked, 0 passed, 0 failed" in output
+        assert "NOT ASSESSED (no candidate skills)" in output
+        assert "ALL CLEAR" not in output
+        assert "System Status: Good" in output
+
+    def test_legacy_zero_counts_are_reported_as_not_assessed(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {"passed": 0, "failed": 0},
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert (
+            "Verifications performed: 1 (verified: 0, skipped: 1, failed: 0)" in output
+        )
+        assert "NOT ASSESSED (no candidate skills)" in output
+        assert "ALL CLEAR" not in output
+
+    def test_latest_no_candidates_does_not_clear_prior_full_failure(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {
+                        "outcome": "failed",
+                        "checked": 1,
+                        "passed": 0,
+                        "failed": 1,
+                    },
+                },
+                timestamp=_ts_minutes_ago(10),
+            ),
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {
+                        "outcome": "no_candidates",
+                        "checked": 0,
+                        "passed": 0,
+                        "failed": 0,
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert "NOT ASSESSED (no candidate skills)" in output
+        assert "System Status: Needs attention" in output
+
+    def test_nested_no_candidates_overrides_failed_event_envelope(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="failed",
+                details={
+                    "request": {"skill": None},
+                    "result": {
+                        "outcome": "no_candidates",
+                        "checked": 0,
+                        "passed": 0,
+                        "failed": 0,
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert (
+            "Verifications performed: 1 (verified: 0, skipped: 1, failed: 0)" in output
+        )
+        assert "NOT ASSESSED (no candidate skills)" in output
+        assert "System Status: Good" in output
+
+    def test_nested_failed_outcome_overrides_successful_event_envelope(self):
+        events = [
+            _make_event(
+                event_type="verify",
+                category="asset_verify",
+                result="succeeded",
+                details={
+                    "request": {"skill": None},
+                    "result": {
+                        "outcome": "failed",
+                        "checked": 1,
+                        "passed": 1,
+                        "failed": 0,
+                    },
+                },
+                timestamp=_ts_minutes_ago(5),
+            ),
+        ]
+
+        output = format_summary(events, "last 24 hours")
+
+        assert (
+            "Verifications performed: 1 (verified: 0, skipped: 0, failed: 1)" in output
+        )
+        assert "FAILURES DETECTED" in output
+        assert "System Status: Needs attention" in output
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_asset_verify_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_asset_verify_backend.py
@@ -24,6 +24,8 @@ class TestAssetVerifyBackend(unittest.TestCase):
     @patch(_PATCH_TARGET)
     def test_single_skill_pass(self, mock_run):
         mock_run.return_value = {
+            "outcome": "verified",
+            "checked": 1,
             "passed": ["my-skill"],
             "failed": [],
         }
@@ -33,11 +35,16 @@ class TestAssetVerifyBackend(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.data["passed"], 1)
         self.assertEqual(result.data["failed"], 0)
+        self.assertEqual(result.data["outcome"], "verified")
+        self.assertEqual(result.data["checked"], 1)
+        self.assertEqual(result.exit_code, 0)
         self.assertIn("[OK]", result.stdout)
 
     @patch(_PATCH_TARGET)
     def test_single_skill_fail(self, mock_run):
         mock_run.return_value = {
+            "outcome": "failed",
+            "checked": 1,
             "passed": [],
             "failed": [{"name": "bad-skill", "error": "signature mismatch"}],
         }
@@ -45,12 +52,16 @@ class TestAssetVerifyBackend(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertEqual(result.data["failed"], 1)
+        self.assertEqual(result.data["outcome"], "failed")
+        self.assertEqual(result.exit_code, 1)
         self.assertIn("[ERROR]", result.stdout)
         self.assertEqual(result.error_type, "")
 
     @patch(_PATCH_TARGET)
     def test_full_scan(self, mock_run):
         mock_run.return_value = {
+            "outcome": "failed",
+            "checked": 3,
             "passed": ["skill-a", "skill-b"],
             "failed": [{"name": "skill-c", "error": "bad sig"}],
         }
@@ -62,11 +73,34 @@ class TestAssetVerifyBackend(unittest.TestCase):
         self.assertEqual(result.data["failed"], 1)
 
     @patch(_PATCH_TARGET)
+    def test_no_candidates_is_successful_skip(self, mock_run):
+        mock_run.return_value = {
+            "outcome": "no_candidates",
+            "checked": 0,
+            "passed": [],
+            "failed": [],
+        }
+
+        result = self.backend.execute(self.ctx)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            result.data,
+            {"outcome": "no_candidates", "checked": 0, "passed": 0, "failed": 0},
+        )
+        self.assertIn("VERIFICATION SKIPPED", result.stdout)
+        self.assertNotIn("VERIFICATION PASSED", result.stdout)
+        self.assertNotIn("[WARN]", result.stdout)
+
+    @patch(_PATCH_TARGET)
     def test_verification_exception(self, mock_run):
         mock_run.side_effect = RuntimeError("no module")
         result = self.backend.execute(self.ctx)
 
         self.assertFalse(result.success)
+        self.assertEqual(result.data, {})
+        self.assertEqual(result.exit_code, 1)
         self.assertIn("Verification error", result.error)
         self.assertEqual(result.error_type, "RuntimeError")
 

--- a/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/test_lifecycle.py
@@ -109,6 +109,27 @@ class TestPostAction(unittest.TestCase):
         self.assertEqual(event.details["result"]["passed"], 20)
 
     @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
+    def test_post_action_preserves_no_candidates_outcome(self, mock_log):
+        ctx = RequestContext(action="verify", trace_id="t-no-candidates")
+        result = ActionResult(
+            success=True,
+            data={
+                "outcome": "no_candidates",
+                "checked": 0,
+                "passed": 0,
+                "failed": 0,
+            },
+            exit_code=0,
+        )
+
+        post_action(ctx, result, {"skill": None}, DummyBackend())
+
+        event = mock_log.call_args[0][0]
+        self.assertEqual(event.result, "succeeded")
+        self.assertEqual(event.details["result"]["outcome"], "no_candidates")
+        self.assertEqual(event.details["result"]["checked"], 0)
+
+    @patch("agent_sec_cli.security_middleware.lifecycle.log_event")
     def test_post_action_copies_request_tracing_to_security_event(self, mock_log):
         ctx = RequestContext(
             action="code_scan",

--- a/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
+++ b/src/agent-sec-core/tests/unit-test/telemetry/test_schema.py
@@ -26,6 +26,7 @@ SECCORE_COMMON_FIELDS = {
 }
 SCAN_FIELDS = {"seccore.verdict", "seccore.elapsed_ms"}
 ASSET_FIELDS = {"seccore.asset_passed_count", "seccore.asset_failed_count"}
+ASSET_OUTCOME_FIELD = {"seccore.asset_outcome"}
 BASELINE_FIELDS = {
     "baseline.result",
     "baseline.timestamp",
@@ -131,7 +132,7 @@ def test_scan_actions_share_verdict_and_elapsed_fields(action: str) -> None:
     assert "CUSTOMER-CANARY" not in json.dumps(record)
 
 
-def test_asset_verify_has_only_approved_numeric_counts() -> None:
+def test_legacy_asset_verify_has_only_approved_numeric_counts() -> None:
     event = _event(
         event_type="verify",
         category="asset_verify",
@@ -149,6 +150,62 @@ def test_asset_verify_has_only_approved_numeric_counts() -> None:
     assert record["seccore.category"] == "asset_verify"
     assert record["seccore.asset_passed_count"] == 12
     assert record["seccore.asset_failed_count"] == 1
+
+
+@pytest.mark.parametrize("outcome", ["verified", "failed", "no_candidates"])
+def test_asset_verify_projects_approved_outcome(outcome: str) -> None:
+    event = _event(
+        event_type="verify",
+        category="asset_verify",
+        details={
+            "result": {
+                "outcome": outcome,
+                "passed": 0,
+                "failed": 0,
+            }
+        },
+    )
+
+    record = build_telemetry_security_event(event, _TelemetryCtx())
+
+    assert record is not None
+    assert set(record) == (
+        COMPONENT_FIELDS | SECCORE_COMMON_FIELDS | ASSET_FIELDS | ASSET_OUTCOME_FIELD
+    )
+    assert record["seccore.asset_outcome"] == outcome
+
+
+def test_asset_verify_omits_unapproved_outcome() -> None:
+    event = _event(
+        event_type="verify",
+        category="asset_verify",
+        details={"result": {"outcome": "CUSTOMER-CANARY"}},
+    )
+
+    record = build_telemetry_security_event(event, _TelemetryCtx())
+
+    assert record is not None
+    assert set(record) == COMPONENT_FIELDS | SECCORE_COMMON_FIELDS
+
+
+def test_asset_verify_operation_error_omits_outcome() -> None:
+    event = _event(
+        event_type="verify",
+        category="asset_verify",
+        result="failed",
+        details={
+            "result": {},
+            "error_type": "PermissionError",
+            "exit_code": 1,
+        },
+    )
+
+    record = build_telemetry_security_event(event, _TelemetryCtx())
+
+    assert record is not None
+    assert "seccore.asset_outcome" not in record
+    assert record["seccore.error_type"] == "PermissionError"
+    assert record["seccore.exit_code"] == 1
 
 
 def test_harden_has_exact_baseline_fields() -> None:

--- a/src/agent-sec-core/tests/unit-test/test_cli.py
+++ b/src/agent-sec-core/tests/unit-test/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from agent_sec_cli.asset_verify.verifier import format_verification_result
 from agent_sec_cli.cli import (
     _extract_trace_context_arg,
     _is_read_only_skill_analyze,
@@ -22,6 +23,29 @@ from agent_sec_cli.correlation_context import (
 from agent_sec_cli.security_middleware.result import ActionResult
 from click import unstyle
 from typer.testing import CliRunner
+
+
+@patch("agent_sec_cli.cli.invoke")
+def test_verify_preserves_shared_formatter_output(mock_invoke):
+    rendered = format_verification_result(
+        {
+            "outcome": "no_candidates",
+            "checked": 0,
+            "passed": [],
+            "failed": [],
+        }
+    )
+    mock_invoke.return_value = ActionResult(
+        success=True,
+        exit_code=0,
+        stdout=rendered,
+    )
+
+    result = CliRunner().invoke(app, ["verify"])
+
+    assert result.exit_code == 0
+    assert result.output == rendered
+    mock_invoke.assert_called_once_with("verify", skill=None)
 
 
 @patch("agent_sec_cli.cli.invoke")

--- a/src/agent-sec-core/tests/unit-test/test_run_verification.py
+++ b/src/agent-sec-core/tests/unit-test/test_run_verification.py
@@ -6,11 +6,23 @@ so we can validate the returned dict shape for every code path without
 needing real GPG keys or signed skills.
 """
 
+import argparse
+import sys
+import tempfile
 import unittest
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import call, patch
 
-from agent_sec_cli.asset_verify.errors import ErrManifestMissing, ErrSigInvalid
-from agent_sec_cli.asset_verify.verifier import run_verification
+from agent_sec_cli.asset_verify.errors import (
+    ErrHashMismatch,
+    ErrManifestMissing,
+    ErrSigInvalid,
+)
+from agent_sec_cli.asset_verify.verifier import (
+    format_verification_result,
+    main,
+    run_verification,
+)
 
 _MOD = "agent_sec_cli.asset_verify.verifier"
 
@@ -25,8 +37,13 @@ class TestRunVerificationSingleSkill(unittest.TestCase):
 
         self.assertIsInstance(result["passed"], list)
         self.assertIsInstance(result["failed"], list)
+        self.assertEqual(result["outcome"], "verified")
+        self.assertEqual(result["checked"], 1)
         self.assertEqual(result["passed"], ["my-skill"])
         self.assertEqual(result["failed"], [])
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
 
     @patch(f"{_MOD}.verify_skill", side_effect=ErrSigInvalid("bad-skill", "bad sig"))
     def test_failure_returns_failed_list(self, _mock_vs, _mock_keys):
@@ -34,38 +51,310 @@ class TestRunVerificationSingleSkill(unittest.TestCase):
 
         self.assertIsInstance(result["passed"], list)
         self.assertIsInstance(result["failed"], list)
+        self.assertEqual(result["outcome"], "failed")
+        self.assertEqual(result["checked"], 1)
         self.assertEqual(result["passed"], [])
         self.assertEqual(len(result["failed"]), 1)
         self.assertEqual(result["failed"][0]["name"], "bad-skill")
         self.assertIn("bad sig", result["failed"][0]["error"])
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
 
     @patch(f"{_MOD}.verify_skill", side_effect=ErrManifestMissing("no-manifest"))
     def test_missing_manifest_returns_failed_list(self, _mock_vs, _mock_keys):
         result = run_verification(skill="/opt/skills/no-manifest")
 
         self.assertEqual(result["passed"], [])
+        self.assertEqual(result["outcome"], "failed")
+        self.assertEqual(result["checked"], 1)
         self.assertEqual(len(result["failed"]), 1)
         self.assertIn("name", result["failed"][0])
         self.assertIn("error", result["failed"][0])
 
+    def test_hash_manifest_and_signature_failures_are_never_skipped(self, _mock_keys):
+        failures = [
+            ErrHashMismatch("bad-skill", "main.py", "expected", "actual"),
+            ErrManifestMissing("bad-skill"),
+            ErrSigInvalid("bad-skill", "bad signature"),
+        ]
+
+        for failure in failures:
+            with self.subTest(error=type(failure).__name__):
+                with patch(f"{_MOD}.verify_skill", side_effect=failure):
+                    result = run_verification(skill="/opt/skills/bad-skill")
+
+                self.assertEqual(result["outcome"], "failed")
+                self.assertEqual(result["checked"], 1)
+                self.assertEqual(result["passed"], [])
+                self.assertEqual(len(result["failed"]), 1)
+                self.assertEqual(
+                    result["checked"], len(result["passed"]) + len(result["failed"])
+                )
+
 
 @patch(f"{_MOD}.load_trusted_keys", return_value=["fake-key"])
-@patch(f"{_MOD}.load_config", return_value={"skills_dirs": ["/opt/skills"]})
 class TestRunVerificationBatch(unittest.TestCase):
     """Batch path: run_verification(skill=None)."""
 
+    @patch(f"{_MOD}.load_config", return_value={"skills_dirs": ["/opt/skills"]})
     @patch(
         f"{_MOD}.verify_skills_dir",
-        return_value={"passed": ["a", "b"], "failed": [{"name": "c", "error": "err"}]},
+        return_value={
+            "checked": 3,
+            "passed": ["a", "b"],
+            "failed": [{"name": "c", "error": "err"}],
+        },
     )
     def test_batch_aggregates_results(self, _mock_vsd, _mock_cfg, _mock_keys):
         result = run_verification(skill=None)
 
         self.assertIsInstance(result["passed"], list)
         self.assertIsInstance(result["failed"], list)
+        self.assertEqual(result["outcome"], "failed")
+        self.assertEqual(result["checked"], 3)
         self.assertEqual(result["passed"], ["a", "b"])
         self.assertEqual(len(result["failed"]), 1)
         self.assertEqual(result["failed"][0]["name"], "c")
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
+
+    @patch(f"{_MOD}.load_config", return_value={"skills_dirs": []})
+    @patch(f"{_MOD}.verify_skills_dir")
+    def test_empty_root_config_is_no_candidates(
+        self, mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        result = run_verification(skill=None)
+
+        self.assertEqual(
+            result,
+            {"outcome": "no_candidates", "checked": 0, "passed": [], "failed": []},
+        )
+        mock_verify_dir.assert_not_called()
+
+    @patch(
+        f"{_MOD}.load_config",
+        return_value={"skills_dirs": ["/usr/share/skills", "/usr/local/skills"]},
+    )
+    @patch(
+        f"{_MOD}.verify_skills_dir",
+        side_effect=[
+            {"checked": 0, "passed": [], "failed": []},
+            {"checked": 1, "passed": ["raw-skill"], "failed": []},
+        ],
+    )
+    def test_missing_or_empty_root_is_best_effort(
+        self, mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        result = run_verification(skill=None)
+
+        self.assertEqual(result["outcome"], "verified")
+        self.assertEqual(result["checked"], 1)
+        self.assertEqual(result["passed"], ["raw-skill"])
+        self.assertEqual(mock_verify_dir.call_count, 2)
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
+
+    @patch(
+        f"{_MOD}.load_config",
+        return_value={"skills_dirs": ["/usr/share/skills", "/usr/local/skills"]},
+    )
+    @patch(
+        f"{_MOD}.verify_skills_dir",
+        side_effect=[
+            {"checked": 1, "passed": ["packaged-skill"], "failed": []},
+            {"checked": 0, "passed": [], "failed": []},
+        ],
+    )
+    def test_packaged_root_succeeds_when_raw_root_is_missing_or_empty(
+        self, mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        result = run_verification(skill=None)
+
+        self.assertEqual(result["outcome"], "verified")
+        self.assertEqual(result["checked"], 1)
+        self.assertEqual(result["passed"], ["packaged-skill"])
+        self.assertEqual(mock_verify_dir.call_count, 2)
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
+
+    @patch(
+        f"{_MOD}.load_config",
+        return_value={"skills_dirs": ["/usr/share/skills", "/usr/local/skills"]},
+    )
+    @patch(
+        f"{_MOD}.verify_skills_dir",
+        side_effect=[
+            {"checked": 0, "passed": [], "failed": []},
+            {"checked": 0, "passed": [], "failed": []},
+        ],
+    )
+    def test_two_empty_or_missing_roots_are_no_candidates(
+        self, mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        result = run_verification(skill=None)
+
+        self.assertEqual(
+            result,
+            {"outcome": "no_candidates", "checked": 0, "passed": [], "failed": []},
+        )
+        self.assertEqual(mock_verify_dir.call_count, 2)
+
+    @patch(f"{_MOD}.load_config")
+    def test_distinct_roots_each_verify_same_named_candidate(
+        self, mock_load_config, _mock_keys
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first_root = Path(tmpdir) / "rpm"
+            second_root = Path(tmpdir) / "raw"
+            first_skill = first_root / "shared-name"
+            second_skill = second_root / "shared-name"
+            first_skill.mkdir(parents=True)
+            second_skill.mkdir(parents=True)
+            mock_load_config.return_value = {
+                "skills_dirs": [str(first_root), str(second_root)]
+            }
+
+            with patch(
+                f"{_MOD}.verify_skill", return_value=(True, "shared-name")
+            ) as mock_verify_skill:
+                result = run_verification(skill=None)
+
+        self.assertEqual(result["outcome"], "verified")
+        self.assertEqual(result["checked"], 2)
+        self.assertEqual(result["passed"], ["shared-name", "shared-name"])
+        self.assertEqual(result["failed"], [])
+        self.assertEqual(
+            mock_verify_skill.call_args_list,
+            [
+                call(str(first_skill), ["fake-key"]),
+                call(str(second_skill), ["fake-key"]),
+            ],
+        )
+        self.assertEqual(
+            result["checked"], len(result["passed"]) + len(result["failed"])
+        )
+
+    @patch(
+        f"{_MOD}.load_config",
+        return_value={"skills_dirs": ["/opt/skills", "/opt/../opt/skills"]},
+    )
+    @patch(
+        f"{_MOD}.verify_skills_dir",
+        return_value={"checked": 1, "passed": ["a"], "failed": []},
+    )
+    def test_canonical_duplicate_roots_are_scanned_once(
+        self, mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        result = run_verification(skill=None)
+
+        self.assertEqual(result["outcome"], "verified")
+        mock_verify_dir.assert_called_once_with("/opt/skills", ["fake-key"])
+
+    @patch(f"{_MOD}.load_config", return_value={"skills_dirs": ["/opt/skills"]})
+    @patch(f"{_MOD}.verify_skills_dir", side_effect=PermissionError("denied"))
+    def test_unreadable_existing_root_is_operation_error(
+        self, _mock_verify_dir, _mock_cfg, _mock_keys
+    ):
+        with self.assertRaisesRegex(PermissionError, "denied"):
+            run_verification(skill=None)
+
+
+class TestVerificationFormatting(unittest.TestCase):
+    def test_no_candidates_is_silent_and_skipped(self):
+        output = format_verification_result(
+            {"outcome": "no_candidates", "checked": 0, "passed": [], "failed": []}
+        )
+
+        self.assertIn("CHECKED: 0", output)
+        self.assertIn("VERIFICATION SKIPPED: NO CANDIDATE SKILLS", output)
+        self.assertNotIn("[WARN]", output)
+        self.assertNotIn("VERIFICATION PASSED", output)
+
+    def test_verified_and_failed_have_distinct_statuses(self):
+        verified = format_verification_result(
+            {"outcome": "verified", "checked": 1, "passed": ["a"], "failed": []}
+        )
+        failed = format_verification_result(
+            {
+                "outcome": "failed",
+                "checked": 1,
+                "passed": [],
+                "failed": [{"name": "a", "error": "bad signature"}],
+            }
+        )
+
+        self.assertIn("VERIFICATION PASSED", verified)
+        self.assertIn("VERIFICATION FAILED", failed)
+
+
+class TestStandaloneMain(unittest.TestCase):
+    @patch(
+        f"{_MOD}.argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(skill=None),
+    )
+    @patch(
+        f"{_MOD}.run_verification",
+        return_value={
+            "outcome": "no_candidates",
+            "checked": 0,
+            "passed": [],
+            "failed": [],
+        },
+    )
+    @patch("builtins.print")
+    def test_no_candidates_prints_shared_output_and_exits_zero(
+        self, mock_print, _mock_run, _mock_args
+    ):
+        self.assertEqual(main(), 0)
+        rendered = format_verification_result(
+            {"outcome": "no_candidates", "checked": 0, "passed": [], "failed": []}
+        )
+        mock_print.assert_called_once_with(rendered, end="")
+
+    @patch(
+        f"{_MOD}.argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(skill="/missing/skill"),
+    )
+    @patch(
+        f"{_MOD}.run_verification",
+        return_value={
+            "outcome": "failed",
+            "checked": 1,
+            "passed": [],
+            "failed": [{"name": "skill", "error": "manifest missing"}],
+        },
+    )
+    @patch("builtins.print")
+    def test_explicit_skill_failure_exits_one(self, mock_print, _mock_run, _mock_args):
+        self.assertEqual(main(), 1)
+        _mock_run.assert_called_once_with("/missing/skill")
+        rendered = format_verification_result(
+            {
+                "outcome": "failed",
+                "checked": 1,
+                "passed": [],
+                "failed": [{"name": "skill", "error": "manifest missing"}],
+            }
+        )
+        mock_print.assert_called_once_with(rendered, end="")
+
+    @patch(
+        f"{_MOD}.argparse.ArgumentParser.parse_args",
+        return_value=argparse.Namespace(skill=None),
+    )
+    @patch(f"{_MOD}.run_verification", side_effect=RuntimeError("boom"))
+    @patch("builtins.print")
+    def test_operation_error_is_written_to_stderr(
+        self, mock_print, _mock_run, _mock_args
+    ):
+        self.assertEqual(main(), 1)
+        self.assertEqual(
+            mock_print.call_args_list, [call("[ERROR] boom", file=sys.stderr)]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Default asset verification currently reports success when it checks no Skills, and the packaged
configuration does not discover Skills installed by the standard raw layout. This makes a zero-work
run look like an integrity proof and leaves raw-installed assets outside verification.

## What changed

Add explicit `verified`, `failed`, and `no_candidates` outcomes with a checked count shared by the
standalone verifier and middleware. Treat missing or empty default roots as silent best-effort
sources while preserving operational failures, add the `/usr/local` raw root, and carry the outcome
through events, summaries, telemetry, packaging tests, and EN/ZH docs.

## Related issue

Closes #2852
Closes #2859

## User / Agent impact

`agent-sec-cli verify` now prints `CHECKED`, `PASSED`, and `FAILED`. A completed zero-candidate run
prints `VERIFICATION SKIPPED: NO CANDIDATE SKILLS` and returns 0 without claiming integrity; an
explicit invalid `--skill` or a discovered verification failure still returns 1.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The existing `passed` and `failed` fields remain present, and the top-level Security Event result
enum remains `succeeded|failed`. Summary handling treats legacy `passed=0, failed=0` events as
`no_candidates`; telemetry adds only the allowlisted `seccore.asset_outcome` enum.

## Validation

- Python 3.11.6; `make python-code-pretty`
- Targeted CLI/verifier/backend/lifecycle/summary/telemetry pytest: 243 passed, 1 skipped,
  7 subtests passed
- Asset verifier integration suite: 28 passed
- `bash -n tests/packaging/test-package-raw.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`
- Full Linux raw packaging script was not run on Darwin
- Linux CI passed: RPM build, Ubuntu/Alinux4 source builds, system install, and full component tests

## Documentation and rollback

Adds bilingual Asset Verification guides and updates both component READMEs, the CLI README, user
guide indexes, and the telemetry design. Roll back by reverting the two commits; no stored-data or
configuration migration is introduced.
