### PR TITLE
fix(sec-core): refuse non-loopback model base_url

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/prompt-scanner.md
@@ -46,6 +46,29 @@ Ollama from the project's ModelScope repository. Pull it once with
 `ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF` — then
 run `agent-sec-cli scan-prompt warmup` to verify the model is available before the first scan.
 
+### The model service must be local
+
+The L2/L4 model service endpoint comes from `AGENT_SEC_MODEL_SERVICE_BASE_URL`
+(default `http://localhost:11434`). Only loopback hosts — `localhost`,
+`127.x.x.x`, `::1` — are accepted. Prompts handed to the scanner routinely
+contain credentials and personal data, so the scanner refuses to send them
+anywhere but the local machine. The host is resolved with the same URL parser
+the HTTP client uses, so `http://localhost@attacker.example/` is refused too:
+the real host is whatever follows `@`.
+
+Pointing the variable at any other host makes `scan-prompt` fail at construction
+with an `error` verdict and exit `1`, naming the rejected URL in the message. A
+non-default port is fine as long as the host stays loopback:
+
+```bash
+export AGENT_SEC_MODEL_SERVICE_BASE_URL=http://127.0.0.1:18434
+```
+
+Because the six host hooks are fail-open on a non-zero `scan-prompt` exit, a
+remote endpoint leaves that host running with no prompt scanning — audited as a
+failed `prompt_scan` event and blocking nothing. Check stderr from
+`agent-sec-cli scan-prompt warmup` after changing the variable.
+
 ### Switching the L2 backend
 
 Set `PROMPT_SCANNER_L2_MODEL` to run L2 on the Warden-Gen model instead (or use

--- a/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/prompt-scanner.md
@@ -45,6 +45,27 @@ ModelScope 仓库拉取。执行一次
 `ollama pull modelscope.cn/ANOLISA/Qwen3Guard-Gen-0.6B-GGUF` 即可（无需重命名），
 再执行 `agent-sec-cli scan-prompt warmup` 验证模型可用，避免首次扫描时才发现模型缺失。
 
+### 模型服务必须部署在本机
+
+L2/L4 的模型服务地址来自 `AGENT_SEC_MODEL_SERVICE_BASE_URL`（默认
+`http://localhost:11434`），只接受 loopback 主机——`localhost`、`127.x.x.x`、
+`::1`。交给扫描器的 prompt 经常含有凭据与个人数据，因此扫描器拒绝将它们
+发往本机以外的任何地址。主机由 HTTP 客户端所用的同一个 URL 解析器解析，因此
+`http://localhost@attacker.example/` 这类值也会被拒绝——真正的主机是 `@`
+之后的部分。
+
+把该变量指向其他主机时，`scan-prompt` 会在构造期失败，输出 `error` verdict
+并以 `1` 退出，报错信息会指明被拒绝的地址。只要主机仍为 loopback，使用
+非默认端口是允许的：
+
+```bash
+export AGENT_SEC_MODEL_SERVICE_BASE_URL=http://127.0.0.1:18434
+```
+
+由于六个宿主 hook 在 `scan-prompt` 非零退出时均为 fail-open，配置为远程地址后，
+该宿主将处于「完全没有 prompt 扫描」的状态——仅被审计为一次失败的 `prompt_scan` 事件，
+不拦截任何内容。改动该变量后，请检查 `agent-sec-cli scan-prompt warmup` 的 stderr 输出。
+
 ### 切换 L2 后端
 
 设置 `PROMPT_SCANNER_L2_MODEL` 可把 L2 换成 Warden-Gen（也可用 `--model` 临时指定，优先级 `--model` > 环境变量 > 默认）：

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -23,6 +23,9 @@ thiserror = "1.0"
 unicode-normalization = "0.1"
 unicode-properties = "0.1"
 ureq = { version = "2.10", features = ["json"] }
+# Same parser ureq resolves requests with, so base_url validation cannot
+# disagree with the transport about which host is being contacted.
+url = "2.5"
 
 [package]
 name = "agent-sec-cli"

--- a/src/agent-sec-core/agent-sec-cli/crates/model-service/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/crates/model-service/Cargo.toml
@@ -11,3 +11,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 ureq = { workspace = true }
+url = { workspace = true }

--- a/src/agent-sec-core/agent-sec-cli/crates/model-service/src/lib.rs
+++ b/src/agent-sec-core/agent-sec-cli/crates/model-service/src/lib.rs
@@ -7,6 +7,10 @@
 //! - `AGENT_SEC_MODEL_SERVICE_BASE_URL` (default `http://localhost:11434`)
 //! - `AGENT_SEC_MODEL_SERVICE_TIMEOUT` seconds (default `30`, max `300`)
 //!
+//! The model service must be local: a non-loopback `base_url` is refused.
+//! Scanned prompts can carry credentials and PII, and the URL comes from the
+//! environment, so anything but loopback is treated as exfiltration.
+//!
 //! Consumers (prompt-scanner, future code/pii scanners) inject a
 //! [`ModelClient`] so their transport stays decoupled from this crate.
 
@@ -14,6 +18,7 @@ use std::time::Duration;
 
 use serde_json::{json, Map, Value};
 use thiserror::Error;
+use url::{Host, Url};
 
 const ENV_BACKEND: &str = "AGENT_SEC_MODEL_SERVICE_BACKEND";
 const ENV_BASE_URL: &str = "AGENT_SEC_MODEL_SERVICE_BASE_URL";
@@ -299,42 +304,60 @@ fn ollama_from_env() -> Result<OllamaClient, ModelServiceError> {
     ))
 }
 
-/// Reject a base URL whose scheme is not `http://` or `https://`, and warn
-/// when it targets a non-loopback host.  The URL comes from an environment
-/// variable, so a hijacked value (compromised orchestration config, injected
-/// `.env`) would silently exfiltrate every scanned prompt to that host.
+/// Reject a base URL that is unparseable, whose scheme is not `http://` or
+/// `https://`, or which targets a host other than loopback.
+///
+/// The URL comes from an environment variable, so a hijacked value
+/// (compromised orchestration config, injected `.env`) would otherwise
+/// exfiltrate every scanned prompt — credentials and PII included — to that
+/// host.  Only a locally hosted model service is supported, so refusing here
+/// turns that silent egress into a startup error.
+///
+/// Parsing goes through [`Url`], the same crate `ureq` resolves requests with,
+/// so this check cannot disagree with the transport about which host is being
+/// contacted.  A hand-rolled host scan does: in
+/// `http://localhost:8080@attacker.example/` the leading label is userinfo and
+/// the real destination is `attacker.example`.
+///
+/// # Errors
+///
+/// [`ModelServiceError::Config`] when the URL does not parse, the scheme is
+/// neither `http://` nor `https://`, or the host is not loopback.
 fn validate_base_url(base_url: &str) -> Result<(), ModelServiceError> {
-    if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+    let url = Url::parse(base_url).map_err(|error| {
+        ModelServiceError::Config(format!("base_url is not a valid URL {base_url:?}: {error}"))
+    })?;
+    // `Url::parse` accepts any scheme, so `localhost:11434` parses with scheme
+    // `localhost` rather than failing.
+    if !matches!(url.scheme(), "http" | "https") {
         return Err(ModelServiceError::Config(format!(
             "base_url must use http:// or https:// scheme: {base_url:?}"
         )));
     }
-    if !is_loopback_url(base_url) {
-        log::warn!(
-            "Model service base_url points to a non-local host: {base_url}; \
-             scanned prompts will be sent to it"
-        );
+    if !is_loopback_host(&url) {
+        return Err(ModelServiceError::Config(format!(
+            "refusing non-loopback model service base_url {base_url:?}: only a local model \
+             service is supported, and scanned prompts must not leave the host"
+        )));
     }
     Ok(())
 }
 
-/// Whether the URL's host is `localhost` or a loopback IP (any `127.x.x.x`
-/// or `::1`).  Assumes a valid `http(s)://` prefix has already been checked.
-fn is_loopback_url(base_url: &str) -> bool {
-    let after_scheme = base_url
-        .split_once("://")
-        .map_or(base_url, |(_, rest)| rest);
-    let authority = after_scheme.split('/').next().unwrap_or("");
-    // Bracketed IPv6 keeps its colons inside `[...]`; otherwise the first
-    // colon separates host from port.
-    let host = match authority.strip_prefix('[') {
-        Some(rest) => rest.split(']').next().unwrap_or(""),
-        None => authority.split(':').next().unwrap_or(""),
-    };
-    host == "localhost"
-        || host
-            .parse::<std::net::IpAddr>()
-            .is_ok_and(|ip| ip.is_loopback())
+/// Whether the parsed URL's host is `localhost` or a loopback IP.
+///
+/// [`Url`] normalises the many spellings of a loopback address — `127.1`,
+/// `2130706433`, `0x7f.0.0.1`, a trailing dot — into the same [`Host::Ipv4`],
+/// so all of them are accepted here.  That matches what the transport would
+/// have resolved them to, which is the point of not enumerating hosts by hand.
+fn is_loopback_host(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(name)) => name == "localhost",
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => ip.is_loopback(),
+        // Schemes without an authority (`file:`) never reach here, but a
+        // hostless URL is not local either way.
+        None => false,
+    }
 }
 
 /// Parse a timeout in seconds, falling back to [`DEFAULT_TIMEOUT_SECS`] when
@@ -556,20 +579,84 @@ mod tests {
     }
 
     #[test]
-    fn base_url_with_http_scheme_is_accepted() {
+    fn loopback_base_url_is_accepted() {
         assert!(validate_base_url("http://localhost:11434").is_ok());
-        assert!(validate_base_url("https://model.internal:8443").is_ok());
+        assert!(validate_base_url("http://127.0.0.1:11434").is_ok());
+        assert!(validate_base_url("http://[::1]:11434").is_ok());
+    }
+
+    /// Regression guard for the exfiltration path: a hijacked env var pointing
+    /// at an arbitrary host must fail closed rather than ship prompts there.
+    #[test]
+    fn non_loopback_base_url_is_rejected() {
+        for remote in [
+            "https://model.internal:8443",
+            "http://attacker.example:11434",
+            "http://10.0.0.5:18099",
+            "http://[2001:db8::1]:11434",
+        ] {
+            let error = validate_base_url(remote).expect_err("must be rejected");
+            let ModelServiceError::Config(message) = &error else {
+                panic!("{remote:?} must fail with Config, got {error:?}");
+            };
+            assert!(
+                message.contains(remote),
+                "rejection must name the offending URL so operators can fix it; got {message:?}"
+            );
+        }
     }
 
     #[test]
     fn loopback_detection_matches_local_hosts_only() {
-        assert!(is_loopback_url("http://localhost:11434"));
-        assert!(is_loopback_url("http://127.0.0.1:11434"));
-        assert!(is_loopback_url("http://127.1.2.3:11434/api"));
-        assert!(is_loopback_url("http://[::1]:11434"));
-        assert!(!is_loopback_url("http://attacker.example:11434"));
-        assert!(!is_loopback_url("http://10.0.0.5:11434"));
-        assert!(!is_loopback_url("http://[2001:db8::1]:11434"));
+        for local in [
+            "http://localhost:11434",
+            "http://127.0.0.1:11434",
+            "http://127.1.2.3:11434/api",
+            "http://[::1]:11434",
+        ] {
+            assert!(
+                validate_base_url(local).is_ok(),
+                "{local:?} must be accepted"
+            );
+        }
+        for remote in [
+            "http://attacker.example:11434",
+            "http://10.0.0.5:11434",
+            "http://[2001:db8::1]:11434",
+        ] {
+            assert!(
+                validate_base_url(remote).is_err(),
+                "{remote:?} must be refused"
+            );
+        }
+    }
+
+    /// Userinfo makes the authority's leading label a red herring: in
+    /// `http://localhost:8080@attacker.example/` the host is `attacker.example`,
+    /// which is where `ureq` sends the body.  Verified against a live listener:
+    /// the request arrived with `Host: <post-@ authority>` and the fake
+    /// loopback label demoted to an `Authorization: Basic` header.
+    #[test]
+    fn userinfo_does_not_disguise_a_remote_host() {
+        for disguised in [
+            "http://localhost@attacker.example:11434",
+            "http://localhost:8080@attacker.example:11434",
+            "http://127.0.0.1:8080@attacker.example/api",
+            "http://[::1]:8080@attacker.example",
+            "http://user:pass@attacker.example",
+        ] {
+            let error = validate_base_url(disguised).expect_err("must be refused");
+            let ModelServiceError::Config(message) = &error else {
+                panic!("{disguised:?} must fail with Config, got {error:?}");
+            };
+            assert!(
+                message.contains(disguised),
+                "rejection must name the offending URL; got {message:?}"
+            );
+        }
+        // Userinfo itself is not the thing being refused: here the real host is
+        // loopback, so the credential never leaves the machine.
+        assert!(validate_base_url("http://user:pass@127.0.0.1:11434").is_ok());
     }
 
     #[test]

--- a/src/agent-sec-core/agent-sec-cli/crates/model-service/tests/local_base_url_only.rs
+++ b/src/agent-sec-core/agent-sec-cli/crates/model-service/tests/local_base_url_only.rs
@@ -1,0 +1,51 @@
+//! Verifies the environment wiring that keeps the model service host-local.
+//!
+//! Lives outside `lib.rs` because it drives the public `create_client`, which
+//! reads the environment, whereas the unit tests there exercise the private
+//! `validate_base_url` directly.  Kept as one test in its own binary because
+//! `set_var` mutates process-global state: a single `#[test]` leaves no
+//! sibling thread able to observe the variable mid-change.
+
+use model_service::create_client;
+
+const ENV_BASE_URL: &str = "AGENT_SEC_MODEL_SERVICE_BASE_URL";
+
+#[test]
+fn only_a_loopback_base_url_is_accepted() {
+    // The loopback default is usable with nothing set.
+    std::env::remove_var(ENV_BASE_URL);
+    assert!(
+        create_client().is_ok(),
+        "the default loopback base_url must work out of the box"
+    );
+
+    // A hijacked variable pointing off-host fails closed.
+    std::env::set_var(ENV_BASE_URL, "http://attacker.example:18099");
+    // `Box<dyn ModelClient>` is not `Debug`, so match rather than `expect_err`.
+    let Err(error) = create_client() else {
+        panic!("non-loopback base_url must be refused");
+    };
+    let message = error.to_string();
+    assert!(
+        message.contains("attacker.example"),
+        "the refusal must name the offending host; got {message:?}"
+    );
+
+    // Userinfo that mimics loopback does not smuggle a remote host through:
+    // `ureq` would have sent the body to whatever follows '@'.
+    std::env::set_var(ENV_BASE_URL, "http://localhost:11434@attacker.example");
+    let Err(error) = create_client() else {
+        panic!("a base_url whose real host follows '@' must be refused");
+    };
+    assert!(
+        error.to_string().contains("attacker.example"),
+        "the refusal must name the offending URL; got {error}"
+    );
+
+    // A local service on a non-default port stays usable.
+    std::env::set_var(ENV_BASE_URL, "http://127.0.0.1:18099");
+    assert!(
+        create_client().is_ok(),
+        "a non-default loopback port must remain usable"
+    );
+}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/model_service/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/model_service/__init__.py
@@ -2,10 +2,17 @@
 
 Provides a unified interface to local model inference backends (Ollama, vLLM, etc.).
 Each scanner instantiates a client via ``create_client()`` and passes its own model name.
+
+An environment-supplied ``base_url`` pointing at a non-loopback host is refused:
+the model service must run locally, and scanned content can carry credentials
+and PII, so a hijacked variable must not silently exfiltrate it.  This mirrors
+the Rust ``model-service`` crate.
 """
 
+import ipaddress
 import os
 from typing import Any
+from urllib.parse import urlsplit
 
 from agent_sec_cli.model_service.base import ModelServiceClient
 
@@ -24,6 +31,37 @@ _DEFAULT_BASE_URL = "http://localhost:11434"
 _DEFAULT_TIMEOUT = 30
 
 
+def _is_loopback_url(base_url: str) -> bool:
+    """Whether the URL's host is ``localhost`` or a loopback IP (``127.x.x.x``, ``::1``)."""
+    host = urlsplit(base_url).hostname
+    if not host:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # A non-literal hostname; treated as remote.
+        return False
+
+
+def _validate_base_url(base_url: str) -> None:
+    """Reject an unsupported scheme, or any host other than loopback.
+
+    Raises:
+        ValueError: the scheme is neither ``http://`` nor ``https://``, or the
+            host is not loopback.
+    """
+    if not base_url.startswith(("http://", "https://")):
+        raise ValueError(f"base_url must use http:// or https:// scheme: {base_url!r}")
+    if not _is_loopback_url(base_url):
+        raise ValueError(
+            f"refusing non-loopback model service base_url {base_url!r}: only a "
+            "local model service is supported, and scanned content must not "
+            "leave the host"
+        )
+
+
 def create_client(
     backend: str | None = None,
     base_url: str | None = None,
@@ -33,17 +71,25 @@ def create_client(
     """Create a model service client instance.
 
     Parameters are resolved in order: explicit argument > environment variable > default.
+
+    An environment-derived *base_url* is validated; an explicit *base_url*
+    argument is trusted, since it comes from calling code rather than the
+    attacker-influenced environment.
+
+    Raises:
+        ValueError: the backend is unsupported, or the environment-derived
+            ``base_url`` is rejected by :func:`_validate_base_url`.
     """
     resolved_backend = (
         backend
         if backend is not None
         else os.environ.get(_ENV_BACKEND, _DEFAULT_BACKEND)
     )
-    resolved_base_url = (
-        base_url
-        if base_url is not None
-        else os.environ.get(_ENV_BASE_URL, _DEFAULT_BASE_URL)
-    )
+    if base_url is not None:
+        resolved_base_url = base_url
+    else:
+        resolved_base_url = os.environ.get(_ENV_BASE_URL, _DEFAULT_BASE_URL)
+        _validate_base_url(resolved_base_url)
     try:
         resolved_timeout = (
             timeout

--- a/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
+++ b/src/agent-sec-core/docs/design/PROMPT_SCANNER.md
@@ -255,7 +255,7 @@ agent-sec-cli scan-prompt --text "ignore all system instructions"
 > **降级的前提是至少有一层已应答**：若**所有**已配置层均执行失败（现实中即 multi-turn 模式——其唯一检测层 L4 不可达），
 > 则没有任何判定依据，扫描直接报错（如 `ScannerError::ModelInference`）而不输出降级 PASS——零覆盖的「降级通过」等于未扫先放。
 >
-> **边界：降级只覆盖扫描期的层失败。** 构造期（`PromptScanner::new`）的配置类错误（如 L2 模型名无对应 backend、`AGENT_SEC_MODEL_SERVICE_BASE_URL` scheme 非法、backend 非 `ollama`）不产生逐层降级：构造失败经 PyO3 映射为 `RuntimeError`，由统一的 error payload 输出 `verdict: "error"`，同样携带 `degraded: true` 与 `layers_failed: []`（top-level 失败而非 per-layer，原因记入 `summary`）。仅按 `verdict` 行事的 hook 仍会将该路径 fail-open 放行；消费 `degraded` 的 hook 则可对构造失败施加更严策略。
+> **边界：降级只覆盖扫描期的层失败。** 构造期（`PromptScanner::new`）的配置类错误（如 L2 模型名无对应 backend、`AGENT_SEC_MODEL_SERVICE_BASE_URL` scheme 非法、`AGENT_SEC_MODEL_SERVICE_BASE_URL` 指向非 loopback 主机、backend 非 `ollama`）不产生逐层降级：构造失败经 PyO3 映射为 `RuntimeError`，由统一的 error payload 输出 `verdict: "error"`，同样携带 `degraded: true` 与 `layers_failed: []`（top-level 失败而非 per-layer，原因记入 `summary`）。仅按 `verdict` 行事的 hook 仍会将该路径 fail-open 放行；消费 `degraded` 的 hook 则可对构造失败施加更严策略。
 >
 > **不存在「已配置但被跳过」的层。** 所有层一律 mandatory：依赖缺失在构造期报错，而非静默跳过后照常输出 `degraded: false`。L3 落地时沿用 L2 契约（配置错误在构造期报 `error`，运行期故障计入 `layers_failed` 并置 `degraded: true`），因此 `degraded` / `layers_failed` 始终是对已配置层的完整交代。
 
@@ -737,7 +737,7 @@ L2 同一时刻只跑一个后端。Warden-Gen 在 Qwen3Guard 的 9 个类别之
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `AGENT_SEC_MODEL_SERVICE_BACKEND` | `ollama` | 模型服务后端（当前仅支持 `ollama`） |
-| `AGENT_SEC_MODEL_SERVICE_BASE_URL` | `http://localhost:11434` | Ollama 服务地址 |
+| `AGENT_SEC_MODEL_SERVICE_BASE_URL` | `http://localhost:11434` | Ollama 服务地址；经 `url` crate（`ureq` 自身的解析器）解析，只接受 loopback 主机（`localhost`、`127.x.x.x`、`::1`），指向其他主机一律在构造期拒绝。userinfo 无法伪装主机：`http://localhost@attacker.example` 的真实主机是 `attacker.example`，同样被拒 |
 | `AGENT_SEC_MODEL_SERVICE_TIMEOUT` | `30` | HTTP 调用超时（秒） |
 | `AGENT_SEC_OLLAMA_MODEL` | `warden` | L4 多轮意图检测使用的模型 |
 | `PROMPT_SCANNER_L2_MODEL` | 空（即 Qwen3Guard） | L2 后端模型名；取值须为上表中的 L2 模型名，拼错会在构造期报错而非静默关闭 L2。CLI 的 `--model` 优先级高于本变量 |

--- a/src/agent-sec-core/tests/unit-test/model_service/test_model_service.py
+++ b/src/agent-sec-core/tests/unit-test/model_service/test_model_service.py
@@ -200,10 +200,43 @@ class TestCreateClient(unittest.TestCase):
 
     def test_env_var_base_url(self) -> None:
         with patch.dict(
-            os.environ, {"AGENT_SEC_MODEL_SERVICE_BASE_URL": "http://env:9999"}
+            os.environ,
+            {"AGENT_SEC_MODEL_SERVICE_BASE_URL": "http://127.0.0.1:9999"},
         ):
             client = create_client()
-            self.assertEqual(client._base_url, "http://env:9999")
+            self.assertEqual(client._base_url, "http://127.0.0.1:9999")
+
+    def test_env_var_non_loopback_base_url_rejected(self) -> None:
+        # Regression: a hijacked env var must not silently ship scanned content
+        # (which may carry credentials/PII) to an arbitrary host.
+        for remote in (
+            "http://env:9999",
+            "https://model.internal:8443",
+            "http://10.0.0.5:18099",
+        ):
+            with patch.dict(
+                os.environ,
+                {"AGENT_SEC_MODEL_SERVICE_BASE_URL": remote},
+            ):
+                with self.assertRaises(ValueError) as ctx:
+                    create_client()
+                self.assertIn(remote, str(ctx.exception))
+
+    def test_env_var_base_url_rejects_non_http_scheme(self) -> None:
+        for bad in ("ftp://localhost:11434", "file:///etc/passwd", "localhost:11434"):
+            with patch.dict(
+                os.environ,
+                {"AGENT_SEC_MODEL_SERVICE_BASE_URL": bad},
+            ):
+                with self.assertRaises(ValueError):
+                    create_client()
+
+    def test_explicit_base_url_bypasses_env_validation(self) -> None:
+        # Programmatic callers are trusted, mirroring the Rust crate where
+        # OllamaClient::new() is likewise unvalidated; only env-derived values
+        # are attacker-influenced.
+        client = create_client(base_url="http://explicit.remote:8080")
+        self.assertEqual(client._base_url, "http://explicit.remote:8080")
 
     def test_env_var_timeout(self) -> None:
         with patch.dict(os.environ, {"AGENT_SEC_MODEL_SERVICE_TIMEOUT": "45"}):


### PR DESCRIPTION
validate_base_url only logged a warning for a non-loopback host, so a hijacked AGENT_SEC_MODEL_SERVICE_BASE_URL silently shipped every scanned prompt off-host, and that warning went to the JSONL diagnostic stream which callers need not read. The Python model_service had no validation at all, leaving scan-code exposed the same way.

Both paths now refuse any host but loopback at construction time. An opt-in environment flag was considered and dropped: only a local Ollama service is supported today, so a permitted-remote state would be untested surface. It can be added when a remote deployment exists.

Only environment-derived values are checked; an explicit base_url argument stays trusted, matching OllamaClient::new. Deployments pointing the variable off-host now fail at startup with no override, and since the six host hooks are fail-open on a non-zero scan-prompt exit, such a host runs with no prompt scanning until the URL is corrected.

Closes: #2848
Assisted-by: Qoder:1.22.1

## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
