### PR TITLE
test(tokenless): pin RTK lifecycle state

### DIFF
--- a/src/tokenless/python/tokenless/tests/test_sdk.py
+++ b/src/tokenless/python/tokenless/tests/test_sdk.py
@@ -147,6 +147,34 @@ class TokenlessSdkTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(composed.rewritten)
         self.assertIn("\ncargo test", composed.arguments["command"])
 
+    async def test_rtk_rewrite_state_bypasses_result_optimization(self) -> None:
+        sdk = self.sdk()
+        rewritten = await sdk.before_tool_call(
+            ToolCall(
+                "shell",
+                {"command": "grep needle file.txt"},
+                Attribution("sdk-agent", "sdk-session", "call-rtk"),
+                command_field="command",
+            )
+        )
+        self.assertTrue(rewritten.rewritten)
+
+        sdk._response.compress_text = AsyncMock(
+            side_effect=AssertionError("RTK output reached response compression")
+        )
+        sdk._compress_toon = AsyncMock(
+            side_effect=AssertionError("RTK output reached TOON compression")
+        )
+        result = ToolResult(
+            rewritten,
+            json.dumps({"items": list(range(100))}),
+            ToolStatus.SUCCESS,
+        )
+
+        self.assertIs(await sdk.after_tool_call(result), result)
+        sdk._response.compress_text.assert_not_awaited()
+        sdk._compress_toon.assert_not_awaited()
+
     def test_rtk_anchoring_preserves_shell_separators_and_quotes(self) -> None:
         sdk = self.sdk()
         attribution = Attribution("sdk-agent", "sdk-session", "call-anchor")

--- a/src/tokenless/tests/test_agentscope_middleware.py
+++ b/src/tokenless/tests/test_agentscope_middleware.py
@@ -9,7 +9,7 @@ import json
 import sys
 import types
 import unittest
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
 
@@ -269,6 +269,48 @@ class MiddlewareTest(unittest.IsolatedAsyncioTestCase):
         self.assertIs(output[0], chunk)
         self.assertEqual(output[1].content[0].text, "short")
         self.assertEqual(response.content[0].text, "long " * 100)
+
+    async def test_rtk_state_reaches_the_final_response(self) -> None:
+        async def rewrite(call):
+            return replace(
+                call,
+                arguments={**call.arguments, "command": "rtk grep needle file.txt"},
+                rewritten=True,
+            )
+
+        self.middleware.sdk.before_tool_call = rewrite
+
+        def fail_compression(_value, **_kwargs):
+            raise AssertionError("RTK output reached response compression")
+
+        self.middleware.sdk.runtime.compress_impl = fail_compression
+        source = _Call(
+            "call-rtk",
+            "shell",
+            json.dumps({"command": "grep needle file.txt"}),
+        )
+        chunk = _ToolChunk([_TextBlock("stream")])
+        response = _ToolResponse([_TextBlock(json.dumps({"items": list(range(100))}))])
+
+        async def next_handler(**kwargs):
+            self.assertEqual(
+                json.loads(kwargs["tool_call"].input)["command"],
+                "rtk grep needle file.txt",
+            )
+            yield chunk
+            yield response
+
+        output = await _collect(
+            self.middleware.on_acting(
+                self.agent,
+                {"tool_call": source},
+                next_handler,
+            )
+        )
+
+        self.assertEqual(json.loads(source.input)["command"], "grep needle file.txt")
+        self.assertIs(output[0], chunk)
+        self.assertIs(output[1], response)
 
     async def test_error_adds_environment_guidance(self) -> None:
         response = _ToolResponse(

--- a/src/tokenless/tests/test_agentscope_v1.py
+++ b/src/tokenless/tests/test_agentscope_v1.py
@@ -8,7 +8,7 @@ import json
 import sys
 import types
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -186,6 +186,55 @@ class AgentScopeV1Test(unittest.IsolatedAsyncioTestCase):
         result = await hook(self.agent, {"tool_call": original})
         self.assertIsNot(result["tool_call"], original)
         self.assertEqual(original["input"], {"value": 1})
+
+    async def test_rtk_state_survives_until_the_final_response(self) -> None:
+        async def rewrite(call):
+            return replace(
+                call,
+                arguments={**call.arguments, "command": "rtk grep needle file.txt"},
+                rewritten=True,
+            )
+
+        self.integration.sdk.before_tool_call = rewrite
+        original = {
+            "name": "shell",
+            "id": "call-rtk",
+            "input": {"command": "grep needle file.txt"},
+        }
+        hook = self.agent.hooks[("pre_acting", "tokenless")]
+        transformed = (await hook(self.agent, {"tool_call": original}))["tool_call"]
+
+        self.assertEqual(original["input"]["command"], "grep needle file.txt")
+        self.assertEqual(transformed["input"]["command"], "rtk grep needle file.txt")
+        self.assertIn("call-rtk", self.toolkit.rewritten_calls)
+
+        def fail_compression(_value: str, **_kwargs) -> _CompressionResult:
+            raise AssertionError("RTK output reached response compression")
+
+        self.integration.sdk.runtime.compress_impl = fail_compression
+        partial = _Response(
+            [{"type": "text", "text": "stream"}],
+            is_last=False,
+        )
+        self.assertIs(
+            await self.integration._after_tool(self.toolkit, transformed, partial),
+            partial,
+        )
+        self.assertIn("call-rtk", self.toolkit.rewritten_calls)
+
+        final = _Response(
+            [
+                {
+                    "type": "text",
+                    "text": json.dumps({"items": list(range(100))}),
+                }
+            ]
+        )
+        self.assertIs(
+            await self.integration._after_tool(self.toolkit, transformed, final),
+            final,
+        )
+        self.assertNotIn("call-rtk", self.toolkit.rewritten_calls)
 
     def test_retrieve_name_collision_is_rejected(self) -> None:
         original = self.toolkit.tools["tokenless_retrieve"].original_func


### PR DESCRIPTION
## Why

RTK-rewritten tool calls must carry their output-optimization state through PostTool handling so their results are not compressed a second time. Existing tests covered the individual seams but did not pin the cross-seam handoff in the SDK and AgentScope integrations.

## What changed

- Exercise a real packaged RTK rewrite through the Python SDK and assert that Response Compression and TOON are not invoked afterward.
- Pin AgentScope 1.x per-call state across streaming and final responses, including final state cleanup.
- Pin AgentScope 2.x forwarding of rewritten arguments and preservation of streaming/final response objects.

## Related issue

no-issue: regression contract coverage only

## User / Agent impact

None. This PR changes tests only.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: no production code or public contract changes. Common hooks and OpenClaw remain outside this Protocol v1 characterization.

## Validation

- `python3 tests/test_agentscope_v1.py`
- `python3 tests/test_agentscope_middleware.py`
- `make test-integration`
- `make test-python-runtime` with uv-managed CPython 3.13.15
- `make test-agentscope-integration` against AgentScope 1.0.11, 1.0.21, 2.0.0, 2.0.1, 2.0.3, and 2.0.7.post1

## Documentation and rollback

No documentation change is required for this test-only PR. Revert commit `fadd4055` to remove the added regression coverage.