### PR TITLE
fix(cosh-ng): [shell] harden secret gate

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction.rs
@@ -5,6 +5,10 @@ use regex::Regex;
 use crate::tools::{classify_command_interaction, OutputStability};
 use crate::types::{CommandBlock, CommandStatus};
 
+mod shell_word;
+
+use shell_word::redact_shell_cookie_headers;
+
 const PROVIDER_COMMAND_MAX_BYTES: usize = 4 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,12 +97,20 @@ fn redact_home_path(value: &str) -> String {
 
 pub(crate) fn redact_sensitive_text(text: &str) -> (String, bool) {
     let (mut redacted, mut changed) = redact_private_key_blocks(text);
+    let next = conservative_cookie_header_pattern()
+        .replace_all(&redacted, "$prefix<redacted>")
+        .into_owned();
+    changed |= next != redacted;
+    redacted = next;
+    let (next, cookie_changed) = redact_shell_cookie_headers(&redacted);
+    redacted = next;
+    changed |= cookie_changed;
     for (pattern, replacement) in [
-        (cookie_header_pattern(), "$prefix<redacted>"),
         (authorization_pattern(), "$prefix$scheme <redacted>"),
         (bearer_pattern(), "$prefix<redacted>"),
         (url_password_pattern(), "$prefix<redacted>@"),
         (sensitive_flag_pattern(), "$prefix<redacted>"),
+        (sensitive_cookie_assignment_pattern(), "$prefix<redacted>"),
         (sensitive_assignment_pattern(), "$prefix<redacted>"),
         (github_token_pattern(), "<redacted>"),
         (opaque_token_pattern(), "<redacted>"),
@@ -152,12 +164,13 @@ fn private_key_marker_range(line: &str, marker: &str) -> Option<(usize, usize)> 
     Some((start, start + marker_end + "PRIVATE KEY-----".len()))
 }
 
-fn cookie_header_pattern() -> &'static Regex {
+fn conservative_cookie_header_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        // The pattern is a compile-time constant covered by the tests below.
-        Regex::new(r"(?im)(?P<prefix>^(?:set-cookie|cookie)\s*:\s*).*$")
-            .unwrap_or_else(|_| unreachable!("static cookie pattern must compile"))
+        Regex::new(
+            r#"(?im)(?P<prefix>(?:^(?:set-cookie|cookie)\s*:\s*|\s(?:set-cookie|cookie)\s*:\s+))[^=\s;,]+\s*=\s*[^\r\n]*"#,
+        )
+        .unwrap_or_else(|_| unreachable!("static cookie pattern must compile"))
     })
 }
 
@@ -185,7 +198,7 @@ fn url_password_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
         // The pattern is a compile-time constant covered by the tests below.
-        Regex::new(r"(?i)(?P<prefix>(?-u:\b)[a-z][a-z0-9+.-]*://[^/\s:@]+:)[^@/\s]+@")
+        Regex::new(r"(?i)(?P<prefix>(?-u:\b)[a-z][a-z0-9+.-]*://[^/\s:@]*:)[^@/\s]+@")
             .unwrap_or_else(|_| unreachable!("static URL password pattern must compile"))
     })
 }
@@ -230,8 +243,7 @@ fn sensitive_assignment_pattern() -> &'static Regex {
                    dashscope[_-]?api[_-]?key|openai[_-]?api[_-]?key|
                    client[_-]?secret|security[_-]?token|refresh[_-]?token|
                    access[_-]?token|github[_-]?token|id[_-]?token|
-                   password|passphrase|passwd|api[_-]?key|apikey|token|secret|
-                   cookie|set[_-]?cookie)
+                   password|passphrase|passwd|api[_-]?key|apikey|token|secret)
                 ["']?
                 \s*(?:=|:)\s*
             )
@@ -247,6 +259,28 @@ fn sensitive_assignment_pattern() -> &'static Regex {
     })
 }
 
+fn sensitive_cookie_assignment_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        // Cookie colons are reserved for structured JSON or name=value headers.
+        Regex::new(
+            r#"(?ix)
+            (?P<prefix>
+                (?:^|[^A-Za-z0-9_-])["']?(?:cookie|set[_-]?cookie)["']?\s*=\s*|
+                ["'](?:cookie|set[_-]?cookie)["']\s*:\s*
+            )
+            (?:
+                "(?:\\(?:\r?\n|[^\r\n])|[^"\\])*(?:"|$)|
+                '[^']*(?:'|$)|
+                \\(?:\r?\n|[^\r\n])|
+                [^\s;&|()<>"'\\]
+            )+
+            "#,
+        )
+        .unwrap_or_else(|_| unreachable!("static cookie assignment pattern must compile"))
+    })
+}
+
 fn github_token_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
@@ -259,9 +293,9 @@ fn github_token_pattern() -> &'static Regex {
 fn opaque_token_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
     PATTERN.get_or_init(|| {
-        // The pattern is a compile-time constant covered by the tests below.
+        // A five-character sk- suffix needs a digit to exclude sk-hynix prose.
         Regex::new(
-            r"(?-u:\b)(?:sk-[A-Za-z0-9_-]{10,}|sk_(?:live|test)_[A-Za-z0-9]{10,}|glpat-[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{20,}|(?i:xox.)-[A-Za-z0-9-]{10,})(?-u:\b)",
+            r"(?-u:\b)(?:sk-(?:[A-Za-z0-9_-]{6,}|[0-9][A-Za-z0-9_-]{4}|[A-Za-z0-9_-][0-9][A-Za-z0-9_-]{3}|[A-Za-z0-9_-]{2}[0-9][A-Za-z0-9_-]{2}|[A-Za-z0-9_-]{3}[0-9][A-Za-z0-9_-]|[A-Za-z0-9_-]{4}[0-9])|sk_(?:live|test)_[A-Za-z0-9]{10,}|glpat-[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,}|AIza[A-Za-z0-9_-]{20,}|(?i:xox.)-[A-Za-z0-9-]{10,})(?-u:\b)",
         )
         .unwrap_or_else(|_| unreachable!("static opaque token pattern must compile"))
     })
@@ -348,9 +382,10 @@ mod tests {
             "cookie=assignment-cookie set-cookie=assignment-set-cookie ",
             "'https://example.test/?client_secret=query-value&next=ok'\n",
             "https://user:url-password@example.test/path\n",
-            r#"{"api_key":"json-value","password":"json-password"}"#,
+            r#"{"api_key":"json-value","password":"json-password","cookie":"json-cookie-value"}"#,
             "\nAuthorization: Basic dXNlcjpwYXNz\n",
             "Cookie: session=private; other=value\n",
+            "Set-Cookie: csrf=set-cookie-header-value; Path=/\n",
         );
 
         let (redacted, changed) = redact_sensitive_text(input);
@@ -371,9 +406,11 @@ mod tests {
             "url-password",
             "json-value",
             "json-password",
+            "json-cookie-value",
             "dXNlcjpwYXNz",
             "session=private",
             "other=value",
+            "set-cookie-header-value",
         ] {
             assert!(!redacted.contains(secret), "{redacted}");
         }

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction/shell_word.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction/shell_word.rs
@@ -1,0 +1,556 @@
+//! Finds static Cookie header shell-word boundaries without executing shell syntax.
+
+#[derive(Clone, Copy)]
+enum InitialContext {
+    Unquoted,
+    Quoted(u8),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ShellContext {
+    Unquoted,
+    SingleQuoted,
+    DoubleQuoted,
+}
+
+enum ScanResult {
+    Precise {
+        value_len: usize,
+        quote_closed: bool,
+    },
+    Dynamic,
+}
+
+struct CookieHeaderMatch {
+    start: usize,
+    prefix_end: usize,
+    value_start: usize,
+    prefix_quote: Option<u8>,
+    initial_context: InitialContext,
+}
+
+enum HeaderSearchResult {
+    Match(CookieHeaderMatch),
+    Dynamic,
+    None,
+}
+
+enum HeaderParseResult {
+    Match(CookieHeaderMatch),
+    Dynamic,
+    NoMatch,
+}
+
+struct StaticChar {
+    byte: u8,
+    raw_start: usize,
+    raw_end: usize,
+    context_before: ShellContext,
+    context_after: ShellContext,
+}
+
+enum StaticCharResult {
+    Char(StaticChar),
+    Dynamic,
+    End(ShellContext),
+}
+
+enum CandidateStartResult {
+    Match(ShellContext),
+    Dynamic,
+    NoMatch,
+}
+
+enum StaticOptionPrefix {
+    Decoded {
+        bytes: Vec<u8>,
+        context: ShellContext,
+    },
+    Dynamic,
+}
+
+/// Redacts static Cookie header values through their complete shell word.
+///
+/// Dynamic shell syntax is redacted as a whole because finding its boundary
+/// requires the complete Bash and Zsh grammars.
+pub(super) fn redact_shell_cookie_headers(text: &str) -> (String, bool) {
+    let mut output = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let mut changed = false;
+
+    loop {
+        let header = match find_cookie_header(text, cursor) {
+            HeaderSearchResult::Match(header) => header,
+            HeaderSearchResult::Dynamic => return ("<redacted>".to_string(), true),
+            HeaderSearchResult::None => break,
+        };
+        let ScanResult::Precise {
+            value_len,
+            quote_closed,
+        } = shell_word_value_len(&text[header.value_start..], header.initial_context)
+        else {
+            return ("<redacted>".to_string(), true);
+        };
+
+        output.push_str(&text[cursor..header.start]);
+        output.push_str(&text[header.start..header.prefix_end]);
+        output.push_str("<redacted>");
+        if let Some(prefix_quote) = header.prefix_quote {
+            let value_keeps_prefix_quote = matches!(header.initial_context, InitialContext::Quoted(quote) if quote == prefix_quote);
+            if !value_keeps_prefix_quote || quote_closed {
+                output.push(prefix_quote as char);
+            }
+        }
+        cursor = header.value_start + value_len;
+        changed = true;
+    }
+    output.push_str(&text[cursor..]);
+
+    (output, changed)
+}
+
+fn find_cookie_header(text: &str, search_start: usize) -> HeaderSearchResult {
+    let bytes = text.as_bytes();
+    for start in search_start..bytes.len() {
+        if !could_start_cookie_header(bytes[start]) {
+            continue;
+        }
+        match is_cookie_header_candidate_start(bytes, start) {
+            CandidateStartResult::Match(context) => {
+                match parse_cookie_header(bytes, start, context) {
+                    HeaderParseResult::Match(header) => {
+                        return HeaderSearchResult::Match(header);
+                    }
+                    HeaderParseResult::Dynamic => return HeaderSearchResult::Dynamic,
+                    HeaderParseResult::NoMatch => {}
+                }
+            }
+            CandidateStartResult::Dynamic => {
+                for context in [
+                    ShellContext::Unquoted,
+                    ShellContext::SingleQuoted,
+                    ShellContext::DoubleQuoted,
+                ] {
+                    if !matches!(
+                        parse_cookie_header(bytes, start, context),
+                        HeaderParseResult::NoMatch
+                    ) {
+                        return HeaderSearchResult::Dynamic;
+                    }
+                }
+            }
+            CandidateStartResult::NoMatch => {}
+        }
+    }
+
+    HeaderSearchResult::None
+}
+
+fn could_start_cookie_header(byte: u8) -> bool {
+    matches!(byte, b'c' | b'C' | b's' | b'S' | b'\'' | b'"' | b'\\')
+}
+
+fn is_cookie_header_candidate_start(bytes: &[u8], start: usize) -> CandidateStartResult {
+    if start == 0 || is_shell_word_boundary(bytes[start - 1]) {
+        return CandidateStartResult::Match(ShellContext::Unquoted);
+    }
+
+    let word_start = bytes[..start]
+        .iter()
+        .rposition(|byte| is_shell_word_boundary(*byte))
+        .map_or(0, |boundary| boundary + 1);
+    match decode_static_option_prefix(&bytes[word_start..start]) {
+        StaticOptionPrefix::Decoded {
+            bytes: option_prefix,
+            context,
+        } if option_prefix == b"--header=" || is_attached_short_header_option(&option_prefix) => {
+            CandidateStartResult::Match(context)
+        }
+        StaticOptionPrefix::Dynamic => CandidateStartResult::Dynamic,
+        StaticOptionPrefix::Decoded { .. } => CandidateStartResult::NoMatch,
+    }
+}
+
+fn decode_static_option_prefix(raw_prefix: &[u8]) -> StaticOptionPrefix {
+    let mut decoded = Vec::with_capacity(raw_prefix.len());
+    let mut cursor = 0;
+    let mut context = ShellContext::Unquoted;
+
+    loop {
+        match next_static_char(raw_prefix, cursor, context) {
+            StaticCharResult::Char(character) => {
+                decoded.push(character.byte);
+                cursor = character.raw_end;
+                context = character.context_after;
+            }
+            StaticCharResult::Dynamic => return StaticOptionPrefix::Dynamic,
+            StaticCharResult::End(final_context) => {
+                return StaticOptionPrefix::Decoded {
+                    bytes: decoded,
+                    context: final_context,
+                };
+            }
+        }
+    }
+}
+
+fn is_attached_short_header_option(option_prefix: &[u8]) -> bool {
+    option_prefix.starts_with(b"-")
+        && !option_prefix.starts_with(b"--")
+        && option_prefix.ends_with(b"H")
+        && option_prefix[1..]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'#')
+}
+
+fn parse_cookie_header(
+    bytes: &[u8],
+    start: usize,
+    initial_context: ShellContext,
+) -> HeaderParseResult {
+    for expected_prefix in [b"set-cookie:".as_slice(), b"cookie:".as_slice()] {
+        let mut cursor = start;
+        let mut context = initial_context;
+        if !consume_static_literal(bytes, &mut cursor, &mut context, expected_prefix) {
+            continue;
+        }
+
+        match consume_static_whitespace(bytes, &mut cursor, &mut context) {
+            StaticCharResult::Dynamic => return HeaderParseResult::Dynamic,
+            StaticCharResult::Char(_) | StaticCharResult::End(_) => {}
+        }
+        let prefix_end = cursor;
+        let prefix_quote = context_quote(context);
+        let mut name_seen = false;
+
+        loop {
+            match next_static_char(bytes, cursor, context) {
+                StaticCharResult::Char(character) if character.byte == b'=' && name_seen => {
+                    return cookie_header_match(start, prefix_end, prefix_quote, character);
+                }
+                StaticCharResult::Char(character)
+                    if character.byte.is_ascii_whitespace() && name_seen =>
+                {
+                    match consume_static_whitespace(bytes, &mut cursor, &mut context) {
+                        StaticCharResult::Dynamic => return HeaderParseResult::Dynamic,
+                        StaticCharResult::Char(_) | StaticCharResult::End(_) => {}
+                    }
+                    return match next_static_char(bytes, cursor, context) {
+                        StaticCharResult::Char(character) if character.byte == b'=' => {
+                            cookie_header_match(start, prefix_end, prefix_quote, character)
+                        }
+                        StaticCharResult::Dynamic => HeaderParseResult::Dynamic,
+                        StaticCharResult::Char(_) | StaticCharResult::End(_) => {
+                            HeaderParseResult::NoMatch
+                        }
+                    };
+                }
+                StaticCharResult::Char(character)
+                    if matches!(character.byte, b'=' | b';' | b',') =>
+                {
+                    return HeaderParseResult::NoMatch;
+                }
+                StaticCharResult::Char(character) => {
+                    name_seen = true;
+                    cursor = character.raw_end;
+                    context = character.context_after;
+                }
+                StaticCharResult::Dynamic => return HeaderParseResult::Dynamic,
+                StaticCharResult::End(_) => return HeaderParseResult::NoMatch,
+            }
+        }
+    }
+
+    HeaderParseResult::NoMatch
+}
+
+fn cookie_header_match(
+    start: usize,
+    prefix_end: usize,
+    prefix_quote: Option<u8>,
+    equals: StaticChar,
+) -> HeaderParseResult {
+    HeaderParseResult::Match(CookieHeaderMatch {
+        start,
+        prefix_end,
+        value_start: equals.raw_end,
+        prefix_quote,
+        initial_context: initial_context(equals.context_after),
+    })
+}
+
+fn consume_static_literal(
+    bytes: &[u8],
+    cursor: &mut usize,
+    context: &mut ShellContext,
+    expected: &[u8],
+) -> bool {
+    for expected_byte in expected {
+        let StaticCharResult::Char(character) = next_static_char(bytes, *cursor, *context) else {
+            return false;
+        };
+        if !character.byte.eq_ignore_ascii_case(expected_byte) {
+            return false;
+        }
+        *cursor = character.raw_end;
+        *context = character.context_after;
+    }
+
+    true
+}
+
+fn consume_static_whitespace(
+    bytes: &[u8],
+    cursor: &mut usize,
+    context: &mut ShellContext,
+) -> StaticCharResult {
+    loop {
+        match next_static_char(bytes, *cursor, *context) {
+            StaticCharResult::Char(character) if character.byte.is_ascii_whitespace() => {
+                *cursor = character.raw_end;
+                *context = character.context_after;
+            }
+            StaticCharResult::Char(character) => {
+                *cursor = character.raw_start;
+                *context = character.context_before;
+                return StaticCharResult::Char(character);
+            }
+            other => return other,
+        }
+    }
+}
+
+fn next_static_char(
+    bytes: &[u8],
+    mut cursor: usize,
+    mut context: ShellContext,
+) -> StaticCharResult {
+    loop {
+        let Some(&byte) = bytes.get(cursor) else {
+            return StaticCharResult::End(context);
+        };
+        match context {
+            ShellContext::Unquoted => match byte {
+                b'\'' => {
+                    context = ShellContext::SingleQuoted;
+                    cursor += 1;
+                }
+                b'"' => {
+                    context = ShellContext::DoubleQuoted;
+                    cursor += 1;
+                }
+                b'\\' => match bytes.get(cursor + 1) {
+                    Some(b'\r') if bytes.get(cursor + 2) == Some(&b'\n') => cursor += 3,
+                    Some(b'\n') => cursor += 2,
+                    Some(&escaped) => {
+                        return StaticCharResult::Char(StaticChar {
+                            byte: escaped,
+                            raw_start: cursor,
+                            raw_end: cursor + 2,
+                            context_before: context,
+                            context_after: context,
+                        });
+                    }
+                    None => return StaticCharResult::End(context),
+                },
+                b'$' | b'`' => return StaticCharResult::Dynamic,
+                boundary if is_shell_word_boundary(boundary) => {
+                    return StaticCharResult::End(context);
+                }
+                _ => {
+                    return StaticCharResult::Char(StaticChar {
+                        byte,
+                        raw_start: cursor,
+                        raw_end: cursor + 1,
+                        context_before: context,
+                        context_after: context,
+                    });
+                }
+            },
+            ShellContext::SingleQuoted => {
+                if byte == b'\'' {
+                    context = ShellContext::Unquoted;
+                    cursor += 1;
+                } else {
+                    return StaticCharResult::Char(StaticChar {
+                        byte,
+                        raw_start: cursor,
+                        raw_end: cursor + 1,
+                        context_before: context,
+                        context_after: context,
+                    });
+                }
+            }
+            ShellContext::DoubleQuoted => match byte {
+                b'"' => {
+                    context = ShellContext::Unquoted;
+                    cursor += 1;
+                }
+                b'\\' => match bytes.get(cursor + 1) {
+                    Some(b'\r') if bytes.get(cursor + 2) == Some(&b'\n') => cursor += 3,
+                    Some(b'\n') => cursor += 2,
+                    Some(&escaped) if matches!(escaped, b'$' | b'`' | b'"' | b'\\') => {
+                        return StaticCharResult::Char(StaticChar {
+                            byte: escaped,
+                            raw_start: cursor,
+                            raw_end: cursor + 2,
+                            context_before: context,
+                            context_after: context,
+                        });
+                    }
+                    Some(_) => {
+                        return StaticCharResult::Char(StaticChar {
+                            byte,
+                            raw_start: cursor,
+                            raw_end: cursor + 1,
+                            context_before: context,
+                            context_after: context,
+                        });
+                    }
+                    None => return StaticCharResult::End(context),
+                },
+                b'$' | b'`' => return StaticCharResult::Dynamic,
+                _ => {
+                    return StaticCharResult::Char(StaticChar {
+                        byte,
+                        raw_start: cursor,
+                        raw_end: cursor + 1,
+                        context_before: context,
+                        context_after: context,
+                    });
+                }
+            },
+        }
+    }
+}
+
+fn initial_context(context: ShellContext) -> InitialContext {
+    match context {
+        ShellContext::Unquoted => InitialContext::Unquoted,
+        ShellContext::SingleQuoted => InitialContext::Quoted(b'\''),
+        ShellContext::DoubleQuoted => InitialContext::Quoted(b'"'),
+    }
+}
+
+fn context_quote(context: ShellContext) -> Option<u8> {
+    match context {
+        ShellContext::Unquoted => None,
+        ShellContext::SingleQuoted => Some(b'\''),
+        ShellContext::DoubleQuoted => Some(b'"'),
+    }
+}
+
+fn shell_word_value_len(value: &str, initial_context: InitialContext) -> ScanResult {
+    let bytes = value.as_bytes();
+    let (mut cursor, quote_closed) = match initial_context {
+        InitialContext::Unquoted => (0, false),
+        InitialContext::Quoted(outer_quote) => match scan_quoted_segment(bytes, 0, outer_quote) {
+            ScanResult::Precise {
+                value_len,
+                quote_closed,
+            } => (value_len, quote_closed),
+            ScanResult::Dynamic => return ScanResult::Dynamic,
+        },
+    };
+
+    if matches!(initial_context, InitialContext::Quoted(_)) && !quote_closed {
+        return ScanResult::Precise {
+            value_len: cursor,
+            quote_closed: false,
+        };
+    }
+
+    while cursor < bytes.len() && !is_shell_word_boundary(bytes[cursor]) {
+        match bytes[cursor] {
+            b'\'' | b'"' => match scan_quoted_segment(bytes, cursor + 1, bytes[cursor]) {
+                ScanResult::Precise { value_len, .. } => cursor = value_len,
+                ScanResult::Dynamic => return ScanResult::Dynamic,
+            },
+            b'\\' => cursor = skip_shell_escape(bytes, cursor),
+            b'$' | b'`' => return ScanResult::Dynamic,
+            _ => cursor += 1,
+        }
+    }
+
+    if bytes.get(cursor) == Some(&b'(')
+        || (matches!(bytes.get(cursor), Some(b'<') | Some(b'>'))
+            && bytes.get(cursor + 1) == Some(&b'('))
+    {
+        return ScanResult::Dynamic;
+    }
+    if matches!(initial_context, InitialContext::Unquoted)
+        && starts_additional_cookie_pair(bytes, cursor)
+    {
+        return ScanResult::Dynamic;
+    }
+
+    ScanResult::Precise {
+        value_len: cursor,
+        quote_closed,
+    }
+}
+
+fn starts_additional_cookie_pair(bytes: &[u8], cursor: usize) -> bool {
+    if bytes.get(cursor) != Some(&b';') {
+        return false;
+    }
+
+    let mut next = cursor + 1;
+    while bytes
+        .get(next)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        next += 1;
+    }
+    let name_start = next;
+    while bytes
+        .get(next)
+        .is_some_and(|byte| !byte.is_ascii_whitespace() && !matches!(byte, b'=' | b';' | b','))
+    {
+        next += 1;
+    }
+    if next == name_start {
+        return false;
+    }
+    while bytes
+        .get(next)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        next += 1;
+    }
+
+    bytes.get(next) == Some(&b'=')
+}
+
+fn scan_quoted_segment(bytes: &[u8], mut cursor: usize, quote: u8) -> ScanResult {
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            byte if byte == quote => {
+                return ScanResult::Precise {
+                    value_len: cursor + 1,
+                    quote_closed: true,
+                };
+            }
+            b'\\' if quote == b'"' => cursor = skip_shell_escape(bytes, cursor),
+            b'$' | b'`' if quote == b'"' => return ScanResult::Dynamic,
+            _ => cursor += 1,
+        }
+    }
+
+    ScanResult::Precise {
+        value_len: cursor,
+        quote_closed: false,
+    }
+}
+
+fn skip_shell_escape(bytes: &[u8], cursor: usize) -> usize {
+    match bytes.get(cursor + 1) {
+        Some(b'\r') if bytes.get(cursor + 2) == Some(&b'\n') => cursor + 3,
+        Some(_) => cursor + 2,
+        None => cursor + 1,
+    }
+}
+
+fn is_shell_word_boundary(byte: u8) -> bool {
+    byte.is_ascii_whitespace() || matches!(byte, b';' | b'&' | b'|' | b'(' | b')' | b'<' | b'>')
+}

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction_boundary_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction_boundary_tests.rs
@@ -23,10 +23,290 @@ fn redacts_sensitive_patterns_adjacent_to_cjk_text() {
         ),
         ("令牌bearer abc123def456ghi789", "abc123def456ghi789"),
         ("看一下https://user:p4ssw0rd@example.com/x", "p4ssw0rd"),
+        ("看一下http://:s3cr3t42@example.test/", "s3cr3t42"),
     ] {
         let (redacted, changed) = redact_sensitive_text(input);
 
         assert!(changed, "{input}");
         assert!(!redacted.contains(secret), "{redacted}");
+    }
+}
+
+#[test]
+fn redacts_short_sk_tokens_without_matching_prose() {
+    for secret in ["sk-abc123", "sk-fbaa6"] {
+        for input in [
+            format!("key是{secret}"),
+            format!("（{secret}）"),
+            format!("密钥为{secret}"),
+            format!("key：{secret}"),
+        ] {
+            let (redacted, changed) = redact_sensitive_text(&input);
+            assert!(changed, "short token not detected: {input}");
+            assert!(!redacted.contains(secret), "{redacted}");
+        }
+    }
+
+    for input in [
+        "sk-hynix 内存条什么价格",
+        "npm_package_version 怎么读",
+        "cookie: 头是干什么的",
+        "cookie: header meaning",
+        "bearer 是什么认证方式",
+        "shf_test 文件在哪",
+        "xsk-abc123",
+        "http://:@example.test/",
+    ] {
+        assert_eq!(
+            redact_sensitive_text(input),
+            (input.to_string(), false),
+            "safe control rejected: {input}"
+        );
+    }
+}
+
+#[test]
+fn redacts_embedded_cookie_headers_and_keeps_bare_token_prose() {
+    for (input, secret, expected) in [
+        (
+            "curl -H 'Cookie: session=abc123def'",
+            "session=abc123def",
+            "curl -H 'Cookie: <redacted>'",
+        ),
+        (
+            "2026-08-31 req Cookie: session=abc123def; Path=/",
+            "session=abc123def",
+            "2026-08-31 req Cookie: <redacted>",
+        ),
+        (
+            "curl -H Cookie:session=abc123def --region cn",
+            "session=abc123def",
+            "curl -H Cookie:<redacted> --region cn",
+        ),
+        (
+            r"curl -H Cookie:\ session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -H Cookie:\ <redacted> --region cn",
+        ),
+        (
+            r#"curl -H"Cookie: session=quoted-cookie-value-42" --region cn"#,
+            "quoted-cookie-value-42",
+            r#"curl -H"Cookie: <redacted>" --region cn"#,
+        ),
+        (
+            "curl -H'Cookie: session=quoted-cookie-value-42' --region cn",
+            "quoted-cookie-value-42",
+            "curl -H'Cookie: <redacted>' --region cn",
+        ),
+        (
+            "curl -HCookie:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -HCookie:<redacted> --region cn",
+        ),
+        (
+            r#"curl --header="Set-Cookie: csrf=quoted-cookie-value-42" --region cn"#,
+            "quoted-cookie-value-42",
+            r#"curl --header="Set-Cookie: <redacted>" --region cn"#,
+        ),
+        (
+            r"curl -HCookie\:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -HCookie\:<redacted> --region cn",
+        ),
+        (
+            "curl -sH'Cookie: session=quoted-cookie-value-42' --region cn",
+            "quoted-cookie-value-42",
+            "curl -sH'Cookie: <redacted>' --region cn",
+        ),
+        (
+            r#"curl -fsSLH"Cookie: session=quoted-cookie-value-42" --region cn"#,
+            "quoted-cookie-value-42",
+            r#"curl -fsSLH"Cookie: <redacted>" --region cn"#,
+        ),
+        (
+            r"curl -sHCookie\:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -sHCookie\:<redacted> --region cn",
+        ),
+        (
+            "curl -s'H'Cookie:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -s'H'Cookie:<redacted> --region cn",
+        ),
+        (
+            r"curl -s\HCookie:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -s\HCookie:<redacted> --region cn",
+        ),
+        (
+            r#"curl "-HCookie: session=whole-option-secret-42" --region cn"#,
+            "whole-option-secret-42",
+            r#"curl "-HCookie: <redacted>" --region cn"#,
+        ),
+        (
+            "curl '-HCookie: session=whole-option-secret-42' --region cn",
+            "whole-option-secret-42",
+            "curl '-HCookie: <redacted>' --region cn",
+        ),
+        (
+            r"curl -H Cookie\:session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -H Cookie\:<redacted> --region cn",
+        ),
+        (
+            "curl -H Cookie':'session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -H Cookie':'<redacted> --region cn",
+        ),
+        (
+            "curl -H Coo'kie:'session=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -H Coo'kie:'<redacted> --region cn",
+        ),
+        (
+            "curl -H 'Cookie: session = quoted-cookie-value-42' --region cn",
+            "quoted-cookie-value-42",
+            "curl -H 'Cookie: <redacted>' --region cn",
+        ),
+        (
+            "curl -H Cookie:'session'=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -H Cookie:'<redacted>' --region cn",
+        ),
+        (
+            r"curl -H Set\-Cookie\:csrf=quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            r"curl -H Set\-Cookie\:<redacted> --region cn",
+        ),
+        (
+            "Cookie:session=abc123def; other=second-cookie-value\nsafe",
+            "second-cookie-value",
+            "Cookie:<redacted>\nsafe",
+        ),
+        (
+            r#"curl -H "Cookie: session=literal\$value" --region cn"#,
+            r#"literal\$value"#,
+            r#"curl -H "Cookie: <redacted>" --region cn"#,
+        ),
+        (
+            r#"curl -H 'Cookie: session="quoted-cookie-value-42"'"#,
+            "quoted-cookie-value-42",
+            "curl -H 'Cookie: <redacted>'",
+        ),
+        (
+            r#"curl -H "Set-Cookie: csrf='quoted-cookie-value-42'; Path=/""#,
+            "quoted-cookie-value-42",
+            "curl -H \"Set-Cookie: <redacted>\"",
+        ),
+        (
+            r#"Cookie: session="quoted-cookie-value-42""#,
+            "quoted-cookie-value-42",
+            "Cookie: <redacted>",
+        ),
+        (
+            r#"curl -H "Cookie: session=\"quoted-cookie-value-42\"""#,
+            "quoted-cookie-value-42",
+            "curl -H \"Cookie: <redacted>\"",
+        ),
+        (
+            "curl -H 'Cookie: session='quoted-cookie-value-42",
+            "quoted-cookie-value-42",
+            "curl -H 'Cookie: <redacted>'",
+        ),
+        (
+            "curl -H 'Cookie: session='quoted-cookie-value-42 --region cn",
+            "quoted-cookie-value-42",
+            "curl -H 'Cookie: <redacted>' --region cn",
+        ),
+        (
+            r#"curl -H "Cookie: session="'quoted-cookie-value-42'"#,
+            "quoted-cookie-value-42",
+            "curl -H \"Cookie: <redacted>\"",
+        ),
+        (
+            r#"curl -H 'Set-Cookie: csrf='"quoted cookie value 42""#,
+            "quoted cookie value 42",
+            "curl -H 'Set-Cookie: <redacted>'",
+        ),
+        (
+            "curl -H 'Cookie: session='$(printf quoted-cookie-value-42)",
+            "quoted-cookie-value-42",
+            "<redacted>",
+        ),
+        (
+            "curl -H 'Cookie: session='$(printf $(true) quoted-cookie-value-42) --region cn",
+            "quoted-cookie-value-42",
+            "<redacted>",
+        ),
+        (
+            "curl -H 'Cookie: session='$(printf '%s' \\\n  quoted-cookie-value-42)",
+            "quoted-cookie-value-42",
+            "<redacted>",
+        ),
+        (
+            r#"curl -H 'Cookie: session='$(printf quoted-cookie-value-42) --region "$(uname)""#,
+            "quoted-cookie-value-42",
+            "<redacted>",
+        ),
+        (
+            "curl -H 'Cookie: session='$(case x in x) printf '%s' quoted-cookie-value-42;; esac)",
+            "quoted-cookie-value-42",
+            "<redacted>",
+        ),
+        (
+            "curl -H 'Cookie: session='$(printf case) --region cn",
+            "case",
+            "<redacted>",
+        ),
+        (
+            r#"curl -H "Set-Cookie: csrf="`printf 'quoted cookie value 42'`"#,
+            "quoted cookie value 42",
+            "<redacted>",
+        ),
+    ] {
+        let (redacted, changed) = redact_sensitive_text(input);
+
+        assert!(changed, "embedded Cookie header not detected: {input}");
+        assert!(
+            !redacted.contains(secret),
+            "cookie value leaked: {redacted}"
+        );
+        assert_eq!(redacted, expected);
+    }
+
+    for input in [
+        "curl -H 'Cookie: session='$(if true; then case x in x) printf '%s' quoted-cookie-value-42;; esac; fi) --region cn",
+        "curl -H 'Cookie: session='$(printf '%s' start # )\nprintf '%s' quoted-cookie-value-42) --region cn",
+        "curl -H 'Cookie: session='$(cat <<'EOF'\nquoted-cookie-value-42)\nEOF\n) --region cn",
+        "curl -H Cookie:session=$COOKIE_VALUE --region cn",
+        "curl -s${HEADER_OPTION}Cookie:session=quoted-cookie-value-42 --region cn",
+        r#"curl ${HEADER_OPTION}"Cookie: session=dynamic-option-secret-42" --region cn"#,
+        "curl -H 'Cookie: session='<(printf quoted-cookie-value-42) --region cn",
+        "request Cookie:session=quoted-cookie-value-42; other=second-cookie-value",
+        "Cookie: first=first-cookie-value\ncurl -H 'Cookie: session='$(printf quoted-cookie-value-42)",
+    ] {
+        let (redacted, changed) = redact_sensitive_text(input);
+
+        assert!(changed, "dynamic Cookie header not detected: {input}");
+        assert_eq!(redacted, "<redacted>");
+    }
+
+    // A header-shaped cookie requires name=value to avoid redacting prose.
+    for input in [
+        "Cookie: abc123baretoken",
+        "Set-Cookie: abc123baretoken",
+        r"curl -H Cookie\:header-meaning",
+        r"curl -H Crookie\:session=quoted-cookie-value-42",
+        r#"tool x-H"Cookie: session=quoted-cookie-value-42""#,
+        r#"tool x-sH"Cookie: session=quoted-cookie-value-42""#,
+        r#"curl --sH"Cookie: session=quoted-cookie-value-42""#,
+        r#"tool -s'Hx'Cookie:session=quoted-cookie-value-42"#,
+        r#"curl --header-label="Cookie: session=quoted-cookie-value-42""#,
+    ] {
+        assert_eq!(
+            redact_sensitive_text(input),
+            (input.to_string(), false),
+            "bare token boundary changed: {input}"
+        );
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
@@ -243,20 +243,31 @@ _cosh_command_has_secret() {
   local lower
   lower="$(printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
   case "$lower" in
-    *"-----begin "*"private key-----"*|*"bearer "*|*"://"*":"*"@"*|*ghp_*|*github_pat_*|*glpat-*|*npm_*|*hf_*|*xox?-*|*aiza*)
-      return 0
-      ;;
-    *ltai????????????*)
-      return 0
-      ;;
-    *akia????????????????*|*asia????????????????*)
-      return 0
-      ;;
-    sk-*|sk_live_*|sk_test_*|*" sk-"*|*"=sk-"*|*":sk-"*|*"\"sk-"*|*"'sk-"*|*" sk_live_"*|*" sk_test_"*|*"=sk_live_"*|*"=sk_test_"*)
+    *"-----begin "*"private key-----"*)
       return 0
       ;;
   esac
-  # Keep recovered-history privacy aligned with Rust's canonical assignment detector.
+  # ASCII boundaries allow credentials next to CJK text without matching inside
+  # identifiers such as npm_package_version or shf_test.
+  local bearer_pattern='(^|[^a-z0-9_])bearer[[:space:]]+[a-z0-9._~+/=-]+([^a-z0-9_]|$)'
+  local url_password_pattern='[a-z][a-z0-9+.-]*://[^/[:space:]:@]*:[^@/[:space:]]+@'
+  local github_pattern='(^|[^a-z0-9_])(gh[pousr]_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{20,})([^a-z0-9_]|$)'
+  # A five-character sk- suffix needs a digit so short keys stay private
+  # without classifying the sk-hynix product name as a credential.
+  local short_sk_pattern='([0-9][a-z0-9_-]{4}|[a-z0-9_-][0-9][a-z0-9_-]{3}|[a-z0-9_-]{2}[0-9][a-z0-9_-]{2}|[a-z0-9_-]{3}[0-9][a-z0-9_-]|[a-z0-9_-]{4}[0-9])'
+  local opaque_pattern="(^|[^a-z0-9_])(sk-([a-z0-9_-]{6,}|${short_sk_pattern})|sk_(live|test)_[a-z0-9]{10,}|glpat-[a-z0-9_-]{10,}|npm_[a-z0-9]{20,}|hf_[a-z0-9]{20,}|aiza[a-z0-9_-]{20,}|xox[a-z]-[a-z0-9-]{10,})([^a-z0-9_]|$)"
+  local alibaba_pattern='(^|[^a-z0-9_])ltai[a-z0-9]{12,32}([^a-z0-9_]|$)'
+  local aws_pattern='(^|[^a-z0-9_])(akia|asia)[a-z0-9]{16}([^a-z0-9_]|$)'
+  if [[ "$lower" =~ $bearer_pattern
+     || "$lower" =~ $url_password_pattern
+     || "$lower" =~ $github_pattern
+     || "$lower" =~ $opaque_pattern
+     || "$lower" =~ $alibaba_pattern
+     || "$lower" =~ $aws_pattern ]]; then
+    return 0
+  fi
+
+  # Shell gating protects native history; Rust separately redacts persisted evidence.
   local canonical_assignment_key
   canonical_assignment_key='(alibaba[_-]?cloud[_-]?access[_-]?key[_-]?id|'
   canonical_assignment_key+='aws[_-]?access[_-]?key[_-]?id|access[_-]?key[_-]?id|'
@@ -265,23 +276,38 @@ _cosh_command_has_secret() {
   canonical_assignment_key+='client[_-]?secret|security[_-]?token|refresh[_-]?token|'
   canonical_assignment_key+='access[_-]?token|github[_-]?token|id[_-]?token|'
   canonical_assignment_key+='password|passphrase|passwd|api[_-]?key|apikey|token|secret|'
-  canonical_assignment_key+='cookie|set[_-]?cookie)'
-  local canonical_assignment_pattern="(^|[^a-z0-9_-])['\"]?${canonical_assignment_key}['\"]?[[:space:]]*(=|:)[[:space:]]*[^[:space:]]"
-  if [[ "$lower" =~ $canonical_assignment_pattern ]]; then
+  canonical_assignment_key+='authorization)'
+  local assignment_value="['\"]?[^[:space:]]"
+  # Match canonical suffixes across complete shell assignment identifiers.
+  local canonical_assignment_pattern="(^|[^a-z0-9_-])['\"]?([a-z_][a-z0-9_]*)?${canonical_assignment_key}['\"]?[[:space:]]*(=|:)[[:space:]]*${assignment_value}"
+  local canonical_flag_pattern="(^|[^a-z0-9_-])--${canonical_assignment_key}([[:space:]]+|=)[[:space:]]*${assignment_value}"
+  local cookie_key='(cookie|set[_-]?cookie)'
+  local cookie_flag_pattern="(^|[^a-z0-9_-])--${cookie_key}([[:space:]]+|=)[[:space:]]*[^[:space:]]"
+  local cookie_assignment_pattern="(^|[^a-z0-9_-])['\"]?${cookie_key}['\"]?[[:space:]]*=[[:space:]]*[^[:space:]]"
+  local cookie_json_pattern="(^|[^a-z0-9_-])['\"]${cookie_key}['\"][[:space:]]*:[[:space:]]*['\"][^'\"]+['\"]"
+  local cookie_header_pattern="(^|[[:space:]'\"])${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local attached_cookie_header_pattern="(^|[[:space:]])(-[[:alnum:]#]*h|--header=)${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local dynamic_cookie_header_pattern='(\$|`)[^;&|]*'
+  dynamic_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  # Operators inside a closed substitution do not terminate its outer word.
+  local dynamic_substitution_cookie_header_pattern='(\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
+  dynamic_substitution_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  # Quote removal and backslash escapes can construct a static Cookie prefix
+  # even when the raw command does not contain a contiguous `Cookie:` token.
+  local static_cookie_input="${lower//\\/}"
+  static_cookie_input="${static_cookie_input//\'/}"
+  static_cookie_input="${static_cookie_input//\"/}"
+  if [[ "$lower" =~ $canonical_assignment_pattern
+     || "$lower" =~ $canonical_flag_pattern
+     || "$lower" =~ $cookie_flag_pattern
+     || "$lower" =~ $cookie_assignment_pattern
+     || "$lower" =~ $cookie_json_pattern
+     || "$static_cookie_input" =~ $cookie_header_pattern
+     || "$static_cookie_input" =~ $attached_cookie_header_pattern
+     || "$static_cookie_input" =~ $dynamic_cookie_header_pattern
+     || "$static_cookie_input" =~ $dynamic_substitution_cookie_header_pattern ]]; then
     return 0
   fi
-  local key
-  for key in password passwd passphrase token access_token access-token refresh_token refresh-token id_token id-token secret client_secret client-secret api_key api-key apikey access_key_id access-key-id access_key_secret access-key-secret security_token security-token authorization cookie set-cookie; do
-    local assignment_pattern="(^|[^a-z0-9_-])['\"]?${key}['\"]?[[:space:]]*(=|:)[[:space:]]*[^[:space:]]"
-    if [[ "$lower" =~ $assignment_pattern ]]; then
-      return 0
-    fi
-    case "$lower" in
-      *"$key="*|*"$key:"*|*"--$key "*|*"--$key="*)
-        return 0
-        ;;
-    esac
-  done
   return 1
 }
 _cosh_scrub_sensitive_native_history() {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -2,7 +2,8 @@
 // byte-identical to the pre-split marker.rs; golden coverage lives in
 // osc_tests.rs and tests/shell_host/marker.rs.
 pub(in crate::shell_host) fn zsh_marker_script() -> &'static str {
-    r#"
+    concat!(
+        r#"
 if [[ -n "${COSH_OSC_MARKER_LOADED:-}" ]]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -381,33 +382,9 @@ _cosh_restore_handoff_pager_policy() {
   done
   return 0
 }
-_cosh_command_has_secret() {
-  local lower="${(L)1}"
-  case "$lower" in
-    *"-----begin "*"private key-----"*|*"bearer "*|*"://"*":"*"@"*|*ghp_*|*github_pat_*|*glpat-*|*npm_*|*hf_*|*xox?-*|*aiza*)
-      return 0
-      ;;
-    *ltai????????????*)
-      return 0
-      ;;
-    *akia????????????????*|*asia????????????????*)
-      return 0
-      ;;
-    sk-*|sk_live_*|sk_test_*|*" sk-"*|*"=sk-"*|*":sk-"*|*"\"sk-"*|*"'sk-"*|*" sk_live_"*|*" sk_test_"*|*"=sk_live_"*|*"=sk_test_"*)
-      return 0
-      ;;
-  esac
-  local key
-  for key in password passwd passphrase token access_token access-token refresh_token refresh-token id_token id-token secret client_secret client-secret api_key api-key apikey access_key_id access-key-id access_key_secret access-key-secret security_token security-token authorization cookie set-cookie; do
-    case "$lower" in
-      *"$key="*|*"$key:"*|*"--$key "*|*"--$key="*)
-        return 0
-        ;;
-    esac
-  done
-  return 1
-}
-_cosh_zshaddhistory_marker() {
+"#,
+        include_str!("zsh_secret_detector.zsh"),
+        r#"_cosh_zshaddhistory_marker() {
   setopt localoptions noxtrace
   local command="${1%$'\n'}"
   if _cosh_is_handoff_wrapper "$command"; then
@@ -695,5 +672,6 @@ autoload -Uz add-zsh-hook
 add-zsh-hook zshaddhistory _cosh_zshaddhistory_marker
 add-zsh-hook preexec _cosh_preexec_marker
 add-zsh-hook precmd _cosh_precmd_marker
-"#
+"#,
+    )
 }

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh
@@ -1,0 +1,74 @@
+_cosh_command_has_secret() {
+  local jwt_pattern='(^|[^A-Za-z0-9_])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}([^A-Za-z0-9_]|$)'
+  if [[ "$1" =~ $jwt_pattern ]]; then
+    return 0
+  fi
+  local lower="${(L)1}"
+  case "$lower" in
+    *"-----begin "*"private key-----"*)
+      return 0
+      ;;
+  esac
+  # ASCII boundaries allow credentials next to CJK text without matching inside
+  # identifiers such as npm_package_version or shf_test.
+  local bearer_pattern='(^|[^a-z0-9_])bearer[[:space:]]+[a-z0-9._~+/=-]+([^a-z0-9_]|$)'
+  local url_password_pattern='[a-z][a-z0-9+.-]*://[^/[:space:]:@]*:[^@/[:space:]]+@'
+  local github_pattern='(^|[^a-z0-9_])(gh[pousr]_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{20,})([^a-z0-9_]|$)'
+  # A five-character sk- suffix needs a digit so short keys stay private
+  # without classifying the sk-hynix product name as a credential.
+  local short_sk_pattern='([0-9][a-z0-9_-]{4}|[a-z0-9_-][0-9][a-z0-9_-]{3}|[a-z0-9_-]{2}[0-9][a-z0-9_-]{2}|[a-z0-9_-]{3}[0-9][a-z0-9_-]|[a-z0-9_-]{4}[0-9])'
+  local opaque_pattern="(^|[^a-z0-9_])(sk-([a-z0-9_-]{6,}|${short_sk_pattern})|sk_(live|test)_[a-z0-9]{10,}|glpat-[a-z0-9_-]{10,}|npm_[a-z0-9]{20,}|hf_[a-z0-9]{20,}|aiza[a-z0-9_-]{20,}|xox[a-z]-[a-z0-9-]{10,})([^a-z0-9_]|$)"
+  local alibaba_pattern='(^|[^a-z0-9_])ltai[a-z0-9]{12,32}([^a-z0-9_]|$)'
+  local aws_pattern='(^|[^a-z0-9_])(akia|asia)[a-z0-9]{16}([^a-z0-9_]|$)'
+  if [[ "$lower" =~ $bearer_pattern
+     || "$lower" =~ $url_password_pattern
+     || "$lower" =~ $github_pattern
+     || "$lower" =~ $opaque_pattern
+     || "$lower" =~ $alibaba_pattern
+     || "$lower" =~ $aws_pattern ]]; then
+    return 0
+  fi
+
+  # Shell gating protects native history; Rust separately redacts persisted evidence.
+  local canonical_assignment_key
+  canonical_assignment_key='(alibaba[_-]?cloud[_-]?access[_-]?key[_-]?id|'
+  canonical_assignment_key+='aws[_-]?access[_-]?key[_-]?id|access[_-]?key[_-]?id|'
+  canonical_assignment_key+='aws[_-]?secret[_-]?access[_-]?key|access[_-]?key[_-]?secret|'
+  canonical_assignment_key+='dashscope[_-]?api[_-]?key|openai[_-]?api[_-]?key|'
+  canonical_assignment_key+='client[_-]?secret|security[_-]?token|refresh[_-]?token|'
+  canonical_assignment_key+='access[_-]?token|github[_-]?token|id[_-]?token|'
+  canonical_assignment_key+='password|passphrase|passwd|api[_-]?key|apikey|token|secret|'
+  canonical_assignment_key+='authorization)'
+  local assignment_value="['\"]?[^[:space:]]"
+  # Match canonical suffixes across complete shell assignment identifiers.
+  local canonical_assignment_pattern="(^|[^a-z0-9_-])['\"]?([a-z_][a-z0-9_]*)?${canonical_assignment_key}['\"]?[[:space:]]*(=|:)[[:space:]]*${assignment_value}"
+  local canonical_flag_pattern="(^|[^a-z0-9_-])--${canonical_assignment_key}([[:space:]]+|=)[[:space:]]*${assignment_value}"
+  local cookie_key='(cookie|set[_-]?cookie)'
+  local cookie_flag_pattern="(^|[^a-z0-9_-])--${cookie_key}([[:space:]]+|=)[[:space:]]*[^[:space:]]"
+  local cookie_assignment_pattern="(^|[^a-z0-9_-])['\"]?${cookie_key}['\"]?[[:space:]]*=[[:space:]]*[^[:space:]]"
+  local cookie_json_pattern="(^|[^a-z0-9_-])['\"]${cookie_key}['\"][[:space:]]*:[[:space:]]*['\"][^'\"]+['\"]"
+  local cookie_header_pattern="(^|[[:space:]'\"])${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local attached_cookie_header_pattern="(^|[[:space:]])(-[[:alnum:]#]*h|--header=)${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local dynamic_cookie_header_pattern='(\$|`)[^;&|]*'
+  dynamic_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  # Operators inside a closed substitution do not terminate its outer word.
+  local dynamic_substitution_cookie_header_pattern='(\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
+  dynamic_substitution_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  # Quote removal and backslash escapes can construct a static Cookie prefix
+  # even when the raw command does not contain a contiguous `Cookie:` token.
+  local static_cookie_input="${lower//\\/}"
+  static_cookie_input="${static_cookie_input//\'/}"
+  static_cookie_input="${static_cookie_input//\"/}"
+  if [[ "$lower" =~ $canonical_assignment_pattern
+     || "$lower" =~ $canonical_flag_pattern
+     || "$lower" =~ $cookie_flag_pattern
+     || "$lower" =~ $cookie_assignment_pattern
+     || "$lower" =~ $cookie_json_pattern
+     || "$static_cookie_input" =~ $cookie_header_pattern
+     || "$static_cookie_input" =~ $attached_cookie_header_pattern
+     || "$static_cookie_input" =~ $dynamic_cookie_header_pattern
+     || "$static_cookie_input" =~ $dynamic_substitution_cookie_header_pattern ]]; then
+    return 0
+  fi
+  return 1
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -53,45 +53,39 @@ fn shell_function<'a>(script: &'a str, name: &str) -> &'a str {
 }
 
 #[test]
-fn bash_secret_detector_matches_canonical_jwt_shape() {
-    if Command::new("bash").arg("--version").output().is_err() {
-        return;
-    }
-    let script = include_str!("../../src/shell_host/marker/bash.sh");
-    let function = shell_function(script, "_cosh_command_has_secret");
-    let command = format!("{function}\n_cosh_command_has_secret \"$1\"");
-    for input in [
+fn shell_secret_detectors_match_canonical_shapes_and_boundaries() {
+    let detectors = [
+        ("bash", include_str!("../../src/shell_host/marker/bash.sh")),
+        (
+            "zsh",
+            include_str!("../../src/shell_host/marker/zsh_secret_detector.zsh"),
+        ),
+    ];
+    let sensitive = [
         "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature",
         "inspect eyJabcde.fghijk.lmnopq now",
-    ] {
-        let status = Command::new("bash")
-            .args(["-c", command.as_str(), "cosh-marker-test", input])
-            .status()
-            .expect("run bash JWT detector");
-        assert!(status.success(), "secret not detected: {input}");
-    }
-    for input in [
-        "xeyJabcde.fghijk.lmnopq",
-        "eyJabcd.fghijk.lmnopq",
-        "eyJabcde.fghi.lmnopq",
-    ] {
-        let status = Command::new("bash")
-            .args(["-c", command.as_str(), "cosh-marker-test", input])
-            .status()
-            .expect("run bash JWT control");
-        assert!(!status.success(), "safe control rejected: {input}");
-    }
-}
-
-#[test]
-fn bash_secret_detector_matches_canonical_assignment_shape() {
-    if Command::new("bash").arg("--version").output().is_err() {
-        return;
-    }
-    let script = include_str!("../../src/shell_host/marker/bash.sh");
-    let function = shell_function(script, "_cosh_command_has_secret");
-    let command = format!("{function}\n_cosh_command_has_secret \"$1\"");
-    for input in [
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+        "Bearer abc",
+        "https://user:password@example.test/path",
+        "http://:s3cr3t42@example.test/",
+        "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+        "glpat-abcdefghijklmnop",
+        "npm_abcdefghijklmnopqrstuvwxyz123456",
+        "hf_abcdefghijklmnopqrstuvwxyz123456",
+        "xoxb-1234567890abcdefghijklmnop",
+        "AIzaabcdefghijklmnopqrstuvwxyz123456",
+        "LTAI5tExampleAccessKey",
+        "AKIA1234567890ABCDEF",
+        "ASIA1234567890ABCDEF",
+        "sk-fbaa6",
+        "sk-abc123",
+        "sk_live_abcdefghijklmnop",
+        "sk_test_abcdefghijklmnop",
+        "key是sk-abc123",
+        "（sk-abc123）",
+        "密钥为sk-abc123",
+        "key：sk-abc123",
         "你好 \"token\" = TEST_ONLY_RECOVERY_SECRET",
         "inspect 'client-secret' : TEST_ONLY_RECOVERY_SECRET",
         "你好 AWS_SECRET_ACCESS_KEY=TEST_ONLY_RECOVERY_SECRET",
@@ -101,26 +95,115 @@ fn bash_secret_detector_matches_canonical_assignment_shape() {
         "你好 DASHSCOPE_API_KEY = TEST_ONLY_RECOVERY_SECRET",
         "你好 GITHUB_TOKEN = TEST_ONLY_RECOVERY_SECRET",
         "你好 ALIBABA_CLOUD_ACCESS_KEY_ID = TEST_ONLY_RECOVERY_SECRET",
-    ] {
-        let status = Command::new("bash")
-            .args(["-c", command.as_str(), "cosh-marker-test", input])
-            .status()
-            .expect("run Bash assignment detector");
-        assert!(status.success(), "secret not detected: {input}");
-    }
-    for input in [
+        "MEMORY_OPENAI_API_KEY=TEST_ONLY_RECOVERY_SECRET",
+        "MY_TOKEN=TEST_ONLY_RECOVERY_SECRET",
+        "FOO_PASSWORD=TEST_ONLY_RECOVERY_SECRET",
+        "AUTH_REFRESH_TOKEN=TEST_ONLY_RECOVERY_SECRET",
+        "AUTHTOKEN=TEST_ONLY_RECOVERY_SECRET",
+        "myAccessToken=TEST_ONLY_RECOVERY_SECRET",
+        "dbPassword=TEST_ONLY_RECOVERY_SECRET",
+        "serviceSecret=TEST_ONLY_RECOVERY_SECRET",
+        "customApiKey=TEST_ONLY_RECOVERY_SECRET",
+        "你好 MY_OPENAI_API_KEY = public-name",
+        "tool --password 'correct horse battery staple'",
+        "tool --access-token=TEST_ONLY_RECOVERY_SECRET",
+        "curl --cookie session=supersecret",
+        "tool --set-cookie csrf=supersecret",
+        "curl --cookie=session=supersecret",
+        "TOKEN=$SECRET",
+        "API_KEY=${VALUE}",
+        "tool --password \"$PASSWORD\"",
+        "tool --token '$TOKEN'",
+        r"token=\escaped",
+        "TOKEN=`secret-command`",
+        "TOKEN=秘密123",
+        "cookie=session-secret",
+        "set_cookie=session-secret",
+        r#"{"cookie":"json-cookie-secret"}"#,
+        "Cookie: session=session-secret",
+        "Set-Cookie: session=session-secret; Path=/",
+        r"curl -H Cookie:\ session=quoted-cookie-value-42",
+        r"curl -H Cookie\:session=quoted-cookie-value-42",
+        "curl -H Cookie':'session=quoted-cookie-value-42",
+        "curl -H Coo'kie:'session=quoted-cookie-value-42",
+        r"curl -H Set\-Cookie\:csrf=quoted-cookie-value-42",
+        r#"curl -H"Cookie: session=quoted-cookie-value-42""#,
+        "curl -H'Cookie: session=quoted-cookie-value-42'",
+        "curl -HCookie:session=quoted-cookie-value-42",
+        r#"curl --header="Set-Cookie: csrf=quoted-cookie-value-42""#,
+        r"curl -HCookie\:session=quoted-cookie-value-42",
+        "curl -sH'Cookie: session=quoted-cookie-value-42'",
+        r#"curl -fsSLH"Cookie: session=quoted-cookie-value-42""#,
+        r"curl -sHCookie\:session=quoted-cookie-value-42",
+        "curl -s'H'Cookie:session=quoted-cookie-value-42",
+        r"curl -s\HCookie:session=quoted-cookie-value-42",
+        r#"curl "-HCookie: session=whole-option-secret-42""#,
+        "curl '-HCookie: session=whole-option-secret-42'",
+        r#"curl ${HEADER_OPTION}"Cookie: session=dynamic-option-secret-42" https://example.test"#,
+        r#"curl ${HEADER_OPTION}'Cookie: session=dynamic-option-secret-42' https://example.test"#,
+        r#"curl $(printf -- -H)"Cookie: session=dynamic-option-secret-42" https://example.test"#,
+        r#"curl `printf -- -H`"Cookie: session=dynamic-option-secret-42" https://example.test"#,
+        r#"curl $(true; printf -- -H)"Cookie: session=semicolon-dynamic-secret-42" https://example.test"#,
+        r#"curl $(true && printf -- -H)"Cookie: session=and-dynamic-secret-42" https://example.test"#,
+        r#"curl $(printf -- -H | cat)"Cookie: session=pipe-dynamic-secret-42" https://example.test"#,
+        r#"curl `true; printf -- -H`"Cookie: session=backtick-dynamic-secret-42" https://example.test"#,
+        r#"curl $(printf %s "$(printf -- -H)")"Cookie: session=nested-dynamic-secret-42" https://example.test"#,
+    ];
+    let safe = [
+        "sk-hynix 内存条什么价格",
+        "npm_package_version 怎么读",
+        "cookie: 头是干什么的",
+        "cookie: header meaning",
+        "bearer 是什么认证方式",
+        "shf_test 文件在哪",
+        "xsk-abc123",
+        "ghp_documentation",
+        "npm_package_identifier",
+        "hf_model_name",
+        "https://example.test/path:docs@example",
+        "http://:@example.test/",
+        "eyJabcd.fghijk.lmnopq",
+        "eyJabcde.fghi.lmnopq",
+        "xeyJabcde.fghijk.lmnopq",
         "你好 token candidate",
         "inspect monkey = value",
         "inspect token =",
         "你好 AWS_ACCESS_KEY_ID candidate",
         "你好 AWS_ACCESS_KEY_ID =",
-        "你好 MY_OPENAI_API_KEY = public-name",
-    ] {
-        let status = Command::new("bash")
-            .args(["-c", command.as_str(), "cosh-marker-test", input])
-            .status()
-            .expect("run Bash assignment control");
-        assert!(!status.success(), "safe control rejected: {input}");
+        "你好 MY_OPENAI_API_KEY_LABEL = public-name",
+        "你好 MY_TOKEN_COUNT = 5",
+        r"curl -H Cookie\:header-meaning",
+        r"curl -H Crookie\:session=quoted-cookie-value-42",
+        r#"tool x-H"Cookie: session=quoted-cookie-value-42""#,
+        r#"tool x-sH"Cookie: session=quoted-cookie-value-42""#,
+        r#"curl --sH"Cookie: session=quoted-cookie-value-42""#,
+        r#"tool -s'Hx'Cookie:session=quoted-cookie-value-42"#,
+        r#"curl --header-label="Cookie: session=quoted-cookie-value-42""#,
+        r#"curl ${HEADER_OPTION}"Crookie: session=dynamic-option-secret-42""#,
+        r#"echo $HOME; tool xCookie:session=dynamic-option-secret-42"#,
+        r#"echo $(printf x); tool xCookie:session=dynamic-option-secret-42"#,
+    ];
+
+    for (shell, script) in detectors {
+        if Command::new(shell).arg("--version").output().is_err() {
+            continue;
+        }
+        let function = shell_function(script, "_cosh_command_has_secret");
+        let command = format!("{function}\n_cosh_command_has_secret \"$1\"");
+        for input in sensitive {
+            let status = Command::new(shell)
+                .args(["-c", command.as_str(), "cosh-marker-test", input])
+                .status()
+                .unwrap_or_else(|error| panic!("run {shell} secret detector: {error}"));
+            assert!(status.success(), "{shell}: secret not detected: {input}");
+        }
+        for input in safe {
+            let status = Command::new(shell)
+                .args(["-c", command.as_str(), "cosh-marker-test", input])
+                .status()
+                .unwrap_or_else(|error| panic!("run {shell} secret control: {error}"));
+            assert!(!status.success(), "{shell}: safe control rejected: {input}");
+        }
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/relay.rs
@@ -1370,6 +1370,9 @@ fn raw_relay_bash_excludes_secrets_from_history_and_journal() {
     let edited_secret = "history-edited-secret-value";
     let access_key = "LTAI5tExampleAccessKey";
     let url_password = "history-url-password";
+    let empty_user_url_password = "history-empty-user-url-password";
+    let dynamic_option_secret = "history-dynamic-option-secret";
+    let nested_dynamic_option_secret = "history-nested-dynamic-option-secret";
     let mut config = ShellHostConfig::new("bash-secret-history-test", &work_dir);
     config.native_mode = false;
     let output = run_raw_relay_bash_with_actions(
@@ -1385,6 +1388,26 @@ fn raw_relay_bash_excludes_secrets_from_history_and_journal() {
             RawRelayAction::wait(Duration::from_millis(100)),
             RawRelayAction::line(format!(": https://user:{url_password}@example.test")),
             RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(": http://:{empty_user_url_password}@example.test")),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line("HEADER_OPTION=-H"),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": ${{HEADER_OPTION}}\"Cookie: session={dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(true; printf -- -H)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(true && printf -- -H)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(printf -- -H | cat)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
             RawRelayAction::line(format!("history > {}", shell_arg(&history_snapshot))),
             RawRelayAction::wait(Duration::from_millis(100)),
             RawRelayAction::line("exit"),
@@ -1399,17 +1422,26 @@ fn raw_relay_bash_excludes_secrets_from_history_and_journal() {
     assert!(!history.contains(edited_secret), "{history}");
     assert!(!history.contains(access_key), "{history}");
     assert!(!history.contains(url_password), "{history}");
+    assert!(!history.contains(empty_user_url_password), "{history}");
+    assert!(!history.contains(dynamic_option_secret), "{history}");
+    assert!(!history.contains(nested_dynamic_option_secret), "{history}");
     assert!(!journal.contains(secret), "{journal}");
     assert!(!journal.contains(edited_secret), "{journal}");
     assert!(!journal.contains(access_key), "{journal}");
     assert!(!journal.contains(url_password), "{journal}");
+    assert!(!journal.contains(empty_user_url_password), "{journal}");
+    assert!(!journal.contains(dynamic_option_secret), "{journal}");
+    assert!(!journal.contains(nested_dynamic_option_secret), "{journal}");
     assert!(ledger_from_output(&output)
         .blocks
         .iter()
         .all(|block| !block.command.contains(secret)
             && !block.command.contains(edited_secret)
             && !block.command.contains(access_key)
-            && !block.command.contains(url_password)));
+            && !block.command.contains(url_password)
+            && !block.command.contains(empty_user_url_password)
+            && !block.command.contains(dynamic_option_secret)
+            && !block.command.contains(nested_dynamic_option_secret)));
 }
 
 #[test]
@@ -1428,6 +1460,9 @@ fn raw_relay_zsh_excludes_secrets_from_history_and_journal() {
     let secret = "history-secret-value";
     let access_key = "LTAI5tExampleAccessKey";
     let url_password = "history-url-password";
+    let empty_user_url_password = "history-empty-user-url-password";
+    let dynamic_option_secret = "history-dynamic-option-secret";
+    let nested_dynamic_option_secret = "history-nested-dynamic-option-secret";
     let mut config = ShellHostConfig::new("zsh-secret-history-test", &work_dir);
     config.native_mode = false;
     let output = run_raw_relay_zsh_with_actions(
@@ -1438,6 +1473,26 @@ fn raw_relay_zsh_excludes_secrets_from_history_and_journal() {
             RawRelayAction::line(format!(": {access_key}")),
             RawRelayAction::wait(Duration::from_millis(100)),
             RawRelayAction::line(format!(": https://user:{url_password}@example.test")),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(": http://:{empty_user_url_password}@example.test")),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line("HEADER_OPTION=-H"),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": ${{HEADER_OPTION}}\"Cookie: session={dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(true; printf -- -H)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(true && printf -- -H)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line(format!(
+                ": $(printf -- -H | cat)\"Cookie: session={nested_dynamic_option_secret}\""
+            )),
             RawRelayAction::wait(Duration::from_millis(100)),
             RawRelayAction::line(format!("fc -l -100 > {}", shell_arg(&history_snapshot))),
             RawRelayAction::wait(Duration::from_millis(100)),
@@ -1452,15 +1507,24 @@ fn raw_relay_zsh_excludes_secrets_from_history_and_journal() {
     assert!(!history.contains(secret), "{history}");
     assert!(!history.contains(access_key), "{history}");
     assert!(!history.contains(url_password), "{history}");
+    assert!(!history.contains(empty_user_url_password), "{history}");
+    assert!(!history.contains(dynamic_option_secret), "{history}");
+    assert!(!history.contains(nested_dynamic_option_secret), "{history}");
     assert!(!journal.contains(secret), "{journal}");
     assert!(!journal.contains(access_key), "{journal}");
     assert!(!journal.contains(url_password), "{journal}");
+    assert!(!journal.contains(empty_user_url_password), "{journal}");
+    assert!(!journal.contains(dynamic_option_secret), "{journal}");
+    assert!(!journal.contains(nested_dynamic_option_secret), "{journal}");
     assert!(ledger_from_output(&output)
         .blocks
         .iter()
         .all(|block| !block.command.contains(secret)
             && !block.command.contains(access_key)
-            && !block.command.contains(url_password)));
+            && !block.command.contains(url_password)
+            && !block.command.contains(empty_user_url_password)
+            && !block.command.contains(dynamic_option_secret)
+            && !block.command.contains(nested_dynamic_option_secret)));
 }
 
 #[test]


### PR DESCRIPTION
## Why

The shell secret gate uses raw substring matches that redact normal prose while missing short credentials next to CJK text. Bash, Zsh, and Rust also disagree on JWT, assignment, Bearer, and Cookie shapes, leaving history and journal privacy dependent on the entry path.

## What changed

Replace substring checks with boundary-aware credential shapes shared by the Bash and Zsh contracts. Align Rust redaction for short `sk-` tokens and structured, quoted, escaped, shell-word-concatenated, or curl-option-attached Cookie forms. Attached curl headers now decode static option prefixes before accepting `--header=` or any single short-option cluster ending in `H`, including `-H`, `-sH`, and `-fsSLH`. Static Cookie shell words retain independent trailing arguments; dynamic prefixes or values, backticks, and ambiguous compact multi-pair headers redact the whole field.

## Related issue

Closes #2155

## User / Agent impact

Normal prose such as `sk-hynix`, `npm_package_version`, and Cookie/Bearer questions remains visible in local evidence. Short CJK-adjacent credentials and structured secret assignments are consistently excluded from native history and redacted before journal persistence.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed

The change intentionally adjusts the security-sensitive classification boundary but does not change public CLI, configuration, or cross-component contracts. Static Cookie values preserve unrelated command arguments; commands with dynamic Cookie construction may lose provider-facing context because privacy takes precedence when the shell-word boundary cannot be proven.

## Validation

Local Linux aarch64 on commit `b26e7b71`:

- `cargo test --package cosh-shell --lib evidence::redaction::tests -- --nocapture` — 8 passed.
- `cargo test --package cosh-shell --lib redaction_boundary_tests -- --nocapture` — 3 passed.
- `cargo test --package cosh-shell --test shell_host shell_secret_detectors_match_canonical_shapes_and_boundaries -- --nocapture` — 1 passed.
- `cargo test --locked -p cosh-shell --test shell_host raw_relay_bash_excludes_secrets_from_history_and_journal -- --nocapture --test-threads=1` — 1 passed.
- `cargo test --locked -p cosh-shell --test shell_host raw_relay_zsh_excludes_secrets_from_history_and_journal -- --nocapture --test-threads=1` — 1 passed.
- `cargo clippy --package cosh-shell --lib -- -D warnings` — passed.
- `cargo clippy --package cosh-shell --test shell_host -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `bash -n crates/cosh-shell/src/shell_host/marker/bash.sh` — passed.
- `zsh -n crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh` — passed.
- `crates/cosh-shell/scripts/check-layout.sh` — passed.
- `git diff --check` — passed.

The regression matrix covers escaped-space, escaped-colon, adjacent-quote, attached `-H`, combined `-sH` / `-fsSLH`, statically quoted or escaped option prefixes, direct `-HCookie:`, and `--header=` spellings in Rust, Bash, and Zsh. It also covers dynamic option-prefix fail-closed behavior, nested substitution operators (`;`, `&&`, and pipelines), dynamic `then case`, comment and here-doc forms, compact multi-pair headers, safe internal-substring controls, and preservation of trailing arguments. Full workspace gates and provider validation were not run because this is a focused redaction change; broader coverage remains with CI.

## Documentation and rollback

No documentation changes are needed because this corrects internal privacy classification behavior. Roll back by reverting commit `b26e7b71`.


