### PR TITLE
refactor(anolisa): use snapshots in update check

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/component_observation.rs
@@ -12,7 +12,7 @@ use anolisa_core::{
     PendingJournalSnapshot, ProbeEvidence, SnapshotContractError, SnapshotProbe, StateProvenance,
     StateRootScope, StateSnapshot, StateVisibilitySnapshot,
 };
-use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError};
+use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError, PackageVersion};
 use thiserror::Error;
 
 use crate::commands::common;
@@ -47,6 +47,13 @@ pub(crate) enum RpmDrift {
     Drifted { reason: String },
     /// The recorded native package is absent.
     Missing,
+}
+
+/// Native-package evidence plus the backend-native version from the same query.
+pub(crate) struct NativePackageObservation {
+    pub(crate) evidence: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
+    pub(crate) installed_version: Option<PackageVersion>,
+    pub(crate) query_error: Option<PackageQueryError>,
 }
 
 /// Apply the read-only state normalization shared by status and doctor.
@@ -102,7 +109,8 @@ pub(crate) fn snapshot_from_record(
         mutable_by_current_invocation: record.mutable_by_current_invocation,
         shadowed_by: record.shadowed_by.map(snapshot_scope),
     };
-    let mut probes = vec![SnapshotProbe::State, SnapshotProbe::OwnedFiles];
+    let mut probes = vec![SnapshotProbe::State];
+    push_requested_probe(&mut probes, SnapshotProbe::OwnedFiles, &owned_files);
     push_requested_probe(&mut probes, SnapshotProbe::NativePackage, &native_package);
     push_requested_probe(&mut probes, SnapshotProbe::ManifestHealth, &manifest_health);
     push_requested_probe(&mut probes, SnapshotProbe::Adapters, &adapters);
@@ -198,30 +206,56 @@ pub(crate) fn native_package_evidence(
     query: &dyn PackageQuery,
     observed_at: &str,
 ) -> ProbeEvidence<NativePackageSnapshot, NativePackageProvenance> {
+    observe_native_package(manager, package, query, observed_at).evidence
+}
+
+/// Query one native package once and retain its structured version for ordering.
+pub(crate) fn observe_native_package(
+    manager: NativePm,
+    package: &str,
+    query: &dyn PackageQuery,
+    observed_at: &str,
+) -> NativePackageObservation {
     let provenance = NativePackageProvenance {
         manager,
         package: package.to_string(),
     };
     match query.query_installed(package) {
-        Ok(Some(info)) => ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::Installed(Observation {
-                version: info.version.version.clone(),
-                evr: Some(info.version.to_string()),
-                arch: Some(info.arch),
-                source_repo: info.origin,
-                observed_at: observed_at.to_string(),
-            }),
+        Ok(Some(info)) => NativePackageObservation {
+            installed_version: Some(info.version.clone()),
+            query_error: None,
+            evidence: ProbeEvidence::Present {
+                provenance,
+                value: NativePackageSnapshot::Installed(Observation {
+                    version: info.version.version.clone(),
+                    evr: Some(info.version.to_string()),
+                    arch: Some(info.arch),
+                    source_repo: info.origin,
+                    observed_at: observed_at.to_string(),
+                }),
+            },
         },
-        Ok(None) => ProbeEvidence::Absent { provenance },
-        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => ProbeEvidence::Present {
-            provenance,
-            value: NativePackageSnapshot::UnexpectedOutput { detail },
+        Ok(None) => NativePackageObservation {
+            evidence: ProbeEvidence::Absent { provenance },
+            installed_version: None,
+            query_error: None,
         },
-        Err(error) => ProbeEvidence::Unavailable {
-            provenance,
-            reason: error.to_string(),
+        Err(PackageQueryError::UnexpectedOutput { detail, .. }) => NativePackageObservation {
+            evidence: ProbeEvidence::Present {
+                provenance,
+                value: NativePackageSnapshot::UnexpectedOutput { detail },
+            },
+            installed_version: None,
+            query_error: None,
         },
+        Err(error) => {
+            let reason = error.to_string();
+            NativePackageObservation {
+                evidence: ProbeEvidence::Unavailable { provenance, reason },
+                installed_version: None,
+                query_error: Some(error),
+            }
+        }
     }
 }
 
@@ -465,6 +499,18 @@ mod tests {
                     && value.files[0].path == binary
                     && value.files[0].status == IntegrityStatus::Unverified
         ));
+
+        let state_only = snapshot_from_record(
+            &selected[0],
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+            ProbeEvidence::NotRequested,
+        )
+        .expect("state-only component snapshot");
+        assert_eq!(state_only.owned_files(), &ProbeEvidence::NotRequested);
+        assert!(!state_only.request().requests(SnapshotProbe::OwnedFiles));
     }
 
     #[derive(Clone, Copy)]
@@ -508,14 +554,18 @@ mod tests {
 
     #[test]
     fn native_package_evidence_preserves_query_outcomes() {
-        let present = native_package_evidence(
+        let present = observe_native_package(
             NativePm::Rpm,
             "tokenless",
             &ScriptedQuery(InstalledReply::Present),
             "2026-08-25T00:00:00Z",
         );
+        assert_eq!(
+            present.installed_version.as_ref().map(ToString::to_string),
+            Some("1.2.3-1.al4".to_string())
+        );
         assert!(matches!(
-            present,
+            present.evidence,
             ProbeEvidence::Present {
                 value: NativePackageSnapshot::Installed(Observation { evr: Some(evr), .. }),
                 ..
@@ -530,14 +580,18 @@ mod tests {
         );
         assert!(matches!(absent, ProbeEvidence::Absent { .. }));
 
-        let unavailable = native_package_evidence(
+        let unavailable = observe_native_package(
             NativePm::Rpm,
             "tokenless",
             &ScriptedQuery(InstalledReply::Unavailable),
             "2026-08-25T00:00:00Z",
         );
         assert!(matches!(
-            unavailable,
+            unavailable.query_error,
+            Some(PackageQueryError::CommandMissing { command }) if command == "rpm"
+        ));
+        assert!(matches!(
+            unavailable.evidence,
             ProbeEvidence::Unavailable { reason, .. } if reason == "command not found: rpm"
         ));
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check.rs
@@ -47,13 +47,17 @@ use serde::{Deserialize, Serialize};
 use anolisa_core::domain::{Installation, ManagementRelation, ProviderBinding};
 use anolisa_core::self_update;
 use anolisa_core::state::ObjectKind;
-use anolisa_core::state_store::StateStore;
+use anolisa_core::{
+    ComponentSnapshot, NativePackageProvenance, NativePackageSnapshot, ProbeEvidence, StateSnapshot,
+};
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageQuery, PackageQueryError, PackageVersion, rpm_evr_cmp};
 use anolisa_platform::rpm_query::RpmPackageQuery;
 
 use super::UpdateArgs;
 use crate::commands::common;
+use crate::commands::state_view::{ScopedInstalledObject, StateView, StateVisibility};
+use crate::commands::tier1::component_observation::{self, AggregateSelection};
 use crate::context::CliContext;
 use crate::progress;
 use crate::repo_config::{BackendConfig, RepoConfig};
@@ -216,7 +220,7 @@ impl TargetProfile {
 /// Read-only inputs for [`run_update_check`]; injected so tests drive the whole
 /// report without a live rpmdb/dnf.
 struct CheckInputs<'a> {
-    installed: &'a StateStore,
+    view: &'a StateView,
     query: &'a dyn PackageQuery,
     /// Path of the running executable, used to find its owning RPM.
     cli_exe_path: &'a str,
@@ -328,6 +332,12 @@ pub(crate) fn compute_update_check_report(
     )?;
     let query = RpmPackageQuery::system_with_repo(repo);
     let installed = common::load_state_store(ctx, CHECK_COMMAND)?;
+    let view = StateView::load_with_writable_state(
+        ctx,
+        CHECK_COMMAND,
+        StateVisibility::UserPlusSystem,
+        installed,
+    )?;
 
     let exe = self_update::resolve_current_exe().map_err(|err| CliError::Runtime {
         command: CHECK_COMMAND.to_string(),
@@ -357,8 +367,8 @@ pub(crate) fn compute_update_check_report(
     let component_index =
         crate::resolution::load_optional_component_index(layout, &env, &repo_config);
 
-    Ok(run_update_check(CheckInputs {
-        installed: &installed,
+    run_update_check(CheckInputs {
+        view: &view,
         query: &query,
         cli_exe_path: &exe_path,
         arch: &env.arch,
@@ -366,7 +376,7 @@ pub(crate) fn compute_update_check_report(
         target: Some(target_profile),
         component_index: component_index.as_ref(),
         rpm_backend: repo_config.backends.get("rpm"),
-    }))
+    })
 }
 
 /// Load repo config without ever writing it, keeping `--check` read-only.
@@ -386,24 +396,27 @@ fn load_repo_config_read_only(ctx: &CliContext, layout: &FsLayout) -> Result<Rep
 }
 
 /// Pure report builder over the injected read-only inputs.
-fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
+fn run_update_check(inputs: CheckInputs<'_>) -> Result<UpdateCheckReport, CliError> {
     let mut summary = CheckSummary::default();
 
     let cli = build_cli_check(inputs.query, inputs.cli_exe_path, inputs.arch, &mut summary);
 
     let mut components = Vec::new();
-    for installation in &inputs.installed.installations {
-        if installation.kind != ObjectKind::Component {
-            continue;
-        }
+    let observed_at = super::now_iso8601();
+    for record in component_observation::select_visible_components(
+        inputs.view,
+        None,
+        AggregateSelection::ActiveOnly,
+    ) {
         components.push(check_component(
             inputs.query,
             inputs.component_index,
             inputs.rpm_backend,
-            installation,
+            &record,
             inputs.arch,
+            &observed_at,
             &mut summary,
-        ));
+        )?);
     }
 
     // Profile defaults absent from ANOLISA state are surfaced as a gap (issue
@@ -424,7 +437,13 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
             // was already checked by the installed loop above, and must not
             // be re-normalized into a second identity — or, with no index,
             // into a spurious validation error.
-            if inputs.installed.find(ObjectKind::Component, name).is_some() {
+            if inputs
+                .view
+                .writable
+                .state
+                .find(ObjectKind::Component, name)
+                .is_some()
+            {
                 seen_defaults.insert(name.clone());
                 continue;
             }
@@ -455,7 +474,9 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
             };
             if !seen_defaults.insert(canonical.clone())
                 || inputs
-                    .installed
+                    .view
+                    .writable
+                    .state
                     .find(ObjectKind::Component, &canonical)
                     .is_some()
             {
@@ -475,7 +496,7 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
     let upgrade_available = summary.updates > 0;
     let action_required =
         upgrade_available || summary.reconciliations > 0 || summary.missing_defaults > 0;
-    UpdateCheckReport {
+    Ok(UpdateCheckReport {
         target: inputs.target_name,
         backend: "rpm".to_string(),
         upgrade_available,
@@ -483,7 +504,7 @@ fn run_update_check(inputs: CheckInputs<'_>) -> UpdateCheckReport {
         cli,
         components,
         summary,
-    }
+    })
 }
 
 /// Determine whether the running CLI binary is RPM-owned and, if so, whether a
@@ -584,18 +605,21 @@ fn check_component(
     query: &dyn PackageQuery,
     component_index: Option<&ComponentIndex>,
     rpm_backend: Option<&BackendConfig>,
-    installation: &Installation,
+    record: &ScopedInstalledObject<'_>,
     arch: &str,
+    observed_at: &str,
     summary: &mut CheckSummary,
-) -> ComponentCheck {
+) -> Result<ComponentCheck, CliError> {
+    let state_snapshot = update_check_snapshot(record, ProbeEvidence::NotRequested)?;
+    let installation = active_snapshot_installation(&state_snapshot)?;
     let component = installation.name.clone();
 
     // Owned components are explicitly out of the RPM upgrade path. Nothing is
     // queried, touched, or migrated — only reported.
-    let (identity, relation, last_observed) = match &installation.binding {
+    let (manager, identity, relation, last_observed) = match &installation.binding {
         ProviderBinding::Owned { artifact } => {
             summary.unsupported += 1;
-            return ComponentCheck {
+            return Ok(ComponentCheck {
                 component,
                 package: artifact.raw_package.clone(),
                 ownership: Some("owned".to_string()),
@@ -605,14 +629,15 @@ fn check_component(
                 error: None,
                 absent_from_state: false,
                 backfill_rpm_metadata: false,
-            };
+            });
         }
         ProviderBinding::Delegated {
+            pm,
             package,
             relation,
             last_observed,
             ..
-        } => (package, relation, last_observed),
+        } => (*pm, package, relation, last_observed),
     };
 
     let ownership_label = relation.label().to_string();
@@ -633,66 +658,104 @@ fn check_component(
                 Ok(package) => (package, true),
                 Err(reason) => {
                     summary.errors += 1;
-                    return component_error(
+                    return Ok(component_error(
                         component,
                         None,
                         ownership_label,
                         recorded_version,
                         reason,
-                    );
+                    ));
                 }
             }
         }
     };
 
-    let installed = match query.query_installed(&package) {
-        Ok(Some(info)) => info.version,
+    let native =
+        component_observation::observe_native_package(manager, &package, query, observed_at);
+    let installed_version = native.installed_version;
+    let query_error = native.query_error;
+    let snapshot = update_check_snapshot(record, native.evidence)?;
+    let installed = match snapshot.native_package() {
+        ProbeEvidence::Present {
+            value: NativePackageSnapshot::Installed(observation),
+            ..
+        } => {
+            let version = installed_version.ok_or_else(|| CliError::Runtime {
+                command: CHECK_COMMAND.to_string(),
+                reason: format!(
+                    "component snapshot for '{}' lost the structured native package version",
+                    snapshot.request().component()
+                ),
+            })?;
+            (
+                version,
+                observation
+                    .evr
+                    .clone()
+                    .unwrap_or_else(|| observation.version.clone()),
+            )
+        }
         // rpmdb no longer has the package (e.g. removed with `rpm -e`): item
         // error, not a crash — the rest of the check continues.
-        Ok(None) => {
+        ProbeEvidence::Absent { .. } => {
             summary.errors += 1;
-            return component_error(
+            return Ok(component_error(
                 component,
                 Some(package),
                 ownership_label,
                 recorded_version.clone(),
                 "package recorded in ANOLISA state is not present in rpmdb; run `anolisa forget` or reinstall".to_string(),
-            );
+            ));
         }
-        Err(PackageQueryError::UnexpectedOutput { .. }) => {
+        ProbeEvidence::Present {
+            value:
+                NativePackageSnapshot::MultipleVersions | NativePackageSnapshot::UnexpectedOutput { .. },
+            ..
+        } => {
             summary.errors += 1;
-            return component_error(
+            return Ok(component_error(
                 component,
                 Some(package),
                 ownership_label,
                 recorded_version.clone(),
                 "rpmdb reports multiple installed versions for this package".to_string(),
-            );
+            ));
         }
-        Err(PackageQueryError::CommandMissing { .. }) => {
+        ProbeEvidence::Unavailable { .. }
+            if matches!(query_error, Some(PackageQueryError::CommandMissing { .. })) =>
+        {
             summary.errors += 1;
-            return component_error(
+            return Ok(component_error(
                 component,
                 Some(package),
                 ownership_label,
                 recorded_version.clone(),
                 "rpm/dnf not found; cannot query the installed version".to_string(),
-            );
+            ));
         }
-        Err(err) => {
+        ProbeEvidence::Unavailable { reason, .. } => {
             summary.errors += 1;
-            return component_error(
+            return Ok(component_error(
                 component,
                 Some(package),
                 ownership_label,
                 recorded_version.clone(),
-                format!("rpm query failed: {err}"),
-            );
+                format!("rpm query failed: {reason}"),
+            ));
+        }
+        ProbeEvidence::NotRequested => {
+            return Err(CliError::Runtime {
+                command: CHECK_COMMAND.to_string(),
+                reason: format!(
+                    "component snapshot for '{}' did not request native package evidence",
+                    snapshot.request().component()
+                ),
+            });
         }
     };
-    let installed_evr = installed.to_string();
+    let installed_evr = installed.1;
 
-    match repo_upgrade(query, &package, arch, &installed) {
+    Ok(match repo_upgrade(query, &package, arch, &installed.0) {
         Ok(Some(available)) => {
             summary.updates += 1;
             ComponentCheck {
@@ -736,6 +799,46 @@ fn check_component(
                 format!("repo candidate query failed: {err}"),
             )
         }
+    })
+}
+
+fn update_check_snapshot(
+    record: &ScopedInstalledObject<'_>,
+    native_package: ProbeEvidence<NativePackageSnapshot, NativePackageProvenance>,
+) -> Result<ComponentSnapshot, CliError> {
+    component_observation::snapshot_from_record(
+        record,
+        ProbeEvidence::NotRequested,
+        native_package,
+        ProbeEvidence::NotRequested,
+        ProbeEvidence::NotRequested,
+        ProbeEvidence::NotRequested,
+    )
+    .map_err(|error| CliError::Runtime {
+        command: CHECK_COMMAND.to_string(),
+        reason: format!("failed to assemble component snapshot: {error}"),
+    })
+}
+
+fn active_snapshot_installation(snapshot: &ComponentSnapshot) -> Result<&Installation, CliError> {
+    match snapshot.state() {
+        ProbeEvidence::Present {
+            value: StateSnapshot::Active(installation),
+            ..
+        } => Ok(installation),
+        ProbeEvidence::Absent { .. }
+        | ProbeEvidence::Unavailable { .. }
+        | ProbeEvidence::NotRequested
+        | ProbeEvidence::Present {
+            value: StateSnapshot::Quarantined(_),
+            ..
+        } => Err(CliError::Runtime {
+            command: CHECK_COMMAND.to_string(),
+            reason: format!(
+                "component snapshot for '{}' does not contain active state",
+                snapshot.request().component()
+            ),
+        }),
     }
 }
 

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/check/tests.rs
@@ -2,7 +2,7 @@
 //! [`PackageQuery`] fake plus in-memory state, so no live rpmdb/dnf is required.
 
 use super::*;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anolisa_platform::pkg_query::{PackageInfo, PackageVersion};
@@ -13,6 +13,7 @@ use anolisa_core::state::{
     InstalledObject, ObjectStatus, Ownership, RpmMetadata, SubscriptionScope,
 };
 use anolisa_core::state_migration::migrate_state;
+use anolisa_core::state_store::StateStore;
 
 use super::super::UpdateArgs;
 use super::render::build_motd;
@@ -32,6 +33,11 @@ struct FakeHost {
     available_errors: HashSet<String>,
     /// packages whose `query_installed` reports a multi-version drift.
     installed_multi: HashSet<String>,
+    /// packages whose installed query cannot start rpm.
+    installed_command_missing: HashSet<String>,
+    /// packages whose installed query reports a hard rpmdb failure.
+    installed_errors: HashSet<String>,
+    installed_queries: RefCell<Vec<String>>,
     /// capabilities whose `what_provides_installed` returns a query error.
     provides_errors: HashSet<String>,
     /// capability → available repo provider package names.
@@ -56,10 +62,25 @@ impl FakeHost {
 
 impl PackageQuery for FakeHost {
     fn query_installed(&self, package: &str) -> Result<Option<PackageInfo>, PackageQueryError> {
+        self.installed_queries
+            .borrow_mut()
+            .push(package.to_string());
         if self.installed_multi.contains(package) {
             return Err(PackageQueryError::UnexpectedOutput {
                 command: "rpm".to_string(),
                 detail: "2 installed versions".to_string(),
+            });
+        }
+        if self.installed_command_missing.contains(package) {
+            return Err(PackageQueryError::CommandMissing {
+                command: "rpm".to_string(),
+            });
+        }
+        if self.installed_errors.contains(package) {
+            return Err(PackageQueryError::QueryFailed {
+                command: "rpm".to_string(),
+                code: Some(1),
+                stderr: "rpmdb unavailable".to_string(),
             });
         }
         Ok(self.installed.get(package).cloned())
@@ -250,8 +271,16 @@ fn run_with_index_and_backend(
     component_index: Option<&crate::resolution::ComponentIndex>,
     rpm_backend: Option<&crate::repo_config::BackendConfig>,
 ) -> UpdateCheckReport {
+    let ctx = system_ctx();
+    let view = StateView::load_with_writable_state(
+        &ctx,
+        CHECK_COMMAND,
+        StateVisibility::UserPlusSystem,
+        installed.clone(),
+    )
+    .expect("test state view");
     run_update_check(CheckInputs {
-        installed,
+        view: &view,
         query: host,
         cli_exe_path: "/usr/bin/anolisa",
         arch: "x86_64",
@@ -260,6 +289,7 @@ fn run_with_index_and_backend(
         component_index,
         rpm_backend,
     })
+    .expect("update check report")
 }
 
 /// Identity-only component index naming `components`, so profile defaults
@@ -461,6 +491,14 @@ fn update_check_raw_component_is_unsupported() {
         host.txn_calls.get(),
         0,
         "raw component must not run a transaction"
+    );
+    assert!(
+        !host
+            .installed_queries
+            .borrow()
+            .iter()
+            .any(|package| package == "tokenless"),
+        "owned component must not request native package evidence"
     );
 }
 
@@ -1234,6 +1272,100 @@ fn update_check_component_missing_from_rpmdb_is_item_error() {
     let item = &report.components[0];
     assert_eq!(item.action, ACTION_ERROR);
     assert!(item.error.as_deref().unwrap().contains("forget"));
+    assert_eq!(report.summary.errors, 1);
+}
+
+#[test]
+fn update_check_component_native_probe_runs_once() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed.insert(
+        "copilot-shell".to_string(),
+        info("copilot-shell", "1.0.0", Some("1.al4")),
+    );
+    let state = state_with(vec![rpm_component(
+        "cosh",
+        "copilot-shell",
+        "1.0.0-1.al4",
+        Ownership::RpmObserved,
+    )]);
+
+    let report = run(&host, &state, None, None);
+
+    assert_eq!(report.components[0].action, ACTION_NOOP);
+    assert_eq!(
+        host.installed_queries
+            .borrow()
+            .iter()
+            .filter(|package| package.as_str() == "copilot-shell")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn update_check_component_multiple_versions_remains_item_error() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed_multi.insert("copilot-shell".to_string());
+    let state = state_with(vec![rpm_component(
+        "cosh",
+        "copilot-shell",
+        "1.0.0-1.al4",
+        Ownership::RpmObserved,
+    )]);
+
+    let report = run(&host, &state, None, None);
+    let item = &report.components[0];
+
+    assert_eq!(item.action, ACTION_ERROR);
+    assert_eq!(
+        item.error.as_deref(),
+        Some("rpmdb reports multiple installed versions for this package")
+    );
+    assert_eq!(report.summary.errors, 1);
+}
+
+#[test]
+fn update_check_component_missing_rpm_command_keeps_existing_error() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed_command_missing
+        .insert("copilot-shell".to_string());
+    let state = state_with(vec![rpm_component(
+        "cosh",
+        "copilot-shell",
+        "1.0.0-1.al4",
+        Ownership::RpmObserved,
+    )]);
+
+    let report = run(&host, &state, None, None);
+    let item = &report.components[0];
+
+    assert_eq!(item.action, ACTION_ERROR);
+    assert_eq!(
+        item.error.as_deref(),
+        Some("rpm/dnf not found; cannot query the installed version")
+    );
+    assert_eq!(report.summary.errors, 1);
+}
+
+#[test]
+fn update_check_component_rpm_failure_keeps_source_detail() {
+    let mut host = FakeHost::with_cli_noop();
+    host.installed_errors.insert("copilot-shell".to_string());
+    let state = state_with(vec![rpm_component(
+        "cosh",
+        "copilot-shell",
+        "1.0.0-1.al4",
+        Ownership::RpmObserved,
+    )]);
+
+    let report = run(&host, &state, None, None);
+    let item = &report.components[0];
+
+    assert_eq!(item.action, ACTION_ERROR);
+    assert_eq!(
+        item.error.as_deref(),
+        Some("rpm query failed: rpm failed (code Some(1)): rpmdb unavailable")
+    );
     assert_eq!(report.summary.errors, 1);
 }
 


### PR DESCRIPTION
## Why

`status` and `doctor` already consume request-scoped component snapshots, while
`update --check` still reinterpreted state rows and native-package query results.
This duplicated host-fact classification and allowed the read-only consumers to drift.

## What changed

- Select active installed components through the shared observation layer and project
  state and native-package facts from `ComponentSnapshot`.
- Retain the structured RPM version and typed query failure from the same exactly-once
  probe so EVR ordering and existing error text remain unchanged.
- Keep repository candidates, target profiles, missing defaults, report rendering, and
  upgrade planning on their existing paths.

## Related issue

Closes #2882

## User / Agent impact

None. CLI, JSON, MOTD, cache, exit-code, and repair-guidance behavior are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The change is read-only and does not modify update/upgrade mutation,
reconciliation, locking, or transaction execution.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test -p anolisa-cli --locked` (917 passed, 1 ignored)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- Alibaba Cloud Linux 4.0.3, Rust 1.93.1, offline read-only-source container:
  - `cargo test -p anolisa-cli update_check --locked` (55 passed)
  - `cargo test -p anolisa-cli component_observation --locked` (5 passed)
  - `cargo test -p anolisa-cli upgrade --locked` (67 passed)

An additional full CLI run in the non-privileged container reached 916 passed and
1 ignored, with the pre-existing
`raw_update_rollback_hydrates_legacy_required_capability` test failing because the
container safety policy disables capability hydration. The host workspace suite and
all tests scoped to this change pass.

## Documentation and rollback

No tracked documentation changed; the local refactoring roadmap remains excluded from
the commit. Roll back by reverting commit `3e85a0bc`.
