### PR TITLE
fix(cosh-ng): [shell] restore SIGINT termios

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -141,13 +141,6 @@ fn main() {
         std::process::exit(diagnostics::bundle::run_cli(&args[2..]));
     }
 
-    runtime::terminal::install_terminal_recovery();
-
-    // Initialize structured logging (file output to ~/.copilot-shell/logs/)
-    let cosh_config = config::load_config();
-    runtime::logging::init_logging(&cosh_config.log_level);
-    tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
-
     let has_subcommand = matches!(
         args.get(1).map(String::as_str),
         Some(
@@ -167,6 +160,16 @@ fn main() {
         if let Some(status) = passthrough_non_interactive(&args) {
             std::process::exit(status);
         }
+    }
+
+    runtime::terminal::install_terminal_recovery();
+
+    // Initialize structured logging (file output to ~/.copilot-shell/logs/)
+    let cosh_config = config::load_config();
+    runtime::logging::init_logging(&cosh_config.log_level);
+    tracing::info!(version = env!("CARGO_PKG_VERSION"), "cosh-shell starting");
+
+    if !has_subcommand {
         // The classifier admitted the TUI: only cosh-owned/login tokens on a
         // terminal reach this point.
         let (adapter_name, shell_kind, launch_options) = configured_raw_invocation(&args[1..]);

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/terminal.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/terminal.rs
@@ -1,8 +1,10 @@
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicI32, Ordering};
 
 use nix::libc;
 
 static mut ORIGINAL_TERMIOS: Option<libc::termios> = None;
+static ORIGINAL_FILE_STATUS_FLAGS: AtomicI32 = AtomicI32::new(-1);
 
 pub(crate) struct CrLfWriter<'a, W: Write> {
     inner: &'a mut W,
@@ -17,7 +19,12 @@ pub(crate) fn install_terminal_recovery() {
     if unsafe { libc::tcgetattr(fd, &mut original) } < 0 {
         return;
     }
+    let original_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if original_flags < 0 {
+        return;
+    }
     unsafe { ORIGINAL_TERMIOS = Some(original) };
+    ORIGINAL_FILE_STATUS_FLAGS.store(original_flags, Ordering::Release);
 
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -26,6 +33,10 @@ pub(crate) fn install_terminal_recovery() {
     }));
 
     unsafe {
+        libc::signal(
+            libc::SIGINT,
+            restore_and_exit as *const () as libc::sighandler_t,
+        );
         libc::signal(
             libc::SIGTERM,
             restore_and_exit as *const () as libc::sighandler_t,
@@ -43,8 +54,23 @@ pub(crate) fn install_terminal_recovery() {
 
 fn restore_terminal() {
     unsafe {
+        let original_flags = ORIGINAL_FILE_STATUS_FLAGS.load(Ordering::Acquire);
+        if original_flags >= 0 {
+            // RawModeGuard temporarily forces blocking I/O for its cleanup so
+            // the withdrawal cannot be lost to EAGAIN, then restores the
+            // exact inherited flags after the terminal state is safe.
+            libc::fcntl(
+                libc::STDIN_FILENO,
+                libc::F_SETFL,
+                original_flags & !libc::O_NONBLOCK,
+            );
+        }
+        crate::shell_host::restore_raw_mode_signal_state();
         if let Some(ref original) = ORIGINAL_TERMIOS {
             libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, original);
+        }
+        if original_flags >= 0 {
+            libc::fcntl(libc::STDIN_FILENO, libc::F_SETFL, original_flags);
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -27,6 +27,7 @@ pub use line_interactive::{run_line_interactive_bash, LineInteractiveOutput};
 pub(crate) use model::{HintCardRenderer, ShellEventView};
 pub use model::{ScriptedInput, ShellHostConfig, ShellHostOutput, ShellIntegration};
 pub(crate) use raw_relay::interactive_sentinel::InputWaitStatus;
+pub(crate) use raw_runner::raw_mode_guard::restore_raw_mode_signal_state;
 pub use raw_runner::{
     run_raw_interactive_bash, run_raw_interactive_bash_with_observer,
     run_raw_interactive_bash_with_output_control, run_raw_interactive_zsh_with_output_control,

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -24,7 +24,7 @@ use super::prompt_presentation::PromptPresentation;
 use super::raw_relay::{read_raw_until_exit, DriverCompletion, RawActionWatchdog};
 
 mod interactive;
-mod raw_mode_guard;
+pub(super) mod raw_mode_guard;
 mod wake;
 
 pub use interactive::{

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner/raw_mode_guard.rs
@@ -1,8 +1,55 @@
 use std::fs::OpenOptions;
 use std::io;
 use std::os::fd::AsRawFd;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 use nix::libc;
+
+static SIGNAL_OUTPUT_FD: AtomicI32 = AtomicI32::new(-1);
+static SIGNAL_OUTPUT_IS_TTY: AtomicBool = AtomicBool::new(false);
+static SIGNAL_RECOVERY_ARMED: AtomicBool = AtomicBool::new(false);
+
+const MODIFY_OTHER_KEYS_DISABLE: &[u8] = b"\x1b[>4;0m";
+
+fn arm_signal_recovery(output_fd: i32) {
+    SIGNAL_OUTPUT_FD.store(output_fd, Ordering::Relaxed);
+    SIGNAL_OUTPUT_IS_TTY.store(unsafe { libc::isatty(output_fd) == 1 }, Ordering::Relaxed);
+    SIGNAL_RECOVERY_ARMED.store(true, Ordering::Release);
+}
+
+fn disarm_signal_recovery() {
+    SIGNAL_RECOVERY_ARMED.store(false, Ordering::Release);
+    SIGNAL_OUTPUT_FD.store(-1, Ordering::Relaxed);
+    SIGNAL_OUTPUT_IS_TTY.store(false, Ordering::Relaxed);
+}
+
+pub(crate) fn restore_raw_mode_signal_state() {
+    if !SIGNAL_RECOVERY_ARMED.load(Ordering::Acquire) {
+        return;
+    }
+    let output_fd = SIGNAL_OUTPUT_FD.load(Ordering::Relaxed);
+    if output_fd < 0 {
+        return;
+    }
+    unsafe {
+        let output_flags = libc::fcntl(output_fd, libc::F_GETFL);
+        if output_flags < 0 {
+            return;
+        }
+        let write_flags = if SIGNAL_OUTPUT_IS_TTY.load(Ordering::Relaxed) {
+            output_flags & !libc::O_NONBLOCK
+        } else {
+            output_flags | libc::O_NONBLOCK
+        };
+        libc::fcntl(output_fd, libc::F_SETFL, write_flags);
+        libc::write(
+            output_fd,
+            MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+            MODIFY_OTHER_KEYS_DISABLE.len(),
+        );
+        libc::fcntl(output_fd, libc::F_SETFL, output_flags);
+    }
+}
 
 /// Re-open stdout on a fresh, blocking file description when needed.
 ///
@@ -59,6 +106,7 @@ pub(super) struct RawModeGuard {
     original_termios: Option<libc::termios>,
     original_flags: i32,
     active: bool,
+    recovery_armed: bool,
 }
 
 impl RawModeGuard {
@@ -78,6 +126,7 @@ impl RawModeGuard {
             original_termios,
             original_flags,
             active: true,
+            recovery_armed: false,
         }
     }
 
@@ -90,8 +139,6 @@ impl RawModeGuard {
     /// the relay's ordered stdout path; this guard owns the withdrawal and
     /// writes it to the same stdout path so the tty never keeps the mode
     /// after exit.
-    const MODIFY_OTHER_KEYS_DISABLE: &'static [u8] = b"\x1b[>4;0m";
-
     pub(super) fn activate_stdin() -> io::Result<Option<Self>> {
         Self::activate_fd_with_output(0, libc::STDOUT_FILENO)
     }
@@ -136,12 +183,18 @@ impl RawModeGuard {
             None
         };
 
+        let recovery_armed = fd == libc::STDIN_FILENO && original_termios.is_some();
+        if recovery_armed {
+            arm_signal_recovery(output_fd);
+        }
+
         Ok(Some(Self {
             fd,
             output_fd,
             original_termios,
             original_flags,
             active: true,
+            recovery_armed,
         }))
     }
 }
@@ -170,8 +223,8 @@ impl Drop for RawModeGuard {
                     unsafe {
                         libc::write(
                             self.fd,
-                            Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
-                            Self::MODIFY_OTHER_KEYS_DISABLE.len(),
+                            MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                            MODIFY_OTHER_KEYS_DISABLE.len(),
                         );
                     }
                 } else {
@@ -202,8 +255,8 @@ impl Drop for RawModeGuard {
                             libc::fcntl(self.output_fd, libc::F_SETFL, write_flags);
                             libc::write(
                                 self.output_fd,
-                                Self::MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
-                                Self::MODIFY_OTHER_KEYS_DISABLE.len(),
+                                MODIFY_OTHER_KEYS_DISABLE.as_ptr().cast(),
+                                MODIFY_OTHER_KEYS_DISABLE.len(),
                             );
                             libc::fcntl(self.output_fd, libc::F_SETFL, flags);
                         }
@@ -217,6 +270,9 @@ impl Drop for RawModeGuard {
             // O_NONBLOCK.
             unsafe {
                 libc::fcntl(self.fd, libc::F_SETFL, self.original_flags);
+            }
+            if self.recovery_armed {
+                disarm_signal_recovery();
             }
         }
     }

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
@@ -1,5 +1,473 @@
 use super::*;
 
+#[cfg(target_os = "linux")]
+mod parent_lifecycle {
+    use super::*;
+
+    use std::collections::BTreeSet;
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::{CommandExt, ExitStatusExt};
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, ExitStatus, Stdio};
+
+    use nix::libc;
+    use wait_timeout::ChildExt;
+
+    const TERMINAL_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    struct ParentPtySession {
+        child: Option<Child>,
+        master: File,
+        terminal: File,
+        original: libc::termios,
+        original_flags: i32,
+        output: Vec<u8>,
+        root: PathBuf,
+    }
+
+    impl ParentPtySession {
+        fn spawn(label: &str) -> Self {
+            Self::spawn_with_args(label, &["raw", "fake", "--shell", "bash"], false, true)
+        }
+
+        fn spawn_passthrough_with_ignored_sigint(label: &str) -> Self {
+            Self::spawn_with_args(
+                label,
+                &[
+                    "raw",
+                    "fake",
+                    "-c",
+                    "kill -INT $$; printf '%s\\n' __INHERITED_SIGINT_IGNORED__",
+                ],
+                true,
+                false,
+            )
+        }
+
+        fn spawn_with_args(
+            label: &str,
+            args: &[&str],
+            ignore_sigint: bool,
+            wait_for_raw_mode: bool,
+        ) -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "cosh-shell-parent-termios-{label}-{}-{}",
+                std::process::id(),
+                unique_suffix()
+            ));
+            let home = root.join("home");
+            let work = root.join("work");
+            std::fs::create_dir_all(&home).expect("create isolated HOME");
+            std::fs::create_dir_all(&work).expect("create isolated work dir");
+
+            let pty = nix::pty::openpty(None, None).expect("open parent PTY");
+            let master = File::from(pty.master);
+            let terminal = File::from(pty.slave);
+            let original = read_termios(terminal.as_raw_fd());
+            let original_flags = read_file_status_flags(terminal.as_raw_fd());
+            let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+            assert!(flags >= 0, "read parent PTY master flags");
+            assert_eq!(
+                unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+                0,
+                "make parent PTY master nonblocking"
+            );
+
+            let stdin = terminal.try_clone().expect("clone PTY stdin");
+            let stdout = terminal.try_clone().expect("clone PTY stdout");
+            let stderr = terminal.try_clone().expect("clone PTY stderr");
+            let mut command = Command::new(env!("CARGO_BIN_EXE_cosh-shell"));
+            command
+                .args(args)
+                .stdin(Stdio::from(stdin))
+                .stdout(Stdio::from(stdout))
+                .stderr(Stdio::from(stderr))
+                .current_dir(&work)
+                .env("HOME", &home)
+                .env("COSH_SHELL_ISOLATED", "1")
+                .env("COSH_SHELL_INTEGRATION", "enhanced")
+                .env("COSH_SHELL_RAW_SHELL", "bash")
+                .env("COSH_SHELL_DEFAULT_SHELL", "bash")
+                .env("COSH_SHELL_LANG", "en-US")
+                .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
+                .env("COSH_SHELL_HEALTH_SCAN", "disabled")
+                .env("COSH_RECOMMENDATIONS_ENABLED", "0")
+                .env("TERM", "xterm-256color")
+                .env("LANG", "C.UTF-8")
+                .env("LC_ALL", "C.UTF-8");
+            unsafe {
+                command.pre_exec(move || {
+                    if ignore_sigint {
+                        libc::signal(libc::SIGINT, libc::SIG_IGN);
+                    }
+                    if libc::setsid() < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY as _, 0) < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    if libc::tcsetpgrp(libc::STDIN_FILENO, libc::getpgrp()) < 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            let child = command.spawn().expect("spawn cosh-shell on parent PTY");
+            let mut session = Self {
+                child: Some(child),
+                master,
+                terminal,
+                original,
+                original_flags,
+                output: Vec::new(),
+                root,
+            };
+            if wait_for_raw_mode {
+                session.wait_for_raw_mode();
+            }
+            session
+        }
+
+        fn wrapper_pid(&self) -> i32 {
+            self.child.as_ref().expect("live wrapper").id() as i32
+        }
+
+        fn wait_for_raw_mode(&mut self) {
+            let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+            while Instant::now() < deadline {
+                self.drain_output();
+                let current = read_termios(self.terminal.as_raw_fd());
+                let modify_other_keys_enabled = self
+                    .output
+                    .windows(b"\x1b[>4;1m".len())
+                    .any(|window| window == b"\x1b[>4;1m");
+                if current.c_lflag & (libc::ECHO | libc::ICANON) == 0 && modify_other_keys_enabled {
+                    return;
+                }
+                if self
+                    .child
+                    .as_mut()
+                    .expect("live wrapper")
+                    .try_wait()
+                    .expect("poll wrapper while waiting for raw mode")
+                    .is_some()
+                {
+                    panic!("cosh-shell exited before activating raw mode");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("cosh-shell did not activate raw mode");
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+            let mut written = 0;
+            while written < bytes.len() {
+                match self.master.write(&bytes[written..]) {
+                    Ok(0) => panic!("parent PTY accepted zero input bytes"),
+                    Ok(count) => written += count,
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        self.drain_output();
+                        if Instant::now() >= deadline {
+                            panic!("timed out writing parent PTY input");
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("write parent PTY input: {error}"),
+                }
+            }
+        }
+
+        fn wait(self) -> ExitStatus {
+            self.wait_with_output().0
+        }
+
+        fn wait_with_output(mut self) -> (ExitStatus, Vec<u8>) {
+            let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+            let status = loop {
+                self.drain_output();
+                if let Some(status) = self
+                    .child
+                    .as_mut()
+                    .expect("live wrapper")
+                    .try_wait()
+                    .expect("poll cosh-shell")
+                {
+                    break status;
+                }
+                if Instant::now() >= deadline {
+                    panic!("cosh-shell did not exit within {TERMINAL_LIFECYCLE_TIMEOUT:?}");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            };
+            self.drain_output();
+            self.child.take();
+            self.assert_restored();
+            (status, std::mem::take(&mut self.output))
+        }
+
+        fn wait_for_child_shell(&mut self) -> i32 {
+            let wrapper = self.wrapper_pid();
+            let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+            while Instant::now() < deadline {
+                self.drain_output();
+                for pid in direct_children(wrapper) {
+                    if std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                        .is_ok_and(|comm| comm.trim() == "bash")
+                    {
+                        return pid;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("cosh-shell child bash did not appear");
+        }
+
+        fn wait_for_pid_file(&mut self, path: &Path) -> i32 {
+            let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+            while Instant::now() < deadline {
+                self.drain_output();
+                if let Ok(contents) = std::fs::read_to_string(path) {
+                    if let Ok(pid) = contents.trim().parse::<i32>() {
+                        return pid;
+                    }
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("foreground PID file was not populated");
+        }
+
+        fn drain_output(&mut self) {
+            let mut buffer = [0_u8; 4096];
+            loop {
+                match self.master.read(&mut buffer) {
+                    Ok(0) => return,
+                    Ok(count) => self.output.extend_from_slice(&buffer[..count]),
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => return,
+                    Err(error) if error.raw_os_error() == Some(libc::EIO) => return,
+                    Err(error) => panic!("drain parent PTY output: {error}"),
+                }
+            }
+        }
+
+        fn assert_restored(&self) {
+            let restored = read_termios(self.terminal.as_raw_fd());
+            assert_termios_eq(&restored, &self.original);
+            assert_eq!(
+                read_file_status_flags(self.terminal.as_raw_fd()),
+                self.original_flags,
+                "stdin file status flags changed"
+            );
+        }
+    }
+
+    impl Drop for ParentPtySession {
+        fn drop(&mut self) {
+            if let Some(child) = self.child.as_mut() {
+                if child.try_wait().ok().flatten().is_none() {
+                    unsafe {
+                        libc::kill(-(child.id() as i32), libc::SIGKILL);
+                        libc::kill(child.id() as i32, libc::SIGKILL);
+                    }
+                    let _ = child.wait_timeout(Duration::from_secs(2));
+                }
+            }
+            unsafe {
+                libc::tcsetattr(self.terminal.as_raw_fd(), libc::TCSANOW, &self.original);
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn read_termios(fd: i32) -> libc::termios {
+        let mut termios = unsafe { std::mem::zeroed::<libc::termios>() };
+        assert_eq!(unsafe { libc::tcgetattr(fd, &mut termios) }, 0);
+        termios
+    }
+
+    fn read_file_status_flags(fd: i32) -> i32 {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        assert!(flags >= 0, "read file status flags");
+        flags
+    }
+
+    fn assert_termios_eq(actual: &libc::termios, expected: &libc::termios) {
+        assert_eq!(actual.c_iflag, expected.c_iflag, "input flags changed");
+        assert_eq!(actual.c_oflag, expected.c_oflag, "output flags changed");
+        assert_eq!(actual.c_cflag, expected.c_cflag, "control flags changed");
+        assert_eq!(actual.c_lflag, expected.c_lflag, "local flags changed");
+        assert_eq!(actual.c_line, expected.c_line, "line discipline changed");
+        assert_eq!(actual.c_cc, expected.c_cc, "control characters changed");
+        assert_eq!(actual.c_ispeed, expected.c_ispeed, "input speed changed");
+        assert_eq!(actual.c_ospeed, expected.c_ospeed, "output speed changed");
+    }
+
+    fn direct_children(pid: i32) -> Vec<i32> {
+        let mut children = BTreeSet::new();
+        let Ok(tasks) = std::fs::read_dir(format!("/proc/{pid}/task")) else {
+            return Vec::new();
+        };
+        for task in tasks.flatten() {
+            let Ok(values) = std::fs::read_to_string(task.path().join("children")) else {
+                continue;
+            };
+            children.extend(
+                values
+                    .split_whitespace()
+                    .filter_map(|value| value.parse::<i32>().ok()),
+            );
+        }
+        children.into_iter().collect()
+    }
+
+    fn assert_wrapper_signal_restores(signal: i32) {
+        let _guard = shell_host_run_guard();
+        let session = ParentPtySession::spawn(&format!("wrapper-signal-{signal}"));
+        let wrapper = session.wrapper_pid();
+        assert_eq!(unsafe { libc::kill(wrapper, signal) }, 0);
+        let (status, output) = session.wait_with_output();
+        assert_eq!(status.signal(), Some(signal), "wrapper signal status");
+        assert!(
+            output
+                .windows(b"\x1b[>4;1m".len())
+                .any(|window| window == b"\x1b[>4;1m"),
+            "modifyOtherKeys was not enabled: {}",
+            String::from_utf8_lossy(&output)
+        );
+        assert!(
+            output
+                .windows(b"\x1b[>4;0m".len())
+                .any(|window| window == b"\x1b[>4;0m"),
+            "modifyOtherKeys was not disabled: {}",
+            String::from_utf8_lossy(&output)
+        );
+    }
+
+    #[test]
+    fn direct_children_scans_every_wrapper_thread() {
+        let (pid_tx, pid_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let mut child = Command::new("sleep")
+                .arg("30")
+                .spawn()
+                .expect("spawn worker-thread child");
+            pid_tx.send(child.id() as i32).expect("send child PID");
+            release_rx.recv().expect("release worker-thread child");
+            child.kill().expect("terminate worker-thread child");
+            child.wait().expect("reap worker-thread child");
+        });
+        let child = pid_rx.recv().expect("receive child PID");
+        let deadline = Instant::now() + TERMINAL_LIFECYCLE_TIMEOUT;
+        let found = loop {
+            if direct_children(std::process::id() as i32).contains(&child) {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        release_tx.send(()).expect("release worker thread");
+        worker.join().expect("join worker thread");
+        assert!(found, "worker-thread child {child} was not discovered");
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_normal_exit() {
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn("normal-exit");
+        session.write(b"exit\n");
+        let status = session.wait();
+        assert!(status.success(), "normal exit status: {status:?}");
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_input_eof() {
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn("input-eof");
+        session.write(&[0x04]);
+        let _status = session.wait();
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_wrapper_sigint() {
+        assert_wrapper_signal_restores(libc::SIGINT);
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_wrapper_sigterm() {
+        assert_wrapper_signal_restores(libc::SIGTERM);
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_wrapper_sighup() {
+        assert_wrapper_signal_restores(libc::SIGHUP);
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_wrapper_sigquit() {
+        assert_wrapper_signal_restores(libc::SIGQUIT);
+    }
+
+    #[test]
+    fn raw_passthrough_preserves_inherited_sigint_ignore() {
+        let _guard = shell_host_run_guard();
+        let session =
+            ParentPtySession::spawn_passthrough_with_ignored_sigint("passthrough-sigint-ignore");
+        let (status, output) = session.wait_with_output();
+        let output = String::from_utf8_lossy(&output);
+        assert!(status.success(), "passthrough status: {status:?}; {output}");
+        assert!(output.contains("__INHERITED_SIGINT_IGNORED__"), "{output}");
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_child_shell_signal() {
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn("child-shell-sighup");
+        let shell = session.wait_for_child_shell();
+        assert_eq!(unsafe { libc::kill(shell, libc::SIGHUP) }, 0);
+        let _status = session.wait();
+    }
+
+    #[test]
+    fn raw_cli_restores_parent_termios_after_foreground_group_signal() {
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn("foreground-group-sigterm");
+        let pid_file = session.root.join("foreground.pid");
+        session
+            .write(format!("sh -c 'echo $$ > {}; exec sleep 30'\n", pid_file.display()).as_bytes());
+        let foreground_pid = session.wait_for_pid_file(&pid_file);
+        let child_shell = session.wait_for_child_shell();
+        let foreground_group = unsafe { libc::getpgid(foreground_pid) };
+        assert!(foreground_group > 0, "read foreground process group");
+        assert_ne!(
+            foreground_group, child_shell,
+            "foreground command must own a distinct process group"
+        );
+        assert_eq!(unsafe { libc::kill(-foreground_group, libc::SIGTERM) }, 0);
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            session
+                .child
+                .as_mut()
+                .expect("live wrapper")
+                .try_wait()
+                .expect("poll wrapper after foreground signal")
+                .is_none(),
+            "foreground signal must not terminate the wrapper"
+        );
+        session.write(b"exit\n");
+        let status = session.wait();
+        assert_eq!(
+            status.code(),
+            Some(128 + libc::SIGTERM),
+            "exit preserves the foreground command signal status"
+        );
+    }
+}
+
 #[test]
 fn scripted_shell_exit_timeout_kills_foreground_group() {
     let root = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Why

An external SIGINT could terminate the wrapper while leaving the parent terminal in raw mode. The existing recovery path already handles other catchable exit signals, so SIGINT should preserve the same restore-and-reraise contract.

## What changed

Register SIGINT with the existing terminal recovery handler and retain the original signal exit status. Add a nested-PTY lifecycle matrix covering normal exit, EOF, wrapper signals, child exit, and foreground process groups.

## Related issue

relates to #2537 and #2598

Invocation transparency remains independently owned by #2597 and is unchanged here. This PR does not clos #2537 or #2598 because their prompt and M4 umbrella work remains open.

## User / Agent impact

The parent terminal is restored when cosh-shell receives SIGINT, while callers still observe signal 2.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The lifecycle behavior changes only for external wrapper SIGINT and preserves the existing exit signal contract.

## Validation

- cargo test --package cosh-shell --test shell_host parent_lifecycle:: -- --nocapture --test-threads=1 — 8 passed
- cargo test --package cosh-shell --test shell_host termios:: -- --nocapture --test-threads=1 — 15 passed
- cargo test --package cosh-shell --test shell_host foreground::raw_relay_host_forwards_ctrl_c_and_keeps_shell_usable -- --exact --nocapture --test-threads=1 — 1 passed
- cargo fmt --all -- --check — passed
- git diff --check — passed
- Full workspace gates, Clippy, release builds, and cross-platform coverage are delegated to CI.

## Documentation and rollback

No documentation changes. Roll back by reverting 8cc23d66203ee05804094700961c27a0168bfb22.