### PR TITLE
feat(tokenless): route by content origin instead of a tool-name skip list

### DIFF
--- a/src/tokenless/Cargo.lock
+++ b/src/tokenless/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "tokenless-compressors"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "tokenless-ccr",
 ]

--- a/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
+++ b/src/tokenless/adapters/tokenless/common/hooks/compress_response_hook.py
@@ -334,10 +334,12 @@ def main() -> None:
         can_replace = False
         replace_with_text = True
 
-    # 11. Spawn-avoidance prefilters. The entry point re-checks all three
-    # authoritatively; skipping here just saves the exec. SKIP_TOOLS reads
-    # the same tool_categories.json the entry point embeds, so content
-    # retrieval — the hottest PostToolUse traffic — never pays a spawn.
+    # 11. Prefilters. Two of them only save the exec; SKIP_TOOLS does more
+    # than that now. The entry point no longer keeps a tool list of its own
+    # (roadmap §6.3), so until this hook declares a content origin per tool
+    # (item 10) this check is the only thing keeping content retrieval — the
+    # hottest PostToolUse traffic — away from the compressor. It is
+    # load-bearing, not an optimization: do not drop it as one.
     if not can_replace:
         _emit_attribution_or_skip(env_attribution)
     if tool_name in SKIP_TOOLS:

--- a/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/pipeline.rs
@@ -22,8 +22,8 @@ use std::time::{Duration, Instant};
 
 use tokenless_ccr::{StashError, StashStore, StashWrite, marker_for};
 use tokenless_protocol::{
-    CompressionRequest, CompressionResponse, DIAGNOSTIC_MAX_BYTES, Disposition, PROTOCOL_VERSION,
-    Reversibility, TOKENIZER_ID,
+    CompressionRequest, CompressionResponse, ContentOrigin, DIAGNOSTIC_MAX_BYTES, Disposition,
+    PROTOCOL_VERSION, Reversibility, TOKENIZER_ID,
 };
 use tokenless_stats::estimate_tokens;
 
@@ -137,6 +137,12 @@ pub fn run(
     let before_tokens = tokens(&request.content);
     let content_type = detect(&request.content);
 
+    if request.content_origin == ContentOrigin::FileContent && !released_from_a_file(content_type) {
+        let mut response = CompressionResponse::passthrough(request, before_tokens);
+        response.content_type = Some(content_type.wire_str().to_owned());
+        return response;
+    }
+
     let mut lossless: Vec<&dyn Compressor> = Vec::new();
     let mut lossy: Vec<&dyn Compressor> = Vec::new();
     let mut truncation: Vec<&dyn Compressor> = Vec::new();
@@ -202,6 +208,54 @@ pub fn run(
         return arb.rejected(Disposition::Timeout);
     }
     arb.judge(config)
+}
+
+/// The release list of roadmap §4.3: content types safe to compress when the
+/// authoritative copy lives elsewhere.
+///
+/// It names data that is generated rather than authored, and that no agent
+/// patches byte by byte. Gating on "is this `SourceCode`" instead would be a
+/// block list, and would fail exactly where the detector is weakest — code in
+/// a language it does not recognize falls through to `PlainText`. Naming what
+/// may be removed keeps a detection failure on the protected side.
+///
+/// Membership does not follow from a compressor existing for a type:
+/// `SourceCode` and `PlainText` stay protected here even once their
+/// compressors land, because those serve the command-output path.
+///
+/// `JsonRecords` is deliberately absent, though it is the one type whose
+/// compressor is already shipping. The taxonomy has a single bucket for all
+/// JSON, so it cannot tell a generated record dump from a hand-authored
+/// `package.json` — and the response cleanup drops null and empty fields,
+/// which silently rewrites the second kind. Releasing the bucket would
+/// therefore break exactly the edit this gate protects. It is restored the
+/// day the taxonomy separates generated records from authored configuration
+/// (roadmap §4.3); until then the same read stays protected, at the cost of
+/// savings rather than of correctness.
+///
+/// `BuildLog` is absent for the same reason, found one review later. Its
+/// detector scores content alone — any two of two dozen markers — so a log
+/// committed as a test fixture, or a contributor doc that quotes a compiler
+/// twice, lands in the bucket beside the output of the build that just ran
+/// (`prose_carrying_two_generic_markers_is_a_known_detection_boundary` pins
+/// that tolerance). The chain then strips SGR and folds runs of lines into a
+/// retrieval marker. Being retrievable does not rescue it: the model writes
+/// its next edit against the view it was shown, and that view carries markers
+/// the file does not.
+///
+/// Both absences leave the list with no type whose compressor ships today.
+/// That is where the gate is meant to rest, not an oversight — it defaults to
+/// protecting a read, and a type joins only once its bucket can be shown to
+/// hold generated data alone.
+fn released_from_a_file(content_type: ContentType) -> bool {
+    matches!(
+        content_type,
+        ContentType::SearchResults
+            | ContentType::StackTrace
+            | ContentType::Diff
+            | ContentType::Html
+            | ContentType::Tabular
+    )
 }
 
 /// Normalized token count under the protocol's `heuristic-v1` counter.

--- a/src/tokenless/crates/tokenless-pipeline/src/tests/pipeline_tests.rs
+++ b/src/tokenless/crates/tokenless-pipeline/src/tests/pipeline_tests.rs
@@ -7,7 +7,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokenless_ccr::InMemoryStore;
-use tokenless_protocol::{Capabilities, Seam};
+use tokenless_protocol::{Capabilities, ContentOrigin, Seam};
 
 use crate::registry::CostClass;
 
@@ -371,6 +371,56 @@ fn undeclared_capabilities_filter_out_candidates() {
     let response = run(&request, &[&SpaceSquisher], None, &config());
     assert_eq!(response.disposition, Disposition::Passthrough);
     assert_eq!(response.output, SPACEY);
+}
+
+#[test]
+fn file_content_protects_types_off_the_release_list() {
+    // `SPACEY_MULTILINE` is prose — `PlainText`, which the list protects.
+    // The gate runs before routing, so not even a lossless compressor sees
+    // it: protected means full passthrough, and a rewritten copy of a file
+    // breaks the model's next exact-match edit just as a lossy one would.
+    let mut request = request(SPACEY_MULTILINE, FULL);
+    request.content_origin = ContentOrigin::FileContent;
+    let store = InMemoryStore::new();
+    let mut config = config();
+    config.max_tokens = Some(10);
+    let response = run(
+        &request,
+        &[&SpaceSquisher, &TailStasher],
+        Some(&store),
+        &config,
+    );
+    assert_eq!(response.disposition, Disposition::Passthrough);
+    assert_eq!(response.output, SPACEY_MULTILINE);
+    assert_eq!(response.after_tokens, response.before_tokens);
+    assert!(response.compressor_chain.is_empty());
+    assert_eq!(store.len(), 0);
+    // The detected type is still reported: a protected passthrough has to be
+    // distinguishable from a no-savings one when tuning the list (§4.7).
+    assert_eq!(response.content_type.as_deref(), Some("plain_text"));
+
+    // Same content, same compressors, command output: the gate is about
+    // where the content came from, not what it is.
+    request.content_origin = ContentOrigin::CommandOutput;
+    let response = run(
+        &request,
+        &[&SpaceSquisher, &TailStasher],
+        Some(&store),
+        &config,
+    );
+    assert_eq!(response.disposition, Disposition::Applied);
+}
+
+#[test]
+fn an_undeclared_origin_never_reaches_the_release_gate() {
+    // The migration default: protected content still compresses, because no
+    // caller has claimed it came from a file.
+    let request = request(SPACEY_MULTILINE, FULL);
+    assert_eq!(request.content_origin, ContentOrigin::Unspecified);
+    let mut config = config();
+    config.max_tokens = Some(10);
+    let response = run(&request, &[&SpaceSquisher], None, &config);
+    assert_eq!(response.disposition, Disposition::Applied);
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-protocol/src/lib.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/lib.rs
@@ -105,6 +105,50 @@ impl Seam {
     }
 }
 
+/// Where the content came from, as observed by the adapter (roadmap §4.3).
+///
+/// Detection answers what the content *is*; only the caller knows whether an
+/// authoritative copy of it lives somewhere else. Compressing a copy of
+/// stored content desynchronizes the model from that authority — the model
+/// cannot see the divergence, and its next exact-match edit fails against a
+/// string it believes it read. Command output has no such authority to
+/// diverge from.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContentOrigin {
+    /// No origin declared. The pre-migration path: no origin gate applies,
+    /// and tool-name-based selectors stay in effect.
+    #[default]
+    Unspecified,
+    /// Produced by executing something; no authoritative copy exists
+    /// elsewhere.
+    CommandOutput,
+    /// A copy of stored content whose authority lives elsewhere.
+    FileContent,
+    /// A service or framework result that is neither of the above.
+    ApiResponse,
+}
+
+impl ContentOrigin {
+    /// Whether no origin was declared. Also the serde skip predicate: an
+    /// unspecified origin never reaches the wire.
+    #[must_use]
+    pub fn is_unspecified(&self) -> bool {
+        matches!(self, Self::Unspecified)
+    }
+
+    /// The `snake_case` wire name, identical to this enum's serde encoding.
+    #[must_use]
+    pub fn wire_str(self) -> &'static str {
+        match self {
+            Self::Unspecified => "unspecified",
+            Self::CommandOutput => "command_output",
+            Self::FileContent => "file_content",
+            Self::ApiResponse => "api_response",
+        }
+    }
+}
+
 /// What the requesting adapter's host can actually do with the result.
 ///
 /// The pipeline intersects compressor candidates with these capabilities
@@ -159,6 +203,12 @@ pub struct CompressionRequest {
     pub tool_name: Option<String>,
     /// Where in the agent loop this content was intercepted.
     pub seam: Seam,
+    /// Where the content came from. Absent on the wire means
+    /// [`ContentOrigin::Unspecified`], and an unspecified origin is left off
+    /// the wire, so an adapter that has not migrated keeps both its current
+    /// behaviour and its current payload.
+    #[serde(default, skip_serializing_if = "ContentOrigin::is_unspecified")]
+    pub content_origin: ContentOrigin,
     /// What the host can do with the result. Missing fields are `false`.
     #[serde(default)]
     pub capabilities: Capabilities,
@@ -176,6 +226,7 @@ impl CompressionRequest {
             tool_use_id: None,
             tool_name: None,
             seam,
+            content_origin: ContentOrigin::Unspecified,
             capabilities: Capabilities::default(),
         }
     }

--- a/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
+++ b/src/tokenless/crates/tokenless-protocol/src/tests/protocol_tests.rs
@@ -177,6 +177,14 @@ fn wire_format_is_stable() {
         r#"{"protocol_version":1,"content":"c","agent_id":"a","seam":"post_tool","capabilities":{"replace_output":true,"publish_retrieve_tool":false,"replace_with_text":false}}"#
     );
 
+    // A declared origin adds one field; an unspecified one stays off the
+    // wire entirely, which is what keeps unmigrated adapters byte-identical.
+    req.content_origin = ContentOrigin::FileContent;
+    assert_eq!(
+        req.to_json().unwrap(),
+        r#"{"protocol_version":1,"content":"c","agent_id":"a","seam":"post_tool","content_origin":"file_content","capabilities":{"replace_output":true,"publish_retrieve_tool":false,"replace_with_text":false}}"#
+    );
+
     let resp = CompressionResponse {
         protocol_version: PROTOCOL_VERSION,
         output: "o".into(),
@@ -194,6 +202,33 @@ fn wire_format_is_stable() {
         resp.to_json().unwrap(),
         r#"{"protocol_version":1,"output":"o","disposition":"no_savings","content_type":"search_results","compressor_chain":["search"],"reversibility":"unrecoverable","before_tokens":10,"after_tokens":10,"stash_keys":["k"],"tokenizer_id":"heuristic-v1","diagnostic":"d"}"#
     );
+}
+
+#[test]
+fn every_origin_round_trips_and_absence_reads_as_unspecified() {
+    for origin in [
+        ContentOrigin::Unspecified,
+        ContentOrigin::CommandOutput,
+        ContentOrigin::FileContent,
+        ContentOrigin::ApiResponse,
+    ] {
+        let mut req = CompressionRequest::new("c", "a", Seam::PostTool);
+        req.content_origin = origin;
+        let parsed = CompressionRequest::from_json(&req.to_json().unwrap()).unwrap();
+        assert_eq!(parsed.content_origin, origin);
+        // `wire_str` is hand-written beside a serde rename: assert the two
+        // agree, rather than that the enum equals itself.
+        assert_eq!(
+            serde_json::to_value(origin).unwrap(),
+            serde_json::Value::String(origin.wire_str().to_owned())
+        );
+    }
+
+    // The pre-migration payload: no field at all.
+    let legacy = r#"{"protocol_version":1,"content":"c","agent_id":"a","seam":"post_tool"}"#;
+    let parsed = CompressionRequest::from_json(legacy).unwrap();
+    assert_eq!(parsed.content_origin, ContentOrigin::Unspecified);
+    assert!(parsed.content_origin.is_unspecified());
 }
 
 #[test]

--- a/src/tokenless/crates/tokenless-runtime/src/entry.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/entry.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use tokenless_ccr::StashStore;
 use tokenless_protocol::{
-    CompressionRequest, CompressionResponse, Disposition, Reversibility, Seam,
+    CompressionRequest, CompressionResponse, ContentOrigin, Disposition, Reversibility, Seam,
 };
 use tokenless_schema::SchemaCompressor;
 use tokenless_stats::{OperationType, estimate_tokens};
@@ -196,13 +196,6 @@ fn post_tool(
     options: &EntryOptions,
     stash_store: Option<&Arc<dyn StashStore>>,
 ) -> EntryOutcome {
-    if request
-        .tool_name
-        .as_deref()
-        .is_some_and(taxonomy::is_skip_tool)
-    {
-        return EntryOutcome::passthrough(request, None);
-    }
     let Some((normalized, original_value)) = normalize_content(&request.content) else {
         return post_tool_text(request, options, stash_store);
     };
@@ -211,7 +204,7 @@ fn post_tool(
         return EntryOutcome::passthrough(request, None);
     }
 
-    let thresholds = taxonomy::thresholds_for(request.tool_name.as_deref());
+    let thresholds = taxonomy::thresholds_for(request.content_origin, request.tool_name.as_deref());
     let compress_options = CompressOptions {
         truncate_strings_at: Some(thresholds.truncate_strings_at),
         truncate_arrays_at: Some(thresholds.truncate_arrays_at),
@@ -340,9 +333,23 @@ fn decide_post_tool_winner(
     original_value: &serde_json::Value,
     cleanup_candidate: Option<String>,
 ) -> Option<Winner> {
+    // TOON runs outside the pipeline, so the release gate of §4.3 does not
+    // reach it on its own — and `JsonRecords` is protected, which is exactly
+    // the shape TOON encodes. Left alone it would re-encode a `package.json`
+    // read from disk into a format the file does not have, which is the same
+    // desynchronization the gate exists to prevent, arriving by another door.
+    //
+    // On the file-content path TOON may therefore only run on top of a
+    // candidate the pipeline itself produced, which means on a released type.
+    // No released type has a compressor today, so in practice this switches
+    // TOON off for file reads outright; the condition reopens on its own the
+    // day one lands. §9 removes the carve-out for good by moving TOON inside
+    // the JSON compressor, where the gate covers it like any other.
+    let released_by_the_pipeline =
+        request.content_origin != ContentOrigin::FileContent || cleanup_candidate.is_some();
     // TOON is a non-JSON encoding: only hosts whose slot accepts arbitrary
     // text can apply it.
-    let toon = if request.capabilities.replace_with_text {
+    let toon = if request.capabilities.replace_with_text && released_by_the_pipeline {
         let base_text = cleanup_candidate.as_deref().unwrap_or(normalized);
         let base_chars = base_text.chars().count();
         if base_chars >= MIN_TOON_CHARS {
@@ -703,14 +710,144 @@ mod tests {
     }
 
     #[test]
-    fn skip_tools_pass_through_untouched() {
+    fn a_tool_name_no_longer_decides_on_its_own() {
+        // The layer-1 skip list is gone (roadmap §6.3): a request naming a
+        // read tool but declaring no origin is judged by its content like any
+        // other. Adapters still prefilter these before spawning, so this is
+        // not a change any host sees — it is a change to what this API means.
         let outcome = compress_with_store(
             &post_tool_request(&compressible_object(), "Read"),
             &ENABLED,
             None,
         );
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
+    }
+
+    /// The same request with an origin declared.
+    fn origin_request(content: &str, tool: &str, origin: ContentOrigin) -> CompressionRequest {
+        let mut request = post_tool_request(content, tool);
+        request.content_origin = origin;
+        request
+    }
+
+    /// A build log committed to this repository, read back the way an agent
+    /// would read any tracked file.
+    const TRACKED_BUILD_LOG: &str =
+        include_str!("../../tokenless-compressors/tests/fixtures/build_logs/cargo_failure.txt");
+
+    #[test]
+    fn a_build_log_read_from_disk_is_not_rewritten() {
+        // `BuildLog` was released until review found it shares the flaw that
+        // keeps `JsonRecords` protected: the detector scores content alone, so
+        // this fixture — or a contributor doc quoting a compiler twice, see
+        // `prose_carrying_two_generic_markers_is_a_known_detection_boundary` —
+        // sits in the bucket beside the output of the build that just ran.
+        let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
+
+        let mut file = text_request(TRACKED_BUILD_LOG);
+        file.content_origin = ContentOrigin::FileContent;
+        let file = compress_with_store(&file, &ENABLED, Some(&store));
+        assert_eq!(file.response.disposition, Disposition::Passthrough);
+        assert_eq!(file.response.output, TRACKED_BUILD_LOG);
+        assert!(file.response.compressor_chain.is_empty());
+        assert!(file.response.stash_keys.is_empty());
+        // Protected means full passthrough: nothing was stashed either.
+        assert_eq!(store.len(), 0);
+
+        // The same bytes as command output still compress. Measured on the
+        // released list this replaces: the file path ran `["terminal-cleanup",
+        // "build-log"]`, stripped SGR and folded a run of lines behind a
+        // retrieval marker — a view the file on disk does not have, which the
+        // model's next exact-match edit would be written against.
+        let mut command = text_request(TRACKED_BUILD_LOG);
+        command.content_origin = ContentOrigin::CommandOutput;
+        let command = compress_with_store(&command, &ENABLED, Some(&store));
+        assert_eq!(command.response.disposition, Disposition::Applied);
+        assert_ne!(command.response.output, TRACKED_BUILD_LOG);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn an_authored_json_config_read_from_disk_is_not_rewritten() {
+        // The taxonomy has one bucket for all JSON, so releasing it would hand
+        // the response cleanup a hand-authored `package.json`: it drops null
+        // and empty fields, and the model's next exact-match edit then fails
+        // against a file it believes it read. Measured before this test
+        // existed: `"description"` and `"license"` were both removed.
+        let package_json = serde_json::to_string_pretty(&serde_json::json!({
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "",
+            "license": null,
+            "keywords": [],
+            "dependencies": (0..40)
+                .map(|i| (format!("dep-{i:02}"), serde_json::json!("^1.0.0")))
+                .collect::<serde_json::Map<_, _>>(),
+        }))
+        .unwrap();
+
+        // A text slot, where the cleanup's removals are final — a structured
+        // slot restores top-level fields on the way out, which hides the
+        // damage for that shape but not for this one. It is also the slot
+        // TOON needs, so the byte-identical assertion below pins the entry's
+        // carve-out too: no pipeline candidate on a file read, no TOON.
+        let mut file = origin_request(&package_json, "Read", ContentOrigin::FileContent);
+        file.capabilities.replace_with_text = true;
+        let outcome = compress_with_store(&file, &ENABLED, None);
         assert_eq!(outcome.response.disposition, Disposition::Passthrough);
-        assert!(outcome.response.compressor_chain.is_empty());
+        assert_eq!(outcome.response.output, package_json);
+
+        // The same bytes as command output: still compressed, and the fields
+        // do go. The gate is about where the content came from, not what it
+        // is — and this is what the file path was about to do.
+        let mut command = origin_request(&package_json, "Bash", ContentOrigin::CommandOutput);
+        command.capabilities.replace_with_text = true;
+        let outcome = compress_with_store(&command, &ENABLED, None);
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
+        assert!(!outcome.response.output.contains("description"));
+        assert!(!outcome.response.output.contains("license"));
+    }
+
+    /// Long enough to engage the generic mode, and detected as `PlainText` —
+    /// the release list protects it.
+    fn prose_text() -> String {
+        (0..120)
+            .map(|i| format!("record {i} holding some ordinary content\n"))
+            .collect()
+    }
+
+    #[test]
+    fn protected_content_from_a_file_passes_through_byte_identical() {
+        // The detector cannot tell prose from source code in a language it
+        // does not know, and a rewritten copy of either breaks the model's
+        // next exact-match edit against the file.
+        let prose = prose_text();
+        let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
+
+        let mut command = text_request(&prose);
+        command.content_origin = ContentOrigin::CommandOutput;
+        let command = compress_with_store(&command, &ENABLED, Some(&store));
+        assert_eq!(command.response.disposition, Disposition::Applied);
+
+        let mut file = text_request(&prose);
+        file.content_origin = ContentOrigin::FileContent;
+        let before = store.len();
+        let file = compress_with_store(&file, &ENABLED, Some(&store));
+        assert_eq!(file.response.disposition, Disposition::Passthrough);
+        assert_eq!(file.response.output, prose);
+        assert!(file.response.compressor_chain.is_empty());
+        assert!(file.response.stash_keys.is_empty());
+        // Protected means full passthrough: not even the lossless stage ran.
+        assert_eq!(store.len(), before);
+    }
+
+    #[test]
+    fn an_undeclared_origin_never_reaches_the_release_gate() {
+        // The migration's inert default: the same protected content, with no
+        // origin declared, compresses exactly as it did before this change.
+        let store: Arc<dyn StashStore> = Arc::new(InMemoryStore::new());
+        let outcome = compress_with_store(&text_request(&prose_text()), &ENABLED, Some(&store));
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-runtime/src/lib.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/lib.rs
@@ -1080,6 +1080,7 @@ pub fn record_compression(
     .with_entry_metadata(
         request.seam.wire_str(),
         response.content_type.clone(),
+        Some(request.content_origin.wire_str().to_owned()),
         chain_json,
         response.tokenizer_id.clone(),
         outcome.stats.unrecoverable_truncations.map(|n| n as i64),
@@ -1135,6 +1136,7 @@ fn resolve_runtime_data_dir(explicit: Option<&Path>) -> Result<PathBuf, RuntimeE
 mod tests {
     use super::*;
     use tokenless_ccr::{InMemoryStore, StashError};
+    use tokenless_protocol::ContentOrigin;
 
     struct AlwaysFail;
 
@@ -1914,6 +1916,29 @@ mod tests {
         assert_eq!(records[0].seam.as_deref(), Some("post_tool"));
         assert!(records[0].content_type.is_some());
         assert!(records[0].compressor_chain.is_some());
+        // An undeclared origin lands as `unspecified`, not NULL.
+        assert_eq!(records[0].content_origin.as_deref(), Some("unspecified"));
+    }
+
+    #[test]
+    fn record_compression_carries_the_declared_origin_to_the_column() {
+        // `record_compression` is the only writer of `content_origin`; this
+        // pins the wire string end to end, through the column §4.7 will read
+        // to tell a protected-path passthrough from an ordinary no-savings
+        // row. `ApiResponse` because it is off the release gate, so the row
+        // exists to carry the value.
+        let directory = tempfile::tempdir().unwrap();
+        let recorder = StatsRecorder::new(directory.path().join("stats.db")).unwrap();
+
+        let mut request = entry_request(&compressible_api_json(), Seam::PostTool);
+        request.content_origin = ContentOrigin::ApiResponse;
+        let outcome = compress_with_store(&request, &ENTRY_ENABLED, None);
+        assert_eq!(outcome.response.disposition, Disposition::Applied);
+        record_compression(&request, &outcome, Some(&recorder), false);
+
+        let records = recorder.records_by_session("session-r", None).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].content_origin.as_deref(), Some("api_response"));
     }
 
     #[test]

--- a/src/tokenless/crates/tokenless-runtime/src/taxonomy.rs
+++ b/src/tokenless/crates/tokenless-runtime/src/taxonomy.rs
@@ -1,9 +1,9 @@
-//! Tool taxonomy for the unified entry point (roadmap §5.4).
+//! Truncation thresholds for the unified entry point (roadmap §5.4).
 //!
-//! Skip list and truncation thresholds move here from the common Python
-//! hooks (`hook_utils.py`), sourced from the same
-//! `adapters/tokenless/common/hooks/tool_categories.json` so the JSON file
-//! stays the single source of truth (OpenClaw still reads it at runtime).
+//! Thresholds come from the common Python hooks (`hook_utils.py`), sourced
+//! from the same `adapters/tokenless/common/hooks/tool_categories.json` so
+//! the JSON file stays the single source of truth (OpenClaw still reads it
+//! at runtime).
 //! The file is embedded at compile time — the binary must work without
 //! adapter files installed — which ties this crate to the workspace layout;
 //! acceptable for a workspace-internal crate that is never `cargo package`d.
@@ -11,11 +11,17 @@
 //! A malformed edit of the JSON falls back to the hardcoded sets below
 //! (mirroring the Python fail-open behaviour), and the unit tests fail so
 //! CI reports the breakage instead of silently degrading.
+//!
+//! The layer-1 skip list is gone from here (roadmap §6.3): whether content
+//! is compressed follows from its type, its origin, and whether a compressor
+//! is registered. `tool_categories.json` keeps the list for the adapters,
+//! which use it to avoid a spawn; this crate no longer reads it.
 
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
 use serde::Deserialize;
+use tokenless_protocol::ContentOrigin;
 
 static TAXONOMY_JSON: &str =
     include_str!("../../../adapters/tokenless/common/hooks/tool_categories.json");
@@ -41,30 +47,9 @@ const API_THRESHOLDS: ToolThresholds = ToolThresholds {
     max_depth: 32,
 };
 
-// Minimum safe classification, matching `hook_utils.py`'s fallback sets:
-// content-retrieval tools are never accidentally compressed even when the
-// embedded JSON fails to parse.
-const FALLBACK_SKIP_TOOLS: &[&str] = &[
-    "Read",
-    "read",
-    "read_file",
-    "read_many_files",
-    "Glob",
-    "glob",
-    "search_file",
-    "list_directory",
-    "list_dir",
-    "Grep",
-    "grep",
-    "grep_code",
-    "grep_search",
-    "search_files",
-    "Lsp",
-    "lsp",
-    "NotebookRead",
-    "notebook_read",
-    "notebookread",
-];
+// Minimum safe classification, matching `hook_utils.py`'s fallback set.
+// Only `ContentOrigin::Unspecified` still reaches it; it goes when every
+// adapter declares an origin (roadmap §6.3, item 10).
 const FALLBACK_SHELL_TOOLS: &[&str] = &[
     "Bash",
     "bash",
@@ -81,7 +66,6 @@ const FALLBACK_SHELL_TOOLS: &[&str] = &[
 
 #[derive(Deserialize)]
 struct RawTaxonomy {
-    layer_1_skip: RawLayer,
     layer_2_shell: RawLayer,
     layer_3_api: RawLayer,
 }
@@ -120,7 +104,6 @@ impl RawThresholds {
 }
 
 struct Taxonomy {
-    skip_tools: HashSet<String>,
     shell_tools: HashSet<String>,
     shell_thresholds: ToolThresholds,
     api_thresholds: ToolThresholds,
@@ -128,7 +111,6 @@ struct Taxonomy {
 
 fn fallback_taxonomy() -> Taxonomy {
     Taxonomy {
-        skip_tools: FALLBACK_SKIP_TOOLS.iter().map(|t| (*t).into()).collect(),
         shell_tools: FALLBACK_SHELL_TOOLS.iter().map(|t| (*t).into()).collect(),
         shell_thresholds: SHELL_THRESHOLDS,
         api_thresholds: API_THRESHOLDS,
@@ -139,40 +121,35 @@ fn taxonomy() -> &'static Taxonomy {
     static TAXONOMY: OnceLock<Taxonomy> = OnceLock::new();
     TAXONOMY.get_or_init(
         || match serde_json::from_str::<RawTaxonomy>(TAXONOMY_JSON) {
-            Ok(raw)
-                if !raw.layer_1_skip.tools.is_empty() && !raw.layer_2_shell.tools.is_empty() =>
-            {
-                Taxonomy {
-                    skip_tools: raw.layer_1_skip.tools.into_iter().collect(),
-                    shell_tools: raw.layer_2_shell.tools.into_iter().collect(),
-                    shell_thresholds: RawThresholds::resolve(
-                        raw.layer_2_shell.thresholds,
-                        SHELL_THRESHOLDS,
-                    ),
-                    api_thresholds: RawThresholds::resolve(
-                        raw.layer_3_api.thresholds,
-                        API_THRESHOLDS,
-                    ),
-                }
-            }
+            Ok(raw) if !raw.layer_2_shell.tools.is_empty() => Taxonomy {
+                shell_tools: raw.layer_2_shell.tools.into_iter().collect(),
+                shell_thresholds: RawThresholds::resolve(
+                    raw.layer_2_shell.thresholds,
+                    SHELL_THRESHOLDS,
+                ),
+                api_thresholds: RawThresholds::resolve(raw.layer_3_api.thresholds, API_THRESHOLDS),
+            },
             _ => fallback_taxonomy(),
         },
     )
 }
 
-/// Whether the tool is layer 1 (content retrieval): skip all compression.
-pub(crate) fn is_skip_tool(tool_name: &str) -> bool {
-    taxonomy().skip_tools.contains(tool_name)
-}
-
-/// Truncation thresholds for a tool: layer 2 limits for shell/exec tools,
-/// layer 3 zero-truncation limits for everything else (including requests
-/// without a tool name).
-pub(crate) fn thresholds_for(tool_name: Option<&str>) -> ToolThresholds {
+/// Truncation thresholds: layer 2 limits for command output, layer 3
+/// zero-truncation limits for everything else.
+///
+/// A declared origin decides on its own. `Unspecified` falls back to the
+/// tool-name test, because the two sets differ by more than an order of
+/// magnitude — handing an unmigrated caller the API set would silently
+/// change the shape of its shell output (roadmap §4.3).
+pub(crate) fn thresholds_for(origin: ContentOrigin, tool_name: Option<&str>) -> ToolThresholds {
     let tax = taxonomy();
-    match tool_name {
-        Some(name) if tax.shell_tools.contains(name) => tax.shell_thresholds,
-        _ => tax.api_thresholds,
+    match origin {
+        ContentOrigin::CommandOutput => tax.shell_thresholds,
+        ContentOrigin::FileContent | ContentOrigin::ApiResponse => tax.api_thresholds,
+        ContentOrigin::Unspecified => match tool_name {
+            Some(name) if tax.shell_tools.contains(name) => tax.shell_thresholds,
+            _ => tax.api_thresholds,
+        },
     }
 }
 
@@ -185,23 +162,42 @@ mod tests {
     #[test]
     fn embedded_taxonomy_parses_with_expected_layers() {
         let raw: RawTaxonomy = serde_json::from_str(TAXONOMY_JSON).expect("embedded JSON parses");
-        assert!(raw.layer_1_skip.tools.contains(&"Read".to_string()));
         assert!(raw.layer_2_shell.tools.contains(&"Bash".to_string()));
         assert!(raw.layer_2_shell.thresholds.is_some());
         assert!(raw.layer_3_api.thresholds.is_some());
     }
 
     #[test]
-    fn classification_matches_the_python_hooks() {
-        assert!(is_skip_tool("Read"));
-        assert!(is_skip_tool("grep_search"));
-        assert!(!is_skip_tool("Bash"));
-        assert!(!is_skip_tool("WebFetch"));
+    fn unspecified_origin_still_classifies_by_tool_name() {
+        use ContentOrigin::Unspecified;
+        assert_eq!(thresholds_for(Unspecified, Some("Bash")), SHELL_THRESHOLDS);
+        assert_eq!(
+            thresholds_for(Unspecified, Some("run_shell_command")),
+            SHELL_THRESHOLDS
+        );
+        assert_eq!(
+            thresholds_for(Unspecified, Some("WebFetch")),
+            API_THRESHOLDS
+        );
+        assert_eq!(thresholds_for(Unspecified, None), API_THRESHOLDS);
+    }
 
-        assert_eq!(thresholds_for(Some("Bash")), SHELL_THRESHOLDS);
-        assert_eq!(thresholds_for(Some("run_shell_command")), SHELL_THRESHOLDS);
-        assert_eq!(thresholds_for(Some("WebFetch")), API_THRESHOLDS);
-        assert_eq!(thresholds_for(None), API_THRESHOLDS);
+    #[test]
+    fn a_declared_origin_ignores_the_tool_name() {
+        // Both directions: the origin decides even when the tool name would
+        // have said otherwise.
+        assert_eq!(
+            thresholds_for(ContentOrigin::CommandOutput, Some("WebFetch")),
+            SHELL_THRESHOLDS
+        );
+        assert_eq!(
+            thresholds_for(ContentOrigin::ApiResponse, Some("Bash")),
+            API_THRESHOLDS
+        );
+        assert_eq!(
+            thresholds_for(ContentOrigin::FileContent, Some("Bash")),
+            API_THRESHOLDS
+        );
     }
 
     #[test]
@@ -210,7 +206,6 @@ mod tests {
         // so a fallback activation changes availability, never behaviour.
         let fallback = fallback_taxonomy();
         let parsed = taxonomy();
-        assert_eq!(fallback.skip_tools, parsed.skip_tools);
         assert_eq!(fallback.shell_tools, parsed.shell_tools);
         assert_eq!(fallback.shell_thresholds, parsed.shell_thresholds);
         assert_eq!(fallback.api_thresholds, parsed.api_thresholds);

--- a/src/tokenless/crates/tokenless-stats/src/record.rs
+++ b/src/tokenless/crates/tokenless-stats/src/record.rs
@@ -131,6 +131,17 @@ pub struct StatsRecord {
     /// `None` for legacy paths and seams without a detector (before_model).
     #[serde(default)]
     pub content_type: Option<String>,
+    /// Origin declared by the adapter (protocol `content_origin` wire
+    /// string). `None` outside the unified entry point.
+    ///
+    /// Roadmap §4.7 wants this to separate a protected-path passthrough from
+    /// an ordinary no-savings outcome when tuning the release list. It cannot
+    /// do that yet: `record_compression` returns before writing any row when
+    /// `after_tokens >= before_tokens`, so neither outcome is recorded at
+    /// all. This column is what those rows will carry once a recording policy
+    /// emits them.
+    #[serde(default)]
+    pub content_origin: Option<String>,
     /// Protocol seam wire string (`before_model`, `pre_tool`, `post_tool`,
     /// `proxy`). `None` for rows written outside the unified entry point.
     #[serde(default)]
@@ -180,6 +191,7 @@ impl StatsRecord {
             stash_errors: None,
             stash_size: None,
             content_type: None,
+            content_origin: None,
             seam: None,
             compressor_chain: None,
             tokenizer_id: None,
@@ -260,12 +272,14 @@ impl StatsRecord {
         mut self,
         seam: impl Into<String>,
         content_type: Option<String>,
+        content_origin: Option<String>,
         compressor_chain: Option<String>,
         tokenizer_id: impl Into<String>,
         unrecoverable_truncations: Option<i64>,
     ) -> Self {
         self.seam = Some(seam.into());
         self.content_type = content_type;
+        self.content_origin = content_origin;
         self.compressor_chain = compressor_chain;
         self.tokenizer_id = Some(tokenizer_id.into());
         self.unrecoverable_truncations = unrecoverable_truncations;

--- a/src/tokenless/crates/tokenless-stats/src/recorder.rs
+++ b/src/tokenless/crates/tokenless-stats/src/recorder.rs
@@ -152,6 +152,7 @@ impl StatsRecorder {
             ("stash_errors", "INTEGER"),
             ("stash_size", "INTEGER"),
             ("content_type", "TEXT"),
+            ("content_origin", "TEXT"),
             ("seam", "TEXT"),
             ("compressor_chain", "TEXT"),
             ("tokenizer_id", "TEXT"),
@@ -207,9 +208,9 @@ impl StatsRecorder {
                 before_text, after_text,
                 before_output, after_output, mode,
                 stash_writes, stash_errors, stash_size,
-                content_type, seam, compressor_chain, tokenizer_id,
+                content_type, content_origin, seam, compressor_chain, tokenizer_id,
                 unrecoverable_truncations
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             rusqlite::params![
                 record.timestamp.to_rfc3339(),
                 record.operation.as_str(),
@@ -230,6 +231,7 @@ impl StatsRecorder {
                 record.stash_errors,
                 record.stash_size,
                 record.content_type,
+                record.content_origin,
                 record.seam,
                 record.compressor_chain,
                 record.tokenizer_id,
@@ -254,7 +256,7 @@ impl StatsRecorder {
         "session_id, tool_use_id, before_chars, before_tokens, ",
         "after_chars, after_tokens, before_text, after_text, ",
         "before_output, after_output, mode, stash_writes, ",
-        "stash_errors, stash_size, content_type, seam, ",
+        "stash_errors, stash_size, content_type, content_origin, seam, ",
         "compressor_chain, tokenizer_id, unrecoverable_truncations"
     );
 
@@ -401,7 +403,8 @@ impl StatsRecorder {
                 NULL AS before_output, NULL AS after_output,
                 ordered.mode, ordered.stash_writes, ordered.stash_errors,
                 ordered.stash_size,
-                NULL AS content_type, NULL AS seam, NULL AS compressor_chain,
+                NULL AS content_type, NULL AS content_origin,
+                NULL AS seam, NULL AS compressor_chain,
                 NULL AS tokenizer_id, NULL AS unrecoverable_truncations,
                 CASE
                     WHEN ordered.tool_use_id IS NOT NULL
@@ -443,9 +446,11 @@ impl StatsRecorder {
             rusqlite::params![session_id, Self::DEFAULT_LIMIT as i64],
             |row| {
                 let record = Self::row_to_record(row)?;
-                // linked_to_previous sits right after the SELECT_COLS span —
-                // its index is the SELECT_COLS column count.
-                let linked_to_previous = row.get::<_, i64>(24)? != 0;
+                // linked_to_previous is the last column, right after the
+                // SELECT_COLS span. Asking the row for its width keeps this
+                // index from drifting the next time a column is added.
+                let last = row.as_ref().column_count() - 1;
+                let linked_to_previous = row.get::<_, i64>(last)? != 0;
                 Ok((record, linked_to_previous))
             },
         )?;
@@ -612,10 +617,11 @@ impl StatsRecorder {
             stash_errors: row.get(17)?,
             stash_size: row.get(18)?,
             content_type: row.get(19)?,
-            seam: row.get(20)?,
-            compressor_chain: row.get(21)?,
-            tokenizer_id: row.get(22)?,
-            unrecoverable_truncations: row.get(23)?,
+            content_origin: row.get(20)?,
+            seam: row.get(21)?,
+            compressor_chain: row.get(22)?,
+            tokenizer_id: row.get(23)?,
+            unrecoverable_truncations: row.get(24)?,
         })
     }
 }

--- a/src/tokenless/crates/tokenless-stats/src/sls.rs
+++ b/src/tokenless/crates/tokenless-stats/src/sls.rs
@@ -173,6 +173,9 @@ pub struct SlsRecord {
     #[serde(rename = "tokenless.compression.content_type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_type: Option<String>,
+    #[serde(rename = "tokenless.compression.content_origin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_origin: Option<String>,
     #[serde(rename = "tokenless.compression.seam")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seam: Option<String>,
@@ -206,6 +209,7 @@ impl From<&StatsRecord> for SlsRecord {
             chars_saved_percent: r.chars_percent(),
             tokens_saved_percent: r.tokens_percent(),
             content_type: r.content_type.clone(),
+            content_origin: r.content_origin.clone(),
             seam: r.seam.clone(),
             compressor_chain: r.compressor_chain.clone(),
             tokenizer_id: r.tokenizer_id.clone(),
@@ -372,6 +376,7 @@ mod tests {
         let r = make_record().with_entry_metadata(
             "post_tool",
             Some("api-records".to_string()),
+            Some("file_content".to_string()),
             Some(r#"["response-cleanup"]"#.to_string()),
             "heuristic-v1",
             Some(1),
@@ -381,6 +386,7 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&sls).unwrap()).unwrap();
         assert_eq!(json["tokenless.compression.seam"], "post_tool");
         assert_eq!(json["tokenless.compression.content_type"], "api-records");
+        assert_eq!(json["tokenless.compression.content_origin"], "file_content");
         assert_eq!(
             json["tokenless.compression.compressor_chain"],
             r#"["response-cleanup"]"#

--- a/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
+++ b/src/tokenless/crates/tokenless-stats/src/tests/recorder_tests.rs
@@ -511,6 +511,7 @@ fn entry_metadata_round_trips() {
         .with_entry_metadata(
             "post_tool",
             Some("api-records".into()),
+            Some("command_output".into()),
             Some(r#"["response-cleanup","toon"]"#.into()),
             "heuristic-v1",
             Some(2),
@@ -519,6 +520,7 @@ fn entry_metadata_round_trips() {
     let got = rec.record_by_id(id).unwrap().unwrap();
     assert_eq!(got.seam.as_deref(), Some("post_tool"));
     assert_eq!(got.content_type.as_deref(), Some("api-records"));
+    assert_eq!(got.content_origin.as_deref(), Some("command_output"));
     assert_eq!(
         got.compressor_chain.as_deref(),
         Some(r#"["response-cleanup","toon"]"#)

--- a/src/tokenless/python/tokenless/python/anolisa_tokenless/stats.py
+++ b/src/tokenless/python/tokenless/python/anolisa_tokenless/stats.py
@@ -127,6 +127,7 @@ class StatsRecord:
     stash_errors: int | None
     stash_size: int | None
     content_type: str | None
+    content_origin: str | None
     seam: str | None
     compressor_chain: str | None
     tokenizer_id: str | None
@@ -500,6 +501,7 @@ def _parse_record(value: Mapping[str, Any]) -> StatsRecord:
         stash_errors=value["stash_errors"],
         stash_size=value["stash_size"],
         content_type=value.get("content_type"),
+        content_origin=value.get("content_origin"),
         seam=value.get("seam"),
         compressor_chain=value.get("compressor_chain"),
         tokenizer_id=value.get("tokenizer_id"),

--- a/src/tokenless/python/tokenless/src/lib.rs
+++ b/src/tokenless/python/tokenless/src/lib.rs
@@ -472,6 +472,7 @@ fn record_metadata_json(record: &StatsRecord) -> serde_json::Value {
         "stash_errors": record.stash_errors,
         "stash_size": record.stash_size,
         "content_type": record.content_type,
+        "content_origin": record.content_origin,
         "seam": record.seam,
         "compressor_chain": record.compressor_chain,
         "tokenizer_id": record.tokenizer_id,
@@ -488,4 +489,42 @@ fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add("TokenlessError", module.py().get_type::<TokenlessError>())?;
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokenless_stats::OperationType;
+
+    /// `show` serializes the record; `list` builds its payload by hand. A
+    /// field added to [`StatsRecord`] therefore reads as `None` through
+    /// `list` until it is added here too — silently, because the Python
+    /// parser uses `.get()`. Compare the shapes rather than any one field.
+    #[test]
+    fn the_list_payload_carries_every_field_show_does() {
+        let record = StatsRecord::new(
+            OperationType::CompressResponse,
+            "cli".into(),
+            100,
+            40,
+            50,
+            20,
+        );
+        let mut shown: Vec<String> = serde_json::to_value(&record)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        let mut listed: Vec<String> = record_metadata_json(&record)
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        shown.sort();
+        listed.sort();
+        assert_eq!(listed, shown);
+    }
 }


### PR DESCRIPTION
## Summary

Roadmap step: content origin and the file-read release list (§4.3 / §6.3, item 9 of the sequence). Whether a tool's output is compressed is decided today by matching the tool name against two host vocabularies embedded in `tokenless-runtime` — `FALLBACK_SKIP_TOOLS`, which the entry gates on, and `FALLBACK_SHELL_TOOLS`, which selects truncation thresholds. This PR replaces the first with a fact the caller declares, and makes the second origin-driven.

**The distinction that matters is not what the content is, but where it came from.** Detection answers the first; only the adapter can answer the second. The same hundred lines may be one-shot command output or the model's copy of a file whose authoritative version is on disk. Compressing the second kind desynchronizes the model's copy from that authority — the model cannot observe the divergence, and its next exact-match edit fails against a string it believes it read. Command output has no such authority to diverge from, and the model recovers what it needs through the emitted marker.

- **Protocol**: `CompressionRequest` gains `content_origin` — `command_output`, `file_content`, `api_response`, `unspecified`. It is `#[serde(default)]` **and** `skip_serializing_if`, so an adapter that has not migrated keeps both its behaviour and its payload byte-for-byte. No adapter declares an origin yet; that is item 10.
- **Release list** (pipeline, immediately after detection, `file_content` only): released — `SearchResults`, `StackTrace`, `Diff`, `Html`, `Tabular`; protected — `JsonRecords`, `BuildLog`, `SourceCode`, `PlainText`, `Unknown`, and any detection failure. Protected means **full passthrough**, not lossless-only: the lossless stage still rewrites bytes, which is enough to break an exact-match edit.
  Naming the removable half rather than blocking `SourceCode` is the point. A block list would fail exactly where the detector is weakest — code in a language it does not recognize falls through to `PlainText` — whereas a release list keeps every detection failure on the protected side.
  Membership does not follow from a compressor existing for a type: `SourceCode` and `PlainText` stay protected here even once their compressors land, because those serve the `command_output` path. `JsonRecords` is protected for the opposite reason — its compressor already ships, but the taxonomy has one bucket for all JSON and cannot separate a generated record dump from a hand-authored `package.json`, which the cleanup would rewrite by dropping null and empty fields. Restored once the taxonomy makes that split; Headroom keeps `JSON_ARRAY` releasable and `STRUCTURED_CONFIG` protected for the same reason.
  `BuildLog` is protected on the same grounds after review (thanks @kongche-jbw, @Forrest-ly), and it is the sharper case because both of its compressors ship. `is_build_log` scores content alone — any two of two dozen markers, no path and no git signal — so a log committed as a test fixture, and even a contributor document that quotes a compiler twice, land in the bucket beside the output of the build that just ran; `prose_carrying_two_generic_markers_is_a_known_detection_boundary` already pinned that tolerance. Retrievability does not exempt it: retrieval hands the text back on request, while the model writes its next exact-match edit against the view it was shown, and that view carries markers the file does not.
  **Consequence, stated plainly:** no released type has a compressor today, so `file_content` is full passthrough. That is the gate resting where the principle points, not a gap — it protects by default, and Milestone 4's `SearchResults`, `Diff` and `Tabular` compressors are the first candidates for release, judged against the same standard.
- **Skip list deleted**: `FALLBACK_SKIP_TOOLS`, `is_skip_tool`, `Taxonomy::skip_tools`, and the `layer_1_skip` parse are gone. `tool_categories.json` keeps the list for the adapters; this crate no longer reads it.
- **Thresholds**: `thresholds_for(origin, tool_name)`. A declared origin decides on its own; `unspecified` keeps the tool-name test. The two sets differ by more than an order of magnitude (`truncate_strings_at` 65 536 vs 1 048 576), so handing an unmigrated caller the API set would not be "unchanged behavior" — that list goes at the end of the migration, not at its start.
- **Stats**: a nullable `content_origin` column through the existing `pragma_table_info` + `ALTER TABLE` migration, carried into SLS and the Python reader. §4.7 wants it to separate a protected-path passthrough from an ordinary no-savings outcome, which needs a recording-policy change first: `record_compression` returns before writing any row when `after_tokens >= before_tokens`, so today neither outcome produces a row at all. The column is what those rows will carry — the field doc and roadmap say so rather than promising the comparison works today.

## Why deleting the skip list is safe before any adapter migrates

Its one production gate re-decided what the caller had already decided. Traced end to end rather than assumed:

- `is_skip_tool` had exactly one call site, in the unified entry's `post_tool`.
- The unified entry is reachable only through the `tokenless compress` subcommand and `Runtime::compress`.
- Every hook that runs that subcommand prefilters first, before spawning: `compress_response_hook.py` (`SKIP_TOOLS`), `compress_toon_hook.py` (`CONTENT_RETRIEVAL_TOOLS`), hermes (`_SKIP_TOOLS`). The comment at `compress_response_hook.py:338` says as much — "the entry point re-checks all three authoritatively; skipping here just saves the exec".
- The Python bindings expose `compress_response` / `compress_schema` / `compress_toon` only, none of which reach the unified entry — so `tool_response.py`'s conservative-mode bypass of `SKIP_TOOLS` never met this gate either.

The one real change is what this **Rust API** means: `Runtime::compress` with `tool_name: "Read"` and no declared origin is now judged by its content. That is pinned as `a_tool_name_no_longer_decides_on_its_own` rather than left implicit.

## Activation gate (§6.3, item 9)

| Gate | Evidence |
|---|---|
| With every adapter on `unspecified`, externally visible output is unchanged | Contract goldens unchanged (0 files), `make test-hook-parity` 2/2, `make test-integration` 12/12 |
| A `file_content` request whose content is protected returns `Passthrough`, byte-identical, no Stash write | `protected_content_from_a_file_passes_through_byte_identical`, `file_content_protects_types_off_the_release_list` (asserts `store.len() == 0`) |
| No released type holds a compressor, so the released half of the gate is vacuous today | Re-checked against Milestone 4's first released compressor |
| A tracked build log read from disk is not rewritten | `a_build_log_read_from_disk_is_not_rewritten` — the repo's own `cargo_failure.txt` fixture: `Passthrough`, byte-identical, `store.len() == 0`; the same bytes as `command_output` still compress |
| An authored JSON file is not rewritten on the file path | `an_authored_json_config_read_from_disk_is_not_rewritten` — byte-identical from a file, fields still removed from a command |

## Design notes

- **TOON runs outside the pipeline and needs an explicit carve-out.** It is the shape TOON encodes — `JsonRecords` — that is protected, so left alone TOON would re-encode a `package.json` read from disk into a format the file does not have: the same desynchronization the gate prevents, arriving by another door. On the file-content path TOON therefore runs only on top of a candidate the pipeline itself produced, which means on a released type; it borrows the gate's decision rather than restating it. With no released type holding a compressor, that condition is an empty set today — TOON is off for file reads outright, and reopens on its own the day one lands. Pinned by `an_authored_json_config_read_from_disk_is_not_rewritten`, whose byte-identical assertion runs on a text slot, the slot TOON needs. §9 moving TOON inside the JSON compressor deletes the carve-out along with the exception.
- **`unspecified` is not just a default, it is the migration.** Items 9 and 10 are split so the engine change lands inert and each adapter migrates on its own evidence.

## Incidental

- `recorder.rs` read `linked_to_previous` at a hardcoded index 24, which the new column broke (`run_command_stats_diff_session_and_tool` failed). It now asks the row for its width.
- `Cargo.lock` carries a one-line sync: `tokenless-compressors` was left at `0.7.13` while its manifest says `0.7.14`, so every build dirtied the tree.

## Test plan

- `cargo test --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` (CI toolchain 1.89), `cargo doc --workspace --no-deps` — all green.
- Protocol: wire-format lock extended (a declared origin adds one field; an unspecified one stays off the wire), every origin round-trips, and a payload with no field at all reads as `Unspecified`.
- Pipeline: the gate fires on `file_content` + protected before routing (no compressor runs, no stash row, detected type still reported), does not fire for the same content as `command_output`, and is never reached without a declared origin.
- Runtime: `unspecified` still classifies thresholds by tool name; a declared origin ignores the tool name in both directions.
- Contract: **zero goldens changed** — the whole point of the inert default.


