### PR TITLE
fix(anolisa): validate local osbase dry-run

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -202,7 +202,7 @@ fn render_grouped_help(cap: &[(String, String)], mgmt: &[(String, String)]) -> S
 /// `args` struct.
 pub fn dispatch(cli: Cli, ctx: &CliContext) -> Result<(), CliError> {
     let policy = command_policy(&cli.command);
-    validate_global_args(&cli, ctx, policy)?;
+    validate_command_args(&cli, ctx, policy)?;
     match cli.command {
         Commands::Component(cmd) => match cmd {
             ComponentCommands::List(args) => tier1::list::handle(args, ctx),
@@ -279,24 +279,42 @@ impl CommandPolicy {
     }
 }
 
-fn validate_global_args(
+fn validate_command_args(
     cli: &Cli,
     ctx: &CliContext,
     policy: CommandPolicy,
 ) -> Result<(), CliError> {
-    validate_global_args_with_euid(
+    validate_command_args_with_euid(
         ctx,
         policy,
         anolisa_platform::privilege::effective_uid(),
         cli.install_mode.is_some(),
+        ctx.dry_run || command_local_dry_run(&cli.command),
     )
 }
 
+#[cfg(test)]
 fn validate_global_args_with_euid(
     ctx: &CliContext,
     policy: CommandPolicy,
     effective_uid: u32,
     install_mode_explicit: bool,
+) -> Result<(), CliError> {
+    validate_command_args_with_euid(
+        ctx,
+        policy,
+        effective_uid,
+        install_mode_explicit,
+        ctx.dry_run,
+    )
+}
+
+fn validate_command_args_with_euid(
+    ctx: &CliContext,
+    policy: CommandPolicy,
+    effective_uid: u32,
+    install_mode_explicit: bool,
+    dry_run_requested: bool,
 ) -> Result<(), CliError> {
     if let Some(prefix) = &ctx.prefix
         && !is_safe_absolute_path(prefix)
@@ -322,7 +340,7 @@ fn validate_global_args_with_euid(
         _ => {}
     }
 
-    if ctx.dry_run
+    if dry_run_requested
         && policy
             .scope
             .dry_run_policy()
@@ -334,13 +352,13 @@ fn validate_global_args_with_euid(
     match policy.scope {
         CommandScope::ReadOnly => {}
         CommandScope::ModeScopedMutation { dry_run } => {
-            let dry_run_preview = ctx.dry_run && dry_run.waives_root();
+            let dry_run_preview = dry_run_requested && dry_run.waives_root();
             if ctx.install_mode == InstallMode::System && effective_uid != 0 && !dry_run_preview {
                 return Err(system_permission_error(ctx, policy.label, true));
             }
         }
         CommandScope::SystemOnlyMutation { dry_run } => {
-            let dry_run_preview = ctx.dry_run && dry_run.waives_root();
+            let dry_run_preview = dry_run_requested && dry_run.waives_root();
             if effective_uid != 0 && !dry_run_preview {
                 return Err(system_permission_error(ctx, policy.label, false));
             }
@@ -353,6 +371,31 @@ fn validate_global_args_with_euid(
     }
 
     Ok(())
+}
+
+fn command_local_dry_run(command: &Commands) -> bool {
+    let Commands::Management(ManagementCommands::Osbase(args)) = command else {
+        return false;
+    };
+
+    match &args.command {
+        osbase::OsbaseCommands::Kernel(kernel) => match &kernel.command {
+            osbase::KernelCommands::Install { dry_run } => *dry_run,
+            osbase::KernelCommands::Remove | osbase::KernelCommands::Status => false,
+        },
+        osbase::OsbaseCommands::Sandbox(sandbox) => match &sandbox.command {
+            osbase::SandboxCommands::Install { dry_run, .. }
+            | osbase::SandboxCommands::Uninstall { dry_run, .. }
+            | osbase::SandboxCommands::Remove { dry_run, .. } => *dry_run,
+            osbase::SandboxCommands::List { .. } | osbase::SandboxCommands::Status { .. } => false,
+        },
+        osbase::OsbaseCommands::Security(security) => match &security.command {
+            osbase::SecurityCommands::Install { dry_run, .. } => *dry_run,
+            osbase::SecurityCommands::Remove { .. } | osbase::SecurityCommands::Status { .. } => {
+                false
+            }
+        },
+    }
 }
 
 pub(crate) fn unsupported_dry_run_error(command: &str) -> CliError {
@@ -476,9 +519,15 @@ fn command_policy(command: &Commands) -> CommandPolicy {
             ManagementCommands::Bug(_) => CommandPolicy::new("bug", CommandScope::ReadOnly),
             ManagementCommands::Osbase(args) => {
                 let label = match &args.command {
+                    osbase::OsbaseCommands::Kernel(osbase::KernelArgs {
+                        command: osbase::KernelCommands::Install { .. },
+                    }) => "osbase kernel install",
                     osbase::OsbaseCommands::Sandbox(osbase::SandboxArgs {
                         command: osbase::SandboxCommands::Remove { .. },
                     }) => "osbase sandbox remove",
+                    osbase::OsbaseCommands::Security(osbase::SecurityArgs {
+                        command: osbase::SecurityCommands::Install { .. },
+                    }) => "osbase security install",
                     _ => "osbase",
                 };
                 CommandPolicy::new(label, osbase_command_scope(args))
@@ -616,6 +665,92 @@ mod tests {
                 ..Default::default()
             },
         )
+    }
+
+    #[test]
+    fn command_local_dry_run_covers_every_local_osbase_flag() {
+        let commands: &[&[&str]] = &[
+            &["anolisa", "osbase", "kernel", "install"],
+            &["anolisa", "osbase", "sandbox", "install", "gvisor"],
+            &["anolisa", "osbase", "sandbox", "uninstall", "gvisor"],
+            &["anolisa", "osbase", "sandbox", "remove", "gvisor"],
+            &["anolisa", "osbase", "security", "install", "loongshield"],
+        ];
+
+        for arguments in commands {
+            let cli = Cli::try_parse_from(*arguments).expect("command without local dry-run");
+            assert!(!command_local_dry_run(&cli.command));
+
+            let mut with_dry_run = arguments.to_vec();
+            with_dry_run.push("--dry-run");
+            let cli = Cli::try_parse_from(with_dry_run).expect("command with local dry-run");
+            assert!(command_local_dry_run(&cli.command));
+        }
+
+        let cli = Cli::try_parse_from(["anolisa", "osbase", "kernel", "status"])
+            .expect("read-only command");
+        assert!(!command_local_dry_run(&cli.command));
+    }
+
+    #[test]
+    fn unsupported_osbase_install_dry_runs_match_for_local_global_root_and_non_root() {
+        let cases: &[(&str, &[&str])] = &[
+            (
+                "osbase kernel install",
+                &["anolisa", "osbase", "kernel", "install", "--dry-run"],
+            ),
+            (
+                "osbase kernel install",
+                &["anolisa", "--dry-run", "osbase", "kernel", "install"],
+            ),
+            (
+                "osbase security install",
+                &[
+                    "anolisa",
+                    "osbase",
+                    "security",
+                    "install",
+                    "loongshield",
+                    "--dry-run",
+                ],
+            ),
+            (
+                "osbase security install",
+                &[
+                    "anolisa",
+                    "--dry-run",
+                    "osbase",
+                    "security",
+                    "install",
+                    "loongshield",
+                ],
+            ),
+        ];
+
+        for (label, arguments) in cases {
+            let cli = Cli::try_parse_from(*arguments).expect("valid dry-run command");
+            let mut ctx = ctx_with_prefix(PathBuf::from("/"));
+            ctx.dry_run = cli.dry_run;
+            let dry_run_requested = ctx.dry_run || command_local_dry_run(&cli.command);
+
+            for effective_uid in [0, 1000] {
+                let err = validate_command_args_with_euid(
+                    &ctx,
+                    command_policy(&cli.command),
+                    effective_uid,
+                    true,
+                    dry_run_requested,
+                )
+                .expect_err("unsupported local and global dry-run must fail closed");
+
+                assert_eq!(err.code(), "INVALID_ARGUMENT");
+                assert_eq!(err.command(), *label);
+                assert_eq!(
+                    err.reason(),
+                    format!("command '{label}' does not support --dry-run; no action was taken")
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/osbase.rs
@@ -38,6 +38,7 @@ pub struct KernelArgs {
 pub enum KernelCommands {
     /// Install kernel modules and eBPF programs
     Install {
+        /// Request an install preview; currently fails closed without executing
         #[arg(long)]
         dry_run: bool,
     },
@@ -134,6 +135,7 @@ pub enum SecurityCommands {
     Install {
         /// Target: loongshield, seccomp-profiles
         target: String,
+        /// Request an install preview; currently fails closed without executing
         #[arg(long)]
         dry_run: bool,
     },

--- a/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
+++ b/src/anolisa/crates/anolisa-cli/tests/clap_output.rs
@@ -186,6 +186,97 @@ fn sandbox_remove_local_and_global_dry_run_share_the_json_error() {
     }
 }
 
+#[test]
+fn unsupported_osbase_install_dry_runs_share_human_and_json_errors() {
+    for help_args in [
+        &["osbase", "kernel", "install", "--help"][..],
+        &["osbase", "security", "install", "--help"][..],
+    ] {
+        let help = run(help_args);
+        assert_eq!(Some(0), help.status.code());
+        assert!(
+            String::from_utf8_lossy(&help.stdout)
+                .contains("Request an install preview; currently fails closed without executing")
+        );
+    }
+
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "osbase kernel install",
+            &["osbase", "kernel", "install", "--dry-run"],
+        ),
+        (
+            "osbase kernel install",
+            &["--dry-run", "osbase", "kernel", "install"],
+        ),
+        (
+            "osbase security install",
+            &["osbase", "security", "install", "loongshield", "--dry-run"],
+        ),
+        (
+            "osbase security install",
+            &["--dry-run", "osbase", "security", "install", "loongshield"],
+        ),
+    ];
+
+    for (command, arguments) in cases {
+        let reason = format!("command '{command}' does not support --dry-run; no action was taken");
+        for json in [false, true] {
+            let mut invocation = vec![if json { "--json" } else { "--no-color" }];
+            invocation.extend_from_slice(arguments);
+            let output = run(&invocation);
+
+            assert_eq!(Some(2), output.status.code());
+            if json {
+                let envelope: serde_json::Value = serde_json::from_slice(&output.stdout)
+                    .expect("error output must remain valid JSON");
+                assert!(output.stderr.is_empty());
+                assert_eq!(Some(false), envelope["ok"].as_bool());
+                assert_eq!(Some(1), envelope["schema_version"].as_u64());
+                assert_eq!(Some(*command), envelope["command"].as_str());
+                assert_eq!(Some("INVALID_ARGUMENT"), envelope["error"]["code"].as_str());
+                assert_eq!(Some(reason.as_str()), envelope["error"]["reason"].as_str());
+            } else {
+                assert!(output.stdout.is_empty());
+                assert_eq!(
+                    format!("error: {reason}\n"),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn unsupported_osbase_installs_without_dry_run_remain_not_implemented() {
+    let invocations: &[(&str, &[&str])] = &[
+        (
+            "osbase kernel install",
+            &["--json", "osbase", "kernel", "install"],
+        ),
+        (
+            "osbase security install loongshield",
+            &["--json", "osbase", "security", "install", "loongshield"],
+        ),
+    ];
+
+    for (command, arguments) in invocations {
+        let output = run(arguments);
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("error output must remain valid JSON");
+
+        assert_eq!(Some(64), output.status.code());
+        assert!(output.stderr.is_empty());
+        assert_eq!(Some(false), envelope["ok"].as_bool());
+        assert_eq!(Some(*command), envelope["command"].as_str());
+        assert_eq!(Some("NOT_IMPLEMENTED"), envelope["error"]["code"].as_str());
+        assert_eq!(
+            Some(format!("command '{command}' is not implemented").as_str()),
+            envelope["error"]["reason"].as_str()
+        );
+    }
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn help_reports_stdout_failure_when_output_device_is_full() {


### PR DESCRIPTION
## Why

`osbase kernel install` and `osbase security install` exposed command-local `--dry-run`, but dispatch policy only inspected the global flag. Non-root callers could therefore hit permission checks first, while root callers reached the existing `NOT_IMPLEMENTED` handler instead of failing closed consistently.

## What changed

Compute effective dry-run once from the global and command-local flags, then pass it into command-level validation. Unsupported kernel and security install previews now return the same precise `INVALID_ARGUMENT` response before privilege checks or handlers; supported sandbox previews and apply behavior remain unchanged.

## Related issue

Closes #2960
Relates to #2702

## User / Agent impact

Local and global `--dry-run` now behave identically for unsupported osbase installs. Both return exit code 2 without executing; invocations without dry-run retain the existing target-aware `NOT_IMPLEMENTED` response and exit code 64.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The change is limited to pre-dispatch validation for two currently unimplemented install commands. JSON schema, helper protocol, sandbox intent mapping, and apply paths are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- Re-ran focused policy and CLI tests after syncing the latest `upstream/main`
- Ran focused command-policy, human/JSON, and sandbox regression tests in `anolisa/alinux4-rust-selftest:20260824` with no network, read-only source, and an isolated target directory

## Documentation and rollback

Updated the two local flag help strings to state that preview currently fails closed. The local Chinese refactoring roadmap remains untracked and is intentionally excluded from this PR. Roll back by reverting this commit.