### PR TITLE
fix(anolisa): honor sandbox remove dry-run

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -328,13 +328,7 @@ fn validate_global_args_with_euid(
             .dry_run_policy()
             .is_some_and(|dry_run| !dry_run.is_supported())
     {
-        return Err(CliError::InvalidArgument {
-            command: policy.label.to_string(),
-            reason: format!(
-                "command '{}' does not support --dry-run; no action was taken",
-                policy.label
-            ),
-        });
+        return Err(unsupported_dry_run_error(policy.label));
     }
 
     match policy.scope {
@@ -359,6 +353,13 @@ fn validate_global_args_with_euid(
     }
 
     Ok(())
+}
+
+pub(crate) fn unsupported_dry_run_error(command: &str) -> CliError {
+    CliError::InvalidArgument {
+        command: command.to_string(),
+        reason: format!("command '{command}' does not support --dry-run; no action was taken"),
+    }
 }
 
 fn root_user_mode_error(command: &str) -> CliError {
@@ -474,7 +475,13 @@ fn command_policy(command: &Commands) -> CommandPolicy {
             ManagementCommands::Env(_) => CommandPolicy::new("env", CommandScope::ReadOnly),
             ManagementCommands::Bug(_) => CommandPolicy::new("bug", CommandScope::ReadOnly),
             ManagementCommands::Osbase(args) => {
-                CommandPolicy::new("osbase", osbase_command_scope(args))
+                let label = match &args.command {
+                    osbase::OsbaseCommands::Sandbox(osbase::SandboxArgs {
+                        command: osbase::SandboxCommands::Remove { .. },
+                    }) => "osbase sandbox remove",
+                    _ => "osbase",
+                };
+                CommandPolicy::new(label, osbase_command_scope(args))
             }
             ManagementCommands::System(args) => {
                 CommandPolicy::new("system", system_command_scope(args))

--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -97,7 +97,7 @@ pub enum SandboxCommands {
         #[arg(long)]
         purge: bool,
 
-        /// Print removal plan without executing
+        /// Request a removal preview; currently fails closed without executing
         #[arg(long)]
         dry_run: bool,
     },
@@ -199,7 +199,15 @@ fn sandbox_request(command: SandboxCommands, global_dry_run: bool) -> SandboxReq
             scenario,
             intent: execution_intent(dry_run || global_dry_run),
         },
-        SandboxCommands::Remove { target, purge, .. } => SandboxRequest::Remove { target, purge },
+        SandboxCommands::Remove {
+            target,
+            purge,
+            dry_run,
+        } => SandboxRequest::Remove {
+            target,
+            purge,
+            intent: execution_intent(dry_run || global_dry_run),
+        },
         SandboxCommands::List { .. } => unreachable!(),
         SandboxCommands::Status { target, .. } => SandboxRequest::Status { target },
     }
@@ -325,6 +333,32 @@ mod tests {
                     assert_eq!(intent, expected_intent);
                 }
                 _ => panic!("uninstall command must map to an uninstall request"),
+            }
+        }
+    }
+
+    #[test]
+    fn sandbox_remove_combines_global_and_local_dry_run() {
+        for (global_dry_run, local_dry_run, expected_intent) in [
+            (false, false, ExecutionIntent::Apply),
+            (false, true, ExecutionIntent::Plan),
+            (true, false, ExecutionIntent::Plan),
+            (true, true, ExecutionIntent::Plan),
+        ] {
+            let request = sandbox_request(
+                SandboxCommands::Remove {
+                    target: "gvisor".to_string(),
+                    purge: true,
+                    dry_run: local_dry_run,
+                },
+                global_dry_run,
+            );
+
+            match request {
+                SandboxRequest::Remove { intent, .. } => {
+                    assert_eq!(intent, expected_intent);
+                }
+                _ => panic!("remove command must map to a remove request"),
             }
         }
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase/application.rs
@@ -11,6 +11,7 @@ use anolisa_core::system_helper::HelperRequest;
 use anolisa_platform::ipc::SYSTEM_HELPER_SOCKET;
 use anolisa_platform::privilege;
 
+use crate::commands::unsupported_dry_run_error;
 use crate::helper_client::{HelperClient, HelperClientError, HelperOperationOutcome};
 use crate::response::CliError;
 
@@ -28,8 +29,12 @@ pub(super) enum SandboxRequest {
         scenario: String,
         intent: ExecutionIntent,
     },
-    /// Remove one sandbox scenario through the helper.
-    Remove { target: String, purge: bool },
+    /// Remove one sandbox scenario through the helper or reject its preview.
+    Remove {
+        target: String,
+        purge: bool,
+        intent: ExecutionIntent,
+    },
     /// Query sandbox status through the helper.
     Status { target: Option<String> },
 }
@@ -112,6 +117,16 @@ fn run_with_dependencies<F>(
 where
     F: FnOnce() -> Result<HelperClient, HelperClientError>,
 {
+    if matches!(
+        &request,
+        SandboxRequest::Remove {
+            intent: ExecutionIntent::Plan,
+            ..
+        }
+    ) {
+        return Err(unsupported_dry_run_error("osbase sandbox remove"));
+    }
+
     match preflight_with(connect, is_root)? {
         ExecutionMode::ViaHelper(mut client) => execute_via_helper(request, &mut client, output),
         ExecutionMode::Direct => execute_direct(request, direct),
@@ -155,7 +170,7 @@ fn execute_via_helper(
                 "osbase sandbox uninstall",
             )
         }
-        SandboxRequest::Remove { target, purge } => (
+        SandboxRequest::Remove { target, purge, .. } => (
             HelperRequest::OsbaseRemove {
                 scenario: target,
                 purge,
@@ -317,7 +332,7 @@ fn map_osbase_error(error: OsbaseInstallError, action: &str, target: &str) -> Cl
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::collections::VecDeque;
     use std::io;
     use std::path::PathBuf;
@@ -458,6 +473,42 @@ mod tests {
     }
 
     #[test]
+    fn remove_preview_rejects_before_connection_for_root_and_non_root() {
+        for is_root in [false, true] {
+            let connected = Cell::new(false);
+            let direct = FakeDirectExecutor::default();
+            let mut events = Vec::new();
+            let error = run_with_dependencies(
+                SandboxRequest::Remove {
+                    target: "gvisor".to_string(),
+                    purge: true,
+                    intent: ExecutionIntent::Plan,
+                },
+                || {
+                    connected.set(true);
+                    Err(connect_error())
+                },
+                is_root,
+                &direct,
+                &mut |event| events.push(event),
+            )
+            .expect_err("remove preview must fail closed");
+
+            assert!(!connected.get(), "preview must not connect to the helper");
+            assert!(events.is_empty());
+            assert!(direct.install_requests.borrow().is_empty());
+            assert!(direct.uninstall_requests.borrow().is_empty());
+            assert_eq!(error.command(), "osbase sandbox remove");
+            assert_eq!(error.code(), "INVALID_ARGUMENT");
+            assert_eq!(error.exit_code(), 2);
+            assert_eq!(
+                error.reason(),
+                "command 'osbase sandbox remove' does not support --dry-run; no action was taken"
+            );
+        }
+    }
+
+    #[test]
     fn helper_install_preserves_request_and_scenario_event() {
         let (client, sent) = client_with_responses(vec![
             HelperResponse::HandshakeOk {
@@ -547,6 +598,7 @@ mod tests {
                 SandboxRequest::Remove {
                     target: "gvisor".to_string(),
                     purge: true,
+                    intent: ExecutionIntent::Apply,
                 },
                 HelperRequest::OsbaseRemove {
                     scenario: "gvisor".to_string(),
@@ -804,6 +856,7 @@ mod tests {
             SandboxRequest::Remove {
                 target: "runc".to_string(),
                 purge: false,
+                intent: ExecutionIntent::Apply,
             },
             SandboxRequest::Status { target: None },
         ] {
@@ -812,5 +865,19 @@ mod tests {
                     .expect_err("direct operation remains unavailable");
             assert!(matches!(error, CliError::NotImplemented { .. }));
         }
+
+        let error = run_with_dependencies(
+            SandboxRequest::Remove {
+                target: "runc".to_string(),
+                purge: false,
+                intent: ExecutionIntent::Apply,
+            },
+            || Err(connect_error()),
+            false,
+            &direct,
+            &mut |_| {},
+        )
+        .expect_err("non-root remove requires the helper");
+        assert!(matches!(error, CliError::PermissionDenied { .. }));
     }
 }

--- a/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
@@ -107,6 +107,85 @@ fn handler_errors_use_human_labels_without_exposing_machine_codes() {
     assert_eq!(Some("INVALID_ARGUMENT"), envelope["error"]["code"].as_str());
 }
 
+#[test]
+fn sandbox_remove_local_and_global_dry_run_fail_closed_in_human_output() {
+    let help = run(&["osbase", "sandbox", "remove", "--help"]);
+    assert_eq!(Some(0), help.status.code());
+    assert!(
+        String::from_utf8_lossy(&help.stdout)
+            .contains("Request a removal preview; currently fails closed without executing")
+    );
+
+    let invocations: &[&[&str]] = &[
+        &[
+            "--no-color",
+            "osbase",
+            "sandbox",
+            "remove",
+            "gvisor",
+            "--dry-run",
+        ],
+        &[
+            "--no-color",
+            "--dry-run",
+            "osbase",
+            "sandbox",
+            "remove",
+            "gvisor",
+        ],
+    ];
+
+    for arguments in invocations {
+        let output = run(arguments);
+
+        assert_eq!(Some(2), output.status.code());
+        assert!(output.stdout.is_empty());
+        assert_eq!(
+            "error: command 'osbase sandbox remove' does not support --dry-run; no action was taken\n",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn sandbox_remove_local_and_global_dry_run_share_the_json_error() {
+    let invocations: &[&[&str]] = &[
+        &[
+            "--json",
+            "osbase",
+            "sandbox",
+            "remove",
+            "gvisor",
+            "--dry-run",
+        ],
+        &[
+            "--json",
+            "--dry-run",
+            "osbase",
+            "sandbox",
+            "remove",
+            "gvisor",
+        ],
+    ];
+
+    for arguments in invocations {
+        let output = run(arguments);
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("error output must remain valid JSON");
+
+        assert_eq!(Some(2), output.status.code());
+        assert!(output.stderr.is_empty());
+        assert_eq!(Some(false), envelope["ok"].as_bool());
+        assert_eq!(Some(1), envelope["schema_version"].as_u64());
+        assert_eq!(Some("osbase sandbox remove"), envelope["command"].as_str());
+        assert_eq!(Some("INVALID_ARGUMENT"), envelope["error"]["code"].as_str());
+        assert_eq!(
+            Some("command 'osbase sandbox remove' does not support --dry-run; no action was taken"),
+            envelope["error"]["reason"].as_str()
+        );
+    }
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn help_reports_stdout_failure_when_output_device_is_full() {


### PR DESCRIPTION
## Why

`anolisa osbase sandbox remove` exposed `--dry-run` but discarded the command-local flag before building the helper request. That left the application boundary able to dispatch a real `OsbaseRemove` request for an invocation that promised no effects.

## What changed

Carry local and global dry-run into `SandboxRequest::Remove` as `ExecutionIntent`, then reject plan intent before helper connection, handshake, or root fallback. Reuse the global policy's fail-closed error, keep the apply wire request unchanged, and update CLI help plus human/JSON regression coverage.

## Related issue

closes #2940

## User / Agent impact

Local and global remove dry-run invocations now return `INVALID_ARGUMENT` with exit code 2 and explicitly state that no action was taken. Real remove invocations retain their existing helper and fallback behavior.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

The behavior change is limited to remove preview requests. The helper protocol, JSON schema, apply request, root fallback, and other osbase commands are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- ALinux 4: osbase tests (15 passed) and sandbox remove human/JSON tests (2 passed), with no network, read-only source, and an isolated target directory
- After fast-forwarding to the latest `upstream/main`, reran fmt, diff, workspace check, osbase tests, and sandbox remove CLI tests

## Documentation and rollback

The command's built-in help now describes the fail-closed preview behavior. The local Chinese refactoring roadmap remains intentionally untracked and is not part of this PR. Roll back by reverting this commit; no data migration is required.
