### PR TITLE
fix(sight): use append_policy_delta to prevent fail-open enforcement

### DIFF
--- a/src/agentsight/crates/agentsight-enforcer/src/actplane.rs
+++ b/src/agentsight/crates/agentsight-enforcer/src/actplane.rs
@@ -246,10 +246,13 @@ impl ActPlaneBackend {
                 cleanup,
             ));
         }
-        if let Err(error) = self.reload.reload_policy_delta(id, &compiled.bytes) {
+        if let Err(error) = self
+            .reload
+            .append_policy_delta(control_pid, id, &compiled.bytes)
+        {
             let cleanup = self.cleanup_binding(&request, id);
             return Err(kernel_error_with_cleanup(
-                "reload policy delta",
+                "append policy delta",
                 error,
                 cleanup,
             ));


### PR DESCRIPTION
## Problem

PR #2979 (commit 066fb14) switched the runtime delta injection path from `append_policy_delta` to `reload_policy_delta`. The RELOAD path performs fire-and-forget writes to the BPF ring **without verifying** that the kernel actually installed the policy rules.

This causes `install_prepared_locked` to report `state=Enforced` while **no rules are active** in the BPF capability engine — a **silent fail-open** security regression.

### Evidence

On Alibaba Cloud Linux 4 / kernel 7.1.10 with current main:
- `enforce_unlink_demo`: reports `state=Enforced`, but `rm` succeeds and file is deleted
- HTTP `POST /bindings` with `block unlink` DSL: reports `state=enforced`, file deleted, no violation

### Root Cause

`reload_policy_delta` uses raw `self.submit(...)` which writes to the BPF ring and returns Ok immediately. The prebuilt BPF object does not process RELOAD tags (-1/-2/-3), so submissions are silently discarded.

In contrast, `append_policy_delta` uses `submit_expect_count` which polls the BPF map counter after each submission, failing loudly when the kernel rejects or silently drops a rule.

## Fix

One-line change: switch back to `append_policy_delta(control_pid, id, &compiled.bytes)`.

The control process is already bound with `AUTH_BIND_RULE` authority via `bind_state` (line 241), so the APPEND admission check passes. This was the original working path before the RELOAD switch.

## Verification

Tested on 47.111.114.232 (Alibaba Cloud Linux 4 / kernel 7.1.10):

| Test | Before fix | After fix |
|------|-----------|-----------|
| `enforce_unlink_demo` | `rm` succeeds, FAIL | `rm: Operation not permitted`, PASS |
| HTTP `/bindings` + `block unlink` | File deleted, no violation | File survives, violation `effect=block, blocked=true` |
| Node.js multi-threaded gateway | File deleted | `child_process.spawn` tool blocked |
| `DELETE /bindings` | 204 ✓ | 204 ✓ |
| Path ≥64 bytes | `compile_failure` ✓ | `compile_failure` ✓ |

