### PR TITLE
fix(cosh-ng): [shell] restore slash echo

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
@@ -411,6 +411,11 @@ _cosh_is_slash_control_candidate() {
   return 1
 }
 _cosh_guard_slash_submission() {
+  local restore_xtrace=0
+  if [[ $- == *x* ]]; then
+    restore_xtrace=1
+    set +x
+  fi
   local input="$READLINE_LINE"
   if [[ "${1:-false}" == true && "$input" == ' '* ]]; then
     input="${input# }"
@@ -421,14 +426,11 @@ _cosh_guard_slash_submission() {
   done
   local first_word="${command_word_source%%[[:space:]]*}"
   if ! _cosh_assistance_enabled || ! _cosh_is_slash_control_candidate "$first_word"; then
+    (( restore_xtrace == 1 )) && set -x
     return 0
   fi
 
-  local sensitive=false restore_xtrace=0
-  if [[ $- == *x* ]]; then
-    restore_xtrace=1
-    set +x
-  fi
+  local sensitive=false
   if _cosh_command_has_secret "$input"; then
     sensitive=true
   fi

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -243,12 +243,9 @@ impl OscParser {
 
         let compact_prompt_marker = marker.normalize_compact_prompt();
 
-        if marker.event == "slash_guard" {
-            self.flush_pending_slash_guard_echo()?;
-            self.pending_slash_guard_echo = Some(PendingSlashGuardEcho::new());
+        if self.handle_slash_guard_marker(&marker)? {
             return Ok(());
         }
-        self.flush_pending_slash_guard_echo()?;
 
         if marker.has_trusted_history_context(&self.session_id, compact_prompt_marker) {
             self.history_file_tracker

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/slash_guard_echo.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/slash_guard_echo.rs
@@ -1,20 +1,46 @@
-//! Bounded suppression for Bash Readline's internal slash-guard redisplay.
+//! Bounded replacement for Bash Readline's internal slash-guard redisplay.
 //!
-//! An authenticated marker arms one submission window. Only a complete guard
-//! redraw and its optional verbose echo are suppressed; other bytes fail open.
+//! An authenticated arm suppresses the static guard until the matching slash
+//! intercept supplies Readline's exact line; unrelated output stays ordered.
 
 use std::{borrow::Cow, io};
 
-use super::OscParser;
+use super::{marker_sequence::Marker, OscParser};
 
 const GUARD_COMMAND: &[u8] = b"case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac";
 const GUARD_REDRAW_TAIL: &[u8] = b"__cosh_slash_guard__; builtin set -x ;; *) : ;; esac";
+// A 40-column Bash redraw exposes this exact 25-byte tail. Shorter suffixes
+// are too weak to distinguish safely from unrelated terminal output.
+const MIN_PROVEN_HSCROLL_SUFFIX: &[u8] = b"in set -x ;; *) : ;; esac";
 const MAX_PENDING_BYTES: usize = 64 * 1024;
 const MAX_PENDING_LINES: usize = 16;
 
+pub(super) fn safe_display_command(command: &str) -> bool {
+    // Preserve Readline's ordinary tab-stop rendering, but reject controls
+    // that could make authenticated marker text affect another screen line.
+    !command.is_empty()
+        && command.len() <= MAX_PENDING_BYTES
+        && !command
+            .chars()
+            .any(|character| character.is_control() && character != '\t')
+}
+
 enum GuardEcho {
     ReadlineRedraw { starts_at: usize },
-    Verbose { starts_at: usize },
+    Subsequent { starts_at: usize },
+}
+
+#[derive(Debug)]
+struct SuppressedRedraw {
+    prefix: Vec<u8>,
+    line_ending: Vec<u8>,
+    deferred: Vec<u8>,
+}
+
+pub(super) struct SlashGuardResolution {
+    pub(super) prefix: Vec<u8>,
+    pub(super) suffix: Vec<u8>,
+    pub(super) insert_command: bool,
 }
 
 #[derive(Debug)]
@@ -23,15 +49,22 @@ pub(super) struct PendingSlashGuardEcho {
     lines: usize,
     bytes_seen: usize,
     redraw_suppressed: bool,
+    suppressed_redraw: Option<SuppressedRedraw>,
+    // Used only to avoid duplicating a direct submission that Readline had
+    // already painted exactly; any dirty-redisplay mismatch is reconstructed.
+    before_arm: Vec<u8>,
 }
 
 impl PendingSlashGuardEcho {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(before_arm: &[u8]) -> Self {
+        let retained_from = before_arm.len().saturating_sub(MAX_PENDING_BYTES);
         Self {
             line: Vec::new(),
             lines: 0,
             bytes_seen: 0,
             redraw_suppressed: false,
+            suppressed_redraw: None,
+            before_arm: before_arm[retained_from..].to_vec(),
         }
     }
 
@@ -48,34 +81,47 @@ impl PendingSlashGuardEcho {
             pending.line.push(byte);
             pending.bytes_seen += 1;
             if pending.bytes_seen >= MAX_PENDING_BYTES {
-                output.extend_from_slice(&pending.line);
+                output.extend_from_slice(&pending.release_suppress_only());
                 *slot = None;
                 continue;
             }
             if byte == b'\n' {
                 match pending.classify_guard_echo() {
                     Some(GuardEcho::ReadlineRedraw { starts_at }) => {
-                        output.extend_from_slice(&pending.line[..starts_at]);
-                        output.extend_from_slice(pending.line_ending());
+                        pending.suppressed_redraw = Some(SuppressedRedraw {
+                            prefix: pending.line[..starts_at].to_vec(),
+                            line_ending: pending.line_ending().to_vec(),
+                            deferred: Vec::new(),
+                        });
                         pending.line.clear();
                         pending.redraw_suppressed = true;
                         continue;
                     }
-                    Some(GuardEcho::Verbose { starts_at }) => {
-                        output.extend_from_slice(&pending.line[..starts_at]);
-                        output.extend_from_slice(pending.line_ending());
-                        *slot = None;
+                    Some(GuardEcho::Subsequent { starts_at }) => {
+                        let ending = pending.line_ending().to_vec();
+                        if let Some(redraw) = pending.suppressed_redraw.as_mut() {
+                            redraw
+                                .deferred
+                                .extend_from_slice(&pending.line[..starts_at]);
+                            redraw.deferred.extend_from_slice(&ending);
+                        }
+                        pending.line.clear();
                         continue;
                     }
                     None => {}
                 }
-                // A complete non-matching line may be asynchronous user or
-                // job output. Release it immediately while the bounded arm
-                // waits for the guard redraw or its verbose duplicate.
-                output.extend_from_slice(&pending.line);
+                // Before the redraw, complete unrelated lines can be released
+                // immediately. After it, retain them so the replacement stays
+                // ahead of asynchronous job output when the intercept arrives.
+                if let Some(redraw) = pending.suppressed_redraw.as_mut() {
+                    redraw.deferred.extend_from_slice(&pending.line);
+                } else {
+                    output.extend_from_slice(&pending.line);
+                }
                 pending.line.clear();
                 pending.lines += 1;
                 if pending.lines >= MAX_PENDING_LINES {
+                    output.extend_from_slice(&pending.release_suppress_only());
                     *slot = None;
                 }
             }
@@ -84,46 +130,128 @@ impl PendingSlashGuardEcho {
     }
 
     pub(super) fn flush(slot: &mut Option<Self>) -> Vec<u8> {
-        slot.take().map_or_else(Vec::new, |pending| pending.line)
+        slot.take()
+            .map_or_else(Vec::new, |mut pending| pending.release_suppress_only())
+    }
+
+    pub(super) fn resolve(slot: &mut Option<Self>, command: &[u8]) -> Option<SlashGuardResolution> {
+        let mut pending = slot.take()?;
+        let Some(redraw) = pending.suppressed_redraw.take() else {
+            *slot = Some(pending);
+            return None;
+        };
+        // Exact suffix matching deliberately biases ambiguous Readline state
+        // toward inserting the authenticated command instead of dropping it.
+        let insert_command = !pending
+            .before_arm
+            .strip_suffix(redraw.line_ending.as_slice())
+            .is_some_and(|before_ending| {
+                Self::proves_painted_command(before_ending, command, &redraw.prefix)
+            });
+        let mut suffix = redraw.line_ending;
+        suffix.extend_from_slice(&redraw.deferred);
+        suffix.extend_from_slice(&pending.line);
+        Some(SlashGuardResolution {
+            prefix: redraw.prefix,
+            suffix,
+            insert_command,
+        })
+    }
+
+    fn proves_painted_command(before_ending: &[u8], command: &[u8], prefix: &[u8]) -> bool {
+        let Some(before_command) = before_ending.strip_suffix(command) else {
+            return false;
+        };
+        if before_command.ends_with(prefix) {
+            return true;
+        }
+        if !before_command.ends_with(b"\x08") {
+            return false;
+        }
+
+        // Readline may expose Home-Space-End as an exact repaint sequence:
+        // command, back to its start, padded command, back again, command.
+        let Ok(command) = std::str::from_utf8(command) else {
+            return false;
+        };
+        if command.contains('\t') {
+            return false;
+        }
+        let columns = unicode_width::UnicodeWidthStr::width(command);
+        if columns == 0 {
+            return false;
+        }
+        let command = command.as_bytes();
+        Self::strip_backspaces(before_command, columns)
+            .and_then(|before_end_move| before_end_move.strip_suffix(command))
+            .and_then(|before_padding| before_padding.strip_suffix(b" "))
+            .and_then(|before_home| Self::strip_backspaces(before_home, columns))
+            .and_then(|before_original| before_original.strip_suffix(command))
+            .is_some_and(|before_rewrite| before_rewrite.ends_with(prefix))
+    }
+
+    fn strip_backspaces(bytes: &[u8], count: usize) -> Option<&[u8]> {
+        let split = bytes.len().checked_sub(count)?;
+        bytes[split..]
+            .iter()
+            .all(|byte| *byte == b'\x08')
+            .then_some(&bytes[..split])
     }
 
     fn classify_guard_echo(&self) -> Option<GuardEcho> {
         let body = self.line_body()?;
+        let starts_at = Self::unique_static_guard_start(body)?;
         if self.redraw_suppressed {
-            return body
-                .strip_suffix(GUARD_COMMAND)
-                .map(|prefix| GuardEcho::Verbose {
-                    starts_at: prefix.len(),
-                });
+            Some(GuardEcho::Subsequent { starts_at })
+        } else {
+            Some(GuardEcho::ReadlineRedraw { starts_at })
         }
+    }
 
-        // A carriage return is ordinary terminal output, not an ownership
-        // boundary. Delete only a complete static replacement or a verified
-        // '<' horizontal-scroll suffix; every preceding byte remains user/job
-        // output.
-        let mut matches = body
-            .windows(GUARD_REDRAW_TAIL.len())
+    fn unique_static_guard_start(body: &[u8]) -> Option<usize> {
+        // Readline may replace the omitted left side with '<'. Require the
+        // remaining suffix to be long, exact, and the only guard-shaped text;
+        // ambiguity fails open so unrelated terminal output is never deleted.
+        let trimmed_end = body
+            .iter()
+            .rposition(|byte| !matches!(byte, b' ' | b'\x08'))?
+            + 1;
+        let trimmed = &body[..trimmed_end];
+        let full = trimmed
+            .strip_suffix(GUARD_COMMAND)
+            .map(|prefix| prefix.len());
+        let hscroll = trimmed
+            .iter()
             .enumerate()
-            .filter(|(_, window)| *window == GUARD_REDRAW_TAIL);
-        let tail_start = matches.next()?.0;
-        if matches.next().is_some()
-            || !body[tail_start + GUARD_REDRAW_TAIL.len()..]
-                .iter()
-                .all(|byte| matches!(byte, b' ' | b'\x08'))
-        {
+            .filter(|(_, byte)| **byte == b'<')
+            .filter_map(|(start, _)| {
+                let suffix = &trimmed[start + 1..];
+                (suffix.len() >= MIN_PROVEN_HSCROLL_SUFFIX.len()
+                    && suffix.len() < GUARD_COMMAND.len()
+                    && GUARD_COMMAND.ends_with(suffix))
+                .then_some(start)
+            });
+        let mut matches = full.into_iter().chain(hscroll);
+        let starts_at = matches.next()?;
+        if matches.next().is_some() {
             return None;
         }
-        let guard_end = tail_start + GUARD_REDRAW_TAIL.len();
-        let starts_at = body[..guard_end]
-            .windows(GUARD_COMMAND.len())
-            .position(|window| window == GUARD_COMMAND)
-            .or_else(|| {
-                body[..tail_start]
-                    .iter()
-                    .rposition(|byte| *byte == b'<')
-                    .filter(|start| GUARD_COMMAND.ends_with(&body[*start + 1..guard_end]))
-            })?;
-        Some(GuardEcho::ReadlineRedraw { starts_at })
+
+        let static_suffix = if trimmed[starts_at] == b'<' {
+            &trimmed[starts_at + 1..]
+        } else {
+            &trimmed[starts_at..]
+        };
+        let expected_tails = usize::from(
+            static_suffix
+                .windows(GUARD_REDRAW_TAIL.len())
+                .any(|window| window == GUARD_REDRAW_TAIL),
+        );
+        let observed_tails = trimmed
+            .windows(GUARD_REDRAW_TAIL.len())
+            .filter(|window| *window == GUARD_REDRAW_TAIL)
+            .count();
+        (observed_tails == expected_tails).then_some(starts_at)
     }
 
     fn line_body(&self) -> Option<&[u8]> {
@@ -138,9 +266,43 @@ impl PendingSlashGuardEcho {
             b"\n"
         }
     }
+
+    fn release_suppress_only(&mut self) -> Vec<u8> {
+        let Some(redraw) = self.suppressed_redraw.take() else {
+            return std::mem::take(&mut self.line);
+        };
+        let mut output = redraw.prefix;
+        output.extend_from_slice(&redraw.line_ending);
+        output.extend_from_slice(&redraw.deferred);
+        output.append(&mut self.line);
+        output
+    }
 }
 
 impl OscParser {
+    /// Handles authenticated slash guard lifecycle markers before routing
+    /// records an intervention display cut.
+    pub(super) fn handle_slash_guard_marker(&mut self, marker: &Marker) -> io::Result<bool> {
+        if marker.event == "slash_guard" {
+            self.flush_pending_slash_guard_echo()?;
+            let pending = PendingSlashGuardEcho::new(self.last_prompt_display());
+            self.pending_slash_guard_echo = Some(pending);
+            return Ok(true);
+        }
+
+        let matching_command = (marker.event == "intercept"
+            && marker.reason.as_deref() == Some("slash"))
+        .then_some(marker.command.as_deref())
+        .flatten()
+        .filter(|command| safe_display_command(command));
+        if let Some(command) = matching_command {
+            self.resolve_pending_slash_guard_echo(command)?;
+        } else {
+            self.flush_pending_slash_guard_echo()?;
+        }
+        Ok(false)
+    }
+
     pub(super) fn flush_pending_slash_guard_echo(&mut self) -> io::Result<()> {
         let pending = PendingSlashGuardEcho::flush(&mut self.pending_slash_guard_echo);
         if pending.is_empty() {
@@ -148,122 +310,173 @@ impl OscParser {
         }
         self.append_passthrough(&pending)
     }
+
+    pub(super) fn resolve_pending_slash_guard_echo(&mut self, command: &str) -> io::Result<()> {
+        let Some(resolution) =
+            PendingSlashGuardEcho::resolve(&mut self.pending_slash_guard_echo, command.as_bytes())
+        else {
+            return self.flush_pending_slash_guard_echo();
+        };
+        self.append_passthrough(&resolution.prefix)?;
+        if resolution.insert_command {
+            self.append_display_only(command.as_bytes())?;
+        }
+        self.append_passthrough(&resolution.suffix)
+    }
+
+    fn append_display_only(&mut self, data: &[u8]) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        self.alt_screen.observe(data);
+        self.visible_tail.feed(data);
+        self.display.append(data)?;
+        self.append_prompt_display_tail(data);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn resolve(pending: &mut Option<PendingSlashGuardEcho>) -> SlashGuardResolution {
+        PendingSlashGuardEcho::resolve(pending, b"/mode").expect("suppressed guard redraw")
+    }
+
     #[test]
     fn suppresses_fragmented_guard_redisplay() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
         assert!(PendingSlashGuardEcho::filter(&mut pending, b"<builtin ").is_empty());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"\r\n"
-        );
-        assert!(pending.is_some());
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        let resolution = resolve(&mut pending);
+        assert!(resolution.prefix.is_empty());
+        assert_eq!(resolution.suffix, b"\r\n");
     }
 
     #[test]
     fn suppresses_multiline_prompt_redisplay() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
         assert_eq!(
             PendingSlashGuardEcho::filter(&mut pending, b"first prompt line\r\n").as_ref(),
             b"first prompt line\r\n"
         );
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"\r\n"
-        );
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        assert_eq!(resolve(&mut pending).suffix, b"\r\n");
     }
 
     #[test]
     fn suppresses_readline_cleanup_after_shorter_guard() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac      \x08\x08\x08\r\n"
-            )
-            .as_ref(),
-            b"\r\n"
-        );
-        assert!(pending.is_some());
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac      \x08\x08\x08\r\n"
+        )
+        .is_empty());
+        assert_eq!(resolve(&mut pending).suffix, b"\r\n");
     }
 
     #[test]
     fn preserves_partial_output_before_guard_redisplay() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"BACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"BACKGROUND_PARTIAL\r\n"
-        );
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"BACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        let resolution = resolve(&mut pending);
+        assert_eq!(resolution.prefix, b"BACKGROUND_PARTIAL");
+        assert_eq!(resolution.suffix, b"\r\n");
     }
 
     #[test]
     fn preserves_carriage_return_partial_output_before_guard_redisplay() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"BEFORE\rBACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"BEFORE\rBACKGROUND_PARTIAL\r\n"
-        );
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"BEFORE\rBACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        let resolution = resolve(&mut pending);
+        assert_eq!(resolution.prefix, b"BEFORE\rBACKGROUND_PARTIAL");
+        assert_eq!(resolution.suffix, b"\r\n");
     }
 
     #[test]
     fn suppresses_verbose_echo_after_guard_redisplay() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\ncase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"\r\n\r\n"
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\ncase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        assert_eq!(resolve(&mut pending).suffix, b"\r\n\r\n");
+    }
+
+    #[test]
+    fn suppresses_hscroll_duplicate_after_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"BACKGROUND<_cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+
+        let resolution = resolve(&mut pending);
+        assert_eq!(resolution.prefix, b"");
+        assert_eq!(resolution.suffix, b"\r\nBACKGROUND\r\n");
+        assert!(!resolution
+            .suffix
+            .windows(b"_cosh_slash_guard__".len())
+            .any(|window| window == b"_cosh_slash_guard__"));
+    }
+
+    #[test]
+    fn suppresses_narrow_hscroll_as_first_guard_redisplay() {
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(
+            PendingSlashGuardEcho::filter(&mut pending, b"<in set -x ;; *) : ;; esac\r\n")
+                .is_empty()
         );
-        assert!(pending.is_none());
+
+        let resolution = resolve(&mut pending);
+        assert_eq!(resolution.prefix, b"");
+        assert_eq!(resolution.suffix, b"\r\n");
+        assert!(resolution.insert_command);
     }
 
     #[test]
     fn verbose_echo_preserves_unrelated_partial_prefix() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"\r\n"
-        );
-        assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"BACKGROUND_PARTIALcase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"BACKGROUND_PARTIAL\r\n"
-        );
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"BACKGROUND_PARTIALcase $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        assert_eq!(resolve(&mut pending).suffix, b"\r\nBACKGROUND_PARTIAL\r\n");
     }
 
     #[test]
     fn unproven_sentinel_line_fails_open() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
         let line = b"BACKGROUND_PARTIAL builtin true __cosh_slash_guard__ unrelated\r\n";
         assert_eq!(
             PendingSlashGuardEcho::filter(&mut pending, line).as_ref(),
@@ -273,16 +486,31 @@ mod tests {
     }
 
     #[test]
-    fn complete_guard_match_preserves_preceding_angle_bracket() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
+    fn ambiguous_static_guard_lines_fail_open() {
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        let mut line = GUARD_REDRAW_TAIL.to_vec();
+        line.extend_from_slice(b" unrelated ");
+        line.extend_from_slice(GUARD_COMMAND);
+        line.extend_from_slice(b"\r\n");
+
         assert_eq!(
-            PendingSlashGuardEcho::filter(
-                &mut pending,
-                b"BACKGROUND_PARTIAL<case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
-            )
-            .as_ref(),
-            b"BACKGROUND_PARTIAL<\r\n"
+            PendingSlashGuardEcho::filter(&mut pending, &line).as_ref(),
+            line
         );
+        assert!(pending.is_some());
+    }
+
+    #[test]
+    fn complete_guard_match_preserves_preceding_angle_bracket() {
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
+        assert!(PendingSlashGuardEcho::filter(
+            &mut pending,
+            b"BACKGROUND_PARTIAL<case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n"
+        )
+        .is_empty());
+        let resolution = resolve(&mut pending);
+        assert_eq!(resolution.prefix, b"BACKGROUND_PARTIAL<");
+        assert_eq!(resolution.suffix, b"\r\n");
     }
 
     #[test]
@@ -296,12 +524,12 @@ mod tests {
 
     #[test]
     fn mismatch_and_cap_fail_open() {
-        let mut mismatch = Some(PendingSlashGuardEcho::new());
+        let mut mismatch = Some(PendingSlashGuardEcho::new(b""));
         let bytes = vec![b'x'; MAX_PENDING_BYTES];
         assert_eq!(PendingSlashGuardEcho::filter(&mut mismatch, &bytes), bytes);
         assert!(mismatch.is_none());
 
-        let mut marker = Some(PendingSlashGuardEcho::new());
+        let mut marker = Some(PendingSlashGuardEcho::new(b""));
         assert!(PendingSlashGuardEcho::filter(&mut marker, b"partial").is_empty());
         assert_eq!(PendingSlashGuardEcho::flush(&mut marker), b"partial");
         assert!(marker.is_none());
@@ -309,7 +537,7 @@ mod tests {
 
     #[test]
     fn line_cap_preserves_every_non_matching_line() {
-        let mut pending = Some(PendingSlashGuardEcho::new());
+        let mut pending = Some(PendingSlashGuardEcho::new(b""));
         for _ in 0..MAX_PENDING_LINES {
             assert_eq!(
                 PendingSlashGuardEcho::filter(&mut pending, b"background\r\n").as_ref(),
@@ -317,5 +545,77 @@ mod tests {
             );
         }
         assert!(pending.is_none());
+    }
+
+    #[test]
+    fn guard_command_stays_in_sync_with_bash() {
+        let guard = std::str::from_utf8(GUARD_COMMAND).expect("ASCII guard command");
+        let bash = include_str!("../marker/bash.sh");
+
+        assert_eq!(bash.matches(guard).count(), 2);
+        assert!(GUARD_COMMAND.ends_with(GUARD_REDRAW_TAIL));
+        assert!(GUARD_COMMAND.ends_with(MIN_PROVEN_HSCROLL_SUFFIX));
+    }
+
+    #[test]
+    fn display_replacement_rejects_unbounded_or_control_text() {
+        assert!(safe_display_command("/mode"));
+        assert!(safe_display_command("/mode\targ"));
+        assert!(!safe_display_command(""));
+        assert!(!safe_display_command("/mode\nnext"));
+        assert!(!safe_display_command(&"x".repeat(MAX_PENDING_BYTES + 1)));
+    }
+
+    #[test]
+    fn direct_suffix_proof_controls_authenticated_command_insertion() {
+        let guard = b"guard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n";
+
+        let mut exact = Some(PendingSlashGuardEcho::new(b"guard$ /mode\r\n"));
+        assert!(PendingSlashGuardEcho::filter(&mut exact, guard).is_empty());
+        assert!(!resolve(&mut exact).insert_command);
+
+        let mut private_rewrite = Some(PendingSlashGuardEcho::new(
+            b"guard$ /mode\x08\x08\x08\x08\x08 /mode\x08\x08\x08\x08\x08/mode\r\n",
+        ));
+        assert!(PendingSlashGuardEcho::filter(&mut private_rewrite, guard).is_empty());
+        assert!(!resolve(&mut private_rewrite).insert_command);
+
+        let mut rewrite_mismatch = Some(PendingSlashGuardEcho::new(
+            b"guard$ /mode\x08\x08\x08\x08 /mode\x08\x08\x08\x08\x08/mode\r\n",
+        ));
+        assert!(PendingSlashGuardEcho::filter(&mut rewrite_mismatch, guard).is_empty());
+        assert!(resolve(&mut rewrite_mismatch).insert_command);
+
+        let mut dirty = Some(PendingSlashGuardEcho::new(b"guard$ /mo\x1b[?2004hde\r\n"));
+        assert!(PendingSlashGuardEcho::filter(&mut dirty, guard).is_empty());
+        assert!(resolve(&mut dirty).insert_command);
+    }
+
+    #[test]
+    fn narrow_hscroll_proof_requires_the_exact_unique_boundary() {
+        let boundary = b"<in set -x ;; *) : ;; esac";
+        let below_boundary = b"<n set -x ;; *) : ;; esac";
+        let near_miss = b"<in set +x ;; *) : ;; esac";
+        assert_eq!(boundary.len() - 1, MIN_PROVEN_HSCROLL_SUFFIX.len());
+        assert_eq!(
+            PendingSlashGuardEcho::unique_static_guard_start(boundary),
+            Some(0)
+        );
+        assert_eq!(
+            PendingSlashGuardEcho::unique_static_guard_start(below_boundary),
+            None
+        );
+        assert_eq!(
+            PendingSlashGuardEcho::unique_static_guard_start(near_miss),
+            None
+        );
+
+        let mut ambiguous = GUARD_REDRAW_TAIL.to_vec();
+        ambiguous.extend_from_slice(b" unrelated ");
+        ambiguous.extend_from_slice(boundary);
+        assert_eq!(
+            PendingSlashGuardEcho::unique_static_guard_start(&ambiguous),
+            None
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -383,25 +383,83 @@ fn slash_guard_echo_requires_an_authenticated_one_shot_arm() {
         .feed(SENTINEL_LINE)
         .expect("feed sentinel after wrong-session arm");
     assert_eq!(wrong_session.display.resident_slice(), SENTINEL_LINE);
+
+    let mut wrong_reason = parser_for_test("slash-guard-wrong-reason");
+    wrong_reason
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07guard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed trusted arm");
+    wrong_reason
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\",\"reason\":\"natural_language\"}\x07")
+        .expect("feed wrong intercept kind");
+    assert_eq!(wrong_reason.display.resident_slice(), b"guard$ \r\n");
 }
 
 #[test]
 fn slash_guard_echo_keeps_the_original_line_exactly_once() {
     let mut parser = parser_for_test("slash-guard-display");
-    parser.feed(b"guard$ /mode").expect("feed original line");
     parser
-        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07guard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
         .expect("feed guarded redisplay");
+    assert!(parser.display.is_empty());
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\",\"reason\":\"slash\"}\x07")
+        .expect("resolve guarded redisplay");
     assert_eq!(parser.display.resident_slice(), b"guard$ /mode\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"guard$ \r\n");
+}
+
+#[test]
+fn slash_guard_echo_does_not_duplicate_an_already_painted_direct_line() {
+    let mut parser = parser_for_test("slash-guard-direct-display");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"precmd\",\"t\":\"test-marker-token\",\"status\":0}\x07guard$ /mode\r\n\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07guard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed direct line and guarded redisplay");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\",\"reason\":\"slash\"}\x07")
+        .expect("resolve direct slash input");
+
+    assert_eq!(
+        parser.display.resident_slice(),
+        b"guard$ /mode\r\nguard$ \r\n"
+    );
+    assert_eq!(
+        parser.clean.resident_slice(),
+        b"guard$ /mode\r\nguard$ \r\n"
+    );
+}
+
+#[test]
+fn slash_guard_echo_restores_tabbed_input_only_to_display() {
+    let mut parser = parser_for_test("slash-guard-tabbed-display");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07guard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .expect("feed tabbed guard redraw");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\\targ\",\"reason\":\"slash\"}\x07")
+        .expect("resolve tabbed slash input");
+
+    assert_eq!(parser.display.resident_slice(), b"guard$ /mode\targ\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"guard$ \r\n");
 }
 
 #[test]
 fn slash_guard_echo_preserves_complete_background_lines() {
     let mut parser = parser_for_test("slash-guard-background");
     parser
-        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07background\r\n<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
+        .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07background\r\nguard$ case $- in *x*) builtin set +x; builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\nAFTER\r\n")
         .expect("feed background output before guarded redisplay");
-    assert_eq!(parser.display.resident_slice(), b"background\r\n\r\n");
+    assert_eq!(parser.display.resident_slice(), b"background\r\n");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\",\"reason\":\"slash\"}\x07")
+        .expect("resolve background ordering");
+    assert_eq!(
+        parser.display.resident_slice(),
+        b"background\r\nguard$ /mode\r\nAFTER\r\n"
+    );
+    assert_eq!(
+        parser.clean.resident_slice(),
+        b"background\r\nguard$ \r\nAFTER\r\n"
+    );
     assert!(!parser
         .display
         .resident_slice()
@@ -415,10 +473,19 @@ fn slash_guard_echo_preserves_carriage_return_partial_output_in_both_streams() {
     parser
         .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07BEFORE\rBACKGROUND_PARTIAL<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
         .expect("feed CR partial output before horizontally scrolled guard");
+    assert!(parser.display.is_empty());
+    parser
+        .feed(b"\x1b]1337;COSH;{\"e\":\"intercept\",\"t\":\"test-marker-token\",\"command\":\"/mode\",\"reason\":\"slash\"}\x07")
+        .expect("resolve CR partial output");
     assert_eq!(
         parser.display.resident_slice(),
-        b"BEFORE\rBACKGROUND_PARTIAL\r\n"
+        b"BEFORE\rBACKGROUND_PARTIAL/mode\r\n"
     );
+    assert!(!parser
+        .clean
+        .resident_slice()
+        .windows(b"/mode".len())
+        .any(|window| window == b"/mode"));
     assert!(parser
         .clean
         .resident_slice()
@@ -438,7 +505,7 @@ fn authenticated_slash_guard_echo_handles_fragmentation_and_fails_open() {
     parser
         .feed(b"__cosh_slash_guard__; builtin set -x ;; *) : ;; esac    \x08\x08\r\nfollowing")
         .expect("finish shadow echo");
-    assert_eq!(parser.display.resident_slice(), b"\r\n");
+    assert!(parser.display.is_empty());
     parser
         .feed(b"\x1b]1337;COSH;{\"event\":\"prompt_ready\",\"token\":\"test-marker-token\",\"session_id\":\"slash-guard-fragmented\"}\x07")
         .expect("flush following output at lifecycle boundary");
@@ -457,6 +524,10 @@ fn authenticated_slash_guard_echo_handles_fragmentation_and_fails_open() {
     nested
         .feed(b"\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07partial\x1b]1337;COSH;{\"e\":\"slash_guard\",\"t\":\"test-marker-token\"}\x07<builtin true __cosh_slash_guard__; builtin set -x ;; *) : ;; esac\r\n")
         .expect("feed nested arm");
+    assert_eq!(nested.display.resident_slice(), b"partial");
+    nested
+        .feed(b"\x1b]1337;COSH;{\"e\":\"prompt_ready\",\"t\":\"test-marker-token\"}\x07")
+        .expect("flush nested arm without intercept");
     assert_eq!(nested.display.resident_slice(), b"partial\r\n");
 
     let mut capped = parser_for_test("slash-guard-cap");

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host.rs
@@ -31,8 +31,8 @@ mod support_shell_host;
 use support_shell_host::{
     assert_clean_shell_output_ref, assert_fullscreen_terminal_modes_balanced, assert_no_osc_marker,
     assert_no_synthetic_terminal_restore_after_interrupt, ledger_from_output,
-    ledger_output_refs_text, make_executable, shell_arg, stty_flag_probe, unique_suffix,
-    DelayedInput,
+    ledger_output_refs_text, make_executable, render_terminal_screen, shell_arg, stty_flag_probe,
+    unique_suffix, DelayedInput,
 };
 
 fn bash_supports_command_not_found_handler() -> bool {

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -1,5 +1,187 @@
 use super::*;
 
+fn xtrace_record_contains_secret(rendered: &str, trace_prefix: &str, secret: &str) -> bool {
+    rendered
+        .split(['\r', '\n'])
+        .any(|record| record.contains(trace_prefix) && record.contains(secret))
+}
+
+fn exact_screen_text_occurrences(screen: &str, expected: &str) -> usize {
+    screen
+        .match_indices(expected)
+        .filter(|(start, _)| {
+            screen
+                .as_bytes()
+                .get(start + expected.len())
+                .is_none_or(|next| !next.is_ascii_alphanumeric())
+        })
+        .count()
+}
+
+#[test]
+fn xtrace_secret_scan_treats_cr_as_a_record_boundary() {
+    let separate_echo = " /auth SECRET\r...\rxxtrace-guard: command\r\n";
+    let traced_secret = " /auth SECRET\r...\rxxtrace-guard: command SECRET\r\n";
+
+    assert!(!xtrace_record_contains_secret(
+        separate_echo,
+        "xtrace-guard:",
+        "SECRET"
+    ));
+    assert!(xtrace_record_contains_secret(
+        traced_secret,
+        "xtrace-guard:",
+        "SECRET"
+    ));
+}
+
+#[test]
+fn terminal_screen_redraw_erases_typed_line_and_cursor_ghost() {
+    let output = concat!(
+        "[root@host ~]# /mode",
+        "\x1b7\x1b[2m hint\x1b[0m\x1b8",
+        "\r\x1b[K",
+        "[root@host ~]# builtin true __cosh_slash_guard__\r\n"
+    );
+
+    let screen = render_terminal_screen(output.as_bytes(), 200, 50);
+    assert_eq!(
+        screen
+            .iter()
+            .filter(|line| line.contains("]# /mode"))
+            .count(),
+        0
+    );
+    assert_eq!(
+        screen.first().map(String::as_str),
+        Some("[root@host ~]# builtin true __cosh_slash_guard__")
+    );
+
+    let scrolled = render_terminal_screen(b"first\r\nsecond\r\nthird", 20, 2);
+    assert_eq!(scrolled, ["second", "third"]);
+
+    let tabbed = render_terminal_screen(b"a\tb", 20, 2);
+    assert_eq!(tabbed.first().map(String::as_str), Some("a       b"));
+}
+
+#[test]
+fn raw_relay_bash_renders_direct_slash_submission_exactly_once() {
+    assert_bash_slash_screen(
+        "bash-direct-slash-screen",
+        "/mode",
+        200,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line("/mode"),
+            RawRelayAction::wait(Duration::from_millis(600)),
+        ],
+    );
+}
+
+#[test]
+fn raw_relay_bash_renders_recalled_slash_submission_exactly_once() {
+    assert_bash_slash_screen(
+        "bash-recalled-slash-screen",
+        "/mode",
+        200,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::write(b"\x1b[A".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::write(b"\n".to_vec()),
+            RawRelayAction::wait(Duration::from_millis(600)),
+        ],
+    );
+}
+
+#[test]
+fn raw_relay_bash_renders_wrapped_ascii_slash_submission_exactly_once() {
+    let command = "/mode aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    assert_bash_slash_screen(
+        "bash-wrapped-ascii-slash-screen",
+        command,
+        40,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line(command),
+            RawRelayAction::wait(Duration::from_millis(600)),
+        ],
+    );
+}
+
+fn assert_bash_slash_screen(
+    test_id: &str,
+    command: &str,
+    width: u16,
+    mut actions: Vec<RawRelayAction>,
+) {
+    let root = std::env::temp_dir().join(format!(
+        "cosh-shell-{test_id}-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ));
+    let home = root.join("home");
+    let work_dir = root.join("work");
+    std::fs::create_dir_all(&home).expect("home");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n\
+         PS1='[root@host ~]# '\n",
+    )
+    .expect("bashrc");
+    std::fs::write(home.join(".bash_history"), format!("{command}\n")).expect("history");
+
+    let mut config =
+        ShellHostConfig::new(test_id, &work_dir).with_env("HOME", home.display().to_string());
+    config.slash_via_shell = true;
+    config.winsize.ws_col = width;
+    config.winsize.ws_row = 50;
+    let mut rendered = Vec::new();
+    actions.push(RawRelayAction::line("exit"));
+    let output = run_raw_relay_bash_with_actions(&config, actions, &mut rendered)
+        .expect("slash screen relay");
+
+    // The enhanced shell adds a UTF-8 ownership glyph outside PS1. Remove
+    // that decoration so this oracle exercises only ASCII column semantics.
+    let ascii_rendered: Vec<u8> = rendered.iter().copied().filter(u8::is_ascii).collect();
+    let screen = render_terminal_screen(&ascii_rendered, usize::from(width), 50);
+    assert_eq!(
+        exact_screen_text_occurrences(&screen.concat(), command),
+        1,
+        "screen: {screen:#?}"
+    );
+    assert!(
+        screen
+            .iter()
+            .all(|line| !line.contains("__cosh_slash_guard__")),
+        "screen: {screen:#?}"
+    );
+    assert!(
+        !rendered
+            .windows(b"__cosh_slash_guard__".len())
+            .any(|window| window == b"__cosh_slash_guard__"),
+        "raw terminal bytes leaked the internal slash guard"
+    );
+    assert!(
+        !rendered
+            .windows(b"in set -x ;; *) : ;; esac".len())
+            .any(|window| window == b"in set -x ;; *) : ;; esac"),
+        "raw terminal bytes leaked the horizontally scrolled slash guard"
+    );
+    assert!(output.events.iter().any(|event| {
+        event.kind == ShellEventKind::UserInputIntercepted
+            && event.input.as_deref() == Some(command)
+            && event.component.as_deref() == Some("slash")
+    }));
+    let history = std::fs::read_to_string(home.join(".bash_history")).expect("history");
+    assert!(history.lines().any(|line| line == command), "{history}");
+    assert!(!history.contains("__cosh_slash_guard__"), "{history}");
+
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
 #[test]
 fn raw_relay_bash_invalid_utf8_never_enters_event_provenance() {
     let work_dir = std::env::temp_dir().join(format!(
@@ -375,18 +557,29 @@ fn raw_relay_bash_xtrace_hides_guard_protocol_and_sentinel() {
     let home = root.join("home");
     let work_dir = root.join("work");
     std::fs::create_dir_all(&home).expect("home");
-    std::fs::write(home.join(".bashrc"), "PS4='xtrace-guard: '; set -x\n").expect("bashrc");
+    std::fs::write(
+        home.join(".bashrc"),
+        "export HISTFILE=\"$HOME/.bash_history\"\n\
+         export HISTSIZE=1000\n\
+         shopt -s histappend\n\
+         PS4='xtrace-guard: '; set -x\n",
+    )
+    .expect("bashrc");
 
     let mut config = ShellHostConfig::new("bash-xtrace-guard", &work_dir)
         .with_env("HOME", home.display().to_string());
     config.slash_via_shell = true;
     let mut rendered = Vec::new();
+    let secret = "sk-test-private-2942";
+    let private_auth = format!(" /auth {secret}");
     let xtrace_probe = "case $- in *x*) probe=ON ;; *) probe=OFF ;; esac; \
                         printf '__XTRACE_%s__\\n' \"$probe\"; unset probe";
     let output = run_raw_relay_bash_with_actions(
         &config,
         vec![
             RawRelayAction::wait(Duration::from_millis(200)),
+            RawRelayAction::line(private_auth),
+            RawRelayAction::wait(Duration::from_millis(600)),
             RawRelayAction::line("/mode"),
             RawRelayAction::wait(Duration::from_millis(600)),
             RawRelayAction::line(xtrace_probe),
@@ -403,6 +596,19 @@ fn raw_relay_bash_xtrace_hides_guard_protocol_and_sentinel() {
             && event.input.as_deref() == Some("/mode")
             && event.component.as_deref() == Some("slash")
     }));
+    assert!(
+        output.events.iter().any(|event| {
+            event.kind == ShellEventKind::UserInputIntercepted
+                && event.component.as_deref() == Some("slash")
+                && event.input.as_deref() == Some("<redacted>")
+                && event
+                    .routing
+                    .as_ref()
+                    .is_some_and(|routing| routing.sensitive)
+        }),
+        "events: {:#?}\nrendered: {rendered_text}",
+        output.events
+    );
     assert!(output.events.iter().any(|event| {
         event.kind == ShellEventKind::CommandStarted
             && event.command.as_deref() == Some(xtrace_probe)
@@ -416,12 +622,31 @@ fn raw_relay_bash_xtrace_hides_guard_protocol_and_sentinel() {
         "xtrace leaked the authenticated marker protocol: {rendered_text}"
     );
     assert!(
+        !xtrace_record_contains_secret(&rendered_text, "xtrace-guard:", secret),
+        "xtrace leaked the private slash input: {rendered_text}"
+    );
+    assert!(
         rendered_text.contains("__XTRACE_ON__"),
         "slash guard did not preserve xtrace: {rendered_text}"
     );
     assert!(
         !rendered_text.contains("__XTRACE_OFF__"),
         "slash guard disabled the user's xtrace state: {rendered_text}"
+    );
+    let history = std::fs::read_to_string(home.join(".bash_history")).unwrap_or_default();
+    assert!(
+        !history.contains(secret),
+        "private history leaked: {history}"
+    );
+    let journal = std::fs::read_to_string(&output.journal_path).expect("journal");
+    assert!(
+        !journal.contains(secret),
+        "journal leaked private slash input"
+    );
+    let evidence = ledger_output_refs_text(&ledger_from_output(&output));
+    assert!(
+        !evidence.contains(secret),
+        "evidence leaked private slash input"
     );
 
     std::fs::remove_dir_all(root).expect("cleanup");

--- a/src/cosh-ng/crates/cosh-shell/tests/support/shell_host.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/support/shell_host.rs
@@ -41,6 +41,143 @@ pub(crate) fn assert_no_osc_marker(output: &[u8]) {
         .any(|window| window == b"\x1b]1337;COSH;"));
 }
 
+/// Models observed ASCII bytes and controls, not Unicode cell widths or graphemes.
+pub(crate) fn render_terminal_screen(output: &[u8], width: usize, height: usize) -> Vec<String> {
+    assert!(width > 0, "terminal width must be non-zero");
+    assert!(height > 0, "terminal height must be non-zero");
+    let mut rows = vec![Vec::<u8>::new(); height];
+    let (mut row, mut column, mut index) = (0usize, 0usize, 0usize);
+    let mut saved_cursor = None;
+
+    while index < output.len() {
+        match output[index] {
+            b'\r' => {
+                column = 0;
+                index += 1;
+            }
+            b'\n' => {
+                terminal_line_feed(&mut rows, &mut row);
+                column = 0;
+                index += 1;
+            }
+            b'\x08' => {
+                column = column.saturating_sub(1);
+                index += 1;
+            }
+            b'\t' => {
+                column = (((column / 8) + 1) * 8).min(width - 1);
+                index += 1;
+            }
+            b'\x1b' if output.get(index + 1) == Some(&b']') => {
+                index += 2;
+                while index < output.len() {
+                    if output[index] == b'\x07' {
+                        index += 1;
+                        break;
+                    }
+                    if output[index] == b'\x1b' && output.get(index + 1) == Some(&b'\\') {
+                        index += 2;
+                        break;
+                    }
+                    index += 1;
+                }
+            }
+            b'\x1b' if output.get(index + 1) == Some(&b'[') => {
+                let params_start = index + 2;
+                index = params_start;
+                while index < output.len() && !(0x40..=0x7e).contains(&output[index]) {
+                    index += 1;
+                }
+                if index == output.len() {
+                    break;
+                }
+                let final_byte = output[index];
+                let params = &output[params_start..index];
+                let first = terminal_csi_param(params, 0, 1);
+                match final_byte {
+                    b'A' => row = row.saturating_sub(first),
+                    b'B' => row = (row + first).min(height - 1),
+                    b'C' => column = (column + first).min(width - 1),
+                    b'D' => column = column.saturating_sub(first),
+                    b'G' => column = first.saturating_sub(1).min(width - 1),
+                    b'H' | b'f' => {
+                        row = terminal_csi_param(params, 0, 1)
+                            .saturating_sub(1)
+                            .min(height - 1);
+                        column = terminal_csi_param(params, 1, 1).saturating_sub(1);
+                        column = column.min(width - 1);
+                    }
+                    b'K' => {
+                        let mode = terminal_csi_param(params, 0, 0);
+                        match mode {
+                            1 => {
+                                let end = column.saturating_add(1).min(rows[row].len());
+                                rows[row][..end].fill(b' ');
+                            }
+                            2 => rows[row].clear(),
+                            _ => rows[row].truncate(column),
+                        }
+                    }
+                    _ => {}
+                }
+                index += 1;
+            }
+            b'\x1b' if output.get(index + 1) == Some(&b'7') => {
+                saved_cursor = Some((row, column));
+                index += 2;
+            }
+            b'\x1b' if output.get(index + 1) == Some(&b'8') => {
+                if let Some((saved_row, saved_column)) = saved_cursor {
+                    row = saved_row;
+                    column = saved_column;
+                }
+                index += 2;
+            }
+            b'\x1b' => index += usize::from(index + 1 < output.len()) + 1,
+            byte if byte >= b' ' => {
+                if column == width {
+                    terminal_line_feed(&mut rows, &mut row);
+                    column = 0;
+                }
+                if rows[row].len() <= column {
+                    rows[row].resize(column + 1, b' ');
+                }
+                rows[row][column] = byte;
+                column += 1;
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    rows.into_iter()
+        .map(|mut row| {
+            while row.last() == Some(&b' ') {
+                row.pop();
+            }
+            String::from_utf8_lossy(&row).into_owned()
+        })
+        .collect()
+}
+
+fn terminal_line_feed(rows: &mut [Vec<u8>], row: &mut usize) {
+    if *row + 1 < rows.len() {
+        *row += 1;
+    } else {
+        rows.rotate_left(1);
+        rows.last_mut().expect("non-empty terminal").clear();
+    }
+}
+
+fn terminal_csi_param(params: &[u8], index: usize, default: usize) -> usize {
+    params
+        .split(|byte| *byte == b';')
+        .nth(index)
+        .and_then(|value| std::str::from_utf8(value).ok())
+        .and_then(|value| value.trim_start_matches('?').parse().ok())
+        .unwrap_or(default)
+}
+
 pub(crate) fn assert_clean_shell_output_ref(block: &CommandBlock, expected: &str) {
     let output_ref = block
         .output


### PR DESCRIPTION
## Why

#2943 suppresses the internal slash-guard sentinel, but Bash Readline still erases the original slash line, so the terminal-rendered contract remains at zero visible `]# /mode` occurrences. The fix is needed to restore the pre-regression exactly-once display contract without weakening history, routing, or dirty Readline handling.

## What changed

The authenticated slash intercept now resolves a bounded pending guard redraw with the authoritative `READLINE_LINE`. Dirty paths such as Up recall rebuild the line in the display stream only, while a strict pre-arm suffix proof avoids duplicating direct submissions that Readline already painted, including the exact Home-Space-End repaint emitted by the private-history binding on recalled submissions. Horizontally scrolled guard redraws require an exact, unique static suffix; the proven lower bound covers the 25-byte tail observed in a 40-column ASCII PTY, while shorter, approximate, or ambiguous text still fails open. Background and `set -v` output remain ordered, invalid or incomplete state falls back to suppress-only output, and xtrace is disabled before reading sensitive input and restored on every exit path.

## Related issue

closes #2942

## User / Agent impact

Direct, recalled, and narrow-terminal slash commands remain visible exactly once before their panel, while the internal guard and horizontally scrolled wrapper tail stay absent from external terminal bytes, history, journal, and evidence output. Slash routing and command suppression behavior are unchanged.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

Sensitive slash input is no longer expanded by Bash xtrace before the widget disables it. Replacement text comes only from an authenticated slash intercept, accepts tab as ordinary terminal whitespace, rejects other controls and oversized content, and is written to display rather than clean/evidence storage. The short horizontal-scroll rule remains constrained by the authenticated one-shot window, exact static suffix matching, and uniqueness checks.

## Validation

Linux, focused `cosh-shell` validation after rebasing onto `up/main@10a79215`:

- `cargo test --locked -p cosh-shell --lib slash_guard_echo -- --nocapture` — 26 passed
- `cargo test --locked -p cosh-shell --test shell_host raw_relay_bash -- --test-threads=4` — 31 passed
- Real PTY screen regressions cover direct input, Up recall, and a 40x50 wrapped ASCII submission; each requires the authenticated command exactly once and rejects raw sentinel and short wrapper-tail bytes
- PTY coverage also includes Ctrl-O, vi mode, partial and carriage-return DEBUG output, `set -v`, and sensitive xtrace behavior
- Parser regressions cover direct deduplication, exact private-binding repaint recognition, dirty reconstruction,/ tabbed input, background ordering, repeated Bash 4.4 horizontal-scroll redraws, a narrow first redraw, near misses, ambiguity, fragmentation, caps, and display/clean separation
- Sensitive xtrace regression splits CR and LF terminal records and reaches event, history, journal, and evidence redaction assertions
- Test screen renderer models the observed ASCII/control subset and implements 8-column tab stops; it is not a general Unicode/grapheme emulator
- `cargo clippy --locked -p cosh-shell --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n crates/cosh-shell/src/shell_host/marker/bash.sh`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check up/main...HEAD`

## Documentation and rollback

No public documentation changes are required because this restores the existing terminal display contract. Roll back by reverting `ef4af93c`.