### PR TITLE
docs(tokenless): land the unified compression pipeline evolution roadmap

### DIFF
--- a/src/tokenless/crates/tokenless-pipeline/src/lib.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/lib.rs
@@ -16,7 +16,7 @@
 //! existing JSON response cleanup ([`RESPONSE_CLEANUP`]), whose executable
 //! implementation lives with the Runtime that owns its stash and per-call
 //! configuration. The roadmap section numbers refer to the tokenless
-//! evolution roadmap, which has not landed in this repository yet.
+//! evolution roadmap at `docs/roadmap/evolution-roadmap.md`.
 
 mod content;
 mod pipeline;

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -9,9 +9,10 @@
 //! adapter needs to build its host-specific envelope.
 //!
 //! The roadmap section numbers cited throughout this crate (§4.1, §4.5,
-//! §5.1, §5.6, …) refer to the tokenless evolution roadmap, which has not
-//! landed in this repository yet. Until it does, the JSON examples and
-//! contract tests in this crate are the authoritative wire contract.
+//! §5.1, §5.6, …) refer to the tokenless evolution roadmap at
+//! `docs/roadmap/evolution-roadmap.md`. The JSON examples and contract
+//! tests in this crate are the drift guard between that document and the
+//! wire types.
 //!
 //! # Compatibility rules
 //!

--- a/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
@@ -1,8 +1,7 @@
 // Contract tests for protocol v1. The two *_roadmap_example tests pin the
-// §4.1 JSON examples from the evolution roadmap draft. That document has not
-// landed in-repo yet, so until it does the JSON here is the authoritative
-// wire contract; once it lands, these tests become the drift guard between
-// the document and the types.
+// §4.1 JSON examples from the evolution roadmap
+// (`docs/roadmap/evolution-roadmap.md`); they are the drift guard between
+// that document and the wire types.
 
 #[test]
 fn request_roadmap_example_parses() {

--- a/src/tokenless/docs/roadmap/evolution-roadmap.md
+++ b/src/tokenless/docs/roadmap/evolution-roadmap.md
@@ -1,0 +1,291 @@
+# Tokenless Evolution Roadmap — The Unified Compression Pipeline
+
+[中文版](evolution-roadmap_zh.md)
+
+> **Status: living document.** This roadmap consolidates the evolution plan that
+> the tokenless crates already cite by section number (§4.x / §5.x). Where
+> implementation exists, the code is the source of truth; the protocol contract
+> tests in `crates/tokenless-protocol/src/tests/protocol_tests.rs` are the drift
+> guard between this document and the wire types.
+
+## 1. Why a unified pipeline
+
+Tokenless compresses model-visible content (tool results, published tool
+schemas) before it reaches the model, so agents spend tokens on task content
+instead of boilerplate. Before this roadmap, each integration point made its
+own compression decisions:
+
+- the Python hooks, the CLI subcommands (`compress-response`,
+  `compress-schema`, `compress-toon`), and the in-process runtime each
+  re-implemented JSON detection, threshold selection, and final-size
+  acceptance;
+- hosts that cannot replace model-visible output, or cannot retrieve stashed
+  content, had no uniform way to declare that;
+- dispositions and statistics were not comparable across entry points.
+
+The goal is one unified compression pipeline:
+
+1. one **protocol boundary** between adapters and the pipeline (§4.1);
+2. one **content taxonomy**, one deterministic **detector**, and one static
+   **compressor registry** (§4.2);
+3. one **staged execution engine** with end-to-end arbitration (§4.3);
+4. one **external entry point** (`tokenless compress` subcommand and the
+   in-process `TokenlessRuntime::compress`) shared by every adapter (§5.4);
+5. comparable **dispositions and statistics** across CLI, runtime, and
+   language bindings (§5.5–§5.6).
+
+Adapters shrink to envelope translation: they build one protocol request,
+route it through the shared entry, and emit `output` exactly as returned —
+no fallback logic of their own.
+
+## 2. Principles
+
+The implementation cites these principles by number. Where a principle is
+encoded, the enforcing code is listed.
+
+| # | Principle | Enforced by |
+|---|-----------|-------------|
+| 2 | **Route by content, constrain by seam.** A compressor is a candidate only when it supports the detected content type, runs at the request's seam, and every capability it requires is declared by the adapter. | `CompressorSpec::matches` / `candidates` (tokenless-pipeline) |
+| 3 | **Staged escalation.** Lossless runs before retrievable-lossy, retrievable-lossy before bounded truncation; escalate only while the configured size policy is unmet. | `Stage` ordering + `run` (tokenless-pipeline) |
+| 5 | **Explicit reversibility.** Every applied outcome states its recovery state — lossless, retrievable, or unrecoverable; required-reversible mode rejects unrecoverable candidates outright. | `Reversibility` + end-to-end arbitration |
+| 6 | **Fail-open, bounded diagnostics.** Compression is an optional optimization: a failing step never fails the request, the first failure is kept as a diagnostic bounded to 4096 bytes, and `output` always holds exactly what the adapter must emit. | `Disposition::Error`, `DIAGNOSTIC_MAX_BYTES`, fail-open contract |
+| 7 | **Static registration.** The registry is a compile-time `const` slice; dynamic plugin loading and configuration-driven registration are out of scope. | `REGISTRY` (tokenless-pipeline) |
+
+Principles 1 and 4 belong to the draft numbering but are not yet pinned by any
+implementation citation; they are deliberately left unstated here until the
+steps that encode them land.
+
+## 3. Target architecture (§4)
+
+### §4.1 Protocol v1 — the compatibility boundary
+
+`tokenless-protocol` defines protocol v1: the boundary between
+agent-specific adapters and the shared compression pipeline. It is
+deliberately not an OpenAI or Anthropic request shape.
+
+- `CompressionRequest` carries only the model-visible content plus the
+  attribution and capability facts the pipeline needs: `protocol_version`,
+  `content`, `agent_id`, optional `session_id` / `tool_use_id` /
+  `tool_name`, `seam`, and `capabilities`.
+- `CompressionResponse` carries the final content plus the decision the
+  adapter needs to build its host-specific envelope: `output`,
+  `disposition`, optional `content_type`, `compressor_chain`,
+  `reversibility`, `before_tokens` / `after_tokens`, `stash_keys`,
+  `tokenizer_id`, and an optional bounded `diagnostic`.
+
+Wire example (request):
+
+```json
+{
+  "protocol_version": 1,
+  "content": "...",
+  "agent_id": "claude-code",
+  "session_id": "...",
+  "tool_use_id": "...",
+  "tool_name": "Bash",
+  "seam": "post_tool",
+  "capabilities": {
+    "replace_output": true,
+    "publish_retrieve_tool": true
+  }
+}
+```
+
+Wire example (response, illustrative compressor IDs):
+
+```json
+{
+  "protocol_version": 1,
+  "output": "...",
+  "disposition": "applied",
+  "content_type": "build_log",
+  "compressor_chain": ["terminal-cleanup", "build-log"],
+  "reversibility": "retrievable",
+  "before_tokens": 1200,
+  "after_tokens": 340,
+  "stash_keys": ["0123456789abcdef01234567"]
+}
+```
+
+Compatibility rules:
+
+- readers ignore unknown fields within a supported major protocol version,
+  so optional fields may be added without a version bump;
+- an incompatible shape requires a new `protocol_version`, never a parallel
+  adapter-specific payload;
+- the version is checked before the full parse, so a future version is
+  reported as `UnsupportedVersion` rather than a shape error;
+- **fail-open contract**: `output` always holds exactly what the adapter
+  must emit. On every non-`applied` disposition it is the original
+  model-visible content, so adapters never need fallback logic of their own.
+
+The disposition vocabulary is shared by every frontend: `applied`, `dry_run`,
+`passthrough`, `no_savings`, `reversibility_unavailable`, `timeout`, `error`.
+
+### §4.2 Content taxonomy, detector, registry
+
+Detection is a pure, deterministic function of the content with bounded
+work: only the first 64 KiB / 200 lines are inspected (plus a bounded tail
+for the JSON bracket sniff), and no format is fully parsed — expensive
+parsing belongs inside the selected compressor, not in a detector that runs
+on every input. When no cheap signal is decisive, the detector prefers the
+more general class, and ultimately `plain_text` or `unknown`, which the
+pipeline routes to passthrough until a conservative fallback compressor
+exists.
+
+First taxonomy (stable wire values): `json_records`, `search_results`,
+`build_log`, `stack_trace`, `diff`, `html`, `tabular`, `source_code`,
+`plain_text`, `unknown`. Checks run from the most distinctive shape to the
+most general one, so a build log that merely *contains* a traceback stays
+`build_log` while content that *starts as* a traceback is `stack_trace`.
+Ambiguous fragments are not classified as HTML (**M4 policy**).
+
+Routing by detected content is the contract: record-shaped JSON
+(`{...}`/`[...]`) routes to the JSON cleanup; a scalar JSON root passes
+through untouched and waits for its own compressor rather than being
+truncated by a compressor that does not understand it.
+
+The compressor registry is static (principle 7): a compile-time `const`
+slice of `CompressorSpec { id, content_types, seams, required_capabilities,
+stage, cost_class }`. Entries are appended together with the compressor that
+implements them, never speculatively. `candidates` filters the registry by
+the principle-2 rule — content type ∩ seam ∩ declared capabilities.
+
+### §4.3 Staged execution and end-to-end arbitration
+
+`tokenless_pipeline::run` takes one request through detection, routing, and
+the escalation ladder (principle 3):
+
+1. **steps 1–2** — every applicable lossless transformation runs; a result
+   that does not remove normalized tokens is dropped outright;
+2. **steps 3–4** — escalate only while the configured size policy is unmet,
+   one compressor per stage: at most one content-specific retrievable-lossy
+   compressor, then at most one bounded truncation. A specialized lossy
+   decision is final — no second lossy compressor and no generic lossy
+   fallback runs after it; only the bounded truncation stage (step 4, the
+   ladder's last resort) may still follow. A stash write whose marker a
+   later stage cuts out of the output is rolled back rather than committed;
+3. **steps 5–6** — arbitration is end-to-end: the original and the final
+   candidate are compared once. A candidate that does not remove normalized
+   tokens, violates required reversibility, or exceeds the overall timeout
+   budget is rejected as a whole — its newly created stash keys are rolled
+   back and the original content is emitted unchanged.
+
+One `PipelineConfig` carries the arbitration policy for a call: the overall
+`timeout` budget (checked at stage boundaries), `max_tokens` (the size
+policy; `None` never escalates beyond lossless), `require_reversibility`,
+and `dry_run`.
+
+### §4.5 Adapters own their private host contracts
+
+Adapters keep their host-specific envelopes and business objects to
+themselves; only the model-visible value is copied into a protocol request.
+UI or business objects that must remain unmodified never enter the
+protocol.
+
+### §4.6 Seams
+
+The `seam` field records where in the agent loop the content was
+intercepted: `before_model` (e.g. schema publication), `pre_tool` (e.g.
+command rewrite), `post_tool` (tool output after execution — the primary
+compression seam), and `proxy` (a proxy frontend observing model traffic).
+Stash keys are reported only for applied, emitted results: rolled-back
+candidates never leak keys.
+
+## 4. Migration plan (§5)
+
+### §5.1 Token counter identity
+
+All token counts in protocol v1 use one counter identity: `heuristic-v1`,
+the character-class heuristic implemented by `tokenless-stats` (CJK ≈ 1
+token per character, other content ≈ 1 token per 4 characters) — not a
+provider tokenizer. Counts are normalized tokens for arbitration and
+attribution, not billing estimates. Any change to the estimator's character
+classes or ratios requires a new `tokenizer_id`; rows and responses produced
+under different IDs must never be merged into one series without an explicit
+per-counter breakdown. A payload missing the field reads as `heuristic-v1`:
+the heuristic estimator is the only counter that ever shipped before the
+field existed.
+
+### §5.2–§5.3 The shared pipeline crate and its first compressor
+
+`tokenless-pipeline` carries the pieces that sit between the protocol
+boundary and the compressors themselves: the taxonomy and detector (§4.2),
+the registry and capability filter (§4.2), and the staged execution engine
+with end-to-end arbitration (§4.3).
+
+The first production compressor is the existing JSON response cleanup
+(`response-cleanup`), moved behind the pipeline's `Compressor` trait:
+structural cleanup and bounded truncation of record-shaped JSON, with
+truncated content stashed and marker-referenced when a stash store is
+attached. Its executable implementation lives with the runtime, which owns
+the stash store and the per-call configuration; its `spec()` returns a
+reference to the registry entry so the two cannot drift. The runtime honors
+the one-budget contract: a single overall pipeline budget (10 s in-process)
+replaces per-step timeouts, and timeout is fail-open.
+
+Further compressors join the registry the same way — appended together with
+their implementation, never speculatively.
+
+### §5.4 One external entry point
+
+All external hooks converge on a single entry: a protocol-v1
+`tokenless compress` subcommand (stdin `CompressionRequest` → stdout
+`CompressionResponse`) and the in-process `TokenlessRuntime::compress`, both
+routed through one shared seam router in the runtime. The decisions
+previously duplicated across the common Python hooks and the CLI
+subcommands — JSON detection (including string-unwrap semantics), tool
+threshold selection, TOON selection, and the final size acceptance — happen
+exactly once, in Rust.
+
+The Python hooks become envelope-only adapters: each builds one request,
+spawns at most one tokenless subprocess, and translates the response into
+its host's envelope. Matchers, hooks configuration, and extension manifests
+stay untouched.
+
+### §5.5 Statistics migration
+
+Statistics follow the winner: at most one row per invocation, keyed by the
+winning operation (e.g. TOON win → `compress-toon`, cleanup win →
+`compress-response`, schema → `compress-schema`), with savings re-based
+from the original input to the final output. The legacy measurement side
+channels (the runtime's separate `compressed_output` candidate field and the
+pre-protocol disposition types) are retired with this migration.
+
+### §5.6 Disposition parity and adapter contract fixtures
+
+CLI and runtime must agree on one disposition vocabulary — the shared
+`Disposition` enum from protocol v1 (**M1 exit gate**) — and on one canonical
+passthrough shape, so dispositions stay comparable across entry points.
+Adapter behavior is pinned by contract fixtures covering five classes —
+passthrough, replacement, no-savings, timeout, malformed — exercised against
+a mock protocol binary for every migrated agent, plus a golden parity suite
+that replays a shared corpus through the rewritten hooks against envelopes
+captured from the pre-rewrite hooks.
+
+### Legacy removal
+
+The legacy `compress-response` / `compress-schema` / `compress-toon`
+subcommands and the old Python helpers stay until the removal step, after
+every adapter has converged on the unified entry.
+
+## 5. Implementation status
+
+| Step | Content | Section | Status |
+|------|---------|---------|--------|
+| Protocol v1 request/response types | `tokenless-protocol` crate | §4.1 | Merged ([#2783](https://github.com/alibaba/anolisa/pull/2783)) |
+| Content taxonomy, detector, static registry | `tokenless-pipeline` crate | §4.2 | Merged ([#2788](https://github.com/alibaba/anolisa/pull/2788)) |
+| Staged pipeline and end-to-end arbitration | `tokenless-pipeline` crate | §4.3 | Merged ([#2799](https://github.com/alibaba/anolisa/pull/2799)) |
+| Response compression behind the registry | `tokenless-runtime` | §5.3 | Merged ([#2816](https://github.com/alibaba/anolisa/pull/2816)) |
+| Unified external hook entry + contract fixtures | runtime entry router, envelope-only hooks | §5.4 / §5.6 | Open ([#2844](https://github.com/alibaba/anolisa/pull/2844), PR 6 of the sequence) |
+| Statistics attribution rework | one row per invocation, winner-keyed | §5.5 | Planned (roadmap PR 7) |
+| Legacy subcommand/helper removal | retire `compress-response` / `compress-schema` / `compress-toon` | — | Planned (roadmap PR 18) |
+
+## 6. Related documents
+
+- [Response compression rules](../response-compression.md) — the seven
+  cleanup rules behind the `response-cleanup` compressor
+- [Stash and reversible compression](../stash-reversible-compression.md) —
+  the stash store and marker retrieval contract
+- [Runtime library](../design/runtime-library.md) — the stateful runtime
+  API shared by frontends

--- a/src/tokenless/docs/roadmap/evolution-roadmap_zh.md
+++ b/src/tokenless/docs/roadmap/evolution-roadmap_zh.md
@@ -1,0 +1,241 @@
+# Tokenless 演进路线 —— 统一压缩管线
+
+[English](evolution-roadmap.md)
+
+> **状态：长期维护文档。** 本路线汇总了 tokenless 各 crate 已按章节号
+> （§4.x / §5.x）引用的演进计划。已有实现之处，以代码为准；
+> `crates/tokenless-protocol/src/tests/protocol_tests.rs` 中的协议契约测试
+> 是本文档与线上类型之间的防漂移护栏。
+
+## 1. 为什么要统一管线
+
+Tokenless 在模型可见内容（工具结果、发布的工具 schema）到达模型之前对其进行
+压缩，让 agent 把 token 花在任务内容而非样板信息上。在本路线之前，每个集成点
+各自实现压缩决策：
+
+- Python hooks、CLI 子命令（`compress-response`、`compress-schema`、
+  `compress-toon`）与进程内 runtime 各自重复实现 JSON 检测、阈值选择与
+  最终大小验收；
+- 无法替换模型可见输出、或无法取回暂存（stash）内容的宿主，没有统一的方式
+  声明这一事实；
+- 各入口之间的处置结果（disposition）与统计不可比较。
+
+目标是单一的压缩管线：
+
+1. 适配器与管线之间唯一的**协议边界**（§4.1）；
+2. 唯一的**内容分类**、确定性的**检测器**与静态的**压缩器注册表**（§4.2）；
+3. 唯一的**分阶段执行引擎**，配合端到端仲裁（§4.3）；
+4. 所有适配器共享的**唯一外部入口**（`tokenless compress` 子命令与进程内
+   `TokenlessRuntime::compress`）（§5.4）；
+5. CLI、runtime 与语言绑定之间可比较的**处置与统计**（§5.5–§5.6）。
+
+适配器收缩为信封转换：构造一个协议请求，经由共享入口路由，并原样输出返回的
+`output` —— 不需要自己的兜底逻辑。
+
+## 2. 原则
+
+实现按编号引用以下原则。已编码的原则列出其落点代码。
+
+| # | 原则 | 落点 |
+|---|------|------|
+| 2 | **按内容路由，按缝（seam）约束。** 压缩器成为候选，当且仅当它支持检测出的内容类型、运行于请求的缝、且适配器声明了它要求的全部能力。 | `CompressorSpec::matches` / `candidates`（tokenless-pipeline） |
+| 3 | **分阶段升级。** 无损先于可取回有损，可取回有损先于有界截断；仅在配置的大小策略未满足时才升级。 | `Stage` 顺序 + `run`（tokenless-pipeline） |
+| 5 | **显式可逆性。** 每个应用结果声明其恢复状态——无损、可取回或不可恢复；required-reversible 模式直接拒绝不可恢复的候选。 | `Reversibility` + 端到端仲裁 |
+| 6 | **失败开放，诊断有界。** 压缩是可选优化：失败步骤永不使请求失败，首个失败保留为不超过 4096 字节的诊断，`output` 始终恰好是适配器应输出的内容。 | `Disposition::Error`、`DIAGNOSTIC_MAX_BYTES`、fail-open 契约 |
+| 7 | **静态注册。** 注册表是编译期 `const` 切片；动态插件加载与配置驱动注册不在范围内。 | `REGISTRY`（tokenless-pipeline） |
+
+原则 1 与 4 属于草案编号，但尚无实现引用将其固化；在编码它们的步骤落地之前，
+此处刻意不作陈述。
+
+## 3. 目标架构（§4）
+
+### §4.1 协议 v1 —— 兼容性边界
+
+`tokenless-protocol` 定义协议 v1：agent 专用适配器与共享压缩管线之间的边界。
+它刻意不采用 OpenAI 或 Anthropic 的请求形状。
+
+- `CompressionRequest` 只携带模型可见内容加管线所需的归因与能力事实：
+  `protocol_version`、`content`、`agent_id`、可选 `session_id` /
+  `tool_use_id` / `tool_name`、`seam` 与 `capabilities`。
+- `CompressionResponse` 携带最终内容加适配器构造宿主信封所需的决策：
+  `output`、`disposition`、可选 `content_type`、`compressor_chain`、
+  `reversibility`、`before_tokens` / `after_tokens`、`stash_keys`、
+  `tokenizer_id` 与可选的有界 `diagnostic`。
+
+线上示例（请求）：
+
+```json
+{
+  "protocol_version": 1,
+  "content": "...",
+  "agent_id": "claude-code",
+  "session_id": "...",
+  "tool_use_id": "...",
+  "tool_name": "Bash",
+  "seam": "post_tool",
+  "capabilities": {
+    "replace_output": true,
+    "publish_retrieve_tool": true
+  }
+}
+```
+
+线上示例（响应，压缩器 ID 为示意）：
+
+```json
+{
+  "protocol_version": 1,
+  "output": "...",
+  "disposition": "applied",
+  "content_type": "build_log",
+  "compressor_chain": ["terminal-cleanup", "build-log"],
+  "reversibility": "retrievable",
+  "before_tokens": 1200,
+  "after_tokens": 340,
+  "stash_keys": ["0123456789abcdef01234567"]
+}
+```
+
+兼容性规则：
+
+- 在受支持的主协议版本内，读取方忽略未知字段，因此可选字段可在不升版本号的
+  情况下添加；
+- 不兼容的形状必须使用新的 `protocol_version`，绝不允许并行的适配器专用负载；
+- 先检查版本再完整解析，未来版本报告为 `UnsupportedVersion` 而非形状错误；
+- **失败开放（fail-open）契约**：`output` 始终恰好是适配器应输出的内容。任何
+  非 `applied` 处置下它就是原始模型可见内容，适配器无需自带兜底逻辑。
+
+处置词汇表由所有前端共享：`applied`、`dry_run`、`passthrough`、
+`no_savings`、`reversibility_unavailable`、`timeout`、`error`。
+
+### §4.2 内容分类、检测器与注册表
+
+检测是内容的纯函数、确定性且有界：只检查前 64 KiB / 200 行（JSON 括号嗅探
+另含一段有界尾部），且不完整解析任何格式——昂贵的解析属于被选中的压缩器，
+而不是每个输入都要运行的检测器。当没有廉价信号足以定夺时，检测器倾向更通用
+的类别，最终为 `plain_text` 或 `unknown`；在保守兜底压缩器出现之前，管线把
+它们路由为 passthrough。
+
+第一版分类（稳定线上值）：`json_records`、`search_results`、`build_log`、
+`stack_trace`、`diff`、`html`、`tabular`、`source_code`、`plain_text`、
+`unknown`。检查从最特殊的形状到最通用的形状依次进行：仅仅*包含* traceback 的
+构建日志仍是 `build_log`，而*以* traceback *开头*的内容是 `stack_trace`。
+歧义片段不归类为 HTML（**M4 策略**）。
+
+按检测内容路由是契约：记录形状的 JSON（`{...}`/`[...]`）路由到 JSON 清理；
+标量 JSON 根原样通过，等待它自己的压缩器，而不是被不理解它的压缩器截断。
+
+压缩器注册表是静态的（原则 7）：编译期 `const` 切片，元素为
+`CompressorSpec { id, content_types, seams, required_capabilities, stage,
+cost_class }`。条目与其实现者一同追加，绝不投机性注册。`candidates` 按
+原则 2 过滤注册表——内容类型 ∩ 缝 ∩ 已声明能力。
+
+### §4.3 分阶段执行与端到端仲裁
+
+`tokenless_pipeline::run` 把一个请求带过检测、路由与升级阶梯（原则 3）：
+
+1. **步骤 1–2**——所有适用的无损变换全部执行；未减少归一化 token 的结果
+   直接丢弃；
+2. **步骤 3–4**——仅在配置的大小策略未满足时升级，每阶段一个压缩器：至多
+   一个内容专用的可取回有损压缩器，然后至多一次有界截断。专用有损决策是
+   终局——其后不再运行第二个有损压缩器或通用有损兜底；只有有界截断阶段
+   （步骤 4，阶梯的最后手段）仍可跟随。标记被后续阶段从输出中切掉的暂存写入
+   会回滚而非提交；
+3. **步骤 5–6**——仲裁是端到端的：原始内容与最终候选只比较一次。未减少
+   归一化 token、违反必需可逆性或超出总超时预算的候选被整体拒绝——新建的
+   暂存键被回滚，输出原始内容不变。
+
+单个 `PipelineConfig` 携带一次调用的仲裁策略：总 `timeout` 预算（在阶段边界
+检查）、`max_tokens`（大小策略；`None` 表示永不越过无损阶段升级）、
+`require_reversibility` 与 `dry_run`。
+
+### §4.5 适配器保有私有的宿主契约
+
+适配器保留其宿主专用信封与业务对象；只有模型可见值被复制进协议请求。必须
+保持不变的 UI 或业务对象绝不进入协议。
+
+### §4.6 缝（Seam）
+
+`seam` 字段记录内容在 agent 循环中被拦截的位置：`before_model`（如 schema
+发布）、`pre_tool`（如命令改写）、`post_tool`（工具执行后的输出——主要压缩
+缝）、`proxy`（观察模型流量的代理前端）。暂存键只在应用且已输出的结果中
+报告：被回滚的候选绝不泄漏键。
+
+## 4. 迁移计划（§5）
+
+### §5.1 Token 计数器身份
+
+协议 v1 的所有 token 计数使用同一计数器身份：`heuristic-v1`，即
+`tokenless-stats` 实现的字符类启发式（CJK ≈ 1 token/字符，其他内容 ≈
+1 token/4 字符）——而非提供方分词器。计数是用于仲裁与归因的归一化 token，
+不是计费估算。估算器的字符类或比例发生任何变更都需要新的 `tokenizer_id`；
+不同 ID 产出的行与响应，若没有显式的按计数器拆分，绝不合并进同一序列。
+缺失该字段的负载按 `heuristic-v1` 读取：启发式估算器是该字段存在之前唯一
+发布过的计数器。
+
+### §5.2–§5.3 共享管线 crate 与第一个压缩器
+
+`tokenless-pipeline` 承载位于协议边界与压缩器之间的部分：分类与检测器
+（§4.2）、注册表与能力过滤（§4.2）、以及带端到端仲裁的分阶段执行引擎
+（§4.3）。
+
+第一个生产压缩器是既有的 JSON 响应清理（`response-cleanup`），被移到管线的
+`Compressor` trait 之后：对记录形状的 JSON 做结构清理与有界截断，截断内容在
+挂载了暂存库时写入暂存并以标记引用。其可执行实现位于 runtime——runtime 拥有
+暂存库与按调用配置；其 `spec()` 返回注册表条目的引用，使两者不会漂移。
+Runtime 遵守单预算契约：单一的总体管线预算（进程内 10 秒）取代按步骤的超时，
+超时即失败开放。
+
+后续压缩器以同样方式加入注册表——与实现一同追加，绝不投机性注册。
+
+### §5.4 唯一外部入口
+
+所有外部钩子汇聚到单一入口：协议 v1 的 `tokenless compress` 子命令（stdin
+`CompressionRequest` → stdout `CompressionResponse`）与进程内
+`TokenlessRuntime::compress`，二者都经由 runtime 中共享的缝路由器。此前在
+公共 Python hooks 与 CLI 子命令间重复的决策——JSON 检测（含字符串解包语义）、
+工具阈值选择、TOON 选择与最终大小验收——在 Rust 中恰好发生一次。
+
+Python hooks 变为仅做信封转换的适配器：各自构造一个请求、至多启动一个
+tokenless 子进程，并把响应翻译成宿主的信封。Matchers、hooks 配置与扩展
+清单保持不变。
+
+### §5.5 统计迁移
+
+统计跟随赢家：每次调用至多一行，以获胜操作为键（如 TOON 胜 →
+`compress-toon`、清理胜 → `compress-response`、schema → `compress-schema`），
+节省率以原始输入到最终输出重新计算基线。遗留的测量旁路（runtime 单独的
+`compressed_output` 候选字段与协议前处置类型）随本次迁移退役。
+
+### §5.6 处置对等与适配器契约夹具
+
+CLI 与 runtime 必须共用一套处置词汇表——协议 v1 的共享 `Disposition` 枚举
+（**M1 出口门**）——以及同一个标准 passthrough 形状，使处置在各入口之间可比。
+适配器行为由契约夹具固化，覆盖五类——passthrough、replacement、no-savings、
+timeout、malformed——针对 mock 协议二进制在每个已迁移 agent 上执行，另有黄金
+对等套件：用共享语料回放改写后的 hooks，与改写前 hooks 捕获的信封比对。
+
+### 遗留移除
+
+遗留的 `compress-response` / `compress-schema` / `compress-toon` 子命令与旧
+Python helpers 保留到移除步骤，直到所有适配器都汇聚到统一入口。
+
+## 5. 实现状态
+
+| 步骤 | 内容 | 章节 | 状态 |
+|------|------|------|------|
+| 协议 v1 请求/响应类型 | `tokenless-protocol` crate | §4.1 | 已合并（[#2783](https://github.com/alibaba/anolisa/pull/2783)） |
+| 内容分类、检测器、静态注册表 | `tokenless-pipeline` crate | §4.2 | 已合并（[#2788](https://github.com/alibaba/anolisa/pull/2788)） |
+| 分阶段管线与端到端仲裁 | `tokenless-pipeline` crate | §4.3 | 已合并（[#2799](https://github.com/alibaba/anolisa/pull/2799)） |
+| 响应压缩置于注册表之后 | `tokenless-runtime` | §5.3 | 已合并（[#2816](https://github.com/alibaba/anolisa/pull/2816)） |
+| 统一外部钩子入口 + 契约夹具 | runtime 入口路由器、信封化 hooks | §5.4 / §5.6 | 开放（[#2844](https://github.com/alibaba/anolisa/pull/2844)，序列 PR 6） |
+| 统计归因重构 | 每次调用一行、以赢家为键 | §5.5 | 计划中（路线 PR 7） |
+| 遗留子命令/助手移除 | 退役 `compress-response` / `compress-schema` / `compress-toon` | — | 计划中（路线 PR 18） |
+
+## 6. 相关文档
+
+- [Response 压缩规则](../response-compression.md)——`response-cleanup`
+  压缩器背后的七条清理规则
+- [暂存与可逆压缩](../stash-reversible-compression.md)——暂存库与标记取回
+  契约
+- [Runtime 库](../design/runtime-library.md)——前端共享的有状态 runtime API


### PR DESCRIPTION
## Why

The `tokenless-protocol`, `tokenless-pipeline`, and `tokenless-runtime` crates
cite the evolution roadmap by section number throughout their doc comments —
§4.1–§4.6, §5.1–§5.6, principles 2/3/5/6/7, the M1 exit gate, and the M4
detection policy — and each citation notes that the roadmap "has not landed in
this repository yet". The protocol contract tests were explicitly written so
that "once it lands, these tests become the drift guard between the document
and the types". This PR lands the document at the exact path the code already
references (`src/tokenless/docs/roadmap/evolution-roadmap.md`).

## What changed

- **`src/tokenless/docs/roadmap/evolution-roadmap.md` (+ `_zh.md`)** — the
  unified compression pipeline evolution roadmap, consolidated strictly from
  what the merged implementation encodes:
  - the five encoded principles with their enforcing code (route by content /
    constrain by seam, staged escalation, explicit reversibility, fail-open
    with bounded diagnostics, static registration);
  - §4 target architecture: the protocol v1 boundary with the exact wire
    examples pinned by the contract tests, compatibility rules, and the shared
    disposition vocabulary; the content taxonomy, bounded deterministic
    detector, and static registry; the §4.3 six-step staged execution with
    end-to-end arbitration; adapter-owned host contracts (§4.5); seams (§4.6);
  - §5 migration: token-counter identity (§5.1), the shared pipeline crate and
    the `response-cleanup` first compressor (§5.2–§5.3), one external entry
    point (§5.4, in flight via #2844), the statistics migration (§5.5),
    disposition parity and adapter contract fixtures (§5.6), and legacy
    subcommand removal;
  - an implementation-status table mapping each step to its PR.
- Updated three stale doc comments (`tokenless-pipeline/src/lib.rs`,
  `tokenless-protocol/src/lib.rs`,
  `tokenless-protocol/src/tests/protocol_tests.rs`) that said the roadmap had
  not landed; they now point at the document, and the contract tests are
  described as the drift guard they were written to be.

Doc-comment-only changes on the Rust side; no functional code changed.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Documentation only. Roll back by reverting the commit.

## 测试情况（脱敏测试报告）

**测试范围与命令**（本次仅新增文档 + 修改文档注释，无功能代码变更）：

- `cargo test -p tokenless-protocol -p tokenless-pipeline -p tokenless-runtime`
  — **77 passed, 0 failed**（覆盖被修改注释所在的全部 crate；
  `request_roadmap_example_parses` / `response_roadmap_example_parses` 通过）
- `cargo fmt --all -- --check` — 通过
- `cargo clippy -p tokenless-protocol -p tokenless-pipeline -p tokenless-runtime --all-targets -- -D warnings` — 0 告警（仅本地环境的
  cargo 配置噪音 `unused config key net.timeout`，与代码无关）
- `scripts/docs-lint.sh` — 命名规范 ✓、en/zh 目录对等 ✓
- `scripts/docs-link-check.py` — 全部相对链接可解析 ✓
- 一致性自检：用脚本比对文档 §4.1 两段 JSON 示例与
  `protocol_tests.rs` 中 `*_roadmap_example` 固定示例，**逐字段一致**

**环境概要**：Linux x86_64；rustc/cargo 1.96.0。

**未运行项及原因**：

- 全仓库 `cargo test --workspace`、`make test-integration`、
  `make test-hook-parity`：本次未改动任何功能代码、构建配置或测试目标，
  受影响三个 crate 的测试套件已全量通过，故未重复运行更大套件。

## Documentation and rollback

Adds `src/tokenless/docs/roadmap/evolution-roadmap.md` and its `_zh` mirror
per the bilingual documentation standard, cross-linked in both headers. Roll
back by reverting the single commit.
