### PR TITLE
fix(sight): bound event bytes, recover after OOM

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/configuration.md
+++ b/docs/user-guide/en/agent-observability/agentsight/configuration.md
@@ -43,6 +43,7 @@ use. The reference copy shipped with the source is `src/agentsight/agentsight.js
   "runtime_limits": {
     "event_channel_capacity": 10000,
     "event_channel_policy": "backpressure",
+    "event_channel_max_bytes_mb": 64,
     "pending_genai_max_count": 1000,
     "pending_genai_max_bytes_mb": 64,
     "pid_cache_size": 1024,
@@ -106,6 +107,7 @@ memory-constrained ones. `MemoryMax=350M` in the packaged systemd unit assumes r
 |---|---|---|
 | `event_channel_capacity` | `10000` | Bounded probe → pipeline channel |
 | `event_channel_policy` | `backpressure` | Behaviour when the channel is full: `backpressure`, `drop_newest`, `sample` |
+| `event_channel_max_bytes_mb` | `64` | Byte budget for events queued in that channel; `0` disables it. Enforced alongside the slot count, because one captured SSL record can be up to 4 MiB — 10 000 slots alone do not bound memory. Events arriving over budget are dropped and counted in the log |
 | `pending_genai_max_count` | `1000` | Events waiting for a session ID |
 | `pending_genai_max_bytes_mb` | `64` | Byte cap for the same queue |
 | `pid_cache_size` | `1024` | PID → Agent name LRU entries |

--- a/docs/user-guide/en/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/en/agent-observability/agentsight/deployment.md
@@ -34,7 +34,13 @@ Two units are installed:
 
 What the packaged unit gives you:
 
-- `Restart=on-failure` with `RestartSec=10`, capped at 10 restarts per day;
+- `Restart=always` with `RestartSec=10` and no start rate limit, so a repeated crash or OOM kill can
+  never leave the host permanently unobserved. The trade-off is visible: a service that cannot start
+  at all keeps retrying every 10 s and says so in the journal, rather than going quiet;
+- `OOMPolicy=continue`, so one OOM-killed worker does not tear down the whole unit — the supervisor
+  stops its sibling and exits, and `Restart=always` brings both back. Requires systemd 243+; older
+  releases (Anolis 8 / systemd 239) log an unknown-key warning, ignore the directive and fall back to
+  stopping the unit, which `Restart=always` still recovers from;
 - `CPUQuota=30%` and `MemoryMax=350M`, sized for the default `runtime_limits`;
 - `UMask=0077`, so data under `/var/log/sysak/.agentsight` is root-only;
 - `systemctl reload` sends `SIGHUP`, and the supervisor restarts both workers so they re-read

--- a/docs/user-guide/en/agent-observability/agentsight/troubleshooting.md
+++ b/docs/user-guide/en/agent-observability/agentsight/troubleshooting.md
@@ -126,12 +126,33 @@ The packaged unit caps the service at `CPUQuota=30%` and `MemoryMax=350M`, which
 "runtime_limits": {
   "event_channel_capacity": 5000,
   "event_channel_policy": "drop_newest",
+  "event_channel_max_bytes_mb": 32,
   "pending_genai_max_bytes_mb": 32,
   "max_connection_body_mb": 4
 }
 ```
 
 `drop_newest` and `sample` trade completeness for a hard bound on memory.
+
+`event_channel_max_bytes_mb` bounds what the slot count cannot: one captured SSL record can be up to
+4 MiB, so a full channel is not the same as a full buffer. Set it to `0` to disable the byte gate.
+When the budget rejects events, the service logs a watermark line once a minute:
+
+```bash
+sudo journalctl -u agentsight | grep "Buffer watermarks"
+```
+
+A rising `dropped over budget` count means the pipeline cannot keep up — events are being shed to
+stay inside `MemoryMax`. A count that stays at zero while the cgroup still approaches its cap means
+the memory is held downstream (HTTP connection buffers) rather than in the channel, so lower
+`max_connection_body_mb` instead:
+
+```bash
+sudo cat /sys/fs/cgroup/system.slice/agentsight.service/memory.current
+```
+
+If the service is ever OOM-killed it restarts on its own; the packaged unit disables systemd's start
+rate limit precisely so a repeated kill cannot leave the host permanently unobserved.
 
 ## Interruption events look wrong
 

--- a/docs/user-guide/zh/agent-observability/agentsight/configuration.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/configuration.md
@@ -42,6 +42,7 @@ AgentSight 只读一个 JSON 文件：`/etc/agentsight/config.json`（可用 `--
   "runtime_limits": {
     "event_channel_capacity": 10000,
     "event_channel_policy": "backpressure",
+    "event_channel_max_bytes_mb": 64,
     "pending_genai_max_count": 1000,
     "pending_genai_max_bytes_mb": 64,
     "pid_cache_size": 1024,
@@ -104,6 +105,7 @@ AgentSight 只读一个 JSON 文件：`/etc/agentsight/config.json`（可用 `--
 |---|---|---|
 | `event_channel_capacity` | `10000` | 探针到流水线的有界通道容量 |
 | `event_channel_policy` | `backpressure` | 通道满时的策略：`backpressure`、`drop_newest`、`sample` |
+| `event_channel_max_bytes_mb` | `64` | 该通道中排队事件的字节预算，`0` 表示不限制。与容量同时生效：单条 SSL 记录最大可达 4 MiB，仅靠 10000 个槽位无法限定内存。超出预算的事件会被丢弃并计入日志 |
 | `pending_genai_max_count` | `1000` | 等待 session ID 的事件条数上限 |
 | `pending_genai_max_bytes_mb` | `64` | 同一队列的字节上限 |
 | `pid_cache_size` | `1024` | PID → Agent 名称的 LRU 条目数 |

--- a/docs/user-guide/zh/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/deployment.md
@@ -33,7 +33,11 @@ sudo systemctl enable --now agentsight.service
 
 安装包 unit 自带的保障：
 
-- `Restart=on-failure`、`RestartSec=10`，每天最多重启 10 次；
+- `Restart=always`、`RestartSec=10`，且不限制启动次数，因此反复崩溃或被 OOM 杀掉都不会让主机永久失去观测。
+  代价是显式的：完全起不来的服务会每 10 秒重试一次并在 journal 里持续报错，而不是静默消失；
+- `OOMPolicy=continue`，单个工作进程被 OOM 杀掉不会拖垮整个 unit —— 守护脚本会停掉另一个工作进程并退出，
+  再由 `Restart=always` 把两者拉起。该指令需要 systemd 243+；更老的版本（Anolis 8 / systemd 239）会打一条
+  unknown-key 警告并忽略它，退回到停掉 unit 的默认行为，而这种情况 `Restart=always` 同样能恢复；
 - `CPUQuota=30%`、`MemoryMax=350M`，按默认 `runtime_limits` 估算；
 - `UMask=0077`，`/var/log/sysak/.agentsight` 下的数据仅 root 可读；
 - `systemctl reload` 发送 `SIGHUP`，守护脚本会重启两个工作进程以重新读取 `config.json`，无需整体重启。

--- a/docs/user-guide/zh/agent-observability/agentsight/troubleshooting.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/troubleshooting.md
@@ -115,12 +115,31 @@ sudo du -sh /var/log/sysak/.agentsight
 "runtime_limits": {
   "event_channel_capacity": 5000,
   "event_channel_policy": "drop_newest",
+  "event_channel_max_bytes_mb": 32,
   "pending_genai_max_bytes_mb": 32,
   "max_connection_body_mb": 4
 }
 ```
 
 `drop_newest` 和 `sample` 以牺牲完整性换取内存的硬上限。
+
+`event_channel_max_bytes_mb` 限定的是槽位数管不了的部分：单条 SSL 记录最大可达 4 MiB，所以“通道没满”并不等于
+“内存没满”。设为 `0` 可关闭字节门。当预算开始拒收事件时，服务每分钟记录一条水位日志：
+
+```bash
+sudo journalctl -u agentsight | grep "Buffer watermarks"
+```
+
+`dropped over budget` 计数持续上涨，说明流水线消费跟不上——为了守住 `MemoryMax`，事件被主动丢弃。如果计数
+一直为 0、但 cgroup 内存仍在逼近上限，说明内存占在下游（HTTP 连接缓冲）而不是通道里，应该改为调小
+`max_connection_body_mb`：
+
+```bash
+sudo cat /sys/fs/cgroup/system.slice/agentsight.service/memory.current
+```
+
+服务如果被 OOM 杀掉会自行拉起；安装包 unit 特意关闭了 systemd 的启动频率限制，就是为了避免反复被杀后
+主机陷入永久无观测状态。
 
 ## 中断事件看起来不对
 

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -314,6 +314,7 @@ Agent 规则配置文件路径：`/etc/agentsight/config.json`（可通过 `--co
 |--------|--------|------|
 | `event_channel_capacity` | 10,000 | Probe 事件有界通道容量 |
 | `event_channel_policy` | `backpressure` | 满载策略：backpressure / drop_newest / sample |
+| `event_channel_max_bytes_mb` | 64 | 排队事件的字节预算（单条 SSL 记录可达 4 MiB，槽位数无法限定内存）|
 | `pending_genai_max_count` | 1,000 | 等待 session_id 的最大事件数 |
 | `pending_genai_max_bytes_mb` | 64 | 等待 session_id 的最大字节数 |
 | `pid_cache_size` | 1,024 | PID → agent_name LRU 缓存 |

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -427,6 +427,7 @@ Configure buffer caps to prevent unbounded memory growth:
 |--------|---------|-------------|
 | `event_channel_capacity` | 10,000 | Bounded channel capacity for probe events |
 | `event_channel_policy` | `"backpressure"` | Full-channel policy: `backpressure` / `drop_newest` / `sample` |
+| `event_channel_max_bytes_mb` | 64 | Byte budget for queued probe events (one SSL record reaches 4 MiB, so the slot count alone cannot bound memory) |
 | `pending_genai_max_count` | 1,000 | Max pending events awaiting session_id |
 | `pending_genai_max_bytes_mb` | 64 | Max bytes for pending events |
 | `pid_cache_size` | 1,024 | PID → agent_name LRU cache size |

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -411,6 +411,7 @@ AgentSight 通过 `agentsight.json` 配置文件进行统一管理（默认路�
 |--------|--------|------|
 | `event_channel_capacity` | 10,000 | Probe → 事件通道的有界容量 |
 | `event_channel_policy` | `"backpressure"` | 满载策略：`backpressure` / `drop_newest` / `sample` |
+| `event_channel_max_bytes_mb` | 64 | 排队事件的字节预算（单条 SSL 记录可达 4 MiB，仅靠槽位数无法限定内存）|
 | `pending_genai_max_count` | 1,000 | 等待 session_id 的最大事件数 |
 | `pending_genai_max_bytes_mb` | 64 | 等待 session_id 的最大字节数 |
 | `pid_cache_size` | 1,024 | PID → agent_name 的 LRU 缓存大小 |

--- a/src/agentsight/agentsight.json
+++ b/src/agentsight/agentsight.json
@@ -45,6 +45,7 @@
   "runtime_limits": {
     "event_channel_capacity": 10000,
     "event_channel_policy": "backpressure",
+    "event_channel_max_bytes_mb": 64,
     "pending_genai_max_count": 1000,
     "pending_genai_max_bytes_mb": 64,
     "pid_cache_size": 1024,

--- a/src/agentsight/scripts/agentsight.service
+++ b/src/agentsight/scripts/agentsight.service
@@ -2,14 +2,27 @@
 Description=AgentSight - eBPF-based AI Agent Observability Tool
 Wants=agentsight-enforcer.service
 After=network.target agentsight-enforcer.service
-StartLimitIntervalSec=86400
-StartLimitBurst=10
+# No start rate limit: hitting StartLimitBurst puts the unit in failed state
+# permanently until someone runs `systemctl reset-failed`, which is exactly how
+# a host ended up unobserved for the rest of its life after a recurring OOM
+# (#2888). A restart loop that keeps complaining in the journal every
+# RestartSec is the lesser evil for an observability agent.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 UMask=0077
-Restart=on-failure
+# Always, not on-failure: observability must come back after any exit, including
+# a clean one triggered by a worker dying.
+Restart=always
 RestartSec=10
+# systemd's default OOMPolicy=stop tears the cgroup down as soon as one worker
+# is OOM-killed, so agentsight-start never gets to reap its sibling worker.
+# With continue, the wrapper stops the sibling and exits, and Restart=always
+# brings the unit back through a single, predictable path.
+# Requires systemd 243+; older releases (e.g. Anolis 8 / systemd 239) log an
+# unknown-key warning and ignore it, falling back to the default behaviour.
+OOMPolicy=continue
 CPUQuota=30%
 MemoryMax=350M
 ExecStart=/usr/local/bin/agentsight-start

--- a/src/agentsight/src/config.rs
+++ b/src/agentsight/src/config.rs
@@ -45,6 +45,14 @@ pub const DEFAULT_MAX_DB_SIZE_MB: u64 = 500;
 /// Default bounded channel capacity for probe → event loop events.
 pub const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 10_000;
 
+/// Default byte budget for probe events queued in the event channel (64 MiB).
+///
+/// A slot count cannot bound memory on its own: one SSL record carries up to
+/// `MAX_BUF_SIZE` (4 MiB) of payload, so the 10 000 default slots admit
+/// gigabytes of in-flight data under real HTTPS traffic. Admission is therefore
+/// gated on bytes as well.
+pub const DEFAULT_EVENT_CHANNEL_MAX_BYTES: usize = 64 * 1024 * 1024;
+
 /// Default maximum number of pending GenAI events waiting for session_id resolution.
 pub const DEFAULT_PENDING_GENAI_MAX_COUNT: usize = 1_000;
 
@@ -390,6 +398,9 @@ pub struct JsonRuntimeLimits {
     pub event_channel_capacity: Option<usize>,
     #[serde(default)]
     pub event_channel_policy: Option<String>,
+    /// Byte budget for events queued in the probe event channel, in MiB.
+    /// Bounds in-flight memory that the slot count alone cannot (#2888).
+    pub event_channel_max_bytes_mb: Option<usize>,
     pub pending_genai_max_count: Option<usize>,
     pub pending_genai_max_bytes_mb: Option<usize>,
     pub pid_cache_size: Option<usize>,
@@ -745,6 +756,12 @@ pub struct RuntimeLimits {
     pub event_channel_capacity: usize,
     /// Policy when the event channel is full.
     pub event_channel_policy: ChannelPolicy,
+    /// Byte budget for events queued in the event channel.
+    ///
+    /// Enforced alongside `event_channel_capacity`: whichever limit is reached
+    /// first stops admission. Needed because event sizes span four orders of
+    /// magnitude (a 16 KiB SSL record vs. a 4 MiB one).
+    pub event_channel_max_bytes: usize,
     /// Max pending GenAI events waiting for session_id resolution.
     pub pending_genai_max_count: usize,
     /// Max bytes for pending GenAI events.
@@ -764,6 +781,7 @@ impl Default for RuntimeLimits {
         Self {
             event_channel_capacity: DEFAULT_EVENT_CHANNEL_CAPACITY,
             event_channel_policy: ChannelPolicy::Backpressure,
+            event_channel_max_bytes: DEFAULT_EVENT_CHANNEL_MAX_BYTES,
             pending_genai_max_count: DEFAULT_PENDING_GENAI_MAX_COUNT,
             pending_genai_max_bytes: DEFAULT_PENDING_GENAI_MAX_BYTES,
             pid_cache_size: DEFAULT_PID_CACHE_SIZE,
@@ -1234,6 +1252,10 @@ impl AgentsightConfig {
                     .as_deref()
                     .map(ChannelPolicy::from)
                     .unwrap_or_default(),
+                event_channel_max_bytes: limits
+                    .event_channel_max_bytes_mb
+                    .map(|mb| mb * 1024 * 1024)
+                    .unwrap_or(DEFAULT_EVENT_CHANNEL_MAX_BYTES),
                 pending_genai_max_count: limits
                     .pending_genai_max_count
                     .unwrap_or(DEFAULT_PENDING_GENAI_MAX_COUNT),
@@ -1916,6 +1938,10 @@ mod tests {
             DEFAULT_EVENT_CHANNEL_CAPACITY
         );
         assert_eq!(
+            limits.event_channel_max_bytes,
+            DEFAULT_EVENT_CHANNEL_MAX_BYTES
+        );
+        assert_eq!(
             limits.pending_genai_max_count,
             DEFAULT_PENDING_GENAI_MAX_COUNT
         );
@@ -1955,6 +1981,7 @@ mod tests {
             "runtime_limits": {
                 "event_channel_capacity": 5000,
                 "event_channel_policy": "drop_newest",
+                "event_channel_max_bytes_mb": 16,
                 "pending_genai_max_count": 500,
                 "pending_genai_max_bytes_mb": 32,
                 "pid_cache_size": 256,
@@ -1971,6 +1998,10 @@ mod tests {
             ChannelPolicy::DropNewest
         ));
         assert_eq!(config.runtime_limits.pending_genai_max_count, 500);
+        assert_eq!(
+            config.runtime_limits.event_channel_max_bytes,
+            16 * 1024 * 1024
+        );
         assert_eq!(
             config.runtime_limits.pending_genai_max_bytes,
             32 * 1024 * 1024

--- a/src/agentsight/src/event.rs
+++ b/src/agentsight/src/event.rs
@@ -30,6 +30,33 @@ impl Event {
             Event::UdpDns(_) => "UdpDns",
         }
     }
+
+    /// Approximate memory footprint of this event, in bytes.
+    ///
+    /// Counts the enum itself plus the variable-length payloads it owns, which
+    /// is what makes events differ by four orders of magnitude: an SSL record
+    /// carries anywhere from a few bytes to 4 MiB. The probe event channel uses
+    /// this to bound in-flight memory, something its slot count cannot do
+    /// (#2888). Approximate by design — allocator overhead and `String`
+    /// capacity beyond `len()` are not tracked, so it under-reports slightly
+    /// and the budget should be set with headroom.
+    pub fn approx_bytes(&self) -> usize {
+        let payload = match self {
+            Event::Ssl(e) => e.comm.len() + e.buf.len(),
+            Event::Proc(e) => match e {
+                ProcEvent::Exec { filename, args, .. } => filename.len() + args.len(),
+                ProcEvent::Stdout { payload, .. } => payload.len(),
+                ProcEvent::Exit { .. } | ProcEvent::Unknown(_) => 0,
+            },
+            Event::ProcMon(e) => match e {
+                ProcMonEvent::Exec { comm, .. } | ProcMonEvent::Exit { comm, .. } => comm.len(),
+            },
+            Event::FileWatch(e) => e.comm.len() + e.filename.len(),
+            Event::FileWrite(e) => e.comm.len() + e.filename.len() + e.buf.len(),
+            Event::UdpDns(e) => e.comm.len() + e.domain.len(),
+        };
+        std::mem::size_of::<Self>() + payload
+    }
 }
 
 impl Event {
@@ -236,5 +263,105 @@ mod tests {
         assert!(e.as_procmon().is_none());
         assert!(e.as_filewatch().is_none());
         assert!(e.as_filewrite().is_none());
+    }
+
+    #[test]
+    fn approx_bytes_tracks_payload_not_just_the_enum() {
+        let small = Event::Ssl(make_ssl_event());
+        let mut big_event = make_ssl_event();
+        big_event.buf = vec![0u8; 4 * 1024 * 1024];
+        let big = Event::Ssl(big_event);
+
+        // Two events occupying the same channel slot differ by ~4 MiB: exactly
+        // why the slot count cannot bound in-flight memory (#2888).
+        let baseline = std::mem::size_of::<Event>() + "test".len();
+        assert_eq!(small.approx_bytes(), baseline + "hello".len());
+        assert_eq!(big.approx_bytes(), baseline + 4 * 1024 * 1024);
+        assert!(big.approx_bytes() > small.approx_bytes() * 1000);
+    }
+
+    #[test]
+    fn approx_bytes_counts_every_variant_payload() {
+        /// A zeroed header stands in for the fixed part of a proc event.
+        ///
+        /// SAFETY: `proc_event_header` is a `#[repr(C)]` bindgen struct of plain
+        /// integers, so an all-zero bit pattern is a valid value. `approx_bytes`
+        /// reads none of its fields — only the variable-length ones alongside it.
+        fn proc_header() -> crate::probes::proctrace::ProcEventHeader {
+            unsafe { std::mem::zeroed() }
+        }
+        // A variant whose payload is ignored would silently escape the budget, so
+        // every one of them is checked against its own payload size.
+        let baseline = std::mem::size_of::<Event>();
+
+        let filewrite = Event::FileWrite(make_filewrite_event());
+        assert_eq!(
+            filewrite.approx_bytes(),
+            baseline + "writer".len() + "test.jsonl".len() + "content".len()
+        );
+
+        let filewatch = Event::FileWatch(make_filewatch_event());
+        assert_eq!(
+            filewatch.approx_bytes(),
+            baseline + "watcher".len() + "data.jsonl".len()
+        );
+
+        let exec = Event::Proc(ProcEvent::Exec {
+            header: proc_header(),
+            filename: "/usr/bin/node".to_string(),
+            args: "node index.js".to_string(),
+        });
+        assert_eq!(
+            exec.approx_bytes(),
+            baseline + "/usr/bin/node".len() + "node index.js".len()
+        );
+
+        let stdout = Event::Proc(ProcEvent::Stdout {
+            header: proc_header(),
+            fd: 1,
+            payload: vec![0u8; 128],
+        });
+        assert_eq!(stdout.approx_bytes(), baseline + 128);
+
+        // Fixed-size variants carry no payload beyond the enum itself.
+        let exit = Event::Proc(ProcEvent::Exit {
+            header: proc_header(),
+            exit_code: 0,
+        });
+        assert_eq!(exit.approx_bytes(), baseline);
+        assert_eq!(Event::Proc(ProcEvent::Unknown(7)).approx_bytes(), baseline);
+
+        let procmon_exec = Event::ProcMon(ProcMonEvent::Exec {
+            pid: 1,
+            tid: 1,
+            ppid: 0,
+            uid: 0,
+            timestamp_ns: 1,
+            comm: "claude".to_string(),
+        });
+        assert_eq!(procmon_exec.approx_bytes(), baseline + "claude".len());
+
+        let procmon_exit = Event::ProcMon(ProcMonEvent::Exit {
+            pid: 1,
+            tid: 1,
+            uid: 0,
+            timestamp_ns: 2,
+            comm: "claude".to_string(),
+            exit_code: 0,
+        });
+        assert_eq!(procmon_exit.approx_bytes(), baseline + "claude".len());
+
+        let dns = Event::UdpDns(UdpDnsEvent {
+            pid: 1,
+            tid: 1,
+            uid: 0,
+            timestamp_ns: 3,
+            comm: "curl".to_string(),
+            domain: "api.anthropic.com".to_string(),
+        });
+        assert_eq!(
+            dns.approx_bytes(),
+            baseline + "curl".len() + "api.anthropic.com".len()
+        );
     }
 }

--- a/src/agentsight/src/probes/mod.rs
+++ b/src/agentsight/src/probes/mod.rs
@@ -17,7 +17,7 @@ mod elf_buildid;
 pub use filewatch::{FileWatch, FileWatchEvent};
 pub use filewrite::{FileWrite as FileWriteProbe, FileWriteEvent};
 pub use pidns::observer_in_init_pidns;
-pub use probes::{Probes, ProbesPoller};
+pub use probes::{ChannelWatermarks, Probes, ProbesPoller};
 pub use procmon::{Event as ProcMonEventExt, ProcMon, ProcMonEvent};
 pub use proctrace::{ProcPoller, ProcTrace, VariableEvent as ProcEvent};
 pub use shared_maps::{MapKind, SharedMaps};

--- a/src/agentsight/src/probes/probes.rs
+++ b/src/agentsight/src/probes/probes.rs
@@ -10,7 +10,7 @@ use std::{
     mem,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     thread,
     time::Duration,
@@ -30,6 +30,103 @@ use super::udpdns::{RawUdpDnsEvent, UdpDns};
 use crate::config::TcpTarget;
 
 const POLL_TIMEOUT_MS: u64 = 100;
+
+/// Snapshot of the probe event channel's byte accounting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelWatermarks {
+    /// Approximate bytes of events queued in the channel.
+    pub in_flight_bytes: usize,
+    /// Configured budget; 0 means unlimited.
+    pub budget_bytes: usize,
+    /// Events rejected so far because the budget was exhausted.
+    pub dropped_over_budget: usize,
+}
+
+/// Byte-accounted admission gate for the probe event channel.
+///
+/// The channel's slot count cannot bound memory on its own: one SSL record
+/// carries up to `MAX_BUF_SIZE` (4 MiB), so the 10 000 default slots admit
+/// gigabytes of in-flight payload (#2888).
+///
+/// `max_bytes == 0` disables *rejection* but keeps accounting, matching how
+/// `retention_days` and `max_db_size_mb` already read 0 as "no limit" while
+/// still reporting size — an operator following that convention must not end up
+/// with everything dropped, nor lose the watermark readings.
+#[derive(Clone)]
+struct ChannelBudget {
+    max_bytes: usize,
+    in_flight: Arc<AtomicUsize>,
+    dropped: Arc<AtomicUsize>,
+}
+
+impl ChannelBudget {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            dropped: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Reserve `bytes` for an event about to be published.
+    ///
+    /// Must be called *before* the event becomes visible to the consumer: a
+    /// post-send charge can lose the race against [`Self::release`] on the
+    /// consumer side, and the saturating subtraction would then turn the late
+    /// charge into a permanent phantom reservation that eventually wedges the
+    /// budget shut. Returns false and counts a drop when over budget.
+    fn reserve(&self, bytes: usize) -> bool {
+        let max_bytes = self.max_bytes;
+        let admitted = self
+            .in_flight
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                // Saturating so a pathological size cannot wrap into a false pass.
+                let next = cur.saturating_add(bytes);
+                (max_bytes == 0 || next <= max_bytes).then_some(next)
+            })
+            .is_ok();
+        if !admitted {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        admitted
+    }
+
+    /// Give back a reservation whose event never reached the channel.
+    fn refund(&self, bytes: usize) {
+        self.give_back(bytes);
+    }
+
+    /// Give back a reservation once the event has been delivered to the consumer.
+    fn release(&self, bytes: usize) {
+        self.give_back(bytes);
+    }
+
+    /// Saturating so an accounting mismatch cannot wrap the counter and lock out
+    /// admission forever.
+    fn give_back(&self, bytes: usize) {
+        let _ = self
+            .in_flight
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                Some(cur.saturating_sub(bytes))
+            });
+    }
+
+    fn watermarks(&self) -> ChannelWatermarks {
+        ChannelWatermarks {
+            in_flight_bytes: self.in_flight.load(Ordering::Relaxed),
+            budget_bytes: self.max_bytes,
+            dropped_over_budget: self.dropped.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Whether this cumulative drop count should be logged.
+///
+/// A saturated budget rejects events in bursts, so one line per drop would
+/// itself become the load; powers of two keep the signal without the flood.
+fn should_report_drop(dropped: usize) -> bool {
+    dropped.is_power_of_two()
+}
 
 // Event source constants matching common.h event_source_t
 const EVENT_SOURCE_PROC: u32 = 1;
@@ -68,6 +165,8 @@ pub struct Probes {
     event_rx: crossbeam_channel::Receiver<Event>,
     /// Policy applied when the bounded event channel is full.
     event_channel_policy: ChannelPolicy,
+    /// Byte-accounted admission gate; bounds memory the slot count cannot.
+    budget: ChannelBudget,
 }
 
 impl Probes {
@@ -206,6 +305,7 @@ impl Probes {
             event_tx,
             event_rx,
             event_channel_policy: runtime_limits.event_channel_policy,
+            budget: ChannelBudget::new(runtime_limits.event_channel_max_bytes),
         })
     }
 
@@ -270,6 +370,7 @@ impl Probes {
 
         let event_tx = self.event_tx.clone();
         let event_policy = self.event_channel_policy;
+        let budget = self.budget.clone();
         let drop_counter = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_flag_inner = Arc::clone(&stop_flag);
@@ -337,10 +438,33 @@ impl Probes {
                 };
 
                 if let Some(e) = event {
-                    match event_policy {
+                    // Admission is gated on bytes as well as slots: the capacity
+                    // counts events, but a single SSL record carries up to 4 MiB,
+                    // so the slot bound alone cannot keep the tracer inside its
+                    // memory budget (#2888). Reserve before publishing — see
+                    // ChannelBudget::reserve for why the order matters.
+                    let bytes = e.approx_bytes();
+                    if !budget.reserve(bytes) {
+                        let marks = budget.watermarks();
+                        if should_report_drop(marks.dropped_over_budget) {
+                            log::warn!(
+                                "Probes event channel byte budget exhausted ({} / {} bytes in flight); \
+                                 dropped {} events so far",
+                                marks.in_flight_bytes,
+                                marks.budget_bytes,
+                                marks.dropped_over_budget
+                            );
+                        }
+                        return 0;
+                    }
+
+                    let sent = match event_policy {
                         ChannelPolicy::Backpressure => {
                             if event_tx.send(e).is_err() {
                                 log::warn!("Probes event channel closed");
+                                false
+                            } else {
+                                true
                             }
                         }
                         ChannelPolicy::DropNewest => {
@@ -349,6 +473,9 @@ impl Probes {
                                     "Probes event channel full (capacity={}); dropping event",
                                     event_tx.capacity().unwrap_or(0)
                                 );
+                                false
+                            } else {
+                                true
                             }
                         }
                         ChannelPolicy::Sample(n) => {
@@ -359,9 +486,20 @@ impl Probes {
                                         "Probes event channel full (capacity={}); dropping sampled event",
                                         event_tx.capacity().unwrap_or(0)
                                     );
+                                    false
+                                } else {
+                                    true
                                 }
+                            } else {
+                                false
                             }
                         }
+                    };
+
+                    // Refund what never reached the channel, so a dropped or
+                    // sampled-out event cannot leak the reservation.
+                    if !sent {
+                        budget.refund(bytes);
                     }
                 }
                 0
@@ -397,12 +535,21 @@ impl Probes {
 
     /// Receive the next event from any probe (blocking)
     pub fn recv(&self) -> Option<Event> {
-        self.event_rx.recv().ok()
+        let event = self.event_rx.recv().ok()?;
+        self.budget.release(event.approx_bytes());
+        Some(event)
     }
 
     /// Try to receive an event from any probe (non-blocking)
     pub fn try_recv(&self) -> Option<Event> {
-        self.event_rx.try_recv().ok()
+        let event = self.event_rx.try_recv().ok()?;
+        self.budget.release(event.approx_bytes());
+        Some(event)
+    }
+
+    /// Current byte accounting of the probe event channel.
+    pub fn channel_watermarks(&self) -> ChannelWatermarks {
+        self.budget.watermarks()
     }
 
     /// Add a PID to the traced_processes map at runtime
@@ -478,5 +625,125 @@ impl ProbesPoller {
 impl Drop for ProbesPoller {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budget_admits_until_exhausted() {
+        let budget = ChannelBudget::new(1024);
+        assert!(budget.reserve(1000));
+        assert!(budget.reserve(24));
+        assert!(!budget.reserve(1));
+        let marks = budget.watermarks();
+        assert_eq!(marks.in_flight_bytes, 1024);
+        assert_eq!(marks.dropped_over_budget, 1);
+    }
+
+    #[test]
+    fn budget_rejects_single_oversized_event() {
+        // A 4 MiB SSL record must not be admitted into a smaller budget: this is
+        // the case the slot-count bound alone let through (#2888).
+        let budget = ChannelBudget::new(64 * 1024);
+        assert!(!budget.reserve(4 * 1024 * 1024));
+        assert_eq!(budget.watermarks().in_flight_bytes, 0);
+    }
+
+    #[test]
+    fn rejected_reservation_does_not_consume_budget() {
+        // A rejected event must leave room for the next, smaller one; otherwise a
+        // single oversized record would wedge the channel shut.
+        let budget = ChannelBudget::new(1024);
+        assert!(!budget.reserve(2048));
+        assert!(budget.reserve(1024));
+    }
+
+    #[test]
+    fn refund_returns_unsent_reservation() {
+        let budget = ChannelBudget::new(1024);
+        assert!(budget.reserve(512));
+        budget.refund(512);
+        assert_eq!(budget.watermarks().in_flight_bytes, 0);
+        // Full budget available again after the refund.
+        assert!(budget.reserve(1024));
+    }
+
+    #[test]
+    fn zero_budget_means_unlimited_but_still_accounts() {
+        // Operators read 0 as "no limit" from retention_days / max_db_size_mb;
+        // treating it as a 1-byte budget would silently drop every event. The
+        // watermark must stay readable so the gate can be diagnosed while off.
+        let budget = ChannelBudget::new(0);
+        assert!(budget.reserve(4 * 1024 * 1024));
+        assert!(budget.reserve(4 * 1024 * 1024));
+        let marks = budget.watermarks();
+        assert_eq!(marks.in_flight_bytes, 8 * 1024 * 1024);
+        assert_eq!(marks.dropped_over_budget, 0);
+        assert_eq!(marks.budget_bytes, 0);
+    }
+
+    #[test]
+    fn accounting_saturates_instead_of_wrapping() {
+        let budget = ChannelBudget::new(usize::MAX);
+        assert!(budget.reserve(usize::MAX));
+        // Would wrap to a tiny value and falsely pass without saturation.
+        assert!(budget.reserve(8));
+        budget.release(usize::MAX);
+        budget.release(usize::MAX);
+        assert_eq!(budget.watermarks().in_flight_bytes, 0);
+    }
+
+    #[test]
+    fn drop_reports_are_rate_limited_to_powers_of_two() {
+        assert!(should_report_drop(1));
+        assert!(should_report_drop(2));
+        assert!(should_report_drop(1024));
+        assert!(!should_report_drop(3));
+        assert!(!should_report_drop(1000));
+    }
+
+    /// Reserve-then-publish must survive the consumer draining concurrently.
+    ///
+    /// Charging after the send loses the race when the consumer receives and
+    /// releases first: the saturating subtraction floors at zero and the late
+    /// charge becomes a permanent phantom reservation, which eventually reports
+    /// the budget as exhausted and drops valid events forever.
+    #[test]
+    fn concurrent_drain_leaves_no_phantom_reservation() {
+        const EVENTS: usize = 2_000;
+        const BYTES: usize = 4096;
+
+        let budget = ChannelBudget::new(EVENTS * BYTES);
+        let (tx, rx) = crossbeam_channel::bounded::<usize>(4);
+
+        let consumer_budget = budget.clone();
+        let consumer = thread::spawn(move || {
+            let mut received = 0usize;
+            while let Ok(bytes) = rx.recv() {
+                consumer_budget.release(bytes);
+                received += 1;
+            }
+            received
+        });
+
+        for _ in 0..EVENTS {
+            assert!(budget.reserve(BYTES));
+            tx.send(BYTES).expect("consumer alive");
+        }
+        drop(tx);
+
+        assert_eq!(consumer.join().expect("consumer thread"), EVENTS);
+        let marks = budget.watermarks();
+        assert_eq!(
+            marks.in_flight_bytes, 0,
+            "every reservation must be released once the channel is drained"
+        );
+        assert_eq!(marks.dropped_over_budget, 0);
+
+        // The budget is fully reusable, i.e. no reservation leaked.
+        assert!(budget.reserve(EVENTS * BYTES));
     }
 }

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -38,7 +38,7 @@ use crate::interruption::{
     DetectorConfig, InterruptionDetector, ProcessExitStatus, recover_oom_events,
 };
 use crate::parser::Parser;
-use crate::probes::{FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
+use crate::probes::{ChannelWatermarks, FileWatchEvent, FileWriteEvent, Probes, ProbesPoller};
 use crate::response_map::ResponseSessionMapper;
 use crate::storage::sqlite::{GenAISqliteStore, InterruptionStore, sibling_db_path};
 use crate::storage::{SqliteConfig, Storage, TimePeriod, TokenQuery, TokenQueryResult};
@@ -103,6 +103,8 @@ pub struct AgentSight {
     last_drain_check: std::time::Instant,
     /// Rate-limiter for interruption DB purge (at most once per 60 s)
     last_interruption_purge: std::time::Instant,
+    /// Rate-limiter for the buffer watermark log (at most once per 60 s)
+    last_watermark_log: std::time::Instant,
     /// Cache of pid → agent_name, persists after process exit for deferred resolution
     pid_agent_name_cache: lru::LruCache<u32, String>,
     /// HTTP domain patterns from config, used for runtime DNS-based tcpsniff target addition
@@ -591,6 +593,7 @@ impl AgentSight {
             ffi_sender: None,
             last_drain_check: std::time::Instant::now(),
             last_interruption_purge: std::time::Instant::now(),
+            last_watermark_log: std::time::Instant::now(),
             pid_agent_name_cache,
             http_domains,
             pending_logtail,
@@ -1102,6 +1105,10 @@ impl AgentSight {
 
         // Main event loop
         while self.running.load(Ordering::SeqCst) {
+            // Rate-limited internally, and deliberately outside the idle branch:
+            // a saturated byte budget keeps the queue non-empty, which is exactly
+            // when the watermarks matter most.
+            self.maybe_log_buffer_watermarks();
             if let Some(result) = self.try_process() {
                 log::trace!("[Event {result}] Processed");
             } else {
@@ -2198,6 +2205,26 @@ impl AgentSight {
             }
         }
     }
+
+    /// Periodically report event-buffer watermarks.
+    ///
+    /// The tracer runs under `MemoryMax=350M`; when it is killed the journal is
+    /// the only evidence left, and a cgroup total says nothing about *which*
+    /// buffer grew (#2888).
+    fn maybe_log_buffer_watermarks(&mut self) {
+        if self.last_watermark_log.elapsed() < std::time::Duration::from_secs(60) {
+            return;
+        }
+        self.last_watermark_log = std::time::Instant::now();
+
+        let (needs_attention, report) =
+            watermark_report(self.probes.channel_watermarks(), self.pending_genai.len());
+        if needs_attention {
+            log::info!("{report}");
+        } else {
+            log::debug!("{report}");
+        }
+    }
 }
 
 impl Drop for AgentSight {
@@ -2528,10 +2555,85 @@ fn record_agent_crash_interruptions(
     }
 }
 
+/// Render the buffer watermark report, and whether it needs operator attention.
+///
+/// Split out from the logging call site so the wording is covered by tests: this
+/// line is the only evidence left after an OOM kill, and it has to say which
+/// buffer holds the memory. Attention means the byte budget already rejected
+/// events, which is reported at INFO so diagnosing an OOM does not require
+/// turning on debug logging; a quiet pipeline stays at DEBUG.
+fn watermark_report(marks: ChannelWatermarks, pending_genai: usize) -> (bool, String) {
+    let mut report = format!(
+        "Buffer watermarks: event channel {} / {} bytes in flight",
+        marks.in_flight_bytes, marks.budget_bytes
+    );
+    let needs_attention = marks.dropped_over_budget > 0;
+    if needs_attention {
+        report.push_str(&format!(
+            ", {} events dropped over budget",
+            marks.dropped_over_budget
+        ));
+    }
+    report.push_str(&format!(", pending_genai {pending_genai} entries"));
+    (needs_attention, report)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[test]
+    fn watermark_report_stays_quiet_without_drops() {
+        let (needs_attention, report) = watermark_report(
+            ChannelWatermarks {
+                in_flight_bytes: 1024,
+                budget_bytes: 64 * 1024 * 1024,
+                dropped_over_budget: 0,
+            },
+            3,
+        );
+        assert!(!needs_attention);
+        assert_eq!(
+            report,
+            "Buffer watermarks: event channel 1024 / 67108864 bytes in flight, \
+             pending_genai 3 entries"
+        );
+    }
+
+    #[test]
+    fn watermark_report_surfaces_drops() {
+        // The drop count is the signal that separates channel pressure from
+        // downstream growth, so it must appear and must raise the level.
+        let (needs_attention, report) = watermark_report(
+            ChannelWatermarks {
+                in_flight_bytes: 67108864,
+                budget_bytes: 67108864,
+                dropped_over_budget: 42,
+            },
+            17,
+        );
+        assert!(needs_attention);
+        assert!(report.contains("42 events dropped over budget"));
+        assert!(report.contains("67108864 / 67108864 bytes in flight"));
+        assert!(report.contains("pending_genai 17 entries"));
+    }
+
+    #[test]
+    fn watermark_report_shows_unlimited_budget_as_zero() {
+        // With the gate disabled the reading must still be usable, otherwise an
+        // operator who set 0 loses the only in-flight measurement.
+        let (needs_attention, report) = watermark_report(
+            ChannelWatermarks {
+                in_flight_bytes: 8 * 1024 * 1024,
+                budget_bytes: 0,
+                dropped_over_budget: 0,
+            },
+            0,
+        );
+        assert!(!needs_attention);
+        assert!(report.contains("8388608 / 0 bytes in flight"));
+    }
 
     /// Generate a unique temp directory for each test invocation.
     fn unique_tmp_dir(tag: &str) -> PathBuf {


### PR DESCRIPTION
## Description

`agentsight.service` filled its `MemoryMax=350M` cgroup within minutes under real HTTPS traffic and got OOM-killed, then never came back (#2888). Two independent defects: the probe event channel was bounded by **slot count only** while a single SSL record carries up to `MAX_BUF_SIZE` (4 MiB), so 10 000 slots admit gigabytes of in-flight payload; and `StartLimitIntervalSec=86400` + `StartLimitBurst=10` meant a recurring OOM burned the whole restart budget within an hour and left the unit permanently `failed`. Admission is now additionally gated on an accounted byte budget, and the start rate limit is removed so observability always comes back.

The byte gate was chosen over simply lowering `event_channel_capacity` because event sizes span four orders of magnitude (16 KiB / 128 KiB / 512 KiB / 4 MiB tiers) — no slot count can bound memory when one event alone can be 4 MiB. This also explains the reporter's own observation that process churn never reproduced the OOM while real download traffic did.

## Related Issue

closes #2888

## Risk and compatibility

- **Behaviour change**: under the default `backpressure` policy the channel now *sheds* events once the byte budget is exhausted, instead of growing without bound. Drops are counted and reported, and losing some events is strictly better than an OOM kill that loses all observability. Set `event_channel_max_bytes_mb: 0` to disable the gate (`0` = unlimited, consistent with `retention_days` / `max_db_size_mb`).
- **Config**: new optional `runtime_limits.event_channel_max_bytes_mb`, default 64. Existing configs keep working unchanged.
- **systemd**: `OOMPolicy=` requires systemd 243+. Older targets (Anolis 8 / systemd 239) log an unknown-key warning and ignore it, falling back to current behaviour — no startup failure. Removing the start rate limit means a permanently unstartable service now retries every `RestartSec=10` instead of going quiet; for an observability agent a noisy restart loop is preferable to silent death.

## Validation

```bash
cd src/agentsight
cargo fmt --all -- --check          # clean
cargo clippy --workspace --all-targets -- -D warnings   # 0 warnings
cargo test --lib                    # 1566 passed, 0 failed
```

Scope: unit tests. 6 new cases covering the admission arithmetic (budget exhaustion, a single 4 MiB event against a smaller budget, saturating instead of wrapping, `0` meaning unlimited) and the byte accounting (payload dominates the enum size; every variant's payload is counted, so no variant silently escapes the budget).

Edge cases covered: `0` budget, `usize` overflow, sampled-out and dropped events not leaking budget (only events that actually reached the channel are charged), and saturating release so a mismatch cannot wrap the counter and lock out admission permanently.

**Not verified here**: convergence under the reported production load. The 60s watermark line (`journalctl -u agentsight | grep "Buffer watermarks"`) exists precisely so this can be settled in the field — a rising drop count means the channel was the consumer; a count stuck at zero while the cgroup still approaches its cap means the memory sits downstream.

## Known limitations

Deliberately out of scope, to keep this change reviewable:

- HTTP connection buffers still allow `connection_capacity` x `max_connection_body_bytes` plus an equally sized SSE continuation buffer; the watermark log is what identifies whether this is the dominant consumer.
- The SSL uprobe re-attach leak (`_links` grows on every re-attach) and the whole-file read in the static SSL probe are untouched; both need #2792 to land first since they touch the same code.
- The eBPF ring buffer size is unchanged — shrinking it would worsen burst drops, which is exactly what the tiered reservation work set out to fix.

## Documentation and rollback

Documented in `docs/user-guide/{en,zh}/agent-observability/agentsight/configuration.md` (new field, `0` semantics) and `troubleshooting.md` (how to read the watermark line, how to tell channel pressure from downstream buffering, and that the service now restarts itself after an OOM). Component `README.md` / `README_zh.md` / `AGENTS.md` runtime-limit tables updated, and `agentsight.json` ships the new key explicitly.

Rollback: revert both commits. The config key is optional and the systemd unit change is self-contained, so a revert needs no data migration and no operator action beyond `systemctl daemon-reload`.
