### PR TITLE
fix(anolisa): honor telemetry dry-run

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -445,7 +445,7 @@ fn telemetry_command_scope(args: &telemetry::TelemetryArgs) -> CommandScope {
     match &args.command {
         telemetry::TelemetryCommands::Status { .. } => CommandScope::ReadOnly,
         // enable / disable / link / unlink / upload / init mutate system state
-        // and need root; an explicit dry-run may preview without root.
+        // and need root; an explicit system-mode dry-run may preview without root.
         telemetry::TelemetryCommands::Enable
         | telemetry::TelemetryCommands::Disable
         | telemetry::TelemetryCommands::Link
@@ -664,6 +664,40 @@ mod tests {
 
         validate_global_args_with_euid(&ctx, system_only("repair", true), 1000, true)
             .expect("non-root system dry-run should reach preview-capable system handlers");
+    }
+
+    #[test]
+    fn telemetry_mutations_allow_non_root_system_dry_run_only() {
+        let commands = [
+            telemetry::TelemetryCommands::Enable,
+            telemetry::TelemetryCommands::Disable,
+            telemetry::TelemetryCommands::Link,
+            telemetry::TelemetryCommands::Unlink,
+            telemetry::TelemetryCommands::Upload { loop_flag: false },
+            telemetry::TelemetryCommands::Upload { loop_flag: true },
+            telemetry::TelemetryCommands::Init,
+        ];
+
+        for command in commands {
+            let command =
+                Commands::Management(ManagementCommands::Telemetry(telemetry::TelemetryArgs {
+                    command,
+                }));
+            let policy = command_policy(&command);
+            let mut preview = ctx_with_prefix(PathBuf::from("/"));
+            preview.dry_run = true;
+
+            validate_global_args_with_euid(&preview, policy, 1000, true)
+                .expect("non-root telemetry dry-run should reach the preview dispatcher");
+            let err = validate_global_args_with_euid(
+                &ctx_with_prefix(PathBuf::from("/")),
+                policy,
+                1000,
+                true,
+            )
+            .expect_err("telemetry apply still requires root in system mode");
+            assert_eq!(err.code(), "PERMISSION_DENIED");
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/telemetry.rs
@@ -14,8 +14,9 @@ use anolisa_core::{
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::systemd::{Systemd, SystemdError};
 use clap::{Parser, Subcommand};
+use serde::Serialize;
 
-use crate::context::CliContext;
+use crate::context::{CliContext, InstallMode};
 use crate::response::{CliError, render_json};
 
 /// systemd unit that runs the resident upload loop.
@@ -66,7 +67,51 @@ pub enum TelemetryCommands {
 
 /// Dispatch `telemetry` subcommands.
 pub fn handle(args: TelemetryArgs, ctx: &CliContext) -> Result<(), CliError> {
-    match args.command {
+    dispatch(args.command, ctx, apply)
+}
+
+fn dispatch(
+    command: TelemetryCommands,
+    ctx: &CliContext,
+    apply: impl FnOnce(TelemetryCommands, &CliContext) -> Result<(), CliError>,
+) -> Result<(), CliError> {
+    if ctx.dry_run
+        && let Some((command_name, message)) = preview(&command)
+    {
+        if ctx.install_mode != InstallMode::System {
+            return Err(CliError::InvalidArgument {
+                command: command_name.to_string(),
+                reason: format!(
+                    "command '{command_name}' operates on system scope; use `--install-mode system` to preview it"
+                ),
+            });
+        }
+        if ctx.json {
+            return render_json(
+                command_name,
+                TelemetryPreviewPayload {
+                    dry_run: true,
+                    message,
+                },
+            );
+        }
+        if !ctx.quiet {
+            println!("[dry-run] {message}");
+        }
+        return Ok(());
+    }
+
+    apply(command, ctx)
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct TelemetryPreviewPayload {
+    dry_run: bool,
+    message: &'static str,
+}
+
+fn apply(command: TelemetryCommands, ctx: &CliContext) -> Result<(), CliError> {
+    match command {
         TelemetryCommands::Enable => handle_enable(ctx),
         TelemetryCommands::Disable => handle_disable(ctx),
         TelemetryCommands::Status { json } => handle_status(json),
@@ -74,6 +119,39 @@ pub fn handle(args: TelemetryArgs, ctx: &CliContext) -> Result<(), CliError> {
         TelemetryCommands::Unlink => handle_unlink(),
         TelemetryCommands::Upload { loop_flag } => handle_upload(loop_flag),
         TelemetryCommands::Init => handle_init(ctx),
+    }
+}
+
+fn preview(command: &TelemetryCommands) -> Option<(&'static str, &'static str)> {
+    match command {
+        TelemetryCommands::Enable => Some((
+            "telemetry enable",
+            "would enable telemetry collection and start the uploader",
+        )),
+        TelemetryCommands::Disable => Some((
+            "telemetry disable",
+            "would disable telemetry collection and stop the uploader",
+        )),
+        TelemetryCommands::Status { .. } => None,
+        TelemetryCommands::Link => Some((
+            "telemetry link",
+            "would link this instance to named reporting",
+        )),
+        TelemetryCommands::Unlink => Some((
+            "telemetry unlink",
+            "would unlink this instance and erase the cached identity",
+        )),
+        TelemetryCommands::Upload { loop_flag: true } => Some((
+            "telemetry upload",
+            "would start the continuous telemetry upload loop",
+        )),
+        TelemetryCommands::Upload { loop_flag: false } => {
+            Some(("telemetry upload", "would upload buffered telemetry once"))
+        }
+        TelemetryCommands::Init => Some((
+            "telemetry init",
+            "would initialize the telemetry operations channel",
+        )),
     }
 }
 
@@ -322,6 +400,9 @@ mod tests {
     use super::*;
     use clap::Parser;
 
+    use crate::context::InstallMode;
+    use crate::test_support::{TestContextOptions, context_for_root};
+
     #[derive(Parser)]
     struct TestCli {
         #[command(subcommand)]
@@ -330,6 +411,31 @@ mod tests {
 
     fn parse(args: &[&str]) -> TelemetryCommands {
         TestCli::parse_from(args).command
+    }
+
+    fn ctx(dry_run: bool) -> CliContext {
+        context_for_root(
+            Path::new("/tmp/anolisa-telemetry-validation"),
+            InstallMode::System,
+            None,
+            TestContextOptions {
+                dry_run,
+                quiet: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    fn mutation_commands() -> Vec<TelemetryCommands> {
+        vec![
+            TelemetryCommands::Enable,
+            TelemetryCommands::Disable,
+            TelemetryCommands::Link,
+            TelemetryCommands::Unlink,
+            TelemetryCommands::Upload { loop_flag: false },
+            TelemetryCommands::Upload { loop_flag: true },
+            TelemetryCommands::Init,
+        ]
     }
 
     #[test]
@@ -385,6 +491,117 @@ mod tests {
             parse(&["t", "upload"]),
             TelemetryCommands::Upload { loop_flag: false }
         ));
+    }
+
+    #[test]
+    fn dry_run_never_enters_the_apply_dispatcher() {
+        for command in mutation_commands() {
+            let mut applied = false;
+            dispatch(command, &ctx(true), |_, _| {
+                applied = true;
+                Ok(())
+            })
+            .expect("telemetry preview");
+            assert!(!applied, "dry-run must not dispatch telemetry effects");
+        }
+    }
+
+    #[test]
+    fn user_mode_dry_run_rejects_every_mutation_before_apply() {
+        for command in mutation_commands() {
+            let mut user_ctx = ctx(true);
+            user_ctx.install_mode = InstallMode::User;
+            let mut applied = false;
+
+            let error = dispatch(command, &user_ctx, |_, _| {
+                applied = true;
+                Ok(())
+            })
+            .expect_err("user mode cannot preview system telemetry mutations");
+
+            assert_eq!(error.code(), "INVALID_ARGUMENT");
+            assert!(
+                error
+                    .to_string()
+                    .contains("use `--install-mode system` to preview it")
+            );
+            assert!(!applied, "rejected preview must not dispatch effects");
+        }
+    }
+
+    #[test]
+    fn apply_dispatches_every_mutation() {
+        for command in mutation_commands() {
+            let mut applied = false;
+            dispatch(command, &ctx(false), |_, _| {
+                applied = true;
+                Ok(())
+            })
+            .expect("telemetry apply dispatch");
+            assert!(applied, "apply must retain the existing dispatcher");
+        }
+    }
+
+    #[test]
+    fn status_remains_read_only_when_global_dry_run_is_set() {
+        let mut user_ctx = ctx(true);
+        user_ctx.install_mode = InstallMode::User;
+        let mut dispatched = false;
+        dispatch(
+            TelemetryCommands::Status { json: false },
+            &user_ctx,
+            |_, _| {
+                dispatched = true;
+                Ok(())
+            },
+        )
+        .expect("telemetry status dispatch");
+        assert!(dispatched, "dry-run must not replace the status read path");
+    }
+
+    #[test]
+    fn upload_preview_distinguishes_once_from_loop() {
+        assert_eq!(
+            preview(&TelemetryCommands::Upload { loop_flag: false }),
+            Some(("telemetry upload", "would upload buffered telemetry once"))
+        );
+        assert_eq!(
+            preview(&TelemetryCommands::Upload { loop_flag: true }),
+            Some((
+                "telemetry upload",
+                "would start the continuous telemetry upload loop"
+            ))
+        );
+    }
+
+    #[test]
+    fn json_preview_never_enters_the_apply_dispatcher() {
+        let mut ctx = ctx(true);
+        ctx.json = true;
+
+        let mut applied = false;
+        dispatch(TelemetryCommands::Enable, &ctx, |_, _| {
+            applied = true;
+            Ok(())
+        })
+        .expect("telemetry JSON preview");
+
+        assert!(!applied, "JSON preview must not dispatch telemetry effects");
+    }
+
+    #[test]
+    fn preview_payload_is_machine_readable() {
+        let payload = TelemetryPreviewPayload {
+            dry_run: true,
+            message: preview(&TelemetryCommands::Link).expect("link preview").1,
+        };
+        let value = serde_json::to_value(payload).expect("serialize telemetry preview");
+
+        assert_eq!(value["dry_run"], true);
+        assert_eq!(
+            value["message"],
+            "would link this instance to named reporting"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

The global `--dry-run` contract and telemetry command policy promise an
unprivileged system-mode preview, but every telemetry mutation ignored the
flag. A root preview could therefore apply telemetry effects, while most
non-root system previews failed the handler-level root check.

## What changed

Route telemetry mutations through a narrow preview/apply dispatcher. Preview
returns before privilege checks or effects for enable, disable, link, unlink,
upload, and init; status and all apply paths remain unchanged. System-mode
preview works without root, while default or explicit user-mode preview is
rejected because telemetry has no user-scope implementation. When global
`--json` is also set, preview uses the standard envelope before quiet/human
rendering. Add table-driven coverage for effect isolation, scope, upload modes,
status routing, and non-root policy.

## Related issue

Closes #2924

## User / Agent impact

`anolisa --install-mode system --dry-run telemetry <mutation>` now prints the
planned action without changing consent, link identity, systemd, uploader,
upload, or telemetry state. It works without root as promised by command policy;
user-mode preview fails instead of reporting an inapplicable system plan.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This fixes the documented dry-run behavior. Existing apply dispatch,
status behavior, CLI flags, JSON schema, and apply exit codes are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli telemetry --locked`
- `cargo test -p anolisa-cli --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- Actual CLI: default and explicit user-mode dry-run returned
  `INVALID_ARGUMENT`; explicit non-root system-mode dry-run returned its plan;
  JSON preview emitted one standard success envelope.
- ALinux 4 ephemeral container, network disabled: root and non-root system-mode
  previews for enable, disable, link, unlink, upload once/loop, and init;
  verified telemetry, consent, link, and systemd paths remained absent.

## Documentation and rollback

No public documentation update is required because this restores the existing
global dry-run contract without changing flags or schemas. Roll back by
reverting commit `e96a2bcd`.