### PR TITLE
feat(sight): add preference analysis and trajectory step query APIs

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -261,7 +261,8 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/optimize/config` | GET/POST | 优化 LLM 配置（api_key 脱敏；持久化到 `optimization_config.json`） |
 | `/api/trajectories` | GET | 采集轨迹列表（`project`, `source`, `agent_name`, `limit`；不含 `atif_json`，按采集时间倒序） |
 | `/api/trajectories/filters` | GET | 轨迹过滤下拉选项（distinct project/source/agent_name） |
-| `/api/trajectories/{session_id}` | GET | 单条轨迹的原始 ATIF v1.7 JSON（store 不可用或 session 不存在均返回 404，消息不同；列表/过滤端点则降级为空 + 200） |
+| `/api/trajectories/steps` | GET | 按步骤分类检索（`category` 逗号分隔多值 OR：`user_input`/`system`/`agent_message`/`thinking`/`tool_call`/`tool_result`；另支持 `agent_name`, `project`, `source`, `session_id`, `limit`, `context`, `max_scan`）。每条命中附带同会话前后各 `context` 条步骤；分类为多标签，非法 `category` 返回 400 |
+| `/api/trajectories/{session_id}` | GET | 单条轨迹的原始 ATIF v1.7 JSON（store 不可用或 session 不存在均返回 404，消息不同；列表/过滤/步骤端点则降级为空 + 200） |
 
 ## 9. Frontend
 

--- a/src/agentsight/CHANGELOG.md
+++ b/src/agentsight/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Add `GET /api/preferences` and `GET /api/preferences/export` to surface the
+  working habits inferred from recent conversations (language, plan-first
+  workflow, test expectations, correction patterns, tool leanings), with
+  `/api/preferences/turns` exposing the user turns an analysis was based on.
+  Analysis runs per request over `genai_events` on Linux or collected
+  trajectories elsewhere, so there is no derived state to migrate or go stale.
+- Add `GET /api/trajectories/steps` to find ATIF steps by derived category
+  (`user_input`, `system`, `agent_message`, `thinking`, `tool_call`,
+  `tool_result`), returning each hit with its neighbouring steps. Categories are
+  multi-label because a single agent step can carry a message, reasoning, tool
+  calls and observations at once.
+
+### Fixes
+- Initialize logging in the macOS `trace` path so trajectory collection failures
+  surface instead of being silently dropped.
+
 ## 0.11.2
 
 ### Features

--- a/src/agentsight/CHANGELOG_zh.md
+++ b/src/agentsight/CHANGELOG_zh.md
@@ -1,5 +1,14 @@
 # 更新日志
 
+## 未发布
+
+### 新功能
+- 新增 `GET /api/preferences` 与 `GET /api/preferences/export`，从近期会话中识别用户的工作习惯（语言偏好、先出方案再动手、要求补测试、纠正模式、常用工具倾向），并通过 `/api/preferences/turns` 返回本次分析所依据的用户输入。分析在请求时实时计算，Linux 读取 `genai_events`，其他平台读取已采集的轨迹，因此不产生需要迁移或会过期的派生数据。
+- 新增 `GET /api/trajectories/steps`，按派生类别（`user_input`、`system`、`agent_message`、`thinking`、`tool_call`、`tool_result`）检索 ATIF 步骤，并随每个命中返回其上下文步骤。类别是多标签的：同一个 agent 步骤可能同时包含消息、推理、工具调用与观测结果。
+
+### 修复
+- macOS `trace` 路径下初始化日志，使轨迹采集失败可见，不再被静默丢弃。
+
 ## 0.11.2
 
 ### 新功能

--- a/src/agentsight/crates/agentsight-atif/src/lib.rs
+++ b/src/agentsight/crates/agentsight-atif/src/lib.rs
@@ -53,6 +53,13 @@ pub struct SubagentTrajectoryRef {
 // ObservationResult & Observation
 // ---------------------------------------------------------------------------
 
+/// Key under which a provider's out-of-band tool-failure flag is preserved in
+/// [`ObservationResult::extra`]. ATIF has no typed status field, and folding the
+/// flag into `content` would force consumers to re-derive failure by matching
+/// error words in free text — which misfires on successful calls whose output
+/// merely mentions "error".
+pub const EXTRA_IS_ERROR: &str = "is_error";
+
 /// A single observation result from a tool call or action.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ObservationResult {
@@ -64,6 +71,17 @@ pub struct ObservationResult {
     pub subagent_trajectory_ref: Option<Vec<SubagentTrajectoryRef>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl ObservationResult {
+    /// Whether the tool call behind this result failed, as reported by the
+    /// provider.
+    ///
+    /// `None` means the provider reported nothing, which is **not** the same as
+    /// success — callers must treat it as unknown rather than passing.
+    pub fn is_error(&self) -> Option<bool> {
+        self.extra.as_ref()?.get(EXTRA_IS_ERROR)?.as_bool()
+    }
 }
 
 /// Environment feedback/results after actions.
@@ -150,6 +168,72 @@ pub enum StepSource {
     Agent,
 }
 
+impl StepSource {
+    /// Wire representation, matching the `lowercase` serde renaming.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::User => "user",
+            Self::Agent => "agent",
+        }
+    }
+}
+
+/// Derived, multi-label classification of a [`Step`] for querying.
+///
+/// Not part of the ATIF wire format: `source` alone cannot express tool or
+/// reasoning activity (both live *inside* an agent step), so these labels are
+/// computed from the typed step fields by [`Step::categories`]. A single step
+/// may carry several labels — an agent step can reason and call tools at once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepCategory {
+    UserInput,
+    System,
+    AgentMessage,
+    Thinking,
+    ToolCall,
+    ToolResult,
+}
+
+impl StepCategory {
+    /// Every category, in the order surfaced to API clients.
+    pub const ALL: [StepCategory; 6] = [
+        Self::UserInput,
+        Self::System,
+        Self::AgentMessage,
+        Self::Thinking,
+        Self::ToolCall,
+        Self::ToolResult,
+    ];
+
+    /// Wire representation, matching the `snake_case` serde renaming.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::UserInput => "user_input",
+            Self::System => "system",
+            Self::AgentMessage => "agent_message",
+            Self::Thinking => "thinking",
+            Self::ToolCall => "tool_call",
+            Self::ToolResult => "tool_result",
+        }
+    }
+
+    /// Parses a query-parameter token; `None` for an unknown category so
+    /// callers can reject it rather than silently returning wrong results.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim() {
+            "user_input" => Some(Self::UserInput),
+            "system" => Some(Self::System),
+            "agent_message" => Some(Self::AgentMessage),
+            "thinking" => Some(Self::Thinking),
+            "tool_call" => Some(Self::ToolCall),
+            "tool_result" => Some(Self::ToolResult),
+            _ => None,
+        }
+    }
+}
+
 /// A single step in an ATIF trajectory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Step {
@@ -177,6 +261,71 @@ pub struct Step {
     pub llm_call_count: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_copied_context: Option<bool>,
+}
+
+impl Step {
+    /// Derived query labels for this step; see [`StepCategory`].
+    ///
+    /// Multi-label by design: an agent step that reasons and then calls a tool
+    /// yields `agent_message`/`thinking`/`tool_call` together, so filtering on
+    /// any one of them finds it. Labels are emitted in [`StepCategory::ALL`]
+    /// order for stable output.
+    pub fn categories(&self) -> Vec<StepCategory> {
+        let mut out = Vec::new();
+        match self.source {
+            StepSource::User => out.push(StepCategory::UserInput),
+            StepSource::System => out.push(StepCategory::System),
+            StepSource::Agent => {
+                // Blank agent turns (pure tool dispatch, empty completion)
+                // carry no message worth surfacing as `agent_message`.
+                if !self.message.trim().is_empty() {
+                    out.push(StepCategory::AgentMessage);
+                }
+            }
+        }
+        if self.has_reasoning() {
+            out.push(StepCategory::Thinking);
+        }
+        if self.has_tool_calls() {
+            out.push(StepCategory::ToolCall);
+        }
+        if self.has_observation() {
+            out.push(StepCategory::ToolResult);
+        }
+        out
+    }
+
+    /// Whether this step carries non-blank reasoning content.
+    pub fn has_reasoning(&self) -> bool {
+        self.reasoning_content
+            .as_ref()
+            .is_some_and(|r| !r.trim().is_empty())
+    }
+
+    /// Whether this step dispatched at least one tool call.
+    pub fn has_tool_calls(&self) -> bool {
+        self.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty())
+    }
+
+    /// Whether this step carries at least one observation result.
+    ///
+    /// An `Observation` with an empty `results` vector conveys nothing, so it
+    /// does not count as a tool result.
+    pub fn has_observation(&self) -> bool {
+        self.observation
+            .as_ref()
+            .is_some_and(|o| !o.results.is_empty())
+    }
+
+    /// Names of the functions invoked by this step, in call order.
+    pub fn tool_names(&self) -> Vec<&str> {
+        self.tool_calls
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|tc| tc.function_name.as_str())
+            .collect()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -349,5 +498,170 @@ mod tests {
         let v = serde_json::json!({"a": null, "b": {"c": null, "d": 1}, "e": [null, 2]});
         let stripped = strip_nulls(v);
         assert_eq!(stripped, serde_json::json!({"b": {"d": 1}, "e": [null, 2]}));
+    }
+
+    // ─── Derived step categories ─────────────────────────────────────────
+
+    /// A bare step with everything optional left unset.
+    fn bare_step(source: StepSource) -> Step {
+        Step {
+            step_id: 1,
+            source,
+            message: String::new(),
+            timestamp: None,
+            model_name: None,
+            reasoning_effort: None,
+            reasoning_content: None,
+            tool_calls: None,
+            observation: None,
+            metrics: None,
+            extra: None,
+            llm_call_count: None,
+            is_copied_context: None,
+        }
+    }
+
+    fn tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            tool_call_id: "tc-1".into(),
+            function_name: name.into(),
+            arguments: serde_json::json!({}),
+            extra: None,
+        }
+    }
+
+    #[test]
+    fn category_user_input() {
+        let mut step = bare_step(StepSource::User);
+        step.message = "list files".into();
+        assert_eq!(step.categories(), vec![StepCategory::UserInput]);
+    }
+
+    #[test]
+    fn category_system() {
+        let mut step = bare_step(StepSource::System);
+        step.message = "you are a helpful assistant".into();
+        assert_eq!(step.categories(), vec![StepCategory::System]);
+    }
+
+    #[test]
+    fn category_agent_message() {
+        let mut step = bare_step(StepSource::Agent);
+        step.message = "Only a.txt exists.".into();
+        assert_eq!(step.categories(), vec![StepCategory::AgentMessage]);
+    }
+
+    #[test]
+    fn category_thinking() {
+        let mut step = bare_step(StepSource::Agent);
+        step.reasoning_content = Some("need to run ls".into());
+        assert_eq!(step.categories(), vec![StepCategory::Thinking]);
+    }
+
+    #[test]
+    fn category_tool_call() {
+        let mut step = bare_step(StepSource::Agent);
+        step.tool_calls = Some(vec![tool_call("bash")]);
+        assert_eq!(step.categories(), vec![StepCategory::ToolCall]);
+        assert_eq!(step.tool_names(), vec!["bash"]);
+    }
+
+    #[test]
+    fn category_tool_result() {
+        let mut step = bare_step(StepSource::User);
+        step.observation = Some(Observation {
+            results: vec![ObservationResult {
+                source_call_id: Some("tc-1".into()),
+                content: Some(serde_json::json!("a.txt")),
+                subagent_trajectory_ref: None,
+                extra: None,
+            }],
+        });
+        // A tool result arrives on a user-role turn, so both labels apply.
+        assert_eq!(
+            step.categories(),
+            vec![StepCategory::UserInput, StepCategory::ToolResult]
+        );
+    }
+
+    #[test]
+    fn categories_are_multi_label() {
+        let mut step = bare_step(StepSource::Agent);
+        step.message = "Let me check.".into();
+        step.reasoning_content = Some("need to run ls".into());
+        step.tool_calls = Some(vec![tool_call("bash"), tool_call("read")]);
+        assert_eq!(
+            step.categories(),
+            vec![
+                StepCategory::AgentMessage,
+                StepCategory::Thinking,
+                StepCategory::ToolCall,
+            ]
+        );
+        assert_eq!(step.tool_names(), vec!["bash", "read"]);
+    }
+
+    #[test]
+    fn blank_agent_message_is_not_a_category() {
+        let mut step = bare_step(StepSource::Agent);
+        step.message = "   \n\t ".into();
+        step.tool_calls = Some(vec![tool_call("bash")]);
+        // Pure tool dispatch: no readable message, so no `agent_message`.
+        assert_eq!(step.categories(), vec![StepCategory::ToolCall]);
+    }
+
+    #[test]
+    fn blank_reasoning_is_not_thinking() {
+        let mut step = bare_step(StepSource::Agent);
+        step.message = "done".into();
+        step.reasoning_content = Some("  ".into());
+        assert_eq!(step.categories(), vec![StepCategory::AgentMessage]);
+        assert!(!step.has_reasoning());
+    }
+
+    #[test]
+    fn empty_collections_are_not_categories() {
+        let mut step = bare_step(StepSource::Agent);
+        step.message = "done".into();
+        step.tool_calls = Some(Vec::new());
+        step.observation = Some(Observation {
+            results: Vec::new(),
+        });
+        // Present-but-empty conveys nothing.
+        assert_eq!(step.categories(), vec![StepCategory::AgentMessage]);
+        assert!(!step.has_tool_calls());
+        assert!(!step.has_observation());
+        assert!(step.tool_names().is_empty());
+    }
+
+    #[test]
+    fn category_parse_roundtrip() {
+        for category in StepCategory::ALL {
+            assert_eq!(StepCategory::parse(category.as_str()), Some(category));
+        }
+        assert_eq!(
+            StepCategory::parse(" tool_call "),
+            Some(StepCategory::ToolCall)
+        );
+        assert_eq!(StepCategory::parse("assistant"), None);
+        assert_eq!(StepCategory::parse(""), None);
+    }
+
+    #[test]
+    fn category_wire_names_match_serde() {
+        // `as_str` must agree with the snake_case serde renaming, since clients
+        // filter using the values they see in responses.
+        for category in StepCategory::ALL {
+            let json = serde_json::to_string(&category).unwrap();
+            assert_eq!(json, format!("\"{}\"", category.as_str()));
+        }
+    }
+
+    #[test]
+    fn step_source_wire_names_match_serde() {
+        for source in [StepSource::System, StepSource::User, StepSource::Agent] {
+            let json = serde_json::to_string(&source).unwrap();
+            assert_eq!(json, format!("\"{}\"", source.as_str()));
+        }
     }
 }

--- a/src/agentsight/crates/agentsight-opt/src/lib.rs
+++ b/src/agentsight/crates/agentsight-opt/src/lib.rs
@@ -17,6 +17,7 @@ pub mod cost;
 pub mod llm;
 pub mod perf;
 pub mod pipeline;
+pub mod preference;
 pub mod summary;
 pub mod trace;
 pub mod types;

--- a/src/agentsight/crates/agentsight-opt/src/preference.rs
+++ b/src/agentsight/crates/agentsight-opt/src/preference.rs
@@ -1,0 +1,191 @@
+//! LLM-based user preference analysis over a window of user turns.
+//!
+//! Complements the rule engine in the main crate: the caller collects the
+//! user-authored turn texts from a query window, this module compacts them
+//! into one prompt and asks the configured LLM for structured preference
+//! findings. Failures are surfaced as [`PreferenceError`] so the API layer
+//! can degrade to rule-only results.
+
+use serde::Deserialize;
+
+use crate::llm::{ChatMessage, LlmClient};
+
+/// Per-turn character cap — one verbose turn must not crowd out the rest.
+pub const MAX_TURN_CHARS: usize = 400;
+
+/// Total input character budget (~8K tokens at a conservative ~3 chars per
+/// token for mixed Chinese/English developer text).
+pub const MAX_TOTAL_CHARS: usize = 24_000;
+
+/// System prompt: extraction task, taxonomy, and the strict JSON contract.
+const PREFERENCE_SYSTEM_PROMPT: &str = r#"You are an analyst extracting durable USER PREFERENCES from a list of user messages sent to a coding agent.
+
+Only report preferences with recurring or explicit evidence — ignore one-off task details. Focus on:
+- communication: language, tone, verbosity expectations
+- workflow: planning before coding, review habits, correction style, commit/PR discipline
+- technical: testing requirements, preferred tools/frameworks/languages, code style demands
+
+Respond with ONLY a JSON object in this exact shape (no markdown, no commentary):
+{"preferences":[{"category":"communication|workflow|technical","key":"short_snake_case_key","value":"short_snake_case_or_plain_value","rationale":"one short sentence citing the evidence"}]}
+
+Rules:
+- "category" must be exactly one of: communication, workflow, technical.
+- Use concise stable keys (e.g. "language", "workflow_style", "testing", "preferred_tool").
+- Return {"preferences":[]} when no durable preference is evident."#;
+
+/// One preference finding produced by the LLM.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LlmPreference {
+    /// Expected to be one of `communication` / `workflow` / `technical`;
+    /// the caller validates before merging.
+    pub category: String,
+    pub key: String,
+    pub value: String,
+    /// Short evidence sentence; optional in the model output.
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// Top-level response object (`response_format: json_object` requires the
+/// model to emit an object, not a bare array).
+#[derive(Debug, Deserialize)]
+struct PreferenceReport {
+    #[serde(default)]
+    preferences: Vec<LlmPreference>,
+}
+
+/// Why LLM preference analysis could not produce findings.
+#[derive(Debug)]
+pub enum PreferenceError {
+    /// No usable user turns after dedup/trimming — nothing to analyze.
+    EmptyInput,
+    /// The chat call or JSON parsing failed.
+    Llm(anyhow::Error),
+}
+
+impl std::fmt::Display for PreferenceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyInput => write!(f, "no user turns to analyze"),
+            Self::Llm(e) => write!(f, "LLM preference analysis failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for PreferenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::EmptyInput => None,
+            Self::Llm(e) => Some(e.as_ref()),
+        }
+    }
+}
+
+/// Compact user turns into the prompt payload: trim, deduplicate exact
+/// repeats (agents re-send the same query across follow-up calls), cap each
+/// turn at [`MAX_TURN_CHARS`] chars and the total at [`MAX_TOTAL_CHARS`].
+/// Returns an empty string when nothing usable remains.
+pub fn build_analysis_input(turns: &[String]) -> String {
+    let mut seen: Vec<&str> = Vec::new();
+    let mut out = String::new();
+    let mut index = 0usize;
+    for turn in turns {
+        let trimmed = turn.trim();
+        if trimmed.is_empty() || seen.contains(&trimmed) {
+            continue;
+        }
+        seen.push(trimmed);
+        index += 1;
+        let capped: String = if trimmed.chars().count() > MAX_TURN_CHARS {
+            let mut s: String = trimmed.chars().take(MAX_TURN_CHARS).collect();
+            s.push('…');
+            s
+        } else {
+            trimmed.to_string()
+        };
+        let line = format!("{index}. {capped}\n");
+        if out.chars().count() + line.chars().count() > MAX_TOTAL_CHARS {
+            break;
+        }
+        out.push_str(&line);
+    }
+    out
+}
+
+/// Ask the LLM for preference findings over the given user turns.
+///
+/// # Errors
+///
+/// [`PreferenceError::EmptyInput`] when no usable text remains after
+/// compaction; [`PreferenceError::Llm`] when the chat call or response
+/// parsing fails. Callers are expected to degrade to rule-only results.
+pub async fn analyze_user_turns(
+    client: &LlmClient,
+    turns: &[String],
+) -> Result<Vec<LlmPreference>, PreferenceError> {
+    let input = build_analysis_input(turns);
+    if input.is_empty() {
+        return Err(PreferenceError::EmptyInput);
+    }
+    let messages = vec![
+        ChatMessage::system(PREFERENCE_SYSTEM_PROMPT),
+        ChatMessage::user(format!("User messages (most recent last):\n{input}")),
+    ];
+    let report: PreferenceReport = client
+        .chat_json_parsed_labeled(messages, Some("preference_analysis"))
+        .await
+        .map_err(PreferenceError::Llm)?;
+    Ok(report.preferences)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_input_dedups_trims_and_numbers() {
+        let turns = vec![
+            "  fix the bug in parser  ".to_string(),
+            "fix the bug in parser".to_string(), // exact dup after trim
+            String::new(),
+            "请先出方案再写代码".to_string(),
+        ];
+        let input = build_analysis_input(&turns);
+        assert_eq!(input, "1. fix the bug in parser\n2. 请先出方案再写代码\n");
+    }
+
+    #[test]
+    fn build_input_caps_turn_and_total_length() {
+        let long_turn = "x".repeat(MAX_TURN_CHARS * 3);
+        let input = build_analysis_input(std::slice::from_ref(&long_turn));
+        // "1. " + capped turn + ellipsis + newline
+        assert_eq!(input.chars().count(), 3 + MAX_TURN_CHARS + 1 + 1);
+        assert!(input.trim_end().ends_with('…'));
+
+        // Many distinct near-cap turns must stop at the total budget.
+        let turns: Vec<String> = (0..200)
+            .map(|i| format!("{i:04} {}", "y".repeat(MAX_TURN_CHARS - 10)))
+            .collect();
+        let input = build_analysis_input(&turns);
+        assert!(input.chars().count() <= MAX_TOTAL_CHARS);
+        assert!(!input.is_empty());
+    }
+
+    #[test]
+    fn empty_turns_produce_empty_input() {
+        assert!(build_analysis_input(&[]).is_empty());
+        assert!(build_analysis_input(&["   ".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn report_parses_with_and_without_optional_fields() {
+        let json = r#"{"preferences":[{"category":"workflow","key":"workflow_style","value":"plan_first","rationale":"asked for plans twice"},{"category":"technical","key":"testing","value":"require_tests"}]}"#;
+        let report: PreferenceReport = serde_json::from_str(json).expect("parse");
+        assert_eq!(report.preferences.len(), 2);
+        assert_eq!(report.preferences[0].value, "plan_first");
+        assert_eq!(report.preferences[1].rationale, "");
+
+        let report: PreferenceReport = serde_json::from_str("{}").expect("parse empty");
+        assert!(report.preferences.is_empty());
+    }
+}

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
@@ -14,8 +14,9 @@ pub mod qoder;
 pub mod store;
 
 pub use store::{
-    strip_system_context, TrajectoryAgentActivitySummary, TrajectoryFilters, TrajectoryRecord,
-    TrajectoryStore, TrajectorySummary,
+    strip_system_context, StepContext, StepHit, StepScanFilter, StepScanOutcome, StepView,
+    TrajectoryAgentActivitySummary, TrajectoryFilters, TrajectoryRecord, TrajectoryStore,
+    TrajectorySummary,
 };
 
 use std::path::PathBuf;

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/lib.rs
@@ -14,8 +14,8 @@ pub mod qoder;
 pub mod store;
 
 pub use store::{
-    TrajectoryAgentActivitySummary, TrajectoryFilters, TrajectoryRecord, TrajectoryStore,
-    TrajectorySummary,
+    strip_system_context, TrajectoryAgentActivitySummary, TrajectoryFilters, TrajectoryRecord,
+    TrajectoryStore, TrajectorySummary,
 };
 
 use std::path::PathBuf;

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
@@ -366,6 +366,44 @@ impl TrajectoryStore {
         Ok(out)
     }
 
+    /// Returns `(session_id, atif_json)` of the most recent main-agent
+    /// trajectories collected at or after `since_collected_at_ns`, newest
+    /// first, capped at `limit`.
+    ///
+    /// Read-only, built for preference analysis: subagent rows are excluded
+    /// because their "user" steps are the parent agent's instructions, not
+    /// genuine user input. The window filter uses `collected_at_ns` (always
+    /// present, monotonic i64) rather than the optional ISO `start_time` /
+    /// `end_time` strings.
+    ///
+    /// Memory / locking: the result holds the complete ATIF JSON string of
+    /// every matched row — a single call can return tens of MB — and the
+    /// store's connection mutex stays held while the rows are collected.
+    /// Callers must keep `limit` conservative and avoid concurrent calls.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn list_recent_atif_jsons(
+        &self,
+        since_collected_at_ns: i64,
+        limit: i64,
+    ) -> Result<Vec<(String, String)>> {
+        let conn = self.lock_conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT session_id, atif_json FROM collected_trajectories
+             WHERE collected_at_ns >= ?1 AND is_subagent = 0
+             ORDER BY collected_at_ns DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![since_collected_at_ns, limit], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Returns the stored ATIF v1.7 JSON for one session, if present.
     ///
     /// # Errors
@@ -519,7 +557,14 @@ const SYSTEM_TAG_PAIRS: &[(&str, &str)] = &[
 
 /// Remove system-injected tag blocks from a user message. An unterminated
 /// opening tag swallows the rest of the text (matches AgentOpt semantics).
-fn strip_system_context(text: &str) -> String {
+/// Public because preference analysis needs the same cleaning when it reads
+/// user turns straight out of stored ATIF steps.
+///
+/// Stable contract for external callers: only the `SYSTEM_TAG_PAIRS`
+/// blocks are removed; user-authored text outside those blocks is preserved
+/// verbatim, apart from collapsing the blank runs the removal leaves behind
+/// and trimming the edges.
+pub fn strip_system_context(text: &str) -> String {
     let mut result = text.to_string();
     for &(open, close) in SYSTEM_TAG_PAIRS {
         while let Some(start) = result.find(open) {
@@ -762,6 +807,32 @@ mod tests {
         );
         // limit caps the result
         assert_eq!(store.list_summaries(None, None, None, 1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_list_recent_atif_jsons_window_limit_and_subagents() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("recent")).unwrap();
+        for (id, is_subagent) in [("m-1", false), ("m-2", false), ("m-1:subagent:x", true)] {
+            let mut rec = sample_record();
+            rec.session_id = id.into();
+            rec.is_subagent = is_subagent;
+            store.upsert_trajectory(&rec).unwrap();
+        }
+
+        // Subagent rows never appear; the newest row comes first.
+        let rows = store.list_recent_atif_jsons(0, 100).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|(id, _)| !id.contains("subagent")));
+        assert_eq!(rows[0].1, sample_record().atif_json);
+
+        // The limit caps the result set.
+        assert_eq!(store.list_recent_atif_jsons(0, 1).unwrap().len(), 1);
+
+        // A window bound in the future excludes everything.
+        assert!(store
+            .list_recent_atif_jsons(i64::MAX, 100)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
+++ b/src/agentsight/crates/agentsight-trajectory-collector/src/store.rs
@@ -12,6 +12,8 @@ use anyhow::{anyhow, Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
 
+use agentsight_atif::{AtifTrajectory, Step, StepCategory};
+
 /// A row of `collected_trajectories` ready for upsert.
 #[derive(Debug, Clone)]
 pub struct TrajectoryRecord {
@@ -81,6 +83,80 @@ pub struct TrajectoryAgentActivitySummary {
     pub total_steps: i64,
     /// Prompt and completion tokens across all trajectories.
     pub total_tokens: i64,
+}
+
+/// Filter for [`TrajectoryStore::scan_steps`].
+///
+/// The trajectory-level fields (`project` / `source` / `agent_name` /
+/// `session_id`) narrow rows in SQL *before* any `atif_json` is parsed;
+/// `categories` is applied per step afterwards.
+#[derive(Debug, Clone, Default)]
+pub struct StepScanFilter {
+    pub project: Option<String>,
+    pub source: Option<String>,
+    pub agent_name: Option<String>,
+    pub session_id: Option<String>,
+    /// Match steps carrying **any** of these labels; empty means "any".
+    pub categories: Vec<StepCategory>,
+    /// Stop after this many hits.
+    pub limit: i64,
+    /// How many neighbouring steps to return on each side of a hit.
+    pub context_radius: i64,
+    /// Upper bound on trajectories read from disk, capping query cost.
+    pub max_scan: i64,
+}
+
+/// One step projected for the query response: the bulky `message` is reduced
+/// to a preview and tool/reasoning presence to booleans.
+#[derive(Debug, Clone, Serialize)]
+pub struct StepView {
+    pub step_id: usize,
+    /// Step-level role: "user", "agent" or "system".
+    pub source: String,
+    /// Derived labels; see [`agentsight_atif::StepCategory`].
+    pub categories: Vec<String>,
+    pub timestamp: Option<String>,
+    pub message_preview: String,
+    pub message_truncated: bool,
+    pub tool_names: Vec<String>,
+    pub has_observation: bool,
+    pub has_reasoning: bool,
+}
+
+/// Neighbouring steps around a hit, for reading it in context.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct StepContext {
+    pub before: Vec<StepView>,
+    pub after: Vec<StepView>,
+}
+
+/// A matching step plus the trajectory it belongs to.
+#[derive(Debug, Clone, Serialize)]
+pub struct StepHit {
+    pub session_id: String,
+    pub agent_name: String,
+    pub project: String,
+    /// Which product wrote the file: "qoder" or "qoderwork". Distinct from
+    /// `step.source`, which is the step's role.
+    pub source: String,
+    pub step: StepView,
+    pub context: StepContext,
+}
+
+/// Result of a step scan.
+///
+/// No total-match count is reported: the scan stops early once `limit` is
+/// reached, so a total would be a guess.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct StepScanOutcome {
+    pub hits: Vec<StepHit>,
+    pub scanned_trajectories: i64,
+    /// `true` when the scan stopped early (reached `limit`) or exhausted
+    /// `max_scan` with candidates left unread: `hits` is then a prefix of the
+    /// full match set, not all of it.
+    pub truncated: bool,
+    /// Rows whose `atif_json` could not be parsed and were skipped.
+    pub skipped_unparsable: i64,
 }
 
 /// Thread-safe store over a dedicated `trajectories.db`.
@@ -519,11 +595,179 @@ impl TrajectoryStore {
             .map_err(Into::into)
     }
 
+    /// Finds steps matching `filter`, each with its neighbouring steps.
+    ///
+    /// Steps are not stored as rows: they live inside the `atif_json` column,
+    /// so matching requires deserializing candidate trajectories. Cost is
+    /// bounded three ways — the SQL `WHERE` narrows candidates first, newest
+    /// trajectories are visited first, and `max_scan` caps how many are read
+    /// at all. Rows whose JSON fails to parse are counted and skipped rather
+    /// than failing the query, since one corrupt document must not hide every
+    /// other result.
+    ///
+    /// # Errors
+    /// Returns an error on SQL failure or poisoned mutex.
+    pub fn scan_steps(&self, filter: &StepScanFilter) -> Result<StepScanOutcome> {
+        let conn = self.lock_conn()?;
+        let mut sql = String::from(
+            "SELECT session_id, agent_name, project, source, atif_json
+             FROM collected_trajectories",
+        );
+        let mut clauses: Vec<String> = Vec::new();
+        let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(p) = &filter.project {
+            clauses.push("project = ?".to_string());
+            args.push(Box::new(p.clone()));
+        }
+        if let Some(s) = &filter.source {
+            clauses.push("source = ?".to_string());
+            args.push(Box::new(s.clone()));
+        }
+        if let Some(a) = &filter.agent_name {
+            clauses.push("agent_name = ?".to_string());
+            args.push(Box::new(a.clone()));
+        }
+        if let Some(sid) = &filter.session_id {
+            clauses.push("session_id = ?".to_string());
+            args.push(Box::new(sid.clone()));
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        // One row beyond `max_scan` is requested purely to detect whether the
+        // cap hid further candidates. `limit` is bound as a parameter (never
+        // interpolated) to stay injection-free.
+        sql.push_str(&format!(
+            " ORDER BY collected_at_ns DESC LIMIT ?{}",
+            args.len() + 1
+        ));
+        args.push(Box::new(filter.max_scan.saturating_add(1)));
+
+        let params_ref: Vec<&dyn rusqlite::ToSql> = args.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt.query(params_ref.as_slice())?;
+
+        let mut outcome = StepScanOutcome::default();
+        while let Some(row) = rows.next()? {
+            if outcome.scanned_trajectories >= filter.max_scan {
+                // This row exists beyond the cap, so candidates were left unread.
+                outcome.truncated = true;
+                break;
+            }
+            let session_id: String = row.get(0)?;
+            let agent_name: String = row.get(1)?;
+            let project: String = row.get(2)?;
+            let source: String = row.get(3)?;
+            let atif_json: String = row.get(4)?;
+            outcome.scanned_trajectories += 1;
+
+            let Ok(trajectory) = serde_json::from_str::<AtifTrajectory>(&atif_json) else {
+                outcome.skipped_unparsable += 1;
+                continue;
+            };
+            let reached_limit = collect_step_hits(
+                &trajectory,
+                &session_id,
+                &agent_name,
+                &project,
+                &source,
+                filter,
+                &mut outcome.hits,
+            );
+            if reached_limit {
+                outcome.truncated = true;
+                break;
+            }
+        }
+        Ok(outcome)
+    }
+
     fn lock_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
         self.conn
             .lock()
             .map_err(|_| anyhow!("trajectory store mutex poisoned"))
     }
+}
+
+/// Appends the steps of one trajectory that match `filter` to `hits`.
+///
+/// Returns `true` once `filter.limit` is reached so the caller stops reading
+/// further trajectories.
+fn collect_step_hits(
+    trajectory: &AtifTrajectory,
+    session_id: &str,
+    agent_name: &str,
+    project: &str,
+    source: &str,
+    filter: &StepScanFilter,
+    hits: &mut Vec<StepHit>,
+) -> bool {
+    let radius = usize::try_from(filter.context_radius.max(0)).unwrap_or(0);
+    let limit = usize::try_from(filter.limit.max(0)).unwrap_or(0);
+    let steps = &trajectory.steps;
+    for (idx, step) in steps.iter().enumerate() {
+        if hits.len() >= limit {
+            return true;
+        }
+        if !filter.categories.is_empty() {
+            let categories = step.categories();
+            if !filter.categories.iter().any(|c| categories.contains(c)) {
+                continue;
+            }
+        }
+        // Neighbours come from the same in-memory slice, so context is free.
+        // Saturating/min keeps the ranges valid at the first and last step.
+        let before_start = idx.saturating_sub(radius);
+        let after_end = idx
+            .saturating_add(radius)
+            .saturating_add(1)
+            .min(steps.len());
+        hits.push(StepHit {
+            session_id: session_id.to_string(),
+            agent_name: agent_name.to_string(),
+            project: project.to_string(),
+            source: source.to_string(),
+            step: step_view(step),
+            context: StepContext {
+                before: steps[before_start..idx].iter().map(step_view).collect(),
+                after: steps[idx + 1..after_end].iter().map(step_view).collect(),
+            },
+        });
+    }
+    false
+}
+
+/// Projects a step into the response shape.
+fn step_view(step: &Step) -> StepView {
+    let (message_preview, message_truncated) =
+        preview_chars(&step.message, STEP_MESSAGE_PREVIEW_CHARS);
+    StepView {
+        step_id: step.step_id,
+        source: step.source.as_str().to_string(),
+        categories: step
+            .categories()
+            .iter()
+            .map(|c| c.as_str().to_string())
+            .collect(),
+        timestamp: step.timestamp.clone(),
+        message_preview,
+        message_truncated,
+        tool_names: step.tool_names().iter().map(|n| (*n).to_string()).collect(),
+        has_observation: step.has_observation(),
+        has_reasoning: step.has_reasoning(),
+    }
+}
+
+/// Truncates `text` to at most `max` **characters**, returning the preview and
+/// whether anything was cut.
+///
+/// Counting characters (not bytes) is mandatory: trajectory content is largely
+/// CJK, and slicing by byte offset would split a multi-byte codepoint and panic.
+fn preview_chars(text: &str, max: usize) -> (String, bool) {
+    let preview: String = text.chars().take(max).collect();
+    let truncated = text.chars().nth(max).is_some();
+    (preview, truncated)
 }
 
 fn now_ns() -> i64 {
@@ -540,6 +784,11 @@ const SCHEMA_USER_VERSION: i32 = 2;
 
 /// Max characters kept per user-message preview column.
 const MESSAGE_PREVIEW_CHARS: usize = 200;
+
+/// Max characters kept per step message in [`TrajectoryStore::scan_steps`]
+/// results. Larger than [`MESSAGE_PREVIEW_CHARS`] because these previews are
+/// read by a human inspecting a step and its surrounding context.
+const STEP_MESSAGE_PREVIEW_CHARS: usize = 500;
 
 /// XML-style tag pairs injected into user turns by IDEs/CLIs (Qoder slash
 /// commands, Claude Code local-command transcripts, system reminders). Their
@@ -982,5 +1231,361 @@ mod tests {
         assert_eq!(summaries[0].last_seen_ns, 300);
         assert_eq!(summaries[0].total_steps, 8);
         assert_eq!(summaries[0].total_tokens, 320);
+    }
+
+    // ─── scan_steps ──────────────────────────────────────────────────
+
+    /// Baseline filter: no narrowing, generous limits.
+    fn scan_all() -> StepScanFilter {
+        StepScanFilter {
+            limit: 100,
+            context_radius: 3,
+            max_scan: 100,
+            ..Default::default()
+        }
+    }
+
+    /// A 5-step trajectory covering every category:
+    /// 1 user, 2 agent+thinking+tool_call, 3 tool_result, 4 agent, 5 system.
+    fn five_step_atif() -> String {
+        serde_json::json!({
+            "schema_version": "ATIF-v1.7",
+            "agent": {"name": "qoder", "version": "1.0"},
+            "session_id": "s-1",
+            "steps": [
+                {"step_id": 1, "source": "user", "message": "list files"},
+                {"step_id": 2, "source": "agent", "message": "Checking.",
+                 "reasoning_content": "need ls",
+                 "tool_calls": [{"tool_call_id": "t1", "function_name": "bash",
+                                 "arguments": {"cmd": "ls"}}]},
+                {"step_id": 3, "source": "user", "message": "",
+                 "observation": {"results": [{"source_call_id": "t1", "content": "a.txt"}]}},
+                {"step_id": 4, "source": "agent", "message": "Only a.txt exists."},
+                {"step_id": 5, "source": "system", "message": "session ended"}
+            ]
+        })
+        .to_string()
+    }
+
+    fn seed_five_steps(store: &TrajectoryStore) {
+        let mut rec = sample_record();
+        rec.num_steps = 5;
+        rec.atif_json = five_step_atif();
+        store.upsert_trajectory(&rec).unwrap();
+    }
+
+    #[test]
+    fn test_scan_steps_single_category() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-single")).unwrap();
+        seed_five_steps(&store);
+
+        let filter = StepScanFilter {
+            categories: vec![StepCategory::ToolCall],
+            ..scan_all()
+        };
+        let out = store.scan_steps(&filter).unwrap();
+        assert_eq!(out.hits.len(), 1);
+        assert_eq!(out.hits[0].step.step_id, 2);
+        assert_eq!(out.hits[0].step.tool_names, vec!["bash".to_string()]);
+        assert_eq!(out.scanned_trajectories, 1);
+        assert!(!out.truncated);
+        assert_eq!(out.skipped_unparsable, 0);
+        // Trajectory-level source stays the product name, not the step role.
+        assert_eq!(out.hits[0].source, "qoder");
+        assert_eq!(out.hits[0].step.source, "agent");
+    }
+
+    #[test]
+    fn test_scan_steps_multi_category_is_or() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-multi")).unwrap();
+        seed_five_steps(&store);
+
+        let filter = StepScanFilter {
+            categories: vec![StepCategory::System, StepCategory::ToolResult],
+            ..scan_all()
+        };
+        let out = store.scan_steps(&filter).unwrap();
+        let ids: Vec<usize> = out.hits.iter().map(|h| h.step.step_id).collect();
+        assert_eq!(ids, vec![3, 5]);
+    }
+
+    #[test]
+    fn test_scan_steps_no_category_returns_every_step() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-nocat")).unwrap();
+        seed_five_steps(&store);
+
+        let out = store.scan_steps(&scan_all()).unwrap();
+        assert_eq!(out.hits.len(), 5);
+    }
+
+    #[test]
+    fn test_scan_steps_context_window_and_boundaries() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-ctx")).unwrap();
+        seed_five_steps(&store);
+
+        // Middle step: full window on both sides.
+        let mid = store
+            .scan_steps(&StepScanFilter {
+                categories: vec![StepCategory::ToolResult],
+                context_radius: 2,
+                ..scan_all()
+            })
+            .unwrap();
+        let hit = &mid.hits[0];
+        assert_eq!(hit.step.step_id, 3);
+        assert_eq!(
+            hit.context
+                .before
+                .iter()
+                .map(|s| s.step_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(
+            hit.context
+                .after
+                .iter()
+                .map(|s| s.step_id)
+                .collect::<Vec<_>>(),
+            vec![4, 5]
+        );
+
+        // First step: nothing before it.
+        let first = store
+            .scan_steps(&StepScanFilter {
+                categories: vec![StepCategory::UserInput],
+                context_radius: 3,
+                ..scan_all()
+            })
+            .unwrap();
+        let first_hit = &first.hits[0];
+        assert_eq!(first_hit.step.step_id, 1);
+        assert!(first_hit.context.before.is_empty());
+        assert_eq!(first_hit.context.after.len(), 3);
+
+        // Last step: nothing after it.
+        let last = store
+            .scan_steps(&StepScanFilter {
+                categories: vec![StepCategory::System],
+                context_radius: 3,
+                ..scan_all()
+            })
+            .unwrap();
+        let last_hit = &last.hits[0];
+        assert_eq!(last_hit.step.step_id, 5);
+        assert_eq!(last_hit.context.before.len(), 3);
+        assert!(last_hit.context.after.is_empty());
+    }
+
+    #[test]
+    fn test_scan_steps_zero_context() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-ctx0")).unwrap();
+        seed_five_steps(&store);
+
+        let out = store
+            .scan_steps(&StepScanFilter {
+                categories: vec![StepCategory::ToolResult],
+                context_radius: 0,
+                ..scan_all()
+            })
+            .unwrap();
+        assert!(out.hits[0].context.before.is_empty());
+        assert!(out.hits[0].context.after.is_empty());
+    }
+
+    #[test]
+    fn test_scan_steps_limit_marks_truncated() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-limit")).unwrap();
+        seed_five_steps(&store);
+
+        let out = store
+            .scan_steps(&StepScanFilter {
+                limit: 2,
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(out.hits.len(), 2);
+        assert!(out.truncated);
+    }
+
+    #[test]
+    fn test_scan_steps_max_scan_marks_truncated() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-maxscan")).unwrap();
+        for id in ["s-1", "s-2", "s-3"] {
+            let mut rec = sample_record();
+            rec.session_id = id.into();
+            rec.file_path = format!("/root/.qoder/projects/x/{id}.jsonl");
+            rec.atif_json = five_step_atif();
+            store.upsert_trajectory(&rec).unwrap();
+        }
+
+        let out = store
+            .scan_steps(&StepScanFilter {
+                max_scan: 2,
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(out.scanned_trajectories, 2);
+        assert!(out.truncated);
+
+        // Exactly as many candidates as the cap is not truncation.
+        let exact = store
+            .scan_steps(&StepScanFilter {
+                max_scan: 3,
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(exact.scanned_trajectories, 3);
+        assert!(!exact.truncated);
+    }
+
+    #[test]
+    fn test_scan_steps_skips_unparsable_without_failing() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-bad")).unwrap();
+        let mut bad = sample_record();
+        bad.session_id = "bad".into();
+        bad.file_path = "/root/.qoder/projects/x/bad.jsonl".into();
+        bad.atif_json = "{not valid json".into();
+        store.upsert_trajectory(&bad).unwrap();
+        seed_five_steps(&store);
+
+        // One corrupt document must not hide the healthy trajectory's steps.
+        let out = store.scan_steps(&scan_all()).unwrap();
+        assert_eq!(out.skipped_unparsable, 1);
+        assert_eq!(out.scanned_trajectories, 2);
+        assert_eq!(out.hits.len(), 5);
+    }
+
+    #[test]
+    fn test_scan_steps_narrows_by_trajectory_fields() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-narrow")).unwrap();
+        seed_five_steps(&store);
+        let mut other = sample_record();
+        other.session_id = "s-2".into();
+        other.agent_name = "qoderwork".into();
+        other.project = "otherapp".into();
+        other.file_path = "/root/.qoderwork/projects/y/s-2.jsonl".into();
+        other.atif_json = five_step_atif();
+        store.upsert_trajectory(&other).unwrap();
+
+        let by_session = store
+            .scan_steps(&StepScanFilter {
+                session_id: Some("s-2".into()),
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(by_session.scanned_trajectories, 1);
+        assert!(by_session.hits.iter().all(|h| h.session_id == "s-2"));
+
+        let by_agent = store
+            .scan_steps(&StepScanFilter {
+                agent_name: Some("qoder".into()),
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(by_agent.scanned_trajectories, 1);
+        assert!(by_agent.hits.iter().all(|h| h.agent_name == "qoder"));
+
+        let by_project = store
+            .scan_steps(&StepScanFilter {
+                project: Some("otherapp".into()),
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(by_project.scanned_trajectories, 1);
+
+        let no_match = store
+            .scan_steps(&StepScanFilter {
+                session_id: Some("nope".into()),
+                ..scan_all()
+            })
+            .unwrap();
+        assert!(no_match.hits.is_empty());
+        assert_eq!(no_match.scanned_trajectories, 0);
+    }
+
+    #[test]
+    fn test_scan_steps_truncates_cjk_preview_on_char_boundary() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-cjk")).unwrap();
+        // Multi-byte content longer than the preview cap: byte slicing here
+        // would split a codepoint and panic.
+        let long = "\u{4fee}".repeat(STEP_MESSAGE_PREVIEW_CHARS + 50);
+        let mut rec = sample_record();
+        rec.atif_json = serde_json::json!({
+            "schema_version": "ATIF-v1.7",
+            "agent": {"name": "qoder", "version": "1.0"},
+            "steps": [{"step_id": 1, "source": "user", "message": long}]
+        })
+        .to_string();
+        store.upsert_trajectory(&rec).unwrap();
+
+        let out = store.scan_steps(&scan_all()).unwrap();
+        let view = &out.hits[0].step;
+        assert!(view.message_truncated);
+        assert_eq!(
+            view.message_preview.chars().count(),
+            STEP_MESSAGE_PREVIEW_CHARS
+        );
+
+        // A short message is returned whole and not flagged.
+        let mut short = sample_record();
+        short.session_id = "s-short".into();
+        short.file_path = "/root/.qoder/projects/x/short.jsonl".into();
+        short.atif_json = serde_json::json!({
+            "schema_version": "ATIF-v1.7",
+            "agent": {"name": "qoder", "version": "1.0"},
+            "steps": [{"step_id": 1, "source": "user", "message": "\u{4fee}\u{590d} bug"}]
+        })
+        .to_string();
+        store.upsert_trajectory(&short).unwrap();
+
+        let out = store
+            .scan_steps(&StepScanFilter {
+                session_id: Some("s-short".into()),
+                ..scan_all()
+            })
+            .unwrap();
+        assert_eq!(out.hits[0].step.message_preview, "\u{4fee}\u{590d} bug");
+        assert!(!out.hits[0].step.message_truncated);
+    }
+
+    #[test]
+    fn test_scan_steps_view_exposes_derived_flags() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-flags")).unwrap();
+        seed_five_steps(&store);
+
+        let out = store.scan_steps(&scan_all()).unwrap();
+        let by_id: std::collections::HashMap<usize, &StepView> =
+            out.hits.iter().map(|h| (h.step.step_id, &h.step)).collect();
+
+        let agent_tool_step = by_id[&2];
+        assert!(agent_tool_step.has_reasoning);
+        assert!(!agent_tool_step.has_observation);
+        assert_eq!(
+            agent_tool_step.categories,
+            vec![
+                "agent_message".to_string(),
+                "thinking".to_string(),
+                "tool_call".to_string()
+            ]
+        );
+
+        let result_step = by_id[&3];
+        assert!(result_step.has_observation);
+        assert!(result_step.tool_names.is_empty());
+        // Tool results ride on a user-role turn, so the role label applies too.
+        assert_eq!(
+            result_step.categories,
+            vec!["user_input".to_string(), "tool_result".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_scan_steps_empty_store() {
+        let store = TrajectoryStore::new_with_path(&tmp_db("scan-empty")).unwrap();
+        let out = store.scan_steps(&scan_all()).unwrap();
+        assert!(out.hits.is_empty());
+        assert_eq!(out.scanned_trajectories, 0);
+        assert!(!out.truncated);
     }
 }

--- a/src/agentsight/docs/design-docs/trajectory-query-api.md
+++ b/src/agentsight/docs/design-docs/trajectory-query-api.md
@@ -158,6 +158,7 @@ pub fn sibling_db_path(filename: &str) -> PathBuf {
 | `/api/trajectories` | GET | `project`, `source`, `agent_name`, `limit`(默认 200) | `Vec<TrajectorySummary>` |
 | `/api/trajectories/{session_id}` | GET | — | 原始 ATIF v1.7 JSON（直接回传存储的 `atif_json` 字符串，`Content-Type: application/json`，不二次解析） |
 | `/api/trajectories/filters` | GET | — | `TrajectoryFilters` |
+| `/api/trajectories/steps` | GET | `category`, `agent_name`, `project`, `source`, `session_id`, `limit`(默认 50), `context`(默认 3), `max_scan`(默认 500) | `StepScanOutcome`（见 §4.4） |
 
 错误语义：
 
@@ -168,8 +169,56 @@ pub fn sibling_db_path(filename: &str) -> PathBuf {
 
 > 注意路由注册顺序：`/api/trajectories/filters` 必须在 `/api/trajectories/{session_id}` **之前**
 > 注册，否则 `filters` 会被当成 `session_id` 捕获（actix 动态段匹配）。
+> 同理，后续新增的 `/api/trajectories/steps` 也必须注册在动态段之前。
 
-### 4.4 文档同步
+### 4.4 步骤分类查询（`/api/trajectories/steps`）
+
+轨迹列表回答「有哪些会话」，步骤查询回答「哪些步骤属于某一类」——例如只看工具调用，或只看思考过程，并顺带读到命中步骤的上下文。
+
+#### 4.4.1 分类为派生标签
+
+ATIF 的 `StepSource` 只有 `system` / `user` / `agent` 三值，**没有工具维度**：工具调用在 `step.tool_calls`，工具结果在 `step.observation`，思考过程在 `step.reasoning_content`，都是 agent 步骤内部的字段。因此分类由 `Step::categories()` 从类型化字段派生（`crates/agentsight-atif/src/lib.rs` 的 `StepCategory`），不写入 ATIF 线上格式。
+
+| 分类 | 判定条件 |
+|------|----------|
+| `user_input` | `source == User` |
+| `system` | `source == System` |
+| `agent_message` | `source == Agent` 且 `message.trim()` 非空 |
+| `thinking` | `reasoning_content` 存在且 `trim()` 非空 |
+| `tool_call` | `tool_calls` 存在且非空 |
+| `tool_result` | `observation.results` 非空 |
+
+**多标签**：一个 agent 步骤可以同时思考并调用工具，此时它同时带 `agent_message` / `thinking` / `tool_call`，按任一分类过滤都能命中。「present-but-empty」不算命中——`tool_calls: []` 或 `observation.results: []` 不传递任何信息。
+
+需注意工具结果落在 `source == user` 的回合上，因此这类步骤同时带 `user_input` 与 `tool_result`。
+
+#### 4.4.2 参数与默认值
+
+| 参数 | 默认 | 上限 | 说明 |
+|------|------|------|------|
+| `category` | — | — | 逗号分隔多值，语义为 OR；缺省表示不按分类过滤 |
+| `agent_name` / `project` / `source` / `session_id` | — | — | 轨迹级过滤，在 SQL 中先行收窄 |
+| `limit` | 50 | 500 | 命中数上限 |
+| `context` | 3 | 10 | 每条命中前后各返回几条邻居；允许为 0 |
+| `max_scan` | 500 | 2000 | 最多读取多少条轨迹，成本硬上限 |
+
+非正的 `limit` / `max_scan` 一律落回默认值：SQLite 把负 `LIMIT` 视为无限制，直接透传会退化成全表扫描。
+
+#### 4.4.3 实现方式与 `truncated` 语义
+
+步骤并非独立行——它们在 `atif_json` 大字段里，所以匹配需要反序列化候选轨迹。成本由三处收敛：SQL `WHERE` 先收窄候选、`collected_at_ns DESC` 让新轨迹优先、`max_scan` 限制读取条数。命中后取邻居是零成本的，因为文档已在内存中。
+
+`truncated: true` 表示 `hits` 只是完整匹配集的前缀，出现在两种情况：命中数达到 `limit` 提前结束，或候选轨迹超过 `max_scan` 被截断。**响应不返回匹配总数**——提前结束后任何总数都是猜测。
+
+`atif_json` 解析失败的行计入 `skipped_unparsable` 并跳过，不使整个查询失败：一份损坏文档不应遮蔽其余所有结果。
+
+错误语义与既有端点一致：非法 `category` → `400 {"error":"invalid_category", "valid_categories":[...]}`（拒绝而非静默忽略，否则会返回一批看似合法的无关步骤）；store 为 `None` → 空结果 + 200；SQL 失败 → 500。
+
+#### 4.4.4 后续升级路径
+
+若轨迹量增长导致响应变慢，可新增 `trajectory_steps` 派生索引表（采集时写入 `source` 与工具/思考布尔标记），接口契约不变，只替换 `scan_steps` 内部实现。
+
+### 4.5 文档同步
 
 - `AGENTS.md` §8 API Endpoints 表新增 3 行；
 - `AGENTS.md` §4 Module Map 的 TrajectoryCollector 行补充"可经 `/api/trajectories` 查询"。

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -31,6 +31,7 @@ LAYER_MAP = {
     "security":    7,   # L7: Security audit and containment
     "server":      7,   # L7: Serve
     "health":      7,   # L7: Serve
+    "preferences": 7,   # L7: Serve (on-demand analysis shared by both servers)
     "bin":         8,   # L8: Entry
     "unified":     8,   # L8: Entry
     "config":      8,   # L8: Entry
@@ -59,7 +60,11 @@ ALLOWED_DEPS = {
         "grader",
         "enforcement",
         "security",
+        "preferences",
     },
+    # Same-layer peer of `server`: a transport-agnostic contract the Linux and
+    # macOS handlers share, so it may only read downwards.
+    "preferences": {"genai", "storage", "atif"},
     "agent_sec":   set(),
     "health":      {"storage"},
     "unified":     "*",

--- a/src/agentsight/scripts/check-arch-boundaries.py
+++ b/src/agentsight/scripts/check-arch-boundaries.py
@@ -32,6 +32,7 @@ LAYER_MAP = {
     "server":      7,   # L7: Serve
     "health":      7,   # L7: Serve
     "preferences": 7,   # L7: Serve (on-demand analysis shared by both servers)
+    "semantic_search": 7,  # L7: Serve (session search contract shared by both servers)
     "bin":         8,   # L8: Entry
     "unified":     8,   # L8: Entry
     "config":      8,   # L8: Entry
@@ -61,10 +62,12 @@ ALLOWED_DEPS = {
         "enforcement",
         "security",
         "preferences",
+        "semantic_search",
     },
-    # Same-layer peer of `server`: a transport-agnostic contract the Linux and
-    # macOS handlers share, so it may only read downwards.
+    # Same-layer peers of `server`: both are transport-agnostic contracts the
+    # Linux and macOS handlers share, so they may only read downwards.
     "preferences": {"genai", "storage", "atif"},
+    "semantic_search": {"storage"},
     "agent_sec":   set(),
     "health":      {"storage"},
     "unified":     "*",

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -53,7 +53,7 @@ impl TraceCommand {
 
         #[cfg(not(target_os = "linux"))]
         {
-            agentsight::local::trace::run_local_trace();
+            agentsight::local::trace::run_local_trace(self.verbose);
         }
     }
 }

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -509,15 +509,17 @@ impl GenAIBuilder {
     /// ```
     ///
     /// [Tue 2026-03-31 17:19 GMT+8] 用户实际输入
-    /// ```
     ///
-    /// **QwenCode**: `<system-reminder>` 标签块
+    /// **QwenCode**: <system-reminder> 标签块
     /// ```text
     /// <system-reminder>...skills...</system-reminder>
     /// <system-reminder>...context...</system-reminder>
     /// 用户实际输入
     /// ```
-    pub(super) fn strip_user_query_prefix(text: &str) -> String {
+    /// `pub(crate)` rather than `pub(super)`: the preference rule engine
+    /// (`crate::preferences::detector`) reuses this stripper so evidence
+    /// excerpts quote the user's actual words, not agent template noise.
+    pub(crate) fn strip_user_query_prefix(text: &str) -> String {
         // cosh-ng: find a line starting with "user_input:" (after trimming)
         // and extract its value. This line-by-line approach tolerates template
         // adjustments such as indentation changes, missing leading newlines,

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -32,6 +32,9 @@ mod logging;
 pub mod preferences;
 mod private_sqlite;
 pub mod security;
+// Cross-platform: the request/response contract and LLM ranking call behind
+// `POST /api/sessions/search`, shared by the Linux and macOS server handlers.
+pub mod semantic_search;
 pub mod tokenizer;
 pub mod utils;
 

--- a/src/agentsight/src/lib.rs
+++ b/src/agentsight/src/lib.rs
@@ -27,6 +27,9 @@ pub mod chrome_trace;
 pub mod config;
 pub mod ecs_metadata;
 mod logging;
+// Cross-platform: rules run over either genai events (Linux) or collected
+// trajectories (all OSes); only the genai provider inside is Linux-gated.
+pub mod preferences;
 mod private_sqlite;
 pub mod security;
 pub mod tokenizer;

--- a/src/agentsight/src/local/server.rs
+++ b/src/agentsight/src/local/server.rs
@@ -404,9 +404,10 @@ pub async fn run_server(host: &str, port: u16) -> std::io::Result<()> {
             .wrap(cors)
             .app_data(local_state.clone())
             .app_data(optimize_data.clone())
-            // Trajectory collection API
+            // Trajectory collection API (static paths before the dynamic segment)
             .service(trajectories::list_trajectories)
             .service(trajectories::trajectory_filters)
+            .service(trajectories::list_trajectory_steps)
             .service(trajectories::get_trajectory_detail)
             // Local session discovery + ATIF conversion API
             .service(local_sessions::list_local_sessions)

--- a/src/agentsight/src/local/server.rs
+++ b/src/agentsight/src/local/server.rs
@@ -441,6 +441,7 @@ pub async fn run_server(host: &str, port: u16) -> std::io::Result<()> {
             // User preference analysis API (registered before api_fallback)
             .service(preferences::export_preferences)
             .service(preferences::get_preferences)
+            .service(preferences::get_preference_turns)
             .service(export_atif_unavailable)
             // Catch-all for unregistered API endpoints (returns empty array)
             .service(api_fallback)

--- a/src/agentsight/src/local/server.rs
+++ b/src/agentsight/src/local/server.rs
@@ -6,6 +6,7 @@
 mod agents;
 mod local_sessions;
 mod optimize;
+mod preferences;
 mod trajectories;
 
 use actix_cors::Cors;
@@ -437,6 +438,9 @@ pub async fn run_server(host: &str, port: u16) -> std::io::Result<()> {
             .service(optimize::get_optimize_config)
             .service(optimize::update_optimize_config)
             .service(optimize::semantic_search_sessions)
+            // User preference analysis API (registered before api_fallback)
+            .service(preferences::export_preferences)
+            .service(preferences::get_preferences)
             .service(export_atif_unavailable)
             // Catch-all for unregistered API endpoints (returns empty array)
             .service(api_fallback)

--- a/src/agentsight/src/local/server/optimize.rs
+++ b/src/agentsight/src/local/server/optimize.rs
@@ -117,7 +117,9 @@ impl OptimizeState {
         self.config.read().map(|c| c.clone()).unwrap_or_default()
     }
 
-    fn build_client(&self) -> Result<LlmClient, HttpResponse> {
+    // `pub(super)` so the sibling preferences module can reuse the same
+    // configured client for its optional LLM layer.
+    pub(super) fn build_client(&self) -> Result<LlmClient, HttpResponse> {
         let config = self.snapshot();
         let Some(api_key) = config.effective_api_key() else {
             return Err(HttpResponse::BadRequest().json(serde_json::json!({

--- a/src/agentsight/src/local/server/optimize.rs
+++ b/src/agentsight/src/local/server/optimize.rs
@@ -12,7 +12,7 @@ use agentsight_opt_store::{Dimension, OptimizationStore};
 use agentsight_trajectory_collector::TrajectoryStore;
 use serde::{Deserialize, Serialize};
 
-use crate::server::semantic_search;
+use crate::semantic_search;
 
 const CONFIG_FILE_NAME: &str = "optimization_config.json";
 const DB_FILE_NAME: &str = "optimization.db";

--- a/src/agentsight/src/local/server/preferences.rs
+++ b/src/agentsight/src/local/server/preferences.rs
@@ -1,0 +1,182 @@
+//! macOS preference API over collected trajectories.
+//!
+//! Thin platform adapter: all shared mechanics (source selection, TTL
+//! cache, LLM merging, Markdown export) live in `crate::preferences::api`
+//! and match the Linux server. The eBPF genai pipeline does not exist on
+//! macOS, so `source=genai` fails loudly and `source=auto` degrades
+//! straight to `trajectories.db`.
+
+use actix_web::{HttpResponse, Responder, get, web};
+use agentsight_opt::preference::{LlmPreference, analyze_user_turns};
+use agentsight_trajectory_collector::TrajectoryStore;
+
+use super::optimize::OptimizeAppState;
+use crate::preferences::api::{
+    AutoResolution, PreferenceSourceParam, PreferencesQuery, cache_get, cache_put,
+    clamp_window_days, merge_llm_preferences, render_markdown, resolve_auto, window_start_ns,
+};
+use crate::preferences::{aggregator, analyze_rows, detector, trajectory_source};
+
+// ─── Source loading ──────────────────────────────────────────────────────────
+
+fn trajectory_unavailable() -> HttpResponse {
+    HttpResponse::ServiceUnavailable().json(serde_json::json!({
+        "error": "trajectory source unavailable",
+        "message": "trajectories.db not found; run `agentsight trace` to collect trajectories first.",
+    }))
+}
+
+fn load_trajectory_rows(
+    store: &TrajectoryStore,
+    since_ns: i64,
+) -> Result<(Vec<detector::PreferenceEventRow>, PreferenceSourceParam), HttpResponse> {
+    trajectory_source::load_window_rows(store, since_ns)
+        .map(|rows| (rows, PreferenceSourceParam::Trajectory))
+        .map_err(|e| {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        })
+}
+
+/// Resolve the requested source and load its window. Returns the rows
+/// together with the source that actually served them (never `Auto`), so
+/// handlers can report real provenance in the response body.
+fn load_rows(
+    data: &OptimizeAppState,
+    source: PreferenceSourceParam,
+    window_days: u32,
+) -> Result<(Vec<detector::PreferenceEventRow>, PreferenceSourceParam), HttpResponse> {
+    let since_ns = window_start_ns(window_days);
+    let store = data.local_state.trajectory_store();
+    match source {
+        PreferenceSourceParam::Genai => {
+            Err(HttpResponse::ServiceUnavailable().json(serde_json::json!({
+                "error": "genai source unavailable",
+                "message": "The eBPF genai pipeline does not exist on macOS; \
+                            use source=trajectory (or the default auto).",
+            })))
+        }
+        PreferenceSourceParam::Trajectory => match store {
+            Some(store) => load_trajectory_rows(&store, since_ns),
+            None => Err(trajectory_unavailable()),
+        },
+        // No genai store exists to probe on macOS, so auto resolution is
+        // decided by trajectory availability alone.
+        PreferenceSourceParam::Auto => match resolve_auto(None, store.is_some()) {
+            AutoResolution::Trajectory => match store {
+                Some(store) => load_trajectory_rows(&store, since_ns),
+                None => Err(trajectory_unavailable()),
+            },
+            _ => Err(HttpResponse::ServiceUnavailable().json(serde_json::json!({
+                "error": "no preference data source available",
+                "message": "trajectories.db not found; run `agentsight trace` to collect trajectories first.",
+            }))),
+        },
+    }
+}
+
+/// Parse `?source=`, mapping bad values to a 400 with the parser's message.
+fn parse_source(query: &PreferencesQuery) -> Result<PreferenceSourceParam, HttpResponse> {
+    PreferenceSourceParam::parse(query.source.as_deref()).map_err(|message| {
+        HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid source",
+            "message": message,
+        }))
+    })
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+/// GET /api/preferences?window_days=7&llm=true&source=auto
+///
+/// Rule-based preference analysis over the recent trajectory window,
+/// optionally augmented with LLM findings when `llm=true` and the local
+/// optimization LLM is configured. LLM problems never fail the request —
+/// the response degrades to rule-only results with `llm_enabled: false`.
+#[get("/api/preferences")]
+pub async fn get_preferences(
+    data: web::Data<OptimizeAppState>,
+    query: web::Query<PreferencesQuery>,
+) -> impl Responder {
+    let source = match parse_source(&query) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let llm_requested = query.llm.unwrap_or(false);
+    let cache_key = (window_days, llm_requested, source);
+
+    if let Some(body) = cache_get(cache_key) {
+        return HttpResponse::Ok().json(body);
+    }
+
+    let (rows, resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let mut prefs = analyze_rows(&rows);
+
+    let mut llm_enabled = false;
+    if llm_requested {
+        match llm_findings(&data, &rows).await {
+            Ok(findings) => {
+                llm_enabled = true;
+                merge_llm_preferences(&mut prefs, findings);
+                // Re-run conflict marking so exclusivity (e.g. "language")
+                // holds across rule and LLM entries together.
+                aggregator::mark_conflicts(&mut prefs);
+            }
+            Err(reason) => log::warn!("Preference API: LLM layer skipped: {reason}"),
+        }
+    }
+
+    let body = serde_json::json!({
+        "window_days": window_days,
+        "analyzed_events": rows.len(),
+        "llm_enabled": llm_enabled,
+        "source": resolved.as_str(),
+        "preferences": prefs,
+    });
+    cache_put(cache_key, body.clone());
+    HttpResponse::Ok().json(body)
+}
+
+/// Run the LLM layer over the window's user turns; every failure mode is
+/// reduced to one human-readable reason for the degradation log.
+async fn llm_findings(
+    data: &OptimizeAppState,
+    rows: &[detector::PreferenceEventRow],
+) -> Result<Vec<LlmPreference>, String> {
+    let client = data
+        .optimize
+        .build_client()
+        .map_err(|_| "LLM not configured".to_string())?;
+    let turns: Vec<String> = rows.iter().filter_map(|r| r.user_text.clone()).collect();
+    analyze_user_turns(&client, &turns)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// GET /api/preferences/export?window_days=7&source=auto
+///
+/// Markdown digest of the confident, active rule-based preferences —
+/// suitable for pasting into an agent memory/config file. Accepts the same
+/// `source` parameter as the JSON endpoint.
+#[get("/api/preferences/export")]
+pub async fn export_preferences(
+    data: web::Data<OptimizeAppState>,
+    query: web::Query<PreferencesQuery>,
+) -> impl Responder {
+    let source = match parse_source(&query) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let (rows, _resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let prefs = analyze_rows(&rows);
+    HttpResponse::Ok()
+        .content_type("text/markdown; charset=utf-8")
+        .body(render_markdown(&prefs))
+}

--- a/src/agentsight/src/local/server/preferences.rs
+++ b/src/agentsight/src/local/server/preferences.rs
@@ -6,14 +6,17 @@
 //! macOS, so `source=genai` fails loudly and `source=auto` degrades
 //! straight to `trajectories.db`.
 
+use std::collections::HashSet;
+
 use actix_web::{HttpResponse, Responder, get, web};
 use agentsight_opt::preference::{LlmPreference, analyze_user_turns};
 use agentsight_trajectory_collector::TrajectoryStore;
 
 use super::optimize::OptimizeAppState;
 use crate::preferences::api::{
-    AutoResolution, PreferenceSourceParam, PreferencesQuery, cache_get, cache_put,
-    clamp_window_days, merge_llm_preferences, render_markdown, resolve_auto, window_start_ns,
+    AutoResolution, DEFAULT_TURNS_LIMIT, MAX_TURNS_LIMIT, PreferenceSourceParam, PreferencesQuery,
+    TurnsQuery, cache_get, cache_put, clamp_window_days, merge_llm_preferences, render_markdown,
+    resolve_auto, window_start_ns,
 };
 use crate::preferences::{aggregator, analyze_rows, detector, trajectory_source};
 
@@ -75,8 +78,8 @@ fn load_rows(
 }
 
 /// Parse `?source=`, mapping bad values to a 400 with the parser's message.
-fn parse_source(query: &PreferencesQuery) -> Result<PreferenceSourceParam, HttpResponse> {
-    PreferenceSourceParam::parse(query.source.as_deref()).map_err(|message| {
+fn parse_source(source: Option<&str>) -> Result<PreferenceSourceParam, HttpResponse> {
+    PreferenceSourceParam::parse(source).map_err(|message| {
         HttpResponse::BadRequest().json(serde_json::json!({
             "error": "invalid source",
             "message": message,
@@ -97,7 +100,7 @@ pub async fn get_preferences(
     data: web::Data<OptimizeAppState>,
     query: web::Query<PreferencesQuery>,
 ) -> impl Responder {
-    let source = match parse_source(&query) {
+    let source = match parse_source(query.source.as_deref()) {
         Ok(source) => source,
         Err(resp) => return resp,
     };
@@ -166,7 +169,7 @@ pub async fn export_preferences(
     data: web::Data<OptimizeAppState>,
     query: web::Query<PreferencesQuery>,
 ) -> impl Responder {
-    let source = match parse_source(&query) {
+    let source = match parse_source(query.source.as_deref()) {
         Ok(source) => source,
         Err(resp) => return resp,
     };
@@ -179,4 +182,46 @@ pub async fn export_preferences(
     HttpResponse::Ok()
         .content_type("text/markdown; charset=utf-8")
         .body(render_markdown(&prefs))
+}
+
+/// GET /api/preferences/turns?window_days=7&source=auto&limit=200
+///
+/// Returns the deduped raw user turns inside the window — the same text the
+/// `llm=true` path feeds to the server-side LLM, but handed back verbatim so
+/// an agent (which already has its own model) can run the enhancement itself
+/// without agentsight holding any LLM credentials. Newest unique turns first;
+/// `limit` bounds the count (default 200, max 1000).
+#[get("/api/preferences/turns")]
+pub async fn get_preference_turns(
+    data: web::Data<OptimizeAppState>,
+    query: web::Query<TurnsQuery>,
+) -> impl Responder {
+    let source = match parse_source(query.source.as_deref()) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let (rows, resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_TURNS_LIMIT)
+        .clamp(1, MAX_TURNS_LIMIT);
+    let mut seen: HashSet<String> = HashSet::new();
+    let turns: Vec<String> = rows
+        .iter()
+        .filter_map(|r| r.user_text.clone())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .filter(|s| seen.insert(s.clone()))
+        .take(limit)
+        .collect();
+    HttpResponse::Ok().json(serde_json::json!({
+        "window_days": window_days,
+        "source": resolved.as_str(),
+        "turns_count": turns.len(),
+        "turns": turns,
+    }))
 }

--- a/src/agentsight/src/local/server/trajectories.rs
+++ b/src/agentsight/src/local/server/trajectories.rs
@@ -5,10 +5,9 @@
 //! Linux-only `AppState`. On macOS the collector scans Qoder/QoderWork session
 //! directories and stores ATIF v1.7 documents in `trajectories.db`.
 
-use std::sync::Arc;
-
 use actix_web::{HttpResponse, Responder, get, web};
-use agentsight_trajectory_collector::TrajectoryStore;
+use agentsight_atif::StepCategory;
+use agentsight_trajectory_collector::StepScanFilter;
 use serde::Deserialize;
 
 use super::LocalState;
@@ -111,12 +110,101 @@ pub async fn get_trajectory_detail(
     }
 }
 
+/// Defaults and hard caps for `/api/trajectories/steps`.
+const STEP_DEFAULT_LIMIT: i64 = 50;
+const STEP_MAX_LIMIT: i64 = 500;
+const STEP_DEFAULT_CONTEXT: i64 = 3;
+const STEP_MAX_CONTEXT: i64 = 10;
+const STEP_DEFAULT_MAX_SCAN: i64 = 500;
+const STEP_MAX_MAX_SCAN: i64 = 2000;
+
+#[derive(Deserialize)]
+pub struct TrajectoryStepQuery {
+    /// Comma-separated step categories, matched as OR. Omit for every step.
+    pub category: Option<String>,
+    pub agent_name: Option<String>,
+    pub project: Option<String>,
+    pub source: Option<String>,
+    pub session_id: Option<String>,
+    pub limit: Option<i64>,
+    pub context: Option<i64>,
+    pub max_scan: Option<i64>,
+}
+
+/// GET /api/trajectories/steps
+///
+/// Must be registered before `/api/trajectories/{session_id}`.
+#[get("/api/trajectories/steps")]
+pub async fn list_trajectory_steps(
+    state: web::Data<LocalState>,
+    query: web::Query<TrajectoryStepQuery>,
+) -> impl Responder {
+    // An unknown category is rejected rather than ignored: silently dropping it
+    // would return unrelated steps that look like a legitimate empty result.
+    let mut categories = Vec::new();
+    if let Some(raw) = query.category.as_deref() {
+        for token in raw.split(',').filter(|t| !t.trim().is_empty()) {
+            match StepCategory::parse(token) {
+                Some(c) => categories.push(c),
+                None => {
+                    return HttpResponse::BadRequest().json(serde_json::json!({
+                        "error": "invalid_category",
+                        "message": format!("Unknown category '{}'", token.trim()),
+                        "valid_categories": StepCategory::ALL
+                            .iter()
+                            .map(|c| c.as_str())
+                            .collect::<Vec<_>>(),
+                    }));
+                }
+            }
+        }
+    }
+
+    let Some(tstore) = state.trajectory_store() else {
+        return HttpResponse::Ok().json(serde_json::json!({
+            "hits": [], "scanned_trajectories": 0,
+            "truncated": false, "skipped_unparsable": 0
+        }));
+    };
+
+    let limit = match query.limit {
+        Some(v) if v > 0 => v.min(STEP_MAX_LIMIT),
+        _ => STEP_DEFAULT_LIMIT,
+    };
+    let context_radius = match query.context {
+        Some(v) if v >= 0 => v.min(STEP_MAX_CONTEXT),
+        _ => STEP_DEFAULT_CONTEXT,
+    };
+    let max_scan = match query.max_scan {
+        Some(v) if v > 0 => v.min(STEP_MAX_MAX_SCAN),
+        _ => STEP_DEFAULT_MAX_SCAN,
+    };
+
+    let filter = StepScanFilter {
+        project: query.project.clone(),
+        source: query.source.clone(),
+        agent_name: query.agent_name.clone(),
+        session_id: query.session_id.clone(),
+        categories,
+        limit,
+        context_radius,
+        max_scan,
+    };
+    match tstore.scan_steps(&filter) {
+        Ok(outcome) => HttpResponse::Ok().json(outcome),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use actix_web::{App, test};
+    use agentsight_trajectory_collector::TrajectoryStore;
     use std::path::PathBuf;
-    use std::sync::RwLock;
+    use std::sync::{Arc, RwLock};
 
     fn make_state(store: Option<Arc<TrajectoryStore>>) -> web::Data<LocalState> {
         web::Data::new(LocalState {

--- a/src/agentsight/src/local/trace.rs
+++ b/src/agentsight/src/local/trace.rs
@@ -11,7 +11,13 @@ use agentsight_trajectory_collector::{
 ///
 /// Opens (or creates) the trajectory SQLite DB, runs one immediate scan,
 /// then enters the polling loop until Ctrl+C.
-pub fn run_local_trace() {
+///
+/// Logging is initialized here because the collector reports per-file scan
+/// failures through `log::warn!`; without a logger installed those failures
+/// are dropped and a stalled collector looks identical to an idle one.
+pub fn run_local_trace(verbose: bool) {
+    crate::config::init_logging(verbose, None);
+
     let db_path = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("agentsight")

--- a/src/agentsight/src/preferences.rs
+++ b/src/agentsight/src/preferences.rs
@@ -1,0 +1,72 @@
+//! Rule-based user preference mining from captured agent trajectories.
+//!
+//! Analysis is on-demand and table-free: the `/api/preferences` handlers
+//! read a time window of turns from one of two sources — `genai_events.db`
+//! (Linux eBPF pipeline, [`genai_source`]) or `trajectories.db` (trajectory
+//! collector, [`trajectory_source`], the only source on macOS). Both
+//! providers flatten their storage format into the same
+//! [`detector::PreferenceEventRow`] shape, so the pure keyword / statistical
+//! rules ([`detector`]) and the signal folding ([`aggregator`]) never learn
+//! where a turn came from. Nothing is persisted — the server keeps a
+//! short-lived in-process cache only ([`api`]). An optional LLM layer lives
+//! in the `agentsight-opt` crate and merges its findings at the API level.
+
+pub mod aggregator;
+#[cfg(feature = "server")]
+pub mod api;
+pub mod detector;
+#[cfg(target_os = "linux")]
+pub mod genai_source;
+pub mod signals;
+pub mod trajectory_source;
+
+use detector::PreferenceEventRow;
+use signals::Preference;
+
+/// Default analysis window when the request omits `window_days`.
+pub const DEFAULT_WINDOW_DAYS: u32 = 7;
+/// Hard cap for `window_days` — wider windows only add stale evidence.
+pub const MAX_WINDOW_DAYS: u32 = 30;
+/// Minimum confidence for a preference to appear in the Markdown export.
+pub const EXPORT_MIN_CONFIDENCE: f64 = 0.6;
+
+/// Run the full rule pipeline over one window of event rows:
+/// detect signals, then aggregate them into preference entries.
+pub fn analyze_rows(rows: &[PreferenceEventRow]) -> Vec<Preference> {
+    let signals = detector::detect_signals(rows);
+    aggregator::aggregate(&signals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signals::{PreferenceCategory, PreferenceSource, PreferenceStatus};
+
+    #[test]
+    fn pipeline_produces_aggregated_rule_preferences() {
+        let rows: Vec<PreferenceEventRow> = (1..=3)
+            .map(|i| PreferenceEventRow {
+                id: i,
+                session_id: Some("s1".to_string()),
+                conversation_id: Some(format!("c{i}")),
+                timestamp_ns: Some(i * 1_000_000_000_000),
+                user_text: Some("改完之后跑测试，确认没有回归问题".to_string()),
+                tool_names: Vec::new(),
+            })
+            .collect();
+        let prefs = analyze_rows(&rows);
+        let testing = prefs
+            .iter()
+            .find(|p| p.key == "testing")
+            .expect("testing preference");
+        assert_eq!(testing.category, PreferenceCategory::Technical);
+        assert_eq!(testing.evidence_count, 3);
+        assert_eq!(testing.source, PreferenceSource::Rule);
+        assert_eq!(testing.status, PreferenceStatus::Active);
+    }
+
+    #[test]
+    fn empty_window_yields_no_preferences() {
+        assert!(analyze_rows(&[]).is_empty());
+    }
+}

--- a/src/agentsight/src/preferences/aggregator.rs
+++ b/src/agentsight/src/preferences/aggregator.rs
@@ -1,0 +1,251 @@
+//! Aggregation: folds a window's [`PreferenceSignal`]s into [`Preference`]s.
+//!
+//! Signals sharing the same (category, key, value) tuple merge into one
+//! entry whose confidence grows with evidence count; mutually exclusive
+//! keys with two strongly evidenced values are flagged as conflicting.
+
+use std::collections::BTreeMap;
+
+use super::signals::{
+    Preference, PreferenceCategory, PreferenceSignal, PreferenceSource, PreferenceStatus,
+    is_exclusive_key,
+};
+
+/// Per-observation decay base: confidence = 1 - CONFIDENCE_DECAY^n.
+pub const CONFIDENCE_DECAY: f64 = 0.8;
+/// Confidence is capped below 1.0 — rule evidence is never absolute proof.
+pub const MAX_CONFIDENCE: f64 = 0.99;
+/// Both values of an exclusive key need at least this much evidence before
+/// the pair is marked conflicting (fewer observations are just noise).
+pub const CONFLICT_MIN_EVIDENCE: usize = 3;
+/// Max deduplicated evidence excerpts kept per aggregated preference.
+pub const MAX_SAMPLE_EVIDENCE: usize = 3;
+
+/// Saturating confidence curve: 1 observation ≈ 0.2, 3 ≈ 0.49, 10 ≈ 0.89,
+/// capped at [`MAX_CONFIDENCE`].
+pub fn confidence_for_evidence(count: usize) -> f64 {
+    if count == 0 {
+        return 0.0;
+    }
+    let raw = 1.0 - CONFIDENCE_DECAY.powi(count.min(i32::MAX as usize) as i32);
+    raw.min(MAX_CONFIDENCE)
+}
+
+/// Fold raw signals into aggregated preferences (source is always `rule`;
+/// the LLM layer produces its own entries).
+///
+/// Output is deterministically ordered by (category, key, value) and every
+/// entry starts `active`; exclusive keys where two values each collected at
+/// least [`CONFLICT_MIN_EVIDENCE`] observations have *both* sides flipped
+/// to `conflicting`.
+pub fn aggregate(signals: &[PreferenceSignal]) -> Vec<Preference> {
+    // BTreeMap gives the deterministic ordering for free.
+    let mut groups: BTreeMap<(PreferenceCategory, &'static str, String), Group> = BTreeMap::new();
+    for signal in signals {
+        let tuple = (
+            signal.kind.category(),
+            signal.kind.key(),
+            signal.kind.value(),
+        );
+        let group = groups.entry(tuple).or_default();
+        group.count += 1;
+        if group.samples.len() < MAX_SAMPLE_EVIDENCE
+            && !signal.excerpt.is_empty()
+            && !group.samples.iter().any(|s| s == &signal.excerpt)
+        {
+            group.samples.push(signal.excerpt.clone());
+        }
+    }
+
+    let mut prefs: Vec<Preference> = groups
+        .into_iter()
+        .map(|((category, key, value), group)| Preference {
+            category,
+            key: key.to_string(),
+            value,
+            confidence: confidence_for_evidence(group.count),
+            evidence_count: group.count,
+            source: PreferenceSource::Rule,
+            status: PreferenceStatus::Active,
+            sample_evidence: group.samples,
+        })
+        .collect();
+
+    mark_conflicts(&mut prefs);
+    prefs
+}
+
+#[derive(Default)]
+struct Group {
+    count: usize,
+    samples: Vec<String>,
+}
+
+/// Flip both sides of an exclusive key to `conflicting` when at least two
+/// of its values are strongly evidenced. Public so the API layer can re-run
+/// conflict marking after merging LLM findings into the rule results — the
+/// exclusivity semantics must hold across sources, not per source.
+pub fn mark_conflicts(prefs: &mut [Preference]) {
+    let mut strong_values: BTreeMap<(PreferenceCategory, &str), usize> = BTreeMap::new();
+    for pref in prefs.iter() {
+        if is_exclusive_key(&pref.key) && is_strong(pref) {
+            *strong_values
+                .entry((pref.category, pref.key.as_str()))
+                .or_default() += 1;
+        }
+    }
+    let conflicted: Vec<(PreferenceCategory, String)> = strong_values
+        .into_iter()
+        .filter(|(_, n)| *n >= 2)
+        .map(|((category, key), _)| (category, key.to_string()))
+        .collect();
+    for pref in prefs.iter_mut() {
+        if is_strong(pref)
+            && conflicted
+                .iter()
+                .any(|(c, k)| *c == pref.category && *k == pref.key)
+        {
+            pref.status = PreferenceStatus::Conflicting;
+        }
+    }
+}
+
+/// Whether an entry is weighty enough to participate in conflict detection:
+/// [`CONFLICT_MIN_EVIDENCE`]+ rule observations, or any LLM finding — one
+/// LLM row is already a holistic judgment over the whole window, not a
+/// single observation.
+fn is_strong(pref: &Preference) -> bool {
+    pref.source == PreferenceSource::Llm || pref.evidence_count >= CONFLICT_MIN_EVIDENCE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::signals::SignalKind;
+    use super::*;
+
+    fn signal(kind: SignalKind, event_id: i64, excerpt: &str) -> PreferenceSignal {
+        PreferenceSignal {
+            kind,
+            event_id,
+            session_id: Some("s1".to_string()),
+            timestamp_ns: Some(event_id),
+            excerpt: excerpt.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_no_preferences() {
+        assert!(aggregate(&[]).is_empty());
+    }
+
+    #[test]
+    fn confidence_curve_saturates_below_one() {
+        assert_eq!(confidence_for_evidence(0), 0.0);
+        assert!((confidence_for_evidence(1) - 0.2).abs() < 1e-9);
+        assert!((confidence_for_evidence(3) - 0.488).abs() < 1e-3);
+        assert!(confidence_for_evidence(10) > 0.85);
+        assert!(confidence_for_evidence(10_000) <= MAX_CONFIDENCE);
+    }
+
+    #[test]
+    fn merges_same_tuple_and_dedups_samples() {
+        let signals = vec![
+            signal(SignalKind::TestRequirement, 1, "跑测试"),
+            signal(SignalKind::TestRequirement, 2, "run tests please"),
+            signal(SignalKind::TestRequirement, 3, "跑测试"), // duplicate excerpt
+            signal(SignalKind::PlanFirst, 4, "先出方案"),
+        ];
+        let prefs = aggregate(&signals);
+        assert_eq!(prefs.len(), 2);
+
+        let testing = prefs.iter().find(|p| p.key == "testing").expect("testing");
+        assert_eq!(testing.evidence_count, 3);
+        assert_eq!(testing.value, "require_tests");
+        assert_eq!(testing.source, PreferenceSource::Rule);
+        assert_eq!(testing.status, PreferenceStatus::Active);
+        assert_eq!(testing.sample_evidence, vec!["跑测试", "run tests please"]);
+
+        let plan = prefs
+            .iter()
+            .find(|p| p.key == "workflow_style")
+            .expect("plan");
+        assert_eq!(plan.evidence_count, 1);
+        assert!((plan.confidence - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exclusive_key_with_two_strong_values_conflicts() {
+        let mut signals = Vec::new();
+        for i in 0..3 {
+            signals.push(signal(
+                SignalKind::Language {
+                    language: "chinese",
+                },
+                i,
+                "中文查询",
+            ));
+            signals.push(signal(
+                SignalKind::Language {
+                    language: "english",
+                },
+                100 + i,
+                "english query",
+            ));
+        }
+        let prefs = aggregate(&signals);
+        assert_eq!(prefs.len(), 2);
+        assert!(
+            prefs
+                .iter()
+                .all(|p| p.status == PreferenceStatus::Conflicting)
+        );
+    }
+
+    #[test]
+    fn weak_opposition_or_non_exclusive_key_stays_active() {
+        // Only 2 english observations: below CONFLICT_MIN_EVIDENCE.
+        let mut signals = Vec::new();
+        for i in 0..3 {
+            signals.push(signal(
+                SignalKind::Language {
+                    language: "chinese",
+                },
+                i,
+                "中文查询",
+            ));
+        }
+        for i in 0..2 {
+            signals.push(signal(
+                SignalKind::Language {
+                    language: "english",
+                },
+                100 + i,
+                "english query",
+            ));
+        }
+        let prefs = aggregate(&signals);
+        assert!(prefs.iter().all(|p| p.status == PreferenceStatus::Active));
+
+        // preferred_tool is not exclusive: many strong values coexist.
+        let mut signals = Vec::new();
+        for i in 0..4 {
+            signals.push(signal(
+                SignalKind::ToolUsage {
+                    tool_name: "bash".to_string(),
+                },
+                i,
+                "tool_call: bash",
+            ));
+            signals.push(signal(
+                SignalKind::ToolUsage {
+                    tool_name: "grep".to_string(),
+                },
+                100 + i,
+                "tool_call: grep",
+            ));
+        }
+        let prefs = aggregate(&signals);
+        assert_eq!(prefs.len(), 2);
+        assert!(prefs.iter().all(|p| p.status == PreferenceStatus::Active));
+    }
+}

--- a/src/agentsight/src/preferences/api.rs
+++ b/src/agentsight/src/preferences/api.rs
@@ -95,6 +95,26 @@ pub struct PreferencesQuery {
     pub source: Option<String>,
 }
 
+/// Query string accepted by the turns endpoint (`/api/preferences/turns`).
+///
+/// Mirrors [`PreferencesQuery`] for `window_days`/`source` but drops `llm`
+/// (the turns endpoint serves raw text for the caller to reason over) and
+/// adds `limit` to bound how many deduped user turns are returned.
+#[derive(Debug, Deserialize)]
+pub struct TurnsQuery {
+    pub window_days: Option<u32>,
+    pub source: Option<String>,
+    pub limit: Option<usize>,
+}
+
+/// Default number of user turns returned when `limit` is omitted. Capped so a
+/// single response stays manageable for an agent to reason over in one pass.
+pub const DEFAULT_TURNS_LIMIT: usize = 200;
+
+/// Hard maximum for `limit` — a misbehaving caller must not be able to pull an
+/// unbounded blob of raw conversation text out of the API.
+pub const MAX_TURNS_LIMIT: usize = 1000;
+
 /// Clamp the requested window into `1..=MAX_WINDOW_DAYS`, defaulting to
 /// [`DEFAULT_WINDOW_DAYS`].
 pub fn clamp_window_days(requested: Option<u32>) -> u32 {

--- a/src/agentsight/src/preferences/api.rs
+++ b/src/agentsight/src/preferences/api.rs
@@ -1,0 +1,549 @@
+//! Framework-free support layer shared by the preference API handlers.
+//!
+//! The Linux server (`crate::server::preferences`) and the macOS local
+//! viewer (`crate::local::server::preferences`) expose the same two
+//! endpoints over different app states. Everything that does not need
+//! actix types lives here — source selection, the TTL response cache,
+//! LLM-result merging and the Markdown export — so both handler sets stay
+//! thin and behave identically.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use agentsight_opt::preference::LlmPreference;
+use serde::Deserialize;
+
+use super::signals::{Preference, PreferenceCategory, PreferenceSource, PreferenceStatus};
+use super::{DEFAULT_WINDOW_DAYS, EXPORT_MIN_CONFIDENCE, MAX_WINDOW_DAYS};
+
+// ─── Source selection ────────────────────────────────────────────────────────
+
+/// Requested data source for one preference API call (`?source=` parameter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PreferenceSourceParam {
+    /// Prefer genai events, fall back to collected trajectories.
+    Auto,
+    /// `genai_events.db` only (Linux eBPF pipeline).
+    Genai,
+    /// `trajectories.db` only (trajectory collector).
+    Trajectory,
+}
+
+impl PreferenceSourceParam {
+    /// Parse the raw query value; `None` means the parameter was omitted.
+    ///
+    /// # Errors
+    /// Returns a human-readable message for unknown values so the handler
+    /// can answer 400 instead of silently picking a default.
+    pub fn parse(raw: Option<&str>) -> Result<Self, String> {
+        match raw.map(str::trim) {
+            None | Some("") | Some("auto") => Ok(Self::Auto),
+            Some("genai") => Ok(Self::Genai),
+            Some("trajectory") => Ok(Self::Trajectory),
+            Some(other) => Err(format!(
+                "unknown source {other:?}; expected auto, genai or trajectory"
+            )),
+        }
+    }
+
+    /// Wire name, used in cache keys and response bodies.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Genai => "genai",
+            Self::Trajectory => "trajectory",
+        }
+    }
+}
+
+/// Outcome of `source=auto` selection, decided from cheap availability
+/// probes before any analysis runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoResolution {
+    /// Serve from genai events.
+    Genai,
+    /// Serve from collected trajectories.
+    Trajectory,
+    /// Neither store can be read — the request must fail loudly.
+    Unavailable,
+}
+
+/// Pick the effective source for `source=auto`.
+///
+/// `genai_row_count` is `None` when the genai store cannot be read at all
+/// (missing on Linux, or the platform has no eBPF pipeline). A readable but
+/// empty genai window falls back to trajectories when they are available;
+/// otherwise it stays on genai so the response keeps the pre-`source` shape
+/// (an empty result, not an error).
+pub fn resolve_auto(genai_row_count: Option<usize>, trajectory_available: bool) -> AutoResolution {
+    match (genai_row_count, trajectory_available) {
+        (Some(n), _) if n > 0 => AutoResolution::Genai,
+        (_, true) => AutoResolution::Trajectory,
+        (Some(_), false) => AutoResolution::Genai,
+        (None, false) => AutoResolution::Unavailable,
+    }
+}
+
+// ─── Request parsing ─────────────────────────────────────────────────────────
+
+/// Query string accepted by both preference endpoints.
+#[derive(Debug, Deserialize)]
+pub struct PreferencesQuery {
+    pub window_days: Option<u32>,
+    pub llm: Option<bool>,
+    pub source: Option<String>,
+}
+
+/// Clamp the requested window into `1..=MAX_WINDOW_DAYS`, defaulting to
+/// [`DEFAULT_WINDOW_DAYS`].
+pub fn clamp_window_days(requested: Option<u32>) -> u32 {
+    requested
+        .unwrap_or(DEFAULT_WINDOW_DAYS)
+        .clamp(1, MAX_WINDOW_DAYS)
+}
+
+/// Window start in epoch nanoseconds: now − `window_days`. Clamped at 0 so
+/// a misbehaving system clock cannot produce a negative bound that silently
+/// degrades the query into a full-table scan of all history.
+pub fn window_start_ns(window_days: u32) -> i64 {
+    // Defensive conversion mirrors the collector's `now_ns()`: nanoseconds
+    // overflow i64 in year 2262, and a pre-epoch clock yields 0 instead of
+    // a panic or wraparound.
+    let now_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| i64::try_from(d.as_nanos()).unwrap_or(i64::MAX))
+        .unwrap_or(0);
+    now_ns
+        .saturating_sub(i64::from(window_days) * 86_400 * 1_000_000_000)
+        .max(0)
+}
+
+// ─── In-process TTL cache ────────────────────────────────────────────────────
+
+/// How long one computed response stays valid.
+const CACHE_TTL: Duration = Duration::from_secs(600);
+
+/// Cache key: (window_days, llm, requested source). Keying on the requested
+/// (not the resolved) source keeps `auto` responsive to a store appearing
+/// mid-TTL only via expiry, which is acceptable for a 10-minute cache.
+pub type CacheKey = (u32, bool, PreferenceSourceParam);
+
+struct CacheEntry {
+    at: Instant,
+    body: serde_json::Value,
+}
+
+/// Lazily initialized process-wide cache. A plain `Mutex<HashMap>` is enough:
+/// the key space is tiny (window_days ∈ 1..=30 × llm ∈ {false, true} ×
+/// three sources).
+fn cache() -> &'static Mutex<HashMap<CacheKey, CacheEntry>> {
+    static CACHE: OnceLock<Mutex<HashMap<CacheKey, CacheEntry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Fetch a still-valid cached response body for `key`, if any.
+pub fn cache_get(key: CacheKey) -> Option<serde_json::Value> {
+    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    guard
+        .get(&key)
+        .filter(|entry| entry.at.elapsed() < CACHE_TTL)
+        .map(|entry| entry.body.clone())
+}
+
+/// Store a freshly computed response body under `key`.
+pub fn cache_put(key: CacheKey, body: serde_json::Value) {
+    let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    // Drop stale entries in passing — the map never exceeds 180 keys anyway.
+    guard.retain(|_, entry| entry.at.elapsed() < CACHE_TTL);
+    guard.insert(
+        key,
+        CacheEntry {
+            at: Instant::now(),
+            body,
+        },
+    );
+}
+
+// ─── LLM result merging ──────────────────────────────────────────────────────
+
+/// Confidence assigned to LLM findings — informative but not rule-verified.
+pub const LLM_CONFIDENCE: f64 = 0.7;
+
+/// Per-field character cap applied to LLM-produced key/value/rationale — a
+/// misbehaving model must not be able to bloat the response body.
+pub const MAX_LLM_FIELD_CHARS: usize = 128;
+
+/// Fold validated LLM findings into the rule results. Tuples the rule layer
+/// already reported keep their rule provenance (evidence beats inference);
+/// duplicate findings within the LLM output itself are dropped too. All
+/// free-text fields are capped at [`MAX_LLM_FIELD_CHARS`] characters.
+pub fn merge_llm_preferences(prefs: &mut Vec<Preference>, findings: Vec<LlmPreference>) {
+    for finding in findings {
+        let Some(category) = PreferenceCategory::parse(finding.category.trim()) else {
+            log::debug!(
+                "Preference API: dropping LLM finding with unknown category {:?}",
+                finding.category
+            );
+            continue;
+        };
+        let key = cap_llm_field(finding.key.trim());
+        let value = cap_llm_field(finding.value.trim());
+        if key.is_empty() || value.is_empty() {
+            continue;
+        }
+        if prefs
+            .iter()
+            .any(|p| p.category == category && p.key == key && p.value == value)
+        {
+            continue;
+        }
+        let rationale = cap_llm_field(finding.rationale.trim());
+        prefs.push(Preference {
+            category,
+            key,
+            value,
+            confidence: LLM_CONFIDENCE,
+            evidence_count: 1,
+            source: PreferenceSource::Llm,
+            status: PreferenceStatus::Active,
+            sample_evidence: if rationale.is_empty() {
+                Vec::new()
+            } else {
+                vec![rationale]
+            },
+        });
+    }
+}
+
+/// Cap an LLM-produced field at [`MAX_LLM_FIELD_CHARS`] characters
+/// (char-boundary safe; an ellipsis marks the cut).
+fn cap_llm_field(text: &str) -> String {
+    if text.chars().count() <= MAX_LLM_FIELD_CHARS {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(MAX_LLM_FIELD_CHARS).collect();
+    out.push('…');
+    out
+}
+
+// ─── Markdown export ─────────────────────────────────────────────────────────
+
+/// Render the Markdown export: category-grouped bullets, restricted to
+/// confident (≥ [`EXPORT_MIN_CONFIDENCE`]) active entries.
+pub fn render_markdown(prefs: &[Preference]) -> String {
+    let mut out = String::from("## User Preferences\n");
+    let mut any = false;
+    for category in [
+        PreferenceCategory::Communication,
+        PreferenceCategory::Workflow,
+        PreferenceCategory::Technical,
+    ] {
+        let entries: Vec<&Preference> = prefs
+            .iter()
+            .filter(|p| {
+                p.category == category
+                    && p.status == PreferenceStatus::Active
+                    && p.confidence >= EXPORT_MIN_CONFIDENCE
+            })
+            .collect();
+        if entries.is_empty() {
+            continue;
+        }
+        any = true;
+        out.push_str(&format!("\n### {}\n\n", capitalize(category.as_str())));
+        for p in entries {
+            out.push_str(&format!(
+                "- **{}**: {} _(confidence {:.2}, {} observation{})_\n",
+                escape_markdown(&p.key),
+                escape_markdown(&p.value),
+                p.confidence,
+                p.evidence_count,
+                if p.evidence_count == 1 { "" } else { "s" },
+            ));
+        }
+    }
+    if !any {
+        out.push_str("\n_No high-confidence preferences detected in this window._\n");
+    }
+    out
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Minimal Markdown escaping for free-form text (keys/values include tool
+/// names lifted straight from captured traffic): backslash-prefix every
+/// character that could open emphasis/links/headings and break the exported
+/// document structure.
+fn escape_markdown(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if matches!(
+            c,
+            '\\' | '`' | '*' | '_' | '{' | '}' | '[' | ']' | '(' | ')' | '#' | '+' | '-' | '!'
+        ) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pref(
+        category: PreferenceCategory,
+        key: &str,
+        value: &str,
+        confidence: f64,
+        status: PreferenceStatus,
+    ) -> Preference {
+        Preference {
+            category,
+            key: key.to_string(),
+            value: value.to_string(),
+            confidence,
+            evidence_count: 5,
+            source: PreferenceSource::Rule,
+            status,
+            sample_evidence: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn source_param_parses_known_values_and_rejects_unknown() {
+        assert_eq!(
+            PreferenceSourceParam::parse(None),
+            Ok(PreferenceSourceParam::Auto)
+        );
+        assert_eq!(
+            PreferenceSourceParam::parse(Some("")),
+            Ok(PreferenceSourceParam::Auto)
+        );
+        assert_eq!(
+            PreferenceSourceParam::parse(Some("auto")),
+            Ok(PreferenceSourceParam::Auto)
+        );
+        assert_eq!(
+            PreferenceSourceParam::parse(Some("genai")),
+            Ok(PreferenceSourceParam::Genai)
+        );
+        assert_eq!(
+            PreferenceSourceParam::parse(Some(" trajectory ")),
+            Ok(PreferenceSourceParam::Trajectory)
+        );
+        let err = PreferenceSourceParam::parse(Some("ebpf")).unwrap_err();
+        assert!(err.contains("ebpf"), "message names the bad value: {err}");
+    }
+
+    #[test]
+    fn auto_prefers_populated_genai_and_falls_back_in_order() {
+        // Populated genai window wins even when trajectories exist.
+        assert_eq!(resolve_auto(Some(3), true), AutoResolution::Genai);
+        assert_eq!(resolve_auto(Some(3), false), AutoResolution::Genai);
+        // Empty or unreadable genai falls back when trajectories exist.
+        assert_eq!(resolve_auto(Some(0), true), AutoResolution::Trajectory);
+        assert_eq!(resolve_auto(None, true), AutoResolution::Trajectory);
+        // Readable-but-empty genai without trajectories keeps the legacy
+        // empty-result behavior instead of erroring.
+        assert_eq!(resolve_auto(Some(0), false), AutoResolution::Genai);
+        // Nothing to read at all.
+        assert_eq!(resolve_auto(None, false), AutoResolution::Unavailable);
+    }
+
+    #[test]
+    fn window_days_is_clamped_to_bounds() {
+        assert_eq!(clamp_window_days(None), DEFAULT_WINDOW_DAYS);
+        assert_eq!(clamp_window_days(Some(0)), 1);
+        assert_eq!(clamp_window_days(Some(14)), 14);
+        assert_eq!(clamp_window_days(Some(365)), MAX_WINDOW_DAYS);
+    }
+
+    #[test]
+    fn merge_keeps_rule_entries_and_validates_llm_rows() {
+        let mut prefs = vec![pref(
+            PreferenceCategory::Technical,
+            "testing",
+            "require_tests",
+            0.8,
+            PreferenceStatus::Active,
+        )];
+        let findings = vec![
+            // Duplicate of the rule entry: dropped.
+            LlmPreference {
+                category: "technical".to_string(),
+                key: "testing".to_string(),
+                value: "require_tests".to_string(),
+                rationale: "asks for tests".to_string(),
+            },
+            // Unknown category: dropped.
+            LlmPreference {
+                category: "style".to_string(),
+                key: "tone".to_string(),
+                value: "casual".to_string(),
+                rationale: String::new(),
+            },
+            // New finding: merged with LLM provenance.
+            LlmPreference {
+                category: "communication".to_string(),
+                key: "verbosity".to_string(),
+                value: "concise".to_string(),
+                rationale: "repeatedly asks for short answers".to_string(),
+            },
+        ];
+        merge_llm_preferences(&mut prefs, findings);
+        assert_eq!(prefs.len(), 2);
+        assert_eq!(prefs[0].source, PreferenceSource::Rule);
+        let added = &prefs[1];
+        assert_eq!(added.source, PreferenceSource::Llm);
+        assert_eq!(added.confidence, LLM_CONFIDENCE);
+        assert_eq!(
+            added.sample_evidence,
+            vec!["repeatedly asks for short answers"]
+        );
+    }
+
+    #[test]
+    fn markdown_export_groups_and_filters() {
+        let prefs = vec![
+            pref(
+                PreferenceCategory::Communication,
+                "language",
+                "chinese",
+                0.9,
+                PreferenceStatus::Active,
+            ),
+            // Below the export threshold: hidden.
+            pref(
+                PreferenceCategory::Workflow,
+                "workflow_style",
+                "plan_first",
+                0.3,
+                PreferenceStatus::Active,
+            ),
+            // Conflicting: hidden.
+            pref(
+                PreferenceCategory::Communication,
+                "language",
+                "english",
+                0.9,
+                PreferenceStatus::Conflicting,
+            ),
+            pref(
+                PreferenceCategory::Technical,
+                "testing",
+                "require_tests",
+                0.7,
+                PreferenceStatus::Active,
+            ),
+        ];
+        let md = render_markdown(&prefs);
+        assert!(md.starts_with("## User Preferences\n"));
+        assert!(md.contains("### Communication"));
+        assert!(md.contains("- **language**: chinese"));
+        assert!(md.contains("### Technical"));
+        // Snake_case values pick up the underscore escape.
+        assert!(md.contains("- **testing**: require\\_tests"));
+        assert!(!md.contains("plan_first"));
+        assert!(!md.contains("english"));
+        assert!(!md.contains("### Workflow"));
+    }
+
+    #[test]
+    fn markdown_escapes_special_characters() {
+        let prefs = vec![pref(
+            PreferenceCategory::Technical,
+            "preferred_tool",
+            "evil*[tool](x) #1 `rm`!",
+            0.9,
+            PreferenceStatus::Active,
+        )];
+        let md = render_markdown(&prefs);
+        assert!(md.contains("- **preferred\\_tool**: evil\\*\\[tool\\]\\(x\\) \\#1 \\`rm\\`\\!"));
+        // The raw link/emphasis syntax must not survive.
+        assert!(!md.contains("[tool](x)"));
+    }
+
+    #[test]
+    fn markdown_export_handles_empty_window() {
+        let md = render_markdown(&[]);
+        assert!(md.starts_with("## User Preferences\n"));
+        assert!(md.contains("_No high-confidence preferences detected"));
+    }
+
+    #[test]
+    fn merge_caps_overlong_llm_fields() {
+        let mut prefs = Vec::new();
+        let findings = vec![LlmPreference {
+            category: "technical".to_string(),
+            key: "k".repeat(MAX_LLM_FIELD_CHARS * 2),
+            value: "值".repeat(MAX_LLM_FIELD_CHARS * 2),
+            rationale: "r".repeat(MAX_LLM_FIELD_CHARS * 2),
+        }];
+        merge_llm_preferences(&mut prefs, findings);
+        assert_eq!(prefs.len(), 1);
+        let p = &prefs[0];
+        // Capped at the limit plus the ellipsis, on char boundaries.
+        assert_eq!(p.key.chars().count(), MAX_LLM_FIELD_CHARS + 1);
+        assert!(p.key.ends_with('…'));
+        assert_eq!(p.value.chars().count(), MAX_LLM_FIELD_CHARS + 1);
+        assert!(p.value.ends_with('…'));
+        assert_eq!(
+            p.sample_evidence[0].chars().count(),
+            MAX_LLM_FIELD_CHARS + 1
+        );
+
+        // Short fields pass through untouched.
+        assert_eq!(cap_llm_field("short"), "short");
+    }
+
+    #[test]
+    fn llm_exclusive_value_conflicts_with_rule() {
+        use super::super::aggregator;
+
+        // Rule layer saw Chinese (5 observations); the LLM reports English.
+        let mut prefs = vec![pref(
+            PreferenceCategory::Communication,
+            "language",
+            "chinese",
+            0.8,
+            PreferenceStatus::Active,
+        )];
+        let findings = vec![LlmPreference {
+            category: "communication".to_string(),
+            key: "language".to_string(),
+            value: "english".to_string(),
+            rationale: "several turns are written in English".to_string(),
+        }];
+        merge_llm_preferences(&mut prefs, findings);
+        aggregator::mark_conflicts(&mut prefs);
+        assert_eq!(prefs.len(), 2);
+        assert!(
+            prefs
+                .iter()
+                .all(|p| p.status == PreferenceStatus::Conflicting),
+            "both sources of an exclusive key must be flagged"
+        );
+    }
+
+    #[test]
+    fn cache_round_trips_within_ttl_and_keys_on_source() {
+        let key = (29, true, PreferenceSourceParam::Trajectory);
+        assert!(cache_get(key).is_none());
+        cache_put(key, serde_json::json!({"analyzed_events": 1}));
+        assert_eq!(
+            cache_get(key),
+            Some(serde_json::json!({"analyzed_events": 1}))
+        );
+        // The same window/llm pair under a different source is a miss.
+        assert!(cache_get((29, true, PreferenceSourceParam::Genai)).is_none());
+    }
+}

--- a/src/agentsight/src/preferences/detector.rs
+++ b/src/agentsight/src/preferences/detector.rs
@@ -1,0 +1,338 @@
+//! Signal detection: turns unified event rows into [`PreferenceSignal`]s.
+//!
+//! Pure keyword/statistical rules over a query window — no persistence and
+//! no LLM calls. Rows arrive in the source-agnostic [`PreferenceEventRow`]
+//! shape produced by the data-source providers (`genai_source`,
+//! `trajectory_source`), so nothing here knows where a turn came from. All
+//! thresholds and keyword tables live in [`super::signals`] so rule tuning
+//! never touches this file.
+
+use std::collections::BTreeMap;
+
+use super::signals::{
+    CJK_RATIO_THRESHOLD, CORRECTION_PATTERNS, CORRECTION_WINDOW_NS, MIN_QUERY_CHARS_FOR_LANGUAGE,
+    PLAN_FIRST_PATTERNS, PreferenceSignal, SignalKind, TEST_REQUIREMENT_PATTERNS, truncate_excerpt,
+};
+
+/// One analysis turn in the unified, source-agnostic shape both data-source
+/// providers produce (`genai_source` for `genai_events.db`,
+/// `trajectory_source` for `trajectories.db`).
+#[derive(Debug, Clone)]
+pub struct PreferenceEventRow {
+    /// Source row id (genai) or synthetic sequence number (trajectory) —
+    /// only used as signal provenance.
+    pub id: i64,
+    pub session_id: Option<String>,
+    /// Grouping key for cross-turn rules: the genai `conversation_id` or
+    /// the trajectory session id.
+    pub conversation_id: Option<String>,
+    /// Per-turn timestamp in epoch nanoseconds. `None` when the source has
+    /// no reliable value (e.g. an ATIF step without a parseable timestamp);
+    /// time-gap rules skip such turns instead of running on made-up values.
+    pub timestamp_ns: Option<i64>,
+    /// User message text with source-specific template noise already
+    /// stripped by the provider. `None` when nothing usable is left.
+    pub user_text: Option<String>,
+    /// Names of the tool calls the turn's response issued.
+    pub tool_names: Vec<String>,
+}
+
+/// Extract all preference signals from a batch of event rows.
+///
+/// Per-row rules (language, plan-first, testing, correction keywords, tool
+/// calls) are applied independently; the rapid follow-up correction rule
+/// needs cross-row context and runs over the whole batch. Malformed message
+/// JSON is tolerated: the row is skipped with a debug log, never an error.
+pub fn detect_signals(rows: &[PreferenceEventRow]) -> Vec<PreferenceSignal> {
+    let mut out = Vec::new();
+    for row in rows {
+        detect_row_signals(row, &mut out);
+    }
+    detect_rapid_followups(rows, &mut out);
+    out
+}
+
+/// Rules that only need a single row.
+fn detect_row_signals(row: &PreferenceEventRow, out: &mut Vec<PreferenceSignal>) {
+    if let Some(query) = row.user_text.as_deref() {
+        let excerpt = truncate_excerpt(query);
+        if let Some(language) = detect_language(query) {
+            out.push(make_signal(
+                row,
+                SignalKind::Language { language },
+                &excerpt,
+            ));
+        }
+        let lowered = query.to_lowercase();
+        if matches_any(&lowered, PLAN_FIRST_PATTERNS) {
+            out.push(make_signal(row, SignalKind::PlanFirst, &excerpt));
+        }
+        if matches_any(&lowered, TEST_REQUIREMENT_PATTERNS) {
+            out.push(make_signal(row, SignalKind::TestRequirement, &excerpt));
+        }
+        if matches_any(&lowered, CORRECTION_PATTERNS) {
+            out.push(make_signal(row, SignalKind::Correction, &excerpt));
+        }
+    }
+    detect_tool_calls(row, out);
+}
+
+fn make_signal(row: &PreferenceEventRow, kind: SignalKind, excerpt: &str) -> PreferenceSignal {
+    PreferenceSignal {
+        kind,
+        event_id: row.id,
+        session_id: row.session_id.clone(),
+        timestamp_ns: row.timestamp_ns,
+        excerpt: excerpt.to_string(),
+    }
+}
+
+/// Classify the dominant natural language of a query.
+///
+/// Counts CJK ideographs versus ASCII letters; punctuation, digits, and
+/// whitespace are ignored so code snippets bias the ratio less. Returns
+/// `None` for texts too short to classify.
+fn detect_language(text: &str) -> Option<&'static str> {
+    let mut cjk = 0usize;
+    let mut ascii_alpha = 0usize;
+    for c in text.chars() {
+        if is_cjk(c) {
+            cjk += 1;
+        } else if c.is_ascii_alphabetic() {
+            ascii_alpha += 1;
+        }
+    }
+    let total = cjk + ascii_alpha;
+    if total < MIN_QUERY_CHARS_FOR_LANGUAGE {
+        return None;
+    }
+    if (cjk as f64) / (total as f64) >= CJK_RATIO_THRESHOLD {
+        Some("chinese")
+    } else {
+        Some("english")
+    }
+}
+
+/// True for CJK Unified Ideographs (base block + Extension A) — enough to
+/// separate Chinese from English queries without a full Unicode table.
+fn is_cjk(c: char) -> bool {
+    matches!(c, '\u{4E00}'..='\u{9FFF}' | '\u{3400}'..='\u{4DBF}')
+}
+
+fn matches_any(lowered_text: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|p| lowered_text.contains(p))
+}
+
+/// One `ToolUsage` signal per tool call the providers extracted into
+/// `tool_names`, so call frequency directly becomes evidence count during
+/// aggregation.
+fn detect_tool_calls(row: &PreferenceEventRow, out: &mut Vec<PreferenceSignal>) {
+    for name in &row.tool_names {
+        if !name.is_empty() {
+            let excerpt = truncate_excerpt(&format!("tool_call: {name}"));
+            out.push(make_signal(
+                row,
+                SignalKind::ToolUsage {
+                    tool_name: name.clone(),
+                },
+                &excerpt,
+            ));
+        }
+    }
+}
+
+/// Cross-row correction rule: within one conversation, a *changed* user
+/// query arriving shortly after the previous turn means the user cut the
+/// assistant off to redirect it. Adjacent events with identical queries are
+/// the agent's own follow-up calls for the same turn, not corrections.
+/// Rows without a reliable timestamp cannot prove the time gap and are
+/// excluded rather than compared on fabricated values.
+fn detect_rapid_followups(rows: &[PreferenceEventRow], out: &mut Vec<PreferenceSignal>) {
+    // Group by conversation_id, keeping only rows with a usable query and
+    // a real timestamp.
+    let mut by_conversation: BTreeMap<&str, Vec<(&PreferenceEventRow, &str, i64)>> =
+        BTreeMap::new();
+    for row in rows {
+        let Some(conversation_id) = row.conversation_id.as_deref() else {
+            continue;
+        };
+        let Some(query) = row.user_text.as_deref() else {
+            continue;
+        };
+        let Some(ts) = row.timestamp_ns else {
+            continue;
+        };
+        by_conversation
+            .entry(conversation_id)
+            .or_default()
+            .push((row, query, ts));
+    }
+
+    for events in by_conversation.values_mut() {
+        events.sort_by_key(|(_, _, ts)| *ts);
+        for pair in events.windows(2) {
+            let (_, prev_query, prev_ts) = &pair[0];
+            let (curr, curr_query, curr_ts) = &pair[1];
+            if curr_query == prev_query {
+                continue;
+            }
+            let gap = curr_ts.saturating_sub(*prev_ts);
+            if gap > 0 && gap < CORRECTION_WINDOW_NS {
+                out.push(make_signal(
+                    curr,
+                    SignalKind::Correction,
+                    &truncate_excerpt(curr_query),
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: i64, query: &str) -> PreferenceEventRow {
+        PreferenceEventRow {
+            id,
+            session_id: Some("s1".to_string()),
+            conversation_id: Some("c1".to_string()),
+            timestamp_ns: Some(id * 1_000_000_000),
+            user_text: Some(query.to_string()),
+            tool_names: Vec::new(),
+        }
+    }
+
+    fn kinds_of(rows: &[PreferenceEventRow]) -> Vec<SignalKind> {
+        detect_signals(rows).into_iter().map(|s| s.kind).collect()
+    }
+
+    #[test]
+    fn empty_input_yields_no_signals() {
+        assert!(detect_signals(&[]).is_empty());
+        let empty = PreferenceEventRow {
+            id: 1,
+            session_id: None,
+            conversation_id: None,
+            timestamp_ns: Some(0),
+            user_text: None,
+            tool_names: Vec::new(),
+        };
+        assert!(detect_signals(&[empty]).is_empty());
+    }
+
+    #[test]
+    fn detects_chinese_and_english_language() {
+        assert_eq!(
+            detect_language("请帮我重构这个模块的错误处理"),
+            Some("chinese")
+        );
+        assert_eq!(
+            detect_language("please refactor the error handling"),
+            Some("english")
+        );
+        // Mixed developer query: enough CJK to count as Chinese.
+        assert_eq!(
+            detect_language("帮我修一下 parse_event 的 bug"),
+            Some("chinese")
+        );
+        // Too short to classify.
+        assert_eq!(detect_language("ok"), None);
+        assert_eq!(detect_language(""), None);
+    }
+
+    #[test]
+    fn detects_workflow_and_test_patterns_bilingual() {
+        let kinds = kinds_of(&[row(1, "先计划再动手，别急着写代码")]);
+        assert!(kinds.contains(&SignalKind::PlanFirst));
+
+        let kinds = kinds_of(&[row(2, "Please make a plan first before writing code")]);
+        assert!(kinds.contains(&SignalKind::PlanFirst));
+
+        let kinds = kinds_of(&[row(3, "改完之后跑测试")]);
+        assert!(kinds.contains(&SignalKind::TestRequirement));
+
+        let kinds = kinds_of(&[row(4, "Run the tests after the change please")]);
+        assert!(kinds.contains(&SignalKind::TestRequirement));
+    }
+
+    #[test]
+    fn detects_correction_keywords_and_records_excerpt() {
+        let signals = detect_signals(&[row(1, "不对，不是这个意思，重新来")]);
+        let correction = signals
+            .iter()
+            .find(|s| s.kind == SignalKind::Correction)
+            .expect("correction signal");
+        assert_eq!(correction.event_id, 1);
+        assert_eq!(correction.excerpt, "不对，不是这个意思，重新来");
+
+        let kinds = kinds_of(&[row(2, "That's wrong, please start over here")]);
+        assert!(kinds.contains(&SignalKind::Correction));
+    }
+
+    #[test]
+    fn each_tool_name_is_one_evidence_unit() {
+        let mut r = row(1, "run it now for me please");
+        r.tool_names = vec!["bash".to_string(), "bash".to_string(), String::new()];
+        let kinds = kinds_of(std::slice::from_ref(&r));
+        let bash_count = kinds
+            .iter()
+            .filter(|k| matches!(k, SignalKind::ToolUsage { tool_name } if tool_name == "bash"))
+            .count();
+        assert_eq!(bash_count, 2, "each call is one evidence unit");
+        // Empty names never become signals.
+        assert_eq!(
+            kinds
+                .iter()
+                .filter(|k| matches!(k, SignalKind::ToolUsage { .. }))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn rapid_followup_in_same_conversation_is_a_correction() {
+        let mut a = row(1, "implement feature x for me please");
+        let mut b = row(2, "stop, use the other module instead");
+        a.timestamp_ns = Some(1_000_000_000);
+        b.timestamp_ns = Some(10_000_000_000); // 9s later, inside the window
+        let detected = detect_signals(&[a.clone(), b.clone()]);
+        let corrections: Vec<_> = detected
+            .iter()
+            .filter(|s| s.kind == SignalKind::Correction)
+            .collect();
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].event_id, 2, "attributed to the later event");
+
+        // Outside the window: no correction.
+        b.timestamp_ns = Some(1_000_000_000 + CORRECTION_WINDOW_NS + 1);
+        let detected = detect_signals(&[a.clone(), b.clone()]);
+        assert!(!detected.iter().any(|s| s.kind == SignalKind::Correction));
+
+        // Same query re-sent (agent's follow-up calls): no correction.
+        b.timestamp_ns = Some(2_000_000_000);
+        b.user_text = a.user_text.clone();
+        let detected = detect_signals(&[a.clone(), b.clone()]);
+        assert!(!detected.iter().any(|s| s.kind == SignalKind::Correction));
+
+        // Different conversations: no correction.
+        let mut c = row(3, "now do something entirely different");
+        c.conversation_id = Some("c2".to_string());
+        c.timestamp_ns = Some(3_000_000_000);
+        let detected = detect_signals(&[a, c]);
+        assert!(!detected.iter().any(|s| s.kind == SignalKind::Correction));
+    }
+
+    #[test]
+    fn rows_without_timestamps_never_trigger_the_followup_rule() {
+        // Two clearly different queries in one conversation, but neither
+        // carries a reliable timestamp: the time-gap rule must stay silent
+        // rather than assume adjacency in time.
+        let mut a = row(1, "implement feature x for me please");
+        let mut b = row(2, "stop, use the other module instead");
+        a.timestamp_ns = None;
+        b.timestamp_ns = None;
+        let detected = detect_signals(&[a, b]);
+        assert!(!detected.iter().any(|s| s.kind == SignalKind::Correction));
+    }
+}

--- a/src/agentsight/src/preferences/genai_source.rs
+++ b/src/agentsight/src/preferences/genai_source.rs
@@ -1,0 +1,118 @@
+//! `genai_events.db` provider: maps raw event columns to the unified
+//! [`PreferenceEventRow`] shape consumed by the rule engine.
+//!
+//! Linux-only because the cleaning/mining steps lean on the eBPF-side genai
+//! parser types; the trajectory provider covers macOS.
+
+use super::detector::PreferenceEventRow;
+use crate::genai::GenAIBuilder;
+use crate::genai::semantic::{MessagePart, OutputMessage};
+
+/// Build one unified row from the narrow `genai_events` column set.
+///
+/// The user query is cleaned of agent template noise (cosh-ng `user_input:`
+/// lines, timestamp prefixes, `<system-reminder>` blocks) and the
+/// `output_messages` JSON is mined for tool-call names, so the rule engine
+/// never touches raw wire-capture formats.
+pub fn row_from_event(
+    id: i64,
+    session_id: Option<String>,
+    conversation_id: Option<String>,
+    start_timestamp_ns: i64,
+    user_query: Option<&str>,
+    output_messages: Option<&str>,
+) -> PreferenceEventRow {
+    PreferenceEventRow {
+        id,
+        session_id,
+        conversation_id,
+        timestamp_ns: Some(start_timestamp_ns),
+        user_text: user_query.and_then(cleaned_user_query),
+        tool_names: output_messages
+            .map(|raw| tool_names_from_output_messages(id, raw))
+            .unwrap_or_default(),
+    }
+}
+
+/// User query with agent template noise stripped. Returns `None` when there
+/// is no usable text left.
+fn cleaned_user_query(raw: &str) -> Option<String> {
+    let cleaned = GenAIBuilder::strip_user_query_prefix(raw);
+    if cleaned.trim().is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+/// Tool-call names mined from the `output_messages` JSON array. Bodies come
+/// from wire capture and may be truncated, so malformed JSON is tolerated
+/// with a debug log rather than an error.
+fn tool_names_from_output_messages(event_id: i64, raw: &str) -> Vec<String> {
+    let messages: Vec<OutputMessage> = match serde_json::from_str(raw) {
+        Ok(m) => m,
+        Err(e) => {
+            log::debug!(
+                "Preference genai source: unparseable output_messages (event_id={event_id}): {e}"
+            );
+            return Vec::new();
+        }
+    };
+    let mut names = Vec::new();
+    for message in &messages {
+        for part in &message.parts {
+            if let MessagePart::ToolCall { name, .. } = part {
+                if !name.is_empty() {
+                    names.push(name.clone());
+                }
+            }
+        }
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_agent_template_prefix_from_user_query() {
+        let row = row_from_event(
+            1,
+            Some("s1".to_string()),
+            Some("c1".to_string()),
+            42,
+            Some("Some preamble text\n  user_input: 先出方案再写代码\n\nruntime_frame:"),
+            None,
+        );
+        assert_eq!(row.user_text.as_deref(), Some("先出方案再写代码"));
+        assert_eq!(row.timestamp_ns, Some(42));
+        assert!(row.tool_names.is_empty());
+
+        // Nothing usable left after stripping → None, not an empty string.
+        let row = row_from_event(2, None, None, 0, Some("   "), None);
+        assert!(row.user_text.is_none());
+    }
+
+    #[test]
+    fn mines_tool_names_and_tolerates_bad_json() {
+        let output = r#"[{"role":"assistant","parts":[
+            {"type":"tool_call","name":"bash","arguments":{"cmd":"ls"}},
+            {"type":"text","content":"done"},
+            {"type":"tool_call","name":"bash"}
+        ]}]"#;
+        let row = row_from_event(1, None, None, 0, None, Some(output));
+        assert_eq!(row.tool_names, vec!["bash", "bash"]);
+
+        // Truncated JSON must not error out or emit tool names.
+        let row = row_from_event(
+            2,
+            None,
+            None,
+            0,
+            None,
+            Some(r#"[{"role":"assistant","parts":[{"type":"tool_c"#),
+        );
+        assert!(row.tool_names.is_empty());
+    }
+}

--- a/src/agentsight/src/preferences/signals.rs
+++ b/src/agentsight/src/preferences/signals.rs
@@ -1,0 +1,322 @@
+//! Preference taxonomy types and the centralized rule/threshold tables.
+//!
+//! Every matching rule (keyword lists, numeric thresholds, exclusivity)
+//! lives here so tuning a rule never requires touching detection or
+//! aggregation logic.
+
+use serde::Serialize;
+
+// ─── Rule tables and thresholds ─────────────────────────────────────────────
+
+/// Minimum alphabetic/CJK character count in a user query before language
+/// classification is attempted — shorter texts are statistically meaningless.
+pub const MIN_QUERY_CHARS_FOR_LANGUAGE: usize = 8;
+
+/// Fraction of CJK characters (over CJK + ASCII letters) above which a query
+/// is classified as Chinese. Well below 0.5 because Chinese developer queries
+/// are typically interleaved with English identifiers and paths.
+pub const CJK_RATIO_THRESHOLD: f64 = 0.3;
+
+/// Two user queries in the same conversation closer than this are treated as
+/// a rapid follow-up, i.e. the user overriding/correcting the previous turn.
+pub const CORRECTION_WINDOW_NS: i64 = 60 * 1_000_000_000;
+
+/// Max characters kept in an evidence excerpt — enough context to recognize
+/// the quote without shipping multi-KB prompts through the API.
+pub const EXCERPT_MAX_CHARS: usize = 120;
+
+/// "Plan before coding" phrasings (matched case-insensitively as substrings).
+pub const PLAN_FIRST_PATTERNS: &[&str] = &[
+    "先计划",
+    "先规划",
+    "先给出方案",
+    "先出方案",
+    "先设计",
+    "别急着写代码",
+    "先不要写代码",
+    "不要直接写代码",
+    "plan first",
+    "make a plan",
+    "plan before",
+    "before writing code",
+    "don't code yet",
+    "do not code yet",
+    "don't write code yet",
+    "do not write code yet",
+];
+
+/// "Run/require tests" phrasings (matched case-insensitively as substrings).
+pub const TEST_REQUIREMENT_PATTERNS: &[&str] = &[
+    "跑测试",
+    "跑一下测试",
+    "运行测试",
+    "执行测试",
+    "写测试",
+    "加测试",
+    "补测试",
+    "加单测",
+    "单元测试",
+    "run the tests",
+    "run tests",
+    "run unit tests",
+    "add tests",
+    "write tests",
+    "add a test",
+    "unit test",
+    "make test",
+    "cargo test",
+    "npm test",
+    "pytest",
+];
+
+/// Phrasings that signal the user is correcting/overriding the assistant
+/// (matched case-insensitively as substrings).
+pub const CORRECTION_PATTERNS: &[&str] = &[
+    "不对",
+    "不是这样",
+    "不是这个意思",
+    "重新来",
+    "重新做",
+    "改回去",
+    "撤销",
+    "别这样",
+    "that's wrong",
+    "that is wrong",
+    "not what i meant",
+    "not what i asked",
+    "undo that",
+    "revert that",
+    "start over",
+    "redo this",
+];
+
+/// Preference keys whose values are mutually exclusive: two strongly
+/// evidenced values for the same key mean a genuine conflict rather than
+/// coexisting habits (e.g. a user speaks either Chinese or English per key,
+/// but may legitimately prefer several tools).
+pub const EXCLUSIVE_KEYS: &[&str] = &["language"];
+
+/// True when two different values under `key` cannot both hold.
+pub fn is_exclusive_key(key: &str) -> bool {
+    EXCLUSIVE_KEYS.contains(&key)
+}
+
+/// Trim and cap a piece of evidence text at [`EXCERPT_MAX_CHARS`] characters
+/// (char-boundary safe; an ellipsis marks the cut).
+pub fn truncate_excerpt(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= EXCERPT_MAX_CHARS {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(EXCERPT_MAX_CHARS).collect();
+    out.push('…');
+    out
+}
+
+// ─── Taxonomy types ──────────────────────────────────────────────────────────
+
+/// Coarse preference grouping used by the API and the Markdown export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreferenceCategory {
+    Communication,
+    Workflow,
+    Technical,
+}
+
+impl PreferenceCategory {
+    /// Stable lowercase name (the API/export contract).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Communication => "communication",
+            Self::Workflow => "workflow",
+            Self::Technical => "technical",
+        }
+    }
+
+    /// Parse the lowercase name back; used to validate LLM-produced rows.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "communication" => Some(Self::Communication),
+            "workflow" => Some(Self::Workflow),
+            "technical" => Some(Self::Technical),
+            _ => None,
+        }
+    }
+}
+
+/// Which analysis layer produced a preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreferenceSource {
+    Rule,
+    Llm,
+}
+
+/// Lifecycle of a preference within one analysis window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreferenceStatus {
+    Active,
+    Conflicting,
+}
+
+/// What kind of observation a signal is.
+///
+/// Each variant maps to a stable (category, key, value) tuple via the
+/// accessor methods below; those strings are the API contract.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignalKind {
+    /// Dominant natural language of the user query ("chinese" / "english").
+    Language { language: &'static str },
+    /// The user asked for a plan/design before any code is written.
+    PlanFirst,
+    /// The user asked to run or add tests.
+    TestRequirement,
+    /// The user corrected/overrode the assistant (keyword or rapid re-send).
+    Correction,
+    /// A tool invoked by the model; frequency accumulates into a preference.
+    ToolUsage { tool_name: String },
+}
+
+impl SignalKind {
+    /// Category the signal aggregates under.
+    pub fn category(&self) -> PreferenceCategory {
+        match self {
+            Self::Language { .. } => PreferenceCategory::Communication,
+            Self::PlanFirst | Self::Correction => PreferenceCategory::Workflow,
+            Self::TestRequirement | Self::ToolUsage { .. } => PreferenceCategory::Technical,
+        }
+    }
+
+    /// Stable preference key within the category.
+    pub fn key(&self) -> &'static str {
+        match self {
+            Self::Language { .. } => "language",
+            Self::PlanFirst => "workflow_style",
+            Self::TestRequirement => "testing",
+            Self::Correction => "interaction_style",
+            Self::ToolUsage { .. } => "preferred_tool",
+        }
+    }
+
+    /// Observed value for the key.
+    pub fn value(&self) -> String {
+        match self {
+            Self::Language { language } => (*language).to_string(),
+            Self::PlanFirst => "plan_first".to_string(),
+            Self::TestRequirement => "require_tests".to_string(),
+            Self::Correction => "frequent_corrections".to_string(),
+            Self::ToolUsage { tool_name } => tool_name.clone(),
+        }
+    }
+}
+
+/// One preference observation extracted from a single analysis turn,
+/// carrying the provenance and evidence excerpt shown to the user.
+#[derive(Debug, Clone)]
+pub struct PreferenceSignal {
+    pub kind: SignalKind,
+    /// Id of the unified row the signal came from (see
+    /// `detector::PreferenceEventRow::id`).
+    pub event_id: i64,
+    pub session_id: Option<String>,
+    /// Turn timestamp in epoch nanoseconds; `None` when the source row had
+    /// no reliable value.
+    pub timestamp_ns: Option<i64>,
+    /// Short quote of the triggering text (capped at [`EXCERPT_MAX_CHARS`]).
+    pub excerpt: String,
+}
+
+/// One aggregated preference entry as returned by the API.
+#[derive(Debug, Clone, Serialize)]
+pub struct Preference {
+    pub category: PreferenceCategory,
+    pub key: String,
+    pub value: String,
+    /// Explainable score in [0, 0.99]; see `aggregator::confidence_for_evidence`.
+    pub confidence: f64,
+    pub evidence_count: usize,
+    pub source: PreferenceSource,
+    pub status: PreferenceStatus,
+    /// Up to a few deduplicated evidence excerpts backing the entry.
+    pub sample_evidence: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_tuple_mapping_is_stable() {
+        let s = SignalKind::Language {
+            language: "chinese",
+        };
+        assert_eq!(
+            (s.category(), s.key(), s.value().as_str()),
+            (PreferenceCategory::Communication, "language", "chinese")
+        );
+
+        let s = SignalKind::PlanFirst;
+        assert_eq!(
+            (s.category(), s.key(), s.value().as_str()),
+            (PreferenceCategory::Workflow, "workflow_style", "plan_first")
+        );
+
+        let s = SignalKind::TestRequirement;
+        assert_eq!(
+            (s.category(), s.key(), s.value().as_str()),
+            (PreferenceCategory::Technical, "testing", "require_tests")
+        );
+
+        let s = SignalKind::Correction;
+        assert_eq!(
+            (s.category(), s.key(), s.value().as_str()),
+            (
+                PreferenceCategory::Workflow,
+                "interaction_style",
+                "frequent_corrections"
+            )
+        );
+
+        let s = SignalKind::ToolUsage {
+            tool_name: "bash".to_string(),
+        };
+        assert_eq!(
+            (s.category(), s.key(), s.value().as_str()),
+            (PreferenceCategory::Technical, "preferred_tool", "bash")
+        );
+    }
+
+    #[test]
+    fn category_round_trips_and_rejects_unknown() {
+        for c in [
+            PreferenceCategory::Communication,
+            PreferenceCategory::Workflow,
+            PreferenceCategory::Technical,
+        ] {
+            assert_eq!(PreferenceCategory::parse(c.as_str()), Some(c));
+        }
+        assert_eq!(PreferenceCategory::parse("style"), None);
+        assert_eq!(PreferenceCategory::parse(""), None);
+    }
+
+    #[test]
+    fn only_language_is_exclusive() {
+        assert!(is_exclusive_key("language"));
+        assert!(!is_exclusive_key("preferred_tool"));
+        assert!(!is_exclusive_key("workflow_style"));
+    }
+
+    #[test]
+    fn excerpts_are_trimmed_and_capped_on_char_boundaries() {
+        assert_eq!(truncate_excerpt("  hello  "), "hello");
+        assert_eq!(truncate_excerpt(""), "");
+
+        // Multi-byte text longer than the cap must not split a char.
+        let long: String = "偏好".repeat(200);
+        let cut = truncate_excerpt(&long);
+        assert_eq!(cut.chars().count(), EXCERPT_MAX_CHARS + 1);
+        assert!(cut.ends_with('…'));
+    }
+}

--- a/src/agentsight/src/preferences/trajectory_source.rs
+++ b/src/agentsight/src/preferences/trajectory_source.rs
@@ -1,0 +1,206 @@
+//! `trajectories.db` provider: flattens stored ATIF trajectories into the
+//! unified [`PreferenceEventRow`] shape consumed by the rule engine.
+//!
+//! This is the only preference data source available on macOS, where the
+//! eBPF genai pipeline does not exist and turns are collected by the
+//! trajectory collector instead.
+
+use agentsight_atif::{AtifTrajectory, StepSource};
+use agentsight_trajectory_collector::{TrajectoryStore, strip_system_context};
+
+use super::detector::PreferenceEventRow;
+
+/// Hard cap on trajectories loaded per analysis window. Unlike the genai
+/// cap (`PREFERENCE_WINDOW_MAX_ROWS`), which counts individual event rows,
+/// this counts whole ATIF documents: one document can reach several MB of
+/// JSON and flatten into many turns, so the budget is deliberately far
+/// smaller.
+pub const PREFERENCE_TRAJECTORY_MAX_ROWS: usize = 50;
+
+/// Load one analysis window from `trajectories.db`: the most recent
+/// main-agent trajectories collected at or after `since_ns`, flattened to
+/// unified rows. Trajectories whose ATIF JSON fails to parse are skipped
+/// with a debug log — a single corrupted row must not fail the request.
+///
+/// # Errors
+/// Returns an error when the store query itself fails.
+pub fn load_window_rows(
+    store: &TrajectoryStore,
+    since_ns: i64,
+) -> anyhow::Result<Vec<PreferenceEventRow>> {
+    let documents =
+        store.list_recent_atif_jsons(since_ns, PREFERENCE_TRAJECTORY_MAX_ROWS as i64)?;
+    let mut rows = Vec::new();
+    // Ids only serve as signal provenance; a per-window sequence keeps them
+    // unique across trajectories without inventing fake storage ids.
+    let mut next_id: i64 = 1;
+    for (session_id, atif_json) in &documents {
+        rows.extend(rows_from_atif_json(session_id, atif_json, &mut next_id));
+    }
+    Ok(rows)
+}
+
+/// Flatten one ATIF document into unified rows.
+///
+/// Each user step opens a turn; tool-call names from the agent steps that
+/// follow attach to that turn, mirroring the genai shape where one row
+/// carries both the user query and the tools the response invoked. Adjacent
+/// turns follow the steps order, so the rapid-followup rule works exactly
+/// as on genai rows when steps carry parseable timestamps — and is skipped
+/// for turns that do not. Returns an empty vec on malformed JSON.
+pub fn rows_from_atif_json(
+    session_id: &str,
+    atif_json: &str,
+    next_id: &mut i64,
+) -> Vec<PreferenceEventRow> {
+    let trajectory: AtifTrajectory = match serde_json::from_str(atif_json) {
+        Ok(t) => t,
+        Err(e) => {
+            log::debug!(
+                "Preference trajectory source: unparseable ATIF JSON (session={session_id}): {e}"
+            );
+            return Vec::new();
+        }
+    };
+    let mut rows: Vec<PreferenceEventRow> = Vec::new();
+    for step in &trajectory.steps {
+        match step.source {
+            StepSource::User => {
+                let cleaned = strip_system_context(&step.message);
+                let id = *next_id;
+                *next_id += 1;
+                rows.push(PreferenceEventRow {
+                    id,
+                    session_id: Some(session_id.to_string()),
+                    // One trajectory is one conversation, so the session id
+                    // doubles as the cross-turn grouping key.
+                    conversation_id: Some(session_id.to_string()),
+                    timestamp_ns: step.timestamp.as_deref().and_then(parse_step_timestamp_ns),
+                    user_text: (!cleaned.is_empty()).then_some(cleaned),
+                    tool_names: Vec::new(),
+                });
+            }
+            StepSource::Agent => {
+                // Tool calls belong to the preceding user turn; agent steps
+                // before any user turn have no turn to attach to (a shape
+                // real trajectories do not produce) and are dropped.
+                if let (Some(turn), Some(calls)) = (rows.last_mut(), step.tool_calls.as_ref()) {
+                    turn.tool_names.extend(
+                        calls
+                            .iter()
+                            .map(|call| call.function_name.clone())
+                            .filter(|name| !name.is_empty()),
+                    );
+                }
+            }
+            StepSource::System => {}
+        }
+    }
+    rows
+}
+
+/// RFC 3339 step timestamp → epoch nanoseconds. `None` for missing or
+/// unparseable values so time-gap rules skip the turn instead of running on
+/// a fabricated timestamp.
+fn parse_step_timestamp_ns(raw: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()?
+        .timestamp_nanos_opt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flatten(atif_json: &str) -> Vec<PreferenceEventRow> {
+        let mut next_id = 1;
+        rows_from_atif_json("traj-1", atif_json, &mut next_id)
+    }
+
+    #[test]
+    fn extracts_user_turns_with_tool_names_and_timestamps() {
+        let atif = r#"{
+            "agent": {"name": "qoder"},
+            "steps": [
+                {"step_id": 1, "source": "user", "message": "先出方案再写代码",
+                 "timestamp": "2026-07-25T10:00:00Z"},
+                {"step_id": 2, "source": "agent", "message": "ok",
+                 "tool_calls": [
+                    {"tool_call_id": "t1", "function_name": "bash", "arguments": {}},
+                    {"tool_call_id": "t2", "function_name": "", "arguments": {}}
+                 ]},
+                {"step_id": 3, "source": "agent", "message": "more",
+                 "tool_calls": [
+                    {"tool_call_id": "t3", "function_name": "grep", "arguments": {}}
+                 ]},
+                {"step_id": 4, "source": "user", "message": "改完之后跑测试",
+                 "timestamp": "2026-07-25T10:00:30Z"}
+            ]
+        }"#;
+        let rows = flatten(atif);
+        assert_eq!(rows.len(), 2);
+
+        let first = &rows[0];
+        assert_eq!(first.id, 1);
+        assert_eq!(first.session_id.as_deref(), Some("traj-1"));
+        assert_eq!(first.conversation_id.as_deref(), Some("traj-1"));
+        assert_eq!(first.user_text.as_deref(), Some("先出方案再写代码"));
+        // Both agent steps of the turn contribute; empty names are dropped.
+        assert_eq!(first.tool_names, vec!["bash", "grep"]);
+        assert_eq!(first.timestamp_ns, Some(1_784_973_600_000_000_000));
+
+        let second = &rows[1];
+        assert_eq!(second.id, 2);
+        assert_eq!(second.user_text.as_deref(), Some("改完之后跑测试"));
+        assert!(second.tool_names.is_empty());
+        // 30 seconds after the first turn — inside the correction window.
+        assert_eq!(
+            second.timestamp_ns.map(|ts| ts - 1_784_973_600_000_000_000),
+            Some(30_000_000_000)
+        );
+    }
+
+    #[test]
+    fn strips_system_context_and_skips_unreliable_timestamps() {
+        let atif = r#"{
+            "agent": {"name": "qoder"},
+            "steps": [
+                {"step_id": 1, "source": "user",
+                 "message": "<system-reminder>memo</system-reminder>跑测试"},
+                {"step_id": 2, "source": "user",
+                 "message": "<command-message>clear</command-message>",
+                 "timestamp": "not-a-timestamp"}
+            ]
+        }"#;
+        let rows = flatten(atif);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].user_text.as_deref(), Some("跑测试"));
+        // No timestamp on the step → no fabricated value.
+        assert_eq!(rows[0].timestamp_ns, None);
+        // Only injected tags left → no usable user text.
+        assert!(rows[1].user_text.is_none());
+        // Unparseable timestamp → None as well.
+        assert_eq!(rows[1].timestamp_ns, None);
+    }
+
+    #[test]
+    fn malformed_json_and_empty_steps_yield_no_rows() {
+        assert!(flatten("not json at all").is_empty());
+        assert!(flatten(r#"{"agent": {"name": "qoder"}, "steps": []}"#).is_empty());
+        // `steps` missing entirely: the ATIF schema defaults it to empty.
+        assert!(flatten(r#"{"agent": {"name": "qoder"}}"#).is_empty());
+    }
+
+    #[test]
+    fn ids_stay_unique_across_trajectories() {
+        let atif = r#"{
+            "agent": {"name": "qoder"},
+            "steps": [{"step_id": 1, "source": "user", "message": "hello there my friend"}]
+        }"#;
+        let mut next_id = 1;
+        let a = rows_from_atif_json("t-1", atif, &mut next_id);
+        let b = rows_from_atif_json("t-2", atif, &mut next_id);
+        assert_eq!(a[0].id, 1);
+        assert_eq!(b[0].id, 2);
+    }
+}

--- a/src/agentsight/src/semantic_search.rs
+++ b/src/agentsight/src/semantic_search.rs
@@ -2,7 +2,9 @@
 //!
 //! Both `server::optimize` and `local::server::optimize` expose
 //! `POST /api/sessions/search`. This module owns the request/response contract
-//! and the LLM ranking call so the two handlers cannot drift apart.
+//! and the LLM ranking call so the two handlers cannot drift apart. It lives at
+//! the crate root rather than under `server` because the latter is gated to
+//! Linux, which would put it out of reach of the macOS handler.
 
 use actix_web::HttpResponse;
 use agentsight_opt::LlmClient;

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -7,6 +7,9 @@ use actix_web::{HttpResponse, Responder, get, post, web};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use agentsight_atif::StepCategory;
+use agentsight_trajectory_collector::StepScanFilter;
+
 use super::AppState;
 use crate::agent_sec::{AgentSecClient, AgentSecClientError, DaemonResponse};
 use crate::grader::{
@@ -1986,6 +1989,207 @@ mod tests {
         assert_eq!(filters.status(), StatusCode::OK);
     }
 
+    // ─── Trajectory step query tests ───────────────────────────────────
+
+    /// Store holding one trajectory whose steps cover several categories.
+    fn stepped_trajectory_store(tag: &str) -> Arc<TrajectoryStore> {
+        let db = unique_handler_db(tag);
+        let store = TrajectoryStore::new_with_path(&db).unwrap();
+        let mut record = trajectory_record("s-steps", "proj-a", "qoder");
+        record.num_steps = 4;
+        record.atif_json = serde_json::json!({
+            "schema_version": "ATIF-v1.7",
+            "agent": {"name": "qoder", "version": "1.0"},
+            "session_id": "s-steps",
+            "steps": [
+                {"step_id": 1, "source": "user", "message": "列一下文件"},
+                {"step_id": 2, "source": "agent", "message": "好的",
+                 "reasoning_content": "需要执行 ls",
+                 "tool_calls": [{"tool_call_id": "t1", "function_name": "bash",
+                                 "arguments": {"cmd": "ls"}}]},
+                {"step_id": 3, "source": "user", "message": "",
+                 "observation": {"results": [{"source_call_id": "t1", "content": "a.txt"}]}},
+                {"step_id": 4, "source": "agent", "message": "只有 a.txt"}
+            ]
+        })
+        .to_string();
+        store.upsert_trajectory(&record).unwrap();
+        Arc::new(store)
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_route_not_captured_by_session_id() {
+        let data =
+            test_app_state_with_trajectory_store(Some(stepped_trajectory_store("steps-route")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        // `steps` must hit the step handler (object with `hits`), not the detail
+        // handler, which would 404 on a session named "steps".
+        assert!(body["hits"].is_array());
+        assert_eq!(body["scanned_trajectories"], 1);
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_filters_by_category_with_context() {
+        let data =
+            test_app_state_with_trajectory_store(Some(stepped_trajectory_store("steps-cat")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps?category=tool_call&context=1")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        let hits = body["hits"].as_array().unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["step"]["step_id"], 2);
+        assert_eq!(hits[0]["session_id"], "s-steps");
+        assert_eq!(hits[0]["agent_name"], "qoder");
+        assert_eq!(hits[0]["step"]["tool_names"], serde_json::json!(["bash"]));
+        // context=1 yields exactly one neighbour on each side.
+        assert_eq!(hits[0]["context"]["before"][0]["step_id"], 1);
+        assert_eq!(hits[0]["context"]["after"][0]["step_id"], 3);
+        assert_eq!(hits[0]["context"]["before"].as_array().unwrap().len(), 1);
+        assert_eq!(hits[0]["context"]["after"].as_array().unwrap().len(), 1);
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_multi_category_is_or() {
+        let data = test_app_state_with_trajectory_store(Some(stepped_trajectory_store("steps-or")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps?category=thinking,tool_result")
+                .to_request(),
+        )
+        .await;
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        let ids: Vec<i64> = body["hits"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|h| h["step"]["step_id"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_rejects_unknown_category() {
+        let data =
+            test_app_state_with_trajectory_store(Some(stepped_trajectory_store("steps-bad")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps?category=assistant")
+                .to_request(),
+        )
+        .await;
+        // Rejecting beats silently ignoring: an ignored filter would return
+        // unrelated steps that look like a legitimate result.
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        assert_eq!(body["error"], "invalid_category");
+        let valid = body["valid_categories"].as_array().unwrap();
+        assert_eq!(valid.len(), 6);
+        assert!(valid.contains(&serde_json::json!("tool_call")));
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_graceful_when_store_absent() {
+        let data = test_app_state_with_trajectory_store(None);
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        assert_eq!(body["hits"], serde_json::json!([]));
+        assert_eq!(body["scanned_trajectories"], 0);
+        assert_eq!(body["truncated"], false);
+    }
+
+    #[actix_web::test]
+    async fn trajectory_steps_caps_limit_and_marks_truncated() {
+        let data =
+            test_app_state_with_trajectory_store(Some(stepped_trajectory_store("steps-lim")));
+        let app = awtest::init_service(
+            App::new()
+                .app_data(data)
+                .configure(crate::server::configure_routes),
+        )
+        .await;
+
+        let resp = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps?limit=1")
+                .to_request(),
+        )
+        .await;
+        let body: serde_json::Value = awtest::read_body_json(resp).await;
+        assert_eq!(body["hits"].as_array().unwrap().len(), 1);
+        assert_eq!(body["truncated"], true);
+
+        // A non-positive limit falls back to the default rather than acting as
+        // "no limit" (SQLite treats a negative LIMIT as unbounded).
+        let zero = awtest::call_service(
+            &app,
+            awtest::TestRequest::get()
+                .uri("/api/trajectories/steps?limit=0")
+                .to_request(),
+        )
+        .await;
+        let zero_body: serde_json::Value = awtest::read_body_json(zero).await;
+        assert_eq!(zero_body["hits"].as_array().unwrap().len(), 4);
+    }
+
     fn make_interruption_event(
         id: &str,
         session_id: &str,
@@ -3737,6 +3941,105 @@ pub async fn get_trajectory_detail(
         }
         Ok(None) => HttpResponse::NotFound()
             .json(serde_json::json!({"error": "not_found", "message": "Trajectory not found"})),
+        Err(e) => {
+            HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
+        }
+    }
+}
+
+/// Query parameters for `/api/trajectories/steps`.
+#[derive(Debug, Deserialize)]
+pub struct TrajectoryStepQuery {
+    /// Comma-separated step categories, matched as OR. Omit for every step.
+    pub category: Option<String>,
+    pub agent_name: Option<String>,
+    pub project: Option<String>,
+    pub source: Option<String>,
+    pub session_id: Option<String>,
+    /// Max hits returned (default 50).
+    pub limit: Option<i64>,
+    /// Neighbouring steps returned on each side of a hit (default 3).
+    pub context: Option<i64>,
+    /// Max trajectories read from disk (default 500).
+    pub max_scan: Option<i64>,
+}
+
+/// Defaults and hard caps for `/api/trajectories/steps`.
+const STEP_DEFAULT_LIMIT: i64 = 50;
+const STEP_MAX_LIMIT: i64 = 500;
+const STEP_DEFAULT_CONTEXT: i64 = 3;
+const STEP_MAX_CONTEXT: i64 = 10;
+const STEP_DEFAULT_MAX_SCAN: i64 = 500;
+const STEP_MAX_MAX_SCAN: i64 = 2000;
+
+/// GET /api/trajectories/steps?category=&agent_name=&project=&source=&session_id=&limit=&context=&max_scan=
+///
+/// Finds steps by derived category (`user_input`, `system`, `agent_message`,
+/// `thinking`, `tool_call`, `tool_result`), each returned with its neighbouring
+/// steps so a hit can be read in context. Categories are multi-label: a step
+/// that reasons and calls a tool matches either filter.
+///
+/// Must be registered before `/trajectories/{session_id}`.
+#[get("/trajectories/steps")]
+pub async fn list_trajectory_steps(
+    data: web::Data<AppState>,
+    query: web::Query<TrajectoryStepQuery>,
+) -> impl Responder {
+    // An unknown category is rejected rather than ignored: silently dropping it
+    // would return unrelated steps that look like a legitimate empty result.
+    let mut categories = Vec::new();
+    if let Some(raw) = query.category.as_deref() {
+        for token in raw.split(',').filter(|t| !t.trim().is_empty()) {
+            match StepCategory::parse(token) {
+                Some(c) => categories.push(c),
+                None => {
+                    return HttpResponse::BadRequest().json(serde_json::json!({
+                        "error": "invalid_category",
+                        "message": format!("Unknown category '{}'", token.trim()),
+                        "valid_categories": StepCategory::ALL
+                            .iter()
+                            .map(|c| c.as_str())
+                            .collect::<Vec<_>>(),
+                    }));
+                }
+            }
+        }
+    }
+
+    let Some(tstore) = data.trajectory_store() else {
+        return HttpResponse::Ok().json(serde_json::json!({
+            "hits": [], "scanned_trajectories": 0,
+            "truncated": false, "skipped_unparsable": 0
+        }));
+    };
+
+    // Normalize: <= 0 falls back to default and every value is capped, so a
+    // hostile `limit` cannot turn into an unbounded scan. `context` may be 0.
+    let limit = match query.limit {
+        Some(v) if v > 0 => v.min(STEP_MAX_LIMIT),
+        _ => STEP_DEFAULT_LIMIT,
+    };
+    let context_radius = match query.context {
+        Some(v) if v >= 0 => v.min(STEP_MAX_CONTEXT),
+        _ => STEP_DEFAULT_CONTEXT,
+    };
+    let max_scan = match query.max_scan {
+        Some(v) if v > 0 => v.min(STEP_MAX_MAX_SCAN),
+        _ => STEP_DEFAULT_MAX_SCAN,
+    };
+
+    let filter = StepScanFilter {
+        project: query.project.clone(),
+        source: query.source.clone(),
+        agent_name: query.agent_name.clone(),
+        session_id: query.session_id.clone(),
+        categories,
+        limit,
+        context_radius,
+        max_scan,
+    };
+    match tstore.scan_steps(&filter) {
+        Ok(outcome) => HttpResponse::Ok().json(outcome),
         Err(e) => {
             HttpResponse::InternalServerError().json(serde_json::json!({"error": e.to_string()}))
         }

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -292,6 +292,7 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
                 // User preference analysis API routes (export before the shorter path)
                 .service(preferences::export_preferences)
                 .service(preferences::get_preferences)
+                .service(preferences::get_preference_turns)
                 // Causal attribution API routes
                 .service(causal::run_causal_attribution)
                 // Trajectory collection API routes (filters before the dynamic segment)
@@ -543,6 +544,11 @@ const API_ROUTES: &[(&str, &str, &str)] = &[
         "GET",
         "/api/preferences/export",
         "User preferences as Markdown",
+    ),
+    (
+        "GET",
+        "/api/preferences/turns",
+        "Raw user turns for agent-side LLM reasoning",
     ),
     ("POST", "/api/causal-attribution", "Run causal attribution"),
     ("GET", "/api/trajectories", "List collected trajectories"),

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -10,6 +10,7 @@ mod containment;
 mod enforcement;
 mod handlers;
 pub mod optimize;
+mod preferences;
 mod secret;
 pub mod semantic_search;
 mod system_audit;
@@ -288,6 +289,9 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
                 .service(optimize::get_optimize_config)
                 .service(optimize::update_optimize_config)
                 .service(optimize::semantic_search_sessions)
+                // User preference analysis API routes (export before the shorter path)
+                .service(preferences::export_preferences)
+                .service(preferences::get_preferences)
                 // Causal attribution API routes
                 .service(causal::run_causal_attribution)
                 // Trajectory collection API routes (filters before the dynamic segment)
@@ -530,6 +534,16 @@ const API_ROUTES: &[(&str, &str, &str)] = &[
     ),
     ("GET", "/api/optimize/config", "Optimization config"),
     ("POST", "/api/optimize/config", "Update optimization config"),
+    (
+        "GET",
+        "/api/preferences",
+        "User preference analysis (rule + optional LLM)",
+    ),
+    (
+        "GET",
+        "/api/preferences/export",
+        "User preferences as Markdown",
+    ),
     ("POST", "/api/causal-attribution", "Run causal attribution"),
     ("GET", "/api/trajectories", "List collected trajectories"),
     (

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -12,7 +12,6 @@ mod handlers;
 pub mod optimize;
 mod preferences;
 mod secret;
-pub mod semantic_search;
 mod system_audit;
 mod token_savings;
 

--- a/src/agentsight/src/server/mod.rs
+++ b/src/agentsight/src/server/mod.rs
@@ -294,9 +294,10 @@ fn configure_routes(cfg: &mut web::ServiceConfig) {
                 .service(preferences::get_preference_turns)
                 // Causal attribution API routes
                 .service(causal::run_causal_attribution)
-                // Trajectory collection API routes (filters before the dynamic segment)
+                // Trajectory collection API routes (static paths before the dynamic segment)
                 .service(handlers::list_trajectories)
                 .service(handlers::trajectory_filters)
+                .service(handlers::list_trajectory_steps)
                 .service(handlers::get_trajectory_detail)
                 // API self-documentation
                 .service(web::resource("/docs").route(web::get().to(api_docs)))
@@ -555,6 +556,11 @@ const API_ROUTES: &[(&str, &str, &str)] = &[
         "GET",
         "/api/trajectories/filters",
         "Trajectory filter values",
+    ),
+    (
+        "GET",
+        "/api/trajectories/steps",
+        "Steps by derived category, with surrounding context",
     ),
     ("GET", "/api/trajectories/{session_id}", "Trajectory detail"),
 ];

--- a/src/agentsight/src/server/optimize.rs
+++ b/src/agentsight/src/server/optimize.rs
@@ -19,7 +19,7 @@ use agentsight_trajectory_collector::{TrajectoryRecord, TrajectoryStore};
 
 use super::AppState;
 use super::secret;
-use super::semantic_search;
+use crate::semantic_search;
 use crate::storage::sqlite::GenAISqliteStore;
 
 const CONFIG_FILE_NAME: &str = "optimization_config.json";

--- a/src/agentsight/src/server/preferences.rs
+++ b/src/agentsight/src/server/preferences.rs
@@ -1,0 +1,243 @@
+//! User preference API: on-demand analysis over recent agent activity.
+//!
+//! No persistence — every request reads one analysis window from the
+//! selected source (`genai_events.db` or `trajectories.db`), runs the rule
+//! pipeline (`crate::preferences`) and optionally merges LLM findings from
+//! `agentsight-opt`. All source-agnostic mechanics (source selection, TTL
+//! cache, LLM merging, Markdown export) live in `crate::preferences::api`
+//! and are shared with the macOS local server.
+
+use actix_web::{HttpResponse, Responder, get, web};
+use agentsight_opt::preference::{LlmPreference, analyze_user_turns};
+
+use super::AppState;
+use crate::preferences::api::{
+    AutoResolution, PreferenceSourceParam, PreferencesQuery, cache_get, cache_put,
+    clamp_window_days, merge_llm_preferences, render_markdown, resolve_auto, window_start_ns,
+};
+use crate::preferences::{aggregator, analyze_rows, detector, genai_source, trajectory_source};
+use crate::storage::sqlite::GenAISqliteStore;
+
+// ─── Source loading ──────────────────────────────────────────────────────────
+
+/// Fetch one genai window; the error string doubles as the "unavailable"
+/// reason for both the explicit-source error response and the auto-fallback
+/// debug log.
+fn load_genai_rows(
+    data: &AppState,
+    since_ns: i64,
+) -> Result<Vec<detector::PreferenceEventRow>, String> {
+    if !data.storage_path.exists() {
+        return Err(
+            "SQLite storage is not enabled or no events have been captured yet.".to_string(),
+        );
+    }
+    let store = GenAISqliteStore::new_with_path(&data.storage_path).map_err(|e| e.to_string())?;
+    let raw = store
+        .get_preference_window_events(since_ns)
+        .map_err(|e| e.to_string())?;
+    // Interpret raw columns here rather than in the store: the mapping strips
+    // agent template noise and mines tool names, which is analysis, not storage.
+    Ok(raw
+        .iter()
+        .map(|row| {
+            genai_source::row_from_event(
+                row.id,
+                row.session_id.clone(),
+                row.conversation_id.clone(),
+                row.start_timestamp_ns,
+                row.user_query.as_deref(),
+                row.output_messages.as_deref(),
+            )
+        })
+        .collect())
+}
+
+/// Fetch one trajectory window from `trajectories.db` (lazily opened by the
+/// shared app state, same as the trajectory browsing endpoints).
+fn load_trajectory_rows(
+    data: &AppState,
+    since_ns: i64,
+) -> Result<Vec<detector::PreferenceEventRow>, String> {
+    let store = data.trajectory_store().ok_or_else(|| {
+        "trajectories.db not found; run `agentsight trace` with trajectory collection enabled."
+            .to_string()
+    })?;
+    trajectory_source::load_window_rows(&store, since_ns).map_err(|e| e.to_string())
+}
+
+fn source_unavailable(source: PreferenceSourceParam, reason: &str) -> HttpResponse {
+    HttpResponse::ServiceUnavailable().json(serde_json::json!({
+        "error": format!("{} source unavailable", source.as_str()),
+        "message": reason,
+    }))
+}
+
+/// Resolve the requested source and load its window. Returns the rows
+/// together with the source that actually served them (never `Auto`), so
+/// handlers can report real provenance in the response body.
+fn load_rows(
+    data: &AppState,
+    source: PreferenceSourceParam,
+    window_days: u32,
+) -> Result<(Vec<detector::PreferenceEventRow>, PreferenceSourceParam), HttpResponse> {
+    let since_ns = window_start_ns(window_days);
+    match source {
+        PreferenceSourceParam::Genai => load_genai_rows(data, since_ns)
+            .map(|rows| (rows, PreferenceSourceParam::Genai))
+            .map_err(|reason| source_unavailable(source, &reason)),
+        PreferenceSourceParam::Trajectory => load_trajectory_rows(data, since_ns)
+            .map(|rows| (rows, PreferenceSourceParam::Trajectory))
+            .map_err(|reason| source_unavailable(source, &reason)),
+        PreferenceSourceParam::Auto => {
+            let genai_rows = match load_genai_rows(data, since_ns) {
+                Ok(rows) => Some(rows),
+                Err(reason) => {
+                    log::debug!("Preference API: auto source skips genai: {reason}");
+                    None
+                }
+            };
+            // Trajectories are only probed when genai cannot serve the
+            // window — parsing stored ATIF JSON is the expensive path.
+            let trajectory_rows = match &genai_rows {
+                Some(rows) if !rows.is_empty() => None,
+                _ => match load_trajectory_rows(data, since_ns) {
+                    Ok(rows) => Some(rows),
+                    Err(reason) => {
+                        log::debug!("Preference API: auto source skips trajectory: {reason}");
+                        None
+                    }
+                },
+            };
+            match resolve_auto(genai_rows.as_ref().map(Vec::len), trajectory_rows.is_some()) {
+                AutoResolution::Genai => {
+                    Ok((genai_rows.unwrap_or_default(), PreferenceSourceParam::Genai))
+                }
+                AutoResolution::Trajectory => Ok((
+                    trajectory_rows.unwrap_or_default(),
+                    PreferenceSourceParam::Trajectory,
+                )),
+                AutoResolution::Unavailable => {
+                    Err(HttpResponse::ServiceUnavailable().json(serde_json::json!({
+                        "error": "no preference data source available",
+                        "message": "Neither genai_events.db nor trajectories.db can be read; \
+                                    capture some agent activity first.",
+                    })))
+                }
+            }
+        }
+    }
+}
+
+/// Parse `?source=`, mapping bad values to a 400 with the parser's message.
+fn parse_source(query: &PreferencesQuery) -> Result<PreferenceSourceParam, HttpResponse> {
+    PreferenceSourceParam::parse(query.source.as_deref()).map_err(|message| {
+        HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "invalid source",
+            "message": message,
+        }))
+    })
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+/// GET /api/preferences?window_days=7&llm=true&source=auto
+///
+/// Rule-based preference analysis over the recent activity window,
+/// optionally augmented with LLM findings when `llm=true` and the
+/// optimization LLM is configured. LLM problems never fail the request —
+/// the response degrades to rule-only results with `llm_enabled: false`.
+/// `source` picks the data source (`auto` falls back from genai events to
+/// collected trajectories); the response's `source` field reports which
+/// one actually served the request.
+#[get("/preferences")]
+pub async fn get_preferences(
+    data: web::Data<AppState>,
+    query: web::Query<PreferencesQuery>,
+) -> impl Responder {
+    let source = match parse_source(&query) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let llm_requested = query.llm.unwrap_or(false);
+    let cache_key = (window_days, llm_requested, source);
+
+    if let Some(body) = cache_get(cache_key) {
+        return HttpResponse::Ok().json(body);
+    }
+
+    let (rows, resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let mut prefs = analyze_rows(&rows);
+
+    let mut llm_enabled = false;
+    if llm_requested {
+        match llm_findings(&data, &rows).await {
+            Ok(findings) => {
+                llm_enabled = true;
+                merge_llm_preferences(&mut prefs, findings);
+                // Re-run conflict marking so exclusivity (e.g. "language")
+                // holds across rule and LLM entries together.
+                aggregator::mark_conflicts(&mut prefs);
+            }
+            Err(reason) => log::warn!("Preference API: LLM layer skipped: {reason}"),
+        }
+    }
+
+    let body = serde_json::json!({
+        "window_days": window_days,
+        "analyzed_events": rows.len(),
+        "llm_enabled": llm_enabled,
+        "source": resolved.as_str(),
+        "preferences": prefs,
+    });
+    cache_put(cache_key, body.clone());
+    HttpResponse::Ok().json(body)
+}
+
+/// Run the LLM layer over the window's user turns; every failure mode is
+/// reduced to one human-readable reason for the degradation log.
+async fn llm_findings(
+    data: &AppState,
+    rows: &[detector::PreferenceEventRow],
+) -> Result<Vec<LlmPreference>, String> {
+    let state = data
+        .optimize
+        .as_ref()
+        .ok_or_else(|| "optimization feature unavailable".to_string())?;
+    let client = state
+        .build_client()
+        .map_err(|_| "LLM not configured".to_string())?;
+    let turns: Vec<String> = rows.iter().filter_map(|r| r.user_text.clone()).collect();
+    analyze_user_turns(&client, &turns)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// GET /api/preferences/export?window_days=7&source=auto
+///
+/// Markdown digest of the confident, active rule-based preferences —
+/// suitable for pasting into an agent memory/config file. Accepts the same
+/// `source` parameter as the JSON endpoint.
+#[get("/preferences/export")]
+pub async fn export_preferences(
+    data: web::Data<AppState>,
+    query: web::Query<PreferencesQuery>,
+) -> impl Responder {
+    let source = match parse_source(&query) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let (rows, _resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let prefs = analyze_rows(&rows);
+    HttpResponse::Ok()
+        .content_type("text/markdown; charset=utf-8")
+        .body(render_markdown(&prefs))
+}

--- a/src/agentsight/src/server/preferences.rs
+++ b/src/agentsight/src/server/preferences.rs
@@ -7,13 +7,16 @@
 //! cache, LLM merging, Markdown export) live in `crate::preferences::api`
 //! and are shared with the macOS local server.
 
+use std::collections::HashSet;
+
 use actix_web::{HttpResponse, Responder, get, web};
 use agentsight_opt::preference::{LlmPreference, analyze_user_turns};
 
 use super::AppState;
 use crate::preferences::api::{
-    AutoResolution, PreferenceSourceParam, PreferencesQuery, cache_get, cache_put,
-    clamp_window_days, merge_llm_preferences, render_markdown, resolve_auto, window_start_ns,
+    AutoResolution, DEFAULT_TURNS_LIMIT, MAX_TURNS_LIMIT, PreferenceSourceParam, PreferencesQuery,
+    TurnsQuery, cache_get, cache_put, clamp_window_days, merge_llm_preferences, render_markdown,
+    resolve_auto, window_start_ns,
 };
 use crate::preferences::{aggregator, analyze_rows, detector, genai_source, trajectory_source};
 use crate::storage::sqlite::GenAISqliteStore;
@@ -130,8 +133,8 @@ fn load_rows(
 }
 
 /// Parse `?source=`, mapping bad values to a 400 with the parser's message.
-fn parse_source(query: &PreferencesQuery) -> Result<PreferenceSourceParam, HttpResponse> {
-    PreferenceSourceParam::parse(query.source.as_deref()).map_err(|message| {
+fn parse_source(source: Option<&str>) -> Result<PreferenceSourceParam, HttpResponse> {
+    PreferenceSourceParam::parse(source).map_err(|message| {
         HttpResponse::BadRequest().json(serde_json::json!({
             "error": "invalid source",
             "message": message,
@@ -155,7 +158,7 @@ pub async fn get_preferences(
     data: web::Data<AppState>,
     query: web::Query<PreferencesQuery>,
 ) -> impl Responder {
-    let source = match parse_source(&query) {
+    let source = match parse_source(query.source.as_deref()) {
         Ok(source) => source,
         Err(resp) => return resp,
     };
@@ -227,7 +230,7 @@ pub async fn export_preferences(
     data: web::Data<AppState>,
     query: web::Query<PreferencesQuery>,
 ) -> impl Responder {
-    let source = match parse_source(&query) {
+    let source = match parse_source(query.source.as_deref()) {
         Ok(source) => source,
         Err(resp) => return resp,
     };
@@ -240,4 +243,46 @@ pub async fn export_preferences(
     HttpResponse::Ok()
         .content_type("text/markdown; charset=utf-8")
         .body(render_markdown(&prefs))
+}
+
+/// GET /api/preferences/turns?window_days=7&source=auto&limit=200
+///
+/// Returns the deduped raw user turns inside the window — the same text the
+/// `llm=true` path feeds to the server-side LLM, but handed back verbatim so
+/// an agent (which already has its own model) can run the enhancement itself
+/// without agentsight holding any LLM credentials. Newest unique turns first;
+/// `limit` bounds the count (default 200, max 1000).
+#[get("/preferences/turns")]
+pub async fn get_preference_turns(
+    data: web::Data<AppState>,
+    query: web::Query<TurnsQuery>,
+) -> impl Responder {
+    let source = match parse_source(query.source.as_deref()) {
+        Ok(source) => source,
+        Err(resp) => return resp,
+    };
+    let window_days = clamp_window_days(query.window_days);
+    let (rows, resolved) = match load_rows(&data, source, window_days) {
+        Ok(loaded) => loaded,
+        Err(resp) => return resp,
+    };
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_TURNS_LIMIT)
+        .clamp(1, MAX_TURNS_LIMIT);
+    let mut seen: HashSet<String> = HashSet::new();
+    let turns: Vec<String> = rows
+        .iter()
+        .filter_map(|r| r.user_text.clone())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .filter(|s| seen.insert(s.clone()))
+        .take(limit)
+        .collect();
+    HttpResponse::Ok().json(serde_json::json!({
+        "window_days": window_days,
+        "source": resolved.as_str(),
+        "turns_count": turns.len(),
+        "turns": turns,
+    }))
 }

--- a/src/agentsight/src/storage/sqlite/genai/events.rs
+++ b/src/agentsight/src/storage/sqlite/genai/events.rs
@@ -9,6 +9,31 @@ use crate::genai::semantic::GenAISemanticEvent;
 
 // ─── Query result types ────────────────────────────────────────────────────────
 
+/// Hard cap on rows returned by [`GenAISqliteStore::get_preference_window_events`]
+/// — preference analysis is a bounded-cost, best-effort feature. 300 keeps the
+/// per-request memory peak modest: `output_messages` alone can reach hundreds
+/// of KB per row. Counts individual event rows (one LLM call each); the
+/// trajectory source uses a much smaller per-document cap
+/// (`PREFERENCE_TRAJECTORY_MAX_ROWS`) because each document bundles a whole
+/// session.
+pub const PREFERENCE_WINDOW_MAX_ROWS: usize = 300;
+
+/// Raw `genai_events` columns for one row of a preference analysis window.
+///
+/// Deliberately unparsed: `user_query` still carries agent template noise and
+/// `output_messages` is the raw wire-capture JSON. Mapping these into the
+/// analysis shape is the preference layer's job, which keeps the dependency
+/// pointing downwards from analysis to storage.
+#[derive(Debug, Clone)]
+pub struct PreferenceWindowRow {
+    pub id: i64,
+    pub session_id: Option<String>,
+    pub conversation_id: Option<String>,
+    pub start_timestamp_ns: i64,
+    pub user_query: Option<String>,
+    pub output_messages: Option<String>,
+}
+
 /// One LLM call event within a trace
 #[derive(Debug, serde::Serialize)]
 pub struct TraceEventDetail {
@@ -99,6 +124,51 @@ impl GenAISqliteStore {
                 interruption_type: row.get(20)?,
             })
         })?;
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row?);
+        }
+        Ok(result)
+    }
+
+    /// Fetch the narrow column set preference analysis needs for completed
+    /// main-flow LLM calls at or after `since_ns`, oldest first, capped at
+    /// [`PREFERENCE_WINDOW_MAX_ROWS`]. Read-only: no schema or writes.
+    /// `input_messages` is deliberately not selected — no rule reads it and
+    /// it would multiply the memory peak of a window fetch.
+    ///
+    /// Rows are returned as raw columns: interpreting them (stripping agent
+    /// template noise, mining tool names) belongs to the preference layer
+    /// above, so the store does not depend upwards on it.
+    pub fn get_preference_window_events(
+        &self,
+        since_ns: i64,
+    ) -> Result<Vec<PreferenceWindowRow>, Box<dyn std::error::Error>> {
+        let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
+        let mut stmt = conn.prepare(
+            "SELECT id, session_id, conversation_id, start_timestamp_ns,
+                    user_query, output_messages
+             FROM genai_events
+             WHERE start_timestamp_ns >= ?1
+               AND event_type = 'llm_call'
+               AND status = 'complete'
+               AND call_kind = 'main'
+             ORDER BY start_timestamp_ns ASC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(
+            params![since_ns, PREFERENCE_WINDOW_MAX_ROWS as i64],
+            |row| {
+                Ok(PreferenceWindowRow {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    conversation_id: row.get(2)?,
+                    start_timestamp_ns: row.get(3)?,
+                    user_query: row.get(4)?,
+                    output_messages: row.get(5)?,
+                })
+            },
+        )?;
         let mut result = Vec::new();
         for row in rows {
             result.push(row?);


### PR DESCRIPTION
## Description

Adds two read-only query capabilities to the AgentSight API.

**Preference analysis** (`GET /api/preferences`, `/api/preferences/export`,
`/api/preferences/turns`) infers working habits from recent conversations:
preferred language, plan-before-code workflow, test expectations, correction
patterns and tool leanings. A deterministic rule layer produces the findings;
an optional LLM layer refines them when an optimize client is configured
(`llm=true`), otherwise the response reports `llm_enabled: false`.

Key design decision: the analysis runs **in-request with a 10-minute in-process
TTL cache** rather than in a background job writing a new table. That keeps
derived state out of the database entirely, so there is nothing to migrate and
nothing that can silently go stale — the trade-off is per-request CPU, which is
bounded by the caps below.

Data comes from one of two sources selected by `source=auto|genai|trajectory`:
eBPF-captured `genai_events` on Linux, or collected trajectories elsewhere,
with `auto` falling back to trajectories when genai data is empty. Memory stays
bounded by conservative caps: at most 300 genai event rows or 50 whole ATIF
documents per window.

**Trajectory step query** (`GET /api/trajectories/steps`) finds ATIF steps by
derived category (`user_input`, `system`, `agent_message`, `thinking`,
`tool_call`, `tool_result`) and returns each hit with its neighbouring steps so
it can be read in context. Categories are deliberately **multi-label**: a single
agent step can carry a message, reasoning, tool calls and observations at once,
so filtering on any one of them finds it. `limit`, `context` and `max_scan` are
all clamped, so a hostile query cannot turn into an unbounded scan.

Also included: a fix moving `semantic_search` from `server::` to the crate root
(the `server` module is Linux-gated, which put it out of reach of the macOS
handler and broke that build), and logging initialization in the macOS `trace`
path so trajectory collection failures surface instead of being dropped.

## Related Issue

closes #2970

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Scope

- [x] `sight` (agentsight)

## Checklist

- [x] I have read the Contributing Guide
- [x] My code follows the project's code style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] For `sight`: `cargo clippy -- -D warnings` and `cargo fmt --check` pass
- [x] Lock files are up to date (`Cargo.lock`)

## Testing

Preflight on Linux x86_64, rebased onto current `upstream/main`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings
- `cargo test --workspace` — 35 suites, 0 failures

Runtime verification against a live `agentsight serve`, using **6 real agent
session logs** collected through the pure user-space trajectory collector
(6 trajectories / 790 steps):

- All six step categories classify correctly; multi-label confirmed (one step
  returned as `thinking` + `tool_call` + `tool_result` together)
- Context radius returns the correct adjacent steps
- `truncated` is set and `scanned_trajectories` reports the early stop when
  `limit` is reached
- `source=auto` correctly falls back to `trajectory` when genai data is empty
- `window_days` clamps to 1..30; unknown `source` and unknown `category` both
  return 400 rather than an empty 200

## Additional Notes

The preference rule layer currently treats `language` as the only mutually
exclusive key, and marks both values `conflicting` once each has 3+
observations regardless of ratio. On real data a 36-vs-3 Chinese/English split
is therefore flagged as conflicting and drops out of the Markdown export, which
only emits `active` entries. Separately, `preferred_tool` is mined from agent
tool calls, so it reflects agent behaviour rather than a user-stated
preference and dominates the export by volume. Both are rule-tuning matters
rather than API-contract issues; happy to address them here or in a follow-up,
whichever reviewers prefer.