### PR TITLE
docs(tokenless): sync SDK and agent guides

### DIFF
--- a/docs/user-guide/en/README.md
+++ b/docs/user-guide/en/README.md
@@ -75,8 +75,10 @@ ANOLISA provides a complete server-side runtime for AI Agent workloads. Componen
 |----------|-----------|-------------|
 | [Tokenless Quick Start](token-saving/tokenless/QUICKSTART.md) | tokenless | Install, connect an agent, run the first compression, and verify |
 | [Tokenless User Manual](token-saving/tokenless/user-manual.md) | tokenless | Capability boundaries, runtime behavior, and task navigation |
-| [Tokenless Framework Integration](token-saving/tokenless/framework-integration.md) | tokenless | cosh, OpenClaw, Hermes, Qoder, Claude Code, Codex, and Qwen Code |
-| [Tokenless CLI Reference](token-saving/tokenless/cli-reference.md) | tokenless | Compression, environment checks, Stash, MCP, and statistics commands |
+| [Tokenless Python SDK](token-saving/tokenless/sdk.md) | tokenless | Framework-neutral and AgentScope layers, Runtime operations, statistics, and examples |
+| [Tokenless AgentScope SDK Integration](token-saving/tokenless/sdk/agentscope.md) | tokenless | AgentScope 1.x, 2.x, and App attachment to the generic SDK |
+| [Tokenless Agent Integration](token-saving/tokenless/framework-integration.md) | tokenless | Product adapters, hooks, and plugins |
+| [Tokenless CLI Reference](token-saving/tokenless/cli-reference.md) | tokenless | Protocol pipeline, direct compression, Stash, MCP, and statistics commands |
 | [Measuring Tokenless Savings](token-saving/tokenless/measuring-savings.md) | tokenless | Statistics, diffs, dry runs, AgentSight, and SLS measurement |
 | [Tokenless Configuration and Data Privacy](token-saving/tokenless/configuration-and-privacy.md) | tokenless | Configuration precedence, local data, and sensitive workloads |
 | [Tokenless Troubleshooting](token-saving/tokenless/troubleshooting.md) | tokenless | Adapters, databases, Stash, upgrades, and uninstall |

--- a/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/en/token-saving/tokenless/QUICKSTART.md
@@ -121,7 +121,7 @@ anolisa adapter scan
 | Claude Code | `anolisa adapter enable tokenless claude-code` |
 | Codex | `anolisa adapter enable tokenless codex` |
 | DeepSeek Harness (dsh) | `anolisa adapter enable tokenless dsh --profile <profile>` |
-| OpenCode | Lifecycle script (see below) |
+| OpenCode | `anolisa adapter enable tokenless opencode` |
 | Qwen Code | `anolisa adapter enable tokenless qwencode` |
 
 Restart the Agent CLI or IDE after setting it up. OpenClaw also requires
@@ -140,9 +140,8 @@ anolisa adapter enable tokenless dsh \
 Every later enable or re-enable replaces the entire recorded profile set.
 Include every profile that should retain Tokenless each time.
 
-OpenCode is not registered with `anolisa adapter enable` in this release; use
-the bundled lifecycle script described in the
-[OpenCode integration instructions](framework-integration.md#opencode).
+OpenCode is available through the same adapter command. The bundled lifecycle script remains an
+alternative for npm installations that have no ANOLISA component record.
 
 ## Optional: test compression without an Agent
 
@@ -175,7 +174,9 @@ standalone CLI from source, see
 
 ## Next steps
 
-- [Agent and framework integration](framework-integration.md): Agent adapter activation and AgentScope application integration
+- [Python SDK](sdk.md): framework-neutral and AgentScope layers with runnable examples
+- [AgentScope SDK integration](sdk/agentscope.md): AgentScope 1.x, 2.x, and App attachment
+- [Agent integration](framework-integration.md): product adapter activation
 - [User manual](user-manual.md): behavior boundaries and documentation map
 - [CLI reference](cli-reference.md): all subcommands and options
 - [Measuring savings](measuring-savings.md): statistics, dual runs, and AgentSight/SLS

--- a/docs/user-guide/en/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/en/token-saving/tokenless/cli-reference.md
@@ -2,12 +2,15 @@
 
 [中文版](../../../zh/token-saving/tokenless/cli-reference.md)
 
-The `tokenless` CLI can compress schemas and responses, encode and decode TOON, retrieve Stash content, check tool environments, and query statistics. Agent adapters call the same capabilities internally.
+The `tokenless` CLI exposes a unified content-aware compression command, direct schema/JSON/TOON
+operations, Stash retrieval, environment status, and statistics. Shared Agent hooks use
+`tokenless compress`; the direct commands remain useful for scripts and diagnosis.
 
 ## Command overview
 
 | Command | Purpose |
 |---------|---------|
+| `tokenless compress` | Send model-visible content through the content-aware Pipeline |
 | `tokenless compress-schema` | Compress Function Calling tool schemas |
 | `tokenless compress-response` | Compress JSON/API/tool responses |
 | `tokenless compress-toon` | Encode JSON as TOON |
@@ -59,6 +62,73 @@ string, array, and depth thresholds below only decide when individual
 transformations run; they are not minimum total payload sizes. Agent adapters
 can apply separate pre-spawn size gates; see
 [Adapter processing rules](framework-integration.md#adapter-processing-rules).
+
+## `compress`
+
+`compress` is the stable JSON boundary used by shared Agent hooks. It accepts one
+`CompressionRequest` on stdin or through `--file` and always writes one `CompressionResponse` JSON
+object when the request is decodable:
+
+```bash
+jq -n \
+  --rawfile content build.log \
+  '{
+    protocol_version: 1,
+    content: $content,
+    agent_id: "my-agent",
+    session_id: "session-42",
+    tool_use_id: "tool-7",
+    tool_name: "Bash",
+    seam: "post_tool",
+    capabilities: {
+      replace_output: true,
+      publish_retrieve_tool: true,
+      replace_with_text: true
+    }
+  }' \
+  | tokenless compress \
+  | jq '{disposition, content_type, compressor_chain, reversibility, output}'
+```
+
+Request fields:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `protocol_version` | Yes | Compression request format version; currently `1` |
+| `content` | Yes | The exact model-visible string to consider |
+| `agent_id` | Yes | Stable frontend identifier |
+| `session_id`, `tool_use_id`, `tool_name` | No | Attribution and tool routing data |
+| `seam` | Yes | `before_model`, `pre_tool`, `post_tool`, or `proxy` |
+| `capabilities.replace_output` | No; default `false` | The host can replace the original model-visible value |
+| `capabilities.publish_retrieve_tool` | No; default `false` | The host exposes a usable retrieval Tool |
+| `capabilities.replace_with_text` | No; default `false` | The replacement slot accepts arbitrary text instead of schema-stable JSON |
+
+The pipeline detects `json_records`, `search_results`, `build_log`, `stack_trace`, `diff`, `html`,
+`tabular`, `source_code`, `plain_text`, or `unknown`, then runs only compressors compatible with the
+seam and declared host capabilities. Current production routing is:
+
+- `before_model` JSON tool arrays: schema compression.
+- `post_tool` JSON records: structural response cleanup; TOON may win for text-capable slots.
+- `post_tool` build logs and long plain text: lossless terminal cleanup followed by retrievable
+  build/log compression when replacement, retrieval, and text capabilities are all present.
+- Other detected content types: passthrough until a matching compressor is implemented.
+
+Only `disposition: "applied"` means `output` differs from the original. `dry_run`, `passthrough`,
+`no_savings`, `reversibility_unavailable`, `timeout`, and `error` all carry the original `content` in
+`output`, so adapters can emit it unconditionally. Responses also report `content_type`, ordered
+`compressor_chain`, `reversibility`, token estimates, committed `stash_keys`, `tokenizer_id`, and an
+optional bounded diagnostic.
+
+Unreadable, oversized, malformed, or unsupported-version requests exit with status `2` because the
+CLI cannot recover the original content from a valid request. Once decoding succeeds, compression
+failures are represented by a fail-open response and exit status `0`. `--stash-db` overrides the
+Stash path under the same path-safety rules as the direct commands.
+
+The build/log compressor engages only for real multi-line logs, preserves signal and trace regions,
+keeps fixed head/tail and failure-context windows, and replaces each eligible omitted gap with a
+retrievable marker. It rejects candidates saving fewer than 200 characters. Generic plain text uses
+a conservative 40-line head/tail window once it reaches 100 lines, plus a 16,384-character
+head/tail safety path for text at least 65,536 characters long.
 
 ## `compress-schema`
 
@@ -166,7 +236,7 @@ Field matching and truncation change the response representation seen by the mod
 
 Stash applies only to truncation of strings, the dropped middle segment of truncated arrays, and deep subtrees. Tail items are kept inline, not stashed. Blacklisted fields, `null`, and empty values are removed without a retrieval marker.
 
-Most adapters override these standalone defaults. Their shared shell profile uses `65536`, `128`, and `8`; the other-structured-tool profile uses `1048576`, `65536`, and `32`. Content-retrieval tools are skipped. See [Framework integration · Adapter processing rules](framework-integration.md#adapter-processing-rules).
+Most adapters override these standalone defaults. Their shared shell profile uses `65536`, `128`, and `8`; the other-structured-tool profile uses `1048576`, `65536`, and `32`. Content-retrieval tools are skipped. See [Agent integration · Adapter processing rules](framework-integration.md#adapter-processing-rules).
 
 ## `compress-toon` and `decompress-toon`
 

--- a/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/en/token-saving/tokenless/configuration-and-privacy.md
@@ -103,7 +103,7 @@ An empty value is treated as unset. `TOKENLESS_DATA_DIR` may name a directory th
 | Data | Default path | Default content | Retention | Stop new data |
 |------|--------------|-----------------|-----------|---------------|
 | Local statistics | `~/.tokenless/stats.db` | Complete before/after text, identifiers, and metrics | No automatic TTL; retained until cleared | `tokenless stats disable` |
-| Stash | `~/.tokenless/stash.db` | Original strings, dropped middle segments of truncated arrays, deep subtrees, and schema descriptions removed by truncation | One-hour TTL and 10,000 live entries; expired rows are purged lazily | CLI: `--no-stash`; agent: disable the adapter |
+| Stash | `~/.tokenless/stash.db` | Original strings, dropped middle segments of truncated arrays, deep subtrees, schema descriptions removed by truncation, and build/log gaps | One-hour TTL and 10,000 live entries; expired rows are purged lazily | CLI: `--no-stash`; agent: disable the adapter |
 | Configuration | `~/.tokenless/config.json` | Three Boolean toggles | Persistent | Not applicable |
 | SLS JSONL | `/var/log/anolisa/sls/ops/tokenless.jsonl` | Metrics and identifiers, no compressed source text | Managed by SLS/Logtail infrastructure | `TOKENLESS_SLS_ENABLED=0` or config false |
 
@@ -238,5 +238,5 @@ These values are managed by OpenClaw plugin configuration, not `~/.tokenless/con
 
 - [Measuring savings](measuring-savings.md)
 - [CLI reference](cli-reference.md)
-- [Framework integration](framework-integration.md)
+- [Agent integration](framework-integration.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -1,24 +1,24 @@
-# Tokenless Agent and Framework Integration
+# Tokenless Agent Integration
 
 [中文版](../../../zh/token-saving/tokenless/framework-integration.md)
 
-Tokenless has two integration layers. Agent adapters connect the installed binaries to concrete
-Agent products through plugins, hooks, and extensions. AgentScope support is instead an in-process
-Python framework package that application developers install and register explicitly.
+Tokenless connects to Agent products through plugins, hooks, and extensions. This guide covers
+product adapters. The Python SDK and its AgentScope-specific child document live under
+[Python SDK](sdk.md).
 
 ## Agent adapter support matrix
 
 | Agent product | Value | Tool Ready | Rewrite behavior | Response delivery | TOON | Schema |
 |-----------|-------|------------|------------------|-------------------|------|--------|
-| cosh | `cosh` | Hard-disabled | Replaces supported shell input | Cosh-NG replaces the response; legacy Copilot Shell appends context | Attempted after response compression | ✅ |
+| cosh | `cosh` | Hard-disabled | Replaces supported shell input | Cosh-NG replaces the response; legacy Copilot Shell passes through | Pipeline-selected for replaceable text | ✅ |
 | OpenClaw | `openclaw` | Hard-disabled | Replaces the `exec` command input | Replaces the persisted tool-result message | Off by default; opt in | — |
 | Hermes | `hermes` | Hard-disabled | Blocks the first call and asks the agent to retry | Replaces the result string | Attempted after response compression | — |
-| Qoder | `qoder` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
-| Claude Code | `claude-code` | Hard-disabled | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Used only when the replacement can remain text | — |
+| Qoder | `qoder` | Hard-disabled | Emits rewritten shell input | Replaces output through `updatedToolOutput` | Pipeline-selected for replaceable text | — |
+| Claude Code | `claude-code` | Hard-disabled | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Pipeline-selected for replaceable text | — |
 | Codex | `codex` | Hard-disabled | Replaces supported shell input | Keeps the original; adds context only for classified environment failures | — | — |
 | DeepSeek Harness | `dsh` | — | — | Replaces an accepted single-text JSON result when the replacement is smaller | — | — |
-| OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Attempted after response compression | ✅ |
-| Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Emits `additionalContext` | Attempted after response compression | — |
+| OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Pipeline-selected for replaceable text | ✅ |
+| Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Passes through because the host has no replacement field | — | — |
 
 “—” means that the capability is not available: the current adapter does not register it, or current host releases do not run it. The corresponding Tokenless CLI command may still be available.
 
@@ -26,14 +26,37 @@ Schema compression reaches the model path differently per host: cosh and Cosh-NG
 
 Tool Ready remains registered by these adapters but is unconditionally hard-disabled before checking, repair, or blocking. No runtime setting can re-enable it. Post-tool failure attribution is independent.
 
-`additionalContext` is an additive hook field. The Tokenless source does not remove the original result on those paths; the final treatment also depends on the host implementation. A statistics record proves that a candidate became smaller, not that the host removed the original from its model request.
-
-OpenCode currently uses the bundled lifecycle scripts documented below and is not registered with
-the `anolisa adapter enable` driver set in this release.
+`additionalContext` is an additive hook field. The shared hook does not place compressed copies
+there because the original would remain visible and total context would grow. It uses that field
+only for additive environment-error guidance. A statistics record proves that a candidate became
+smaller, not by itself that the host removed the original from its model request.
 
 ## Adapter processing rules
 
-The standalone `compress-response` defaults are not the defaults used by most adapters. Shared adapters classify tools as follows:
+The shared Cosh-NG, Qoder, Claude Code, and OpenCode hook sends one compression request to
+`tokenless compress`. The command detects the model-visible content, filters compressors by the
+host's declared replacement and retrieval capabilities, runs the eligible stages, and returns the
+original for every non-`applied` disposition. It currently routes:
+
+| Content | Current shared-hook behavior |
+|---------|------------------------------|
+| JSON records | Structural response cleanup, with TOON considered for text-capable replacement slots |
+| Build/test/package logs | Lossless terminal cleanup, then signal-preserving build/log compression with retrievable gap markers |
+| Long plain text | Lossless terminal cleanup, then conservative head/tail retention with retrievable gap markers |
+| Diff, stack trace, HTML, search results, tables, source code, unknown | Passthrough until a matching compressor exists |
+
+Build/log compression requires all three capabilities: replace the original output, publish a
+retrieval Tool, and replace with arbitrary text. It preserves signal lines and stack-trace regions,
+keeps context around failures plus fixed head/tail windows, and stashes each omitted gap. Short logs
+or candidates saving fewer than 200 characters pass through. Plain text engages at 100 lines, or at
+65,536 characters for the single-line safety path.
+
+Legacy OpenClaw, Hermes, and DeepSeek Harness integrations still use their dedicated response paths.
+Their response thresholds and feature sets are described below; the content-aware build/log path
+does not run there yet. The standalone `compress-response` command also remains the explicit JSON
+cleanup interface.
+
+For JSON response cleanup, shared and legacy adapters classify tools as follows:
 
 | Class | Default adapter behavior |
 |-------|--------------------------|
@@ -41,7 +64,13 @@ The standalone `compress-response` defaults are not the defaults used by most ad
 | Shell/exec | 65,536-character strings, 128 retained array items, depth 8 |
 | Other structured tools | 1,048,576-character strings, 65,536 retained array items, depth 32 |
 
-The shared response hook, OpenClaw, and Hermes skip inputs shorter than 200 characters. Skill-like text with YAML frontmatter is also skipped by the shared paths. The TOON encoding step only runs on payloads of at least 500 characters (the current implementation threshold, which may be adjusted later); smaller payloads keep the compressed form, because TOON savings on small JSON are negligible. The threshold applies to every TOON-capable pipeline: the shared response hook, the standalone TOON hook, OpenClaw, Hermes, and the standalone `tokenless compress-toon` CLI with the runtime/SDK TOON path (the CLI can lower the threshold per call with `--min-toon-chars`). Codex does not run response compression or TOON because its PostToolUse hook cannot replace the original output.
+The shared response hook, OpenClaw, and Hermes skip inputs shorter than 200 characters. Skill-like
+text with YAML frontmatter is also skipped by the shared paths. TOON runs only on payloads of at
+least 500 characters and only when the selected host slot accepts text; smaller payloads keep the
+prior candidate. The same default minimum applies to the standalone `compress-toon` CLI and SDK
+TOON path, while the CLI can lower it per call with `--min-toon-chars`. Codex and Qwen Code do not
+run response compression or TOON because their current PostToolUse contracts cannot replace the
+original model-visible output.
 
 Claude Code requires version 2.1.121 or later for `updatedToolOutput`. On older or unknown versions, response compression is disabled to avoid duplicating the original. Structured tool outputs preserve their host schema and do not switch to textual TOON; JSON carried as a string can use TOON when it is smaller.
 
@@ -162,6 +191,7 @@ anolisa adapter enable tokenless hermes
 anolisa adapter enable tokenless qoder
 anolisa adapter enable tokenless claude-code
 anolisa adapter enable tokenless codex
+anolisa adapter enable tokenless opencode
 anolisa adapter enable tokenless qwencode
 anolisa adapter enable tokenless dsh \
   --profile web \
@@ -176,9 +206,6 @@ DeepSeek Harness is profile-scoped and therefore requires at least one
 `--profile`. Each name must match one passed to `dsh --profile <profile>`; the
 generic command without a profile is rejected. A later enable or re-enable
 must repeat every profile that should remain registered.
-
-OpenCode uses its bundled install script under
-[Manual integration after npm installation](#manual-integration-after-npm-installation).
 
 For OpenClaw, anolisa first attempts a normal install and does not add an unsafe-install bypass by default. If OpenClaw rejects the plugin on its safety scan, read the reported findings. Only after accepting them, retry explicitly:
 
@@ -304,151 +331,12 @@ The extension loads in a new Qwen Code session. Restart and run one tool call to
 
 ## AgentScope framework integration
 
-The Python package supports AgentScope 1.0.11 through 1.0.x and AgentScope
-2.0.x. Choose the attachment point for the installed framework version:
+AgentScope is the second Python SDK layer, not a product adapter. Its complete build, version,
+attachment, configuration, and validation guidance now lives in
+[AgentScope SDK integration](sdk/agentscope.md). This heading remains as a compatibility pointer for
+existing links.
 
-| AgentScope version | Supported entry point |
-|---|---|
-| 1.0.11 through 1.0.x | Tokenless Toolkit plus `install(..., session_id=...)` |
-| 2.0.0 | Direct Agent construction with `integration.tools` and `integration.middlewares` |
-| 2.0.1 through 2.0.x | Direct Agent construction or App through `integration.app_options()` |
-
-The native `anolisa-tokenless` runtime wheel and AgentScope integration wheel
-are not currently published to a Python package index. Build and install both
-same-version wheels from a source checkout:
-
-```bash
-make python-wheel agentscope-wheel
-python -m pip install \
-  target/wheels/anolisa_tokenless-*.whl \
-  target/wheels/anolisa_tokenless_agentscope-*.whl
-```
-
-The native wheel also exposes the same read-only statistics capabilities as
-the CLI through typed Python values:
-
-```python
-from anolisa_tokenless import TokenlessStats
-
-stats = TokenlessStats("/absolute/path/to/tenant-tokenless-data")
-
-status = stats.status
-summary = stats.summary()
-recent = stats.list(limit=20)
-record = stats.show(recent[0].id)
-session_diff = stats.diff(session_id="conversation-id")
-comparison = stats.compare("baseline-session", "tokenless-session")
-```
-
-`TokenlessSdk.stats` lazily returns a client bound to that SDK's data directory.
-Token counts are estimates and only operations with positive savings are
-recorded. `show()` and record/tool-use `diff()` results may contain sensitive
-tool input and output from `stats.db`; summary, list, and comparison results do
-not return stored content. The API cannot clear data or change recording
-settings. Read-only describes those public operations: opening the client
-follows CLI initialization and may create or migrate `stats.db`, so the data
-directory must be writable. `limit=None` for summary or comparison reads at most
-the newest 10,000 records. Session and tool-use diffs also read at most the
-newest 10,000 matching records. For a meaningful comparison, pass a dry-run
-baseline session first and an active Tokenless session second.
-
-Both major versions use `TokenlessAgentScope` and `TokenlessConfig`; only the
-final attachment step differs. AgentScope 1.x uses a Tokenless Toolkit whose
-regular and MCP registration paths also cover tools added after construction:
-
-```python
-from agentscope.agent import ReActAgent
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(
-        mode="balanced",
-        data_dir="/absolute/path/to/tenant-tokenless-data",
-    ),
-)
-toolkit = integration.create_toolkit()
-toolkit.register_tool_function(application_tool)
-agent = ReActAgent(..., toolkit=toolkit)
-integration.install(agent, session_id="conversation-id")
-```
-
-In AgentScope 2.x, pass the retrieval Tool and middleware when constructing the
-Toolkit and Agent. This works from 2.0.0 and does not depend on mutable Toolkit
-APIs introduced in later patch releases:
-
-```python
-from agentscope.agent import Agent
-from agentscope.tool import Toolkit
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(
-        mode="balanced",
-        data_dir="/absolute/path/to/tenant-tokenless-data",
-        # retrieve_tool_name="tenant_tokenless_retrieve",
-    ),
-)
-toolkit = Toolkit(tools=[*application_tools, *integration.tools])
-
-agent = Agent(
-    ...,
-    toolkit=toolkit,
-    middlewares=integration.middlewares,
-)
-```
-
-AgentScope App is supported from 2.0.1. `app_options()` derives an isolated
-Tokenless data directory for every user/agent/session below the configured
-absolute base directory:
-
-```python
-from agentscope.app import create_app
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(data_dir="/srv/tokenless-tenants"),
-)
-app = create_app(..., **integration.app_options())
-```
-
-Set a unique `retrieve_tool_name` in `TokenlessConfig` if the application
-already defines `tokenless_retrieve`; App assembly does not expose other tools
-to its factory for a preflight collision check. AgentScope 2.0.0 does not
-provide App-level Agent middleware or Tool injection, so it supports direct
-Agent construction only. The existing `TokenlessMiddleware` 2.x API remains
-available for compatibility; new code should use `TokenlessAgentScope` to
-avoid patch-specific Toolkit mutation and automatic Tool collection behavior.
-
-Choose a mode according to how much inline truncation the application accepts:
-
-| Mode | Read/Glob/Grep | Other tools |
-|------|----------------|-------------|
-| `conservative` | Compress | 1 MiB strings, 65,536 array items, depth 32 |
-| `balanced` (default) | Skip | Shell: 65,536 / 128 / depth 8; others: conservative limits |
-| `aggressive` | Skip | CLI defaults: 4,096 / 32 / depth 8 |
-
-The integration passes intermediate streaming chunks through unchanged, preserves framework
-objects, and transforms only copied call arguments and final model-visible text. Tokenless keeps
-the original whenever an optimization fails or does not make the UTF-8 result strictly smaller.
-`DataBlock` values are never changed.
-
-The integration also exposes a retrieval Tool named `tokenless_retrieve` by
-default. It is published to the model only when a marker is visible and returns
-content only for an exact 24-character hexadecimal hash retained in that
-session's marker set. The Tool is permanently excluded from compression. This
-narrow permission still depends on storage isolation: pass a
-separate absolute `data_dir` for every user or tenant. If `data_dir` is omitted,
-`TOKENLESS_DATA_DIR` is only a process-wide fallback and must not be shared by
-multiple tenants. Retrieval does not work across nodes. Stash entries expire
-after the current fixed one-hour TTL, so the Agent should retrieve necessary
-content before that boundary.
-
-Both adapters enable schema compression, RTK command rewriting, response compression, TOON,
-retrieval, environment-error guidance, and per-call attribution. The platform wheel contains RTK
-and links TOON directly, so it does not search for system helper binaries. Tool Ready remains
-hard-disabled.
-
-## Verify the actual integration
+## Verify an Agent adapter
 
 For an Agent adapter, do not treat a zero install exit code as the only success criterion. At
 minimum, run:
@@ -461,20 +349,11 @@ tokenless stats list --limit 5
 
 Then execute a tool task with visible output in the target agent. If `stats list` remains empty, follow [No statistics appear after enabling the adapter](troubleshooting.md#no-statistics-appear-after-enabling-the-adapter).
 
-For the AgentScope framework package, validate the two wheels and the declared AgentScope version
-range from a source checkout with:
-
-```bash
-make test-agentscope-integration
-```
-
-Then exercise one successful, compressible tool response in the application and confirm that the
-middleware returns the smaller result and that `tokenless_retrieve` can recover marker-scoped
-content from the same `data_dir`.
-
 ## Related documents
 
 - [Quick Start](QUICKSTART.md)
+- [Python SDK](sdk.md)
+- [AgentScope SDK integration](sdk/agentscope.md)
 - [Measuring savings](measuring-savings.md)
 - [Configuration and data privacy](configuration-and-privacy.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/user-guide/en/token-saving/tokenless/sdk.md
+++ b/docs/user-guide/en/token-saving/tokenless/sdk.md
@@ -1,0 +1,404 @@
+# Tokenless Python SDK
+
+[中文版](../../../zh/token-saving/tokenless/sdk.md)
+
+Tokenless provides two Python SDK layers:
+
+| Layer | Package | Purpose |
+|-------|---------|---------|
+| Framework-neutral SDK | `anolisa-tokenless` | Integrate any Agent lifecycle, invoke individual Tokenless operations, or query statistics |
+| AgentScope integration | `anolisa-tokenless-agentscope` | Attach the framework-neutral SDK to the supported AgentScope 1.x and 2.x lifecycle APIs |
+
+The AgentScope layer depends on the exact same version of the framework-neutral SDK and delegates
+Tokenless operations to it; it is not a separate compression implementation. This page introduces
+both layers. Detailed AgentScope usage lives in the
+[AgentScope SDK integration](sdk/agentscope.md) child document, while product plugins remain in
+[Agent integration](framework-integration.md).
+
+## Layer 1: Framework-neutral SDK
+
+The `anolisa-tokenless` wheel lets Python applications run Tokenless in process. Use
+`TokenlessSdk` when integrating Tokenless into an Agent lifecycle. Use `TokenlessRuntime` when you
+do not need lifecycle integration and only want to invoke a specific operation, such as compressing
+one response or retrieving one Stash entry. Use `TokenlessStats` only for statistics queries.
+
+### Install from GitHub Release
+
+Official SDK wheels are attached to Tokenless GitHub Releases starting with
+[v0.7.14](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.7.14). They require
+CPython 3.11 or later. Select the native `anolisa-tokenless` wheel for the target system:
+
+| System | Release asset |
+|--------|---------------|
+| Linux x86_64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` |
+| Linux aarch64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` |
+| macOS Apple silicon | `anolisa_tokenless-<version>-cp311-abi3-macosx_11_0_arm64.whl` |
+
+For example, install v0.7.14 on Linux x86_64 into a virtual environment:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless-0.7.14-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+```
+
+The Linux assets target glibc-based distributions compatible with `manylinux_2_17`; they do not
+support Alpine Linux or other musl-based distributions. The Release also includes
+`SHA256SUMS-python-wheels.txt` for download verification.
+
+The wheel contains the native Tokenless runtime and the matching RTK executable. It does not need
+the `tokenless` CLI, a system RTK binary, or a separate TOON executable.
+
+### Build from source
+
+Source builds in this repository are Linux-only. Build the SDK from the Tokenless component
+directory with a discoverable CPython 3.11 or later development environment:
+
+```bash
+make python-wheel
+python3 -m venv /tmp/tokenless-sdk
+/tmp/tokenless-sdk/bin/pip install target/wheels/anolisa_tokenless-*.whl
+```
+
+`make python-wheel` uses `uvx` to provide Maturin by default. Install
+[`uv`](https://docs.astral.sh/uv/) first, or use a compatible Maturin already on `PATH`:
+
+```bash
+make python-wheel MATURIN=maturin
+```
+
+Pip installs the wheel in unpacked form, which gives the packaged RTK executable the stable path
+required by command rewriting.
+
+### Choose an API
+
+| API | Role | Use it for |
+|-----|------|------------|
+| `TokenlessSdk` | Lifecycle integration | Connect Tokenless to the model-call and tool-call stages of an Agent framework |
+| `TokenlessRuntime` | Individual operations | Directly compress one schema, response, or TOON payload, or retrieve one Stash entry |
+| `TokenlessStats` | Statistics queries | Read status, summaries, recent records, record details, diffs, and session comparisons |
+
+`TokenlessSdk` is the recommended integration surface for a new agent framework. It owns one
+`TokenlessRuntime`, exposes the same state directory through `sdk.runtime.data_dir`, and creates
+`sdk.stats` lazily when statistics are queried.
+
+### Complete lifecycle example
+
+This example compresses a model-visible tool schema, compresses a successful tool result, and
+recovers one marker-authorized Stash payload. It disables RTK and TOON so the example focuses on the
+schema/response lifecycle and has no command-execution dependency.
+
+```python
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from anolisa_tokenless import (
+    Attribution,
+    ModelRequest,
+    RetrieveRequest,
+    TokenlessConfig,
+    TokenlessSdk,
+    ToolCall,
+    ToolResult,
+    ToolStatus,
+)
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="tokenless-sdk-") as data_dir:
+        sdk = TokenlessSdk(
+            TokenlessConfig(
+                data_dir=Path(data_dir),
+                mode="aggressive",
+                min_chars=0,
+                rtk_enabled=False,
+                toon_enabled=False,
+            )
+        )
+        model_attribution = Attribution("my-agent", "session-42")
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Detailed lookup instructions. " * 100,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        model_request = await sdk.before_model(
+            ModelRequest((tool,), "", model_attribution)
+        )
+        print([item.get("function", {}).get("name") for item in model_request.tools])
+
+        call = ToolCall(
+            "api",
+            {},
+            Attribution("my-agent", "session-42", "tool-7"),
+        )
+        original = json.dumps(
+            {"items": [{"name": "same", "value": index} for index in range(300)]}
+        )
+        result = await sdk.after_tool_call(
+            ToolResult(call, original, ToolStatus.SUCCESS)
+        )
+        print(result.transformed, len(original), len(result.content))
+
+        visible_markers = sdk.extract_markers(result.content)
+        if visible_markers:
+            marker_hash = next(iter(visible_markers))
+            recovered = await sdk.retrieve(
+                RetrieveRequest(marker_hash, visible_markers, model_attribution)
+            )
+            print(f"recovered {len(recovered)} characters")
+
+
+asyncio.run(main())
+```
+
+`TemporaryDirectory` keeps the example self-contained and deletes its state on exit. In production,
+use a stable, writable absolute `data_dir`, with a different directory for every tenant or security
+boundary.
+
+The SDK treats lifecycle values as immutable contracts: it copies tool schemas and argument maps
+instead of modifying caller-owned objects. Keep the returned `ModelRequest`, `ToolCall`, and
+`ToolResult`; the original values do not reflect transformations.
+
+### The four lifecycle seams
+
+#### Before a model call
+
+```python
+request = await sdk.before_model(
+    ModelRequest(tuple(model_tools), visible_context, attribution)
+)
+```
+
+`before_model()` compresses OpenAI Function Calling tools, scans the transformed tools and visible
+context for `<<tokenless:HASH>>` markers, and publishes the configured retrieval schema only when at
+least one marker is visible. The name defaults to `tokenless_retrieve` and is reserved; set a unique
+`retrieve_tool_name` when the application already owns that name.
+
+#### Before a tool call
+
+```python
+call = await sdk.before_tool_call(
+    ToolCall(
+        "shell",
+        {"command": "grep needle large.log"},
+        Attribution("my-agent", "session-42", "tool-8"),
+        command_field="command",
+    )
+)
+```
+
+The SDK considers only the explicitly named `command_field`. If RTK has a rewrite, the returned
+arguments contain the packaged RTK path and per-call attribution environment. Execute the returned
+arguments, and preserve `call.rewritten` when constructing the final `ToolResult`; rewritten calls
+skip result compression because RTK already reduced their output at the source.
+
+#### After a tool call
+
+```python
+result = await sdk.after_tool_call(
+    ToolResult(call, model_visible_text, ToolStatus.SUCCESS)
+)
+```
+
+Successful, non-rewritten final text can pass through response compression and then TOON. The SDK
+keeps the original unless the UTF-8 result is strictly smaller. `ERROR` results are not compressed;
+recognized dependency, permission, path, network, and package failures may instead receive
+`additional_context` guidance. `INTERRUPTED` and `DENIED` results pass through.
+
+#### Marker-scoped retrieval
+
+```python
+markers = sdk.extract_markers(model_visible_context)
+payload = await sdk.retrieve(
+    RetrieveRequest(marker_hash, markers, attribution)
+)
+```
+
+Retrieval accepts exactly 24 hexadecimal characters and only a hash present in the supplied visible
+marker set. Treat that set as model-call state: recompute it from the actual model-visible context
+instead of accumulating every marker ever seen in a session. Retrieval also requires the same
+Tokenless data directory and an unexpired Stash entry.
+
+### Configuration
+
+```python
+config = TokenlessConfig(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    min_chars=200,
+    excluded_tools={"read_database"},
+    retrieve_tool_name="tokenless_retrieve",
+    schema_compression_enabled=True,
+    response_compression_enabled=True,
+    toon_enabled=True,
+    rtk_enabled=True,
+)
+```
+
+| Mode | Content-retrieval tools | Other tools |
+|------|-------------------------|-------------|
+| `conservative` | Compress | 1 MiB strings, 65,536 array items, depth 32 |
+| `balanced` (default) | Skip | Shell: 65,536 / 128 / depth 8; others use conservative limits |
+| `aggressive` | Skip | 4,096-character strings, 32 array items, depth 8 |
+
+`data_dir` must be absolute and writable. Use a different directory for every tenant or security
+boundary; `TOKENLESS_DATA_DIR` is only a process-wide fallback. `excluded_tools` is added to
+Tokenless's built-in exclusions, and the retrieval tool is always excluded from response
+optimization.
+
+The SDK lifecycle currently uses the schema/response/TOON Runtime operations. The CLI and shared
+Agent hooks additionally expose the content-aware Pipeline, including build/log compression; that
+Pipeline is not a `TokenlessSdk` method yet.
+
+### Direct Runtime examples
+
+Use `TokenlessRuntime` when the caller does not need `TokenlessSdk` to coordinate an Agent lifecycle
+and wants to invoke Tokenless operations directly. Create one Runtime for the data directory:
+
+```python
+import json
+import re
+from anolisa_tokenless import TokenlessRuntime
+
+runtime = TokenlessRuntime("/absolute/path/to/tokenless-data")
+```
+
+#### Compress a response
+
+```python
+original_response = json.dumps(
+    {"items": [f"record-{index:04d}" for index in range(200)]}
+)
+response_result = runtime.compress_response(
+    original_response,
+    truncate_arrays_at=32,
+    agent_id="my-agent",
+    session_id="session-42",
+    tool_use_id="tool-7",
+    require_reversible=True,
+)
+model_visible_response = response_result.output
+print(response_result.disposition, response_result.before_tokens, response_result.after_tokens)
+```
+
+#### Compress a tool schema
+
+```python
+tool_schema = {
+    "type": "function",
+    "function": {
+        "name": "lookup",
+        "description": "Detailed lookup instructions. " * 100,
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+schema_result = runtime.compress_schema(
+    json.dumps(tool_schema),
+    agent_id="my-agent",
+    session_id="session-42",
+)
+model_visible_schema = json.loads(schema_result.output)
+```
+
+#### Encode JSON as TOON
+
+```python
+records = {
+    "items": [
+        {"name": f"item-{index:04d}", "status": "ready"}
+        for index in range(100)
+    ]
+}
+toon_result = runtime.compress_toon(
+    json.dumps(records),
+    agent_id="my-agent",
+    session_id="session-42",
+    tool_use_id="tool-8",
+)
+model_visible_text = toon_result.output
+```
+
+`compress_toon()` keeps the original JSON when TOON would not reduce the estimated token count.
+
+#### Retrieve stashed content
+
+Response or schema compression may place omitted content in Stash and leave a marker in the output:
+
+```python
+marker = re.search(r"<<tokenless:([0-9a-f]{24})>>", response_result.output)
+if marker is not None:
+    recovered_content = runtime.retrieve(marker.group(0))
+    print(recovered_content)
+```
+
+`retrieve()` accepts either the complete marker or its 24-character hash. Direct Runtime callers
+must decide which markers are authorized for retrieval; `TokenlessSdk.retrieve()` applies the SDK's
+model-visible marker check.
+
+Runtime inputs and outputs are strings. Use each `CompressionResult.output` as the exact downstream
+value, then inspect its `disposition`, token counts, and Stash fields when the caller needs to
+understand whether and how the input changed.
+
+### Query statistics
+
+```python
+from anolisa_tokenless import TokenlessStats
+
+stats = TokenlessStats("/absolute/path/to/tokenless-data")
+status = stats.status
+summary = stats.summary()
+recent = stats.list(limit=20)
+
+print(status.database_path, summary.total.tokens_saved)
+if recent:
+    record = stats.show(recent[0].id)
+    change = stats.diff(record_id=record.id)
+```
+
+Use `stats.diff(session_id="...")` for a session overview,
+`stats.diff(session_id="...", tool_use_id="...")` for one tool lifecycle, and
+`stats.compare("baseline-session", "tokenless-session")` for a dry-run versus active comparison.
+
+Token counts are estimates, and only operations with positive savings are recorded. `list()`,
+`summary()`, and `compare()` do not return stored content; `show()` and detailed `diff()` results may
+contain sensitive tool input or output. The public query API does not clear data or change settings,
+but opening it may create or migrate `stats.db`, so the selected data directory must be writable.
+
+## Layer 2: AgentScope integration
+
+`anolisa-tokenless-agentscope` maps the framework-neutral lifecycle to AgentScope. Application code
+uses `TokenlessAgentScope` instead of calling `before_model()`, `before_tool_call()`,
+`after_tool_call()`, and `retrieve()` itself. The integration also carries AgentScope session and
+tool-call attribution into the generic SDK.
+
+See [AgentScope SDK integration](sdk/agentscope.md) for supported versions, build and installation,
+complete 1.x/2.x/App examples, configuration, retrieval boundaries, and validation. Product adapters
+such as Claude Code and OpenCode are separate from both Python SDK layers.
+
+## Validate both SDK layers
+
+Build the framework-neutral wheel and run its installed-wheel tests:
+
+```bash
+make python-wheel
+make test-python-runtime
+```
+
+Validate the AgentScope layer with the commands in its
+[child document](sdk/agentscope.md#validate-the-integration).
+
+## Related documents
+
+- [Agent integration](framework-integration.md)
+- [AgentScope SDK integration](sdk/agentscope.md)
+- [CLI reference](cli-reference.md)
+- [Measuring savings](measuring-savings.md)
+- [Configuration and data privacy](configuration-and-privacy.md)
+- [Runtime design](../../../../../src/tokenless/docs/design/runtime-library.md)

--- a/docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md
+++ b/docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md
@@ -1,0 +1,167 @@
+# Tokenless AgentScope SDK Integration
+
+[中文版](../../../../zh/token-saving/tokenless/sdk/agentscope.md)
+
+`anolisa-tokenless-agentscope` is the AgentScope-specific layer above the framework-neutral
+`anolisa-tokenless` SDK. It maps AgentScope lifecycle APIs to `TokenlessSdk` and depends on the
+exact same package version; it does not implement compression separately.
+
+Read the [Python SDK overview](../sdk.md) first when choosing between the generic SDK and this
+AgentScope layer. Product adapters such as Claude Code and OpenCode are documented separately in
+[Agent integration](../framework-integration.md).
+
+## Supported AgentScope versions
+
+| AgentScope version | Supported entry point |
+|--------------------|-----------------------|
+| 1.0.11 through 1.0.x | Tokenless Toolkit plus `install(..., session_id=...)` |
+| 2.0.0 | Direct Agent construction with `integration.tools` and `integration.middlewares` |
+| 2.0.1 through 2.0.x | Direct Agent construction or App through `integration.app_options()` |
+
+## Install
+
+The AgentScope integration wheel requires the exact same version of the native Runtime wheel.
+Install both assets from the same Tokenless GitHub Release in one command. For example, install
+[v0.7.14](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.7.14) on Linux x86_64:
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless-0.7.14-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless_agentscope-0.7.14-py3-none-any.whl"
+```
+
+For Linux aarch64 or macOS Apple silicon, replace the native Runtime URL with the matching asset
+listed in the [SDK overview](../sdk.md); keep both package versions identical.
+
+### Build from source
+
+Alternatively, build and install both same-version wheels from a source checkout:
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+## AgentScope 1.x
+
+AgentScope 1.x uses a Tokenless Toolkit. Its regular and MCP registration paths also cover tools
+added after construction:
+
+```python
+from agentscope.agent import ReActAgent
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(
+        mode="balanced",
+        data_dir="/absolute/path/to/tenant-tokenless-data",
+    ),
+)
+toolkit = integration.create_toolkit()
+toolkit.register_tool_function(application_tool)
+agent = ReActAgent(..., toolkit=toolkit)
+integration.install(agent, session_id="conversation-id")
+```
+
+## AgentScope 2.x
+
+Pass the retrieval Tool and middleware when constructing the Toolkit and Agent. This works from
+2.0.0 and does not depend on mutable Toolkit APIs introduced in later patch releases:
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(
+        mode="balanced",
+        data_dir="/absolute/path/to/tenant-tokenless-data",
+        # retrieve_tool_name="tenant_tokenless_retrieve",
+    ),
+)
+toolkit = Toolkit(tools=[*application_tools, *integration.tools])
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=integration.middlewares,
+)
+```
+
+The existing `TokenlessMiddleware` 2.x API remains available for compatibility. New code should
+use `TokenlessAgentScope` to avoid patch-specific Toolkit mutation and automatic Tool collection
+behavior.
+
+## AgentScope App
+
+AgentScope App is supported from 2.0.1. `app_options()` derives an isolated Tokenless data directory
+for every user/agent/session below the configured absolute base directory:
+
+```python
+from agentscope.app import create_app
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(data_dir="/srv/tokenless-tenants"),
+)
+app = create_app(..., **integration.app_options())
+```
+
+AgentScope 2.0.0 does not provide App-level Agent middleware or Tool injection, so it supports
+direct Agent construction only.
+
+## Configuration and behavior
+
+Set a unique `retrieve_tool_name` in `TokenlessConfig` if the application already defines
+`tokenless_retrieve`; App assembly does not expose other tools to its factory for a preflight
+collision check.
+
+Choose a mode according to how much inline truncation the application accepts:
+
+| Mode | Read/Glob/Grep | Other tools |
+|------|----------------|-------------|
+| `conservative` | Compress | 1 MiB strings, 65,536 array items, depth 32 |
+| `balanced` (default) | Skip | Shell: 65,536 / 128 / depth 8; others: conservative limits |
+| `aggressive` | Skip | CLI defaults: 4,096 / 32 / depth 8 |
+
+The integration passes intermediate streaming chunks through unchanged, preserves framework
+objects, and transforms only copied call arguments and final model-visible text. Tokenless keeps
+the original whenever an optimization fails or does not make the UTF-8 result strictly smaller.
+`DataBlock` values are never changed.
+
+The integration exposes a retrieval Tool named `tokenless_retrieve` by default. It is published to
+the model only when a marker is visible and accepts only an exact 24-character hexadecimal hash
+retained in that session's marker set. The Tool is permanently excluded from compression.
+
+Pass a separate absolute `data_dir` for every user or tenant. `TOKENLESS_DATA_DIR` is only a
+process-wide fallback and must not be shared by multiple tenants. Retrieval does not work across
+nodes. Stash entries expire after the current fixed one-hour TTL.
+
+Both AgentScope version paths enable schema compression, RTK command rewriting, response
+compression, TOON, retrieval, environment-error guidance, and per-call attribution. The platform
+wheel contains RTK and links TOON directly, so it does not search for system helper binaries. Tool
+Ready remains hard-disabled.
+
+## Validate the integration
+
+Run the installed-wheel and supported-version matrix tests from a source checkout:
+
+```bash
+make test-agentscope-integration
+```
+
+Then exercise one successful, compressible tool response in the application. Confirm that the
+middleware returns the smaller result and that `tokenless_retrieve` can recover marker-scoped
+content from the same `data_dir`.
+
+## Related documents
+
+- [Python SDK overview](../sdk.md)
+- [Agent integration](../framework-integration.md)
+- [Configuration and data privacy](../configuration-and-privacy.md)
+- [Troubleshooting](../troubleshooting.md)

--- a/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/en/token-saving/tokenless/troubleshooting.md
@@ -177,7 +177,7 @@ anolisa adapter scan
 anolisa --verbose adapter enable tokenless <framework>
 ```
 
-For npm installations, use [Framework integration · Manual integration after npm installation](framework-integration.md#manual-integration-after-npm-installation).
+For npm installations, use [Agent integration · Manual integration after npm installation](framework-integration.md#manual-integration-after-npm-installation).
 
 For a directly installed RPM, create the missing state record, then rerun the
 adapter command as the target framework user:
@@ -274,7 +274,12 @@ Expired or never-successfully-written content cannot be recovered.
 
 ## Statistics exist but the prompt is not smaller
 
-First check the framework's response-delivery path in the [support matrix](framework-integration.md#agent-adapter-support-matrix). Qoder and Qwen Code emit `additionalContext`, and legacy Copilot Shell appends it. Codex intentionally avoids response compression because it cannot replace the original result; its PostToolUse context is limited to classified environment failures. Actual Codex savings should be measured on RTK-rewritten shell calls.
+First check the framework's response-delivery path in the
+[support matrix](framework-integration.md#agent-adapter-support-matrix). Qoder replaces output
+through `updatedToolOutput`. Qwen Code and legacy Copilot Shell pass post-tool output through because
+their current contracts provide no replacement field; compressed copies are not injected through
+`additionalContext`. Codex also avoids response compression and limits its PostToolUse context to
+classified environment failures. Measure Codex savings on RTK-rewritten shell calls.
 
 For Claude Code, response replacement requires version 2.1.121 or later. Older or unrecognized versions pass the original through. OpenClaw replaces persisted results, but TOON remains off unless `toon_compression_enabled=true`.
 

--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -19,10 +19,10 @@ cargo build --release --locked -p tokenless-cli
 
 This path produces only the standalone `tokenless` CLI. It does not install `rtk` or the agent integration resources. To use the complete feature set in an agent, install through the anolisa CLI as described in the [Quick Start](QUICKSTART.md).
 
-## Build the Python runtime from source
+## Build the Python SDK from source
 
-Framework integrations running in CPython can use Tokenless in-process instead of starting the
-CLI for every response:
+CPython applications can use Tokenless in process instead of starting the CLI for every lifecycle
+operation:
 
 ```bash
 make python-wheel
@@ -30,53 +30,25 @@ python3 -m venv /tmp/tokenless-python
 /tmp/tokenless-python/bin/pip install target/wheels/anolisa_tokenless-*.whl
 ```
 
-The build requires a discoverable CPython 3.11+ development environment.
-`make python-wheel` uses `uvx` to provision Maturin, so install
-[`uv`](https://docs.astral.sh/uv/) first; alternatively, install Maturin and run
-`make python-wheel MATURIN=maturin`. Full `cargo test --workspace` commands also
-compile the Python member and require the same environment, while default
-workspace Cargo commands exclude it.
+The build requires a discoverable CPython 3.11+ development environment. The wheel uses the
+CPython 3.11 stable ABI and remains specific to the operating system and architecture for which it
+was built.
 
-The wheel uses the CPython 3.11 stable ABI, so it supports CPython 3.11 and later on the operating
-system and CPU architecture where it was built. The package is not yet published to PyPI.
-
-The first API accepts JSON text and exposes response compression and Stash retrieval:
-
-```python
-import json
-from pathlib import Path
-
-from anolisa_tokenless import TokenlessRuntime
-
-runtime = TokenlessRuntime(Path.home() / ".local/state/my-agent/tokenless")
-result = runtime.compress_response(
-    json.dumps({"items": list(range(200))}),
-    truncate_arrays_at=32,
-    agent_id="my-agent",
-    session_id="session-42",
-    tool_use_id="tool-7",
-)
-model_visible_output = result.output
-```
-
-The Python API defaults to reversible fail-open behavior: when Stash was requested but is
-unavailable, a write fails, or a configured limit cannot fit a retrieval marker,
-`result.output` remains the original JSON and
-`result.disposition` is `reversibility-unavailable`. Use a separate absolute data directory for
-each user or tenant. Schema compression, TOON, RTK, MCP, and framework middleware are not included
-in this first API. See the [runtime design](../../../../../src/tokenless/docs/design/runtime-library.md)
-for the state and concurrency contract.
+The Python SDK has two layers. The `anolisa-tokenless` package exposes the framework-neutral
+`TokenlessSdk`, direct `TokenlessRuntime` operations, and typed `TokenlessStats` queries. The
+same-version `anolisa-tokenless-agentscope` package maps that generic lifecycle to AgentScope. See
+the [Python SDK guide](sdk.md) for both layers, runnable examples, and configuration.
 
 ## Capabilities and boundaries
 
 | Capability | Behavior implemented in the current code | Important boundary |
 |------------|------------------------------------------|--------------------|
 | Schema compression | Removes `title` and `examples`, removes fenced and inline code from descriptions, collapses whitespace, and truncates descriptions | Runs on the cosh/Cosh-NG `BeforeModel` hook and per OpenCode tool definition (Qwen Code's manifest entry is skipped by current hosts); other users can call the CLI |
-| Response compression | Removes exact, case-sensitive debug-field names, `null`, empty strings/arrays/objects, and truncates values past configured limits | Accepts JSON; content-retrieval tools are intentionally skipped by adapters |
-| TOON encoding | Encodes JSON and keeps the JSON input when the estimated token count does not decrease | Whether TOON replaces or accompanies the original depends on the adapter |
+| Content-aware response compression | Routes JSON records, build logs, and long plain text through matching compressors, then accepts only a smaller end-to-end result | Direct `compress-response` remains JSON-only; host capabilities decide whether shared hooks can replace with text and publish retrieval |
+| TOON encoding | Encodes JSON and keeps the JSON input when the estimated token count does not decrease | Replaces the original when the host accepts text replacement; hosts without replacement capability pass through |
 | Command rewriting | Calls `rtk rewrite` and submits the rewritten shell input when a rule is available | The command actually sent to the shell changes; unsupported or denied rewrites pass through |
 | Tool Ready | Legacy pre-call checks for declared binaries, versions, configuration, permissions, and optional dependencies | Hard-disabled; it cannot inspect, repair, or block tool execution |
-| Stash | Stores content removed by string, array, depth, or schema-description truncation | One-hour TTL and 10,000 live entries by default; other removed fields are not stashed |
+| Stash | Stores content removed by string, array, depth, or schema-description truncation and by build/log gap removal | One-hour TTL and 10,000 live entries by default; other removed fields are not stashed |
 
 The implementation contains no fixed saving-rate guarantee. Results depend on the payload, adapter delivery semantics, and the share of the model context that came from tool data. Measure your own workload as described in [Measuring savings](measuring-savings.md).
 
@@ -86,11 +58,15 @@ After an adapter is enabled, a tool call may pass through these stages:
 
 ```text
 Before the tool: hard-disabled Tool Ready hook → command rewrite
-After the tool: response compression → optional Stash → TOON encoding → statistics
+After the tool: content detection → eligible compressors → optional Stash/TOON → statistics
 Before the model: schema compression
 ```
 
-This is a capability map, not a pipeline that every framework runs. For example, OpenClaw disables TOON by default, Codex relies on RTK source reduction and does not run response compression, and schema compression only runs on cosh/Cosh-NG (`BeforeModel` hook) and OpenCode (per tool definition). See [Framework integration](framework-integration.md).
+This is a capability map, not a pipeline that every framework runs. For example, the content-aware
+protocol path currently serves Cosh-NG, Qoder, supported Claude Code releases, and OpenCode;
+OpenClaw, Hermes, and DeepSeek Harness retain dedicated JSON response paths. Codex and Qwen Code do
+not replace post-tool output under their current host contracts. See
+[Agent integration](framework-integration.md).
 
 ## Behaviors to understand
 
@@ -106,7 +82,9 @@ CLI-only use does not require an adapter.
 
 ### “Compression off” affects only compression operations
 
-With `compression_enabled=false` or `TOKENLESS_COMPRESSION_ENABLED=0`, `compress-schema`, `compress-response`, and `compress-toon`—whether called directly or through an adapter—still calculate predicted savings and may write statistics, but return the original input. They do not write Stash entries in this mode.
+With `compression_enabled=false` or `TOKENLESS_COMPRESSION_ENABLED=0`, `compress`,
+`compress-schema`, `compress-response`, and `compress-toon` still calculate predicted savings and
+may write statistics, but return the original input. They do not write Stash entries in this mode.
 
 This setting does not disable RTK command rewriting, adapter execution, or retrieval. Tool Ready is independently hard-disabled. To stop all Tokenless behavior in an agent, disable the adapter:
 
@@ -116,7 +94,8 @@ anolisa adapter disable tokenless <framework>
 
 ### Reversible compression is conditional
 
-Active response and schema truncation stash the removed payload in `~/.tokenless/stash.db` by default and add a marker such as:
+Active response/schema truncation and build/log gap removal stash the removed payload in
+`~/.tokenless/stash.db` by default and add a marker such as:
 
 ```text
 <<tokenless:0123456789abcdef01234567>>
@@ -135,7 +114,10 @@ Stash does not make all compression reversible. Removed `debug`/`trace` fields, 
 
 ### Processing errors usually fail open
 
-Compression and rewrite hooks normally return no modification when `tokenless` or `rtk` is missing, compression provides no savings, or an ordinary processing error occurs. Tool Ready is hard-disabled before its legacy check, repair, and blocking logic. Post-tool failure attribution is independent and remains unchanged. A Stash write failure may still allow lossy compression to continue.
+Compression and rewrite hooks normally return no modification when `tokenless` or `rtk` is missing,
+compression provides no savings, or an ordinary processing error occurs. The `compress` command returns
+the original in every non-`applied` response. Tool Ready is hard-disabled before its legacy check,
+repair, and blocking logic. Post-tool failure attribution is independent and remains unchanged.
 
 Command rewriting also changes the shell command submitted by the host. Most adapters replace the command input directly; Hermes blocks the first call and tells the agent to retry with the rewritten command. Validate important command workflows as well as compressed output.
 
@@ -143,14 +125,14 @@ Command rewriting also changes the shell command submitted by the host. Most ada
 
 | Agent product | Integration | Current code path |
 |-----------|-------------|-------------------|
-| cosh | Extension | Hard-disabled Tool Ready, rewrite, response + TOON, Schema; Cosh-NG has a replacement path, while legacy Copilot Shell appends additional context |
+| cosh | Extension | Hard-disabled Tool Ready, rewrite, Schema; Cosh-NG replaces eligible pipeline output, while legacy Copilot Shell passes post-tool output through |
 | OpenClaw | Plugin | Hard-disabled Tool Ready, `exec` rewrite, persisted-result replacement, optional TOON; no Schema |
 | Hermes | Plugin | Hard-disabled Tool Ready, block-and-retry rewrite, result replacement with response + TOON; no Schema |
-| Qoder | Plugin | Hard-disabled Tool Ready, rewrite, response + TOON through `additionalContext`; no Schema |
+| Qoder | Plugin | Hard-disabled Tool Ready, rewrite, response pipeline through `updatedToolOutput`; no Schema |
 | Claude Code | Marketplace plugin | Hard-disabled Tool Ready, Bash rewrite, response replacement on Claude Code 2.1.121 or later; conditional TOON; no Schema |
 | Codex | Plugin | Hard-disabled Tool Ready, RTK rewrite, environment-failure diagnostics; no response/TOON replacement or Schema |
 | OpenCode | Plugin | Hard-disabled Tool Ready, Bash rewrite, tool-output replacement with response + TOON, Schema |
-| Qwen Code | Extension | Hard-disabled Tool Ready, rewrite, response + TOON through `additionalContext`, Schema |
+| Qwen Code | Extension | Hard-disabled Tool Ready, rewrite; current host lacks post-tool replacement and skips the declared BeforeModel event |
 
 ## Supported Agent development frameworks
 
@@ -164,8 +146,9 @@ Command rewriting also changes the shell command submitted by the host. Most ada
 |-----------|----------|
 | Install and verify for the first time | [Quick Start](QUICKSTART.md) |
 | Build the standalone CLI from source | [This page · Build the standalone CLI from source](#build-the-standalone-cli-from-source) |
-| Build the in-process Python runtime | [This page · Build the Python runtime from source](#build-the-python-runtime-from-source) |
-| Connect an Agent product or integrate AgentScope | [Agent and framework integration](framework-integration.md) |
+| Use the in-process Python SDK | [Python SDK](sdk.md) |
+| Integrate AgentScope | [AgentScope SDK integration](sdk/agentscope.md) |
+| Connect an Agent product | [Agent integration](framework-integration.md) |
 | Compress, retrieve, or run MCP manually | [CLI reference](cli-reference.md) |
 | Inspect savings or content changes, or run a dual comparison | [Measuring savings](measuring-savings.md) |
 | Change settings or understand local data | [Configuration and data privacy](configuration-and-privacy.md) |

--- a/docs/user-guide/zh/README.md
+++ b/docs/user-guide/zh/README.md
@@ -75,8 +75,10 @@ ANOLISA 为 AI Agent 提供完整的服务端运行时能力。通过 `anolisa` 
 |------|------|------|
 | [Tokenless 快速开始](token-saving/tokenless/QUICKSTART.md) | tokenless | 安装、接入 Agent、首次压缩与验收 |
 | [Tokenless 用户手册](token-saving/tokenless/user-manual.md) | tokenless | 能力边界、运行行为与任务导航 |
-| [Tokenless 框架集成](token-saving/tokenless/framework-integration.md) | tokenless | cosh、OpenClaw、Hermes、Qoder、Claude Code、Codex、Qwen Code |
-| [Tokenless CLI 参考](token-saving/tokenless/cli-reference.md) | tokenless | 压缩、环境检查、Stash、MCP 与统计命令 |
+| [Tokenless Python SDK](token-saving/tokenless/sdk.md) | tokenless | 通用与 AgentScope 两层、Runtime 操作、统计与示例 |
+| [Tokenless AgentScope SDK 集成](token-saving/tokenless/sdk/agentscope.md) | tokenless | 把 AgentScope 1.x、2.x 与 App 挂载到通用 SDK |
+| [Tokenless Agent 集成](token-saving/tokenless/framework-integration.md) | tokenless | 产品 Adapter、Hook 与 Plugin |
+| [Tokenless CLI 参考](token-saving/tokenless/cli-reference.md) | tokenless | Protocol Pipeline、直接压缩、Stash、MCP 与统计命令 |
 | [Tokenless 效果度量](token-saving/tokenless/measuring-savings.md) | tokenless | 统计、diff、dry-run、AgentSight 与 SLS 度量 |
 | [Tokenless 配置与数据隐私](token-saving/tokenless/configuration-and-privacy.md) | tokenless | 配置优先级、本地数据与敏感工作负载 |
 | [Tokenless 故障排查](token-saving/tokenless/troubleshooting.md) | tokenless | Adapter、数据库、Stash、升级与卸载 |

--- a/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
+++ b/docs/user-guide/zh/token-saving/tokenless/QUICKSTART.md
@@ -117,7 +117,7 @@ anolisa adapter scan
 | Claude Code | `anolisa adapter enable tokenless claude-code` |
 | Codex | `anolisa adapter enable tokenless codex` |
 | DeepSeek Harness（dsh） | `anolisa adapter enable tokenless dsh --profile <profile>` |
-| OpenCode | 生命周期脚本（见下文） |
+| OpenCode | `anolisa adapter enable tokenless opencode` |
 | Qwen Code | `anolisa adapter enable tokenless qwencode` |
 
 接入后重启对应的 Agent CLI 或 IDE。OpenClaw 还需要运行
@@ -136,9 +136,8 @@ anolisa adapter enable tokenless dsh \
 后续每次 enable 或 re-enable 都会替换 receipt 记录的完整 profile 集合。每次都要
 列出需要继续使用 Tokenless 的全部 profile。
 
-本版本尚未将
-OpenCode 注册到 `anolisa adapter enable`；请使用
-[OpenCode 接入说明](framework-integration.md#opencode)中的随附生命周期脚本。
+OpenCode 可使用相同的 Adapter 命令。对于没有 ANOLISA 组件记录的 npm 安装，随附生命周期
+脚本仍可作为替代方式。
 
 ## 可选：不接入 Agent 测试压缩
 
@@ -169,7 +168,9 @@ tokenless stats list --limit 1
 
 ## 下一步
 
-- [Agent 与框架集成](framework-integration.md)：Agent Adapter 激活和 AgentScope 应用集成
+- [Python SDK](sdk.md)：通用与 AgentScope 两层及可运行示例
+- [AgentScope SDK 集成](sdk/agentscope.md)：AgentScope 1.x、2.x 与 App 挂载
+- [Agent 集成](framework-integration.md)：产品 Adapter 激活
 - [用户手册](user-manual.md)：能力边界和文档导航
 - [CLI 参考](cli-reference.md)：全部子命令和参数
 - [效果度量](measuring-savings.md)：统计、双跑对比和 AgentSight/SLS

--- a/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
+++ b/docs/user-guide/zh/token-saving/tokenless/cli-reference.md
@@ -2,12 +2,15 @@
 
 [English](../../../en/token-saving/tokenless/cli-reference.md)
 
-`tokenless` CLI 可独立压缩 Schema 和响应、进行 TOON 编解码、取回 Stash 内容、检查工具环境并查询统计。Agent Adapter 在内部调用同一组能力。
+`tokenless` CLI 开放统一的 content-aware 压缩命令、直接 Schema/JSON/TOON 操作、Stash
+恢复、环境状态与统计。共享 Agent Hook 使用 `tokenless compress`；直接命令继续用于脚本和
+诊断。
 
 ## 命令总览
 
 | 命令 | 用途 |
 |------|------|
+| `tokenless compress` | 让模型可见内容进入 content-aware Pipeline |
 | `tokenless compress-schema` | 压缩 Function Calling 工具 Schema |
 | `tokenless compress-response` | 压缩 JSON/API/工具响应 |
 | `tokenless compress-toon` | 将 JSON 编码为 TOON |
@@ -55,6 +58,70 @@ cat response.json | tokenless compress-response
 字符串、数组和深度阈值只决定单项转换何时触发，并不是整个 Payload 的最小大小。
 Agent Adapter 还可能在启动 CLI 前应用独立的大小门槛，详见
 [Adapter 处理规则](framework-integration.md#adapter-处理规则)。
+
+## `compress`
+
+`compress` 是共享 Agent Hook 使用的稳定 JSON 边界。它从 stdin 或 `--file` 接收一个
+`CompressionRequest`；请求可解码时，始终输出一个 `CompressionResponse` JSON 对象：
+
+```bash
+jq -n \
+  --rawfile content build.log \
+  '{
+    protocol_version: 1,
+    content: $content,
+    agent_id: "my-agent",
+    session_id: "session-42",
+    tool_use_id: "tool-7",
+    tool_name: "Bash",
+    seam: "post_tool",
+    capabilities: {
+      replace_output: true,
+      publish_retrieve_tool: true,
+      replace_with_text: true
+    }
+  }' \
+  | tokenless compress \
+  | jq '{disposition, content_type, compressor_chain, reversibility, output}'
+```
+
+请求字段：
+
+| 字段 | 是否必需 | 含义 |
+|------|----------|------|
+| `protocol_version` | 是 | 压缩请求格式版本；当前为 `1` |
+| `content` | 是 | 要处理的精确模型可见字符串 |
+| `agent_id` | 是 | 稳定的前端标识 |
+| `session_id`、`tool_use_id`、`tool_name` | 否 | 归属与工具路由数据 |
+| `seam` | 是 | `before_model`、`pre_tool`、`post_tool` 或 `proxy` |
+| `capabilities.replace_output` | 否；默认 `false` | 宿主可以替换原始模型可见值 |
+| `capabilities.publish_retrieve_tool` | 否；默认 `false` | 宿主暴露可用的恢复 Tool |
+| `capabilities.replace_with_text` | 否；默认 `false` | 替换槽接受任意文本，而不是要求保持稳定 JSON Schema |
+
+Pipeline 会检测 `json_records`、`search_results`、`build_log`、`stack_trace`、`diff`、
+`html`、`tabular`、`source_code`、`plain_text` 或 `unknown`，随后只运行与 seam 和宿主声明
+能力兼容的 Compressor。当前生产路由为：
+
+- `before_model` JSON 工具数组：Schema 压缩。
+- `post_tool` JSON Records：结构化响应清理；文本槽还可能选择 TOON。
+- `post_tool` 构建日志与长纯文本：无损 Terminal 清理；同时具备替换、恢复与文本能力时，
+  再执行可恢复的 build/log 压缩。
+- 其他检测类型：尚无匹配 Compressor，原样透传。
+
+只有 `disposition: "applied"` 表示 `output` 与原文不同。`dry_run`、`passthrough`、
+`no_savings`、`reversibility_unavailable`、`timeout` 和 `error` 的 `output` 都携带原始
+`content`，Adapter 可以无条件交付。响应还会报告 `content_type`、有序
+`compressor_chain`、`reversibility`、Token 估算、已提交 `stash_keys`、`tokenizer_id` 和
+可选的限长诊断。
+
+无法读取、超过大小限制、格式错误或版本不支持的请求以状态 `2` 退出，因为 CLI 无法从合法
+请求中恢复原文。解码成功后，压缩失败会表示为 fail-open 响应，并以状态 `0` 退出。
+`--stash-db` 按与直接命令相同的路径安全规则覆盖 Stash 路径。
+
+build/log Compressor 只处理真实多行日志，保留 Signal 与 Trace 区域、固定头尾窗口和失败
+周围 Context，并把每个符合条件的省略区间替换为可恢复 marker。节省少于 200 字符的候选会
+被拒绝。通用纯文本在达到 100 行后使用保守的 40 行头尾窗口；达到 65,536 字符的文本还会
+使用 16,384 字符头尾的单行保护路径。
 
 ## `compress-schema`
 
@@ -161,7 +228,7 @@ debug, trace, traces, stack, stacktrace, logs, logging
 
 Stash 只作用于字符串、截断数组中被丢弃的中间段和深层子树截断。尾部元素直接保留在输出中，不进入 Stash。黑名单字段、`null` 和空值会直接移除，不会生成取回标记。
 
-大多数 Adapter 会覆盖这些独立 CLI 默认值。共享 Shell 策略使用 `65536`、`128`、`8`；其他结构化工具策略使用 `1048576`、`65536`、`32`。内容读取类工具会被跳过。详见[框架集成 · Adapter 处理规则](framework-integration.md#adapter-处理规则)。
+大多数 Adapter 会覆盖这些独立 CLI 默认值。共享 Shell 策略使用 `65536`、`128`、`8`；其他结构化工具策略使用 `1048576`、`65536`、`32`。内容读取类工具会被跳过。详见[Agent 集成 · Adapter 处理规则](framework-integration.md#adapter-处理规则)。
 
 ## `compress-toon` 与 `decompress-toon`
 

--- a/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
+++ b/docs/user-guide/zh/token-saving/tokenless/configuration-and-privacy.md
@@ -103,7 +103,7 @@ tokenless stats disable
 | 数据 | 默认路径 | 默认内容 | 保留方式 | 如何停止新增 |
 |------|----------|----------|----------|--------------|
 | 本地统计 | `~/.tokenless/stats.db` | 压缩前后完整文本、标识和度量 | 无自动 TTL，直到清理 | `tokenless stats disable` |
-| Stash | `~/.tokenless/stash.db` | 截断时移除的原始字符串、截断数组中被丢弃的中间段、深层子树和 Schema 描述 | TTL 1 小时、最多 10,000 个有效条目，过期行延迟清理 | CLI 使用 `--no-stash`；Agent 场景禁用 Adapter |
+| Stash | `~/.tokenless/stash.db` | 截断时移除的原始字符串、截断数组中被丢弃的中间段、深层子树、Schema 描述和 build/log 间隙内容 | TTL 1 小时、最多 10,000 个有效条目，过期行延迟清理 | CLI 使用 `--no-stash`；Agent 场景禁用 Adapter |
 | 配置 | `~/.tokenless/config.json` | 三个布尔开关 | 持续保留 | 不适用 |
 | SLS JSONL | `/var/log/anolisa/sls/ops/tokenless.jsonl` | 度量和标识，不含压缩原文 | 由 SLS/Logtail 设施管理 | `TOKENLESS_SLS_ENABLED=0` 或配置为 false |
 
@@ -238,5 +238,5 @@ OpenClaw Adapter 当前未实现 Schema 压缩；需要时可以直接调用 `to
 
 - [效果度量](measuring-savings.md)
 - [CLI 参考](cli-reference.md)
-- [框架集成](framework-integration.md)
+- [Agent 集成](framework-integration.md)
 - [故障排查](troubleshooting.md)

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -1,24 +1,23 @@
-# Tokenless Agent 与框架集成
+# Tokenless Agent 集成
 
 [English](../../../en/token-saving/tokenless/framework-integration.md)
 
-Tokenless 提供两类集成。Agent Adapter 通过 Plugin、Hook 和 Extension，把已安装的
-二进制接入具体 Agent 产品；AgentScope 支持则是供应用开发者显式安装和注册的进程内
-Python 框架包。
+Tokenless 通过 Plugin、Hook 和 Extension 接入具体 Agent 产品。本文只说明产品 Adapter。
+Python SDK 及其 AgentScope 专用子文档放在 [Python SDK 指南](sdk.md) 下。
 
 ## Agent Adapter 支持矩阵
 
 | Agent 产品 | 值 | Tool Ready | 命令重写行为 | 响应交付方式 | TOON | Schema |
 |------|----|------------|--------------|--------------|------|--------|
-| cosh | `cosh` | 已硬关闭 | 替换受支持的 Shell 输入 | Cosh-NG 替换响应；旧版 Copilot Shell 追加上下文 | 在响应压缩后尝试 | ✅ |
+| cosh | `cosh` | 已硬关闭 | 替换受支持的 Shell 输入 | Cosh-NG 替换响应；旧版 Copilot Shell 透传 | 对可替换文本由 Pipeline 选择 | ✅ |
 | OpenClaw | `openclaw` | 已硬关闭 | 替换 `exec` 命令输入 | 替换持久化工具结果消息 | 默认关闭，需主动启用 | — |
 | Hermes | `hermes` | 已硬关闭 | 阻止第一次调用并要求 Agent 重试 | 替换结果字符串 | 在响应压缩后尝试 | — |
-| Qoder | `qoder` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
-| Claude Code | `claude-code` | 已硬关闭 | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 仅在替换结果可保持文本时使用 | — |
+| Qoder | `qoder` | 已硬关闭 | 输出改写后的 Shell 输入 | 通过 `updatedToolOutput` 替换输出 | 对可替换文本由 Pipeline 选择 | — |
+| Claude Code | `claude-code` | 已硬关闭 | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 对可替换文本由 Pipeline 选择 | — |
 | Codex | `codex` | 已硬关闭 | 替换受支持的 Shell 输入 | 保留原文；仅对识别出的环境失败追加上下文 | — | — |
 | DeepSeek Harness | `dsh` | 未注册 | 未注册 | 只在结果更小时替换已接受的单文本块 JSON 结果 | 未注册 | 未注册 |
-| OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 在响应压缩后尝试 | ✅ |
-| Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 输出 `additionalContext` | 在响应压缩后尝试 | — |
+| OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 对可替换文本由 Pipeline 选择 | ✅ |
+| Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 宿主没有替换字段，因此透传 | — | — |
 
 “—”表示该能力不可用：当前 Adapter 没有注册，或当前宿主版本不会运行；对应的 Tokenless CLI 命令仍可能可用。
 
@@ -26,14 +25,33 @@ Schema 压缩到达模型路径的方式因宿主而异：cosh 与 Cosh-NG 触�
 
 这些 Adapter 仍会注册 Tool Ready，但会在检查、修复或阻断之前无条件硬退出，任何运行时设置都无法重新启用。工具执行后的失败归因不受影响。
 
-`additionalContext` 是追加型 Hook 字段。在这些路径上，Tokenless 源码本身不会删除原始结果，最终处理方式还取决于宿主实现。统计记录只能证明压缩候选内容变小了，不能证明宿主已经从模型请求中移除原文。
-
-OpenCode 当前使用下文说明的随附生命周期脚本，本版本尚未把它注册到
-`anolisa adapter enable` 的驱动集合。
+`additionalContext` 是追加型 Hook 字段。共享 Hook 不会把压缩副本放入其中，否则原文
+仍然可见，总 Context 反而增加；该字段只用于追加环境错误指引。统计记录只能证明压缩候选
+内容变小了，不能单独证明宿主已经从模型请求中移除原文。
 
 ## Adapter 处理规则
 
-独立运行 `compress-response` 的默认值并不是大多数 Adapter 使用的默认值。共享 Adapter 按以下方式分类工具：
+共享 Cosh-NG、Qoder、Claude Code 和 OpenCode Hook 会向 `tokenless compress` 发送一个
+压缩请求。该命令检测模型可见内容，根据宿主声明的替换与恢复能力筛选 Compressor，
+运行符合条件的阶段，并对所有非 `applied` disposition 返回原文。当前路由如下：
+
+| 内容 | 当前共享 Hook 行为 |
+|------|--------------------|
+| JSON Records | 结构化响应清理；文本替换槽还会考虑 TOON |
+| 构建/测试/包管理日志 | 无损 Terminal 清理，再运行保留 Signal 的 build/log 压缩，并为省略区间写入可恢复 marker |
+| 长纯文本 | 无损 Terminal 清理，再保守保留头尾，并为省略区间写入可恢复 marker |
+| Diff、Stack Trace、HTML、搜索结果、表格、源码、Unknown | 尚无匹配 Compressor，原样透传 |
+
+build/log 压缩要求宿主同时具备三项能力：替换原输出、发布恢复 Tool、以任意文本替换。它会
+保留 Signal 行和 Stack Trace 区域、失败周围 Context 以及固定头尾窗口，并把每个省略区间
+写入 Stash。短日志或节省少于 200 字符的候选会透传。纯文本在达到 100 行时触发；单行保护
+路径在达到 65,536 字符时触发。
+
+旧版 OpenClaw、Hermes 和 DeepSeek Harness 集成仍使用各自的专用响应路径，其阈值与能力见
+下文；content-aware build/log 路径尚未接入这些 Adapter。独立 `compress-response` 命令也
+继续作为显式 JSON 清理入口。
+
+对于 JSON 响应清理，共享与旧版 Adapter 按以下方式分类工具：
 
 | 类别 | Adapter 默认行为 |
 |------|------------------|
@@ -41,7 +59,11 @@ OpenCode 当前使用下文说明的随附生命周期脚本，本版本尚未�
 | Shell/exec | 字符串 65,536 字符、数组保留 128 项、深度 8 |
 | 其他结构化工具 | 字符串 1,048,576 字符、数组保留 65,536 项、深度 32 |
 
-共享响应 Hook、OpenClaw 和 Hermes 会跳过短于 200 字符的输入。共享路径还会跳过带 YAML frontmatter、形似 Skill 的文本。TOON 编码仅对至少 500 字符的负载执行（当前实现的阈值，后续可能调整）；更小的负载保留压缩后的形式，因为 TOON 对小型 JSON 的节省可以忽略不计。该阈值适用于所有支持 TOON 的管线：共享响应 Hook、独立 TOON Hook、OpenClaw、Hermes，以及独立的 `tokenless compress-toon` CLI 与 Runtime/SDK TOON 路径（CLI 可通过 `--min-toon-chars` 按次调低该阈值）。Codex 的 PostToolUse Hook 不能替换原始输出，因此不执行响应压缩或 TOON。
+共享响应 Hook、OpenClaw 与 Hermes 会跳过短于 200 字符的输入；共享路径也会跳过带 YAML
+Frontmatter 的 Skill 文本。TOON 只处理至少 500 字符的 Payload，并且要求选中的宿主槽支持
+文本；更短 Payload 保留前一阶段结果。独立 `compress-toon` CLI 和 SDK TOON 路径使用相同
+默认阈值，CLI 可通过 `--min-toon-chars` 为单次调用降低阈值。Codex 和 Qwen Code 当前的
+PostToolUse 契约不能替换原始模型可见输出，因此不运行响应压缩或 TOON。
 
 Claude Code 需要 2.1.121 或更高版本才能使用 `updatedToolOutput`。版本更旧或无法确定时，响应压缩会关闭，以免重复注入原文。结构化工具输出会保留宿主 Schema，不会转换成文本 TOON；以字符串承载的 JSON 在 TOON 更小时可以使用 TOON。
 
@@ -152,6 +174,7 @@ anolisa adapter enable tokenless hermes
 anolisa adapter enable tokenless qoder
 anolisa adapter enable tokenless claude-code
 anolisa adapter enable tokenless codex
+anolisa adapter enable tokenless opencode
 anolisa adapter enable tokenless qwencode
 anolisa adapter enable tokenless dsh \
   --profile web \
@@ -164,8 +187,6 @@ anolisa adapter enable tokenless dsh \
 DeepSeek Harness 按 profile 管理，因此必须至少提供一个 `--profile`。每个名称应与
 `dsh --profile <profile>` 使用的名称一致，不带 profile 的通用命令会被拒绝。
 后续 enable 或 re-enable 必须再次列出需要保留的全部 profile。
-
-OpenCode 应使用 [npm 安装后的手动接入](#npm-安装后的手动接入)中的随附安装脚本。
 
 对于 OpenClaw，anolisa 会先尝试普通安装，默认不会加入 unsafe-install 覆盖参数。如果 OpenClaw 的安全扫描拒绝此 Plugin，应先阅读其报告；确认接受风险后，才显式重试：
 
@@ -299,134 +320,10 @@ Extension 在新的 Qwen Code 会话中加载。重启后执行一次工具调�
 
 ## AgentScope 框架集成
 
-Python 包支持 AgentScope 1.0.11 至 1.0.x 和 AgentScope 2.0.x。应根据已安装版本选择
-挂载入口：
+AgentScope 是 Python SDK 的第二层，不是产品 Adapter。完整的构建、版本、挂载、配置与验证说明
+现已放在 [AgentScope SDK 集成](sdk/agentscope.md) 子文档。本标题继续保留，作为已有链接的兼容入口。
 
-| AgentScope 版本 | 支持的入口 |
-|---|---|
-| 1.0.11 至 1.0.x | 使用 Tokenless Toolkit 和 `install(..., session_id=...)` |
-| 2.0.0 | 通过 `integration.tools` 和 `integration.middlewares` 直接构造 Agent |
-| 2.0.1 至 2.0.x | 直接构造 Agent，或通过 `integration.app_options()` 接入 App |
-
-原生 `anolisa-tokenless` Runtime Wheel 和 AgentScope 集成 Wheel 当前都尚未发布到
-Python 包索引。请从源码 checkout 构建并同时安装两个相同版本的 Wheel：
-
-```bash
-make python-wheel agentscope-wheel
-python -m pip install \
-  target/wheels/anolisa_tokenless-*.whl \
-  target/wheels/anolisa_tokenless_agentscope-*.whl
-```
-
-原生 Wheel 还通过 typed Python 对象开放与 CLI 相同的只读 Stats 查询能力：
-
-```python
-from anolisa_tokenless import TokenlessStats
-
-stats = TokenlessStats("/absolute/path/to/tenant-tokenless-data")
-
-status = stats.status
-summary = stats.summary()
-recent = stats.list(limit=20)
-record = stats.show(recent[0].id)
-session_diff = stats.diff(session_id="conversation-id")
-comparison = stats.compare("baseline-session", "tokenless-session")
-```
-
-`TokenlessSdk.stats` 会延迟返回绑定该 SDK 数据目录的客户端。Token 数量是估算值，并且
-只有产生正向节省的操作才会记录。`show()` 和 Record/Tool-use 的 `diff()` 结果可能包含
-`stats.db` 中保存的敏感工具输入与输出；Summary、List 和 Compare 不返回保存的内容。
-该 API 不能清空数据或修改记录开关。这里的只读是指这些公开操作；打开客户端时遵循
-CLI 初始化流程，可能创建或迁移 `stats.db`，所以数据目录必须可写。Summary 或 Compare
-未指定 Limit 时，最多读取最近 10,000 条记录；Session 和 Tool-use Diff 同样最多读取
-最近 10,000 条匹配记录。要获得有意义的对比，应先传入 dry-run Baseline Session，再
-传入启用 Tokenless 的 Session。
-
-两个大版本都使用 `TokenlessAgentScope` 和 `TokenlessConfig`，只有最后的挂载方式不同。
-AgentScope 1.x 使用 Tokenless Toolkit；普通工具与 MCP 注册入口也会覆盖构造后新增的工具：
-
-```python
-from agentscope.agent import ReActAgent
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(
-        mode="balanced",
-        data_dir="/absolute/path/to/tenant-tokenless-data",
-    ),
-)
-toolkit = integration.create_toolkit()
-toolkit.register_tool_function(application_tool)
-agent = ReActAgent(..., toolkit=toolkit)
-integration.install(agent, session_id="conversation-id")
-```
-
-AgentScope 2.x 应在构造 Toolkit 和 Agent 时传入恢复 Tool 和中间件。该方式从 2.0.0
-即可使用，不依赖后续补丁版本才引入的 Toolkit 动态修改 API：
-
-```python
-from agentscope.agent import Agent
-from agentscope.tool import Toolkit
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(
-        mode="balanced",
-        data_dir="/absolute/path/to/tenant-tokenless-data",
-        # retrieve_tool_name="tenant_tokenless_retrieve",
-    ),
-)
-toolkit = Toolkit(tools=[*application_tools, *integration.tools])
-
-agent = Agent(
-    ...,
-    toolkit=toolkit,
-    middlewares=integration.middlewares,
-)
-```
-
-AgentScope App 从 2.0.1 开始支持。`app_options()` 会在配置的绝对基础目录下，为每个
-user/agent/session 派生独立的 Tokenless 数据目录：
-
-```python
-from agentscope.app import create_app
-from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
-
-integration = TokenlessAgentScope(
-    TokenlessConfig(data_dir="/srv/tokenless-tenants"),
-)
-app = create_app(..., **integration.app_options())
-```
-
-如果应用已经定义 `tokenless_retrieve`，应在 `TokenlessConfig` 中设置唯一的
-`retrieve_tool_name`；App 组装阶段不会把其他工具暴露给该 factory，无法预先检查重名。
-AgentScope 2.0.0 尚未提供 App 级 Agent middleware 和 Tool 注入，因此只支持直接构造
-Agent。原有 `TokenlessMiddleware` 2.x API 继续保留兼容；新代码应使用
-`TokenlessAgentScope`，避免依赖特定补丁版本的 Toolkit 动态修改或 Tool 自动收集行为。
-
-请根据应用可接受的 inline 截断程度选择模式：
-
-| 模式 | Read/Glob/Grep | 其他工具 |
-|------|----------------|----------|
-| `conservative` | 压缩 | 字符串 1 MiB、数组 65,536 项、深度 32 |
-| `balanced`（默认） | 跳过 | Shell：65,536 / 128 / 深度 8；其他采用 conservative 限制 |
-| `aggressive` | 跳过 | CLI 默认值：4,096 / 32 / 深度 8 |
-
-集成会原样转发中间流式 chunk 并保留框架对象，只转换复制后的调用参数和最终模型可见
-文本。Tokenless 优化失败或 UTF-8 结果没有严格变小时保留原文，`DataBlock` 永不修改。
-
-集成还提供默认名为 `tokenless_retrieve` 的恢复 Tool。只有 marker 对当前模型可见时才
-会向模型发布该 Tool，并且只接受该 Session 精确保留的 marker 集合中的 24 位十六进制
-hash；该 Tool 永远不参与压缩。这一窄权限仍依赖
-存储隔离：每个用户或租户必须显式传入独立的绝对 `data_dir`。省略 `data_dir` 时，
-`TOKENLESS_DATA_DIR` 只作为进程级回退，不得由多个租户共用；也不要依赖跨节点恢复。
-stash 当前使用固定的一小时 TTL，Agent 应在这一边界前恢复所需内容。
-
-两个 Adapter 都启用 Schema 压缩、RTK 命令改写、响应压缩、TOON、恢复、环境错误提示
-和逐调用归属。平台 Wheel 内置 RTK 并直接链接 TOON，不会搜索系统 helper。Tool Ready
-仍保持硬关闭。
-
-## 验证是否真正接入
+## 验证 Agent Adapter
 
 对于 Agent Adapter，不要只以“安装命令退出码为 0”作为成功标准。至少完成：
 
@@ -438,19 +335,11 @@ tokenless stats list --limit 5
 
 然后在目标 Agent 中执行一次有明显输出的工具任务。如果 `stats list` 仍为空，请按照[启用后没有产生统计记录](troubleshooting.md#启用后没有产生统计记录)排查。
 
-对于 AgentScope 框架包，在源码 checkout 中运行下面的命令，验证两个 Wheel 和声明
-支持的 AgentScope 版本范围：
-
-```bash
-make test-agentscope-integration
-```
-
-随后在应用中执行一次成功且可压缩的工具响应，确认中间件返回更小的结果，并确认
-`tokenless_retrieve` 可以从同一个 `data_dir` 恢复 marker 对应的内容。
-
 ## 相关文档
 
 - [快速开始](QUICKSTART.md)
+- [Python SDK](sdk.md)
+- [AgentScope SDK 集成](sdk/agentscope.md)
 - [效果度量](measuring-savings.md)
 - [配置与数据隐私](configuration-and-privacy.md)
 - [故障排查](troubleshooting.md)

--- a/docs/user-guide/zh/token-saving/tokenless/sdk.md
+++ b/docs/user-guide/zh/token-saving/tokenless/sdk.md
@@ -1,0 +1,392 @@
+# Tokenless Python SDK
+
+[English](../../../en/token-saving/tokenless/sdk.md)
+
+Tokenless 提供两层 Python SDK：
+
+| 层级 | 包 | 用途 |
+|------|----|------|
+| 通用 SDK | `anolisa-tokenless` | 接入任意 Agent 生命周期、执行单项 Tokenless 操作或查询统计 |
+| AgentScope 集成 | `anolisa-tokenless-agentscope` | 把通用 SDK 挂载到受支持的 AgentScope 1.x 和 2.x 生命周期 API |
+
+AgentScope 层依赖完全相同版本的通用 SDK，并把 Tokenless 操作交给通用 SDK 执行；
+它不是另一套压缩实现。本页介绍两层的关系。AgentScope 详细用法放在
+[AgentScope SDK 集成](sdk/agentscope.md) 子文档，产品 Plugin 仍放在
+[Agent 集成](framework-integration.md)。
+
+## 第一层：通用 SDK
+
+`anolisa-tokenless` Wheel 让 Python 应用可以在进程内运行 Tokenless。把 Tokenless 接入
+Agent 生命周期时使用 `TokenlessSdk`。不需要接入生命周期、只想执行某一项具体操作时
+使用 `TokenlessRuntime`，例如单独压缩一个响应或恢复一条 Stash 内容。只查询统计时
+使用 `TokenlessStats`。
+
+### 从 GitHub Release 安装
+
+从 [v0.7.14](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.7.14) 开始，
+Tokenless GitHub Release 会附带官方 SDK Wheel。Wheel 需要 CPython 3.11 或更高版本，
+请根据目标系统选择原生 `anolisa-tokenless` Wheel：
+
+| 系统 | Release 产物 |
+|------|--------------|
+| Linux x86_64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl` |
+| Linux aarch64 | `anolisa_tokenless-<version>-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl` |
+| macOS Apple 芯片 | `anolisa_tokenless-<version>-cp311-abi3-macosx_11_0_arm64.whl` |
+
+例如，在 Linux x86_64 上把 v0.7.14 安装到虚拟环境：
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless-0.7.14-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+```
+
+Linux 产物面向兼容 `manylinux_2_17` 的 glibc 发行版，不支持 Alpine Linux 等 musl 发行版。
+Release 同时提供 `SHA256SUMS-python-wheels.txt`，可用于校验下载内容。
+
+Wheel 包含原生 Tokenless Runtime 和匹配的 RTK 可执行文件，不需要 `tokenless` CLI、系统
+RTK 或独立 TOON 可执行文件。
+
+### 从源码构建
+
+本仓库仅支持在 Linux 上从源码构建。请在 Tokenless 组件目录中构建，并确保系统可发现
+CPython 3.11 或更高版本的开发环境：
+
+```bash
+make python-wheel
+python3 -m venv /tmp/tokenless-sdk
+/tmp/tokenless-sdk/bin/pip install target/wheels/anolisa_tokenless-*.whl
+```
+
+`make python-wheel` 默认通过 `uvx` 提供 Maturin。请先安装
+[`uv`](https://docs.astral.sh/uv/)，也可以直接使用 `PATH` 中已有的兼容 Maturin：
+
+```bash
+make python-wheel MATURIN=maturin
+```
+
+Pip 会以展开形式安装 Wheel，从而为命令改写提供 Wheel 内置 RTK 所需的稳定可执行路径。
+
+### 选择 API
+
+| API | 职责 | 适用场景 |
+|-----|------|----------|
+| `TokenlessSdk` | 生命周期集成 | 把 Tokenless 接入 Agent 框架的 Model 调用和工具调用阶段 |
+| `TokenlessRuntime` | 单项操作 | 直接压缩一个 Schema、响应或 TOON Payload，或恢复一条 Stash 内容 |
+| `TokenlessStats` | 统计查询 | 读取状态、汇总、最近记录、记录详情、Diff 和 Session 对比 |
+
+新接入 Agent 框架时建议使用 `TokenlessSdk`。它持有一个 `TokenlessRuntime`，通过
+`sdk.runtime.data_dir` 暴露相同状态目录，并在查询统计时延迟创建 `sdk.stats`。
+
+### 完整生命周期示例
+
+下面的示例会压缩模型可见工具 Schema、压缩一次成功的工具结果，并恢复一个通过 marker
+授权的 Stash Payload。示例关闭 RTK 与 TOON，以便只展示 Schema/响应生命周期且不依赖
+命令执行。
+
+```python
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+
+from anolisa_tokenless import (
+    Attribution,
+    ModelRequest,
+    RetrieveRequest,
+    TokenlessConfig,
+    TokenlessSdk,
+    ToolCall,
+    ToolResult,
+    ToolStatus,
+)
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="tokenless-sdk-") as data_dir:
+        sdk = TokenlessSdk(
+            TokenlessConfig(
+                data_dir=Path(data_dir),
+                mode="aggressive",
+                min_chars=0,
+                rtk_enabled=False,
+                toon_enabled=False,
+            )
+        )
+        model_attribution = Attribution("my-agent", "session-42")
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Detailed lookup instructions. " * 100,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+
+        model_request = await sdk.before_model(
+            ModelRequest((tool,), "", model_attribution)
+        )
+        print([item.get("function", {}).get("name") for item in model_request.tools])
+
+        call = ToolCall(
+            "api",
+            {},
+            Attribution("my-agent", "session-42", "tool-7"),
+        )
+        original = json.dumps(
+            {"items": [{"name": "same", "value": index} for index in range(300)]}
+        )
+        result = await sdk.after_tool_call(
+            ToolResult(call, original, ToolStatus.SUCCESS)
+        )
+        print(result.transformed, len(original), len(result.content))
+
+        visible_markers = sdk.extract_markers(result.content)
+        if visible_markers:
+            marker_hash = next(iter(visible_markers))
+            recovered = await sdk.retrieve(
+                RetrieveRequest(marker_hash, visible_markers, model_attribution)
+            )
+            print(f"recovered {len(recovered)} characters")
+
+
+asyncio.run(main())
+```
+
+`TemporaryDirectory` 让示例可以独立运行，并会在退出时删除状态。生产环境应使用稳定、可写
+的绝对 `data_dir`，并为每个租户或安全边界使用不同目录。
+
+SDK 把生命周期值视为不可变契约：它会复制工具 Schema 和参数 Map，而不会修改调用方持有
+的对象。请使用返回的 `ModelRequest`、`ToolCall` 和 `ToolResult`；原始值不会反映转换结果。
+
+### 四个生命周期接缝
+
+#### Model 调用前
+
+```python
+request = await sdk.before_model(
+    ModelRequest(tuple(model_tools), visible_context, attribution)
+)
+```
+
+`before_model()` 压缩 OpenAI Function Calling 工具，在转换后的工具和可见 Context 中扫描
+`<<tokenless:HASH>>` marker，并且只在至少一个 marker 可见时发布配置的恢复 Schema。默认
+名称为 `tokenless_retrieve`，且由 Tokenless 保留；应用已经使用该名称时，应设置唯一的
+`retrieve_tool_name`。
+
+#### 工具调用前
+
+```python
+call = await sdk.before_tool_call(
+    ToolCall(
+        "shell",
+        {"command": "grep needle large.log"},
+        Attribution("my-agent", "session-42", "tool-8"),
+        command_field="command",
+    )
+)
+```
+
+SDK 只处理显式指定的 `command_field`。如果 RTK 产生改写，返回参数会包含 Wheel 内置 RTK
+路径和逐调用归属环境变量。应执行返回的参数，并在构造最终 `ToolResult` 时保留
+`call.rewritten`；已改写调用会跳过结果压缩，因为 RTK 已经从源头缩减输出。
+
+#### 工具调用后
+
+```python
+result = await sdk.after_tool_call(
+    ToolResult(call, model_visible_text, ToolStatus.SUCCESS)
+)
+```
+
+成功且未改写的最终文本可以依次经过响应压缩和 TOON；只有 UTF-8 结果严格更小时才会替换
+原文。`ERROR` 结果不会压缩；已识别的依赖、权限、路径、网络和包错误可能改为获得
+`additional_context` 指引。`INTERRUPTED` 和 `DENIED` 结果原样透传。
+
+#### 受 marker 约束的恢复
+
+```python
+markers = sdk.extract_markers(model_visible_context)
+payload = await sdk.retrieve(
+    RetrieveRequest(marker_hash, markers, attribution)
+)
+```
+
+恢复只接受精确的 24 位十六进制字符，并要求 Hash 存在于传入的可见 marker 集合中。该集合
+应当视为单次 Model 调用状态：从真实模型可见 Context 重新计算，不要持续累积 Session 中
+见过的所有 marker。恢复还要求使用相同 Tokenless 数据目录，并且 Stash 条目尚未过期。
+
+### 配置
+
+```python
+config = TokenlessConfig(
+    mode="balanced",
+    data_dir="/absolute/path/to/tenant-tokenless-data",
+    min_chars=200,
+    excluded_tools={"read_database"},
+    retrieve_tool_name="tokenless_retrieve",
+    schema_compression_enabled=True,
+    response_compression_enabled=True,
+    toon_enabled=True,
+    rtk_enabled=True,
+)
+```
+
+| 模式 | 内容读取类工具 | 其他工具 |
+|------|----------------|----------|
+| `conservative` | 压缩 | 字符串 1 MiB、数组 65,536 项、深度 32 |
+| `balanced`（默认） | 跳过 | Shell：65,536 / 128 / 深度 8；其他使用 conservative 限制 |
+| `aggressive` | 跳过 | 字符串 4,096 字符、数组 32 项、深度 8 |
+
+`data_dir` 必须是可写的绝对路径。每个租户或安全边界应使用不同目录；
+`TOKENLESS_DATA_DIR` 只是进程级回退。`excluded_tools` 会与 Tokenless 内置排除集合合并，恢复
+工具始终排除在响应优化之外。
+
+SDK 生命周期当前使用 Schema/响应/TOON Runtime 操作。CLI 和共享 Agent Hook 还开放了
+content-aware Pipeline，包括 build/log 压缩；该 Pipeline 目前还不是 `TokenlessSdk`
+方法。
+
+### Runtime 直接调用示例
+
+不需要由 `TokenlessSdk` 协调 Agent 生命周期、希望直接执行 Tokenless 操作时，使用
+`TokenlessRuntime`。先为数据目录创建一个 Runtime：
+
+```python
+import json
+import re
+from anolisa_tokenless import TokenlessRuntime
+
+runtime = TokenlessRuntime("/absolute/path/to/tokenless-data")
+```
+
+#### 压缩响应
+
+```python
+original_response = json.dumps(
+    {"items": [f"record-{index:04d}" for index in range(200)]}
+)
+response_result = runtime.compress_response(
+    original_response,
+    truncate_arrays_at=32,
+    agent_id="my-agent",
+    session_id="session-42",
+    tool_use_id="tool-7",
+    require_reversible=True,
+)
+model_visible_response = response_result.output
+print(response_result.disposition, response_result.before_tokens, response_result.after_tokens)
+```
+
+#### 压缩工具 Schema
+
+```python
+tool_schema = {
+    "type": "function",
+    "function": {
+        "name": "lookup",
+        "description": "Detailed lookup instructions. " * 100,
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+schema_result = runtime.compress_schema(
+    json.dumps(tool_schema),
+    agent_id="my-agent",
+    session_id="session-42",
+)
+model_visible_schema = json.loads(schema_result.output)
+```
+
+#### 编码为 TOON
+
+```python
+records = {
+    "items": [
+        {"name": f"item-{index:04d}", "status": "ready"}
+        for index in range(100)
+    ]
+}
+toon_result = runtime.compress_toon(
+    json.dumps(records),
+    agent_id="my-agent",
+    session_id="session-42",
+    tool_use_id="tool-8",
+)
+model_visible_text = toon_result.output
+```
+
+如果 TOON 不能减少预估 Token 数量，`compress_toon()` 会保留原始 JSON。
+
+#### 恢复 Stash 内容
+
+响应或 Schema 压缩可能会把省略内容写入 Stash，并在输出中留下 Marker：
+
+```python
+marker = re.search(r"<<tokenless:([0-9a-f]{24})>>", response_result.output)
+if marker is not None:
+    recovered_content = runtime.retrieve(marker.group(0))
+    print(recovered_content)
+```
+
+`retrieve()` 既可以接收完整 Marker，也可以接收其中 24 个字符的 Hash。直接调用 Runtime
+时，需要由调用方决定允许恢复哪些 Marker；`TokenlessSdk.retrieve()` 会执行 SDK 的模型可见
+Marker 检查。
+
+Runtime 的输入输出都是字符串。下游应直接使用各个 `CompressionResult.output`；需要了解
+输入是否以及如何变化时，再检查它的 `disposition`、Token 数量和 Stash 字段。
+
+### 查询统计
+
+```python
+from anolisa_tokenless import TokenlessStats
+
+stats = TokenlessStats("/absolute/path/to/tokenless-data")
+status = stats.status
+summary = stats.summary()
+recent = stats.list(limit=20)
+
+print(status.database_path, summary.total.tokens_saved)
+if recent:
+    record = stats.show(recent[0].id)
+    change = stats.diff(record_id=record.id)
+```
+
+Session 总览使用 `stats.diff(session_id="...")`；单次工具生命周期使用
+`stats.diff(session_id="...", tool_use_id="...")`；dry-run 与 active Session 对比使用
+`stats.compare("baseline-session", "tokenless-session")`。
+
+Token 数量是估算值，并且只有产生正向节省的操作才会记录。`list()`、`summary()` 和
+`compare()` 不返回保存内容；`show()` 和详细 `diff()` 结果可能包含敏感工具输入或输出。
+公开查询 API 不会清空数据或修改设置，但打开客户端时可能创建或迁移 `stats.db`，因此选定
+的数据目录必须可写。
+
+## 第二层：AgentScope 集成
+
+`anolisa-tokenless-agentscope` 把通用 SDK 生命周期映射到 AgentScope。应用代码使用
+`TokenlessAgentScope`，不需要自行调用 `before_model()`、`before_tool_call()`、
+`after_tool_call()` 和 `retrieve()`。该集成还会把 AgentScope Session 与 Tool Call 归属传入
+通用 SDK。
+
+支持版本、构建安装、1.x/2.x/App 完整示例、配置、恢复边界和验证见
+[AgentScope SDK 集成](sdk/agentscope.md)。Claude Code、OpenCode 等产品 Adapter 与这两层
+Python SDK 都是不同的接入方式。
+
+## 验证两层 SDK
+
+构建通用 SDK Wheel 并运行 installed-wheel 测试：
+
+```bash
+make python-wheel
+make test-python-runtime
+```
+
+根据 [子文档](sdk/agentscope.md#验证集成) 中的命令单独验证 AgentScope 层。
+
+## 相关文档
+
+- [Agent 集成](framework-integration.md)
+- [AgentScope SDK 集成](sdk/agentscope.md)
+- [CLI 参考](cli-reference.md)
+- [效果度量](measuring-savings.md)
+- [配置与数据隐私](configuration-and-privacy.md)
+- [Runtime 设计](../../../../../src/tokenless/docs/design/runtime-library_zh.md)

--- a/docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md
+++ b/docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md
@@ -1,0 +1,159 @@
+# Tokenless AgentScope SDK 集成
+
+[English](../../../../en/token-saving/tokenless/sdk/agentscope.md)
+
+`anolisa-tokenless-agentscope` 是通用 `anolisa-tokenless` SDK 之上的 AgentScope 专用层。
+它把 AgentScope 生命周期 API 映射到 `TokenlessSdk`，并依赖完全相同的包版本；它不单独
+实现压缩。
+
+选择通用 SDK 或 AgentScope 层时，先阅读 [Python SDK 概览](../sdk.md)。Claude Code、
+OpenCode 等产品 Adapter 单独记录在 [Agent 集成](../framework-integration.md)。
+
+## 支持的 AgentScope 版本
+
+| AgentScope 版本 | 支持的入口 |
+|-----------------|------------|
+| 1.0.11 至 1.0.x | Tokenless Toolkit 加 `install(..., session_id=...)` |
+| 2.0.0 | 通过 `integration.tools` 和 `integration.middlewares` 直接构造 Agent |
+| 2.0.1 至 2.0.x | 直接构造 Agent，或通过 `integration.app_options()` 接入 App |
+
+## 安装
+
+AgentScope 集成 Wheel 要求原生 Runtime Wheel 的版本与它完全相同。请从同一个
+Tokenless GitHub Release 同时安装两个产物。例如，在 Linux x86_64 上安装
+[v0.7.14](https://github.com/alibaba/anolisa/releases/tag/tokenless/v0.7.14)：
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless-0.7.14-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" \
+  "https://github.com/alibaba/anolisa/releases/download/tokenless/v0.7.14/anolisa_tokenless_agentscope-0.7.14-py3-none-any.whl"
+```
+
+在 Linux aarch64 或 macOS Apple 芯片上，请按 [SDK 概览](../sdk.md) 替换原生 Runtime
+URL，并保持两个包的版本完全一致。
+
+### 从源码构建
+
+也可以从源码 checkout 构建并同时安装两个相同版本的 Wheel：
+
+```bash
+make python-wheel agentscope-wheel
+python -m pip install \
+  target/wheels/anolisa_tokenless-*.whl \
+  target/wheels/anolisa_tokenless_agentscope-*.whl
+```
+
+## AgentScope 1.x
+
+AgentScope 1.x 使用 Tokenless Toolkit。普通工具与 MCP 注册入口也会覆盖构造后新增的
+工具：
+
+```python
+from agentscope.agent import ReActAgent
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(
+        mode="balanced",
+        data_dir="/absolute/path/to/tenant-tokenless-data",
+    ),
+)
+toolkit = integration.create_toolkit()
+toolkit.register_tool_function(application_tool)
+agent = ReActAgent(..., toolkit=toolkit)
+integration.install(agent, session_id="conversation-id")
+```
+
+## AgentScope 2.x
+
+构造 Toolkit 和 Agent 时传入恢复 Tool 和 Middleware。该方式从 2.0.0 开始可用，不依赖
+后续补丁版本才引入的 Toolkit 动态修改 API：
+
+```python
+from agentscope.agent import Agent
+from agentscope.tool import Toolkit
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(
+        mode="balanced",
+        data_dir="/absolute/path/to/tenant-tokenless-data",
+        # retrieve_tool_name="tenant_tokenless_retrieve",
+    ),
+)
+toolkit = Toolkit(tools=[*application_tools, *integration.tools])
+
+agent = Agent(
+    ...,
+    toolkit=toolkit,
+    middlewares=integration.middlewares,
+)
+```
+
+现有 `TokenlessMiddleware` 2.x API 继续保留兼容。新代码应使用 `TokenlessAgentScope`，避免依赖
+特定补丁版本的 Toolkit 动态修改或 Tool 自动收集行为。
+
+## AgentScope App
+
+AgentScope App 从 2.0.1 开始支持。`app_options()` 会在配置的绝对基础目录下，为每个
+user/agent/session 派生独立的 Tokenless 数据目录：
+
+```python
+from agentscope.app import create_app
+from tokenless_agentscope import TokenlessAgentScope, TokenlessConfig
+
+integration = TokenlessAgentScope(
+    TokenlessConfig(data_dir="/srv/tokenless-tenants"),
+)
+app = create_app(..., **integration.app_options())
+```
+
+AgentScope 2.0.0 尚未提供 App 级 Agent Middleware 或 Tool 注入，因此只支持直接构造
+Agent。
+
+## 配置与行为
+
+如果应用已定义 `tokenless_retrieve`，应在 `TokenlessConfig` 中设置唯一的
+`retrieve_tool_name`；App 组装阶段不会把其他工具暴露给该 Factory，无法预先检查重名。
+
+请根据应用可接受的 inline 截断程度选择模式：
+
+| 模式 | Read/Glob/Grep | 其他工具 |
+|------|----------------|----------|
+| `conservative` | 压缩 | 字符串 1 MiB、数组 65,536 项、深度 32 |
+| `balanced`（默认） | 跳过 | Shell：65,536 / 128 / 深度 8；其他采用 conservative 限制 |
+| `aggressive` | 跳过 | CLI 默认值：4,096 / 32 / 深度 8 |
+
+集成会原样转发中间流式 Chunk 并保留框架对象，只转换复制后的调用参数和最终模型可见
+文本。Tokenless 优化失败或 UTF-8 结果没有严格变小时保留原文，`DataBlock` 永不修改。
+
+集成还提供默认名为 `tokenless_retrieve` 的恢复 Tool。只有 Marker 对当前模型可见时才会
+向模型发布该 Tool，并且只接受该 Session 精确保留的 Marker 集合中的 24 位十六进制
+Hash。该 Tool 永远不参与压缩。
+
+每个用户或租户必须传入独立的绝对 `data_dir`。`TOKENLESS_DATA_DIR` 只是进程级回退，
+不得由多个租户共用；也不要依赖跨节点恢复。Stash 条目使用当前固定的一小时 TTL。
+
+两条 AgentScope 版本路径都启用 Schema 压缩、RTK 命令改写、响应压缩、TOON、恢复、
+环境错误提示和逐调用归属。平台 Wheel 内置 RTK 并直接链接 TOON，不会搜索系统 Helper。
+Tool Ready 仍保持硬关闭。
+
+## 验证集成
+
+在源码 checkout 中运行 installed-wheel 与支持版本矩阵测试：
+
+```bash
+make test-agentscope-integration
+```
+
+随后在应用中执行一次成功且可压缩的工具响应。确认 Middleware 返回更小的结果，并确认
+`tokenless_retrieve` 可以从同一 `data_dir` 恢复 Marker 对应的内容。
+
+## 相关文档
+
+- [Python SDK 概览](../sdk.md)
+- [Agent 集成](../framework-integration.md)
+- [配置与数据隐私](../configuration-and-privacy.md)
+- [故障排查](../troubleshooting.md)

--- a/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
+++ b/docs/user-guide/zh/token-saving/tokenless/troubleshooting.md
@@ -172,7 +172,7 @@ anolisa adapter scan
 anolisa --verbose adapter enable tokenless <framework>
 ```
 
-npm 安装请使用[框架集成 · npm 安装后的手动接入](framework-integration.md#npm-安装后的手动接入)。
+npm 安装请使用[Agent 集成 · npm 安装后的手动接入](framework-integration.md#npm-安装后的手动接入)。
 
 直接安装 RPM 后，请先补充状态记录，再用拥有目标框架配置的用户重试 adapter
 命令。
@@ -269,7 +269,11 @@ tokenless retrieve <hash> --stash-db ~/.tokenless/stash.db
 
 ## 有统计记录但 Prompt 没有变小
 
-先查看[支持矩阵](framework-integration.md#agent-adapter-支持矩阵)中的响应交付路径。Qoder 和 Qwen Code 输出 `additionalContext`，旧版 Copilot Shell 会追加该字段。Codex 无法替换原始结果，因此有意不执行响应压缩；其 PostToolUse 上下文仅包含识别出的环境失败。Codex 的实际节省应在经过 RTK 重写的 Shell 调用上测量。
+先查看[支持矩阵](framework-integration.md#agent-adapter-支持矩阵)中的响应交付路径。Qoder 通过
+`updatedToolOutput` 替换输出。Qwen Code 与旧版 Copilot Shell 的当前契约没有替换字段，
+因此会透传工具后输出，也不会通过 `additionalContext` 注入压缩副本。Codex 同样不执行响应
+压缩，其 PostToolUse Context 只包含识别出的环境失败；实际节省应在经过 RTK 改写的 Shell
+调用上测量。
 
 Claude Code 需要 2.1.121 或更高版本才能替换响应；旧版本或无法识别版本时会透传原文。OpenClaw 会替换持久化结果，但只有设置 `toon_compression_enabled=true` 才会启用 TOON。
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -19,10 +19,9 @@ cargo build --release --locked -p tokenless-cli
 
 这条路径只生成独立的 `tokenless` CLI，不会安装 `rtk` 或 Agent 接入资源。需要在 Agent 中使用完整能力时，请按照[快速开始](QUICKSTART.md)通过 anolisa CLI 安装。
 
-## 从源码构建 Python Runtime
+## 从源码构建 Python SDK
 
-运行在 CPython 中的框架集成可以在进程内使用 Tokenless，无需为每个响应启动
-CLI：
+CPython 应用可以在进程内使用 Tokenless，无需为每个生命周期操作启动 CLI：
 
 ```bash
 make python-wheel
@@ -30,51 +29,24 @@ python3 -m venv /tmp/tokenless-python
 /tmp/tokenless-python/bin/pip install target/wheels/anolisa_tokenless-*.whl
 ```
 
-构建时要求系统可发现 CPython 3.11+ 开发环境。`make python-wheel` 默认通过
-`uvx` 提供 Maturin，因此需要先安装 [`uv`](https://docs.astral.sh/uv/)；也可以
-先安装 Maturin，再执行 `make python-wheel MATURIN=maturin`。完整的
-`cargo test --workspace` 也会编译 Python member，需要相同环境；默认的 Cargo
-workspace 命令则不包含它。
+构建要求系统可发现 CPython 3.11+ 开发环境。Wheel 使用 CPython 3.11 stable ABI，但仍与
+构建时的操作系统和 CPU 架构绑定。
 
-Wheel 使用 CPython 3.11 stable ABI，因此支持构建平台上的 CPython 3.11 及更高
-版本，但仍受操作系统和 CPU 架构限制。该包目前尚未发布到 PyPI。
-
-首版 API 接收 JSON 文本，开放响应压缩和 Stash 取回：
-
-```python
-import json
-from pathlib import Path
-
-from anolisa_tokenless import TokenlessRuntime
-
-runtime = TokenlessRuntime(Path.home() / ".local/state/my-agent/tokenless")
-result = runtime.compress_response(
-    json.dumps({"items": list(range(200))}),
-    truncate_arrays_at=32,
-    agent_id="my-agent",
-    session_id="session-42",
-    tool_use_id="tool-7",
-)
-model_visible_output = result.output
-```
-
-Python API 默认采用可逆 fail-open 策略：请求使用 Stash，但数据库不可用、
-写入失败或配置阈值无法容纳取回 marker 时，`result.output` 保留原始 JSON，
-`result.disposition` 为 `reversibility-unavailable`。每个用户或租户应使用独立的
-绝对数据目录。
-首版 API 不包含 Schema 压缩、TOON、RTK、MCP 或框架 Middleware。状态和并发
-契约见 [Runtime 设计](../../../../../src/tokenless/docs/design/runtime-library_zh.md)。
+Python SDK 分为两层。`anolisa-tokenless` 包开放通用 `TokenlessSdk`、可直接调用的
+`TokenlessRuntime` 操作和 typed `TokenlessStats` 查询；相同版本的
+`anolisa-tokenless-agentscope` 包把该通用生命周期映射到 AgentScope。两层结构、可运行示例与
+配置见 [Python SDK 指南](sdk.md)。
 
 ## 能力与边界
 
 | 能力 | 当前代码实际执行的行为 | 重要边界 |
 |------|------------------------|----------|
 | Schema 压缩 | 移除 `title` 和 `examples`，删除描述中的围栏代码和行内代码，合并空白并截断描述 | 通过 cosh/Cosh-NG 的 `BeforeModel` Hook 和 OpenCode 的逐工具定义 Hook 运行（Qwen Code 清单中的条目会被当前宿主跳过）；其他场景可直接调用 CLI |
-| 响应压缩 | 移除名称完全匹配且区分大小写的调试字段、`null`、空字符串/数组/对象，并按配置阈值截断 | 输入必须是 JSON；Adapter 会主动跳过内容读取类工具 |
-| TOON 编码 | 编码 JSON；估算 Token 没有下降时保留 JSON 输入 | TOON 是替换原文还是与原文并存，取决于 Adapter |
+| Content-aware 响应压缩 | 把 JSON Records、构建日志和长纯文本路由到匹配 Compressor，只接受端到端更小的结果 | 直接 `compress-response` 仍只处理 JSON；宿主能力决定共享 Hook 能否用文本替换并发布恢复能力 |
+| TOON 编码 | 编码 JSON；估算 Token 没有下降时保留 JSON 输入 | 宿主支持文本替换时替换原文；无替换能力的宿主透传 |
 | 命令重写 | 有匹配规则时调用 `rtk rewrite`，再向框架提交改写后的 Shell 输入 | 真正提交给 Shell 的命令会变化；无规则或被拒绝时透传 |
 | Tool Ready | 旧版调用前能力，用于检查声明的二进制、版本、配置、权限和可选依赖 | 已硬关闭；不会检查、修复或阻断工具调用 |
-| Stash | 保存因字符串、数组、深度或 Schema 描述截断而移除的内容 | 默认 TTL 一小时、最多 10,000 个有效条目；其他被移除字段不会进入 Stash |
+| Stash | 保存因字符串、数组、深度或 Schema 描述截断以及 build/log 间隙移除而省略的内容 | 默认 TTL 一小时、最多 10,000 个有效条目；其他被移除字段不会进入 Stash |
 
 代码没有提供固定节省率保证。结果取决于 Payload、Adapter 交付语义，以及工具数据在模型上下文中的占比。请按[效果度量](measuring-savings.md)使用自己的工作负载测量。
 
@@ -84,11 +56,14 @@ Python API 默认采用可逆 fail-open 策略：请求使用 Stash，但数据�
 
 ```text
 工具调用前：已硬关闭的 Tool Ready Hook → 命令重写
-工具调用后：响应压缩 → 可选 Stash → TOON 编码 → 写入统计
+工具调用后：内容检测 → 符合条件的 Compressor → 可选 Stash/TOON → 写入统计
 模型调用前：Schema 压缩
 ```
 
-这是能力示意，不是所有框架都会完整执行的固定流水线。例如 OpenClaw 默认关闭 TOON，Codex 依靠 RTK 从源头缩减输出且不运行响应压缩，Schema 压缩只在 cosh/Cosh-NG（`BeforeModel` Hook）和 OpenCode（逐工具定义）上运行。具体见[框架集成](framework-integration.md)。
+这是能力示意，不是所有框架都会完整执行的固定流水线。例如 content-aware Protocol 路径
+当前服务于 Cosh-NG、Qoder、受支持的 Claude Code 版本和 OpenCode；OpenClaw、Hermes 与
+DeepSeek Harness 保留专用 JSON 响应路径。Codex 和 Qwen Code 当前宿主契约不能替换工具后
+输出。具体见 [Agent 集成](framework-integration.md)。
 
 ## 需要特别理解的行为
 
@@ -102,9 +77,11 @@ anolisa adapter enable tokenless <framework>
 
 CLI-only 用法不需要 Adapter。
 
-### “关闭压缩”只影响三个压缩操作
+### “关闭压缩”只影响压缩操作
 
-设置 `compression_enabled=false` 或 `TOKENLESS_COMPRESSION_ENABLED=0` 后，无论是直接调用还是通过 Adapter 调用，`compress-schema`、`compress-response` 和 `compress-toon` 都仍会计算预测节省并可能写入统计，但会返回原始输入。该模式不会写入 Stash 条目。
+设置 `compression_enabled=false` 或 `TOKENLESS_COMPRESSION_ENABLED=0` 后，`compress`、
+`compress-schema`、`compress-response` 和 `compress-toon` 仍会计算预测节省并可能写入统计，
+但会返回原始输入。该模式不会写入 Stash 条目。
 
 这个设置不会关闭 RTK 命令重写、Adapter 执行或内容取回。Tool Ready 已独立硬关闭。如需停止 Agent 中的所有 Tokenless 行为，应禁用 Adapter：
 
@@ -114,7 +91,8 @@ anolisa adapter disable tokenless <framework>
 
 ### 可逆压缩是有条件的
 
-启用压缩时，响应和 Schema 截断默认会把被移除的 Payload 写入 `~/.tokenless/stash.db`，并在输出中加入：
+启用压缩时，响应/Schema 截断和 build/log 省略区间默认会把被移除的 Payload 写入
+`~/.tokenless/stash.db`，并在输出中加入：
 
 ```text
 <<tokenless:0123456789abcdef01234567>>
@@ -133,7 +111,9 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 
 ### 普通处理错误通常 fail-open
 
-缺少 `tokenless` 或 `rtk`、压缩无收益或发生普通处理错误时，压缩和重写 Hook 通常不返回修改。Tool Ready 会在旧版检查、修复和阻断逻辑之前硬退出。工具执行后的失败归因是独立能力，保持不变。Stash 写入失败时，仍可能继续执行有损压缩。
+缺少 `tokenless` 或 `rtk`、压缩无收益或发生普通处理错误时，压缩和重写 Hook 通常不返回
+修改。`compress` 命令的所有非 `applied` 响应都会返回原文。Tool Ready 会在旧版检查、修复和
+阻断逻辑之前硬退出；工具执行后的失败归因是独立能力，保持不变。
 
 命令重写也会改变宿主提交的 Shell 命令。大多数 Adapter 会直接替换命令输入；Hermes 会先阻止第一次调用，再提示 Agent 使用改写命令重试。因此，除了压缩结果，还应验证重要命令工作流。
 
@@ -141,14 +121,14 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 
 | Agent 产品 | 集成方式 | 当前代码路径 |
 |------|----------|--------------|
-| cosh | Extension | Tool Ready（已硬关闭）、命令重写、响应压缩 + TOON、Schema；Cosh-NG 有替换路径，旧版 Copilot Shell 则追加额外上下文 |
+| cosh | Extension | Tool Ready（已硬关闭）、命令重写、Schema；Cosh-NG 替换符合条件的 Pipeline 输出，旧版 Copilot Shell 透传工具后输出 |
 | OpenClaw | Plugin | Tool Ready（已硬关闭）、`exec` 命令重写、替换持久化结果、可选 TOON；无 Schema |
 | Hermes | Plugin | Tool Ready（已硬关闭）、阻止后重试的命令重写、用响应压缩 + TOON 替换结果；无 Schema |
-| Qoder | Plugin | Tool Ready（已硬关闭）、命令重写、通过 `additionalContext` 交付响应压缩 + TOON；无 Schema |
+| Qoder | Plugin | Tool Ready（已硬关闭）、命令重写、通过 `updatedToolOutput` 交付响应 Pipeline；无 Schema |
 | Claude Code | Marketplace Plugin | Tool Ready（已硬关闭）、Bash 命令重写；Claude Code 2.1.121 及以上可替换响应；条件式 TOON；无 Schema |
 | Codex | Plugin | Tool Ready（已硬关闭）、RTK 命令重写、环境失败诊断；不替换响应/TOON，无 Schema |
 | OpenCode | Plugin | Tool Ready（已硬关闭）、Bash 命令重写、用响应压缩 + TOON 替换工具输出、Schema |
-| Qwen Code | Extension | Tool Ready（已硬关闭）、命令重写、通过 `additionalContext` 交付响应压缩 + TOON、Schema |
+| Qwen Code | Extension | Tool Ready（已硬关闭）、命令重写；当前宿主缺少工具后替换能力，并跳过声明的 BeforeModel 事件 |
 
 ## 支持的 Agent 开发框架
 
@@ -162,8 +142,9 @@ Stash 并不能让所有压缩都可逆。被移除的 `debug`/`trace` 字段、
 |------------|------|
 | 第一次安装并验证 | [快速开始](QUICKSTART.md) |
 | 从源码构建独立 CLI | [本页 · 从源码构建独立 CLI](#从源码构建独立-cli) |
-| 从源码构建进程内 Python Runtime | [本页 · 从源码构建 Python Runtime](#从源码构建-python-runtime) |
-| 接入 Agent 产品或集成 AgentScope | [Agent 与框架集成](framework-integration.md) |
+| 使用进程内 Python SDK | [Python SDK](sdk.md) |
+| 集成 AgentScope | [AgentScope SDK 集成](sdk/agentscope.md) |
+| 接入 Agent 产品 | [Agent 集成](framework-integration.md) |
 | 手动压缩、取回或运行 MCP | [CLI 参考](cli-reference.md) |
 | 查看节省或内容变化、做双跑对比 | [效果度量](measuring-savings.md) |
 | 修改配置或了解本地数据 | [配置与数据隐私](configuration-and-privacy.md) |

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -2,46 +2,49 @@
 
 [中文版](README_zh.md)
 
-**LLM token optimization toolkit** — schema/response compression + command rewriting + tool environment readiness.
+**LLM token optimization toolkit** — content-aware compression + command rewriting + diagnostics.
 
 Token-Less combines complementary strategies to minimize LLM token consumption:
 
-- **Schema & Response Compression** — Compresses OpenAI Function Calling tool definitions and API responses via the `tokenless-schema` library, cutting structural overhead before tokens ever reach the context window.
+- **Content-aware Compression** — Routes tool schemas, JSON records, build logs, and long plain text through a capability-aware pipeline, accepting only a smaller end-to-end result.
 - **TOON Context Compression** — Encodes JSON responses to TOON (Token-Oriented Object Notation) format via the `toon-format` library linked into `tokenless`, reducing syntax overhead for suitable structured data.
 - **Command Rewriting** — Integrates [RTK](https://github.com/rtk-ai/rtk) to filter and rewrite CLI command output, eliminating noise that would otherwise waste 60–90% of tokens.
 - **Tool Ready (legacy, hard-disabled)** — Its pre-call dependency checks are retained in source but unconditionally bypassed while the readiness model is redesigned.
 
 Agent adapters are available for:
 
-- **OpenClaw plugin** — covers command rewriting, response compression, and schema compression in one plugin.
+- **OpenClaw plugin** — covers command rewriting and response/TOON compression in one plugin.
 - **copilot-shell hook** — intercepts Shell commands via a PreToolUse hook and delegates to RTK for command rewriting + output filtering.
 - **Hermes Agent plugin** — response compression, TOON encoding, command rewriting (block + suggest), and registered but hard-disabled Tool Ready via Hermes's native plugin system.
 - **Qoder CLI plugin** — registered but hard-disabled Tool Ready, command rewriting, and response compression via Qoder's native hook system.
 - **Claude Code plugin** — RTK command rewriting, response/TOON compression, and registered but hard-disabled Tool Ready via Claude Code's official plugin marketplace.
 - **Codex plugin** — RTK command rewriting, environment-failure diagnostics, and registered but hard-disabled Tool Ready via Codex's native hook system.
 - **OpenCode plugin** — schema/response/TOON compression, registered but hard-disabled Tool Ready, and command rewriting via OpenCode's local plugin API.
+- **Qwen Code extension** — command rewriting and registered but hard-disabled Tool Ready; current host releases cannot replace post-tool output and skip the declared schema event.
 - **DeepSeek Harness plugin** — native response compression and environment-error attribution through DSH's `tools/post-execute` seam.
 
-For framework developers, the self-contained Python SDK and separate **AgentScope integration**
-cover schema compression, RTK rewriting, response compression, TOON, retrieval, and attribution.
+For framework developers, the Python SDK has a framework-neutral layer and an **AgentScope-specific
+layer**. Together they cover schema compression, RTK rewriting, response compression, TOON,
+retrieval, and attribution.
 
 ## Features
 
 | Capability | Savings indicator | Details |
 |---|---|---|
 | Schema compression | 47.3% on reference fixture | Compresses OpenAI Function Calling tool schemas |
-| Response compression | 65.8% on reference fixture | Compresses API / tool responses |
+| Content-aware response compression | 65.8% on the JSON reference fixture | Routes JSON, build logs, and long plain text through matching compressors |
 | Reversible compression (stash) | — | Dropped array items are stashed and retrievable via `<<tokenless:KEY>>` markers |
 | TOON context compression | 17.0% on reference response | Encodes JSON to TOON format for LLMs |
 | Command rewriting | 60–90% | Filters CLI output via RTK (70+ commands supported) |
 | Tool Ready | reduces retry waste | Legacy pre-call check, auto-fix, and blocking; hard-disabled |
-| OpenClaw plugin | — | Command rewriting ✅, Response compression ✅, Schema compression ✅ |
-| copilot-shell hooks | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ✅ |
+| OpenClaw plugin | — | Command rewriting ✅, Response compression ✅, optional TOON ✅, Schema compression — |
+| copilot-shell hooks | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Schema compression ✅; Cosh-NG can replace pipeline output, legacy Copilot Shell cannot |
 | Hermes Agent plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅, Schema compression ⏳ |
 | Qoder CLI plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅ |
 | Claude Code plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response compression ✅, TOON ✅ |
 | Codex plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Environment diagnostics ✅, Response compression — protocol-blocked |
 | OpenCode plugin | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Schema compression ✅, Response compression ✅, TOON ✅ |
+| Qwen Code extension | — | Tool Ready ⛔ hard-disabled, Command rewriting ✅, Response/Schema replacement unavailable in current host |
 | DeepSeek Harness plugin | — | Response compression ✅, Environment-error attribution ✅ |
 | AgentScope framework integration | — | Schema ✅, RTK ✅, Response ✅, TOON ✅, Retrieval ✅ |
 | Zero runtime deps | — | Pure Rust, single static binary |
@@ -107,6 +110,9 @@ Token-Less/
 ├── crates/tokenless-schema/   # Core library: SchemaCompressor + ResponseCompressor
 ├── crates/tokenless-ccr/      # Reversible compression stash (Compress-Cache-Retrieve)
 ├── crates/tokenless-runtime/  # Stateful in-process compression and retrieval API
+├── crates/tokenless-protocol/ # Versioned adapter request/response contract
+├── crates/tokenless-pipeline/ # Content detection, routing, staging, and arbitration
+├── crates/tokenless-compressors/ # Terminal and build/log compressors
 ├── crates/tokenless-cli/      # CLI binary: `tokenless` command (env-check, compress, retrieve, stats)
 ├── python/tokenless/          # PyO3 package: `anolisa_tokenless`
 ├── python/agentscope/         # Pure-Python AgentScope integration package
@@ -200,7 +206,7 @@ make setup
 The source setup installs `tokenless` to `~/.local/bin`, places the `rtk`
 helper alongside it, and deploys all adapters for development.
 
-### Build the Python runtime
+### Build the Python SDK
 
 Framework authors can build the in-process Python API from source:
 
@@ -222,8 +228,12 @@ where its native wheel was built. It exposes the four Tokenless lifecycle
 methods and bundles the matching RTK executable; TOON is linked into the native
 runtime. It does not require the Tokenless CLI or system helper binaries. The
 package is built and tested in this repository but is not yet published to
-PyPI. See the [runtime design](docs/design/runtime-library.md)
-and the [user manual](../../docs/user-guide/en/token-saving/tokenless/user-manual.md#build-the-python-runtime-from-source).
+PyPI. See the [Python SDK guide](../../docs/user-guide/en/token-saving/tokenless/sdk.md) for
+runnable lifecycle and Stats examples, the
+[AgentScope SDK integration](../../docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md) for
+AgentScope attachment, the
+[Agent integration guide](../../docs/user-guide/en/token-saving/tokenless/framework-integration.md)
+for product adapters, and the [runtime design](docs/design/runtime-library.md) for internal contracts.
 
 The same wheel provides typed, read-only statistics queries without requiring
 the CLI. Point `TokenlessStats` at the state directory used by the runtime, or
@@ -255,7 +265,17 @@ The description, string, array, and depth limits in the
 [CLI reference](../../docs/user-guide/en/token-saving/tokenless/cli-reference.md)
 trigger individual transformations; they are not minimum total payload sizes.
 Agent adapters may apply separate pre-check thresholds; see the
-[framework integration guide](../../docs/user-guide/en/token-saving/tokenless/framework-integration.md#adapter-processing-rules).
+[Agent integration guide](../../docs/user-guide/en/token-saving/tokenless/framework-integration.md#adapter-processing-rules).
+
+### compress
+
+Shared Agent hooks send a compression request to `tokenless compress`. The command
+detects content, filters compressors by the host's declared
+capabilities, and returns a structured disposition plus the exact output to
+emit. It currently handles model tool schemas, JSON records, build logs, and
+long plain text; other detected content types pass through. See the
+[CLI reference](../../docs/user-guide/en/token-saving/tokenless/cli-reference.md#compress)
+for the request/response contract and an executable example.
 
 ### compress-schema
 

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -2,14 +2,14 @@
 
 [English](README.md)
 
-LLM Token 优化工具包——Schema/响应压缩 + 命令重写 + 工具环境就绪检查。Token-Less 是 [ANOLISA](../../README_zh.md) 的 Token 节省组件，通过多种互补策略最小化 LLM Token 消耗。
+LLM Token 优化工具包——content-aware 压缩 + 命令重写 + 环境失败诊断。Token-Less 是 [ANOLISA](../../README_zh.md) 的 Token 节省组件，通过多种互补策略最小化 LLM Token 消耗。
 
 ## 核心能力
 
 | 能力 | 节省率示例 | 说明 |
 |------|-----------|------|
 | Schema 压缩 | 参考 fixture 47.3% | 压缩 OpenAI Function Calling 工具定义 |
-| 响应压缩 | 参考 fixture 65.8% | 压缩 API/工具响应 |
+| Content-aware 响应压缩 | JSON 参考 fixture 65.8% | 把 JSON、构建日志和长纯文本路由到匹配 Compressor |
 | TOON 上下文压缩 | 参考响应 17.0% | 将 JSON 编码为 TOON 格式 |
 | 命令重写 | 60–90% | 通过 RTK 过滤 CLI 输出（支持 70+ 命令） |
 | Tool Ready | 减少重试浪费 | 旧版调用前预检、自动修复与阻断；当前硬关闭 |
@@ -74,20 +74,22 @@ tokenless 优化进入 LLM 上下文前、由它实际处理的工具相关内�
 
 ### Agent Adapter
 
-- **OpenClaw 插件** — 命令重写 + 响应压缩 + Schema 压缩
-- **copilot-shell 钩子** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
+- **OpenClaw 插件** — 命令重写 + 响应压缩 + 可选 TOON；不支持 Schema 压缩
+- **copilot-shell 钩子** — Tool Ready（已硬关闭）+ 命令重写 + Schema；Cosh-NG 可替换 Pipeline 输出，旧版 Copilot Shell 透传
 - **Hermes Agent 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
-- **Qoder CLI 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩
+- **Qoder CLI 插件** — Tool Ready（已硬关闭）+ 命令重写 + 通过 `updatedToolOutput` 交付响应 Pipeline
 - **Claude Code 插件** — Tool Ready（已硬关闭）+ 命令重写 + 响应压缩 + TOON
 - **Codex 插件** — Tool Ready（已硬关闭）+ RTK 命令重写 + 环境失败诊断；Codex
   协议不支持替换原始输出，因此不追加压缩副本
 - **OpenCode 插件** — Tool Ready（已硬关闭）+ 命令重写 + Schema/响应压缩 + TOON
 - **DeepSeek Harness 插件**。通过 DSH 原生 `tools/post-execute` 接入响应压缩和环境错误归因
+- **Qwen Code Extension** — Tool Ready（已硬关闭）+ 命令重写；当前宿主不支持工具后输出替换，并跳过声明的 Schema 事件
 
 ### Agent 开发框架集成
 
-- **AgentScope Python 集成** — 完整开放 Schema 压缩、RTK 改写、响应压缩、TOON、
-  受 marker 约束的恢复和归属统计。
+- **通用 Python SDK** — 面向任意 Agent 框架的生命周期 API、单项 Runtime 操作与统计查询。
+- **AgentScope 专用层** — 基于通用 SDK，完整开放 Schema 压缩、RTK 改写、响应压缩、
+  TOON、受 marker 约束的恢复和归属统计。
 
 ## 快速开始
 
@@ -141,6 +143,14 @@ anolisa adapter enable tokenless dsh --profile <profile>
 dsh --profile <profile>
 ```
 
+### `compress` 压缩入口
+
+共享 Agent Hook 会向 `tokenless compress` 发送压缩请求。该命令检测内容，根据
+宿主声明能力筛选 Compressor，并返回结构化 disposition 与应当交付的精确输出。当前覆盖
+模型工具 Schema、JSON Records、构建日志和长纯文本；其他已检测内容类型原样透传。请求/
+响应契约和可执行示例见
+[CLI 参考](../../docs/user-guide/zh/token-saving/tokenless/cli-reference.md#compress)。
+
 ### Schema 压缩 CLI
 
 `compress-schema` 支持单个工具定义、工具定义 JSON 数组，以及包含顶层
@@ -189,7 +199,7 @@ make setup
 源码安装会把 `tokenless` 放在 `~/.local/bin`，`rtk` 辅助
 二进制也位于同一个目录，并部署开发所需的全部 adapter。
 
-### 构建 Python Runtime
+### 构建 Python SDK
 
 框架开发者可以从源码构建进程内 Python API：
 
@@ -208,9 +218,11 @@ Maturin。请先安装 [`uv`](https://docs.astral.sh/uv/)，或者在 `PATH` 中
 `anolisa_tokenless` 模块支持 CPython 3.11 及更高版本，但只能在构建该原生
 Wheel 的对应平台使用。它开放四个 Tokenless 生命周期接口并内置对应平台的 RTK；
 TOON 已链接进原生 Runtime，不依赖 Tokenless CLI 或系统 helper。仓库会构建并测试该包，
-但目前尚未发布到
-PyPI。具体见 [Runtime 设计](docs/design/runtime-library_zh.md) 和
-[用户手册](../../docs/user-guide/zh/token-saving/tokenless/user-manual.md#从源码构建-python-runtime)。
+但目前尚未发布到 PyPI。可运行生命周期与 Stats 示例见
+[Python SDK 指南](../../docs/user-guide/zh/token-saving/tokenless/sdk.md)，AgentScope 挂载见
+[AgentScope SDK 集成](../../docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md)，产品 Adapter 见
+[Agent 集成指南](../../docs/user-guide/zh/token-saving/tokenless/framework-integration.md)，内部契约见
+[Runtime 设计](docs/design/runtime-library_zh.md)。
 
 同一个 Wheel 还提供不依赖 CLI 的只读 typed Stats 查询。可以让 `TokenlessStats` 指向
 Runtime 使用的状态目录，或使用延迟创建的 `sdk.stats`：
@@ -464,6 +476,9 @@ tokenless env-check --tool Shell --fix
 - `crates/tokenless-schema/` — 核心库：SchemaCompressor + ResponseCompressor
 - `crates/tokenless-ccr/` — 可逆压缩缓存（Compress-Cache-Retrieve）
 - `crates/tokenless-runtime/` — CLI 与语言绑定共用的有状态 Rust API
+- `crates/tokenless-protocol/` — 版本化 Adapter 请求/响应契约
+- `crates/tokenless-pipeline/` — 内容检测、路由、分阶段执行与仲裁
+- `crates/tokenless-compressors/` — Terminal 与 build/log Compressor
 - `crates/tokenless-cli/` — CLI 二进制
 - `python/tokenless/` — 面向 CPython 3.11+ 的 PyO3 `anolisa_tokenless` 包
 - `python/agentscope/` — 独立的 AgentScope 框架集成与 Wheel 元数据

--- a/src/tokenless/npm/README.md
+++ b/src/tokenless/npm/README.md
@@ -1,6 +1,9 @@
 # anolisa-tokenless
 
-LLM token optimization toolkit — schema/response compression, command rewriting, and tool environment readiness.
+LLM token optimization toolkit — content-aware compression, command rewriting, and diagnostics.
+
+Tool Ready's legacy pre-call checks remain registered but are hard-disabled. Post-tool environment
+failure diagnostics are independent and remain active where the host supports additive context.
 
 > **Release status:** These npm packages are private and are not currently
 > published to the public registry. This document describes the intended
@@ -19,7 +22,7 @@ This automatically installs the correct prebuilt binary for your platform.
 
 | Binary | Description |
 |--------|-------------|
-| `tokenless` | Main CLI — schema compression, response compression, TOON encoding, stats |
+| `tokenless` | Main CLI — content-aware protocol, direct compression, retrieval, and stats |
 | `rtk` | Command rewriting engine (filters CLI output noise) |
 
 TOON (Token-Oriented Object Notation) encoding is built into `tokenless`
@@ -45,9 +48,12 @@ The correct platform-specific binaries are automatically installed via `optional
 ## Agent Adapters
 
 The root package bundles the Tokenless adapters for Agent products (cosh,
-OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, and Qwen Code). The
+OpenClaw, Hermes, Qoder, Claude Code, Codex, OpenCode, Qwen Code, and DeepSeek Harness). The
 adapter hooks are plain bash/python scripts — OS and architecture independent —
 so they work on both Linux and macOS.
+
+DeepSeek Harness uses its dedicated `tools/post-execute` path for JSON response compression and
+environment-error attribution. It does not use the content-aware build/log Pipeline.
 
 On install, they are copied to the user-level data directory searched by the
 hook dispatcher:
@@ -66,6 +72,13 @@ bash ~/.local/share/anolisa/adapters/tokenless/claude-code/scripts/install.sh
 ## Usage
 
 ```bash
+# Run the content-aware Pipeline used by shared Agent hooks
+jq -n --rawfile content build.log \
+  '{protocol_version: 1, content: $content, agent_id: "manual", seam: "post_tool",
+    capabilities: {replace_output: true, publish_retrieve_tool: true,
+                   replace_with_text: true}}' \
+  | tokenless compress
+
 # Compress an API response
 tokenless compress-response -f response.json
 
@@ -84,7 +97,7 @@ rtk ls -la
 # Or use rewrite subcommand
 rtk rewrite "ls -la"
 
-# Check tool environment readiness
+# Report the current hard-disabled Tool Ready status
 tokenless env-check --all
 ```
 

--- a/src/tokenless/python/tokenless/README.md
+++ b/src/tokenless/python/tokenless/README.md
@@ -6,8 +6,51 @@ TOON encoding, and marker-scoped Stash retrieval.
 The package is built from the ANOLISA monorepo and supports CPython 3.11 or later on the platform
 targeted by its wheel. The pinned RTK executable is included in the wheel; no Tokenless binary is
 required on `PATH`. See the
-[Tokenless user manual](https://github.com/alibaba/anolisa/blob/main/src/tokenless/README.md#build-the-python-runtime)
-for source-build prerequisites, instructions, and API boundaries.
+[Tokenless Python SDK guide](https://github.com/alibaba/anolisa/blob/main/docs/user-guide/en/token-saving/tokenless/sdk.md)
+for source-build prerequisites, lifecycle contracts, configuration, and runnable examples. This
+package is the framework-neutral SDK layer. The same-version `anolisa-tokenless-agentscope` package
+builds the AgentScope-specific layer on top; its detailed attachment steps are in the
+[AgentScope SDK integration guide](https://github.com/alibaba/anolisa/blob/main/docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md).
+The [Tokenless component README](https://github.com/alibaba/anolisa/blob/main/src/tokenless/README.md)
+provides the CLI, adapter, and source-build overview.
+
+```python
+import asyncio
+import json
+
+from anolisa_tokenless import (
+    Attribution,
+    TokenlessConfig,
+    TokenlessSdk,
+    ToolCall,
+    ToolResult,
+    ToolStatus,
+)
+
+
+async def main() -> None:
+    sdk = TokenlessSdk(
+        TokenlessConfig(
+            data_dir="/absolute/path/to/tokenless-data",
+            mode="aggressive",
+            rtk_enabled=False,
+            toon_enabled=False,
+        )
+    )
+    call = ToolCall(
+        "api",
+        {},
+        Attribution("my-agent", "session-42", "tool-7"),
+    )
+    original = json.dumps({"items": list(range(300))})
+    result = await sdk.after_tool_call(
+        ToolResult(call, original, ToolStatus.SUCCESS)
+    )
+    print(result.content)
+
+
+asyncio.run(main())
+```
 
 The public `TokenlessStats` client provides typed, read-only status, summary, recent-record,
 record-detail, structured-diff, and session-comparison queries over the Runtime's `stats.db`.

--- a/src/tokenless/tests/test-agentscope-integration.sh
+++ b/src/tokenless/tests/test-agentscope-integration.sh
@@ -7,8 +7,8 @@ TEST_ROOT="$(mktemp -d /tmp/tokenless-agentscope-integration-test.XXXXXX)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 GUIDES=(
-    "$ROOT/../../docs/user-guide/en/token-saving/tokenless/framework-integration.md"
-    "$ROOT/../../docs/user-guide/zh/token-saving/tokenless/framework-integration.md"
+    "$ROOT/../../docs/user-guide/en/token-saving/tokenless/sdk/agentscope.md"
+    "$ROOT/../../docs/user-guide/zh/token-saving/tokenless/sdk/agentscope.md"
 )
 GUIDE_FRAGMENTS=(
     '| 1.0.11'


### PR DESCRIPTION
## Why

Tokenless documentation still described older SDK boundaries, adapter delivery paths, and
response-only compression behavior. The current implementation needs a clear relationship between
the framework-neutral SDK and the AgentScope-specific layer without mixing in product adapters.

## What changed

- Add English and Chinese Python SDK guides that separately introduce the framework-neutral layer
  and the same-version AgentScope-specific layer.
- Keep complete lifecycle, Stats, and configuration examples in the generic layer, and add direct
  Runtime examples for response, Schema, TOON, and Stash retrieval operations.
- Document the GitHub Release wheel matrix and a copyable Runtime installation command, while
  keeping the Linux source build as an alternative.
- Move AgentScope build, version, attachment, configuration, and validation guidance into the
  `sdk/agentscope.md` child document, including same-version Runtime and integration wheel
  installation.
- Retarget the AgentScope integration documentation check to the new child document.
- Focus the Agent integration guide on product adapters, with a compatibility pointer for existing
  AgentScope links.
- Align the CLI reference, user manuals, troubleshooting, and package READMEs with the current
  compression request, content-aware pipeline, build/log compression, and host capabilities.

## Related issue

no-issue: documentation sync with the current Tokenless implementation

## User / Agent impact

Users can navigate from the generic SDK overview to its AgentScope child guide while keeping product
adapter setup separate, then choose lifecycle integration, direct Runtime operations, or statistics
queries. Adapter capability and output-delivery guidance now matches the current host contracts.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Documentation and documentation-validation-only change. It describes existing behavior and does
not change runtime contracts.

## Validation

- `bash scripts/docs-lint.sh`
- `python3 scripts/docs-link-check.py`
- `git diff --check`
- Matched the v0.7.14 Linux x86_64 Runtime and AgentScope Release wheels to
  `SHA256SUMS-python-wheels.txt`, then passed the CI wheel verifier for both packages
- Installed both verified Release wheels with `pip --no-deps`, imported `TokenlessRuntime`, and
  confirmed the packaged RTK executable is present and executable
- Parsed all 31 added or updated Python example blocks with `ast.parse`
- Installed the built `anolisa-tokenless` Wheel and ran the four direct Runtime examples end to end
- `RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= make test-python-runtime` (28 tests, including Wheel
  documentation metadata)
- `RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= make test-agentscope-integration` (AgentScope 1.0.11,
  1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.7)
- `RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= cargo test -p tokenless-protocol -p tokenless-pipeline -p tokenless-compressors -p tokenless-runtime`
- `RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= cargo test -p tokenless-cli` compiled and ran;
  184 tests passed, 2 were ignored, and 45 database-path tests were blocked when the Codex sandbox
  rejected the suite's simulated-home directory on the read-only root filesystem

## Documentation and rollback

Updated the paired English and Chinese Tokenless user guides plus component, npm, and Python package
READMEs. Revert this documentation commit to roll back.
