### PR TITLE
chore(tokenless): bump version to 0.7.14

### DIFF
--- a/src/anolisa/manifests/components/tokenless/component.toml
+++ b/src/anolisa/manifests/components/tokenless/component.toml
@@ -1,6 +1,6 @@
 [component]
 name = "tokenless"
-version = "0.7.13"
+version = "0.7.14"
 layer = "runtime"
 domain = "optimization"
 display_name = "Tokenless"

--- a/src/tokenless/CHANGELOG.md
+++ b/src/tokenless/CHANGELOG.md
@@ -9,6 +9,22 @@ Releases from 0.7.2 onward follow
 
 ## [Unreleased]
 
+## [0.7.14] - 2026-08-26
+
+### Added
+
+- The protocol-v1 `tokenless compress` command and `TokenlessRuntime::compress` now provide one entry point for schema, response, and TOON compression, so adapters make at most one subprocess call, apply one final size decision, and record only the winning operation ([#2844](https://github.com/alibaba/anolisa/pull/2844)).
+- `tokenless stats summary` now excludes dry-run rows from active totals while reporting their count, and adds gross savings, retrieved tokens, net savings, Retrieve hit/miss/error counts, and unrecoverable truncation attribution; JSON output uses schema version 1.1, and the Python `TokenlessStats` API exposes the same typed fields ([#2885](https://github.com/alibaba/anolisa/pull/2885)).
+
+### Changed
+
+- Truncation markers now include a directly runnable `tokenless retrieve` command, retrievals through the CLI, MCP, and embedded Runtime contribute to attribution, and MCP retrieval accepts uppercase hashes like the CLI ([#2885](https://github.com/alibaba/anolisa/pull/2885)).
+
+### Fixed
+
+- The Codex integration no longer appends a second compressed copy after Tool use; it keeps environment diagnostics and RTK source reduction without increasing the Model-visible Prompt ([#2866](https://github.com/alibaba/anolisa/pull/2866)).
+- `tokenless compress-toon` and the Runtime/Python SDK now consistently leave valid payloads shorter than 500 characters unchanged, while `--min-toon-chars 0` can force encoding; malformed JSON still fails, and CLI output preserves the input's exact trailing-newline form ([#2869](https://github.com/alibaba/anolisa/pull/2869)).
+
 ## [0.7.13] - 2026-08-25
 
 ### Added

--- a/src/tokenless/CHANGELOG_zh.md
+++ b/src/tokenless/CHANGELOG_zh.md
@@ -9,6 +9,22 @@ Tokenless 的所有重要变更都会记录在此文件中。
 
 ## [未发布]
 
+## [0.7.14] - 2026-08-26
+
+### 新增
+
+- 协议 v1 的 `tokenless compress` 命令与 `TokenlessRuntime::compress` 现在为 Schema、Response 和 TOON 压缩提供统一入口，使 Adapter 最多调用一次子进程、只执行一次最终大小判定，并且只记录胜出的操作（[#2844](https://github.com/alibaba/anolisa/pull/2844)）。
+- `tokenless stats summary` 现在会从活跃汇总中排除 Dry-run Row 并报告排除数量，同时新增总节省、Retrieve Token、净节省、Retrieve 命中/未命中/错误计数和不可恢复截断归因；JSON 输出使用 Schema 版本 1.1，Python `TokenlessStats` API 也开放相同的类型化字段（[#2885](https://github.com/alibaba/anolisa/pull/2885)）。
+
+### 变更
+
+- 截断 Marker 现在包含可直接运行的 `tokenless retrieve` 命令，通过 CLI、MCP 和内嵌 Runtime 执行的 Retrieve 都会计入归因，并且 MCP Retrieve 与 CLI 一样接受大写 Hash（[#2885](https://github.com/alibaba/anolisa/pull/2885)）。
+
+### 修复
+
+- Codex 集成不再在 Tool 使用后追加第二份压缩副本；它会保留环境诊断与 RTK 源头压缩能力，同时避免增加 Model 可见 Prompt（[#2866](https://github.com/alibaba/anolisa/pull/2866)）。
+- `tokenless compress-toon` 与 Runtime/Python SDK 现在会一致地保持少于 500 字符的有效 Payload 不变，同时可用 `--min-toon-chars 0` 强制编码；格式错误的 JSON 仍会失败，CLI 输出也会精确保留输入末尾换行符的原有形式（[#2869](https://github.com/alibaba/anolisa/pull/2869)）。
+
 ## [0.7.13] - 2026-08-25
 
 ### 新增

--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-cli"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "chrono",
  "clap",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-pipeline"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "thiserror 2.0.18",
  "tokenless-ccr",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-protocol"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-python"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-runtime"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "rusqlite",
  "serde",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "regex",
  "serde_json",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-stats"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "chrono",
  "dirs",

--- a/src/tokenless/Cargo.toml
+++ b/src/tokenless/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.13"
+version = "0.7.14"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/tokenless/adapters/tokenless/common/cosh-extension.json
+++ b/src/tokenless/adapters/tokenless/common/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenless",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "contextFileName": "COPILOT.md",
   "hooks": {
     "PreToolUse": [

--- a/src/tokenless/adapters/tokenless/openclaw/package-lock.json
+++ b/src/tokenless/adapters/tokenless/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tokenless/openclaw-plugin",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tokenless/openclaw-plugin",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": ">=22",

--- a/src/tokenless/benchmark/l1-compressor/Cargo.lock
+++ b/src/tokenless/benchmark/l1-compressor/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "rusqlite",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/benchmark/l2-module/Cargo.lock
+++ b/src/tokenless/benchmark/l2-module/Cargo.lock
@@ -1168,7 +1168,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenless-ccr"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "blake3",
  "thiserror",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-schema"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "regex",
  "serde_json",

--- a/src/tokenless/npm/package.json
+++ b/src/tokenless/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anolisa-tokenless",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Token-Less — LLM token optimization toolkit (schema/response compression, command rewriting, tool readiness)",
   "type": "module",
@@ -44,9 +44,9 @@
     "arm64"
   ],
   "optionalDependencies": {
-    "@anolisa/tokenless-linux-x64": "0.7.13",
-    "@anolisa/tokenless-linux-arm64": "0.7.13",
-    "@anolisa/tokenless-darwin-x64": "0.7.13",
-    "@anolisa/tokenless-darwin-arm64": "0.7.13"
+    "@anolisa/tokenless-linux-x64": "0.7.14",
+    "@anolisa/tokenless-linux-arm64": "0.7.14",
+    "@anolisa/tokenless-darwin-x64": "0.7.14",
+    "@anolisa/tokenless-darwin-arm64": "0.7.14"
   }
 }

--- a/src/tokenless/npm/platforms/darwin-arm64/package.json
+++ b/src/tokenless/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-arm64",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Token-Less native binaries for macOS aarch64 (Apple Silicon)",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/darwin-x64/package.json
+++ b/src/tokenless/npm/platforms/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-darwin-x64",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Token-Less native binaries for macOS x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-arm64/package.json
+++ b/src/tokenless/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-arm64",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Token-Less native binaries for Linux aarch64",
   "license": "Apache-2.0",

--- a/src/tokenless/npm/platforms/linux-x64/package.json
+++ b/src/tokenless/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/tokenless-linux-x64",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "private": true,
   "description": "Token-Less native binaries for Linux x86_64",
   "license": "Apache-2.0",

--- a/src/tokenless/tests/run-all-tests.sh
+++ b/src/tokenless/tests/run-all-tests.sh
@@ -600,8 +600,8 @@ print('CLASSIFY_OK')
 
     # ==========================================
     # 6.26h Behavioral dispatch: Read skips, Bash proceeds to compression
-    # Read must produce empty output (skip); Bash must attempt compression
-    # (produces non-empty hook output even if compression saves nothing).
+    # Use a replacement-capable host so this test isolates tool classification
+    # from the unified entry's fail-open behavior for unknown/additive hosts.
     # ==========================================
     log_info "Test 6.26h: Read skips entirely, Bash enters compression pipeline"
     local large_body
@@ -613,7 +613,7 @@ print('CLASSIFY_OK')
     local read_input
     read_input=$(jq -n --arg r "$dispatch_resp" '{"tool_name":"Read","tool_response":$r}')
     local read_out
-    read_out=$(echo "$read_input" | python3 "$COMPRESS_SCRIPT" 2>&1)
+    read_out=$(echo "$read_input" | python3 "$COMPRESS_SCRIPT" --agent-id qoder-cli 2>&1)
     local read_trimmed
     read_trimmed=$(echo "$read_out" | tr -d '[:space:]')
     [ "$read_trimmed" = "{}" ] && log_pass "Read (layer 1) skips entirely" || log_fail "Read should skip with {}, got: $read_out"
@@ -622,7 +622,7 @@ print('CLASSIFY_OK')
     local bash_input
     bash_input=$(jq -n --arg r "$dispatch_resp" '{"tool_name":"Bash","tool_response":$r}')
     local bash_out
-    bash_out=$(echo "$bash_input" | python3 "$COMPRESS_SCRIPT" 2>&1)
+    bash_out=$(echo "$bash_input" | python3 "$COMPRESS_SCRIPT" --agent-id qoder-cli 2>&1)
     local bash_trimmed
     bash_trimmed=$(echo "$bash_out" | tr -d '[:space:]')
     [ -n "$bash_trimmed" ] && [ "$bash_trimmed" != "{}" ] && log_pass "Bash (layer 2) enters compression pipeline" || log_fail "Bash should attempt compression, got: $bash_out"

--- a/src/tokenless/tokenless.spec.in
+++ b/src/tokenless/tokenless.spec.in
@@ -470,6 +470,12 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Aug 26 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.14-1
+- feat(tokenless): unify external compression entry
+- feat(tokenless): attribute statistics and retrieval events
+- fix(tokenless): correct Codex savings path
+- fix(tokenless): enforce the TOON minimum
+
 * Tue Aug 25 2026 爱鲲 <jiawa.syx@alibaba-inc.com> - 0.7.13-1
 - feat(tokenless): add protocol v1 compression types
 - feat(tokenless): add content detection and registry routing


### PR DESCRIPTION
## Why

Tokenless changes merged after 0.7.13 expose the unified compression entry,
attribution-aware statistics, and final Codex and TOON fixes. This PR cuts the
next patch boundary by synchronizing every active release surface and documenting
the final user-visible behavior.

## What changed

- Add paired English and Chinese 0.7.14 changelog entries for #2844, #2866, #2869, and #2885.
- Bump all 15 active release surfaces, including the OpenClaw package lock, to 0.7.14.
- Pin the shell replacement test to qoder-cli so host classification cannot change its expectation.
- Keep the local evolution roadmap documents outside the commit and PR.

## Related issue

no-issue: routine Tokenless patch release

## User / Agent impact

Users gain the unified tokenless compress and Runtime entry, attribution-aware
net-savings and retrieval statistics, corrected Codex output replacement, and
consistent TOON pass-through below the 500-character threshold.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The runtime behavior changes were already merged; this release bump adds no new
runtime behavior. The statistics schema migration is additive and in place.
The component catalog version is updated with the package metadata.

The prior 0.7.13 source tag exists, but its GitHub Release is absent and the
Darwin x64 npm package is not publicly readable. This PR does not claim that
0.7.13 publication was complete.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo doc --workspace --no-deps
- make build
- Full make test with the freshly built tokenless and pinned RTK binaries on PATH
- Python ABI3 runtime tests and AgentScope smoke tests for 1.0.11 through 2.0.7
- L1 and L2 locked test suites
- Release audit against HEAD, CLI version, npm/raw packaging, and rendered RPM checks

## Documentation and rollback

The paired component changelogs describe the final user-visible behavior. The
local evolution roadmap documents are intentionally excluded.

Before publication, revert the release bump and test-fix commits to roll back.
After publication, issue a higher patch version instead of rewriting 0.7.14.