### PR TITLE
feat(sec-core): add health probe for daemon

### DIFF
--- a/src/agent-sec-core/tests/unit-test/daemon/test_healthcheck_shell.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_healthcheck_shell.py
@@ -1,0 +1,204 @@
+"""Tests for the lightweight daemon health probe."""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PROBE = _REPO_ROOT / "tools" / "agent-sec-daemon-health.sh"
+_REQUIRED_COMMANDS = ("curl", "jq")
+
+pytestmark = pytest.mark.skipif(
+    any(shutil.which(command) is None for command in _REQUIRED_COMMANDS),
+    reason="shell health probe runtime commands are unavailable",
+)
+
+
+def _daemon_environment(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    socket_path = tmp_path / "runtime" / "daemon.sock"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "AGENT_SEC_DAEMON_SOCKET": str(socket_path),
+            "AGENT_SEC_DATA_DIR": str(tmp_path / "events"),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+        }
+    )
+    return environment, socket_path
+
+
+def _start_daemon_at(
+    environment: dict[str, str], socket_path: Path
+) -> subprocess.Popen[str]:
+    process = subprocess.Popen(
+        [sys.executable, "-m", "agent_sec_cli.daemon.server", "serve"],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if socket_path.is_socket():
+            return process
+        if process.poll() is not None:
+            _stdout, stderr = process.communicate()
+            pytest.fail(f"daemon exited before creating its socket: {stderr}")
+        time.sleep(0.02)
+
+    process.terminate()
+    _stdout, stderr = process.communicate(timeout=5)
+    pytest.fail(f"daemon did not create its socket: {stderr}")
+
+
+def _start_daemon(tmp_path: Path) -> tuple[subprocess.Popen[str], dict[str, str], Path]:
+    environment, socket_path = _daemon_environment(tmp_path)
+    process = _start_daemon_at(environment, socket_path)
+    return process, environment, socket_path
+
+
+def _stop_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.communicate(timeout=5)
+
+
+def test_shell_probe_accepts_the_real_daemon(tmp_path: Path) -> None:
+    daemon, environment, _socket_path = _start_daemon(tmp_path)
+    try:
+        result = subprocess.run(
+            [str(_PROBE)],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    finally:
+        _stop_process(daemon)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+
+
+def test_shell_probe_uses_daemon_xdg_socket_default(tmp_path: Path) -> None:
+    environment, _explicit_socket = _daemon_environment(tmp_path)
+    environment.pop("AGENT_SEC_DAEMON_SOCKET")
+    environment["XDG_RUNTIME_DIR"] = str(tmp_path / "xdg-runtime")
+    socket_path = (
+        Path(environment["XDG_RUNTIME_DIR"]) / "agent-sec-core" / "daemon.sock"
+    )
+    daemon = _start_daemon_at(environment, socket_path)
+    try:
+        result = subprocess.run(
+            [str(_PROBE)],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    finally:
+        _stop_process(daemon)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("option", ["--require-model", "--require-same-cgroup"])
+def test_shell_probe_rejects_obsolete_options(option: str) -> None:
+    result = subprocess.run(
+        [str(_PROBE), option],
+        capture_output=True,
+        text=True,
+        timeout=3,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert f"unknown argument: {option}" in result.stderr
+
+
+def test_shell_probe_rejects_unhealthy_daemon_status(tmp_path: Path) -> None:
+    environment, socket_path = _daemon_environment(tmp_path)
+    fake_server_code = r"""
+import json
+import socket
+import sys
+from pathlib import Path
+
+socket_path = Path(sys.argv[1])
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+socket_path.parent.mkdir(parents=True, exist_ok=True)
+server.bind(str(socket_path))
+server.listen()
+print("ready", flush=True)
+connection, _ = server.accept()
+with connection:
+    request = b""
+    while b"\n" not in request:
+        chunk = connection.recv(4096)
+        if not chunk:
+            break
+        request += chunk
+    response = {
+        "request_id": "test",
+        "ok": True,
+        "data": {"status": "stopping"},
+    }
+    connection.sendall(json.dumps(response).encode("utf-8") + b"\n")
+"""
+    fake_server = subprocess.Popen(
+        [sys.executable, "-c", fake_server_code, str(socket_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        assert fake_server.stdout is not None
+        ready = fake_server.stdout.readline().strip()
+        if ready != "ready":
+            _stdout, stderr = fake_server.communicate(timeout=3)
+            pytest.fail(f"fake health server failed to start: {stderr}")
+        result = subprocess.run(
+            [str(_PROBE)],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    finally:
+        _stop_process(fake_server)
+
+    assert result.returncode == 1
+    assert "daemon returned an invalid or unhealthy response" in result.stderr
+
+
+def test_shell_probe_short_circuits_when_socket_is_missing(tmp_path: Path) -> None:
+    environment, socket_path = _daemon_environment(tmp_path)
+
+    result = subprocess.run(
+        [str(_PROBE)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=3,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert f"socket is missing or is not a Unix socket: {socket_path}" in result.stderr

--- a/src/agent-sec-core/tools/agent-sec-daemon-health.sh
+++ b/src/agent-sec-core/tools/agent-sec-daemon-health.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Lightweight health probe for agent-sec-daemon.
+
+set -eu
+
+readonly DEFAULT_TIMEOUT_SECONDS="1"
+
+fail() {
+    printf 'agent-sec-daemon health check failed: %s\n' "$1" >&2
+    exit 1
+}
+
+usage() {
+    printf '%s\n' \
+        "Usage: ${0##*/}" \
+        "" \
+        "Checks daemon.health status over its Unix socket."
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+    shift
+done
+
+for command_name in curl jq; do
+    command -v "$command_name" >/dev/null 2>&1 || fail "missing command: $command_name"
+done
+
+if [ -n "${AGENT_SEC_DAEMON_SOCKET:-}" ]; then
+    socket_path=$AGENT_SEC_DAEMON_SOCKET
+elif [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+    socket_path="$XDG_RUNTIME_DIR/agent-sec-core/daemon.sock"
+else
+    current_uid=$(id -u)
+    if [ -d "/run/user/$current_uid" ]; then
+        socket_path="/run/user/$current_uid/agent-sec-core/daemon.sock"
+    else
+        fail "XDG_RUNTIME_DIR is required when AGENT_SEC_DAEMON_SOCKET is unset"
+    fi
+fi
+timeout_seconds=${AGENT_SEC_HEALTH_TIMEOUT_SECONDS:-$DEFAULT_TIMEOUT_SECONDS}
+
+case "$socket_path" in
+    /*) ;;
+    *) fail "socket path must be absolute: $socket_path" ;;
+esac
+[ -S "$socket_path" ] || fail "socket is missing or is not a Unix socket: $socket_path"
+
+request='{"method":"daemon.health","params":{},"trace_context":{},"caller":"container-health","timeout_ms":1000}'
+response=$(
+    printf '%s\n' "$request" |
+        curl \
+            --silent \
+            --show-error \
+            --no-buffer \
+            --proto '=telnet' \
+            --connect-timeout "$timeout_seconds" \
+            --max-time "$timeout_seconds" \
+            --unix-socket "$socket_path" \
+            --upload-file - \
+            telnet://localhost
+) || fail "daemon.health request failed (socket: $socket_path, timeout: ${timeout_seconds}s)"
+
+printf '%s\n' "$response" |
+    jq --exit-status --slurp \
+        'length == 1
+            and .[0].ok == true
+            and .[0].data.status == "ok"' >/dev/null ||
+    fail "daemon returned an invalid or unhealthy response"


### PR DESCRIPTION
## Why

The existing container health probe starts the bundled Python runtime for every
check. Its observed cold-start latency is close to the Kubernetes two-second
probe timeout, which can cause false unhealthy results and unnecessary daemon
restarts under load.

## What changed

- Add a POSIX shell probe that sends `daemon.health` over the daemon Unix socket
  with `curl` and validates the response with `jq`.
- Check only RPC success and `data.status == "ok"`; model readiness and process,
  lock, cgroup, inode, or peer-identity checks are intentionally not part of this
  probe.
- Fail immediately when the socket is absent and use the same explicit/XDG UID
  fallback socket resolution as the daemon.
- Ship `/usr/local/bin/agent-sec-daemon-health` in source, RPM, and raw-package
  install artifacts, with `curl` and `jq` declared as runtime dependencies.

## Related issue

fixes https://github.com/alibaba/anolisa/issues/2849

The forged-UDS peer-authentication problem in #2846 remains out of scope and is
not fixed by this PR.

## User / Agent impact

Container health checks avoid Python cold-start overhead. The probe reports only
daemon status; callers must not pass the former `--require-model` option.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The installed probe path is unchanged, but its accepted arguments are narrowed
to status-only operation. Remove `--require-model` from existing probe commands.
The probe does not authenticate the UDS peer and therefore makes no security
claim for #2846.

## Validation

- `agent-sec-cli/.venv/bin/pytest tests/unit-test/daemon/test_healthcheck_shell.py -q`
  (`6 passed`)
- `bash tests/packaging/test-package-raw.sh`
- `sh -n tools/agent-sec-daemon-health.sh`
- `ruff check` on the changed Python test and raw release verifier
- Local healthy-response benchmark, 30 samples: median 107.13 ms, p95 108.89 ms,
  max 109.94 ms

## Documentation and rollback

The PR description documents the status-only behavior and removal of
`--require-model`. Roll back by reverting this change and restoring the previous
Python health probe in the image build.
