### PR TITLE
chore(skillfs): bump version to 0.4.2

### DIFF
--- a/src/skillfs/CHANGELOG.md
+++ b/src/skillfs/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-27
+
+### Added
+
+- An optional Alibaba Cloud Linux 4 sidecar image now provides a reproducible
+  alternative to the existing Debian image, with bilingual guidance for
+  building and operating both variants
+  ([#2777](https://github.com/alibaba/anolisa/pull/2777),
+  [#2787](https://github.com/alibaba/anolisa/pull/2787)).
+
+### Fixed
+
+- Startup reconciliation now retries transient notify-daemon endpoint failures
+  with bounded backoff, allowing hidden skills to converge automatically when
+  the daemon starts late or restarts
+  ([#2790](https://github.com/alibaba/anolisa/pull/2790)).
+- Flat normal-mode mounts now resolve categorized skills through their stored
+  physical directories, so writes, truncation, renames, and synchronization no
+  longer fail with `ENOENT`
+  ([#2901](https://github.com/alibaba/anolisa/pull/2901)).
+
 ## [0.4.1] - 2026-08-21
 
 ### Added

--- a/src/skillfs/CHANGELOG_zh.md
+++ b/src/skillfs/CHANGELOG_zh.md
@@ -9,6 +9,24 @@
 
 ## [未发布]
 
+## [0.4.2] - 2026-08-27
+
+### 新增
+
+- 新增可选的 Alibaba Cloud Linux 4 Sidecar 镜像，为现有 Debian 镜像提供可复现的
+  替代方案，并通过中英文文档说明两个镜像版本的构建和运行方式
+  ([#2777](https://github.com/alibaba/anolisa/pull/2777)，
+  [#2787](https://github.com/alibaba/anolisa/pull/2787))。
+
+### 修复
+
+- 启动 reconcile 现在会通过有界退避重试 notify daemon endpoint 的临时故障，
+  当 daemon 延迟启动或重启时，隐藏 Skill 可自动恢复到正确状态
+  ([#2790](https://github.com/alibaba/anolisa/pull/2790))。
+- Flat normal-mode mount 现在会通过已记录的物理目录解析 categorized Skill，
+  write、truncate、rename 和同步操作不再因 `ENOENT` 失败
+  ([#2901](https://github.com/alibaba/anolisa/pull/2901))。
+
 ## [0.4.1] - 2026-08-21
 
 ### 新增

--- a/src/skillfs/Cargo.lock
+++ b/src/skillfs/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "libc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "notify",
  "parking_lot",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "skillfs-fuse"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "fuser",

--- a/src/skillfs/Cargo.toml
+++ b/src/skillfs/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.86"
 license = "Apache-2.0"

--- a/src/skillfs/component.toml
+++ b/src/skillfs/component.toml
@@ -3,7 +3,7 @@ anolisa_min_version = "0.1.0"
 
 [component]
 name = "skillfs"
-version = "0.4.1"
+version = "0.4.2"
 layer = "runtime"
 domain = "tools"
 description = "AI agent skill management via virtual filesystem"

--- a/src/skillfs/skillfs.spec.in
+++ b/src/skillfs/skillfs.spec.in
@@ -62,6 +62,11 @@ cp -rp docs/skills/skillfs-mount/. \
 %{_datadir}/anolisa/runtime/skills/skillfs/
 
 %changelog
+* Thu Aug 27 2026 kongche-jbw <kongche.jbw@alibaba-inc.com> - 0.4.2-1
+- Add an optional Alibaba Cloud Linux 4 sidecar image and operator guidance.
+- Retry startup reconciles after transient notify daemon endpoint failures.
+- Fix flat writes and renames for categorized Skill sources.
+
 * Fri Aug 21 2026 kongche-jbw <kongche.jbw@alibaba-inc.com> - 0.4.1-1
 - Add Kubernetes sidecar deployment and authenticated container peers.
 - Fix nested Hermes activation and harden metadata and backing aliases.


### PR DESCRIPTION
## Why

SkillFS needs a patch release containing the changes merged after v0.4.1,
including the categorized-source write fix from #2901.

## What changed

Bump Cargo, component, and RPM template metadata to v0.4.2. Add bilingual
release notes covering all user-visible SkillFS changes since v0.4.1.

## Related issue

no-issue: prepare the v0.4.2 patch release

## User / Agent impact

Users receive the Alibaba Cloud Linux 4 sidecar option, bounded startup
reconcile retries, and correct writes to categorized sources through flat
normal-mode mounts.

## Risk and compatibility

Low risk. This commit changes release metadata and changelogs only; runtime
changes were reviewed in their originating pull requests.

## Validation

- `python3 scripts/check-component-versions.py`
- `git diff --check`
- Rust, FUSE, and container tests were not rerun for this release-only commit,
  as requested by the release owner.

## Documentation and rollback

Updated the English and Chinese SkillFS changelogs. Roll back by reverting the
version bump commit before tagging; no data migration is involved.