### PR TITLE
fix(anolisa): remove unused raw cache settings

### DIFF
--- a/docs/user-guide/en/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/en/user-entrypoint/anolisa-cli.md
@@ -247,20 +247,25 @@ anolisa status
 
 ## Configuration
 
-Registry settings are read from `/etc/anolisa/config.toml` in system mode or
-`~/.config/anolisa/config.toml` in user mode. Only the `[registry]` table is
-used for registry resolution:
+Backend selection and endpoints are read from `/etc/anolisa/repo.toml` in
+system mode or `~/.config/anolisa/repo.toml` in user mode:
 
 ```toml
-[registry]
-url = "https://registry.example.com/index.toml"
-cache_ttl_secs = 3600
-offline_fallback = true
+schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "https://repo.example.com/anolisa/v1/"
 ```
 
-Backend selection and endpoints live in the corresponding `repo.toml`
-(`/etc/anolisa/repo.toml` or `~/.config/anolisa/repo.toml`). CLI flags override
-the operation being run; there is no `[install] mode` setting.
+The raw backend re-fetches the distribution index on every run: there is no
+index cache and no stale-index fallback, so an unreachable repository fails the
+command instead of resolving against older data. `cache_ttl_secs` and
+`offline_fallback` were never wired up; configs that still set them keep
+parsing, but the values are ignored.
+
+CLI flags override the operation being run; there is no `[install] mode`
+setting.
 
 ---
 

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -245,10 +245,10 @@ default_backend = "raw"
 base_url = "https://repo.example.com/anolisa/v1/"
 ```
 
-The raw backend fetches the distribution index on every run. It does not use an index cache or fall back to stale metadata, so commands fail when the repository is unavailable.
-`cache_ttl_secs` and `offline_fallback` were never wired into the active implementation. Existing configuration files that still contain these fields continue to parse correctly, but the values are ignored.
+raw backend 每次执行都会重新拉取 distribution index。当前不会使用缓存的 index 作为回退，因此仓库不可达时命令会直接失败。
+旧的 `cache_ttl_secs` 和 `offline_fallback` 字段仍可正常解析以保持向后兼容，但当前 raw backend 不会使用这些值。
 
-CLI arguments control the current operation. There is no `[install] mode` configuration.
+CLI 参数只影响当前执行的操作，不存在 `[install] mode` 配置。
 
 ---
 

--- a/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
+++ b/docs/user-guide/zh/user-entrypoint/anolisa-cli.md
@@ -234,20 +234,21 @@ anolisa status
 
 ## 配置
 
-system mode 从 `/etc/anolisa/config.toml` 读取 registry 设置，user mode 从
-`~/.config/anolisa/config.toml` 读取。registry resolution 只使用
-`[registry]` 表：
+system mode 从 `/etc/anolisa/repo.toml` 读取 backend 选择和 endpoint，
+user mode 从 `~/.config/anolisa/repo.toml` 读取：
 
 ```toml
-[registry]
-url = "https://registry.example.com/index.toml"
-cache_ttl_secs = 3600
-offline_fallback = true
+schema_version = 1
+default_backend = "raw"
+
+[backends.raw]
+base_url = "https://repo.example.com/anolisa/v1/"
 ```
 
-backend 选择和 endpoint 位于对应的 `repo.toml`（`/etc/anolisa/repo.toml`
-或 `~/.config/anolisa/repo.toml`）。CLI 参数覆盖当前执行的操作；不存在
-`[install] mode` 配置。
+The raw backend fetches the distribution index on every run. It does not use an index cache or fall back to stale metadata, so commands fail when the repository is unavailable.
+`cache_ttl_secs` and `offline_fallback` were never wired into the active implementation. Existing configuration files that still contain these fields continue to parse correctly, but the values are ignored.
+
+CLI arguments control the current operation. There is no `[install] mode` configuration.
 
 ---
 

--- a/src/anolisa/README.md
+++ b/src/anolisa/README.md
@@ -97,6 +97,11 @@ The lifecycle planner separates ANOLISA-owned files from native-package
 authority and records crash-recovery intent before side effects. Component
 metadata is declared through `component.toml`.
 
+The raw backend re-fetches the distribution index on every resolve and fails
+when the repository is unreachable. Legacy `cache_ttl_secs` and
+`offline_fallback` keys in `repo.toml` are still accepted for compatibility,
+but the current raw backend ignores their values.
+
 ## Requirements
 
 - Linux (x86_64 / aarch64) or macOS (arm64, limited)

--- a/src/anolisa/README_zh.md
+++ b/src/anolisa/README_zh.md
@@ -95,6 +95,10 @@ scope。因此，即使 system scope 已安装同名组件，
 planner 区分 ANOLISA 自有文件与 native package authority，并在副作用前
 记录崩溃恢复意图。组件元数据通过 `component.toml` 声明。
 
+raw backend 每次解析都会重新拉取 distribution index，仓库不可达时命令直接
+失败。`repo.toml` 中旧的 `cache_ttl_secs` 和 `offline_fallback` 字段仍可正常
+解析以保持向后兼容，但当前 raw backend 不会使用这些值。
+
 ## 环境要求
 
 - Linux（x86_64 / aarch64）或 macOS（arm64，功能受限）

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -1124,6 +1124,31 @@ mod tests {
         assert!(content.contains("schema_version = 1"));
     }
 
+    /// Fail-closed: a warm download cache never stands in for a repository
+    /// that has become unreachable, so a withdrawn or revoked index entry
+    /// cannot be resurrected from disk.
+    #[test]
+    fn fetch_raw_index_does_not_serve_a_cached_index_when_the_repo_is_gone() {
+        let repo = tempdir().unwrap();
+        let root = repo.path().join("v1");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("index.toml"), "schema_version = 1\n").unwrap();
+        let cache = tempdir().unwrap();
+        let dl = DownloadCache::new(cache.path().to_path_buf());
+        let base_url = format!("file://{}", root.display());
+        fetch_raw_index(&dl, &base_url, None).expect("prime the cache");
+
+        std::fs::remove_file(root.join("index.toml")).unwrap();
+        let err = fetch_raw_index(&dl, &base_url, None).unwrap_err();
+        let CliError::Runtime { reason, .. } = err else {
+            panic!("expected runtime error");
+        };
+        assert!(
+            reason.contains("local raw repository index not found"),
+            "got: {reason}"
+        );
+    }
+
     /// With neither file published the error must attribute the miss to
     /// `index.toml` (the canonical location), not to the optional v2 file.
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/repo_config.rs
+++ b/src/anolisa/crates/anolisa-cli/src/repo_config.rs
@@ -259,22 +259,21 @@ pub struct BackendConfig {
     #[serde(default)]
     pub insecure: bool,
     /// rpm: signature verification toggle, handed to dnf.
-    ///
-    /// This and the two raw cache knobs below are deserialized for the
-    /// executors that will consume them (rpm delegation / raw index
-    /// cache); nothing reads them during resolution, hence the narrow
-    /// dead-code allowance until those land.
     #[serde(default)]
-    #[allow(dead_code)]
     pub gpgcheck: Option<bool>,
     /// npm: default package scope (`@anolis` → `@anolis/<component>`).
     #[serde(default)]
     pub scope: Option<String>,
-    /// raw: index cache freshness window.
+    /// Accepted but ignored: the raw backend re-fetches the index every run.
+    ///
+    /// Both knobs were written for an index cache that no CLI path uses;
+    /// `deny_unknown_fields` means dropping them would reject configs already
+    /// on disk, so they stay parseable and inert. Shipped templates no longer
+    /// emit them.
     #[serde(default)]
     #[allow(dead_code)]
     pub cache_ttl_secs: Option<u64>,
-    /// raw: serve a stale cached index when the network is down.
+    /// Accepted but ignored; see [`BackendConfig::cache_ttl_secs`].
     #[serde(default)]
     #[allow(dead_code)]
     pub offline_fallback: Option<bool>,
@@ -947,6 +946,44 @@ mod tests {
         let content = std::fs::read_to_string(&repo_path).expect("read repo manifest");
         let cfg = RepoConfig::from_toml_str(&content).expect("repo manifest");
         cfg.select_backend(Some("rpm")).expect("rpm backend");
+    }
+
+    /// Neither shipped file may advertise the inert raw cache knobs.
+    #[test]
+    fn shipped_repo_configs_omit_raw_cache_knobs() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for relative in ["../../templates/repo.toml", "../../manifests/repo.toml"] {
+            let path = manifest_dir.join(relative);
+            let content = std::fs::read_to_string(&path).expect("read shipped repo config");
+            let cfg = RepoConfig::from_toml_str(&content).expect("shipped repo config");
+            let raw = cfg.backends.get("raw").expect("raw backend");
+            assert_eq!(raw.cache_ttl_secs, None, "{relative}");
+            assert_eq!(raw.offline_fallback, None, "{relative}");
+        }
+    }
+
+    /// Configs written by older releases still carry the knobs and must load.
+    #[test]
+    fn legacy_raw_cache_knobs_still_parse() {
+        let cfg = RepoConfig::from_toml_str(
+            r#"schema_version = 1
+default_backend = "raw"
+[backends.raw]
+base_url = "https://repo.test/v1/"
+cache_ttl_secs = 3600
+offline_fallback = true
+"#,
+        )
+        .expect("legacy repo config must load");
+
+        let (name, backend) = cfg.select_backend(None).expect("default backend");
+        assert_eq!(name, "raw");
+        assert_eq!(backend.cache_ttl_secs, Some(3600));
+        assert_eq!(backend.offline_fallback, Some(true));
+        assert_eq!(
+            cfg.resolved_base_url(name, backend, &host()).expect("url"),
+            "https://repo.test/v1"
+        );
     }
 
     #[test]

--- a/src/anolisa/manifests/repo.toml
+++ b/src/anolisa/manifests/repo.toml
@@ -52,10 +52,11 @@ releasever = "4"
 # always wins over the derived layout. The index itself stays mandatory
 # either way: it is the version list and sha256 manifest -- resolution
 # and verification never run on URL guessing.
+#
+# The index is re-fetched on every run and an unreachable repository fails
+# the command; there is no index cache and no stale-index fallback.
 [backends.raw]
 base_url = "https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/"
-cache_ttl_secs = 3600
-offline_fallback = true
 
 # rpm -- resolution/install delegated to dnf against this repo.
 [backends.rpm]

--- a/src/anolisa/templates/repo.toml
+++ b/src/anolisa/templates/repo.toml
@@ -52,10 +52,11 @@ releasever = "4"
 # always wins over the derived layout. The index itself stays mandatory
 # either way: it is the version list and sha256 manifest — resolution
 # and verification never run on URL guessing.
+#
+# The index is re-fetched on every run and an unreachable repository fails
+# the command; there is no index cache and no stale-index fallback.
 [backends.raw]
 base_url = "https://anolisa.oss-cn-hangzhou.aliyuncs.com/anolisa-releases/anolisa/v1/"
-cache_ttl_secs = 3600
-offline_fallback = true
 
 # rpm — resolution/install delegated to dnf against this repo.
 [backends.rpm]


### PR DESCRIPTION
## Summary

The raw backend currently exposes `cache_ttl_secs` and `offline_fallback` in `repo.toml`, but the active CLI paths do not use either setting.

The current raw backend re-fetches repository metadata on every resolve and fails when the repository is unavailable. The stale-cache fallback implementation in `RegistryClient` is not used by the current CLI.

This change makes the shipped configuration and documentation match the actual runtime behavior.

## Changes

- remove `cache_ttl_secs` and `offline_fallback` from newly shipped `repo.toml` files
- keep both fields parseable for compatibility with existing installations
- update the English and Chinese CLI documentation
- add tests covering legacy config parsing
- add a regression test confirming raw index resolution remains fail-closed

## Backward compatibility

Existing `repo.toml` files may still contain:

```toml
cache_ttl_secs = 3600
offline_fallback = true
```

These fields are still accepted by `BackendConfig`, so existing installations continue to parse normally. Their values remain unused by the current raw backend.

## Behavior

Install behavior is unchanged.

The raw backend still fetches the current distribution index and fails if the repository cannot be reached. This PR does not introduce stale-index fallback.

## Testing

Focused tests:

```text
repo_config::      29 passed
install::raw::     33 passed
```

Local CLI verification on macOS/aarch64:

```text
./target/debug/anolisa list
→ success

./target/debug/anolisa install tokenless --dry-run
→ success
```

An existing user `repo.toml` containing both legacy cache settings also parses successfully with the patched CLI.

Broader test results:

```text
anolisa-cli: 958 passed, 1 pre-existing failure
anolisa-core: 1043 passed, 1 pre-existing failure
```

The unrelated failures are:

```text
commands::tier1::update::tests::raw_update_rollback_hydrates_legacy_required_capability
adapter::managed_files::tests::symlinked_source_root_scopes_canonical_package_files
```

Formatting and focused checks pass.

## Notes

I did not wire stale cached indexes into raw install. Using stale index metadata changes rollback and release-removal semantics, so that should be handled separately if offline installation is desired.

Related #3000 