### PR TITLE
fix(ci): map Maturin manifest into Cross

### DIFF
--- a/.github/actions/build-tokenless-prebuilt/build.sh
+++ b/.github/actions/build-tokenless-prebuilt/build.sh
@@ -206,6 +206,7 @@ PYTHON_RTK_DIR="$COMPONENT_ROOT/python/tokenless/python/anolisa_tokenless/_bin"
     TOKENLESS_CROSS_PROFILE_SCRIPT="$COMMON_DIR/cross-profile.sh" \
     TOKENLESS_CROSS_PROFILE="$PROFILE" \
     TOKENLESS_RUST_TARGET="$RUST_TARGET" \
+    TOKENLESS_CARGO_MANIFEST="$COMPONENT_ROOT/python/tokenless/Cargo.toml" \
         python3 "$COMMON_DIR/reproducible-build.py" \
             --source-root "$COMPONENT_ROOT" \
             --source-date-epoch "$SOURCE_DATE_EPOCH" \

--- a/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
+++ b/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
@@ -11,6 +11,7 @@ HOST_CARGO="${TOKENLESS_HOST_CARGO:?TOKENLESS_HOST_CARGO is required}"
 CROSS_PROFILE_SCRIPT="${TOKENLESS_CROSS_PROFILE_SCRIPT:?TOKENLESS_CROSS_PROFILE_SCRIPT is required}"
 PROFILE="${TOKENLESS_CROSS_PROFILE:?TOKENLESS_CROSS_PROFILE is required}"
 EXPECTED_TARGET="${TOKENLESS_RUST_TARGET:?TOKENLESS_RUST_TARGET is required}"
+EXPECTED_MANIFEST="${TOKENLESS_CARGO_MANIFEST:?TOKENLESS_CARGO_MANIFEST is required}"
 
 case "$PROFILE/$EXPECTED_TARGET" in
     gnu2.17-x86_64/x86_64-unknown-linux-gnu | \
@@ -42,6 +43,24 @@ case "${1:-}" in
                     requested_target="${1#--target=}"
                     [ "$requested_target" = "$EXPECTED_TARGET" ] || \
                         die "Maturin requested target $requested_target, expected $EXPECTED_TARGET"
+                    shift
+                    ;;
+                --manifest-path)
+                    [ "$#" -ge 2 ] || die '--manifest-path requires a value'
+                    [ "$2" = "$EXPECTED_MANIFEST" ] || \
+                        die "Maturin requested unexpected manifest path: $2"
+                    [ "$PWD/Cargo.toml" = "$EXPECTED_MANIFEST" ] || \
+                        die "Maturin Cargo manifest is not in the current directory"
+                    arguments+=(--manifest-path Cargo.toml)
+                    shift 2
+                    ;;
+                --manifest-path=*)
+                    requested_manifest="${1#--manifest-path=}"
+                    [ "$requested_manifest" = "$EXPECTED_MANIFEST" ] || \
+                        die "Maturin requested unexpected manifest path: $requested_manifest"
+                    [ "$PWD/Cargo.toml" = "$EXPECTED_MANIFEST" ] || \
+                        die "Maturin Cargo manifest is not in the current directory"
+                    arguments+=(--manifest-path=Cargo.toml)
                     shift
                     ;;
                 *)

--- a/.github/actions/build-tokenless-prebuilt/test.sh
+++ b/.github/actions/build-tokenless-prebuilt/test.sh
@@ -73,6 +73,8 @@ for binding in (
 ):
     if binding not in wrapped_command:
         raise SystemExit(f"Maturin reproducible build is missing: {binding}")
+if 'TOKENLESS_CARGO_MANIFEST="$COMPONENT_ROOT/python/tokenless/Cargo.toml"' not in build:
+    raise SystemExit("Maturin Cargo shim does not bind the expected manifest")
 PY
 
 python3 - "$REPO_ROOT/.github/actions/package-source/action.yaml" <<'PY'
@@ -364,6 +366,9 @@ fi
 
 SHIM_LOG="$TEMPORARY/cargo-shim.log"
 SHIM_RUSTFLAGS_LOG="$TEMPORARY/cargo-shim-rustflags.log"
+SHIM_COMPONENT="$TEMPORARY/shim-component"
+install -d -m 0755 "$SHIM_COMPONENT"
+touch "$SHIM_COMPONENT/Cargo.toml"
 # shellcheck disable=SC2016  # Expand shim arguments and log paths in the fakes.
 printf '%s\n' \
     '#!/usr/bin/env bash' \
@@ -384,16 +389,22 @@ SHIM_ENV=(
     TOKENLESS_CROSS_PROFILE_SCRIPT="$FAKE_BIN/cross-profile"
     TOKENLESS_CROSS_PROFILE=gnu2.17-x86_64
     TOKENLESS_RUST_TARGET=x86_64-unknown-linux-gnu
+    TOKENLESS_CARGO_MANIFEST="$SHIM_COMPONENT/Cargo.toml"
     CARGO_ENCODED_RUSTFLAGS=--remap-path-prefix=/source=/workspace
     SHIM_LOG="$SHIM_LOG"
     SHIM_RUSTFLAGS_LOG="$SHIM_RUSTFLAGS_LOG"
 )
 env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" metadata --locked
-env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
-    --target x86_64-unknown-linux-gnu --profile python-release
+(
+    cd "$SHIM_COMPONENT"
+    env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+        --target x86_64-unknown-linux-gnu \
+        --manifest-path "$SHIM_COMPONENT/Cargo.toml" \
+        --profile python-release
+)
 grep -Fxq 'cargo <metadata> <--locked>' "$SHIM_LOG"
 grep -Fxq \
-    'cross <gnu2.17-x86_64> <rustc> <--profile> <python-release>' \
+    'cross <gnu2.17-x86_64> <rustc> <--manifest-path> <Cargo.toml> <--profile> <python-release>' \
     "$SHIM_LOG"
 grep -Fxq -- '--remap-path-prefix=/source=/workspace' "$SHIM_RUSTFLAGS_LOG"
 if env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
@@ -406,6 +417,15 @@ fi
     printf 'ERROR: Cargo shim target executed a command\n' >&2
     exit 1
 }
+if (
+    cd "$SHIM_COMPONENT"
+    env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+        --target x86_64-unknown-linux-gnu \
+        --manifest-path "$TEMPORARY/other/Cargo.toml"
+) >"$TEMPORARY/shim-manifest.log" 2>&1; then
+    printf 'ERROR: unexpected Cargo shim manifest path was accepted\n' >&2
+    exit 1
+fi
 
 python3 "$ACTION_DIR/test_verify_wheels.py"
 


### PR DESCRIPTION
## Why

The first real Tokenless wheel backfill after #2934 failed on all three Cross profiles because Maturin passed the historical worktree absolute `Cargo.toml` path into the containers. The path exists on the runner but not inside Cross, so every native wheel stopped after the raw binaries completed.

## What changed

Bind the exact expected manifest to the Cargo shim and rewrite only that host absolute path to relative `Cargo.toml` before entering Cross. Unexpected manifest and target paths continue to fail closed, with regression coverage for both accepted and rejected paths.

## Related issue

no-issue: follow-up to merged PR #2934 and failed preview run [33139755203](https://github.com/alibaba/anolisa/actions/runs/33139755203)

## User / Agent impact

No public API change. Tokenless release and historical preview jobs can build native wheels through the existing Cross profiles.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The rewrite is restricted to the exact manifest already selected by the build action; all other paths are rejected.

## Validation

- Failed preview run reproduced the same missing absolute manifest path on Linux x86_64, Linux aarch64, and macOS arm64.
- `env RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= .github/actions/build-tokenless-prebuilt/test.sh`
- `python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `shellcheck` and `bash -n` on the changed shell scripts
- `git diff --check`

## Documentation and rollback

No documentation changes. Revert this commit to restore the previous shim behavior.