### PR TITLE
refactor(anolisa): add typed adapter outcome

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands.rs
@@ -563,8 +563,8 @@ fn adapter_command_scope(args: &adapter::AdapterArgs) -> CommandScope {
         adapter::AdapterCommands::Scan | adapter::AdapterCommands::Status { .. } => {
             CommandScope::ReadOnly
         }
-        // Both adapter mutations take the install lock before planning, so
-        // their previews still require the same privilege as real execution.
+        // Keep adapter previews privileged in system mode for compatibility
+        // with the existing mutation authorization policy.
         adapter::AdapterCommands::Enable { .. } | adapter::AdapterCommands::Disable { .. } => {
             CommandScope::ModeScopedMutation {
                 dry_run: DryRunPolicy::PrivilegedPreview,
@@ -945,7 +945,7 @@ mod tests {
                 Some(DryRunPolicy::PrivilegedPreview)
             );
             let err = validate_global_args_with_euid(&ctx, policy, 1000, true)
-                .expect_err("adapter previews take the privileged install lock");
+                .expect_err("adapter previews retain the system root policy");
             assert_eq!(err.code(), "PERMISSION_DENIED");
             validate_global_args_with_euid(&ctx, policy, 0, true)
                 .expect("root should reach the adapter preview handler");

--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter.rs
@@ -39,14 +39,20 @@ use anolisa_core::adapter::AdapterError;
 use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus};
 use anolisa_core::adapter::driver::{AdapterStatusReport, DriverPlan};
 use anolisa_core::adapter::manager::{
-    AdapterManager, AdapterSourceStatus, DisableOutcome, EnableOptions, EnableOutcome, ScanEntry,
-    ScanReport, StatusReport,
+    AdapterManager, AdapterSourceStatus, EnableOptions, ScanEntry, ScanReport, StatusReport,
 };
+use anolisa_core::execution::{CommandOutcomeStatus, ExecutionIntent};
 use anolisa_core::manifest::{AdapterNotice, NoticeLevel, NoticeWhen};
 
 use crate::commands::common;
 use crate::context::CliContext;
 use crate::response::{CliError, render_json};
+
+use self::application::{
+    AdapterApplicationOutcome, AdapterApplied, AdapterPreview, AdapterRequest,
+};
+
+mod application;
 
 /// CLI arguments for the `adapter` sub-surface.
 #[derive(Parser)]
@@ -350,22 +356,21 @@ fn handle_enable(
     profiles: Vec<String>,
 ) -> Result<(), CliError> {
     const COMMAND: &str = "adapter enable";
-    let (component, view) = common::resolve_adapter_target(component, ctx, COMMAND)?;
-    let manager = common::build_adapter_manager_from_view(ctx, &view);
-    let outcome = manager
-        .enable_with_options(
-            &component,
+    let outcome = application::run(
+        AdapterRequest::Enable {
+            component,
             framework,
-            ctx.dry_run,
-            EnableOptions {
+            options: EnableOptions {
                 allow_unsafe_plugin_install,
                 profiles,
             },
-        )
-        .map_err(|e| map_err(COMMAND, e))?;
+            intent: execution_intent(ctx.dry_run),
+        },
+        ctx,
+    )?;
 
     match outcome {
-        EnableOutcome::Planned { plan, notices } => {
+        AdapterApplicationOutcome::Preview(AdapterPreview::Enable { plan, notices }) => {
             if ctx.json {
                 let payload = EnablePayload {
                     component: plan.component.clone(),
@@ -390,8 +395,25 @@ fn handle_enable(
             print_notices(&notices, true, ctx.quiet);
             Ok(())
         }
-        EnableOutcome::Enabled(claim) => {
-            let notices = post_enable_notices(&claim);
+        AdapterApplicationOutcome::Applied {
+            result: AdapterApplied::Enable { claim, notices },
+            outcome,
+        } => {
+            match outcome.status() {
+                CommandOutcomeStatus::Completed => {}
+                CommandOutcomeStatus::Partial { reason } => {
+                    return Err(CliError::Degraded {
+                        command: COMMAND.to_string(),
+                        reason: reason.clone(),
+                    });
+                }
+                CommandOutcomeStatus::Failed { reason } => {
+                    return Err(CliError::Runtime {
+                        command: COMMAND.to_string(),
+                        reason: reason.clone(),
+                    });
+                }
+            }
             if ctx.json {
                 let payload = EnablePayload {
                     component: claim.component.clone(),
@@ -410,6 +432,11 @@ fn handle_enable(
             print_notices(&notices, false, ctx.quiet);
             Ok(())
         }
+        AdapterApplicationOutcome::Preview(AdapterPreview::Disable(_))
+        | AdapterApplicationOutcome::Applied {
+            result: AdapterApplied::Disable(_),
+            ..
+        } => unreachable!("an enable request cannot return a disable result"),
     }
 }
 
@@ -423,84 +450,89 @@ fn handle_disable(
     framework: Option<&str>,
 ) -> Result<(), CliError> {
     const COMMAND: &str = "adapter disable";
-    let (component, view) = common::resolve_adapter_target(component, ctx, COMMAND)?;
-    let manager = common::build_adapter_manager_from_view(ctx, &view);
-    let outcome: DisableOutcome = manager
-        .disable(&component, framework, ctx.dry_run)
-        .map_err(|e| map_err(COMMAND, e))?;
+    let outcome = application::run(
+        AdapterRequest::Disable {
+            component,
+            framework,
+            intent: execution_intent(ctx.dry_run),
+        },
+        ctx,
+    )?;
 
-    if outcome.dry_run {
-        if ctx.json {
-            let payload = DisablePayload {
-                component: outcome.component.clone(),
-                framework: outcome.framework.clone(),
-                dry_run: true,
-                claim_removed: false,
-                cleanup_complete: outcome.report.cleanup_complete,
-                messages: outcome.report.messages.clone(),
-                notices: outcome.notices.iter().map(NoticeRow::from).collect(),
+    match outcome {
+        AdapterApplicationOutcome::Preview(AdapterPreview::Disable(outcome)) => {
+            if ctx.json {
+                let payload = DisablePayload {
+                    component: outcome.component.clone(),
+                    framework: outcome.framework.clone(),
+                    dry_run: true,
+                    claim_removed: false,
+                    cleanup_complete: outcome.report.cleanup_complete,
+                    messages: outcome.report.messages.clone(),
+                    notices: outcome.notices.iter().map(NoticeRow::from).collect(),
+                };
+                return render_json(COMMAND, payload);
+            }
+            let target = disable_target(&outcome.component, outcome.framework.as_deref());
+            println!("[dry-run] would disable {target}:");
+            for msg in &outcome.report.messages {
+                println!("  - {msg}");
+            }
+            print_notices(&outcome.notices, true, ctx.quiet);
+            Ok(())
+        }
+        AdapterApplicationOutcome::Applied {
+            result: AdapterApplied::Disable(result),
+            outcome,
+        } => {
+            let terminal_error = match outcome.status() {
+                CommandOutcomeStatus::Completed => None,
+                CommandOutcomeStatus::Partial { reason } => Some(CliError::Degraded {
+                    command: COMMAND.to_string(),
+                    reason: reason.clone(),
+                }),
+                CommandOutcomeStatus::Failed { reason } => Some(CliError::Runtime {
+                    command: COMMAND.to_string(),
+                    reason: reason.clone(),
+                }),
             };
-            return render_json(COMMAND, payload);
+
+            if ctx.json {
+                if let Some(err) = terminal_error {
+                    return Err(err);
+                }
+                let payload = DisablePayload {
+                    component: result.component.clone(),
+                    framework: result.framework.clone(),
+                    dry_run: false,
+                    claim_removed: result.claim_removed,
+                    cleanup_complete: result.report.cleanup_complete,
+                    messages: result.report.messages.clone(),
+                    notices: result.notices.iter().map(NoticeRow::from).collect(),
+                };
+                return render_json(COMMAND, payload);
+            }
+
+            let target = disable_target(&result.component, result.framework.as_deref());
+            if result.claim_removed {
+                println!("Disabled {target}.");
+            } else if result.report.cleanup_complete {
+                println!("Nothing to disable for {target}.");
+            } else {
+                println!("Disable of {target} did not complete cleanly:");
+            }
+            for msg in &result.report.messages {
+                println!("  - {msg}");
+            }
+            print_notices(&result.notices, false, ctx.quiet);
+            terminal_error.map_or(Ok(()), Err)
         }
-        let target = disable_target(&outcome);
-        println!("[dry-run] would disable {target}:");
-        for msg in &outcome.report.messages {
-            println!("  - {msg}");
-        }
-        print_notices(&outcome.notices, true, ctx.quiet);
-        return Ok(());
+        AdapterApplicationOutcome::Preview(AdapterPreview::Enable { .. })
+        | AdapterApplicationOutcome::Applied {
+            result: AdapterApplied::Enable { .. },
+            ..
+        } => unreachable!("a disable request cannot return an enable result"),
     }
-
-    // Cleanup that did not complete is a degraded outcome: the receipt was
-    // kept (marked cleanup_failed) so the operator can retry. Surface a
-    // non-zero exit rather than a silent success.
-    let degraded = (!outcome.report.cleanup_complete).then(|| CliError::Degraded {
-        command: COMMAND.to_string(),
-        reason: format!(
-            "adapter '{}' cleanup incomplete; receipt kept for retry",
-            outcome.component
-        ),
-    });
-
-    if ctx.json {
-        if let Some(err) = degraded {
-            return Err(err);
-        }
-        let payload = DisablePayload {
-            component: outcome.component.clone(),
-            framework: outcome.framework.clone(),
-            dry_run: false,
-            claim_removed: outcome.claim_removed,
-            cleanup_complete: outcome.report.cleanup_complete,
-            messages: outcome.report.messages.clone(),
-            notices: outcome.notices.iter().map(NoticeRow::from).collect(),
-        };
-        return render_json(COMMAND, payload);
-    }
-
-    let target = disable_target(&outcome);
-    if outcome.claim_removed {
-        println!("Disabled {target}.");
-    } else if outcome.report.cleanup_complete {
-        println!("Nothing to disable for {target}.");
-    } else {
-        println!("Disable of {target} did not complete cleanly:");
-    }
-    for msg in &outcome.report.messages {
-        println!("  - {msg}");
-    }
-    print_notices(&outcome.notices, false, ctx.quiet);
-    degraded.map_or(Ok(()), Err)
-}
-
-/// The `post_enable` notices persisted in a receipt.
-fn post_enable_notices(claim: &AdapterClaim) -> Vec<AdapterNotice> {
-    claim
-        .notices
-        .iter()
-        .filter(|notice| notice.when == NoticeWhen::PostEnable)
-        .cloned()
-        .collect()
 }
 
 /// Print notices for human output. Suppressed entirely under `--quiet`.
@@ -543,10 +575,18 @@ fn escape_notice_for_terminal(value: &str) -> String {
 
 /// Human-facing `component/framework` label for a disable outcome, falling
 /// back to the component alone when no framework was resolved.
-fn disable_target(outcome: &DisableOutcome) -> String {
-    match &outcome.framework {
-        Some(f) => format!("{}/{}", outcome.component, f),
-        None => outcome.component.clone(),
+fn disable_target(component: &str, framework: Option<&str>) -> String {
+    match framework {
+        Some(framework) => format!("{component}/{framework}"),
+        None => component.to_string(),
+    }
+}
+
+fn execution_intent(dry_run: bool) -> ExecutionIntent {
+    if dry_run {
+        ExecutionIntent::Plan
+    } else {
+        ExecutionIntent::Apply
     }
 }
 
@@ -684,6 +724,12 @@ mod tests {
     struct TestCli {
         #[command(subcommand)]
         command: AdapterCommands,
+    }
+
+    #[test]
+    fn global_dry_run_maps_to_execution_intent() {
+        assert_eq!(execution_intent(true), ExecutionIntent::Plan);
+        assert_eq!(execution_intent(false), ExecutionIntent::Apply);
     }
 
     #[test]

--- a/src/anolisa/crates/anolisa-cli/src/commands/adapter/application.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/adapter/application.rs
@@ -1,0 +1,396 @@
+//! Application boundary for adapter enable and disable mutations.
+
+use anolisa_core::adapter::claim::AdapterClaim;
+use anolisa_core::adapter::driver::DriverPlan;
+use anolisa_core::adapter::manager::{DisableOutcome, EnableOptions, EnableOutcome};
+use anolisa_core::execution::{CommandOutcome, CommandOutcomeStatus, ExecutionIntent};
+use anolisa_core::manifest::{AdapterNotice, NoticeWhen};
+
+use crate::commands::common;
+use crate::context::CliContext;
+use crate::response::CliError;
+
+/// Adapter mutation request after CLI arguments have been normalized.
+pub(super) enum AdapterRequest<'a> {
+    /// Enables one component adapter.
+    Enable {
+        /// Component name or package alias to resolve.
+        component: &'a str,
+        /// Explicit framework, or `None` to use manager resolution.
+        framework: Option<&'a str>,
+        /// Existing enable options forwarded without reinterpretation.
+        options: EnableOptions,
+        /// Selects read-only preview or state-changing application.
+        intent: ExecutionIntent,
+    },
+    /// Disables one component adapter.
+    Disable {
+        /// Component name or package alias to resolve.
+        component: &'a str,
+        /// Explicit framework, or `None` to use manager resolution.
+        framework: Option<&'a str>,
+        /// Selects read-only preview or state-changing application.
+        intent: ExecutionIntent,
+    },
+}
+
+/// Typed adapter changes produced by an applied mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum AdapterChange {
+    /// An adapter claim was enabled for the resolved framework.
+    Enabled {
+        /// Resolved component identity.
+        component: String,
+        /// Resolved framework identity.
+        framework: String,
+    },
+    /// An adapter claim was removed after cleanup completed.
+    Disabled {
+        /// Resolved component identity.
+        component: String,
+        /// Resolved framework identity.
+        framework: String,
+    },
+    /// Cleanup remained incomplete and the claim was retained for retry.
+    CleanupFailed {
+        /// Resolved component identity.
+        component: String,
+        /// Resolved framework identity.
+        framework: String,
+    },
+}
+
+/// Read-only adapter result without a terminal execution outcome.
+pub(super) enum AdapterPreview {
+    /// Enable plan and notices to display without applying driver effects.
+    Enable {
+        /// Driver plan generated from the current framework state.
+        plan: DriverPlan,
+        /// Preview notices kept separate from terminal status.
+        notices: Vec<AdapterNotice>,
+    },
+    /// Disable preview produced by the existing manager contract.
+    Disable(DisableOutcome),
+}
+
+/// Applied manager result and display-only notices.
+pub(super) enum AdapterApplied {
+    /// Enabled claim and post-enable notices.
+    Enable {
+        /// Persisted claim returned by the manager.
+        claim: Box<AdapterClaim>,
+        /// Post-enable notices kept separate from outcome warnings.
+        notices: Vec<AdapterNotice>,
+    },
+    /// Disable result produced by the existing manager contract.
+    Disable(DisableOutcome),
+}
+
+/// Typed application result separating previews from applied mutations.
+pub(super) enum AdapterApplicationOutcome {
+    /// Read-only result that never carries an applied command outcome.
+    Preview(AdapterPreview),
+    /// Applied result paired with its terminal status and typed changes.
+    Applied {
+        /// Manager result used to preserve existing CLI output.
+        result: AdapterApplied,
+        /// Terminal status and changes; operation ID remains absent.
+        outcome: CommandOutcome<AdapterChange>,
+    },
+}
+
+/// Resolves the target, dispatches the manager, and projects its typed outcome.
+///
+/// # Errors
+///
+/// Returns the existing CLI error when target resolution or manager execution
+/// fails.
+pub(super) fn run(
+    request: AdapterRequest<'_>,
+    ctx: &CliContext,
+) -> Result<AdapterApplicationOutcome, CliError> {
+    match request {
+        AdapterRequest::Enable {
+            component,
+            framework,
+            options,
+            intent,
+        } => {
+            const COMMAND: &str = "adapter enable";
+            let (component, view) = common::resolve_adapter_target(component, ctx, COMMAND)?;
+            let manager = common::build_adapter_manager_from_view(ctx, &view);
+            let result = manager
+                .enable_with_options(&component, framework, is_preview(intent), options)
+                .map_err(|err| super::map_err(COMMAND, err))?;
+            Ok(project_enable(result))
+        }
+        AdapterRequest::Disable {
+            component,
+            framework,
+            intent,
+        } => {
+            const COMMAND: &str = "adapter disable";
+            let (component, view) = common::resolve_adapter_target(component, ctx, COMMAND)?;
+            let manager = common::build_adapter_manager_from_view(ctx, &view);
+            let result = manager
+                .disable(&component, framework, is_preview(intent))
+                .map_err(|err| super::map_err(COMMAND, err))?;
+            Ok(project_disable(result))
+        }
+    }
+}
+
+fn is_preview(intent: ExecutionIntent) -> bool {
+    matches!(intent, ExecutionIntent::Plan)
+}
+
+fn project_enable(result: EnableOutcome) -> AdapterApplicationOutcome {
+    match result {
+        EnableOutcome::Planned { plan, notices } => {
+            AdapterApplicationOutcome::Preview(AdapterPreview::Enable { plan, notices })
+        }
+        EnableOutcome::Enabled(claim) => {
+            let notices = claim
+                .notices
+                .iter()
+                .filter(|notice| notice.when == NoticeWhen::PostEnable)
+                .cloned()
+                .collect();
+            let change = AdapterChange::Enabled {
+                component: claim.component.clone(),
+                framework: claim.framework.clone(),
+            };
+            AdapterApplicationOutcome::Applied {
+                result: AdapterApplied::Enable { claim, notices },
+                outcome: CommandOutcome::new(
+                    CommandOutcomeStatus::Completed,
+                    None,
+                    vec![change],
+                    Vec::new(),
+                ),
+            }
+        }
+    }
+}
+
+fn project_disable(result: DisableOutcome) -> AdapterApplicationOutcome {
+    if result.dry_run {
+        return AdapterApplicationOutcome::Preview(AdapterPreview::Disable(result));
+    }
+
+    let status = if result.report.cleanup_complete {
+        CommandOutcomeStatus::Completed
+    } else {
+        CommandOutcomeStatus::Partial {
+            reason: format!(
+                "adapter '{}' cleanup incomplete; receipt kept for retry",
+                result.component
+            ),
+        }
+    };
+    let changes = match (
+        result.claim_removed,
+        result.report.cleanup_complete,
+        result.framework.clone(),
+    ) {
+        (true, _, Some(framework)) => vec![AdapterChange::Disabled {
+            component: result.component.clone(),
+            framework,
+        }],
+        (false, false, Some(framework)) => vec![AdapterChange::CleanupFailed {
+            component: result.component.clone(),
+            framework,
+        }],
+        _ => Vec::new(),
+    };
+
+    AdapterApplicationOutcome::Applied {
+        result: AdapterApplied::Disable(result),
+        outcome: CommandOutcome::new(status, None, changes, Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use anolisa_core::adapter::claim::{AdapterClaim, ClaimStatus, DriverPayload, OpenClawClaim};
+    use anolisa_core::adapter::driver::{DisableReport, DriverPlan};
+    use anolisa_core::adapter::manager::{DisableOutcome, EnableOutcome};
+    use anolisa_core::execution::{CommandOutcomeStatus, ExecutionIntent};
+    use anolisa_core::manifest::{AdapterNotice, NoticeLevel, NoticeWhen};
+
+    use super::{
+        AdapterApplicationOutcome, AdapterApplied, AdapterChange, AdapterPreview, is_preview,
+        project_disable, project_enable,
+    };
+
+    fn sample_notice(when: NoticeWhen) -> AdapterNotice {
+        AdapterNotice {
+            when,
+            level: NoticeLevel::Warning,
+            text: "restart the framework".to_string(),
+            command: None,
+        }
+    }
+
+    fn sample_claim() -> AdapterClaim {
+        AdapterClaim {
+            claim_schema: 1,
+            component: "tokenless".to_string(),
+            framework: "openclaw".to_string(),
+            plugin_id: None,
+            adapter_type: None,
+            enabled_at: "2026-09-01T00:00:00Z".to_string(),
+            resource_root: PathBuf::from("/tmp/tokenless/openclaw"),
+            bundle_digest: None,
+            source_revision: None,
+            materialized_files: Vec::new(),
+            driver_schema: 1,
+            status: ClaimStatus::Enabled,
+            notices: vec![
+                sample_notice(NoticeWhen::PostEnable),
+                sample_notice(NoticeWhen::PostDisable),
+            ],
+            resources: Vec::new(),
+            driver_payload: DriverPayload::OpenClaw(OpenClawClaim {
+                state_dir_resource: "state".to_string(),
+                plugin_resource: "plugin".to_string(),
+                skill_resources: Vec::new(),
+                config_resources: Vec::new(),
+            }),
+        }
+    }
+
+    fn disable_outcome(
+        dry_run: bool,
+        claim_removed: bool,
+        cleanup_complete: bool,
+        notices: Vec<AdapterNotice>,
+    ) -> DisableOutcome {
+        DisableOutcome {
+            component: "tokenless".to_string(),
+            framework: Some("openclaw".to_string()),
+            report: DisableReport {
+                cleanup_complete,
+                messages: vec!["driver report".to_string()],
+            },
+            claim_removed,
+            dry_run,
+            notices,
+        }
+    }
+
+    #[test]
+    fn execution_intent_maps_only_plan_to_manager_preview() {
+        assert!(is_preview(ExecutionIntent::Plan));
+        assert!(!is_preview(ExecutionIntent::Apply));
+    }
+
+    #[test]
+    fn enable_preview_preserves_plan_and_notices() {
+        let notice = sample_notice(NoticeWhen::PostEnable);
+        let outcome = project_enable(EnableOutcome::Planned {
+            plan: DriverPlan {
+                framework: "openclaw".to_string(),
+                component: "tokenless".to_string(),
+                actions: vec!["register plugin".to_string()],
+                register_command: Some("openclaw plugins install".to_string()),
+            },
+            notices: vec![notice.clone()],
+        });
+
+        let AdapterApplicationOutcome::Preview(AdapterPreview::Enable { plan, notices }) = outcome
+        else {
+            panic!("expected enable preview");
+        };
+        assert_eq!(plan.component, "tokenless");
+        assert_eq!(notices, vec![notice]);
+    }
+
+    #[test]
+    fn enable_applied_returns_completed_change_and_display_notices() {
+        let outcome = project_enable(EnableOutcome::Enabled(Box::new(sample_claim())));
+        let AdapterApplicationOutcome::Applied { result, outcome } = outcome else {
+            panic!("expected applied enable");
+        };
+        let AdapterApplied::Enable { notices, .. } = result else {
+            panic!("expected enable result");
+        };
+
+        assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+        assert_eq!(
+            outcome.changes(),
+            &[AdapterChange::Enabled {
+                component: "tokenless".to_string(),
+                framework: "openclaw".to_string(),
+            }]
+        );
+        assert!(outcome.operation_id().is_none());
+        assert!(outcome.warnings().is_empty());
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0].when, NoticeWhen::PostEnable);
+    }
+
+    #[test]
+    fn disable_preview_preserves_report_without_terminal_outcome() {
+        let outcome = project_disable(disable_outcome(true, false, true, Vec::new()));
+        let AdapterApplicationOutcome::Preview(AdapterPreview::Disable(result)) = outcome else {
+            panic!("expected disable preview");
+        };
+        assert!(result.dry_run);
+        assert!(result.report.cleanup_complete);
+    }
+
+    #[test]
+    fn disable_completed_distinguishes_removed_claim_from_noop() {
+        let removed = project_disable(disable_outcome(false, true, true, Vec::new()));
+        let AdapterApplicationOutcome::Applied { outcome, .. } = removed else {
+            panic!("expected applied disable");
+        };
+        assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+        assert_eq!(
+            outcome.changes(),
+            &[AdapterChange::Disabled {
+                component: "tokenless".to_string(),
+                framework: "openclaw".to_string(),
+            }]
+        );
+
+        let noop = project_disable(disable_outcome(false, false, true, Vec::new()));
+        let AdapterApplicationOutcome::Applied { outcome, .. } = noop else {
+            panic!("expected applied disable no-op");
+        };
+        assert_eq!(outcome.status(), &CommandOutcomeStatus::Completed);
+        assert!(outcome.changes().is_empty());
+    }
+
+    #[test]
+    fn cleanup_failure_is_partial_while_notices_remain_non_terminal() {
+        let notice = sample_notice(NoticeWhen::PostDisable);
+        let outcome = project_disable(disable_outcome(false, false, false, vec![notice.clone()]));
+        let AdapterApplicationOutcome::Applied { result, outcome } = outcome else {
+            panic!("expected applied disable");
+        };
+        let AdapterApplied::Disable(result) = result else {
+            panic!("expected disable result");
+        };
+
+        assert_eq!(
+            outcome.status(),
+            &CommandOutcomeStatus::Partial {
+                reason: "adapter 'tokenless' cleanup incomplete; receipt kept for retry"
+                    .to_string(),
+            }
+        );
+        assert_eq!(
+            outcome.changes(),
+            &[AdapterChange::CleanupFailed {
+                component: "tokenless".to_string(),
+                framework: "openclaw".to_string(),
+            }]
+        );
+        assert!(outcome.warnings().is_empty());
+        assert_eq!(result.notices, vec![notice]);
+    }
+}

--- a/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
+++ b/src/anolisa/crates/anolisa-core/src/adapter/manager.rs
@@ -796,7 +796,8 @@ impl AdapterManager {
     /// when `None` and exactly one framework is present). When `dry_run`,
     /// returns the plan without mutating any state.
     ///
-    /// Takes the install lock for the whole operation.
+    /// Apply takes the install lock before loading state; dry-run remains
+    /// read-only and does not create or acquire the lock file.
     ///
     /// # Errors
     ///
@@ -833,7 +834,11 @@ impl AdapterManager {
         dry_run: bool,
         options: EnableOptions,
     ) -> Result<EnableOutcome, AdapterError> {
-        let _lock = InstallLock::acquire(&self.layout.lock_file)?;
+        let _lock = if dry_run {
+            None
+        } else {
+            Some(InstallLock::acquire(&self.layout.lock_file)?)
+        };
         let mut state = self.load_state()?;
 
         let (manifest, scoped_datadir_roots, contract_datadir_root, rpm_provenance) =
@@ -969,7 +974,8 @@ impl AdapterManager {
             component.to_string(),
             label.clone(),
             vec![resource_root.clone()],
-        );
+        )
+        .with_invocation_logging(!dry_run);
         let probe_ctx = DriverCtx {
             component: component.to_string(),
             framework: framework.clone(),
@@ -1010,7 +1016,8 @@ impl AdapterManager {
             component.to_string(),
             label.clone(),
             allowed_roots,
-        );
+        )
+        .with_invocation_logging(!dry_run);
         let ctx = DriverCtx {
             component: component.to_string(),
             framework: framework.clone(),
@@ -1247,7 +1254,8 @@ impl AdapterManager {
     /// descriptive plan without mutating framework state, adapter receipts,
     /// or `installed.toml`.
     ///
-    /// Takes the install lock for the whole operation.
+    /// Apply takes the install lock before loading state; dry-run remains
+    /// read-only and does not create or acquire the lock file.
     ///
     /// # Errors
     ///
@@ -1261,7 +1269,11 @@ impl AdapterManager {
         framework: Option<&str>,
         dry_run: bool,
     ) -> Result<DisableOutcome, AdapterError> {
-        let _lock = InstallLock::acquire(&self.layout.lock_file)?;
+        let _lock = if dry_run {
+            None
+        } else {
+            Some(InstallLock::acquire(&self.layout.lock_file)?)
+        };
         let mut state = self.load_state()?;
 
         let framework = match framework {
@@ -1343,7 +1355,8 @@ impl AdapterManager {
             component.to_string(),
             label.clone(),
             vec![resource_root.clone()],
-        );
+        )
+        .with_invocation_logging(!dry_run);
         let probe_ctx = DriverCtx {
             component: component.to_string(),
             framework: framework.clone(),
@@ -1374,7 +1387,8 @@ impl AdapterManager {
             component.to_string(),
             label.clone(),
             allowed_roots,
-        );
+        )
+        .with_invocation_logging(!dry_run);
         let ctx = DriverCtx {
             component: component.to_string(),
             framework: framework.clone(),
@@ -2585,6 +2599,9 @@ struct ManagerOps {
     /// under. Populated from the driver's `allowed_external_roots` plus
     /// the resource root.
     allowed_roots: Vec<PathBuf>,
+    /// Read-only previews may probe framework capabilities but must not
+    /// persist those invocations as operation records.
+    record_invocations: bool,
 }
 
 /// Persists incremental receipt facts while the Manager holds the enable
@@ -2631,12 +2648,21 @@ impl ManagerOps {
             component,
             label,
             allowed_roots,
+            record_invocations: true,
         }
+    }
+
+    fn with_invocation_logging(mut self, enabled: bool) -> Self {
+        self.record_invocations = enabled;
+        self
     }
 
     /// Record one framework CLI invocation. Best-effort; a log failure
     /// never propagates.
     fn record(&self, cmd: &FrameworkCommand, output: &CliOutput) {
+        if !self.record_invocations {
+            return;
+        }
         let severity = if output.success() {
             Severity::Debug
         } else {

--- a/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
+++ b/src/anolisa/crates/anolisa-core/tests/adapter_manager.rs
@@ -597,6 +597,10 @@ fn enable_status_disable_happy_path() {
         EnableOutcome::Enabled(c) => *c,
         EnableOutcome::Planned { .. } => panic!("expected enabled, got plan"),
     };
+    assert!(
+        world.layout.lock_file.is_file(),
+        "apply must retain the existing install-lock boundary"
+    );
     assert_eq!(claim.component, COMPONENT);
     assert_eq!(claim.framework, FRAMEWORK);
     assert_eq!(claim.plugin_id.as_deref(), Some(COMPONENT));
@@ -1431,6 +1435,8 @@ fn dry_run_enable_does_not_register_or_persist() {
     let world = stage();
     world.apply_env(&guard, None);
     let manager = world.manager();
+    assert!(!world.layout.lock_file.exists());
+    assert!(!world.layout.central_log.exists());
 
     let outcome = manager
         .enable(COMPONENT, Some(FRAMEWORK), true)
@@ -1457,6 +1463,14 @@ fn dry_run_enable_does_not_register_or_persist() {
             .join("registry")
             .join(COMPONENT)
             .exists()
+    );
+    assert!(
+        !world.layout.lock_file.exists(),
+        "dry-run must not create the install lock file"
+    );
+    assert!(
+        !world.layout.central_log.exists(),
+        "dry-run probes must not create operation records"
     );
 }
 
@@ -1662,6 +1676,8 @@ fn dry_run_disable_leaves_state_unchanged() {
         .expect("enable");
     let state_path = world.layout.state_dir.join("installed.toml");
     let state_bytes_before = std::fs::read(&state_path).expect("read state file");
+    let log_bytes_before = std::fs::read(&world.layout.central_log).expect("read central log");
+    std::fs::remove_file(&world.layout.lock_file).expect("remove released seed lock file");
     assert!(
         world
             .load_state()
@@ -1701,6 +1717,15 @@ fn dry_run_disable_leaves_state_unchanged() {
         state_bytes_before, state_bytes_after,
         "installed.toml must be byte-identical after dry-run disable"
     );
+    assert!(
+        !world.layout.lock_file.exists(),
+        "dry-run disable must not recreate the install lock file"
+    );
+    assert_eq!(
+        std::fs::read(&world.layout.central_log).expect("read central log after dry-run"),
+        log_bytes_before,
+        "dry-run disable must not append operation records"
+    );
     // Double-check: receipt still present and status unchanged.
     let state_after = world.load_state();
     let claim_after = state_after
@@ -1724,6 +1749,7 @@ fn dry_run_disable_leaves_state_unchanged() {
         .expect("real disable");
     assert!(!real.dry_run);
     assert!(real.claim_removed, "real disable must remove receipt");
+    assert!(world.layout.lock_file.is_file());
     assert!(
         world
             .load_state()


### PR DESCRIPTION
## Why

Adapter dry-run still acquired the install lock, and read-only framework probes could append central-log records. This violated the preview no-side-effect contract and left adapter mutations outside the shared typed execution model.

## What changed

- Add a CLI-private application boundary for adapter enable and disable requests.
- Project typed preview and applied outcomes back to the existing CLI responses.
- Keep the AdapterManager public bool API while making previews skip the install lock and invocation logging.
- Classify successful apply as Completed and incomplete cleanup as Partial, while keeping notices independent.

## Related issue

closes #3010

## User / Agent impact

No CLI, JSON, human-output, or exit-code changes. Adapter previews no longer create a lock file or append framework-probe operation records.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The existing system-mode privilege policy is unchanged; this only removes filesystem and central-log writes from preview execution. Apply retains the previous lock ordering, driver behavior, persistence, notices, and errors.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p anolisa-cli adapter --locked`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`
- ALinux 4 container: adapter CLI tests (53), scope identity tests (3), and core adapter dry-run tests (10), all passed with read-only source and an isolated target directory.

## Documentation and rollback

No tracked documentation changes are required for this internal refactor. Roll back by reverting commit `0d0d831d`.