### PR TITLE
fix(cosh-ng): [shell] preserve PTY boundaries

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -523,7 +523,19 @@ fn flush_candidate_line_to_shell(
         wrapped.extend_from_slice(b"\x1b[201~");
         bytes = wrapped;
     }
-    submit_line_bytes_to_shell(relay, bytes, Vec::new(), emit_activity)
+    submit_line_bytes_to_shell(
+        relay,
+        bytes,
+        Vec::new(),
+        emit_activity,
+        ShellBatchOwnership::ReadlineSafe,
+    )
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum ShellBatchOwnership {
+    Opaque,
+    ReadlineSafe,
 }
 
 /// Clears the cosh-echoed candidate line and writes the whole read batch to
@@ -534,33 +546,39 @@ fn submit_line_bytes_to_shell(
     mut bytes: Vec<u8>,
     remainder: Vec<u8>,
     emit_activity: bool,
+    ownership: ShellBatchOwnership,
 ) -> io::Result<bool> {
     // A remainder was read with the candidate submission. Once any line in a
     // read is Shell-owned, the complete batch stays Shell-owned even if Bash
     // paints another prompt before this function returns.
     bytes.extend_from_slice(&remainder);
     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);
-    let guard_submission = bash_submission_needs_guard(
-        relay.input_classifier.bash_slash_submission_guard_enabled(),
-        relay.main_prompt_gate.is_at_prompt(),
-        relay.input_classifier,
-        relay.native_line_state,
-        relay.line_submits,
-        &bytes,
-    );
+    let guard_submission = matches!(ownership, ShellBatchOwnership::ReadlineSafe)
+        && bash_submission_needs_guard(
+            relay.input_classifier.bash_slash_submission_guard_enabled(),
+            relay.main_prompt_gate.is_at_prompt(),
+            relay.input_classifier,
+            relay.native_line_state,
+            relay.line_submits,
+            &bytes,
+        );
     send_raw_input_events(&bytes, relay.input_events);
     observe_native_line(relay.native_line_state, &bytes, relay.input_events);
     if emit_activity && !bytes.is_empty() {
         send_shell_input_state(relay.native_line_state.is_empty(), relay.input_events);
     }
     relay.exit_tracker.observe_shell_bytes(&bytes);
-    let guarded_bytes = guarded_bash_submission(
-        guard_submission,
-        false,
-        relay.input_classifier,
-        relay.line_submits,
-        &bytes,
-    );
+    let guarded_bytes = matches!(ownership, ShellBatchOwnership::ReadlineSafe)
+        .then(|| {
+            guarded_bash_submission(
+                guard_submission,
+                false,
+                relay.input_classifier,
+                relay.line_submits,
+                &bytes,
+            )
+        })
+        .flatten();
     write_user_bytes_to_pty(
         relay.master,
         relay.input_generation,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/bash_submission_guard.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/bash_submission_guard.rs
@@ -17,15 +17,22 @@ pub(super) fn guarded_bash_submission(
     let mut guards = Vec::new();
     let mut line_start = 0;
     let mut readline_owned = false;
+    let mut batch_readline_safe = required;
     for (index, submit) in submissions.into_iter().enumerate() {
-        let needs_guard = if index == 0 {
+        let line = &bytes[line_start..submit];
+        let exact_slash = exact_slash_submission(input_classifier, line);
+        let blank = line.iter().all(u8::is_ascii_whitespace);
+        let ctrl_o = bytes[submit] == 0x0f;
+        let needs_guard = if !batch_readline_safe {
+            false
+        } else if index == 0 {
             required
         } else if readline_owned {
             // Ctrl-O loads another history entry before the next submitted
             // bytes, so the relay cannot prove the resulting Readline line.
             true
         } else {
-            exact_slash_submission(input_classifier, &bytes[line_start..submit])
+            exact_slash
         };
         if needs_guard {
             let guard = if index == 0 && history_private {
@@ -35,7 +42,15 @@ pub(super) fn guarded_bash_submission(
             };
             guards.push((submit, guard));
         }
-        readline_owned = bytes[submit] == 0x0f;
+        if index == 0 {
+            batch_readline_safe &= exact_slash || ctrl_o;
+        } else if (readline_owned && !ctrl_o) || (!exact_slash && !blank && !ctrl_o) {
+            // An ordinary command ends the part of the batch whose future
+            // consumer is provably Readline. Later bytes stay byte-exact for
+            // whichever shell/foreground reader owns the PTY next.
+            batch_readline_safe = false;
+        }
+        readline_owned = batch_readline_safe && ctrl_o;
         line_start = submit + 1;
     }
     if guards.is_empty() {

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/candidate.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/candidate.rs
@@ -12,7 +12,7 @@ use super::super::mode::new_delay_input_mode;
 use super::super::RawInputEvent;
 use super::{
     flush_candidate_line_to_shell, relay_passthrough_input_with_policy, send_shell_input_state,
-    submit_line_bytes_to_shell, InputRelayContext,
+    submit_line_bytes_to_shell, InputRelayContext, ShellBatchOwnership,
 };
 
 pub(super) fn relay_candidate_line(
@@ -87,7 +87,13 @@ pub(super) fn relay_candidate_line(
             wrapped.extend_from_slice(BRACKETED_PASTE_START);
             wrapped.extend_from_slice(&bytes);
             wrapped.extend_from_slice(BRACKETED_PASTE_END);
-            return submit_line_bytes_to_shell(relay, wrapped, after_paste, emit_activity);
+            return submit_line_bytes_to_shell(
+                relay,
+                wrapped,
+                after_paste,
+                emit_activity,
+                ShellBatchOwnership::Opaque,
+            );
         }
     }
     match candidate_line_status(
@@ -194,7 +200,13 @@ pub(super) fn relay_candidate_line(
                         // Readline records it in native history (#1718).
                         // Once accepted by Bash it remains Shell-owned; the
                         // bounded marker only observes its command boundary.
-                        return submit_line_bytes_to_shell(relay, bytes, remainder, emit_activity);
+                        return submit_line_bytes_to_shell(
+                            relay,
+                            bytes,
+                            remainder,
+                            emit_activity,
+                            ShellBatchOwnership::ReadlineSafe,
+                        );
                     }
                     let _ = relay.input_events.send(RawInputEvent::CandidateCommit(
                         redact_extension_setting_value(line.as_bytes()),
@@ -248,7 +260,13 @@ pub(super) fn relay_candidate_line(
                         wrapped.extend_from_slice(b"\x1b[201~");
                         bytes = wrapped;
                     }
-                    submit_line_bytes_to_shell(relay, bytes, remainder, emit_activity)
+                    submit_line_bytes_to_shell(
+                        relay,
+                        bytes,
+                        remainder,
+                        emit_activity,
+                        ShellBatchOwnership::Opaque,
+                    )
                 }
                 InputDecision::Consume => {
                     let _ = relay.input_events.send(RawInputEvent::CandidateClearLine);

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -2185,6 +2185,43 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
 }
 
 #[test]
+fn native_exact_slash_tab_submit_keeps_readline_guard() {
+    let (path, mut master) = output_file("native-slash-tab-submit");
+    let (tx, _rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default().with_bash_slash_submission_guard(true);
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: true,
+    };
+
+    relay_passthrough_input(b"/help\t\n", &mut relay).expect("submit completed slash");
+    master.sync_all().expect("sync test output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"/help\t\x1b[99~\n"
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
 fn native_shell_input_reports_editing_then_empty_without_content() {
     let (path, mut master) = output_file("input-state");
     let (tx, rx) = mpsc::channel();
@@ -3820,6 +3857,46 @@ fn slash_guard_does_not_infer_follow_up_readline_ownership() {
             b"/mode approval\r\x1b[D/skills detail $(touch should-not-run)\r",
         ),
         Some(b"/mode approval\x1b[99~\r\x1b[D/skills detail $(touch should-not-run)\r".to_vec())
+    );
+}
+
+#[test]
+fn slash_guard_stops_after_ordinary_shell_submission() {
+    let classifier = InputClassifier::default();
+    let line_submits = LineSubmitCounter::default();
+
+    assert_eq!(
+        guarded_bash_submission(
+            true,
+            false,
+            &classifier,
+            &line_submits,
+            b"/mode approval\necho ordinary\n/skills detail $(touch should-not-run)\n",
+        ),
+        Some(
+            b"/mode approval\x1b[99~\necho ordinary\n/skills detail $(touch should-not-run)\n"
+                .to_vec()
+        )
+    );
+}
+
+#[test]
+fn slash_guard_does_not_trust_blank_bytes_with_dirty_mirror() {
+    let classifier = InputClassifier::default();
+    let line_submits = LineSubmitCounter::default();
+
+    // `required` may represent an ordinary command recalled outside the
+    // mirror. The raw blank only submits that unknown line; it does not prove
+    // that a later slash is still owned by Readline.
+    assert_eq!(
+        guarded_bash_submission(
+            true,
+            false,
+            &classifier,
+            &line_submits,
+            b"\n/skills detail $(touch should-not-run)\n",
+        ),
+        Some(b"\x1b[99~\n/skills detail $(touch should-not-run)\n".to_vec())
     );
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
@@ -94,13 +94,42 @@ _cosh_apply_internal_recovery() {
   rm -f -- "$COSH_RECOVERY_REQUEST_FILE" 2>/dev/null || true
   stty echo icanon isig iexten opost 2>/dev/null || true
 }
+# Shell variables cannot represent NUL; escape every representable C0 byte and DEL.
 _cosh_json_escape() {
   local value="$1"
   value=${value//\\/\\\\}
   value=${value//\"/\\\"}
+  value=${value//$'\001'/\\u0001}; value=${value//$'\002'/\\u0002}
+  value=${value//$'\003'/\\u0003}
+  value=${value//$'\004'/\\u0004}
+  value=${value//$'\005'/\\u0005}
+  value=${value//$'\006'/\\u0006}
+  value=${value//$'\a'/\\u0007}
+  value=${value//$'\b'/\\b}
   value=${value//$'\n'/\\n}
+  value=${value//$'\v'/\\u000b}
+  value=${value//$'\f'/\\f}
   value=${value//$'\r'/\\r}
+  value=${value//$'\016'/\\u000e}
+  value=${value//$'\017'/\\u000f}
+  value=${value//$'\020'/\\u0010}
+  value=${value//$'\021'/\\u0011}
+  value=${value//$'\022'/\\u0012}
+  value=${value//$'\023'/\\u0013}
+  value=${value//$'\024'/\\u0014}
+  value=${value//$'\025'/\\u0015}
+  value=${value//$'\026'/\\u0016}
+  value=${value//$'\027'/\\u0017}
+  value=${value//$'\030'/\\u0018}
+  value=${value//$'\031'/\\u0019}
+  value=${value//$'\032'/\\u001a}
+  value=${value//$'\e'/\\u001b}
+  value=${value//$'\034'/\\u001c}
+  value=${value//$'\035'/\\u001d}
+  value=${value//$'\036'/\\u001e}
+  value=${value//$'\037'/\\u001f}
   value=${value//$'\t'/\\t}
+  value=${value//$'\177'/\\u007f}
   printf '%s' "$value"
 }
 _cosh_native_history_file_path() {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -90,13 +90,42 @@ _cosh_apply_internal_recovery() {
   rm -f -- "$COSH_RECOVERY_REQUEST_FILE" 2>/dev/null || true
   stty echo icanon isig iexten opost 2>/dev/null || true
 }
+# Shell variables cannot represent NUL; escape every representable C0 byte and DEL.
 _cosh_json_escape() {
   local value="$1"
   value=${value//\\/\\\\}
   value=${value//\"/\\\"}
+  value=${value//$'\001'/\\u0001}; value=${value//$'\002'/\\u0002}
+  value=${value//$'\003'/\\u0003}
+  value=${value//$'\004'/\\u0004}
+  value=${value//$'\005'/\\u0005}
+  value=${value//$'\006'/\\u0006}
+  value=${value//$'\a'/\\u0007}
+  value=${value//$'\b'/\\b}
   value=${value//$'\n'/\\n}
+  value=${value//$'\v'/\\u000b}
+  value=${value//$'\f'/\\f}
   value=${value//$'\r'/\\r}
+  value=${value//$'\016'/\\u000e}
+  value=${value//$'\017'/\\u000f}
+  value=${value//$'\020'/\\u0010}
+  value=${value//$'\021'/\\u0011}
+  value=${value//$'\022'/\\u0012}
+  value=${value//$'\023'/\\u0013}
+  value=${value//$'\024'/\\u0014}
+  value=${value//$'\025'/\\u0015}
+  value=${value//$'\026'/\\u0016}
+  value=${value//$'\027'/\\u0017}
+  value=${value//$'\030'/\\u0018}
+  value=${value//$'\031'/\\u0019}
+  value=${value//$'\032'/\\u001a}
+  value=${value//$'\e'/\\u001b}
+  value=${value//$'\034'/\\u001c}
+  value=${value//$'\035'/\\u001d}
+  value=${value//$'\036'/\\u001e}
+  value=${value//$'\037'/\\u001f}
   value=${value//$'\t'/\\t}
+  value=${value//$'\177'/\\u007f}
   printf '%s' "$value"
 }
 _cosh_now_ms() {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -447,7 +447,7 @@ impl OscParser {
             return None;
         }
         let path = marker.path.as_deref()?;
-        if path.len() > SHELL_PATH_MAX_BYTES {
+        if path.len() > SHELL_PATH_MAX_BYTES || path.chars().any(char::is_control) {
             return None;
         }
         let normalized = normalize_shell_path(path);

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -717,6 +717,65 @@ fn path_snapshot_accepts_exact_eight_kibibyte_boundary() {
 }
 
 #[test]
+fn environment_marker_with_control_path_does_not_update_state() {
+    let mut parser = parser_for_test("path-control");
+
+    feed_environment_marker(
+        &mut parser,
+        "preexec",
+        Some("echo unsafe path"),
+        "/safe:/control\u{7}entry:/tail",
+        true,
+        Some("path-control"),
+    );
+
+    let start = parser
+        .events
+        .iter()
+        .find(|event| event.kind == ShellEventKind::CommandStarted)
+        .expect("command start");
+    assert_eq!(start.shell_environment_generation, None);
+    assert!(parser.shell_environment_snapshot.is_none());
+}
+
+#[test]
+fn control_physical_cwd_stays_untrusted_until_clean_prompt() {
+    let mut parser = parser_for_test("physical-cwd-control");
+    let prompt_cwd = crate::input::ShellPromptCwd::default();
+    parser.set_prompt_cwd(prompt_cwd.clone());
+
+    // #2918 may route a path-bearing prompt only from a trusted physical cwd.
+    for unsafe_cwd in [
+        "/tmp/bell\u{7}cwd",
+        "/tmp/st\u{1b}\\cwd",
+        "/tmp/del\u{7f}cwd",
+    ] {
+        let marker = serde_json::json!({
+            "e": "p",
+            "t": TEST_MARKER_TOKEN,
+            "c": unsafe_cwd,
+            "pc": unsafe_cwd,
+            "s": 0,
+        });
+        let bytes = format!("\x1b]1337;COSH;{marker}\x07");
+        parser.feed(bytes.as_bytes()).expect("feed unsafe prompt");
+        assert_eq!(prompt_cwd.current(), None, "{unsafe_cwd:?}");
+    }
+
+    let clean_cwd = "/tmp/clean-after-control";
+    let marker = serde_json::json!({
+        "e": "p",
+        "t": TEST_MARKER_TOKEN,
+        "c": clean_cwd,
+        "pc": clean_cwd,
+        "s": 0,
+    });
+    let bytes = format!("\x1b]1337;COSH;{marker}\x07");
+    parser.feed(bytes.as_bytes()).expect("feed clean prompt");
+    assert_eq!(prompt_cwd.current().as_deref(), Some(clean_cwd));
+}
+
+#[test]
 fn environment_marker_with_wrong_token_does_not_update_state() {
     let mut parser = parser_for_test("path-wrong-token");
     let marker = serde_json::json!({

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -1,6 +1,139 @@
 use super::*;
 
 #[test]
+fn marker_json_escape_removes_raw_controls_and_preserves_utf8() {
+    let input = concat!(
+        "A中\"\\",
+        "\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\t\n\u{b}\u{c}\r",
+        "\u{e}\u{f}\u{10}\u{11}\u{12}\u{13}\u{14}\u{15}\u{16}\u{17}",
+        "\u{18}\u{19}\u{1a}\u{1b}\\\u{1c}\u{1d}\u{1e}\u{1f}\u{7f}Z"
+    );
+    let expected = concat!(
+        "A中\\\"\\\\",
+        "\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000b\\f\\r",
+        "\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017",
+        "\\u0018\\u0019\\u001a\\u001b\\\\\\u001c\\u001d\\u001e\\u001f\\u007fZ"
+    );
+    let scripts = [
+        ("bash", include_str!("../../src/shell_host/marker/bash.sh")),
+        ("zsh", include_str!("../../src/shell_host/marker/zsh.rs")),
+    ];
+
+    for (shell, script) in scripts {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        let function = shell_function(script, "_cosh_json_escape");
+        let command = format!("{function}\n_cosh_json_escape \"$1\"");
+        let output = Command::new(shell)
+            .args(["-c", command.as_str(), "cosh-marker-test", input])
+            .output()
+            .unwrap_or_else(|error| panic!("run {shell}: {error}"));
+
+        assert!(output.status.success(), "{shell}: {output:?}");
+        assert_eq!(output.stdout, expected.as_bytes(), "{shell}");
+        assert!(
+            output.stdout.iter().all(|byte| !byte.is_ascii_control()),
+            "{shell}: {:?}",
+            output.stdout
+        );
+    }
+}
+
+fn shell_function<'a>(script: &'a str, name: &str) -> &'a str {
+    let start_pattern = format!("{name}() {{\n");
+    let start = script
+        .find(&start_pattern)
+        .unwrap_or_else(|| panic!("missing {name}"));
+    let rest = &script[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("unterminated {name}"));
+    &rest[..end + 2]
+}
+
+#[test]
+fn shell_host_marker_control_cwd_keeps_json_frame_intact() {
+    let control_name = concat!(
+        "cwd-中-",
+        "\u{1}\u{2}\u{3}\u{4}\u{5}\u{6}\u{7}\u{8}\t\n\u{b}\u{c}\r",
+        "\u{e}\u{f}\u{10}\u{11}\u{12}\u{13}\u{14}\u{15}\u{16}\u{17}",
+        "\u{18}\u{19}\u{1a}\u{1b}\\\u{1c}\u{1d}\u{1e}\u{1f}\u{7f}"
+    );
+    let shell_control_name = concat!(
+        "$'cwd-中-",
+        "\\001\\002\\003\\004\\005\\006\\007\\010\\011\\012\\013\\014\\015",
+        "\\016\\017\\020\\021\\022\\023\\024\\025\\026\\027",
+        "\\030\\031\\032\\033\\\\\\034\\035\\036\\037\\177'"
+    );
+    let tail_sentinel = "__post_cwd_marker_tail__";
+
+    for shell in ["bash", "zsh"] {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        let work_dir =
+            std::env::temp_dir().join(format!("cosh-marker-control-{shell}-{}", unique_suffix()));
+        let control_dir = work_dir.join(control_name);
+        std::fs::create_dir_all(&control_dir).expect("control cwd");
+        let path = format!(
+            "/{tail_sentinel}:{}",
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let config = ShellHostConfig::new(format!("marker-control-{shell}"), &work_dir)
+            .with_env("PATH", path);
+        let cd = format!(
+            "builtin cd -- {}/{shell_control_name}",
+            shell_arg(&work_dir)
+        );
+        let command = "printf '__marker_frame_survived__\\n'";
+        let output = if shell == "bash" {
+            run_scripted_bash(
+                &config,
+                &[
+                    ScriptedInput::user_line(cd.clone()),
+                    ScriptedInput::user_line(command),
+                ],
+            )
+        } else {
+            run_scripted_zsh(
+                &config,
+                &[
+                    ScriptedInput::user_line(cd.clone()),
+                    ScriptedInput::user_line(command),
+                ],
+            )
+        }
+        .unwrap_or_else(|error| panic!("{shell}: {error}"));
+        let terminal = String::from_utf8_lossy(&output.terminal_output);
+
+        assert!(
+            terminal.contains("__marker_frame_survived__"),
+            "{shell}: {terminal}"
+        );
+        assert!(!terminal.contains(tail_sentinel), "{shell}: {terminal}");
+        assert!(
+            output.events.iter().any(|event| {
+                event.kind == ShellEventKind::CommandStarted
+                    && event.command.as_deref() == Some(command)
+                    && event.cwd.as_deref() == control_dir.to_str()
+            }),
+            "{shell}: {:?}",
+            output.events
+        );
+        assert!(
+            !output.events.iter().any(|event| {
+                event.kind == ShellEventKind::ComponentFailed
+                    && event.component.as_deref() == Some("osc_parser")
+            }),
+            "{shell}: {:?}",
+            output.events
+        );
+        std::fs::remove_dir_all(&work_dir).expect("cleanup control cwd");
+    }
+}
+
+#[test]
 fn shell_host_runs_bash_pty_and_emits_command_events() {
     if Command::new("bash").arg("--version").output().is_err() {
         return;

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -513,6 +513,81 @@ fn raw_relay_bash_preserves_same_read_foreground_stdin_bytes() {
 }
 
 #[test]
+fn raw_relay_bash_shell_opaque_bytes_ignore_slash_route() {
+    struct ForegroundSynchronizedInput {
+        batch: Option<Vec<u8>>,
+        foreground_done: std::path::PathBuf,
+        exit_sent: bool,
+        deadline: Instant,
+    }
+
+    impl Read for ForegroundSynchronizedInput {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if let Some(batch) = self.batch.take() {
+                std::thread::sleep(Duration::from_millis(200));
+                assert!(batch.len() <= buf.len());
+                buf[..batch.len()].copy_from_slice(&batch);
+                return Ok(batch.len());
+            }
+            if !self.exit_sent {
+                while std::fs::metadata(&self.foreground_done)
+                    .map(|metadata| metadata.len() == 0)
+                    .unwrap_or(true)
+                {
+                    if Instant::now() >= self.deadline {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "foreground reader did not complete",
+                        ));
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                self.exit_sent = true;
+                buf[..b"exit\n".len()].copy_from_slice(b"exit\n");
+                return Ok(b"exit\n".len());
+            }
+            Ok(0)
+        }
+    }
+
+    fn run(slash_via_shell: bool) {
+        let root = std::env::temp_dir().join(format!(
+            "cosh-shell-bash-shell-opaque-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ));
+        let work_dir = root.join("work");
+        let captured = root.join("captured-stdin");
+        let command = format!(
+            "/bin/sh -c 'IFS= read -r first; IFS= read -r second; \
+             printf \"%s\\n%s\" \"$first\" \"$second\" > \"$1\"' sh {}",
+            shell_arg(&captured)
+        );
+
+        let mut config = ShellHostConfig::new("bash-shell-opaque", &work_dir);
+        config.slash_via_shell = slash_via_shell;
+        config.raw_action_watchdog = Duration::from_secs(10);
+        let mut rendered = Vec::new();
+        let mut batch = command.into_bytes();
+        batch.extend_from_slice(b"\n/help\nstdin-probe\nforeground-second\n");
+        let input = ForegroundSynchronizedInput {
+            batch: Some(batch),
+            foreground_done: captured.clone(),
+            exit_sent: false,
+            deadline: Instant::now() + Duration::from_secs(10),
+        };
+        run_raw_relay_bash(&config, input, &mut rendered).expect("same-read shell-opaque relay");
+
+        let captured_bytes = std::fs::read(&captured).expect("captured foreground stdin");
+        assert!(!captured_bytes.contains(&0x1b), "{captured_bytes:?}");
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    run(true);
+    run(false);
+}
+
+#[test]
 fn raw_relay_bash_slash_route_switch_off_keeps_rust_intercept() {
     let root = std::env::temp_dir().join(format!(
         "cosh-shell-bash-1718-switch-off-{}-{}",


### PR DESCRIPTION
## Why

The #2918 same-read path could decorate bytes that remained in the same
candidate-buffer write after an ordinary shell submission, allowing the #2917
Bash guard to reach a foreground stdin consumer. OSC markers also emitted
other C0 and DEL bytes without JSON escaping, allowing cwd or PATH data to
break marker framing (#2927).

## What changed

- Keep remainder bytes opaque only when they share the candidate-buffer write
  with an ordinary shell command; already split deferred lines retain #2918
  UserInterceptAtPrompt routing.
- Preserve guards for proven exact slash and Ctrl-O Readline chains, retain the
  guard for prompt-owned candidate flushes, and fail closed for dirty blank
  submissions or ordinary commands.
- Escape every representable C0 byte and DEL in Bash and Zsh markers, reject
  control-bearing PATH snapshots, and keep unsafe cwd values untrusted.

## Related issue

fixes #2927

Follow-up to #2918 and #2917.

## User / Agent impact

Same-write foreground input cannot be mutated by a follow-up Cosh Readline
guard. Deferred slash commands still route through Rust at the next prompt.
Control-bearing cwd and PATH values no longer desynchronize OSC parsing.

## Risk and compatibility

Moderate PTY behavior risk, limited to Enhanced native shell routing. Bash
Readline versus foreground-process consumption remains unspecified for opaque
same-write remainder bytes. Non-UTF-8 filename bytes remain a known marker
limitation.

## Validation

- cargo fmt --all -- --check
- cargo clippy --locked -p cosh-shell --lib --tests -- -D warnings
- cargo test --locked -p cosh-shell --lib raw_input (227 passed)
- cargo test --locked -p cosh-shell --test shell_host marker:: (63 passed)
- Exact PTY regressions for opaque remainder, foreground stdin, slash batches,
  slash history, and Tab plus Enter candidate flushes
- Opaque-batch termination synchronized after foreground reader completion;
  repeated eight times locally
- All six raw_cli tests that failed in the first CI run pass locally
- Exact OSC regressions for control-bearing PATH and physical cwd
- bash -n crates/cosh-shell/src/shell_host/marker/bash.sh
- crates/cosh-shell/scripts/check-layout.sh
- git diff --check

## Documentation and rollback

No documentation change is required. Revert c0634f08 for marker framing or
5f2a92e7 for same-read ownership if either behavior must be rolled back.