### PR TITLE
chore(sec-core): bump version to 0.11.1

### DIFF
--- a/src/agent-sec-core/.anolisa/component.toml
+++ b/src/agent-sec-core/.anolisa/component.toml
@@ -2,7 +2,7 @@ manifest_version = 2
 
 [component]
 name = "sec-core"
-version = "0.11.0"
+version = "0.11.1"
 layer = "runtime"
 domain = "security"
 display_name = "Agent Security Core"

--- a/src/agent-sec-core/CHANGELOG.md
+++ b/src/agent-sec-core/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.11.1
+
+**Prompt Scanner**
+
+- Restricted the invisible-character injection rule so emoji ZWJ sequences, Persian ZWNJ, and leading BOM no longer score as critical injections. (#2900)
+- Refused non-loopback model service base URLs derived from the environment in both the Rust and Python model service paths. (#2893)
+- Reported `daemon.health` prompt_scan state as untracked instead of unconditionally ready now that scanning runs in-process. (#2892)
+- Dropped the dead prompt model preload environment flag and the obsolete scan-prompt protocol document. (#2886)
+
+**Skill Ledger Runtime**
+
+- Skipped host-backed read-only system Skills in batch `scan --all` and default `init` instead of failing them. (#2906)
+- Rejected the placeholder `set-policy` and `rotate-keys` commands so they no longer report false success. (#2876)
+
+**Asset Verification**
+
+- Reported explicit `CHECKED` / `PASSED` / `FAILED` counters and a distinct zero-candidate outcome for `agent-sec-cli verify`. (#2875)
+
+**Security Events & CLI**
+
+- Enforced owner-only permissions on files created by the CLI. (#2873)
+
+**Documentation**
+
+- Documented the five hidden `agent-sec-cli` integration commands and their contract caveats. (#2887)
+- Documented the rule-only L1 detection boundary and how to read `pass` together with degraded fields. (#2895)
+
 ## 0.11.0
 
 **Prompt Scanner**

--- a/src/agent-sec-core/agent-sec-cli/Cargo.lock
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "prompt-scanner",
  "pyo3",

--- a/src/agent-sec-core/agent-sec-cli/Cargo.toml
+++ b/src/agent-sec-core/agent-sec-cli/Cargo.toml
@@ -29,7 +29,7 @@ url = "2.5"
 
 [package]
 name = "agent-sec-cli"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Agent Security Core CLI - Native Rust extensions"
 license = "Apache-2.0"

--- a/src/agent-sec-core/agent-sec-cli/pyproject.toml
+++ b/src/agent-sec-core/agent-sec-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-sec-cli"
-version = "0.11.0"
+version = "0.11.1"
 description = "Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification for AI Agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/__init__.py
@@ -1,3 +1,3 @@
 """Agent Security Core CLI - System hardening, sandbox isolation, and asset integrity verification."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
+++ b/src/agent-sec-core/agent-sec-cli/src/agent_sec_cli/cli.py
@@ -36,7 +36,7 @@ try:
 
     __version__ = get_version("agent-sec-cli")
 except Exception:
-    __version__ = "0.11.0"  # pragma: no cover
+    __version__ = "0.11.1"  # pragma: no cover
 
 app = typer.Typer(
     name="agent-sec-cli",

--- a/src/agent-sec-core/agent-sec-cli/uv.lock
+++ b/src/agent-sec-core/agent-sec-cli/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sec-cli"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/src/agent-sec-core/agent-sec-core.spec.in
+++ b/src/agent-sec-core/agent-sec-core.spec.in
@@ -258,6 +258,9 @@ rm -rf $RPM_BUILD_ROOT
 make install-all-for-rpmbuild DESTDIR=$RPM_BUILD_ROOT
 
 %changelog
+* Thu Aug 27 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.11.1-1
+- Update version to 0.11.1
+
 * Fri Aug 21 2026 YiZheng Yang <YiZheng.Yang@linux.alibaba.com> - 0.11.0-1
 - Update version to 0.11.0
 

--- a/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
+++ b/src/agent-sec-core/codex-plugin/hooks-plugin/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Agent security core plugin for Codex - code scanning, prompt scanning, PII checking, skill ledger integrity verification, and turn/tool observability."
 }

--- a/src/agent-sec-core/cosh-extension/cosh-extension.json
+++ b/src/agent-sec-core/cosh-extension/cosh-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "hooks": {
     "PreToolUse": [
       {

--- a/src/agent-sec-core/hermes-plugin/src/plugin.yaml
+++ b/src/agent-sec-core/hermes-plugin/src/plugin.yaml
@@ -1,5 +1,5 @@
 name: agent-sec-core-hermes-plugin
-version: 0.11.0
+version: 0.11.1
 description: "OS-level security guardrails for Hermes Agent — powered by agent-sec-cli"
 provides_hooks:
   - pre_llm_call

--- a/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
+++ b/src/agent-sec-core/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-sec",
   "name": "Agent Security",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Security hooks powered by agent-sec-cli",
   "activation": {
     "onCapabilities": ["hook"]

--- a/src/agent-sec-core/openclaw-plugin/package-lock.json
+++ b/src/agent-sec-core/openclaw-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-sec-openclaw-plugin",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "devDependencies": {
         "@types/node": ">=22",
         "c8": "^10.1.0",

--- a/src/agent-sec-core/openclaw-plugin/package.json
+++ b/src/agent-sec-core/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-openclaw-plugin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
+++ b/src/agent-sec-core/qoder-plugin/.qoder-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-sec-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Agent security core hooks for Qoder CLI."
 }

--- a/src/agent-sec-core/qwen-code-extension/qwen-extension.json
+++ b/src/agent-sec-core/qwen-code-extension/qwen-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-sec-core-qwen-code-extension",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "ANOLISA security integration for Qwen Code",
   "hooks": {
     "UserPromptSubmit": [


### PR DESCRIPTION
## Why

`release/agent-sec-core/v0.11.0` 分支已合入 10 个 sec-core 修复与文档 PR，需要发布
0.11.1 补丁版本，把版本标识和发布材料一次性对齐。

## What changed

- 将版本号从 `0.11.0` 更新为 `0.11.1`：component 声明、CLI Python 包元数据与
  `__init__.py`、Cargo 包与 lock、uv.lock、`spec.in`，以及 codex / cosh / hermes /
  openclaw / qoder / qwen-code 六个宿主插件清单。
- `spec.in` `%changelog` 新增 `0.11.1-1` 条目。
- `CHANGELOG.md` 新增 `0.11.1` section，按交付能力分组覆盖本轮全部 10 个 PR：
  - Prompt Scanner：#2900 #2893 #2892 #2886
  - Skill Ledger Runtime：#2906 #2876
  - Asset Verification：#2875
  - Security Events & CLI：#2873
  - Documentation：#2887 #2895

## Related issue

no-issue: 版本发布类变更，无对应 issue

## User / Agent impact

None。本 PR 只更新版本标识与 CHANGELOG，不改变任何运行时行为；用户可感知的变化由
本轮已合入的各修复 PR 提供。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk。纯版本号与文档更新，`agent-sec-cli --version` 及各插件清单版本随之显示
0.11.1。

## Validation

- 逐个核对 10 个 PR 的正文与 files，确认 CHANGELOG 分组与实际交付范围一致
- 确认变更文件中不存在遗留的 `0.11.0` 版本标识（仅历史 `%changelog` 条目与第三方包
  版本保留）
- `git diff --check` 无空白问题
- 提交前确认 Cargo.toml / Cargo.lock / uv.lock 中 release 分支独有的依赖未被覆盖

## Documentation and rollback

`CHANGELOG.md` 新增 0.11.1 section，无其他文档变更。回滚方式为 revert 本 commit，
不涉及数据或配置迁移。
