### PR TITLE
fix(sight): stop VACUUM in purge to avoid cgroup OOM

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/data-and-storage.md
+++ b/docs/user-guide/en/agent-observability/agentsight/data-and-storage.md
@@ -39,6 +39,14 @@ how you browse a copy or an archive. The tracer itself always writes to the defa
 | `genai_events.db` | 200 MB by default; pruning starts at 90% of the cap and removes the oldest 5% of records per pass | `AGENTSIGHT_GENAI_DB_MAX_SIZE_MB=500` in the service environment |
 | `interruption_events.db` | 30 days and 100 MB | `features.interruption_detection.retention_days` / `max_db_size_mb` |
 
+The limit is a logical-data cap (physical file size minus free pages); pruning
+removes the oldest records first until the logical size fits. The physical file
+does not shrink after pruning: freed pages go to the freelist and are reused by
+future writes, so the file stabilizes at its historical peak. To return disk
+space to the filesystem, run `sudo sqlite3 /var/log/sysak/.agentsight/<db>
+'VACUUM;'` manually during a low-traffic window — VACUUM rebuilds the whole
+file, so stop the service first to avoid tripping the cgroup memory limit.
+
 To raise the GenAI cap for the packaged service:
 
 ```bash

--- a/docs/user-guide/zh/agent-observability/agentsight/data-and-storage.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/data-and-storage.md
@@ -36,6 +36,12 @@ tracer 自身始终写入默认目录。
 | `genai_events.db` | 默认 200 MB；达到上限的 90% 开始清理，每轮删除最旧的 5% 记录 | 在服务环境里设置 `AGENTSIGHT_GENAI_DB_MAX_SIZE_MB=500` |
 | `interruption_events.db` | 30 天 + 100 MB | `features.interruption_detection.retention_days` / `max_db_size_mb` |
 
+上限按逻辑容量计（物理文件大小减去空闲页），清理按最旧优先收敛到阈值内。清理后
+物理文件不会自动缩小：释放的页进入空闲页表并被后续写入复用，文件大小稳定在
+历史峰值。如需向文件系统归还磁盘空间，在低峰期手动执行
+`sudo sqlite3 /var/log/sysak/.agentsight/<db> 'VACUUM;'`（VACUUM 会重建整个文件，
+建议先停止服务，避免 cgroup 内存限制下触发 OOM）。
+
 给安装包服务调高 GenAI 上限：
 
 ```bash

--- a/src/agentsight/src/storage/sqlite/audit.rs
+++ b/src/agentsight/src/storage/sqlite/audit.rs
@@ -6,7 +6,9 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, params};
 use std::path::{Path, PathBuf};
 
-use super::connection::{create_connection, default_base_path, wal_checkpoint};
+use super::connection::{
+    create_connection, default_base_path, wal_checkpoint, wal_checkpoint_busy,
+};
 use crate::analyzer::{AuditEventType, AuditExtra, AuditRecord, AuditSummary};
 
 /// SQLite-based audit event store
@@ -228,9 +230,30 @@ impl AuditStore {
         Ok(())
     }
 
-    /// Execute WAL checkpoint to flush WAL data back to the main database file
+    /// Execute WAL checkpoint to flush WAL data back to the main database file.
     pub fn checkpoint(&self) -> Result<()> {
         wal_checkpoint(&self.conn)
+    }
+
+    /// Truncating WAL checkpoint that reports whether it was blocked (busy).
+    ///
+    /// See [`wal_checkpoint_busy`]; size-based purge uses this to stop
+    /// deleting when the WAL cannot be truncated (#2888).
+    pub fn checkpoint_busy(&self) -> Result<bool> {
+        wal_checkpoint_busy(&self.conn)
+    }
+
+    /// Free-page bytes on the shared database file (freelist count x page size).
+    ///
+    /// Used by size-based purge convergence: deleted rows grow the freelist
+    /// instead of shrinking the file, so the logical data size is
+    /// `physical - freelist_bytes`.
+    pub fn freelist_bytes(&self) -> Result<u64> {
+        let freelist: i64 = self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))?;
+        let page_size: i64 = self.conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+        Ok((freelist.max(0) * page_size.max(0)) as u64)
     }
 
     /// Get summary statistics since a given timestamp

--- a/src/agentsight/src/storage/sqlite/connection.rs
+++ b/src/agentsight/src/storage/sqlite/connection.rs
@@ -67,6 +67,23 @@ pub fn wal_checkpoint(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Execute a truncating WAL checkpoint and report whether it actually completed.
+///
+/// `PRAGMA wal_checkpoint(TRUNCATE)` succeeds as a statement even when another
+/// connection holds a read snapshot — it then returns `busy = 1` and leaves the
+/// WAL intact, without raising an SQL error. Size-based purge loops must treat
+/// that as a failed reclaim: the WAL stays in the size measurement while every
+/// `DELETE` appends more frames, so continuing to delete never converges.
+///
+/// Returns `Ok(true)` when the checkpoint was blocked (busy), `Ok(false)` when
+/// the WAL was fully checkpointed and truncated.
+pub fn wal_checkpoint_busy(conn: &Connection) -> Result<bool> {
+    let busy: i32 = conn
+        .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |r| r.get(0))
+        .context("Failed to execute WAL checkpoint")?;
+    Ok(busy != 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/agentsight/src/storage/sqlite/genai/events.rs
+++ b/src/agentsight/src/storage/sqlite/genai/events.rs
@@ -297,9 +297,9 @@ impl GenAISqliteStore {
     /// Size is checked via [`check_and_prune_if_needed`] before the write.
     /// If the insert fails with `SQLITE_FULL`, up to `MAX_PRUNE_RETRIES`
     /// retries are attempted — each retry prunes 5% of the oldest records and
-    /// runs VACUUM. VACUUM failures (e.g. disk-full) are tolerated: the
-    /// `DELETE` still frees internal pages that SQLite can reuse for the
-    /// retry insert.
+    /// runs a truncating WAL checkpoint. Checkpoint failures (e.g. disk-full)
+    /// are tolerated: the `DELETE` still frees internal pages that SQLite can
+    /// reuse for the retry insert.
     pub(super) fn store_event(
         &self,
         event: &GenAISemanticEvent,
@@ -325,10 +325,15 @@ impl GenAISqliteStore {
                                 "Database full (SQLITE_FULL), pruning old records (attempt {retries}/{MAX_PRUNE_RETRIES})"
                             );
                             self.prune_old_records()?;
-                            // VACUUM may fail if disk is full; continue
-                            // anyway — freed pages are reusable by the retry.
-                            if let Err(vacuum_err) = self.checkpoint() {
-                                log::warn!("VACUUM failed during SQLITE_FULL retry: {vacuum_err}");
+                            // Truncate the WAL so the retry sees a compact
+                            // file; freed pages are reusable by the retry.
+                            // Never VACUUM here (#2888). A busy return is
+                            // fine on this path: the freed pages remain
+                            // reusable even with the WAL intact.
+                            if let Err(vacuum_err) = self.wal_checkpoint() {
+                                log::warn!(
+                                    "WAL checkpoint failed during SQLITE_FULL retry: {vacuum_err}"
+                                );
                             }
                             continue;
                         }

--- a/src/agentsight/src/storage/sqlite/genai/schema.rs
+++ b/src/agentsight/src/storage/sqlite/genai/schema.rs
@@ -231,6 +231,37 @@ impl GenAISqliteStore {
         total
     }
 
+    /// Logical data size: physical size minus freelist pages.
+    ///
+    /// Purge convergence is measured on this: deleting rows does not shrink
+    /// the file without VACUUM — freed pages go to the freelist and are
+    /// reused by future inserts, so the physical file stabilizes at its
+    /// historical peak while the logical size reflects live data.
+    pub(super) fn effective_db_size(&self) -> u64 {
+        let physical = self.get_total_db_size();
+        let free_bytes = {
+            let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+            let freelist: i64 = match conn.query_row("PRAGMA freelist_count", [], |r| r.get(0)) {
+                Ok(v) => v,
+                Err(e) => {
+                    // Fall back to the physical size (conservative: the prune
+                    // loop may over-delete by the freelist amount) — but make
+                    // the degraded measurement visible.
+                    log::warn!(
+                        "freelist_count query failed; logical size falls back \
+                         to physical size: {e}"
+                    );
+                    0
+                }
+            };
+            let page_size: i64 = conn
+                .query_row("PRAGMA page_size", [], |r| r.get(0))
+                .unwrap_or(4096);
+            (freelist.max(0) * page_size.max(0)) as u64
+        };
+        physical.saturating_sub(free_bytes)
+    }
+
     /// Check database size and prune if approaching limit.
     ///
     /// Uses adaptive pruning: the fraction of records deleted per iteration
@@ -238,15 +269,26 @@ impl GenAISqliteStore {
     /// severely oversized database is brought back under control quickly
     /// instead of inching down 5% at a time.
     ///
-    /// VACUUM failures (e.g. insufficient temporary disk space) are
-    /// tolerated — deleted records leave free pages that SQLite reuses for
-    /// future inserts, preventing further file growth even when VACUUM cannot
-    /// shrink the file.
+    /// The loop never runs VACUUM: rebuilding the whole file would push its
+    /// pages through the page cache, which counts against the service's
+    /// cgroup memory limit and can OOM-kill the process on large databases
+    /// (#2888). Deleting rows + a truncating WAL checkpoint is enough — the
+    /// freelist is reused by future inserts, so the physical file stops
+    /// growing once the logical size fits.
     pub(super) fn check_and_prune_if_needed(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut current_size = self.get_total_db_size();
+        let physical_size = self.get_total_db_size();
         let threshold = get_prune_threshold();
 
+        // Trigger on physical size (disk safety is physical), converge on
+        // logical size (deletes only shrink the logical size via freelist).
+        if physical_size < threshold {
+            return Ok(());
+        }
+
+        let mut current_size = self.effective_db_size();
         if current_size < threshold {
+            // Physically large but mostly freelist: future writes reuse free
+            // pages, no rows need to be deleted.
             return Ok(());
         }
 
@@ -276,12 +318,6 @@ impl GenAISqliteStore {
 
         const MAX_ITERATIONS: u32 = 20;
         let mut iterations = 0u32;
-        let mut last_size = current_size;
-        // Consecutive iterations where file size did not decrease — signals
-        // that VACUUM is failing (e.g. disk full). Once this hits the limit
-        // we stop: the freed pages will be reused by future inserts, so the
-        // file will not grow further even without VACUUM.
-        let mut size_stuck_count = 0u32;
 
         while current_size >= threshold && iterations < MAX_ITERATIONS {
             iterations += 1;
@@ -291,41 +327,27 @@ impl GenAISqliteStore {
                 break;
             }
 
-            // VACUUM may fail when disk space is tight; continue regardless.
-            if let Err(e) = self.checkpoint() {
-                log::warn!("VACUUM/checkpoint failed on iteration {iterations}: {e}");
+            // Flush and truncate the WAL so freed pages are visible and the
+            // WAL does not grow unbounded. Never VACUUM here (#2888). A busy
+            // checkpoint (another connection holds a read snapshot) leaves the
+            // WAL intact — stop pruning: further deletes would keep appending
+            // WAL frames and never converge.
+            match self.wal_checkpoint() {
+                Ok(true) => {
+                    log::warn!(
+                        "WAL checkpoint busy on iteration {iterations}; \
+                         stopping prune (the WAL could not be truncated)"
+                    );
+                    break;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    log::warn!("WAL checkpoint failed on iteration {iterations}: {e}");
+                }
             }
 
-            let new_size = self.get_total_db_size();
-            if new_size < last_size {
-                size_stuck_count = 0;
-            } else {
-                size_stuck_count += 1;
-            }
-            last_size = new_size;
+            let new_size = self.effective_db_size();
             current_size = new_size;
-
-            // If the file hasn't shrunk for several iterations, VACUUM is
-            // likely failing. Stop — deleted pages are now free and will be
-            // reused, preventing further growth. Escalate with the remaining
-            // record count so operators can judge how much prunable data is
-            // left behind.
-            if size_stuck_count >= 3 {
-                let remaining: i64 = {
-                    let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
-                    conn.query_row("SELECT COUNT(*) FROM genai_events", [], |row| row.get(0))
-                        .unwrap_or(-1)
-                };
-                log::error!(
-                    "GenAI prune stalled: file is {}MB (threshold {}MB) with {remaining} \
-                     records remaining after {iterations} iterations. VACUUM is likely \
-                     failing (e.g. disk full) — manual intervention required \
-                     (free disk space or remove the database).",
-                    current_size / 1024 / 1024,
-                    threshold / 1024 / 1024,
-                );
-                break;
-            }
 
             if current_size >= threshold {
                 log::info!(
@@ -401,36 +423,20 @@ impl GenAISqliteStore {
         Ok(())
     }
 
-    /// Execute WAL checkpoint and VACUUM to reclaim disk space
-    ///
-    /// 1. VACUUM: rebuild database to compact data
-    /// 2. Checkpoint: flush and truncate WAL file
-    ///
-    /// Note: VACUUM in WAL mode creates a new db file, so we need to
-    /// re-enable WAL and checkpoint after VACUUM.
-    pub(super) fn checkpoint(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
-
-        // VACUUM rebuilds the database (works better before checkpoint in WAL mode)
-        conn.execute_batch("VACUUM;")?;
-
-        // Re-enable WAL mode (VACUUM may reset it)
-        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
-
-        // Checkpoint with TRUNCATE to shrink WAL file
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
-
-        Ok(())
-    }
-
     /// Flush WAL frames to the main database and truncate the WAL file.
     ///
     /// Call during graceful shutdown to clean up `-wal` / `-shm` files —
     /// mirrors the sibling stores (token, http, audit) which do this via
     /// `connection::wal_checkpoint` in their own `checkpoint()` methods.
-    pub fn wal_checkpoint(&self) -> Result<(), Box<dyn std::error::Error>> {
+    ///
+    /// Returns `Ok(true)` when the checkpoint was blocked by another
+    /// connection's read snapshot (busy): the statement succeeds but the WAL
+    /// is NOT truncated. Purge loops must stop deleting in that case — the
+    /// WAL stays in the size measurement while deletes keep appending frames,
+    /// so the loop never converges (#2888).
+    pub fn wal_checkpoint(&self) -> Result<bool, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
-        Ok(())
+        let busy: i32 = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |r| r.get(0))?;
+        Ok(busy != 0)
     }
 }

--- a/src/agentsight/src/storage/sqlite/genai/tests.rs
+++ b/src/agentsight/src/storage/sqlite/genai/tests.rs
@@ -1039,9 +1039,8 @@ fn test_prune_old_records() {
 }
 
 #[test]
-fn test_wal_checkpoint_methods() {
+fn test_wal_checkpoint_method() {
     let (store, path) = create_populated_store("wal_ckpt");
-    store.checkpoint().unwrap();
     store.wal_checkpoint().unwrap();
     cleanup_db(&path);
 }
@@ -1464,10 +1463,12 @@ fn check_and_prune_converges_for_all_overshoot_levels() {
 
         store.check_and_prune_if_needed().unwrap();
 
+        // Convergence is on logical size: the physical file keeps its peak
+        // size (freed pages stay on the freelist, #2888).
         assert!(
-            store.get_total_db_size() < threshold,
-            "{label}: database must shrink below threshold, got {} bytes",
-            store.get_total_db_size()
+            store.effective_db_size() < threshold,
+            "{label}: logical size must drop below threshold, got {} bytes",
+            store.effective_db_size()
         );
         assert!(
             row_count(&store) < rows as i64,
@@ -1497,6 +1498,39 @@ fn check_and_prune_noop_below_threshold() {
     cleanup_size_test_db(&path);
 }
 
+/// When another connection holds a read snapshot, the truncating WAL
+/// checkpoint returns busy and the prune loop must stop instead of deleting
+/// round after round against a size that cannot converge (only the WAL keeps
+/// growing) — under the pre-fix behavior the loop deleted until the table was
+/// empty.
+#[test]
+fn check_and_prune_stops_when_wal_checkpoint_busy() {
+    set_test_db_limit();
+    let path = unique_size_test_db("busy");
+    let store = GenAISqliteStore::new_with_path(&path).unwrap();
+    grow_db(&store, 300, 10 * 1024);
+    store.wal_checkpoint().unwrap();
+
+    // Hold a read snapshot on a separate connection: this blocks
+    // `PRAGMA wal_checkpoint(TRUNCATE)` from completing (busy).
+    let reader = rusqlite::Connection::open(&path).unwrap();
+    reader
+        .execute_batch("BEGIN; SELECT COUNT(*) FROM genai_events;")
+        .unwrap();
+
+    store.check_and_prune_if_needed().unwrap();
+
+    let rows = row_count(&store);
+    assert!(
+        rows > 0,
+        "prune must stop once the WAL cannot be truncated, not delete everything \
+         (remaining: {rows})"
+    );
+    drop(reader);
+    drop(store);
+    cleanup_size_test_db(&path);
+}
+
 /// Reopening an oversized database triggers the startup cleanup path in
 /// `new_with_path_and_batch`.
 #[test]
@@ -1512,8 +1546,8 @@ fn startup_cleanup_prunes_oversized_db() {
 
     let threshold = super::schema::get_prune_threshold();
     assert!(
-        store.get_total_db_size() < threshold,
-        "startup cleanup must bring the database below the threshold"
+        store.effective_db_size() < threshold,
+        "startup cleanup must bring the logical size below the threshold"
     );
     drop(store);
     cleanup_size_test_db(&path);

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -776,7 +776,7 @@ impl InterruptionStore {
         let mut stuck_rounds = 0u32;
 
         for _ in 0..20 {
-            let size = self.total_db_file_size();
+            let size = self.effective_db_file_size()?;
             if size <= threshold {
                 break;
             }
@@ -804,12 +804,25 @@ impl InterruptionStore {
 
             // A DELETE in WAL mode does not shrink the main file (it appends
             // to the WAL instead), so size must be re-measured after a
-            // checkpoint or the loop cannot observe progress.
-            if let Err(e) = self.checkpoint() {
-                log::warn!("checkpoint during interruption trim failed: {e}");
+            // checkpoint or the loop cannot observe progress. A busy
+            // checkpoint (another connection holds a read snapshot) leaves
+            // the WAL intact — stop trimming: further deletes would keep
+            // appending WAL frames and never converge.
+            match self.checkpoint() {
+                Ok(true) => {
+                    log::warn!(
+                        "WAL checkpoint busy during interruption trim; \
+                         stopping (the WAL could not be truncated)"
+                    );
+                    break;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    log::warn!("checkpoint during interruption trim failed: {e}");
+                }
             }
 
-            let new_size = self.total_db_file_size();
+            let new_size = self.effective_db_file_size()?;
             if new_size < size {
                 stuck_rounds = 0;
             } else {
@@ -866,6 +879,27 @@ impl InterruptionStore {
         total
     }
 
+    /// Logical data size: physical size minus freelist pages. Trim convergence
+    /// is measured on this: deletes free pages into the freelist without
+    /// shrinking the physical file.
+    ///
+    /// # Errors
+    /// Returns an error when the connection mutex is poisoned.
+    fn effective_db_file_size(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        let physical = self.total_db_file_size();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| format!("interruption store connection mutex poisoned: {e}"))?;
+        let freelist: i64 = conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .unwrap_or(0);
+        let page_size: i64 = conn
+            .query_row("PRAGMA page_size", [], |r| r.get(0))
+            .unwrap_or(4096);
+        Ok(physical.saturating_sub((freelist.max(0) * page_size.max(0)) as u64))
+    }
+
     fn row_count(&self) -> Result<i64, Box<dyn std::error::Error>> {
         let conn = self
             .conn
@@ -875,20 +909,24 @@ impl InterruptionStore {
         Ok(count)
     }
 
-    /// Reclaim free pages and truncate the WAL.
+    /// Flush and truncate the WAL.
     ///
-    /// VACUUM rebuilds the main file; in WAL mode it can reset the journal
-    /// mode, so WAL is re-enabled before the truncating checkpoint. Mirrors
-    /// the sibling genai store's `checkpoint()`.
-    fn checkpoint(&self) -> Result<(), Box<dyn std::error::Error>> {
+    /// Never VACUUMs: rebuilding the file would push its pages through the
+    /// page cache, which counts against the service's cgroup memory limit and
+    /// can OOM-kill the process on large databases (#2888). Freed pages stay
+    /// on the freelist and are reused by future inserts, so the physical file
+    /// stops growing once the logical size fits.
+    ///
+    /// Returns `Ok(true)` when the checkpoint was blocked by another
+    /// connection's read snapshot (busy): the statement succeeds but the WAL
+    /// is NOT truncated.
+    fn checkpoint(&self) -> Result<bool, Box<dyn std::error::Error>> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| format!("interruption store connection mutex poisoned: {e}"))?;
-        conn.execute_batch("VACUUM;")?;
-        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
-        conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
-        Ok(())
+        let busy: i32 = conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |r| r.get(0))?;
+        Ok(busy != 0)
     }
 }
 
@@ -1697,12 +1735,15 @@ mod tests {
     }
 
     /// Regression for #2818: an oversized database must be trimmed to the
-    /// limit (newest rows survive) and the file must actually shrink, not
-    /// stay put while the table is wiped. Reverting to a main-file-only size
-    /// check without an in-loop checkpoint makes this fail: the loop then
-    /// cannot observe progress and deletes until the table is empty.
+    /// limit (newest rows survive) and the logical size must converge, without
+    /// wiping the table. Reverting to a main-file-only size check without an
+    /// in-loop checkpoint makes this fail: the loop then cannot observe
+    /// progress and deletes until the table is empty.
+    ///
+    /// The physical file may stay at its historical peak (#2888): freed pages
+    /// go to the freelist and are reused by future inserts.
     #[test]
-    fn purge_size_based_keeps_newest_and_shrinks_file() {
+    fn purge_size_based_keeps_newest_and_converges() {
         let dir = std::env::temp_dir();
         let path = dir.join(format!(
             "test_interruption_size_{}_{}.db",
@@ -1749,11 +1790,13 @@ mod tests {
             "newest row must survive size-based trim"
         );
 
-        // File (main + WAL) actually shrank below the limit.
-        let size_after = store.total_db_file_size();
+        // Logical size (physical minus freelist) converges below the limit;
+        // the physical file may stay at its peak since pages are not returned
+        // to the OS without VACUUM (#2888).
+        let size_after = store.effective_db_file_size().unwrap();
         assert!(
             size_after <= 1024 * 1024,
-            "file must fit after trim, got {size_after}"
+            "logical size must fit after trim, got {size_after}"
         );
 
         // Once the file fits, the next purge is a no-op.
@@ -1814,6 +1857,55 @@ mod tests {
         let deleted = store.purge_old_and_oversized(0, 1).unwrap();
         assert_eq!(deleted, 0, "below the configured limit must not trim");
 
+        drop(store);
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{}-wal", path.display()));
+        let _ = std::fs::remove_file(format!("{}-shm", path.display()));
+    }
+
+    /// When another connection holds a read snapshot, the truncating WAL
+    /// checkpoint returns busy and the trim loop must stop instead of deleting
+    /// against a size that can never converge (only the WAL keeps growing).
+    #[test]
+    fn purge_size_based_stops_when_wal_checkpoint_busy() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "test_interruption_busy_{}_{}.db",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let store = InterruptionStore::new_with_path(&path).unwrap();
+
+        // ~1.2MB across 300 rows (~4KB each), over a 1MB limit.
+        let blob = "z".repeat(4 * 1024);
+        for i in 0..300u64 {
+            let mut e = make_event("conv-busy", InterruptionType::LlmError);
+            e.interruption_id = format!("int-busy-{i:04}");
+            e.occurred_at_ns = 1_000 + i as i64;
+            e.detail = Some(blob.clone());
+            store.insert(&e).unwrap();
+        }
+        store.checkpoint().unwrap();
+
+        // Hold a read snapshot on a separate connection: this blocks
+        // `PRAGMA wal_checkpoint(TRUNCATE)` from completing (busy).
+        let reader = rusqlite::Connection::open(&path).unwrap();
+        reader
+            .execute_batch("BEGIN; SELECT COUNT(*) FROM interruption_events;")
+            .unwrap();
+
+        let deleted = store.purge_old_and_oversized(0, 1).unwrap();
+        let remaining = store.row_count().unwrap();
+        assert!(
+            remaining > 0,
+            "trim must stop once the WAL cannot be truncated, not delete \
+             everything (deleted {deleted}, remaining {remaining})"
+        );
+
+        drop(reader);
         drop(store);
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(format!("{}-wal", path.display()));

--- a/src/agentsight/src/storage/unified.rs
+++ b/src/agentsight/src/storage/unified.rs
@@ -347,13 +347,11 @@ impl Storage {
                 consumption_deleted,
             );
 
-            // Reclaim free pages after bulk deletes. VACUUM writes through
-            // the WAL, so a TRUNCATE checkpoint is needed for the file to
-            // actually shrink. Both are best-effort: freed pages are reusable
-            // by future inserts even when they fail.
-            if let Err(e) = self.audit_store.vacuum() {
-                log::warn!("VACUUM after age-based purge failed: {e}");
-            }
+            // Flush and truncate the WAL so freed pages become visible.
+            // Never VACUUM here: rebuilding the file would push its pages
+            // through the page cache, which counts against the service's
+            // cgroup memory limit and can OOM-kill the process on large
+            // databases (#2888). Freed pages are reused by future inserts.
             if let Err(e) = self.audit_store.checkpoint() {
                 log::warn!("WAL checkpoint after age-based purge failed: {e}");
             }
@@ -369,15 +367,16 @@ impl Storage {
     /// file, so checking the main file alone would under-report.
     ///
     /// Work is organized in rounds: each round deletes a fraction of every
-    /// table's oldest rows, then runs one VACUUM + checkpoint before
-    /// re-measuring. VACUUM rewrites the whole file, so it must not run per
-    /// batch — bounding it per round keeps a multi-GB cleanup tractable.
+    /// table's oldest rows (bigger bites when far over the limit), then runs
+    /// one truncating WAL checkpoint before re-measuring the logical size.
     ///
-    /// Rounds continue until the size is within the limit. A round that does
-    /// not shrink the file is not necessarily a failure (deleting small rows
-    /// may free no page), so the bite doubles while the file stands still;
-    /// the purge stops early only when VACUUM/checkpoint itself keeps failing
-    /// or after 20 rounds, both reported as errors.
+    /// Rounds continue until the logical size (physical minus freelist) is
+    /// within the limit. Deleting rows never shrinks the physical file —
+    /// freed pages stay on the freelist and are reused by future inserts, so
+    /// the file stops growing once the logical size fits. This path never
+    /// runs VACUUM: on a cgroup memory-capped service the full-file rebuild
+    /// can push the page cache over the limit and OOM-kill the process
+    /// (#2888).
     ///
     /// Called automatically by `store()` during purge checks and by
     /// `with_sqlite_config()` on startup.
@@ -388,13 +387,13 @@ impl Storage {
 
         let mut round = 0u32;
         let mut reclaim_failures = 0u32;
-        // Rows and bytes can decouple (B-tree page sharing): deleting many
-        // small rows may free no page at all, so a non-shrinking round is
-        // normal and triggers a bigger bite next round instead of a stall.
+        // A round whose checkpoint fails leaves the WAL unflushed, so the
+        // logical size cannot drop; double the bite while the measured size
+        // stands still instead of treating one flat round as a stall.
         let mut pct_boost = 1.0f64;
 
         loop {
-            let size = self.total_db_size();
+            let size = self.effective_db_size();
             if size <= self.max_db_size_bytes {
                 break;
             }
@@ -443,20 +442,28 @@ impl Storage {
                 break; // Nothing left to delete
             }
 
-            // VACUUM first, then checkpoint: in WAL mode VACUUM writes the
-            // rebuilt database through the WAL, so the file only shrinks once
-            // a TRUNCATE checkpoint flushes it back. Failures are the real
-            // stall signal (e.g. disk full): deleting further rows would
-            // destroy data without freeing space, so stop after repeated
-            // failures and escalate.
+            // Flush and truncate the WAL so freed pages become visible in
+            // the logical size. A checkpoint failure is the real stall signal
+            // (e.g. disk full); never VACUUM here — the full-file rebuild
+            // would push its pages through the page cache, which counts
+            // against the service's cgroup memory limit (#2888).
             let mut reclaim_ok = true;
-            if let Err(e) = self.audit_store.vacuum() {
-                log::warn!("VACUUM during size-based purge failed: {e}");
-                reclaim_ok = false;
-            }
-            if let Err(e) = self.audit_store.checkpoint() {
-                log::warn!("WAL checkpoint during size-based purge failed: {e}");
-                reclaim_ok = false;
+            match self.audit_store.checkpoint_busy() {
+                Ok(true) => {
+                    // Another connection holds a read snapshot: the statement
+                    // succeeds but the WAL is NOT truncated. Keep deleting and
+                    // the WAL keeps growing, so treat it as a failed reclaim.
+                    log::warn!(
+                        "WAL checkpoint during size-based purge was busy; \
+                         the WAL could not be truncated"
+                    );
+                    reclaim_ok = false;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    log::warn!("WAL checkpoint during size-based purge failed: {e}");
+                    reclaim_ok = false;
+                }
             }
             if reclaim_ok {
                 reclaim_failures = 0;
@@ -465,7 +472,7 @@ impl Storage {
                 if reclaim_failures >= 3 {
                     log::error!(
                         "Size-based purge suspended after {reclaim_failures} failed \
-                         VACUUM/checkpoint rounds at {size} bytes (limit {}). Freed \
+                         WAL checkpoint rounds at {size} bytes (limit {}). Freed \
                          pages remain reusable by future inserts; free disk space or \
                          remove the database to enforce the cap.",
                         self.max_db_size_bytes
@@ -474,7 +481,7 @@ impl Storage {
                 }
             }
 
-            let new_size = self.total_db_size();
+            let new_size = self.effective_db_size();
             log::info!(
                 "Size-based purge round {round}: deleted {round_deleted} rows, \
                  database now {new_size} bytes (limit {})",
@@ -484,14 +491,30 @@ impl Storage {
             if new_size < size {
                 pct_boost = 1.0;
             } else {
-                // Deletion made no dent in the file (page sharing). Double the
-                // bite so subsequent rounds reach the rows that dominate the
-                // file instead of stalling on small-row deletions.
+                // The logical size did not drop (unflushed WAL after a failed
+                // checkpoint). Double the bite so subsequent rounds reach the
+                // rows that dominate the file faster.
                 pct_boost = (pct_boost * 2.0).min(9.0);
             }
         }
 
         Ok(())
+    }
+
+    /// Logical data size: [`Self::total_db_size`] minus freelist pages.
+    ///
+    /// Deletes grow the freelist instead of shrinking the file, so purge
+    /// convergence must be measured on the logical size.
+    ///
+    /// Conservative approximation: WAL pages are pending versions of
+    /// main-file pages (double-counted on the physical side) while the
+    /// freelist only covers main-file pages, so any estimation error is in
+    /// the over-estimating direction — the purge may trim a little further
+    /// than strictly needed, never less. The in-loop checkpoint truncates
+    /// the WAL, so the overlap is transient anyway.
+    fn effective_db_size(&self) -> u64 {
+        self.total_db_size()
+            .saturating_sub(self.audit_store.freelist_bytes().unwrap_or(0))
     }
 
     /// Total on-disk size of the database: main file + `-wal` + `-shm`.
@@ -728,10 +751,17 @@ mod tests {
 
         storage.purge_oversized().unwrap();
 
+        // Convergence is on logical size: the physical file keeps its peak
+        // size (freed pages stay on the freelist, #2888), but the deleted
+        // rows must be gone and the logical size must fit.
         assert!(
-            storage.total_db_size() <= limit_mb * 1024 * 1024,
-            "database must be within the size limit after purge, got {} bytes",
-            storage.total_db_size()
+            storage.token_store.count() < 300,
+            "purge must delete rows when oversized"
+        );
+        let effective = storage.effective_db_size();
+        assert!(
+            effective <= limit_mb * 1024 * 1024,
+            "logical size must be within the limit after purge, got {effective} bytes"
         );
         drop(storage);
         let _ = std::fs::remove_dir_all(&dir);
@@ -768,9 +798,11 @@ mod tests {
         let remaining = storage.token_store.count();
         assert!(remaining > 0, "purge must not wipe the table (#2870)");
         assert!(remaining < 110, "oversized db must be trimmed");
+        let effective = storage.effective_db_size();
         assert!(
-            storage.total_db_size() <= limit_mb * 1024 * 1024,
-            "must converge below the limit"
+            effective <= limit_mb * 1024 * 1024,
+            "logical size must converge below the limit (#2888: the physical \
+             file keeps its peak): {effective} bytes"
         );
 
         // Oldest-first trimming removes low timestamps, so the newest seeded
@@ -789,10 +821,9 @@ mod tests {
     }
 
     /// When the file is dominated by a few large NEW rows and the oldest rows
-    /// are tiny, deleting the oldest fraction frees no page (B-tree page
-    /// sharing). Treating a non-shrinking round as a stall exits with the cap
-    /// still exceeded; the purge must keep trimming until it reaches the rows
-    /// that dominate the file.
+    /// are tiny, deleting the oldest fraction moves few bytes. The purge must
+    /// still keep trimming (the logical size drops with every deletion) until
+    /// it converges, rather than stalling on the small-row rounds.
     #[test]
     fn test_purge_oversized_skewed_row_sizes_still_converges() {
         let dir = unique_base_dir("skewed");
@@ -814,8 +845,8 @@ mod tests {
                 .unwrap();
         }
         storage.checkpoint().unwrap();
-        // Compact once up front so the first purge round's VACUUM cannot hide
-        // behind rebuild gains instead of actual deletions.
+        // Compact once up front so the physical baseline is deterministic
+        // (purge itself never VACUUMs anymore, #2888).
         storage.audit_store.vacuum().unwrap();
         let size_before = storage.total_db_size();
         assert!(
@@ -825,10 +856,11 @@ mod tests {
 
         storage.purge_oversized().unwrap();
 
+        let effective = storage.effective_db_size();
         assert!(
-            storage.total_db_size() <= limit_mb * 1024 * 1024,
-            "must converge below the limit even when early rounds free nothing, got {}",
-            storage.total_db_size()
+            effective <= limit_mb * 1024 * 1024,
+            "logical size must converge below the limit even when early rounds \
+             free little, got {effective} bytes"
         );
         let conn = rusqlite::Connection::open(dir.join("agentsight.db")).unwrap();
         let max_ts: u64 = conn
@@ -840,6 +872,46 @@ mod tests {
         drop(conn);
 
         drop(storage);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// When another connection holds a read snapshot, the truncating WAL
+    /// checkpoint reports busy without an SQL error and the WAL stays intact.
+    /// The purge must stop instead of deleting round after round against a
+    /// size that can never converge (only the WAL keeps growing) — under the
+    /// pre-fix behavior the loop kept deleting until the tables were empty.
+    #[test]
+    fn test_purge_oversized_stops_when_wal_checkpoint_busy() {
+        let dir = unique_base_dir("busy_ckpt");
+        let limit_mb = 1u64;
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), 0)).unwrap();
+        for i in 0..300u64 {
+            storage
+                .token_store
+                .insert(&bulky_token_record(i, 10 * 1024))
+                .unwrap();
+        }
+        storage.checkpoint().unwrap();
+        drop(storage);
+
+        // Hold a read snapshot on a separate connection: this blocks
+        // `PRAGMA wal_checkpoint(TRUNCATE)` from completing (busy).
+        let reader = rusqlite::Connection::open(dir.join("agentsight.db")).unwrap();
+        reader
+            .execute_batch("BEGIN; SELECT COUNT(*) FROM token_records;")
+            .unwrap();
+
+        // Reopen with the limit enabled; the startup purge runs against the
+        // busy checkpoint.
+        let storage = Storage::with_sqlite_config(&test_config(dir.clone(), limit_mb)).unwrap();
+        let remaining = storage.token_store.count();
+        assert!(
+            remaining >= 100,
+            "purge must stop early while the WAL cannot be truncated, \
+             only a few rounds may delete (got {remaining}/300)"
+        );
+        drop(storage);
+        drop(reader);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -863,9 +935,10 @@ mod tests {
 
         // Reopening with a limit must trigger the startup cleanup.
         let storage = Storage::with_sqlite_config(&test_config(dir.clone(), limit_mb)).unwrap();
+        let effective = storage.effective_db_size();
         assert!(
-            storage.total_db_size() <= limit_mb * 1024 * 1024,
-            "startup cleanup must bring the database within the limit"
+            effective <= limit_mb * 1024 * 1024,
+            "startup cleanup must bring the logical size within the limit: {effective}"
         );
         drop(storage);
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
## Why

`agentsight.service` (MemoryMax=350M) gets OOM-killed within minutes under ordinary load and never recovers (#2888). Root cause, **reproduced and measured on ECS** against a seeded 560MB `genai_events.db` with a 350MB cgroup limit:

- Every size-purge round ran `VACUUM`, which rebuilds the whole database file. The rebuild's reads and writes go through the **page cache**, and cgroup v2's `memory.current` charges page cache to the unit.
- Measured: tracer RSS stayed flat at 107MB while the cgroup hit **366MB (the limit) twice** during startup purge; `memory.events` recorded **1554 max events**. On a slower/busier disk, reclaim cannot keep up and the OOM killer fires.
- After the OOM kill, restart re-runs the startup purge on the same oversized database → same VACUUM storm → repeated kills exhaust `StartLimitBurst` → the unit stays dead. This also explains the issue's "user-space tasks stayed small and kernel-side memory dominated" observation: the kernel-side memory is page cache.

**Scope note**: this PR fixes the page-cache amplifier. The report shows a second, independent failure mode ("the tracer reached ~399MB RSS per the OOM task dump" — user-space heap), root-caused in #2925 as the probe event channel's slot-only bound (a single SSL event carries up to 4 MiB). The two PRs are complementary with zero file overlap; both are needed to fully resolve #2888.

## What changed

All automatic purge paths (`genai` `check_and_prune_if_needed` + SQLITE_FULL retry, `interruption` `purge_old_and_oversized`/`trim_to_size_limit`, `unified` `purge_oversized`/`purge_expired`) now:

- **Never run VACUUM.** Reclaim is `PRAGMA wal_checkpoint(TRUNCATE)` only.
- **Converge on logical size** — physical size minus freelist pages (`PRAGMA freelist_count × page_size`). Deleting rows frees pages into the freelist immediately, so the loop observes progress without any file rebuild. The genai store keeps triggering on physical size (disk safety), then early-returns if the overshoot is already freelist.

**Behavioral change (disk reclaim semantics):** the physical file no longer shrinks after a purge — freed pages stay on the freelist and are reused by future inserts, so the file stabilizes at its historical peak instead of growing. Reclaiming disk space now requires an explicit `sqlite3 <db> 'VACUUM;'` during a low-traffic window (a future `agentsight compact` CLI could wrap this; out of scope here).

Tests updated from "file shrinks" to "logical size converges" assertions — the old assertions fail under this change by design, and the new ones fail if purge stops converging.

Note: `src/storage/unified.rs::purge_oversized` overlaps with #2872 (percentage batching); this PR is branched from main and the two combine cleanly (percentage batches + no-VACUUM convergence).

## Related issue

refs #2888 (fixes the page-cache amplifier; #2925 fixes the event-channel amplifier and owns the issue close)

## User / Agent impact

The service no longer OOM-dies when a SQLite store crosses its size cap under a cgroup memory limit; purge converges on freelist instead of file size. Trade-off: the physical file keeps its peak size until a manual VACUUM.

## Risk and compatibility

- [x] Documented behavior changed

Purge still triggers on physical size, so disk safety is unchanged; only the reclaim mechanism and convergence measure change. Data loss risk is lower than before (no more VACUUM-failure edge cases). Rollback: revert the single commit.

## Validation

On ECS (Alinux, kernel 6.6, rustup 1.89.0 matching CI), seeded 560MB `genai_events.db` + 350MB cgroup:

| metric | before (main) | after (this PR) |
|---|---|---|
| cgroup peak during startup purge | 366MB (hit limit twice) | **1.97MB** |
| `memory.events` max events added | 1554 | **0** |
| rows kept | n/a (wipe risk) | oldest-first: 560→178 rows, logical 196MB < 450MB threshold |
| physical file | shrank via VACUUM | 588MB peak kept (392MB freelist reused by future inserts) — by design |
| tracer alive | OOM risk | alive |

- `cargo fmt --all --check` — pass
- `python3 scripts/check-arch-boundaries.py` — 0 violations
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib --bins --tests` — **1901 passed, 0 failed**

## Documentation and rollback

The size-limit release-note contract ("reclaims disk space through VACUUM") needs a follow-up wording update: space is now reclaimed by freelist reuse (bounded file), not by shrinking. Revert the single commit to roll back; `Fixes: 33ed3846` identifies the introducing commit.
