### PR TITLE
test(cosh-ng): [shell] pin hook parity

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/external_hook.rs
@@ -46,9 +46,9 @@ fn spawn_hook_session(
     let session = thread::spawn(move || {
         let home = home.to_string_lossy().into_owned();
         // These tests measure hook deadlines after observing the hook PID.
-        // Keep their startup outside competing raw CLI sessions so scheduler
-        // load cannot consume the independent hook-start watchdog first.
-        run_raw_cli_serial_with_args_env_and_delayed_input_after_start(
+        // Keep startup outside the independent hook-start watchdog and away
+        // from competing raw CLI sessions.
+        run_raw_cli_serial_with_args_env_and_delayed_input_after_ready(
             "fake",
             &[],
             &[("HOME", home.as_str())],
@@ -63,10 +63,10 @@ fn spawn_hook_session(
 }
 
 fn large_hook_input_command() -> Vec<u8> {
-    let mut command = b"printf '' #".to_vec();
-    command.resize(command.len() + 1024 * 1024, b'x');
-    command.push(b'\n');
-    command
+    // Produce more than the maximum Linux pipe capacity using lines below
+    // the redaction line limit. The short source avoids spending the hook
+    // startup watchdog on echoing and parsing a 1 MiB interactive command.
+    b"printf '%32767s\\n' {1..40}\n".to_vec()
 }
 
 #[test]
@@ -316,9 +316,8 @@ fn raw_cli_external_hook_ignoring_large_stdin_respects_deadline() {
     );
     install_user_hook(&home, "ignore_stdin.sh", &body);
 
-    // Keep the serialized command itself larger than a pipe buffer. Bounded
-    // output retention may replace an oversized output line with a short
-    // fail-closed placeholder before hook evaluation.
+    // Keep the serialized hook input larger than a pipe buffer without an
+    // oversized output line, which bounded retention replaces fail-closed.
     let command = large_hook_input_command();
     let (session, session_started) = spawn_hook_session(&home, &command);
     session_started.recv().expect("raw CLI session to start");

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
@@ -73,6 +73,8 @@ mod input_intent;
 mod marker;
 #[path = "shell_host/native.rs"]
 mod native;
+#[path = "shell_host/parity.rs"]
+mod parity;
 #[path = "shell_host/relay.rs"]
 mod relay;
 #[path = "shell_host/termios.rs"]

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
@@ -1,0 +1,237 @@
+use super::*;
+
+fn bash_available() -> bool {
+    match Command::new("bash").arg("--version").output() {
+        Ok(_) => true,
+        Err(error) => {
+            eprintln!("SKIP: bash is unavailable: {error}");
+            false
+        }
+    }
+}
+
+#[test]
+fn enhanced_bash_errexit_context_keeps_interactive_session_alive() {
+    if !bash_available() {
+        return;
+    }
+
+    for login_shell in [false, true] {
+        let mode = if login_shell { "login" } else { "nonlogin" };
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-errexit-{mode}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let mut config = ShellHostConfig::new(format!("errexit-{mode}"), &work_dir)
+            .with_integration(ShellIntegration::Enhanced)
+            .with_env("LANG", "C.UTF-8")
+            .with_env("LC_ALL", "C.UTF-8");
+        config.login_shell = login_shell;
+
+        let output = run_scripted_bash(
+            &config,
+            &[
+                ScriptedInput::command(
+                    "{ set -e; false && printf bad; printf '__ERREXIT_CONTEXT__\\n'; }",
+                ),
+                ScriptedInput::command("printf '__SESSION_CONTINUED__\\n'"),
+            ],
+        )
+        .unwrap_or_else(|error| panic!("{mode} scripted bash: {error}"));
+
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+        assert!(
+            terminal.contains("__ERREXIT_CONTEXT__"),
+            "{mode}: {terminal}"
+        );
+        assert!(
+            terminal.contains("__SESSION_CONTINUED__"),
+            "{mode}: {terminal}"
+        );
+        assert_eq!(output.exit_status, Some(0), "{mode}: {terminal}");
+
+        let context = output
+            .events
+            .iter()
+            .find(|event| {
+                event.kind == ShellEventKind::CommandCompleted
+                    && event.command.as_deref().is_some_and(|command| {
+                        command.contains("false && printf bad")
+                            && command.contains("__ERREXIT_CONTEXT__")
+                    })
+            })
+            .unwrap_or_else(|| panic!("{mode}: missing errexit completion: {:?}", output.events));
+        assert_eq!(context.exit_code, Some(0), "{mode}: {terminal}");
+        assert!(
+            output.events.iter().any(|event| {
+                event.kind == ShellEventKind::CommandCompleted
+                    && event.command.as_deref() == Some("printf '__SESSION_CONTINUED__\\n'")
+                    && event.exit_code == Some(0)
+            }),
+            "{mode}: missing continuation completion: {:?}",
+            output.events
+        );
+
+        let _ = std::fs::remove_dir_all(&work_dir);
+    }
+}
+
+#[test]
+fn enhanced_bash_preserves_last_argument_across_prompt_boundary() {
+    if !bash_available() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-last-argument-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("last-argument", &work_dir)
+        .with_integration(ShellIntegration::Enhanced)
+        .with_env("LANG", "C.UTF-8")
+        .with_env("LC_ALL", "C.UTF-8");
+    let output = run_scripted_bash(
+        &config,
+        &[
+            ScriptedInput::command("echo hello world"),
+            ScriptedInput::command("printf '__LAST_ARGUMENT__=[%s]\\n' \"$_\""),
+        ],
+    )
+    .expect("scripted bash");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    assert!(terminal.contains("__LAST_ARGUMENT__=[world]"), "{terminal}");
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn enhanced_bash_keeps_internal_prompt_hooks_out_of_child_env() {
+    if !bash_available() {
+        return;
+    }
+
+    let work_dir = std::env::temp_dir().join(format!(
+        "cosh-shell-prompt-command-env-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let config = ShellHostConfig::new("prompt-command-env", &work_dir)
+        .with_integration(ShellIntegration::Enhanced)
+        .with_env("PROMPT_COMMAND", "printf ''")
+        .with_env("LANG", "C.UTF-8")
+        .with_env("LC_ALL", "C.UTF-8");
+    let output = run_scripted_bash(
+        &config,
+        &[ScriptedInput::command(
+            "printf '__PROMPT_COMMAND__=%s\\n' \"$(declare -p PROMPT_COMMAND)\"; \
+             if env | grep -q '^PROMPT_COMMAND='; then \
+               printf '__CHILD_PROMPT_COMMAND__=present\\n'; \
+             else \
+               printf '__CHILD_PROMPT_COMMAND__=absent\\n'; \
+             fi; \
+             (PROMPT_COMMAND=('printf p1' 'printf p2'); \
+             printf '__REASSIGNED_PROMPT_COMMAND__=%s\\n' \
+             \"$(declare -p PROMPT_COMMAND)\")",
+        )],
+    )
+    .expect("scripted bash");
+
+    let terminal = String::from_utf8_lossy(&output.terminal_output);
+    let expected = if bash_supports_prompt_command_array() {
+        "__PROMPT_COMMAND__=declare -ax PROMPT_COMMAND="
+    } else {
+        "__PROMPT_COMMAND__=declare -- PROMPT_COMMAND="
+    };
+    assert!(terminal.contains(expected), "{terminal}");
+    assert!(
+        terminal.contains("__CHILD_PROMPT_COMMAND__=absent"),
+        "{terminal}"
+    );
+    let reassigned = if bash_supports_prompt_command_array() {
+        "__REASSIGNED_PROMPT_COMMAND__=declare -ax PROMPT_COMMAND="
+    } else {
+        "__REASSIGNED_PROMPT_COMMAND__=declare -a PROMPT_COMMAND="
+    };
+    assert!(terminal.contains(reassigned), "{terminal}");
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+}
+
+#[test]
+fn enhanced_bash_keeps_three_background_jobs_concurrent() {
+    if !bash_available() {
+        return;
+    }
+
+    for login_shell in [false, true] {
+        let mode = if login_shell { "login" } else { "nonlogin" };
+        let work_dir = std::env::temp_dir().join(format!(
+            "cosh-shell-background-parity-{mode}-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let results = shell_arg(&work_dir.join("background-results"));
+        let release = shell_arg(&work_dir.join("background-release"));
+        let command = format!(
+            "rm -f {results} {release}; \
+             for i in 1 2 3; do \
+               (sleep 0.3; while [[ ! -e {release} ]]; do sleep 0.05; done; \
+                printf 'h%s\\n' \"$i\" >> {results}) & \
+             done; \
+             third=$!; pids=($(jobs -p)); jobs -r; \
+             if [[ \"$third\" == \"${{pids[2]-}}\" ]]; then \
+               printf '__LAST_IS_THIRD__=yes\\n'; \
+             else \
+               printf '__LAST_IS_THIRD__=no\\n'; \
+             fi; \
+             : > {release}; wait; sort {results}"
+        );
+        let mut config = ShellHostConfig::new(format!("background-parity-{mode}"), &work_dir)
+            .with_integration(ShellIntegration::Enhanced)
+            .with_env("LANG", "C.UTF-8")
+            .with_env("LC_ALL", "C.UTF-8");
+        config.login_shell = login_shell;
+        let output = run_scripted_bash(&config, &[ScriptedInput::command(command.clone())])
+            .unwrap_or_else(|error| panic!("{mode} scripted bash: {error}"));
+
+        let ledger = ledger_from_output(&output);
+        let block = ledger
+            .blocks
+            .iter()
+            .find(|block| block.command == command)
+            .unwrap_or_else(|| panic!("{mode}: missing background command: {:#?}", ledger.blocks));
+        assert_eq!(block.exit_code, 0, "{mode}");
+        let output_ref = block
+            .output
+            .terminal_output_ref
+            .as_deref()
+            .unwrap_or_else(|| panic!("{mode}: background output ref"));
+        let command_output = std::fs::read_to_string(output_ref)
+            .unwrap_or_else(|error| panic!("{mode}: background output: {error}"));
+
+        for job in ["[1]", "[2]", "[3]"] {
+            assert!(command_output.contains(job), "{mode}: {command_output}");
+        }
+        assert_eq!(
+            command_output
+                .lines()
+                .filter(|line| line.contains("Running"))
+                .count(),
+            3,
+            "{mode}: {command_output}"
+        );
+        assert!(
+            command_output.contains("__LAST_IS_THIRD__=yes"),
+            "{mode}: {command_output}"
+        );
+        let lines = command_output.lines().map(str::trim).collect::<Vec<_>>();
+        for result in ["h1", "h2", "h3"] {
+            assert!(lines.contains(&result), "{mode}: {command_output}");
+        }
+
+        let _ = std::fs::remove_dir_all(&work_dir);
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/raw_cli.rs
@@ -132,12 +132,12 @@ pub(crate) fn run_raw_cli_with_args_env_and_delayed_input(
     )
 }
 
-pub(crate) fn run_raw_cli_serial_with_args_env_and_delayed_input_after_start(
+pub(crate) fn run_raw_cli_serial_with_args_env_and_delayed_input_after_ready(
     adapter: &str,
     extra_args: &[&str],
     envs: &[(&str, &str)],
     chunks: Vec<(Vec<u8>, Duration)>,
-    session_started: mpsc::Sender<()>,
+    session_ready: mpsc::Sender<()>,
 ) -> String {
     run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(
         adapter,
@@ -146,7 +146,7 @@ pub(crate) fn run_raw_cli_serial_with_args_env_and_delayed_input_after_start(
         Path::new(env!("CARGO_MANIFEST_DIR")),
         chunks,
         RawCliRunMode::Exclusive,
-        Some(session_started),
+        Some(session_ready),
         None,
     )
 }
@@ -709,7 +709,7 @@ fn run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(
     current_dir: &Path,
     chunks: Vec<(Vec<u8>, Duration)>,
     run_mode: RawCliRunMode,
-    session_started: Option<mpsc::Sender<()>>,
+    session_ready: Option<mpsc::Sender<()>>,
     ready_marker: Option<&str>,
 ) -> String {
     let _run_guard = raw_cli_run_guard(run_mode);
@@ -724,16 +724,33 @@ fn run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(
         .stderr(Stdio::piped());
     configure_raw_cli_command(&mut command);
     apply_raw_cli_envs(&mut command, envs);
+    let mut input_readiness = session_ready.as_ref().map(|_| RawCliInputReadiness::new());
+    if let Some(input_readiness) = input_readiness.as_ref() {
+        input_readiness.configure(&mut command);
+    }
     command.process_group(0);
     let mut child = command.spawn().expect("spawn cosh-shell raw");
     let stdout = child.stdout.take().expect("child stdout");
     let stderr = child.stderr.take().expect("child stderr");
     let (output_receiver, stdout_reader) = read_pipe_with_chunks(stdout);
     let stderr_reader = read_pipe(stderr);
-    if let Some(session_started) = session_started {
-        session_started
+    if let Some(session_ready) = session_ready {
+        let input_readiness = input_readiness
+            .as_mut()
+            .expect("session readiness probe is configured");
+        let request = input_readiness.request();
+        let mut observed = Vec::new();
+        wait_for_raw_cli_input_ready(
+            &output_receiver,
+            &mut observed,
+            0,
+            input_readiness.token(),
+            request,
+        )
+        .unwrap_or_else(|error| panic!("{error}"));
+        session_ready
             .send(())
-            .expect("signal raw CLI session start");
+            .expect("signal raw CLI session readiness");
     }
     if let Some(marker) = ready_marker {
         let mut observed = Vec::new();
@@ -750,7 +767,10 @@ fn run_raw_cli_with_args_env_current_dir_and_delayed_input_inner(
         }
     }
 
-    let output = wait_for_raw_cli_output_with_readers(child, (stdout_reader, stderr_reader));
+    let mut output = wait_for_raw_cli_output_with_readers(child, (stdout_reader, stderr_reader));
+    if let Some(input_readiness) = input_readiness.as_ref() {
+        output.stdout = input_readiness.strip_frames(&output.stdout);
+    }
     assert!(
         output.status.success(),
         "status={:?}\nstdout={}\nstderr={}",


### PR DESCRIPTION
## Why

The #2832 architecture removed the old DEBUG-trap failure paths, but the
resolved shell contracts still lacked precise regression coverage. CI also
exposed a pre-existing external-hook deadline fixture whose watchdog included
runner-dependent PTY startup and parsing work. Review proved that restoring the
PROMPT_COMMAND export bit on legacy Bash would export Cosh internal hook text,
so this PR intentionally keeps production prompt behavior unchanged.

## What changed

- add regressions for errexit context, `$_`, and concurrent background jobs;
- make Bash availability skips visible and keep the job probe Bash 3.2-safe in login/non-login modes;
- assert Enhanced prompt hooks never enter child process environments;
- start hook-test watchdogs after raw relay readiness and generate large hook
  input without sending a 1 MiB interactive command through the PTY.

## Related issue

closes #2541
closes #2539
closes #2684

These closures record behavior delivered by #2625 and #2832 and pinned by
this PR's regressions.

Related: #2540 — intentionally out of scope. Array `-x` is inert in Bash 5.1+,
while restoring it on the legacy scalar fallback would export Cosh hook source
to every child process. #2598 remains open for the outstanding shell-contract
work.

## User / Agent impact

No product behavior changes. The tests pin the shell parity already delivered
by #2832 and ensure Enhanced prompt hooks remain absent from child environments.

## Risk and compatibility

The changes are test-only. Product hook deadlines, PROMPT_COMMAND handling, and
public interfaces remain unchanged. The background-job probe avoids Bash 4-only
builtins and remains active on macOS Bash 3.2.

## Validation

- `cargo test --locked -p cosh-shell --test shell_host parity:: -- --test-threads=1`
  (4 passed)
- `cargo test --locked -p cosh-shell --test raw_cli external_hook::raw_cli_external_hook_ -- --test-threads=1`
  (5 passed)
- formerly failing external-hook exact case repeated 5/5 at about 3.3 seconds
- `cargo clippy --locked -p cosh-shell --test raw_cli --test shell_host -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

Full workspace gates and ECS validation were intentionally left to CI because
this is a focused test and fixture correction.

## Documentation and rollback

No documentation changes are required. Reverting `d63ee108` and `56b5326d`
restores the previous tests and fixtures.
