### PR TITLE
fix(sight): scope conversation counts by session

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -247,7 +247,7 @@ agentsight interruption --db /path/to/interruption_events.db list --last 48
 | `/api/interruptions/count` | GET | 中断计数按严重级别（`start_ns`, `end_ns`, `agent_name`）— 固定只统计 `resolved=false`，不接受 `resolved` 参数 |
 | `/api/interruptions/stats` | GET | 中断按（类型, 严重级别）统计（`start_ns`, `end_ns`）— 同样固定只统计 `resolved=false` |
 | `/api/interruptions/session-counts` | GET | 按 session 分组的未解决中断计数（`start_ns`, `end_ns`, `agent_name`），NULL session_id 归入 `__unassigned__` |
-| `/api/interruptions/conversation-counts` | GET | 按 conversation 分组的未解决中断计数（`start_ns`, `end_ns`, `agent_name`），NULL conversation_id 归入 `__unassigned__` |
+| `/api/interruptions/conversation-counts` | GET | 按 session + conversation 分组的未解决中断计数（`start_ns`, `end_ns`, `agent_name`），NULL session_id / conversation_id 归入 `__unassigned__`；session 维度不可省略，否则会话未识别的中断会被计入拥有该 conversation 的 session |
 | `/api/interruptions/{id}` | GET | 单个中断事件详情 |
 | `/api/interruptions/{id}/resolve` | POST | 标记中断为已解决 |
 | `/api/sessions/{id}/interruptions` | GET | 指定 session 的所有中断 |

--- a/src/agentsight/dashboard/src/components/InterruptionPanel.tsx
+++ b/src/agentsight/dashboard/src/components/InterruptionPanel.tsx
@@ -146,6 +146,14 @@ export const InterruptionPanel: React.FC<Props> = ({ sessionId, conversationId, 
       let data: InterruptionRecord[];
       if (conversationId) {
         data = await fetchConversationInterruptions(conversationId);
+        // Passing both ids narrows the panel to one session's share of the
+        // conversation, matching the badge that opens it: that badge is keyed
+        // on (session_id, conversation_id), so an interruption detected before
+        // its session was resolved is counted by the unassigned-session row
+        // instead of by this session.
+        if (sessionId) {
+          data = data.filter((event) => event.session_id === sessionId);
+        }
       } else if (sessionId) {
         data = await fetchSessionInterruptions(sessionId);
       } else {

--- a/src/agentsight/dashboard/src/pages/ConversationList.tsx
+++ b/src/agentsight/dashboard/src/pages/ConversationList.tsx
@@ -25,6 +25,7 @@ import {
   fetchInterruptionConversationCounts,
   fetchLatestEvaluation,
   fetchTokenSavings,
+  conversationInterruptionKey,
   UNASSIGNED_INTERRUPTION_BUCKET,
   SessionSummary,
   TraceSummary,
@@ -449,11 +450,14 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
         </tr>
       )}
 
-      {/* Interruptions with no conversation_id. Without this row they would
-          show up in the session badge and then disappear on expand, since the
-          rows below only look up counts by a real trace's conversation_id. */}
+      {/* Interruptions this session owns but that never got a conversation_id.
+          Without this row they would count toward the session badge and then
+          vanish on expand, since the rows below only look up counts by a real
+          trace's conversation_id. */}
       {(() => {
-        const ic = conversationInterruptionCounts.get(UNASSIGNED_INTERRUPTION_BUCKET);
+        const ic = conversationInterruptionCounts.get(
+          conversationInterruptionKey(sessionId, UNASSIGNED_INTERRUPTION_BUCKET)
+        );
         if (!ic || ic.total === 0) return null;
         return (
           <tr className="bg-amber-50 border-t border-amber-100">
@@ -557,7 +561,9 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
                 </div>
                 <div>
                   {(() => {
-                    const ic = conversationInterruptionCounts.get(tr.conversation_id);
+                    const ic = conversationInterruptionCounts.get(
+                      conversationInterruptionKey(sessionId, tr.conversation_id)
+                    );
                     if (!ic || ic.total === 0) return <span className="text-xs text-gray-300">—</span>;
                     return (
                       <InterruptionBadge
@@ -595,6 +601,7 @@ const TraceSubTable: React.FC<TraceSubTableProps> = ({ sessionId, conversationIn
               <td colSpan={10} className="px-4 lg:px-8 pb-3 pt-0">
                 <div className="border border-gray-200 rounded-lg overflow-hidden">
                   <InterruptionPanel
+                    sessionId={sessionId}
                     conversationId={tr.conversation_id}
                     onClose={() => setExpandedTracePanel(null)}
                     onResolvedEvent={onResolvedEvent}
@@ -976,7 +983,10 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
     // 3. Update conversation-level badge counts. A null id belongs to the
     //    unassigned bucket, which is a real row in the breakdown.
     {
-      const convKey = info.conversation_id ?? UNASSIGNED_INTERRUPTION_BUCKET;
+      const convKey = conversationInterruptionKey(
+        info.session_id ?? UNASSIGNED_INTERRUPTION_BUCKET,
+        info.conversation_id ?? UNASSIGNED_INTERRUPTION_BUCKET
+      );
       setConversationInterruptionCounts(prev => {
         const existing = prev.get(convKey);
         if (!existing) return prev;
@@ -1071,7 +1081,9 @@ export const ConversationList: React.FC<ConversationListProps> = () => {
     setInterruptionCount(intData);
     setInterruptionStats(iStats);
     setSessionInterruptionCounts(new Map(iSessionCounts.map((c) => [c.session_id, c])));
-    setConversationInterruptionCounts(new Map(iConvCounts.map((c) => [c.conversation_id, c])));
+    setConversationInterruptionCounts(new Map(
+      iConvCounts.map((c) => [conversationInterruptionKey(c.session_id, c.conversation_id), c])
+    ));
     setSavingsMap(new Map(
       savingsResp?.sessions.map((s) => [s.session_id, s.compounded_saved ?? s.saved_tokens]) ?? []
     ));

--- a/src/agentsight/dashboard/src/utils/apiClient.ts
+++ b/src/agentsight/dashboard/src/utils/apiClient.ts
@@ -935,6 +935,7 @@ export interface SessionInterruptionCount {
 }
 
 export interface ConversationInterruptionCount {
+  session_id: string;
   conversation_id: string;
   total: number;
   by_severity: {
@@ -944,6 +945,23 @@ export interface ConversationInterruptionCount {
     low: number;
   };
   types: InterruptionTypeDetail[];
+}
+
+/**
+ * Key for the per-conversation breakdown, which the backend groups by
+ * (session_id, conversation_id).
+ *
+ * Both halves are needed: an interruption detected before its session was
+ * resolved carries the unassigned session bucket, and must not be looked up
+ * under the real session that owns the same conversation.
+ *
+ * Invariant: neither id contains U+0000, so the joined key cannot collide.
+ * Both are either a UUID, a 32-hex fallback hash, or the `__unassigned__`
+ * sentinel — an id carrying a NUL byte would already have failed to round-trip
+ * through the SQLite TEXT columns these values come from.
+ */
+export function conversationInterruptionKey(sessionId: string, conversationId: string): string {
+  return `${sessionId}\u0000${conversationId}`;
 }
 
 /**

--- a/src/agentsight/docs/agent-diagnostics-guide.md
+++ b/src/agentsight/docs/agent-diagnostics-guide.md
@@ -499,7 +499,7 @@ AgentSight 自动识别并解析以下 LLM API 格式：
 | `/api/interruptions/count` | GET | 中断统计（按严重级别） |
 | `/api/interruptions/stats` | GET | 中断统计（按类型） |
 | `/api/interruptions/session-counts` | GET | 各 Session 的中断聚合 |
-| `/api/interruptions/conversation-counts` | GET | 各 Conversation 的中断聚合 |
+| `/api/interruptions/conversation-counts` | GET | 各 Session + Conversation 的中断聚合 |
 | `/api/sessions/{id}/interruptions` | GET | 指定 Session 的中断 |
 | `/api/conversations/{id}/interruptions` | GET | 指定 Conversation 的中断 |
 | `/api/export/atif/trace/{id}` | GET | ATIF 格式导出 |

--- a/src/agentsight/src/server/handlers.rs
+++ b/src/agentsight/src/server/handlers.rs
@@ -2521,10 +2521,12 @@ mod tests {
                 .to_request(),
         )
         .await;
-        assert_eq!(
-            service_response_json(conversation_counts).await[0]["total"],
-            2
-        );
+        let conversation_row = service_response_json(conversation_counts).await;
+        assert_eq!(conversation_row[0]["total"], 2);
+        // The owning session must ship with the row; the dashboard keys the
+        // breakdown on (session_id, conversation_id).
+        assert_eq!(conversation_row[0]["session_id"], "sess-handler");
+        assert_eq!(conversation_row[0]["conversation_id"], "conv-handler-i");
 
         let by_session = awtest::call_service(
             &app,
@@ -3483,7 +3485,13 @@ pub async fn interruption_session_counts(
 
 /// GET /api/interruptions/conversation-counts?start_ns=<i64>&end_ns=<i64>
 ///
-/// Returns unresolved interruption breakdown per conversation_id, grouped by severity and type.
+/// Returns unresolved interruption breakdown per (session_id, conversation_id),
+/// grouped by severity and type.
+///
+/// The pair is the grouping key, not `conversation_id` alone: the dashboard
+/// nests conversation rows under a session, so a session-less event must not be
+/// attributed to whichever session owns its conversation — the
+/// unassigned-session row already accounts for it.
 #[get("/interruptions/conversation-counts")]
 pub async fn interruption_conversation_counts(
     data: web::Data<AppState>,
@@ -3506,16 +3514,16 @@ pub async fn interruption_conversation_counts(
     ) {
         Ok(rows) => {
             let mut map: std::collections::HashMap<
-                String,
+                (String, String),
                 (
                     i64,
                     std::collections::HashMap<String, i64>,
                     Vec<serde_json::Value>,
                 ),
             > = std::collections::HashMap::new();
-            for (cid, severity, itype, cnt) in rows {
+            for (sid, cid, severity, itype, cnt) in rows {
                 let entry = map
-                    .entry(cid)
+                    .entry((sid, cid))
                     .or_insert_with(|| (0, std::collections::HashMap::new(), Vec::new()));
                 entry.0 += cnt;
                 *entry.1.entry(severity.clone()).or_insert(0) += cnt;
@@ -3527,8 +3535,9 @@ pub async fn interruption_conversation_counts(
             }
             let json: Vec<_> = map
                 .into_iter()
-                .map(|(cid, (total, by_sev, types))| {
+                .map(|((sid, cid), (total, by_sev, types))| {
                     serde_json::json!({
+                        "session_id": sid,
                         "conversation_id": cid,
                         "total": total,
                         "by_severity": {

--- a/src/agentsight/src/storage/sqlite/interruption.rs
+++ b/src/agentsight/src/storage/sqlite/interruption.rs
@@ -544,36 +544,51 @@ impl InterruptionStore {
         Ok(result)
     }
 
-    /// Count unresolved interruptions grouped by (conversation_id, severity, type).
+    /// Count unresolved interruptions grouped by
+    /// (session_id, conversation_id, severity, type).
     ///
-    /// NULL `conversation_id` is bucketed under [`UNASSIGNED_CONVERSATION_ID`]
-    /// for the same total-versus-breakdown consistency reason as
-    /// [`Self::count_unresolved_by_session_detailed`], and `agent_name` scopes
-    /// the result the same way.
+    /// NULL ids are bucketed under [`UNASSIGNED_SESSION_ID`] /
+    /// [`UNASSIGNED_CONVERSATION_ID`] for the same total-versus-breakdown
+    /// consistency reason as [`Self::count_unresolved_by_session_detailed`], and
+    /// `agent_name` scopes the result the same way.
+    ///
+    /// `session_id` is part of the grouping key because a conversation-only
+    /// breakdown cannot say which session an event belongs to: the dashboard
+    /// nests conversation rows under a session, so it would render every
+    /// session-less event under whichever session happens to own that
+    /// conversation, double-counting it against the unassigned-session row.
     pub fn count_unresolved_by_conversation_detailed(
         &self,
         start_ns: i64,
         end_ns: i64,
         agent_name: Option<&str>,
-    ) -> Result<Vec<(String, String, String, i64)>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<(String, String, String, String, i64)>, Box<dyn std::error::Error>> {
         let conn = self.conn.lock().unwrap_or_else(|e| e.into_inner());
         let mut stmt = conn.prepare(
-            "SELECT COALESCE(conversation_id, ?3) AS cid, severity, interruption_type, COUNT(*) AS cnt
+            "SELECT COALESCE(session_id, ?3) AS sid, COALESCE(conversation_id, ?4) AS cid,
+                    severity, interruption_type, COUNT(*) AS cnt
              FROM interruption_events
              WHERE resolved = 0
                AND occurred_at_ns BETWEEN ?1 AND ?2
-               AND (?4 IS NULL OR agent_name = ?4)
-             GROUP BY cid, severity, interruption_type
-             ORDER BY cid, cnt DESC",
+               AND (?5 IS NULL OR agent_name = ?5)
+             GROUP BY sid, cid, severity, interruption_type
+             ORDER BY sid, cid, cnt DESC",
         )?;
         let rows = stmt.query_map(
-            params![start_ns, end_ns, UNASSIGNED_CONVERSATION_ID, agent_name],
+            params![
+                start_ns,
+                end_ns,
+                UNASSIGNED_SESSION_ID,
+                UNASSIGNED_CONVERSATION_ID,
+                agent_name
+            ],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
-                    row.get::<_, i64>(3)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, i64>(4)?,
                 ))
             },
         )?;
@@ -1343,7 +1358,8 @@ mod tests {
             .count_unresolved_by_conversation_detailed(0, i64::MAX, None)
             .unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].0, "conv-ccd");
+        assert_eq!(rows[0].0, "sess-1");
+        assert_eq!(rows[0].1, "conv-ccd");
     }
 
     // ── total-versus-breakdown consistency (issue: 7 high interruptions with a
@@ -1403,7 +1419,51 @@ mod tests {
             .count_unresolved_by_conversation_detailed(0, i64::MAX, None)
             .unwrap();
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].0, UNASSIGNED_CONVERSATION_ID);
+        assert_eq!(rows[0].0, "sess-1");
+        assert_eq!(rows[0].1, UNASSIGNED_CONVERSATION_ID);
+    }
+
+    #[test]
+    fn conversation_breakdown_keeps_session_less_events_out_of_a_real_session() {
+        let store = temp_store();
+
+        // One conversation, two events: one attributed to the session, one
+        // detected before the session was resolved. Grouping by conversation
+        // alone would file both under the session that owns the conversation,
+        // while the unassigned-session row counts the second one as well.
+        let mut attributed = make_event("conv-shared", InterruptionType::ToolFailure);
+        attributed.interruption_id = "int-shared-attributed".to_string();
+        attributed.session_id = Some("sess-owner".to_string());
+        store.insert(&attributed).unwrap();
+
+        let mut session_less = make_event("conv-shared", InterruptionType::EmptyResponse);
+        session_less.interruption_id = "int-shared-orphan".to_string();
+        session_less.session_id = None;
+        store.insert(&session_less).unwrap();
+
+        let rows = store
+            .count_unresolved_by_conversation_detailed(0, i64::MAX, None)
+            .unwrap();
+
+        let owned: i64 = rows
+            .iter()
+            .filter(|(sid, cid, _, _, _)| sid == "sess-owner" && cid == "conv-shared")
+            .map(|(_, _, _, _, cnt)| cnt)
+            .sum();
+        assert_eq!(
+            owned, 1,
+            "the session's own row must not absorb the session-less event"
+        );
+
+        let orphaned: i64 = rows
+            .iter()
+            .filter(|(sid, _, _, _, _)| sid == UNASSIGNED_SESSION_ID)
+            .map(|(_, _, _, _, cnt)| cnt)
+            .sum();
+        assert_eq!(
+            orphaned, 1,
+            "the session-less event stays in the unassigned-session bucket"
+        );
     }
 
     #[test]
@@ -1459,7 +1519,9 @@ mod tests {
             .count_unresolved_by_conversation_detailed(0, i64::MAX, Some("AgentB"))
             .unwrap();
         assert_eq!(conv_only_b.len(), 1);
-        assert_eq!(conv_only_b[0].3, 1);
+        assert_eq!(conv_only_b[0].0, UNASSIGNED_SESSION_ID);
+        assert_eq!(conv_only_b[0].1, "conv-agent");
+        assert_eq!(conv_only_b[0].4, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Why

The per-conversation interruption breakdown grouped by `conversation_id` alone, which made the dashboard show the same interruption several times.

- A NULL `conversation_id` collapsed into a single **global** `__unassigned__` bucket. Every expanded session looked that fixed key up, so one unattributed interruption rendered an "unassigned conversation" row under **every** session, plus the top-level "unassigned session" row.
- An event whose session was never resolved was attributed to whichever session owns its conversation, while the unassigned-session row counted it as well.

The frontend could not scope this itself: the endpoint response carried no session dimension at all.

## What changed

- `count_unresolved_by_conversation_detailed` now groups by `(session_id, conversation_id, severity, type)`; NULL ids keep using the existing `__unassigned__` sentinels.
- `/api/interruptions/conversation-counts` gains a `session_id` field per row and keys its aggregation on the pair.
- The dashboard keys its breakdown map on `(session_id, conversation_id)` via a new `conversationInterruptionKey` helper, used by the per-conversation badge, the unassigned-conversation row, and the resolve-time decrement.

No schema change, no migration, no new route.

## Related issue

closes #3013

## User / Agent impact

Interruption counts in the dashboard are no longer inflated. Each interruption now appears in exactly one place, and a session badge equals the sum of its expanded rows. Interruptions with a NULL `session_id` are intentionally rendered only in the top-level unassigned row, never nested under a session.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

`/api/interruptions/conversation-counts` adds a field rather than changing one, but its row identity becomes the `(session_id, conversation_id)` pair: a consumer that keys on `conversation_id` alone can now see multiple rows for one conversation. The only in-tree consumer is the dashboard, which is embedded into the binary at build time, so there is no mixed-version path. Documented in `src/agentsight/AGENTS.md`.

## Validation

Run from `src/agentsight`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p agentsight --all-targets -- -D warnings` — zero warnings (the pre-existing `actplane-ifc-compiler` clippy failures on `main` are untouched by this change)
- `cargo test -p agentsight --lib` — 1669 passed, 0 failed
- `cargo doc -p agentsight --no-deps` — no new warnings
- `dashboard`: `npm run typecheck`, `npm run build`, `npm run test:api-client` (24), `npm run test:i18n` (5), `npm run test:product-branding` (2) — all pass

New test `conversation_breakdown_keeps_session_less_events_out_of_a_real_session` covers the second defect: one conversation holding both an attributed and a session-less event must not fold the latter into the owning session's row. The endpoint test now asserts `session_id` / `conversation_id` are present on the response row.

Not covered: no automated UI test exercises the rendering paths; the row-level behavior was verified by reading the two lookup sites against the new key.

## Documentation and rollback

Updated the endpoint tables in `src/agentsight/AGENTS.md` (and its `CLAUDE.md` symlink) and `src/agentsight/docs/agent-diagnostics-guide.md` to state the session + conversation grouping and why the session dimension is required.

Rollback is a plain revert of the single commit: no persisted data changes shape, so reverting restores the previous behavior with no cleanup.
