### PR TITLE
fix(cosh-ng): vendor OpenSSL in prebuilt artifacts

### DIFF
--- a/.github/actions/build-cosh-ng-prebuilt/build.sh
+++ b/.github/actions/build-cosh-ng-prebuilt/build.sh
@@ -153,6 +153,7 @@ cargo metadata \
         --release \
         --workspace \
         --locked \
+        --features cosh-core/vendored-openssl \
         --manifest-path src/cosh-ng/Cargo.toml
 )
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -2008,10 +2008,6 @@ runtime_dependency_for_source_build() {
     if [[ "$component" == "sec-core" && "$name" == "systemd" ]]; then
         # Source installs do not install or manage the packaged systemd unit.
         return 0
-    elif [[ "$component" == "cosh-ng" && "$name" == "openssl1.1" ]]; then
-        # The packaged cosh-ng contract targets OpenSSL 1.1, while a source
-        # build links against the host development package.
-        echo 'cosh-ng|openssl|system-package|pkg-config --exists openssl|openssl-devel|libssl-dev|||'
     elif [[ "$component" == "sec-core" && "$name" == "nodejs" ]]; then
         # The manifest only probes runtime presence, while the OpenClaw plugin
         # source build requires the same Node version as copilot-shell.
@@ -2025,6 +2021,11 @@ source_build_runtime_dependencies() {
     local component
     while IFS= read -r component; do
         case "$component" in
+            cosh-ng)
+                # Prebuilt cosh-ng vendors OpenSSL; a source build links
+                # against the host development package.
+                echo 'cosh-ng|openssl|system-package|pkg-config --exists openssl|openssl-devel|libssl-dev|||'
+                ;;
             sight)
                 echo 'sight|node|language-runtime|node --version|nodejs|nodejs||>=20|'
                 ;;

--- a/src/anolisa/manifests/components/cosh-ng/component.toml
+++ b/src/anolisa/manifests/components/cosh-ng/component.toml
@@ -22,12 +22,6 @@ os = ["linux"]
 arch = ["x86_64"]
 
 [[component.dependencies]]
-name = "openssl1.1"
-kind = "system-package"
-probe = "test -e /usr/lib64/libssl.so.1.1 -a -e /usr/lib64/libcrypto.so.1.1"
-packages = { rpm = "openssl1.1", deb = "libssl1.1" }
-
-[[component.dependencies]]
 name = "bash"
 kind = "system-package"
 packages = { rpm = "bash", deb = "bash" }

--- a/src/cosh-ng/.anolisa/component.toml
+++ b/src/cosh-ng/.anolisa/component.toml
@@ -21,11 +21,6 @@ os = ["linux"]
 arch = ["x86_64", "aarch64"]
 
 [[component.dependencies]]
-name = "openssl1.1"
-kind = "system-package"
-packages = { rpm = "openssl1.1", deb = "libssl1.1" }
-
-[[component.dependencies]]
 name = "bash"
 kind = "system-package"
 probe = "bash --version"

--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -2399,6 +2399,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2415,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -48,6 +48,10 @@ tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 wait-timeout.workspace = true
 
+[features]
+# Prebuilt releases must not inherit the builder image's libssl SONAME.
+vendored-openssl = ["reqwest/native-tls-vendored"]
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }

--- a/src/cosh-ng/packaging/raw/verify-binaries.py
+++ b/src/cosh-ng/packaging/raw/verify-binaries.py
@@ -63,10 +63,65 @@ def verify_build_metadata(
             raise ValueError(f"SHA-256 for {binary.name} does not match build metadata")
 
 
+def elf_needed(blob: bytes) -> list[str]:
+    """Collect the DT_NEEDED names of a 64-bit little-endian ELF binary."""
+    phoff, phentsize, phnum = struct.unpack_from("<Q14xHH", blob, 32)
+    dynamic = None
+    for index in range(phnum):
+        offset = phoff + index * phentsize
+        if offset + 56 > len(blob):
+            raise ValueError("program header table is truncated")
+        p_type, _, p_offset, _, _, p_filesz = struct.unpack_from("<II4Q", blob, offset)
+        if p_type == 2:  # PT_DYNAMIC
+            dynamic = (p_offset, p_filesz)
+            break
+    if dynamic is None:
+        return []
+
+    offset, size = dynamic
+    entries = []
+    strtab = None
+    for position in range(offset, min(offset + size, len(blob)) - 15, 16):
+        tag, value = struct.unpack_from("<qQ", blob, position)
+        if tag == 0:  # DT_NULL
+            break
+        if tag == 1:  # DT_NEEDED
+            entries.append(value)
+        elif tag == 5:  # DT_STRTAB
+            strtab = value
+    if not entries:
+        return []
+    if strtab is None:
+        raise ValueError("DT_NEEDED entries without a string table")
+
+    # DT_STRTAB holds a virtual address; map it back through the loadable
+    # segment that contains it.
+    base = None
+    for index in range(phnum):
+        header_offset = phoff + index * phentsize
+        p_type, _, p_offset, p_vaddr, _, p_filesz = struct.unpack_from(
+            "<II4Q", blob, header_offset
+        )
+        if p_type == 1 and p_vaddr <= strtab < p_vaddr + p_filesz:  # PT_LOAD
+            base = p_offset + strtab - p_vaddr
+            break
+    if base is None:
+        raise ValueError("DT_STRTAB is outside every loadable segment")
+
+    names = []
+    for entry in entries:
+        start = base + entry
+        end = blob.find(b"\0", start)
+        if start >= len(blob) or end < 0:
+            raise ValueError("DT_NEEDED name is outside the string table")
+        names.append(blob[start:end].decode("utf-8", "replace"))
+    return names
+
+
 def verify_elf(path: Path, arch: str) -> None:
-    """Verify one 64-bit little-endian ELF binary's architecture."""
-    with path.open("rb") as stream:
-        header = stream.read(64)
+    """Verify one 64-bit little-endian ELF binary's architecture and linkage."""
+    blob = path.read_bytes()
+    header = blob[:64]
     if len(header) < 20 or header[:4] != b"\x7fELF":
         raise ValueError("not an ELF binary")
     if header[4] != 2:
@@ -76,6 +131,17 @@ def verify_elf(path: Path, arch: str) -> None:
     machine = struct.unpack_from("<H", header, 18)[0]
     if machine != ELF_MACHINES[arch]:
         raise ValueError(f"ELF machine {machine} does not match {arch}")
+    if len(blob) >= 64:
+        linked = [
+            name
+            for name in elf_needed(blob)
+            if name.startswith(("libssl.so", "libcrypto.so"))
+        ]
+        if linked:
+            raise ValueError(
+                f"dynamically links OpenSSL ({', '.join(linked)}); "
+                "build with --features cosh-core/vendored-openssl"
+            )
 
 
 def verify_macho(path: Path, arch: str) -> None:

--- a/src/cosh-ng/tests/test-package-raw.sh
+++ b/src/cosh-ng/tests/test-package-raw.sh
@@ -167,6 +167,46 @@ if python3 "$ROOT/packaging/raw/verify-binaries.py" \
     exit 1
 fi
 
+OPENSSL_LINKED="$TMP/openssl-linked-cosh-core"
+python3 - "$OPENSSL_LINKED" <<'PY'
+import struct
+import sys
+
+# Minimal ELF carrying DT_NEEDED libssl.so.1.1, as a non-vendored release
+# build of cosh-core does.
+strings = b"\0libssl.so.1.1\0"
+dynamic = struct.pack("<qQqQqQ", 1, 1, 5, 0x1000, 0, 0)
+vaddr = 0x1000
+strtab_offset = 0x1000
+dynamic_offset = strtab_offset + len(strings)
+
+header = bytearray(64)
+header[:6] = b"\x7fELF\x02\x01"
+struct.pack_into("<H", header, 16, 2)
+struct.pack_into("<H", header, 18, 62)
+struct.pack_into("<I", header, 20, 1)
+struct.pack_into("<Q", header, 32, 64)
+struct.pack_into("<HH", header, 54, 56, 2)
+
+load = struct.pack(
+    "<II6Q", 1, 4, strtab_offset, vaddr, vaddr, len(strings), len(strings), 0x1000
+)
+dyn = struct.pack(
+    "<II6Q", 2, 4, dynamic_offset, 0x2000, 0x2000, len(dynamic), len(dynamic), 8
+)
+
+blob = bytearray(header + load + dyn)
+blob.extend(b"\0" * (strtab_offset - len(blob)))
+blob.extend(strings)
+blob.extend(dynamic)
+open(sys.argv[1], "wb").write(bytes(blob))
+PY
+if python3 "$ROOT/packaging/raw/verify-binaries.py" \
+    --os linux --arch x86_64 "$OPENSSL_LINKED" >/dev/null 2>&1; then
+    echo "ERROR: binary dynamically linking OpenSSL was accepted" >&2
+    exit 1
+fi
+
 EXTRA_BUILD="$TMP/extra-build.toml"
 install -p -m 0644 "$LINUX_ARM64/cosh-ng-build.toml" "$EXTRA_BUILD"
 printf 'unexpected-tool = "%064d"\n' 0 >> "$EXTRA_BUILD"
@@ -386,8 +426,8 @@ linux_dependencies = {
 macos_dependencies = {
     dependency["name"]: dependency for dependency in macos["component"]["dependencies"]
 }
-assert "probe" not in linux_dependencies["openssl1.1"]
-assert "openssl1.1" not in macos_dependencies
+for dependencies in (linux_dependencies, macos_dependencies):
+    assert not [name for name in dependencies if "ssl" in name]
 linux_common = dict(linux["component"])
 macos_common = dict(macos["component"])
 for component in (linux_common, macos_common):
@@ -434,9 +474,7 @@ install -d -m 0755 "$MACOS_EXTRACTED"
 tar -xzf "$TMP/out-macos-arm64/$MACOS_ARTIFACT" -C "$MACOS_EXTRACTED"
 cmp "$MACOS_CONTRACT" "$MACOS_EXTRACTED/.anolisa/component.toml"
 test ! -e "$MACOS_EXTRACTED/share/anolisa/cosh-ng/cosh-gateway@.service.in"
-grep -Fq 'name = "openssl1.1"' "$ROOT/.anolisa/component.toml"
-test -z "$(grep -F 'name = "openssl1.1"' \
-    "$ROOT/.anolisa/component.macos.toml" || true)"
+test -z "$(grep -F 'libssl' "$ROOT/.anolisa/component.toml" || true)"
 grep -Fq 'source = "bin/cosh"' "$ROOT/.anolisa/component.toml"
 grep -Fq 'source = "libexec/anolisa/cosh-ng/cosh-shell"' \
     "$ROOT/.anolisa/component.toml"

--- a/tests/test-build-all-runtime-deps.sh
+++ b/tests/test-build-all-runtime-deps.sh
@@ -116,20 +116,20 @@ test_manifest_parser_covers_component_dependencies() {
 
     assert_contains "$output" 'cosh|node|language-runtime|node --version|nodejs|nodejs||>=20|'
     assert_contains "$output" 'sec-core|bubblewrap|system-package|bwrap --version|bubblewrap|bubblewrap|||'
-    assert_contains "$output" 'cosh-ng|openssl1.1|system-package||openssl1.1|libssl1.1|||'
+    assert_not_contains "$output" 'libssl1.1'
     assert_contains "$output" 'tokenless|python3|system-package|python3 --version|python3|python3|||'
     assert_contains "$output" 'ws-ckpt|btrfs-progs|system-package|mkfs.btrfs --version|btrfs-progs|btrfs-progs|||'
     assert_contains "$output" 'ws-ckpt|rsync|system-package|rsync --version|rsync|rsync|||'
     assert_contains "$output" 'ws-ckpt|btrfs|platform-capability||||btrfs||5.4'
     assert_contains "$output" 'sight|ebpf-btf|platform-capability||||btf||5.8'
-    [[ "$(wc -l < "$output")" -eq 15 ]] || fail "unexpected manifest dependency count"
+    [[ "$(wc -l < "$output")" -eq 14 ]] || fail "unexpected manifest dependency count"
 
     local source_dependency
-    source_dependency="$(runtime_dependency_for_source_build \
-        'cosh-ng|openssl1.1|system-package||openssl1.1|libssl1.1|||')"
+    COMPONENTS=(cosh-ng)
+    source_dependency="$(source_build_runtime_dependencies)"
     [[ "$source_dependency" == \
         'cosh-ng|openssl|system-package|pkg-config --exists openssl|openssl-devel|libssl-dev|||' ]] || \
-        fail "cosh-ng source dependency was not adapted"
+        fail "cosh-ng source build did not require the host OpenSSL headers"
 
     source_dependency="$(runtime_dependency_for_source_build \
         'sec-core|nodejs|system-package|node --version|nodejs|nodejs||||')"


### PR DESCRIPTION
## Summary

Fixes the `cosh-ng` portable prebuilt artifact depending on the host OpenSSL 1.1 runtime.

The currently published prebuilt is dynamically linked against:

```text
libssl.so.1.1
libcrypto.so.1.1
```

which causes `anolisa install cosh-ng` to fail on Ubuntu 24.04 where `libssl1.1` is no longer available.

This change makes the portable prebuilt vendor OpenSSL instead of inheriting the OpenSSL version from the build environment.

## Changes

- add a `vendored-openssl` feature to `cosh-core`
- enable it in the cosh-ng prebuilt build
- remove the OpenSSL 1.1 runtime dependency from the raw cosh-ng manifests
- keep system OpenSSL dependencies for source builds
- add packaging validation to reject Linux prebuilts that dynamically link `libssl` / `libcrypto`
- update regression tests

## Why

Changing the Debian package mapping from `libssl1.1` to `libssl3t64` would not be sufficient because the published binary itself requires the OpenSSL 1.1 ABI.

Vendoring OpenSSL removes that host runtime dependency from the portable artifact.

## Scope

RPM/source builds continue using system OpenSSL as before.

Previously published cosh-ng artifacts remain unchanged and will require a new release to pick up this fix.

Related #2980 