### PR TITLE
fix(cosh-ng): [core] bound one-shot approval

### DIFF
--- a/src/cosh-ng/crates/cosh-core/src/core.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use tokio::io::AsyncBufReadExt;
@@ -94,6 +94,10 @@ pub struct CoshCore {
     /// both flags opts trust-mode shell commands into the core-issued
     /// approval channel instead (#2067).
     pub client_capabilities: ClientControlCapabilities,
+    // One-shot mode shortens only this fallback; explicit overrides and
+    // receipt-based handoff keep their existing semantics.
+    approval_response_timeout_default: Duration,
+    approval_timed_out: AtomicBool,
     /// First control-transport failure of this process, if any.
     ///
     /// Set from `&self` paths (`handle_ask_user`, `handle_shell_evidence`), so
@@ -110,6 +114,15 @@ impl CoshCore {
 
     pub(crate) fn set_session_resumed(&mut self, resumed: bool) {
         self.session_resumed = resumed;
+    }
+
+    pub(crate) fn use_one_shot_approval_timeout(&mut self) {
+        self.approval_response_timeout_default =
+            Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_ONE_SHOT_DEFAULT_SECS);
+    }
+
+    pub(crate) fn approval_timed_out(&self) -> bool {
+        self.approval_timed_out.load(Ordering::SeqCst)
     }
 
     fn apply_execution_profile_constraints(&mut self) {
@@ -351,6 +364,7 @@ impl CoshCore {
         W: Write,
         R: AsyncBufReadExt + Unpin,
     {
+        self.approval_timed_out.store(false, Ordering::SeqCst);
         self.bind_current_extension_snapshot();
         let _generation_pin = self.extension_generation.pin();
         // Generate a unique run_id for this agent run.
@@ -2070,14 +2084,20 @@ impl CoshCore {
         // guard is disarmed: a legitimate wait (a card pending on the user,
         // a host-executed command running) can then take as long as it
         // needs, and a dead shell still surfaces via EOF below.
-        let mut deadline = Some(tokio::time::Instant::now() + approval_response_timeout());
+        let mut deadline = Some(
+            tokio::time::Instant::now()
+                + approval_response_timeout(self.approval_response_timeout_default),
+        );
         loop {
             let line = match deadline {
                 Some(deadline) => {
                     match tokio::time::timeout_at(deadline, reader.next_line()).await {
                         Ok(Ok(Some(line))) => line,
                         Ok(Ok(None)) | Ok(Err(_)) => return ApprovalResult::Interrupted,
-                        Err(_) => return ApprovalResult::TimedOut,
+                        Err(_) => {
+                            self.approval_timed_out.store(true, Ordering::SeqCst);
+                            return ApprovalResult::TimedOut;
+                        }
                     }
                 }
                 None => match reader.next_line().await {
@@ -2282,14 +2302,16 @@ enum ApprovalResult {
 /// degrades through the shell's OwnerUnavailable recovery path.
 /// env override exists for tests and incident response.
 const APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS: u64 = 6 * 60 * 60;
+/// A one-shot caller has no built-in approval surface, so an unanswered
+/// request should fail closed instead of inheriting the terminal wait horizon.
+const APPROVAL_RESPONSE_TIMEOUT_ONE_SHOT_DEFAULT_SECS: u64 = 30;
 /// Upper bound for the env override: an absurd value would overflow
 /// `Instant + Duration` and panic at the next approval wait.
 const APPROVAL_RESPONSE_TIMEOUT_MAX_SECS: u64 = 30 * 24 * 60 * 60;
 
-fn approval_response_timeout() -> std::time::Duration {
-    let fallback = || std::time::Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS);
+fn approval_response_timeout(fallback: Duration) -> Duration {
     let Ok(raw) = std::env::var("COSH_CORE_APPROVAL_TIMEOUT_SECS") else {
-        return fallback();
+        return fallback;
     };
     match raw.parse::<u64>() {
         Ok(secs) if secs > 0 && secs <= APPROVAL_RESPONSE_TIMEOUT_MAX_SECS => {
@@ -2304,7 +2326,7 @@ fn approval_response_timeout() -> std::time::Duration {
                  falling back to the default approval timeout",
                 APPROVAL_RESPONSE_TIMEOUT_MAX_SECS
             );
-            fallback()
+            fallback
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/extensions.rs
@@ -104,6 +104,10 @@ impl CoshCore {
             truncator: OutputTruncator::default(),
             loop_detector: LoopDetector::new(),
             client_capabilities: crate::protocol::ClientControlCapabilities::default(),
+            approval_response_timeout_default: Duration::from_secs(
+                APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS,
+            ),
+            approval_timed_out: std::sync::atomic::AtomicBool::new(false),
             control_transport_failure: std::sync::OnceLock::new(),
             execution_profile,
         };

--- a/src/cosh-ng/crates/cosh-core/src/core/tests.rs
+++ b/src/cosh-ng/crates/cosh-core/src/core/tests.rs
@@ -1618,6 +1618,22 @@ async fn brokered_profile_rejects_a_checkpoint_execution_result() {
 /// `remove_var` could send the hanging test back to the 6h default.
 static APPROVAL_TIMEOUT_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+#[test]
+fn one_shot_approval_uses_a_short_default_timeout() {
+    let mut core = make_core(MockProvider::text_only(""));
+    assert_eq!(
+        core.approval_response_timeout_default,
+        Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_DEFAULT_SECS)
+    );
+
+    core.use_one_shot_approval_timeout();
+
+    assert_eq!(
+        core.approval_response_timeout_default,
+        Duration::from_secs(APPROVAL_RESPONSE_TIMEOUT_ONE_SHOT_DEFAULT_SECS)
+    );
+}
+
 #[tokio::test]
 async fn unanswered_approval_times_out_instead_of_hanging_forever() {
     // #1940 residual guard: hours-scale by default, overridden here so the

--- a/src/cosh-ng/crates/cosh-core/src/headless.rs
+++ b/src/cosh-ng/crates/cosh-core/src/headless.rs
@@ -34,6 +34,7 @@ use auth::request_auth;
 /// transport we cannot write to would only reproduce the #1994 hang.
 const EXIT_CONTROL_TRANSPORT_FAILURE: i32 = 74;
 const EXIT_PROTOCOL_MISMATCH: i32 = 65;
+const EXIT_TURN_FAILURE: i32 = 1;
 
 pub async fn run(
     args: &CliArgs,
@@ -170,6 +171,7 @@ pub async fn run(
         engine.model = session.record.model.clone();
     }
     if let Some(ref prompt) = args.prompt {
+        engine.use_one_shot_approval_timeout();
         if !session.resumable() {
             engine.emit(
                 &mut writer,
@@ -217,6 +219,11 @@ pub async fn run(
                 upload_handle = sls::emit(&engine.build_sls_record(start.elapsed())).await;
             }
         }
+        let turn_exit_code = if engine.approval_timed_out() {
+            EXIT_TURN_FAILURE
+        } else {
+            0
+        };
         let transport_failed = engine.control_transport_failure().is_some();
         engine.shutdown_extension_runtime().await;
         // Await the standalone upload handle with a 1-second grace period
@@ -231,7 +238,7 @@ pub async fn run(
         return Ok(if transport_failed {
             EXIT_CONTROL_TRANSPORT_FAILURE
         } else {
-            0
+            turn_exit_code
         });
     }
 

--- a/src/cosh-ng/crates/cosh-core/tests/tool_approval.rs
+++ b/src/cosh-ng/crates/cosh-core/tests/tool_approval.rs
@@ -1,9 +1,136 @@
+use std::fs;
 use std::io::Write;
-use std::process::Stdio;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
 mod common;
+
+fn one_shot_prompt_ask_command(home: &std::path::Path) -> Command {
+    let config_dir = home.join(".copilot-shell");
+    fs::create_dir_all(&config_dir).expect("create config directory");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[ai]
+active_provider = "mock"
+
+[ai.providers.mock]
+type = "mock"
+
+[hooks]
+enabled = true
+
+[[hooks.UserPromptSubmit]]
+command = '''python3 -c 'print("{\"decision\":\"ask\",\"reason\":\"needs review\"}")' '''
+name = "prompt-ask"
+"#,
+    )
+    .expect("write cosh-core config");
+
+    let mut command = common::cosh_core_command(home);
+    command
+        .args(["--headless", "review this prompt"])
+        .env("COSH_STATES_DIR", home.join("states"))
+        .env("COSH_CORE_APPROVAL_TIMEOUT_SECS", "1")
+        .env_remove("COSH_AI_PROVIDER")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn wait_with_stdin_open(mut child: Child, stdin: std::process::ChildStdin) -> std::process::Output {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().expect("poll cosh-core").is_some() {
+            drop(stdin);
+            return child.wait_with_output().expect("collect cosh-core output");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            drop(stdin);
+            let output = child.wait_with_output().expect("collect timed out output");
+            panic!(
+                "one-shot cosh-core did not exit\nstdout={}\nstderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn output_messages(output: &std::process::Output) -> Vec<Value> {
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str::<Value>(line)
+                .unwrap_or_else(|error| panic!("invalid JSONL output: {error}: {line}"))
+        })
+        .collect()
+}
+
+#[test]
+fn one_shot_prompt_ask_times_out_with_open_stdin() {
+    let home = tempfile::tempdir().expect("temp home");
+    let mut child = one_shot_prompt_ask_command(home.path())
+        .spawn()
+        .expect("spawn cosh-core");
+    let stdin = child.stdin.take().expect("piped stdin");
+
+    let output = wait_with_stdin_open(child, stdin);
+
+    assert_eq!(output.status.code(), Some(1), "status={:?}", output.status);
+    let messages = output_messages(&output);
+    assert!(messages.iter().any(|message| {
+        message["type"] == "control_request"
+            && message["request"]["subtype"] == "can_use_tool"
+            && message["request"]["hook_requires_approval"] == true
+    }));
+    let result = messages
+        .iter()
+        .find(|message| message["type"] == "result")
+        .expect("terminal result");
+    assert_eq!(result["is_error"], true);
+    assert!(result["errors"][0]
+        .as_str()
+        .is_some_and(|error| error.contains("prompt approval timed out")));
+}
+
+#[test]
+fn one_shot_prompt_ask_accepts_an_approval_response() {
+    let home = tempfile::tempdir().expect("temp home");
+    let mut child = one_shot_prompt_ask_command(home.path())
+        .spawn()
+        .expect("spawn cosh-core");
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    writeln!(
+        stdin,
+        r#"{{"type":"control_response","response":{{"subtype":"success","request_id":"req-0","response":{{"behavior":"allow"}}}}}}"#
+    )
+    .expect("write approval response");
+    stdin.flush().expect("flush approval response");
+
+    let output = wait_with_stdin_open(child, stdin);
+
+    assert!(
+        output.status.success(),
+        "status={:?}\nstdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let messages = output_messages(&output);
+    let result = messages
+        .iter()
+        .find(|message| message["type"] == "result")
+        .expect("terminal result");
+    assert_eq!(result["is_error"], false);
+}
 
 fn interact(messages: &[&str]) -> Vec<Value> {
     let home = tempfile::tempdir().expect("temp home");


### PR DESCRIPTION
## Why

One-shot `cosh-core --headless <prompt>` waits up to six hours when a hook requests approval and stdin remains open. Automated callers without an approval consumer therefore appear hung instead of failing closed.

## What changed

Use a 30-second approval fallback only for one-shot prompts while preserving `COSH_CORE_APPROVAL_TIMEOUT_SECS`, the six-hour persistent-session fallback, and receipt-based handoff. One-shot turn failures now emit the existing structured error result and exit with status 1. Regression coverage keeps stdin open for the unanswered case and includes an allow-response control.

## Related issue

closes #2863

## User / Agent impact

Unanswered one-shot approvals fail closed after 30 seconds by default. Approved requests and long-running tool execution are unchanged.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The one-shot failure exit status changes from 0 to 1, and approval timing becomes fail-closed sooner. No protocol or configuration schema changes are introduced; persistent clients retain the existing behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cosh-core one_shot_approval_uses_a_short_default_timeout` (1 passed)
- `cargo test -p cosh-core --test tool_approval` (10 passed)
- `cargo test -p cosh-core unanswered_approval_times_out_instead_of_hanging_forever` (1 passed)
- `cargo test -p cosh-core approval_receipt_disarms_the_residual_timeout_for_a_slow_host_command` (1 passed)
- `cargo clippy -p cosh-core --all-targets -- -D warnings`

Full workspace gates are delegated to CI.

## Documentation and rollback

No documentation change is needed because the existing environment override remains unchanged. Roll back this commit or set `COSH_CORE_APPROVAL_TIMEOUT_SECS=21600` to restore the previous one-shot wait horizon.