### PR TITLE
chore(anolisa): bump version to 0.3.9

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-08-27
+
+### Fixed
+
+- `anolisa --dry-run osbase sandbox uninstall <scenario>` now passes preview
+  intent through both helper and root-direct execution paths, matching the
+  command-local `--dry-run` flag. Global previews no longer uninstall sandbox
+  packages while reporting a planned operation
+  ([#2922](https://github.com/alibaba/anolisa/pull/2922)).
+- System-mode `--dry-run` now returns a read-only preview for every telemetry
+  mutation (`enable`, `disable`, `link`, `unlink`, `upload`, and `init`) before
+  privilege checks or effect dispatch. Users can inspect human-readable or JSON
+  plans without root access or changing telemetry state, while `status` keeps
+  its existing read-only behavior
+  ([#2926](https://github.com/alibaba/anolisa/pull/2926)).
+
 ## [0.3.8] - 2026-08-26
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,21 @@
 
 ## [未发布]
 
+## [0.3.9] - 2026-08-27
+
+### 修复
+
+- `anolisa --dry-run osbase sandbox uninstall <scenario>` 现会在 helper 和
+  root-direct execution path 中传递 preview intent，与 command-local
+  `--dry-run` flag 保持一致。全局预览不再一边报告 planned operation，一边实际
+  卸载 sandbox package
+  ([#2922](https://github.com/alibaba/anolisa/pull/2922))。
+- System mode 的 `--dry-run` 现会在 privilege check 或 effect dispatch 前，
+  为所有 telemetry mutation（`enable`、`disable`、`link`、`unlink`、`upload`
+  和 `init`）返回只读预览。用户无需 root 权限或修改 telemetry state，即可检查
+  human-readable 或 JSON plan；`status` 保持既有只读行为
+  ([#2926](https://github.com/alibaba/anolisa/pull/2926))。
+
 ## [0.3.8] - 2026-08-26
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,10 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Aug 26 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Thu Aug 27 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Sandbox uninstall and telemetry dry-runs now remain read-only.
+
+* Wed Aug 26 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.8-1
 - GitHub releases now include verified prebuilt CLI archives for three supported targets.
 - Raw installs now preserve runtime ${VAR} references in rendered file content.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.8",
-    "@anolisa/cli-linux-arm64": "0.3.8",
-    "@anolisa/cli-darwin-arm64": "0.3.8"
+    "@anolisa/cli-linux-x64": "0.3.9",
+    "@anolisa/cli-linux-arm64": "0.3.9",
+    "@anolisa/cli-darwin-arm64": "0.3.9"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Publish the ANOLISA fixes merged after 0.3.8 as the next patch release. The
release boundary contains the sandbox uninstall and telemetry dry-run fixes;
the terminal-outcome refactor preserves existing behavior and is intentionally
excluded from release notes.

## What changed

- Bump the Cargo workspace and lockfile package versions to 0.3.9.
- Synchronize the npm root package, its three native payload templates, and the
  RPM release boundary at 0.3.9.
- Add semantically equivalent English and Chinese 0.3.9 changelog entries for
  PRs #2922 and #2926.

## Related issue

no-issue: version-only release boundary for merged PRs #2922 and #2926.

## User / Agent impact

ANOLISA 0.3.9 documents and packages two existing fixes: global and
command-local sandbox uninstall dry-runs remain read-only, and system-mode
telemetry mutations return previews before privilege checks or effect dispatch.
This bump itself adds no new runtime behavior.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. This commit changes only release metadata and paired release notes;
the underlying behavior changes were already reviewed and merged in #2922 and
#2926. There is no migration and no cross-component contract change.

## Validation

Linux x86_64; Rust 1.93.1; Node.js 24.15.0:

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `check_release.py` against the working tree and committed `HEAD`
- `git diff --check` and `git diff --cached --check`
- `node npm/scripts/package-npm.js --validate`
- `node --test npm/tests/platforms.test.js`
- `bash tests/test-package-prebuilt.sh`
- RPM template expansion with `rpmspec -P /dev/stdin`
- `cargo run --locked -q -p anolisa-cli -- --version` (`anolisa 0.3.9`)
- Built and installed the Linux x64 npm root/platform tarballs; installed CLI
  reported `anolisa 0.3.9`
- Website `npm run typecheck`, `npm run build`, and `npm run check:links`
- `bash -n src/anolisa/scripts/install-anolisa.sh`

Linux arm64 and macOS arm64 were template-, metadata-, and packer-validated but
cannot be executed natively on this Linux x86_64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM `%changelog`
with the 0.3.9 release boundary. Revert commit
`3b9b241f4f9b2ae264bdfeba8fd96df27bd83d18` to roll back the version bump before
tagging or publication.
