### PR TITLE
fix(cosh-ng): hide bash slash guard echo

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
@@ -395,16 +395,23 @@ _cosh_guard_slash_submission() {
     return 0
   fi
 
-  local sensitive=false
+  local sensitive=false restore_xtrace=0
+  if [[ $- == *x* ]]; then
+    restore_xtrace=1
+    set +x
+  fi
   if _cosh_command_has_secret "$input"; then
     sensitive=true
   fi
   _COSH_PENDING_SLASH_INPUT="$input"
   _COSH_PENDING_SLASH_SENSITIVE="$sensitive"
-  # Accept a static no-op so Readline records a replaceable native-history
-  # entry before the prompt hook restores the original slash text.
-  READLINE_LINE='builtin true __cosh_slash_guard__'
+  # Arm one bounded guard-display window; marker failure remains visual-only.
+  printf '\033]1337;COSH;{"e":"slash_guard","t":"%s"}\a' \
+    "$_COSH_MARKER_TOKEN" > /dev/tty || true
+  # The static no-op makes one replaceable native-history entry.
+  READLINE_LINE='case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac'
   READLINE_POINT=${#READLINE_LINE}
+  (( restore_xtrace == 1 )) && set -x
   return 0
 }
 _cosh_guard_private_slash_submission() {
@@ -421,7 +428,7 @@ _cosh_commit_pending_slash() {
   history_entry="$(_cosh_history_entry)"
   history_no="$(_cosh_history_no "$history_entry")"
   history_command="$(_cosh_history_command_from_entry "$history_entry")"
-  if [[ "$history_command" == 'builtin true __cosh_slash_guard__' ]]; then
+  if [[ "$history_command" == 'case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac' ]]; then
     builtin history -d "$history_no" 2>/dev/null || true
   fi
   if [[ "$sensitive" != true && -o history ]]; then

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -1,23 +1,24 @@
-// Owner: shell_host. Routing marker handling is isolated in osc/routing.rs;
-// the pending-handoff claim slot (#2142) is owned by osc/handoff_claim.rs;
-// alt-screen tracking (#2025) is owned by osc/alt_screen.rs; CurrentCommand
-// state and the display-window helpers are owned by osc/command.rs.
+// Owner: shell_host. Routing lives in osc/routing.rs; the pending-handoff
+// claim lives in osc/handoff_claim.rs; alt-screen tracking in osc/alt_screen.rs.
+// CurrentCommand state and display-window helpers are owned by osc/command.rs.
 mod alt_screen;
 mod command;
 mod event_store;
 mod handoff_claim;
 mod marker_sequence;
 mod routing;
+mod slash_guard_echo;
 mod transcript_store;
 
 use alt_screen::AltScreenTracker;
-use command::CurrentCommand;
+use command::{is_shell_exit_command, CurrentCommand};
 pub(crate) use command::{VisibleTailTracker, VISIBLE_TAIL_MAX_CHARS};
 use event_store::EventStore;
 use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
 use marker_sequence::{find_bytes, osc_prefix_suffix_len, HistoryFileTracker, Marker};
+use slash_guard_echo::PendingSlashGuardEcho;
 
 use std::collections::HashSet;
 use std::io;
@@ -87,6 +88,7 @@ pub(super) struct OscParser {
     /// staged request/token sidecars the shell never claimed.
     expired_handoff_staging: bool,
     pending_handoff_echo: Option<PendingHandoffEcho>,
+    pending_slash_guard_echo: Option<PendingSlashGuardEcho>,
     pub(super) shell_environment_snapshot: Option<ShellEnvironmentSnapshot>,
     environment_observer: Option<ShellEnvironmentObserver>,
     history_file_tracker: HistoryFileTracker,
@@ -240,6 +242,13 @@ impl OscParser {
         }
 
         let compact_prompt_marker = marker.normalize_compact_prompt();
+
+        if marker.event == "slash_guard" {
+            self.flush_pending_slash_guard_echo()?;
+            self.pending_slash_guard_echo = Some(PendingSlashGuardEcho::new());
+            return Ok(());
+        }
+        self.flush_pending_slash_guard_echo()?;
 
         if marker.has_trusted_history_context(&self.session_id, compact_prompt_marker) {
             self.history_file_tracker
@@ -481,11 +490,13 @@ impl OscParser {
     pub(super) fn flush_pending(&mut self) -> io::Result<()> {
         let pending = std::mem::take(&mut self.pending);
         self.append_passthrough(&pending)?;
+        self.flush_pending_slash_guard_echo()?;
         self.flush_pending_clean_control()
     }
 
     fn append_passthrough(&mut self, data: &[u8]) -> io::Result<()> {
-        let data = self.filter_pending_handoff_echo(data);
+        let data = PendingSlashGuardEcho::filter(&mut self.pending_slash_guard_echo, data);
+        let data = self.filter_pending_handoff_echo(&data);
         if data.is_empty() {
             return Ok(());
         }
@@ -875,11 +886,6 @@ impl OscParser {
             capture: None,
         });
     }
-}
-
-fn is_shell_exit_command(command: &str) -> bool {
-    let trimmed = command.trim();
-    trimmed == "exit" || trimmed.starts_with("exit ") || trimmed == "logout"
 }
 
 fn command_finished_event(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/command.rs
@@ -8,6 +8,11 @@ use super::OscParser;
 use crate::evidence::ControlSequenceScanner;
 use crate::types::{CommandOrigin, ShellCommandAuditIdentity};
 
+pub(super) fn is_shell_exit_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    trimmed == "exit" || trimmed.starts_with("exit ") || trimmed == "logout"
+}
+
 /// A foreground command tracked between its preexec and precmd markers.
 #[derive(Debug)]
 pub(super) struct CurrentCommand {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/slash_guard_echo.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/slash_guard_echo.rs
@@ -1,0 +1,321 @@
+//! Bounded suppression for Bash Readline's internal slash-guard redisplay.
+//!
+//! An authenticated marker arms one submission window. Only a complete guard
+//! redraw and its optional verbose echo are suppressed; other bytes fail open.
+
+use std::{borrow::Cow, io};
+
+use super::OscParser;
+
+const GUARD_COMMAND: &[u8] = b"case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac";
+const GUARD_REDRAW_TAIL: &[u8] = b"__cosh_slash_guard__; builtin set -x ;; *) : ;; esac";
+const MAX_PENDING_BYTES: usize = 64 * 1024;
+const MAX_PENDING_LINES: usize = 16;
+
+enum GuardEcho {
+    ReadlineRedraw { starts_at: usize },
+    Verbose { starts_at: usize },
+}
+
+#[derive(Debug)]
+pub(super) struct PendingSlashGuardEcho {
+    line: Vec<u8>,
+    lines: usize,
+    bytes_seen: usize,
+    redraw_suppressed: bool,
+}
+
+impl PendingSlashGuardEcho {
+    pub(super) fn new() -> Self {
+        Self {
+            line: Vec::new(),
+            lines: 0,
+            bytes_seen: 0,
+            redraw_suppressed: false,
+        }
+    }
+
+    pub(super) fn filter<'a>(slot: &mut Option<Self>, data: &'a [u8]) -> Cow<'a, [u8]> {
+        if slot.is_none() {
+            return Cow::Borrowed(data);
+        }
+        let mut output = Vec::with_capacity(data.len());
+        for byte in data.iter().copied() {
+            let Some(pending) = slot.as_mut() else {
+                output.push(byte);
+                continue;
+            };
+            pending.line.push(byte);
+            pending.bytes_seen += 1;
+            if pending.bytes_seen >= MAX_PENDING_BYTES {
+                output.extend_from_slice(&pending.line);
+                *slot = None;
+                continue;
+            }
+            if byte == b'\n' {
+                match pending.classify_guard_echo() {
+                    Some(GuardEcho::ReadlineRedraw { starts_at }) => {
+                        output.extend_from_slice(&pending.line[..starts_at]);
+                        output.extend_from_slice(pending.line_ending());
+                        pending.line.clear();
+                        pending.redraw_suppressed = true;
+                        continue;
+                    }
+                    Some(GuardEcho::Verbose { starts_at }) => {
+                        output.extend_from_slice(&pending.line[..starts_at]);
+                        output.extend_from_slice(pending.line_ending());
+                        *slot = None;
+                        continue;
+                    }
+                    None => {}
+                }
+                // A complete non-matching line may be asynchronous user or
+                // job output. Release it immediately while the bounded arm
+                // waits for the guard redraw or its verbose duplicate.
+                output.extend_from_slice(&pending.line);
+                pending.line.clear();
+                pending.lines += 1;
+                if pending.lines >= MAX_PENDING_LINES {
+                    *slot = None;
+                }
+            }
+        }
+        Cow::Owned(output)
+    }
+
+    pub(super) fn flush(slot: &mut Option<Self>) -> Vec<u8> {
+        slot.take().map_or_else(Vec::new, |pending| pending.line)
+    }
+
+    fn classify_guard_echo(&self) -> Option<GuardEcho> {
+        let body = self.line_body()?;
+        if self.redraw_suppressed {
+            return body
+                .strip_suffix(GUARD_COMMAND)
+                .map(|prefix| GuardEcho::Verbose {
+                    starts_at: prefix.len(),
+                });
+        }
+
+        // A carriage return is ordinary terminal output, not an ownership
+        // boundary. Delete only a complete static replacement or a verified
+        // '<' horizontal-scroll suffix; every preceding byte remains user/job
+        // output.
+        let mut matches = body
+            .windows(GUARD_REDRAW_TAIL.len())
+            .enumerate()
+            .filter(|(_, window)| *window == GUARD_REDRAW_TAIL);
+        let tail_start = matches.next()?.0;
+        if matches.next().is_some()
+            || !body[tail_start + GUARD_REDRAW_TAIL.len()..]
+                .iter()
+                .all(|byte| matches!(byte, b' ' | b'\x08'))
+        {
+            return None;
+        }
+        let guard_end = tail_start + GUARD_REDRAW_TAIL.len();
+        let starts_at = body[..guard_end]
+            .windows(GUARD_COMMAND.len())
+            .position(|window| window == GUARD_COMMAND)
+            .or_else(|| {
+                body[..tail_start]
+                    .iter()
+                    .rposition(|byte| *byte == b'<')
+                    .filter(|start| GUARD_COMMAND.ends_with(&body[*start + 1..guard_end]))
+            })?;
+        Some(GuardEcho::ReadlineRedraw { starts_at })
+    }
+
+    fn line_body(&self) -> Option<&[u8]> {
+        let without_lf = self.line.strip_suffix(b"\n")?;
+        Some(without_lf.strip_suffix(b"\r").unwrap_or(without_lf))
+    }
+
+    fn line_ending(&self) -> &'static [u8] {
+        if self.line.ends_with(b"\r\n") {
+            b"\r\n"
+        } else {
+            b"\n"
+        }
+    }
+}
+
+impl OscParser {
+    pub(super) fn flush_pending_slash_guard_echo(&mut self) -> io::Result<()> {
+        let pending = PendingSlashGuardEcho::flush(&mut self.pending_slash_guard_echo);
+        if pending.is_empty() {
+            return Ok(());
+        }
+        self.append_passthrough(&pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suppresses_fragmented_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert!(PendingSlashGuardEcho::filter(&mut pending, b"<builtin ").is_empty());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"\r\n"
+        );
+        assert!(pending.is_some());
+    }
+
+    #[test]
+    fn suppresses_multiline_prompt_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(&mut pending, b"first prompt line\r\n").as_ref(),
+            b"first prompt line\r\n"
+        );
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"\r\n"
+        );
+    }
+
+    #[test]
+    fn suppresses_readline_cleanup_after_shorter_guard() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac      \x08\x08\x08\r\n"
+            )
+            .as_ref(),
+            b"\r\n"
+        );
+        assert!(pending.is_some());
+    }
+
+    #[test]
+    fn preserves_partial_output_before_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"BACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"BACKGROUND_PARTIAL\r\n"
+        );
+    }
+
+    #[test]
+    fn preserves_carriage_return_partial_output_before_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"BEFORE\rBACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"BEFORE\rBACKGROUND_PARTIAL\r\n"
+        );
+    }
+
+    #[test]
+    fn suppresses_verbose_echo_after_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\ncase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"\r\n\r\n"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn verbose_echo_preserves_unrelated_partial_prefix() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"\r\n"
+        );
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"BACKGROUND_PARTIALcase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"BACKGROUND_PARTIAL\r\n"
+        );
+    }
+
+    #[test]
+    fn unproven_sentinel_line_fails_open() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        let line = b"BACKGROUND_PARTIAL builtin true __cosh_slash_guard__ unrelated\r\n";
+        assert_eq!(
+            PendingSlashGuardEcho::filter(&mut pending, line).as_ref(),
+            line
+        );
+        assert!(pending.is_some());
+    }
+
+    #[test]
+    fn complete_guard_match_preserves_preceding_angle_bracket() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        assert_eq!(
+            PendingSlashGuardEcho::filter(
+                &mut pending,
+                b"BACKGROUND_PARTIAL<case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+            )
+            .as_ref(),
+            b"BACKGROUND_PARTIAL<\r\n"
+        );
+    }
+
+    #[test]
+    fn unarmed_filter_borrows_the_input() {
+        let mut pending = None;
+        assert!(matches!(
+            PendingSlashGuardEcho::filter(&mut pending, b"ordinary output"),
+            Cow::Borrowed(b"ordinary output")
+        ));
+    }
+
+    #[test]
+    fn mismatch_and_cap_fail_open() {
+        let mut mismatch = Some(PendingSlashGuardEcho::new());
+        let bytes = vec![b'x'; MAX_PENDING_BYTES];
+        assert_eq!(PendingSlashGuardEcho::filter(&mut mismatch, &bytes), bytes);
+        assert!(mismatch.is_none());
+
+        let mut marker = Some(PendingSlashGuardEcho::new());
+        assert!(PendingSlashGuardEcho::filter(&mut marker, b"partial").is_empty());
+        assert_eq!(PendingSlashGuardEcho::flush(&mut marker), b"partial");
+        assert!(marker.is_none());
+    }
+
+    #[test]
+    fn line_cap_preserves_every_non_matching_line() {
+        let mut pending = Some(PendingSlashGuardEcho::new());
+        for _ in 0..MAX_PENDING_LINES {
+            assert_eq!(
+                PendingSlashGuardEcho::filter(&mut pending, b"background\r\n").as_ref(),
+                b"background\r\n"
+            );
+        }
+        assert!(pending.is_none());
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
@@ -100,6 +100,7 @@ impl OscParser {
             pending_command_origin: None,
             expired_handoff_staging: false,
             pending_handoff_echo: None,
+            pending_slash_guard_echo: None,
             shell_environment_snapshot: None,
             environment_observer: None,
             history_file_tracker: super::HistoryFileTracker::default(),

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -360,6 +360,115 @@ fn parser_clean_handles_split_zsh_bracketed_paste_control() {
 }
 
 #[test]
+fn slash_guard_echo_requires_an_authenticated_one_shot_arm() {
+    const SENTINEL_LINE: &[u8] = b"\rprompt$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n";
+    let mut unarmed = parser_for_test("slash-guard-unarmed");
+    unarmed.feed(SENTINEL_LINE).expect("feed unarmed sentinel");
+    assert_eq!(unarmed.display.resident_slice(), SENTINEL_LINE);
+
+    let mut wrong_token = parser_for_test("slash-guard-wrong-token");
+    wrong_token
+        .feed(b"\x1b]1337;COSH;{\"event\":\"slash_guard\",\"token\":\"wrong\",\"session_id\":\"slash-guard-wrong-token\"}\x07")
+        .expect("feed untrusted arm");
+    wrong_token
+        .feed(SENTINEL_LINE)
+        .expect("feed sentinel after untrusted arm");
+    assert_eq!(wrong_token.display.resident_slice(), SENTINEL_LINE);
+
+    let mut wrong_session = parser_for_test("slash-guard-wrong-session");
+    wrong_session
+        .feed(b"\x1b]1337;COSH;{\"event\":\"slash_guard\",\"token\":\"test-marker-token\",\"session_id\":\"other-session\"}\x07")
+        .expect("feed wrong-session arm");
+    wrong_session
+        .feed(SENTINEL_LINE)
+        .expect("feed sentinel after wrong-session arm");
+    assert_eq!(wrong_session.display.resident_slice(), SENTINEL_LINE);
+}
+
+#[test]
+fn slash_guard_echo_keeps_the_original_line_exactly_once() {
+    let mut parser = parser_for_test("slash-guard-display");
+    parser.feed(b"guard$ /mode").expect("feed original line");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed guarded redisplay");
+    assert_eq!(parser.display.resident_slice(), b"guard$ /mode\r\n");
+}
+
+#[test]
+fn slash_guard_echo_preserves_complete_background_lines() {
+    let mut parser = parser_for_test("slash-guard-background");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07background\r\n<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed background output before guarded redisplay");
+    assert_eq!(parser.display.resident_slice(), b"background\r\n\r\n");
+    assert!(!parser
+        .display
+        .resident_slice()
+        .windows(b"__cosh_slash_guard__".len())
+        .any(|window| window == b"__cosh_slash_guard__"));
+}
+
+#[test]
+fn slash_guard_echo_preserves_carriage_return_partial_output_in_both_streams() {
+    let mut parser = parser_for_test("slash-guard-partial-output");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07BEFORE\rBACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed CR partial output before horizontally scrolled guard");
+    assert_eq!(
+        parser.display.resident_slice(),
+        b"BEFORE\rBACKGROUND_PARTIAL\r\n"
+    );
+    assert!(parser
+        .clean
+        .resident_slice()
+        .windows(b"BACKGROUND_PARTIAL".len())
+        .any(|window| window == b"BACKGROUND_PARTIAL"));
+}
+
+#[test]
+fn authenticated_slash_guard_echo_handles_fragmentation_and_fails_open() {
+    let mut parser = parser_for_test("slash-guard-fragmented");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"slash_guard\",\"token\":\"test-marker-")
+        .expect("feed partial arm");
+    parser
+        .feed(b"token\",\"session_id\":\"slash-guard-fragmented\"}\x07<builtin true ")
+        .expect("finish arm and partial echo");
+    parser
+        .feed(b"__cosh_slash_guard__; builtin set -x ;; *) : ;; esac    \x08\x08\r\nfollowing")
+        .expect("finish shadow echo");
+    assert_eq!(parser.display.resident_slice(), b"\r\n");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"prompt_ready\",\"token\":\"test-marker-token\",\"session_id\":\"slash-guard-fragmented\"}\x07")
+        .expect("flush following output at lifecycle boundary");
+    assert_eq!(parser.display.resident_slice(), b"\r\nfollowing");
+
+    let mut mismatch = parser_for_test("slash-guard-mismatch");
+    mismatch
+        .feed(b"\x1b]1337;COSH;{\"event\":\"slash_guard\",\"token\":\"test-marker-token\",\"session_id\":\"slash-guard-mismatch\"}\x07ordinary output")
+        .expect("feed armed mismatch");
+    mismatch
+        .feed(b"\x1b]1337;COSH;{\"event\":\"prompt_ready\",\"token\":\"test-marker-token\",\"session_id\":\"slash-guard-mismatch\"}\x07")
+        .expect("flush mismatch at lifecycle boundary");
+    assert_eq!(mismatch.display.resident_slice(), b"ordinary output");
+
+    let mut nested = parser_for_test("slash-guard-nested");
+    nested
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07partial\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed nested arm");
+    assert_eq!(nested.display.resident_slice(), b"partial\r\n");
+
+    let mut capped = parser_for_test("slash-guard-cap");
+    capped
+        .feed(b"\x1b]1337;COSH;{\"event\":\"slash_guard\",\"token\":\"test-marker-token\",\"session_id\":\"slash-guard-cap\"}\x07")
+        .expect("feed capped arm");
+    let cap = vec![b'x'; 64 * 1024];
+    capped.feed(&cap).expect("feed cap");
+    assert_eq!(capped.display.resident_slice(), cap);
+}
+
+#[test]
 fn precmd_count_tracks_shell_ready_and_command_events() {
     let mut parser = parser_for_test("precmd-count");
     assert_eq!(parser.precmd_count(), 0);

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -248,7 +248,8 @@ fn raw_relay_bash_up_recalls_intercepted_slash_command() {
         home.join(".bashrc"),
         "export HISTFILE=\"$HOME/.bash_history\"\n\
          export HISTSIZE=1000\n\
-         shopt -s histappend\n",
+         shopt -s histappend\n\
+         PS1='guard$ '\n",
     )
     .expect("bashrc");
     std::fs::write(home.join(".bash_history"), "echo prior-shell-cmd\n").expect("history");
@@ -293,6 +294,14 @@ fn raw_relay_bash_up_recalls_intercepted_slash_command() {
     assert!(!recalled_prior_shell_cmd, "{rendered_text}");
     // The routed line must never execute as a shell command.
     assert!(!rendered_text.contains("bash: /skills"), "{rendered_text}");
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "the internal slash guard must never reach the terminal: {rendered_text}"
+    );
+    assert!(
+        rendered_text.contains("/skills detail xlsx"),
+        "the original slash line must remain visible: {rendered_text}"
+    );
 
     std::fs::remove_dir_all(root).expect("cleanup");
 }
@@ -347,7 +356,194 @@ fn raw_relay_bash_vi_mode_guards_slash_without_mutating_commands() {
         "{rendered_text}"
     );
     assert!(!rendered_text.contains("bash: /skills"), "{rendered_text}");
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "the internal slash guard must never reach the vi terminal: {rendered_text}"
+    );
     assert!(!rendered_text.contains("bash: exiT"), "{rendered_text}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn raw_relay_bash_xtrace_hides_guard_protocol_and_sentinel() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-xtrace-guard-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(home.join(".bashrc"), "PS4='xtrace-guard: '; set -x\n").expect("bashrc");
+
+    let mut config = ShellHostConfig::new("bash-xtrace-guard", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let xtrace_probe = "case $- in *x*) probe=ON ;; *) probe=OFF ;; esac; \
+                        printf '__XTRACE_%s__\\n' \"$probe\"; unset probe";
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/mode"),
+            RawRelayAction::wait(Duration::from_millis(600)),
+            RawRelayAction::line(xtrace_probe),
+            RawRelayAction::wait(Duration::from_millis(300)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("xtrace slash guard relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some("/mode")
+            && event.component.as_deref() == Some("slash")
+    }));
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::CommandStarted
+            && event.command.as_deref() == Some(xtrace_probe)
+    }));
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "xtrace leaked the internal sentinel: {rendered_text}"
+    );
+    assert!(
+        !rendered_text.contains("1337;COSH;"),
+        "xtrace leaked the authenticated marker protocol: {rendered_text}"
+    );
+    assert!(
+        rendered_text.contains("__XTRACE_ON__"),
+        "slash guard did not preserve xtrace: {rendered_text}"
+    );
+    assert!(
+        !rendered_text.contains("__XTRACE_OFF__"),
+        "slash guard disabled the user's xtrace state: {rendered_text}"
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+fn assert_bash_guard_preserves_partial_debug_output(
+    test_id: &str,
+    trap_output: &str,
+    expected_output: &str,
+) {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-{test_id}-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(home.join(".bashrc"), "PS1='guard$ '\n").expect("bashrc");
+
+    let mut config =
+        ShellHostConfig::new(test_id, &work_dir).with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let trap_setup = format!(
+        "set -T; trap 'case \"$BASH_COMMAND\" in READLINE_LINE=*) \
+         {trap_output} > /dev/tty;; esac' DEBUG"
+    );
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line(&trap_setup),
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/mode"),
+            RawRelayAction::wait(Duration::from_millis(600)),
+            RawRelayAction::line("trap - DEBUG"),
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("partial-output slash guard relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some("/mode")
+            && event.component.as_deref() == Some("slash")
+    }));
+    assert!(
+        rendered_text.contains(expected_output),
+        "the guard filter dropped unrelated partial output: {rendered_text}"
+    );
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "the internal sentinel reached the terminal: {rendered_text}"
+    );
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+#[test]
+fn raw_relay_bash_preserves_partial_debug_output_before_guard_shadow() {
+    assert_bash_guard_preserves_partial_debug_output(
+        "partial-guard",
+        "printf \"BACKGROUND_%s\" PARTIAL",
+        "BACKGROUND_PARTIAL",
+    );
+}
+
+#[test]
+fn raw_relay_bash_preserves_carriage_return_debug_output_before_guard_shadow() {
+    assert_bash_guard_preserves_partial_debug_output(
+        "carriage-partial-guard",
+        "printf \"BEFORE\\rBACKGROUND_%s\" PARTIAL",
+        "BACKGROUND_PARTIAL",
+    );
+}
+
+#[test]
+fn raw_relay_bash_verbose_mode_hides_both_guard_echoes() {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-bash-verbose-guard-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(home.join(".bashrc"), "PS1='guard$ '\n").expect("bashrc");
+
+    let mut config = ShellHostConfig::new("bash-verbose-guard", &work_dir)
+        .with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    let mut rendered = Vec::new();
+    let output = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("set -v"),
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/mode"),
+            RawRelayAction::wait(Duration::from_millis(600)),
+            RawRelayAction::line("set +v"),
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("exit"),
+        ],
+        &mut rendered,
+    )
+    .expect("verbose slash guard relay");
+
+    let rendered_text = String::from_utf8_lossy(&rendered);
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some("/mode")
+            && event.component.as_deref() == Some("slash")
+    }));
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "verbose mode leaked the internal sentinel: {rendered_text}"
+    );
 
     std::fs::remove_dir_all(root).expect("cleanup");
 }
@@ -404,9 +600,14 @@ fn routing_c4_bash_route_enters_native_history_file() {
     // Bash owns persistence after the Readline guard records the slash line.
     let history = std::fs::read_to_string(home.join(".bash_history")).expect("histfile");
     assert!(history.contains(&slash_input), "{history}");
+    assert!(!history.contains("__cosh_slash_guard__"), "{history}");
     assert!(
         !expansion_side_effect.exists(),
         "slash input reached Bash expansion"
+    );
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "a slash longer than the guard must not leak the guard: {rendered_text}"
     );
 
     std::fs::remove_dir_all(root).expect("cleanup");
@@ -458,6 +659,10 @@ fn raw_relay_bash_guards_each_slash_in_shell_owned_batch() {
         "batched slash reached Bash expansion"
     );
     assert!(!rendered_text.contains("bash: /skills"), "{rendered_text}");
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "same-write slash guards leaked internal redisplay: {rendered_text}"
+    );
 
     std::fs::remove_dir_all(root).expect("cleanup");
 }
@@ -612,6 +817,10 @@ fn routing_c4_history_privacy_secret_slash_never_persists() {
             && event.component.as_deref() == Some("slash")
     });
     assert!(intercepted, "{rendered_text}");
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "sensitive slash submission leaked the guard: {rendered_text}"
+    );
     // The Readline guard recognizes the secret and omits it from history.
     let history = std::fs::read_to_string(home.join(".bash_history")).unwrap_or_default();
     assert!(!history.contains("api_key"), "{history}");
@@ -676,6 +885,10 @@ fn raw_relay_bash_intercepts_history_recalled_slash_with_enter_and_ctrl_o() {
     assert!(
         !rendered_text.contains("bash: /skills: No such file or directory"),
         "{rendered_text}"
+    );
+    assert!(
+        !rendered_text.contains("__cosh_slash_guard__"),
+        "the internal slash guard must never reach Ctrl-O or Enter output: {rendered_text}"
     );
 
     std::fs::remove_dir_all(root).expect("cleanup");


### PR DESCRIPTION
## Why

Bash Readline redisplays the internal slash guard after an exact slash command, leaving `__cosh_slash_guard__` visible in the terminal even though command interception and history restoration succeed.

## What changed

The Bash widget emits a static authenticated arm marker before installing its no-op guard. The OSC parser applies a bounded submission-window filter that removes only a complete static replacement or a verified Readline `<` horizontal-scroll suffix, plus an optional exact Bash verbose echo. Carriage returns never establish output ownership: unrelated complete, partial, and CR-progress output is preserved in display and evidence streams. Ambiguous input fails open, the unarmed path borrows PTY bytes without allocating, and raw-input ownership remains unchanged. Xtrace is temporarily disabled around marker setup and restored afterward so the token, protocol, and sentinel do not leak.

## Related issue

refs #2942

This PR partially addresses #2942 by suppressing the internal slash-guard sentinel. Restoring the original slash input in the terminal-rendered pane remains tracked by #2942.

## User / Agent impact

Exact slash commands in native Bash no longer leave the internal guard sentinel visible, including under `set -v`. Slash routing, command execution, history recall, foreground stdin ownership, xtrace state, and unrelated terminal output remain unchanged.

## Risk and compatibility

Low risk. The change is limited to authenticated Bash marker output and terminal display filtering. Malformed, ambiguous, oversized, unauthenticated, or incomplete protocol states preserve bytes and fail open visually; no public CLI, API, configuration, cross-component contract, or migration changes are introduced.

## Validation

Linux, focused `cosh-shell` unit and PTY coverage:

- `cargo test --locked -p cosh-shell --lib slash_guard_echo -- --nocapture` — 17 passed
- `cargo test --locked -p cosh-shell --test shell_host raw_relay_bash -- --test-threads=4 --quiet` — 27 passed
- Real Bash regressions cover plain partial output, `BEFORE\rBACKGROUND_PARTIAL` progress output, and duplicate guard output under `set -v`
- Parser coverage verifies CR-progress bytes reach both display and clean/evidence streams
- Existing Up recall, vi mode, Ctrl-O, same-write double slash, long slash, sensitive history, same-read foreground stdin, and xtrace paths remain covered
- `cargo clippy --locked -p cosh-shell --lib --test shell_host -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n crates/cosh-shell/src/shell_host/marker/bash.sh`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

## Documentation and rollback

No documentation changes are required because this restores intended terminal behavior. Roll back by reverting commit `49848040`.
