### PR TITLE
ci(tokenless): publish Python wheels

### DIFF
--- a/.github/actions/build-tokenless-prebuilt/action.yaml
+++ b/.github/actions/build-tokenless-prebuilt/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: Prepared Cross release profile.
     required: true
   tag:
-    description: Release tag to bind to the checked-out commit. Empty for previews.
+    description: Exact Tokenless source tag to bind; empty uses the checked-out commit.
     required: false
     default: ''
 
@@ -23,6 +23,9 @@ outputs:
   artifact-directory:
     description: Directory containing the tar, checksums, and CycloneDX SBOM.
     value: ${{ steps.build.outputs.artifact-directory }}
+  wheel-directory:
+    description: Directory containing the Python wheels for this target.
+    value: ${{ steps.build.outputs.wheel-directory }}
 
 runs:
   using: composite
@@ -31,6 +34,11 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+
+    - name: Select uv
+      uses: astral-sh/setup-uv@v8.0.0
+      with:
+        version: '0.11.7'
 
     - name: Select Node.js 22
       uses: actions/setup-node@v4
@@ -42,6 +50,8 @@ runs:
       shell: bash
       env:
         TOKENLESS_OUTPUT_DIR: ${{ runner.temp }}/tokenless-prebuilt-${{ inputs.target-os }}-${{ inputs.target-arch }}
+        TOKENLESS_WHEEL_DIR: ${{ runner.temp }}/tokenless-python-wheels-${{ inputs.target-os }}-${{ inputs.target-arch }}
+        TOKENLESS_SOURCE_WORKTREE: ${{ runner.temp }}/anolisa-raw-release-source-worktrees/tokenless
         TOKENLESS_VERSION: ${{ inputs.version }}
         TOKENLESS_TARGET_OS: ${{ inputs.target-os }}
         TOKENLESS_TARGET_ARCH: ${{ inputs.target-arch }}
@@ -51,9 +61,11 @@ runs:
         "$GITHUB_ACTION_PATH/build.sh" \
           --source-repo "$GITHUB_WORKSPACE" \
           --output-dir "$TOKENLESS_OUTPUT_DIR" \
+          --wheel-output-dir "$TOKENLESS_WHEEL_DIR" \
           --version "$TOKENLESS_VERSION" \
           --target-os "$TOKENLESS_TARGET_OS" \
           --target-arch "$TOKENLESS_TARGET_ARCH" \
           --profile "$TOKENLESS_PROFILE" \
           --tag "$TOKENLESS_TAG"
         echo "artifact-directory=$TOKENLESS_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+        echo "wheel-directory=$TOKENLESS_WHEEL_DIR" >> "$GITHUB_OUTPUT"

--- a/.github/actions/build-tokenless-prebuilt/build.sh
+++ b/.github/actions/build-tokenless-prebuilt/build.sh
@@ -12,7 +12,10 @@ PROFILE=""
 TAG=""
 SOURCE_REPO=""
 OUTPUT_DIR=""
+WHEEL_OUTPUT_DIR=""
 WORKTREE_READY=0
+MATURIN_VERSION=1.15.0
+PYPROJECT_BUILD_VERSION=1.3.0
 
 die() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -21,7 +24,8 @@ die() {
 
 usage() {
     cat <<'EOF'
-Usage: build.sh --source-repo PATH --output-dir PATH --version X.Y.Z \
+Usage: build.sh --source-repo PATH --output-dir PATH --wheel-output-dir PATH \
+  --version X.Y.Z \
   --target-os {linux|macos} --target-arch {x86_64|aarch64} \
   --profile PROFILE [--tag tokenless/vX.Y.Z]
 EOF
@@ -31,6 +35,7 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --source-repo) SOURCE_REPO="${2:-}"; shift 2 ;;
         --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+        --wheel-output-dir) WHEEL_OUTPUT_DIR="${2:-}"; shift 2 ;;
         --version) VERSION="${2:-}"; shift 2 ;;
         --target-os) TARGET_OS="${2:-}"; shift 2 ;;
         --target-arch) TARGET_ARCH="${2:-}"; shift 2 ;;
@@ -46,6 +51,7 @@ done
 [ -n "$PROFILE" ] || die '--profile is required'
 [ -n "$SOURCE_REPO" ] || die '--source-repo is required'
 [ -n "$OUTPUT_DIR" ] || die '--output-dir is required'
+[ -n "$WHEEL_OUTPUT_DIR" ] || die '--wheel-output-dir is required'
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || \
     die "invalid Tokenless version: $VERSION"
 
@@ -67,7 +73,7 @@ esac
 if [ -n "$TAG" ] && [ "$TAG" != "tokenless/v$VERSION" ]; then
     die "release tag $TAG does not match requested version $VERSION"
 fi
-for command in cargo flock git install just make node npm patch python3 sha256sum; do
+for command in cargo flock git install just make node npm patch python3 sha256sum uvx; do
     command -v "$command" >/dev/null || die "missing required command: $command"
 done
 SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
@@ -75,10 +81,8 @@ SOURCE_REPO="$(git -C "$SOURCE_REPO" rev-parse --show-toplevel)" || \
 SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
 
 if [ -n "$TAG" ]; then
-    TAG_COMMIT="$(git -C "$SOURCE_REPO" rev-parse --verify "refs/tags/$TAG^{commit}")" || \
+    SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse --verify "refs/tags/$TAG^{commit}")" || \
         die "release tag is unavailable in the checkout: $TAG"
-    [ "$TAG_COMMIT" = "$SOURCE_COMMIT" ] || \
-        die "release tag $TAG does not point at checked-out commit $SOURCE_COMMIT"
 fi
 
 install -d -m 0755 "$(dirname "$FIXED_WORKTREE")"
@@ -117,7 +121,7 @@ git -C "$SOURCE_REPO" worktree lock --reason 'Tokenless prebuilt package build' 
 COMPONENT_ROOT="$FIXED_WORKTREE/src/tokenless"
 (
     cd "$COMPONENT_ROOT"
-    make -B stamp-adapter-templates
+    make -B stamp-adapter-templates stamp-python-packages
 )
 CONTRACT="$COMPONENT_ROOT/.anolisa/component.toml"
 SOURCE_VERSION="$(
@@ -129,7 +133,7 @@ SOURCE_VERSION="$(
 (
     cd "$COMPONENT_ROOT"
     make build-openclaw-plugin build-dsh-plugin
-    just setup-rtk
+    bash "$ACTION_DIR/setup-rtk.sh" "$COMPONENT_ROOT"
 )
 RTK_ROOT="$COMPONENT_ROOT/third_party/rtk"
 # RTK is excluded from Tokenless's workspace; make its cloned source an explicit
@@ -139,7 +143,12 @@ printf '\n[workspace]\n' >> "$RTK_ROOT/Cargo.toml"
 if [ -e "$OUTPUT_DIR" ] && [ -n "$(find "$OUTPUT_DIR" -mindepth 1 -print -quit)" ]; then
     die "output directory must be empty: $OUTPUT_DIR"
 fi
+if [ -e "$WHEEL_OUTPUT_DIR" ] && \
+    [ -n "$(find "$WHEEL_OUTPUT_DIR" -mindepth 1 -print -quit)" ]; then
+    die "wheel output directory must be empty: $WHEEL_OUTPUT_DIR"
+fi
 install -d -m 0755 "$OUTPUT_DIR"
+install -d -m 0755 "$WHEEL_OUTPUT_DIR"
 SOURCE_DATE_EPOCH="$(git -C "$FIXED_WORKTREE" show -s --format=%ct HEAD)"
 case "$SOURCE_DATE_EPOCH" in
     '' | *[!0-9]*) die 'source commit timestamp is not numeric' ;;
@@ -172,6 +181,55 @@ done
         --locked \
         --manifest-path src/tokenless/third_party/rtk/Cargo.toml
 )
+
+HOST_CARGO="$(command -v cargo)"
+CARGO_SHIM_DIR="$COMPONENT_ROOT/target/maturin-cargo-shim"
+install -d -m 0755 "$CARGO_SHIM_DIR"
+ln -s "$ACTION_DIR/cargo-shim.sh" "$CARGO_SHIM_DIR/cargo"
+PYTHON_RTK_DIR="$COMPONENT_ROOT/python/tokenless/python/anolisa_tokenless/_bin"
+(
+    set -e
+    install -d -m 0755 "$PYTHON_RTK_DIR"
+    install -p -m 0755 \
+        "$RTK_ROOT/target/$RUST_TARGET/release/rtk" \
+        "$PYTHON_RTK_DIR/rtk"
+    trap 'rm -f "$PYTHON_RTK_DIR/rtk"' EXIT
+    cd "$COMPONENT_ROOT/python/tokenless"
+    compatibility=(--compatibility pypi)
+    if [ "$TARGET_OS" = linux ]; then
+        compatibility=(--compatibility manylinux2014)
+    else
+        export MACOSX_DEPLOYMENT_TARGET=11.0
+    fi
+    PATH="$CARGO_SHIM_DIR:$PATH" \
+    TOKENLESS_HOST_CARGO="$HOST_CARGO" \
+    TOKENLESS_CROSS_PROFILE_SCRIPT="$COMMON_DIR/cross-profile.sh" \
+    TOKENLESS_CROSS_PROFILE="$PROFILE" \
+    TOKENLESS_RUST_TARGET="$RUST_TARGET" \
+        python3 "$COMMON_DIR/reproducible-build.py" \
+            --source-root "$COMPONENT_ROOT" \
+            --source-date-epoch "$SOURCE_DATE_EPOCH" \
+            -- uvx --from "maturin==$MATURIN_VERSION" maturin build \
+            --profile python-release \
+            --interpreter python3 \
+            --target "$RUST_TARGET" \
+            --locked \
+            "${compatibility[@]}" \
+            --auditwheel check \
+            --out "$WHEEL_OUTPUT_DIR"
+)
+if [ "$TARGET_OS/$TARGET_ARCH" = linux/x86_64 ]; then
+    uvx --from "build==$PYPROJECT_BUILD_VERSION" pyproject-build \
+        --wheel \
+        --outdir "$WHEEL_OUTPUT_DIR" \
+        "$COMPONENT_ROOT/python/agentscope"
+fi
+python3 "$ACTION_DIR/verify-wheels.py" \
+    --directory "$WHEEL_OUTPUT_DIR" \
+    --version "$VERSION" \
+    --layout flat \
+    --os "$TARGET_OS" \
+    --arch "$TARGET_ARCH"
 
 BIN_DIR="$COMPONENT_ROOT/target/raw-prebuilt/$RUST_TARGET"
 install -d -m 0755 "$BIN_DIR"
@@ -223,3 +281,5 @@ python3 "$COMMON_DIR/verify-artifacts.py" \
     --arch "$TARGET_ARCH"
 printf 'Built Tokenless %s for %s/%s at %s\n' \
     "$VERSION" "$TARGET_OS" "$TARGET_ARCH" "$OUTPUT_DIR"
+printf 'Built Tokenless Python wheels for %s/%s at %s\n' \
+    "$TARGET_OS" "$TARGET_ARCH" "$WHEEL_OUTPUT_DIR"

--- a/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
+++ b/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Keep Maturin metadata on the host and route compilation through the release Cross profile.
+set -euo pipefail
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+HOST_CARGO="${TOKENLESS_HOST_CARGO:?TOKENLESS_HOST_CARGO is required}"
+CROSS_PROFILE_SCRIPT="${TOKENLESS_CROSS_PROFILE_SCRIPT:?TOKENLESS_CROSS_PROFILE_SCRIPT is required}"
+PROFILE="${TOKENLESS_CROSS_PROFILE:?TOKENLESS_CROSS_PROFILE is required}"
+EXPECTED_TARGET="${TOKENLESS_RUST_TARGET:?TOKENLESS_RUST_TARGET is required}"
+
+case "$PROFILE/$EXPECTED_TARGET" in
+    gnu2.17-x86_64/x86_64-unknown-linux-gnu | \
+    gnu2.17-aarch64/aarch64-unknown-linux-gnu | \
+    darwin11-aarch64/aarch64-apple-darwin) ;;
+    *) die "Cross profile $PROFILE does not match target $EXPECTED_TARGET" ;;
+esac
+[ -x "$HOST_CARGO" ] || die "host Cargo is not executable: $HOST_CARGO"
+[ -x "$CROSS_PROFILE_SCRIPT" ] || \
+    die "Cross profile script is not executable: $CROSS_PROFILE_SCRIPT"
+
+case "${1:-}" in
+    metadata | locate-project | --version | -V)
+        exec "$HOST_CARGO" "$@"
+        ;;
+    build | rustc)
+        command_name="$1"
+        shift
+        arguments=()
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --target)
+                    [ "$#" -ge 2 ] || die '--target requires a value'
+                    [ "$2" = "$EXPECTED_TARGET" ] || \
+                        die "Maturin requested target $2, expected $EXPECTED_TARGET"
+                    shift 2
+                    ;;
+                --target=*)
+                    requested_target="${1#--target=}"
+                    [ "$requested_target" = "$EXPECTED_TARGET" ] || \
+                        die "Maturin requested target $requested_target, expected $EXPECTED_TARGET"
+                    shift
+                    ;;
+                *)
+                    arguments+=("$1")
+                    shift
+                    ;;
+            esac
+        done
+        exec "$CROSS_PROFILE_SCRIPT" "$PROFILE" "$command_name" "${arguments[@]}"
+        ;;
+    *)
+        die "unsupported Maturin Cargo command: ${1:-<empty>}"
+        ;;
+esac

--- a/.github/actions/build-tokenless-prebuilt/setup-rtk.sh
+++ b/.github/actions/build-tokenless-prebuilt/setup-rtk.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Fetch the immutable RTK source required by current and historical Tokenless trees.
+set -euo pipefail
+
+RTK_REPOSITORY="https://github.com/rtk-ai/rtk.git"
+TEMPORARY=""
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$TEMPORARY" ] && [ -d "$TEMPORARY" ]; then
+        rm -rf -- "$TEMPORARY"
+    fi
+}
+trap cleanup EXIT
+
+[ "$#" -eq 1 ] || die 'usage: setup-rtk.sh COMPONENT_ROOT'
+COMPONENT_ROOT="$(cd "$1" && pwd)"
+RTK_DIR="$COMPONENT_ROOT/third_party/rtk"
+
+if [ -f "$COMPONENT_ROOT/scripts/setup-rtk.sh" ]; then
+    bash "$COMPONENT_ROOT/scripts/setup-rtk.sh" "$RTK_DIR"
+    exit 0
+fi
+
+RTK_RELEASE="$(
+    sed -n 's/^rtk_tag[[:space:]]*:=[[:space:]]*"\(.*\)"/\1/p' \
+        "$COMPONENT_ROOT/justfile"
+)"
+case "$RTK_RELEASE" in
+    v0.43.0) RTK_COMMIT="5a7880d404db8364d602f2ecdc41dd790f64013f" ;;
+    *) die "unsupported historical RTK release: ${RTK_RELEASE:-missing}" ;;
+esac
+
+[ ! -e "$RTK_DIR" ] || die "RTK destination already exists: $RTK_DIR"
+install -d -m 0755 "$(dirname "$RTK_DIR")"
+TEMPORARY="$(mktemp -d "${RTK_DIR}.tmp.XXXXXX")"
+git init --quiet "$TEMPORARY"
+git -C "$TEMPORARY" remote add origin "$RTK_REPOSITORY"
+git -C "$TEMPORARY" fetch --quiet --depth 1 origin "$RTK_COMMIT"
+git -C "$TEMPORARY" checkout --quiet --detach "$RTK_COMMIT"
+[ "$(git -C "$TEMPORARY" rev-parse HEAD)" = "$RTK_COMMIT" ] || \
+    die "fetched RTK does not match pinned commit $RTK_COMMIT"
+
+patch --forward -p1 --no-backup-if-mismatch \
+    -d "$TEMPORARY" < "$COMPONENT_ROOT/third_party/patches/rtk-tokenless-stats.patch"
+patch --forward -p1 --no-backup-if-mismatch \
+    -d "$TEMPORARY" < "$COMPONENT_ROOT/third_party/patches/rtk-pytest-error-report.patch"
+printf '%s\n' "$RTK_COMMIT" > "$TEMPORARY/.anolisa-rtk-commit"
+
+mv "$TEMPORARY" "$RTK_DIR"
+TEMPORARY=""
+printf 'RTK %s setup complete at %s\n' "$RTK_RELEASE" "$RTK_COMMIT"

--- a/.github/actions/build-tokenless-prebuilt/test.sh
+++ b/.github/actions/build-tokenless-prebuilt/test.sh
@@ -6,20 +6,32 @@ ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMON_DIR="$(cd "$ACTION_DIR/../prebuilt-rust-common" && pwd)"
 REPO_ROOT="$(git -C "$ACTION_DIR" rev-parse --show-toplevel)"
 TEMPORARY="$(mktemp -d)"
-trap 'rm -rf -- "$TEMPORARY"' EXIT
+HISTORICAL_ARCHIVE_NAME="tokenless-historical-${TEMPORARY##*/}"
+HISTORICAL_BUILD="/tmp/build/$HISTORICAL_ARCHIVE_NAME"
+HISTORICAL_DRIFT_BUILD="${HISTORICAL_BUILD}-drift"
+trap 'rm -rf -- "$TEMPORARY" "$HISTORICAL_BUILD" "$HISTORICAL_DRIFT_BUILD"' EXIT
 
-python3 - "$ACTION_DIR/action.yaml" <<'PY'
+python3 - \
+    "$ACTION_DIR/action.yaml" \
+    "$REPO_ROOT/.github/workflows/release-preview.yaml" \
+    "$ACTION_DIR/build.sh" <<'PY'
 import sys
 from pathlib import Path
 
 
 action = Path(sys.argv[1]).read_text(encoding="utf-8")
+pinned_uv = "uses: astral-sh/setup-uv@v8.0.0\n      with:\n        version: '0.11.7'"
+if pinned_uv not in action:
+    raise SystemExit("composite action does not install the pinned uv release")
 expected_bindings = (
+    "TOKENLESS_WHEEL_DIR: ${{ runner.temp }}/tokenless-python-wheels-${{ inputs.target-os }}-${{ inputs.target-arch }}",
+    "TOKENLESS_SOURCE_WORKTREE: ${{ runner.temp }}/anolisa-raw-release-source-worktrees/tokenless",
     "TOKENLESS_VERSION: ${{ inputs.version }}",
     "TOKENLESS_TARGET_OS: ${{ inputs.target-os }}",
     "TOKENLESS_TARGET_ARCH: ${{ inputs.target-arch }}",
     "TOKENLESS_PROFILE: ${{ inputs.profile }}",
     "TOKENLESS_TAG: ${{ inputs.tag }}",
+    "wheel-directory=$TOKENLESS_WHEEL_DIR",
 )
 for binding in expected_bindings:
     if binding not in action:
@@ -31,6 +43,36 @@ if marker not in action:
 run_block = action.split(marker, 1)[1]
 if "${{ inputs." in run_block:
     raise SystemExit("composite action interpolates an input directly into Bash")
+
+preview = Path(sys.argv[2]).read_text(encoding="utf-8")
+expected_preview_bindings = (
+    "      - uses: actions/checkout@v4\n\n      - name: Checkout Tokenless source tag",
+    "if: inputs.tokenless_source_tag != ''",
+    "description: 'Optional exact Tokenless source tag with Python packaging (v0.7.7+, e.g. tokenless/v0.7.14)'",
+    'if [ "$SOURCE_TAG" != "tokenless/v$VERSION" ]; then',
+    "ref: ${{ format('refs/tags/{0}', inputs.tokenless_source_tag) }}",
+    "path: tokenless-source",
+    "tokenless-source-root: ${{ inputs.tokenless_source_tag != '' && 'tokenless-source' || '.' }}",
+    "python3 .github/actions/prebuilt-rust-common/plan_matrix.py",
+)
+for binding in expected_preview_bindings:
+    if binding not in preview:
+        raise SystemExit(f"preview workflow does not bind every artifact to the source tag: {binding}")
+
+build = Path(sys.argv[3]).read_text(encoding="utf-8")
+if 'bash "$ACTION_DIR/setup-rtk.sh" "$COMPONENT_ROOT"' not in build:
+    raise SystemExit("prebuilt build does not use the shared immutable RTK setup")
+maturin = build.index('uvx --from "maturin==$MATURIN_VERSION" maturin build')
+wrapper = build.rfind('python3 "$COMMON_DIR/reproducible-build.py"', 0, maturin)
+if wrapper == -1:
+    raise SystemExit("Maturin build does not use the reproducible environment")
+wrapped_command = build[wrapper:maturin]
+for binding in (
+    '--source-root "$COMPONENT_ROOT"',
+    '--source-date-epoch "$SOURCE_DATE_EPOCH"',
+):
+    if binding not in wrapped_command:
+        raise SystemExit(f"Maturin reproducible build is missing: {binding}")
 PY
 
 python3 - "$REPO_ROOT/.github/actions/package-source/action.yaml" <<'PY'
@@ -39,25 +81,147 @@ from pathlib import Path
 
 
 action = Path(sys.argv[1]).read_text(encoding="utf-8")
-if "bash scripts/setup-rtk.sh third_party/rtk" not in action:
-    raise SystemExit("source packaging does not use the pinned RTK setup script")
-if "RTK_TAG=" in action or "git clone --depth 1 --branch" in action:
+setup_command = (
+    'bash "$GITHUB_ACTION_PATH/../build-tokenless-prebuilt/setup-rtk.sh" "$PWD"'
+)
+if setup_command not in action:
+    raise SystemExit("source packaging does not use the shared immutable RTK setup")
+if "git clone --depth 1 --branch" in action:
     raise SystemExit("source packaging still resolves RTK through a mutable tag")
+expected_source_root_bindings = (
+    "tokenless-source-root:",
+    "TOKENLESS_SOURCE_ROOT: ${{ inputs.tokenless-source-root }}",
+    'tokenless)     SRC_DIR="${TOKENLESS_SOURCE_ROOT}/src/tokenless" ;;',
+)
+for binding in expected_source_root_bindings:
+    if binding not in action:
+        raise SystemExit(f"source packaging does not isolate tagged Tokenless sources: {binding}")
 PY
 
-RTK_SETUP="$REPO_ROOT/src/tokenless/scripts/setup-rtk.sh"
-PINNED_RTK_COMMIT="$(
-    sed -n 's/^RTK_COMMIT="\([0-9a-f]\{40\}\)"$/\1/p' "$RTK_SETUP"
-)"
-[ -n "$PINNED_RTK_COMMIT" ] || {
-    printf 'ERROR: RTK setup script has no pinned 40-character commit\n' >&2
+install -d -m 0755 "$HISTORICAL_BUILD"
+HISTORICAL_SOURCE_REF="refs/tags/tokenless/v0.7.12"
+if ! git cat-file -e "${HISTORICAL_SOURCE_REF}^{commit}" 2>/dev/null; then
+    git fetch --no-tags --depth=1 origin "$HISTORICAL_SOURCE_REF"
+    HISTORICAL_SOURCE_REF="FETCH_HEAD"
+fi
+git archive "${HISTORICAL_SOURCE_REF}:src/tokenless" | tar -x -C "$HISTORICAL_BUILD"
+[ ! -f "$HISTORICAL_BUILD/scripts/setup-rtk.sh" ] || {
+    printf 'ERROR: historical source fixture unexpectedly has setup-rtk.sh\n' >&2
     exit 1
 }
+cp -a "$HISTORICAL_BUILD" "$HISTORICAL_DRIFT_BUILD"
+
+HISTORICAL_RTK_SETUP="$ACTION_DIR/setup-rtk.sh"
+PINNED_RTK_COMMIT="$(
+    sed -n 's/^[[:space:]]*v0\.43\.0) RTK_COMMIT="\([0-9a-f]\{40\}\)".*/\1/p' \
+        "$HISTORICAL_RTK_SETUP"
+)"
+CURRENT_RTK_COMMIT="$(
+    sed -n 's/^RTK_COMMIT="\([0-9a-f]\{40\}\)"$/\1/p' \
+        "$REPO_ROOT/src/tokenless/scripts/setup-rtk.sh"
+)"
+[ -n "$PINNED_RTK_COMMIT" ] || {
+    printf 'ERROR: historical RTK setup has no pinned 40-character commit\n' >&2
+    exit 1
+}
+[ "$PINNED_RTK_COMMIT" = "$CURRENT_RTK_COMMIT" ] || {
+    printf 'ERROR: historical and current RTK commits differ\n' >&2
+    exit 1
+}
+
+HISTORICAL_FAKE_BIN="$TEMPORARY/historical-fake-bin"
+install -d -m 0755 "$HISTORICAL_FAKE_BIN"
+# shellcheck disable=SC2016  # Expand the fixture variables when the fake runs.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "$*" >> "$HISTORICAL_GIT_LOG"' \
+    'case "${1:-}" in' \
+    '    init)' \
+    '        destination="${!#}"' \
+    '        mkdir -p "$destination/.git"' \
+    '        ;;' \
+    '    -C)' \
+    '        repository="$2"' \
+    '        shift 2' \
+    '        case "${1:-}" in' \
+    '            remote | fetch) ;;' \
+    '            checkout)' \
+    '                printf "[workspace]\n" > "$repository/Cargo.toml"' \
+    '                printf "version = 3\n" > "$repository/Cargo.lock"' \
+    '                ;;' \
+    '            rev-parse) printf "%s\n" "$HISTORICAL_FAKE_HEAD" ;;' \
+    '            *) exit 91 ;;' \
+    '        esac' \
+    '        ;;' \
+    '    *) exit 92 ;;' \
+    'esac' \
+    > "$HISTORICAL_FAKE_BIN/git"
+# shellcheck disable=SC2016  # Expand the fixture variables when the fake runs.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\n" "$*" >> "$HISTORICAL_PATCH_LOG"' \
+    'cat >/dev/null' \
+    > "$HISTORICAL_FAKE_BIN/patch"
+chmod 0755 "$HISTORICAL_FAKE_BIN/git" "$HISTORICAL_FAKE_BIN/patch"
+
+python3 - "$REPO_ROOT/.github/actions/package-source/action.yaml" \
+    "$TEMPORARY/vendor-rtk-step.sh" <<'PY'
+import sys
+from pathlib import Path
+
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+start = lines.index("    - name: Vendor rtk source (tokenless)")
+run = lines.index("      run: |", start) + 1
+end = next(
+    index for index in range(run, len(lines)) if lines[index].startswith("    - name:")
+)
+script = "\n".join(line[8:] for line in lines[run:end]) + "\n"
+Path(sys.argv[2]).write_text(script, encoding="utf-8")
+PY
+HISTORICAL_GIT_LOG="$TEMPORARY/historical-git.log"
+HISTORICAL_PATCH_LOG="$TEMPORARY/historical-patch.log"
+PATH="$HISTORICAL_FAKE_BIN:$PATH" \
+    ARCHIVE_NAME="$HISTORICAL_ARCHIVE_NAME" \
+    GITHUB_ACTION_PATH="$REPO_ROOT/.github/actions/package-source" \
+    HISTORICAL_FAKE_HEAD="$PINNED_RTK_COMMIT" \
+    HISTORICAL_GIT_LOG="$HISTORICAL_GIT_LOG" \
+    HISTORICAL_PATCH_LOG="$HISTORICAL_PATCH_LOG" \
+    bash "$TEMPORARY/vendor-rtk-step.sh"
+grep -Fq "fetch --quiet --depth 1 origin $PINNED_RTK_COMMIT" \
+    "$HISTORICAL_GIT_LOG"
+if grep -Fq -- '--branch' "$HISTORICAL_GIT_LOG"; then
+    printf 'ERROR: historical RTK setup fetched a mutable tag\n' >&2
+    exit 1
+fi
+[ "$(wc -l < "$HISTORICAL_PATCH_LOG")" -eq 2 ]
+[ -f "$HISTORICAL_BUILD/third_party/rtk/Cargo.toml" ]
+[ -f "$HISTORICAL_BUILD/third_party/rtk/Cargo.lock" ]
+[ "$(cat "$HISTORICAL_BUILD/third_party/rtk/.anolisa-rtk-commit")" = \
+    "$PINNED_RTK_COMMIT" ]
+[ ! -e "$HISTORICAL_BUILD/third_party/rtk/.git" ]
+make -C "$HISTORICAL_BUILD" generate-component-contract >/dev/null
+[ -f "$HISTORICAL_BUILD/.anolisa/component.toml" ]
+
+if PATH="$HISTORICAL_FAKE_BIN:$PATH" \
+    HISTORICAL_FAKE_HEAD="$(printf '%040d' 0)" \
+    HISTORICAL_GIT_LOG="$TEMPORARY/historical-drift-git.log" \
+    HISTORICAL_PATCH_LOG="$TEMPORARY/historical-drift-patch.log" \
+    bash "$HISTORICAL_RTK_SETUP" "$HISTORICAL_DRIFT_BUILD" \
+        >"$TEMPORARY/historical-drift.log" 2>&1; then
+    printf 'ERROR: historical RTK setup accepted the wrong commit\n' >&2
+    exit 1
+fi
+grep -Fq "does not match pinned commit $PINNED_RTK_COMMIT" \
+    "$TEMPORARY/historical-drift.log"
+[ ! -e "$HISTORICAL_DRIFT_BUILD/third_party/rtk" ]
+
 RTK_DRIFT="$TEMPORARY/rtk-drift"
 install -d -m 0755 "$RTK_DRIFT"
 printf '[package]\nname = "rtk"\nversion = "0.0.0"\n' > "$RTK_DRIFT/Cargo.toml"
 printf '%040d\n' 0 > "$RTK_DRIFT/.anolisa-rtk-commit"
-if bash "$RTK_SETUP" "$RTK_DRIFT" >"$TEMPORARY/rtk-drift.log" 2>&1; then
+if bash "$REPO_ROOT/src/tokenless/scripts/setup-rtk.sh" "$RTK_DRIFT" \
+    >"$TEMPORARY/rtk-drift.log" 2>&1; then
     printf 'ERROR: mismatched RTK revision marker was accepted\n' >&2
     exit 1
 fi
@@ -115,6 +279,7 @@ if TOKENLESS_SOURCE_WORKTREE="$TEMPORARY/version-worktree/tokenless" \
     "$ACTION_DIR/build.sh" \
         --source-repo "$REPO_ROOT" \
         --output-dir "$TEMPORARY/version-output" \
+        --wheel-output-dir "$TEMPORARY/version-wheels" \
         --version "0.7.12\$(touch ${MARKER})" \
         --target-os linux \
         --target-arch x86_64 \
@@ -132,6 +297,7 @@ if TOKENLESS_SOURCE_WORKTREE="$TEMPORARY/tag-worktree/tokenless" \
     "$ACTION_DIR/build.sh" \
         --source-repo "$REPO_ROOT" \
         --output-dir "$TEMPORARY/tag-output" \
+        --wheel-output-dir "$TEMPORARY/tag-wheels" \
         --version 0.7.12 \
         --target-os linux \
         --target-arch x86_64 \
@@ -145,6 +311,103 @@ fi
     printf 'ERROR: malicious tag input executed a command\n' >&2
     exit 1
 }
+
+SOURCE_FIXTURE="$TEMPORARY/source-fixture"
+install -d -m 0755 "$SOURCE_FIXTURE/src/tokenless"
+git -C "$SOURCE_FIXTURE" init -q
+git -C "$SOURCE_FIXTURE" config user.name 'Tokenless CI Test'
+git -C "$SOURCE_FIXTURE" config user.email 'tokenless-ci@example.com'
+printf 'tag source\n' > "$SOURCE_FIXTURE/src/tokenless/source.txt"
+git -C "$SOURCE_FIXTURE" add src/tokenless/source.txt
+git -C "$SOURCE_FIXTURE" commit -q -m 'tag source'
+TAG_COMMIT="$(git -C "$SOURCE_FIXTURE" rev-parse HEAD)"
+git -C "$SOURCE_FIXTURE" tag tokenless/v1.2.3
+printf 'checkout source\n' > "$SOURCE_FIXTURE/src/tokenless/source.txt"
+git -C "$SOURCE_FIXTURE" commit -q -am 'checkout source'
+git -C "$SOURCE_FIXTURE" branch tokenless/v1.2.3
+
+FAKE_BIN="$TEMPORARY/fake-bin"
+install -d -m 0755 "$FAKE_BIN"
+# shellcheck disable=SC2016  # Expand the fixture variable when the fake runs.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'git rev-parse HEAD > "$SOURCE_SELECTION_RESULT"' \
+    'exit 73' > "$FAKE_BIN/make"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 74' > "$FAKE_BIN/uvx"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 75' > "$FAKE_BIN/just"
+chmod 0755 "$FAKE_BIN/make" "$FAKE_BIN/uvx" "$FAKE_BIN/just"
+SOURCE_SELECTION_RESULT="$TEMPORARY/source-selection"
+if PATH="$FAKE_BIN:$PATH" \
+    SOURCE_SELECTION_RESULT="$SOURCE_SELECTION_RESULT" \
+    TOKENLESS_SOURCE_WORKTREE="$TEMPORARY/source-worktree/tokenless" \
+    "$ACTION_DIR/build.sh" \
+        --source-repo "$SOURCE_FIXTURE" \
+        --output-dir "$TEMPORARY/source-output" \
+        --wheel-output-dir "$TEMPORARY/source-wheels" \
+        --version 1.2.3 \
+        --target-os linux \
+        --target-arch x86_64 \
+        --profile gnu2.17-x86_64 \
+        --tag tokenless/v1.2.3 >"$TEMPORARY/source.log" 2>&1; then
+    printf 'ERROR: source selection fixture unexpectedly completed\n' >&2
+    exit 1
+fi
+[ -f "$SOURCE_SELECTION_RESULT" ] || {
+    cat "$TEMPORARY/source.log" >&2
+    printf 'ERROR: source selection did not reach the tagged worktree\n' >&2
+    exit 1
+}
+[ "$(cat "$SOURCE_SELECTION_RESULT")" = "$TAG_COMMIT" ] || {
+    printf 'ERROR: tagged build used the checkout commit instead of the tag commit\n' >&2
+    exit 1
+}
+
+SHIM_LOG="$TEMPORARY/cargo-shim.log"
+SHIM_RUSTFLAGS_LOG="$TEMPORARY/cargo-shim-rustflags.log"
+# shellcheck disable=SC2016  # Expand shim arguments and log paths in the fakes.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "cargo" >> "$SHIM_LOG"' \
+    'printf " <%s>" "$@" >> "$SHIM_LOG"' \
+    'printf "\n" >> "$SHIM_LOG"' > "$FAKE_BIN/host-cargo"
+# shellcheck disable=SC2016  # Expand shim arguments and log paths in the fakes.
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "cross" >> "$SHIM_LOG"' \
+    'printf " <%s>" "$@" >> "$SHIM_LOG"' \
+    'printf "\n" >> "$SHIM_LOG"' \
+    'printf "%s\n" "${CARGO_ENCODED_RUSTFLAGS:-}" >> "$SHIM_RUSTFLAGS_LOG"' \
+    > "$FAKE_BIN/cross-profile"
+chmod 0755 "$FAKE_BIN/host-cargo" "$FAKE_BIN/cross-profile"
+SHIM_ENV=(
+    TOKENLESS_HOST_CARGO="$FAKE_BIN/host-cargo"
+    TOKENLESS_CROSS_PROFILE_SCRIPT="$FAKE_BIN/cross-profile"
+    TOKENLESS_CROSS_PROFILE=gnu2.17-x86_64
+    TOKENLESS_RUST_TARGET=x86_64-unknown-linux-gnu
+    CARGO_ENCODED_RUSTFLAGS=--remap-path-prefix=/source=/workspace
+    SHIM_LOG="$SHIM_LOG"
+    SHIM_RUSTFLAGS_LOG="$SHIM_RUSTFLAGS_LOG"
+)
+env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" metadata --locked
+env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+    --target x86_64-unknown-linux-gnu --profile python-release
+grep -Fxq 'cargo <metadata> <--locked>' "$SHIM_LOG"
+grep -Fxq \
+    'cross <gnu2.17-x86_64> <rustc> <--profile> <python-release>' \
+    "$SHIM_LOG"
+grep -Fxq -- '--remap-path-prefix=/source=/workspace' "$SHIM_RUSTFLAGS_LOG"
+if env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+    --target "x86_64-unknown-linux-gnu;\$(touch ${MARKER})" \
+    >"$TEMPORARY/shim-target.log" 2>&1; then
+    printf 'ERROR: mismatched Cargo shim target was accepted\n' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ] || {
+    printf 'ERROR: Cargo shim target executed a command\n' >&2
+    exit 1
+}
+
+python3 "$ACTION_DIR/test_verify_wheels.py"
 
 for project in tokenless-fixture rtk-fixture; do
     install -d -m 0755 "$TEMPORARY/$project/src"

--- a/.github/actions/build-tokenless-prebuilt/test_verify_wheels.py
+++ b/.github/actions/build-tokenless-prebuilt/test_verify_wheels.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Regression tests for the Tokenless wheel release verifier."""
+
+from __future__ import annotations
+
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+VERSION = "1.2.3"
+ACTION_DIR = Path(__file__).resolve().parent
+VERIFIER = ACTION_DIR / "verify-wheels.py"
+PLATFORMS = {
+    ("linux", "x86_64"): "manylinux_2_17_x86_64.manylinux2014_x86_64",
+    ("linux", "aarch64"): "manylinux_2_17_aarch64.manylinux2014_aarch64",
+    ("macos", "aarch64"): "macosx_11_0_arm64",
+}
+
+
+def binary_payload(os_name: str, architecture: str) -> bytes:
+    if os_name == "macos":
+        payload = bytearray(32)
+        payload[:4] = b"\xcf\xfa\xed\xfe"
+        struct.pack_into("<I", payload, 4, 0x0100000C if architecture == "aarch64" else 0x01000007)
+        return bytes(payload)
+    payload = bytearray(64)
+    payload[:7] = b"\x7fELF\x02\x01\x01"
+    struct.pack_into("<H", payload, 18, 62 if architecture == "x86_64" else 183)
+    return bytes(payload)
+
+
+def add_member(archive: zipfile.ZipFile, name: str, payload: bytes, mode: int = 0o100644) -> None:
+    info = zipfile.ZipInfo(name)
+    info.create_system = 3
+    info.external_attr = mode << 16
+    archive.writestr(info, payload)
+
+
+def create_runtime(
+    directory: Path,
+    os_name: str,
+    architecture: str,
+    *,
+    version: str = VERSION,
+    platform: str | None = None,
+    binary_architecture: str | None = None,
+) -> Path:
+    platform = platform or PLATFORMS[(os_name, architecture)]
+    path = directory / f"anolisa_tokenless-{version}-cp311-abi3-{platform}.whl"
+    dist_info = f"anolisa_tokenless-{version}.dist-info"
+    payload = binary_payload(os_name, binary_architecture or architecture)
+    with zipfile.ZipFile(path, "w") as archive:
+        add_member(
+            archive,
+            f"{dist_info}/METADATA",
+            f"Metadata-Version: 2.4\nName: anolisa-tokenless\nVersion: {version}\n\n".encode(),
+        )
+        add_member(
+            archive,
+            f"{dist_info}/WHEEL",
+            (
+                "Wheel-Version: 1.0\n"
+                + "".join(
+                    f"Tag: cp311-abi3-{platform_tag}\n"
+                    for platform_tag in platform.split(".")
+                )
+                + "\n"
+            ).encode(),
+        )
+        add_member(archive, "anolisa_tokenless/_native.abi3.so", payload, 0o100755)
+        add_member(archive, "anolisa_tokenless/_bin/rtk", payload, 0o100755)
+    return path
+
+
+def create_agentscope(
+    directory: Path,
+    *,
+    version: str = VERSION,
+    dependency_version: str | None = None,
+) -> Path:
+    dependency_version = dependency_version or version
+    path = directory / f"anolisa_tokenless_agentscope-{version}-py3-none-any.whl"
+    dist_info = f"anolisa_tokenless_agentscope-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        add_member(
+            archive,
+            f"{dist_info}/METADATA",
+            (
+                "Metadata-Version: 2.4\n"
+                "Name: anolisa-tokenless-agentscope\n"
+                f"Version: {version}\n"
+                f"Requires-Dist: anolisa-tokenless=={dependency_version}\n\n"
+            ).encode(),
+        )
+        add_member(
+            archive,
+            f"{dist_info}/WHEEL",
+            b"Wheel-Version: 1.0\nTag: py3-none-any\n\n",
+        )
+        add_member(archive, "tokenless_agentscope/__init__.py", b"")
+    return path
+
+
+def run_verifier(
+    directory: Path,
+    *arguments: str,
+    version: str = VERSION,
+    expect_success: bool = True,
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(VERIFIER),
+            "--directory",
+            str(directory),
+            "--version",
+            version,
+            *arguments,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if (result.returncode == 0) != expect_success:
+        raise AssertionError(
+            f"verifier returned {result.returncode}, expected success={expect_success}:\n"
+            f"{result.stdout}"
+        )
+
+
+def populate_aggregate(directory: Path) -> None:
+    for os_name, architecture in PLATFORMS:
+        create_runtime(directory, os_name, architecture)
+    create_agentscope(directory)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        for os_name, architecture in PLATFORMS:
+            flat = root / f"flat-{os_name}-{architecture}"
+            flat.mkdir()
+            create_runtime(flat, os_name, architecture)
+            if (os_name, architecture) == ("linux", "x86_64"):
+                create_agentscope(flat)
+            run_verifier(flat, "--layout", "flat", "--os", os_name, "--arch", architecture)
+
+        aggregate = root / "aggregate"
+        aggregate.mkdir()
+        populate_aggregate(aggregate)
+        manifest = aggregate / "SHA256SUMS-python-wheels.txt"
+        run_verifier(
+            aggregate,
+            "--layout",
+            "aggregate",
+            "--write-checksums",
+            str(manifest),
+        )
+        run_verifier(
+            aggregate,
+            "--layout",
+            "aggregate",
+            "--checksum-file",
+            str(manifest),
+        )
+
+        prerelease = root / "prerelease"
+        prerelease.mkdir()
+        python_prerelease = "1.2.4rc1"
+        for os_name, architecture in PLATFORMS:
+            create_runtime(prerelease, os_name, architecture, version=python_prerelease)
+        create_agentscope(
+            prerelease,
+            version=python_prerelease,
+            dependency_version="1.2.4-rc.1",
+        )
+        run_verifier(
+            prerelease,
+            "--layout",
+            "aggregate",
+            version="1.2.4-rc.1",
+        )
+
+        wrong_version = root / "wrong-version"
+        wrong_version.mkdir()
+        populate_aggregate(wrong_version)
+        runtime = next(wrong_version.glob("anolisa_tokenless-*.whl"))
+        runtime.unlink()
+        create_runtime(wrong_version, "linux", "x86_64", version="1.2.4")
+        run_verifier(wrong_version, "--layout", "aggregate", expect_success=False)
+
+        missing = root / "missing"
+        shutil.copytree(aggregate, missing)
+        next(missing.glob("*aarch64*.whl")).unlink()
+        run_verifier(missing, "--layout", "aggregate", expect_success=False)
+
+        duplicate = root / "duplicate"
+        duplicate.mkdir()
+        create_runtime(duplicate, "linux", "x86_64")
+        create_runtime(duplicate, "linux", "x86_64", platform="manylinux2014_x86_64")
+        create_runtime(duplicate, "macos", "aarch64")
+        create_agentscope(duplicate)
+        run_verifier(duplicate, "--layout", "aggregate", expect_success=False)
+
+        macos_x86 = root / "macos-x86"
+        macos_x86.mkdir()
+        create_runtime(macos_x86, "linux", "x86_64")
+        create_runtime(
+            macos_x86,
+            "macos",
+            "aarch64",
+            platform="macosx_10_9_x86_64",
+            binary_architecture="x86_64",
+        )
+        create_runtime(macos_x86, "macos", "aarch64")
+        create_agentscope(macos_x86)
+        run_verifier(macos_x86, "--layout", "aggregate", expect_success=False)
+
+        bad_architecture = root / "bad-architecture"
+        bad_architecture.mkdir()
+        populate_aggregate(bad_architecture)
+        runtime = next(bad_architecture.glob("*manylinux*x86_64.whl"))
+        runtime.unlink()
+        create_runtime(
+            bad_architecture,
+            "linux",
+            "x86_64",
+            binary_architecture="aarch64",
+        )
+        run_verifier(bad_architecture, "--layout", "aggregate", expect_success=False)
+
+        manifest.write_text("0" * 64 + "  invalid.whl\n", encoding="utf-8")
+        run_verifier(
+            aggregate,
+            "--layout",
+            "aggregate",
+            "--checksum-file",
+            str(manifest),
+            expect_success=False,
+        )
+
+    print("Tokenless wheel verifier tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/build-tokenless-prebuilt/verify-wheels.py
+++ b/.github/actions/build-tokenless-prebuilt/verify-wheels.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Validate the complete Tokenless Python wheel release contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import struct
+import zipfile
+from dataclasses import dataclass
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path
+
+
+RUNTIME_NAME = "anolisa-tokenless"
+RUNTIME_FILENAME = "anolisa_tokenless"
+AGENTSCOPE_NAME = "anolisa-tokenless-agentscope"
+AGENTSCOPE_FILENAME = "anolisa_tokenless_agentscope"
+WHEEL_PATTERN = re.compile(
+    r"^(anolisa_tokenless(?:_agentscope)?)-([^-]+)-([^-]+)-([^-]+)-([^-]+)\.whl$"
+)
+PYTHON_VERSION_PATTERN = re.compile(
+    r"^(?P<release>[0-9]+\.[0-9]+\.[0-9]+)"
+    r"(?:(?:[-_.]?)(?P<pre>alpha|beta|preview|pre|rc|a|b|c)"
+    r"(?:[-_.]?(?P<pre_number>[0-9]+))?)?"
+    r"(?:(?:-(?P<post_number1>[0-9]+))|"
+    r"(?:[-_.]?(?P<post>post|rev|r)(?:[-_.]?(?P<post_number2>[0-9]+))?))?"
+    r"(?:[-_.]?(?P<dev>dev)(?:[-_.]?(?P<dev_number>[0-9]+))?)?$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class NativeTarget:
+    os_name: str
+    architecture: str
+    platform_tags: frozenset[str]
+    binary_format: str
+
+
+TARGETS = {
+    ("linux", "x86_64"): NativeTarget(
+        "linux",
+        "x86_64",
+        frozenset({"manylinux_2_17_x86_64", "manylinux2014_x86_64"}),
+        "elf",
+    ),
+    ("linux", "aarch64"): NativeTarget(
+        "linux",
+        "aarch64",
+        frozenset({"manylinux_2_17_aarch64", "manylinux2014_aarch64"}),
+        "elf",
+    ),
+    ("macos", "aarch64"): NativeTarget(
+        "macos", "aarch64", frozenset({"macosx_11_0_arm64"}), "macho"
+    ),
+}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def normalize_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def normalize_python_version(value: str) -> str:
+    match = PYTHON_VERSION_PATTERN.fullmatch(value)
+    if not match:
+        fail(f"version is not supported by the wheel verifier: {value}")
+    normalized = match.group("release")
+    if phase := match.group("pre"):
+        phase = {
+            "alpha": "a",
+            "beta": "b",
+            "c": "rc",
+            "pre": "rc",
+            "preview": "rc",
+        }.get(phase.lower(), phase.lower())
+        normalized += f"{phase}{int(match.group('pre_number') or 0)}"
+    post_number = match.group("post_number1") or match.group("post_number2")
+    if match.group("post") or post_number:
+        normalized += f".post{int(post_number or 0)}"
+    if match.group("dev"):
+        normalized += f".dev{int(match.group('dev_number') or 0)}"
+    return normalized
+
+
+def parse_filename(path: Path) -> tuple[str, str, str, str, frozenset[str]]:
+    match = WHEEL_PATTERN.fullmatch(path.name)
+    if not match:
+        fail(f"unexpected wheel filename: {path.name}")
+    distribution, version, python_tag, abi_tag, platform = match.groups()
+    return distribution, version, python_tag, abi_tag, frozenset(platform.split("."))
+
+
+def platform_matches(actual: frozenset[str], target: NativeTarget) -> bool:
+    if target.os_name == "macos":
+        return actual == target.platform_tags
+    return bool(actual) and actual.issubset(target.platform_tags)
+
+
+def identify_native_target(platform_tags: frozenset[str]) -> NativeTarget:
+    matches = [target for target in TARGETS.values() if platform_matches(platform_tags, target)]
+    if len(matches) != 1:
+        fail(f"unsupported or ambiguous native platform tags: {sorted(platform_tags)}")
+    return matches[0]
+
+
+def single_member(archive: zipfile.ZipFile, suffix: str) -> str:
+    matches = [name for name in archive.namelist() if name.endswith(suffix)]
+    if len(matches) != 1:
+        fail(f"wheel must contain exactly one {suffix}, found {len(matches)}")
+    return matches[0]
+
+
+def wheel_headers(archive: zipfile.ZipFile) -> tuple[object, object]:
+    metadata_path = single_member(archive, ".dist-info/METADATA")
+    wheel_path = single_member(archive, ".dist-info/WHEEL")
+    parser = BytesParser(policy=default)
+    metadata = parser.parsebytes(archive.read(metadata_path))
+    wheel = parser.parsebytes(archive.read(wheel_path))
+    return metadata, wheel
+
+
+def verify_wheel_tags(
+    headers: object, python_tag: str, abi_tag: str, platforms: frozenset[str]
+) -> None:
+    tags = headers.get_all("Tag", [])
+    if not tags:
+        fail("WHEEL metadata has no Tag header")
+    metadata_platforms: set[str] = set()
+    for tag in tags:
+        parts = tag.split("-")
+        if len(parts) != 3:
+            fail(f"invalid WHEEL Tag header: {tag}")
+        tag_platforms = frozenset(parts[2].split("."))
+        if parts[:2] != [python_tag, abi_tag] or not tag_platforms.issubset(platforms):
+            fail(f"WHEEL Tag {tag} does not match the wheel filename")
+        metadata_platforms.update(tag_platforms)
+    if metadata_platforms != set(platforms):
+        fail("WHEEL Tag headers do not cover every filename platform tag")
+
+
+def verify_elf(payload: bytes, architecture: str, member: str) -> None:
+    if len(payload) < 20 or payload[:4] != b"\x7fELF" or payload[4] != 2:
+        fail(f"{member} is not a 64-bit ELF binary")
+    byte_order = {1: "<", 2: ">"}.get(payload[5])
+    if byte_order is None:
+        fail(f"{member} has an invalid ELF byte order")
+    machine = struct.unpack_from(f"{byte_order}H", payload, 18)[0]
+    expected = {"x86_64": 62, "aarch64": 183}[architecture]
+    if machine != expected:
+        fail(f"{member} has ELF machine {machine}, expected {expected}")
+
+
+def verify_macho(payload: bytes, member: str) -> None:
+    if len(payload) < 8 or payload[:4] != b"\xcf\xfa\xed\xfe":
+        fail(f"{member} is not a thin 64-bit little-endian Mach-O binary")
+    cpu_type = struct.unpack_from("<I", payload, 4)[0]
+    if cpu_type != 0x0100000C:
+        fail(f"{member} has Mach-O CPU type {cpu_type:#x}, expected arm64")
+
+
+def verify_binary(payload: bytes, target: NativeTarget, member: str) -> None:
+    if target.binary_format == "elf":
+        verify_elf(payload, target.architecture, member)
+    else:
+        verify_macho(payload, member)
+
+
+def verify_runtime(path: Path, version: str) -> NativeTarget:
+    distribution, filename_version, python_tag, abi_tag, platforms = parse_filename(path)
+    if distribution != RUNTIME_FILENAME:
+        fail(f"{path.name} is not a {RUNTIME_NAME} wheel")
+    if filename_version != version:
+        fail(f"{path.name} has version {filename_version}, expected {version}")
+    if (python_tag, abi_tag) != ("cp311", "abi3"):
+        fail(f"{path.name} must use cp311-abi3")
+    target = identify_native_target(platforms)
+
+    with zipfile.ZipFile(path) as archive:
+        corrupt = archive.testzip()
+        if corrupt is not None:
+            fail(f"{path.name} has a corrupt ZIP member: {corrupt}")
+        metadata, wheel = wheel_headers(archive)
+        if normalize_name(metadata.get("Name", "")) != RUNTIME_NAME:
+            fail(f"{path.name} has the wrong METADATA Name")
+        if metadata.get("Version") != version:
+            fail(f"{path.name} has the wrong METADATA Version")
+        verify_wheel_tags(wheel, python_tag, abi_tag, platforms)
+
+        native_members = [
+            name
+            for name in archive.namelist()
+            if name.startswith("anolisa_tokenless/_native") and name.endswith(".so")
+        ]
+        if len(native_members) != 1:
+            fail(f"{path.name} must contain exactly one native extension")
+        rtk_members = [
+            name for name in archive.namelist() if name == "anolisa_tokenless/_bin/rtk"
+        ]
+        if len(rtk_members) != 1:
+            fail(f"{path.name} must contain exactly one embedded RTK binary")
+        rtk_info = archive.getinfo(rtk_members[0])
+        if not ((rtk_info.external_attr >> 16) & 0o111):
+            fail(f"{path.name} embeds a non-executable RTK binary")
+        for member in (native_members[0], rtk_members[0]):
+            verify_binary(archive.read(member), target, member)
+    return target
+
+
+def verify_agentscope(path: Path, version: str) -> None:
+    distribution, filename_version, python_tag, abi_tag, platforms = parse_filename(path)
+    if distribution != AGENTSCOPE_FILENAME:
+        fail(f"{path.name} is not an {AGENTSCOPE_NAME} wheel")
+    if filename_version != version or (python_tag, abi_tag, platforms) != (
+        "py3",
+        "none",
+        frozenset({"any"}),
+    ):
+        fail(f"{path.name} must use version {version} and py3-none-any")
+    with zipfile.ZipFile(path) as archive:
+        corrupt = archive.testzip()
+        if corrupt is not None:
+            fail(f"{path.name} has a corrupt ZIP member: {corrupt}")
+        metadata, wheel = wheel_headers(archive)
+        if normalize_name(metadata.get("Name", "")) != AGENTSCOPE_NAME:
+            fail(f"{path.name} has the wrong METADATA Name")
+        if metadata.get("Version") != version:
+            fail(f"{path.name} has the wrong METADATA Version")
+        verify_wheel_tags(wheel, python_tag, abi_tag, platforms)
+        dependencies = metadata.get_all("Requires-Dist", [])
+        expected = f"{RUNTIME_NAME}=={version}"
+        runtime_dependencies = [
+            dependency
+            for dependency in dependencies
+            if normalize_name(re.split(r"[ (<>=!~;]", dependency, maxsplit=1)[0])
+            == RUNTIME_NAME
+        ]
+        requirement = None
+        if len(runtime_dependencies) == 1:
+            requirement = re.fullmatch(
+                r"\s*([A-Za-z0-9_.-]+)\s*==\s*([^\s;]+)\s*", runtime_dependencies[0]
+            )
+        if (
+            requirement is None
+            or normalize_name(requirement.group(1)) != RUNTIME_NAME
+            or normalize_python_version(requirement.group(2)) != version
+        ):
+            fail(f"{path.name} must require exactly {expected}")
+        native_suffixes = (".so", ".dylib", ".dll", ".exe")
+        if any(name.endswith(native_suffixes) for name in archive.namelist()):
+            fail(f"{path.name} must be a platform-independent wheel")
+
+
+def expected_targets(
+    layout: str, os_name: str | None, architecture: str | None
+) -> set[tuple[str, str]]:
+    if layout == "aggregate":
+        if os_name is not None or architecture is not None:
+            fail("--os and --arch are invalid for aggregate layout")
+        return set(TARGETS)
+    if os_name is None or architecture is None:
+        fail("--os and --arch are required for flat layout")
+    target = (os_name, architecture)
+    if target not in TARGETS:
+        fail(f"unsupported Tokenless wheel target: {os_name}/{architecture}")
+    return {target}
+
+
+def checksum_text(wheels: list[Path]) -> str:
+    lines = []
+    for wheel in sorted(wheels, key=lambda item: item.name):
+        digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+        lines.append(f"{digest}  {wheel.name}\n")
+    return "".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--directory", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--layout", choices=("flat", "aggregate"), required=True)
+    parser.add_argument("--os", choices=("linux", "macos"))
+    parser.add_argument("--arch", choices=("x86_64", "aarch64"))
+    checksum_group = parser.add_mutually_exclusive_group()
+    checksum_group.add_argument("--write-checksums", type=Path)
+    checksum_group.add_argument("--checksum-file", type=Path)
+    args = parser.parse_args()
+
+    try:
+        python_version = normalize_python_version(args.version)
+        if not args.directory.is_dir():
+            fail(f"wheel directory does not exist: {args.directory}")
+        targets = expected_targets(args.layout, args.os, args.arch)
+        wheels = sorted(args.directory.glob("*.whl"))
+        expected_count = len(targets) + (1 if ("linux", "x86_64") in targets else 0)
+        if len(wheels) != expected_count:
+            fail(f"expected {expected_count} wheels, found {len(wheels)}")
+
+        actual_targets: set[tuple[str, str]] = set()
+        agentscope_wheels = []
+        for wheel in wheels:
+            if wheel.name.startswith(f"{AGENTSCOPE_FILENAME}-"):
+                agentscope_wheels.append(wheel)
+                continue
+            target = verify_runtime(wheel, python_version)
+            key = (target.os_name, target.architecture)
+            if key in actual_targets:
+                fail(f"duplicate runtime wheel for {target.os_name}/{target.architecture}")
+            actual_targets.add(key)
+        if actual_targets != targets:
+            fail(f"native wheel targets are {sorted(actual_targets)}, expected {sorted(targets)}")
+
+        requires_agentscope = ("linux", "x86_64") in targets
+        if len(agentscope_wheels) != int(requires_agentscope):
+            fail(
+                f"expected {int(requires_agentscope)} AgentScope wheel, "
+                f"found {len(agentscope_wheels)}"
+            )
+        if agentscope_wheels:
+            verify_agentscope(agentscope_wheels[0], python_version)
+
+        expected_checksums = checksum_text(wheels)
+        if args.write_checksums:
+            if args.layout != "aggregate":
+                fail("checksums can only be generated for aggregate layout")
+            args.write_checksums.write_text(expected_checksums, encoding="utf-8")
+        if args.checksum_file:
+            if args.checksum_file.read_text(encoding="utf-8") != expected_checksums:
+                fail(f"checksum manifest does not match the wheel set: {args.checksum_file}")
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        parser.error(str(error))
+
+    print(f"Verified {len(wheels)} Tokenless Python wheels for {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/package-source/action.yaml
+++ b/.github/actions/package-source/action.yaml
@@ -10,6 +10,10 @@ inputs:
   version:
     description: 'Version string without v prefix (e.g. 2.1.0)'
     required: true
+  tokenless-source-root:
+    description: 'Repository root containing the Tokenless source tree'
+    required: false
+    default: '.'
   artifact-suffix:
     description: 'Suffix appended to both the tar.gz filename and artifact name (e.g. ".preview"). Leave empty for official builds.'
     required: false
@@ -40,6 +44,8 @@ runs:
     # -----------------------------------------------------------------
     - name: Resolve source directory
       shell: bash
+      env:
+        TOKENLESS_SOURCE_ROOT: ${{ inputs.tokenless-source-root }}
       run: |
         COMPONENT="${{ inputs.component }}"
         VERSION="${{ inputs.version }}"
@@ -50,7 +56,7 @@ runs:
           cosh-ng)        SRC_DIR="src/cosh-ng" ;;
           agent-sec-core) SRC_DIR="src/agent-sec-core" ;;
           agentsight)     SRC_DIR="src/agentsight" ;;
-          tokenless)     SRC_DIR="src/tokenless" ;;
+          tokenless)     SRC_DIR="${TOKENLESS_SOURCE_ROOT}/src/tokenless" ;;
           os-skills)      SRC_DIR="src/os-skills" ;;
           ws-ckpt)        SRC_DIR="src/ws-ckpt" ;;
           agent-memory)   SRC_DIR="src/agent-memory" ;;
@@ -157,7 +163,7 @@ runs:
         cd /tmp/build/${ARCHIVE_NAME}
 
         rm -rf third_party/rtk
-        bash scripts/setup-rtk.sh third_party/rtk
+        bash "$GITHUB_ACTION_PATH/../build-tokenless-prebuilt/setup-rtk.sh" "$PWD"
         rm -rf third_party/rtk/.git
 
     - name: Generate tokenless component contract

--- a/.github/actions/prebuilt-rust-common/cross-profile.sh
+++ b/.github/actions/prebuilt-rust-common/cross-profile.sh
@@ -213,6 +213,8 @@ run_profile() {
     shift
     local image target target_env image_env safe_path linker archiver
     local cargo_home container_opts deployment encoded
+    local argument requested_target separator
+    local -a cargo_args rustc_args
 
     target="$(profile_target "$profile")"
     image="$(profile_image_id "$profile")"
@@ -221,6 +223,41 @@ run_profile() {
     image_env="CROSS_TARGET_${target_env}_IMAGE"
     safe_path="$(profile_path "$profile")"
     cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+    separator=0
+    cargo_args=()
+    rustc_args=()
+    while [ "$#" -gt 0 ]; do
+        argument="$1"
+        shift
+        if [ "$separator" -eq 1 ]; then
+            rustc_args+=("$argument")
+            continue
+        fi
+        case "$argument" in
+            --)
+                separator=1
+                ;;
+            --target)
+                [ "$#" -gt 0 ] || die '--target requires a value'
+                requested_target="$1"
+                shift
+                [ "$requested_target" = "$target" ] || \
+                    die "Cargo target $requested_target does not match profile $profile"
+                ;;
+            --target=*)
+                requested_target="${argument#--target=}"
+                [ "$requested_target" = "$target" ] || \
+                    die "Cargo target $requested_target does not match profile $profile"
+                ;;
+            *)
+                cargo_args+=("$argument")
+                ;;
+        esac
+    done
+    cargo_args+=(--target "$target")
+    if [ "$separator" -eq 1 ]; then
+        cargo_args+=(-- "${rustc_args[@]}")
+    fi
     install -d -m 0755 "$cargo_home/sccache"
     case "$profile" in
         gnu2.17-x86_64|gnu2.28-x86_64) linker=gcc; archiver='ar' ;;
@@ -264,7 +301,7 @@ run_profile() {
             "AR_${target//-/_}=$archiver" \
             "CFLAGS_${target//-/_}=-mmacosx-version-min=$deployment" \
             "CXXFLAGS_${target//-/_}=-mmacosx-version-min=$deployment" \
-            cross "$@" --target "$target"
+            cross "${cargo_args[@]}"
     else
         if [ "$profile" = gnu2.17-aarch64 ] || [ "$profile" = gnu2.28-aarch64 ]; then
             local sysroot=/usr/xcc/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/sysroot
@@ -277,7 +314,7 @@ run_profile() {
             "CARGO_TARGET_${target_env}_LINKER=$linker" \
             "CC_${target//-/_}=$linker" \
             "AR_${target//-/_}=$archiver" \
-            cross "$@" --target "$target"
+            cross "${cargo_args[@]}"
     fi
 }
 

--- a/.github/workflows/release-preview.yaml
+++ b/.github/workflows/release-preview.yaml
@@ -28,6 +28,11 @@ on:
         description: 'Version (e.g. 2.1.0, without v prefix)'
         required: true
         type: string
+      tokenless_source_tag:
+        description: 'Optional exact Tokenless source tag with Python packaging (v0.7.7+, e.g. tokenless/v0.7.14)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -49,7 +54,31 @@ jobs:
       prebuilt-enabled: ${{ steps.plan-prebuilt.outputs.enabled }}
       prebuilt-matrix: ${{ steps.plan-prebuilt.outputs.matrix }}
     steps:
+      - name: Validate Tokenless source tag
+        if: inputs.tokenless_source_tag != ''
+        env:
+          COMPONENT: ${{ inputs.component }}
+          VERSION: ${{ inputs.version }}
+          SOURCE_TAG: ${{ inputs.tokenless_source_tag }}
+        run: |
+          if [ "$COMPONENT" != tokenless ]; then
+            echo "::error::tokenless_source_tag is only valid for Tokenless previews"
+            exit 1
+          fi
+          if [ "$SOURCE_TAG" != "tokenless/v$VERSION" ]; then
+            echo "::error::Tokenless source tag must be tokenless/v$VERSION"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
+
+      - name: Checkout Tokenless source tag
+        if: inputs.tokenless_source_tag != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ format('refs/tags/{0}', inputs.tokenless_source_tag) }}
+          path: tokenless-source
+          persist-credentials: false
 
       - name: Plan precompiled packages
         id: plan-prebuilt
@@ -64,6 +93,7 @@ jobs:
         with:
           component: ${{ inputs.component }}
           version: ${{ inputs.version }}
+          tokenless-source-root: ${{ inputs.tokenless_source_tag != '' && 'tokenless-source' || '.' }}
           artifact-suffix: '.preview'
           retention-days: 14
           skill-sign-private-key: ${{ secrets.SKILL_SIGN_PRIVATE_KEY }}
@@ -113,6 +143,7 @@ jobs:
           target-os: ${{ matrix.target-os }}
           target-arch: ${{ matrix.target-arch }}
           profile: ${{ matrix.profile }}
+          tag: ${{ inputs.tokenless_source_tag }}
 
       - name: Build ANOLISA CLI precompiled package
         id: anolisa-prebuilt
@@ -153,6 +184,15 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Upload Tokenless Python wheels
+        if: matrix.component == 'tokenless'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenless-python-wheels-${{ inputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          path: ${{ steps.tokenless-prebuilt.outputs.wheel-directory }}/*
+          if-no-files-found: error
+          retention-days: 14
+
   verify-prebuilt-preview:
     name: Verify preview ${{ inputs.component }} artifacts
     needs: build-prebuilt-preview
@@ -184,3 +224,22 @@ jobs:
             --component "$COMPONENT" \
             --version "$VERSION" \
             --layout actions
+
+      - name: Download Tokenless Python wheels
+        if: inputs.component == 'tokenless'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tokenless-python-wheels-${{ inputs.version }}-*
+          merge-multiple: true
+          path: /tmp/python-wheels-preview
+
+      - name: Verify Tokenless Python wheels
+        if: inputs.component == 'tokenless'
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 .github/actions/build-tokenless-prebuilt/verify-wheels.py \
+            --directory /tmp/python-wheels-preview \
+            --version "$VERSION" \
+            --layout aggregate \
+            --write-checksums /tmp/python-wheels-preview/SHA256SUMS-python-wheels.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -185,6 +185,15 @@ jobs:
           if-no-files-found: error
           retention-days: 28
 
+      - name: Upload Tokenless Python wheels
+        if: matrix.component == 'tokenless'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenless-python-wheels-${{ needs.package.outputs.version }}-${{ matrix.target-os }}-${{ matrix.target-arch }}
+          path: ${{ steps.tokenless-prebuilt.outputs.wheel-directory }}/*
+          if-no-files-found: error
+          retention-days: 28
+
   # =========================================================================
   # Step 2: Publish (requires manual approval via GitHub Environment)
   #
@@ -258,6 +267,25 @@ jobs:
             --version "$VERSION" \
             --layout actions
 
+      - name: Download Tokenless Python wheels
+        if: needs.package.outputs.component == 'tokenless'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tokenless-python-wheels-${{ needs.package.outputs.version }}-*
+          merge-multiple: true
+          path: /tmp/python-wheels
+
+      - name: Verify Tokenless Python wheels
+        if: needs.package.outputs.component == 'tokenless'
+        env:
+          VERSION: ${{ needs.package.outputs.version }}
+        run: |
+          python3 .github/actions/build-tokenless-prebuilt/verify-wheels.py \
+            --directory /tmp/python-wheels \
+            --version "$VERSION" \
+            --layout aggregate \
+            --write-checksums /tmp/python-wheels/SHA256SUMS-python-wheels.txt
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -302,6 +330,15 @@ jobs:
             done < <(
               find /tmp/prebuilt -mindepth 2 -maxdepth 2 -type f -print |
                 LC_ALL=C sort
+            )
+          fi
+          if [ "$COMPONENT" = tokenless ]; then
+            while IFS= read -r asset; do
+              ASSETS+=("$asset")
+            done < <(
+              find /tmp/python-wheels -maxdepth 1 -type f \
+                \( -name '*.whl' -o -name 'SHA256SUMS-python-wheels.txt' \) \
+                -print | LC_ALL=C sort
             )
           fi
 


### PR DESCRIPTION
## Why

Tokenless GitHub Releases currently publish raw prebuilt archives but no installable Python wheels. Historical backfills also need to build from the exact component tag instead of the workflow checkout.

## What changed

Reuses the existing prebuilt and publish jobs to build three cp311-abi3 runtime wheels plus one py3-none-any AgentScope wheel, validate their metadata and embedded binaries, and publish a SHA256 manifest. Native Maturin compilation is pinned and routed through the prepared Cross profiles, while preview builds can select an exact Tokenless source tag. PyPI and macOS x86_64 remain out of scope.

## Related issue

refs #2837

## User / Agent impact

Users can install supported Tokenless Python wheels from GitHub Releases after the workflow change is merged and a release is published or backfilled.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low API risk. The packaging risk is gated by exact wheel count, tag, metadata, ZIP, native architecture, embedded RTK, and checksum validation before Release creation.

## Validation

- `.github/actions/build-tokenless-prebuilt/test.sh`
- `python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `shellcheck` on the changed shell scripts
- Fresh local Linux x86_64 cp311-abi3 wheel build with Maturin 1.15.0
- Clean virtualenv install, import and version check, and embedded `rtk --version` smoke test
- `git diff --check`

## Documentation and rollback

No documentation changes are required. Revert this commit to restore the previous raw-only Tokenless release workflow.