### PR TITLE
docs(sec-core): document hidden CLI commands

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -60,6 +60,7 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 | [Asset Verification](agent-security/agent-sec-core/asset-verification.md) | agent-sec-core | GPG-signed skill distribution verification and discovery outcomes |
 | [Skill Ledger User Guide](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | Skill integrity chain and signing workflow |
 | [OpenClaw Deployment & Upgrade](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw plugin deployment and upgrade guide |
+| [Internal Commands](agent-security/agent-sec-core/internal-commands.md) | agent-sec-core | Contract and inventory of the hidden, hook-invoked commands |
 
 ### Token Saving (`token-saving/`)
 

--- a/docs/user-guide/en/agent-security/agent-sec-core/internal-commands.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/internal-commands.md
@@ -1,0 +1,216 @@
+# AgentSecCore Internal Commands
+
+[中文版](../../../zh/agent-security/agent-sec-core/internal-commands.md)
+
+A few `agent-sec-cli` surfaces are deliberately omitted from `--help`. Being
+hidden is not a status: `hidden=True` controls help visibility only, and says
+nothing about whether a command is implemented, supported, or driven by an
+internal integration. The four surfaces below serve three different roles, and
+the difference decides whether you may depend on them:
+
+- **Live integration points.** `--trace-context` and `log-sandbox` are called by
+  hooks and plugins on your behalf. They are documented because AgentSecCore's
+  own audit path depends on them: to audit the events they produce, or to debug
+  why a hook behaved a certain way, you need their contract.
+- **Compatibility command.** `skill-ledger init-keys` predates
+  `skill-ledger init` and is kept for callers written against it. It works, but
+  it is not the entry point new automation should target.
+- **Reserved but unavailable.** `skill-ledger rotate-keys` only reserves the
+  name. Invoking it fails on purpose and changes nothing.
+
+None of them carry the stability expectations of the visible commands: each is
+tied to the host it serves and can change when that integration changes.
+
+## Inventory
+
+| Surface | Defined in | Role | Invoking it |
+|---------|-----------|------|-------------|
+| `--trace-context JSON` (top-level option) | `agent-sec-cli/src/agent_sec_cli/cli.py` | Live integration point | Works |
+| `log-sandbox` | `agent-sec-cli/src/agent_sec_cli/cli.py` | Live integration point | Works |
+| `skill-ledger init-keys` | `agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py` | Compatibility command | Works |
+| `skill-ledger rotate-keys` | `agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py` | Reserved, not implemented | Fails with exit code `1` |
+
+Because they are hidden, none of them appear in `agent-sec-cli --help` or
+`agent-sec-cli skill-ledger --help`. Their `--help` output is still reachable by
+naming them explicitly, and so is invocation — with the outcome listed above.
+
+A fifth surface, `skill-ledger set-policy`, was removed; see
+[Removed: `skill-ledger set-policy`](#removed-skill-ledger-set-policy).
+
+## `log-sandbox`
+
+Records one sandbox pre-hook decision as a Security Event. This is the audit
+half of Copilot Shell's sandbox protection: the
+[`sandbox-guard` hook](../../user-entrypoint/copilot-shell/hooks.md) decides how
+to treat a dangerous shell command, then spawns `log-sandbox` so the decision
+lands in the local event store.
+
+```bash
+agent-sec-cli log-sandbox \
+  --decision sandbox \
+  --command 'rm -rf /tmp/test' \
+  --reasons 'recursive-delete' \
+  --network-policy restricted \
+  --cwd /home/user/project
+```
+
+### Options
+
+Every option is a free-form string and defaults to empty. Nothing is rejected or
+normalized — the value you pass is what gets recorded.
+
+| Option | Recorded meaning |
+|--------|------------------|
+| `--decision` | The pre-hook verdict. `sandbox-guard` only ever emits `block` or `sandbox` |
+| `--command` | The shell command that was evaluated |
+| `--reasons` | Why the decision was made, as produced by the caller's rule labels |
+| `--network-policy` | Network posture of the sandboxed run: `restricted` or `enabled`. Omitted on the `block` path, so it lands as an empty string |
+| `--cwd` | Working directory the command was about to run in |
+
+Those are the values `sandbox-guard` produces, not values the CLI enforces.
+Nothing is validated against an allowed set, so an unexpected value is stored
+verbatim and a typo becomes a silently mislabeled audit record rather than an
+error. If you filter events on these fields, filter on what the hook actually
+emits — there is no `allow` record and no `unrestricted` policy.
+
+### Output and exit codes
+
+The command is silent by design — no stdout, no stderr on success, because the
+caller spawns it detached and never reads its output.
+
+| Exit code | Condition |
+|-----------|-----------|
+| `0` | The logging-only backend ran to completion. This is the normal outcome, and it is *not* a confirmation that the event reached storage |
+| Non-zero | An unexpected internal failure propagated out of the middleware |
+
+Event writing itself is best-effort: if the JSONL or the SQLite writer fails, the
+failure is swallowed and the exit code stays `0`. Never treat exit `0` as proof
+that a record exists — query the event store instead, as shown in
+[Verifying the record](#verifying-the-record). Combined with the fact that
+`sandbox-guard` spawns the process detached with output discarded, the exit code
+has no influence on sandbox enforcement — losing an audit record never blocks or
+unblocks a command.
+
+### What it does not do
+
+`log-sandbox` and `linux-sandbox` are easy to confuse. Only one of them isolates
+anything.
+
+| | `linux-sandbox` | `agent-sec-cli log-sandbox` |
+|---|---|---|
+| Form | Standalone binary at `/usr/local/bin/linux-sandbox` | Hidden `agent-sec-cli` subcommand |
+| Role | Actually runs a command under filesystem and network isolation | Records that a decision was made |
+| Effect on the command | Wraps and executes it | None — it never executes, blocks, or rewrites anything |
+| How `sandbox-guard` uses it | Rewrites the tool call to run through it | Spawns it detached, fire-and-forget |
+
+So a `--decision block` record does not block anything. The blocking already
+happened in the hook; `log-sandbox` only makes it auditable.
+
+### Verifying the record
+
+Sandbox decisions are stored with event type `sandbox_prehook` under category
+`sandbox`:
+
+```bash
+agent-sec-cli events --category sandbox --last-hours 1
+agent-sec-cli events --event-type sandbox_prehook --output json --limit 5
+```
+
+In the JSON output, `details.request` holds the five options as passed, and the
+decision is at `details.result.decision`. Events live in
+`/var/log/agent-sec/` when writable, otherwise `~/.agent-sec-core/`;
+`AGENT_SEC_DATA_DIR` overrides both.
+
+## `--trace-context`
+
+A top-level option that lets a calling plugin attach its own correlation IDs to
+every Security Event the invocation produces, so security records can be joined
+with the host Agent's traces.
+
+```bash
+agent-sec-cli --trace-context '{"trace_id":"t-1","session_id":"s-1"}' \
+  log-sandbox --decision block --command 'rm -rf /'
+```
+
+The value is a JSON object. Recognized fields are `trace_id`, `session_id`,
+`run_id`, `call_id`, `tool_call_id`, and `agent_name`; each also accepts its
+camelCase spelling (`traceId`, `sessionId`, …). Unknown fields are ignored, and
+values longer than 256 characters are truncated with a `...[truncated]` marker.
+
+The first five land on the Security Event as correlation columns. `agent_name` is
+the exception: it is carried as Observability metadata (`component.agent_name`)
+and is not stored on the event, so do not expect to filter events by it.
+
+It must appear before the subcommand — it is a process-level option, parsed
+ahead of the command so that a subcommand's own flags keep their meaning.
+Malformed JSON is rejected loudly: the CLI prints `Error: invalid trace context
+JSON` to stderr and exits `1` without running the subcommand. An empty value is
+treated as absent.
+
+## `skill-ledger init-keys`
+
+A compatibility command kept for callers written before `skill-ledger init`
+existed. It generates the Ed25519 signing key pair and nothing else.
+
+| Invocation | Closest supported command |
+|------------|---------------------------|
+| `skill-ledger init-keys` | `skill-ledger init --no-baseline` |
+| `skill-ledger init-keys --force` | `skill-ledger init --no-baseline --force-keys` |
+| `skill-ledger init-keys --passphrase` | `skill-ledger init --no-baseline --passphrase` |
+
+That mapping holds on a fresh ledger. Once a key pair exists, the two commands
+diverge — without a force flag:
+
+| | `init-keys` | `init --no-baseline` |
+|---|---|---|
+| Behaviour | Refuses to run, reporting `KeyAlreadyExistsError` | Skips key generation and proceeds |
+| Reported state | Error message | `keyCreated: false` in the JSON output |
+| Exit code | `1` | `0` |
+
+Migrating automation off `init-keys` therefore turns a failing run into a passing
+one. If a script relies on the non-zero exit to detect "keys already present",
+switch it to reading `keyCreated` from the `init` output rather than the exit
+code.
+
+Prefer `skill-ledger init`, documented in the
+[Skill Ledger user guide](skill-ledger.md) — it creates the keys and baselines
+covered skills in one step. Key storage and file permissions are identical
+between the two, and so is passphrase handling on a fresh ledger.
+
+## `skill-ledger rotate-keys`
+
+Hidden and reserved: the name is claimed, but key rotation is not implemented.
+Invoking it fails without touching any key material.
+
+| | Behaviour |
+|---|-----------|
+| stdout | Empty |
+| stderr | `Error: rotate-keys is not implemented; no keys were changed.` |
+| Exit code | `1` |
+| Key store | `key.enc`, `key.pub`, and the keyring are left unchanged |
+
+`rotate-keys --help` still exits `0` and reports that the command is not
+implemented, so a caller probing for the command does find it. That is why the
+failure is loud rather than a silent no-op.
+
+There is no supported way to rotate signing keys today, and `--force-keys` is not
+one. It is an option on `init`, not a rotation entry point: it forces a fresh key
+pair as part of initializing a ledger, and does not carry out the rest of what
+rotating a key implies. Use it when you intend to re-initialize, not when you
+intend to rotate.
+
+## Removed: `skill-ledger set-policy`
+
+A hidden placeholder that was never implemented, since removed rather than left
+exiting `0` while doing nothing. It is recorded here only so callers written
+against it can recognise the new failure:
+
+| | Behaviour |
+|---|-----------|
+| stdout | Empty |
+| stderr | Usage error naming `set-policy`, reported as no such command |
+| Exit code | `2` |
+| Ledger state | Nothing is created |
+
+`decide` is the only supported command for recording a per-Skill user decision —
+see the [Skill Ledger guide](skill-ledger.md).

--- a/docs/user-guide/en/user-entrypoint/copilot-shell/hooks.md
+++ b/docs/user-guide/en/user-entrypoint/copilot-shell/hooks.md
@@ -163,3 +163,4 @@ Allow execution with modified parameters:
 - [Hook Development Guide](../../../../developer-guide/en/copilot-shell/hooks/index.md)
 - [Hook API Reference](../../../../developer-guide/en/copilot-shell/hooks/reference.md)
 - [Writing Custom Hooks](../../../../developer-guide/en/copilot-shell/hooks/writing-hooks.md)
+- [AgentSecCore Internal Commands](../../agent-security/agent-sec-core/internal-commands.md) — contract of the `agent-sec-cli log-sandbox` audit command that `sandbox-guard` spawns

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -60,6 +60,7 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 | [资产验证](agent-security/agent-sec-core/asset-verification.md) | agent-sec-core | GPG 签名的 Skill 分发验证与发现结果 |
 | [Skill Ledger 用户指南](agent-security/agent-sec-core/skill-ledger.md) | agent-sec-core | 技能账本完整性链与签名工作流 |
 | [OpenClaw 兼容部署与升级](agent-security/agent-sec-core/openclaw-deploy.md) | agent-sec-core | OpenClaw 插件部署与升级指南 |
+| [内部命令](agent-security/agent-sec-core/internal-commands.md) | agent-sec-core | hook 调用的隐藏命令契约与清单 |
 
 ### Token 节省 `token-saving/`
 

--- a/docs/user-guide/zh/agent-security/agent-sec-core/internal-commands.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/internal-commands.md
@@ -1,0 +1,190 @@
+# AgentSecCore 内部命令
+
+[English](../../../en/agent-security/agent-sec-core/internal-commands.md)
+
+`agent-sec-cli` 有少数几个入口被有意从 `--help` 中隐去。「隐藏」本身不是一种状态：
+`hidden=True` 只控制帮助可见性，并不说明该命令是否已实现、是否受支持、是否被内部集成
+调用。下列四个入口承担三种不同角色，这一区别决定了你能否依赖它们：
+
+- **在用的集成点。** `--trace-context` 与 `log-sandbox` 由 hook 与插件代你调用。之所以
+  在此文档化：AgentSecCore 自身的审计链路依赖它们——当你审计它们产生的事件，或排查某个
+  hook 为何如此表现时，需要它们的契约。
+- **兼容命令。** `skill-ledger init-keys` 早于 `skill-ledger init` 存在，为已按它编写的
+  调用方保留。它可用，但不是新自动化应当对接的入口。
+- **已预留但不可用。** `skill-ledger rotate-keys` 仅占住名字。调用它会按设计失败，且不做
+  任何改动。
+
+三者都不享有可见命令的稳定性预期：每个都与所服务的宿主绑定，宿主集成变化时可能随之变化。
+
+## 隐藏入口清单
+
+| 入口 | 定义位置 | 角色 | 调用结果 |
+|------|---------|------|---------|
+| `--trace-context JSON`（顶层选项） | `agent-sec-cli/src/agent_sec_cli/cli.py` | 在用的集成点 | 可用 |
+| `log-sandbox` | `agent-sec-cli/src/agent_sec_cli/cli.py` | 在用的集成点 | 可用 |
+| `skill-ledger init-keys` | `agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py` | 兼容命令 | 可用 |
+| `skill-ledger rotate-keys` | `agent-sec-cli/src/agent_sec_cli/skill_ledger/cli.py` | 已预留，未实现 | 失败，退出码 `1` |
+
+由于处于隐藏状态，它们都不会出现在 `agent-sec-cli --help` 或
+`agent-sec-cli skill-ledger --help` 中。显式写出名字仍可查看各自的 `--help`，也仍可调用
+——结果见上表。
+
+第五个入口 `skill-ledger set-policy` 已被移除，见
+[已移除：`skill-ledger set-policy`](#已移除skill-ledger-set-policy)。
+
+## `log-sandbox`
+
+把一次沙箱前置决策记录为一条 Security Event。它是 Copilot Shell 沙箱防护的审计侧：
+[`sandbox-guard` hook](../../user-entrypoint/copilot-shell/hooks.md) 决定如何处理一条
+危险 shell 命令后，spawn `log-sandbox` 把该决策落到本地事件库。
+
+```bash
+agent-sec-cli log-sandbox \
+  --decision sandbox \
+  --command 'rm -rf /tmp/test' \
+  --reasons 'recursive-delete' \
+  --network-policy restricted \
+  --cwd /home/user/project
+```
+
+### 参数
+
+所有参数都是自由字符串，默认为空。不做拒绝也不做归一化——传什么就记什么。
+
+| 参数 | 记录含义 |
+|------|---------|
+| `--decision` | 前置决策结论。`sandbox-guard` 只会产出 `block` 或 `sandbox` |
+| `--command` | 被评估的 shell 命令 |
+| `--reasons` | 决策理由，取自调用方的规则标签 |
+| `--network-policy` | 沙箱执行的网络策略：`restricted` 或 `enabled`。`block` 路径不传此参数，因此落库为空字符串 |
+| `--cwd` | 该命令即将执行的工作目录 |
+
+以上是 `sandbox-guard` 实际产出的取值，而不是 CLI 强制约束的取值。CLI 不校验任何
+取值范围，非预期取值会被原样存入，因此拼写错误不会报错，而是产生一条标签错误却
+看不出来的审计记录。若要按这些字段过滤事件，请按 hook 实际产出的值过滤——不存在
+`allow` 记录，也不存在 `unrestricted` 策略。
+
+### 输出与退出码
+
+该命令按设计静默：成功时无 stdout、无 stderr——因为调用方以 detached 方式 spawn 它，
+从不读取其输出。
+
+| 退出码 | 条件 |
+|--------|------|
+| `0` | 仅做记录的 backend 执行完毕。这是正常结果，但它*不*代表事件已落盘 |
+| 非 0 | 中间件层抛出了未预期的内部故障 |
+
+事件写入本身是 best-effort：JSONL 或 SQLite writer 任一失败都会被吞掉，退出码仍为
+`0`。绝不要把退出码 `0` 当作记录已存在的证据——请按[校验记录是否落库](#校验记录是否落库)
+查询事件库来确认。再加上 `sandbox-guard` 以 detached 方式 spawn 且丢弃输出，退出码对
+沙箱执行没有任何影响——丢一条审计记录既不会拦住命令，也不会放开命令。
+
+### 它不做什么
+
+`log-sandbox` 与 `linux-sandbox` 很容易混淆，而其中只有一个真正做隔离。
+
+| | `linux-sandbox` | `agent-sec-cli log-sandbox` |
+|---|---|---|
+| 形态 | 位于 `/usr/local/bin/linux-sandbox` 的独立二进制 | `agent-sec-cli` 的隐藏子命令 |
+| 职责 | 真正在文件系统与网络隔离下执行命令 | 记录「做过一次决策」这件事 |
+| 对命令的影响 | 包装并执行它 | 无——从不执行、拦截或改写任何东西 |
+| `sandbox-guard` 如何使用 | 改写工具调用，使其经由它执行 | detached spawn，fire-and-forget |
+
+因此一条 `--decision block` 记录并不拦截任何东西。拦截早已在 hook 中完成，
+`log-sandbox` 只是让它可审计。
+
+### 校验记录是否落库
+
+沙箱决策以 event type `sandbox_prehook`、category `sandbox` 存储：
+
+```bash
+agent-sec-cli events --category sandbox --last-hours 1
+agent-sec-cli events --event-type sandbox_prehook --output json --limit 5
+```
+
+在 JSON 输出中，`details.request` 保存传入的五个参数，决策位于
+`details.result.decision`。事件在 `/var/log/agent-sec/` 可写时落在该目录，否则落到
+`~/.agent-sec-core/`；`AGENT_SEC_DATA_DIR` 可覆盖两者。
+
+## `--trace-context`
+
+顶层选项，让调用方插件把自己的关联 ID 附加到本次调用产生的每条 Security Event 上，
+从而把安全记录与宿主 Agent 的 trace 关联起来。
+
+```bash
+agent-sec-cli --trace-context '{"trace_id":"t-1","session_id":"s-1"}' \
+  log-sandbox --decision block --command 'rm -rf /'
+```
+
+取值是一个 JSON 对象。可识别字段为 `trace_id`、`session_id`、`run_id`、`call_id`、
+`tool_call_id`、`agent_name`，每个字段同时接受 camelCase 写法（`traceId`、
+`sessionId`……）。未知字段被忽略；超过 256 字符的值会被截断并追加
+`...[truncated]` 标记。
+
+前五个作为关联字段落到 Security Event 上。`agent_name` 是例外：它以
+可观测元数据（`component.agent_name`）的形式传递，不存入事件本体，因此不要指望
+用它过滤事件。
+
+它必须出现在子命令之前——这是进程级选项，在命令之前解析，以保证子命令自身的 flag
+保持原有语义。JSON 格式错误会显式失败：CLI 向 stderr 打印
+`Error: invalid trace context JSON` 并以 `1` 退出，不执行子命令。空值等同于未提供。
+
+## `skill-ledger init-keys`
+
+为 `skill-ledger init` 出现之前编写的调用方保留的兼容命令。它只生成 Ed25519 签名
+密钥对，不做别的事。
+
+| 调用方式 | 最接近的受支持命令 |
+|---------|------------------|
+| `skill-ledger init-keys` | `skill-ledger init --no-baseline` |
+| `skill-ledger init-keys --force` | `skill-ledger init --no-baseline --force-keys` |
+| `skill-ledger init-keys --passphrase` | `skill-ledger init --no-baseline --passphrase` |
+
+上述对应关系仅在全新 ledger 上成立。一旦已有密钥对，在不加 force 标志的情况下，
+两者行为相反：
+
+| | `init-keys` | `init --no-baseline` |
+|---|---|---|
+| 行为 | 拒绝执行，报 `KeyAlreadyExistsError` | 跳过密钥生成，继续往下跑 |
+| 状态体现 | 错误信息 | JSON 输出中 `keyCreated: false` |
+| 退出码 | `1` | `0` |
+
+因此把自动化从 `init-keys` 迁移过去，会把原本失败的执行变成成功。如果脚本靠非 0
+退出码来判定“密钥已存在”，请改为读取 `init` 输出里的 `keyCreated`，而不是看退出码。
+
+请优先使用 `skill-ledger init`（见
+[Skill Ledger 用户指南](skill-ledger.md)）——它一步完成建密钥并为已覆盖 Skill 建立
+baseline。两者在密钥存放位置与文件权限上完全一致；在全新 ledger 上，口令行为也一致。
+
+## `skill-ledger rotate-keys`
+
+隐藏且已预留：名字占住了，但密钥轮换并未实现。调用它会失败，且不触碰任何密钥材料。
+
+| | 行为 |
+|---|------|
+| stdout | 空 |
+| stderr | `Error: rotate-keys is not implemented; no keys were changed.` |
+| 退出码 | `1` |
+| 密钥存储 | `key.enc`、`key.pub` 与 keyring 保持不变 |
+
+`rotate-keys --help` 仍以 `0` 退出并说明该命令未实现，因此探测命令是否存在的调用方确实
+能找到它。正因如此，失败才做成显式报错，而不是静默空转。
+
+当前没有受支持的密钥轮换入口，`--force-keys` 也不是。它是 `init` 的一个选项，而非轮换
+入口：它作为初始化 ledger 的一部分强制生成新密钥对，并不完成轮换密钥所隐含的其余工作。
+当你的意图是重新初始化时才用它，而不是当你的意图是轮换时。
+
+## 已移除：`skill-ledger set-policy`
+
+一个从未实现的隐藏占位命令，已被移除——而不是留着以 `0` 退出却什么都不做。此处记录它，
+仅为让已按它编写的调用方能识别新的失败形态：
+
+| | 行为 |
+|---|------|
+| stdout | 空 |
+| stderr | 用法错误，指出 `set-policy` 为无此命令 |
+| 退出码 | `2` |
+| ledger 状态 | 不产生任何创建 |
+
+`decide` 是记录单个 Skill 用户决策的唯一受支持命令，见
+[Skill Ledger 指南](skill-ledger.md)。

--- a/docs/user-guide/zh/user-entrypoint/copilot-shell/hooks.md
+++ b/docs/user-guide/zh/user-entrypoint/copilot-shell/hooks.md
@@ -162,3 +162,4 @@ Hook 脚本通过 stdin 接收 JSON 输入，通过 stdout 返回 JSON 输出。
 - [Hook 开发指南](../../../../developer-guide/zh/copilot-shell/hooks/index.md)
 - [Hook API 参考](../../../../developer-guide/zh/copilot-shell/hooks/reference.md)
 - [编写自定义 Hook](../../../../developer-guide/zh/copilot-shell/hooks/writing-hooks.md)
+- [AgentSecCore 内部命令](../../agent-security/agent-sec-core/internal-commands.md) — `sandbox-guard` spawn 的 `agent-sec-cli log-sandbox` 审计命令契约


### PR DESCRIPTION
log-sandbox is real, working, and the default action of the cosh sandbox-guard hook, yet docs/ had zero coverage of it. The same held for the other four hidden agent-sec-cli surfaces.

Documented all five in a dedicated user-guide page rather than dropping hidden=True. These are integration points that hooks and plugins call on the user's behalf; listing them in --help would present them as daily commands and imply a stability contract they do not have.

Recorded three contract details the issue did not mention but that bite in practice: --decision is unvalidated, so a typo yields a silently mislabeled audit record instead of an error; log-sandbox isolates nothing, which is linux-sandbox's job, so a block record blocks no command; set-policy and rotate-keys exit 0 while doing nothing.

Trade-off: the page pins behaviour that carries no compatibility promise, so it needs revisiting whenever a host integration changes.

Closes: #2862
Assisted-by: Qoder:1.22.1

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
