### PR TITLE
fix(ckpt): retry loop attach when udev races device registration

### DIFF
--- a/src/ws-ckpt/docs/k8s-sidecar-deploy.md
+++ b/src/ws-ckpt/docs/k8s-sidecar-deploy.md
@@ -1,29 +1,38 @@
-# ws-ckpt K8s Sidecar 部署指南
+# Deploy ws-ckpt as a Kubernetes Sidecar
 
-## 前置条件
+[中文版](k8s-sidecar-deploy_zh.md)
 
-- 宿主机内核已加载 btrfs 模块（`modprobe btrfs && modprobe loop`）
-- 宿主机 `/dev/loop-control` 和 `/dev/loop*` 可用
-- 容器镜像包含：ws-ckpt 二进制、btrfs-progs、util-linux（losetup/mount/findmnt）、psmisc（fuser）、rsync、kmod
+This guide deploys `ws-ckpt` as a privileged daemon sidecar alongside an
+unprivileged application container. The example persists daemon state on the
+host and propagates the btrfs mount into the application container.
 
-## 构建镜像示例
+## Prerequisites
+
+- The host kernel has the btrfs and loop modules available
+  (`modprobe btrfs && modprobe loop`).
+- `/dev/loop-control` and `/dev/loop*` are available on the host.
+- The image contains `ws-ckpt`, `btrfs-progs`,
+  `util-linux`, `psmisc`, `rsync`, and `kmod`.
+
+## Build an image
+
+The following example builds an image on Alibaba Cloud Linux 3.
 
 ```bash
-# 1. 编译 ws-ckpt（需要 Rust stable >= 1.78）
+# 1. Build ws-ckpt (requires Rust stable 1.78 or later)
 cd anolisa/src/ws-ckpt/src
 cargo build --release --workspace
 ls target/release/ws-ckpt
 
-# 2. 准备构建上下文
+# 2. Prepare the image context
 mkdir -p ~/wsckpt-image
-# 拷贝编译好的二进制可执行文件
 cp target/release/ws-ckpt ~/wsckpt-image/
 
-# 3. 如果宿主机是源码编译的 btrfs-progs（dnf 无包），需要拷贝用户态工具：
+# 3. Copy locally built btrfs-progs when the package is unavailable from dnf
 cp /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs ~/wsckpt-image/
-# 若 dnf 有 btrfs-progs 则 Dockerfile 里直接 dnf install 即可，跳过此步
+# Skip this step and install btrfs-progs in the Dockerfile when dnf provides it
 
-# 4. 写 Dockerfile
+# 4. Create the Dockerfile
 cat > ~/wsckpt-image/Dockerfile <<'EOF'
 FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3:latest
 
@@ -31,7 +40,7 @@ RUN dnf install -y --setopt=tsflags=nodocs \
       util-linux psmisc rsync kmod which findutils \
     && dnf clean all
 
-# btrfs-progs：若 dnf 有包则换成 dnf install btrfs-progs
+# Replace these lines with dnf install btrfs-progs when the package is available
 COPY btrfs mkfs.btrfs /usr/local/bin/
 RUN chmod 0755 /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs \
     && ln -sf /usr/local/bin/btrfs /usr/bin/btrfs
@@ -40,84 +49,105 @@ COPY ws-ckpt /usr/local/bin/ws-ckpt
 RUN chmod 0755 /usr/local/bin/ws-ckpt
 EOF
 
-# 5. 构建 + 验证
+# 5. Build and verify the image
 cd ~/wsckpt-image
 docker build -t localhost/ws-ckpt:smoke .
 docker run --rm localhost/ws-ckpt:smoke ws-ckpt --version
 docker run --rm localhost/ws-ckpt:smoke btrfs --version
 
-# 6. 导入到集群节点（以 k3s 为例；标准 k8s 推送到 registry 即可）
+# 6. Import the image into cluster nodes (k3s example)
 docker save -o ws-ckpt-smoke.tar localhost/ws-ckpt:smoke
 sudo k3s ctr images import ws-ckpt-smoke.tar
-# 或推送到私有 registry：
+# For standard Kubernetes, push the image to a registry instead
 # docker tag localhost/ws-ckpt:smoke your-registry/ws-ckpt:smoke
 # docker push your-registry/ws-ckpt:smoke
 ```
 
-## 部署
+## Deploy the Pod
 
 ```bash
-# 确保宿主机内核模块就绪
+# Ensure that the required host kernel modules are loaded
 sudo modprobe loop && sudo modprobe btrfs
 
-# 应用 Pod 清单（yaml 示例见 k8s-sidecar-example.yaml）
+# Apply the example Pod manifest
 kubectl apply -f k8s-sidecar-example.yaml
-kubectl get pod wsckpt-smoke -w          # 等待 2/2 Running
-kubectl logs wsckpt-smoke -c daemon      # 确认 bootstrap 成功
+kubectl get pod wsckpt-smoke -w          # Wait for 2/2 Running
+kubectl logs wsckpt-smoke -c daemon      # Confirm successful bootstrap
 ```
 
-完整 Pod yaml 示例见 [`k8s-sidecar-example.yaml`](../k8s-sidecar-example.yaml)。
+The complete manifest is available in
+[`k8s-sidecar-example.yaml`](../k8s-sidecar-example.yaml).
 
-## Pod 设计
+## Pod design
 
-单 Pod 双容器，共用同一镜像：
+The Pod runs two containers from the same image.
 
-| 容器 | 角色 | 权限 |
-|------|------|------|
-| daemon | 运行 `ws-ckpt daemon`，管理 btrfs loop | privileged: true |
-| app | 业务负载，通过 UDS 调用 CLI 与 daemon 通信 | 无特权 |
+| Container | Role | Privileges |
+|-----------|------|------------|
+| daemon | Runs `ws-ckpt daemon` and manages the btrfs loop device | `privileged: true` |
+| app | Runs the workload and invokes the CLI over UDS | Unprivileged |
 
-## 必需 Volume
+## Required volumes
 
-| 名称 | 类型 | 用途 |
-|------|------|------|
-| sock | emptyDir | UDS socket（`/run/ws-ckpt/ws-ckpt.sock`） |
-| dev | hostPath `/dev` | loop 设备访问（`/dev/loop-control`、`/dev/loop*`） |
-| ws-state | hostPath `/var/lib/ws-ckpt` | **必须持久化** — 存放 btrfs-data.img、state.json、daemon.lock。丢失此 volume = 数据丢失。 |
-| ws-ckpt-mount | hostPath（anchor 目录） | daemon 在此 overmount btrfs；daemon 侧 `mountPropagation: Bidirectional`，app 侧 `HostToContainer` |
-| data | emptyDir | workspace 父目录；workspace 使用其子目录（如 `/data/workspace`） |
-| config | emptyDir | `/etc/ws-ckpt` —— 全局配置面。CLI 写 `config.toml`，daemon 重载同一份文件。**不共享则所有 `config --global` 设置对 daemon 无效。** |
+| Name | Type | Purpose |
+|------|------|---------|
+| sock | `emptyDir` | UDS socket at `/run/ws-ckpt/ws-ckpt.sock` |
+| dev | `hostPath` for `/dev` | Access to the host loop devices |
+| ws-state | `hostPath` for `/var/lib/ws-ckpt` | Persistent loop image, state, and daemon lock |
+| ws-ckpt-mount | `hostPath` anchor | btrfs mount propagated to the application |
+| data | `emptyDir` | Workspace parent directory, such as `/data` |
+| config | `emptyDir` | Shared global configuration at `/etc/ws-ckpt` |
 
-## 关键约束
+Losing the `ws-state` volume loses the loop image and its data.
 
-1. **`privileged: true`** — losetup/mount/mkfs.btrfs 需要。
+## Deployment constraints
 
-2. **hostPath `/dev` 透传** — k3s containerd 不会自动向 privileged 容器暴露宿主机 loop 设备节点，必须显式挂载。
+1. Set `privileged: true` for the daemon. `losetup`, `mount`,
+   and `mkfs.btrfs` require it.
 
-3. **`/var/lib/ws-ckpt` 必须持久化**（hostPath 或 PVC）。btrfs 镜像路径不可配置。若此目录落在容器可写层，pod 重启后 img 消失，但 orphan loop/mount 泄漏到宿主机。
+2. Mount the host `/dev` into the daemon. A privileged container under
+   k3s containerd does not automatically receive the host loop device nodes.
 
-4. **`--mount-path` 必须指向一个两容器同路径挂载的共享 volume**（mount anchor），daemon 侧配 `mountPropagation: Bidirectional`，app 侧配 `HostToContainer`。不能使用容器 rootfs 里的普通目录，那样 overmount 只存在于 daemon 容器私有的 mount namespace 里，无法传播到 app 容器，`init` 之后 app 会拿到悬空 symlink，而 daemon 侧无任何报错。
+3. Persist `/var/lib/ws-ckpt` with a `hostPath` or PVC. The btrfs
+   image path is not configurable. If this directory remains in the writable
+   container layer, a Pod restart removes the image while leaving host-level
+   loop devices or mounts behind.
 
-5. **workspace 必须是共享 volume 的子目录**，不能直接使用 volume 挂载点本身。`ws-ckpt init` 会对 workspace 路径执行 `rename()`，对挂载点 rename 返回 EBUSY。
+4. Point `--mount-path` to a shared volume mounted at the same path in
+   both containers. Use `Bidirectional` propagation for the daemon and
+   `HostToContainer` for the app. A root filesystem directory is private
+   to the daemon's mount namespace, so the app would receive a dangling symlink
+   after `init`.
 
-6. **`shareProcessNamespace: true`** — 使 `fuser -m`（rollback/recover/img-shrink 判断挂载是否空闲时调用）能看到 app 容器的进程。
+5. Place the workspace below the shared data volume instead of using the
+   volume mount point itself. `ws-ckpt init` renames the workspace, and
+   renaming a mount point fails with `EBUSY`.
 
-7. **后端自动检测**：若宿主机 `/var/lib` 在原生 btrfs 上，`auto_detect` 选择 BtrfsBase（直接操作 subvolume，无需 loop 设备）。BtrfsLoop overmount 路径仅在 ext4/xfs 宿主机上激活。两种后端均可正常工作，无需 ConfigMap 强制指定。
+6. Enable `shareProcessNamespace: true`. This lets `fuser -m` see
+   application processes while rollback, recovery, and image shrinking check
+   whether a mount is busy.
 
-8. **`/etc/ws-ckpt` 必须两容器共享**。全局配置是文件面而非 socket 面：`ws-ckpt config --global` 由 CLI 直接写 `/etc/ws-ckpt/config.toml`，daemon 重载时读**它自己容器内**的同一路径。两容器各用镜像层时，daemon 读不到文件即回落内置默认值，`auto-cleanup` 等策略全部失效。CLI 写入后会比对 daemon 的 effective 配置并报错，但根治方式是把 `/etc/ws-ckpt` 挂成共享 volume（`emptyDir` 即可）。
+7. Backend selection is automatic. When the filesystem containing
+   `/var/lib` is btrfs, `auto_detect` selects `BtrfsBase` and
+   operates on subvolumes without a loop device. Filesystems such as ext4 and
+   XFS use the `BtrfsLoop` overmount path.
 
-   per-workspace 配置（`config -w`）走 daemon 状态，不受此约束。
+8. Share `/etc/ws-ckpt` between both containers.
+   `ws-ckpt config --global` writes
+   `/etc/ws-ckpt/config.toml` directly, and the daemon reloads its own
+   view of that path. Without the shared volume, the daemon keeps its built-in
+   defaults and policies such as `auto-cleanup` do not take effect.
+   Per-workspace configuration through `config -w` is stored in daemon
+   state and does not have this requirement.
 
-## SIGTERM 与 Loop 设备清理
+## SIGTERM and loop device cleanup
 
-**daemon 收到 SIGTERM 只退出，不执行 `umount` 或 `losetup -d`。**
+The daemon exits on `SIGTERM` without running `umount` or
+`losetup -d`. Without cleanup, the host-level btrfs mount and loop device
+can outlive the container. Repeated Pod recreation can then accumulate stacked
+mounts and exhaust `/dev/loop*` devices.
 
-不做清理的后果：
-- 宿主机级 btrfs 挂载在容器死亡后持续存在
-- loop 设备保持 attached，backing path 指向已消失的容器 rootfs 内路径
-- 反复重建 pod 会累积 stacked mount 并耗尽 `/dev/loop*` 设备
-
-**缓解方案：** daemon 容器配置 `preStop` lifecycle hook：
+Configure this `preStop` lifecycle hook on the daemon container.
 
 ```yaml
 lifecycle:
@@ -140,19 +170,32 @@ lifecycle:
           done
 ```
 
-两条规则对应两类遗留，且都**不能用路径存在性（`-e`）作为判断依据**：
+The hook covers two kinds of leftovers. Neither rule uses path existence as
+the identifying signal.
 
-- 本 Pod 自己的 loop 在 umount **之前**用 `losetup -j` 捕获——它按 backing 文件的**（设备, inode）**匹配。路径字符串相同不代表是同一个文件：旧 Pod 的 loop 可能仍挂着已删除的旧 inode，而新 Pod 已在同一路径创建了另一个文件，用 `-e` 检查会把两者混淆；
-- 历史孤儿按内核显式追加的 ` (deleted)` 后缀识别：只有 backing 文件已被 unlink 的 loop 才带该后缀，运行中容器的设备不会命中；`/data/ws-ckpt` 为旧版本遗留镜像路径，一并覆盖。
+- Before unmounting, `losetup -j` captures the loop devices owned by the
+  current Pod. It matches the backing file by device and inode. A previous Pod
+  may still hold an unlinked inode after a new Pod creates another file at the
+  same path.
+- The kernel's ` (deleted)` suffix identifies historical orphan devices
+  whose backing files have been unlinked. It does not match a live container's
+  device. The legacy `/data/ws-ckpt` image path is also included.
 
-若 preStop 运行时 daemon 仍持有挂载，umount/detach 会以 EBUSY 失败——这是预期内的最好努力，下次启动的孤儿恢复（同样按 inode 匹配）会兜底。
+The hook is best effort. If an application process still uses the mount,
+`umount` can fail with `EBUSY`. On Linux 3.7 and later,
+`losetup -d` uses lazy device destruction for a busy loop device and
+marks it for automatic clearing when its final user exits. The next daemon
+startup also detaches a loop device that still backs the persistent image but
+is no longer mounted.
 
-对于 preStop 无法执行的异常场景（OOMKill、节点故障）：daemon 下次启动时 `try_exists` 检测到 orphan loop 设备（backing file 已不存在），跳过陈尸挂载走冷路径重新 bootstrap。此场景下旧挂载中的数据不可恢复 — 持久化 `ws-state` volume 是防止此情况发生的根本保障。
+A `preStop` hook does not run in every failure mode, including some node
+failures. Persisting `ws-state` is therefore essential for keeping the
+image and for inode-based orphan recovery on the next startup.
 
-裸 `docker run`（没有 preStop）每次容器退出都会遗留一个 attached loop 设备，反复运行会持续累积，建议：
-
-- 给 `/var/lib/ws-ckpt` 挂持久卷。镜像文件跨运行保留后，下次启动的孤儿恢复能按 inode 匹配到上次遗留并自动 detach，不再累积，状态也得以保留；
-- 清理存量遗留前先确认没有 ws-ckpt 容器在运行。只处理 ws-ckpt 两个镜像路径（默认 `/var/lib/ws-ckpt`、旧版本遗留 `/data/ws-ckpt`，daemon 与卸载流程对两者均保留支持）的悬空设备，**不要对全部 loop 设备做扫描**——宿主机上其他服务的 loop 设备同样可能存在悬空 backing 路径，全量扫描会误杀：
+With bare `docker run`, mount `/var/lib/ws-ckpt` from persistent
+storage. Before manually cleaning existing leftovers, make sure that no
+`ws-ckpt` container is running. Limit cleanup to the current and legacy
+image paths instead of detaching every loop device on the host.
 
 ```bash
 sudo sh <<'CLEANUP'
@@ -162,8 +205,8 @@ losetup -ln -O NAME,BACK-FILE | while read dev file; do
         /var/lib/ws-ckpt/btrfs-data.img|/data/ws-ckpt/btrfs-data.img) ;;
         *) continue ;;
     esac
-    # "(deleted)" = backing inode 已随容器删除；文件不存在 = 陈旧 attach。
-    # 宿主机级（systemd）部署的镜像文件真实存在，自动跳过。
+    # "(deleted)" means that the backing inode was removed with its container
+    # An existing host-level image is skipped
     if [ "$file" != "$clean" ] || [ ! -e "$clean" ]; then
         losetup -d "$dev"
     fi
@@ -171,19 +214,22 @@ done
 CLEANUP
 ```
 
-  `losetup -d` 需要 root，故整段以 `sudo` 运行；detach 失败原样报错，不做重定向静默。
+Run the block with `sudo` because `losetup -d` requires root.
+Detach failures remain visible so that they can be investigated.
 
-## 冒烟验证
+## Smoke test
+
+After the Pod reaches `2/2 Running`, run the following commands.
 
 ```bash
-# Pod 达到 2/2 Running 后：
+# Create and initialize a workspace
 kubectl exec wsckpt-smoke -c app -- mkdir -p /data/workspace
 kubectl exec wsckpt-smoke -c app -- sh -c 'echo hello > /data/workspace/file.txt'
 kubectl exec wsckpt-smoke -c app -- ws-ckpt init --workspace /data/workspace
 kubectl exec wsckpt-smoke -c app -- ws-ckpt checkpoint --workspace /data/workspace --message smoke-v1
 kubectl exec wsckpt-smoke -c app -- ws-ckpt list --workspace /data/workspace
 
-# init 后 workspace 仍可正常读写（验证 symlink + btrfs 传播链完整）：
+# Verify that the workspace remains writable after init
 kubectl exec wsckpt-smoke -c app -- sh -c 'echo bug6-verify-$(date +%s) > /data/workspace/verify.txt'
 kubectl exec wsckpt-smoke -c app -- cat /data/workspace/verify.txt
 kubectl exec wsckpt-smoke -c app -- ls -la /data/workspace/

--- a/src/ws-ckpt/docs/k8s-sidecar-deploy.md
+++ b/src/ws-ckpt/docs/k8s-sidecar-deploy.md
@@ -127,13 +127,51 @@ lifecycle:
         - /bin/sh
         - -c
         - |
+          own_loops=$(losetup -j /var/lib/ws-ckpt/btrfs-data.img 2>/dev/null | cut -d: -f1)
           umount /opt/ws-ckpt-mount 2>/dev/null || true
+          for dev in $own_loops; do
+            losetup -d "$dev" 2>/dev/null || true
+          done
           losetup -ln -O NAME,BACK-FILE | while read dev file; do
-            [ -e "$file" ] || losetup -d "$dev" 2>/dev/null
+            case "$file" in
+              "/var/lib/ws-ckpt/btrfs-data.img (deleted)"|"/data/ws-ckpt/btrfs-data.img (deleted)")
+                losetup -d "$dev" 2>/dev/null || true ;;
+            esac
           done
 ```
 
+两条规则对应两类遗留，且都**不能用路径存在性（`-e`）作为判断依据**：
+
+- 本 Pod 自己的 loop 在 umount **之前**用 `losetup -j` 捕获——它按 backing 文件的**（设备, inode）**匹配。路径字符串相同不代表是同一个文件：旧 Pod 的 loop 可能仍挂着已删除的旧 inode，而新 Pod 已在同一路径创建了另一个文件，用 `-e` 检查会把两者混淆；
+- 历史孤儿按内核显式追加的 ` (deleted)` 后缀识别：只有 backing 文件已被 unlink 的 loop 才带该后缀，运行中容器的设备不会命中；`/data/ws-ckpt` 为旧版本遗留镜像路径，一并覆盖。
+
+若 preStop 运行时 daemon 仍持有挂载，umount/detach 会以 EBUSY 失败——这是预期内的最好努力，下次启动的孤儿恢复（同样按 inode 匹配）会兜底。
+
 对于 preStop 无法执行的异常场景（OOMKill、节点故障）：daemon 下次启动时 `try_exists` 检测到 orphan loop 设备（backing file 已不存在），跳过陈尸挂载走冷路径重新 bootstrap。此场景下旧挂载中的数据不可恢复 — 持久化 `ws-state` volume 是防止此情况发生的根本保障。
+
+裸 `docker run`（没有 preStop）每次容器退出都会遗留一个 attached loop 设备，反复运行会持续累积，建议：
+
+- 给 `/var/lib/ws-ckpt` 挂持久卷。镜像文件跨运行保留后，下次启动的孤儿恢复能按 inode 匹配到上次遗留并自动 detach，不再累积，状态也得以保留；
+- 清理存量遗留前先确认没有 ws-ckpt 容器在运行。只处理 ws-ckpt 两个镜像路径（默认 `/var/lib/ws-ckpt`、旧版本遗留 `/data/ws-ckpt`，daemon 与卸载流程对两者均保留支持）的悬空设备，**不要对全部 loop 设备做扫描**——宿主机上其他服务的 loop 设备同样可能存在悬空 backing 路径，全量扫描会误杀：
+
+```bash
+sudo sh <<'CLEANUP'
+losetup -ln -O NAME,BACK-FILE | while read dev file; do
+    clean=${file%" (deleted)"}
+    case "$clean" in
+        /var/lib/ws-ckpt/btrfs-data.img|/data/ws-ckpt/btrfs-data.img) ;;
+        *) continue ;;
+    esac
+    # "(deleted)" = backing inode 已随容器删除；文件不存在 = 陈旧 attach。
+    # 宿主机级（systemd）部署的镜像文件真实存在，自动跳过。
+    if [ "$file" != "$clean" ] || [ ! -e "$clean" ]; then
+        losetup -d "$dev"
+    fi
+done
+CLEANUP
+```
+
+  `losetup -d` 需要 root，故整段以 `sudo` 运行；detach 失败原样报错，不做重定向静默。
 
 ## 冒烟验证
 

--- a/src/ws-ckpt/docs/k8s-sidecar-deploy_zh.md
+++ b/src/ws-ckpt/docs/k8s-sidecar-deploy_zh.md
@@ -1,0 +1,230 @@
+# 在 Kubernetes 中以 Sidecar 方式部署 ws-ckpt
+
+[English](k8s-sidecar-deploy.md)
+
+本文介绍如何把 `ws-ckpt` 作为特权 daemon sidecar，与无特权的业务容器
+部署在同一个 Pod 中。示例会在宿主机上持久化 daemon 状态，并把 btrfs
+挂载传播给业务容器。
+
+## 前置条件
+
+- 宿主机内核提供 btrfs 和 loop 模块，可通过
+  `modprobe btrfs && modprobe loop` 加载
+- 宿主机上可以使用 `/dev/loop-control` 和 `/dev/loop*`
+- 容器镜像包含 `ws-ckpt`、`btrfs-progs`、
+  `util-linux`、`psmisc`、`rsync` 和 `kmod`
+
+## 构建镜像
+
+下面以 Alibaba Cloud Linux 3 为例构建镜像。
+
+```bash
+# 1. Build ws-ckpt (requires Rust stable 1.78 or later)
+cd anolisa/src/ws-ckpt/src
+cargo build --release --workspace
+ls target/release/ws-ckpt
+
+# 2. Prepare the image context
+mkdir -p ~/wsckpt-image
+cp target/release/ws-ckpt ~/wsckpt-image/
+
+# 3. Copy locally built btrfs-progs when the package is unavailable from dnf
+cp /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs ~/wsckpt-image/
+# Skip this step and install btrfs-progs in the Dockerfile when dnf provides it
+
+# 4. Create the Dockerfile
+cat > ~/wsckpt-image/Dockerfile <<'EOF'
+FROM registry.cn-hangzhou.aliyuncs.com/alinux/alinux3:latest
+
+RUN dnf install -y --setopt=tsflags=nodocs \
+      util-linux psmisc rsync kmod which findutils \
+    && dnf clean all
+
+# Replace these lines with dnf install btrfs-progs when the package is available
+COPY btrfs mkfs.btrfs /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/btrfs /usr/local/bin/mkfs.btrfs \
+    && ln -sf /usr/local/bin/btrfs /usr/bin/btrfs
+
+COPY ws-ckpt /usr/local/bin/ws-ckpt
+RUN chmod 0755 /usr/local/bin/ws-ckpt
+EOF
+
+# 5. Build and verify the image
+cd ~/wsckpt-image
+docker build -t localhost/ws-ckpt:smoke .
+docker run --rm localhost/ws-ckpt:smoke ws-ckpt --version
+docker run --rm localhost/ws-ckpt:smoke btrfs --version
+
+# 6. Import the image into cluster nodes (k3s example)
+docker save -o ws-ckpt-smoke.tar localhost/ws-ckpt:smoke
+sudo k3s ctr images import ws-ckpt-smoke.tar
+# For standard Kubernetes, push the image to a registry instead
+# docker tag localhost/ws-ckpt:smoke your-registry/ws-ckpt:smoke
+# docker push your-registry/ws-ckpt:smoke
+```
+
+## 部署 Pod
+
+```bash
+# Ensure that the required host kernel modules are loaded
+sudo modprobe loop && sudo modprobe btrfs
+
+# Apply the example Pod manifest
+kubectl apply -f k8s-sidecar-example.yaml
+kubectl get pod wsckpt-smoke -w          # Wait for 2/2 Running
+kubectl logs wsckpt-smoke -c daemon      # Confirm successful bootstrap
+```
+
+完整清单见
+[`k8s-sidecar-example.yaml`](../k8s-sidecar-example.yaml)。
+
+## Pod 设计
+
+Pod 使用同一镜像运行两个容器。
+
+| 容器 | 作用 | 权限 |
+|------|------|------|
+| daemon | 运行 `ws-ckpt daemon` 并管理 btrfs loop 设备 | `privileged: true` |
+| app | 运行业务负载，并通过 UDS 调用 CLI | 无特权 |
+
+## 必需的 Volume
+
+| 名称 | 类型 | 用途 |
+|------|------|------|
+| sock | `emptyDir` | 位于 `/run/ws-ckpt/ws-ckpt.sock` 的 UDS socket |
+| dev | `/dev` 对应的 `hostPath` | 访问宿主机 loop 设备 |
+| ws-state | `/var/lib/ws-ckpt` 对应的 `hostPath` | 持久保存 loop 镜像、状态和 daemon lock |
+| ws-ckpt-mount | 作为锚点目录的 `hostPath` | 向业务容器传播 btrfs 挂载 |
+| data | `emptyDir` | workspace 的父目录，例如 `/data` |
+| config | `emptyDir` | 两个容器共享的全局配置目录 `/etc/ws-ckpt` |
+
+一旦丢失 `ws-state` volume，loop 镜像及其中的数据也会丢失。
+
+## 部署约束
+
+1. daemon 需要设置 `privileged: true`。`losetup`、
+   `mount` 和 `mkfs.btrfs` 都依赖这项权限。
+
+2. daemon 需要挂载宿主机的 `/dev`。k3s containerd 不会自动把
+   宿主机上的 loop 设备节点暴露给特权容器。
+
+3. 需要用 `hostPath` 或 PVC 持久化 `/var/lib/ws-ckpt`。
+   btrfs 镜像路径目前不可配置。这个目录如果留在容器可写层，Pod 重启后
+   镜像会消失，宿主机上的 loop 设备或挂载却可能继续存在。
+
+4. `--mount-path` 需要指向两个容器以相同路径挂载的共享 volume。
+   daemon 使用 `Bidirectional`，app 使用 `HostToContainer`。
+   daemon rootfs 中的普通目录只属于它自己的 mount namespace，
+   挂载无法传播给 app，`init` 后 app 会得到悬空 symlink。
+
+5. workspace 需要放在共享 data volume 的子目录中，不能直接使用 volume
+   挂载点。`ws-ckpt init` 会重命名 workspace，而重命名挂载点会返回
+   `EBUSY`。
+
+6. 需要启用 `shareProcessNamespace: true`。rollback、recover 和
+   image shrink 检查挂载是否繁忙时会调用 `fuser -m`，共享进程
+   namespace 后才能看到 app 容器中的进程。
+
+7. 后端会自动选择。`/var/lib` 所在文件系统为 btrfs 时，
+   `auto_detect` 会选择 `BtrfsBase`，直接操作 subvolume，
+   不需要 loop 设备。ext4 和 XFS 等文件系统会使用 `BtrfsLoop`
+   overmount 路径。
+
+8. 两个容器需要共享 `/etc/ws-ckpt`。
+   `ws-ckpt config --global` 会直接写入
+   `/etc/ws-ckpt/config.toml`，daemon 则从自己看到的同一路径
+   重新加载配置。如果缺少共享 volume，daemon 会继续使用内置默认值，
+   `auto-cleanup` 等策略不会生效。通过 `config -w` 设置的
+   workspace 配置保存在 daemon 状态中，不受这项约束。
+
+## SIGTERM 与 Loop 设备清理
+
+daemon 收到 `SIGTERM` 后会直接退出，不会执行 `umount` 或
+`losetup -d`。如果没有清理，宿主机级 btrfs 挂载和 loop 设备可能
+活得比容器更久。反复重建 Pod 会逐渐叠加挂载，并耗尽
+`/dev/loop*` 设备。
+
+请在 daemon 容器中配置下面的 `preStop` lifecycle hook。
+
+```yaml
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - |
+          own_loops=$(losetup -j /var/lib/ws-ckpt/btrfs-data.img 2>/dev/null | cut -d: -f1)
+          umount /opt/ws-ckpt-mount 2>/dev/null || true
+          for dev in $own_loops; do
+            losetup -d "$dev" 2>/dev/null || true
+          done
+          losetup -ln -O NAME,BACK-FILE | while read dev file; do
+            case "$file" in
+              "/var/lib/ws-ckpt/btrfs-data.img (deleted)"|"/data/ws-ckpt/btrfs-data.img (deleted)")
+                losetup -d "$dev" 2>/dev/null || true ;;
+            esac
+          done
+```
+
+这段 hook 处理两类遗留，两条规则都不把路径是否存在当作判断依据。
+
+- 卸载前先用 `losetup -j` 找到当前 Pod 的 loop 设备。这个命令
+  按 backing 文件的设备号和 inode 匹配。旧 Pod 可能仍持有已经 unlink
+  的 inode，而新 Pod 已经在同一路径创建了另一个文件
+- 内核追加的 ` (deleted)` 后缀用于识别 backing 文件已经 unlink
+  的历史孤儿设备，不会匹配仍在运行的容器。旧部署使用过的
+  `/data/ws-ckpt` 镜像路径也包含在清理范围内
+
+这段 hook 只提供尽力而为的清理。业务进程仍在使用挂载时，
+`umount` 可能返回 `EBUSY`。Linux 3.7 及更高版本中的
+`losetup -d` 会对繁忙设备使用延迟销毁，并把设备标记为
+autoclear，最后一个使用者退出后才会释放。下次 daemon 启动时，
+如果持久化镜像仍由某个 loop 设备承载但没有挂载，也会先将其分离。
+
+部分节点故障等异常场景不会执行 `preStop`。因此必须持久化
+`ws-state`，这样既能保住镜像，也能让下次启动按 inode 识别
+和处理孤儿设备。
+
+直接使用 `docker run` 时，也应当为 `/var/lib/ws-ckpt`
+挂载持久存储。手工清理历史遗留前，先确认没有 `ws-ckpt`
+容器正在运行。清理范围只覆盖当前镜像路径和旧版镜像路径，不要扫描并
+分离宿主机上的所有 loop 设备。
+
+```bash
+sudo sh <<'CLEANUP'
+losetup -ln -O NAME,BACK-FILE | while read dev file; do
+    clean=${file%" (deleted)"}
+    case "$clean" in
+        /var/lib/ws-ckpt/btrfs-data.img|/data/ws-ckpt/btrfs-data.img) ;;
+        *) continue ;;
+    esac
+    # "(deleted)" means that the backing inode was removed with its container
+    # An existing host-level image is skipped
+    if [ "$file" != "$clean" ] || [ ! -e "$clean" ]; then
+        losetup -d "$dev"
+    fi
+done
+CLEANUP
+```
+
+`losetup -d` 需要 root 权限，因此整段命令通过 `sudo` 运行。
+命令不会静默忽略 detach 错误，方便继续排查。
+
+## 冒烟验证
+
+Pod 达到 `2/2 Running` 后，执行下面的命令。
+
+```bash
+# Create and initialize a workspace
+kubectl exec wsckpt-smoke -c app -- mkdir -p /data/workspace
+kubectl exec wsckpt-smoke -c app -- sh -c 'echo hello > /data/workspace/file.txt'
+kubectl exec wsckpt-smoke -c app -- ws-ckpt init --workspace /data/workspace
+kubectl exec wsckpt-smoke -c app -- ws-ckpt checkpoint --workspace /data/workspace --message smoke-v1
+kubectl exec wsckpt-smoke -c app -- ws-ckpt list --workspace /data/workspace
+
+# Verify that the workspace remains writable after init
+kubectl exec wsckpt-smoke -c app -- sh -c 'echo bug6-verify-$(date +%s) > /data/workspace/verify.txt'
+kubectl exec wsckpt-smoke -c app -- cat /data/workspace/verify.txt
+kubectl exec wsckpt-smoke -c app -- ls -la /data/workspace/
+```

--- a/src/ws-ckpt/k8s-sidecar-example.yaml
+++ b/src/ws-ckpt/k8s-sidecar-example.yaml
@@ -82,9 +82,18 @@ spec:
           mountPath: /data
         - name: config
           mountPath: /etc/ws-ckpt
-      # Clean orphan loop devices on pod teardown. Dead containers leave
-      # host-scoped loops pointing at phantom paths (container rootfs gone but
-      # loop persists). Without this, the next pod sees a stale btrfs mount.
+      # Clean loop devices on pod teardown. Two rules for two kinds of
+      # leftovers, neither of which may use path existence as the signal:
+      # - This pod's own loop is captured with `losetup -j` BEFORE umount:
+      #   it matches the backing file by (device, inode), which stays
+      #   correct even if another pod later recreates the same path with a
+      #   different inode.
+      # - Historical orphans from dead pods are recognized by the kernel's
+      #   " (deleted)" marker on the backing file (only an unlinked backing
+      #   file carries it, so a live container's loop never matches).
+      # Best-effort by design: if the daemon still holds the mount when
+      # preStop runs, umount/detach fail with EBUSY and the next daemon's
+      # inode-based orphan recovery finishes the cleanup.
       lifecycle:
         preStop:
           exec:
@@ -92,9 +101,16 @@ spec:
               - /bin/sh
               - -c
               - |
+                own_loops=$(losetup -j /var/lib/ws-ckpt/btrfs-data.img 2>/dev/null | cut -d: -f1)
                 umount /opt/ws-ckpt-mount 2>/dev/null || true
+                for dev in $own_loops; do
+                  losetup -d "$dev" 2>/dev/null || true
+                done
                 losetup -ln -O NAME,BACK-FILE | while read dev file; do
-                  [ -e "$file" ] || losetup -d "$dev" 2>/dev/null
+                  case "$file" in
+                    "/var/lib/ws-ckpt/btrfs-data.img (deleted)"|"/data/ws-ckpt/btrfs-data.img (deleted)")
+                      losetup -d "$dev" 2>/dev/null || true ;;
+                  esac
                 done
     - name: app
       image: localhost/ws-ckpt:smoke

--- a/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
+++ b/src/ws-ckpt/src/crates/daemon/src/backends/btrfs_loop.rs
@@ -1163,19 +1163,125 @@ async fn check_mount_busy(mount_path: &str) -> Option<String> {
 /// logical blocks larger than the loop's 512 (4Kn NVMe, 4096-sector LUKS2)
 /// fail the block-size check. DIO is a performance optimization, not a
 /// correctness requirement, so those hosts fall back to buffered mode.
+///
+/// The retry loop handles a device-node race: when every registered loop
+/// device is attached (e.g. leftovers from containers that exited without
+/// detaching), `LOOP_CTL_GET_FREE` makes the kernel register a new loop
+/// device, but udev creates its /dev node asynchronously — so the very
+/// losetup that triggered the registration fails with ENOENT. `losetup
+/// --find` reports the device that would be handed out next, so its node can
+/// be created synchronously before retrying.
 async fn attach_loop(img: &str) -> anyhow::Result<String> {
-    let dev = run_command("losetup", &["--find", "--show", img])
-        .await
-        .context("Failed to setup loop device")?;
-    let dev = dev.trim().to_string();
-    if let Err(e) = run_command_checked("losetup", &["--direct-io=on", &dev]).await {
-        warn!(
-            "Could not enable direct-io on {} for {}: {:#}. Continuing in buffered mode; \
-             checkpoint latency will be higher.",
-            dev, img, e
-        );
+    const ATTEMPTS: u32 = 5;
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=ATTEMPTS {
+        match run_command("losetup", &["--find", "--show", img]).await {
+            Ok(dev) => {
+                let dev = dev.trim().to_string();
+                if let Err(e) = run_command_checked("losetup", &["--direct-io=on", &dev]).await {
+                    warn!(
+                        "Could not enable direct-io on {} for {}: {:#}. Continuing in buffered mode; \
+                         checkpoint latency will be higher.",
+                        dev, img, e
+                    );
+                }
+                return Ok(dev);
+            }
+            Err(e) => {
+                warn!(
+                    "losetup attach attempt {}/{} for {} failed: {:#}",
+                    attempt, ATTEMPTS, img, e
+                );
+                last_err = Some(e);
+                if let Ok(free) = run_command("losetup", &["--find"]).await {
+                    ensure_loop_node(free.trim()).await;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
     }
-    Ok(dev)
+    Err(last_err.unwrap_or_else(|| anyhow::Error::msg("losetup failed with no recorded error")))
+        .context("Failed to setup loop device")
+}
+
+/// Normalize `losetup --find` output to the canonical `/dev/loopN` path.
+///
+/// util-linux >= 2.40 appends " (lost)" when the kernel device exists but
+/// its /dev node is missing — precisely the state the retry path repairs.
+/// Returns None for empty output or anything that is not a loop device.
+fn normalize_free_loop_dev(raw: &str) -> Option<&str> {
+    let path = raw.split_whitespace().next()?;
+    let name = Path::new(path).file_name()?.to_str()?;
+    let index = name.strip_prefix("loop")?;
+    if index.is_empty() || !index.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(path)
+}
+
+/// Parse the `major:minor` pair exported at `/sys/block/<dev>/dev`.
+///
+/// The device number must come from sysfs, never from the device name: with
+/// `max_part > 0` the loop driver reserves partition minors and assigns the
+/// disk a shifted minor, so `loop1` can be `7:128` rather than `7:1`.
+fn parse_sysfs_dev_numbers(raw: &str) -> Option<(&str, &str)> {
+    let (major, minor) = raw.trim().split_once(':')?;
+    let is_number = |s: &str| !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit());
+    if is_number(major) && is_number(minor) {
+        Some((major, minor))
+    } else {
+        None
+    }
+}
+
+/// Arguments for creating a loop device node: block device with the same
+/// restrictive mode udev applies — never world-readable, since the node
+/// exposes the raw workspace image once attached.
+fn loop_node_mknod_args<'a>(node: &'a str, major: &'a str, minor: &'a str) -> [&'a str; 6] {
+    ["-m", "0660", node, "b", major, minor]
+}
+
+/// Create the `/dev/<free_dev>` node if it does not exist yet.
+///
+/// Called with the device `losetup --find` would hand out next: the kernel
+/// already has the device registered (so `/sys/block/<name>/dev` carries the
+/// authoritative device number), only the udev node is missing. The daemon
+/// runs as root; failure is non-fatal because udev may still deliver the
+/// node before the next retry.
+async fn ensure_loop_node(free_dev: &str) {
+    let free_dev = match normalize_free_loop_dev(free_dev) {
+        Some(path) => path,
+        None => return,
+    };
+    if Path::new(free_dev).exists() {
+        return;
+    }
+    let dev_name = match Path::new(free_dev).file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return,
+    };
+    let dev_str = match tokio::fs::read_to_string(format!("/sys/block/{dev_name}/dev")).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Could not read /sys/block/{}/dev: {}", dev_name, e);
+            return;
+        }
+    };
+    let (major, minor) = match parse_sysfs_dev_numbers(&dev_str) {
+        Some(pair) => pair,
+        None => return,
+    };
+    let args = loop_node_mknod_args(free_dev, major, minor);
+    if let Err(e) = run_command_checked("mknod", &args).await {
+        warn!("Could not create loop device node {}: {:#}", free_dev, e);
+        return;
+    }
+    // Match udev's usual ownership (root:disk) so tools expecting disk-group
+    // access behave the same as with udev-created nodes. Best-effort: the
+    // disk group may be absent in minimal container images.
+    if let Err(e) = run_command_checked("chown", &["root:disk", free_dev]).await {
+        warn!("Could not chown {} to root:disk: {:#}", free_dev, e);
+    }
 }
 
 /// Parse `losetup -j <img>` and return the backing loop device.
@@ -1233,7 +1339,8 @@ fn parse_df_total(output: &str) -> anyhow::Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_target_size, derive_img_dir, parse_df_available, parse_df_total, parse_losetup_j,
+        compute_target_size, derive_img_dir, loop_node_mknod_args, normalize_free_loop_dev,
+        parse_df_available, parse_df_total, parse_losetup_j, parse_sysfs_dev_numbers,
         BtrfsLoopBackend,
     };
     use ws_ckpt_common::SNAPSHOTS_DIR;
@@ -1490,5 +1597,56 @@ mod tests {
         let img = dir.path().join("never-created.img");
         let backend = super::BtrfsLoopBackend::new(dir.path().join("mnt"), img.clone());
         assert!(backend.loop_img_state().await.is_none());
+    }
+
+    #[test]
+    fn normalize_free_loop_dev_accepts_plain_name() {
+        assert_eq!(normalize_free_loop_dev("/dev/loop8"), Some("/dev/loop8"));
+        assert_eq!(normalize_free_loop_dev("/dev/loop8\n"), Some("/dev/loop8"));
+    }
+
+    #[test]
+    fn normalize_free_loop_dev_strips_lost_suffix() {
+        // util-linux >= 2.40 appends " (lost)" when the node is missing.
+        assert_eq!(
+            normalize_free_loop_dev("/dev/loop8 (lost)"),
+            Some("/dev/loop8")
+        );
+    }
+
+    #[test]
+    fn normalize_free_loop_dev_rejects_malformed_output() {
+        for raw in [
+            "",
+            "   ",
+            "garbage",
+            "/dev/sda",
+            "/dev/loop",
+            "/dev/loop1p1",
+        ] {
+            assert_eq!(normalize_free_loop_dev(raw), None, "input: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn parse_sysfs_dev_numbers_plain_and_shifted_minor() {
+        assert_eq!(parse_sysfs_dev_numbers("7:8"), Some(("7", "8")));
+        // max_part > 0 shifts the disk minor: loop1 can be 7:128, not 7:1.
+        assert_eq!(parse_sysfs_dev_numbers(" 7:128 \n"), Some(("7", "128")));
+    }
+
+    #[test]
+    fn parse_sysfs_dev_numbers_rejects_malformed_input() {
+        for raw in ["", "7", "7:", ":8", "a:b", "7:8x"] {
+            assert_eq!(parse_sysfs_dev_numbers(raw), None, "input: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn loop_node_mknod_args_keep_restrictive_mode() {
+        assert_eq!(
+            loop_node_mknod_args("/dev/loop8", "7", "128"),
+            ["-m", "0660", "/dev/loop8", "b", "7", "128"]
+        );
     }
 }


### PR DESCRIPTION
## Why

When every registered loop device is attached (e.g. leftovers from containers that exited without detaching), `LOOP_CTL_GET_FREE` makes the kernel register a new loop device, but udev creates its `/dev/loopN` node asynchronously — the very `losetup` that triggered the registration fails with ENOENT. Reproduced on fresh ECS hosts with the ws-ckpt sidecar image: bootstrap then fails every time a new device number is needed, alternating fail/succeed with device numbers growing past the pre-registered 0-7 range (loop8, loop9, ...).

## What changed

- `attach_loop` (BtrfsLoop backend) now retries: after a failure it asks `losetup --find` which device would be handed out next, creates that node synchronously via `mknod` (the daemon runs as root, and the kernel already has the device registered), sleeps briefly, and retries (up to 5 attempts). On a healthy host the first attempt succeeds and nothing changes.
- Sidecar deploy guide: documented the bare `docker run` leftover-loop behavior, the persistent-volume mitigation (a kept image file lets the bootstrap orphan recovery match the leftover by inode and auto-detach it), and a cleanup one-liner.

## Related issue

no-issue: found while validating ws-ckpt sidecar container deployment on fresh hosts

## User / Agent impact

Daemon bootstrap no longer fails intermittently with `losetup ... failed to set up loop device: No such file or directory` when leftover attachments exhaust the pre-registered loop devices; repeated container starts become deterministic.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The success path is byte-for-byte the old behavior; the retry path only runs after `losetup` already failed, uses at most 5 short attempts, and the only new system change is mknod'ing device nodes the kernel has already registered (the daemon already runs as root and shells out to losetup/mount/mkfs). No CLI/API/protocol changes.

## Validation

- Reproduced the alternating fail/succeed pattern on fresh ECS hosts (failures exactly at runs allocating device numbers beyond the existing node set, e.g. loop8/loop9)
- Rebuilt the sidecar container image with this fix; daemon bootstrap succeeds deterministically end-to-end (sparse image create -> loop attach -> btrfs mount -> listener up)
- Compiled via the container builder stage (`cargo build --release --locked`); CI covers fmt/clippy/tests

## Documentation and rollback

`src/ws-ckpt/docs/k8s-sidecar-deploy.md` SIGTERM section updated. Rollback: revert this commit (changelog/version files untouched).