### PR TITLE
fix(ci): map Cross Cargo output paths

### DIFF
--- a/.github/actions/build-tokenless-prebuilt/build.sh
+++ b/.github/actions/build-tokenless-prebuilt/build.sh
@@ -207,6 +207,8 @@ PYTHON_RTK_DIR="$COMPONENT_ROOT/python/tokenless/python/anolisa_tokenless/_bin"
     TOKENLESS_CROSS_PROFILE="$PROFILE" \
     TOKENLESS_RUST_TARGET="$RUST_TARGET" \
     TOKENLESS_CARGO_MANIFEST="$COMPONENT_ROOT/python/tokenless/Cargo.toml" \
+    TOKENLESS_CROSS_PROJECT_ROOT="$COMPONENT_ROOT" \
+    TOKENLESS_CARGO_OUTPUT_REWRITER="$ACTION_DIR/rewrite-cross-cargo-output.py" \
         python3 "$COMMON_DIR/reproducible-build.py" \
             --source-root "$COMPONENT_ROOT" \
             --source-date-epoch "$SOURCE_DATE_EPOCH" \

--- a/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
+++ b/.github/actions/build-tokenless-prebuilt/cargo-shim.sh
@@ -12,6 +12,8 @@ CROSS_PROFILE_SCRIPT="${TOKENLESS_CROSS_PROFILE_SCRIPT:?TOKENLESS_CROSS_PROFILE_
 PROFILE="${TOKENLESS_CROSS_PROFILE:?TOKENLESS_CROSS_PROFILE is required}"
 EXPECTED_TARGET="${TOKENLESS_RUST_TARGET:?TOKENLESS_RUST_TARGET is required}"
 EXPECTED_MANIFEST="${TOKENLESS_CARGO_MANIFEST:?TOKENLESS_CARGO_MANIFEST is required}"
+PROJECT_ROOT="${TOKENLESS_CROSS_PROJECT_ROOT:?TOKENLESS_CROSS_PROJECT_ROOT is required}"
+OUTPUT_REWRITER="${TOKENLESS_CARGO_OUTPUT_REWRITER:?TOKENLESS_CARGO_OUTPUT_REWRITER is required}"
 
 case "$PROFILE/$EXPECTED_TARGET" in
     gnu2.17-x86_64/x86_64-unknown-linux-gnu | \
@@ -22,6 +24,8 @@ esac
 [ -x "$HOST_CARGO" ] || die "host Cargo is not executable: $HOST_CARGO"
 [ -x "$CROSS_PROFILE_SCRIPT" ] || \
     die "Cross profile script is not executable: $CROSS_PROFILE_SCRIPT"
+[ -d "$PROJECT_ROOT" ] || die "Cross project root is not a directory: $PROJECT_ROOT"
+[ -f "$OUTPUT_REWRITER" ] || die "Cargo output rewriter is not a file: $OUTPUT_REWRITER"
 
 case "${1:-}" in
     metadata | locate-project | --version | -V)
@@ -69,7 +73,8 @@ case "${1:-}" in
                     ;;
             esac
         done
-        exec "$CROSS_PROFILE_SCRIPT" "$PROFILE" "$command_name" "${arguments[@]}"
+        "$CROSS_PROFILE_SCRIPT" "$PROFILE" "$command_name" "${arguments[@]}" | \
+            python3 "$OUTPUT_REWRITER" "$PROJECT_ROOT"
         ;;
     *)
         die "unsupported Maturin Cargo command: ${1:-<empty>}"

--- a/.github/actions/build-tokenless-prebuilt/rewrite-cross-cargo-output.py
+++ b/.github/actions/build-tokenless-prebuilt/rewrite-cross-cargo-output.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Map Cross container paths in Cargo JSON messages back to host paths."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: rewrite-cross-cargo-output.py PROJECT_ROOT")
+
+    project_root = os.fsencode(sys.argv[1])
+    if not os.path.isabs(project_root):
+        raise SystemExit("PROJECT_ROOT must be absolute")
+
+    replacements = (
+        (b"path+file:///project", b"path+file://" + project_root),
+        (b'"/project', b'"' + project_root),
+        (b'"/target', b'"' + project_root + b"/target"),
+    )
+    for line in sys.stdin.buffer:
+        for source, destination in replacements:
+            line = line.replace(source, destination)
+        sys.stdout.buffer.write(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/build-tokenless-prebuilt/test.sh
+++ b/.github/actions/build-tokenless-prebuilt/test.sh
@@ -75,6 +75,10 @@ for binding in (
         raise SystemExit(f"Maturin reproducible build is missing: {binding}")
 if 'TOKENLESS_CARGO_MANIFEST="$COMPONENT_ROOT/python/tokenless/Cargo.toml"' not in build:
     raise SystemExit("Maturin Cargo shim does not bind the expected manifest")
+if 'TOKENLESS_CROSS_PROJECT_ROOT="$COMPONENT_ROOT"' not in build:
+    raise SystemExit("Maturin Cargo shim does not bind the Cross project root")
+if 'TOKENLESS_CARGO_OUTPUT_REWRITER="$ACTION_DIR/rewrite-cross-cargo-output.py"' not in build:
+    raise SystemExit("Maturin Cargo shim does not bind the output rewriter")
 PY
 
 python3 - "$REPO_ROOT/.github/actions/package-source/action.yaml" <<'PY'
@@ -369,6 +373,9 @@ SHIM_RUSTFLAGS_LOG="$TEMPORARY/cargo-shim-rustflags.log"
 SHIM_COMPONENT="$TEMPORARY/shim-component"
 install -d -m 0755 "$SHIM_COMPONENT"
 touch "$SHIM_COMPONENT/Cargo.toml"
+SHIM_BIN="$SHIM_COMPONENT/target/maturin-cargo-shim"
+install -d -m 0755 "$SHIM_BIN"
+ln -s "$ACTION_DIR/cargo-shim.sh" "$SHIM_BIN/cargo"
 # shellcheck disable=SC2016  # Expand shim arguments and log paths in the fakes.
 printf '%s\n' \
     '#!/usr/bin/env bash' \
@@ -382,6 +389,7 @@ printf '%s\n' \
     'printf " <%s>" "$@" >> "$SHIM_LOG"' \
     'printf "\n" >> "$SHIM_LOG"' \
     'printf "%s\n" "${CARGO_ENCODED_RUSTFLAGS:-}" >> "$SHIM_RUSTFLAGS_LOG"' \
+    'printf "%s\n" '\''{"reason":"compiler-artifact","package_id":"path+file:///project#tokenless-python@0.7.14","filenames":["/target/x86_64-unknown-linux-gnu/python-release/libanolisa_tokenless.so"],"manifest_path":"/project/Cargo.toml"}'\''' \
     > "$FAKE_BIN/cross-profile"
 chmod 0755 "$FAKE_BIN/host-cargo" "$FAKE_BIN/cross-profile"
 SHIM_ENV=(
@@ -390,24 +398,34 @@ SHIM_ENV=(
     TOKENLESS_CROSS_PROFILE=gnu2.17-x86_64
     TOKENLESS_RUST_TARGET=x86_64-unknown-linux-gnu
     TOKENLESS_CARGO_MANIFEST="$SHIM_COMPONENT/Cargo.toml"
+    TOKENLESS_CROSS_PROJECT_ROOT="$SHIM_COMPONENT"
+    TOKENLESS_CARGO_OUTPUT_REWRITER="$ACTION_DIR/rewrite-cross-cargo-output.py"
     CARGO_ENCODED_RUSTFLAGS=--remap-path-prefix=/source=/workspace
     SHIM_LOG="$SHIM_LOG"
     SHIM_RUSTFLAGS_LOG="$SHIM_RUSTFLAGS_LOG"
 )
-env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" metadata --locked
+env "${SHIM_ENV[@]}" "$SHIM_BIN/cargo" metadata --locked
+SHIM_OUTPUT="$TEMPORARY/cargo-shim-output.json"
 (
     cd "$SHIM_COMPONENT"
-    env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+    env "${SHIM_ENV[@]}" "$SHIM_BIN/cargo" rustc \
         --target x86_64-unknown-linux-gnu \
         --manifest-path "$SHIM_COMPONENT/Cargo.toml" \
-        --profile python-release
+        --profile python-release > "$SHIM_OUTPUT"
 )
 grep -Fxq 'cargo <metadata> <--locked>' "$SHIM_LOG"
 grep -Fxq \
     'cross <gnu2.17-x86_64> <rustc> <--manifest-path> <Cargo.toml> <--profile> <python-release>' \
     "$SHIM_LOG"
 grep -Fxq -- '--remap-path-prefix=/source=/workspace' "$SHIM_RUSTFLAGS_LOG"
-if env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+grep -Fq \
+    "\"package_id\":\"path+file://$SHIM_COMPONENT#tokenless-python@0.7.14\"" \
+    "$SHIM_OUTPUT"
+grep -Fq \
+    "\"filenames\":[\"$SHIM_COMPONENT/target/x86_64-unknown-linux-gnu/python-release/libanolisa_tokenless.so\"]" \
+    "$SHIM_OUTPUT"
+grep -Fq "\"manifest_path\":\"$SHIM_COMPONENT/Cargo.toml\"" "$SHIM_OUTPUT"
+if env "${SHIM_ENV[@]}" "$SHIM_BIN/cargo" rustc \
     --target "x86_64-unknown-linux-gnu;\$(touch ${MARKER})" \
     >"$TEMPORARY/shim-target.log" 2>&1; then
     printf 'ERROR: mismatched Cargo shim target was accepted\n' >&2
@@ -419,7 +437,7 @@ fi
 }
 if (
     cd "$SHIM_COMPONENT"
-    env "${SHIM_ENV[@]}" "$ACTION_DIR/cargo-shim.sh" rustc \
+    env "${SHIM_ENV[@]}" "$SHIM_BIN/cargo" rustc \
         --target x86_64-unknown-linux-gnu \
         --manifest-path "$TEMPORARY/other/Cargo.toml"
 ) >"$TEMPORARY/shim-manifest.log" 2>&1; then


### PR DESCRIPTION
## Why

The Tokenless v0.7.14 preview run built the native library in Cross but Maturin
discarded its Cargo artifact messages because their `/project` package IDs did
not match host Cargo metadata. The run then failed with a misleading missing
`cdylib` error.

## What changed

Map Cross's fixed `/project` and `/target` paths back to the tagged host
worktree while streaming Cargo JSON through the existing Maturin shim. Add a
regression fixture covering package IDs, artifact filenames, and manifest paths.

## Related issue

Related to #2837; does not close it.

## User / Agent impact

No public API change. Tokenless preview and release workflows can package the
three supported native Python wheels after Cross compilation.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. Rewriting is limited to Cargo's JSON stdout and Cross's fixed container
mount prefixes.

## Validation

- `env RUSTC_WRAPPER= CARGO_BUILD_RUSTC_WRAPPER= .github/actions/build-tokenless-prebuilt/test.sh`
- `python3 .github/actions/prebuilt-rust-common/test_plan_matrix.py`
- `bash -n .github/actions/build-tokenless-prebuilt/{build.sh,cargo-shim.sh,test.sh}`
- `shellcheck .github/actions/build-tokenless-prebuilt/{build.sh,cargo-shim.sh,test.sh}`
- `git diff --check`
- Reproduced on preview run #33141221170 across Linux x86_64, Linux aarch64,
  and macOS arm64

## Documentation and rollback

No documentation change. Revert commit `50ae402d` to restore the previous shim
behavior.