### PR TITLE
fix(skillfs): resolve categorized writes

### DIFF
--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/dir.rs
@@ -1391,60 +1391,14 @@ impl SkillFs {
             PathType::Root | PathType::SkillsDir | PathType::InboxDir => {
                 reply.ok();
             }
-            PathType::SkillDir { ref skill_name } | PathType::InboxSkillDir { ref skill_name } => {
-                if is_skill_discover_path(skill_name) {
-                    reply.ok();
-                } else {
-                    let dir_path = self.source_base().join(skill_name);
-                    match std::fs::metadata(&dir_path) {
-                        Ok(m) if m.is_dir() => match std::fs::File::open(&dir_path) {
-                            Ok(dir_file) => {
-                                let result = if datasync {
-                                    dir_file.sync_data()
-                                } else {
-                                    dir_file.sync_all()
-                                };
-                                match result {
-                                    Ok(()) => reply.ok(),
-                                    Err(e) => reply.error(errno(&e)),
-                                }
-                            }
-                            Err(e) => reply.error(errno(&e)),
-                        },
-                        Ok(_) => reply.error(libc::ENOTDIR),
-                        Err(e) => reply.error(errno(&e)),
-                    }
-                }
+            PathType::SkillDir { ref skill_name } if is_skill_discover_path(skill_name) => {
+                reply.ok();
             }
-            PathType::Passthrough {
-                ref skill_name,
-                ref relative_path,
-            }
-            | PathType::InboxPassthrough {
-                ref skill_name,
-                ref relative_path,
-            } => {
-                let dir_path = self.source_base().join(skill_name).join(relative_path);
-                match std::fs::metadata(&dir_path) {
-                    Ok(m) if m.is_dir() => match std::fs::File::open(&dir_path) {
-                        Ok(dir_file) => {
-                            let result = if datasync {
-                                dir_file.sync_data()
-                            } else {
-                                dir_file.sync_all()
-                            };
-                            match result {
-                                Ok(()) => reply.ok(),
-                                Err(e) => reply.error(errno(&e)),
-                            }
-                        }
-                        Err(e) => reply.error(errno(&e)),
-                    },
-                    Ok(_) => reply.error(libc::ENOTDIR),
-                    Err(e) => reply.error(errno(&e)),
-                }
-            }
-            PathType::HermesMeta { .. }
+            PathType::SkillDir { .. }
+            | PathType::InboxSkillDir { .. }
+            | PathType::Passthrough { .. }
+            | PathType::InboxPassthrough { .. }
+            | PathType::HermesMeta { .. }
             | PathType::HermesMetaChild { .. }
             | PathType::CategoryPassthrough { .. }
             | PathType::CategoryDir { .. }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/link.rs
@@ -622,8 +622,8 @@ impl SkillFs {
             return;
         }
 
-        let src_physical = self.source_base().join(&src_skill).join(&src_rel);
-        let dst_physical = self.source_base().join(&dst_skill).join(&dst_rel);
+        let src_physical = self.skill_physical_dir(&src_skill).join(&src_rel);
+        let dst_physical = self.skill_physical_dir(&dst_skill).join(&dst_rel);
 
         // T2 hardlink scope: same-skill **ordinary regular files only**.
         // `symlink_metadata` deliberately does NOT follow symlinks, so a

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/meta.rs
@@ -7,6 +7,7 @@ use fuser::{FUSE_ROOT_ID, FileType, ReplyAttr, ReplyEmpty, ReplyEntry, ReplyStat
 use tracing::debug;
 
 use super::super::SkillFs;
+use super::super::paths::FlatLiveDirKind;
 use super::super::read_resolution::ReadResolution;
 use crate::attr::{file_attr_from_metadata, file_attr_from_stat};
 use crate::path::{PathType, is_skill_discover_path};
@@ -263,7 +264,7 @@ impl SkillFs {
                             // snapshot.
                             if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
                             {
-                                self.source_base().join(&skill_name)
+                                self.flat_live_dir(&skill_name, FlatLiveDirKind::ExistingSkill)
                             } else {
                                 d
                             }
@@ -274,7 +275,7 @@ impl SkillFs {
                             // whitelist, resolve against physical source.
                             if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
                             {
-                                self.source_base().join(&skill_name)
+                                self.flat_live_dir(&skill_name, FlatLiveDirKind::ExistingSkill)
                             } else {
                                 reply.error(libc::ENOENT);
                                 return;
@@ -754,7 +755,7 @@ impl SkillFs {
                         Some(d) => {
                             if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
                             {
-                                self.source_base().join(&skill_name)
+                                self.flat_live_dir(&skill_name, FlatLiveDirKind::ExistingSkill)
                             } else {
                                 d
                             }
@@ -763,7 +764,7 @@ impl SkillFs {
                             // I4: grace bypass for getattr on passthrough path.
                             if self.is_post_publish_grace_allowed(&skill_name, Some(&relative_path))
                             {
-                                self.source_base().join(&skill_name)
+                                self.flat_live_dir(&skill_name, FlatLiveDirKind::ExistingSkill)
                             } else {
                                 reply.error(libc::ENOENT);
                                 return;
@@ -1085,13 +1086,17 @@ impl SkillFs {
         skill_name: &str,
         relative_path: Option<&Path>,
     ) -> Option<std::path::PathBuf> {
-        let live_dir = self.source_base().join(skill_name);
-        if self.is_staging_skill_root(skill_name)
-            || self.is_pending_install(skill_name)
-            || relative_path.is_some_and(|relative| {
-                self.is_post_publish_grace_allowed(skill_name, Some(relative))
-            })
-        {
+        let source_root_candidate =
+            self.is_staging_skill_root(skill_name) || self.is_pending_install(skill_name);
+        let grace_path = relative_path
+            .is_some_and(|relative| self.is_post_publish_grace_allowed(skill_name, Some(relative)));
+        if source_root_candidate || grace_path {
+            let kind = if source_root_candidate {
+                FlatLiveDirKind::SourceRootCandidate
+            } else {
+                FlatLiveDirKind::ExistingSkill
+            };
+            let live_dir = self.flat_live_dir(skill_name, kind);
             return Some(match relative_path {
                 Some(relative) => live_dir.join(relative),
                 None => live_dir,
@@ -1237,7 +1242,7 @@ impl SkillFs {
                         reply.ok();
                     }
                 } else {
-                    let live_path = self.source_base().join(skill_name).join("SKILL.md");
+                    let live_path = self.skill_physical_dir(skill_name).join("SKILL.md");
                     let read_path =
                         match self.flat_access_read_path(skill_name, Some(Path::new("SKILL.md"))) {
                             Some(path) => path,
@@ -1297,7 +1302,7 @@ impl SkillFs {
                             return;
                         }
                     }
-                    let live_path = self.source_base().join(skill_name).join(relative_path);
+                    let live_path = self.skill_physical_dir(skill_name).join(relative_path);
                     let read_path = match self
                         .flat_access_read_path(skill_name, Some(relative_path.as_path()))
                     {
@@ -1430,5 +1435,64 @@ impl SkillFs {
                 reply.error(libc::ENOENT);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, store::SkillStore};
+
+    use super::*;
+    use crate::security::{
+        PostPublishGraceController, PostPublishSessionKind, PostPublishWritePattern, StagingConfig,
+        StagingMatcher, StagingPattern,
+    };
+
+    #[test]
+    fn flat_access_separates_categorized_grace_from_staging_candidates() {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let skill_dir = source.path().join("catalog/demo");
+        std::fs::create_dir_all(skill_dir.join(".clawhub")).expect("categorized skill directories");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: categorized\n---\nbody\n",
+        )
+        .expect("categorized SKILL.md");
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let grace = PostPublishGraceController::new(
+            Duration::from_secs(5),
+            vec![PostPublishWritePattern::PrefixRecursive(
+                ".clawhub".to_string(),
+            )],
+        );
+        grace.start_session("demo", PostPublishSessionKind::StagingRename);
+        let staging = Arc::new(StagingMatcher::new(StagingConfig {
+            patterns: vec![StagingPattern::Exact(".staging-demo".to_string())],
+            ..StagingConfig::default()
+        }));
+        let fs = SkillFs::new(
+            source.path().join("mount"),
+            source.path().to_path_buf(),
+            Arc::new(RwLock::new(store)),
+            false,
+        )
+        .with_post_publish_controller(grace.clone())
+        .with_staging_matcher(staging);
+
+        assert_eq!(
+            fs.flat_access_read_path("demo", Some(Path::new(".clawhub/origin.json"))),
+            Some(skill_dir.join(".clawhub/origin.json"))
+        );
+        assert_eq!(
+            fs.flat_access_read_path(".staging-demo", Some(Path::new("SKILL.md"))),
+            Some(source.path().join(".staging-demo/SKILL.md"))
+        );
+
+        grace.shutdown();
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/mutate.rs
@@ -12,7 +12,9 @@ use super::super::SkillFs;
 use crate::path::PathType;
 use crate::security::{MutationKind, SkillEvent, SkillEventAction, SkillEventKind};
 use crate::sync::SyncEvent;
-use crate::sys::{errno, mkdirat_leaf, rename_noreplace, renameat2_leaf, unlinkat_leaf};
+use crate::sys::{
+    errno, mkdirat_leaf, open_dir_path, rename_noreplace, renameat2_leaf, unlinkat_leaf,
+};
 
 impl SkillFs {
     pub(in crate::fs) fn mkdir_impl(
@@ -905,7 +907,7 @@ impl SkillFs {
                 return;
             }
         };
-        let new_physical = match self.resolve_physical_path(&new_path) {
+        let resolved_new_physical = match self.resolve_physical_path(&new_path) {
             Some(p) => p,
             None => {
                 self.ro_warn("rename", &new_path);
@@ -921,6 +923,25 @@ impl SkillFs {
                 reply.error(libc::EROFS);
                 return;
             }
+        };
+        let new_physical = match (&old_path_type, &new_path_type) {
+            (
+                PathType::SkillDir { .. },
+                PathType::SkillDir {
+                    skill_name: new_name,
+                },
+            ) if self.skill_source_path(new_name).is_none()
+                && matches!(
+                    std::fs::symlink_metadata(&resolved_new_physical),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound
+                ) =>
+            {
+                old_physical
+                    .parent()
+                    .map(|parent| parent.join(new_name))
+                    .unwrap_or(resolved_new_physical)
+            }
+            _ => resolved_new_physical,
         };
 
         debug!(
@@ -941,10 +962,16 @@ impl SkillFs {
                 // Long-path fallback: rename via two parent dir fds + leafs.
                 // Both sides may exceed PATH_MAX on the absolute physical
                 // path even when each parent dir individually fits.
-                let old_parent = self.open_parent_dir_for(&old_path);
-                let new_parent = self.open_parent_dir_for(&new_path);
+                let old_parent = old_physical
+                    .parent()
+                    .and_then(|parent| open_dir_path(parent).ok())
+                    .zip(old_physical.file_name().map(|leaf| leaf.to_os_string()));
+                let new_parent = new_physical
+                    .parent()
+                    .and_then(|parent| open_dir_path(parent).ok())
+                    .zip(new_physical.file_name().map(|leaf| leaf.to_os_string()));
                 match (old_parent, new_parent) {
-                    (Ok((old_fd, old_leaf)), Ok((new_fd, new_leaf))) => {
+                    (Some((old_fd, old_leaf)), Some((new_fd, new_leaf))) => {
                         let flags: u32 = if no_replace {
                             SUPPORTED_RENAME_FLAGS
                         } else {
@@ -980,7 +1007,7 @@ impl SkillFs {
                         // We must use the *directory* name as the store key regardless
                         // of what SKILL.md frontmatter says (the user may not have
                         // updated the `name:` field yet).
-                        let md_path = self.source_base().join(new_name).join("SKILL.md");
+                        let md_path = new_physical.join("SKILL.md");
                         let new_entry = match parser::parse_skill_file(&md_path) {
                             Ok(mut entry) => {
                                 // Ensure the store key matches the directory name.
@@ -1019,6 +1046,7 @@ impl SkillFs {
                         if let PathType::SkillMd { skill_name } = &new_type {
                             self.send_sync(SyncEvent::Reparse {
                                 skill_name: skill_name.clone(),
+                                source_path: new_physical.clone(),
                             });
                         }
                         if let PathType::SkillMd { skill_name } = &old_type {

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/read.rs
@@ -671,6 +671,7 @@ impl SkillFs {
                 }
                 self.send_sync(SyncEvent::Reparse {
                     skill_name: skill_name.clone(),
+                    source_path: physical.clone(),
                 });
                 self.observe_mutation(
                     skill_name,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/callbacks/write.rs
@@ -138,6 +138,7 @@ impl SkillFs {
                 if let PathType::SkillMd { skill_name } = &path_type {
                     self.send_sync(SyncEvent::Reparse {
                         skill_name: skill_name.clone(),
+                        source_path: self.skill_physical_dir(skill_name).join("SKILL.md"),
                     });
                 }
                 if let PathType::InboxPassthrough {
@@ -148,6 +149,7 @@ impl SkillFs {
                     if relative_path == Path::new("SKILL.md") {
                         self.send_sync(SyncEvent::Reparse {
                             skill_name: skill_name.clone(),
+                            source_path: self.inbox_skill_dir(skill_name).join("SKILL.md"),
                         });
                     }
                 }
@@ -471,6 +473,7 @@ impl SkillFs {
                 if let PathType::SkillMd { skill_name } = &path_type {
                     self.send_sync(SyncEvent::Reparse {
                         skill_name: skill_name.clone(),
+                        source_path: physical.clone(),
                     });
                 }
                 if let PathType::InboxPassthrough {
@@ -481,6 +484,7 @@ impl SkillFs {
                     if relative_path == Path::new("SKILL.md") {
                         self.send_sync(SyncEvent::Reparse {
                             skill_name: skill_name.clone(),
+                            source_path: physical.clone(),
                         });
                     }
                 }
@@ -1007,6 +1011,7 @@ impl SkillFs {
                     if let PathType::SkillMd { ref skill_name } = path_type {
                         self.send_sync(SyncEvent::Reparse {
                             skill_name: skill_name.clone(),
+                            source_path: physical.clone(),
                         });
                     }
                     // D1.3-demo: truncate is the only setattr

--- a/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/mod.rs
@@ -201,18 +201,10 @@ impl SkillFs {
             None
         };
 
-        // Compute source_base for the sync worker before moving fields.
-        let sync_source_base = if let Some(ref fd) = source_dirfd {
-            use std::os::unix::io::AsRawFd;
-            PathBuf::from(format!("/proc/self/fd/{}", fd.as_raw_fd()))
-        } else {
-            source.clone()
-        };
-
         // Spawn the background sync worker.
         let (sync_tx, sync_rx) = std::sync::mpsc::channel();
         let sync_store = store.clone();
-        spawn_sync_worker(sync_rx, sync_store, sync_source_base);
+        spawn_sync_worker(sync_rx, sync_store);
 
         let fs = Self {
             mountpoint,

--- a/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/fs/paths.rs
@@ -18,6 +18,16 @@ use crate::security::{
 };
 use crate::sys::{errno, open_dir_path};
 
+/// Selects whether installer-authorized live I/O targets a loaded skill or a
+/// source-root candidate that has not entered the store yet.
+#[derive(Clone, Copy)]
+pub(super) enum FlatLiveDirKind {
+    /// Resolve an existing skill through its stored manifest path.
+    ExistingSkill,
+    /// Resolve staging and pending-install candidates directly under source.
+    SourceRootCandidate,
+}
+
 impl SkillFs {
     /// Return the base path for physical file access.
     ///
@@ -65,6 +75,14 @@ impl SkillFs {
             self.skill_source_path(skill_name)
                 .and_then(|p| p.parent().map(|d| d.to_path_buf()))
                 .unwrap_or_else(|| self.source.join(skill_name))
+        }
+    }
+
+    /// Resolve the live directory used by flat installer-authorized I/O.
+    pub(super) fn flat_live_dir(&self, skill_name: &str, kind: FlatLiveDirKind) -> PathBuf {
+        match kind {
+            FlatLiveDirKind::ExistingSkill => self.skill_physical_dir(skill_name),
+            FlatLiveDirKind::SourceRootCandidate => self.source_base().join(skill_name),
         }
     }
 
@@ -158,14 +176,14 @@ impl SkillFs {
     /// in-place mode) so that all I/O bypasses the FUSE layer.
     pub(super) fn resolve_physical_path(&self, fuse_path: &str) -> Option<PathBuf> {
         match self.parse_fuse_path(Path::new(fuse_path)) {
-            PathType::SkillDir { skill_name } => Some(self.source_base().join(&skill_name)),
+            PathType::SkillDir { skill_name } => Some(self.skill_physical_dir(&skill_name)),
             PathType::SkillMd { skill_name } => {
-                Some(self.source_base().join(&skill_name).join("SKILL.md"))
+                Some(self.skill_physical_dir(&skill_name).join("SKILL.md"))
             }
             PathType::Passthrough {
                 skill_name,
                 relative_path,
-            } => Some(self.source_base().join(&skill_name).join(&relative_path)),
+            } => Some(self.skill_physical_dir(&skill_name).join(&relative_path)),
             // L1 inbox virtual mapping: `<inbox>/<skill>/<rel>` shares
             // the physical layout with the live source candidate
             // directory. The inbox root itself has no physical backing
@@ -232,29 +250,20 @@ impl SkillFs {
             .map(|n| n.to_os_string())
             .ok_or(libc::EINVAL)?;
         let parent_fuse = path.parent().ok_or(libc::EINVAL)?;
-        let parent_fuse_str = match parent_fuse.to_str() {
-            Some(s) => s.to_string(),
-            None => return Err(libc::EINVAL),
-        };
-        let parent_physical = match crate::path::parse_path_with_layout(
-            parent_fuse,
-            self.in_place,
-            self.skill_layout,
-        ) {
-            PathType::SkillDir { skill_name } | PathType::InboxSkillDir { skill_name } => {
-                self.source_base().join(&skill_name)
-            }
+        let parent_physical = match self.parse_fuse_path(parent_fuse) {
+            PathType::SkillDir { skill_name } => self.skill_physical_dir(&skill_name),
+            PathType::InboxSkillDir { skill_name } => self.inbox_skill_dir(&skill_name),
             PathType::SkillMd { skill_name } => {
-                self.source_base().join(&skill_name).join("SKILL.md")
+                self.skill_physical_dir(&skill_name).join("SKILL.md")
             }
             PathType::Passthrough {
                 skill_name,
                 relative_path,
-            }
-            | PathType::InboxPassthrough {
+            } => self.skill_physical_dir(&skill_name).join(&relative_path),
+            PathType::InboxPassthrough {
                 skill_name,
                 relative_path,
-            } => self.source_base().join(&skill_name).join(&relative_path),
+            } => self.inbox_skill_dir(&skill_name).join(&relative_path),
             PathType::HermesMeta { name } => self.source_base().join(&name),
             PathType::HermesMetaChild {
                 name,
@@ -289,7 +298,6 @@ impl SkillFs {
             PathType::SkillsDir | PathType::Root | PathType::InboxDir => self.source_base(),
             PathType::Invalid => return Err(libc::ENOTDIR),
         };
-        let _ = parent_fuse_str; // suppress unused-binding warning when tracing is off
         open_dir_path(&parent_physical)
             .map(|f| (f, leaf))
             .map_err(|e| errno(&e))
@@ -449,5 +457,75 @@ impl SkillFs {
     /// Skill that has no activation key and would fail closed to hidden.
     pub(super) fn hermes_is_top_level_skill(&self, name: &str) -> bool {
         skillfs_core::store::has_regular_skill_md(&self.source_base().join(name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use skillfs_core::{ParseConfig, store::SkillStore};
+
+    use super::*;
+
+    #[test]
+    fn flat_paths_and_grace_use_the_stored_categorized_source_dir() {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let skill_dir = source.path().join("catalog/demo");
+        std::fs::create_dir_all(&skill_dir).expect("categorized skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: demo\ndescription: categorized\n---\nbody\n",
+        )
+        .expect("categorized SKILL.md");
+        std::fs::write(skill_dir.join("notes.txt"), "notes").expect("passthrough file");
+
+        let mut store = SkillStore::new();
+        store.load_from_directory(source.path(), &ParseConfig::default());
+        let fs = SkillFs::new(
+            source.path().join("mount"),
+            source.path().to_path_buf(),
+            Arc::new(RwLock::new(store)),
+            false,
+        );
+
+        assert_eq!(
+            fs.resolve_physical_path("/skills/demo"),
+            Some(skill_dir.clone())
+        );
+        assert_eq!(
+            fs.resolve_physical_path("/skills/demo/SKILL.md"),
+            Some(skill_dir.join("SKILL.md"))
+        );
+        assert_eq!(
+            fs.resolve_physical_path("/skills/demo/notes.txt"),
+            Some(skill_dir.join("notes.txt"))
+        );
+        assert_eq!(
+            fs.resolve_physical_path("/skills/new-skill"),
+            Some(source.path().join("new-skill"))
+        );
+        assert_eq!(
+            fs.flat_live_dir("demo", FlatLiveDirKind::ExistingSkill),
+            skill_dir
+        );
+        // Grace targets loaded skills, while staging/pending candidates retain
+        // their direct source-root mapping.
+        assert_eq!(
+            fs.flat_live_dir("demo", FlatLiveDirKind::SourceRootCandidate),
+            source.path().join("demo")
+        );
+
+        let (parent, leaf) = fs
+            .open_parent_dir_for("/skills/demo/notes.txt")
+            .expect("open categorized parent");
+        assert_eq!(leaf, "notes.txt");
+        let fd_path = PathBuf::from(format!("/proc/self/fd/{}", parent.as_raw_fd()));
+        assert_eq!(
+            std::fs::canonicalize(fd_path).expect("canonical parent fd"),
+            std::fs::canonicalize(&skill_dir).expect("canonical skill dir")
+        );
     }
 }

--- a/src/skillfs/crates/skillfs-fuse/src/sync.rs
+++ b/src/skillfs/crates/skillfs-fuse/src/sync.rs
@@ -12,7 +12,10 @@ use tracing::{info, warn};
 #[derive(Debug)]
 pub(crate) enum SyncEvent {
     /// Re-parse a skill's SKILL.md after write/create.
-    Reparse { skill_name: String },
+    Reparse {
+        skill_name: String,
+        source_path: PathBuf,
+    },
 }
 
 /// Spawn the background store-sync worker thread.
@@ -23,20 +26,19 @@ pub(crate) enum SyncEvent {
 pub(crate) fn spawn_sync_worker(
     rx: std::sync::mpsc::Receiver<SyncEvent>,
     store: SharedSkillStore,
-    source_base: PathBuf,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         while let Ok(first) = rx.recv() {
             // Collect more events within a 50 ms window (debounce).
             let mut pending: HashMap<String, SyncEvent> = HashMap::new();
             match &first {
-                SyncEvent::Reparse { skill_name } => {
+                SyncEvent::Reparse { skill_name, .. } => {
                     pending.insert(skill_name.clone(), first);
                 }
             }
             while let Ok(ev) = rx.recv_timeout(std::time::Duration::from_millis(50)) {
                 match &ev {
-                    SyncEvent::Reparse { skill_name } => {
+                    SyncEvent::Reparse { skill_name, .. } => {
                         pending.insert(skill_name.clone(), ev);
                     }
                 }
@@ -45,9 +47,11 @@ pub(crate) fn spawn_sync_worker(
             // Process the batch.
             for (_skill_name, event) in pending {
                 match event {
-                    SyncEvent::Reparse { ref skill_name } => {
-                        let md_path = source_base.join(skill_name).join("SKILL.md");
-                        match parser::parse_skill_file(&md_path) {
+                    SyncEvent::Reparse {
+                        ref skill_name,
+                        ref source_path,
+                    } => {
+                        match parser::parse_skill_file(source_path) {
                             Ok(mut entry) => {
                                 // The directory name is the authoritative store key.
                                 // Override metadata.name so that a stale frontmatter
@@ -74,4 +78,44 @@ pub(crate) fn spawn_sync_worker(
         }
         info!("sync worker exiting");
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use parking_lot::RwLock;
+    use skillfs_core::store::SkillStore;
+
+    use super::*;
+
+    #[test]
+    fn reparse_uses_the_event_source_path() {
+        let source = tempfile::tempdir().expect("source tempdir");
+        let md_path = source.path().join("catalog/demo/SKILL.md");
+        std::fs::create_dir_all(md_path.parent().expect("skill parent"))
+            .expect("categorized skill dir");
+        std::fs::write(
+            &md_path,
+            "---\nname: stale\ndescription: categorized\n---\nupdated body\n",
+        )
+        .expect("categorized SKILL.md");
+
+        let store = Arc::new(RwLock::new(SkillStore::new()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        let worker = spawn_sync_worker(rx, store.clone());
+        tx.send(SyncEvent::Reparse {
+            skill_name: "demo".to_string(),
+            source_path: md_path.clone(),
+        })
+        .expect("send reparse");
+        drop(tx);
+        worker.join().expect("sync worker");
+
+        let guard = store.read();
+        let entry = guard.get("demo").expect("reparsed store entry");
+        assert_eq!(entry.metadata.name, "demo");
+        assert_eq!(entry.source_path, md_path);
+        assert!(entry.body.contains("updated body"));
+    }
 }

--- a/src/skillfs/crates/skillfs-fuse/tests/categorized_flat_write_tests.rs
+++ b/src/skillfs/crates/skillfs-fuse/tests/categorized_flat_write_tests.rs
@@ -1,0 +1,231 @@
+//! Regression coverage for flat FUSE views backed by categorized sources.
+
+use std::ffi::CString;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use skillfs_core::{ParseConfig, SharedSkillStore, store::SkillStore};
+use skillfs_fuse::{MountConfig, MountOptions, mount_background_configured};
+
+mod common;
+
+fn wait_for(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if predicate() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    predicate()
+}
+
+fn access(path: &Path, mask: i32) -> i32 {
+    let path = CString::new(path.as_os_str().as_bytes()).expect("path CString");
+    let result = unsafe { libc::access(path.as_ptr(), mask) };
+    if result == 0 {
+        0
+    } else {
+        std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn renameat2(old: &Path, new: &Path, flags: u32) -> Result<(), i32> {
+    let old = CString::new(old.as_os_str().as_bytes()).expect("old path CString");
+    let new = CString::new(new.as_os_str().as_bytes()).expect("new path CString");
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            old.as_ptr(),
+            libc::AT_FDCWD,
+            new.as_ptr(),
+            flags,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO))
+    }
+}
+
+#[test]
+fn categorized_source_supports_flat_reads_writes_and_sync() {
+    skip_if_no_fuse!();
+
+    let source = tempfile::tempdir().expect("source tempdir");
+    let mountpoint = tempfile::tempdir().expect("mount tempdir");
+    let skill_dir = source.path().join("catalog/demo");
+    std::fs::create_dir_all(&skill_dir).expect("categorized skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: categorized\n---\noriginal body\n",
+    )
+    .expect("categorized SKILL.md");
+    std::fs::write(skill_dir.join("notes.txt"), "original notes").expect("categorized passthrough");
+
+    let mut initial_store = SkillStore::new();
+    initial_store.load_from_directory(source.path(), &ParseConfig::default());
+    let store: SharedSkillStore = Arc::new(RwLock::new(initial_store));
+    assert_eq!(
+        store.read().get("demo").expect("loaded demo").source_path,
+        skill_dir.join("SKILL.md")
+    );
+
+    let handle = mount_background_configured(
+        mountpoint.path(),
+        source.path(),
+        store.clone(),
+        MountOptions::default(),
+        false,
+        MountConfig::default(),
+    )
+    .expect("mount categorized source");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let virtual_skill = mountpoint.path().join("skills/demo");
+    let virtual_md = virtual_skill.join("SKILL.md");
+    let virtual_notes = virtual_skill.join("notes.txt");
+    let compiled = std::fs::read_to_string(&virtual_md).expect("compiled categorized read");
+    assert!(compiled.contains("original body"));
+    assert_eq!(access(&virtual_md, libc::W_OK), 0);
+    assert_eq!(access(&virtual_notes, libc::W_OK), 0);
+
+    let mut md = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&virtual_md)
+        .expect("append categorized SKILL.md");
+    md.write_all(b"appended through flat mount\n")
+        .expect("write categorized SKILL.md");
+    drop(md);
+
+    let mut notes = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&virtual_notes)
+        .expect("open categorized passthrough");
+    notes
+        .write_all(b"updated through flat mount")
+        .expect("write categorized passthrough");
+    drop(notes);
+
+    assert!(
+        wait_for(Duration::from_secs(3), || {
+            store
+                .read()
+                .get("demo")
+                .is_some_and(|entry| entry.body.contains("appended through flat mount"))
+        }),
+        "sync worker did not refresh the categorized store entry"
+    );
+    assert!(
+        std::fs::read_to_string(skill_dir.join("SKILL.md"))
+            .expect("physical categorized SKILL.md")
+            .contains("appended through flat mount")
+    );
+    assert_eq!(
+        std::fs::read_to_string(skill_dir.join("notes.txt"))
+            .expect("physical categorized passthrough"),
+        "updated through flat mount"
+    );
+    assert!(
+        std::fs::read_to_string(&virtual_md)
+            .expect("compiled read after sync")
+            .contains("appended through flat mount")
+    );
+
+    let virtual_link = virtual_skill.join("notes-link.txt");
+    std::fs::hard_link(&virtual_notes, &virtual_link)
+        .expect("hardlink categorized passthrough through flat mount");
+    let physical_notes = skill_dir.join("notes.txt");
+    let physical_link = skill_dir.join("notes-link.txt");
+    assert_eq!(
+        std::fs::read_to_string(&physical_link).expect("physical categorized hardlink"),
+        "updated through flat mount"
+    );
+    assert_eq!(
+        std::fs::metadata(&physical_notes)
+            .expect("physical categorized source metadata")
+            .ino(),
+        std::fs::metadata(&physical_link)
+            .expect("physical categorized hardlink metadata")
+            .ino(),
+        "categorized hardlink must share the source inode"
+    );
+    assert!(
+        !source.path().join("demo").exists(),
+        "flat mutations must not create an incorrect source/demo directory"
+    );
+
+    let candidate_dir = source.path().join("reserved-demo");
+    std::fs::create_dir(&candidate_dir).expect("source-root candidate dir");
+    std::fs::write(candidate_dir.join("payload.txt"), "candidate payload")
+        .expect("source-root candidate payload");
+    let candidate_virtual = mountpoint.path().join("skills/reserved-demo");
+
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        renameat2(&virtual_skill, &candidate_virtual, libc::RENAME_NOREPLACE),
+        Err(libc::EEXIST),
+        "NOREPLACE must preserve an existing source-root candidate"
+    );
+
+    let rename_error = std::fs::rename(&virtual_skill, &candidate_virtual)
+        .expect_err("plain rename must not ignore a non-empty source-root candidate");
+    assert!(
+        matches!(
+            rename_error.raw_os_error(),
+            Some(error) if error == libc::EEXIST || error == libc::ENOTEMPTY
+        ),
+        "plain rename returned an unexpected error: {rename_error}"
+    );
+    assert!(
+        skill_dir.is_dir(),
+        "categorized source must remain after conflict"
+    );
+    assert_eq!(
+        std::fs::read_to_string(candidate_dir.join("payload.txt"))
+            .expect("source-root candidate remains readable"),
+        "candidate payload"
+    );
+    assert!(
+        !source.path().join("catalog/reserved-demo").exists(),
+        "conflicting rename must not create a categorized sibling"
+    );
+    assert!(store.read().get("demo").is_some());
+    assert!(store.read().get("reserved-demo").is_none());
+    std::fs::remove_dir_all(&candidate_dir).expect("remove source-root candidate");
+
+    let renamed_virtual = mountpoint.path().join("skills/renamed-demo");
+    std::fs::rename(&virtual_skill, &renamed_virtual).expect("rename categorized flat skill");
+    assert!(source.path().join("catalog/renamed-demo").is_dir());
+    assert!(!source.path().join("renamed-demo").exists());
+    assert!(
+        std::fs::read_to_string(renamed_virtual.join("SKILL.md"))
+            .expect("compiled read after categorized rename")
+            .contains("appended through flat mount")
+    );
+    let renamed_entry_path = store
+        .read()
+        .get("renamed-demo")
+        .expect("renamed store entry")
+        .source_path
+        .clone();
+    assert_eq!(
+        renamed_entry_path,
+        source.path().join("catalog/renamed-demo/SKILL.md")
+    );
+
+    handle.unmount().expect("unmount categorized source");
+}


### PR DESCRIPTION
## Why

Normal-mode FUSE writes reconstructed flat virtual paths directly under the
source root. Categorized sources therefore served reads from the stored
manifest path but sent writes to a nonexistent sibling, returning ENOENT.

## What changed

Resolve existing flat skills through their stored manifest parent while
preserving source-root candidates for new installs and fd-backed in-place
access. Carry resolved manifest paths into store synchronization, preserve a
category during skill renames, and add categorized-source FUSE regressions.

## Related issue

closes #2898

## User / Agent impact

Agents can now write, truncate, rename, and synchronize skills exposed through
a flat normal-mode mount when their physical source is categorized.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

The FUSE live-write and post-publish grace paths now target the same stored
physical directory used by reads. Inbox, staging, pending-install, in-place,
and new-skill fallback semantics remain unchanged.

## Validation

Linux with fuse3 and /dev/fuse:

- cargo +1.86.0 fmt --all -- --check
- cargo +1.86.0 clippy --workspace --all-targets -- -D warnings
- cargo +1.86.0 test --workspace -- --test-threads=1
- cargo +1.86.0 test -p skillfs-fuse categorized -- --nocapture
- scripts/test.sh

## Documentation and rollback

No documentation changes are required because this restores the documented
physical-write passthrough behavior. Roll back by reverting commit
7e908ed21751700aeb2a9a298d1d5f2d6ec84c14.