### PR TITLE
feat(sight): add k8s DaemonSet packaging

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/en/agent-observability/agentsight/deployment.md
@@ -112,6 +112,36 @@ For a Kubernetes sidecar, the same three things matter:
 Keep the Dashboard port inside the cluster and reach it through a Service or port-forward rather
 than exposing 7396 publicly.
 
+## Kubernetes DaemonSet (node-wide)
+
+A DaemonSet gives you one AgentSight pod per node observing every Agent process on that node —
+the sidecar form above watches one pod, this form watches the whole machine. The manifest lives at
+`src/agentsight/packaging/k8s/daemonset.yaml`; build the image with
+`src/agentsight/packaging/docker/Dockerfile`, push it to your registry, and set the `image:` field
+accordingly.
+
+How it works: `hostPID: true` places the pod in the host PID namespace and the probes attach
+host-wide (uprobes register by inode, so Agent binaries inside other pods are covered), while PID
+attribution stays correct because AgentSight reports PIDs in the observer namespace.
+
+```bash
+kubectl apply -f src/agentsight/packaging/k8s/daemonset.yaml
+kubectl -n agentsight rollout status ds/agentsight
+kubectl -n agentsight port-forward ds/agentsight 7396:7396   # then open http://localhost:7396
+```
+
+The manifest requests `BPF` + `PERFMON` + `SYS_PTRACE` capabilities (the last one is needed to
+read `/proc/<pid>/maps` of another uid's process once it is non-dumpable; without it such Agents
+are silently skipped), mounts host `/sys/kernel/btf` read-only, and persists data to hostPath
+`/var/log/sysak`; resource limits mirror the packaged systemd unit (300m CPU / 350Mi memory). It
+talks to no Kubernetes API, so no RBAC is needed. The pod runs only the trace and serve workers
+(`agentsight-start`), so the Risk Enforcement page has no data in this form. To override
+`config.json`, create the `agentsight-config` ConfigMap from the shipped default and uncomment the
+marked blocks in the manifest.
+
+A hostPID-free form (bind-mounting the host procfs instead) is planned once the procfs-root work
+lands; it is not available yet — keep `hostPID: true` until then.
+
 ## macOS
 
 macOS builds contain no eBPF. Two commands exist:

--- a/docs/user-guide/zh/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/deployment.md
@@ -107,6 +107,33 @@ ANOLISA 的容器入口脚本（`docker/docker-entrypoint.sh`）已经按这个�
 
 Dashboard 端口建议只在集群内可达，通过 Service 或端口转发访问，而不是把 7396 直接暴露到公网。
 
+## Kubernetes DaemonSet（节点级）
+
+DaemonSet 让每个节点各跑一个 AgentSight Pod，观测该节点上的所有 Agent 进程——上面的 Sidecar
+形态只看单个 Pod，本形态看整台机器。清单位于 `src/agentsight/packaging/k8s/daemonset.yaml`；
+用 `src/agentsight/packaging/docker/Dockerfile` 构建镜像并推送到你的镜像仓库后，相应修改清单中
+的 `image:` 字段。
+
+工作原理：`hostPID: true` 使 Pod 进入宿主 PID 命名空间，探针在宿主范围挂载（uprobe 按 inode
+注册，其他 Pod 里的 Agent 二进制同样覆盖），而 PID 归属保持正确——AgentSight 按观察者命名空间
+上报 PID。
+
+```bash
+kubectl apply -f src/agentsight/packaging/k8s/daemonset.yaml
+kubectl -n agentsight rollout status ds/agentsight
+kubectl -n agentsight port-forward ds/agentsight 7396:7396   # 然后打开 http://localhost:7396
+```
+
+清单申请了 `BPF` + `PERFMON` + `SYS_PTRACE` 权能（最后一个用于读取其他 uid 进程的
+`/proc/<pid>/maps`——目标进程一旦转为 non-dumpable，缺它会被静默跳过），只读挂载宿主
+`/sys/kernel/btf`，数据持久化到 hostPath `/var/log/sysak`；资源限制与安装包的 systemd unit
+对齐（300m CPU / 350Mi 内存）。它不访问 Kubernetes API，因此无需 RBAC。Pod 内只运行 trace 与
+serve 两个 worker（`agentsight-start`），因此该形态下 Risk Enforcement 页面无数据。如需覆盖
+`config.json`，先用随包默认配置创建 `agentsight-config` ConfigMap，再解开清单中标注的注释块。
+
+免 hostPID 形态（改为 bind 挂载宿主 procfs）计划在 procfs-root 工作落地后提供，目前尚不可
+用——在此之前请保持 `hostPID: true`。
+
 ## macOS
 
 macOS 构建不含 eBPF，只有两个命令：

--- a/src/agentsight/README.md
+++ b/src/agentsight/README.md
@@ -328,6 +328,14 @@ The unit runs as root with `UMask=0077`, so its data under
 Dashboard access commands that read service-owned data. Stop the unit before
 starting a foreground tracer.
 
+### Kubernetes DaemonSet
+
+For node-wide collection in Kubernetes, use the DaemonSet manifest and runtime
+image under `src/agentsight/packaging/` (`k8s/daemonset.yaml` and
+`docker/Dockerfile`). See the
+[deployment guide](../../docs/user-guide/en/agent-observability/agentsight/deployment.md#kubernetes-daemonset-node-wide)
+for prerequisites and verification.
+
 ### Build from Source
 
 ```bash

--- a/src/agentsight/README_zh.md
+++ b/src/agentsight/README_zh.md
@@ -314,6 +314,13 @@ sudo systemctl status agentsight.service
 `/var/log/sysak/.agentsight` 中的数据仅 root 可读。查询服务数据或读取
 Dashboard 访问信息时需要使用 `sudo`。启动前台 tracer 前也要先停止该单元。
 
+### Kubernetes DaemonSet
+
+如需在 Kubernetes 中进行节点级采集，使用 `src/agentsight/packaging/` 下的
+DaemonSet 清单与运行时镜像（`k8s/daemonset.yaml` 与 `docker/Dockerfile`）。
+前置条件与验证步骤见
+[部署指南](../../docs/user-guide/zh/agent-observability/agentsight/deployment.md#kubernetes-daemonset节点级)。
+
 ### 从源码构建
 
 ```bash

--- a/src/agentsight/packaging/docker/Dockerfile
+++ b/src/agentsight/packaging/docker/Dockerfile
@@ -1,0 +1,33 @@
+# AgentSight runtime image.
+#
+# Consumes the release RPM produced by `src/agentsight/scripts/rpm-build.sh`;
+# the binary (with the embedded Dashboard) is not rebuilt here. Build from the
+# repository root after a release build:
+#
+#   docker build -f src/agentsight/packaging/docker/Dockerfile \
+#     --build-arg VERSION=$(git describe --tags --always) -t agentsight:dev .
+#
+# The build context must contain `rpms/<arch>/agentsight-*.rpm`.
+FROM alibaba-cloud-linux-4-registry.cn-hangzhou.cr.aliyuncs.com/alinux4/alinux4:latest
+
+ARG VERSION=unknown
+
+LABEL org.opencontainers.image.title="AgentSight" \
+      org.opencontainers.image.description="eBPF-based observability for AI agents" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.source="https://github.com/alibaba/anolisa"
+
+RUN sed -i -e "s/cloud.aliyuncs/aliyun/g" /etc/yum.repos.d/*.repo
+
+# rpm-build.sh emits arch dirs in RPM naming (x86_64/aarch64); copy the whole
+# tree and glob one level down so Docker's TARGETARCH naming (amd64/arm64)
+# mismatch cannot break the build.
+COPY rpms/ /tmp/rpms/
+RUN dnf install -y /tmp/rpms/*/agentsight-*.rpm && dnf clean all && rm -rf /tmp/rpms
+
+# Dashboard API + UI. Keep it inside the cluster; reach it via port-forward.
+EXPOSE 7396
+
+# agentsight-start supervises `trace` and `serve` and forwards SIGTERM/SIGHUP,
+# so the pod lifecycle (stop, ConfigMap reload via restart) maps onto it.
+ENTRYPOINT ["/usr/local/bin/agentsight-start"]

--- a/src/agentsight/packaging/k8s/daemonset.yaml
+++ b/src/agentsight/packaging/k8s/daemonset.yaml
@@ -1,0 +1,102 @@
+# AgentSight node-wide observability (issue #1238, shape A: hostPID).
+#
+# One pod per node observes every Agent process on that node: `hostPID: true`
+# puts the pod in the host PID namespace, and the eBPF probes attach host-wide
+# (uprobes are registered by inode, so agent binaries in other pods are
+# covered). PID attribution stays correct because AgentSight reports PIDs in
+# the observer namespace (fixed in #2360).
+#
+# Apply:
+#   kubectl apply -f daemonset.yaml
+# Verify:
+#   kubectl -n agentsight rollout status ds/agentsight
+#   kubectl -n agentsight port-forward ds/agentsight 7396:7396
+#
+# Prerequisites on every node: Linux kernel >= 5.8 with BTF
+# (/sys/kernel/btf/vmlinux present). A hostPID-free form that bind-mounts the
+# host procfs instead is planned once the procfs-root work (#2804) lands; it
+# also needs a CLI/env knob that does not exist yet — do not remove
+# `hostPID: true` from this manifest until both ship.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentsight
+  labels:
+    app.kubernetes.io/name: agentsight
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: agentsight
+  namespace: agentsight
+  labels:
+    app.kubernetes.io/name: agentsight
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentsight
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentsight
+    spec:
+      hostPID: true
+      # AgentSight talks to no Kubernetes API; keep the pod credential-free.
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: agentsight
+          # Replace with your registry after building
+          # packaging/docker/Dockerfile (the tag is a placeholder per your
+          # team's registry convention).
+          image: agentsight:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              # BPF+PERFMON: probe load and uprobe attach. SYS_PTRACE: reading
+              # /proc/<pid>/maps of another uid's process requires it once that
+              # process is non-dumpable (verified on kernel 6.6: without it the
+              # read is denied and the agent is silently skipped). On platforms
+              # without fine-grained eBPF capabilities, fall back to
+              # `privileged: true` instead.
+              add: ["BPF", "PERFMON", "SYS_PTRACE"]
+          # Mirrors the packaged systemd unit (CPUQuota=30%,
+          # MemoryMax=350M); the trace loop is sized for these limits.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 350Mi
+          volumeMounts:
+            # CO-RE probes read kernel BTF from the host.
+            - name: btf
+              mountPath: /sys/kernel/btf
+              readOnly: true
+            # Collected data (SQLite) survives pod restarts.
+            - name: data
+              mountPath: /var/log/sysak
+            # Optional: override /etc/agentsight/config.json. Create the
+            # ConfigMap from the shipped default first, e.g.
+            #   kubectl -n agentsight create configmap agentsight-config \
+            #     --from-file=config.json=<repo>/src/agentsight/agentsight.json
+            # then uncomment both blocks.
+            # - name: config
+            #   mountPath: /etc/agentsight/config.json
+            #   subPath: config.json
+            #   readOnly: true
+      volumes:
+        - name: btf
+          hostPath:
+            path: /sys/kernel/btf
+            type: Directory
+        - name: data
+          hostPath:
+            path: /var/log/sysak
+            type: DirectoryOrCreate
+        # - name: config
+        #   configMap:
+        #     name: agentsight-config


### PR DESCRIPTION
## Why

Issue #1238 asks for DaemonSet deployment and monitoring Agents in pods. The kernel-side pieces have landed over the past two months (observer-namespace PID reporting in #2360, container-aware cgroup/container-id extraction), but the repository ships no container image and no DaemonSet manifest, so there is no supported way to run AgentSight node-wide in Kubernetes.

## What changed

- `src/agentsight/packaging/k8s/daemonset.yaml` — one pod per node, `hostPID: true`, `BPF`+`PERFMON`+`SYS_PTRACE` capabilities, read-only host BTF mount, hostPath data persistence, resource limits mirroring the packaged systemd unit, optional ConfigMap override for `config.json`. No RBAC: AgentSight talks to no Kubernetes API.
- `src/agentsight/packaging/docker/Dockerfile` — runtime image that installs the release RPM (the canonical artifact; the binary is not rebuilt) and runs `agentsight-start` as entrypoint so pod lifecycle signals reach both workers.
- Deployment guide (en + zh) gains a "Kubernetes DaemonSet" section; both component READMEs link to it.

The `SYS_PTRACE` entry was added after adversarial review: a hostPID container holding only `BPF`+`PERFMON` cannot read `/proc/<pid>/maps` of a non-dumpable process owned by another uid (verified on kernel 6.6), which would silently skip such Agents.

The hostPID-free form (bind-mounted host procfs) is deliberately not shipped: it depends on the procfs-root work (#2804) plus a CLI/env knob that does not exist yet, and the docs say so instead of implying it works.

## Related issue

refs #1238 (not closing: the hostPID-free shape and the image-publish CI wiring remain open)

## User / Agent impact

New opt-in deployment form. Nothing changes for existing systemd/foreground/container-sidecar users.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: new files plus documentation. The manifest requests elevated capabilities by design (eBPF); it grants no Kubernetes API access and mounts host paths read-only except the data directory.

## Validation

- `scripts/docs-lint.sh` and `scripts/docs-link-check.py` pass (naming, en/zh parity, relative links).
- `daemonset.yaml` parses as Namespace + DaemonSet; capability list and mounts inspected programmatically.
- Capability claim verified empirically (Docker 24, kernel 6.6): with `BPF`+`PERFMON` only, reading `/proc/<pid>/maps` of a `PR_SET_DUMPABLE=0` process owned by another uid is denied; with `SYS_PTRACE` added it succeeds.
- Not covered: a real `docker build` (needs the release RPM in `rpms/<arch>/`) and an apply against a live cluster (none available here). The Dockerfile reuses the base image and install pattern of the existing `docker/Dockerfile.alinux`.

## Documentation and rollback

Docs updated in the same PR (deployment guide en+zh, component READMEs). Rollback: delete the branch files; nothing else references them.
