### PR TITLE
fix(sight): repair doc fence nesting and run doctests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -722,6 +722,11 @@ jobs:
         working-directory: src/agentsight
         run: uv run --python 3.11.6 --no-project make test-raw-package
 
+      - name: Test doctests
+        run: |
+          cd src/agentsight
+          cargo test --workspace --exclude ebpf-ifc-engine --exclude actplane-ifc-compiler --doc
+
       - name: Run tests with coverage
         run: |
           cd src/agentsight

--- a/src/agentsight/src/genai/helpers.rs
+++ b/src/agentsight/src/genai/helpers.rs
@@ -534,14 +534,14 @@ impl GenAIBuilder {
     /// ```
     ///
     /// **OpenClaw**: 时间戳方括号
-    /// ```text
+    /// ````text
     /// Sender (untrusted metadata):
     /// ```json
     /// {"label":"...", ...}
     /// ```
     ///
     /// [Tue 2026-03-31 17:19 GMT+8] 用户实际输入
-    /// ```
+    /// ````
     ///
     /// **QwenCode**: `<system-reminder>` 标签块
     /// ```text


### PR DESCRIPTION
Fix the doctest compile failure on clean main: the OpenClaw example nested ```json inside ```text, so rustdoc paired the fences wrong and compiled prose as Rust. Widen the outer fence to four backticks.

Also add `cargo test --doc` to the test-agentsight CI job — llvm-cov does not execute doctests, so broken ones currently land silently.

Closes #2720