### PR TITLE
fix(sec-core): reject ledger stub commands

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -628,6 +628,13 @@ Per-version verification: schema → hash integrity → signature validity → s
 | `agent-sec-cli skill-ledger audit <dir>` | Deep-verify the version chain |
 | `agent-sec-cli skill-ledger list-scanners` | List registered scanners |
 
+`decide` is the only supported command for recording a per-Skill user decision.
+The former hidden `set-policy` placeholder was never implemented and has been
+removed; invoking it is now an unknown-command usage error with exit code 2.
+`rotate-keys` remains a hidden, reserved interface: invoking it reports
+`not implemented` on stderr, exits non-zero, and does not change `key.enc`,
+`key.pub`, or the keyring.
+
 ## Key Paths
 
 | Path | Purpose |

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -601,6 +601,11 @@ agent-sec-cli skill-ledger audit /path/to/my-skill --verify-snapshots
 | `agent-sec-cli skill-ledger audit <dir>` | 深度验证版本链 |
 | `agent-sec-cli skill-ledger list-scanners` | 查看已注册的扫描器列表 |
 
+`decide` 是记录单个 Skill 用户决策的唯一受支持命令。早期隐藏的 `set-policy`
+占位命令从未实现且现已移除；继续调用会得到 unknown-command 用法错误和退出码 2。
+`rotate-keys` 仍是隐藏的预留接口：调用时会在 stderr 报告 `not implemented`，以非零
+退出码结束，且不会修改 `key.enc`、`key.pub` 或 keyring。
+
 ## 关键路径
 
 | 路径 | 用途 |

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -337,6 +337,12 @@ The six integrity states are `pass` / `none` / `drifted` / `warn` / `deny` /
 | `audit <dir>` | Show version history and signature chain |
 | `check --all` / `scan --all` | Batch mode across all registered skill dirs |
 
+`decide` is the supported interface for recording user decisions. The former
+hidden `set-policy` placeholder was never implemented and is not a supported
+command; invoking it is an unknown-command usage error with exit code 2. The
+hidden `rotate-keys` reservation also remains unavailable: direct execution
+exits non-zero and leaves the signing keys unchanged.
+
 ### Quick Example
 
 ```bash

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -323,6 +323,11 @@ agent-sec-cli scan-pii --input ./sample.log --include-low-confidence
 | `audit <dir>` | 查看版本历史与签名链 |
 | `check --all` / `scan --all` | 对所有已注册 Skill 目录批量执行 |
 
+`decide` 是记录用户决策的受支持入口。早期隐藏的 `set-policy` 占位命令从未实现，
+现在也不是受支持的命令；继续调用会得到 unknown-command 用法错误和退出码 2。
+隐藏的 `rotate-keys` 预留入口同样尚不可用：直接执行会以非零退出码结束，且不会修改
+签名密钥。
+
 ### 快速示例
 
 ```bash

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py
@@ -559,40 +559,21 @@ def cmd_export(
 
 
 # ---------------------------------------------------------------------------
-# set-policy (stub)
-# ---------------------------------------------------------------------------
-
-
-@app.command("set-policy", hidden=True)
-def cmd_set_policy(
-    skill_dir: str = typer.Argument(..., help="Path to the skill directory"),
-    policy: str = typer.Option(
-        ..., "--policy", help="Execution policy to apply: allow | block | warning"
-    ),
-) -> None:
-    """Set a skill's execution policy (coming soon).
-
-    Will control whether a skill is allowed to run, blocked, or triggers a
-    warning based on its security state. Not yet implemented.
-    """
-    typer.echo("set-policy: this feature is coming soon.")
-    raise typer.Exit(code=0)
-
-
-# ---------------------------------------------------------------------------
-# rotate-keys (stub)
+# rotate-keys (reserved stub)
 # ---------------------------------------------------------------------------
 
 
 @app.command("rotate-keys", hidden=True)
 def cmd_rotate_keys() -> None:
-    """Rotate the signing key pair (coming soon).
+    """Report that signing-key rotation is not implemented.
 
-    Will archive the current key pair and generate a new one, allowing
-    continued verification of manifests signed with the old keys.
+    This reserved command makes no key changes and exits non-zero when invoked.
     """
-    typer.echo("rotate-keys: this feature is coming soon.")
-    raise typer.Exit(code=0)
+    typer.echo(
+        "Error: rotate-keys is not implemented; no keys were changed.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -341,7 +341,10 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 
 兼容入口 `init-keys` 仍保留，但作为低层命令隐藏，不在普通 help 与用户主流程中展示。
 
-**`skill-ledger rotate-keys`** — 密钥轮换（预留接口，本版本不实现）
+**`skill-ledger rotate-keys`** — 密钥轮换（隐藏的预留接口，本版本不实现）
+
+当前直接执行该命令会在 stderr 报告 `not implemented`，以退出码 1 结束，且不会修改
+`key.enc`、`key.pub` 或 `keyring/`；`rotate-keys --help` 仍作为只读帮助以退出码 0 结束。
 
 设计思路：生成新密钥对 → 用新密钥重签 `latest.json` → 旧公钥移入 `keyring/` 供历史验证。
 
@@ -436,6 +439,10 @@ agent-sec-cli skill-ledger decide <skill_dir> --clear
 ```
 
 `--clear` 将 latest manifest 的 `userDecision` 置空，恢复全局 activation 行为。`rollback` 未指定 `--version` 时，默认选择当前用户决策或 `pass_warn_only` 策略下的真实 active version；若当前只有 pending stub 或 hidden，没有真实 active version，则报错。
+
+`decide` 是用户决策的唯一 CLI 入口；不保留早期的 `set-policy` 占位命令，因为其
+`allow | block | warning` 执行策略语义与按版本记录的用户决策并不等价。旧调用由 Typer
+按 unknown command 处理并返回退出码 2，不创建或修改 `.skill-meta`。
 
 **`skill-ledger show <skill_dir>`** — 展示统一暴露摘要和诊断信息
 

--- a/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
+++ b/src/agent-sec-core/tests/e2e/skill-ledger/e2e_test.py
@@ -14,7 +14,7 @@ Test groups:
    G6  scan --all
    G7  audit
    G8  status (human-readable)
-   G9  stubs & edge cases
+   G9  Reserved commands & edge cases
    G10 SKILL.md contract assertions
    G11 Passphrase-protected key lifecycle
    G12 cosh hook integration
@@ -122,6 +122,17 @@ def write_findings_file(parent: Path, name: str, findings: list | dict) -> Path:
     return path
 
 
+def snapshot_file_tree(root: Path) -> dict[str, bytes]:
+    """Return relative paths and contents for every file below *root*."""
+    if not root.is_dir():
+        return {}
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
 # ── Workspace ──────────────────────────────────────────────────────────────
 
 
@@ -192,6 +203,8 @@ def case_help_available(ws: Workspace):
     assert (
         "skill-ledger" in r.stdout.lower()
     ), f"Expected 'skill-ledger' in help output: {r.stdout[:200]}"
+    assert "rotate-keys" not in r.stdout
+    assert "set-policy" not in r.stdout
 
 
 # ── G2: init-keys ─────────────────────────────────────────────────────────
@@ -812,24 +825,44 @@ def case_status_drifted_shows_details(ws: Workspace):
     ), f"Expected health 'attention' after drift: {out['skills']}"
 
 
-# ── G9: stubs & edge cases ───────────────────────────────────────────────
+# ── G9: reserved commands & edge cases ───────────────────────────────────
 
 
-def case_set_policy_stub(ws: Workspace):
-    """set-policy → exit 0, 'coming soon' in output."""
-    skill = make_skill(ws.skills_dir, "stub-policy", {"x.txt": "x"})
+def case_set_policy_removed(ws: Workspace) -> None:
+    """The removed set-policy placeholder fails without creating ledger state."""
+    skill = make_skill(ws.skills_dir, "removed-policy", {"x.txt": "x"})
+    metadata_dir = skill / ".skill-meta"
+    assert not metadata_dir.exists()
+
     r = run_skill_ledger(
         ["set-policy", str(skill), "--policy", "allow"], env_extra=ws.env()
     )
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    assert "coming soon" in r.stdout.lower()
+    assert r.returncode == 2, f"exit {r.returncode}: {r.stderr}"
+    assert r.stdout == ""
+    assert "no such command" in r.stderr.lower()
+    assert "set-policy" in r.stderr
+    assert not metadata_dir.exists()
 
 
-def case_rotate_keys_stub(ws: Workspace):
-    """rotate-keys → exit 0, 'coming soon' in output."""
+def case_rotate_keys_not_implemented(ws: Workspace) -> None:
+    """rotate-keys fails explicitly without changing the isolated key store."""
+    key_dir = ws.xdg_data / "agent-sec" / "skill-ledger"
+    before = snapshot_file_tree(key_dir)
+    keyring_existed = (key_dir / "keyring").is_dir()
+    assert {"key.enc", "key.pub"}.issubset(before)
+
     r = run_skill_ledger(["rotate-keys"], env_extra=ws.env())
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    assert "coming soon" in r.stdout.lower()
+    assert r.returncode == 1, f"exit {r.returncode}: {r.stderr}"
+    assert r.stdout == ""
+    assert r.stderr == (
+        "Error: rotate-keys is not implemented; no keys were changed.\n"
+    )
+    assert snapshot_file_tree(key_dir) == before
+    assert (key_dir / "keyring").is_dir() is keyring_existed
+
+    help_result = run_skill_ledger(["rotate-keys", "--help"], env_extra=ws.env())
+    assert help_result.returncode == 0, help_result.stderr
+    assert "not implemented" in help_result.stdout.lower()
 
 
 def case_list_scanners(ws: Workspace):
@@ -1444,8 +1477,8 @@ E2E_CASES = [
     E2ECase("G7: --verify-snapshots", case_audit_verify_snapshots),
     E2ECase("G8: human-readable output", case_status_human_readable_output),
     E2ECase("G8: drifted details", case_status_drifted_shows_details),
-    E2ECase("G9: set-policy stub", case_set_policy_stub),
-    E2ECase("G9: rotate-keys stub", case_rotate_keys_stub),
+    E2ECase("G9: set-policy removed", case_set_policy_removed),
+    E2ECase("G9: rotate-keys unavailable", case_rotate_keys_not_implemented),
     E2ECase("G9: list-scanners", case_list_scanners),
     E2ECase("G9: certify empty skill dir", case_certify_empty_skill_dir),
     E2ECase("G10: empty passphrase env", case_contract_init_keys_empty_passphrase_env),

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -148,6 +148,17 @@ def write_findings_file(parent: Path, name: str, findings: list | dict) -> Path:
     return path
 
 
+def snapshot_file_tree(root: Path) -> dict[str, bytes]:
+    """Return relative paths and contents for every file below *root*."""
+    if not root.is_dir():
+        return {}
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
 def read_latest_manifest(skill_dir: Path) -> dict:
     """Read ``.skill-meta/latest.json`` for assertions."""
     latest = skill_dir / ".skill-meta" / "latest.json"
@@ -3734,25 +3745,46 @@ def test_status_drifted_shows_details(ws):
     ), f"Expected health 'attention' after drift: {out['skills']}"
 
 
-# ── Group 8: stubs & edge cases ───────────────────────────────────────────
+# ── Group 8: reserved commands & edge cases ───────────────────────────────
 
 
-def test_set_policy_stub(ws):
-    """set-policy → exit 0, 'coming soon' in output."""
-    skill = make_skill(ws.skills_dir, "stub-policy", {"x.txt": "x"})
+def test_set_policy_removed(ws: Workspace) -> None:
+    """The removed set-policy placeholder fails without creating ledger state."""
+    skill = make_skill(ws.skills_dir, "removed-policy", {"x.txt": "x"})
+    metadata_dir = skill / ".skill-meta"
+    assert not metadata_dir.exists()
+
     r = run_skill_ledger(
         ["set-policy", str(skill), "--policy", "allow"],
         env_extra=ws.env(),
     )
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    assert "coming soon" in r.stdout.lower()
+    assert r.returncode == 2, f"exit {r.returncode}: {r.stderr}"
+    assert r.stdout == ""
+    error = strip_ansi(r.stderr).lower()
+    assert "no such command" in error
+    assert "set-policy" in error
+    assert not metadata_dir.exists()
 
 
-def test_rotate_keys_stub(ws):
-    """rotate-keys → exit 0, 'coming soon' in output."""
+def test_rotate_keys_not_implemented(ws: Workspace) -> None:
+    """rotate-keys fails explicitly without changing the isolated key store."""
+    key_dir = ws.xdg_data / "agent-sec" / "skill-ledger"
+    before = snapshot_file_tree(key_dir)
+    keyring_existed = (key_dir / "keyring").is_dir()
+    assert {"key.enc", "key.pub"}.issubset(before)
+
     r = run_skill_ledger(["rotate-keys"], env_extra=ws.env())
-    assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
-    assert "coming soon" in r.stdout.lower()
+    assert r.returncode == 1, f"exit {r.returncode}: {r.stderr}"
+    assert r.stdout == ""
+    assert r.stderr == (
+        "Error: rotate-keys is not implemented; no keys were changed.\n"
+    )
+    assert snapshot_file_tree(key_dir) == before
+    assert (key_dir / "keyring").is_dir() is keyring_existed
+
+    help_result = run_skill_ledger(["rotate-keys", "--help"], env_extra=ws.env())
+    assert help_result.returncode == 0, help_result.stderr
+    assert "not implemented" in strip_ansi(help_result.stdout).lower()
 
 
 def test_list_scanners(ws):


### PR DESCRIPTION
## Why

Two hidden Skill Ledger placeholders return success without applying a policy or rotating keys.
Automation can therefore mistake an unimplemented operation for a completed security change.

## What changed

Remove the hidden `set-policy` registration so legacy invocations are Typer usage errors. Keep the
hidden `rotate-keys` reservation, but return rc 1 with an exact stderr error and no key mutation;
document `decide` as the only supported user-decision entry and lock the behavior with integration
and source-backed E2E tests.

## Related issue

Closes #2860

## User / Agent impact

`set-policy` now returns rc 2 as an unknown command. `rotate-keys` returns rc 1, leaves stdout empty,
and reports `Error: rotate-keys is not implemented; no keys were changed.` on stderr; its explicit
help remains available with rc 0 while both commands stay absent from top-level help.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

This intentionally rejects scripts that relied on the old false-success placeholders. It does not
map the obsolete policy model to `decide`, implement key rotation, or call `init --force-keys`.

## Validation

- `make python-code-pretty`
- Full Skill Ledger integration suite: 116 passed
- Full source-backed Skill Ledger E2E suite: 50 passed
- Exact-contract integration selection: 3 passed, 113 deselected
- Exact-contract E2E selection: 3 passed, 47 deselected
- Exact pre/post snapshot of `key.enc`, `key.pub`, and keyring files
- `git diff --check`
- Linux CI passed: RPM build, Ubuntu/Alinux4 source builds, system install, and full component tests

## Documentation and rollback

Updates the EN/ZH component READMEs, EN/ZH Skill Ledger guide, and existing design document. Roll
back by reverting the commit; no keys, manifests, or stored ledger state are migrated.
