### PR TITLE
fix(sight): extract container id from systemd cgroup driver layouts

### DIFF
--- a/src/agentsight/src/container.rs
+++ b/src/agentsight/src/container.rs
@@ -91,6 +91,8 @@ pub fn extract_container_id(pid: u32) -> Option<String> {
 /// 2. Docker cgroup v2 — `docker-<64hex>.scope`
 /// 3. Kubernetes       — `/kubepods/.../<64hex>`
 /// 4. containerd       — last path segment is exactly 64 hex chars
+/// 5. Kubernetes with the systemd cgroup driver —
+///    `/kubepods.slice/.../<runtime>-<64hex>.scope` (cri-containerd-…, crio-…)
 pub fn parse_container_id_from_cgroup(content: &str) -> Option<String> {
     for line in content.lines() {
         // The third colon-separated field is the cgroup path.
@@ -146,7 +148,40 @@ fn try_extract_from_path(path: &str) -> Option<String> {
         }
     }
 
+    // 5. Kubernetes with the systemd cgroup driver: the container unit is
+    //    `<runtime>-<64hex>.scope` under kubepods.slice (cri-containerd-…,
+    //    crio-…; podman's libpod-… is covered too). Layouts 3/4 only match a
+    //    bare <64hex> last segment (cgroupfs driver), so strip the ".scope"
+    //    suffix and the runtime prefix (substring after the last dash).
+    //    Gated on container markers so a host systemd unit never matches.
+    if has_container_marker(path) {
+        if let Some(segment) = path.rsplit('/').next() {
+            let bare = segment.strip_suffix(".scope").unwrap_or(segment);
+            if bare.len() > 64 {
+                let candidate = bare.rsplit('-').next().unwrap_or("");
+                if is_64_hex(candidate) {
+                    return Some(candidate.to_string());
+                }
+            }
+        }
+    }
+
     None
+}
+
+/// Container runtime markers that gate the prefixed-scope rule (layout 5).
+const CONTAINER_MARKERS: [&str; 7] = [
+    "kubepods",
+    "containerd",
+    "crio",
+    "docker",
+    "libpod",
+    "podman",
+    "lxc",
+];
+
+fn has_container_marker(path: &str) -> bool {
+    CONTAINER_MARKERS.iter().any(|marker| path.contains(marker))
 }
 
 /// Returns `true` when `s` is exactly 64 hex characters (case-insensitive).
@@ -198,6 +233,54 @@ mod tests {
             id,
             "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
         );
+    }
+
+    #[test]
+    fn kubernetes_containerd_systemd_cgroup_v2() {
+        let content = "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod27e3a4f0_0000.slice/cri-containerd-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
+        let id = parse_container_id_from_cgroup(content).unwrap();
+        assert_eq!(
+            id,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        );
+    }
+
+    #[test]
+    fn kubernetes_containerd_systemd_cgroup_v1() {
+        let content = "11:memory:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod27e3a4f0_0000.slice/cri-containerd-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
+        let id = parse_container_id_from_cgroup(content).unwrap();
+        assert_eq!(
+            id,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        );
+    }
+
+    #[test]
+    fn kubernetes_crio_systemd() {
+        let content = "0::/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod0000.slice/crio-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
+        let id = parse_container_id_from_cgroup(content).unwrap();
+        assert_eq!(
+            id,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        );
+    }
+
+    #[test]
+    fn podman_libpod_scope() {
+        let content = "0::/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
+        let id = parse_container_id_from_cgroup(content).unwrap();
+        assert_eq!(
+            id,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        );
+    }
+
+    #[test]
+    fn host_systemd_unit_with_hex_tail_is_not_container() {
+        // No container marker in the path: a host systemd unit whose tail
+        // happens to be 64 hex chars must not be mistaken for a container.
+        let content = "0::/system.slice/weird-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
+        assert!(parse_container_id_from_cgroup(content).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Why

agentsight 的消费方（如 loongcollector 的 `input_agentsight`）在 **systemd cgroup
驱动**的 Kubernetes 集群上拿到的 `container_id` 为空。这类集群里容器的 cgroup
路径形如：

```
0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod<uid>.slice/cri-containerd-<64hex>.scope
```

现有四种布局都匹配不了 `<运行时>-<64hex>.scope` 这种段：布局 3/4 要求末段是
裸的 64 位 hex（cgroupfs 驱动），布局 2 只认 `docker-` 前缀。结果就是容器归属
信息静默丢失——gen_ai 和原始 HTTP 两条数据流都没有 `container.id`。该问题在
生产 containerd 集群上实际观察到：两条流同时缺字段。

## What changed

`src/container.rs` 里的一个逻辑变更：为 `try_extract_from_path` 新增第 5 种
布局。当 cgroup 路径带有容器运行时标记（`kubepods` / `containerd` / `crio` /
`docker` / `libpod` / `podman` / `lxc`）时，取路径末段，去掉 `.scope` 后缀，
再去掉运行时前缀（最后一个 `-` 之前的部分），剩余部分若为 64 位 hex 则采纳。
覆盖 `cri-containerd-…`、`crio-…`、`libpod-…`（podman）等 systemd 单元形态。
新增 5 个单测：cgroup v1 / v2 下 systemd 驱动的 containerd、CRI-O、podman
libpod scope，以及一个负例——证明宿主机的 systemd 单元（末段恰为 64 位 hex
时）不会被误判为容器。

## Related issue

no-issue: 该 bug 是在排查 loongcollector input_agentsight 生产 Kubernetes
部署中 container.id 缺失时发现的

## User / Agent impact

运行在 systemd cgroup 驱动（containerd / CRI-O，大多数托管 Kubernetes 集群的
默认配置）下的 agent 现在能正确解析出 `container_id`，消费方按原本设计输出
容器归属信息。已有布局不受影响，cgroupfs 驱动与纯 docker 部署行为不变。

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

低风险。新规则是纯增量的，且由容器运行时标记门禁把关，宿主机的 systemd
单元不可能被误判为容器（负例测试覆盖）。无 FFI / 配置 / CLI 面变更。

## Validation

- `cargo test --lib container::` —— 18/18 通过（13 个存量布局用例 + 5 个新
  用例，无回归）
- `rustfmt --check` 干净
- clippy：`container.rs` 无任何发现
- 复现用的布局取自真实集群的 `/proc/<pid>/cgroup`

## Documentation and rollback

无需用户文档变更（内部解析修复）。revert 本提交即可恢复原有行为。
