### PR TITLE
fix(anolisa): honor sandbox uninstall dry-run

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -176,7 +176,14 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
         return handle_sandbox_list(*json);
     }
 
-    let request = match command {
+    let request = sandbox_request(command, ctx.dry_run);
+    let mut output = render_sandbox_event;
+    let outcome = application::run(request, &mut output)?;
+    render_sandbox_outcome(outcome)
+}
+
+fn sandbox_request(command: SandboxCommands, global_dry_run: bool) -> SandboxRequest {
+    match command {
         SandboxCommands::Install {
             target,
             dry_run,
@@ -184,21 +191,18 @@ fn handle_sandbox(command: SandboxCommands, ctx: &CliContext) -> Result<(), CliE
             no_verify,
         } => SandboxRequest::Install {
             target,
-            intent: execution_intent(dry_run || ctx.dry_run),
+            intent: execution_intent(dry_run || global_dry_run),
             force,
             skip_verify: no_verify,
         },
         SandboxCommands::Uninstall { scenario, dry_run } => SandboxRequest::Uninstall {
             scenario,
-            intent: execution_intent(dry_run),
+            intent: execution_intent(dry_run || global_dry_run),
         },
         SandboxCommands::Remove { target, purge, .. } => SandboxRequest::Remove { target, purge },
         SandboxCommands::List { .. } => unreachable!(),
         SandboxCommands::Status { target, .. } => SandboxRequest::Status { target },
-    };
-    let mut output = render_sandbox_event;
-    let outcome = application::run(request, &mut output)?;
-    render_sandbox_outcome(outcome)
+    }
 }
 
 fn execution_intent(dry_run: bool) -> ExecutionIntent {
@@ -299,6 +303,31 @@ mod tests {
 
     use super::*;
     use crate::helper_client::HelperOperationOutcome;
+
+    #[test]
+    fn sandbox_uninstall_combines_global_and_local_dry_run() {
+        for (global_dry_run, local_dry_run, expected_intent) in [
+            (false, false, ExecutionIntent::Apply),
+            (false, true, ExecutionIntent::Plan),
+            (true, false, ExecutionIntent::Plan),
+            (true, true, ExecutionIntent::Plan),
+        ] {
+            let request = sandbox_request(
+                SandboxCommands::Uninstall {
+                    scenario: "gvisor".to_string(),
+                    dry_run: local_dry_run,
+                },
+                global_dry_run,
+            );
+
+            match request {
+                SandboxRequest::Uninstall { intent, .. } => {
+                    assert_eq!(intent, expected_intent);
+                }
+                _ => panic!("uninstall command must map to an uninstall request"),
+            }
+        }
+    }
 
     #[test]
     fn helper_operation_preserves_success_degraded_and_failure_codes() {

--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase/application.rs
@@ -533,6 +533,17 @@ mod tests {
                 Some(SandboxOutputEvent::Scenario("gvisor".to_string())),
             ),
             (
+                SandboxRequest::Uninstall {
+                    scenario: "gvisor".to_string(),
+                    intent: ExecutionIntent::Plan,
+                },
+                HelperRequest::OsbaseUninstall {
+                    scenario: "gvisor".to_string(),
+                    dry_run: true,
+                },
+                Some(SandboxOutputEvent::Scenario("gvisor".to_string())),
+            ),
+            (
                 SandboxRequest::Remove {
                     target: "gvisor".to_string(),
                     purge: true,
@@ -716,6 +727,28 @@ mod tests {
         assert_eq!(
             direct.uninstall_requests.borrow().as_slice(),
             &[("gvisor".to_string(), false)]
+        );
+        direct
+            .uninstall_results
+            .borrow_mut()
+            .push_back(Ok("planned".to_string()));
+
+        let uninstall_preview = run_with_dependencies(
+            SandboxRequest::Uninstall {
+                scenario: "gvisor".to_string(),
+                intent: ExecutionIntent::Plan,
+            },
+            || Err(connect_error()),
+            true,
+            &direct,
+            &mut |_| {},
+        )
+        .expect("direct uninstall preview");
+
+        assert!(matches!(uninstall_preview, SandboxOutcome::DirectUninstall));
+        assert_eq!(
+            direct.uninstall_requests.borrow().as_slice(),
+            &[("gvisor".to_string(), false), ("gvisor".to_string(), true),]
         );
     }
 


### PR DESCRIPTION
## Why

The top-level `--dry-run` flag was ignored by `osbase sandbox uninstall`, so a
global preview request could reach the helper or root-direct executor in apply
mode.

## What changed

Sandbox command arguments now pass through one request mapping that combines
global and command-local dry-run flags before selecting `ExecutionIntent`.
Tests cover all four flag combinations and both helper and root-direct
uninstall boundaries; sandbox remove remains unchanged.

## Related issue

Closes #2890

## User / Agent impact

`anolisa --dry-run osbase sandbox uninstall <scenario>` now previews the
uninstall without applying package changes, matching the command-local flag.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This restores the existing global dry-run contract. CLI syntax,
helper wire schema, output, exit codes, and non-preview routing are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli osbase --locked`
- `cargo test -p anolisa-cli --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- ALinux 4 `--rm` container with read-only source, no network, and an isolated
  target directory: targeted osbase tests passed

## Documentation and rollback

No tracked documentation change is required because this fixes the behavior of
an existing flag. Roll back by reverting `49289a89`.
