### PR TITLE
fix(sec-core): skip read-only system skills

### DIFF
--- a/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/en/agent-security/agent-sec-core/skill-ledger.md
@@ -21,6 +21,11 @@ Skill Ledger is the security subsystem of agent-sec-core that maintains a versio
 agent-sec-cli skill-ledger init
 ```
 
+The baseline is a batch write operation. Host-backed, read-only packaged system
+Skills follow the skip contract described under
+[Packaged read-only system Skills](#packaged-read-only-system-skills); key
+initialization still completes.
+
 Key locations:
 
 | File | Path | Permissions |
@@ -120,6 +125,39 @@ child.on("close", (code) => {
 future packaging change may extract the shared scanners into a scanner-only
 wheel or RPM subpackage; the scanner rules must remain single-source.
 
+#### Packaged read-only system Skills
+
+`scan` is a stateful certification command: successful work persists scanner
+results, a signed manifest, and a snapshot under `.skill-meta`. It is not a
+read-only alias for `analyze`.
+
+For host-backed packaged Skills that are immediate children of
+`/usr/share/anolisa/skills/` or `/usr/local/share/anolisa/skills/`, batch write
+paths skip an item when its ledger state is not writable. Both `scan --all` and
+the default `init` baseline emit this per-Skill result:
+
+```json
+{
+  "canonicalSkillDir": "/usr/share/anolisa/skills/example",
+  "skillName": "example",
+  "status": "skipped",
+  "reasonCode": "readonly_system_skill",
+  "persisted": false
+}
+```
+
+`skipped` is an operational batch status, not one of the six integrity states.
+It does not mean `pass`, does not attest the Skill, and does not fail the batch
+by itself; the command exits `0` unless another item returns `status=error`.
+No per-Skill scanner result, manifest, snapshot, or `.skill-meta` state is
+written for the skipped item, while global key initialization keeps its normal
+behavior. An explicit `scan <dir>` remains strict: it exits `1` and points the
+caller to `analyze` for read-only findings.
+
+`check` and `status` are unchanged. A skipped Skill with no prior ledger
+artifacts returns `none`, and aggregate health can remain `unscanned`. These
+values do not turn the batch skip into an attestation or a safety verdict.
+
 The default certification path uses the built-in quick scanner and does not depend on an LLM. For a single Skill:
 
 ```bash
@@ -180,6 +218,13 @@ agent-sec-cli skill-ledger status --verbose
 | `skills` | Aggregate health (discovered Skill count, per-status counts, overall health label) |
 
 `health` label meanings: `healthy` (no critical/attention statuses and not all none; may mix pass/none), `unscanned` (all none), `attention` (drifted/warn present), `critical` (deny/tampered/error present), `empty` (no registered Skills).
+
+`none` means that no attested scanner verdict is available; it covers both a
+missing ledger artifact and a verified manifest whose `scanStatus` is `none`.
+`unscanned` means that every discovered Skill currently checks as `none`.
+Neither value may be interpreted as `pass`. A read-only packaged system Skill
+skipped by a batch write remains in those existing states when it has no prior
+ledger artifacts.
 
 With `--verbose`, an additional `results` array contains detailed check results for each Skill.
 
@@ -522,7 +567,7 @@ Non-existent directories are silently ignored. Additionally, running `scan` or `
 
 #### Scheduled Default Quick Scans
 
-To periodically refresh default quick-scan results, put `scan --all` into cron. `scan --all` automatically skips Skills whose files are unchanged and already have complete scan results, re-scanning only new, changed, scan-result-missing, or manifest-anomalous Skills.
+To periodically refresh default quick-scan results, put `scan --all` into cron. `scan --all` automatically skips Skills whose files are unchanged and already have complete scan results, re-scanning only new, changed, scan-result-missing, or manifest-anomalous Skills. It also returns `status=skipped` with `reasonCode=readonly_system_skill` for host-backed, read-only packaged system Skills; inspect the JSON results because this run does not create or refresh an attestation for those items.
 
 Without a key passphrase:
 
@@ -615,13 +660,14 @@ Per-version verification: schema → hash integrity → signature validity → s
 |---------|---------|
 | `agent-sec-cli skill-ledger init` | Initialize keys and build a quick-scan baseline for covered Skills |
 | `agent-sec-cli skill-ledger init --no-baseline` | Initialize keys only, without scanning Skills |
+| `agent-sec-cli skill-ledger analyze <dir> --format json` | Analyze current content without creating ledger state or an attestation |
 | `agent-sec-cli skill-ledger check <dir>` | Check integrity status (JSON output) |
 | `agent-sec-cli skill-ledger show <dir>` | Show latest, active, user decision, activation target, findings, and alerts |
 | `agent-sec-cli skill-ledger export <dir> --version latest --output <path>` | Export a snapshot, manifest, and findings for full review |
 | `agent-sec-cli skill-ledger decide <dir> --action allow|always_allow|block|rollback` | Record a user decision and refresh activation |
 | `agent-sec-cli skill-ledger decide <dir> --clear` | Clear the user decision on the latest manifest |
-| `agent-sec-cli skill-ledger scan <dir>` | Run a quick scan and sign it into the manifest |
-| `agent-sec-cli skill-ledger scan --all` | Gap-filling quick scan across all discovered Skills |
+| `agent-sec-cli skill-ledger scan <dir>` | Run a quick scan and sign it into the manifest; a host-backed, read-only packaged system Skill is an error |
+| `agent-sec-cli skill-ledger scan --all` | Gap-filling quick scan; host-backed, read-only packaged system Skills return operational `skipped` results |
 | `agent-sec-cli skill-ledger certify <dir> --findings <file>` | Sign deep-scan findings into the manifest |
 | `agent-sec-cli skill-ledger status` | Overall security posture (keys, config, Skill health) |
 | `agent-sec-cli skill-ledger status --verbose` | Overall posture including per-Skill detailed results |

--- a/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
+++ b/docs/user-guide/zh/agent-security/agent-sec-core/skill-ledger.md
@@ -21,6 +21,9 @@ Skill Ledger 是 agent-sec-core 的安全子系统，为 AI Agent Skill 提供�
 agent-sec-cli skill-ledger init
 ```
 
+baseline 是批量写操作。由 host 提供的只读已打包系统 Skill 会遵循
+[只读的已打包系统 Skill](#只读的已打包系统-skill) 中的跳过契约；密钥初始化仍会完成。
+
 密钥存放位置：
 
 | 文件 | 路径 | 权限 |
@@ -115,6 +118,35 @@ child.on("close", (code) => {
 `analyze` 当前随完整的 `agent-sec-cli` wheel 和 RPM 交付。后续可将共享 scanner
 提取为 scanner-only wheel 或 RPM 子包，但 scanner 规则必须继续保持单一源码。
 
+#### 只读的已打包系统 Skill
+
+`scan` 是有状态的认证命令：成功时会把 scanner 结果、签名 manifest 和 snapshot
+写入 `.skill-meta`。它不是 `analyze` 的只读别名。
+
+对于 `/usr/share/anolisa/skills/` 或 `/usr/local/share/anolisa/skills/` 的直接
+子目录中由 host 提供的已打包 Skill，如果账本状态不可写，批量写路径会跳过该项。
+`scan --all` 和默认的 `init` baseline 都会返回以下逐 Skill 结果：
+
+```json
+{
+  "canonicalSkillDir": "/usr/share/anolisa/skills/example",
+  "skillName": "example",
+  "status": "skipped",
+  "reasonCode": "readonly_system_skill",
+  "persisted": false
+}
+```
+
+`skipped` 是批量操作状态，不是六种完整性状态之一。它不表示 `pass`，不构成 Skill
+认证，也不会单独使批量命令失败；除非其它项返回 `status=error`，命令退出码为 `0`。
+跳过项不会写入逐 Skill scanner 结果、manifest、snapshot 或 `.skill-meta` 状态，
+全局密钥初始化行为保持不变。显式 `scan <dir>` 仍保持严格语义：退出码为 `1`，并提示
+调用方使用 `analyze` 获取只读 findings。
+
+`check` 和 `status` 的语义不变。若跳过项此前不存在任何账本 artifact，`check`
+返回 `none`，聚合健康度仍可能为 `unscanned`；这些值不会把批量跳过转化为认证或
+安全结论。
+
 默认认证路径使用内置快速扫描器，不依赖 LLM。对单个 Skill 执行：
 
 ```bash
@@ -175,6 +207,11 @@ agent-sec-cli skill-ledger status --verbose
 | `skills` | 聚合健康度（已发现 Skill 数、各状态计数、整体 health 标签） |
 
 `health` 标签含义：`healthy`（没有 critical/attention 状态，且不是全部 none；可能包含 pass/none 混合）、`unscanned`（全部 none）、`attention`（存在 drifted/warn）、`critical`（存在 deny/tampered/error）、`empty`（无已注册 Skill）。
+
+`none` 表示没有可用的已认证 scanner verdict，既可能是账本 artifact 不存在，也可能
+是已验真 manifest 的 `scanStatus` 为 `none`；`unscanned` 表示所有已发现 Skill 当前
+都检查为 `none`。二者都不能解释为 `pass`。批量写操作跳过的只读已打包系统 Skill
+如果没有既有账本 artifact，会继续处于这些已有状态。
 
 使用 `--verbose` 时会额外输出 `results` 数组，包含每个 Skill 的详细检查结果。
 
@@ -495,7 +532,7 @@ agent-sec-cli skill-ledger decide /path/to/skill --clear
 
 #### 定时执行默认快速扫描
 
-如果希望定期刷新默认快速扫描结果，可以把 `scan --all` 放入 cron。`scan --all` 会自动跳过文件未变且已有完整扫描结果的 Skill，只补扫新增、变更、缺少扫描结果或 manifest 异常的 Skill。
+如果希望定期刷新默认快速扫描结果，可以把 `scan --all` 放入 cron。`scan --all` 会自动跳过文件未变且已有完整扫描结果的 Skill，只补扫新增、变更、缺少扫描结果或 manifest 异常的 Skill。对于由 host 提供的只读已打包系统 Skill，它还会返回 `status=skipped` 和 `reasonCode=readonly_system_skill`；本次运行不会为这些项创建或刷新认证，因此应检查 JSON 结果。
 
 无口令密钥场景：
 
@@ -588,13 +625,14 @@ agent-sec-cli skill-ledger audit /path/to/my-skill --verify-snapshots
 |------|------|
 | `agent-sec-cli skill-ledger init` | 初始化密钥，并为已覆盖 Skill 建立快速扫描 baseline |
 | `agent-sec-cli skill-ledger init --no-baseline` | 只初始化密钥，不扫描 Skill |
+| `agent-sec-cli skill-ledger analyze <dir> --format json` | 只读分析当前内容，不创建账本状态或认证 |
 | `agent-sec-cli skill-ledger check <dir>` | 检查完整性状态（JSON 输出） |
 | `agent-sec-cli skill-ledger show <dir>` | 展示 latest、active、用户决策、activation target、findings 与告警信息 |
 | `agent-sec-cli skill-ledger export <dir> --version latest --output <path>` | 导出指定 snapshot、manifest 和 findings 供完整审查 |
 | `agent-sec-cli skill-ledger decide <dir> --action allow|always_allow|block|rollback` | 写入用户决策并刷新 activation |
 | `agent-sec-cli skill-ledger decide <dir> --clear` | 清除 latest manifest 上的用户决策 |
-| `agent-sec-cli skill-ledger scan <dir>` | 执行快速扫描并签名写入 manifest |
-| `agent-sec-cli skill-ledger scan --all` | 对所有已发现 Skill 执行补齐式快速扫描 |
+| `agent-sec-cli skill-ledger scan <dir>` | 执行快速扫描并签名写入 manifest；由 host 提供的只读已打包系统 Skill 会报错 |
+| `agent-sec-cli skill-ledger scan --all` | 执行补齐式快速扫描；由 host 提供的只读已打包系统 Skill 返回运行状态 `skipped` |
 | `agent-sec-cli skill-ledger certify <dir> --findings <file>` | 将深度扫描 findings 签名写入 manifest |
 | `agent-sec-cli skill-ledger status` | 查看整体安全状况（密钥、配置、Skill 健康度） |
 | `agent-sec-cli skill-ledger status --verbose` | 查看整体安全状况（含每个 Skill 详细结果） |

--- a/src/agent-sec-core/README.md
+++ b/src/agent-sec-core/README.md
@@ -347,6 +347,15 @@ For an existing manifest, authenticity is verified before file drift; an unsigne
 The six integrity states are `pass` / `none` / `drifted` / `warn` / `deny` /
 `tampered`.
 
+`scan` and the default `init` baseline are signed-ledger write paths; use
+`analyze` for read-only content findings. In batch mode, a host-backed packaged
+Skill under `/usr/share/anolisa/skills/` or `/usr/local/share/anolisa/skills/`
+whose ledger state is read-only is reported as `status=skipped`,
+`reasonCode=readonly_system_skill`, `persisted=false`. This operational skip is
+not a `pass` result or an attestation. An explicit `scan <dir>` remains an error.
+When a skipped Skill has no prior ledger artifacts, `check` and `status`
+continue to report `none` / `unscanned`; neither value means `pass`.
+
 ### Key Commands
 
 | Command | Description |

--- a/src/agent-sec-core/README_zh.md
+++ b/src/agent-sec-core/README_zh.md
@@ -329,6 +329,14 @@ agent-sec-cli scan-pii --input ./sample.log --include-low-confidence
 
 六种完整性状态为 `pass` / `none` / `drifted` / `warn` / `deny` / `tampered`。
 
+`scan` 和默认的 `init` baseline 都会写入签名账本；如需只读内容 findings，
+请使用 `analyze`。批量模式下，如果 `/usr/share/anolisa/skills/` 或
+`/usr/local/share/anolisa/skills/` 下由 host 提供的已打包 Skill 无法写入账本状态，
+命令会返回 `status=skipped`、`reasonCode=readonly_system_skill`、
+`persisted=false`。这个运行状态不是 `pass` 结果，也不构成认证；显式执行
+`scan <dir>` 仍会报错。如果跳过项此前没有任何账本 artifact，`check` 和 `status`
+仍会分别报告 `none` / `unscanned`；二者都不表示 `pass`。
+
 ### 核心命令
 
 | 命令 | 说明 |

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/config.py
@@ -39,13 +39,16 @@ logger = logging.getLogger(__name__)
 
 _SKILL_MANIFEST = "SKILL.md"
 _DEPRECATED_SKILL_DIRS_KEY = "skillDirs"
+DEFAULT_SYSTEM_SKILL_ROOTS = (
+    Path("/usr/share/anolisa/skills"),
+    Path("/usr/local/share/anolisa/skills"),
+)
 DEFAULT_SKILL_DIRS = [
     "~/.openclaw/skills/*",
     "~/.copilot-shell/skills/*",
     "~/.hermes/skills/**",
     "~/.qoder/skills/*",
-    "/usr/share/anolisa/skills/*",
-    "/usr/local/share/anolisa/skills/*",
+    *(f"{root}/*" for root in DEFAULT_SYSTEM_SKILL_ROOTS),
 ]
 _IGNORED_RECURSIVE_DIRS = frozenset(
     {".git", ".github", ".hub", ".archive", ".skill-meta"}
@@ -352,6 +355,12 @@ def is_managed_covered(skill_dir: Path, config: dict[str, Any] | None = None) ->
         skill_dir,
         managed_skill_dir_entries(config),
     )
+
+
+def is_default_system_skill_dir(skill_dir: str | Path) -> bool:
+    """Return whether *skill_dir* is an immediate child of a packaged system root."""
+    canonical_dir = _lexical_path(Path(skill_dir).expanduser())
+    return canonical_dir.parent in DEFAULT_SYSTEM_SKILL_ROOTS
 
 
 def _is_path_covered_by_entries(skill_dir: Path, entries: list[str]) -> bool:

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/skill_ledger/core/certifier.py
@@ -11,7 +11,10 @@ import logging
 from pathlib import Path
 from typing import Any, Literal
 
-from agent_sec_cli.skill_ledger.config import remember_skill_dir
+from agent_sec_cli.skill_ledger.config import (
+    is_default_system_skill_dir,
+    remember_skill_dir,
+)
 from agent_sec_cli.skill_ledger.core.file_hasher import (
     compute_file_hashes,
     diff_file_hashes,
@@ -20,6 +23,7 @@ from agent_sec_cli.skill_ledger.core.live_root import (
     ResolvedSkillRoot,
     SkillRootInput,
     canonical_skill_operation,
+    ledger_update_access,
     resolve_skill_root,
     validate_resolved_skill_root,
 )
@@ -81,6 +85,24 @@ def _remember_skill_dir_best_effort(skill_dir: str) -> None:
         logger.debug(
             "auto-remember failed for %s, continuing", skill_dir, exc_info=True
         )
+
+
+def _readonly_system_skip_payload(
+    root: ResolvedSkillRoot,
+) -> dict[str, Any] | None:
+    """Return a batch skip result for a host-backed, read-only system Skill."""
+    if root.source != "host" or not is_default_system_skill_dir(root.canonical_dir):
+        return None
+    writable, _reason = ledger_update_access(root)
+    if writable:
+        return None
+    return {
+        "canonicalSkillDir": str(root.canonical_dir),
+        "skillName": root.skill_name,
+        "status": "skipped",
+        "reasonCode": "readonly_system_skill",
+        "persisted": False,
+    }
 
 
 def _sign_manifest(manifest: SignedManifest, backend: SigningBackend) -> SignedManifest:
@@ -499,8 +521,13 @@ def scan_skill(
     """Run built-in scanners as needed and record signed scan results."""
     root = resolve_skill_root(skill_dir)
     validate_resolved_skill_root(root)
+    if _readonly_system_skip_payload(root) is not None:
+        raise SkillLedgerError(
+            f"cannot update read-only system skill: {root.canonical_dir}; "
+            "use 'agent-sec-cli skill-ledger analyze <skill_dir> --format json' "
+            "for read-only analysis"
+        )
     io_skill_dir = str(root.io_dir)
-    _remember_skill_dir_best_effort(str(root.canonical_dir))
 
     current_hashes = compute_file_hashes(io_skill_dir)
     registry = ScannerRegistry.from_config()
@@ -527,7 +554,7 @@ def scan_skill(
             raise SkillLedgerError(
                 f"scan cannot recover {state} skill without scanner results"
             )
-        return _result_payload(
+        result = _result_payload(
             manifest,
             root=root,
             new_version_created=False,
@@ -535,6 +562,8 @@ def scan_skill(
             skipped_scanners=requested,
             status="noop",
         )
+        _remember_skill_dir_best_effort(str(root.canonical_dir))
+        return result
 
     scan_entries = _auto_invoke_scanners(io_skill_dir, registry, scanners_to_run)
     if not scan_entries:
@@ -542,7 +571,7 @@ def scan_skill(
             raise SkillLedgerError(
                 f"scan cannot recover {state} skill without scanner results"
             )
-        return _result_payload(
+        result = _result_payload(
             manifest,
             root=root,
             new_version_created=False,
@@ -550,6 +579,8 @@ def scan_skill(
             skipped_scanners=scanners_to_run,
             status="noop",
         )
+        _remember_skill_dir_best_effort(str(root.canonical_dir))
+        return result
 
     _persist_manifest_update(
         root,
@@ -568,7 +599,7 @@ def scan_skill(
                 scanners_run=scanners_run,
             )
         ]
-    return _result_payload(
+    result = _result_payload(
         manifest,
         root=root,
         new_version_created=new_version_created,
@@ -576,6 +607,8 @@ def scan_skill(
         skipped_scanners=[name for name in requested if name not in scanners_to_run],
         extra=extra,
     )
+    _remember_skill_dir_best_effort(str(root.canonical_dir))
+    return result
 
 
 def scan_batch(
@@ -589,9 +622,15 @@ def scan_batch(
     results: list[dict[str, Any]] = []
     for skill_dir in skill_dirs:
         try:
+            root = resolve_skill_root(skill_dir)
+            validate_resolved_skill_root(root)
+            skipped = _readonly_system_skip_payload(root)
+            if skipped is not None:
+                results.append(skipped)
+                continue
             results.append(
                 scan_skill(
-                    str(skill_dir),
+                    root,
                     backend,
                     scanner_names=scanner_names,
                     force=force,

--- a/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
+++ b/src/agent-sec-core/docs/design/SKILL_LEDGER_zh.md
@@ -46,14 +46,14 @@ AI Agent 通过加载 Skill（结构化指令 + 辅助脚本）扩展能力。Sk
 │                                                       │
 │  ~/.local/share/agent-sec/skill-ledger/                     │
 │    key.enc (私钥)     ← scan/certify 签名                   │
-│    check 只读状态；scan/certify 创建签名版本与 snapshot       │
+│ analyze/check 只读；scan/certify 创建签名版本与 snapshot     │
 │    key.pub (公钥)     ← check 验签                     │
 └───────────────────────────────────────────────────────┘
 ```
 
 **组件职责**：
 
-- **skill-ledger CLI**：核心基础设施。提供 `init`（初始化密钥并可为已覆盖 Skill 建立快速扫描 baseline）、`scan`（运行内置快速扫描器并签名入账）、`check`（只读检查 JSON + 验签 + 比哈希 + 输出状态，可供宿主 hook/capability 调用）、`certify`（导入外部 findings 并签名）等子命令。`scan` / `certify` 写入的 manifest 经 Ed25519 数字签名保护，防止篡改；当 `latest.json` 缺失时，`check` 仅在历史版本 artifact 也不存在时将该缺失判为 `none`，历史 artifact 仍存在则返回 `tampered`；latest 验真且与当前文件匹配时，仍按 `scanStatus` 返回状态（包括 `none`）。`check` 不创建版本或 snapshot。确定性逻辑不依赖 LLM，不可被 prompt injection 绕过。
+- **skill-ledger CLI**：核心基础设施。提供 `init`（初始化密钥并可为已覆盖 Skill 建立快速扫描 baseline）、`analyze`（只读内容分析，不创建账本状态）、`scan`（运行内置快速扫描器并签名入账）、`check`（只读检查 JSON + 验签 + 比哈希 + 输出状态，可供宿主 hook/capability 调用）、`certify`（导入外部 findings 并签名）等子命令。`scan` / `certify` 写入的 manifest 经 Ed25519 数字签名保护，防止篡改；当 `latest.json` 缺失时，`check` 仅在历史版本 artifact 也不存在时将该缺失判为 `none`，历史 artifact 仍存在则返回 `tampered`；latest 验真且与当前文件匹配时，仍按 `scanStatus` 返回状态（包括 `none`）。`analyze` / `check` 不创建版本或 snapshot。确定性逻辑不依赖 LLM，不可被 prompt injection 绕过。
 - **Scanner Registry**：可扩展扫描框架。通过配置注册扫描器（`builtin`/`cli`/`skill`/`api` 四种调用类型）和结果解析器（将异构扫描输出归一化为统一 `NormalizedFinding` 格式）。本版本默认注册 `skill-vetter`（`type: "skill"`，由 Agent 深度扫描后通过 `certify --findings` 消费）、`code-scanner` 和 `static-scanner`（均为 `type: "builtin"`，可由 `scan` 自动调用）。当前仅实现 `findings-array` parser；`cli`/`api` adapter 及其它 parser 类型为预留扩展点。旧名称 `skill-code-scanner`、`cisco-static-scanner` 仅作为兼容 alias 读取，不再作为公开名称展示或写入新 manifest。
 - **skill-ledger Skill**：一个 Skill，三个阶段。Phase 1 做环境准备与状态查看；Phase 2 默认执行快速扫描认证（`scan` 调用内置 `code-scanner` 与 `static-scanner`）；Phase 3 在用户显式要求或确认后执行 Agent 驱动深度扫描（`skill-vetter`），再用 `certify --findings ... --delete-findings` 写入版本链。
 - **SkillFS + daemon activation**：推荐运行态入口。SkillFS 捕获 Skill 文件变化后调用 daemon 的 `skill_ledger.skillfs_notify_change` 接口，daemon 根据签名 manifest 和 activation policy 刷新 `.skill-meta/activation.json`，并尽力同步写入 xattr。
@@ -258,7 +258,7 @@ class SigningBackend(Protocol):
 
 **合并策略**：默认目录默认启用，由 `enableDefaultSkillDirs` 控制；`managedSkillDirs` 存放 skill-ledger 动态管理或用户额外配置的目录，不再兼容旧的 `skillDirs` 字段。解析时默认目录在前，`managedSkillDirs` 在后，自动去重。`scanners` 按 `name` 合并，用户配置可覆盖同名扫描器；`activationPolicy` 是全局运行态策略，当前只执行 `pass_warn_only` 行为，历史配置值 `pass_only` / `latest_scanned` 会兼容读取并归一化；`signingBackend` 当前会被读取到配置摘要中，但不会改变实际签名后端。
 
-**自动记忆**：用户对某个 skill 执行 `scan` 或 `certify` 时，若该 skill 目录不在当前有效目录中，会自动追加到 `managedSkillDirs`。`check` 是只读状态检查，不会写配置、manifest 或 snapshot。若父目录下有 ≥2 个包含 `SKILL.md` 的兄弟 skill，则追加父目录 glob（`parent/*`）而非单个路径。追加后自动压缩（compact）：若某 glob 已覆盖某个单目录条目，则移除冗余的单目录条目。
+**自动记忆**：用户对某个 skill 执行 `scan` 或 `certify` 时，若该 skill 目录不在当前有效目录中，会自动追加到 `managedSkillDirs`。其中 `scan` 只在 manifest 持久化成功或成功返回 `noop` 后记忆；scanner 失败、落盘失败和批量跳过均不触发记忆。`check` 是只读状态检查，不会写配置、manifest 或 snapshot。若父目录下有 ≥2 个包含 `SKILL.md` 的兄弟 skill，则追加父目录 glob（`parent/*`）而非单个路径。追加后自动压缩（compact）：若某 glob 已覆盖某个单目录条目，则移除冗余的单目录条目。
 
 #### 默认后端：Ed25519 + 加密密钥文件
 
@@ -320,6 +320,7 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 | 子命令 | 用途 | 本版本状态 |
 |--------|------|-----------|
 | `init` | 初始化密钥，并默认为已覆盖 Skill 建立快速扫描 baseline | 已实现 |
+| `analyze` | 只读分析当前内容，不创建账本状态或认证 | 已实现 |
 | `scan` | 运行内置快速扫描器并签名写入 manifest | 已实现 |
 | `check` | 低层完整性与扫描状态检查（只读 JSON） | 已实现 |
 | `certify` | 导入外部 findings 并签名写入 manifest | 已实现 |
@@ -337,7 +338,7 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 
 若密钥不存在，生成 Ed25519 密钥对并写入 `~/.local/share/agent-sec/skill-ledger/key.enc`（mode 0600）；若密钥已存在则复用，不轮换。默认不加密（明文种子）；只有指定 `--passphrase` 时才启用口令逻辑，此时可交互输入口令，或设置 `SKILL_LEDGER_PASSPHRASE` 环境变量用于非交互场景。
 
-默认行为还会发现已覆盖目录中的 Skill，并执行补齐式快速扫描，建立签名 baseline。`--no-baseline` 只初始化密钥，不扫描 Skill。不访问、不可写或扫描失败的 Skill 会记录为 `error`/`skipped` 结果，不阻断其它 Skill。
+默认行为还会发现已覆盖目录中的 Skill，并执行补齐式快速扫描，建立签名 baseline。`--no-baseline` 只初始化密钥，不扫描 Skill。对于 `/usr/share/anolisa/skills/` 或 `/usr/local/share/anolisa/skills/` 的直接子目录中由 host 提供、账本状态不可写的已打包 Skill，baseline 返回逐项 `status=skipped`、`reasonCode=readonly_system_skill`、`persisted=false`；该项不会阻断其它 Skill，也不会单独使命令返回非零退出码。其它访问、写入或扫描失败仍记录为 `error`，并使命令返回退出码 1。
 
 兼容入口 `init-keys` 仍保留，但作为低层命令隐藏，不在普通 help 与用户主流程中展示。
 
@@ -367,6 +368,8 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 
 `scan` 是内置快速扫描器的主入口，不是 dry-run。默认 scanner 为 `code-scanner,static-scanner`；执行结束后自动更新 `manifest.scans[]`，聚合 `scanStatus`，重算 `manifestHash`，并写入 Ed25519 签名。
 
+只读内容分析由 `skill-ledger analyze <skill_dir> --format json` 提供。用户显式执行 `scan <skill_dir>` 表示要求持久化签名账本；若目标是上述由 host 提供且账本状态不可写的已打包系统 Skill，命令保持严格语义，返回退出码 1，并提示改用 `analyze`，不会降级为未持久化的扫描结论。
+
 默认采用补齐式扫描：
 
 - 未纳管（`latest.json` 与历史版本 artifact 均不存在）、无扫描结果、缺少部分默认 scanner 结果时，只运行缺失 scanner。
@@ -374,7 +377,7 @@ GPG 仍是**分发签名**（sign-skill.sh → trusted-keys → verifier.py）�
 - `tampered`（包括缺少签名）时用户显式执行 `scan` 即表示按当前文件重新建立可信记录；CLI 不原地补签，也不继承损坏 manifest 的 scans、状态或用户决策，而是重新扫描并写入新版本。
 - 已有对应 scanner 结果且文件未变时跳过该 scanner。
 
-`scan --all` 对所有发现的 Skill 执行相同补齐逻辑；若没有任何 scanner 需要执行，不写 manifest，只报告 `noop`。`--force` 会强制重跑请求 scanner 并重签 manifest。
+`scan --all` 对所有发现的 Skill 执行相同补齐逻辑；若没有任何 scanner 需要执行，不写 manifest，只报告 `noop`。对于上述只读已打包系统 Skill，批量路径不运行 scanner，也不写入逐 Skill manifest、snapshot、`.skill-meta` 状态或配置，返回 `status=skipped`、`reasonCode=readonly_system_skill`、`persisted=false`。`skipped` 是运行状态，不是六种完整性状态之一，不表示 `pass`，也不构成认证；它本身不使批量命令失败，只有实际 `status=error` 才使批量命令返回退出码 1。全局密钥初始化行为不变。`--force` 会强制重跑其它请求 scanner 并重签 manifest。
 
 新版本只会链接历史中最近的完整可信 artifact：候选的 schema、`versionId`/文件名、`skillName`、manifestHash、签名与 snapshot 必须全部匹配。版本号从该可信父版本之后选择首个未被版本 JSON 或 snapshot 占用的编号；没有可信父版本时从 `v000001` 起选择首个空槽。这样既不覆盖损坏或部分写入的证据，也不允许无效 latest 或孤立的超大编号控制恢复可用性。无可信父版本时两个 previous 字段均为 `null`；只有可信父版本的 `always_allow` 决策可以继承。
 
@@ -460,6 +463,8 @@ agent-sec-cli skill-ledger decide <skill_dir> --clear
 - `skills`：聚合健康度（已发现 Skill 数量、各状态计数、整体 `health` 标签：`healthy` / `unscanned` / `attention` / `critical` / `empty`）
 
 使用 `--verbose` 时额外输出 `results` 数组，包含每个已注册 Skill 的详细检查结果。与 `check` 的定位区分：`check` 是单个 Skill 的完整性门禁（供 hook/plugin 调用，退出码语义化），`status` 是系统级态势感知（始终退出码 0，纯信息输出）。
+
+`check` / `status` 不把批量写路径的 `skipped` 解释为完整性结论；如果跳过项此前不存在任何账本 artifact，仍分别表现为 `none` 和 `unscanned`。`none` 也可能来自已验真 manifest 中的 `scanStatus=none`；`unscanned` 表示当前所有已发现 Skill 都检查为 `none`。二者都不能解释为 `pass`。
 
 **`skill-ledger list-scanners`** — 查看已注册扫描器
 

--- a/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
+++ b/src/agent-sec-core/tests/integration-test/skill-ledger/test_skill_ledger_integration.py
@@ -1512,6 +1512,217 @@ def test_scan_all_no_skill_dirs(ws):
     ), f"Expected no-dirs message: {combined}"
 
 
+def test_readonly_system_scan_all_skips_while_read_commands_still_run(
+    ws,
+    monkeypatch,
+):
+    """Batch writes skip read-only system Skills without changing read commands."""
+    case_root = ws.root / "readonly_system_scan"
+    system_root = case_root / "system-skills"
+    system_skill = make_skill(system_root, "weather", {"main.py": "print('ok')\n"})
+    data_root = case_root / "xdg_data"
+    runtime_root = case_root / "runtime"
+    data_root.mkdir(parents=True)
+    runtime_root.mkdir()
+    write_skill_ledger_config(
+        case_root,
+        {
+            "enableDefaultSkillDirs": True,
+            "managedSkillDirs": [],
+        },
+    )
+    env = {
+        "XDG_CONFIG_HOME": str(case_root / "xdg_config"),
+        "XDG_DATA_HOME": str(data_root),
+        "XDG_RUNTIME_DIR": str(runtime_root),
+    }
+    config_path = (
+        case_root / "xdg_config" / "agent-sec" / "skill-ledger" / "config.json"
+    )
+    config_before = config_path.read_text()
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SYSTEM_SKILL_ROOTS",
+        (system_root,),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SKILL_DIRS",
+        [f"{system_root}/*"],
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.skill_ledger.core.certifier.ledger_update_access",
+        lambda _root: (False, "read-only"),
+    )
+
+    scanned = run_skill_ledger(["scan", "--all"], env_extra=env)
+
+    assert scanned.returncode == 0, scanned.stderr
+    scan_out = parse_json_output(scanned.stdout)
+    assert scan_out["keyCreated"] is True
+    assert scan_out["results"] == [
+        {
+            "canonicalSkillDir": str(system_skill),
+            "skillName": "weather",
+            "status": "skipped",
+            "reasonCode": "readonly_system_skill",
+            "persisted": False,
+        }
+    ]
+    assert config_path.read_text() == config_before
+    assert not (system_skill / ".skill-meta").exists()
+
+    explicit_scan = run_skill_ledger(["scan", str(system_skill)], env_extra=env)
+
+    assert explicit_scan.returncode == 1
+    assert "skill-ledger analyze" in (explicit_scan.stdout + explicit_scan.stderr)
+    assert not (system_skill / ".skill-meta").exists()
+
+    analyzed = run_skill_ledger(
+        ["analyze", str(system_skill), "--format", "json"],
+        env_extra=env,
+    )
+    checked = run_skill_ledger(["check", "--all"], env_extra=env)
+    status = run_skill_ledger(["status"], env_extra=env)
+
+    assert analyzed.returncode == 0, analyzed.stderr
+    assert parse_json_output(analyzed.stdout)["status"] in {
+        "pass",
+        "warn",
+        "deny",
+    }
+    assert checked.returncode == 0, checked.stderr
+    assert parse_json_output(checked.stdout)["results"][0]["status"] == "none"
+    assert status.returncode == 0, status.stderr
+    status_out = parse_json_output(status.stdout)
+    assert status_out["skills"]["breakdown"]["none"] == 1
+    assert status_out["skills"]["health"] == "unscanned"
+    assert not (system_skill / ".skill-meta").exists()
+
+
+def test_scan_all_preserves_mixed_skip_success_and_error_exit_codes(
+    ws,
+    monkeypatch,
+):
+    """Skipped system Skills do not mask writable success or real user errors."""
+    case_root = ws.root / "mixed_system_scan"
+    system_root = case_root / "system-skills"
+    system_skill = make_skill(system_root, "system", {"main.py": "print('ok')\n"})
+    user_skill = make_skill(
+        case_root / "user-skills",
+        "user",
+        {"main.py": "print('ok')\n"},
+    )
+    data_root = case_root / "xdg_data"
+    runtime_root = case_root / "runtime"
+    data_root.mkdir(parents=True)
+    runtime_root.mkdir()
+    write_skill_ledger_config(
+        case_root,
+        {
+            "enableDefaultSkillDirs": False,
+            "managedSkillDirs": [str(system_skill), str(user_skill)],
+        },
+    )
+    env = {
+        "XDG_CONFIG_HOME": str(case_root / "xdg_config"),
+        "XDG_DATA_HOME": str(data_root),
+        "XDG_RUNTIME_DIR": str(runtime_root),
+    }
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SYSTEM_SKILL_ROOTS",
+        (system_root,),
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.skill_ledger.core.certifier.ledger_update_access",
+        lambda _root: (False, "read-only"),
+    )
+
+    successful = run_skill_ledger(["scan", "--all"], env_extra=env)
+
+    assert successful.returncode == 0, successful.stderr
+    successful_out = parse_json_output(successful.stdout)
+    assert [result["status"] for result in successful_out["results"]] == [
+        "skipped",
+        "scanned",
+    ]
+    assert not (system_skill / ".skill-meta").exists()
+    assert (user_skill / ".skill-meta" / "latest.json").is_file()
+
+    shutil.rmtree(user_skill / ".skill-meta")
+    original_compute_file_hashes = compute_file_hashes
+
+    def fail_user_hashing(skill_dir: str | Path) -> dict[str, str]:
+        if Path(skill_dir) == user_skill:
+            raise PermissionError("user ledger input is unreadable")
+        return original_compute_file_hashes(skill_dir)
+
+    monkeypatch.setattr(
+        "agent_sec_cli.skill_ledger.core.certifier.compute_file_hashes",
+        fail_user_hashing,
+    )
+
+    failed = run_skill_ledger(["scan", "--all"], env_extra=env)
+
+    assert failed.returncode == 1
+    failed_out = parse_json_output(failed.stdout)
+    assert [result["status"] for result in failed_out["results"]] == [
+        "skipped",
+        "error",
+    ]
+    assert "user ledger input is unreadable" in failed_out["results"][1]["error"]
+
+
+def test_init_baseline_creates_keys_but_skips_readonly_system_skill(
+    ws,
+    monkeypatch,
+):
+    """init retains key initialization while avoiding system Skill metadata writes."""
+    case_root = ws.root / "readonly_system_init"
+    system_root = case_root / "system-skills"
+    system_skill = make_skill(system_root, "weather", {"main.py": "print('ok')\n"})
+    data_root = case_root / "xdg_data"
+    runtime_root = case_root / "runtime"
+    data_root.mkdir(parents=True)
+    runtime_root.mkdir()
+    write_skill_ledger_config(
+        case_root,
+        {
+            "enableDefaultSkillDirs": True,
+            "managedSkillDirs": [],
+        },
+    )
+    env = {
+        "XDG_CONFIG_HOME": str(case_root / "xdg_config"),
+        "XDG_DATA_HOME": str(data_root),
+        "XDG_RUNTIME_DIR": str(runtime_root),
+    }
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SYSTEM_SKILL_ROOTS",
+        (system_root,),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "DEFAULT_SKILL_DIRS",
+        [f"{system_root}/*"],
+    )
+    monkeypatch.setattr(
+        "agent_sec_cli.skill_ledger.core.certifier.ledger_update_access",
+        lambda _root: (False, "read-only"),
+    )
+
+    initialized = run_skill_ledger(["init"], env_extra=env)
+
+    assert initialized.returncode == 0, initialized.stderr
+    out = parse_json_output(initialized.stdout)
+    assert out["keyCreated"] is True
+    assert out["results"][0]["status"] == "skipped"
+    assert (data_root / "agent-sec" / "skill-ledger" / "key.pub").is_file()
+    assert not (system_skill / ".skill-meta").exists()
+
+
 # ── Group 6: audit command ────────────────────────────────────────────────
 
 

--- a/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py
+++ b/src/agent-sec-core/tests/unit-test/security_middleware/backends/test_skill_ledger_backend.py
@@ -326,6 +326,72 @@ def test_batch_event_results_keep_command_and_child_result_contracts():
     }
 
 
+def test_batch_skip_is_not_projected_as_an_integrity_verdict():
+    skipped = {
+        "status": "skipped",
+        "skillName": "system-skill",
+        "canonicalSkillDir": "/usr/share/anolisa/skills/system-skill",
+        "reasonCode": "readonly_system_skill",
+        "persisted": False,
+    }
+
+    all_skipped = _event_result(
+        {
+            "command": "scan",
+            "keyCreated": True,
+            "results": [skipped],
+        }
+    )
+    init_all_skipped = _event_result(
+        {
+            "command": "init",
+            "keyCreated": True,
+            "baseline": True,
+            "results": [skipped],
+        }
+    )
+    mixed = _event_result(
+        {
+            "command": "scan",
+            "keyCreated": False,
+            "results": [
+                skipped,
+                {
+                    "status": "scanned",
+                    "skillName": "user-skill",
+                    "scanStatus": "warn",
+                },
+            ],
+        }
+    )
+    mixed_pass = _event_result(
+        {
+            "command": "scan",
+            "keyCreated": False,
+            "results": [
+                skipped,
+                {
+                    "status": "scanned",
+                    "skillName": "user-skill",
+                    "scanStatus": "pass",
+                },
+            ],
+        }
+    )
+
+    assert "verdict" not in all_skipped
+    assert "verdict" not in init_all_skipped
+    assert all_skipped["results"][0] == {
+        "status": "skipped",
+        "skill_name": "system-skill",
+        "canonical_skill_dir": "/usr/share/anolisa/skills/system-skill",
+        "reason_code": "readonly_system_skill",
+        "persisted": False,
+    }
+    assert mixed["verdict"] == "warn"
+    assert mixed_pass["verdict"] == "pass"
+
+
 def test_batch_check_event_result_uses_declared_severity_order():
     cases = (
         (["pass", "none"], "none"),

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_canonical_workflows.py
@@ -68,6 +68,16 @@ def _backend(
     return backend
 
 
+def _set_system_root(
+    system_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "agent_sec_cli.skill_ledger.config.DEFAULT_SYSTEM_SKILL_ROOTS",
+        (system_root,),
+    )
+
+
 def test_nested_same_basename_skills_keep_canonical_identity_and_live_io(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -189,6 +199,296 @@ def test_batch_error_exposes_only_canonical_path(
     assert result[0]["canonicalSkillDir"] == str(canonical)
     assert str(canonical / "secret.txt") in result[0]["error"]
     assert str(live) not in json.dumps(result)
+
+
+def test_readonly_host_system_skill_is_skipped_without_skill_directory_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    skill = _make_skill(system_root, "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+    scanner_called = False
+    remember_called = False
+
+    def fail_scanner(
+        *_args: object,
+        **_kwargs: object,
+    ) -> list[certifier_core.ScanEntry]:
+        nonlocal scanner_called
+        scanner_called = True
+        return []
+
+    def record_remember(_skill_dir: str) -> None:
+        nonlocal remember_called
+        remember_called = True
+
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core,
+        "ledger_update_access",
+        lambda _root: (False, "read-only"),
+    )
+    monkeypatch.setattr(certifier_core, "_auto_invoke_scanners", fail_scanner)
+    monkeypatch.setattr(
+        certifier_core,
+        "_remember_skill_dir_best_effort",
+        record_remember,
+    )
+
+    result = scan_batch([skill], backend)
+
+    assert result == [
+        {
+            "canonicalSkillDir": str(skill),
+            "skillName": "weather",
+            "status": "skipped",
+            "reasonCode": "readonly_system_skill",
+            "persisted": False,
+        }
+    ]
+    assert not scanner_called
+    assert not remember_called
+    assert not (skill / ".skill-meta").exists()
+
+
+def test_explicit_readonly_host_system_scan_stays_strict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    skill = _make_skill(system_root, "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+    monkeypatch.setattr(
+        certifier_core,
+        "ledger_update_access",
+        lambda _root: (False, "read-only"),
+    )
+
+    with pytest.raises(SkillLedgerError, match="skill-ledger analyze"):
+        scan_skill(root, backend)
+
+    assert not (skill / ".skill-meta").exists()
+    assert not (
+        tmp_path / "config" / "agent-sec" / "skill-ledger" / "config.json"
+    ).exists()
+
+
+def test_writable_host_system_skill_is_scanned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    skill = _make_skill(system_root, "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core,
+        "ledger_update_access",
+        lambda _root: (True, "writable"),
+    )
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+
+    result = scan_batch([skill], backend, scanner_names=["code-scanner"])
+
+    assert result[0]["status"] == "scanned"
+    assert result[0]["scanStatus"] == "pass"
+    assert (skill / ".skill-meta" / "latest.json").is_file()
+
+
+def test_writable_skillfs_backing_under_system_path_is_scanned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    canonical = system_root / "weather"
+    live = _make_skill(tmp_path / "backing", "weather", "weather")
+    root = ResolvedSkillRoot(canonical, live, "skillfs")
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+
+    result = scan_batch([canonical], backend, scanner_names=["code-scanner"])
+
+    assert result[0]["status"] == "scanned"
+    assert (live / ".skill-meta" / "latest.json").is_file()
+    assert not canonical.exists()
+
+
+def test_readonly_skillfs_backing_is_not_downgraded_to_system_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    canonical = system_root / "weather"
+    live = _make_skill(tmp_path / "backing", "weather", "weather")
+    root = ResolvedSkillRoot(canonical, live, "skillfs")
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+
+    def fail_persist(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("backing ledger is read-only")
+
+    monkeypatch.setattr(
+        certifier_core,
+        "_persist_manifest_update",
+        fail_persist,
+    )
+
+    result = scan_batch([canonical], backend, scanner_names=["code-scanner"])
+
+    assert result[0]["status"] == "error"
+    assert "backing ledger is read-only" in result[0]["error"]
+
+
+def test_readonly_user_skill_is_not_downgraded_to_system_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = _make_skill(tmp_path / "user-skills", "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", lambda _path: root)
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+
+    def fail_persist(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("user ledger is read-only")
+
+    monkeypatch.setattr(certifier_core, "_persist_manifest_update", fail_persist)
+
+    result = scan_batch([skill], backend, scanner_names=["code-scanner"])
+
+    assert result[0]["status"] == "error"
+    assert "user ledger is read-only" in result[0]["error"]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "SkillFS resolver timed out",
+        "SkillFS resolver authentication failed",
+        "successful response must contain result",
+    ],
+)
+def test_resolver_failure_is_not_downgraded_to_system_skip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reason: str,
+) -> None:
+    system_root = tmp_path / "system-skills"
+    canonical = system_root / "weather"
+    backend = _backend(tmp_path, monkeypatch)
+    _set_system_root(system_root, monkeypatch)
+
+    def fail_resolve(_path: str | Path) -> ResolvedSkillRoot:
+        raise SkillLedgerError(reason)
+
+    monkeypatch.setattr(certifier_core, "resolve_skill_root", fail_resolve)
+
+    result = scan_batch([canonical], backend)
+
+    assert result[0]["status"] == "error"
+    assert reason in result[0]["error"]
+
+
+def test_failed_scan_does_not_auto_remember_skill_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = _make_skill(tmp_path / "user-skills", "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    remembered: list[str] = []
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+
+    def fail_persist(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("ledger is read-only")
+
+    monkeypatch.setattr(
+        certifier_core,
+        "_persist_manifest_update",
+        fail_persist,
+    )
+    monkeypatch.setattr(
+        certifier_core,
+        "_remember_skill_dir_best_effort",
+        remembered.append,
+    )
+
+    with pytest.raises(PermissionError, match="ledger is read-only"):
+        scan_skill(root, backend, scanner_names=["code-scanner"])
+
+    assert remembered == []
+    assert not (
+        tmp_path / "config" / "agent-sec" / "skill-ledger" / "config.json"
+    ).exists()
+
+
+def test_noop_scan_remembers_skill_dir_after_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = _make_skill(tmp_path / "user-skills", "weather", "weather")
+    root = ResolvedSkillRoot(skill, skill, "host")
+    backend = _backend(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        certifier_core,
+        "_auto_invoke_scanners",
+        lambda *_args, **_kwargs: [
+            certifier_core.ScanEntry(scanner="code-scanner", status="pass")
+        ],
+    )
+    scan_skill(root, backend, scanner_names=["code-scanner"])
+    remembered: list[str] = []
+    monkeypatch.setattr(
+        certifier_core,
+        "_remember_skill_dir_best_effort",
+        remembered.append,
+    )
+
+    result = scan_skill(root, backend, scanner_names=["code-scanner"])
+
+    assert result["status"] == "noop"
+    assert remembered == [str(skill)]
 
 
 def test_scanner_error_paths_are_canonicalized_before_manifest_signing(

--- a/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
+++ b/src/agent-sec-core/tests/unit-test/skill_ledger/test_config.py
@@ -26,6 +26,7 @@ from agent_sec_cli.skill_ledger.config import (
     deprecated_skill_dir_entries,
     effective_skill_dir_entries,
     is_covered,
+    is_default_system_skill_dir,
     is_managed_covered,
     load_config,
     remember_skill_dir,
@@ -55,6 +56,24 @@ class TestDefaultConfig(unittest.TestCase):
 
     def test_default_signing_backend(self):
         self.assertEqual(_DEFAULT_CONFIG["signingBackend"], "ed25519")
+
+    def test_system_skill_matching_uses_exact_parent(self):
+        self.assertTrue(
+            is_default_system_skill_dir("/usr/share/anolisa/skills/weather")
+        )
+        self.assertTrue(
+            is_default_system_skill_dir("/usr/local/share/anolisa/skills/weather")
+        )
+        self.assertTrue(
+            is_default_system_skill_dir("/usr/share/anolisa/skills/../skills/weather")
+        )
+        self.assertFalse(
+            is_default_system_skill_dir("/usr/share/anolisa/skills-evil/weather")
+        )
+        self.assertFalse(is_default_system_skill_dir("/usr/share/anolisa/skills"))
+        self.assertFalse(
+            is_default_system_skill_dir("/usr/share/anolisa/skills/weather/nested")
+        )
 
     def test_default_activation_policy(self):
         self.assertEqual(


### PR DESCRIPTION
## Why

Packaged system Skills are discovered by default, but root-owned read-only
directories cannot persist `.skill-meta`. As a result, non-root `scan --all`
and the default `init` baseline returned errors for every packaged Skill.

## What changed

- Return a structured operational skip for host-backed, read-only immediate
  children of the two built-in system Skill roots in batch scan and init flows.
- Keep explicit scans, user/project roots, SkillFS-backed roots, resolver
  failures, and other write failures strict.
- Remember managed directories only after a successful persisted scan or noop,
  and document and test the skip, exit-code, and event-verdict contracts.

## Related issue

closes #2897

## User / Agent impact

`scan --all` and the default `init` baseline now complete when the only
unwritable targets are packaged system Skills, reporting `status=skipped`,
`reasonCode=readonly_system_skill`, and `persisted=false`. This is not a
`pass` result or an attestation. Explicit `scan <dir>` still fails and directs
users to `analyze` for read-only findings.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The change is limited to batch handling of host-backed, read-only packaged
system Skills. SkillFS-backed roots and real resolution, scanner, or
persistence failures remain errors, and mixed-batch exit codes and event
verdicts continue to use actual scan results. No schema or configuration
migration is required.

## Validation

- Targeted Skill Ledger unit tests: 83 passed, 3 subtests passed.
- `make python-code-pretty`
- `git diff --check`
- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`

## Documentation and rollback

Updated the English and Chinese component READMEs, user guides, and Skill
Ledger design documentation. Roll back by reverting this commit; existing
configuration and ledger artifacts require no migration.
