### PR TITLE
fix(anolisa): keep ${VAR} refs in rendered content

### DIFF
--- a/src/anolisa/crates/anolisa-core/src/adapter.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter.rs
@@ -455,24 +455,44 @@ fn extract_string_list(value: &toml::Value) -> Vec<String> {
 /// `("component", "tokenless")` to expand `{component}`).
 ///
 /// Any `{...}` token that is neither a layout field nor an extra variable
-/// produces an [`AdapterError::UnknownPlaceholder`].
+/// produces an [`AdapterError::UnknownPlaceholder`]. Destination paths are
+/// written by anolisa itself, with no shell or service manager in the loop,
+/// so a `${VAR}` reference in a path template is a manifest bug and is
+/// rejected the same way — see [`expand_layout_placeholders_content`] for the
+/// one context where such references are meaningful.
 pub fn expand_layout_placeholders(
     template: &str,
     layout: &FsLayout,
     extra_vars: &[(&str, &str)],
 ) -> Result<PathBuf, AdapterError> {
-    expand_layout_placeholders_str(template, layout, extra_vars).map(PathBuf::from)
+    expand(template, layout, extra_vars, false).map(PathBuf::from)
 }
 
-/// String-level core of [`expand_layout_placeholders`].
+/// Expand layout placeholders inside *file content* for layout entries that
+/// declare `render = "anolisa-paths-v1"`.
 ///
-/// Shared by path expansion (which wraps the result in a [`PathBuf`]) and
-/// file *content* rendering (`render = "anolisa-paths-v1"` layout entries),
-/// so both consume the identical placeholder vocabulary and cannot drift.
-pub fn expand_layout_placeholders_str(
+/// Uses the identical placeholder vocabulary as [`expand_layout_placeholders`]
+/// so the two cannot drift on what `{bindir}` and friends mean. The single
+/// deliberate difference: a `{` immediately preceded by `$` is a shell or
+/// systemd environment-variable reference (`${VAR}`) that the *consumer*
+/// resolves at runtime — e.g. an `EnvironmentFile=`-fed unit — so it is kept
+/// verbatim instead of being rejected as an unknown placeholder. Content that
+/// wants anolisa expansion must therefore use `{bindir}`, never `${bindir}`.
+pub fn expand_layout_placeholders_content(
     template: &str,
     layout: &FsLayout,
     extra_vars: &[(&str, &str)],
+) -> Result<String, AdapterError> {
+    expand(template, layout, extra_vars, true)
+}
+
+/// Shared expansion core. `preserve_env_refs` keeps `${VAR}` tokens verbatim
+/// instead of failing closed on them.
+fn expand(
+    template: &str,
+    layout: &FsLayout,
+    extra_vars: &[(&str, &str)],
+    preserve_env_refs: bool,
 ) -> Result<String, AdapterError> {
     let mut replacements: BTreeMap<&str, &Path> = BTreeMap::new();
 
@@ -507,6 +527,16 @@ pub fn expand_layout_placeholders_str(
             Some(pos) => open + pos,
             None => break,
         };
+
+        // `${...}` is a shell/systemd environment reference resolved by the
+        // consumer at runtime, so the token stays verbatim. Resume scanning
+        // just past the opener rather than past `close`: a parameter
+        // expansion can carry a layout placeholder as its default
+        // (`${ROOT:-{datadir}}`), and `close` points at that inner `}`.
+        if preserve_env_refs && result[..open].ends_with('$') {
+            search_from = open + 1;
+            continue;
+        }
 
         let key = &result[open + 1..close];
 
@@ -813,6 +843,66 @@ mod tests {
         assert!(
             err.to_string().contains("unknown_thing"),
             "error should name the placeholder: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_content_preserves_dollar_braced_env_reference() {
+        let layout = test_layout();
+        let unit = "ExecStart=\"{libexecdir}/cosh-ng/cosh-gateway\" serve \
+--workspace=${COSH_GATEWAY_WORKSPACE}";
+        let rendered = expand_layout_placeholders_content(unit, &layout, &[]).unwrap();
+        assert_eq!(
+            rendered,
+            "ExecStart=\"/usr/local/libexec/anolisa/cosh-ng/cosh-gateway\" serve \
+--workspace=${COSH_GATEWAY_WORKSPACE}"
+        );
+
+        // The exemption is lexical, not name-aware: `${bindir}` is an
+        // environment reference, not a layout placeholder. COMPONENT_CONTRACT.md
+        // documents `{bindir}` as the only spelling that expands.
+        let rendered = expand_layout_placeholders_content("${bindir}", &layout, &[]).unwrap();
+        assert_eq!(rendered, "${bindir}");
+    }
+
+    #[test]
+    fn expand_content_renders_layout_placeholder_nested_in_env_default() {
+        let layout = test_layout();
+        let rendered =
+            expand_layout_placeholders_content("${ROOT:-{datadir}}/skills", &layout, &[]).unwrap();
+        assert_eq!(rendered, "${ROOT:-/usr/local/share/anolisa}/skills");
+    }
+
+    #[test]
+    fn expand_content_rejects_unknown_placeholder_nested_in_env_default() {
+        let layout = test_layout();
+        let err = expand_layout_placeholders_content("${ROOT:-{unknown_thing}}", &layout, &[])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown_thing"),
+            "nested placeholders must stay fail-closed: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_content_still_rejects_unknown_bare_placeholder() {
+        let layout = test_layout();
+        let err =
+            expand_layout_placeholders_content("{unknown_thing}/${VAR}", &layout, &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown_thing"),
+            "bare placeholders must stay fail-closed: {err}"
+        );
+    }
+
+    #[test]
+    fn expand_path_rejects_dollar_braced_env_reference() {
+        let layout = test_layout();
+        let err = expand_layout_placeholders("{etcdir}/${COSH_GATEWAY_WORKSPACE}/x", &layout, &[])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("COSH_GATEWAY_WORKSPACE"),
+            "paths have no runtime expander and must fail closed: {err}"
         );
     }
 

--- a/src/anolisa/crates/anolisa-core/src/install_runner.rs
+++ b/src/anolisa/crates/anolisa-core/src/install_runner.rs
@@ -719,7 +719,10 @@ impl<'a> InstallRunner<'a> {
     ///
     /// For [`RenderMode::AnolisaPathsV1`] the bytes must be UTF-8 text; layout
     /// placeholders are substituted via the same expansion vocabulary used
-    /// for destination paths, so path and content semantics cannot drift.
+    /// for destination paths, so path and content semantics cannot drift on
+    /// what a placeholder means. Content additionally keeps `${VAR}`
+    /// environment-variable references verbatim for the runtime consumer to
+    /// resolve (see [`crate::adapter::expand_layout_placeholders_content`]).
     fn render_bytes(
         &self,
         file: &ResolvedInstallFile,
@@ -733,7 +736,7 @@ impl<'a> InstallRunner<'a> {
                     reason: "content is not valid UTF-8 — anolisa-paths-v1 renders text files only"
                         .to_string(),
                 })?;
-                let rendered = crate::adapter::expand_layout_placeholders_str(
+                let rendered = crate::adapter::expand_layout_placeholders_content(
                     text,
                     self.layout,
                     &[("component", spec.component.as_str())],
@@ -2628,6 +2631,63 @@ mod tests {
             fs::read_to_string(&dest).unwrap(),
             format!("root={}/adapters/sec-core\n", layout.datadir.display())
         );
+    }
+
+    #[test]
+    fn render_preserves_env_refs_and_expands_nested_placeholders() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        // Shape taken from cosh-gateway@.service.in: a layout placeholder and
+        // an EnvironmentFile-backed reference on one line, plus a parameter
+        // expansion whose default is itself a layout placeholder.
+        let template = concat!(
+            "ExecStart=\"{libexecdir}/cosh-gateway\" --workspace=${COSH_GATEWAY_WORKSPACE}\n",
+            "Environment=SKILLS=${SKILL_ROOT:-{datadir}/skills}\n"
+        );
+        let gz = build_tar_gz(&[("unit.in", template.as_bytes())]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("cosh-gateway@.service");
+        runner
+            .install_files("tar_gz", &cached, &[render_entry("unit.in", dest.clone())])
+            .expect("install ok");
+
+        assert_eq!(
+            fs::read_to_string(&dest).unwrap(),
+            format!(
+                "ExecStart=\"{}/cosh-gateway\" --workspace=${{COSH_GATEWAY_WORKSPACE}}\n\
+                 Environment=SKILLS=${{SKILL_ROOT:-{}/skills}}\n",
+                layout.libexec_dir.display(),
+                layout.datadir.display()
+            )
+        );
+    }
+
+    #[test]
+    fn render_unknown_placeholder_nested_in_env_default_rejected() {
+        let home = tempdir().unwrap();
+        let cache = tempdir().unwrap();
+        let layout = layout_for(home.path());
+        let runner = InstallRunner::new(&layout);
+
+        let gz = build_tar_gz(&[("unit.in", b"Environment=X=${ROOT:-{no_such_dir}}\n")]);
+        let cached = write_cached(cache.path(), "payload.tar.gz", &gz);
+
+        let dest = layout.datadir.join("unit");
+        let err = runner
+            .install_files("tar_gz", &cached, &[render_entry("unit.in", dest.clone())])
+            .expect_err("must reject unknown placeholder inside an env default");
+        match err {
+            InstallError::Render { reason, .. } => assert!(
+                reason.contains("no_such_dir"),
+                "reason must name the placeholder: {reason}"
+            ),
+            other => panic!("expected Render, got {other:?}"),
+        }
+        assert!(!dest.exists(), "nothing may land on a failed render");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-core/src/lib.rs
+++ b/src/anolisa/crates/anolisa-core/src/lib.rs
@@ -58,7 +58,7 @@ pub use adapter::manager::{
 pub use adapter::registry::DriverRegistry;
 pub use adapter::{
     AdapterError, DetectResult, detect_framework, expand_layout_placeholders,
-    expand_layout_placeholders_str,
+    expand_layout_placeholders_content,
 };
 pub use backup::{BackupEntry, BackupSet};
 pub use capability::{

--- a/src/anolisa/docs/COMPONENT_CONTRACT.md
+++ b/src/anolisa/docs/COMPONENT_CONTRACT.md
@@ -206,6 +206,20 @@ Rules:
   content fails the install. Rendering is opt-in per entry, so files that
   legitimately contain braces are unaffected unless they declare
   `render`.
+- A brace token immediately preceded by `$` is left verbatim. `${VAR}` is
+  a shell or systemd environment reference that the **consumer** resolves
+  at runtime — a unit fed by `EnvironmentFile=`, for example — so ANOLISA
+  neither expands nor rejects it. The exemption is purely lexical: write
+  `{bindir}` to get layout expansion, never `${bindir}`, which ships
+  verbatim and is then resolved at runtime as an unset variable. A layout
+  placeholder nested inside such a token still renders, so
+  `${SKILL_ROOT:-{datadir}/skills}` keeps the environment reference and
+  resolves `{datadir}`, and an unknown nested name still fails the
+  install.
+- The `$` exemption applies to file content only. `target` and every other
+  destination path is written by ANOLISA itself, with no shell or service
+  manager in the loop, so `${VAR}` there is rejected as an unknown
+  placeholder.
 - The value is versioned. An installer that does not implement the
   declared value refuses the install rather than copying the template
   verbatim; pair new `render` values with a matching


### PR DESCRIPTION
## Why

`render = "anolisa-paths-v1"` substitutes layout placeholders inside file
content, but `expand_layout_placeholders_str` treated every `{...}` token as a
layout placeholder. cosh-ng's gateway unit passes
`--workspace=${COSH_GATEWAY_WORKSPACE}`, an environment variable systemd
resolves at runtime from `EnvironmentFile=/etc/cosh/gateway-%i.env`, so
`anolisa install cosh-ng --backend raw` failed closed with `content references
unknown placeholder '{COSH_GATEWAY_WORKSPACE}'` and no raw install of the
component could complete.

The RPM backend renders the same template through
`sed 's|{libexecdir}/cosh-ng|%{_libexecdir_cosh}|g'` (`src/cosh-ng/cosh-ng.spec.in`),
which rewrites only the layout placeholder and leaves the environment
reference verbatim. RPM installs were therefore correct all along — the raw
renderer was the outlier, and the two backends disagreed on a file the unified
raw/RPM contract is meant to keep identical.

## What changed

Content rendering now leaves a `{` immediately preceded by `$` verbatim for the
runtime consumer to resolve, and resumes scanning just past that opener rather
than past its closing brace. A parameter expansion can carry a layout
placeholder as its default (`${ROOT:-{datadir}}`), where the first `}` closes
the inner placeholder rather than the expansion; skipping to it would leave
`{datadir}` unrendered in an installed file and drop the fail-closed guarantee
for an unknown nested name. Bare `{...}` tokens stay fail-closed.

Path expansion deliberately keeps rejecting `${VAR}`: anolisa writes
destination paths itself with no shell or service manager in the loop, so such
a reference in a path template is a manifest bug. Relaxing it there would be a
silent-failure risk — capability paths (`install/raw.rs`,
`commands/common.rs`) reach `validate_owned_path` without a leftover-brace
guard, so `{etcdir}/${FOO}/x` would become a literal `/etc/anolisa/${FOO}/x`
and pass.

To make that split explicit, the string entry point is renamed
`expand_layout_placeholders_str` → `expand_layout_placeholders_content`, with
both public wrappers delegating to one private core. The doc comments on
`adapter.rs` and `install_runner.rs::render_bytes` previously asserted that
path and content semantics "cannot drift"; they now state the accurate
invariant — the placeholder vocabulary is still shared, and `${...}` handling
is the single intentional difference.

The exemption is lexical rather than name-aware, so `${bindir}` ships verbatim
instead of expanding. `docs/COMPONENT_CONTRACT.md` previously promised that any
unknown `{...}` token fails the install, which left component authors no way to
tell which brace tokens are exempt, so it now documents the `$` exemption, the
nested-placeholder behavior, and the fact that destination paths still reject
`${VAR}`.

## Related issue

closes #2864

## User / Agent impact

`anolisa install cosh-ng --backend raw` succeeds again on a host with no
conflicting component installed. Relocatable unit templates rendered by
`anolisa-paths-v1` can now carry `EnvironmentFile=`-backed `${VAR}` references
alongside layout placeholders, matching what the RPM backend already produced.

## Risk and compatibility

- [ ] Privileged or security-sensitive behavior changed

No change to path expansion, boundary validation, or ownership checks. The
relaxation is confined to file *content* under an explicit
`render = "anolisa-paths-v1"` opt-in. `expand_layout_placeholders_content` is
an internal `anolisa-core` API with no callers outside this workspace.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p anolisa-core --all-targets` (clean)
- `cargo check --workspace --all-targets` (clean)
- `cargo test -p anolisa-core --lib` — 1048 passed, 0 failed
- `adapter.rs` unit tests: mixed `${COSH_GATEWAY_WORKSPACE}` + `{libexecdir}`
  expands only the latter and `${bindir}` survives verbatim; a layout
  placeholder nested in an env default renders; an unknown name nested in an
  env default still errors; bare unknown placeholders in content still error;
  `${VAR}` in a path template still errors
- `install_runner.rs` end-to-end tests through `install_files`:
  `render_preserves_env_refs_and_expands_nested_placeholders` (real
  `cosh-gateway@.service.in` shape plus `${SKILL_ROOT:-{datadir}/skills}`) and
  `render_unknown_placeholder_nested_in_env_default_rejected`
- Audited both `render = "anolisa-paths-v1"` templates in the repo —
  `cosh-gateway@.service.in` (`{libexecdir}`, `${COSH_GATEWAY_WORKSPACE}`) and
  `agent-sec-core.service.in` (`{bindir}`, `{datadir}`) — both render correctly

## Documentation and rollback

`src/anolisa/docs/COMPONENT_CONTRACT.md` gains three rules under **Content
Rendering**: `$`-prefixed brace tokens are preserved verbatim, layout
placeholders nested inside them still render (and unknown nested names still
fail closed), and the exemption does not extend to `target` or any other
destination path. English-only, matching `specs/documentation-standard.md` §4.2
— `src/<component>/docs/` carries no bilingual requirement and the file has no
`_zh` counterpart. The `render = "anolisa-paths-v1"` contract value itself is
unchanged, so no `min_anolisa_version` bump is implied. Roll back by reverting
the single commit on this branch.
