### PR TITLE
fix(sight): merge Anthropic SSE token usage across events

### DIFF
--- a/src/agentsight/src/analyzer/message/anthropic.rs
+++ b/src/agentsight/src/analyzer/message/anthropic.rs
@@ -30,6 +30,15 @@ use super::types::{
     MessageRole,
 };
 
+/// Max of two optional counters, preserving a value when only one is set.
+fn max_opt(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.max(y)),
+        (x, None) => x,
+        (None, y) => y,
+    }
+}
+
 /// Parser for Anthropic Messages API
 ///
 /// Provides methods to parse JSON request and response bodies
@@ -297,15 +306,29 @@ impl AnthropicParser {
                     } => {
                         stop_reason = delta.stop_reason.clone();
                         if let Some(du) = delta_usage {
+                            // Counters are cumulative and split across events:
+                            // official Anthropic puts input+cache in
+                            // message_start, while some proxies report the full
+                            // terminal usage here instead. Take the max of each
+                            // so neither layout loses data.
+                            let prev = usage.as_ref();
                             usage = Some(AnthropicUsage {
-                                input_tokens: usage.as_ref().map(|u| u.input_tokens).unwrap_or(0),
-                                output_tokens: du.output_tokens,
-                                cache_creation_input_tokens: usage
-                                    .as_ref()
-                                    .and_then(|u| u.cache_creation_input_tokens),
-                                cache_read_input_tokens: usage
-                                    .as_ref()
-                                    .and_then(|u| u.cache_read_input_tokens),
+                                input_tokens: prev
+                                    .map(|u| u.input_tokens)
+                                    .unwrap_or(0)
+                                    .max(du.input_tokens.unwrap_or(0)),
+                                output_tokens: prev
+                                    .map(|u| u.output_tokens)
+                                    .unwrap_or(0)
+                                    .max(du.output_tokens),
+                                cache_creation_input_tokens: max_opt(
+                                    prev.and_then(|u| u.cache_creation_input_tokens),
+                                    du.cache_creation_input_tokens,
+                                ),
+                                cache_read_input_tokens: max_opt(
+                                    prev.and_then(|u| u.cache_read_input_tokens),
+                                    du.cache_read_input_tokens,
+                                ),
                             });
                         }
                     }
@@ -744,6 +767,82 @@ mod tests {
 
         assert_eq!(resp.stop_reason, Some("tool_use".to_string()));
         assert_eq!(resp.usage.output_tokens, 42);
+    }
+
+    /// Official Anthropic layout: input + cache in message_start, output only in
+    /// message_delta. Both must survive the merge.
+    #[test]
+    fn test_aggregate_sse_usage_official_split() {
+        let events = serde_json::json!([
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_split",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-5",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 1234,
+                        "output_tokens": 1,
+                        "cache_creation_input_tokens": 5678,
+                        "cache_read_input_tokens": 90
+                    }
+                }
+            },
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {"output_tokens": 42}
+            }
+        ]);
+
+        let resp = AnthropicParser::parse_response(&events).expect("should aggregate");
+        assert_eq!(resp.usage.input_tokens, 1234);
+        assert_eq!(resp.usage.output_tokens, 42);
+        assert_eq!(resp.usage.cache_creation_input_tokens, Some(5678));
+        assert_eq!(resp.usage.cache_read_input_tokens, Some(90));
+    }
+
+    /// Proxy layout: zero-placeholder message_start, full terminal usage in
+    /// message_delta. The zero start must not mask the delta's counters.
+    #[test]
+    fn test_aggregate_sse_usage_delta_carries_full_usage() {
+        let events = serde_json::json!([
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_proxy",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-5",
+                    "content": [],
+                    "usage": {"input_tokens": 0, "output_tokens": 0}
+                }
+            },
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                "usage": {
+                    "output_tokens": 13,
+                    "input_tokens": 10,
+                    "cache_creation_input_tokens": 22178,
+                    "cache_read_input_tokens": 7
+                }
+            }
+        ]);
+
+        let resp = AnthropicParser::parse_response(&events).expect("should aggregate");
+        assert_eq!(resp.usage.input_tokens, 10);
+        assert_eq!(resp.usage.output_tokens, 13);
+        assert_eq!(resp.usage.cache_creation_input_tokens, Some(22178));
+        assert_eq!(resp.usage.cache_read_input_tokens, Some(7));
     }
 
     /// Test: SSE stream with multiple tool calls

--- a/src/agentsight/src/analyzer/message/types.rs
+++ b/src/agentsight/src/analyzer/message/types.rs
@@ -697,10 +697,25 @@ pub struct AnthropicSseMessageDelta {
 }
 
 /// Anthropic SSE usage delta
+///
+/// Official Anthropic sends only `output_tokens` here and reports
+/// `input_tokens` plus the cache counters in `message_start`. Some
+/// Anthropic-compatible proxies invert this and put the full terminal usage in
+/// the delta instead, so every counter is optional and callers must merge the
+/// delta with `message_start` rather than trusting either alone.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnthropicSseUsageDelta {
     /// Output tokens
     pub output_tokens: u64,
+    /// Input tokens, when the provider reports them in the delta
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<u64>,
+    /// Input tokens used to create cache entries
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u64>,
+    /// Input tokens read from cache
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u64>,
 }
 
 // ============================================================================

--- a/src/agentsight/src/analyzer/token/mod.rs
+++ b/src/agentsight/src/analyzer/token/mod.rs
@@ -132,12 +132,16 @@ pub fn extract_usage_object(
             (input, output)
         }
         LLMProvider::Anthropic => {
-            let input = usage.get("input_tokens").and_then(|v| v.as_u64())?;
-            let output = usage
-                .get("output_tokens")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
-            (input, output)
+            // Anthropic splits usage across events: message_start carries
+            // input_tokens (+cache), while the terminal message_delta carries
+            // only output_tokens. Accept either so the caller can merge them;
+            // requiring input_tokens here would drop the output-only delta.
+            let input = usage.get("input_tokens").and_then(|v| v.as_u64());
+            let output = usage.get("output_tokens").and_then(|v| v.as_u64());
+            if input.is_none() && output.is_none() {
+                return None;
+            }
+            (input.unwrap_or(0), output.unwrap_or(0))
         }
         LLMProvider::Gemini => {
             let input = usage.get("prompt_token_count").and_then(|v| v.as_u64())?;

--- a/src/agentsight/src/analyzer/token/parser.rs
+++ b/src/agentsight/src/analyzer/token/parser.rs
@@ -273,6 +273,27 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_anthropic_message_delta_output_only() {
+        // Official Anthropic message_delta carries only output_tokens; the
+        // parser must still surface it (input defaults to 0) so the caller can
+        // merge it with message_start rather than dropping the event.
+        let parser = TokenParser::new();
+        let data = r#"{
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 42}
+        }"#;
+
+        let event = create_test_event(data);
+        let usage = parser
+            .parse_event(&event)
+            .expect("output-only should parse");
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 42);
+        assert_eq!(usage.provider, LLMProvider::Anthropic);
+    }
+
+    #[test]
     fn test_parse_openai_sse_streaming() {
         let parser = TokenParser::new();
         let data = r#"{"choices":[],"object":"chat.completion.chunk","usage":{"prompt_tokens":61744,"completion_tokens":61,"total_tokens":61805},"created":1773640825,"model":"qwen3.5-plus","id":"chatcmpl-816f7538-0ac9-98c4-8259-9bade0c2cde7"}"#;

--- a/src/agentsight/src/analyzer/unified.rs
+++ b/src/agentsight/src/analyzer/unified.rs
@@ -28,8 +28,8 @@ use crate::tokenizer::get_global_tokenizer;
 
 use super::result::{MessageTokenCount, OutputTokenCount, TokenConsumptionBreakdown};
 use super::{
-    AnalysisResult, AuditAnalyzer, HttpRecord, MessageParser, ParsedApiMessage, TokenParser,
-    TokenRecord, TokenUsage,
+    AnalysisResult, AuditAnalyzer, HttpRecord, LLMProvider, MessageParser, ParsedApiMessage,
+    TokenParser, TokenRecord, TokenUsage,
 };
 
 /// Token count result for request messages
@@ -637,7 +637,16 @@ impl Analyzer {
             .map(AnalysisResult::Message)
     }
 
-    /// Extract token usage from SSE events (reverse search, first match wins)
+    /// Extract token usage from SSE events by merging field-by-field.
+    ///
+    /// Anthropic (and Anthropic-compatible proxies) split token usage across
+    /// events: `message_start` carries `input_tokens` plus the cache counters,
+    /// while the terminal `message_delta` carries only `output_tokens`. Some
+    /// proxies additionally emit a zero-placeholder `message_start` or drop it
+    /// entirely. Picking a single event therefore yields a bogus zero total, so
+    /// we merge every parseable event, taking the max of each cumulative
+    /// counter. OpenAI/Gemini pack all fields into one event, so the merge is a
+    /// no-op for them.
     fn extract_token_from_sse(
         &self,
         sse_events: &[ParsedSseEvent],
@@ -645,40 +654,42 @@ impl Analyzer {
         pid: u32,
         comm: &str,
     ) -> Option<TokenRecord> {
-        let usage = sse_events
+        let mut usage = sse_events
             .iter()
-            .rev()
-            .find_map(|e| self.token.parse_event(e))
-            .or_else(|| {
-                // Fallback: OpenAI Responses API embeds usage in a final
-                // `response.completed` event whose `data:` field routinely
-                // exceeds a single TLS record. The aggregator buffers the
-                // raw continuation bytes; re-parse them with the legacy
-                // SSEParser (which concatenates multi-line data fields)
-                // and walk events in reverse so the canonical usage event
-                // wins. If reassembled events still don't yield usage,
-                // fall back to a partial-scan over the raw buffer text.
-                let extra = continuation_bytes?;
+            .filter_map(|e| self.token.parse_event(e))
+            .fold(None, Self::merge_usage);
+
+        if usage.is_none() {
+            // Fallback: OpenAI Responses API embeds usage in a final
+            // `response.completed` event whose `data:` field routinely
+            // exceeds a single TLS record. The aggregator buffers the
+            // raw continuation bytes; re-parse them with the legacy
+            // SSEParser (which concatenates multi-line data fields)
+            // and merge all events. If reassembled events still don't
+            // yield usage, fall back to a partial-scan over the raw
+            // buffer text.
+            if let Some(extra) = continuation_bytes {
                 let text = String::from_utf8_lossy(extra);
                 let reassembled = SSEParser::parse_stream(&text);
-                let from_events = reassembled
+                usage = reassembled
                     .events
                     .iter()
-                    .rev()
-                    .find_map(|e| self.token.parse_data(&e.data));
-                if from_events.is_some() {
-                    return from_events;
+                    .filter_map(|e| self.token.parse_data(&e.data))
+                    .fold(None, Self::merge_usage);
+                if usage.is_none() {
+                    usage = self.token.parse_data(&text);
+                    if usage.is_none() {
+                        log::debug!(
+                            "[extract_token_from_sse] continuation buffer scan miss: len={} reassembled_events={}",
+                            extra.len(),
+                            reassembled.events.len(),
+                        );
+                    }
                 }
-                let from_scan = self.token.parse_data(&text);
-                if from_scan.is_none() {
-                    log::debug!(
-                        "[extract_token_from_sse] continuation buffer scan miss: len={} reassembled_events={}",
-                        extra.len(),
-                        reassembled.events.len(),
-                    );
-                }
-                from_scan
-            })?;
+            }
+        }
+
+        let usage = usage?;
 
         let record = TokenRecord::new(
             pid,
@@ -701,6 +712,43 @@ impl Analyzer {
         }
 
         Some(record)
+    }
+
+    /// Merge two token-usage snapshots from the same SSE stream.
+    ///
+    /// All counters are cumulative within a stream, so the max resolves the
+    /// split-across-events case (message_start input/cache vs message_delta
+    /// output) and tolerates zero-placeholder events without ever regressing a
+    /// larger value. Model and provider are taken from the first event that
+    /// carries them.
+    fn merge_usage(acc: Option<TokenUsage>, next: TokenUsage) -> Option<TokenUsage> {
+        let Some(mut cur) = acc else {
+            return Some(next);
+        };
+        cur.input_tokens = cur.input_tokens.max(next.input_tokens);
+        cur.output_tokens = cur.output_tokens.max(next.output_tokens);
+        cur.cache_creation_input_tokens = Self::max_opt(
+            cur.cache_creation_input_tokens,
+            next.cache_creation_input_tokens,
+        );
+        cur.cache_read_input_tokens =
+            Self::max_opt(cur.cache_read_input_tokens, next.cache_read_input_tokens);
+        if cur.model.is_none() {
+            cur.model = next.model;
+        }
+        if cur.provider == LLMProvider::Unknown {
+            cur.provider = next.provider;
+        }
+        Some(cur)
+    }
+
+    /// Max of two optional counters, preserving a value when only one is set.
+    fn max_opt(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+        match (a, b) {
+            (Some(x), Some(y)) => Some(x.max(y)),
+            (x, None) => x,
+            (None, y) => y,
+        }
     }
 
     fn extract_token_from_json_body(
@@ -1889,6 +1937,66 @@ data:{"usage":{"input_tokens":57,"output_tokens":3}}"#;
         let continuation = b"event: response.completed\ndata: {\"id\":\"resp_001\"}\n\n";
         let result = analyzer.extract_token_from_sse(&events, Some(continuation), 1234, "test");
         assert!(result.is_none(), "should return None when no usage found");
+    }
+
+    #[test]
+    fn test_extract_token_from_sse_anthropic_official_merges_start_and_delta() {
+        // Dialect A: message_start carries input + cache, terminal message_delta
+        // carries only output_tokens. The merge must combine both instead of
+        // picking one event (which would drop output or drop input+cache).
+        let analyzer = Analyzer::new();
+        let events = vec![
+            create_test_event(
+                "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":1234,\"cache_creation_input_tokens\":5678,\"cache_read_input_tokens\":90,\"output_tokens\":1}}}",
+            ),
+            create_test_event(
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":42}}",
+            ),
+        ];
+        let record = analyzer
+            .extract_token_from_sse(&events, None, 1234, "test")
+            .expect("should merge start + delta");
+        assert_eq!(record.input_tokens, 1234);
+        assert_eq!(record.output_tokens, 42);
+        assert_eq!(record.cache_creation_tokens, Some(5678));
+        assert_eq!(record.cache_read_tokens, Some(90));
+    }
+
+    #[test]
+    fn test_extract_token_from_sse_anthropic_no_message_start() {
+        // Dialect B: proxy strips message_start entirely; only message_delta
+        // (output-only) survives. Must still yield output_tokens rather than
+        // being dropped by a mandatory input_tokens requirement.
+        let analyzer = Analyzer::new();
+        let events = vec![create_test_event(
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":42}}",
+        )];
+        let record = analyzer
+            .extract_token_from_sse(&events, None, 1234, "test")
+            .expect("output-only delta should still produce a record");
+        assert_eq!(record.input_tokens, 0);
+        assert_eq!(record.output_tokens, 42);
+    }
+
+    #[test]
+    fn test_extract_token_from_sse_anthropic_zero_placeholder_start() {
+        // Dialect C: proxy sends a zero-placeholder message_start followed by
+        // the real output in message_delta. The zero start must not mask the
+        // delta's output_tokens.
+        let analyzer = Analyzer::new();
+        let events = vec![
+            create_test_event(
+                "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}}",
+            ),
+            create_test_event(
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":42}}",
+            ),
+        ];
+        let record = analyzer
+            .extract_token_from_sse(&events, None, 1234, "test")
+            .expect("zero placeholder must not mask delta output");
+        assert_eq!(record.input_tokens, 0);
+        assert_eq!(record.output_tokens, 42);
     }
 
     #[test]

--- a/src/agentsight/src/genai/logtail.rs
+++ b/src/agentsight/src/genai/logtail.rs
@@ -42,6 +42,8 @@ const DEFAULT_PATH_KEEP_FIELDS: &[&str] = &[
     "gen_ai.request.model",
     "gen_ai.usage.input_tokens",
     "gen_ai.usage.output_tokens",
+    "gen_ai.usage.cache_creation.input_tokens",
+    "gen_ai.usage.cache_read.input_tokens",
     "agentsight.agent.name",
     "agentsight.http.domain",
     "agent.skill.name",
@@ -333,7 +335,14 @@ impl LogtailExporter {
         }
 
         // 部署检查：目标文件不存在（iLogtail 未部署）则跳过，不自动创建。
+        // 首次跳过打一条 warn，避免"启用了却无数据"时无迹可查（后续静默）。
         if self.require_path_exists && !target_path.exists() {
+            static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+            WARN_ONCE.call_once(|| {
+                log::warn!(
+                    "SLS default-path export skipped: target file {target_path:?} does not exist (iLogtail not deployed?); create it to enable uploads"
+                );
+            });
             return;
         }
 


### PR DESCRIPTION
## Description

For openclaw agents talking to Anthropic (or an Anthropic-compatible proxy), the
default SLS export carried no `gen_ai.usage.*` fields at all, while
OpenAI-protocol calls on the same host were fine.

Anthropic splits token usage across two SSE events — `message_start` carries
`input_tokens` plus the cache counters, the terminal `message_delta` carries only
`output_tokens` — and some proxies invert this, emitting a zero-placeholder
`message_start` (or none) and reporting the real terminal usage in the delta.
Two defects combined: the Anthropic branch of `extract_usage_object` required
`input_tokens`, discarding an output-only delta whole, and
`extract_token_from_sse` picked a single event in reverse and never merged the
two. When the only parseable event was a missing or zero `message_start`, the
record totalled zero, `TokenRecord` became `None`, and the exporter skipped the
entire `token_usage` block.

The key decision is to treat these counters as cumulative and merge
field-by-field (max of each), rather than trusting any single event. That covers
both layouts without branching on provider quirks, and is a no-op for
OpenAI/Gemini, which pack all fields into one event.

Two follow-ons in the same area: `DEFAULT_PATH_KEEP_FIELDS` dropped the cache
counters, so a cache-heavy Anthropic call was still slimmed to a near-zero
`input_tokens` on the default SLS path; and the default-path exporter skipped
silently when its target file was absent, which made "enabled but no data"
impossible to diagnose.

The second commit applies the same merge to the message-content parser's
`AnthropicSseUsageDelta`, which modelled only `output_tokens`. That path does not
feed token statistics today, but `AnthropicUsage` is publicly exported, so this
prevents wrong values for any future consumer.

## Related Issue

closes #2919

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Unit: `cargo test` — 1566 lib + all integration suites pass. Six new regression
tests: three SSE dialects through `extract_token_from_sse`, an output-only
`message_delta` through `TokenParser`, and two through the message parser's SSE
aggregation.

End-to-end on a Linux host running `agentsight trace` with openclaw, driving a
local HTTPS mock that emits each dialect, then re-running against DashScope's
Anthropic-compatible `/v1/messages` endpoint and its OpenAI-protocol endpoint as
control. Inspected the emitted SLS records and the `genai_events` rows.

| SSE dialect | before | after |
|---|---|---|
| input+cache in `message_start`, output-only delta | `input 1234, output 1`, cache absent | `input 1234, output 42, cache_creation 5678, cache_read 90` |
| no `message_start` | no usage fields | `input 0, output 42` |
| zero-placeholder `message_start` | no usage fields | `input 0, output 42` |

Real endpoints: the Anthropic-compatible one now reports its 22k
cache-creation tokens (previously slimmed to `input_tokens: 4`); the
OpenAI-protocol control is unchanged. The two dialects that produced no usage
also moved from `interrupted` to `complete`.

## Additional Notes

`cargo test` reports a pre-existing doctest failure in
`src/genai/helpers.rs:512` (`strip_user_query_prefix`, backtick tokens). It
reproduces on a pristine `upstream/main` checkout and is untouched by this PR.
