### PR TITLE
refactor(anolisa): separate terminal failures

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/adopt.rs
@@ -480,7 +480,7 @@ mod tests {
         assert!(!steps.is_empty());
         assert_eq!(
             outcome.status(),
-            anolisa_core::execution::CommandOutcomeStatus::Completed
+            &anolisa_core::execution::CommandOutcomeStatus::Completed
         );
         assert!(outcome.operation_id().is_some());
         assert_eq!(outcome.changes(), &[AdoptChange::RecordCreated]);

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -2148,7 +2148,7 @@ mod tests {
         assert_eq!(subject.version.as_deref(), Some("2.3.0"));
         assert_eq!(subject.backend, "rpm");
         assert!(!steps.is_empty());
-        assert_eq!(command_outcome.status(), CommandOutcomeStatus::Completed);
+        assert_eq!(command_outcome.status(), &CommandOutcomeStatus::Completed);
         assert!(command_outcome.operation_id().is_some());
         assert_eq!(
             command_outcome.changes(),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair.rs
@@ -1969,21 +1969,18 @@ fn render_application_outcome(
             outcome,
             manifest_reconciliation,
         } => {
-            if matches!(
-                outcome.status(),
-                anolisa_core::execution::CommandOutcomeStatus::Partial
-            ) {
-                let reason = outcome
-                    .warnings()
-                    .first()
-                    .expect("partial repair outcome carries its reconciliation failure");
-                return Err(CliError::Runtime {
-                    command,
-                    reason: reason.clone(),
-                });
-            }
             for warning in outcome.warnings() {
                 eprintln!("warning: {warning}");
+            }
+            match outcome.status() {
+                anolisa_core::execution::CommandOutcomeStatus::Completed => {}
+                anolisa_core::execution::CommandOutcomeStatus::Partial { reason }
+                | anolisa_core::execution::CommandOutcomeStatus::Failed { reason } => {
+                    return Err(CliError::Runtime {
+                        command,
+                        reason: reason.clone(),
+                    });
+                }
             }
             RepairResultPayload {
                 component: subject.component,
@@ -2115,6 +2112,39 @@ mod tests {
             },
             manifest_reconciliation: None,
         }
+    }
+
+    #[test]
+    fn failed_application_outcome_uses_its_terminal_reason() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let ctx = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        let outcome = application::ApplicationOutcome::Applied {
+            command: "repair cosh".to_string(),
+            subject: application::RepairSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            action: application::RepairAction::RefreshObservation,
+            steps: Vec::new(),
+            outcome: anolisa_core::execution::CommandOutcome::new(
+                anolisa_core::execution::CommandOutcomeStatus::Failed {
+                    reason: "native package transaction failed".to_string(),
+                },
+                None,
+                Vec::new(),
+                vec!["non-terminal diagnostic".to_string()],
+            ),
+            manifest_reconciliation: None,
+        };
+
+        let err = render_application_outcome(&ctx, outcome)
+            .expect_err("a failed outcome must use the error path");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert_eq!(err.exit_code(), 1);
+        assert_eq!(err.reason(), "native package transaction failed");
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/repair/application.rs
@@ -196,10 +196,10 @@ pub(super) fn partially_applied(
         action,
         steps,
         outcome: CommandOutcome::new(
-            CommandOutcomeStatus::Partial,
+            CommandOutcomeStatus::Partial { reason },
             Some(operation_id),
             vec![action.change()],
-            vec![reason],
+            Vec::new(),
         ),
         manifest_reconciliation,
     }
@@ -671,10 +671,36 @@ mod tests {
         let ApplicationOutcome::Applied { outcome, .. } = result else {
             panic!("expected applied repair outcome");
         };
-        assert_eq!(outcome.status(), CommandOutcomeStatus::Partial);
         assert_eq!(
-            outcome.warnings(),
-            ["component manifest reconciliation did not complete"]
+            outcome.status(),
+            &CommandOutcomeStatus::Partial {
+                reason: "component manifest reconciliation did not complete".to_string(),
+            }
         );
+        assert!(outcome.warnings().is_empty());
+    }
+
+    #[test]
+    fn completed_repair_keeps_non_terminal_warnings() {
+        let result = applied(
+            "repair cosh",
+            RepairSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            RepairAction::RefreshObservation,
+            vec![Step::WriteRecord(RecordWrite::RefreshObservation)],
+            "operation-1".to_string(),
+            vec!["service state needs verification".to_string()],
+            None,
+        );
+
+        let ApplicationOutcome::Applied { outcome, .. } = result else {
+            panic!("expected applied repair outcome");
+        };
+        assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+        assert_eq!(outcome.warnings(), ["service state needs verification"]);
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/uninstall.rs
@@ -176,7 +176,7 @@ fn render_outcome(ctx: &CliContext, outcome: ApplicationOutcome) -> Result<(), C
         } => {
             debug_assert_eq!(
                 outcome.status(),
-                anolisa_core::execution::CommandOutcomeStatus::Completed
+                &anolisa_core::execution::CommandOutcomeStatus::Completed
             );
             let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
             render_result(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1137,6 +1137,9 @@ fn render_application_outcome(
     ctx: &CliContext,
     application_outcome: application::ApplicationOutcome,
 ) -> ComponentUpdateResult {
+    for warning in application_outcome.warnings() {
+        eprintln!("warning: {warning}");
+    }
     let batch_outcome = application_outcome.batch_outcome()?;
     match application_outcome {
         application::ApplicationOutcome::NoOp { subject } => {
@@ -1177,9 +1180,6 @@ fn render_application_outcome(
             outcome,
             adapter_actions,
         } => {
-            for warning in outcome.warnings() {
-                eprintln!("warning: {warning}");
-            }
             let updated = matches!(batch_outcome, UpdateOutcome::Updated);
             let plan_labels: Vec<String> = steps.iter().map(step_label).collect();
             render_result(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -349,7 +349,7 @@ fn execute_merged_updates(
             },
             &suppressed_ctx,
         )?;
-        application::member_application_outcome(outcome)
+        Ok(application::member_application_outcome(outcome))
     };
     execute_merged_updates_with_deps(
         group,
@@ -746,13 +746,17 @@ fn execute_merged_updates_with_deps(
                         for warning in outcome.warnings {
                             output(BatchOutputEvent::Warning(warning));
                         }
-                        items.push(BatchMemberOutcome {
-                            component: name,
-                            status: batch_status(outcome.outcome, ExecutionIntent::Apply),
-                            reason: None,
-                            plan: None,
-                            adapter_actions: outcome.adapter_actions,
-                        });
+                        let item = match outcome.outcome {
+                            Ok(member) => BatchMemberOutcome {
+                                component: name.clone(),
+                                status: batch_status(member, ExecutionIntent::Apply),
+                                reason: None,
+                                plan: None,
+                                adapter_actions: outcome.adapter_actions,
+                            },
+                            Err(err) => failed_item(&name, err.reason().to_string()),
+                        };
+                        items.push(item);
                     }
                     Err(err) => items.push(failed_item(&name, err.reason().to_string())),
                 }
@@ -961,7 +965,7 @@ mod tests {
 
     fn applied_member(outcome: UpdateOutcome) -> MemberApplicationOutcome {
         MemberApplicationOutcome {
-            outcome,
+            outcome: Ok(outcome),
             warnings: Vec::new(),
             adapter_actions: Vec::new(),
         }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
@@ -93,7 +93,7 @@ pub(super) struct BatchEffectOutcome {
 
 /// Per-member fallback result returned to merged transaction orchestration.
 pub(super) struct MemberApplicationOutcome {
-    pub(super) outcome: UpdateOutcome,
+    pub(super) outcome: Result<UpdateOutcome, CliError>,
     pub(super) warnings: Vec<String>,
     pub(super) adapter_actions: Vec<AdapterAction>,
 }
@@ -225,21 +225,9 @@ pub(super) fn run(
                 intent: request.intent,
             },
             &suppressed_ctx,
-        )
-        .and_then(member_application_outcome);
+        );
         let item = match member {
-            Ok(member) => {
-                for warning in member.warnings {
-                    output(BatchOutputEvent::Warning(warning));
-                }
-                BatchMemberOutcome {
-                    component: name.clone(),
-                    status: batch_status(member.outcome, request.intent),
-                    reason: None,
-                    plan: None,
-                    adapter_actions: member.adapter_actions,
-                }
-            }
+            Ok(outcome) => project_member_application(name, request.intent, outcome, output),
             Err(error) => failed_item(name, error.reason().to_string()),
         };
         results.insert(name.clone(), item);
@@ -261,15 +249,39 @@ pub(super) fn run(
     })
 }
 
+fn project_member_application(
+    name: &str,
+    intent: ExecutionIntent,
+    outcome: update_application::ApplicationOutcome,
+    output: &mut dyn FnMut(BatchOutputEvent),
+) -> BatchMemberOutcome {
+    let member = member_application_outcome(outcome);
+    for warning in member.warnings {
+        output(BatchOutputEvent::Warning(warning));
+    }
+    match member.outcome {
+        Ok(outcome) => BatchMemberOutcome {
+            component: name.to_string(),
+            status: batch_status(outcome, intent),
+            reason: None,
+            plan: None,
+            adapter_actions: member.adapter_actions,
+        },
+        Err(error) => failed_item(name, error.reason().to_string()),
+    }
+}
+
 pub(super) fn member_application_outcome(
     outcome: update_application::ApplicationOutcome,
-) -> Result<MemberApplicationOutcome, CliError> {
-    let batch_outcome = outcome.batch_outcome()?;
-    Ok(MemberApplicationOutcome {
-        outcome: batch_outcome,
-        warnings: outcome.warnings().to_vec(),
-        adapter_actions: outcome.adapter_actions().to_vec(),
-    })
+) -> MemberApplicationOutcome {
+    let warnings = outcome.warnings().to_vec();
+    let adapter_actions = outcome.adapter_actions().to_vec();
+    let outcome = outcome.batch_outcome();
+    MemberApplicationOutcome {
+        outcome,
+        warnings,
+        adapter_actions,
+    }
 }
 
 pub(super) fn failed_item(name: &str, reason: String) -> BatchMemberOutcome {
@@ -292,6 +304,8 @@ pub(super) fn batch_status(outcome: UpdateOutcome, intent: ExecutionIntent) -> B
 
 #[cfg(test)]
 mod tests {
+    use anolisa_core::execution::{CommandOutcome, CommandOutcomeStatus};
+
     use super::*;
 
     #[test]
@@ -322,5 +336,47 @@ mod tests {
 
         assert!(outcome.has_failures());
         assert!(!outcome.is_preview());
+    }
+
+    #[test]
+    fn member_warning_is_surfaced_before_terminal_failure() {
+        let outcome = update_application::ApplicationOutcome::Applied {
+            command: "update cosh".to_string(),
+            subject: update_application::UpdateSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            steps: Vec::new(),
+            outcome: CommandOutcome::new(
+                CommandOutcomeStatus::Partial {
+                    reason: "manifest reconciliation did not complete".to_string(),
+                },
+                Some("operation-1".to_string()),
+                vec![update_application::UpdateChange::NativePackageUpdated],
+                vec!["service state needs verification".to_string()],
+            ),
+            adapter_actions: Vec::new(),
+        };
+        let mut events = Vec::new();
+
+        let item =
+            project_member_application("cosh", ExecutionIntent::Apply, outcome, &mut |event| {
+                events.push(event)
+            });
+
+        assert_eq!(item.status, BatchMemberStatus::Failed);
+        assert_eq!(
+            item.reason.as_deref(),
+            Some(
+                "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile"
+            )
+        );
+        assert_eq!(events.len(), 1);
+        let BatchOutputEvent::Warning(warning) = events.pop().expect("warning event") else {
+            panic!("expected warning event");
+        };
+        assert_eq!(warning, "service state needs verification");
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
@@ -89,26 +89,24 @@ impl ApplicationOutcome {
                 subject,
                 outcome,
                 ..
-            } => {
-                if matches!(outcome.status(), CommandOutcomeStatus::Partial) {
-                    let reason = outcome
-                        .warnings()
-                        .first()
-                        .expect("partial update outcome carries its reconciliation failure");
-                    return Err(CliError::Runtime {
-                        command: command.clone(),
-                        reason: format!(
-                            "the update of '{}' committed, but {reason}; run `anolisa repair {}` to reconcile",
-                            subject.component, subject.component
-                        ),
-                    });
-                }
-                Ok(if outcome.changes().is_empty() {
+            } => match outcome.status() {
+                CommandOutcomeStatus::Completed => Ok(if outcome.changes().is_empty() {
                     super::UpdateOutcome::AlreadyCurrent
                 } else {
                     super::UpdateOutcome::Updated
-                })
-            }
+                }),
+                CommandOutcomeStatus::Partial { reason } => Err(CliError::Runtime {
+                    command: command.clone(),
+                    reason: format!(
+                        "the update of '{}' committed, but {reason}; run `anolisa repair {}` to reconcile",
+                        subject.component, subject.component
+                    ),
+                }),
+                CommandOutcomeStatus::Failed { reason } => Err(CliError::Runtime {
+                    command: command.clone(),
+                    reason: reason.clone(),
+                }),
+            },
         }
     }
 
@@ -423,17 +421,15 @@ fn apply_delegated(
         to_version.as_deref(),
         completion_failure.as_deref(),
     );
-    let status = if completion_failure.is_some() {
-        CommandOutcomeStatus::Partial
-    } else {
-        CommandOutcomeStatus::Completed
-    };
     let changes = updated
         .then_some(UpdateChange::NativePackageUpdated)
         .into_iter()
         .collect();
-    let warnings = completion_failure.into_iter().collect();
-    let adapter_actions = if updated && matches!(status, CommandOutcomeStatus::Completed) {
+    let status = match completion_failure {
+        Some(reason) => CommandOutcomeStatus::Partial { reason },
+        None => CommandOutcomeStatus::Completed,
+    };
+    let adapter_actions = if updated && matches!(&status, CommandOutcomeStatus::Completed) {
         adapter_actions_after_update(ctx, &store, target, &prior_adapter_revisions)
     } else {
         Vec::new()
@@ -448,7 +444,7 @@ fn apply_delegated(
             to_version,
         },
         steps,
-        outcome: CommandOutcome::new(status, Some(operation_id), changes, warnings),
+        outcome: CommandOutcome::new(status, Some(operation_id), changes, Vec::new()),
         adapter_actions,
     })
 }
@@ -598,6 +594,26 @@ mod tests {
 
     use super::*;
 
+    fn applied_outcome(status: CommandOutcomeStatus, warnings: Vec<String>) -> ApplicationOutcome {
+        ApplicationOutcome::Applied {
+            command: "update cosh".to_string(),
+            subject: UpdateSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            steps: Vec::new(),
+            outcome: CommandOutcome::new(
+                status,
+                Some("operation-1".to_string()),
+                vec![UpdateChange::NativePackageUpdated],
+                warnings,
+            ),
+            adapter_actions: Vec::new(),
+        }
+    }
+
     #[test]
     fn plan_intent_never_prepares_update_effects() {
         let plan = Plan::Execute {
@@ -629,5 +645,59 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[test]
+    fn completed_batch_outcome_preserves_non_terminal_warnings() {
+        let outcome = applied_outcome(
+            CommandOutcomeStatus::Completed,
+            vec!["service state needs verification".to_string()],
+        );
+
+        assert_eq!(
+            outcome.batch_outcome().expect("completed update"),
+            super::super::UpdateOutcome::Updated
+        );
+        assert_eq!(outcome.warnings(), ["service state needs verification"]);
+    }
+
+    #[test]
+    fn partial_batch_outcome_uses_terminal_reason_not_warning_order() {
+        let outcome = applied_outcome(
+            CommandOutcomeStatus::Partial {
+                reason: "manifest reconciliation did not complete".to_string(),
+            },
+            vec!["service state needs verification".to_string()],
+        );
+
+        let err = outcome
+            .batch_outcome()
+            .expect_err("partial update must use the error path");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert_eq!(err.exit_code(), 1);
+        assert_eq!(
+            err.reason(),
+            "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile"
+        );
+        assert_eq!(outcome.warnings(), ["service state needs verification"]);
+    }
+
+    #[test]
+    fn failed_batch_outcome_uses_its_terminal_reason() {
+        let outcome = applied_outcome(
+            CommandOutcomeStatus::Failed {
+                reason: "native package transaction failed".to_string(),
+            },
+            vec!["service state needs verification".to_string()],
+        );
+
+        let err = outcome
+            .batch_outcome()
+            .expect_err("failed update must use the error path");
+
+        assert_eq!(err.code(), "EXECUTION_FAILED");
+        assert_eq!(err.exit_code(), 1);
+        assert_eq!(err.reason(), "native package transaction failed");
     }
 }

--- a/src/anolisa/crates/anolisa-core/src/execution.rs
+++ b/src/anolisa/crates/anolisa-core/src/execution.rs
@@ -52,14 +52,20 @@ pub enum PreparedExecution {
 }
 
 /// Terminal classification of an applied command.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandOutcomeStatus {
     /// The requested work completed without a terminal failure.
     Completed,
     /// Some effects completed, but the operation needs reconciliation.
-    Partial,
+    Partial {
+        /// Why the applied work requires reconciliation.
+        reason: String,
+    },
     /// The operation failed without reporting partial completion.
-    Failed,
+    Failed {
+        /// Why the operation could not complete.
+        reason: String,
+    },
 }
 
 /// Typed terminal result returned by a lifecycle application service.
@@ -88,8 +94,8 @@ impl<C> CommandOutcome<C> {
     }
 
     /// Returns the terminal classification.
-    pub fn status(&self) -> CommandOutcomeStatus {
-        self.status
+    pub fn status(&self) -> &CommandOutcomeStatus {
+        &self.status
     }
 
     /// Returns the durable operation identifier when one was created.
@@ -156,26 +162,67 @@ mod tests {
     }
 
     #[test]
-    fn terminal_outcomes_preserve_all_evidence() {
-        for status in [
+    fn completed_outcome_preserves_non_terminal_evidence() {
+        let outcome = CommandOutcome::new(
             CommandOutcomeStatus::Completed,
-            CommandOutcomeStatus::Partial,
-            CommandOutcomeStatus::Failed,
-        ] {
-            let outcome = CommandOutcome::new(
-                status,
-                Some("op-adopt-1".to_string()),
-                vec!["tokenless"],
-                vec!["service state needs verification".to_string()],
-            );
+            Some("op-adopt-1".to_string()),
+            vec!["tokenless"],
+            vec!["service state needs verification".to_string()],
+        );
 
-            assert_eq!(outcome.status(), status);
-            assert_eq!(outcome.operation_id(), Some("op-adopt-1"));
-            assert_eq!(outcome.changes(), &["tokenless"]);
-            assert_eq!(
-                outcome.warnings(),
-                &["service state needs verification".to_string()]
-            );
-        }
+        assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+        assert_eq!(outcome.operation_id(), Some("op-adopt-1"));
+        assert_eq!(outcome.changes(), &["tokenless"]);
+        assert_eq!(
+            outcome.warnings(),
+            &["service state needs verification".to_string()]
+        );
+    }
+
+    #[test]
+    fn partial_outcome_separates_failure_from_warnings() {
+        let outcome = CommandOutcome::new(
+            CommandOutcomeStatus::Partial {
+                reason: "manifest reconciliation failed".to_string(),
+            },
+            Some("op-update-1".to_string()),
+            vec!["tokenless"],
+            vec!["service state needs verification".to_string()],
+        );
+
+        assert_eq!(
+            outcome.status(),
+            &CommandOutcomeStatus::Partial {
+                reason: "manifest reconciliation failed".to_string(),
+            }
+        );
+        assert_eq!(outcome.operation_id(), Some("op-update-1"));
+        assert_eq!(outcome.changes(), &["tokenless"]);
+        assert_eq!(
+            outcome.warnings(),
+            &["service state needs verification".to_string()]
+        );
+    }
+
+    #[test]
+    fn failed_outcome_requires_a_terminal_reason() {
+        let outcome = CommandOutcome::<&str>::new(
+            CommandOutcomeStatus::Failed {
+                reason: "package transaction failed".to_string(),
+            },
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
+
+        assert_eq!(
+            outcome.status(),
+            &CommandOutcomeStatus::Failed {
+                reason: "package transaction failed".to_string(),
+            }
+        );
+        assert_eq!(outcome.operation_id(), None);
+        assert!(outcome.changes().is_empty());
+        assert!(outcome.warnings().is_empty());
     }
 }


### PR DESCRIPTION
## Why

Partial and failed command outcomes currently encode terminal failure details in the first warning. This conflates fatal state with non-terminal diagnostics and makes command projection depend on warning order.

## What changed

CommandOutcomeStatus::Partial and Failed now carry an explicit reason, while warnings remain independent non-terminal diagnostics. Repair and update exhaustively project completed, partial, and failed outcomes without changing existing CLI text, JSON schema, exit codes, durable operation state, or adapter follow-up behavior.

## Related issue

closes #2932

Related to #2702.

## User / Agent impact

None. Existing CLI, human output, JSON schema, error codes, exit codes, and execution behavior are preserved.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The shared Rust outcome API changes at compile time: consumers constructing or matching partial and failed statuses must handle their reasons. All in-workspace consumers were migrated, while the public CLI and wire formats remain unchanged.

## Validation

Local:

- cargo fmt --all
- cargo fmt --all -- --check
- cargo test -p anolisa-core execution --locked
- cargo test -p anolisa-cli repair --locked
- cargo test -p anolisa-cli update --locked
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p anolisa-cli --locked
- cargo test --workspace --locked
- cargo doc --workspace --no-deps --locked
- git diff --check

ALinux 4 using anolisa/alinux4-rust-selftest:20260824, an ephemeral container, a read-only source mount, and isolated target directories:

- Core execution tests: 6 passed.
- Repair unit tests: 81 passed; the scope identity test also passed as a non-root user.
- Update adapter integration tests: 5 passed; the new terminal outcome tests passed.
- One existing raw capability hydration fixture is not applicable inside containers because capability inference intentionally disables itself there; the complete host workspace suite passed, including that fixture.

## Documentation and rollback

The local refactoring roadmap was updated for tracking but remains untracked and is not part of this PR. Roll back by reverting commit ac71df02.