### PR TITLE
refactor(anolisa): add typed upgrade outcome

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade.rs
@@ -37,6 +37,7 @@ use anolisa_core::domain::{
     Installation, InstallationScope, LifecycleStatus, ManagementRelation, NativePm, Observation,
     PackageIdentity, ProviderBinding,
 };
+use anolisa_core::execution::{CommandOutcomeStatus, ExecutionIntent};
 use anolisa_core::facts::{JournalEvidence, JournalInventory};
 use anolisa_core::lock::InstallLock;
 use anolisa_core::state::{ObjectKind, OperationRecord};
@@ -44,24 +45,24 @@ use anolisa_core::state_store::StateStore;
 use anolisa_platform::fs_layout::FsLayout;
 use anolisa_platform::pkg_query::{PackageInfo, PackageQuery, PackageQueryError};
 use anolisa_platform::pkg_transaction::{PackageTransaction, PackageTransactionError};
-use anolisa_platform::privilege;
-use anolisa_platform::rpm_query::RpmPackageQuery;
-use anolisa_platform::rpm_transaction::RpmTransaction;
 
 use super::update::check::{
-    self, ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_RECONCILE, ACTION_UNSUPPORTED,
+    ACTION_ERROR, ACTION_INSTALL, ACTION_NOOP, ACTION_RECONCILE, ACTION_UNSUPPORTED,
     ACTION_UNSUPPORTED_RPM, ACTION_UPDATE, CliCheck, ComponentCheck,
 };
 use crate::color::Palette;
 use crate::commands::common;
-use crate::commands::common::RepoPersistPolicy;
 use crate::commands::tier1::install::{
     inspect_datadir_contract_drift, refresh_datadir_contract_snapshot,
 };
 use crate::commands::tier1::rpm_install;
-use crate::context::{CliContext, InstallMode};
+use crate::context::CliContext;
 use crate::progress::{self, Activity, ProgressReporter};
 use crate::response::{self, CliError};
+
+use self::application::{UpgradeApplicationOutcome, UpgradePreviewStatus, UpgradeRequest};
+
+mod application;
 
 /// Command label for JSON envelopes and error routing.
 const COMMAND: &str = "upgrade";
@@ -110,18 +111,6 @@ pub struct UpgradeArgs {
 /// status (partial / failed / blocked) — in the latter case the result has
 /// already been rendered and only the exit code is propagated.
 pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
-    // System-only: `upgrade` reasons about rpm-owned packages and the configured
-    // RPM repository, which do not exist in user mode. The dispatcher already
-    // gates this, but a direct caller (or a test) must be refused here too.
-    if ctx.install_mode != InstallMode::System {
-        return Err(CliError::InvalidArgument {
-            command: COMMAND.to_string(),
-            reason: "`anolisa upgrade` supports only system/RPM image scenarios; run `sudo anolisa upgrade` without `--install-mode user`".to_string(),
-        });
-    }
-
-    let layout = common::resolve_layout(ctx);
-
     // A single activity spinner spans both planning and the apply transactions,
     // so a slow repo query or `dnf` transaction never looks like a hung process.
     // It is dropped (clearing the line) before `render_result` prints the final
@@ -129,39 +118,18 @@ pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
     let feedback = progress::feedback_for_stderr(ctx.json, ctx.quiet);
     let activity = Activity::start(feedback, "Planning upgrade...");
 
-    // Reuse the read-only planner behind `update --check`. This performs only
-    // rpm/dnf *queries* — no transaction, no state write.
-    let report = check::compute_update_check_report(args.target.as_deref(), ctx, &layout)?;
-
-    // Resolve the configured RPM repository for the apply transactions. The
-    // planner already proved a `[backends.rpm]` table exists, so this load
-    // succeeds; it is repeated here (rather than threaded out of the planner) to
-    // keep the planner's signature read-only and repo-agnostic.
-    let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
-    let env = anolisa_env::EnvService::detect();
-    let repo = super::update::rpm_repo_source_for_update(&repo_config, &env, COMMAND)?
-        .ok_or_else(|| CliError::InvalidArgument {
-            command: COMMAND.to_string(),
-            reason: "repo.toml has no [backends.rpm] table; `anolisa upgrade` needs the configured ANOLISA RPM repository".to_string(),
-        })?;
-    let query = RpmPackageQuery::system_with_repo(repo.clone());
-    let txn = RpmTransaction::system_with_repo(repo);
-
-    let plan = build_plan(report.target.clone(), &report.cli, &report.components);
-    let result = run_upgrade_with_deps(
+    let outcome = application::run(
+        UpgradeRequest {
+            target: args.target.as_deref(),
+            intent: execution_intent(ctx.dry_run),
+        },
         ctx,
-        &layout,
-        &plan,
-        &query,
-        &txn,
-        privilege::is_root(),
-        ctx.dry_run,
-        COMMAND,
         &activity,
     )?;
 
     // Clear the spinner before the final result is rendered to stdout.
     drop(activity);
+    let result = project_outcome(outcome);
     render_result(ctx, &result);
 
     // A non-`ok` status has already been rendered (human or JSON); propagate a
@@ -173,6 +141,66 @@ pub fn handle(args: UpgradeArgs, ctx: &CliContext) -> Result<(), CliError> {
         Err(CliError::BatchPartial {
             command: COMMAND.to_string(),
         })
+    }
+}
+
+fn execution_intent(dry_run: bool) -> ExecutionIntent {
+    if dry_run {
+        ExecutionIntent::Plan
+    } else {
+        ExecutionIntent::Apply
+    }
+}
+
+fn project_outcome(outcome: UpgradeApplicationOutcome) -> UpgradeResult {
+    match outcome {
+        UpgradeApplicationOutcome::Preview {
+            status,
+            report,
+            warnings,
+        } => upgrade_result(report, preview_status_label(status), true, warnings),
+        UpgradeApplicationOutcome::Blocked { reason, report } => {
+            let _reason = reason;
+            upgrade_result(report, STATUS_BLOCKED, false, Vec::new())
+        }
+        UpgradeApplicationOutcome::Applied { report, outcome } => {
+            let status = match outcome.status() {
+                CommandOutcomeStatus::Completed => STATUS_OK,
+                CommandOutcomeStatus::Partial { .. } => STATUS_PARTIAL,
+                CommandOutcomeStatus::Failed { .. } => STATUS_FAILED,
+            };
+            upgrade_result(report, status, false, outcome.warnings().to_vec())
+        }
+    }
+}
+
+fn preview_status_label(status: UpgradePreviewStatus) -> &'static str {
+    match status {
+        UpgradePreviewStatus::Completed => STATUS_OK,
+        UpgradePreviewStatus::Partial => STATUS_PARTIAL,
+        UpgradePreviewStatus::Failed => STATUS_FAILED,
+        UpgradePreviewStatus::Blocked => STATUS_BLOCKED,
+    }
+}
+
+fn upgrade_result(
+    report: UpgradeReport,
+    status: &'static str,
+    dry_run: bool,
+    warnings: Vec<String>,
+) -> UpgradeResult {
+    UpgradeResult {
+        target: report.target,
+        backend: report.backend,
+        status,
+        dry_run,
+        updated: report.updated,
+        installed: report.installed,
+        reconciled: report.reconciled,
+        recorded: report.recorded,
+        skipped: report.skipped,
+        errors: report.errors,
+        warnings,
     }
 }
 
@@ -451,6 +479,58 @@ fn observed_default(component: &ComponentCheck) -> Result<PlannedObservedDefault
 
 // ── result envelope ──────────────────────────────────────────────────────────
 
+/// Execution report without a terminal classification.
+#[derive(Debug)]
+struct UpgradeReport {
+    target: Option<String>,
+    backend: &'static str,
+    updated: Vec<UpdatedItem>,
+    installed: Vec<InstalledItem>,
+    /// RPM-backed state rows refreshed from rpmdb without a package transaction.
+    reconciled: Vec<ReconciledItem>,
+    recorded: Vec<RecordedItem>,
+    skipped: Vec<SkippedResult>,
+    errors: Vec<ErrorResult>,
+}
+
+/// Terminal classification derived from an applied upgrade report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AppliedUpgradeStatus {
+    Completed,
+    Partial,
+    Failed,
+}
+
+impl AppliedUpgradeStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => STATUS_OK,
+            Self::Partial => STATUS_PARTIAL,
+            Self::Failed => STATUS_FAILED,
+        }
+    }
+}
+
+/// Internal executor result before the application layer builds its outcome.
+#[derive(Debug)]
+enum UpgradeEngineOutcome {
+    Preview {
+        status: UpgradePreviewStatus,
+        report: UpgradeReport,
+        warnings: Vec<String>,
+    },
+    Blocked {
+        reason: String,
+        report: UpgradeReport,
+    },
+    Applied {
+        status: AppliedUpgradeStatus,
+        operation_id: Option<String>,
+        report: UpgradeReport,
+        warnings: Vec<String>,
+    },
+}
+
 /// Wire shape for `anolisa upgrade` (`--json`) and the human summary source.
 #[derive(Debug, Serialize)]
 struct UpgradeResult {
@@ -571,6 +651,7 @@ struct ReconciliationInspection {
 /// updated/installed) plus per-item drift errors for changes it refused to make.
 #[derive(Default)]
 struct PersistOutcome {
+    operation_id: Option<String>,
     updated: Vec<UpdatedItem>,
     installed: Vec<InstalledItem>,
     reconciled: Vec<ReconciledItem>,
@@ -688,30 +769,26 @@ fn authorize_plan<'a>(store: &StateStore, plan: &'a UpgradePlan) -> AuthorizedPl
     authorized
 }
 
-/// Core of [`handle`] with the package query, transaction, root status, and
-/// dry-run flag injected so tests drive the whole apply path without a live
-/// rpmdb/dnf or real privileges.
+/// Execute an upgrade plan with explicit host boundaries.
 ///
-/// Dry-run renders the plan (and any item errors) without touching the host.
-/// Real execution requires root, aborts before any `dnf` transaction if the plan
-/// carries errors, then applies CLI update → component updates → missing-default
-/// installs, refreshing ANOLISA state from rpmdb once at the end.
+/// Plan intent renders read-only observations without taking the install lock.
+/// Apply requires root, blocks on plan errors, and refreshes state after RPM work.
 #[allow(clippy::too_many_arguments)]
-fn run_upgrade_with_deps(
+fn execute_upgrade_plan(
     ctx: &CliContext,
     layout: &FsLayout,
     plan: &UpgradePlan,
     query: &dyn PackageQuery,
     txn: &dyn PackageTransaction,
     is_root: bool,
-    dry_run: bool,
+    intent: ExecutionIntent,
     command: &str,
     reporter: &dyn ProgressReporter,
-) -> Result<UpgradeResult, CliError> {
+) -> Result<UpgradeEngineOutcome, CliError> {
     let preview_store = common::load_state_store(ctx, command)?;
     reject_upgrade_pending_claims(layout, &preview_store.operations, command)?;
 
-    if dry_run {
+    if intent == ExecutionIntent::Plan {
         // Dry-run reads state/rpmdb without taking the install lock, applying a
         // transaction, or constructing an operation to persist.
         return Ok(render_plan_preview(
@@ -735,7 +812,13 @@ fn run_upgrade_with_deps(
 
     // Any planning error blocks the whole run before a single dnf transaction.
     if plan.has_errors() {
-        return Ok(blocked_result(plan));
+        return Ok(UpgradeEngineOutcome::Blocked {
+            reason: format!(
+                "upgrade plan contains {} error(s); no action was taken",
+                plan.errors.len()
+            ),
+            report: blocked_report(plan),
+        });
     }
 
     let mut errors: Vec<ErrorResult> = Vec::new();
@@ -744,6 +827,7 @@ fn run_upgrade_with_deps(
     let mut installed: Vec<InstalledItem> = Vec::new();
     let mut reconciled: Vec<ReconciledItem> = Vec::new();
     let mut recorded: Vec<RecordedItem> = Vec::new();
+    let operation_id;
     // An empty transaction plan can still carry RPM state drift caused by an
     // external yum/dnf run, so every real invocation enters the same locked
     // finalize boundary. A true no-op returns before save/audit below.
@@ -1001,6 +1085,7 @@ fn run_upgrade_with_deps(
         if let Some(item) = cli_updated {
             updated.push(item);
         }
+        operation_id = outcome.operation_id;
         updated.extend(outcome.updated);
         installed.extend(outcome.installed);
         reconciled.extend(outcome.reconciled);
@@ -1011,19 +1096,52 @@ fn run_upgrade_with_deps(
     let succeeded = updated.len() + installed.len() + reconciled.len() + recorded.len();
     let status = apply_status(succeeded, errors.len());
 
-    Ok(UpgradeResult {
-        target: plan.target.clone(),
-        backend: BACKEND,
+    Ok(UpgradeEngineOutcome::Applied {
         status,
-        dry_run: false,
-        updated,
-        installed,
-        reconciled,
-        recorded,
-        skipped: skipped_results(plan),
-        errors,
+        operation_id,
+        report: UpgradeReport {
+            target: plan.target.clone(),
+            backend: BACKEND,
+            updated,
+            installed,
+            reconciled,
+            recorded,
+            skipped: skipped_results(plan),
+            errors,
+        },
         warnings,
     })
+}
+
+/// Compatibility projection used by the existing executor-focused tests.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn run_upgrade_with_deps(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    plan: &UpgradePlan,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    dry_run: bool,
+    command: &str,
+    reporter: &dyn ProgressReporter,
+) -> Result<UpgradeResult, CliError> {
+    application::run_with_dependencies(
+        UpgradeRequest {
+            target: plan.target.as_deref(),
+            intent: execution_intent(dry_run),
+        },
+        ctx,
+        layout,
+        plan,
+        query,
+        txn,
+        is_root,
+        command,
+        reporter,
+    )
+    .map(project_outcome)
 }
 
 /// Re-read one upgraded package from rpmdb and stage its state refresh. A
@@ -1362,13 +1480,13 @@ fn reject_upgrade_pending_claims(
 
 /// Status for a completed real run: `ok` when nothing errored, `partial` when
 /// some items succeeded and some failed, `failed` when nothing succeeded.
-fn apply_status(succeeded: usize, error_count: usize) -> &'static str {
+fn apply_status(succeeded: usize, error_count: usize) -> AppliedUpgradeStatus {
     if error_count == 0 {
-        STATUS_OK
+        AppliedUpgradeStatus::Completed
     } else if succeeded > 0 {
-        STATUS_PARTIAL
+        AppliedUpgradeStatus::Partial
     } else {
-        STATUS_FAILED
+        AppliedUpgradeStatus::Failed
     }
 }
 
@@ -1583,7 +1701,7 @@ fn render_plan_preview(
     query: &dyn PackageQuery,
     command: &str,
     packaged_data_probe: &crate::packaged::PackagedDataProbe,
-) -> UpgradeResult {
+) -> UpgradeEngineOutcome {
     let mut updated: Vec<UpdatedItem> = Vec::new();
     if let Some(cli) = &plan.cli {
         updated.push(planned_to_updated(cli));
@@ -1610,17 +1728,18 @@ fn render_plan_preview(
         .collect();
 
     if plan.has_errors() {
-        return UpgradeResult {
-            target: plan.target.clone(),
-            backend: BACKEND,
-            status: STATUS_BLOCKED,
-            dry_run: true,
-            updated,
-            installed,
-            reconciled: Vec::new(),
-            recorded,
-            skipped: skipped_results(plan),
-            errors: plan_errors(plan),
+        return UpgradeEngineOutcome::Preview {
+            status: UpgradePreviewStatus::Blocked,
+            report: UpgradeReport {
+                target: plan.target.clone(),
+                backend: BACKEND,
+                updated,
+                installed,
+                reconciled: Vec::new(),
+                recorded,
+                skipped: skipped_results(plan),
+                errors: plan_errors(plan),
+            },
             warnings: Vec::new(),
         };
     }
@@ -1653,40 +1772,42 @@ fn render_plan_preview(
     let mut errors = plan_errors(plan);
     errors.extend(inspection.errors);
 
-    let status = apply_status(
+    let status = match apply_status(
         updated.len() + installed.len() + recorded.len() + reconciled.len(),
         errors.len(),
-    );
+    ) {
+        AppliedUpgradeStatus::Completed => UpgradePreviewStatus::Completed,
+        AppliedUpgradeStatus::Partial => UpgradePreviewStatus::Partial,
+        AppliedUpgradeStatus::Failed => UpgradePreviewStatus::Failed,
+    };
 
-    UpgradeResult {
-        target: plan.target.clone(),
-        backend: BACKEND,
+    UpgradeEngineOutcome::Preview {
         status,
-        dry_run: true,
-        updated,
-        installed,
-        reconciled,
-        recorded,
-        skipped: skipped_results(plan),
-        errors,
+        report: UpgradeReport {
+            target: plan.target.clone(),
+            backend: BACKEND,
+            updated,
+            installed,
+            reconciled,
+            recorded,
+            skipped: skipped_results(plan),
+            errors,
+        },
         warnings,
     }
 }
 
-/// Build a `blocked` result: the plan carried errors, so no dnf ran.
-fn blocked_result(plan: &UpgradePlan) -> UpgradeResult {
-    UpgradeResult {
+/// Build a blocked report: the plan carried errors, so no dnf ran.
+fn blocked_report(plan: &UpgradePlan) -> UpgradeReport {
+    UpgradeReport {
         target: plan.target.clone(),
         backend: BACKEND,
-        status: STATUS_BLOCKED,
-        dry_run: false,
         updated: Vec::new(),
         installed: Vec::new(),
         reconciled: Vec::new(),
         recorded: Vec::new(),
         skipped: skipped_results(plan),
         errors: plan_errors(plan),
-        warnings: Vec::new(),
     }
 }
 
@@ -2008,7 +2129,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
     state.operations.push(OperationRecord {
         id: audit.operation_id.clone(),
         command: command.to_string(),
-        status: provisional_status.to_string(),
+        status: provisional_status.as_str().to_string(),
         started_at: audit.started_at.clone(),
         finished_at: Some(now_iso8601()),
         parent_operation_id: None,
@@ -2019,6 +2140,7 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         command: command.to_string(),
         reason: format!("failed to save state: {err}"),
     })?;
+    outcome.operation_id = Some(audit.operation_id.clone());
 
     // Refresh package-owned component contracts only after state persisted.
     // This heals stale snapshots left by external yum/dnf upgrades without
@@ -2097,24 +2219,26 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
     let mut final_status_save_failure = None;
     if final_status != provisional_status {
         if let Some(operation) = state.operations.last_mut() {
-            operation.status = final_status.to_string();
+            operation.status = final_status.as_str().to_string();
         }
         if let Err(err) = state.save(&state_path) {
             if let Some(operation) = state.operations.last_mut() {
-                operation.status = provisional_status.to_string();
+                operation.status = provisional_status.as_str().to_string();
             }
             persisted_status = provisional_status;
-            let detail =
-                format!("could not finalize the upgrade operation as '{final_status}': {err}");
+            let detail = format!(
+                "could not finalize the upgrade operation as '{}': {err}",
+                final_status.as_str()
+            );
             warnings.push(detail.clone());
             final_status_save_failure = Some(detail);
         }
     }
 
     let (log_status, severity) = match persisted_status {
-        STATUS_OK => (LogStatus::Ok, Severity::Info),
-        STATUS_PARTIAL => (LogStatus::Partial, Severity::Warn),
-        _ => (LogStatus::Failed, Severity::Error),
+        AppliedUpgradeStatus::Completed => (LogStatus::Ok, Severity::Info),
+        AppliedUpgradeStatus::Partial => (LogStatus::Partial, Severity::Warn),
+        AppliedUpgradeStatus::Failed => (LogStatus::Failed, Severity::Error),
     };
 
     // Audit log is best-effort: state already persisted, so a log failure
@@ -2163,7 +2287,8 @@ fn finalize_upgrade(req: FinalizeUpgrade<'_>) -> Result<PersistOutcome, CliError
         return Err(CliError::Runtime {
             command: command.to_string(),
             reason: format!(
-                "upgrade changes were saved with conservative status '{provisional_status}', but {detail}"
+                "upgrade changes were saved with conservative status '{}', but {detail}",
+                provisional_status.as_str()
             ),
         });
     }

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/application.rs
@@ -1,0 +1,212 @@
+//! Application orchestration for `anolisa upgrade`.
+
+use anolisa_core::execution::{CommandOutcome, CommandOutcomeStatus, ExecutionIntent};
+use anolisa_platform::pkg_query::PackageQuery;
+use anolisa_platform::pkg_transaction::PackageTransaction;
+use anolisa_platform::privilege;
+
+use crate::commands::common::{self, RepoPersistPolicy};
+use crate::context::{CliContext, InstallMode};
+use crate::progress::ProgressReporter;
+use crate::response::CliError;
+
+use super::super::update::check;
+use super::{
+    AppliedUpgradeStatus, COMMAND, UpgradeEngineOutcome, UpgradePlan, UpgradeReport, build_plan,
+    execute_upgrade_plan,
+};
+
+/// Typed input for one image upgrade request.
+pub(super) struct UpgradeRequest<'a> {
+    pub(super) target: Option<&'a str>,
+    pub(super) intent: ExecutionIntent,
+}
+
+/// Durable change confirmed by an applied upgrade.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum UpgradeChange {
+    /// An RPM package advanced to a newer version.
+    PackageUpdated { name: String, package: String },
+    /// A missing target-profile default was installed.
+    DefaultInstalled { component: String, package: String },
+    /// Existing ANOLISA state was reconciled with rpmdb truth.
+    StateReconciled { component: String, package: String },
+    /// An already-installed default was recorded in ANOLISA state.
+    ObservedRecordCreated { component: String, package: String },
+}
+
+/// Typed terminal classification for a plan-only upgrade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UpgradePreviewStatus {
+    /// Every planned observation completed without an item error.
+    Completed,
+    /// Some preview items were available while other observations failed.
+    Partial,
+    /// No preview item succeeded and at least one observation failed.
+    Failed,
+    /// Planning errors make the upgrade ineligible for application.
+    Blocked,
+}
+
+/// Typed application result consumed by the compatibility renderer.
+#[derive(Debug)]
+pub(super) enum UpgradeApplicationOutcome {
+    /// Plan-only result; no lock, transaction, or persistent mutation occurred.
+    Preview {
+        status: UpgradePreviewStatus,
+        report: UpgradeReport,
+        warnings: Vec<String>,
+    },
+    /// Apply was refused by item-level planning errors before any transaction.
+    Blocked {
+        reason: String,
+        report: UpgradeReport,
+    },
+    /// Applied result with typed terminal and durable operation evidence.
+    Applied {
+        report: UpgradeReport,
+        outcome: CommandOutcome<UpgradeChange>,
+    },
+}
+
+/// Run an upgrade request against the production RPM backend.
+pub(super) fn run(
+    request: UpgradeRequest<'_>,
+    ctx: &CliContext,
+    reporter: &dyn ProgressReporter,
+) -> Result<UpgradeApplicationOutcome, CliError> {
+    if ctx.install_mode != InstallMode::System {
+        return Err(CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: "`anolisa upgrade` supports only system/RPM image scenarios; run `sudo anolisa upgrade` without `--install-mode user`".to_string(),
+        });
+    }
+
+    let layout = common::resolve_layout(ctx);
+    let report = check::compute_update_check_report(request.target, ctx, &layout)?;
+    let repo_config = common::load_repo_config(ctx, &layout, COMMAND, RepoPersistPolicy::Require)?;
+    let env = anolisa_env::EnvService::detect();
+    let repo = super::super::update::rpm_repo_source_for_update(&repo_config, &env, COMMAND)?
+        .ok_or_else(|| CliError::InvalidArgument {
+            command: COMMAND.to_string(),
+            reason: "repo.toml has no [backends.rpm] table; `anolisa upgrade` needs the configured ANOLISA RPM repository".to_string(),
+        })?;
+    let query = anolisa_platform::rpm_query::RpmPackageQuery::system_with_repo(repo.clone());
+    let txn = anolisa_platform::rpm_transaction::RpmTransaction::system_with_repo(repo);
+    let plan = build_plan(report.target.clone(), &report.cli, &report.components);
+
+    run_with_dependencies(
+        request,
+        ctx,
+        &layout,
+        &plan,
+        &query,
+        &txn,
+        privilege::is_root(),
+        COMMAND,
+        reporter,
+    )
+}
+
+/// Run an upgrade request with explicit host boundaries.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_with_dependencies(
+    request: UpgradeRequest<'_>,
+    ctx: &CliContext,
+    layout: &anolisa_platform::fs_layout::FsLayout,
+    plan: &UpgradePlan,
+    query: &dyn PackageQuery,
+    txn: &dyn PackageTransaction,
+    is_root: bool,
+    command: &str,
+    reporter: &dyn ProgressReporter,
+) -> Result<UpgradeApplicationOutcome, CliError> {
+    let engine = execute_upgrade_plan(
+        ctx,
+        layout,
+        plan,
+        query,
+        txn,
+        is_root,
+        request.intent,
+        command,
+        reporter,
+    )?;
+
+    Ok(match engine {
+        UpgradeEngineOutcome::Preview {
+            status,
+            report,
+            warnings,
+        } => UpgradeApplicationOutcome::Preview {
+            status,
+            report,
+            warnings,
+        },
+        UpgradeEngineOutcome::Blocked { reason, report } => {
+            UpgradeApplicationOutcome::Blocked { reason, report }
+        }
+        UpgradeEngineOutcome::Applied {
+            status,
+            operation_id,
+            report,
+            warnings,
+        } => {
+            let changes = changes_from_report(&report);
+            let error_count = report.errors.len();
+            let status = match status {
+                AppliedUpgradeStatus::Completed => CommandOutcomeStatus::Completed,
+                AppliedUpgradeStatus::Partial => CommandOutcomeStatus::Partial {
+                    reason: format!(
+                        "upgrade completed with {error_count} item error(s); reconciliation is required"
+                    ),
+                },
+                AppliedUpgradeStatus::Failed => CommandOutcomeStatus::Failed {
+                    reason: format!("upgrade failed with {error_count} item error(s)"),
+                },
+            };
+            UpgradeApplicationOutcome::Applied {
+                report,
+                outcome: CommandOutcome::new(status, operation_id, changes, warnings),
+            }
+        }
+    })
+}
+
+fn changes_from_report(report: &UpgradeReport) -> Vec<UpgradeChange> {
+    report
+        .updated
+        .iter()
+        .map(|item| UpgradeChange::PackageUpdated {
+            name: item.name.clone(),
+            package: item.package.clone(),
+        })
+        .chain(
+            report
+                .installed
+                .iter()
+                .map(|item| UpgradeChange::DefaultInstalled {
+                    component: item.name.clone(),
+                    package: item.package.clone(),
+                }),
+        )
+        .chain(
+            report
+                .reconciled
+                .iter()
+                .map(|item| UpgradeChange::StateReconciled {
+                    component: item.name.clone(),
+                    package: item.package.clone(),
+                }),
+        )
+        .chain(
+            report
+                .recorded
+                .iter()
+                .map(|item| UpgradeChange::ObservedRecordCreated {
+                    component: item.name.clone(),
+                    package: item.package.clone(),
+                }),
+        )
+        .collect()
+}

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/upgrade/tests.rs
@@ -3,6 +3,7 @@
 //! [`PackageTransaction`], so no live rpmdb/dnf is required. The fake records
 //! transaction call order and refuses to be called on the dry-run path.
 
+use super::application::UpgradeChange;
 use super::*;
 
 use anolisa_core::state::InstallMode as StateInstallMode;
@@ -27,6 +28,7 @@ use anolisa_core::transaction::{
 // `Activity` and `ProgressReporter` reach the tests through the module glob
 // (`use super::*`); `NoopReporter` is the only progress item not re-imported by
 // the upgrade module, so it is brought in explicitly here.
+use crate::context::InstallMode;
 use crate::progress::NoopReporter;
 
 // ── fake host ────────────────────────────────────────────────────────────────
@@ -436,6 +438,31 @@ fn user_ctx() -> CliContext {
     )
 }
 
+fn run_typed_upgrade(
+    ctx: &CliContext,
+    layout: &FsLayout,
+    plan: &UpgradePlan,
+    host: &FakeHost,
+    intent: ExecutionIntent,
+    is_root: bool,
+) -> UpgradeApplicationOutcome {
+    application::run_with_dependencies(
+        UpgradeRequest {
+            target: plan.target.as_deref(),
+            intent,
+        },
+        ctx,
+        layout,
+        plan,
+        host,
+        host,
+        is_root,
+        COMMAND,
+        &NoopReporter,
+    )
+    .expect("typed upgrade outcome")
+}
+
 // ── argument parsing ─────────────────────────────────────────────────────────
 
 #[test]
@@ -464,6 +491,281 @@ fn upgrade_parses_assume_yes_long_and_short() {
             .expect("parse")
             .assume_yes
     );
+}
+
+#[test]
+fn upgrade_maps_dry_run_to_execution_intent() {
+    assert_eq!(execution_intent(true), ExecutionIntent::Plan);
+    assert_eq!(execution_intent(false), ExecutionIntent::Apply);
+}
+
+#[test]
+fn typed_preview_reports_plan_without_side_effects() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        Some("agentic_os-latest".to_string()),
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Plan, false);
+
+    let UpgradeApplicationOutcome::Preview {
+        status,
+        report,
+        warnings,
+    } = outcome
+    else {
+        panic!("plan intent must return a preview");
+    };
+    assert_eq!(status, UpgradePreviewStatus::Completed);
+    assert_eq!(report.updated.len(), 1);
+    assert!(warnings.is_empty());
+    assert!(host.txn_calls().is_empty());
+    assert!(!layout.lock_file.exists());
+    assert!(!layout.state_dir.join("installed.toml").exists());
+    assert!(!layout.central_log.exists());
+}
+
+#[test]
+fn typed_apply_blocked_preserves_reason_without_side_effects() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "mystery",
+            None,
+            None,
+            None,
+            None,
+            ACTION_INSTALL,
+            None,
+        )],
+    );
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Apply, true);
+
+    let UpgradeApplicationOutcome::Blocked { reason, report } = outcome else {
+        panic!("plan errors must block apply");
+    };
+    assert_eq!(
+        reason,
+        "upgrade plan contains 1 error(s); no action was taken"
+    );
+    assert_eq!(report.errors.len(), 1);
+    assert!(host.txn_calls().is_empty());
+    assert!(!layout.lock_file.exists());
+    assert!(!layout.state_dir.join("installed.toml").exists());
+    assert!(!layout.central_log.exists());
+}
+
+#[test]
+fn typed_noop_apply_has_no_operation_or_change() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    let host = FakeHost::default();
+    let plan = build_plan(None, &cli_noop(), &[]);
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Apply, true);
+
+    let UpgradeApplicationOutcome::Applied { report, outcome } = outcome else {
+        panic!("clean no-op must be an applied outcome");
+    };
+    assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+    assert_eq!(outcome.operation_id(), None);
+    assert!(outcome.changes().is_empty());
+    assert!(outcome.warnings().is_empty());
+    assert!(report.errors.is_empty());
+    assert!(host.txn_calls().is_empty());
+    assert!(!layout.state_dir.join("installed.toml").exists());
+    assert!(!layout.central_log.exists());
+}
+
+#[test]
+fn typed_completed_apply_carries_change_and_persisted_operation() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "cosh",
+            Some("copilot-shell"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Apply, true);
+
+    let UpgradeApplicationOutcome::Applied { report, outcome } = outcome else {
+        panic!("successful apply must return an applied outcome");
+    };
+    assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+    assert_eq!(
+        outcome.changes(),
+        &[UpgradeChange::PackageUpdated {
+            name: "cosh".to_string(),
+            package: "copilot-shell".to_string(),
+        }]
+    );
+    assert!(outcome.warnings().is_empty());
+    assert!(report.errors.is_empty());
+    let store = load_store(&layout);
+    assert_eq!(
+        outcome.operation_id(),
+        store
+            .operations
+            .last()
+            .map(|operation| operation.id.as_str())
+    );
+}
+
+#[test]
+fn typed_partial_keeps_terminal_reason_separate_from_warning() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "cosh",
+            "copilot-shell",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let mut host = FakeHost::default().with_installed(
+        "copilot-shell",
+        info("copilot-shell", "1.1.0", Some("1.al4")),
+    );
+    host.fail_origin.insert("copilot-shell".to_string());
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[
+            component_check(
+                "cosh",
+                Some("copilot-shell"),
+                Some("rpm-managed"),
+                Some("1.0.0-1.al4"),
+                Some("1.1.0-1.al4"),
+                ACTION_UPDATE,
+                None,
+            ),
+            component_check(
+                "sec-core",
+                Some("agent-sec-core"),
+                Some("rpm-managed"),
+                Some("1.0.0-1.al4"),
+                Some("1.1.0-1.al4"),
+                ACTION_UPDATE,
+                None,
+            ),
+        ],
+    );
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Apply, true);
+
+    let UpgradeApplicationOutcome::Applied { report, outcome } = outcome else {
+        panic!("mixed apply must return an applied outcome");
+    };
+    let CommandOutcomeStatus::Partial { reason } = outcome.status() else {
+        panic!("mixed success and error must be partial");
+    };
+    assert_eq!(
+        reason,
+        "upgrade completed with 1 item error(s); reconciliation is required"
+    );
+    assert_eq!(report.errors.len(), 1);
+    assert_eq!(outcome.changes().len(), 1);
+    assert_eq!(outcome.warnings().len(), 1);
+    assert!(outcome.warnings()[0].contains("source repo"));
+    assert_ne!(outcome.warnings()[0], *reason);
+    assert!(outcome.operation_id().is_some());
+}
+
+#[test]
+fn typed_failed_apply_carries_reason_without_fabricating_changes() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let ctx = system_ctx(tmp.path().to_path_buf());
+    let layout = FsLayout::system(Some(tmp.path().to_path_buf()));
+    seed_state(
+        &layout,
+        vec![rpm_component(
+            "sec-core",
+            "agent-sec-core",
+            "1.0.0-1.al4",
+            Ownership::RpmManaged,
+        )],
+    );
+    let mut host = FakeHost::default().with_installed(
+        "agent-sec-core",
+        info("agent-sec-core", "1.0.0", Some("1.al4")),
+    );
+    host.fail_update.insert("agent-sec-core".to_string());
+    let plan = build_plan(
+        None,
+        &cli_noop(),
+        &[component_check(
+            "sec-core",
+            Some("agent-sec-core"),
+            Some("rpm-managed"),
+            Some("1.0.0-1.al4"),
+            Some("1.1.0-1.al4"),
+            ACTION_UPDATE,
+            None,
+        )],
+    );
+
+    let outcome = run_typed_upgrade(&ctx, &layout, &plan, &host, ExecutionIntent::Apply, true);
+
+    let UpgradeApplicationOutcome::Applied { report, outcome } = outcome else {
+        panic!("failed transaction must return an applied outcome");
+    };
+    assert_eq!(
+        outcome.status(),
+        &CommandOutcomeStatus::Failed {
+            reason: "upgrade failed with 1 item error(s)".to_string(),
+        }
+    );
+    assert_eq!(report.errors.len(), 1);
+    assert!(outcome.changes().is_empty());
+    assert!(outcome.warnings().is_empty());
+    assert!(outcome.operation_id().is_some());
 }
 
 // ── mode / privilege gating ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The upgrade command still mixed application orchestration, string terminal status, and response rendering. R3 needs a typed execution boundary before the remaining mutation audit can be completed.

## What changed

- Add a CLI-private upgrade application module with typed preview, blocked, and applied outcomes.
- Reuse ExecutionIntent and CommandOutcome while keeping the existing RPM planner and transaction engine.
- Project typed outcomes back to the existing human and JSON response without changing status labels or exit codes.
- Cover preview side-effect isolation and applied completed, partial, failed, blocked, and no-op outcomes.

## Related issue

closes #2993

## User / Agent impact

None. Public CLI arguments, JSON fields, human output, RPM behavior, and exit codes remain unchanged.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The compatibility renderer preserves the existing wire and human contracts. Rollback is a normal revert of this commit.

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --locked
- cargo test -p anolisa-cli upgrade --locked (74 passed)
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p anolisa-cli self_update --locked (14 passed after synchronizing upstream/main)
- git diff --check
- ALinux 4 temporary container: upgrade targeted tests with read-only source and an isolated target directory

## Documentation and rollback

The local Chinese refactoring roadmap was updated for tracking but intentionally remains untracked and is not part of this PR. Revert the single commit to roll back the refactor.