### PR TITLE
ci(ci): build anolisa prebuilt packages

### DIFF
--- a/.github/actions/build-anolisa-prebuilt/action.yaml
+++ b/.github/actions/build-anolisa-prebuilt/action.yaml
@@ -1,0 +1,54 @@
+name: Build ANOLISA CLI prebuilt package
+description: Build and package one ANOLISA CLI release target on the release Cross runner.
+
+inputs:
+  version:
+    description: Component version without the v prefix.
+    required: true
+  target-os:
+    description: Package target operating system.
+    required: true
+  target-arch:
+    description: Package target architecture.
+    required: true
+  profile:
+    description: Prepared Cross release profile.
+    required: true
+  tag:
+    description: Release tag to bind to the checked-out commit. Empty for previews.
+    required: false
+    default: ''
+
+outputs:
+  artifact-directory:
+    description: Directory containing the tar, checksums, and CycloneDX SBOM.
+    value: ${{ steps.build.outputs.artifact-directory }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Build precompiled package
+      id: build
+      shell: bash
+      env:
+        ANOLISA_OUTPUT_DIR: ${{ runner.temp }}/anolisa-prebuilt-${{ inputs.target-os }}-${{ inputs.target-arch }}
+        ANOLISA_VERSION: ${{ inputs.version }}
+        ANOLISA_TARGET_OS: ${{ inputs.target-os }}
+        ANOLISA_TARGET_ARCH: ${{ inputs.target-arch }}
+        ANOLISA_PROFILE: ${{ inputs.profile }}
+        ANOLISA_TAG: ${{ inputs.tag }}
+      run: |
+        "$GITHUB_ACTION_PATH/build.sh" \
+          --source-repo "$GITHUB_WORKSPACE" \
+          --output-dir "$ANOLISA_OUTPUT_DIR" \
+          --version "$ANOLISA_VERSION" \
+          --target-os "$ANOLISA_TARGET_OS" \
+          --target-arch "$ANOLISA_TARGET_ARCH" \
+          --profile "$ANOLISA_PROFILE" \
+          --tag "$ANOLISA_TAG"
+        echo "artifact-directory=$ANOLISA_OUTPUT_DIR" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-anolisa-prebuilt/build.sh
+++ b/.github/actions/build-anolisa-prebuilt/build.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Build and package one reproducible ANOLISA CLI precompiled release target.
+set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
+FIXED_WORKTREE="${ANOLISA_SOURCE_WORKTREE:-/tmp/anolisa-raw-release-source-worktrees/anolisa}"
+VERSION=""
+TARGET_OS=""
+TARGET_ARCH=""
+PROFILE=""
+TAG=""
+SOURCE_REPO=""
+OUTPUT_DIR=""
+WORKTREE_READY=0
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: build.sh --source-repo PATH --output-dir PATH --version X.Y.Z \
+  --target-os {linux|macos} --target-arch {x86_64|aarch64} \
+  --profile PROFILE [--tag anolisa/vX.Y.Z]
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --source-repo) SOURCE_REPO="${2:-}"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+        --version) VERSION="${2:-}"; shift 2 ;;
+        --target-os) TARGET_OS="${2:-}"; shift 2 ;;
+        --target-arch) TARGET_ARCH="${2:-}"; shift 2 ;;
+        --profile) PROFILE="${2:-}"; shift 2 ;;
+        --tag) TAG="${2:-}"; shift 2 ;;
+        --help | -h) usage; exit 0 ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+[ -n "$VERSION" ] || die '--version is required'
+[ -n "$TARGET_OS" ] || die '--target-os is required'
+[ -n "$TARGET_ARCH" ] || die '--target-arch is required'
+[ -n "$PROFILE" ] || die '--profile is required'
+[ -n "$SOURCE_REPO" ] || die '--source-repo is required'
+[ -n "$OUTPUT_DIR" ] || die '--output-dir is required'
+SEMVER_PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.'
+SEMVER_PATTERN+='(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?'
+SEMVER_PATTERN+='(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+[[ "$VERSION" =~ $SEMVER_PATTERN ]] || \
+    die "invalid ANOLISA CLI version: $VERSION"
+
+case "$TARGET_OS/$TARGET_ARCH/$PROFILE" in
+    linux/x86_64/gnu2.17-x86_64)
+        RUST_TARGET=x86_64-unknown-linux-gnu
+        ;;
+    linux/aarch64/gnu2.17-aarch64)
+        RUST_TARGET=aarch64-unknown-linux-gnu
+        ;;
+    macos/aarch64/darwin11-aarch64)
+        RUST_TARGET=aarch64-apple-darwin
+        ;;
+    *)
+        die "profile $PROFILE does not match target $TARGET_OS/$TARGET_ARCH"
+        ;;
+esac
+
+if [ -n "$TAG" ] && [ "$TAG" != "anolisa/v$VERSION" ]; then
+    die "release tag $TAG does not match requested version $VERSION"
+fi
+for command in cargo cargo-sbom flock git gzip install python3 readelf sha256sum tar; do
+    command -v "$command" >/dev/null || die "missing required command: $command"
+done
+SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
+    die "source-repo is not a Git worktree"
+SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+
+if [ -n "$TAG" ]; then
+    TAG_COMMIT="$(git -C "$SOURCE_REPO" rev-parse --verify "refs/tags/$TAG^{commit}")" || \
+        die "release tag is unavailable in the checkout: $TAG"
+    [ "$TAG_COMMIT" = "$SOURCE_COMMIT" ] || \
+        die "release tag $TAG does not point at checked-out commit $SOURCE_COMMIT"
+fi
+
+install -d -m 0755 "$(dirname "$FIXED_WORKTREE")"
+exec 9>"${FIXED_WORKTREE}.lock"
+flock -n 9 || die "ANOLISA CLI source worktree is already in use"
+
+worktree_registered() {
+    git -C "$SOURCE_REPO" worktree list --porcelain | \
+        grep -Fxq "worktree $FIXED_WORKTREE"
+}
+
+cleanup() {
+    if [ "$WORKTREE_READY" -eq 1 ] && worktree_registered; then
+        git -C "$SOURCE_REPO" worktree unlock "$FIXED_WORKTREE" >/dev/null 2>&1 || true
+        git -C "$SOURCE_REPO" worktree remove --force "$FIXED_WORKTREE" >/dev/null 2>&1 || \
+            printf 'WARN: failed to remove source worktree: %s\n' "$FIXED_WORKTREE" >&2
+    fi
+}
+trap cleanup EXIT
+
+[ ! -L "$FIXED_WORKTREE" ] || die "fixed worktree path must not be a symbolic link"
+if worktree_registered; then
+    git -C "$SOURCE_REPO" worktree unlock "$FIXED_WORKTREE" >/dev/null 2>&1 || true
+    git -C "$SOURCE_REPO" worktree remove --force "$FIXED_WORKTREE" || \
+        die "cannot remove the previous registered worktree: $FIXED_WORKTREE"
+elif [ -e "$FIXED_WORKTREE" ]; then
+    [ -d "$FIXED_WORKTREE" ] || die "fixed worktree path is not a directory"
+    rmdir "$FIXED_WORKTREE" 2>/dev/null || \
+        die "refusing to delete a non-empty unregistered path: $FIXED_WORKTREE"
+fi
+git -C "$SOURCE_REPO" worktree add --detach "$FIXED_WORKTREE" "$SOURCE_COMMIT"
+WORKTREE_READY=1
+git -C "$SOURCE_REPO" worktree lock --reason 'ANOLISA CLI prebuilt package build' \
+    "$FIXED_WORKTREE"
+
+COMPONENT_ROOT="$FIXED_WORKTREE/src/anolisa"
+SOURCE_VERSION="$(
+    python3 "$COMPONENT_ROOT/packaging/prebuilt/verify-release.py" \
+        "$COMPONENT_ROOT" --os "$TARGET_OS" --arch "$TARGET_ARCH"
+)"
+[ "$VERSION" = "$SOURCE_VERSION" ] || \
+    die "requested version $VERSION does not match ANOLISA CLI $SOURCE_VERSION"
+
+if [ -e "$OUTPUT_DIR" ] && [ -n "$(find "$OUTPUT_DIR" -mindepth 1 -print -quit)" ]; then
+    die "output directory must be empty: $OUTPUT_DIR"
+fi
+install -d -m 0755 "$OUTPUT_DIR"
+SOURCE_DATE_EPOCH="$(git -C "$FIXED_WORKTREE" show -s --format=%ct HEAD)"
+case "$SOURCE_DATE_EPOCH" in
+    '' | *[!0-9]*) die 'source commit timestamp is not numeric' ;;
+esac
+export RUSTUP_TOOLCHAIN=1.93.0-x86_64-unknown-linux-gnu
+export SOURCE_DATE_EPOCH
+
+cargo metadata \
+    --format-version 1 \
+    --locked \
+    --filter-platform "$RUST_TARGET" \
+    --manifest-path "$COMPONENT_ROOT/Cargo.toml" >/dev/null
+
+(
+    cd "$FIXED_WORKTREE"
+    python3 "$COMMON_DIR/reproducible-build.py" \
+        --source-root "$COMPONENT_ROOT" \
+        --source-date-epoch "$SOURCE_DATE_EPOCH" \
+        -- "$COMMON_DIR/cross-profile.sh" "$PROFILE" build \
+        --release \
+        --locked \
+        --package anolisa-cli \
+        --manifest-path src/anolisa/Cargo.toml
+)
+
+BIN_DIR="$COMPONENT_ROOT/target/$RUST_TARGET/release"
+[ -x "$BIN_DIR/anolisa" ] || die "Cross build did not produce $BIN_DIR/anolisa"
+if [ "$TARGET_OS" = macos ]; then
+    python3 "$COMMON_DIR/verify-macho.py" --min 11.0 "$BIN_DIR/anolisa"
+else
+    python3 "$COMMON_DIR/verify-glibc.py" \
+        --arch "$TARGET_ARCH" --max 2.17 "$BIN_DIR/anolisa"
+fi
+
+METADATA="$BIN_DIR/anolisa-build.toml"
+cat > "$METADATA" <<EOF
+version = "$VERSION"
+target_os = "$TARGET_OS"
+target_arch = "$TARGET_ARCH"
+
+[binaries]
+anolisa = "$(sha256sum "$BIN_DIR/anolisa" | awk '{print $1}')"
+EOF
+
+ANOLISA_SOURCE_DIR="$COMPONENT_ROOT" \
+ANOLISA_BUILD_METADATA="$METADATA" \
+BIN_DIR="$BIN_DIR" \
+OUTPUT_DIR="$OUTPUT_DIR" \
+TARGET_OS="$TARGET_OS" \
+TARGET_ARCH="$TARGET_ARCH" \
+SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
+    "$COMPONENT_ROOT/packaging/prebuilt/package.sh" package >/dev/null
+
+ARCHIVE="anolisa-$VERSION-$TARGET_OS-$TARGET_ARCH.tar.gz"
+(
+    cd "$OUTPUT_DIR"
+    sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+)
+python3 "$COMMON_DIR/generate-sbom.py" \
+    --artifact "$OUTPUT_DIR/$ARCHIVE" \
+    --component anolisa \
+    --version "$VERSION" \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH" \
+    --target "$RUST_TARGET" \
+    --project-dir "$COMPONENT_ROOT" \
+    --source-date-epoch "$SOURCE_DATE_EPOCH" >/dev/null
+python3 "$COMMON_DIR/verify-artifacts.py" \
+    --directory "$OUTPUT_DIR" \
+    --component anolisa \
+    --version "$VERSION" \
+    --layout flat \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH"
+printf 'Built ANOLISA CLI %s for %s/%s at %s\n' \
+    "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$OUTPUT_DIR"

--- a/.github/actions/build-anolisa-prebuilt/test.sh
+++ b/.github/actions/build-anolisa-prebuilt/test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Exercise ANOLISA CLI action input binding and release metadata validation.
+set -euo pipefail
+
+ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
+REPO_ROOT="$(git -C "$ACTION_DIR" rev-parse --show-toplevel)"
+COMPONENT_ROOT="$REPO_ROOT/src/anolisa"
+TEMPORARY="$(mktemp -d)"
+trap 'rm -rf -- "$TEMPORARY"' EXIT
+
+python3 - "$ACTION_DIR/action.yaml" <<'PY'
+import sys
+from pathlib import Path
+
+
+action = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected_bindings = (
+    "ANOLISA_VERSION: ${{ inputs.version }}",
+    "ANOLISA_TARGET_OS: ${{ inputs.target-os }}",
+    "ANOLISA_TARGET_ARCH: ${{ inputs.target-arch }}",
+    "ANOLISA_PROFILE: ${{ inputs.profile }}",
+    "ANOLISA_TAG: ${{ inputs.tag }}",
+)
+for binding in expected_bindings:
+    if binding not in action:
+        raise SystemExit(f"composite action is missing environment binding: {binding}")
+
+marker = "      run: |\n"
+if marker not in action:
+    raise SystemExit("composite action is missing its Bash run block")
+run_block = action.split(marker, 1)[1]
+if "${{ inputs." in run_block:
+    raise SystemExit("composite action interpolates an input directly into Bash")
+PY
+
+python3 - "$COMPONENT_ROOT" "$COMMON_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+
+component_root = Path(sys.argv[1])
+sys.path.insert(0, sys.argv[2])
+from targets import TARGETS  # noqa: E402
+
+identity = {
+    ("linux", "x64"): ("linux", "x86_64"),
+    ("linux", "arm64"): ("linux", "aarch64"),
+    ("darwin", "arm64"): ("macos", "aarch64"),
+}
+npm_targets = set()
+for package_file in (component_root / "npm/platforms").glob("*/package.json"):
+    package = json.loads(package_file.read_text(encoding="utf-8"))
+    try:
+        npm_targets.add(identity[(package["os"][0], package["cpu"][0])])
+    except (KeyError, IndexError) as error:
+        raise SystemExit(f"unsupported npm platform metadata: {package_file}") from error
+matrix_targets = {
+    (target["target-os"], target["target-arch"])
+    for target in TARGETS["anolisa"]
+}
+if matrix_targets != npm_targets:
+    raise SystemExit(
+        f"ANOLISA prebuilt matrix does not match npm platforms: "
+        f"matrix={sorted(matrix_targets)} npm={sorted(npm_targets)}"
+    )
+PY
+
+VERSION="$(
+    python3 "$COMPONENT_ROOT/packaging/prebuilt/verify-release.py" \
+        "$COMPONENT_ROOT" --os linux --arch x86_64
+)"
+for target in 'linux aarch64' 'macos aarch64'; do
+    read -r os_name arch <<<"$target"
+    test "$(
+        python3 "$COMPONENT_ROOT/packaging/prebuilt/verify-release.py" \
+            "$COMPONENT_ROOT" --os "$os_name" --arch "$arch"
+    )" = "$VERSION"
+done
+
+SEMVER_REPO="$TEMPORARY/semver-repo"
+install -d -m 0755 "$SEMVER_REPO/src/anolisa/packaging/prebuilt"
+install -p -m 0644 "$COMPONENT_ROOT/Cargo.toml" "$SEMVER_REPO/src/anolisa/Cargo.toml"
+cp -a "$COMPONENT_ROOT/npm" "$SEMVER_REPO/src/anolisa/npm"
+install -p -m 0755 "$COMPONENT_ROOT/packaging/prebuilt/verify-release.py" \
+    "$SEMVER_REPO/src/anolisa/packaging/prebuilt/verify-release.py"
+git -C "$SEMVER_REPO" init -q
+git -C "$SEMVER_REPO" add -- src/anolisa
+git -C "$SEMVER_REPO" \
+    -c user.name='ANOLISA CI' \
+    -c user.email='ci@localhost' \
+    commit -qm 'test fixture'
+SEMVER_BIN="$TEMPORARY/semver-bin"
+install -d -m 0755 "$SEMVER_BIN"
+printf '#!/usr/bin/env sh\nexit 1\n' > "$SEMVER_BIN/cargo-sbom"
+chmod 0755 "$SEMVER_BIN/cargo-sbom"
+
+BUILD_VERSION="${VERSION}+build.1"
+if PATH="$SEMVER_BIN:$PATH" \
+    ANOLISA_SOURCE_WORKTREE="$TEMPORARY/build-version-worktree/anolisa" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$SEMVER_REPO" \
+        --output-dir "$TEMPORARY/build-version-output" \
+        --version "$BUILD_VERSION" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag '' >"$TEMPORARY/build-version.log" 2>&1; then
+    printf 'ERROR: unsynchronized SemVer build metadata was accepted\n' >&2
+    exit 1
+fi
+if ! grep -Fq \
+    "requested version $BUILD_VERSION does not match ANOLISA CLI $VERSION" \
+    "$TEMPORARY/build-version.log"; then
+    cat "$TEMPORARY/build-version.log" >&2
+    exit 1
+fi
+
+MARKER="$TEMPORARY/injected"
+if ANOLISA_SOURCE_WORKTREE="$TEMPORARY/version-worktree/anolisa" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/version-output" \
+        --version "${VERSION}\$(touch ${MARKER})" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag '' >"$TEMPORARY/version.log" 2>&1; then
+    printf 'ERROR: malicious version input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious version input executed a command\n' >&2
+    exit 1
+}
+
+if ANOLISA_SOURCE_WORKTREE="$TEMPORARY/tag-worktree/anolisa" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$REPO_ROOT" \
+        --output-dir "$TEMPORARY/tag-output" \
+        --version "$VERSION" \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag "anolisa/v${VERSION}\$(touch ${MARKER})" \
+        >"$TEMPORARY/tag.log" 2>&1; then
+    printf 'ERROR: malicious tag input was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: malicious tag input executed a command\n' >&2
+    exit 1
+}
+
+printf 'ANOLISA CLI prebuilt action tests passed\n'

--- a/.github/actions/prebuilt-rust-common/targets.py
+++ b/.github/actions/prebuilt-rust-common/targets.py
@@ -4,6 +4,23 @@ from __future__ import annotations
 
 
 TARGETS = {
+    "anolisa": (
+        {
+            "target-os": "linux",
+            "target-arch": "x86_64",
+            "profile": "gnu2.17-x86_64",
+        },
+        {
+            "target-os": "linux",
+            "target-arch": "aarch64",
+            "profile": "gnu2.17-aarch64",
+        },
+        {
+            "target-os": "macos",
+            "target-arch": "aarch64",
+            "profile": "darwin11-aarch64",
+        },
+    ),
     "cosh-ng": (
         {
             "target-os": "linux",

--- a/.github/actions/prebuilt-rust-common/test_plan_matrix.py
+++ b/.github/actions/prebuilt-rust-common/test_plan_matrix.py
@@ -9,6 +9,19 @@ import plan_matrix
 
 
 class PlanMatrixTests(unittest.TestCase):
+    def test_anolisa_targets(self) -> None:
+        matrix = plan_matrix.build_matrix("anolisa")
+
+        self.assertEqual(
+            [(row["target-os"], row["target-arch"], row["profile"]) for row in matrix["include"]],
+            [
+                ("linux", "x86_64", "gnu2.17-x86_64"),
+                ("linux", "aarch64", "gnu2.17-aarch64"),
+                ("macos", "aarch64", "darwin11-aarch64"),
+            ],
+        )
+        self.assertTrue(all(row["component"] == "anolisa" for row in matrix["include"]))
+
     def test_cosh_ng_targets(self) -> None:
         matrix = plan_matrix.build_matrix("cosh-ng")
 
@@ -36,7 +49,7 @@ class PlanMatrixTests(unittest.TestCase):
         self.assertTrue(all(row["component"] == "tokenless" for row in matrix["include"]))
 
     def test_component_without_prebuilt_targets(self) -> None:
-        self.assertEqual(plan_matrix.build_matrix("anolisa"), {"include": []})
+        self.assertEqual(plan_matrix.build_matrix("agentsight"), {"include": []})
 
 
 if __name__ == "__main__":

--- a/.github/workflows/anolisa-prebuilt-ci.yaml
+++ b/.github/workflows/anolisa-prebuilt-ci.yaml
@@ -1,0 +1,53 @@
+name: CI / ANOLISA CLI prebuilt action
+
+on:
+  push:
+    branches: [main, 'release/**']
+    paths:
+      - '.github/actions/build-anolisa-prebuilt/**'
+      - '.github/actions/prebuilt-rust-common/**'
+      - '.github/workflows/anolisa-prebuilt-ci.yaml'
+      - '.github/workflows/release.yaml'
+      - '.github/workflows/release-preview.yaml'
+      - 'src/anolisa/**'
+  pull_request:
+    branches: [main, 'release/**']
+    paths:
+      - '.github/actions/build-anolisa-prebuilt/**'
+      - '.github/actions/prebuilt-rust-common/**'
+      - '.github/workflows/anolisa-prebuilt-ci.yaml'
+      - '.github/workflows/release.yaml'
+      - '.github/workflows/release-preview.yaml'
+      - 'src/anolisa/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  RUSTUP_DIST_SERVER: https://static.rust-lang.org
+  RUSTUP_UPDATE_ROOT: https://static.rust-lang.org/rustup
+  RUSTUP_TOOLCHAIN: '1.93.0'
+
+jobs:
+  test:
+    name: Test ANOLISA CLI prebuilt action
+    runs-on: anolisa-k8s-general-ci-x64
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: dtolnay/rust-toolchain@1.93.0
+
+      - name: Run prebuilt action regression tests
+        run: .github/actions/build-anolisa-prebuilt/test.sh
+
+      - name: Run prebuilt matrix planner tests
+        run: python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py
+
+      - name: Run ANOLISA CLI prebuilt package tests
+        run: src/anolisa/tests/test-package-prebuilt.sh

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -114,15 +114,27 @@ jobs:
           target-arch: ${{ matrix.target-arch }}
           profile: ${{ matrix.profile }}
 
+      - name: Build ANOLISA CLI precompiled package
+        id: anolisa-prebuilt
+        if: matrix.component == 'anolisa'
+        uses: ./.github/actions/build-anolisa-prebuilt
+        with:
+          version: ${{ inputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+
       - name: Select precompiled package output
         id: prebuilt
         shell: bash
         env:
           COMPONENT: ${{ matrix.component }}
+          ANOLISA_DIRECTORY: ${{ steps.anolisa-prebuilt.outputs.artifact-directory }}
           COSH_NG_DIRECTORY: ${{ steps.cosh-ng-prebuilt.outputs.artifact-directory }}
           TOKENLESS_DIRECTORY: ${{ steps.tokenless-prebuilt.outputs.artifact-directory }}
         run: |
           case "$COMPONENT" in
+            anolisa) ARTIFACT_DIRECTORY="$ANOLISA_DIRECTORY" ;;
             cosh-ng) ARTIFACT_DIRECTORY="$COSH_NG_DIRECTORY" ;;
             tokenless) ARTIFACT_DIRECTORY="$TOKENLESS_DIRECTORY" ;;
             *) echo "::error::Unsupported prebuilt component: $COMPONENT"; exit 1 ;;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,15 +145,28 @@ jobs:
           profile: ${{ matrix.profile }}
           tag: ${{ needs.package.outputs.tag }}
 
+      - name: Build ANOLISA CLI precompiled package
+        id: anolisa-prebuilt
+        if: matrix.component == 'anolisa'
+        uses: ./.github/actions/build-anolisa-prebuilt
+        with:
+          version: ${{ needs.package.outputs.version }}
+          target-os: ${{ matrix.target-os }}
+          target-arch: ${{ matrix.target-arch }}
+          profile: ${{ matrix.profile }}
+          tag: ${{ needs.package.outputs.tag }}
+
       - name: Select precompiled package output
         id: prebuilt
         shell: bash
         env:
           COMPONENT: ${{ matrix.component }}
+          ANOLISA_DIRECTORY: ${{ steps.anolisa-prebuilt.outputs.artifact-directory }}
           COSH_NG_DIRECTORY: ${{ steps.cosh-ng-prebuilt.outputs.artifact-directory }}
           TOKENLESS_DIRECTORY: ${{ steps.tokenless-prebuilt.outputs.artifact-directory }}
         run: |
           case "$COMPONENT" in
+            anolisa) ARTIFACT_DIRECTORY="$ANOLISA_DIRECTORY" ;;
             cosh-ng) ARTIFACT_DIRECTORY="$COSH_NG_DIRECTORY" ;;
             tokenless) ARTIFACT_DIRECTORY="$TOKENLESS_DIRECTORY" ;;
             *) echo "::error::Unsupported prebuilt component: $COMPONENT"; exit 1 ;;

--- a/src/anolisa/packaging/prebuilt/package.sh
+++ b/src/anolisa/packaging/prebuilt/package.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Assemble one verified ANOLISA CLI binary into a reproducible release archive.
+set -euo pipefail
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[ "${1:-}" = package ] || die "usage: $0 package"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ROOT="${ANOLISA_SOURCE_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+BIN_DIR="${BIN_DIR:-$SOURCE_ROOT/target/release}"
+OUTPUT_DIR="${OUTPUT_DIR:-$SOURCE_ROOT/target/prebuilt}"
+TARGET_OS="${TARGET_OS:-}"
+TARGET_ARCH="${TARGET_ARCH:-}"
+BUILD_METADATA="${ANOLISA_BUILD_METADATA:-$BIN_DIR/anolisa-build.toml}"
+EPOCH="${SOURCE_DATE_EPOCH:-}"
+
+case "$TARGET_OS/$TARGET_ARCH" in
+    linux/x86_64 | linux/aarch64 | macos/aarch64) ;;
+    *) die "unsupported ANOLISA CLI target: $TARGET_OS/$TARGET_ARCH" ;;
+esac
+case "$EPOCH" in
+    '' | *[!0-9]*) die "SOURCE_DATE_EPOCH must be a non-negative integer" ;;
+esac
+[ -x "$BIN_DIR/anolisa" ] || die "missing executable: $BIN_DIR/anolisa"
+[ ! -L "$BIN_DIR/anolisa" ] || die "ANOLISA CLI binary must not be a symbolic link"
+[ -f "$BUILD_METADATA" ] || die "missing build metadata: $BUILD_METADATA"
+tar --version 2>/dev/null | grep -q 'GNU tar' || \
+    die "GNU tar is required for reproducible prebuilt packages"
+
+VERSION="$(
+    python3 "$SCRIPT_DIR/verify-release.py" "$SOURCE_ROOT" \
+        --os "$TARGET_OS" --arch "$TARGET_ARCH"
+)"
+python3 "$SCRIPT_DIR/verify-binary.py" \
+    --metadata "$BUILD_METADATA" \
+    --version "$VERSION" \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH" \
+    "$BIN_DIR/anolisa"
+
+WORK="$(mktemp -d)"
+TEMP_ARTIFACT=""
+cleanup() {
+    rm -rf "$WORK"
+    if [ -n "$TEMP_ARTIFACT" ]; then
+        rm -f "$TEMP_ARTIFACT"
+    fi
+}
+trap cleanup EXIT
+
+STAGE="$WORK/stage"
+install -d -m 0755 "$STAGE" "$OUTPUT_DIR"
+install -p -m 0755 "$BIN_DIR/anolisa" "$STAGE/anolisa"
+ARTIFACT="anolisa-$VERSION-$TARGET_OS-$TARGET_ARCH.tar.gz"
+TEMP_ARTIFACT="$OUTPUT_DIR/.$ARTIFACT.tmp.$$"
+LC_ALL=C tar \
+    --sort=name \
+    --mtime="@$EPOCH" \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    --hard-dereference \
+    --format=gnu \
+    -C "$STAGE" \
+    -cf - . | gzip -n -9 > "$TEMP_ARTIFACT"
+mv -f "$TEMP_ARTIFACT" "$OUTPUT_DIR/$ARTIFACT"
+TEMP_ARTIFACT=""
+printf '%s\n' "$OUTPUT_DIR/$ARTIFACT"

--- a/src/anolisa/packaging/prebuilt/verify-binary.py
+++ b/src/anolisa/packaging/prebuilt/verify-binary.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Bind one ANOLISA CLI binary to prebuilt build metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import tomllib
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    """Return a file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    """Validate the binary checksum and target identity."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=("x86_64", "aarch64"), required=True)
+    parser.add_argument("binary", type=Path)
+    args = parser.parse_args()
+
+    try:
+        with args.metadata.open("rb") as stream:
+            metadata = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {args.metadata}: {error}") from error
+    if set(metadata) != {"version", "target_os", "target_arch", "binaries"}:
+        raise SystemExit(f"ERROR: unexpected fields in {args.metadata}")
+    binaries = metadata.get("binaries")
+    if not isinstance(binaries, dict) or set(binaries) != {"anolisa"}:
+        raise SystemExit(f"ERROR: {args.metadata} must identify only the anolisa binary")
+    if (
+        metadata.get("version") != args.version
+        or metadata.get("target_os") != args.os
+        or metadata.get("target_arch") != args.arch
+    ):
+        raise SystemExit(f"ERROR: {args.metadata} target identity does not match the package")
+    try:
+        digest = sha256_file(args.binary)
+    except OSError as error:
+        raise SystemExit(f"ERROR: cannot read {args.binary}: {error}") from error
+    if binaries.get("anolisa") != digest:
+        raise SystemExit(f"ERROR: {args.binary} checksum does not match {args.metadata}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/anolisa/packaging/prebuilt/verify-release.py
+++ b/src/anolisa/packaging/prebuilt/verify-release.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate ANOLISA CLI release metadata before prebuilt packaging."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+from pathlib import Path
+
+
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+TARGET_PACKAGES = {
+    ("linux", "x86_64"): ("linux-x64", "linux", "x64"),
+    ("linux", "aarch64"): ("linux-arm64", "linux", "arm64"),
+    ("macos", "aarch64"): ("darwin-arm64", "darwin", "arm64"),
+}
+
+
+def read_toml(path: Path) -> dict[str, object]:
+    """Read one TOML document with path-aware errors."""
+    try:
+        with path.open("rb") as stream:
+            return tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+
+
+def read_json(path: Path) -> dict[str, object]:
+    """Read one JSON object with path-aware errors."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"ERROR: cannot read {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise SystemExit(f"ERROR: {path} must contain a JSON object")
+    return value
+
+
+def source_version(root: Path) -> str:
+    """Return the authoritative workspace version."""
+    cargo = read_toml(root / "Cargo.toml")
+    workspace = cargo.get("workspace")
+    package = workspace.get("package") if isinstance(workspace, dict) else None
+    version = package.get("version") if isinstance(package, dict) else None
+    if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
+        raise SystemExit(f"ERROR: {root / 'Cargo.toml'} has no valid workspace version")
+    return version
+
+
+def verify_release(root: Path, os_name: str, arch: str) -> str:
+    """Return the synchronized version after validating npm release metadata."""
+    target = TARGET_PACKAGES.get((os_name, arch))
+    if target is None:
+        raise SystemExit(f"ERROR: unsupported ANOLISA CLI target: {os_name}/{arch}")
+    suffix, npm_os, npm_cpu = target
+    version = source_version(root)
+    npm_root = root / "npm"
+    root_package = read_json(npm_root / "package.json")
+    if root_package.get("name") != "@anolisa/cli":
+        raise SystemExit(f"ERROR: {npm_root / 'package.json'} has the wrong package name")
+    if root_package.get("version") != version:
+        raise SystemExit(
+            f"ERROR: {npm_root / 'package.json'} version does not match {version}"
+        )
+
+    platform_packages: dict[str, str] = {}
+    platforms = npm_root / "platforms"
+    try:
+        package_files = sorted(platforms.glob("*/package.json"))
+    except OSError as error:
+        raise SystemExit(f"ERROR: cannot list {platforms}: {error}") from error
+    if not package_files:
+        raise SystemExit(f"ERROR: no npm platform packages found under {platforms}")
+    for package_file in package_files:
+        package = read_json(package_file)
+        name = package.get("name")
+        package_version = package.get("version")
+        if not isinstance(name, str) or not name.startswith("@anolisa/cli-"):
+            raise SystemExit(f"ERROR: {package_file} has the wrong package name")
+        if package_version != version:
+            raise SystemExit(f"ERROR: {package_file} version does not match {version}")
+        platform_packages[name] = version
+
+    optional = root_package.get("optionalDependencies")
+    if optional != platform_packages:
+        raise SystemExit(
+            f"ERROR: {npm_root / 'package.json'} optionalDependencies do not match "
+            "the platform packages"
+        )
+
+    target_file = platforms / suffix / "package.json"
+    target_package = read_json(target_file)
+    if (
+        target_package.get("name") != f"@anolisa/cli-{suffix}"
+        or target_package.get("os") != [npm_os]
+        or target_package.get("cpu") != [npm_cpu]
+    ):
+        raise SystemExit(f"ERROR: {target_file} does not describe {os_name}/{arch}")
+    return version
+
+
+def main() -> int:
+    """Print the verified ANOLISA CLI version."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("--os", choices=("linux", "macos"), required=True)
+    parser.add_argument("--arch", choices=("x86_64", "aarch64"), required=True)
+    args = parser.parse_args()
+    print(verify_release(args.source_root.resolve(), args.os, args.arch))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/anolisa/tests/test-package-prebuilt.sh
+++ b/src/anolisa/tests/test-package-prebuilt.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Exercise the component-owned ANOLISA CLI prebuilt packer without compiling.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKER="$ROOT/packaging/prebuilt/package.sh"
+VERIFIER="$ROOT/packaging/prebuilt/verify-release.py"
+TEMPORARY="$(mktemp -d)"
+trap 'rm -rf -- "$TEMPORARY"' EXIT
+
+VERSION="$(python3 "$VERIFIER" "$ROOT" --os linux --arch x86_64)"
+BIN_DIR="$TEMPORARY/bin"
+install -d -m 0755 "$BIN_DIR"
+printf '#!/usr/bin/env sh\nexit 0\n' > "$BIN_DIR/anolisa"
+chmod 0755 "$BIN_DIR/anolisa"
+DIGEST="$(sha256sum "$BIN_DIR/anolisa" | awk '{print $1}')"
+
+write_metadata() {
+    local os_name="$1"
+    local arch="$2"
+    local path="$3"
+
+    cat > "$path" <<EOF
+version = "$VERSION"
+target_os = "$os_name"
+target_arch = "$arch"
+
+[binaries]
+anolisa = "$DIGEST"
+EOF
+}
+
+run_pack() {
+    local os_name="$1"
+    local arch="$2"
+    local output="$3"
+    local metadata="$TEMPORARY/$os_name-$arch.toml"
+
+    write_metadata "$os_name" "$arch" "$metadata"
+    ANOLISA_SOURCE_DIR="$ROOT" \
+    ANOLISA_BUILD_METADATA="$metadata" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$output" \
+    TARGET_OS="$os_name" \
+    TARGET_ARCH="$arch" \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$PACKER" package >/dev/null
+}
+
+OUT_ONE="$TEMPORARY/out-one"
+OUT_TWO="$TEMPORARY/out-two"
+run_pack linux x86_64 "$OUT_ONE"
+run_pack linux x86_64 "$OUT_TWO"
+ARCHIVE="anolisa-$VERSION-linux-x86_64.tar.gz"
+cmp "$OUT_ONE/$ARCHIVE" "$OUT_TWO/$ARCHIVE"
+test "$(tar -tzf "$OUT_ONE/$ARCHIVE" | sed '/^\.\/$/d')" = "./anolisa"
+test "$(tar -tvzf "$OUT_ONE/$ARCHIVE" | awk '$NF == "./anolisa" { print $1 }')" = \
+    "-rwxr-xr-x"
+
+run_pack linux aarch64 "$TEMPORARY/out-linux-arm64"
+test -f "$TEMPORARY/out-linux-arm64/anolisa-$VERSION-linux-aarch64.tar.gz"
+run_pack macos aarch64 "$TEMPORARY/out-macos-arm64"
+test -f "$TEMPORARY/out-macos-arm64/anolisa-$VERSION-macos-aarch64.tar.gz"
+
+if run_pack macos x86_64 "$TEMPORARY/out-unsupported" 2>/dev/null; then
+    printf 'ERROR: unsupported macOS x86_64 package succeeded\n' >&2
+    exit 1
+fi
+
+BAD_METADATA="$TEMPORARY/bad-sha.toml"
+write_metadata linux x86_64 "$BAD_METADATA"
+sed -i "s/$DIGEST/$(printf '%064d' 0)/" "$BAD_METADATA"
+if ANOLISA_SOURCE_DIR="$ROOT" \
+    ANOLISA_BUILD_METADATA="$BAD_METADATA" \
+    BIN_DIR="$BIN_DIR" \
+    OUTPUT_DIR="$TEMPORARY/out-bad-sha" \
+    TARGET_OS=linux \
+    TARGET_ARCH=x86_64 \
+    SOURCE_DATE_EPOCH=1700000000 \
+        "$PACKER" package >/dev/null 2>&1; then
+    printf 'ERROR: mismatched binary checksum was accepted\n' >&2
+    exit 1
+fi
+
+DRIFT_ROOT="$TEMPORARY/version-drift"
+install -d -m 0755 "$DRIFT_ROOT/npm/platforms"
+install -p -m 0644 "$ROOT/Cargo.toml" "$DRIFT_ROOT/Cargo.toml"
+cp -a "$ROOT/npm/package.json" "$DRIFT_ROOT/npm/package.json"
+cp -a "$ROOT/npm/platforms/." "$DRIFT_ROOT/npm/platforms/"
+sed -i '0,/"version":/s/"version": "[^"]*"/"version": "9.9.9"/' \
+    "$DRIFT_ROOT/npm/platforms/linux-x64/package.json"
+if python3 "$VERIFIER" "$DRIFT_ROOT" --os linux --arch x86_64 \
+    >/dev/null 2>&1; then
+    printf 'ERROR: npm version drift was accepted\n' >&2
+    exit 1
+fi
+
+printf 'ANOLISA CLI prebuilt package tests passed\n'


### PR DESCRIPTION
## Why

ANOLISA CLI tags currently publish source/vendor archives but no compiled GitHub Release assets. This moves the existing three-target CLI compilation into the shared prebuilt release path without adding npm, OSS, public-readback, or registry publication.

## What changed

- Add the ANOLISA target matrix for Linux x86_64, Linux aarch64, and macOS aarch64.
- Add a composite build action plus an ANOLISA-owned deterministic binary packer and release-contract checks.
- Attach tar, SHA-256, CycloneDX 1.6 SBOM, and SBOM SHA-256 assets to tagged releases; preview runs upload Actions Artifacts only.
- Add a path-filtered general-runner regression workflow; untrusted PR code is not run on the persistent release runner.

## Related issue

no-issue: migrate ANOLISA CLI prebuilt packaging to the existing GitHub Release framework

## User / Agent impact

Future `anolisa/v*` GitHub Releases gain 12 prebuilt assets across the three supported targets. CLI behavior and npm publication are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The release asset set changes only for ANOLISA tags; existing source/vendor artifacts and other components keep their current paths.

## Validation

- `python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `.github/actions/build-anolisa-prebuilt/test.sh`
- `src/anolisa/tests/test-package-prebuilt.sh`
- `node src/anolisa/npm/tests/platforms.test.js`
- `node src/anolisa/npm/scripts/package-npm.js --validate`
- Existing cosh-ng and Tokenless prebuilt action regression tests
- ShellCheck, actionlint 1.7.12, Python compile, and `git diff --check`
- Self-hosted Runner `anolisa-test`: real builds with `gnu2.17-x86_64`, `gnu2.17-aarch64`, and `darwin11-aarch64`
- Verified GLIBC 2.16/2.17 ceilings, Mach-O arm64 macOS 11.0 minimum, and the complete 12-file Actions Artifact layout

## Documentation and rollback

No user documentation changes are required. Revert this commit to remove ANOLISA from the prebuilt matrix and restore source/vendor-only GitHub Releases.