### PR TITLE
refactor(anolisa): classify batch outcomes

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/application.rs
@@ -3,7 +3,9 @@
 use std::collections::HashSet;
 
 use anolisa_core::execution::{CommandOutcome, ExecutionIntent, PreparedExecution};
+use anolisa_core::executor::PHASE_NATIVE_TXN;
 use anolisa_core::planner::{NoOpReason, Plan, Step};
+use anolisa_core::{Transaction, TransactionOutcomeStatus, TransactionStepStatus};
 use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::pkg_transaction::PackageTransaction;
 use anolisa_platform::privilege;
@@ -73,6 +75,42 @@ pub(super) enum InstallApplicationOutcome {
     },
 }
 
+/// Terminal application failure retained for batch classification.
+#[derive(Debug)]
+pub(super) enum ApplicationFailure {
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial(CliError),
+    /// The application failed without a known partial state.
+    Failed(CliError),
+}
+
+impl ApplicationFailure {
+    /// Classify an execution failure from its in-memory journal evidence.
+    pub(super) fn from_journal(error: CliError, journal: &Transaction) -> Self {
+        let native_transaction_committed = journal.steps.iter().any(|step| {
+            step.phase == PHASE_NATIVE_TXN && step.status == TransactionStepStatus::Done
+        });
+        if journal.status == TransactionOutcomeStatus::Partial || native_transaction_committed {
+            Self::Partial(error)
+        } else {
+            Self::Failed(error)
+        }
+    }
+
+    /// Restore the existing single-command error projection.
+    pub(super) fn into_cli_error(self) -> CliError {
+        match self {
+            Self::Partial(error) | Self::Failed(error) => error,
+        }
+    }
+}
+
+impl From<CliError> for ApplicationFailure {
+    fn from(error: CliError) -> Self {
+        Self::Failed(error)
+    }
+}
+
 impl InstallApplicationOutcome {
     /// Collapse the typed result to the legacy batch-member classification.
     pub(super) fn batch_outcome(&self) -> InstallOutcome {
@@ -99,6 +137,7 @@ pub(super) fn run(
     ctx: &CliContext,
 ) -> Result<InstallApplicationOutcome, CliError> {
     run_with_planned_components(request, ctx, &HashSet::new())
+        .map_err(ApplicationFailure::into_cli_error)
 }
 
 /// Run one batch member without moving batch-level orchestration into this layer.
@@ -106,7 +145,7 @@ pub(super) fn run_with_planned_components(
     request: InstallRequest<'_>,
     ctx: &CliContext,
     planned_components: &HashSet<String>,
-) -> Result<InstallApplicationOutcome, CliError> {
+) -> Result<InstallApplicationOutcome, ApplicationFailure> {
     let mut activity = Activity::start(
         progress::feedback_for_stderr(ctx.json, ctx.quiet),
         &format!("Preparing to install {}...", request.component),
@@ -114,7 +153,7 @@ pub(super) fn run_with_planned_components(
     let (query, txn) = host_backends(request.component, request.args, ctx)?;
     let env = anolisa_env::EnvService::detect();
     let rpmdb = RpmdbProbe::for_host(&env);
-    run_with_dependencies(
+    run_with_dependencies_classified(
         request,
         ctx,
         &env,
@@ -131,6 +170,7 @@ pub(super) fn run_with_planned_components(
 // Tests vary every boundary independently; keeping the parameters explicit
 // makes the application contract visible instead of hiding it in a test bag.
 #[expect(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(super) fn run_with_dependencies(
     request: InstallRequest<'_>,
     ctx: &CliContext,
@@ -142,6 +182,33 @@ pub(super) fn run_with_dependencies(
     planned_components: &HashSet<String>,
     reporter: &mut dyn ProgressReporter,
 ) -> Result<InstallApplicationOutcome, CliError> {
+    run_with_dependencies_classified(
+        request,
+        ctx,
+        env,
+        rpmdb,
+        query,
+        txn,
+        is_root,
+        planned_components,
+        reporter,
+    )
+    .map_err(ApplicationFailure::into_cli_error)
+}
+
+/// Run the application protocol while preserving its terminal classification.
+#[expect(clippy::too_many_arguments)]
+pub(super) fn run_with_dependencies_classified(
+    request: InstallRequest<'_>,
+    ctx: &CliContext,
+    env: &anolisa_env::EnvFacts,
+    rpmdb: &RpmdbProbe,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    planned_components: &HashSet<String>,
+    reporter: &mut dyn ProgressReporter,
+) -> Result<InstallApplicationOutcome, ApplicationFailure> {
     let planned = plan_component(request.component, request.args, ctx, env, rpmdb, query, txn)?;
     let prepared = prepare_plan(&planned.plan, request.intent);
     debug_assert!(matches!(

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch.rs
@@ -54,9 +54,12 @@ use super::{
 };
 
 mod application;
+#[cfg(test)]
+use application::InstallBatchOutcome;
 use application::{
     BatchApplicationOutcome, BatchEffectOutcome, BatchMemberOutcome, BatchMemberStatus,
-    BatchOutputEvent, MemberApplicationOutcome, failed_item,
+    BatchOutputEvent, MemberApplicationOutcome, failed_item, member_application_outcome,
+    partial_item, project_member_application,
 };
 // ── --all support ───────────────────────────────────────────────────
 
@@ -155,7 +158,7 @@ fn render_application_outcome(
     let failed = outcome
         .items
         .iter()
-        .filter(|item| item.status == BatchMemberStatus::Failed)
+        .filter(|item| item.status.is_unsuccessful())
         .count();
     let skipped = outcome
         .items
@@ -351,18 +354,16 @@ fn execute_merged_group(
     };
     let mut degrade = |name: &str| {
         let per_args = per_component_args(name, args);
-        let outcome = super::application::run(
+        let outcome = super::application::run_with_planned_components(
             super::application::InstallRequest {
                 component: name,
                 args: &per_args,
                 intent: ExecutionIntent::Apply,
             },
             &suppressed_ctx,
-        )?;
-        Ok(MemberApplicationOutcome {
-            outcome: outcome.batch_outcome(),
-            warnings: outcome.warnings().to_vec(),
-        })
+            &std::collections::HashSet::new(),
+        );
+        Ok(member_application_outcome(outcome))
     };
     execute_merged_group_with_deps(
         group,
@@ -547,7 +548,7 @@ fn execute_merged_group_with_deps(
             for (item, mut journal) in active {
                 let target = item.planned.component.clone();
                 if let Err(err) = journal.mark_done(0) {
-                    items.push(failed_item(
+                    items.push(partial_item(
                         &item.name,
                         format!(
                             "install of '{target}' failed: the merged native transaction committed but its journal could not be updated: {err}; run `anolisa repair {target}` to reconcile"
@@ -607,7 +608,7 @@ fn execute_merged_group_with_deps(
                             plan: None,
                         });
                     }
-                    Err(err) => items.push(failed_item(
+                    Err(err) => items.push(partial_item(
                         &item.name,
                         format!(
                             "install of '{target}' failed: {err}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
@@ -620,7 +621,7 @@ fn execute_merged_group_with_deps(
             // reads the same as the members' journals.
             let any_member_failed = items[members_start..]
                 .iter()
-                .any(|item| item.status == BatchMemberStatus::Failed);
+                .any(|item| item.status.is_unsuccessful());
             store.operations.push(OperationRecord {
                 id: batch_operation_id,
                 command: BATCH_COMMAND.to_string(),
@@ -654,7 +655,7 @@ fn execute_merged_group_with_deps(
                         TransactionOutcomeStatus::Failed
                     }
                     _ => {
-                        items.push(failed_item(
+                        items.push(partial_item(
                             &item.name,
                             format!(
                                 "merged native transaction failed after '{}' reached the rpmdb: {reason}; run `anolisa repair {target}` to reconcile",
@@ -700,15 +701,15 @@ fn execute_merged_group_with_deps(
                         for warning in outcome.warnings {
                             output(BatchOutputEvent::Warning(warning));
                         }
-                        items.push(BatchMemberOutcome {
-                            component: name,
-                            status: application::batch_status(
-                                outcome.outcome,
-                                ExecutionIntent::Apply,
-                            ),
-                            reason: None,
-                            plan: None,
-                        });
+                        let item = project_member_application(
+                            &name,
+                            ExecutionIntent::Apply,
+                            outcome.outcome,
+                        );
+                        if args.fail_fast && item.status.is_unsuccessful() {
+                            fail_fast_tripped = true;
+                        }
+                        items.push(item);
                     }
                     Err(err) => {
                         items.push(failed_item(&name, err.reason().to_string()));
@@ -804,10 +805,13 @@ mod tests {
     use anolisa_platform::pkg_query::{PackageInfo, PackageQueryError};
     use anolisa_platform::pkg_transaction::PackageTransactionError;
 
+    use super::super::RpmdbProbe;
     use super::super::tests::{
-        FakeInstaller, FakeQuery, load_store, pkg_info, system_ctx_with_configured_rpm_repo,
+        FakeInstaller, FakeQuery, args, linux_env, load_store, pkg_info,
+        system_ctx_with_configured_rpm_repo,
     };
     use super::super::types::InstallOutcome;
+    use crate::progress::NoopReporter;
 
     const NOW: &str = "2026-07-17T00:00:00Z";
 
@@ -972,9 +976,52 @@ mod tests {
 
     fn applied_member() -> MemberApplicationOutcome {
         MemberApplicationOutcome {
-            outcome: InstallOutcome::Installed,
+            outcome: InstallBatchOutcome::Completed(InstallOutcome::Installed),
             warnings: Vec::new(),
         }
+    }
+
+    #[test]
+    fn single_member_batch_preserves_partial_application_failure() {
+        let (_tmp, c) = system_ctx_with_configured_rpm_repo(false);
+        let layout = common::resolve_layout(&c);
+        let fake = FakeInstaller::new(
+            "copilot-shell",
+            pkg_info("copilot-shell", "2.3.0", Some("1.al8"), "x86_64"),
+        )
+        .failing_state_save(layout.state_dir.join("installed.toml"));
+        let mut install_args = args("copilot-shell");
+        install_args.backend = Some("rpm".to_string());
+        let mut reporter = NoopReporter;
+
+        let result = super::super::application::run_with_dependencies_classified(
+            super::super::application::InstallRequest {
+                component: "copilot-shell",
+                args: &install_args,
+                intent: ExecutionIntent::Apply,
+            },
+            &c,
+            &linux_env(),
+            &RpmdbProbe::absent(),
+            &fake,
+            &fake,
+            true,
+            &std::collections::HashSet::new(),
+            &mut reporter,
+        );
+        let member = member_application_outcome(result);
+        let item =
+            project_member_application("copilot-shell", ExecutionIntent::Apply, member.outcome);
+
+        assert_eq!(item.status, BatchMemberStatus::Partial);
+        assert!(
+            item.reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("repair")),
+            "post-transaction record failure must retain repair guidance: {:?}",
+            item.reason
+        );
+        assert_eq!(fake.install_calls.get(), 1, "the native transaction ran");
     }
 
     #[test]
@@ -1268,7 +1315,7 @@ mod tests {
         // Forward-only for the landed member: no retry, repair reconciles.
         assert_eq!(degraded.borrow().as_slice(), ["b"]);
         let a = item_status(&items, "a");
-        assert_eq!(a.status, BatchMemberStatus::Failed);
+        assert_eq!(a.status, BatchMemberStatus::Partial);
         let reason = a.reason.as_deref().unwrap();
         assert!(reason.contains("reached the rpmdb"), "got: {reason}");
         assert!(reason.contains("anolisa repair a"), "got: {reason}");

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/batch/application.rs
@@ -33,7 +33,9 @@ pub(super) enum BatchMemberStatus {
     Planned,
     /// Existing state already covers the requested install.
     AlreadyInstalled,
-    /// Planning or execution failed for this member.
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial,
+    /// The member failed without a known partial state.
     Failed,
     /// Fail-fast prevented this member from being attempted.
     Skipped,
@@ -46,9 +48,14 @@ impl BatchMemberStatus {
             Self::Installed => "installed",
             Self::Planned => "planned",
             Self::AlreadyInstalled => "already-installed",
-            Self::Failed => "failed",
+            Self::Partial | Self::Failed => "failed",
             Self::Skipped => "skipped",
         }
+    }
+
+    /// Returns whether this member makes the aggregate batch unsuccessful.
+    pub(super) fn is_unsuccessful(self) -> bool {
+        matches!(self, Self::Partial | Self::Failed)
     }
 }
 
@@ -88,18 +95,26 @@ pub(super) struct BatchEffectOutcome {
     pub(super) items: Vec<BatchMemberOutcome>,
 }
 
+/// Batch-facing classification of a single-component application result.
+pub(super) enum InstallBatchOutcome {
+    /// The member completed or required no change.
+    Completed(InstallOutcome),
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial { reason: String },
+    /// The member failed without a known partial state.
+    Failed { reason: String },
+}
+
 /// Per-member fallback result returned to merged transaction orchestration.
 pub(super) struct MemberApplicationOutcome {
-    pub(super) outcome: InstallOutcome,
+    pub(super) outcome: InstallBatchOutcome,
     pub(super) warnings: Vec<String>,
 }
 
 impl BatchApplicationOutcome {
     /// Returns whether any member failed.
     pub(super) fn has_failures(&self) -> bool {
-        self.items
-            .iter()
-            .any(|item| item.status == BatchMemberStatus::Failed)
+        self.items.iter().any(|item| item.status.is_unsuccessful())
     }
 
     /// Returns whether this batch was prepared without applying effects.
@@ -219,7 +234,7 @@ pub(super) fn run(
             let any_failed = effect
                 .items
                 .iter()
-                .any(|item| item.status == BatchMemberStatus::Failed);
+                .any(|item| item.status.is_unsuccessful());
             for item in effect.items {
                 results.insert(item.component.clone(), item);
             }
@@ -243,7 +258,7 @@ pub(super) fn run(
             component: name.clone(),
         });
         let per_args = per_component_args(name, request.args);
-        let member = install_application::run_with_planned_components(
+        let member = member_application_outcome(install_application::run_with_planned_components(
             install_application::InstallRequest {
                 component: name,
                 args: &per_args,
@@ -251,33 +266,23 @@ pub(super) fn run(
             },
             &suppressed_ctx,
             &planned_components,
-        );
-        match member {
-            Ok(outcome) => {
-                for warning in outcome.warnings() {
-                    output(BatchOutputEvent::Warning(warning.clone()));
-                }
-                let legacy = outcome.batch_outcome();
-                if preview && legacy == InstallOutcome::Installed {
-                    planned_components.insert(name.clone());
-                }
-                results.insert(
-                    name.clone(),
-                    BatchMemberOutcome {
-                        component: name.clone(),
-                        status: batch_status(legacy, request.intent),
-                        reason: None,
-                        plan: None,
-                    },
-                );
-            }
-            Err(error) => {
-                results.insert(name.clone(), failed_item(name, error.reason().to_string()));
-                if request.args.fail_fast {
-                    fail_fast_tripped = true;
-                }
-            }
+        ));
+        for warning in member.warnings {
+            output(BatchOutputEvent::Warning(warning));
         }
+        if preview
+            && matches!(
+                member.outcome,
+                InstallBatchOutcome::Completed(InstallOutcome::Installed)
+            )
+        {
+            planned_components.insert(name.clone());
+        }
+        let item = project_member_application(name, request.intent, member.outcome);
+        if request.args.fail_fast && item.status.is_unsuccessful() {
+            fail_fast_tripped = true;
+        }
+        results.insert(name.clone(), item);
     }
 
     let items = names
@@ -300,10 +305,62 @@ pub(super) fn run(
     })
 }
 
+pub(super) fn member_application_outcome(
+    result: Result<
+        install_application::InstallApplicationOutcome,
+        install_application::ApplicationFailure,
+    >,
+) -> MemberApplicationOutcome {
+    match result {
+        Ok(outcome) => MemberApplicationOutcome {
+            outcome: InstallBatchOutcome::Completed(outcome.batch_outcome()),
+            warnings: outcome.warnings().to_vec(),
+        },
+        Err(install_application::ApplicationFailure::Partial(error)) => MemberApplicationOutcome {
+            outcome: InstallBatchOutcome::Partial {
+                reason: error.reason(),
+            },
+            warnings: Vec::new(),
+        },
+        Err(install_application::ApplicationFailure::Failed(error)) => MemberApplicationOutcome {
+            outcome: InstallBatchOutcome::Failed {
+                reason: error.reason(),
+            },
+            warnings: Vec::new(),
+        },
+    }
+}
+
+pub(super) fn project_member_application(
+    name: &str,
+    intent: ExecutionIntent,
+    outcome: InstallBatchOutcome,
+) -> BatchMemberOutcome {
+    match outcome {
+        InstallBatchOutcome::Completed(outcome) => BatchMemberOutcome {
+            component: name.to_string(),
+            status: batch_status(outcome, intent),
+            reason: None,
+            plan: None,
+        },
+        InstallBatchOutcome::Partial { reason } => partial_item(name, reason),
+        InstallBatchOutcome::Failed { reason } => failed_item(name, reason),
+    }
+}
+
 pub(super) fn failed_item(name: &str, reason: String) -> BatchMemberOutcome {
     BatchMemberOutcome {
         component: name.to_string(),
         status: BatchMemberStatus::Failed,
+        reason: Some(reason),
+        plan: None,
+    }
+}
+
+pub(super) fn partial_item(name: &str, reason: String) -> BatchMemberOutcome {
+    BatchMemberOutcome {
+        component: name.to_string(),
+        status: BatchMemberStatus::Partial,
         reason: Some(reason),
         plan: None,
     }
@@ -341,13 +398,26 @@ mod tests {
 
     #[test]
     fn aggregate_failure_is_typed() {
-        let outcome = BatchApplicationOutcome {
-            intent: ExecutionIntent::Apply,
-            merged_transaction: None,
-            items: vec![failed_item("cosh", "failed".to_string())],
-        };
+        for item in [
+            partial_item("cosh", "partial".to_string()),
+            failed_item("cosh", "failed".to_string()),
+        ] {
+            let outcome = BatchApplicationOutcome {
+                intent: ExecutionIntent::Apply,
+                merged_transaction: None,
+                items: vec![item],
+            };
 
-        assert!(outcome.has_failures());
-        assert!(!outcome.is_preview());
+            assert!(outcome.has_failures());
+            assert!(!outcome.is_preview());
+        }
+    }
+
+    #[test]
+    fn partial_and_failed_keep_the_legacy_wire_label() {
+        assert_eq!(BatchMemberStatus::Partial.as_str(), "failed");
+        assert_eq!(BatchMemberStatus::Failed.as_str(), "failed");
+        assert!(BatchMemberStatus::Partial.is_unsuccessful());
+        assert!(BatchMemberStatus::Failed.is_unsuccessful());
     }
 }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/dispatch.rs
@@ -54,7 +54,9 @@ use crate::resolution::{
 };
 use crate::response::CliError;
 
-use super::application::{InstallApplicationOutcome, InstallChange, InstallSubject};
+use super::application::{
+    ApplicationFailure, InstallApplicationOutcome, InstallChange, InstallSubject,
+};
 use super::owned_ops::{
     RawInstallOps, ValidatedInstall, installed_version_label, validate_component_conflict,
     validate_owned_install,
@@ -631,7 +633,7 @@ pub(super) fn execute_planned(
     is_root: bool,
     planned_components: &HashSet<String>,
     reporter: &mut dyn ProgressReporter,
-) -> Result<InstallApplicationOutcome, CliError> {
+) -> Result<InstallApplicationOutcome, ApplicationFailure> {
     let PlannedComponent {
         command,
         mut component,
@@ -1247,7 +1249,7 @@ fn install_applied(
     command: &str,
     reporter: &mut dyn ProgressReporter,
     apply: InstallApply<'_>,
-) -> Result<InstallApplicationOutcome, CliError> {
+) -> Result<InstallApplicationOutcome, ApplicationFailure> {
     if let InstallApply::Delegated {
         repo_config,
         index_base_override,
@@ -1261,7 +1263,8 @@ fn install_applied(
                 command: command.to_string(),
                 reason: "installing an RPM-backed component runs dnf and requires root".to_string(),
                 hint: Some(format!("sudo anolisa install {target}")),
-            });
+            }
+            .into());
         }
     }
 
@@ -1328,8 +1331,13 @@ fn install_applied(
                 let note = ops.retained_packages_note();
                 (result, note)
             };
-            let outcome = result
-                .map_err(|err| owned_error_to_cli(err, target, scope, command, &retained_note))?;
+            let outcome = match result {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let error = owned_error_to_cli(err, target, scope, command, &retained_note);
+                    return Err(ApplicationFailure::from_journal(error, &journal));
+                }
+            };
             warnings.extend(outcome.warnings);
             let mut subject = InstallSubject {
                 component: target.to_string(),
@@ -1371,7 +1379,7 @@ fn install_applied(
                     &pin.resolved_arch,
                 );
             }
-            let outcome = {
+            let execution = {
                 let mut sink = StoreRecordSink::new(&mut store, state_path, context);
                 execute_delegated_steps(
                     &locked_steps,
@@ -1381,13 +1389,19 @@ fn install_applied(
                     &mut journal,
                     now,
                 )
-            }
-            .map_err(|err| CliError::Runtime {
-                command: command.to_string(),
-                reason: format!(
-                    "install of '{target}' failed: {err}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
-                ),
-            })?;
+            };
+            let outcome = match execution {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    let error = CliError::Runtime {
+                        command: command.to_string(),
+                        reason: format!(
+                            "install of '{target}' failed: {err}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
+                        ),
+                    };
+                    return Err(ApplicationFailure::from_journal(error, &journal));
+                }
+            };
             let mut subject = InstallSubject {
                 component: target.to_string(),
                 package: Some(package.to_string()),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update.rs
@@ -1140,7 +1140,20 @@ fn render_application_outcome(
     for warning in application_outcome.warnings() {
         eprintln!("warning: {warning}");
     }
-    let batch_outcome = application_outcome.batch_outcome()?;
+    let batch_outcome = match application_outcome.batch_outcome() {
+        application::UpdateBatchOutcome::Completed(outcome) => outcome,
+        application::UpdateBatchOutcome::Partial { reason }
+        | application::UpdateBatchOutcome::Failed { reason } => {
+            let application::ApplicationOutcome::Applied { command, .. } = &application_outcome
+            else {
+                unreachable!("only applied updates have a terminal failure")
+            };
+            return Err(CliError::Runtime {
+                command: command.clone(),
+                reason,
+            });
+        }
+    };
     match application_outcome {
         application::ApplicationOutcome::NoOp { subject } => {
             render_result(
@@ -2195,7 +2208,7 @@ pub(crate) mod tests {
     /// `installed` mutates: a successful [`update`](PackageTransaction::update)
     /// applies `upgrade_to`, modelling rpmdb advancing after dnf runs — so the
     /// pre-update query and the post-update refresh return different EVRs.
-    struct FakeRpm {
+    pub(super) struct FakeRpm {
         package: String,
         installed: RefCell<Option<PackageInfo>>,
         /// PackageInfo the rpmdb holds after a successful update; `None` keeps
@@ -2217,7 +2230,7 @@ pub(crate) mod tests {
     }
 
     impl FakeRpm {
-        fn new(package: &str, installed: Option<PackageInfo>) -> Self {
+        pub(super) fn new(package: &str, installed: Option<PackageInfo>) -> Self {
             Self {
                 package: package.to_string(),
                 installed: RefCell::new(installed),
@@ -2242,9 +2255,13 @@ pub(crate) mod tests {
             self.multi_version = true;
             self
         }
-        fn post_update_missing(mut self) -> Self {
+        pub(super) fn post_update_missing(mut self) -> Self {
             self.post_update_missing = true;
             self
+        }
+
+        pub(super) fn update_call_count(&self) -> usize {
+            self.update_calls.get()
         }
         fn with_on_update(mut self, hook: Box<dyn Fn()>) -> Self {
             self.on_update = Some(hook);
@@ -4063,7 +4080,8 @@ packages = { rpm = "absent-tool", deb = "absent-tool" }
             "update foo",
         )
         .err()
-        .expect("a drifted snapshot must abort under the lock");
+        .expect("a drifted snapshot must abort under the lock")
+        .into_cli_error();
         assert_eq!(err.code(), "EXECUTION_FAILED");
         assert!(
             err.reason().contains("while this update was resolving"),

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all.rs
@@ -41,6 +41,7 @@ use crate::commands::tier1::rpm_install;
 use crate::context::CliContext;
 use crate::response::{CliError, render_json, render_json_with_status};
 
+use super::application::UpdateBatchOutcome;
 use super::{
     AdapterAction, AdapterRevisionSnapshot, COMMAND, PlannedComponentUpdate, PlannedUpdateRoute,
     adapter_actions_after_update, adapter_revision_snapshot, append_update_log,
@@ -51,7 +52,7 @@ use super::{
 mod application;
 use application::{
     BatchApplicationOutcome, BatchEffectOutcome, BatchMemberOutcome, BatchMemberStatus,
-    BatchOutputEvent, MemberApplicationOutcome, batch_status, failed_item,
+    BatchOutputEvent, MemberApplicationOutcome, batch_status, failed_item, partial_item,
 };
 
 const BATCH_COMMAND: &str = "update all";
@@ -151,7 +152,7 @@ fn render_application_outcome(
     let failed = outcome
         .items
         .iter()
-        .filter(|item| item.status == BatchMemberStatus::Failed)
+        .filter(|item| item.status.is_unsuccessful())
         .count();
     debug_assert_eq!(outcome.has_failures(), failed > 0);
     let items = outcome
@@ -342,13 +343,13 @@ fn execute_merged_updates(
         }
     };
     let mut degrade = |name: &str| {
-        let outcome = super::application::run(
+        let outcome = super::application::run_for_batch(
             super::application::ApplicationRequest {
                 component: name,
                 intent: ExecutionIntent::Apply,
             },
             &suppressed_ctx,
-        )?;
+        );
         Ok(application::member_application_outcome(outcome))
     };
     execute_merged_updates_with_deps(
@@ -531,7 +532,7 @@ fn execute_merged_updates_with_deps(
             for (item, mut journal) in active {
                 let target = item.planned.target.clone();
                 if let Err(err) = journal.mark_done(0) {
-                    items.push(failed_item(
+                    items.push(partial_item(
                         &item.name,
                         format!(
                             "update of '{target}' failed: the merged native transaction committed but its journal could not be updated: {err}; run `anolisa repair {target}` to reconcile"
@@ -612,7 +613,7 @@ fn execute_merged_updates_with_deps(
                             completion_failure.as_deref(),
                         );
                         if let Some(reason) = completion_failure {
-                            items.push(failed_item(
+                            items.push(partial_item(
                                 &item.name,
                                 format!(
                                     "the update of '{target}' committed, but {reason}; run `anolisa repair {target}` to reconcile"
@@ -647,7 +648,7 @@ fn execute_merged_updates_with_deps(
                             adapter_actions,
                         });
                     }
-                    Err(err) => items.push(failed_item(
+                    Err(err) => items.push(partial_item(
                         &item.name,
                         format!(
                             "update of '{target}' failed: {err}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
@@ -660,7 +661,7 @@ fn execute_merged_updates_with_deps(
             // history reads the same as the members' journals.
             let any_member_failed = items[members_start..]
                 .iter()
-                .any(|item| item.status == BatchMemberStatus::Failed);
+                .any(|item| item.status.is_unsuccessful());
             if let Some(parent) = store
                 .operations
                 .iter_mut()
@@ -708,7 +709,7 @@ fn execute_merged_updates_with_deps(
                     Err(err) => Some(format!("could not be re-observed in the rpmdb: {err}")),
                 };
                 let journal_outcome = if let Some(uncertain_reason) = uncertain_reason {
-                    items.push(failed_item(
+                    items.push(partial_item(
                         &item.name,
                         format!(
                             "merged native transaction failed and '{}' {uncertain_reason}: {reason}; run `anolisa repair {target}` to reconcile",
@@ -747,14 +748,15 @@ fn execute_merged_updates_with_deps(
                             output(BatchOutputEvent::Warning(warning));
                         }
                         let item = match outcome.outcome {
-                            Ok(member) => BatchMemberOutcome {
+                            UpdateBatchOutcome::Completed(member) => BatchMemberOutcome {
                                 component: name.clone(),
                                 status: batch_status(member, ExecutionIntent::Apply),
                                 reason: None,
                                 plan: None,
                                 adapter_actions: outcome.adapter_actions,
                             },
-                            Err(err) => failed_item(&name, err.reason().to_string()),
+                            UpdateBatchOutcome::Partial { reason } => partial_item(&name, reason),
+                            UpdateBatchOutcome::Failed { reason } => failed_item(&name, reason),
                         };
                         items.push(item);
                     }
@@ -785,7 +787,7 @@ mod tests {
 
     use super::super::UpdateOutcome;
     use super::super::tests::{
-        ctx, load_store, pkg_info, raw_manifest_with_adapter, rpm_object,
+        FakeRpm, ctx, load_store, pkg_info, raw_manifest_with_adapter, rpm_object,
         seed_package_contract_and_stale_snapshot,
     };
     use crate::context::InstallMode;
@@ -965,10 +967,81 @@ mod tests {
 
     fn applied_member(outcome: UpdateOutcome) -> MemberApplicationOutcome {
         MemberApplicationOutcome {
-            outcome: Ok(outcome),
+            outcome: UpdateBatchOutcome::Completed(outcome),
             warnings: Vec::new(),
             adapter_actions: Vec::new(),
         }
+    }
+
+    #[test]
+    fn merged_degrade_preserves_partial_application_failure() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let c = ctx(tmp.path().to_path_buf(), InstallMode::System, false);
+        managed_pair(&c);
+        let merged_host = FakeHost::new(
+            &[
+                (
+                    "copilot-shell",
+                    pkg_info("copilot-shell", "1.0.0", Some("1.al4"), "x86_64"),
+                ),
+                (
+                    "agent-sec-core",
+                    pkg_info("agent-sec-core", "1.0.0", Some("1.al4"), "x86_64"),
+                ),
+            ],
+            true,
+        );
+        let retry_host = FakeRpm::new(
+            "copilot-shell",
+            Some(pkg_info("copilot-shell", "1.0.0", Some("1.al4"), "x86_64")),
+        )
+        .post_update_missing();
+        let mut degrade = |name: &str| -> Result<MemberApplicationOutcome, CliError> {
+            if name != "cosh" {
+                return Ok(applied_member(UpdateOutcome::AlreadyCurrent));
+            }
+            let outcome = super::super::application::run_with_dependencies_classified(
+                super::super::application::ApplicationRequest {
+                    component: name,
+                    intent: ExecutionIntent::Apply,
+                },
+                &c,
+                &retry_host,
+                &retry_host,
+                true,
+            );
+            Ok(application::member_application_outcome(outcome))
+        };
+        let mut output = |_: BatchOutputEvent| {};
+
+        let items = execute_merged_updates_with_deps(
+            vec![
+                u5_item("cosh", "copilot-shell", "1.0.0-1.al4"),
+                u5_item("sec-core", "agent-sec-core", "1.0.0-1.al4"),
+            ],
+            &c,
+            &merged_host,
+            &merged_host,
+            true,
+            &mut degrade,
+            &mut output,
+        )
+        .items;
+
+        let cosh = find(&items, "cosh");
+        assert_eq!(cosh.status, BatchMemberStatus::Partial);
+        assert!(
+            cosh.reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("repair")),
+            "degraded application failure must retain repair guidance: {:?}",
+            cosh.reason
+        );
+        assert_eq!(
+            retry_host.update_call_count(),
+            1,
+            "the retry transaction ran"
+        );
     }
 
     #[test]
@@ -1221,7 +1294,7 @@ mod tests {
         .items;
 
         let cosh_item = find(&items, "cosh");
-        assert_eq!(cosh_item.status, BatchMemberStatus::Failed);
+        assert_eq!(cosh_item.status, BatchMemberStatus::Partial);
         let reason = cosh_item.reason.as_deref().expect("failure reason");
         assert!(
             reason.contains("committed") && reason.contains("repair"),
@@ -1438,7 +1511,7 @@ mod tests {
         // Forward-only for the moved member: no retry, repair reconciles.
         assert_eq!(degraded.borrow().as_slice(), ["sec-core"]);
         let cosh = find(&items, "cosh");
-        assert_eq!(cosh.status, BatchMemberStatus::Failed);
+        assert_eq!(cosh.status, BatchMemberStatus::Partial);
         let reason = cosh.reason.as_deref().unwrap();
         assert!(reason.contains("changed in the rpmdb"), "got: {reason}");
         assert!(reason.contains("anolisa repair cosh"), "got: {reason}");
@@ -1505,7 +1578,7 @@ mod tests {
             "an indeterminate rpmdb state must not trigger a second update"
         );
         let cosh = find(&items, "cosh");
-        assert_eq!(cosh.status, BatchMemberStatus::Failed);
+        assert_eq!(cosh.status, BatchMemberStatus::Partial);
         assert!(
             cosh.reason
                 .as_deref()

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/all/application.rs
@@ -34,7 +34,9 @@ pub(super) enum BatchMemberStatus {
     Planned,
     /// Existing state already covers the latest version.
     AlreadyCurrent,
-    /// Planning or execution failed for this member.
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial,
+    /// The member failed without a known partial state.
     Failed,
 }
 
@@ -45,8 +47,13 @@ impl BatchMemberStatus {
             Self::Updated => "updated",
             Self::Planned => "planned",
             Self::AlreadyCurrent => "already-current",
-            Self::Failed => "failed",
+            Self::Partial | Self::Failed => "failed",
         }
+    }
+
+    /// Returns whether this member makes the aggregate batch unsuccessful.
+    pub(super) fn is_unsuccessful(self) -> bool {
+        matches!(self, Self::Partial | Self::Failed)
     }
 }
 
@@ -93,7 +100,7 @@ pub(super) struct BatchEffectOutcome {
 
 /// Per-member fallback result returned to merged transaction orchestration.
 pub(super) struct MemberApplicationOutcome {
-    pub(super) outcome: Result<UpdateOutcome, CliError>,
+    pub(super) outcome: update_application::UpdateBatchOutcome,
     pub(super) warnings: Vec<String>,
     pub(super) adapter_actions: Vec<AdapterAction>,
 }
@@ -101,9 +108,7 @@ pub(super) struct MemberApplicationOutcome {
 impl BatchApplicationOutcome {
     /// Returns whether any member failed.
     pub(super) fn has_failures(&self) -> bool {
-        self.items
-            .iter()
-            .any(|item| item.status == BatchMemberStatus::Failed)
+        self.items.iter().any(|item| item.status.is_unsuccessful())
     }
 
     /// Returns whether this batch was prepared without applying effects.
@@ -219,17 +224,14 @@ pub(super) fn run(
         output(BatchOutputEvent::Member {
             component: name.clone(),
         });
-        let member = update_application::run(
+        let member = update_application::run_for_batch(
             update_application::ApplicationRequest {
                 component: name,
                 intent: request.intent,
             },
             &suppressed_ctx,
         );
-        let item = match member {
-            Ok(outcome) => project_member_application(name, request.intent, outcome, output),
-            Err(error) => failed_item(name, error.reason().to_string()),
-        };
+        let item = project_member_application(name, request.intent, member, output);
         results.insert(name.clone(), item);
     }
 
@@ -252,7 +254,7 @@ pub(super) fn run(
 fn project_member_application(
     name: &str,
     intent: ExecutionIntent,
-    outcome: update_application::ApplicationOutcome,
+    outcome: Result<update_application::ApplicationOutcome, update_application::ApplicationFailure>,
     output: &mut dyn FnMut(BatchOutputEvent),
 ) -> BatchMemberOutcome {
     let member = member_application_outcome(outcome);
@@ -260,27 +262,41 @@ fn project_member_application(
         output(BatchOutputEvent::Warning(warning));
     }
     match member.outcome {
-        Ok(outcome) => BatchMemberOutcome {
+        update_application::UpdateBatchOutcome::Completed(outcome) => BatchMemberOutcome {
             component: name.to_string(),
             status: batch_status(outcome, intent),
             reason: None,
             plan: None,
             adapter_actions: member.adapter_actions,
         },
-        Err(error) => failed_item(name, error.reason().to_string()),
+        update_application::UpdateBatchOutcome::Partial { reason } => partial_item(name, reason),
+        update_application::UpdateBatchOutcome::Failed { reason } => failed_item(name, reason),
     }
 }
 
 pub(super) fn member_application_outcome(
-    outcome: update_application::ApplicationOutcome,
+    result: Result<update_application::ApplicationOutcome, update_application::ApplicationFailure>,
 ) -> MemberApplicationOutcome {
-    let warnings = outcome.warnings().to_vec();
-    let adapter_actions = outcome.adapter_actions().to_vec();
-    let outcome = outcome.batch_outcome();
-    MemberApplicationOutcome {
-        outcome,
-        warnings,
-        adapter_actions,
+    match result {
+        Ok(outcome) => MemberApplicationOutcome {
+            warnings: outcome.warnings().to_vec(),
+            adapter_actions: outcome.adapter_actions().to_vec(),
+            outcome: outcome.batch_outcome(),
+        },
+        Err(update_application::ApplicationFailure::Partial(error)) => MemberApplicationOutcome {
+            outcome: update_application::UpdateBatchOutcome::Partial {
+                reason: error.reason(),
+            },
+            warnings: Vec::new(),
+            adapter_actions: Vec::new(),
+        },
+        Err(update_application::ApplicationFailure::Failed(error)) => MemberApplicationOutcome {
+            outcome: update_application::UpdateBatchOutcome::Failed {
+                reason: error.reason(),
+            },
+            warnings: Vec::new(),
+            adapter_actions: Vec::new(),
+        },
     }
 }
 
@@ -288,6 +304,16 @@ pub(super) fn failed_item(name: &str, reason: String) -> BatchMemberOutcome {
     BatchMemberOutcome {
         component: name.to_string(),
         status: BatchMemberStatus::Failed,
+        reason: Some(reason),
+        plan: None,
+        adapter_actions: Vec::new(),
+    }
+}
+
+pub(super) fn partial_item(name: &str, reason: String) -> BatchMemberOutcome {
+    BatchMemberOutcome {
+        component: name.to_string(),
+        status: BatchMemberStatus::Partial,
         reason: Some(reason),
         plan: None,
         adapter_actions: Vec::new(),
@@ -328,14 +354,27 @@ mod tests {
 
     #[test]
     fn aggregate_failure_is_typed() {
-        let outcome = BatchApplicationOutcome {
-            intent: ExecutionIntent::Apply,
-            merged_transaction: None,
-            items: vec![failed_item("cosh", "failed".to_string())],
-        };
+        for item in [
+            partial_item("cosh", "partial".to_string()),
+            failed_item("cosh", "failed".to_string()),
+        ] {
+            let outcome = BatchApplicationOutcome {
+                intent: ExecutionIntent::Apply,
+                merged_transaction: None,
+                items: vec![item],
+            };
 
-        assert!(outcome.has_failures());
-        assert!(!outcome.is_preview());
+            assert!(outcome.has_failures());
+            assert!(!outcome.is_preview());
+        }
+    }
+
+    #[test]
+    fn partial_and_failed_keep_the_legacy_wire_label() {
+        assert_eq!(BatchMemberStatus::Partial.as_str(), "failed");
+        assert_eq!(BatchMemberStatus::Failed.as_str(), "failed");
+        assert!(BatchMemberStatus::Partial.is_unsuccessful());
+        assert!(BatchMemberStatus::Failed.is_unsuccessful());
     }
 
     #[test]
@@ -362,16 +401,56 @@ mod tests {
         let mut events = Vec::new();
 
         let item =
-            project_member_application("cosh", ExecutionIntent::Apply, outcome, &mut |event| {
+            project_member_application("cosh", ExecutionIntent::Apply, Ok(outcome), &mut |event| {
+                events.push(event)
+            });
+
+        assert_eq!(item.status, BatchMemberStatus::Partial);
+        assert_eq!(
+            item.reason.as_deref(),
+            Some(
+                "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile"
+            )
+        );
+        assert_eq!(events.len(), 1);
+        let BatchOutputEvent::Warning(warning) = events.pop().expect("warning event") else {
+            panic!("expected warning event");
+        };
+        assert_eq!(warning, "service state needs verification");
+    }
+
+    #[test]
+    fn member_warning_is_surfaced_before_clean_terminal_failure() {
+        let outcome = update_application::ApplicationOutcome::Applied {
+            command: "update cosh".to_string(),
+            subject: update_application::UpdateSubject {
+                component: "cosh".to_string(),
+                package: Some("cosh".to_string()),
+                from_version: Some("2.6.0".to_string()),
+                to_version: Some("2.7.0".to_string()),
+            },
+            steps: Vec::new(),
+            outcome: CommandOutcome::new(
+                CommandOutcomeStatus::Failed {
+                    reason: "native package transaction failed".to_string(),
+                },
+                Some("operation-1".to_string()),
+                Vec::new(),
+                vec!["service state needs verification".to_string()],
+            ),
+            adapter_actions: Vec::new(),
+        };
+        let mut events = Vec::new();
+
+        let item =
+            project_member_application("cosh", ExecutionIntent::Apply, Ok(outcome), &mut |event| {
                 events.push(event)
             });
 
         assert_eq!(item.status, BatchMemberStatus::Failed);
         assert_eq!(
             item.reason.as_deref(),
-            Some(
-                "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile"
-            )
+            Some("native package transaction failed")
         );
         assert_eq!(events.len(), 1);
         let BatchOutputEvent::Warning(warning) = events.pop().expect("warning event") else {

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/update/application.rs
@@ -6,7 +6,7 @@ use anolisa_core::domain::{InstallationScope, NativePm, OwnedArtifact, ProviderB
 use anolisa_core::execution::{
     CommandOutcome, CommandOutcomeStatus, ExecutionIntent, PreparedExecution,
 };
-use anolisa_core::executor::{DelegatedExecutionTarget, execute_delegated_steps};
+use anolisa_core::executor::{DelegatedExecutionTarget, PHASE_NATIVE_TXN, execute_delegated_steps};
 use anolisa_core::facts::JournalEvidence;
 use anolisa_core::lock::InstallLock;
 use anolisa_core::owned_executor::execute_owned_steps;
@@ -15,6 +15,7 @@ use anolisa_core::providers::DelegatedProvider;
 use anolisa_core::record_sink::{DelegatedIdentity, RecordContext, StoreRecordSink};
 use anolisa_core::state::{ObjectKind, OperationRecord};
 use anolisa_core::state_store::StateStore;
+use anolisa_core::{Transaction, TransactionOutcomeStatus, TransactionStepStatus};
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::PackageQuery;
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
@@ -59,6 +60,53 @@ pub(super) enum UpdateChange {
     NativePackageUpdated,
 }
 
+/// Batch-facing classification of a single-component update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum UpdateBatchOutcome {
+    /// The update completed or no change was required.
+    Completed(super::UpdateOutcome),
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial { reason: String },
+    /// The update failed without a known partial state.
+    Failed { reason: String },
+}
+
+/// Terminal application failure retained for batch classification.
+#[derive(Debug)]
+pub(super) enum ApplicationFailure {
+    /// Effects occurred or cannot be excluded, so repair is required.
+    Partial(CliError),
+    /// The application failed without a known partial state.
+    Failed(CliError),
+}
+
+impl ApplicationFailure {
+    /// Classify an execution failure from its in-memory journal evidence.
+    fn from_journal(error: CliError, journal: &Transaction) -> Self {
+        let native_transaction_committed = journal.steps.iter().any(|step| {
+            step.phase == PHASE_NATIVE_TXN && step.status == TransactionStepStatus::Done
+        });
+        if journal.status == TransactionOutcomeStatus::Partial || native_transaction_committed {
+            Self::Partial(error)
+        } else {
+            Self::Failed(error)
+        }
+    }
+
+    /// Restore the existing single-command error projection.
+    pub(super) fn into_cli_error(self) -> CliError {
+        match self {
+            Self::Partial(error) | Self::Failed(error) => error,
+        }
+    }
+}
+
+impl From<CliError> for ApplicationFailure {
+    fn from(error: CliError) -> Self {
+        Self::Failed(error)
+    }
+}
+
 /// Typed application result consumed by the command renderer.
 pub(super) enum ApplicationOutcome {
     /// The owned record already points at the latest resolved artifact.
@@ -79,33 +127,32 @@ pub(super) enum ApplicationOutcome {
 }
 
 impl ApplicationOutcome {
-    /// Collapse the typed result to the legacy batch-member classification.
-    pub(super) fn batch_outcome(&self) -> Result<super::UpdateOutcome, CliError> {
+    /// Project the result to the batch-member terminal classification.
+    pub(super) fn batch_outcome(&self) -> UpdateBatchOutcome {
         match self {
-            Self::NoOp { .. } => Ok(super::UpdateOutcome::AlreadyCurrent),
-            Self::Preview { .. } => Ok(super::UpdateOutcome::Updated),
+            Self::NoOp { .. } => {
+                UpdateBatchOutcome::Completed(super::UpdateOutcome::AlreadyCurrent)
+            }
+            Self::Preview { .. } => UpdateBatchOutcome::Completed(super::UpdateOutcome::Updated),
             Self::Applied {
-                command,
-                subject,
-                outcome,
-                ..
+                subject, outcome, ..
             } => match outcome.status() {
-                CommandOutcomeStatus::Completed => Ok(if outcome.changes().is_empty() {
-                    super::UpdateOutcome::AlreadyCurrent
-                } else {
-                    super::UpdateOutcome::Updated
-                }),
-                CommandOutcomeStatus::Partial { reason } => Err(CliError::Runtime {
-                    command: command.clone(),
+                CommandOutcomeStatus::Completed => {
+                    UpdateBatchOutcome::Completed(if outcome.changes().is_empty() {
+                        super::UpdateOutcome::AlreadyCurrent
+                    } else {
+                        super::UpdateOutcome::Updated
+                    })
+                }
+                CommandOutcomeStatus::Partial { reason } => UpdateBatchOutcome::Partial {
                     reason: format!(
                         "the update of '{}' committed, but {reason}; run `anolisa repair {}` to reconcile",
                         subject.component, subject.component
                     ),
-                }),
-                CommandOutcomeStatus::Failed { reason } => Err(CliError::Runtime {
-                    command: command.clone(),
+                },
+                CommandOutcomeStatus::Failed { reason } => UpdateBatchOutcome::Failed {
                     reason: reason.clone(),
-                }),
+                },
             },
         }
     }
@@ -139,6 +186,15 @@ pub(super) fn run(
     run_with_dependencies(request, ctx, &query, &txn, privilege::is_root())
 }
 
+/// Run one batch member while preserving its terminal classification.
+pub(super) fn run_for_batch(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+) -> Result<ApplicationOutcome, ApplicationFailure> {
+    let (query, txn) = update_backends(request.component, ctx)?;
+    run_with_dependencies_classified(request, ctx, &query, &txn, privilege::is_root())
+}
+
 /// Run the single-component application protocol with explicit host boundaries.
 pub(super) fn run_with_dependencies(
     request: ApplicationRequest<'_>,
@@ -147,6 +203,18 @@ pub(super) fn run_with_dependencies(
     txn: &dyn PackageTransaction,
     is_root: bool,
 ) -> Result<ApplicationOutcome, CliError> {
+    run_with_dependencies_classified(request, ctx, query, txn, is_root)
+        .map_err(ApplicationFailure::into_cli_error)
+}
+
+/// Run the application protocol while preserving its terminal classification.
+pub(super) fn run_with_dependencies_classified(
+    request: ApplicationRequest<'_>,
+    ctx: &CliContext,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+) -> Result<ApplicationOutcome, ApplicationFailure> {
     let planned = plan_component_update(request.component, ctx, query, txn)?;
     let prepared = request.intent.prepare(planned.plan.clone());
     execute_planned_update(planned, prepared, ctx, query, txn, is_root)
@@ -159,7 +227,7 @@ fn execute_planned_update(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
-) -> Result<ApplicationOutcome, CliError> {
+) -> Result<ApplicationOutcome, ApplicationFailure> {
     let PlannedComponentUpdate {
         command,
         target,
@@ -275,7 +343,7 @@ fn apply_delegated(
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
-) -> Result<ApplicationOutcome, CliError> {
+) -> Result<ApplicationOutcome, ApplicationFailure> {
     // Native transactions require root. Refuse before acquiring the lock so
     // the user sees the CLI policy instead of dnf's mid-transaction error.
     if !is_root {
@@ -285,7 +353,8 @@ fn apply_delegated(
                 "updating system RPM '{}' requires root privileges; re-run with sudo: `sudo anolisa update {target}`",
                 native_package.as_deref().unwrap_or(target)
             ),
-        });
+        }
+        .into());
     }
 
     let provider = DelegatedProvider::new(query, txn);
@@ -304,7 +373,8 @@ fn apply_delegated(
             reason: format!(
                 "component '{target}' changed while this update was planning; nothing was changed — re-run `anolisa update {target}`"
             ),
-        });
+        }
+        .into());
     }
     // The lock-time snapshot is the execution authority. It prevents a
     // pre-lock package or journal observation from authorizing stale steps.
@@ -355,7 +425,7 @@ fn apply_delegated(
         }),
         owned_artifact: None,
     };
-    let execution = {
+    let execution_result = {
         let mut sink = StoreRecordSink::new(&mut store, state_path, context);
         execute_delegated_steps(
             &steps,
@@ -365,22 +435,28 @@ fn apply_delegated(
             &mut journal,
             now,
         )
-    }
-    .map_err(|err| match err {
-        anolisa_core::executor::ExecutionError::TransactionFailed {
-            source:
-                anolisa_core::providers::ProviderError::Transaction(
-                    PackageTransactionError::CommandMissing { command: bin },
-                ),
-            ..
-        } => tooling_missing_err(command, &bin, target),
-        other => CliError::Runtime {
-            command: command.to_string(),
-            reason: format!(
-                "update of '{target}' failed: {other}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
-            ),
-        },
-    })?;
+    };
+    let execution = match execution_result {
+        Ok(execution) => execution,
+        Err(err) => {
+            let error = match err {
+                anolisa_core::executor::ExecutionError::TransactionFailed {
+                    source:
+                        anolisa_core::providers::ProviderError::Transaction(
+                            PackageTransactionError::CommandMissing { command: bin },
+                        ),
+                    ..
+                } => tooling_missing_err(command, &bin, target),
+                other => CliError::Runtime {
+                    command: command.to_string(),
+                    reason: format!(
+                        "update of '{target}' failed: {other}; the native transaction is never undone automatically — run `anolisa repair {target}` to reconcile"
+                    ),
+                },
+            };
+            return Err(ApplicationFailure::from_journal(error, &journal));
+        }
+    };
 
     let completion_failure = complete_delegated_update(
         layout,
@@ -462,7 +538,7 @@ pub(super) fn apply_owned(
     resolution: RawResolution,
     prior: OwnedArtifact,
     command: &str,
-) -> Result<ApplicationOutcome, CliError> {
+) -> Result<ApplicationOutcome, ApplicationFailure> {
     // A user prefix may be writable without root; permission failures belong
     // to the exact owned-executor step so compensation remains honest.
     let resolve_warnings = resolution.warnings.clone();
@@ -497,7 +573,8 @@ pub(super) fn apply_owned(
                     "component '{target}' changed from {} to {} while this update was resolving; nothing was changed — re-run `anolisa update {target}`",
                     prior.version, artifact.version
                 ),
-            });
+            }
+            .into());
         }
         _ => {
             return Err(CliError::Runtime {
@@ -505,7 +582,8 @@ pub(super) fn apply_owned(
                 reason: format!(
                     "component '{target}' is no longer an owned installation; nothing was changed — re-run `anolisa update {target}`"
                 ),
-            });
+            }
+            .into());
         }
     };
     let prior_adapter_revisions = adapter_revision_snapshot(ctx, layout, target);
@@ -514,7 +592,7 @@ pub(super) fn apply_owned(
     let mut journal_gate = LockedJournalGate::load(&_lock, evidence, command)?;
     let mut journal = journal_gate.begin(COMMAND, target, state_path.to_path_buf(), command)?;
     let operation_id = journal.operation_id.clone();
-    let execution = {
+    let execution_result = {
         let mut ops = RawReplayOps::new(
             ctx,
             layout,
@@ -534,8 +612,14 @@ pub(super) fn apply_owned(
             ops.discard_backups();
         }
         result
-    }
-    .map_err(|err| owned_error_to_cli(err, target, scope, command))?;
+    };
+    let execution = match execution_result {
+        Ok(execution) => execution,
+        Err(err) => {
+            let error = owned_error_to_cli(err, target, scope, command);
+            return Err(ApplicationFailure::from_journal(error, &journal));
+        }
+    };
 
     // The record commit is authoritative; operation history remains
     // best-effort bookkeeping, matching delegated completion.
@@ -655,8 +739,8 @@ mod tests {
         );
 
         assert_eq!(
-            outcome.batch_outcome().expect("completed update"),
-            super::super::UpdateOutcome::Updated
+            outcome.batch_outcome(),
+            UpdateBatchOutcome::Completed(super::super::UpdateOutcome::Updated)
         );
         assert_eq!(outcome.warnings(), ["service state needs verification"]);
     }
@@ -670,15 +754,11 @@ mod tests {
             vec!["service state needs verification".to_string()],
         );
 
-        let err = outcome
-            .batch_outcome()
-            .expect_err("partial update must use the error path");
-
-        assert_eq!(err.code(), "EXECUTION_FAILED");
-        assert_eq!(err.exit_code(), 1);
         assert_eq!(
-            err.reason(),
-            "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile"
+            outcome.batch_outcome(),
+            UpdateBatchOutcome::Partial {
+                reason: "the update of 'cosh' committed, but manifest reconciliation did not complete; run `anolisa repair cosh` to reconcile".to_string()
+            }
         );
         assert_eq!(outcome.warnings(), ["service state needs verification"]);
     }
@@ -692,12 +772,11 @@ mod tests {
             vec!["service state needs verification".to_string()],
         );
 
-        let err = outcome
-            .batch_outcome()
-            .expect_err("failed update must use the error path");
-
-        assert_eq!(err.code(), "EXECUTION_FAILED");
-        assert_eq!(err.exit_code(), 1);
-        assert_eq!(err.reason(), "native package transaction failed");
+        assert_eq!(
+            outcome.batch_outcome(),
+            UpdateBatchOutcome::Failed {
+                reason: "native package transaction failed".to_string()
+            }
+        );
     }
 }


### PR DESCRIPTION
## Why

Batch execution currently collapses recoverable partial state and clean terminal failures into one internal status. Separating them lets the application layer preserve whether repair is required without changing the established command contract.

## What changed

- Added typed `Completed`, `Partial`, and `Failed` projection for single-component update batch use.
- Classified committed or uncertain merged install/update failures as partial while keeping proven pre-effect failures terminal.
- Kept warnings as ordered output events and projected both unsuccessful statuses to the legacy `failed` wire label.

## Related issue

closes #2966

## User / Agent impact

None. CLI arguments, JSON schema, human output, warning order, summary counts, adapter notices, and exit codes are unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The change only refines crate-private outcome classification and keeps the existing renderer projection.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli --locked` (948 passed, 1 ignored)
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- ALinux 4 offline container: install batch tests (13 passed)
- ALinux 4 offline container: update all tests (17 passed)

## Documentation and rollback

The local refactoring roadmap was updated for tracking but intentionally excluded from this PR. Roll back by reverting commit `cdd8f6df`.