### PR TITLE
feat(cosh-ng): [shell] route zsh prompts

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction/shell_word.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction/shell_word.rs
@@ -155,10 +155,7 @@ fn is_cookie_header_candidate_start(bytes: &[u8], start: usize) -> CandidateStar
         return CandidateStartResult::Match(ShellContext::Unquoted);
     }
 
-    let word_start = bytes[..start]
-        .iter()
-        .rposition(|byte| is_shell_word_boundary(*byte))
-        .map_or(0, |boundary| boundary + 1);
+    let word_start = shell_word_start(bytes, start);
     match decode_static_option_prefix(&bytes[word_start..start]) {
         StaticOptionPrefix::Decoded {
             bytes: option_prefix,
@@ -169,6 +166,50 @@ fn is_cookie_header_candidate_start(bytes: &[u8], start: usize) -> CandidateStar
         StaticOptionPrefix::Dynamic => CandidateStartResult::Dynamic,
         StaticOptionPrefix::Decoded { .. } => CandidateStartResult::NoMatch,
     }
+}
+
+fn shell_word_start(bytes: &[u8], end: usize) -> usize {
+    let mut word_start = 0;
+    let mut cursor = 0;
+    while cursor < end {
+        if bytes[cursor] == b'$' && bytes.get(cursor + 1) == Some(&b'{') {
+            cursor = parameter_expansion_end(bytes, cursor + 2, end);
+            continue;
+        }
+        if is_shell_word_boundary(bytes[cursor]) {
+            word_start = cursor + 1;
+        }
+        cursor += 1;
+    }
+    word_start
+}
+
+fn parameter_expansion_end(bytes: &[u8], mut cursor: usize, end: usize) -> usize {
+    let mut depth = 1usize;
+    while cursor < end {
+        match bytes[cursor] {
+            b'$' if bytes.get(cursor + 1) == Some(&b'{') => {
+                depth += 1;
+                cursor += 2;
+            }
+            // Quotes and nested substitutions require the complete shell
+            // grammar to prove which brace closes this expansion. Consume
+            // the remaining prefix so the caller treats it as dynamic.
+            b'\'' | b'"' | b'`' => return end,
+            b'$' if bytes.get(cursor + 1) == Some(&b'(') => return end,
+            b'<' | b'>' if bytes.get(cursor + 1) == Some(&b'(') => return end,
+            b'}' => {
+                depth -= 1;
+                cursor += 1;
+                if depth == 0 {
+                    return cursor;
+                }
+            }
+            b'\\' => cursor = skip_shell_escape(bytes, cursor),
+            _ => cursor += 1,
+        }
+    }
+    end
 }
 
 fn decode_static_option_prefix(raw_prefix: &[u8]) -> StaticOptionPrefix {

--- a/src/cosh-ng/crates/cosh-shell/src/evidence/redaction_boundary_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/evidence/redaction_boundary_tests.rs
@@ -281,6 +281,9 @@ fn redacts_embedded_cookie_headers_and_keeps_bare_token_prose() {
         "curl -H Cookie:session=$COOKIE_VALUE --region cn",
         "curl -s${HEADER_OPTION}Cookie:session=quoted-cookie-value-42 --region cn",
         r#"curl ${HEADER_OPTION}"Cookie: session=dynamic-option-secret-42" --region cn"#,
+        r#"curl ${HEADER_OPTION#*;}"Cookie: session=parameter-pattern-secret-42" https://example.test"#,
+        r#"curl ${HEADER_OPTION#*|}"Cookie: session=parameter-pipe-secret-42" https://example.test"#,
+        r#"curl ${HEADER_OPTION:-$(printf '}' >/dev/null; printf -- -H)}"Cookie: session=parameter-nested-secret-42""#,
         "curl -H 'Cookie: session='<(printf quoted-cookie-value-42) --region cn",
         "request Cookie:session=quoted-cookie-value-42; other=second-cookie-value",
         "Cookie: first=first-cookie-value\ncurl -H 'Cookie: session='$(printf quoted-cookie-value-42)",
@@ -302,6 +305,8 @@ fn redacts_embedded_cookie_headers_and_keeps_bare_token_prose() {
         r#"curl --sH"Cookie: session=quoted-cookie-value-42""#,
         r#"tool -s'Hx'Cookie:session=quoted-cookie-value-42"#,
         r#"curl --header-label="Cookie: session=quoted-cookie-value-42""#,
+        r#"curl ${HEADER_OPTION#*;}"Crookie: session=parameter-pattern-secret-42""#,
+        r#"curl ${HEADER_OPTION:-$(printf '}' >/dev/null; printf -- -H)}"Crookie: session=parameter-nested-secret-42""#,
     ] {
         assert_eq!(
             redact_sensitive_text(input),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/event_parser.rs
@@ -1,5 +1,6 @@
 use crate::input::InputClassifier;
 
+use super::path_prompt_candidate::zsh_path_candidate_should_hold;
 use super::soft_newline::{
     soft_newline_sequence_len, soft_newline_suffix_len, CANONICAL_SOFT_NEWLINE,
 };
@@ -478,16 +479,19 @@ pub(crate) fn redact_extension_setting_value(input: &[u8]) -> Vec<u8> {
 pub(super) fn starts_native_intercept_candidate(
     bytes: &[u8],
     native_line_state: &NativeLineState,
+    buffer_non_ascii_prefix: bool,
 ) -> bool {
-    // Only explicit slash and `??` routes are buffered. Ordinary text and
-    // paste bytes stay owned by the Shell.
+    // Zsh also buffers a potential Han-leading path prompt because its ZLE
+    // buffer cannot be cleared safely after submit-time classification.
     if !native_line_state.is_at_line_start() {
         return false;
     }
-    if first_visible_input_byte(bytes) == Some(b'/') {
+    let visible = first_visible_input_bytes(bytes);
+    if visible.first() == Some(&b'/')
+        || (buffer_non_ascii_prefix && zsh_path_candidate_should_hold(visible))
+    {
         return true;
     }
-    let visible = first_visible_input_bytes(bytes);
     // A lone `?` may be the first half of a `??` marker typed key by key
     // (#1932): own the line now so the follow-up decides the route; any
     // non-`??` continuation flushes back to bash byte-identically.
@@ -645,5 +649,47 @@ fn incomplete_escape_suffix(bytes: &[u8]) -> bool {
         [0x1b, b'[', parameters @ ..] => parameters.iter().all(|byte| matches!(byte, 0x20..=0x3f)),
         [0x1b, b'O'] => true,
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{starts_native_intercept_candidate, NativeLineState};
+
+    #[test]
+    fn native_intercept_candidate_only_starts_at_line_start() {
+        let mut state = NativeLineState::default();
+
+        assert!(starts_native_intercept_candidate(b"/", &state, false));
+        assert!(starts_native_intercept_candidate(
+            b"?? hello",
+            &state,
+            false
+        ));
+        assert!(!starts_native_intercept_candidate(
+            "你".as_bytes(),
+            &state,
+            false
+        ));
+        assert!(starts_native_intercept_candidate(
+            "你".as_bytes(),
+            &state,
+            true
+        ));
+        state.observe_shell_bytes(b"vim .");
+        assert!(!starts_native_intercept_candidate(b"/", &state, true));
+        assert!(!starts_native_intercept_candidate(
+            b"?? hello",
+            &state,
+            true
+        ));
+        assert!(!starts_native_intercept_candidate(
+            "你".as_bytes(),
+            &state,
+            true
+        ));
+
+        state.observe_shell_bytes(b"\n");
+        assert!(starts_native_intercept_candidate(b"/mode", &state, false));
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/mod.rs
@@ -9,6 +9,7 @@ mod event_sender;
 pub(crate) use draft_editor::PromptDraftEditor;
 mod generation;
 mod mode;
+mod path_prompt_candidate;
 mod prompt_epoch;
 mod pty;
 mod relay;
@@ -28,7 +29,7 @@ pub(crate) use pty::{
 pub use relay_action::RawRelayAction;
 pub(crate) use spawn::{
     spawn_raw_action_relay, spawn_raw_action_relay_with_wake, spawn_raw_input_relay,
-    spawn_raw_input_relay_with_wake,
+    spawn_raw_input_relay_with_wake, RawInputShellRoute, ZshPathPromptBuffering,
 };
 
 pub(super) const CTRL_C: u8 = 0x03;
@@ -79,8 +80,8 @@ pub(crate) enum RawInputEvent {
         cwd: String,
         sensitive: bool,
     },
-    /// A Readline-owned missing-path prompt whose line is cleared before the
-    /// Agent run, so the runtime must acknowledge it on a stable UI surface.
+    /// A missing-path prompt withheld from shell execution, so the runtime
+    /// must acknowledge it on a stable UI surface.
     NativePathPromptIntercept {
         input: String,
         cwd: String,
@@ -195,8 +196,7 @@ pub(crate) enum RawInputEvent {
 mod tests {
     use super::event_parser::{
         candidate_inline_hint, candidate_line_status, native_candidate_should_return_to_shell,
-        redact_extension_setting_value, starts_native_intercept_candidate, CandidateLineBuffer,
-        CandidateLineStatus, NativeLineState,
+        redact_extension_setting_value, CandidateLineBuffer, CandidateLineStatus, NativeLineState,
     };
     use super::relay::ExplicitExitTracker;
     use super::soft_newline::render_soft_newline_markers;
@@ -603,21 +603,6 @@ mod tests {
     fn other_slash_values_are_not_redacted() {
         let command = b"/extensions settings get fixture token";
         assert_eq!(redact_extension_setting_value(command), command);
-    }
-
-    #[test]
-    fn native_slash_candidate_only_starts_at_line_start() {
-        let mut state = NativeLineState::default();
-
-        assert!(starts_native_intercept_candidate(b"/", &state));
-        assert!(starts_native_intercept_candidate(b"?? hello", &state));
-
-        state.observe_shell_bytes(b"vim .");
-        assert!(!starts_native_intercept_candidate(b"/", &state));
-        assert!(!starts_native_intercept_candidate(b"?? hello", &state));
-
-        state.observe_shell_bytes(b"\n");
-        assert!(starts_native_intercept_candidate(b"/mode", &state));
     }
 
     #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/path_prompt_candidate.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/path_prompt_candidate.rs
@@ -1,0 +1,25 @@
+//! Zsh path-prompt candidate prefixes shared by parsing and relay ownership.
+
+pub(super) fn zsh_path_candidate_should_hold(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    // A raw Tab is a ZLE editing action, so only spaces can be held while
+    // waiting to learn whether the first textual token is a path prompt.
+    let candidate = bytes.iter().copied().find(|byte| *byte != b' ');
+    candidate.is_none_or(|byte| byte == b'/' || !byte.is_ascii())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::zsh_path_candidate_should_hold;
+
+    #[test]
+    fn holds_space_prefixed_paths_until_the_prefix_resolves() {
+        assert!(zsh_path_candidate_should_hold(b" "));
+        assert!(zsh_path_candidate_should_hold(b"  /missing"));
+        assert!(zsh_path_candidate_should_hold("  你".as_bytes()));
+        assert!(!zsh_path_candidate_should_hold(b"  echo"));
+        assert!(!zsh_path_candidate_should_hold(b"\t/missing"));
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/public.rs
@@ -11,5 +11,6 @@ pub(crate) use implementation::{
     signal_process_group_id, spawn_raw_action_relay, spawn_raw_action_relay_with_wake,
     spawn_raw_input_relay, spawn_raw_input_relay_with_wake, update_input_mode,
     update_locked_input_mode, write_all_pty, MainPromptGate, PromptDraftEditor,
-    PromptEpochExchange, PromptGhostRoute, RawInputEvent, RawInputMode, UserPtyInputGeneration,
+    PromptEpochExchange, PromptGhostRoute, RawInputEvent, RawInputMode, RawInputShellRoute,
+    UserPtyInputGeneration, ZshPathPromptBuffering,
 };

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay.rs
@@ -13,9 +13,11 @@ use super::event_parser::{
 use super::event_sender::RawInputEventSink;
 use super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::mode::new_delay_input_mode;
+use super::path_prompt_candidate::zsh_path_candidate_should_hold;
 use super::soft_newline::{
     contains_soft_newline_sequence, draft_text_from_bytes, render_soft_newline_markers,
 };
+use super::spawn::ZshPathPromptBuffering;
 use super::{write_all_pty, MainPromptGate, PromptGhostRoute, RawInputEvent, RawInputMode, CTRL_C};
 
 pub(super) struct InputRelayContext<'a> {
@@ -35,6 +37,9 @@ pub(super) struct InputRelayContext<'a> {
     /// until the next prompt_ready marker and later bytes fall back to the
     /// Rust intercept path instead of leaking into a foreground process.
     pub(super) slash_route_enabled: bool,
+    /// Zsh-only capability that keeps slash candidates out of ZLE until Rust
+    /// can route or submit the complete line.
+    pub(super) zsh_path_prompt_buffering: Option<&'a mut ZshPathPromptBuffering>,
 }
 
 /// Writes real user bytes to the PTY, bumping the shared input generation
@@ -114,6 +119,16 @@ fn relay_passthrough_input_with_policy(
     emit_activity: bool,
     pending_shell_submits: usize,
 ) -> io::Result<bool> {
+    if relay
+        .zsh_path_prompt_buffering
+        .as_deref()
+        .is_some_and(ZshPathPromptBuffering::has_deferred_tab_typeahead)
+    {
+        if let Some(buffering) = relay.zsh_path_prompt_buffering.as_deref_mut() {
+            buffering.defer_tab_typeahead(bytes);
+        }
+        return Ok(true);
+    }
     if relay.line_buffer.force_agent_intercept && relay.line_buffer.is_active() {
         relay.line_buffer.soft_newline_enabled = true;
         relay.line_buffer.push(bytes);
@@ -138,6 +153,18 @@ fn relay_passthrough_input_with_policy(
         return candidate::relay_candidate_line(relay, emit_activity, pending_shell_submits);
     }
     relay_native_passthrough(bytes, relay, emit_activity, pending_shell_submits)
+}
+
+pub(super) fn replay_deferred_zsh_tab_typeahead(
+    bytes: &[u8],
+    relay: &mut InputRelayContext<'_>,
+) -> io::Result<()> {
+    // A separate relay turn gives ZLE time to finish the Tab widget. Cancel
+    // its potentially rewritten buffer before replaying preserved input as
+    // the next logical line.
+    relay_native_passthrough(&[CTRL_C], relay, true, 0)?;
+    relay_passthrough_input_with_policy(bytes, relay, true, 0)?;
+    Ok(())
 }
 
 pub(super) fn relay_prompt_ghost_input(
@@ -338,8 +365,21 @@ fn relay_native_passthrough(
     let complete_paste = bytes.starts_with(BRACKETED_PASTE_START);
     if relay.line_buffer.is_active()
         || complete_paste
-        || starts_native_intercept_candidate(bytes, relay.native_line_state)
+        || starts_native_intercept_candidate(
+            bytes,
+            relay.native_line_state,
+            relay.zsh_path_prompt_buffering.is_some(),
+        )
     {
+        if let Some(handled) = tab_handoff::relay_coalesced_zsh_tab(
+            bytes,
+            relay,
+            emit_activity,
+            pending_shell_submits,
+            complete_paste,
+        )? {
+            return Ok(handled);
+        }
         // Route flags must consider the whole draft so far: a bracketed
         // paste opener may arrive as its own chunk (or split mid-delimiter,
         // #1721) before the payload decides CJK vs slash (#1721 D13).
@@ -351,8 +391,21 @@ fn relay_native_passthrough(
         .concat();
         relay.line_buffer.soft_newline_enabled = native_candidate_allows_soft_newline(&combined);
         relay.line_buffer.push(bytes);
+        let zsh_path_candidate = relay.zsh_path_prompt_buffering.is_some();
+        let hold_zsh_path_candidate = zsh_path_candidate
+            && !relay.line_buffer.saw_paste()
+            && zsh_path_candidate_should_hold(&relay.line_buffer.bytes)
+            && !relay.line_buffer.bytes.contains(&b'\t');
+        let return_resolved_zsh_space_prefix = zsh_path_candidate
+            && relay.line_buffer.bytes.first() == Some(&b' ')
+            && !hold_zsh_path_candidate;
         if !relay.line_buffer.in_paste()
-            && native_candidate_should_return_to_shell(relay.input_classifier, relay.line_buffer)
+            && !hold_zsh_path_candidate
+            && (return_resolved_zsh_space_prefix
+                || native_candidate_should_return_to_shell(
+                    relay.input_classifier,
+                    relay.line_buffer,
+                ))
         {
             return flush_candidate_line_to_shell(relay, emit_activity, pending_shell_submits);
         }
@@ -633,6 +686,7 @@ mod candidate;
 mod exit_tracker;
 mod path_prompt_submit;
 mod soft_newline_upgrade;
+mod tab_handoff;
 use bash_submission_guard::{
     bash_submission_has_leading_whitespace, bash_submission_needs_guard, guarded_bash_submission,
     history_private_submission,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/path_prompt_submit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/path_prompt_submit.rs
@@ -15,6 +15,11 @@ pub(super) fn route_missing_path_submission(
     relay: &mut InputRelayContext<'_>,
     pending_shell_submits: usize,
 ) -> io::Result<bool> {
+    // Zsh path candidates remain Rust-owned until Enter. If editing or a
+    // control key already returned the line to ZLE, keep it Shell-owned.
+    if relay.zsh_path_prompt_buffering.is_some() {
+        return Ok(false);
+    }
     if !relay.main_prompt_gate.is_path_prompt_ready() || pending_shell_submits > 0 {
         return Ok(false);
     }
@@ -53,15 +58,15 @@ pub(super) fn route_missing_path_submission(
     if let Ok(mut mode) = relay.input_mode.lock() {
         *mode = new_delay_input_mode();
     }
-    // Bytes typed in this read have not reached Readline yet. Write them
-    // before Ctrl-U so Bash echoes the exact user submission, then accept the
-    // cleared line to repaint PS1. The command itself is never executed.
-    let mut repaint = Vec::with_capacity(submit + 2);
-    repaint.extend_from_slice(&bytes[..submit]);
-    repaint.extend_from_slice(b"\x15\r");
     let _ = relay
         .input_events
         .send(RawInputEvent::SyntheticPromptRepaint);
+    // Bytes typed in this read have not reached Readline yet. Write them
+    // before Ctrl-U so Bash echoes the exact user submission, then accept
+    // the cleared line to repaint PS1. The command itself never executes.
+    let mut repaint = Vec::with_capacity(submit + 2);
+    repaint.extend_from_slice(&bytes[..submit]);
+    repaint.extend_from_slice(b"\x15\r");
     write_user_bytes_to_pty(
         relay.master,
         relay.input_generation,
@@ -111,14 +116,21 @@ pub(super) fn route_candidate_missing_path_submission(
         *mode = new_delay_input_mode();
     }
     let sensitive = redact_sensitive_text(&input).1;
-    let _ = relay
-        .input_events
-        .send(RawInputEvent::UserInterceptWithRouting {
+    let event = if input.starts_with('/') {
+        RawInputEvent::UserInterceptWithRouting {
             input,
             reason: InterceptReason::NaturalLanguage,
             cwd,
             sensitive,
-        });
+        }
+    } else {
+        RawInputEvent::NativePathPromptIntercept {
+            input,
+            cwd,
+            sensitive,
+        }
+    };
+    let _ = relay.input_events.send(event);
     send_shell_input_state(true, relay.input_events);
     true
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/tab_handoff.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/tab_handoff.rs
@@ -1,0 +1,96 @@
+//! Zsh candidate handoff when Tab and later input share one terminal read.
+
+use std::io;
+
+use super::{
+    relay_native_passthrough, relay_passthrough_input_with_policy, send_held_input_events,
+    InputRelayContext,
+};
+
+pub(super) fn relay_coalesced_zsh_tab(
+    bytes: &[u8],
+    relay: &mut InputRelayContext<'_>,
+    emit_activity: bool,
+    pending_shell_submits: usize,
+    complete_paste: bool,
+) -> io::Result<Option<bool>> {
+    if relay.zsh_path_prompt_buffering.is_none()
+        || complete_paste
+        || relay.line_buffer.saw_paste()
+        || !relay.line_buffer.pending_partial_bytes().is_empty()
+    {
+        return Ok(None);
+    }
+    let Some(tab) = bytes.iter().position(|byte| *byte == b'\t') else {
+        return Ok(None);
+    };
+    if let Some(submit) = bytes
+        .iter()
+        .position(|byte| matches!(byte, b'\n' | b'\r'))
+        .filter(|submit| *submit < tab)
+    {
+        let submit_end = submit
+            + usize::from(
+                bytes.get(submit) == Some(&b'\r') && bytes.get(submit + 1) == Some(&b'\n'),
+            )
+            + 1;
+        let routed = relay_passthrough_input_with_policy(
+            &bytes[..submit_end],
+            relay,
+            emit_activity,
+            pending_shell_submits,
+        )?;
+        if submit_end < bytes.len() {
+            if !routed {
+                relay_passthrough_input_with_policy(
+                    &bytes[submit_end..],
+                    relay,
+                    emit_activity,
+                    pending_shell_submits,
+                )?;
+            } else {
+                // A handled submit cut over to a Cosh owner. Match the relay's
+                // ownership-crossing rule instead of reinterpreting suffix
+                // bytes through the stale ZLE owner.
+                send_held_input_events(&bytes[submit_end..], relay.input_events);
+            }
+        }
+        return Ok(Some(true));
+    }
+    if tab + 1 == bytes.len() {
+        return Ok(None);
+    }
+
+    let (through_tab, remainder) = bytes.split_at(tab + 1);
+    relay_native_passthrough(through_tab, relay, emit_activity, pending_shell_submits)?;
+    if let Some(submit) = remainder
+        .iter()
+        .position(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        if submit > 0 {
+            relay_passthrough_input_with_policy(
+                &remainder[..submit],
+                relay,
+                emit_activity,
+                pending_shell_submits,
+            )?;
+        }
+        let submit_end = submit
+            + usize::from(
+                remainder.get(submit) == Some(&b'\r') && remainder.get(submit + 1) == Some(&b'\n'),
+            )
+            + 1;
+        if submit_end < remainder.len() {
+            // PTYs do not preserve write boundaries, so the current read
+            // cannot safely cancel a buffer that the Tab widget may rewrite.
+            // Hold later type-ahead until the next read, then cancel and
+            // replay it as the next logical line.
+            if let Some(buffering) = relay.zsh_path_prompt_buffering.as_deref_mut() {
+                buffering.defer_tab_typeahead(&remainder[submit_end..]);
+            }
+        }
+        return Ok(Some(true));
+    }
+    relay_passthrough_input_with_policy(remainder, relay, emit_activity, pending_shell_submits)
+        .map(Some)
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -7,7 +7,8 @@ use std::time::{Duration, Instant};
 use super::super::generation::LineSubmitCounter;
 use super::super::mode::current_raw_input_mode;
 use super::super::spawn::{
-    finish_input_relay, relay_input_bytes, relay_late_capture_input, RawInputRelayState,
+    finish_input_relay, input_relay_context, relay_input_bytes, relay_late_capture_input,
+    RawInputRelayState, RawInputShellRoute,
 };
 use super::super::{
     update_input_mode, PromptGhostCandidate, RawInputCapture, RawObserverAction, RawRelayAction,
@@ -2099,6 +2100,7 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     assert!(relay_prompt_ghost_input(
@@ -2140,7 +2142,7 @@ fn shell_rewrite_tab_writes_to_native_line_editor_without_agent_intercept() {
 }
 
 #[test]
-fn native_slash_tab_is_not_redrawn_before_shell_completion() {
+fn zsh_native_slash_tab_is_handed_to_shell_immediately() {
     let (path, mut master) = output_file("native-slash-tab");
     let (tx, rx) = mpsc::channel();
     let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
@@ -2151,6 +2153,7 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
     let input_generation = UserPtyInputGeneration::default();
     let mut line_submits = LineSubmitCounter::default();
     let main_prompt_gate = super::super::MainPromptGate::default();
+    let mut zsh_path_prompt_buffering = ZshPathPromptBuffering::new();
     let mut relay = InputRelayContext {
         master: &mut master,
         input_classifier: &classifier,
@@ -2163,11 +2166,13 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: Some(&mut zsh_path_prompt_buffering),
     };
 
     relay_passthrough_input(b"/ho", &mut relay).expect("buffer slash prefix");
-    relay_passthrough_input(b"\t", &mut relay).expect("send completion to shell");
-    master.sync_all().expect("sync test output");
+    relay_passthrough_input(b"\t\r", &mut relay)
+        .expect("split completion from coalesced submission");
+    relay.master.sync_all().expect("sync test output");
 
     let events = rx.try_iter().collect::<Vec<_>>();
     assert!(events.iter().any(|event| matches!(
@@ -2179,8 +2184,158 @@ fn native_slash_tab_is_not_redrawn_before_shell_completion() {
         RawInputEvent::CandidateRedraw { input, .. } if input.contains(&b'\t')
     )));
     assert!(events.contains(&RawInputEvent::CandidateClearLine));
+    let writes = events
+        .iter()
+        .filter_map(|event| match event {
+            RawInputEvent::PtyUserWrite {
+                generation,
+                line_submits,
+            } => Some((*generation, *line_submits)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(writes, vec![(1, 0)]);
     assert_eq!(fs::read(&path).expect("read test output"), b"/ho\t");
-    assert!(!line_buffer.is_active());
+    assert!(!relay.line_buffer.is_active());
+
+    relay_passthrough_input(b"\r", &mut relay).expect("submit after visible completion");
+    relay.master.sync_all().expect("sync confirmed submission");
+    assert_eq!(fs::read(&path).expect("read test output"), b"/ho\t\r");
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn zsh_candidate_submit_precedes_later_tab_in_same_read() {
+    let cwd = tempfile::tempdir().expect("temp cwd");
+    let (path, mut master) = output_file("candidate-submit-before-tab");
+    let (tx, rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    classifier.prompt_cwd().set(Some(
+        cwd.path()
+            .canonicalize()
+            .expect("canonical cwd")
+            .to_string_lossy()
+            .into_owned(),
+    ));
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    main_prompt_gate.set_at_prompt(true);
+    let mut zsh_path_prompt_buffering = ZshPathPromptBuffering::new();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+        zsh_path_prompt_buffering: Some(&mut zsh_path_prompt_buffering),
+    };
+
+    relay_passthrough_input("打开./definitely-not-command".as_bytes(), &mut relay)
+        .expect("buffer missing path candidate");
+    relay_passthrough_input(b"\r\t", &mut relay).expect("route submit before later tab");
+    relay.master.sync_all().expect("sync test output");
+
+    let events = rx.try_iter().collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RawInputEvent::NativePathPromptIntercept { input, .. }
+                if input == "打开./definitely-not-command"
+        )),
+        "{events:?}"
+    );
+    assert!(!fs::read(&path)
+        .expect("read test output")
+        .starts_with("打开./definitely-not-command".as_bytes()));
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn zsh_tab_handoff_drains_preserved_input_at_eof() {
+    let (path, mut master) = output_file("tab-handoff-typeahead");
+    let (tx, _rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let classifier = InputClassifier::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    let mut state = RawInputRelayState::with_shell_route(
+        UserPtyInputGeneration::default(),
+        RawInputShellRoute::new(main_prompt_gate, false, Some(ZshPathPromptBuffering::new())),
+    );
+    {
+        let mut relay = input_relay_context(&mut master, &classifier, &tx, &input_mode, &mut state);
+        relay_passthrough_input(b"/ho", &mut relay).expect("buffer slash prefix");
+        relay_passthrough_input(b"\t\r echo preserved\r", &mut relay)
+            .expect("preserve typeahead after protected submit");
+    }
+    master.sync_all().expect("sync test output");
+    assert_eq!(fs::read(&path).expect("read held output"), b"/ho\t");
+
+    {
+        let mut relay = input_relay_context(&mut master, &classifier, &tx, &input_mode, &mut state);
+        relay_passthrough_input(b"echo next\r", &mut relay)
+            .expect("retain input arriving before the handoff deadline");
+    }
+    master.sync_all().expect("sync retained output");
+    assert_eq!(fs::read(&path).expect("read retained output"), b"/ho\t");
+
+    finish_input_relay(&mut master, &tx, &classifier, &input_mode, &mut state)
+        .expect("EOF drains preserved typeahead");
+    master.sync_all().expect("sync replayed output");
+
+    assert_eq!(
+        fs::read(&path).expect("read test output"),
+        b"/ho\t\x03 echo preserved\recho next\rexit\n"
+    );
+    fs::remove_file(path).ok();
+}
+
+#[test]
+fn zsh_space_prefix_returns_to_shell_when_ascii_command_resolves() {
+    let (path, mut master) = output_file("native-space-prefix");
+    let (tx, _rx) = mpsc::channel();
+    let input_mode = Arc::new(Mutex::new(RawInputMode::Passthrough));
+    let mut line_buffer = CandidateLineBuffer::default();
+    let mut native_line_state = NativeLineState::default();
+    let mut exit_tracker = ExplicitExitTracker::default();
+    let classifier = InputClassifier::default();
+    let input_generation = UserPtyInputGeneration::default();
+    let mut line_submits = LineSubmitCounter::default();
+    let main_prompt_gate = super::super::MainPromptGate::default();
+    let mut zsh_path_prompt_buffering = ZshPathPromptBuffering::new();
+    let mut relay = InputRelayContext {
+        master: &mut master,
+        input_classifier: &classifier,
+        input_events: &tx,
+        input_mode: &input_mode,
+        input_generation: &input_generation,
+        line_submits: &mut line_submits,
+        line_buffer: &mut line_buffer,
+        native_line_state: &mut native_line_state,
+        exit_tracker: &mut exit_tracker,
+        main_prompt_gate: &main_prompt_gate,
+        slash_route_enabled: false,
+        zsh_path_prompt_buffering: Some(&mut zsh_path_prompt_buffering),
+    };
+
+    relay_passthrough_input(b" ", &mut relay).expect("hold unresolved space prefix");
+    assert!(relay.line_buffer.is_active());
+    assert_eq!(fs::read(&path).expect("read held output"), b"");
+
+    relay_passthrough_input(b"echo", &mut relay).expect("return ASCII command to ZLE");
+    relay.master.sync_all().expect("sync returned command");
+    assert!(!relay.line_buffer.is_active());
+    assert_eq!(fs::read(&path).expect("read returned output"), b" echo");
     fs::remove_file(path).ok();
 }
 
@@ -2209,6 +2364,7 @@ fn native_exact_slash_tab_submit_keeps_readline_guard() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"/help\t\n", &mut relay).expect("submit completed slash");
@@ -2245,6 +2401,7 @@ fn native_shell_input_reports_editing_then_empty_without_content() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"partial", &mut relay).expect("type partial line");
@@ -2298,6 +2455,7 @@ fn agent_prompt_tab_stays_local_until_enter_and_keeps_suggestion_id() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2372,6 +2530,7 @@ fn selection_enter_submits_the_active_prompt_without_shell_execution() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_prompt_ghost_input(b"\r", "inspect disk pressure", &route, &mut relay)
@@ -2425,6 +2584,7 @@ fn clearing_accepted_agent_prompt_emits_binding_dismissal() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2468,6 +2628,7 @@ fn unsupported_arrow_after_agent_prompt_tab_cancels_without_writing_to_shell() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2522,6 +2683,7 @@ fn split_cursor_sequences_after_agent_prompt_tab_never_reach_shell() {
             exit_tracker: &mut exit_tracker,
             main_prompt_gate: &main_prompt_gate,
             slash_route_enabled: false,
+            zsh_path_prompt_buffering: None,
         };
 
         relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2572,6 +2734,7 @@ fn clearing_and_submitting_in_one_buffer_dismisses_binding() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_prompt_ghost_input(b"\t", "analyze failure", &route, &mut relay)
@@ -2613,6 +2776,7 @@ fn passthrough_relay_fixture<'a>(
         exit_tracker,
         main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     }
 }
 
@@ -3766,6 +3930,7 @@ fn native_exact_slash_routes_to_shell_when_at_prompt() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"/mode approval\n", &mut relay).expect("route exact slash");
@@ -3996,6 +4161,7 @@ fn native_exact_slash_falls_back_to_rust_intercept_when_not_at_prompt() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"/mode approval\n", &mut relay).expect("fall back to intercept");
@@ -4041,6 +4207,7 @@ fn native_shell_submission_lowers_gate_before_follow_up_slash() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"python\n/mode approval\n", &mut relay)
@@ -4090,6 +4257,7 @@ fn same_batch_follow_up_slash_stays_batch_owned_and_guarded() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(
@@ -4265,6 +4433,7 @@ fn native_hint_prefix_slash_keeps_rust_intercept_when_routed() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: true,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_passthrough_input(b"/sk\n", &mut relay).expect("hint prefix intercept");

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn.rs
@@ -30,6 +30,7 @@ mod action;
 mod assistance;
 mod capture;
 mod deadline;
+mod finish;
 mod prompt_ghost;
 mod read_batch;
 mod reader;
@@ -44,12 +45,13 @@ use action::{
 };
 pub(crate) use action::{spawn_raw_action_relay, spawn_raw_action_relay_with_wake};
 use assistance::{flush_pending_assistance_escape, resolve_assistance_shortcut};
+pub(super) use capture::relay_late_capture_input;
 use capture::{
     capture_generation, capture_owns_input, capture_quarantine_generation, drain_abandoned_capture,
     relay_input_chunk, CaptureOwnedInput,
 };
-pub(super) use capture::{finish_input_relay, relay_late_capture_input};
-use deadline::{next_pending_deadline, receive_input};
+use deadline::{flush_pending_deadlines, next_pending_deadline, receive_input};
+pub(super) use finish::finish_input_relay;
 use prompt_ghost::{
     dismiss_replaced_prompt_ghost, PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix,
 };
@@ -57,8 +59,10 @@ use read_batch::{
     is_pending_shell_submission, should_split_passthrough_batch, InputRead, RelayReadContext,
 };
 use reader::read_input_chunks;
+pub(in crate::raw_input) use state::input_relay_context;
 pub(super) use state::RawInputRelayState;
-use state::{flush_pending_draft_escape, input_relay_context, sync_pending_draft_escape};
+use state::{flush_deferred_zsh_tab_typeahead, sync_pending_draft_escape};
+pub(crate) use state::{RawInputShellRoute, ZshPathPromptBuffering};
 
 const PROMPT_GHOST_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
 const DELAY_ESCAPE_TIMEOUT: Duration = Duration::from_millis(50);
@@ -85,8 +89,7 @@ where
         input_classifier,
         input_mode,
         input_generation,
-        main_prompt_gate,
-        slash_route_enabled,
+        RawInputShellRoute::new(main_prompt_gate, slash_route_enabled, None),
         None,
         None,
     )
@@ -100,8 +103,7 @@ pub(crate) fn spawn_raw_input_relay_with_wake<R>(
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
     input_generation: UserPtyInputGeneration,
-    main_prompt_gate: MainPromptGate,
-    slash_route_enabled: bool,
+    shell_route: RawInputShellRoute,
     input_fd: Option<RawFd>,
     wake: Option<UnixStream>,
 ) -> JoinHandle<io::Result<()>>
@@ -115,59 +117,16 @@ where
         let reader_input_mode = input_mode.clone();
         thread::spawn(move || read_input_chunks(input, read_tx, reader_input_mode, input_fd));
 
-        let mut state = RawInputRelayState::with_generation_and_gate(
-            input_generation,
-            main_prompt_gate,
-            slash_route_enabled,
-        );
+        let mut state = RawInputRelayState::with_shell_route(input_generation, shell_route);
         loop {
             sync_pending_draft_escape(&mut state);
             let input = match receive_input(&read_rx, &mut state) {
                 Ok(input) => input,
                 Err(RecvTimeoutError::Timeout) => {
-                    flush_pending_assistance_escape(
-                        false,
-                        Instant::now(),
-                        &mut master,
-                        &input_events,
-                        &input_classifier,
-                        &input_mode,
-                        &mut state,
-                    )?;
-                    flush_pending_draft_escape(
-                        Instant::now(),
+                    flush_pending_deadlines(
                         &mut master,
                         &input_classifier,
                         &input_events,
-                        &input_mode,
-                        &mut state,
-                    )?;
-                    flush_pending_prompt_ghost_escape(
-                        false,
-                        Instant::now(),
-                        &mut master,
-                        &input_events,
-                        &input_classifier,
-                        &input_mode,
-                        &mut state,
-                    )?;
-                    flush_pending_delay_escape(
-                        false,
-                        Instant::now(),
-                        &mut master,
-                        &input_events,
-                        &input_classifier,
-                        &input_mode,
-                        &mut state,
-                    )?;
-                    let mode = current_raw_input_mode(&input_mode);
-                    flush_pending_replaced_prompt_ghost_suffix(
-                        false,
-                        Instant::now(),
-                        &mode,
-                        &mut master,
-                        &input_events,
-                        &input_classifier,
                         &input_mode,
                         &mut state,
                     )?;
@@ -445,8 +404,7 @@ fn relay_input_bytes_with_read_ahead(
                     read_context,
                 );
             }
-            // The pending prefix belongs to the previous ghost. Route it before
-            // processing the new bytes so they cannot become its Shift+Tab suffix.
+            // Route the previous ghost first so new bytes cannot become its Shift+Tab suffix.
             relay_input_for_mode(
                 &pending.bytes,
                 mode,
@@ -625,6 +583,7 @@ fn relay_input_for_mode(
         line_submits,
         main_prompt_gate,
         slash_route_enabled,
+        zsh_path_prompt_buffering,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -639,6 +598,7 @@ fn relay_input_for_mode(
         exit_tracker,
         main_prompt_gate,
         slash_route_enabled: *slash_route_enabled,
+        zsh_path_prompt_buffering: zsh_path_prompt_buffering.as_mut(),
     };
     relay_input_chunk(
         bytes,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/action.rs
@@ -17,10 +17,11 @@ use super::super::pty::{set_pty_winsize, signal_process_group};
 use super::super::{MainPromptGate, RawInputEvent, RawRelayAction, ESC};
 use super::deadline::next_pending_deadline;
 use super::{
-    finish_input_relay, flush_pending_prompt_ghost_escape,
+    finish_input_relay, flush_deferred_zsh_tab_typeahead, flush_pending_prompt_ghost_escape,
     flush_pending_replaced_prompt_ghost_suffix, is_pending_shell_submission,
     relay_input_bytes_with_read_ahead, relay_input_for_mode, should_split_passthrough_batch,
-    RawInputEventSink, RawInputRelayState, RelayReadContext, WakingRawInputEventSender,
+    RawInputEventSink, RawInputRelayState, RawInputShellRoute, RelayReadContext,
+    WakingRawInputEventSender,
 };
 
 pub(super) struct PendingDelayEscape {
@@ -184,6 +185,15 @@ fn wait_for_raw_action(
             break;
         }
         thread::sleep(deadline.saturating_duration_since(Instant::now()));
+        flush_deferred_zsh_tab_typeahead(
+            false,
+            Instant::now(),
+            master,
+            input_classifier,
+            input_events,
+            input_mode,
+            state,
+        )?;
         flush_pending_prompt_ghost_escape(
             false,
             Instant::now(),
@@ -239,8 +249,7 @@ pub(crate) fn spawn_raw_action_relay(
         input_classifier,
         input_mode,
         input_generation,
-        main_prompt_gate,
-        slash_route_enabled,
+        RawInputShellRoute::new(main_prompt_gate, slash_route_enabled, None),
         None,
     )
 }
@@ -254,18 +263,22 @@ pub(crate) fn spawn_raw_action_relay_with_wake(
     input_classifier: InputClassifier,
     input_mode: Arc<Mutex<RawInputMode>>,
     input_generation: UserPtyInputGeneration,
-    main_prompt_gate: MainPromptGate,
-    slash_route_enabled: bool,
+    shell_route: RawInputShellRoute,
     wake: Option<UnixStream>,
 ) -> JoinHandle<io::Result<()>> {
     thread::spawn(move || {
         let input_events = WakingRawInputEventSender::new(input_events, wake);
-        let mut state = RawInputRelayState::with_generation_and_gate(
-            input_generation,
-            main_prompt_gate,
-            slash_route_enabled,
-        );
+        let mut state = RawInputRelayState::with_shell_route(input_generation, shell_route);
         for action in actions {
+            flush_deferred_zsh_tab_typeahead(
+                false,
+                Instant::now(),
+                &mut master,
+                &input_classifier,
+                &input_events,
+                &input_mode,
+                &mut state,
+            )?;
             flush_pending_prompt_ghost_escape(
                 false,
                 Instant::now(),

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture.rs
@@ -432,6 +432,7 @@ pub(in super::super) fn relay_late_capture_input(
         line_submits,
         main_prompt_gate,
         slash_route_enabled,
+        zsh_path_prompt_buffering,
         ..
     } = state;
     let mut relay = InputRelayContext {
@@ -446,6 +447,7 @@ pub(in super::super) fn relay_late_capture_input(
         exit_tracker,
         main_prompt_gate,
         slash_route_enabled: *slash_route_enabled,
+        zsh_path_prompt_buffering: zsh_path_prompt_buffering.as_mut(),
     };
     relay_late_capture_bytes(
         bytes,
@@ -592,91 +594,6 @@ pub(super) fn drain_abandoned_capture(
         generation,
         relay,
     )
-}
-
-pub(in super::super) fn finish_input_relay(
-    master: &mut File,
-    input_events: &dyn RawInputEventSink,
-    input_classifier: &InputClassifier,
-    input_mode: &Arc<Mutex<RawInputMode>>,
-    state: &mut RawInputRelayState,
-) -> io::Result<()> {
-    // EOF is cancellation, not the timeout path. Pending escape/suffix bytes
-    // are Cosh-owned lookahead and must never become PTY input during
-    // shutdown.
-    let current_mode = current_raw_input_mode(input_mode);
-    let dismiss_prompt_ghost = state.pending_prompt_ghost_escape.take().is_some()
-        || state.pending_replaced_prompt_ghost_suffix.take().is_some()
-        || matches!(current_mode, RawInputMode::PromptGhost { .. });
-    state.pending_delay_escape.take();
-    state.pending_assistance_escape.take();
-    if dismiss_prompt_ghost {
-        let _ = input_events.send(RawInputEvent::CandidateClearLine);
-        let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
-        if matches!(current_mode, RawInputMode::PromptGhost { .. }) {
-            if let Ok(mut mode) = input_mode.lock() {
-                *mode = RawInputMode::Passthrough;
-            }
-        }
-    }
-    if let RawInputMode::Submitted { generation, .. } = current_raw_input_mode(input_mode) {
-        expire_capture_submission(input_mode, generation);
-    }
-    abandon_active_capture(input_mode);
-    if matches!(
-        current_raw_input_mode(input_mode),
-        RawInputMode::Draining { .. }
-    ) {
-        let RawInputRelayState {
-            card_state,
-            line_buffer,
-            native_line_state,
-            exit_tracker,
-            capture_owned_input,
-            input_generation,
-            line_submits,
-            main_prompt_gate,
-            ..
-        } = state;
-        let mut relay = InputRelayContext {
-            master,
-            input_classifier,
-            input_events,
-            input_mode,
-            input_generation,
-            line_submits,
-            line_buffer,
-            native_line_state,
-            exit_tracker,
-            main_prompt_gate,
-            slash_route_enabled: false,
-        };
-        drain_abandoned_capture(card_state, capture_owned_input, &mut relay)?;
-    }
-    // Candidate bytes were never submitted to the Shell. EOF cancels them;
-    // flushing a lone `?`, slash prefix, or partial paste delimiter before
-    // `exit` would turn display state into executable input.
-    let candidate_paste_active = state.line_buffer.in_paste();
-    if state.line_buffer.is_active() {
-        state.line_buffer.clear();
-        let _ = input_events.send(RawInputEvent::CandidateClearLine);
-    }
-    if state.exit_tracker.saw_explicit_exit() {
-        return Ok(());
-    }
-    if !candidate_paste_active && state.native_line_state.is_empty() {
-        write_user_bytes_to_pty(
-            master,
-            &state.input_generation,
-            &mut state.line_submits,
-            input_events,
-            &state.main_prompt_gate,
-            b"exit\n",
-        )?;
-    } else {
-        let _ = input_events.send(RawInputEvent::EofShutdownRequested);
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_matrix_tests.rs
@@ -105,6 +105,7 @@ impl MatrixHarness {
             exit_tracker: &mut self.exit_tracker,
             main_prompt_gate: &self.main_prompt_gate,
             slash_route_enabled: false,
+            zsh_path_prompt_buffering: None,
         };
         relay_input_chunk(
             bytes,
@@ -131,6 +132,7 @@ impl MatrixHarness {
             exit_tracker: &mut self.exit_tracker,
             main_prompt_gate: &self.main_prompt_gate,
             slash_route_enabled: false,
+            zsh_path_prompt_buffering: None,
         };
         drain_abandoned_capture(&mut self.card_state, &mut self.quarantine, &mut relay)
             .expect("drain abandoned capture");
@@ -408,6 +410,7 @@ fn stale_generation_batch_keeps_live_chain_buffer() {
         exit_tracker: &mut harness.exit_tracker,
         main_prompt_gate: &harness.main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
     relay_late_capture_bytes(
         b"stale batch",
@@ -451,6 +454,7 @@ fn stale_generation_batch_rejects_orphan_buffer_visibly() {
         exit_tracker: &mut harness.exit_tracker,
         main_prompt_gate: &harness.main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
     relay_late_capture_bytes(
         b"stale batch",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_owner_matrix_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_owner_matrix_tests.rs
@@ -132,6 +132,7 @@ fn replay_rejects_when_live_owner_superseded_the_drain_terminal() {
         exit_tracker: &mut harness.exit_tracker,
         main_prompt_gate: &harness.main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
     replay_or_reject_after_drain(
         installed,
@@ -330,6 +331,7 @@ fn superseded_hold_owner_rejects_ctrl_c_without_control_events() {
         exit_tracker: &mut harness.exit_tracker,
         main_prompt_gate: &harness.main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
     replay_or_reject_after_drain(
         installed,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/capture_tests.rs
@@ -71,6 +71,7 @@ fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
 
     relay_input_chunk(
@@ -127,6 +128,7 @@ fn generation_cutoff_does_not_retry_input_into_the_replacement_capture() {
         exit_tracker: &mut exit_tracker,
         main_prompt_gate: &main_prompt_gate,
         slash_route_enabled: false,
+        zsh_path_prompt_buffering: None,
     };
     relay_input_chunk(
         b"later",

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/deadline.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/deadline.rs
@@ -1,9 +1,84 @@
 //! Blocking receive deadlines for split escape-sequence handling.
 
+use std::fs::File;
 use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use super::{InputRead, RawInputRelayState};
+use crate::input::InputClassifier;
+
+use super::state::flush_pending_draft_escape;
+use super::{
+    current_raw_input_mode, flush_deferred_zsh_tab_typeahead, flush_pending_assistance_escape,
+    flush_pending_delay_escape, flush_pending_prompt_ghost_escape,
+    flush_pending_replaced_prompt_ghost_suffix, InputRead, RawInputEventSink, RawInputMode,
+    RawInputRelayState,
+};
+
+pub(super) fn flush_pending_deadlines(
+    master: &mut File,
+    input_classifier: &InputClassifier,
+    input_events: &dyn RawInputEventSink,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> std::io::Result<()> {
+    let now = Instant::now();
+    flush_deferred_zsh_tab_typeahead(
+        false,
+        now,
+        master,
+        input_classifier,
+        input_events,
+        input_mode,
+        state,
+    )?;
+    flush_pending_assistance_escape(
+        false,
+        now,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )?;
+    flush_pending_draft_escape(
+        now,
+        master,
+        input_classifier,
+        input_events,
+        input_mode,
+        state,
+    )?;
+    flush_pending_prompt_ghost_escape(
+        false,
+        now,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )?;
+    flush_pending_delay_escape(
+        false,
+        now,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )?;
+    let mode = current_raw_input_mode(input_mode);
+    flush_pending_replaced_prompt_ghost_suffix(
+        false,
+        now,
+        &mode,
+        master,
+        input_events,
+        input_classifier,
+        input_mode,
+        state,
+    )
+}
 
 pub(super) fn receive_input(
     receiver: &Receiver<InputRead>,
@@ -43,5 +118,11 @@ pub(super) fn next_pending_deadline(state: &RawInputRelayState) -> Option<Instan
                 .map(|pending| pending.deadline),
         )
         .chain(state.pending_draft_escape_deadline)
+        .chain(
+            state
+                .zsh_path_prompt_buffering
+                .as_ref()
+                .and_then(|buffering| buffering.tab_typeahead_deadline()),
+        )
         .min()
 }

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/finish.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/finish.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+pub(in super::super) fn finish_input_relay(
+    master: &mut File,
+    input_events: &dyn RawInputEventSink,
+    input_classifier: &InputClassifier,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> io::Result<()> {
+    if let Some(deadline) = state
+        .zsh_path_prompt_buffering
+        .as_ref()
+        .and_then(|buffering| buffering.tab_typeahead_deadline())
+    {
+        thread::sleep(deadline.saturating_duration_since(Instant::now()));
+    }
+    flush_deferred_zsh_tab_typeahead(
+        true,
+        Instant::now(),
+        master,
+        input_classifier,
+        input_events,
+        input_mode,
+        state,
+    )?;
+    // EOF is cancellation, not the timeout path. Pending escape/suffix bytes
+    // are Cosh-owned lookahead and must never become PTY input during
+    // shutdown.
+    let current_mode = current_raw_input_mode(input_mode);
+    let dismiss_prompt_ghost = state.pending_prompt_ghost_escape.take().is_some()
+        || state.pending_replaced_prompt_ghost_suffix.take().is_some()
+        || matches!(current_mode, RawInputMode::PromptGhost { .. });
+    state.pending_delay_escape.take();
+    state.pending_assistance_escape.take();
+    if dismiss_prompt_ghost {
+        let _ = input_events.send(RawInputEvent::CandidateClearLine);
+        let _ = input_events.send(RawInputEvent::PromptGhostDismissed);
+        if matches!(current_mode, RawInputMode::PromptGhost { .. }) {
+            if let Ok(mut mode) = input_mode.lock() {
+                *mode = RawInputMode::Passthrough;
+            }
+        }
+    }
+    if let RawInputMode::Submitted { generation, .. } = current_raw_input_mode(input_mode) {
+        expire_capture_submission(input_mode, generation);
+    }
+    abandon_active_capture(input_mode);
+    if matches!(
+        current_raw_input_mode(input_mode),
+        RawInputMode::Draining { .. }
+    ) {
+        let RawInputRelayState {
+            card_state,
+            line_buffer,
+            native_line_state,
+            exit_tracker,
+            capture_owned_input,
+            input_generation,
+            line_submits,
+            main_prompt_gate,
+            zsh_path_prompt_buffering,
+            ..
+        } = state;
+        let mut relay = InputRelayContext {
+            master,
+            input_classifier,
+            input_events,
+            input_mode,
+            input_generation,
+            line_submits,
+            line_buffer,
+            native_line_state,
+            exit_tracker,
+            main_prompt_gate,
+            slash_route_enabled: false,
+            zsh_path_prompt_buffering: zsh_path_prompt_buffering.as_mut(),
+        };
+        drain_abandoned_capture(card_state, capture_owned_input, &mut relay)?;
+    }
+    // Candidate bytes were never submitted to the Shell. EOF cancels them;
+    // flushing a lone `?`, slash prefix, or partial paste delimiter before
+    // `exit` would turn display state into executable input.
+    let candidate_paste_active = state.line_buffer.in_paste();
+    if state.line_buffer.is_active() {
+        state.line_buffer.clear();
+        let _ = input_events.send(RawInputEvent::CandidateClearLine);
+    }
+    if state.exit_tracker.saw_explicit_exit() {
+        return Ok(());
+    }
+    if !candidate_paste_active && state.native_line_state.is_empty() {
+        write_user_bytes_to_pty(
+            master,
+            &state.input_generation,
+            &mut state.line_submits,
+            input_events,
+            &state.main_prompt_gate,
+            b"exit\n",
+        )?;
+    } else {
+        let _ = input_events.send(RawInputEvent::EofShutdownRequested);
+    }
+    Ok(())
+}

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/spawn/state.rs
@@ -14,13 +14,90 @@ use super::super::event_sender::RawInputEventSink;
 use super::super::generation::{LineSubmitCounter, UserPtyInputGeneration};
 use super::super::mode::current_raw_input_mode;
 use super::super::mode::RawInputMode;
-use super::super::relay::{ExplicitExitTracker, InputRelayContext};
+use super::super::relay::{
+    replay_deferred_zsh_tab_typeahead, ExplicitExitTracker, InputRelayContext,
+};
 use super::super::MainPromptGate;
 use super::action::PendingDelayEscape;
 use super::assistance::PendingAssistanceEscape;
 use super::capture::{drain_capture_submission, CaptureOwnedInput};
 use super::prompt_ghost::{PendingPromptGhostEscape, PendingReplacedPromptGhostSuffix};
 use super::InputRead;
+
+pub(crate) struct RawInputShellRoute {
+    pub(crate) main_prompt_gate: MainPromptGate,
+    pub(crate) slash_route_enabled: bool,
+    pub(crate) zsh_path_prompt_buffering: Option<ZshPathPromptBuffering>,
+}
+
+/// Marks Zsh sessions that keep slash candidates Rust-owned until submission.
+pub(crate) struct ZshPathPromptBuffering {
+    deferred_tab_typeahead: Option<DeferredZshTabTypeahead>,
+}
+
+struct DeferredZshTabTypeahead {
+    bytes: Vec<u8>,
+    deadline: Instant,
+}
+
+const ZSH_TAB_TYPEAHEAD_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+
+impl ZshPathPromptBuffering {
+    pub(crate) fn new() -> Self {
+        Self {
+            deferred_tab_typeahead: None,
+        }
+    }
+
+    pub(in crate::raw_input) fn defer_tab_typeahead(&mut self, bytes: &[u8]) {
+        if let Some(pending) = self.deferred_tab_typeahead.as_mut() {
+            pending.bytes.extend_from_slice(bytes);
+        } else {
+            self.deferred_tab_typeahead = Some(DeferredZshTabTypeahead {
+                bytes: bytes.to_vec(),
+                deadline: Instant::now() + ZSH_TAB_TYPEAHEAD_DELAY,
+            });
+        }
+    }
+
+    pub(in crate::raw_input) fn has_deferred_tab_typeahead(&self) -> bool {
+        self.deferred_tab_typeahead.is_some()
+    }
+
+    pub(in crate::raw_input) fn tab_typeahead_deadline(&self) -> Option<Instant> {
+        self.deferred_tab_typeahead
+            .as_ref()
+            .map(|pending| pending.deadline)
+    }
+
+    fn take_due_tab_typeahead(&mut self, force: bool, now: Instant) -> Option<Vec<u8>> {
+        if !force
+            && self
+                .deferred_tab_typeahead
+                .as_ref()
+                .is_none_or(|pending| now < pending.deadline)
+        {
+            return None;
+        }
+        self.deferred_tab_typeahead
+            .take()
+            .map(|pending| pending.bytes)
+    }
+}
+
+impl RawInputShellRoute {
+    pub(crate) fn new(
+        main_prompt_gate: MainPromptGate,
+        slash_route_enabled: bool,
+        zsh_path_prompt_buffering: Option<ZshPathPromptBuffering>,
+    ) -> Self {
+        Self {
+            main_prompt_gate,
+            slash_route_enabled,
+            zsh_path_prompt_buffering,
+        }
+    }
+}
 
 #[derive(Default)]
 pub(in super::super) struct RawInputRelayState {
@@ -35,6 +112,7 @@ pub(in super::super) struct RawInputRelayState {
     /// recall (issue #1718); gated further by `main_prompt_gate` at
     /// submission time.
     pub(super) slash_route_enabled: bool,
+    pub(super) zsh_path_prompt_buffering: Option<ZshPathPromptBuffering>,
     pub(super) pending_prompt_ghost_escape: Option<PendingPromptGhostEscape>,
     pub(super) pending_delay_escape: Option<PendingDelayEscape>,
     pub(super) pending_assistance_escape: Option<PendingAssistanceEscape>,
@@ -59,8 +137,21 @@ impl RawInputRelayState {
             ..Self::default()
         }
     }
+
+    pub(in crate::raw_input) fn with_shell_route(
+        input_generation: UserPtyInputGeneration,
+        route: RawInputShellRoute,
+    ) -> Self {
+        Self {
+            input_generation,
+            main_prompt_gate: route.main_prompt_gate,
+            slash_route_enabled: route.slash_route_enabled,
+            zsh_path_prompt_buffering: route.zsh_path_prompt_buffering,
+            ..Self::default()
+        }
+    }
 }
-pub(super) fn input_relay_context<'a>(
+pub(in crate::raw_input) fn input_relay_context<'a>(
     master: &'a mut File,
     input_classifier: &'a InputClassifier,
     input_events: &'a dyn RawInputEventSink,
@@ -79,7 +170,28 @@ pub(super) fn input_relay_context<'a>(
         exit_tracker: &mut state.exit_tracker,
         main_prompt_gate: &state.main_prompt_gate,
         slash_route_enabled: state.slash_route_enabled,
+        zsh_path_prompt_buffering: state.zsh_path_prompt_buffering.as_mut(),
     }
+}
+
+pub(in crate::raw_input) fn flush_deferred_zsh_tab_typeahead(
+    force: bool,
+    now: Instant,
+    master: &mut File,
+    input_classifier: &InputClassifier,
+    input_events: &dyn RawInputEventSink,
+    input_mode: &Arc<Mutex<RawInputMode>>,
+    state: &mut RawInputRelayState,
+) -> std::io::Result<()> {
+    let Some(bytes) = state
+        .zsh_path_prompt_buffering
+        .as_mut()
+        .and_then(|buffering| buffering.take_due_tab_typeahead(force, now))
+    else {
+        return Ok(());
+    };
+    let mut relay = input_relay_context(master, input_classifier, input_events, input_mode, state);
+    replay_deferred_zsh_tab_typeahead(&bytes, &mut relay)
 }
 
 // A bare ESC inside the draft card waits this long for a split CR/LF
@@ -146,6 +258,7 @@ pub(super) fn flush_pending_draft_escape(
                 line_submits,
                 main_prompt_gate,
                 slash_route_enabled,
+                zsh_path_prompt_buffering,
                 ..
             } = state;
             let mut relay = InputRelayContext {
@@ -160,6 +273,7 @@ pub(super) fn flush_pending_draft_escape(
                 exit_tracker,
                 main_prompt_gate,
                 slash_route_enabled: *slash_route_enabled,
+                zsh_path_prompt_buffering: zsh_path_prompt_buffering.as_mut(),
             };
             relay.line_buffer.clear();
             relay.native_line_state.clear();

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/adapter.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/adapter.rs
@@ -9,6 +9,9 @@ pub(super) trait ShellAdapter {
     fn marker_filename(&self) -> &'static str;
     fn marker_script(&self) -> &'static str;
     fn isolates_readline(&self) -> bool;
+    fn supports_zsh_path_prompt_buffering(&self) -> bool {
+        false
+    }
     fn configure_command(
         &self,
         command: &mut Command,
@@ -83,6 +86,10 @@ impl ShellAdapter for ZshAdapter {
 
     fn isolates_readline(&self) -> bool {
         false
+    }
+
+    fn supports_zsh_path_prompt_buffering(&self) -> bool {
+        true
     }
 
     fn configure_command(

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
@@ -10,6 +10,8 @@ use std::time::{Duration, SystemTime};
 use nix::libc;
 use nix::pty::openpty;
 
+use crate::raw_input::ZshPathPromptBuffering;
+
 use super::adapter::{BashAdapter, ShellAdapter, ZshAdapter};
 use super::auth::{generate_marker_token, marker_script_with_token};
 use super::lifecycle::push_shell_started_event;
@@ -31,6 +33,7 @@ pub(super) struct PtySession {
     pub(super) parser: OscParser,
     pub(super) recovery_request_file: PathBuf,
     pub(super) handoff_request_file: PathBuf,
+    pub(super) zsh_path_prompt_buffering: Option<ZshPathPromptBuffering>,
 }
 
 pub(super) fn start_bash_session(config: &ShellHostConfig) -> io::Result<PtySession> {
@@ -90,6 +93,9 @@ fn start_shell_session(
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
         Some(path)
     };
+    let zsh_path_prompt_buffering = (marker.is_some()
+        && adapter.supports_zsh_path_prompt_buffering())
+    .then(ZshPathPromptBuffering::new);
 
     let pty = openpty(Some(&config.winsize), None).map_err(nix_to_io)?;
     let master = unsafe { File::from_raw_fd(pty.master.into_raw_fd()) };
@@ -188,6 +194,7 @@ fn start_shell_session(
         parser,
         recovery_request_file,
         handoff_request_file,
+        zsh_path_prompt_buffering,
     })
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/bash.sh
@@ -290,8 +290,8 @@ _cosh_command_has_secret() {
   local dynamic_cookie_header_pattern='(\$|`)[^;&|]*'
   dynamic_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
   # Operators inside a closed substitution do not terminate its outer word.
-  local dynamic_substitution_cookie_header_pattern='(\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
-  dynamic_substitution_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local dynamic_expansion_cookie_header_pattern='(\$\{.*\}|\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
+  dynamic_expansion_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
   # Quote removal and backslash escapes can construct a static Cookie prefix
   # even when the raw command does not contain a contiguous `Cookie:` token.
   local static_cookie_input="${lower//\\/}"
@@ -305,7 +305,7 @@ _cosh_command_has_secret() {
      || "$static_cookie_input" =~ $cookie_header_pattern
      || "$static_cookie_input" =~ $attached_cookie_header_pattern
      || "$static_cookie_input" =~ $dynamic_cookie_header_pattern
-     || "$static_cookie_input" =~ $dynamic_substitution_cookie_header_pattern ]]; then
+     || "$static_cookie_input" =~ $dynamic_expansion_cookie_header_pattern ]]; then
     return 0
   fi
   return 1

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -660,10 +660,6 @@ _cosh_precmd_marker() {
     _cosh_emit_marker "prompt_ready" "" "$exit_status" false
   fi
 }
-# ── Hook setup (re-set after user rcfile may have overridden) ──
-# Slash command function stubs — prevent "zsh: no such file or directory" for
-# commands starting with / that zsh would try to exec as an absolute path.
-# The actual interception and marker emission happens in _cosh_preexec_marker.
 for _cosh_sc in about agent allow answer approval-mode approve audit auth cancel clear config copy debug deny details explain extensions health help hooks mcp mode new recommendations resume select send-to-shell session shell skills stats status; do
   functions[/$_cosh_sc]='_cosh_assistance_enabled || command "$0" "$@"'
 done

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh
@@ -52,8 +52,8 @@ _cosh_command_has_secret() {
   local dynamic_cookie_header_pattern='(\$|`)[^;&|]*'
   dynamic_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
   # Operators inside a closed substitution do not terminate its outer word.
-  local dynamic_substitution_cookie_header_pattern='(\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
-  dynamic_substitution_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
+  local dynamic_expansion_cookie_header_pattern='(\$\{.*\}|\$\(.*\)|`[^`]*`)[^[:space:];&|]*'
+  dynamic_expansion_cookie_header_pattern+="${cookie_key}[[:space:]]*:[[:space:]]*[^=[:space:];,]+[[:space:]]*=[^[:space:]]*"
   # Quote removal and backslash escapes can construct a static Cookie prefix
   # even when the raw command does not contain a contiguous `Cookie:` token.
   local static_cookie_input="${lower//\\/}"
@@ -67,7 +67,7 @@ _cosh_command_has_secret() {
      || "$static_cookie_input" =~ $cookie_header_pattern
      || "$static_cookie_input" =~ $attached_cookie_header_pattern
      || "$static_cookie_input" =~ $dynamic_cookie_header_pattern
-     || "$static_cookie_input" =~ $dynamic_substitution_cookie_header_pattern ]]; then
+     || "$static_cookie_input" =~ $dynamic_expansion_cookie_header_pattern ]]; then
     return 0
   fi
   return 1

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -12,7 +12,8 @@ use nix::libc;
 use crate::input::{AssistanceControl, InputClassifier};
 use crate::raw_input::{
     spawn_raw_action_relay_with_wake, spawn_raw_input_relay_with_wake, MainPromptGate,
-    RawInputEvent, RawInputMode, RawObserverAction, RawRelayAction, UserPtyInputGeneration,
+    RawInputEvent, RawInputMode, RawInputShellRoute, RawObserverAction, RawRelayAction,
+    UserPtyInputGeneration,
 };
 use crate::types::ShellEvent;
 
@@ -115,8 +116,7 @@ where
          input_classifier,
          input_mode,
          input_generation,
-         gate,
-         routed,
+         shell_route,
          wake| {
             spawn_raw_input_relay_with_wake(
                 input,
@@ -125,8 +125,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
-                gate,
-                routed,
+                shell_route,
                 input_fd,
                 Some(wake),
             )
@@ -181,8 +180,7 @@ where
          input_classifier,
          input_mode,
          input_generation,
-         gate,
-         routed,
+         shell_route,
          wake| {
             spawn_raw_input_relay_with_wake(
                 input,
@@ -191,8 +189,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
-                gate,
-                routed,
+                shell_route,
                 input_fd,
                 Some(wake),
             )
@@ -233,8 +230,7 @@ where
          input_classifier,
          input_mode,
          input_generation,
-         gate,
-         routed,
+         shell_route,
          wake| {
             spawn_raw_action_relay_with_wake(
                 actions,
@@ -244,8 +240,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
-                gate,
-                routed,
+                shell_route,
                 Some(wake),
             )
         },
@@ -280,8 +275,7 @@ where
          input_classifier,
          input_mode,
          input_generation,
-         gate,
-         routed,
+         shell_route,
          wake| {
             spawn_raw_action_relay_with_wake(
                 actions,
@@ -291,8 +285,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
-                gate,
-                routed,
+                shell_route,
                 Some(wake),
             )
         },
@@ -324,8 +317,7 @@ where
          input_classifier,
          input_mode,
          input_generation,
-         gate,
-         routed,
+         shell_route,
          wake| {
             spawn_raw_action_relay_with_wake(
                 actions,
@@ -335,8 +327,7 @@ where
                 input_classifier,
                 input_mode,
                 input_generation,
-                gate,
-                routed,
+                shell_route,
                 Some(wake),
             )
         },
@@ -363,8 +354,7 @@ where
         InputClassifier,
         Arc<Mutex<RawInputMode>>,
         UserPtyInputGeneration,
-        MainPromptGate,
-        bool,
+        RawInputShellRoute,
         UnixStream,
     ) -> JoinHandle<io::Result<()>>,
 {
@@ -438,8 +428,11 @@ where
             .with_bash_slash_submission_guard(slash_route_enabled),
         Arc::clone(&input_mode),
         input_generation.clone(),
-        main_prompt_gate,
-        slash_route_enabled,
+        RawInputShellRoute::new(
+            main_prompt_gate,
+            slash_route_enabled,
+            session.zsh_path_prompt_buffering.take(),
+        ),
         wake_writer,
     );
     let (driver_completion_sender, driver_completion_receiver) = mpsc::channel();

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
@@ -105,6 +105,260 @@ fn raw_cli_routes_slash_leading_path_prompt_in_one_input_batch() {
 }
 
 #[test]
+fn raw_cli_zsh_routes_space_prefixed_path_prompt_before_zle() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = temp_zsh_home("space-prefixed-path-prompt");
+    fs::write(
+        home.join(".zshrc"),
+        "PROMPT='zsh-space-path> '\n\
+         RPROMPT=''\n\
+         _cosh_test_accept_line() {\n\
+           [[ \"$BUFFER\" == *nonexistent-cosh-space-prefix* ]] && print -r -- space-path-reached-zle\n\
+           zle .accept-line\n\
+         }\n\
+         _cosh_test_tab_after_agent_submit() {\n\
+           print -r -- tab-after-agent-submit-reached-zle\n\
+           zle .redisplay\n\
+         }\n\
+         zle -N accept-line _cosh_test_accept_line\n\
+         zle -N _cosh_test_tab_after_agent_submit\n\
+         bindkey '^I' _cosh_test_tab_after_agent_submit\n",
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().to_string();
+    let prompt = "  /nonexistent-cosh-space-prefix/SKILL.md 帮我读一下";
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("LANG", "C.UTF-8"),
+            ("LC_ALL", "C.UTF-8"),
+        ],
+        vec![
+            (b" ".to_vec(), Duration::from_millis(300)),
+            (prompt.as_bytes()[1..].to_vec(), Duration::from_millis(50)),
+            (b"\n\t".to_vec(), Duration::from_millis(50)),
+            (
+                b"echo after-space-path\n".to_vec(),
+                Duration::from_millis(500),
+            ),
+            (b"exit\n".to_vec(), Duration::from_millis(100)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(
+        output.contains(&format!("Received shell prompt request: {prompt}")),
+        "{output}"
+    );
+    assert!(output.contains("after-space-path"), "{output}");
+    assert!(!output.contains("space-path-reached-zle"), "{output}");
+    assert!(
+        !output.contains("tab-after-agent-submit-reached-zle"),
+        "{output}"
+    );
+    assert!(!output.contains("no such file or directory"), "{output}");
+}
+
+#[test]
+fn raw_cli_zsh_routes_fragmented_slash_leading_path_prompt() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = temp_zsh_home("path-prompt-custom-kill-line");
+    fs::write(
+        home.join(".zshrc"),
+        "{\n\
+           request_fd=${_COSH_PATH_PROMPT_REQUEST_FD:-${COSH_ZSH_PATH_PROMPT_REQUEST_FD:-}}\n\
+           acknowledgment_fd=${_COSH_PATH_PROMPT_ACK_FD:-${COSH_ZSH_PATH_PROMPT_ACK_FD:-}}\n\
+           if [[ -n \"$request_fd\" && -n \"$acknowledgment_fd\" ]]; then\n\
+             print -r -- path-prompt-fork-channel-exposed\n\
+             IFS= read -r -u \"$request_fd\" request && print -r -- accepted >&\"$acknowledgment_fd\"\n\
+           fi\n\
+         } &!\n\
+         PROMPT='zsh-path:%?> '\nRPROMPT=''\nbindkey -e\nbindkey '^U' self-insert\n\
+         _cosh_test_private_submit() { print -r -- path-prompt-private-binding-ran; zle .redisplay; }\n\
+         zle -N _cosh_test_private_submit\n\
+         bindkey $'\\e[99;99u' _cosh_test_private_submit\n\
+         TRAPINT() { print -r -- path-prompt-user-trap-ran; return 130; }\n\
+         TRAPURG() { print -r -- path-prompt-user-urg-trap-ran; return 0; }\n\
+         typeset -gi COSH_TEST_PRECMD_COUNT=0\n\
+         _cosh_test_slow_third_precmd() {\n\
+           (( ++COSH_TEST_PRECMD_COUNT ))\n\
+           (( COSH_TEST_PRECMD_COUNT == 3 )) && sleep 3\n\
+           return 0\n\
+         }\n\
+         precmd_functions+=(_cosh_test_slow_third_precmd)\n\
+         typeset -g COSH_TEST_PATH_PROMPT='/nonexistent-cosh-1943/SKILL.md 帮我读一下'\n\
+         typeset -g COSH_TEST_HISTORY_LEAK='path-prompt-history-leak'\n\
+         _cosh_test_accept_line() {\n\
+           [[ \"$BUFFER\" == \"$COSH_TEST_PATH_PROMPT\" ]] && print -r -- path-prompt-user-widget-ran\n\
+           zle .accept-line\n\
+         }\n\
+         zle -N accept-line _cosh_test_accept_line\n\
+         typeset -gi COSH_TEST_CUT_BUFFER_SEEDED=0\n\
+         _cosh_test_seed_cut_buffer() {\n\
+           bindkey $'\\e[99;99u' _cosh_test_private_submit\n\
+           (( COSH_TEST_CUT_BUFFER_SEEDED )) && return 0\n\
+           CUTBUFFER='path-prompt-preserved-cut-buffer'\n\
+           killring=('path-prompt-preserved-kill-ring')\n\
+           COSH_TEST_CUT_BUFFER_SEEDED=1\n\
+         }\n\
+         _cosh_test_check_cut_buffer() {\n\
+           if [[ \"$CUTBUFFER\" == path-prompt-preserved-cut-buffer && \"${killring[1]:-}\" == path-prompt-preserved-kill-ring ]]; then\n\
+             print -r -- path-prompt-cut-buffer-preserved\n\
+           else\n\
+             print -r -- path-prompt-cut-buffer-damaged\n\
+           fi\n\
+           zle .redisplay\n\
+         }\n\
+         zle -N zle-line-init _cosh_test_seed_cut_buffer\n\
+         zle -N _cosh_test_check_cut_buffer\n\
+         bindkey '^Xb' _cosh_test_check_cut_buffer\n\
+         _cosh_test_path_history() {\n\
+           [[ \"$1\" == *\"$COSH_TEST_PATH_PROMPT\"* ]] && print -r -- path-prompt-history-hook-ran\n\
+           return 0\n\
+         }\n\
+         autoload -Uz add-zsh-hook\n\
+         add-zsh-hook zshaddhistory _cosh_test_path_history\n",
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().to_string();
+    let prompt = "/nonexistent-cosh-1943/SKILL.md 帮我读一下";
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_INTEGRATION", "enhanced"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("LANG", "C.UTF-8"),
+            ("LC_ALL", "C.UTF-8"),
+        ],
+        vec![
+            (
+                b"echo private-sequence-command-ran".to_vec(),
+                Duration::from_millis(300),
+            ),
+            (b"\x1b[99;99u".to_vec(), Duration::from_millis(100)),
+            (b"\n".to_vec(), Duration::from_millis(300)),
+            (prompt.as_bytes().to_vec(), Duration::from_millis(300)),
+            (b"\n".to_vec(), Duration::from_millis(50)),
+            (b"\x18b".to_vec(), Duration::from_millis(1_000)),
+            (
+                b"fc -l -20 | grep -Fq -- \"$COSH_TEST_PATH_PROMPT\" && print \"$COSH_TEST_HISTORY_LEAK\"\n"
+                    .to_vec(),
+                Duration::from_millis(100),
+            ),
+            (
+                b"echo after-zsh-path-prompt\n".to_vec(),
+                Duration::from_millis(100),
+            ),
+            (b"TRAPURG\n".to_vec(), Duration::from_millis(100)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(100)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    let routed = format!("Received shell prompt request: {prompt}");
+    let routed_offset = output.find(&routed).unwrap_or_else(|| panic!("{output}"));
+    let history_probe_offset = output
+        .find("fc -l -20")
+        .unwrap_or_else(|| panic!("{output}"));
+    let preserved_status_offset = output[routed_offset..]
+        .find("zsh-path:0>")
+        .map(|offset| routed_offset + offset)
+        .unwrap_or_else(|| panic!("{output}"));
+    assert!(preserved_status_offset < history_probe_offset, "{output}");
+    assert!(output.contains("after-zsh-path-prompt"), "{output}");
+    assert!(!output.contains("no such file or directory"), "{output}");
+    assert!(!output.contains("path-prompt-user-trap-ran"), "{output}");
+    assert!(output.contains("path-prompt-user-urg-trap-ran"), "{output}");
+    assert!(!output.contains("path-prompt-user-widget-ran"), "{output}");
+    assert!(output.contains("private-sequence-command-ran"), "{output}");
+    assert_eq!(
+        output.matches("path-prompt-private-binding-ran").count(),
+        1,
+        "{output}"
+    );
+    assert!(
+        output.contains("path-prompt-cut-buffer-preserved"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("path-prompt-cut-buffer-damaged"),
+        "{output}"
+    );
+    assert!(
+        !output.contains("path-prompt-fork-channel-exposed"),
+        "{output}"
+    );
+    assert!(!output.contains("path-prompt-history-hook-ran"), "{output}");
+    assert!(!output.contains("path-prompt-history-leak"), "{output}");
+}
+
+#[test]
+fn raw_cli_zsh_hands_buffered_tab_to_zle_before_follow_up_input() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = temp_zsh_home("path-prompt-tab-handoff");
+    fs::write(
+        home.join(".zshrc"),
+        "PROMPT='zsh-tab:%?> '\nRPROMPT=''\nbindkey -e\n\
+         _cosh_test_tab_rewrite() {\n\
+           print -r -- path-prompt-tab-widget-ran\n\
+           BUFFER=': > \"$HOME/path-prompt-tab-command-executed\"'\n\
+           CURSOR=${#BUFFER}\n\
+           zle .redisplay\n\
+         }\n\
+         zle -N _cosh_test_tab_rewrite\n\
+         bindkey '^I' _cosh_test_tab_rewrite\n",
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().to_string();
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_INTEGRATION", "enhanced"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+        ],
+        vec![
+            (
+                b"/definitely-not-command".to_vec(),
+                Duration::from_millis(300),
+            ),
+            (
+                b"\t\r echo path-prompt-typeahead-preserved\r exit 0\r".to_vec(),
+                Duration::from_millis(300),
+            ),
+            // Hold stdin open without producing another read; the handoff
+            // deadline must drain the complete retained tail on its own.
+            (Vec::new(), Duration::from_millis(300)),
+        ],
+    );
+    assert!(output.contains("path-prompt-tab-widget-ran"), "{output}");
+    assert!(!home.join("path-prompt-tab-command-executed").exists());
+    assert!(
+        output.contains("path-prompt-typeahead-preserved"),
+        "{output}"
+    );
+    let _ = fs::remove_dir_all(&home);
+}
+
+#[test]
 fn raw_cli_shell_only_keeps_slash_bearing_han_prompt_shell_owned() {
     let prompt = "打开./nonexistent-cosh-2913";
     let output = run_raw_cli_with_args_env_and_delayed_input(

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/marker.rs
@@ -141,6 +141,8 @@ fn shell_secret_detectors_match_canonical_shapes_and_boundaries() {
         "curl '-HCookie: session=whole-option-secret-42'",
         r#"curl ${HEADER_OPTION}"Cookie: session=dynamic-option-secret-42" https://example.test"#,
         r#"curl ${HEADER_OPTION}'Cookie: session=dynamic-option-secret-42' https://example.test"#,
+        r#"curl ${HEADER_OPTION#*;}"Cookie: session=parameter-pattern-secret-42" https://example.test"#,
+        r#"curl ${HEADER_OPTION#*|}"Cookie: session=parameter-pipe-secret-42" https://example.test"#,
         r#"curl $(printf -- -H)"Cookie: session=dynamic-option-secret-42" https://example.test"#,
         r#"curl `printf -- -H`"Cookie: session=dynamic-option-secret-42" https://example.test"#,
         r#"curl $(true; printf -- -H)"Cookie: session=semicolon-dynamic-secret-42" https://example.test"#,
@@ -180,6 +182,7 @@ fn shell_secret_detectors_match_canonical_shapes_and_boundaries() {
         r#"tool -s'Hx'Cookie:session=quoted-cookie-value-42"#,
         r#"curl --header-label="Cookie: session=quoted-cookie-value-42""#,
         r#"curl ${HEADER_OPTION}"Crookie: session=dynamic-option-secret-42""#,
+        r#"curl ${HEADER_OPTION#*;}"Crookie: session=parameter-pattern-secret-42""#,
         r#"echo $HOME; tool xCookie:session=dynamic-option-secret-42"#,
         r#"echo $(printf x); tool xCookie:session=dynamic-option-secret-42"#,
     ];


### PR DESCRIPTION
## Why

#2918 moved slash-bearing natural-language classification into Rust, but Zsh still had ownership gaps around non-leading path prompts and coalesced Tab input. The secret hardening merged in #2996 also treated operators inside `${parameter#pattern}` as outer word boundaries, allowing dynamic Cookie headers to bypass native-history gates and Rust redaction.

## What changed

Enhanced-marker Zsh sessions keep slash, space-prefixed, and potential Han-leading path prompts Rust-owned until submission. Ordinary ASCII prefixes return byte-identically to ZLE as soon as classification resolves.

Tab is handed to ZLE before retained typeahead is replayed. A bounded 50 ms handoff lets the widget finish, then Rust cancels any widget-rewritten buffer and replays all retained bytes as the next logical line. Later bytes are appended, and EOF waits out the same deadline before draining them. If an earlier submit routes to Agent in one coalesced read, the remainder follows the new Cosh owner instead of stale ZLE ownership.

Bash and Zsh native-history detectors now recognize Cookie headers following a closed braced parameter expansion. Rust word scanning treats a precisely closed `${...}` expansion as one shell word and fails closed when nested syntax makes the closing brace ambiguous.

The implementation installs no ZLE wrappers, private key sequences, inherited control descriptors, signals, or shell prompt deadlines. The local 50 ms deadline is limited to the ZLE Tab handoff.

## Related issue

closes #1943

Follow-up hardening for #2996.

## User / Agent impact

Eligible path prompts are intercepted before Zsh executes them. Custom Tab widgets receive Tab normally; retained typeahead drains without another key, while bytes after an Agent ownership cutover cannot reach a stale ZLE widget. Dynamically assembled Cookie headers no longer remain in native history or Rust-backed persistence and display paths.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed

The change affects Enhanced Assisted Zsh sessions and secret-redaction boundaries. Candidate buffering remains limited to eligible prefixes, and the Tab handoff retains input for at most 50 ms before cancel-and-replay. Plain braced expansions become one shell word only when a precise matching close is established; ambiguous nested shell syntax fails closed to whole-command redaction.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `cargo test --package cosh-shell --lib --quiet` (1464 passed)
- `cargo test --package cosh-shell --lib zsh_` (12 passed)
- `cargo test --package cosh-shell --test raw_cli raw_cli_zsh_hands_buffered_tab_to_zle_before_follow_up_input -- --nocapture` (1 passed)
- `cargo test --package cosh-shell --test raw_cli raw_cli_zsh_routes_space_prefixed_path_prompt_before_zle -- --nocapture` (1 passed)
- `cargo test --package cosh-shell --lib path_prompt -- --test-threads=1` (6 passed)
- `cargo test --package cosh-shell --test raw_cli path_prompt -- --test-threads=1` (7 passed)
- `cargo test --package cosh-shell --lib evidence::redaction::tests -- --test-threads=1` (8 passed)
- `cargo test --package cosh-shell --lib redaction_boundary_tests -- --test-threads=1` (3 passed)
- `cargo test --package cosh-shell --test shell_host shell_secret_detectors_match_canonical_shapes_and_boundaries -- --test-threads=1` (1 passed)
- `bash -n crates/cosh-shell/src/shell_host/marker/bash.sh`
- `zsh -n crates/cosh-shell/src/shell_host/marker/zsh_secret_detector.zsh`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check up/main...HEAD`

No ECS, real-provider, or full-workspace gate was run; broader coverage is delegated to CI.

## Documentation and rollback

No documentation changes are required. Revert `68ad7198` to remove parameter-pattern redaction hardening, and revert `b651b6d1` to remove Zsh candidate buffering. Shell-only mode remains the immediate runtime fallback.