### PR TITLE
fix(sight): warn when data dir is on overlay storage

### DIFF
--- a/docs/user-guide/en/agent-observability/agentsight/data-and-storage.md
+++ b/docs/user-guide/en/agent-observability/agentsight/data-and-storage.md
@@ -47,6 +47,10 @@ space to the filesystem, run `sudo sqlite3 /var/log/sysak/.agentsight/<db>
 'VACUUM;'` manually during a low-traffic window — VACUUM rebuilds the whole
 file, so stop the service first to avoid tripping the cgroup memory limit.
 
+> For container deployments: retention only matters when the data directory is
+> persistent. Without a volume mount, every container restart wipes all data —
+> see [Containers and sidecars](deployment.md#containers-and-sidecars).
+
 To raise the GenAI cap for the packaged service:
 
 ```bash

--- a/docs/user-guide/en/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/en/agent-observability/agentsight/deployment.md
@@ -109,6 +109,32 @@ For a Kubernetes sidecar, the same three things matter:
    (`shareProcessNamespace: true`) so it can see Agent processes and attach uprobes;
 3. BTF — mount `/sys/kernel/btf` read-only from the host.
 
+**Persistence (mandatory)**: mount a volume at `/var/log/sysak/.agentsight`, or every container restart wipes
+all captured data — the writable layer is recreated from the image on restart (`kubectl exec ... pkill`, OOM,
+image updates, node drains all trigger it). Prefer `hostPath` for host-scoped observation data; use a PVC only
+when the data truly needs to follow the pod across nodes (note the data then lives and dies with the pod);
+`emptyDir` survives container restarts but not pod recreation.
+
+```yaml
+# sidecar reference shape (excerpt)
+volumes:
+  - name: agentsight-data
+    hostPath:
+      path: /var/log/sysak/.agentsight
+      type: DirectoryOrCreate
+containers:
+  - name: agentsight
+    # ...capabilities / shareProcessNamespace as above
+    volumeMounts:
+      - name: agentsight-data
+        mountPath: /var/log/sysak/.agentsight
+```
+
+> Permission note: the databases contain full prompts and responses. `DirectoryOrCreate` creates the host
+> directory root-owned with mode 0755, and the sidecar does not inherit the packaged service's `UMask=0077`.
+> Pre-create the directory with `chmod 700` (or tighten it from an initContainer) before production use so
+> other host users cannot read conversation content.
+
 Keep the Dashboard port inside the cluster and reach it through a Service or port-forward rather
 than exposing 7396 publicly.
 

--- a/docs/user-guide/zh/agent-observability/agentsight/data-and-storage.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/data-and-storage.md
@@ -42,6 +42,9 @@ tracer 自身始终写入默认目录。
 `sudo sqlite3 /var/log/sysak/.agentsight/<db> 'VACUUM;'`（VACUUM 会重建整个文件，
 建议先停止服务，避免 cgroup 内存限制下触发 OOM）。
 
+> 容器部署请注意：这些保留语义只在数据目录持久化时才有意义。不挂卷时容器每次重启都会清空全部数据，
+> 详见 [容器与 Sidecar](deployment.md#容器与-sidecar) 的持久化一节。
+
 给安装包服务调高 GenAI 上限：
 
 ```bash

--- a/docs/user-guide/zh/agent-observability/agentsight/deployment.md
+++ b/docs/user-guide/zh/agent-observability/agentsight/deployment.md
@@ -105,6 +105,30 @@ ANOLISA 的容器入口脚本（`docker/docker-entrypoint.sh`）已经按这个�
    进程并挂载 uprobe；
 3. BTF——以只读方式挂载宿主机的 `/sys/kernel/btf`。
 
+**持久化（必须）**：`/var/log/sysak/.agentsight` 必须挂卷，否则容器每次重启都会清空全部观测数据——
+可写层随容器重建而丢弃（`kubectl exec ... pkill`、OOM、镜像升级、节点漂移都会触发）。主机观测数据推荐
+`hostPath`；PVC 仅在确实需要跨节点迁移时使用（注意数据随 Pod 生命周期走，Pod 删除即丢失）；
+`emptyDir` 只能扛住容器重启，Pod 重建仍会丢失。
+
+```yaml
+# sidecar 参考形态（节选）
+volumes:
+  - name: agentsight-data
+    hostPath:
+      path: /var/log/sysak/.agentsight
+      type: DirectoryOrCreate
+containers:
+  - name: agentsight
+    # ...capabilities / shareProcessNamespace 见上
+    volumeMounts:
+      - name: agentsight-data
+        mountPath: /var/log/sysak/.agentsight
+```
+
+> 权限注意：库里含完整 prompt 与回答。`DirectoryOrCreate` 创建的目录是 root 0755，且 sidecar 没有
+> 打包 systemd 服务的 `UMask=0077`。生产部署前请预建目录并 `chmod 700`（或用 initContainer 收紧权限），
+> 避免主机上其他用户读到对话内容。
+
 Dashboard 端口建议只在集群内可达，通过 Service 或端口转发访问，而不是把 7396 直接暴露到公网。
 
 ## macOS

--- a/src/agentsight/src/bin/cli/serve.rs
+++ b/src/agentsight/src/bin/cli/serve.rs
@@ -44,8 +44,15 @@ impl ServeCommand {
                 .unwrap_or_else(GenAISqliteStore::default_path);
 
             let server_config = super::load_server_config(&self.config);
+            // Initialize logging before warning: standalone `serve` does not
+            // register a logger, so a `log::warn!` before this point is lost.
+            server_config.apply_verbose();
             let auth_config = server_config.server_auth;
             let retention_days = server_config.retention_days;
+
+            if let Some(dir) = db_path.parent() {
+                agentsight::container::warn_if_data_dir_not_persistent(dir);
+            }
 
             actix_web::rt::System::new().block_on(async move {
                 if let Err(e) = run_server(&host, port, db_path, auth_config, retention_days).await

--- a/src/agentsight/src/bin/cli/trace.rs
+++ b/src/agentsight/src/bin/cli/trace.rs
@@ -188,6 +188,11 @@ impl TraceCommand {
             );
             std::process::exit(1);
         };
+        // Warn about the directory the trajectory db will actually live in
+        // (the shared dir or the $HOME fallback), not the unused default.
+        if let Some(dir) = db_path.parent() {
+            agentsight::container::warn_if_data_dir_not_persistent(dir);
+        }
 
         let collector_config = CollectorConfig {
             scan_interval_secs: config.features.trajectory_scan_interval_secs,

--- a/src/agentsight/src/container.rs
+++ b/src/agentsight/src/container.rs
@@ -10,6 +10,7 @@
 
 use lru::LruCache;
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
@@ -154,9 +155,159 @@ fn is_64_hex(s: &str) -> bool {
     s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
+// ─── Storage persistence detection ───────────────────────────────────────────
+
+/// Returns true when `path` resolves onto an overlay filesystem — a
+/// container's writable layer, which is discarded when the container is
+/// recreated (#2826).
+///
+/// Scope: this detects overlayfs only; other non-persistent mounts (e.g.
+/// tmpfs-backed `emptyDir`) are deliberately out of scope — `emptyDir`
+/// survives container restarts, which is the failure mode being flagged.
+///
+/// Reads `/proc/self/mounts`; returns false when the table is unreadable or
+/// no mount matches (unknown is not overlay).
+pub fn path_on_overlayfs(path: &Path) -> bool {
+    // Resolve symlinks first: operators commonly symlink the data dir onto a
+    // mounted volume, and matching the unresolved path would false-positive.
+    // Fall back to the raw path when the directory does not exist yet.
+    let resolved = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let Ok(mounts) = std::fs::read_to_string("/proc/self/mounts") else {
+        return false;
+    };
+    path_on_overlayfs_in(&resolved, &mounts)
+}
+
+/// Warn when the data directory sits on non-persistent storage.
+///
+/// A container restart recreates the writable layer from the image, silently
+/// wiping every database under the directory. Callers invoke this at startup
+/// with the directory that will actually hold the databases; call sites are
+/// once per process by construction (no dedup inside the function).
+pub fn warn_if_data_dir_not_persistent(dir: &Path) {
+    if path_on_overlayfs(dir) {
+        log::warn!(
+            "Data directory {} is on an overlay filesystem (container writable layer): \
+             all captured data is discarded on every container restart. Mount a volume \
+             (hostPath or PVC) at this path for persistence — see the deployment guide, \
+             section \"Containers and sidecars\".",
+            dir.display()
+        );
+    }
+}
+
+/// Evaluate a mount table (the text of `/proc/self/mounts`) for
+/// [`path_on_overlayfs`]; kept separate so tests do not depend on the host.
+fn path_on_overlayfs_in(path: &Path, mounts: &str) -> bool {
+    let target = path.to_string_lossy();
+    let mut best_len = 0usize;
+    let mut overlay = false;
+    for line in mounts.lines() {
+        // Format: <src> <mountpoint> <fstype> <options> <dump> <pass>
+        let mut fields = line.split_whitespace();
+        let (Some(_src), Some(mount_point), Some(fstype)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        // The kernel octal-escapes spaces (and other specials) as \040.
+        let mount_point = mount_point.replace("\\040", " ");
+        let is_prefix = target == mount_point
+            || target.starts_with(&format!("{mount_point}/"))
+            || mount_point == "/";
+        // Longest prefix wins; on ties the later entry wins, because stacked
+        // mounts list the effective (most recently stacked) mount last.
+        if is_prefix && mount_point.len() >= best_len {
+            best_len = mount_point.len();
+            overlay = fstype == "overlay";
+        }
+    }
+    best_len > 0 && overlay
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── path_on_overlayfs ───────────────────────────────────────────────────
+
+    #[test]
+    fn overlayfs_detects_overlay_root() {
+        let overlay_root = "overlay / overlay rw,relatime 0 0\nproc /proc proc rw 0 0\n";
+        assert!(path_on_overlayfs_in(
+            Path::new("/var/log/sysak/.agentsight"),
+            overlay_root
+        ));
+    }
+
+    #[test]
+    fn overlayfs_hostpath_mount_wins_over_overlay_root() {
+        // A hostPath/bind mount over the data dir makes it persistent even
+        // when the root is overlay (longest-prefix match wins).
+        let with_hostpath =
+            "overlay / overlay rw 0 0\n/dev/sda1 /var/log/sysak/.agentsight ext4 rw 0 0\n";
+        assert!(!path_on_overlayfs_in(
+            Path::new("/var/log/sysak/.agentsight"),
+            with_hostpath
+        ));
+    }
+
+    #[test]
+    fn overlayfs_plain_host_is_not_overlay() {
+        let host = "/dev/sda1 / ext4 rw 0 0\nproc /proc proc rw 0 0\n";
+        assert!(!path_on_overlayfs_in(
+            Path::new("/var/log/sysak/.agentsight"),
+            host
+        ));
+    }
+
+    #[test]
+    fn overlayfs_octal_escaped_space_mount_points() {
+        // The kernel octal-escapes spaces in mount points (\040).
+        let spaced =
+            "overlay / overlay rw 0 0\n/dev/sda1 /var/log/sysak/with\\040space ext4 rw 0 0\n";
+        assert!(
+            !path_on_overlayfs_in(Path::new("/var/log/sysak/with space/db"), spaced),
+            "ext4 bind mount must win over the overlay root"
+        );
+        assert!(path_on_overlayfs_in(Path::new("/other"), spaced));
+    }
+
+    #[test]
+    fn overlayfs_stacked_same_mountpoint_last_wins() {
+        // The same mount point mounted twice: the later (most recently
+        // stacked) entry is the one in effect.
+        let stacked = "overlay /data overlay rw 0 0\n/dev/sda1 /data ext4 rw 0 0\n";
+        assert!(
+            !path_on_overlayfs_in(Path::new("/data/db"), stacked),
+            "the later stacked mount is the effective one"
+        );
+    }
+
+    #[test]
+    fn overlayfs_malformed_line_is_skipped() {
+        // A line with fewer than three fields hits the continue branch.
+        let mounts = "garbage\noverlay / overlay rw 0 0\n";
+        assert!(path_on_overlayfs_in(Path::new("/x"), mounts));
+    }
+
+    #[test]
+    fn overlayfs_empty_table_is_not_overlay() {
+        assert!(!path_on_overlayfs_in(Path::new("/x"), ""));
+    }
+
+    #[test]
+    fn overlayfs_wrapper_reads_proc_self_mounts() {
+        // The wrapper must not panic regardless of the host topology; the
+        // boolean outcome is host-dependent.
+        let _ = path_on_overlayfs(Path::new("/"));
+    }
+
+    #[test]
+    fn warn_helper_does_not_panic_on_any_path() {
+        warn_if_data_dir_not_persistent(Path::new("/nonexistent-dir-for-test"));
+        warn_if_data_dir_not_persistent(Path::new("/"));
+    }
 
     #[test]
     fn docker_cgroup_v1() {

--- a/src/agentsight/src/unified.rs
+++ b/src/agentsight/src/unified.rs
@@ -209,6 +209,10 @@ impl AgentSight {
             log::warn!("Failed to load config from {path:?}: {e}, using embedded defaults");
         }
 
+        // Persistence check runs after the config file load so the warning
+        // targets the storage directory actually in effect.
+        crate::container::warn_if_data_dir_not_persistent(&config.storage_base_path);
+
         let all_cmdline_rules = config.cmdline_rules.clone();
 
         // Derive tcp_targets from http_targets (endpoint entries only)


### PR DESCRIPTION
## Why

Deployed as a container, all observation data under `/var/log/sysak/.agentsight` is silently lost on every container restart — the directory lives in the container's writable layer and nothing in the repo told operators to mount a volume (#2826). Deterministic writable-layer semantics, reproduced 3x by the reporter. This also voids the 0.11.0 size-governance work in the container form: bounded retention presumes the data survives in the first place.

## What changed

**Docs (bilingual, per scoped AGENTS.md)** — both `deployment.md` container/sidecar sections now carry a mandatory-persistence paragraph plus a reference sidecar YAML excerpt (`hostPath` at `/var/log/sysak/.agentsight`), and both `data-and-storage.md` retention sections cross-link to it. `hostPath` is recommended for host-scoped observation data; PVC only when data must follow the pod; `emptyDir` noted as surviving container restarts but not pod recreation.

**Code** — a startup warning closes the silent-loss gap: `config::path_on_overlayfs` resolves the storage directory against `/proc/self/mounts` (longest-prefix match, handles the kernel's `\040` space escapes), and `warn_if_data_dir_not_persistent` logs once when it lands on `overlay` (the container writable layer). Wired into all three startup paths: `AgentSight::new` (after the config load, so the warning targets the effective directory), `serve`, and the trajectory-only collector path.

Not included: no standalone manifest artifact (the repo has no K8s-manifest convention or owner; the inline reference YAML covers the intent and adding a file later is additive if real demand shows up), no Dockerfile/entrypoint change.

## Related issue

closes #2826

## User / Agent impact

Operators deploying the container image without a volume now get an explicit warning at startup instead of silent data loss, plus documentation of the correct volume form. No behavior change for host/RPM installs (non-overlay → no warning).

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk: one new warn-level log on a specific mount topology; no functional change. The `Fixes:` trailer is intentionally absent — this is a delivery-form gap, not a regression.

## Validation

On ECS (Alinux, kernel 6.6, rustup 1.89.0 matching CI):

- `cargo fmt --all --check` — pass
- `python3 scripts/check-arch-boundaries.py` — PASS
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib --bins --tests` — **1935 passed, 0 failed**, including the new `test_path_on_overlayfs_parsing` covering: overlay root, hostPath mount winning over the overlay root (longest-prefix), plain host, kernel `\040` space escapes, and empty mount table.

## Documentation and rollback

This PR *is* the documentation change (both languages updated together). Roll back by reverting the single commit; the warning disappears and the docs revert.
