### PR TITLE
chore(anolisa): bump version to 0.3.8

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-08-26
+
+### Added
+
+- Tagged ANOLISA releases now include verified prebuilt CLI archives for Linux
+  x64, Linux arm64, and macOS arm64. Users can download a standalone binary
+  archive for each supported target directly from the GitHub Release
+  ([#2883](https://github.com/alibaba/anolisa/pull/2883)).
+
+### Fixed
+
+- Raw installs now preserve `${VAR}` references in rendered file content for
+  shell and systemd consumers, while continuing to expand nested ANOLISA layout
+  placeholders and reject environment references in destination paths.
+  `anolisa install cosh-ng --backend raw` can now install the gateway service
+  template instead of rejecting its `EnvironmentFile=`-backed workspace
+  reference as an unknown placeholder
+  ([#2903](https://github.com/alibaba/anolisa/pull/2903)).
+
 ## [0.3.7] - 2026-08-25
 
 ### Changed

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,24 @@
 
 ## [未发布]
 
+## [0.3.8] - 2026-08-26
+
+### 新增
+
+- 带 tag 的 ANOLISA Release 现会提供经过验证的 Linux x64、Linux arm64 和
+  macOS arm64 CLI 预编译归档。用户可直接从 GitHub Release 下载各受支持 target
+  的独立 binary 归档
+  ([#2883](https://github.com/alibaba/anolisa/pull/2883))。
+
+### 修复
+
+- Raw 安装现会在渲染 file content 时保留供 shell 与 systemd 消费的 `${VAR}`
+  reference，同时继续展开嵌套的 ANOLISA layout placeholder，并拒绝 destination
+  path 中的 environment reference。`anolisa install cosh-ng --backend raw` 现可安装
+  gateway service template，不再将其由 `EnvironmentFile=` 提供的 workspace
+  reference 误判为 unknown placeholder
+  ([#2903](https://github.com/alibaba/anolisa/pull/2903))。
+
 ## [0.3.7] - 2026-08-25
 
 ### 变更

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,11 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Tue Aug 25 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Aug 26 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- GitHub releases now include verified prebuilt CLI archives for three supported targets.
+- Raw installs now preserve runtime ${VAR} references in rendered file content.
+
+* Tue Aug 25 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.7-1
 - Restart dry-runs now remain read-only and never invoke systemd.
 - Source and RPM builds now require Rust 1.93.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.7",
-    "@anolisa/cli-linux-arm64": "0.3.7",
-    "@anolisa/cli-darwin-arm64": "0.3.7"
+    "@anolisa/cli-linux-x64": "0.3.8",
+    "@anolisa/cli-linux-arm64": "0.3.8",
+    "@anolisa/cli-darwin-arm64": "0.3.8"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Prepare the ANOLISA 0.3.8 patch release from merged changes after 0.3.7. This synchronizes the Cargo workspace, npm root and native packages, RPM boundary, and paired changelogs. The release notes cover verified prebuilt archives from #2883 and the Raw `${VAR}` rendering fix from #2903; behavior-preserving snapshot and restart refactors are intentionally omitted. The bump itself adds no new runtime behavior.

## What changed

- Bumped the Cargo workspace and five lockfile workspace packages to 0.3.8.
- Bumped `@anolisa/cli` and all three native npm package templates to 0.3.8.
- Advanced the RPM changelog boundary while freezing the 0.3.7 entry.
- Added semantically paired English and Chinese 0.3.8 release notes.

## Related issue

no-issue: routine ANOLISA 0.3.8 release aggregation

## User / Agent impact

GitHub Releases can provide verified standalone CLI archives for Linux x64, Linux arm64, and macOS arm64. Raw installation of cosh-ng now preserves the gateway unit runtime environment reference instead of rejecting it as an unknown layout placeholder.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: the release commit changes only version metadata and release documentation. The already-merged rendering fix is backward compatible but affects the Raw component contract consumed by cosh-ng; destination paths remain fail-closed for environment references.

## Validation

Linux x86_64; Rust/Cargo 1.93.1, Node 24.15.0 for npm packaging, and Node 20.20.2 for website gates.

- `check_release.py` passed for the working tree and committed `HEAD`.
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `node npm/tests/platforms.test.js`
- `node npm/scripts/package-npm.js --validate`
- `src/anolisa/tests/test-package-prebuilt.sh`
- `.github/actions/build-anolisa-prebuilt/test.sh`
- `python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `cargo build --release --locked -p anolisa-cli`; binary reported `anolisa 0.3.8`.
- Native Linux x64 npm root/platform packages were packed, installed together, and the installed command reported `anolisa 0.3.8`.
- The 0.3.8 RPM template rendered successfully with `rpmspec -P /dev/stdin`.
- Node 20 bilingual website builds passed at root and sub-path base URLs, plus typecheck, Agent index validation, static link/DOM validation, installer tests, and the current stable installer smoke.

Linux arm64 and macOS arm64 were metadata-, template-, and packer-validated on this Linux x86_64 host; their native binaries were not executed locally.

## Documentation and rollback

Updated `CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM `%changelog` with equivalent release content. Before tagging, rollback by reverting this commit and skipping 0.3.8 publication; after publication, use a follow-up version rather than moving or replacing the released tag.