### PR TITLE
fix(cosh-ng): [shell] recover OSC parser

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -19,6 +19,7 @@ use handoff_claim::{
     claim_pending_command_origin, pending_origin_for_request, PendingCommandOrigin,
 };
 use handoff_echo::PendingHandoffEcho;
+use marker_sequence::resume_abandoned_prefix;
 use marker_sequence::{find_bytes, osc_prefix_suffix_len, HistoryFileTracker, Marker};
 use slash_guard_echo::PendingSlashGuardEcho;
 
@@ -49,7 +50,13 @@ const UNDERLINE_OFF: &[u8] = b"\x1b[24m";
 const ERASE_TO_END_OF_SCREEN: &[u8] = b"\x1b[J";
 const ERASE_TO_END_OF_LINE: &[u8] = b"\x1b[K";
 const BEL: u8 = b'\x07';
+const OSC_CANDIDATE_MAX_BYTES: usize = 64 * 1024;
 const SHELL_PATH_MAX_BYTES: usize = 8 * 1024;
+
+#[cfg(test)]
+thread_local! {
+    static OSC_CANDIDATE_SCAN_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// Why a display cut was recorded, so consumers can tell an intercepted
 /// input (shell has not painted a prompt for it yet) apart from a real
@@ -69,6 +76,9 @@ pub(super) struct OscParser {
     pub(super) display: Transcript,
     marker_token: Option<String>,
     pending: Vec<u8>,
+    /// Leading pending bytes inherited from a discarded private candidate;
+    /// tentative continuation bytes after this boundary remain terminal output.
+    abandoned_prefix_len: usize,
     pending_clean_control: Vec<u8>,
     current: Option<CurrentCommand>,
     command_seq: usize,
@@ -161,6 +171,15 @@ impl OscParser {
         if self.marker_token.is_none() {
             return self.append_passthrough(data);
         }
+        let Some(data) =
+            resume_abandoned_prefix(&mut self.pending, &mut self.abandoned_prefix_len, data)
+        else {
+            return Ok(());
+        };
+        let mut scan_from = self
+            .pending
+            .len()
+            .saturating_sub(OSC_PREFIX.len().saturating_sub(1));
         self.pending.extend_from_slice(data);
         loop {
             let Some(start) = find_bytes(&self.pending, OSC_PREFIX) else {
@@ -178,19 +197,59 @@ impl OscParser {
                 let passthrough = self.pending[..start].to_vec();
                 self.append_passthrough(&passthrough)?;
                 self.pending.drain(..start);
+                scan_from = scan_from.saturating_sub(start);
             }
 
             let payload_start = OSC_PREFIX.len();
-            let Some(end) = self.pending[payload_start..]
-                .iter()
-                .position(|byte| *byte == BEL)
-                .map(|idx| idx + payload_start)
-            else {
+            scan_from = scan_from.max(payload_start).min(self.pending.len());
+            let candidate = &self.pending[scan_from..];
+            let terminator_offset = candidate.iter().position(|byte| *byte == BEL);
+            #[cfg(test)]
+            {
+                let scanned = terminator_offset.map_or(candidate.len(), |idx| idx + 1);
+                OSC_CANDIDATE_SCAN_BYTES
+                    .set(OSC_CANDIDATE_SCAN_BYTES.get().saturating_add(scanned));
+            }
+            let terminator = terminator_offset.map(|idx| idx + scan_from);
+            let restart_before = terminator.unwrap_or(self.pending.len());
+            let restart_candidate = &self.pending[scan_from..restart_before];
+            #[cfg(test)]
+            {
+                OSC_CANDIDATE_SCAN_BYTES.set(
+                    OSC_CANDIDATE_SCAN_BYTES
+                        .get()
+                        .saturating_add(restart_candidate.len()),
+                );
+            }
+            let restart = restart_candidate
+                .windows(OSC_PREFIX.len())
+                .rposition(|window| window == OSC_PREFIX)
+                .map(|idx| idx + scan_from);
+            if let Some(restart) = restart {
+                self.pending.drain(..restart);
+                scan_from = payload_start;
+                continue;
+            }
+
+            let Some(end) = terminator else {
+                if self.pending.len() > OSC_CANDIDATE_MAX_BYTES {
+                    let keep = osc_prefix_suffix_len(&self.pending);
+                    let split_at = self.pending.len() - keep;
+                    let suffix = self.pending.split_off(split_at);
+                    self.pending = suffix;
+                    self.abandoned_prefix_len = self.pending.len();
+                }
                 return Ok(());
             };
+            if end + 1 > OSC_CANDIDATE_MAX_BYTES {
+                self.pending.drain(..=end);
+                scan_from = 0;
+                continue;
+            }
 
             let payload = self.pending[payload_start..end].to_vec();
             self.pending.drain(..=end);
+            scan_from = 0;
             match serde_json::from_slice::<Marker>(&payload) {
                 Ok(marker) => self.handle_marker(marker)?,
                 Err(err) => self.events.push(ShellEvent {
@@ -217,6 +276,16 @@ impl OscParser {
                 }),
             }
         }
+    }
+
+    #[cfg(test)]
+    pub(super) fn reset_osc_candidate_scan_bytes() {
+        OSC_CANDIDATE_SCAN_BYTES.set(0);
+    }
+
+    #[cfg(test)]
+    pub(super) fn osc_candidate_scan_bytes() -> usize {
+        OSC_CANDIDATE_SCAN_BYTES.get()
     }
 
     fn handle_marker(&mut self, mut marker: Marker) -> io::Result<()> {
@@ -477,14 +546,6 @@ impl OscParser {
             observer.observe(snapshot);
         }
         Some(generation)
-    }
-
-    pub(super) fn flush_pending(&mut self) -> io::Result<()> {
-        let pending = std::mem::take(&mut self.pending);
-        self.append_passthrough(&pending)?;
-        self.flush_pending_slash_guard_echo()?;
-        self.flush_pending_handoff_echo()?;
-        self.flush_pending_clean_control()
     }
 
     fn append_passthrough(&mut self, data: &[u8]) -> io::Result<()> {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/marker_sequence.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/marker_sequence.rs
@@ -24,6 +24,38 @@ pub(super) fn osc_prefix_suffix_len(pending: &[u8]) -> usize {
     0
 }
 
+pub(super) fn resume_abandoned_prefix<'a>(
+    pending: &mut Vec<u8>,
+    abandoned_prefix_len: &mut usize,
+    data: &'a [u8],
+) -> Option<&'a [u8]> {
+    if *abandoned_prefix_len == 0 {
+        return Some(data);
+    }
+    let Some(continuation) = super::OSC_PREFIX.strip_prefix(pending.as_slice()) else {
+        discard_abandoned_prefix(pending, abandoned_prefix_len);
+        return Some(data);
+    };
+    if data.starts_with(continuation) {
+        pending.extend_from_slice(continuation);
+        *abandoned_prefix_len = 0;
+        Some(&data[continuation.len()..])
+    } else if continuation.starts_with(data) {
+        pending.extend_from_slice(data);
+        None
+    } else {
+        // Reparse the fresh chunk so abandoning a private fragment cannot
+        // discard tentative continuation bytes that arrived after it.
+        discard_abandoned_prefix(pending, abandoned_prefix_len);
+        Some(data)
+    }
+}
+
+pub(super) fn discard_abandoned_prefix(pending: &mut Vec<u8>, abandoned_prefix_len: &mut usize) {
+    let private_len = std::mem::take(abandoned_prefix_len).min(pending.len());
+    pending.drain(..private_len);
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct Marker {
     #[serde(alias = "e")]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use super::super::transcript::TranscriptRetention;
+use super::marker_sequence::discard_abandoned_prefix;
 use super::{AltScreenTracker, OscParser, Transcript, VisibleTailTracker};
 use crate::types::SESSION_OUTPUT_REF_MAX_BYTES;
 
@@ -13,6 +14,17 @@ use super::super::osc_output::{
 };
 
 impl OscParser {
+    pub(in super::super) fn flush_pending(&mut self) -> io::Result<()> {
+        let mut pending = std::mem::take(&mut self.pending);
+        discard_abandoned_prefix(&mut pending, &mut self.abandoned_prefix_len);
+        if !pending.starts_with(super::OSC_PREFIX) {
+            self.append_passthrough(&pending)?;
+        }
+        self.flush_pending_slash_guard_echo()?;
+        self.flush_pending_handoff_echo()?;
+        self.flush_pending_clean_control()
+    }
+
     pub(crate) fn new(session_id: String, output_ref_dir: PathBuf, marker_token: String) -> Self {
         let work_dir = output_ref_dir
             .parent()
@@ -85,6 +97,7 @@ impl OscParser {
             )?,
             marker_token,
             pending: Vec::new(),
+            abandoned_prefix_len: 0,
             pending_clean_control: Vec::new(),
             current: None,
             command_seq: 0,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc_tests.rs
@@ -177,6 +177,264 @@ fn intercept_marker_without_sensitive_field_defaults_to_not_sensitive() {
 }
 
 #[test]
+fn unterminated_cosh_candidate_resyncs_to_next_marker() {
+    let mut parser = parser_for_test("unterminated-resync");
+    parser.feed(b"before\r\n").expect("feed visible prefix");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"intercept\",\"token\":\"test-marker-token\",\"command\":\"INTERNAL_CANDIDATE\"")
+        .expect("feed unterminated candidate");
+    parser
+        .feed(b"\x1b]1337;")
+        .expect("feed fragmented restart prefix");
+    parser
+        .feed(b"COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"status\":0,\"cwd\":\"/tmp\"}\x07after\r\n")
+        .expect("feed valid marker after candidate");
+
+    assert_eq!(parser.precmd_count(), 1);
+    assert!(!parser
+        .events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::UserInputIntercepted));
+    assert!(!parser
+        .events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::ComponentFailed));
+    assert_eq!(parser.display.resident_slice(), b"before\r\nafter\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"before\r\nafter\r\n");
+}
+
+#[test]
+fn nonzero_scan_resyncs_to_last_of_multiple_prefixes() {
+    let mut parser = parser_for_test("unterminated-multiple-resync");
+    parser
+        .feed(b"\x1b]1337;COSH;stale-candidate-with-a-scanned-tail")
+        .expect("feed initial candidate");
+    parser
+        .feed(b"\x1b]1337;COSH;second-stale\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"status\":0,\"cwd\":\"/tmp\"}\x07visible\r\n")
+        .expect("feed multiple restart candidates");
+
+    assert_eq!(parser.precmd_count(), 1);
+    assert_eq!(parser.display.resident_slice(), b"visible\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible\r\n");
+    assert!(!parser
+        .events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::UserInputIntercepted));
+    assert!(!parser
+        .events
+        .iter()
+        .any(|event| event.kind == ShellEventKind::ComponentFailed));
+}
+
+#[test]
+fn oversized_unterminated_cosh_candidate_recovers_without_leaking() {
+    let mut parser = parser_for_test("unterminated-cap");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+
+    parser.feed(&candidate).expect("feed oversized candidate");
+    parser
+        .feed(b"visible-after-cap\r\n")
+        .expect("feed output after candidate cap");
+
+    assert_eq!(parser.display.resident_slice(), b"visible-after-cap\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible-after-cap\r\n");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn oversized_candidate_preserves_fragmented_restart_prefix() {
+    let mut parser = parser_for_test("unterminated-cap-fragment");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser
+        .feed(b"COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"status\":0,\"cwd\":\"/tmp\"}\x07visible\r\n")
+        .expect("finish valid marker after cap");
+
+    assert_eq!(parser.precmd_count(), 1);
+    assert_eq!(parser.display.resident_slice(), b"visible\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible\r\n");
+}
+
+#[test]
+fn oversized_candidate_drops_stale_prefix_before_fresh_marker() {
+    let mut parser = parser_for_test("unterminated-cap-fresh-marker");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"test-marker-token\",\"status\":0,\"cwd\":\"/tmp\"}\x07visible\r\n")
+        .expect("feed fresh marker after capped fragment");
+
+    assert_eq!(parser.precmd_count(), 1);
+    assert_eq!(parser.display.resident_slice(), b"visible\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible\r\n");
+}
+
+#[test]
+fn oversized_candidate_drops_stale_prefix_and_keeps_output() {
+    let mut parser = parser_for_test("unterminated-cap-stale-prefix");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser
+        .feed(b"visible-after-cap\r\n")
+        .expect("feed output after capped fragment");
+
+    assert_eq!(parser.display.resident_slice(), b"visible-after-cap\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible-after-cap\r\n");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn oversized_candidate_keeps_tentative_output_after_mismatch() {
+    let mut parser = parser_for_test("unterminated-cap-tentative-output");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser.feed(b"CO").expect("feed tentative continuation");
+    parser
+        .feed(b"PY_UNIQUE_OUTPUT\r\n")
+        .expect("feed mismatching output");
+
+    assert_eq!(parser.display.resident_slice(), b"COPY_UNIQUE_OUTPUT\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"COPY_UNIQUE_OUTPUT\r\n");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn flush_keeps_tentative_output_after_oversized_fragment() {
+    let mut parser = parser_for_test("unterminated-cap-tentative-flush");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser.feed(b"CO").expect("feed tentative continuation");
+    parser.flush_pending().expect("flush tentative output");
+
+    assert_eq!(parser.display.resident_slice(), b"CO");
+    assert_eq!(parser.clean.resident_slice(), b"CO");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn flush_drops_oversized_candidate_prefix_fragment() {
+    let mut parser = parser_for_test("unterminated-cap-fragment-flush");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x1b]1337;");
+
+    parser
+        .feed(&candidate)
+        .expect("feed capped prefix fragment");
+    parser.flush_pending().expect("flush capped fragment");
+
+    assert!(parser.display.is_empty());
+    assert!(parser.clean.is_empty());
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn oversized_terminated_candidate_preserves_following_output() {
+    let mut parser = parser_for_test("oversized-terminated-remainder");
+    let mut candidate = b"\x1b]1337;COSH;".to_vec();
+    candidate.extend(std::iter::repeat_n(b'x', 64 * 1024));
+    candidate.extend_from_slice(b"\x07visible-after-frame\r\n");
+
+    parser
+        .feed(&candidate)
+        .expect("feed oversized terminated candidate");
+
+    assert_eq!(parser.display.resident_slice(), b"visible-after-frame\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible-after-frame\r\n");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn byte_fragmented_candidate_scanning_stays_linear() {
+    let mut parser = parser_for_test("unterminated-linear-scan");
+    OscParser::reset_osc_candidate_scan_bytes();
+    parser
+        .feed(b"\x1b]1337;COSH;")
+        .expect("feed candidate prefix");
+    const FRAGMENTS: usize = 4 * 1024;
+    for _ in 0..FRAGMENTS {
+        parser.feed(b"x").expect("feed candidate byte");
+    }
+
+    assert!(
+        OscParser::osc_candidate_scan_bytes() <= FRAGMENTS * 32,
+        "scanned {} bytes for {FRAGMENTS} fragmented bytes",
+        OscParser::osc_candidate_scan_bytes()
+    );
+}
+
+#[test]
+fn flush_drops_unterminated_cosh_candidate_without_leaking() {
+    let mut parser = parser_for_test("unterminated-flush");
+    parser
+        .feed(b"\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"INTERNAL_TOKEN\"")
+        .expect("feed unterminated candidate");
+    parser.flush_pending().expect("flush parser at EOF");
+
+    assert!(parser.display.is_empty());
+    assert!(parser.clean.is_empty());
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn flush_keeps_output_before_mixed_unterminated_cosh_candidate() {
+    let mut parser = parser_for_test("unterminated-mixed-flush");
+    parser
+        .feed(b"visible-before\r\n\x1b]1337;COSH;{\"event\":\"precmd\",\"token\":\"INTERNAL_TOKEN\"visible-looking-private-tail")
+        .expect("feed visible output and unterminated candidate");
+    parser.flush_pending().expect("flush mixed parser at EOF");
+
+    assert_eq!(parser.display.resident_slice(), b"visible-before\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible-before\r\n");
+    assert!(parser.events.is_empty());
+}
+
+#[test]
+fn bel_terminated_malformed_cosh_marker_reports_failure_and_recovers() {
+    let mut parser = parser_for_test("malformed-recovery");
+    parser
+        .feed(b"\x1b]1337;COSH;not-json\x07visible\r\n")
+        .expect("feed malformed marker");
+
+    assert_eq!(
+        parser
+            .events
+            .iter()
+            .filter(|event| event.kind == ShellEventKind::ComponentFailed)
+            .count(),
+        1
+    );
+    assert_eq!(parser.display.resident_slice(), b"visible\r\n");
+    assert_eq!(parser.clean.resident_slice(), b"visible\r\n");
+}
+
+#[test]
 fn trusted_history_file_marker_is_private_and_observed() {
     let observed = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&observed);


### PR DESCRIPTION
## Why

An unterminated private COSH OSC candidate can retain unbounded input, hide terminal output, and prevent later authenticated frames from being parsed. The receiver needs bounded recovery without exposing abandoned internal transport bytes. This change keeps fragmented processing linear while preserving the existing BEL-terminated protocol.

## What changed

- Cap retained COSH OSC candidates at 64 KiB and resynchronize at the latest complete COSH prefix.
- Preserve fragmented restart prefixes across the cap boundary and keep incremental scans linear.
- Drop unterminated private candidates at EOF while retaining existing malformed-frame recovery.

## Related issue

closes #2964

## User / Agent impact

A damaged or unterminated internal OSC frame no longer blocks subsequent terminal output or authenticated COSH markers.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

Low risk. The change is limited to the authenticated private OSC receiver. It does not change the sender, marker schema, BEL framing contract, shell execution policy, or public interfaces. Candidates larger than 64 KiB are intentionally discarded.

## Validation

- `cargo test --package cosh-shell --lib shell_host::implementation::osc_tests:: -- --test-threads=4` — 61 passed
- `cargo test --package cosh-shell --test raw_cli agent_input::raw_cli_routes_path_prompt_after_shell_cwd_change -- --exact` — 1 passed
- `cargo test --package cosh-shell --test shell_host marker::marker_json_escape_removes_raw_controls_and_preserves_utf8 -- --exact` — 1 passed
- `cargo test --package cosh-shell --test shell_host marker::shell_host_marker_control_cwd_keeps_json_frame_intact -- --exact` — 1 passed
- `cargo test --package cosh-shell --test shell_host marker::shell_host_rejects_forged_osc_markers_without_session_token -- --exact` — 1 passed
- `cargo test --package cosh-shell --test shell_host marker::shell_host_pty_cannot_read_private_marker_token -- --exact` — 1 passed
- `cargo test --package cosh-shell --test shell_host marker::shell_host_pty_statusful_precmd_marker_completes_inflight_command -- --exact` — 1 passed
- `cargo fmt --all -- --check`
- `git diff --check`

Full workspace gates, Clippy, release builds, ECS, and provider validation are delegated to CI or later integration validation.

## Documentation and rollback

No documentation changes are needed because the wire protocol and public behavior are unchanged. Roll back by reverting `f7120ff22cf0fd48b6244e9975cb08d90ce66557`.


