### PR TITLE
feat(sight): add --no-ebpf trajectory-only mode

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/cli-reference.md
+++ b/docs/user-guide/en/agent-observability/agentsight/cli-reference.md
@@ -44,6 +44,7 @@ Loads the eBPF probes, discovers Agent processes, and writes captured events to 
 FLAGS:
         --daemon              Run as daemon in background (Linux only)
         --enable-filewatch    Enable file watch probe (monitors .jsonl file opens from traced processes)
+        --no-ebpf             Skip eBPF probes and collect trajectories only (Linux only)
     -v, --verbose             Enable verbose/debug output
 
 OPTIONS:
@@ -58,10 +59,40 @@ sudo agentsight trace
 
 # background with a custom rule file
 sudo agentsight trace --daemon -c /etc/agentsight/config.json
+
+# unprivileged host: trajectory collection only, no root and no CAP_BPF needed
+agentsight trace --no-ebpf
 ```
 
 > Running two tracers at the same time makes both compete for the same uprobes and produces
 > confusing data. Stop `agentsight.service` before starting a foreground tracer.
+
+### Running without privileges (`--no-ebpf`)
+
+Loading the probes requires root or `CAP_BPF`/`CAP_PERFMON`. Without them `trace` stops at probe
+setup and reports `Failed to create probes`. `--no-ebpf` skips the probes and runs only the
+trajectory collector, which is pure user-space: it scans local Agent session files (Claude Code,
+Qoder, QoderWork, Codex), converts them to ATIF v1.7, and stores them in `trajectories.db` for
+`serve` to display.
+
+What this mode does **not** provide: token metering, audit events, interruption detection, and
+process or TLS traffic monitoring all come from the probes, so `agentsight token`, `audit`,
+`metrics`, and `interruption` report no new data.
+
+Two behaviours to keep in mind:
+
+- The flag implies trajectory collection even when `features.trajectory_collection.enabled` is
+  `false`, because it is the only remaining data source. `scan_interval_secs` and `scan_dirs` are
+  still read from the configuration file.
+- `trajectories.db` goes to the shared data directory when it is writable, otherwise to
+  `$HOME/.local/share/agentsight/`. Startup prints the resolved path together with the matching
+  `serve --db` command; pass that path to `serve` when the fallback is used. The fallback directory
+  and database are created owner-only (`0700`/`0600`), because trajectories embed full conversation
+  content.
+
+The default scan roots are `/root` and `/home/*`. If the home directory lies elsewhere (a container
+using `/app`, for example), set `features.trajectory_collection.scan_dirs` to the session
+directories explicitly.
 
 ## agentsight serve
 

--- a/docs/user-guide/en/agent-observability/agentsight/troubleshooting.md
+++ b/docs/user-guide/en/agent-observability/agentsight/troubleshooting.md
@@ -17,7 +17,10 @@ journalctl -u agentsight.service -n 50 --no-pager      # what does it complain a
 ## No data at all
 
 **1. The tracer is not running as root.** eBPF attachment fails silently for an unprivileged user
-and you simply see no events. Run `sudo agentsight trace`, or use the packaged service.
+and you simply see no events. Run `sudo agentsight trace`, or use the packaged service. If the
+environment cannot grant privileges at all, `agentsight trace --no-ebpf` still collects trajectories
+(see [CLI reference](cli-reference.md#running-without-privileges---no-ebpf)); token, audit, and
+interruption data remain unavailable.
 
 **2. The kernel has no BTF.** `ls /sys/kernel/btf/vmlinux` must succeed. Without it the CO-RE probes
 cannot load; `journalctl` shows a probe load error.

--- a/docs/user-guide/zh/agent-observability/agentsight/cli-reference.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/cli-reference.md
@@ -43,6 +43,7 @@ SUBCOMMANDS:
 FLAGS:
         --daemon              Run as daemon in background (Linux only)
         --enable-filewatch    Enable file watch probe (monitors .jsonl file opens from traced processes)
+        --no-ebpf             Skip eBPF probes and collect trajectories only (Linux only)
     -v, --verbose             Enable verbose/debug output
 
 OPTIONS:
@@ -57,10 +58,34 @@ sudo agentsight trace
 
 # 后台运行并指定规则文件
 sudo agentsight trace --daemon -c /etc/agentsight/config.json
+
+# 无特权环境：仅采集轨迹，无需 root 与 CAP_BPF
+agentsight trace --no-ebpf
 ```
 
 > 同时跑两个 tracer 会争抢同一批 uprobe，数据也会变得难以解释。启动前台 tracer 前请先停掉
 > `agentsight.service`。
+
+### 无特权运行（`--no-ebpf`）
+
+加载探针需要 root 或 `CAP_BPF`/`CAP_PERFMON`。没有这些权限时，`trace` 会在探针初始化阶段停下并
+报出 `Failed to create probes`。`--no-ebpf` 跳过探针，仅运行纯用户态的轨迹采集器：扫描本地 Agent
+会话文件（Claude Code、Qoder、QoderWork、Codex），转换为 ATIF v1.7 并存入 `trajectories.db`，供
+`serve` 展示。
+
+此模式**不提供**的能力：Token 计量、审计事件、中断检测以及进程与 TLS 流量监控均来自探针，因此
+`agentsight token`、`audit`、`metrics`、`interruption` 查不到新数据。
+
+两个需要注意的行为：
+
+- 即使 `features.trajectory_collection.enabled` 为 `false`，该参数也会强制启用轨迹采集，因为它是此
+  模式下唯一的数据来源。`scan_interval_secs` 和 `scan_dirs` 仍从配置文件读取。
+- `trajectories.db` 在共享数据目录可写时写入该目录，否则写入 `$HOME/.local/share/agentsight/`。
+  启动时会打印实际路径和对应的 `serve --db` 命令；发生回退时需把该路径传给 `serve`。回退目录与
+  数据库按仅属主权限（`0700`/`0600`）创建，因为轨迹内含完整对话内容。
+
+默认扫描根目录是 `/root` 和 `/home/*`。若 home 目录不在这两处（例如容器使用 `/app`），需显式配置
+`features.trajectory_collection.scan_dirs` 指向会话目录。
 
 ## agentsight serve
 

--- a/docs/user-guide/zh/agent-observability/agentsight/troubleshooting.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/troubleshooting.md
@@ -17,7 +17,8 @@ journalctl -u agentsight.service -n 50 --no-pager      # 它在抱怨什么？
 ## 完全没有数据
 
 **1. tracer 不是以 root 运行。** 非特权用户挂载 eBPF 会静默失败，表现就是「没有任何事件」。请用
-`sudo agentsight trace`，或者直接用安装包的服务。
+`sudo agentsight trace`，或者直接用安装包的服务。若环境根本无法提供特权，`agentsight trace --no-ebpf`
+仍然可以采集轨迹（参见 [CLI 参考](cli-reference.md)）；但 Token、审计、中断数据仍然不可用。
 
 **2. 内核没有 BTF。** `ls /sys/kernel/btf/vmlinux` 必须成功。否则 CO-RE 探针无法加载，
 `journalctl` 里会有探针加载失败的报错。

--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -166,7 +166,7 @@ OpenAI Responses API 的 `response.completed` 事件可能跨多个 TLS record�
 
 | 命令 | 入口 | 功能 |
 |------|------|------|
-| `agentsight trace` | `src/bin/cli/trace.rs` | eBPF 追踪（需 root） |
+| `agentsight trace` | `src/bin/cli/trace.rs` | eBPF 追踪（需 root）；`--no-ebpf` 仅跑轨迹采集，无需特权 |
 | `agentsight serve` | `src/bin/cli/serve.rs` | API + Dashboard 服务器 |
 | `agentsight token` | `src/bin/cli/token.rs` | 查询 Token 消耗 |
 | `agentsight audit` | `src/bin/cli/audit.rs` | 查询审计事件 |
@@ -354,7 +354,7 @@ Agent 规则配置文件路径：`/etc/agentsight/config.json`（可通过 `--co
 - Lead with "zero-instrumentation eBPF observability" — the user installs AgentSight and gets full tracing without touching their Agent code. This is the single most important differentiator.
 
 ### Gotchas to Warn About
-- root/CAP_BPF is required for `agentsight trace` — users who forget get silent "no events" behavior. Every usage section must note this.
+- root/CAP_BPF is required for `agentsight trace` — users who forget get silent "no events" behavior. Every usage section must note this. `--no-ebpf` is the unprivileged fallback and runs the trajectory collector alone; never present it as a substitute for eBPF-derived data (token metering, audit, interruption detection).
 - Config file semantics: user-provided `config.json` **replaces** the built-in defaults entirely (no merge). Users who partially customize lose Agent discovery rules for unmentioned Agents.
 
 ### Content Decisions

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -80,11 +80,16 @@ Start tracing of AI agent activity.
 
 **Linux**: Full eBPF-based tracing (probes → parser → aggregator → storage). Also runs trajectory collector if `features.trajectory_collection.enabled` is set.
 
+**Linux without privileges**: `--no-ebpf` skips the probes and runs the trajectory collector alone, so unprivileged sandboxes and containers still collect trajectories. The flag implies trajectory collection regardless of `features.trajectory_collection.enabled`, since it is the only remaining data source. Data derived from eBPF — token metering, audit events, interruption detection — is unavailable in this mode.
+
 **macOS**: Trajectory collection only — scans local JSONL session files (Claude Code, Qoder, Codex, Cursor), converts to ATIF v1.7, and stores in `trajectories.db`. No eBPF.
 
 ```bash
 # Foreground mode
 sudo agentsight trace
+
+# Trajectory collection only — no root, no CAP_BPF required
+agentsight trace --no-ebpf
 
 # Daemon mode with SLS export
 sudo agentsight trace --daemon \
@@ -92,6 +97,8 @@ sudo agentsight trace --daemon \
   --sls-project <project> \
   --sls-logstore <logstore>
 ```
+
+> With `--no-ebpf`, `trajectories.db` is written to the shared data directory when it is writable, otherwise to `$HOME/.local/share/agentsight/`. The startup output prints the resolved path and the matching `serve --db` command.
 
 ### `agentsight token`
 

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -80,11 +80,16 @@ agentsight/
 
 **Linux**：完整 eBPF 追踪（probes → parser → aggregator → storage）。若 `features.trajectory_collection.enabled` 开启，同时运行轨迹采集器。
 
+**Linux 无特权环境**：`--no-ebpf` 跳过探针，仅运行轨迹采集器，使无特权沙箱与容器同样可以采集轨迹。该参数会强制启用轨迹采集，不受 `features.trajectory_collection.enabled` 影响，因为此模式下它是唯一的数据来源。依赖 eBPF 的数据 —— Token 计量、审计事件、中断检测 —— 在此模式下不可用。
+
 **macOS**：仅轨迹采集 — 扫描本地 JSONL 会话文件（Claude Code、Qoder、Codex、Cursor），转换为 ATIF v1.7 格式，存入 `trajectories.db`。无 eBPF。
 
 ```bash
 # 前台模式
 sudo agentsight trace
+
+# 仅轨迹采集 — 无需 root，无需 CAP_BPF
+agentsight trace --no-ebpf
 
 # 守护进程模式，配合 SLS 导出
 sudo agentsight trace --daemon \
@@ -92,6 +97,8 @@ sudo agentsight trace --daemon \
   --sls-project <project> \
   --sls-logstore <logstore>
 ```
+
+> 使用 `--no-ebpf` 时，`trajectories.db` 在共享数据目录可写时写入该目录，否则写入 `$HOME/.local/share/agentsight/`。启动输出会打印实际路径和对应的 `serve --db` 命令。
 
 ### `agentsight token`
 

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -1,6 +1,7 @@
 //! Trace subcommand - agent activity tracing
 //!
-//! Linux: full eBPF-based tracing (probes → parser → aggregator → storage).
+//! Linux: full eBPF-based tracing (probes → parser → aggregator → storage), or
+//! trajectory collection only when `--no-ebpf` is passed.
 //! macOS: trajectory collection only (JSONL file scanning → ATIF → SQLite).
 
 use structopt::StructOpt;
@@ -30,6 +31,17 @@ pub struct TraceCommand {
     #[cfg(target_os = "linux")]
     #[structopt(short, long, default_value = "/etc/agentsight/config.json")]
     pub config: String,
+
+    /// Skip eBPF probes and collect trajectories only (Linux only)
+    ///
+    /// Loading probes needs root or CAP_BPF/CAP_PERFMON, so an unprivileged run
+    /// otherwise aborts at probe setup. Trajectory collection is pure user-space
+    /// and keeps working. This flag implies trajectory collection regardless of
+    /// `features.trajectory_collection.enabled`, since it is the only remaining
+    /// data source in this mode.
+    #[cfg(target_os = "linux")]
+    #[structopt(long)]
+    pub no_ebpf: bool,
 }
 
 impl TraceCommand {
@@ -56,7 +68,19 @@ impl TraceCommand {
             return;
         }
 
-        self.run_tracing();
+        self.run_selected_mode();
+    }
+
+    /// Dispatch to the eBPF pipeline or the probe-free trajectory collector.
+    ///
+    /// Shared by the foreground and daemon paths so `--no-ebpf` also applies
+    /// when running in the background.
+    fn run_selected_mode(&self) {
+        if self.no_ebpf {
+            self.run_trajectory_only();
+        } else {
+            self.run_tracing();
+        }
     }
 
     /// Run as daemon process
@@ -73,7 +97,7 @@ impl TraceCommand {
 
         match daemonize.start() {
             Ok(_) => {
-                self.run_tracing();
+                self.run_selected_mode();
             }
             Err(e) => {
                 eprintln!("Failed to daemonize: {e}");
@@ -129,5 +153,167 @@ impl TraceCommand {
             }
         }
         // `sight` drops here → Storage::drop → checkpoint
+    }
+
+    /// Collect trajectories without loading eBPF probes.
+    ///
+    /// Mirrors the macOS trace path (agent JSONL sessions → ATIF →
+    /// `trajectories.db`) so unprivileged Linux sandboxes still produce
+    /// trajectory data. Blocks until Ctrl+C.
+    fn run_trajectory_only(&self) {
+        use agentsight::AgentsightConfig;
+        use agentsight_trajectory_collector::{CollectorConfig, run_collector_loop};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let config_path = std::path::PathBuf::from(&self.config);
+        let mut config = AgentsightConfig::new()
+            .set_verbose(self.verbose)
+            .set_config_path(config_path.clone());
+        // Scan interval and directories still come from the config file.
+        // `ensure_default_agents_config` only materialises the default file; an
+        // unprivileged run cannot write /etc/agentsight, and the load result
+        // below reports whether any config was picked up.
+        let _ = agentsight::config::ensure_default_agents_config(&config_path);
+        let load_result = config.load_from_file(&config_path);
+        config.apply_verbose();
+        if let Err(e) = load_result {
+            log::warn!("Config {config_path:?} unavailable ({e}); using built-in defaults");
+        }
+
+        let Some(db_path) = Self::resolve_trajectory_db_path() else {
+            eprintln!(
+                "Failed to open a writable trajectories.db in either the shared \
+                 directory or $HOME; pass a writable HOME or grant write access."
+            );
+            std::process::exit(1);
+        };
+
+        let collector_config = CollectorConfig {
+            scan_interval_secs: config.features.trajectory_scan_interval_secs,
+            scan_dirs: config
+                .features
+                .trajectory_scan_dirs
+                .as_ref()
+                .map(|dirs| dirs.iter().map(std::path::PathBuf::from).collect()),
+            db_path: db_path.clone(),
+        };
+
+        // `run_collector_loop` treats the flag as "keep running", so Ctrl+C
+        // clears it instead of setting it.
+        let running = Arc::new(AtomicBool::new(true));
+        let stop = Arc::clone(&running);
+        // A missing handler only costs the graceful stop, so the collector still
+        // runs; say so instead of aborting a working collection.
+        if let Err(e) = ctrlc::set_handler(move || {
+            stop.store(false, Ordering::SeqCst);
+        }) {
+            eprintln!("Could not install the Ctrl+C handler ({e}); stop with SIGTERM instead.");
+        }
+
+        // Printed rather than logged: the collector is the only output of this
+        // mode, and the log level may suppress info records.
+        println!("eBPF disabled (--no-ebpf): collecting trajectories only.");
+        println!(
+            "Database: {} (scan interval {}s)",
+            db_path.display(),
+            collector_config.scan_interval_secs
+        );
+        // `serve` derives trajectories.db from the --db directory, so a
+        // non-default location has to be passed through explicitly.
+        if let Some(dir) = db_path.parent() {
+            println!(
+                "View with: agentsight serve --db {}/genai_events.db",
+                dir.display()
+            );
+        }
+        println!("Press Ctrl+C to stop.");
+
+        run_collector_loop(&collector_config, &running);
+    }
+
+    /// Pick a writable location for `trajectories.db`.
+    ///
+    /// Prefers the shared directory so `agentsight serve` finds the file without
+    /// extra flags, then falls back to `$HOME/.local/share/agentsight` for
+    /// unprivileged runs. Returns `None` when neither can be opened.
+    fn resolve_trajectory_db_path() -> Option<std::path::PathBuf> {
+        use agentsight::storage::sqlite::sibling_db_path;
+
+        // The `private` flag marks the home-directory fallback: it is the only
+        // candidate whose parents may be traversable by other local users.
+        let mut candidates = vec![(sibling_db_path("trajectories.db"), false)];
+        if let Some(home) = std::env::var_os("HOME") {
+            candidates.push((
+                std::path::PathBuf::from(home)
+                    .join(".local/share/agentsight")
+                    .join("trajectories.db"),
+                true,
+            ));
+        }
+
+        candidates
+            .into_iter()
+            .find(|(path, private)| Self::prepare_trajectory_db(path, *private))
+            .map(|(path, _)| path)
+    }
+
+    /// Report whether `path` can host the trajectory database, creating its
+    /// parent directory and verifying the database opens.
+    ///
+    /// Opening also creates the schema, so the collector's own open cannot then
+    /// fail on permissions. When `private` is set, the directory is restricted to
+    /// `0700` and the database to `0600` before opening: trajectories embed whole
+    /// conversations, which must not be readable by other local users. SQLite
+    /// derives WAL/SHM modes from the main database, so pre-creating it at `0600`
+    /// covers the sidecars as well.
+    fn prepare_trajectory_db(path: &std::path::Path, private: bool) -> bool {
+        use std::fs::{DirBuilder, OpenOptions, Permissions, set_permissions};
+        use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+
+        let created = if private {
+            DirBuilder::new().recursive(true).mode(0o700).create(parent)
+        } else {
+            std::fs::create_dir_all(parent)
+        };
+        if let Err(e) = created {
+            log::warn!("Trajectory DB directory {parent:?} unusable: {e}");
+            return false;
+        }
+
+        if private {
+            // `DirBuilder`'s mode only applies to directories it creates, so an
+            // already-present directory from an earlier run needs tightening too.
+            if let Err(e) = set_permissions(parent, Permissions::from_mode(0o700)) {
+                log::warn!("Could not restrict {parent:?} to 0700: {e}");
+                return false;
+            }
+            if let Err(e) = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .mode(0o600)
+                .open(path)
+            {
+                log::warn!("Trajectory DB {path:?} unusable: {e}");
+                return false;
+            }
+            // The mode above is ignored for a file that already exists.
+            if let Err(e) = set_permissions(path, Permissions::from_mode(0o600)) {
+                log::warn!("Could not restrict {path:?} to 0600: {e}");
+                return false;
+            }
+        }
+
+        match agentsight_trajectory_collector::TrajectoryStore::new_with_path(path) {
+            Ok(_) => true,
+            Err(e) => {
+                log::warn!("Trajectory DB {path:?} unusable: {e}");
+                false
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why

Trajectory collection needs no privileges — it scans local Agent session JSONL files, converts them
to ATIF v1.7, and writes SQLite — but it could only ever be started from inside the eBPF trace flow.
Probes are created before the collector thread is spawned, so without root or
`CAP_BPF`/`CAP_PERFMON` the process exits at `Failed to create probes` and no trajectory data is
produced. macOS already has a probe-free `trace` path; Linux had none.

## What changed

Added `--no-ebpf` to `agentsight trace`. It skips probe setup and runs the trajectory collector
alone, on both the foreground and daemon paths.

The dispatch lives in the CLI layer rather than in `AgentSight::new()`, for two reasons: `new()` is
also used by FFI callers who explicitly want eBPF, and `src/agentsight/src/UNIFIED_AGENTS.md`
requires `new()` to stay assembly-only with no blocking I/O. The eBPF pipeline itself is untouched —
the only change to existing code is that the two former `run_tracing()` call sites now go through a
mode dispatcher that still resolves to `run_tracing()` by default.

Two deliberate behaviours:

- The flag implies trajectory collection even when `features.trajectory_collection.enabled` is
  `false`. That default is `false`, and unprivileged environments usually cannot edit
  `/etc/agentsight/config.json`, so requiring both would make the flag a no-op in practice.
  `scan_interval_secs` and `scan_dirs` are still honoured.
- `trajectories.db` prefers the shared data directory so `serve` finds it with no extra flags, and
  falls back to `$HOME/.local/share/agentsight/` when that directory is not writable. Startup prints
  the resolved path and the matching `serve --db` command, so the data cannot silently become
  unreachable from the UI.

## Related issue

closes #2962

## User / Agent impact

A new opt-in flag; default behaviour is unchanged. With `--no-ebpf`, unprivileged sandboxes and
containers can collect trajectories and browse them in the Dashboard. Data that genuinely comes from
the probes — token metering, audit events, interruption detection, process and TLS monitoring —
remains unavailable in that mode, and the documentation states this so the flag is not mistaken for
an eBPF replacement.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

New CLI flag, hence the first box. The second box is checked for reviewer attention rather than
because privileges are relaxed: the flag only *drops* work that needs capabilities, it never
escalates. It does not weaken the eBPF path's requirements, and the collector performs only
user-space file reads and SQLite writes under the invoking user's own permissions.

## Validation

Ran on Alinux 3 (kernel 5.10.134, BTF present), against this branch rebased on `upstream/main`.

Gates:

- `cargo check --bin agentsight`
- `cargo clippy --bin agentsight -- -D warnings`
- `cargo fmt --all --check`
- `scripts/docs-lint.sh` and `scripts/docs-link-check.py`

End-to-end, in a user namespace with BPF capabilities dropped and `/var/log/sysak` plus
`/etc/agentsight` masked by tmpfs so the checks could not touch real data:

| Check | Result |
|---|---|
| `trace --no-ebpf` without CAP_BPF | Starts and ingests 3 trajectories instead of aborting |
| Config with `enabled: false` | Still collects, confirming the implied enablement |
| `scan_interval_secs` / `scan_dirs` from config | Honoured (5s interval applied) |
| Shared directory read-only | Warns, falls back to `$HOME`, ingests 3 trajectories |
| SIGINT | Graceful shutdown, exit code 0 |
| `serve --db <dir>/genai_events.db` | `GET /api/trajectories` returns 200 with the 3 records |
| `trace` **without** the flag | Unchanged: still exits with `Failed to create probes` |

Not run: `cargo test --workspace`. This change adds no tests and touches only the CLI dispatch layer,
so it was covered by the end-to-end checks above; the full suite is left to CI.

## Documentation and rollback

Updated in this PR: component `README.md` / `README_zh.md` (summary plus example), the user-guide CLI
reference in both languages (full behaviour, limitations, database fallback, scan-root caveat), the
troubleshooting entry readers hit when probes fail, and `src/agentsight/AGENTS.md` so agents stop
concluding that trajectories always require root.

Rollback: omit the flag and behaviour is identical to before; reverting the two commits removes it
entirely. No state, schema, or configuration migration is involved.
