### PR TITLE
fix(cosh-ng): hide handoff wrapper echo

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -5,6 +5,7 @@ mod alt_screen;
 mod command;
 mod event_store;
 mod handoff_claim;
+mod handoff_echo;
 mod marker_sequence;
 mod routing;
 mod slash_guard_echo;
@@ -17,6 +18,7 @@ use event_store::EventStore;
 use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
+use handoff_echo::PendingHandoffEcho;
 use marker_sequence::{find_bytes, osc_prefix_suffix_len, HistoryFileTracker, Marker};
 use slash_guard_echo::PendingSlashGuardEcho;
 
@@ -115,21 +117,6 @@ pub(super) struct OscParser {
     alt_screen: AltScreenTracker,
 }
 
-#[derive(Debug, Clone)]
-struct PendingHandoffEcho {
-    command: Vec<u8>,
-    replacement: Vec<u8>,
-    matched: usize,
-    ansi_after_command: bool,
-}
-
-enum PendingHandoffEchoAction {
-    Continue,
-    PassThrough(u8),
-    Complete(Vec<u8>),
-    Mismatch(Vec<u8>),
-}
-
 impl OscParser {
     /// Shares the main-prompt gate with the raw input relay (#1721 D16).
     pub(crate) fn set_main_prompt_gate(&mut self, gate: crate::raw_input::MainPromptGate) {
@@ -158,6 +145,10 @@ impl OscParser {
         self.pending_command_origin = Some(pending_origin_for_request(request));
         // Fresh staging supersedes any stale expiry signal.
         self.expired_handoff_staging = false;
+    }
+
+    pub(super) fn clear_pending_handoff_origin(&mut self) {
+        self.pending_command_origin = None;
     }
 
     /// Consumes the "an unclaimed handoff expired at a prompt boundary" flag
@@ -240,6 +231,10 @@ impl OscParser {
         {
             return Ok(());
         }
+
+        // A trusted protocol boundary ends the one-shot submission window.
+        // Any incomplete candidate is ordinary terminal output and fails open.
+        self.flush_pending_handoff_echo()?;
 
         let compact_prompt_marker = marker.normalize_compact_prompt();
 
@@ -491,12 +486,13 @@ impl OscParser {
         let pending = std::mem::take(&mut self.pending);
         self.append_passthrough(&pending)?;
         self.flush_pending_slash_guard_echo()?;
+        self.flush_pending_handoff_echo()?;
         self.flush_pending_clean_control()
     }
 
     fn append_passthrough(&mut self, data: &[u8]) -> io::Result<()> {
         let data = PendingSlashGuardEcho::filter(&mut self.pending_slash_guard_echo, data);
-        let data = self.filter_pending_handoff_echo(&data);
+        let data = PendingHandoffEcho::filter(&mut self.pending_handoff_echo, &data);
         if data.is_empty() {
             return Ok(());
         }
@@ -511,68 +507,6 @@ impl OscParser {
     /// alternate screen (fullscreen TUI classification input).
     pub(crate) fn alt_screen_active(&self) -> bool {
         self.alt_screen.active()
-    }
-
-    fn filter_pending_handoff_echo(&mut self, data: &[u8]) -> Vec<u8> {
-        let mut output = Vec::with_capacity(data.len());
-        for byte in data.iter().copied() {
-            let Some(action) = self.pending_handoff_echo_action(byte) else {
-                output.push(byte);
-                continue;
-            };
-            match action {
-                PendingHandoffEchoAction::Continue => {}
-                PendingHandoffEchoAction::PassThrough(byte) => output.push(byte),
-                PendingHandoffEchoAction::Complete(replacement) => {
-                    output.extend_from_slice(&replacement);
-                    self.pending_handoff_echo = None;
-                }
-                PendingHandoffEchoAction::Mismatch(bytes) => {
-                    output.extend_from_slice(&bytes);
-                    self.pending_handoff_echo = None;
-                }
-            }
-        }
-        output
-    }
-
-    fn pending_handoff_echo_action(&mut self, byte: u8) -> Option<PendingHandoffEchoAction> {
-        let echo = self.pending_handoff_echo.as_mut()?;
-        if echo.matched < echo.command.len() {
-            if byte == echo.command[echo.matched] {
-                echo.matched += 1;
-                return Some(PendingHandoffEchoAction::Continue);
-            }
-            if echo.matched == 0 {
-                return Some(PendingHandoffEchoAction::PassThrough(byte));
-            }
-            let mut bytes = echo.command[..echo.matched].to_vec();
-            bytes.push(byte);
-            return Some(PendingHandoffEchoAction::Mismatch(bytes));
-        }
-
-        if byte == b'\r' || byte == b'\n' {
-            let mut replacement = echo.replacement.clone();
-            replacement.push(byte);
-            return Some(PendingHandoffEchoAction::Complete(replacement));
-        }
-        if byte == b'\x1b' {
-            echo.ansi_after_command = true;
-            return Some(PendingHandoffEchoAction::Continue);
-        }
-        if echo.ansi_after_command {
-            if byte == b'[' || byte == b'?' || byte == b';' || byte.is_ascii_digit() {
-                return Some(PendingHandoffEchoAction::Continue);
-            }
-            if (0x40..=0x7e).contains(&byte) {
-                echo.ansi_after_command = false;
-            }
-            return Some(PendingHandoffEchoAction::Continue);
-        }
-
-        let mut bytes = echo.command.clone();
-        bytes.push(byte);
-        Some(PendingHandoffEchoAction::Mismatch(bytes))
     }
 
     fn append_clean(&mut self, data: &[u8]) -> io::Result<()> {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/handoff_echo.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/handoff_echo.rs
@@ -1,0 +1,427 @@
+//! Bounded replacement of Bash's internal handoff-wrapper echo.
+//!
+//! The PTY still receives the complete transport wrapper. This filter replaces
+//! only a proven Readline echo with the approved command and fails open for
+//! every ambiguous or incomplete candidate.
+
+use std::{borrow::Cow, io};
+
+use super::OscParser;
+
+const MAX_PENDING_BYTES: usize = 64 * 1024;
+const MAX_PENDING_LINES: usize = 16;
+
+#[derive(Debug)]
+pub(super) struct PendingHandoffEcho {
+    command: Vec<u8>,
+    replacement: Vec<u8>,
+    line: Vec<u8>,
+    lines: usize,
+    bytes_seen: usize,
+}
+
+struct HandoffEcho {
+    starts_at: usize,
+    ends_at: usize,
+}
+
+impl PendingHandoffEcho {
+    pub(super) fn new(command: &[u8], replacement: &[u8]) -> Self {
+        Self {
+            command: command.to_vec(),
+            replacement: replacement.to_vec(),
+            line: Vec::new(),
+            lines: 0,
+            bytes_seen: 0,
+        }
+    }
+
+    pub(super) fn filter<'a>(slot: &mut Option<Self>, data: &'a [u8]) -> Cow<'a, [u8]> {
+        if slot.is_none() {
+            return Cow::Borrowed(data);
+        }
+
+        let mut output = Vec::with_capacity(data.len());
+        for byte in data.iter().copied() {
+            let Some(pending) = slot.as_mut() else {
+                output.push(byte);
+                continue;
+            };
+
+            pending.line.push(byte);
+            pending.bytes_seen += 1;
+            if pending.bytes_seen >= MAX_PENDING_BYTES {
+                output.extend_from_slice(&pending.line);
+                *slot = None;
+                continue;
+            }
+
+            if byte != b'\n' {
+                continue;
+            }
+
+            if let Some(echo) = pending.classify_handoff_echo() {
+                output.extend_from_slice(&pending.line[..echo.starts_at]);
+                output.extend_from_slice(&pending.replacement);
+                // Terminal state changes after the accepted input belong to
+                // the outer terminal. In particular, dropping ?2004l would
+                // leave bracketed-paste mode enabled while the command runs.
+                output.extend_from_slice(&pending.line[echo.ends_at..]);
+                *slot = None;
+                continue;
+            }
+
+            // Complete unrelated lines can be asynchronous job output. They
+            // fail open immediately while the bounded submission window stays
+            // armed for the wrapper echo.
+            output.extend_from_slice(&pending.line);
+            pending.line.clear();
+            pending.lines += 1;
+            if pending.lines >= MAX_PENDING_LINES {
+                *slot = None;
+            }
+        }
+        Cow::Owned(output)
+    }
+
+    pub(super) fn flush(slot: &mut Option<Self>) -> Vec<u8> {
+        slot.take().map_or_else(Vec::new, |pending| pending.line)
+    }
+
+    fn classify_handoff_echo(&self) -> Option<HandoffEcho> {
+        let body = self.line_body()?;
+        if self.command.is_empty() {
+            return None;
+        }
+
+        let mut matched = None;
+        let mut complete_candidates = 0;
+        for starts_at in body
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, byte)| (*byte == self.command[0]).then_some(idx))
+        {
+            let Some(ends_at) = match_readline_echo(body, starts_at, &self.command) else {
+                continue;
+            };
+            complete_candidates += 1;
+            if complete_candidates > 1 {
+                return None;
+            }
+            if !is_complete_csi_suffix(&body[ends_at..]) {
+                continue;
+            }
+            matched = Some(HandoffEcho { starts_at, ends_at });
+        }
+        matched
+    }
+
+    fn line_body(&self) -> Option<&[u8]> {
+        let without_lf = self.line.strip_suffix(b"\n")?;
+        Some(without_lf.strip_suffix(b"\r").unwrap_or(without_lf))
+    }
+}
+
+/// Matches Bash 4.4's verified wrap redraw without accepting arbitrary noise.
+///
+/// At a terminal-width boundary Readline emits CR followed by the byte it just
+/// painted, then resumes the command. The duplicate is accepted only when it
+/// equals the immediately preceding command byte.
+fn match_readline_echo(line: &[u8], starts_at: usize, command: &[u8]) -> Option<usize> {
+    let mut line_idx = starts_at;
+    let mut command_idx = 0;
+
+    while command_idx < command.len() {
+        if line.get(line_idx) == command.get(command_idx) {
+            line_idx += 1;
+            command_idx += 1;
+            continue;
+        }
+        if command_idx > 0
+            && line.get(line_idx) == Some(&b'\r')
+            && line.get(line_idx + 1) == command.get(command_idx - 1)
+        {
+            line_idx += 2;
+            continue;
+        }
+        return None;
+    }
+
+    // A wrap can occur immediately after the last command byte too.
+    while line.get(line_idx) == Some(&b'\r') && line.get(line_idx + 1) == command.last() {
+        line_idx += 2;
+    }
+    Some(line_idx)
+}
+
+fn is_complete_csi_suffix(bytes: &[u8]) -> bool {
+    let mut idx = 0;
+    while idx < bytes.len() {
+        if bytes.get(idx..idx + 2) != Some(b"\x1b[") {
+            return false;
+        }
+        idx += 2;
+        while bytes
+            .get(idx)
+            .is_some_and(|byte| (0x30..=0x3f).contains(byte))
+        {
+            idx += 1;
+        }
+        while bytes
+            .get(idx)
+            .is_some_and(|byte| (0x20..=0x2f).contains(byte))
+        {
+            idx += 1;
+        }
+        let Some(final_byte) = bytes.get(idx) else {
+            return false;
+        };
+        if !(0x40..=0x7e).contains(final_byte) {
+            return false;
+        }
+        idx += 1;
+    }
+    true
+}
+
+impl OscParser {
+    pub(in super::super) fn arm_pending_handoff_echo(
+        &mut self,
+        command: &[u8],
+        replacement: &[u8],
+    ) -> io::Result<()> {
+        // A fresh handoff supersedes the previous window, but any candidate
+        // bytes already held by that window still belong to the transcript.
+        self.flush_pending_handoff_echo()?;
+        self.pending_handoff_echo = Some(PendingHandoffEcho::new(command, replacement));
+        Ok(())
+    }
+
+    pub(in super::super) fn flush_pending_handoff_echo(&mut self) -> io::Result<()> {
+        let pending = PendingHandoffEcho::flush(&mut self.pending_handoff_echo);
+        if pending.is_empty() {
+            return Ok(());
+        }
+        self.append_passthrough(&pending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WRAPPER: &[u8] = b" _COSH_HANDOFF_DEBUG_TRAP=trap; _COSH_HANDOFF_RETURN_TRAP=trap -p ERR; _cosh_prepare_staged_handoff && eval; _COSH_HANDOFF_STATUS=$?; eval _COSH_HANDOFF_RETURN_TRAP ${_COSH_HANDOFF_RETURN_TRAP} ${_COSH_HANDOFF_DEBUG_TRAP}";
+
+    #[test]
+    fn replaces_fragmented_exact_echo() {
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"printf visible"));
+        assert!(PendingHandoffEcho::filter(&mut pending, &WRAPPER[..41]).is_empty());
+        let mut tail = WRAPPER[41..].to_vec();
+        tail.extend_from_slice(b"\r\nfollowing");
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, &tail).as_ref(),
+            b"printf visible\r\nfollowing"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn accepts_verified_bash_44_wrap_redraw_pairs() {
+        let mut echo = Vec::new();
+        let redraw_after = [23, 59, 91, 127, 166, 197];
+        for (idx, byte) in WRAPPER.iter().copied().enumerate() {
+            echo.push(byte);
+            if redraw_after.contains(&idx) {
+                echo.push(b'\r');
+                echo.push(byte);
+            }
+        }
+        echo.extend_from_slice(b"\r\n");
+
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+            b"approved\r\n"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn matches_observed_bash_44_redraw_fragments() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (
+                b"_COSH_HANDOFF_RETURN_TRAP",
+                b"_COSH_HANDOFF\rF_RETURN_TRAP",
+            ),
+            (b"trap -p ERR", b"trap -p \r ERR"),
+            (
+                b"_cosh_prepare_staged_handoff",
+                b"_cosh_prepare_staged_han\rndoff",
+            ),
+            (b"STATUS=$?; eval", b"STATUS=$?; eva\ral"),
+            (
+                b"_COSH_HANDOFF_RETURN_TRAP _COSH",
+                b"_COSH_HANDOFF_RETURN_TRAP\rP _COSH",
+            ),
+            (
+                b"${_COSH_HANDOFF_RETURN_TRAP}",
+                b"${_COSH_HANDOFF_RETURN_TR\rRAP}",
+            ),
+            (b"_DEBUG_TRAP", b"_DEBU\rUG_TRAP"),
+        ];
+
+        for (command, observed) in cases {
+            let mut echo = observed.to_vec();
+            echo.extend_from_slice(b"\r\n");
+            let mut pending = Some(PendingHandoffEcho::new(command, b"approved"));
+            assert_eq!(
+                PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+                b"approved\r\n"
+            );
+            assert!(pending.is_none());
+        }
+    }
+
+    #[test]
+    fn preserves_trailing_bracketed_paste_disable() {
+        let mut echo = WRAPPER.to_vec();
+        echo.extend_from_slice(b"\x1b[?2004l\r\n");
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+            b"approved\x1b[?2004l\r\n"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn preserves_fragmented_multiple_csi_and_replacement_text() {
+        let replacement = b"printf '\tfirst\nsecond'";
+        let mut first = WRAPPER.to_vec();
+        first.extend_from_slice(b"\x1b[?20");
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, replacement));
+        assert!(PendingHandoffEcho::filter(&mut pending, &first).is_empty());
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, b"04l\x1b[0m\r\n").as_ref(),
+            b"printf '\tfirst\nsecond'\x1b[?2004l\x1b[0m\r\n"
+        );
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn wrong_duplicate_and_bare_carriage_return_fail_open() {
+        for mutation in [b"\rX".as_slice(), b"\r".as_slice()] {
+            let mut echo = WRAPPER[..40].to_vec();
+            echo.extend_from_slice(mutation);
+            echo.extend_from_slice(&WRAPPER[40..]);
+            echo.extend_from_slice(b"\r\n");
+            let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+            assert_eq!(
+                PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+                echo
+            );
+            assert!(pending.is_some());
+        }
+    }
+
+    #[test]
+    fn malformed_or_non_csi_suffix_fails_open() {
+        for suffix in [b"\x1b[?2004\r\n".as_slice(), b"unexpected\r\n".as_slice()] {
+            let mut echo = WRAPPER.to_vec();
+            echo.extend_from_slice(suffix);
+            let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+            assert_eq!(
+                PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+                echo
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_unrelated_prefix_and_rejects_ambiguous_candidates() {
+        let mut echo = b"background".to_vec();
+        echo.extend_from_slice(WRAPPER);
+        echo.extend_from_slice(b"\r\n");
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, &echo).as_ref(),
+            b"backgroundapproved\r\n"
+        );
+
+        let mut ambiguous = WRAPPER.to_vec();
+        ambiguous.extend_from_slice(WRAPPER);
+        ambiguous.extend_from_slice(b"\r\n");
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert_eq!(
+            PendingHandoffEcho::filter(&mut pending, &ambiguous).as_ref(),
+            ambiguous
+        );
+    }
+
+    #[test]
+    fn caps_release_exact_bytes_and_flush_releases_partial() {
+        let bytes = vec![b'x'; MAX_PENDING_BYTES];
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert_eq!(PendingHandoffEcho::filter(&mut pending, &bytes), bytes);
+        assert!(pending.is_none());
+
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        assert!(PendingHandoffEcho::filter(&mut pending, b" partial").is_empty());
+        assert_eq!(PendingHandoffEcho::flush(&mut pending), b" partial");
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn parser_rearm_and_abort_flush_partial_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut parser = OscParser::new(
+            "handoff-echo-rearm".to_string(),
+            temp.path().join("output-ref"),
+            "marker-token".to_string(),
+        );
+
+        parser.arm_pending_handoff_echo(WRAPPER, b"first").unwrap();
+        parser.append_passthrough(b" partial-first").unwrap();
+        assert_eq!(parser.display_position(), 0);
+
+        parser.arm_pending_handoff_echo(WRAPPER, b"second").unwrap();
+        assert_eq!(
+            parser
+                .read_display_range(0, parser.display_position())
+                .unwrap()
+                .as_ref(),
+            b" partial-first"
+        );
+
+        parser.append_passthrough(b" partial-second").unwrap();
+        parser.flush_pending_handoff_echo().unwrap();
+        assert_eq!(
+            parser
+                .read_display_range(0, parser.display_position())
+                .unwrap()
+                .as_ref(),
+            b" partial-first partial-second"
+        );
+    }
+
+    #[test]
+    fn line_cap_preserves_every_non_matching_line() {
+        let mut pending = Some(PendingHandoffEcho::new(WRAPPER, b"approved"));
+        for _ in 0..MAX_PENDING_LINES {
+            assert_eq!(
+                PendingHandoffEcho::filter(&mut pending, b"background\r\n").as_ref(),
+                b"background\r\n"
+            );
+        }
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn unarmed_filter_borrows_input() {
+        let mut pending = None;
+        assert!(matches!(
+            PendingHandoffEcho::filter(&mut pending, b"ordinary"),
+            Cow::Borrowed(b"ordinary")
+        ));
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_relay/pty_emit.rs
@@ -277,13 +277,37 @@ fn emit_to_pty<W: Write>(
         )
     })?;
     pending_terminal_restore.record_intervention_start(terminal_fd);
-    parser.register_pending_handoff_origin(&request);
     // Must land before the shell sees the command: the marker reads both files
     // from the preexec hook that fires between the newline and the command
     // running.
     stage_handoff_files(handoff_request_file, &request)?;
+    if bounded_bash_handoff {
+        // Keep the transport wrapper executable by Bash while presenting only
+        // the approved command on the user's prompt line.
+        let echoed_command = bytes.strip_suffix(b"\n").unwrap_or(&bytes);
+        // Validation excludes escapes and all controls except a safe tab or
+        // quoted line feed, so replacement cannot alter terminal state.
+        if let Err(err) =
+            parser.arm_pending_handoff_echo(echoed_command, request.command.as_bytes())
+        {
+            clear_handoff_files(handoff_request_file);
+            return Err(err);
+        }
+    }
+    parser.register_pending_handoff_origin(&request);
     if let Err(err) = write_all_pty(master, &bytes) {
         clear_handoff_files(handoff_request_file);
+        parser.clear_pending_handoff_origin();
+        if bounded_bash_handoff {
+            if let Err(flush_err) = parser.flush_pending_handoff_echo() {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!(
+                        "{err}; failed to release pending handoff echo after PTY write error: {flush_err}"
+                    ),
+                ));
+            }
+        }
         return Err(err);
     }
     Ok(())

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/host_executed.rs
@@ -396,7 +396,7 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         ],
     );
     let _ = fs::remove_dir_all(&home);
-    let normalized = output.replace('\r', "");
+    let normalized = strip_ansi_escape(&output).replace('\r', "");
 
     assert!(output.contains("Auto-approved req-1"), "{output}");
     assert!(output.contains("Bash tool sent to shell"), "{output}");
@@ -408,9 +408,9 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         !output.contains("duplicate request was not denied"),
         "{output}"
     );
-    // Bounded handoff executes from the owner-only sidecar, so the plaintext
-    // command is not echoed as a standalone terminal line.
-    assert_eq!(count_occurrences(&normalized, "\ndf -h\n"), 0, "{output}");
+    // The transport wrapper remains hidden, while the approved command is
+    // presented exactly once as the shell-owned command line.
+    assert_eq!(count_occurrences(&normalized, "\ndf -h\n"), 1, "{output}");
     assert_eq!(count_occurrences(&normalized, "Filesystem"), 1, "{output}");
     assert!(
         output.contains("host-executed shell result: delivered"),

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/provider_native.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/cosh_core/provider_native.rs
@@ -66,16 +66,16 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         ],
     );
     let _ = fs::remove_dir_all(&home);
-    let normalized = output.replace('\r', "");
+    let normalized = strip_ansi_escape(&output).replace('\r', "");
 
     assert!(output.contains("Approved req-1"), "{output}");
     assert!(!output.contains("Auto-approved req-1"), "{output}");
     assert!(!output.contains("Auto-approved req-2"), "{output}");
     assert!(!output.contains("auto-approved by provider"), "{output}");
     assert!(output.contains("Bash tool sent to shell"), "{output}");
-    // Bounded handoff keeps the plaintext command in its owner-only sidecar;
-    // the provider result remains visible without a standalone command echo.
-    assert!(!normalized.contains("\nsudo -V\n"), "{output}");
+    // The provider-native replay stays suppressed, while the approved command
+    // is presented exactly once as the shell-owned command line.
+    assert_eq!(count_occurrences(&normalized, "\nsudo -V\n"), 1, "{output}");
     assert!(
         output.contains("COSH CORE HOST EXECUTED ECHO FINAL"),
         "{output}"

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/foreground.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/foreground.rs
@@ -289,7 +289,12 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-claude-na
     );
     assert!(!output.contains("host_executed_shell"), "{output}");
     assert!(output.contains("\rCLAUDE_NATIVE\r\n"), "{output}");
-    assert!(!output.contains("cosh-osc$ echo CLAUDE_NATIVE"), "{output}");
+    let visible = strip_ansi_escape(&output);
+    assert_eq!(
+        count_occurrences(&visible, "cosh-osc$ echo CLAUDE_NATIVE"),
+        1,
+        "{output}"
+    );
     assert!(
         !output.contains("missing claude allow response"),
         "{output}"

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/provider_handoff/send_to_shell.rs
@@ -473,6 +473,8 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
 #[test]
 fn raw_cli_approved_shell_handoff_wrapper_does_not_leak() {
     let home = temp_shell_home("cosh-core-handoff-wrapper-leak");
+    let inputrc_path = home.join(".inputrc");
+    fs::write(&inputrc_path, "set enable-bracketed-paste on\n").unwrap();
     let bin_dir = home.join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
     let cosh_core_path = bin_dir.join("cosh-core");
@@ -510,11 +512,17 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
 "#,
     );
     let home_str = home.to_string_lossy().to_string();
+    let inputrc_path_str = inputrc_path.to_string_lossy().to_string();
     let cosh_core_path_str = cosh_core_path.to_string_lossy().to_string();
     let output = run_raw_cli_with_args_env_and_delayed_input(
         "cosh-core",
         &[],
-        &[("HOME", &home_str), ("COSH_CORE_PATH", &cosh_core_path_str)],
+        &[
+            ("HOME", &home_str),
+            ("INPUTRC", &inputrc_path_str),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_CORE_PATH", &cosh_core_path_str),
+        ],
         vec![
             (b"/mode approval trust confirm\n".to_vec(), Duration::ZERO),
             (
@@ -534,7 +542,26 @@ printf '%s\n' '{"type":"result","subtype":"success","session_id":"sess-cosh-core
         output.contains("HANDOFF WRAPPER LEAK HOSTEXEC RECEIVED"),
         "{output}"
     );
+    let visible = strip_ansi_escape(&output).replace('\r', "");
+    assert_eq!(
+        count_occurrences(&visible, "\nprintf wrapper-visible\n"),
+        1,
+        "{output}"
+    );
+    assert!(!output.contains("_COSH_HANDOFF"), "{output}");
+    assert!(!output.contains("_cosh_prepare_staged_handoff"), "{output}");
     assert!(!output.contains("COSH_SHELL_HANDOFF_BYPASS"), "{output}");
+    let command_echo = output
+        .rfind("printf wrapper-visible")
+        .expect("approved command echo");
+    let after_command_echo = &output[command_echo + "printf wrapper-visible".len()..];
+    let command_output = after_command_echo
+        .find("wrapper-visible")
+        .expect("approved command output");
+    assert!(
+        after_command_echo[..command_output].contains("\u{1b}[?2004l"),
+        "bracketed-paste disable did not reach the outer terminal between the approved command echo and its output\n{output:?}"
+    );
     assert!(
         !output.contains("missing wrapper-leak host_executed_shell result"),
         "{output}"


### PR DESCRIPTION
## Why

Approved native Bash tool handoffs execute through a bounded internal wrapper. Bash 5.x can echo that wrapper exactly, while Bash 4.4 Readline inserts narrow redraw fragments at terminal-width boundaries. The prior filter was not armed, and its exact byte matcher would still leak the wrapper on Bash 4.4. Existing tests verified execution and `Bash tool sent to shell` but did not assert the user terminal contract.

## What changed

- Move handoff echo replacement into a dedicated bounded, one-shot filter.
- Replace only one authenticated full wrapper echo with the approved command.
- Accept only the observed Bash 4.4 redraw form, `CR + previous matched byte`; ambiguous, malformed, or over-limit input fails open byte-for-byte.
- Preserve complete trailing CSI sequences such as bracketed-paste disable, and flush pending candidates on rearm, trusted marker, parser flush, or PTY write failure.
- Run the real raw CLI regression in native Bash mode with its supplied bracketed-paste `INPUTRC`.
- Require the approved command exactly once while rejecting `_COSH_HANDOFF`, `_cosh_prepare_staged_handoff`, and the bypass marker from terminal output.

## Related issue

closes #2946

Related but independent: #2942 / #2943 cover the slash-guard echo; #2927 / #2938 cover OSC dynamic-field framing; #2540 covers PROMPT_COMMAND, child-environment, and PS2 contracts. This PR must not close those issues.

## User / Agent impact

Approved Bash commands and their output remain visible and execute as before. Users see the approved command instead of the internal transport wrapper, including on Bash 4.4 narrow terminals.

## Risk and compatibility

The change only affects the authenticated bounded Bash handoff display path. The candidate window is capped at 64 KiB and 16 lines. A replacement occurs only after one complete wrapper and complete CSI suffix are proven; every mismatch, malformed suffix, cap, abort, or lifecycle expiry releases original bytes. Command execution, approval, history, exit status, and public interfaces are unchanged.

## Validation

- `cargo test --package cosh-shell --lib handoff_echo` — 12 passed
- Four exact raw CLI regressions — 4 passed:
  - wrapper invisibility, approved-command execution, and bracketed-paste CSI preservation
  - duplicate host-executed request
  - provider-native echo suppression
  - foreground recovery without host-executed capability
- The exact native handoff raw CLI regression passed with host Bash 5.2.21 and a temporary Bash 4.4.23 container.
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

Full workspace gates and persistent ECS validation remain with CI because this is a focused display-filter change. The reviewer-owned ALinux3 Bash 4.4.20 T1 scope should be rerun on the current head.

## Documentation and rollback

The issue relationship and acceptance criteria are tracked in #2946. No product documentation changes are required because this restores the intended terminal contract. Revert `79b3873b` to roll back the change.