### PR TITLE
fix(cosh-ng): [shell] bound internal xtrace

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.rs
@@ -635,6 +635,12 @@ _cosh_delegate_bash_command_not_found() {
     _COSH_IN_USER_COMMAND_NOT_FOUND=1
     _cosh_user_command_not_found_handle "$@"
     local status=$?
+    local final_xtrace=0
+    if [[ $- == *x* ]]; then
+      final_xtrace=1
+      set +x
+    fi
+    _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE="$final_xtrace"
     _COSH_IN_USER_COMMAND_NOT_FOUND=0
     return "$status"
   fi
@@ -644,13 +650,19 @@ _cosh_delegate_bash_command_not_found() {
 _cosh_user_handler_definition="$(declare -f command_not_found_handle 2>/dev/null || true)"
 if [[ -n "$_cosh_user_handler_definition"
    && "$_cosh_user_handler_definition" != "$_COSH_INITIAL_COMMAND_NOT_FOUND_HANDLE" ]]; then
-  eval "${_cosh_user_handler_definition/command_not_found_handle/_cosh_user_command_not_found_handle}"
+  _cosh_user_handler_definition="${_cosh_user_handler_definition/command_not_found_handle/_cosh_user_command_not_found_handle}"
+  # Resume at the start of user code so the private wrapper invocation cannot
+  # expose dynamic handler arguments before the user's own trace begins.
+  _cosh_user_handler_xtrace_prefix=$'{ \n  if [[ "${_COSH_COMMAND_NOT_FOUND_XTRACE:-0}" == 1 ]]; then set -x; fi\n'
+  _cosh_user_handler_definition="${_cosh_user_handler_definition/\{ /$_cosh_user_handler_xtrace_prefix}"
+  eval "$_cosh_user_handler_definition"
   _COSH_HAS_USER_COMMAND_NOT_FOUND=1
 else
   _COSH_HAS_USER_COMMAND_NOT_FOUND=0
 fi
-unset _cosh_user_handler_definition _COSH_INITIAL_COMMAND_NOT_FOUND_HANDLE
-command_not_found_handle() {
+unset _cosh_user_handler_definition _cosh_user_handler_xtrace_prefix \
+  _COSH_INITIAL_COMMAND_NOT_FOUND_HANDLE
+_cosh_command_not_found_handle() {
   local command="$1"
   shift || true
   if [[ "${_COSH_ATTEMPT_ACTIVE:-0}" != 1 ]]; then
@@ -675,7 +687,7 @@ command_not_found_handle() {
     return $?
   fi
   if [[ "${_COSH_ATTEMPT_SUBSHELL:-}" != "${BASH_SUBSHELL:-0}"
-     || "${#FUNCNAME[@]}" != 1
+     || "${#FUNCNAME[@]}" != 2
      || "${_COSH_ATTEMPT_EXPANSION_DRIFT:-0}" == 1 ]]; then
     _cosh_delegate_bash_command_not_found "$command" "$@"
     return $?
@@ -727,6 +739,19 @@ command_not_found_handle() {
   _cosh_emit_top_level_missing_marker "$intent" "$sensitive" false
   _cosh_delegate_bash_command_not_found "$command" "$@"
   return $?
+}
+command_not_found_handle() {
+  local _COSH_COMMAND_NOT_FOUND_XTRACE=0
+  local _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE=0
+  if [[ $- == *x* ]]; then
+    _COSH_COMMAND_NOT_FOUND_XTRACE=1
+    _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE=1
+    set +x
+  fi
+  _cosh_command_not_found_handle "$@"
+  local status=$?
+  (( _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE == 1 )) && set -x
+  return "$status"
 }
 
 # Expands the leading command word of a history line following bash alias
@@ -817,9 +842,6 @@ _cosh_compact_alias_expanded() {
 }
 
 _cosh_bounded_preexec_marker() {
-  if [[ $- == *x* ]]; then
-    set +x
-  fi
   local history_entry history_no command first_word argc=1 display_command sensitive=false
   history_entry="$(_cosh_history_entry)"
   history_no="$(_cosh_history_no "$history_entry")"
@@ -873,13 +895,7 @@ _cosh_bounded_preexec_marker() {
   _cosh_emit_marker "preexec" "$display_command" 0 false
 }
 _cosh_bounded_prompt_marker() {
-  local status="${1:-$?}" restore_xtrace=0
-  if [[ $- == *x* ]]; then
-    restore_xtrace=1
-    set +x
-  fi
-  _cosh_precmd_marker "$status"
-  (( restore_xtrace == 1 )) && set -x
+  _cosh_precmd_marker "${1:-$?}"
   return 0
 }
 _cosh_precmd_marker() {
@@ -912,7 +928,7 @@ _cosh_precmd_marker() {
   _cosh_initial_history_entry="$(_cosh_history_entry)"
   _cosh_remember_preexec_history_no "$(_cosh_history_no "$_cosh_initial_history_entry")"
   unset _cosh_initial_history_entry
-  PS0='$(trap - DEBUG RETURN ERR 2>/dev/null; _cosh_bounded_preexec_marker > /dev/tty)'"$_COSH_USER_PS0"
+  PS0='$(set +x; trap - DEBUG RETURN ERR 2>/dev/null; _cosh_bounded_preexec_marker > /dev/tty)'"$_COSH_USER_PS0"
   _COSH_USER_PROMPT_COMMAND=()
   if [[ -z "${COSH_SHELL_ISOLATED:-}" ]]; then
     if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
@@ -926,9 +942,9 @@ _cosh_precmd_marker() {
   # resume. Bash before 5.1 executes only element zero of an array
   # PROMPT_COMMAND, so those versions receive the same sequence as one scalar
   # command.
-  PROMPT_COMMAND=('_COSH_PROMPT_STATUS="$?"; _COSH_PROMPT_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null)"; _COSH_PROMPT_RETURN_TRAP="$(trap -p RETURN 2>/dev/null)"; _COSH_PROMPT_ERR_TRAP="$(trap -p ERR 2>/dev/null)"; trap - DEBUG RETURN ERR 2>/dev/null; eval "unset _COSH_PROMPT_DEBUG_TRAP _COSH_PROMPT_RETURN_TRAP _COSH_PROMPT_ERR_TRAP ${_COSH_PROMPT_RETURN_TRAP:+; ${_COSH_PROMPT_RETURN_TRAP}} ${_COSH_PROMPT_ERR_TRAP:+; ${_COSH_PROMPT_ERR_TRAP}} ${_COSH_PROMPT_DEBUG_TRAP:+; ${_COSH_PROMPT_DEBUG_TRAP}}"')
+  PROMPT_COMMAND=('_COSH_PROMPT_STATUS="$?"; _COSH_PROMPT_XTRACE=0; case "$-" in *x*) _COSH_PROMPT_XTRACE=1; set +x;; esac; _COSH_PROMPT_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null)"; _COSH_PROMPT_RETURN_TRAP="$(trap -p RETURN 2>/dev/null)"; _COSH_PROMPT_ERR_TRAP="$(trap -p ERR 2>/dev/null)"; trap - DEBUG RETURN ERR 2>/dev/null; eval "unset _COSH_PROMPT_DEBUG_TRAP _COSH_PROMPT_RETURN_TRAP _COSH_PROMPT_ERR_TRAP ${_COSH_PROMPT_RETURN_TRAP:+; ${_COSH_PROMPT_RETURN_TRAP}} ${_COSH_PROMPT_ERR_TRAP:+; ${_COSH_PROMPT_ERR_TRAP}} ${_COSH_PROMPT_DEBUG_TRAP:+; ${_COSH_PROMPT_DEBUG_TRAP}}"; if (( _COSH_PROMPT_XTRACE == 1 )); then unset _COSH_PROMPT_XTRACE; set -x; else unset _COSH_PROMPT_XTRACE; fi')
   PROMPT_COMMAND+=("${_COSH_USER_PROMPT_COMMAND[@]}")
-  PROMPT_COMMAND+=('_COSH_PROMPT_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null)"; _COSH_PROMPT_RETURN_TRAP="$(trap -p RETURN 2>/dev/null)"; _COSH_PROMPT_ERR_TRAP="$(trap -p ERR 2>/dev/null)"; trap - DEBUG RETURN ERR 2>/dev/null; _cosh_bounded_prompt_marker "$_COSH_PROMPT_STATUS" > /dev/tty; eval "unset _COSH_PROMPT_STATUS _COSH_PROMPT_DEBUG_TRAP _COSH_PROMPT_RETURN_TRAP _COSH_PROMPT_ERR_TRAP ${_COSH_PROMPT_RETURN_TRAP:+; ${_COSH_PROMPT_RETURN_TRAP}} ${_COSH_PROMPT_ERR_TRAP:+; ${_COSH_PROMPT_ERR_TRAP}} ${_COSH_PROMPT_DEBUG_TRAP:+; ${_COSH_PROMPT_DEBUG_TRAP}}"')
+  PROMPT_COMMAND+=('_COSH_PROMPT_XTRACE=0; case "$-" in *x*) _COSH_PROMPT_XTRACE=1; set +x;; esac; _COSH_PROMPT_DEBUG_TRAP="$(trap -p DEBUG 2>/dev/null)"; _COSH_PROMPT_RETURN_TRAP="$(trap -p RETURN 2>/dev/null)"; _COSH_PROMPT_ERR_TRAP="$(trap -p ERR 2>/dev/null)"; trap - DEBUG RETURN ERR 2>/dev/null; _cosh_bounded_prompt_marker "$_COSH_PROMPT_STATUS" > /dev/tty; eval "unset _COSH_PROMPT_STATUS _COSH_PROMPT_DEBUG_TRAP _COSH_PROMPT_RETURN_TRAP _COSH_PROMPT_ERR_TRAP ${_COSH_PROMPT_RETURN_TRAP:+; ${_COSH_PROMPT_RETURN_TRAP}} ${_COSH_PROMPT_ERR_TRAP:+; ${_COSH_PROMPT_ERR_TRAP}} ${_COSH_PROMPT_DEBUG_TRAP:+; ${_COSH_PROMPT_DEBUG_TRAP}}"; if (( _COSH_PROMPT_XTRACE == 1 )); then unset _COSH_PROMPT_XTRACE; set -x; else unset _COSH_PROMPT_XTRACE; fi')
   if (( BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1) )); then
     _COSH_PROMPT_COMMAND_SCALAR="${PROMPT_COMMAND[0]}"
     if [[ -n "${_COSH_USER_PROMPT_COMMAND[0]-}" ]]; then

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -364,6 +364,7 @@ _cosh_command_has_secret() {
   return 1
 }
 _cosh_zshaddhistory_marker() {
+  setopt localoptions noxtrace
   local command="${1%$'\n'}"
   if _cosh_is_handoff_wrapper "$command"; then
     local history_command="$(_cosh_unwrap_handoff_command "$command")"
@@ -427,8 +428,14 @@ _cosh_delegate_zsh_command_not_found() {
   fi
   if [[ "${_COSH_HAS_USER_COMMAND_NOT_FOUND:-0}" == 1 ]]; then
     _COSH_IN_USER_COMMAND_NOT_FOUND=1
+    if [[ "${_COSH_COMMAND_NOT_FOUND_XTRACE:-off}" == on ]]; then
+      setopt xtrace
+    fi
     _cosh_user_command_not_found_handler "$@"
     local result=$?
+    local final_xtrace="${options[xtrace]}"
+    unsetopt xtrace
+    _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE="$final_xtrace"
     _COSH_IN_USER_COMMAND_NOT_FOUND=0
     return "$result"
   fi
@@ -444,7 +451,7 @@ else
   _COSH_HAS_USER_COMMAND_NOT_FOUND=0
 fi
 unset _cosh_user_handler_definition _COSH_INITIAL_COMMAND_NOT_FOUND_HANDLER
-command_not_found_handler() {
+_cosh_command_not_found_handler() {
   local command="$1"
   shift || true
   local original="${_COSH_ATTEMPT_INPUT:-}"
@@ -458,7 +465,7 @@ command_not_found_handler() {
     return $?
   fi
   if (( ${ZSH_SUBSHELL:-0} != ${_COSH_ATTEMPT_SUBSHELL:-0} + 1 )) \
-     || (( ${#funcstack[@]} != 1 )) \
+     || (( ${#funcstack[@]} != 2 )) \
      || [[ "${_COSH_ATTEMPT_EXPANSION_DRIFT:-0}" == 1 ]]; then
     _cosh_delegate_zsh_command_not_found "$command" "$@"
     return $?
@@ -511,7 +518,23 @@ command_not_found_handler() {
   _cosh_delegate_zsh_command_not_found "$command" "$@"
   return $?
 }
+command_not_found_handler() {
+  local _COSH_COMMAND_NOT_FOUND_XTRACE="${options[xtrace]}"
+  # zsh restores XTRACE at every function return even without LOCAL_OPTIONS;
+  # the observed post-handler state therefore already matches native zsh.
+  local _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE="$_COSH_COMMAND_NOT_FOUND_XTRACE"
+  unsetopt xtrace
+  _cosh_command_not_found_handler "$@"
+  local result=$?
+  if [[ "$_COSH_COMMAND_NOT_FOUND_FINAL_XTRACE" == on ]]; then
+    setopt xtrace
+  else
+    unsetopt xtrace
+  fi
+  return "$result"
+}
 _cosh_preexec_marker() {
+  setopt localoptions noxtrace
   local command="$1"
   # zsh passes the abbreviated, size-limited form in $2 and the full text of
   # the command being executed in $3. Long inputs truncate $2, so comparing
@@ -591,6 +614,7 @@ _cosh_preexec_marker() {
 }
 _cosh_precmd_marker() {
   local exit_status=$?
+  setopt localoptions noxtrace
   setopt NO_PROMPT_CR 2>/dev/null || true
   setopt NO_PROMPT_SP 2>/dev/null || true
   _cosh_apply_internal_recovery

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1995,6 +1995,10 @@ fn shell_host_bash_prompt_hook_observes_only_bounded_capture() {
                 || command.starts_with("_COSH_PROMPT_DEBUG_TRAP=")
                 || command.starts_with("_COSH_PROMPT_RETURN_TRAP=")
                 || command.starts_with("_COSH_PROMPT_ERR_TRAP=")
+                || command == "_COSH_PROMPT_XTRACE=0"
+                || command == "_COSH_PROMPT_XTRACE=1"
+                || command == "(( _COSH_PROMPT_XTRACE == 1 ))"
+                || command == "unset _COSH_PROMPT_XTRACE"
                 || (command.starts_with("trap -p DEBUG >")
                     && command.contains("COSH_RECOVERY_REQUEST_FILE")),
             "unexpected Cosh internals in user trap: {line}\n{trace_log}"

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/native.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/native.rs
@@ -14,11 +14,48 @@ fn assert_debug_log_has_only_bounded_cosh_capture(debug_log: &str) {
                 || command.starts_with("_COSH_PROMPT_DEBUG_TRAP=")
                 || command.starts_with("_COSH_PROMPT_RETURN_TRAP=")
                 || command.starts_with("_COSH_PROMPT_ERR_TRAP=")
+                || command == "_COSH_PROMPT_XTRACE=0"
+                || command == "_COSH_PROMPT_XTRACE=1"
+                || command == "(( _COSH_PROMPT_XTRACE == 1 ))"
+                || command == "unset _COSH_PROMPT_XTRACE"
                 || (command.starts_with("trap -p DEBUG >")
                     && command.contains("COSH_RECOVERY_REQUEST_FILE")),
             "unexpected Cosh internals in DEBUG trap: {line}\n{debug_log}"
         );
     }
+}
+
+fn assert_bash_xtrace_has_only_bounded_cosh_entries(trace: &str) {
+    let mut cosh_lines = 0;
+    for line in trace
+        .lines()
+        .filter(|line| line.contains("_cosh") || line.contains("_COSH"))
+    {
+        cosh_lines += 1;
+        let command = line
+            .split_once("BASH_USER_TRACE__ ")
+            .map(|(_, command)| command)
+            .unwrap_or(line);
+        let prompt_status = command
+            .strip_prefix("_COSH_PROMPT_STATUS=")
+            .is_some_and(|status| {
+                !status.is_empty() && status.bytes().all(|byte| byte.is_ascii_digit())
+            });
+        assert!(
+            prompt_status
+                || matches!(
+                    command,
+                    "_COSH_PROMPT_XTRACE=0"
+                        | "_COSH_PROMPT_XTRACE=1"
+                        | "local _COSH_COMMAND_NOT_FOUND_XTRACE=0"
+                        | "local _COSH_COMMAND_NOT_FOUND_FINAL_XTRACE=0"
+                        | "_COSH_COMMAND_NOT_FOUND_XTRACE=1"
+                        | "_COSH_COMMAND_NOT_FOUND_FINAL_XTRACE=1"
+                ),
+            "unexpected Cosh xtrace entry: {line}\n{trace}"
+        );
+    }
+    assert!(cosh_lines <= 64, "unbounded Cosh xtrace entries: {trace}");
 }
 
 #[test]
@@ -405,9 +442,10 @@ set +E +T
     let return_log = std::fs::read_to_string(home_dir.join("return.log")).unwrap_or_default();
     let err_log = std::fs::read_to_string(home_dir.join("err.log")).unwrap_or_default();
     for trap_log in [&debug_log, &return_log, &err_log] {
-        assert!(!trap_log.contains("_cosh"), "{trap_log}");
         assert!(!trap_log.contains(marker_token), "{trap_log}");
     }
+    assert!(!return_log.contains("_cosh"), "{return_log}");
+    assert!(!err_log.contains("_cosh"), "{err_log}");
     assert_debug_log_has_only_bounded_cosh_capture(&debug_log);
     assert!(
         debug_log.contains("DBG=[echo user-visible-cmd]"),
@@ -424,6 +462,72 @@ set +E +T
             && event.command.as_deref() == Some("echo user-visible-cmd")
             && event.exit_code == Some(0)
     }));
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn enhanced_bash_functrace_keeps_prompt_internals_bounded() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-enhanced-functrace-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        r#"PS1='functrace$ '
+set -T
+trap 'printf "DBG=[%s]\n" "$BASH_COMMAND" >> "$HOME/functrace.log"' DEBUG
+"#,
+    )
+    .expect("bashrc");
+    let sensitive_path = "/cosh-functrace-private-2683:/usr/bin:/bin";
+    let config = ShellHostConfig::new("enhanced-functrace", &work_dir)
+        .with_integration(ShellIntegration::Enhanced)
+        .with_env("HOME", home_dir.display().to_string())
+        .with_env("PATH", sensitive_path);
+
+    let mut rendered = Vec::new();
+    run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line("set -x"),
+            RawRelayAction::line("printf '__FUNCTRACE_USER_COMMAND__\\n'"),
+            RawRelayAction::line("set +x"),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("enhanced Bash functrace relay");
+
+    let terminal = String::from_utf8_lossy(&rendered);
+    assert!(
+        terminal.contains("__FUNCTRACE_USER_COMMAND__"),
+        "{terminal}"
+    );
+    let debug_log =
+        std::fs::read_to_string(home_dir.join("functrace.log")).expect("functrace DEBUG log");
+    assert_debug_log_has_only_bounded_cosh_capture(&debug_log);
+    assert!(!debug_log.contains("_cosh_"), "{debug_log}");
+    assert!(!debug_log.contains(sensitive_path), "{debug_log}");
+    assert!(
+        !debug_log.contains(work_dir.to_str().expect("UTF-8 work dir")),
+        "{debug_log}"
+    );
+    let marker =
+        std::fs::read_to_string(work_dir.join("cosh-marker.bash")).expect("enhanced Bash marker");
+    let marker_token = marker
+        .lines()
+        .find_map(|line| line.strip_prefix("COSH_MARKER_TOKEN='")?.strip_suffix('\''))
+        .expect("marker token");
+    assert!(!debug_log.contains(marker_token), "{debug_log}");
 
     let _ = std::fs::remove_dir_all(&work_dir);
 }
@@ -782,6 +886,241 @@ fn enhanced_zsh_xtrace_hides_assistance_state_path() {
     assert!(
         !terminal.contains(&assistance_state_path),
         "assistance state path leaked through Zsh xtrace: {terminal}"
+    );
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn enhanced_bash_xtrace_bounds_internal_hooks_and_preserves_user_state() {
+    if Command::new("bash").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-enhanced-bash-bounded-xtrace-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    std::fs::write(
+        home_dir.join(".bashrc"),
+        "PS1='bash-xtrace$ '\nPROMPT_COMMAND='printf \"__USER_PROMPT_HOOK__\\n\"'\n\
+         command_not_found_handle() {\n\
+           case \"$1\" in\n\
+             toggle-off) set +x; return 41;;\n\
+             toggle-on) set -x; return 42;;\n\
+             *) printf '__USER_BASH_MISSING__\\n'; return 43;;\n\
+           esac\n\
+         }\n",
+    )
+    .expect("bashrc");
+    let trace_path = home_dir.join("xtrace.log");
+    let sensitive_path = "/cosh-private-path-2683:/usr/bin:/bin";
+    let config = ShellHostConfig::new("enhanced-bash-bounded-xtrace", &work_dir)
+        .with_integration(ShellIntegration::Enhanced)
+        .with_env("HOME", home_dir.display().to_string())
+        .with_env("PATH", sensitive_path);
+
+    let mut rendered = Vec::new();
+    run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!("exec 9>{}", trace_path.display())),
+            RawRelayAction::line("BASH_XTRACEFD=9; PS4='__BASH_USER_TRACE__ '"),
+            RawRelayAction::line("set -x"),
+            RawRelayAction::line("printf '__BASH_USER_COMMAND__\\n'"),
+            RawRelayAction::line(
+                "missing-cosh-xtrace-command; printf '__BASH_MISSING_STATUS__=%s\\n' \"$?\"",
+            ),
+            RawRelayAction::line(
+                "case $- in *x*) printf '__BASH_XTRACE_ON__\\n';; *) printf '__BASH_XTRACE_LOST__\\n';; esac",
+            ),
+            RawRelayAction::line(
+                "command_not_found_handle toggle-off; s=$?; case $- in *x*) f=on;; *) f=off;; esac; printf '__BASH_HANDLER_OFF__=%s:%s\\n' \"$s\" \"$f\"",
+            ),
+            RawRelayAction::line(
+                "command_not_found_handle toggle-on; s=$?; case $- in *x*) f=on;; *) f=off;; esac; printf '__BASH_HANDLER_ON__=%s:%s\\n' \"$s\" \"$f\"; set +x",
+            ),
+            RawRelayAction::line("printf '__BASH_PS4__=%s\\n' \"$PS4\""),
+            RawRelayAction::line("printf '__BASH_XTRACEFD__=%s\\n' \"$BASH_XTRACEFD\""),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("enhanced Bash bounded xtrace relay");
+
+    let terminal = String::from_utf8_lossy(&rendered);
+    assert!(terminal.contains("__BASH_USER_COMMAND__"), "{terminal}");
+    assert!(terminal.contains("__USER_BASH_MISSING__"), "{terminal}");
+    assert!(
+        terminal.contains("__BASH_MISSING_STATUS__=43"),
+        "{terminal}"
+    );
+    assert!(terminal.contains("__BASH_XTRACE_ON__"), "{terminal}");
+    assert!(!terminal.contains("__BASH_XTRACE_LOST__\r\n"), "{terminal}");
+    assert!(
+        terminal.contains("__BASH_HANDLER_OFF__=41:off"),
+        "{terminal}"
+    );
+    assert!(terminal.contains("__BASH_HANDLER_ON__=42:on"), "{terminal}");
+    assert!(
+        terminal.contains("__BASH_PS4__=__BASH_USER_TRACE__ "),
+        "{terminal}"
+    );
+    assert!(terminal.contains("__BASH_XTRACEFD__=9"), "{terminal}");
+
+    let trace = std::fs::read_to_string(&trace_path).expect("Bash xtrace log");
+    assert!(trace.contains("__BASH_USER_COMMAND__"), "{trace}");
+    assert!(trace.contains("__USER_PROMPT_HOOK__"), "{trace}");
+    assert!(
+        trace
+            .lines()
+            .any(|line| line.contains("printf '__USER_BASH_MISSING__")),
+        "{trace}"
+    );
+    assert_bash_xtrace_has_only_bounded_cosh_entries(&trace);
+    for private_value in [sensitive_path, work_dir.to_str().expect("UTF-8 work dir")] {
+        assert!(
+            !trace.contains(private_value),
+            "private value leaked: {trace}"
+        );
+    }
+    for internal in [
+        "_cosh_json_escape",
+        "_cosh_emit_marker",
+        "_cosh_emit_boundary_marker",
+        "_cosh_precmd_marker",
+        "COSH_SESSION_ID",
+        "_COSH_MARKER_TOKEN",
+    ] {
+        assert!(!trace.contains(internal), "internal xtrace leaked: {trace}");
+    }
+    let marker =
+        std::fs::read_to_string(work_dir.join("cosh-marker.bash")).expect("enhanced Bash marker");
+    let marker_token = marker
+        .lines()
+        .find_map(|line| line.strip_prefix("COSH_MARKER_TOKEN='")?.strip_suffix('\''))
+        .expect("marker token");
+    assert!(
+        !trace.contains(marker_token),
+        "marker token leaked: {trace}"
+    );
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn enhanced_zsh_xtrace_bounds_internal_hooks_and_preserves_user_state() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-enhanced-zsh-bounded-xtrace-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home_dir = work_dir.join("home");
+    std::fs::create_dir_all(&home_dir).expect("home dir");
+    std::fs::write(
+        home_dir.join(".zshrc"),
+        "PS1='zsh-xtrace% '\n_user_precmd_2683() { print '__USER_ZSH_PRECMD__' }\n\
+         precmd_functions+=(_user_precmd_2683)\n\
+         command_not_found_handler() {\n\
+           case \"$1\" in\n\
+             toggle-off) set +x; return 44;;\n\
+             toggle-on) set -x; return 45;;\n\
+             *) print '__USER_ZSH_MISSING__'; return 46;;\n\
+           esac\n\
+         }\n",
+    )
+    .expect("zshrc");
+    let sensitive_path = "/cosh-private-zsh-path-2683:/usr/bin:/bin";
+    let config = ShellHostConfig::new("enhanced-zsh-bounded-xtrace", &work_dir)
+        .with_integration(ShellIntegration::Enhanced)
+        .with_env("HOME", home_dir.display().to_string())
+        .with_env("ZDOTDIR", home_dir.display().to_string())
+        .with_env("PATH", sensitive_path);
+
+    let mut rendered = Vec::new();
+    run_raw_relay_zsh_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line("PS4='__ZSH_USER_TRACE__ '"),
+            RawRelayAction::line("set -x"),
+            RawRelayAction::line("print '__ZSH_USER_COMMAND__'"),
+            RawRelayAction::line(
+                "missing-cosh-zsh-xtrace-command; print '__ZSH_MISSING_STATUS__='$?",
+            ),
+            RawRelayAction::line(
+                "if [[ -o xtrace ]]; then print '__ZSH_XTRACE_ON__'; else print '__ZSH_XTRACE_LOST__'; fi",
+            ),
+            RawRelayAction::line(
+                "command_not_found_handler toggle-off; s=$?; print '__ZSH_HANDLER_OFF__='$s:${options[xtrace]}; set +x",
+            ),
+            RawRelayAction::line(
+                "command_not_found_handler toggle-on; s=$?; print '__ZSH_HANDLER_ON__='$s:${options[xtrace]}",
+            ),
+            RawRelayAction::line("print -r -- \"__ZSH_PS4__=$PS4\""),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("enhanced Zsh bounded xtrace relay");
+
+    let terminal = String::from_utf8_lossy(&rendered);
+    assert!(terminal.contains("__ZSH_USER_COMMAND__"), "{terminal}");
+    assert!(terminal.contains("__USER_ZSH_PRECMD__"), "{terminal}");
+    assert!(terminal.contains("__USER_ZSH_MISSING__"), "{terminal}");
+    assert!(terminal.contains("__ZSH_MISSING_STATUS__=46"), "{terminal}");
+    assert!(terminal.contains("__ZSH_XTRACE_ON__"), "{terminal}");
+    assert!(!terminal.contains("__ZSH_XTRACE_LOST__\r\n"), "{terminal}");
+    // zsh always restores XTRACE when a function returns, even without
+    // LOCAL_OPTIONS. Match that native contract while preserving the status.
+    assert!(terminal.contains("__ZSH_HANDLER_OFF__=44:on"), "{terminal}");
+    assert!(terminal.contains("__ZSH_HANDLER_ON__=45:off"), "{terminal}");
+    assert!(
+        terminal.contains("__ZSH_PS4__=__ZSH_USER_TRACE__ "),
+        "{terminal}"
+    );
+    assert!(
+        !terminal.lines().any(|line| {
+            line.contains("__ZSH_USER_TRACE__")
+                && (line.contains("_cosh") || line.contains("_COSH"))
+        }),
+        "Cosh hook escaped the zsh xtrace guard: {terminal}"
+    );
+    for private_value in [sensitive_path, work_dir.to_str().expect("UTF-8 work dir")] {
+        assert!(
+            !terminal.contains(private_value),
+            "private value leaked: {terminal}"
+        );
+    }
+    for internal in [
+        "_cosh_json_escape",
+        "_cosh_emit_marker",
+        "_cosh_precmd_marker:",
+        "_cosh_preexec_marker:2",
+        "_cosh_zshaddhistory_marker:2",
+        "COSH_SESSION_ID",
+    ] {
+        assert!(
+            !terminal.contains(internal),
+            "internal xtrace leaked: {terminal}"
+        );
+    }
+    let marker = std::fs::read_to_string(work_dir.join(".zshrc")).expect("enhanced Zsh marker");
+    let marker_token = marker
+        .lines()
+        .find_map(|line| line.strip_prefix("COSH_MARKER_TOKEN='")?.strip_suffix('\''))
+        .expect("marker token");
+    assert!(
+        !terminal.contains(marker_token),
+        "marker token leaked: {terminal}"
     );
 
     let _ = std::fs::remove_dir_all(&work_dir);


### PR DESCRIPTION
## Why

Enhanced Bash and zsh sessions still exposed internal hook execution when users
enabled xtrace. The trace could include dynamic marker, working-directory, and
environment data even after #2832 removed the global DEBUG trap.

## What changed

- disable xtrace around internal Bash prompt, PS0, and command-not-found work;
- make zsh hook entry points function-local and `noxtrace`;
- preserve user PS4, BASH_XTRACEFD, hook return codes, and final xtrace state;
- add PTY regressions for bounded output, sensitive values, and native parity.

## Related issue

closes #2683

This PR is the remaining code fix on the xtrace axis. It does not close #2831,
which remains a separate P2 zero-hook architecture investigation.

## User / Agent impact

User commands and user-defined hooks continue to produce xtrace output, while
Cosh internals no longer expose dynamic session data. Native mode remains free
of Cosh hook traces.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The visible xtrace stream is intentionally reduced. Shell option state, PS4,
BASH_XTRACEFD, command-not-found return codes, and user hooks remain compatible.
The Bash 4.3-5.0 scalar PROMPT_COMMAND path was structurally reviewed but was
not exercised on a real old-Bash runner locally.

## Validation

- `cargo test --locked -p cosh-shell --test shell_host xtrace -- --test-threads=1`
  (3 passed)
- `cargo test --locked -p cosh-shell --test shell_host native::enhanced_bash_functrace_keeps_prompt_internals_bounded -- --exact`
- Bash and zsh command-not-found contract tests
- Native Bash and zsh integration tests
- `cargo test --locked -p cosh-shell --lib bash_bounded` (3 passed)
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

Full workspace gates and ECS validation were intentionally left to CI because
this is a focused shell-host change.

## Documentation and rollback

No documentation changes are required. Reverting commit `dc4c87de` restores
the previous trace behavior.
