### PR TITLE
fix(sec-core): mark prompt_scan health untracked

### DIFF
--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/health.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/daemon/health.py
@@ -11,6 +11,12 @@ from agent_sec_cli.daemon.registry import (
 )
 from agent_sec_cli.daemon.runtime import DaemonRuntime
 
+_PROMPT_SCAN_UNTRACKED_DETAIL = (
+    "Prompt scanning runs in-process in the Rust extension; the daemon does not "
+    "observe scanner or L2 model state. Use `agent-sec-cli scan-prompt` output or "
+    "`agent-sec-cli events --event-type prompt_scan` to assess real availability."
+)
+
 
 def build_health_snapshot(runtime: DaemonRuntime) -> dict[str, Any]:
     """Build the daemon.health response without initializing heavy modules."""
@@ -19,19 +25,21 @@ def build_health_snapshot(runtime: DaemonRuntime) -> dict[str, Any]:
         "pid": os.getpid(),
         "uptime_seconds": runtime.uptime_seconds(),
         "socket": str(runtime.socket_path),
-        # Compatibility stub: scanning moved in-process to the Rust extension,
-        # so the daemon no longer tracks scanner state. Keep the key with the
-        # legacy PromptScanRuntimeState shape frozen at its success terminal
-        # state (ready/loaded) so monitors reading `.prompt_scan.*` neither
-        # fail silently nor raise false not-ready alerts; "native" in the
-        # model field marks the in-process engine.
+        # Scanning moved in-process to the Rust extension, so the daemon has no
+        # scanner state to report. The legacy PromptScanRuntimeState keys stay
+        # present so monitors reading `.prompt_scan.*` keep parsing, but every
+        # availability-bearing field is null/unknown: reporting ready/loaded=true
+        # here would mask an unusable L2 layer behind a green probe. `tracked`
+        # lets probes reject this payload instead of treating it as healthy.
         "prompt_scan": {
-            "status": "ready",
-            "model": "native",
-            "loaded": True,
+            "status": "unknown",
+            "model": None,
+            "loaded": None,
             "last_error": None,
             "last_started_at": None,
             "last_finished_at": None,
+            "tracked": False,
+            "detail": _PROMPT_SCAN_UNTRACKED_DETAIL,
         },
         "jobs": runtime.jobs.status(),
         "queues": runtime.queues.to_dict(),

--- a/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
+++ b/src/agent-sec-core/tests/unit-test/daemon/test_client_server.py
@@ -977,15 +977,6 @@ def test_health_does_not_import_heavy_modules(tmp_path: Path):
     registry = create_default_registry()
 
     assert snapshot["status"] == "ok"
-    # Locks the legacy PromptScanRuntimeState shape of the compat stub.
-    assert snapshot["prompt_scan"] == {
-        "status": "ready",
-        "model": "native",
-        "loaded": True,
-        "last_error": None,
-        "last_started_at": None,
-        "last_finished_at": None,
-    }
     assert registry.methods() == (
         "daemon.health",
         "obs.runs.list",
@@ -998,6 +989,33 @@ def test_health_does_not_import_heavy_modules(tmp_path: Path):
         "skill_ledger.skillfs_notify_change",
     )
     assert _matching_modules(heavy_prefixes) == before
+
+
+def test_health_prompt_scan_is_reported_as_untracked(tmp_path: Path):
+    """Health must not claim scanner readiness it cannot observe."""
+    snapshot = build_health_snapshot(
+        DaemonRuntime(socket_path=tmp_path / "daemon.sock")
+    )
+
+    prompt_scan = snapshot["prompt_scan"]
+
+    assert prompt_scan["tracked"] is False
+    assert prompt_scan["status"] == "unknown"
+    assert prompt_scan["loaded"] is None
+    assert prompt_scan["model"] is None
+    assert prompt_scan["detail"]
+    # Legacy PromptScanRuntimeState keys stay present so monitors reading
+    # `.prompt_scan.*` keep parsing, but none may imply availability.
+    assert set(prompt_scan) == {
+        "status",
+        "model",
+        "loaded",
+        "last_error",
+        "last_started_at",
+        "last_finished_at",
+        "tracked",
+        "detail",
+    }
 
 
 def test_completion_log_is_emitted_when_inflight_request_is_cancelled(


### PR DESCRIPTION
daemon.health froze data.prompt_scan at ready/model=native/loaded=true. Scanning moved in-process to the Rust extension, so the daemon observes no scanner state and those constants were unconditional: an ECS host whose L2 model never loaded still reported a fully green probe, and any probe gating on model readiness passed vacuously. loaded=true alongside null last_started_at/last_finished_at was self-contradictory on its face.

Kept the legacy PromptScanRuntimeState keys so monitors reading .prompt_scan.* keep parsing, but set every availability-bearing field to null/unknown and added tracked=false plus a detail string pointing at scan-prompt output and the prompt_scan event log. Preferred this over probing the scanner live, which would force health to import the scanner module and blow the 1000ms admin timeout, and over dropping the key, which breaks external monitors outright.

The probes-must-not-infer-healthy rule is carried in the health.py comment rather than a design document: the only document describing this payload is the dead scan-prompt protocol file removed by #2857.

Closes: #2847
Assisted-by: Qoder:1.22.1

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
