### PR TITLE
fix(cosh-ng): [shell] isolate bash env

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -22,6 +22,18 @@ Integration is selected at startup. Enhanced is the default. Set
 `shell.integration = "native"` in the user config for persistent hook-free
 sessions, or use the environment variable for one launch.
 
+For command or redirected-stdin execution, place `--isolated` before shell-owned
+options: `cosh --isolated -c '<command>'`. Bash skips startup files and removes
+`BASH_ENV` and `ENV` from its environment. Bash login invocations (`--login`,
+`-l`/`+l`, combined forms such as `-lc`, or login argv[0] such as `-cosh`) are
+rejected before shell startup with status 2: Bash cannot disable `.bash_logout`
+independently. Use a non-login invocation for isolated commands. Command and
+script arguments that happen to contain login flags are preserved.
+
+On this exec path, isolated Zsh accepts no shell-owned arguments; otherwise
+Cosh returns status 2 before starting Zsh. Interactive TUI startup continues
+to use its existing isolation handling.
+
 ## Input and editing
 
 - Native integration sends every input byte to the foreground bash or zsh.

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md
@@ -21,6 +21,16 @@
 集成状态在启动时确定，Enhanced 是默认值。需要长期使用无 Hook 会话时，在
 用户配置中设置 `shell.integration = "native"`；只使用一次时设置环境变量。
 
+执行命令或从重定向的 stdin 执行时，将 `--isolated` 放在 Shell 自有选项之前：
+`cosh --isolated -c '<command>'`。Bash 会跳过启动文件，并从环境中移除 `BASH_ENV`
+和 `ENV`。Bash login 调用（`--login`、`-l`/`+l`、`-lc` 等组合形式，或 `-cosh`
+这样的 login argv[0]）会在 Shell 启动前以状态码 2 拒绝，因为 Bash 无法单独禁用
+`.bash_logout`。隔离命令请使用非 login 调用。命令和脚本参数中出现的 login 选项
+文本会原样保留。
+
+在此 exec 路径中，隔离 Zsh 不接受 Shell 自有参数；携带这些参数时，Cosh 会在
+启动 Zsh 前返回状态码 2。交互 TUI 启动继续使用现有的隔离处理。
+
 ## 输入和编辑
 
 - 原生集成把每个输入字节交给前台 bash 或 zsh。

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -23,6 +23,10 @@ Agent integration.
 Interactive programs, pipes, redirects, job control, bash/zsh configuration,
 and `Ctrl+C` continue to work in the foreground terminal.
 
+For isolated command execution, use `cosh --isolated -c '<command>'` with Bash.
+Isolated Bash login invocations are rejected with status 2 because Bash cannot
+suppress logout files. See [shell invocation options](../../docs/user-guide/en/user-entrypoint/cosh-ng/shell/interactive-mode.md).
+
 ## Install
 
 On Alibaba Cloud Linux 4, install cosh-ng from the RPM backend in system scope

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -21,6 +21,10 @@ JSONL 接口。
 交互程序、管道、重定向、任务控制、bash/zsh 配置和 `Ctrl+C` 都会在前台终端中
 照常工作。
 
+使用 Bash 执行隔离命令时，运行 `cosh --isolated -c '<command>'`。
+Bash 无法禁用退出脚本，因此隔离模式下的 Bash login 调用会以状态码 2 拒绝。
+详见 [Shell 启动选项](../../docs/user-guide/zh/user-entrypoint/cosh-ng/shell/interactive-mode.md)。
+
 ## 安装
 
 在 Alibaba Cloud Linux 4 上，通过 ANOLISA CLI 和 RPM backend 把 cosh-ng

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/invocation.rs
@@ -1,8 +1,9 @@
 //! Invocation-transparency dispatch for the `/usr/bin/cosh` entry.
 //!
 //! Single source of truth for the installed entry: the reserved `agent`
-//! namespace enters the Gateway, the TUI is an allowlist, and every other argv
-//! shape is handed verbatim to the inner shell via `execve`.
+//! namespace enters the Gateway, the TUI is an allowlist, and other shapes
+//! preserve shell-owned argv unless a leading cosh-owned `--isolated` requests
+//! target-specific startup suppression or fail-closed handling.
 
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
@@ -35,10 +36,11 @@ pub(crate) struct ExecPlan {
     /// argv[0] passed through verbatim (login `-` prefix included) so the
     /// inner shell observes the same `$0` contract as a direct bash call.
     pub(crate) arg0: OsString,
-    /// Remaining argv, byte-for-byte. Only a `--shell` with a usable value
-    /// is consumed; TUI-only flags stay in place so the inner shell rejects
-    /// them loudly instead of silently losing their semantics.
+    /// Remaining inner-shell argv. Cosh-owned target metadata is consumed
+    /// before this boundary; bytes after the first shell token stay verbatim.
     pub(crate) args: Vec<OsString>,
+    /// Translate the cosh-owned isolation contract for the selected shell.
+    pub(crate) isolated: bool,
 }
 
 /// True when argv[0] names the `/usr/bin/cosh` entry (optionally with the
@@ -67,11 +69,11 @@ fn login_argv0(argv0: &OsStr) -> bool {
     argv0.as_bytes().first() == Some(&b'-')
 }
 
-/// Standalone allowlist flags kept verbatim for the inner shell. Single
-/// vocabulary source shared by the classifier scan, the launch-side adapter
-/// scan (`cli_args::adapter_name_from_args`), and the vocabulary-contract
-/// test, so adding a flag here mechanically updates all three. Value-carrying
-/// flags (`--shell`, `--resume`) have shape-specific arms and stay explicit.
+/// Standalone allowlist flags recognized by the classifier. Single vocabulary
+/// source shared by the classifier scan, the launch-side adapter scan
+/// (`cli_args::adapter_name_from_args`), and the vocabulary-contract test, so
+/// adding a flag here mechanically updates all three. Exec handling remains
+/// flag-specific; value-carrying flags (`--shell`, `--resume`) stay explicit.
 pub(crate) const TUI_STANDALONE_FLAGS: &[&str] = &["-l", "--login", "--isolated"];
 
 /// Single source of truth for the login-shell bit: argv[0] carries the
@@ -92,11 +94,10 @@ pub(crate) fn is_login_invocation<A: AsRef<OsStr>>(argv0: &OsStr, args: &[A]) ->
 ///    the inner shell). A missing, empty, or dash-leading value is not
 ///    consumed: the token is handed to the inner shell verbatim, which
 ///    reports it as an invalid option.
-/// 2. Login flags (`-l`/`--login`) and TUI-only flags (`--isolated`,
-///    `--resume [id]`, `--resume=id`) stay eligible for the TUI and are
-///    kept verbatim for the inner shell on the exec side, so a TUI-only
-///    flag that ends up on the exec path fails loudly as an invalid bash
-///    option instead of being silently dropped.
+/// 2. Login flags (`-l`/`--login`) and TUI-only resume flags stay eligible
+///    for the TUI and are kept verbatim for the inner shell on the exec side.
+///    `--isolated` is cosh-owned target metadata and is translated only after
+///    the inner shell is selected.
 /// 3. Any other token (options, operands, unknown or future flags, non-UTF-8
 ///    bytes) short-circuits to `ExecShell` with the remainder untouched, so
 ///    the worst case for an unclassified shape is native bash.
@@ -130,10 +131,15 @@ pub(crate) fn classify_invocation(
 
     let mut kept: Vec<OsString> = Vec::new();
     let mut shell_override: Option<OsString> = None;
+    let mut isolated = false;
     let mut idx = 0;
     while idx < args.len() {
         let arg = &args[idx];
         match arg.to_str() {
+            Some("--isolated") => {
+                isolated = true;
+                idx += 1;
+            }
             Some(text) if TUI_STANDALONE_FLAGS.contains(&text) => {
                 kept.push(arg.clone());
                 idx += 1;
@@ -181,6 +187,7 @@ pub(crate) fn classify_invocation(
                     shell_override,
                     arg0: argv0.to_os_string(),
                     args: rest,
+                    isolated,
                 });
             }
         }
@@ -196,6 +203,7 @@ pub(crate) fn classify_invocation(
             shell_override,
             arg0: argv0.to_os_string(),
             args: kept,
+            isolated,
         })
     }
 }
@@ -258,10 +266,12 @@ pub(crate) fn normalize_raw_invocation(args: &[OsString]) -> Option<Vec<OsString
     None
 }
 
-/// Replace the current process with the inner shell (`execve`), preserving
-/// argv[0], argument bytes, and the inherited SIGPIPE disposition. Returns an
-/// exit code only when the exec itself fails (127 missing / 126 otherwise,
-/// matching the shell convention).
+/// Execute the inner-shell plan, preserving shell-owned argv and SIGPIPE state
+/// outside the cosh-owned isolation contract. Isolated Bash execs suppress its
+/// startup inputs and reject login shells (Bash cannot suppress logout files);
+/// isolated Zsh execs use `-f` only with no shell arguments and
+/// reject arguments before exec; unsupported targets retain `--isolated` and
+/// fail loudly. Returns 2 for isolation rejection, or 127/126 when exec fails.
 pub(crate) fn exec_shell(plan: ExecPlan) -> i32 {
     use std::os::unix::process::CommandExt;
 
@@ -270,6 +280,35 @@ pub(crate) fn exec_shell(plan: ExecPlan) -> i32 {
         .or_else(|| std::env::var_os("COSH_SHELL_DEFAULT_SHELL").filter(|value| !value.is_empty()))
         .unwrap_or_else(|| OsString::from("bash"));
     let mut command = std::process::Command::new(&shell);
+    if plan.isolated {
+        match entry_basename(&shell) {
+            b"bash" | b"cosh-shell-bash" => {
+                if bash_login_requested(&plan.arg0, &plan.args) {
+                    let program = String::from_utf8_lossy(entry_basename(&plan.arg0));
+                    eprintln!("{program}: isolated Bash login shells are not supported");
+                    return 2;
+                }
+                // Bash long options must precede single-character options.
+                // `--norc` also covers bash's remote-daemon startup path.
+                command.args(["--noprofile", "--norc"]);
+                command.env_remove("BASH_ENV");
+                command.env_remove("ENV");
+            }
+            b"zsh" | b"cosh-shell-zsh" => {
+                if !plan.args.is_empty() {
+                    let program = String::from_utf8_lossy(entry_basename(&plan.arg0));
+                    eprintln!("{program}: isolated Zsh shell arguments are not supported");
+                    return 2;
+                }
+                command.arg("-f");
+            }
+            _ => {
+                // Unsupported targets retain the fail-loud contract instead
+                // of silently claiming isolation that was not established.
+                command.arg("--isolated");
+            }
+        }
+    }
     command.args(&plan.args).arg0(&plan.arg0);
     unsafe {
         command.pre_exec(crate::shell_host::sigpipe::restore_in_child);
@@ -291,6 +330,46 @@ pub(crate) fn exec_shell(plan: ExecPlan) -> i32 {
     } else {
         126
     }
+}
+
+fn bash_login_requested(argv0: &OsStr, args: &[OsString]) -> bool {
+    if login_argv0(argv0) {
+        return true;
+    }
+    let mut args = args.iter();
+    let mut long_options = true;
+    while let Some(arg) = args.next() {
+        let bytes = arg.as_bytes();
+        match bytes {
+            b"-" | b"--" => break,
+            b"--login" | b"-login" => return true,
+            b"--rcfile" | b"-rcfile" | b"--init-file" | b"-init-file" if long_options => {
+                args.next();
+            }
+            // Bash accepts long names with one dash before its short options.
+            b"-debug" | b"-debugger" | b"-dump-po-strings" | b"-dump-strings" | b"-help"
+            | b"-noediting" | b"-noprofile" | b"-norc" | b"-posix" | b"-pretty-print"
+            | b"-protected" | b"-restricted" | b"-verbose" | b"-version" | b"-wordexp"
+                if long_options => {}
+            _ if bytes.starts_with(b"--") => {}
+            _ if matches!(bytes.first(), Some(b'-' | b'+')) => {
+                long_options = false;
+                for option in &bytes[1..] {
+                    match option {
+                        // Bash treats both -l and +l as a login request.
+                        b'l' => return true,
+                        b'o' | b'O' => {
+                            args.next();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            // Bash finishes option parsing before the command/script operand.
+            _ => break,
+        }
+    }
+    false
 }
 
 /// Replace the installed `cosh` entry with its sibling Gateway binary.
@@ -523,50 +602,6 @@ mod tests {
     }
 
     #[test]
-    fn classify_rows_16_17_tui_only_flags_gate_on_terminals_and_fail_loud() {
-        // On terminals the TUI-only flags admit the TUI…
-        for args in [
-            vec!["--resume"],
-            vec!["--resume", "00000000-0000-4000-8000-000000000000"],
-            vec!["--isolated"],
-            vec!["--shell", "zsh", "--isolated"],
-            vec!["--shell=bash"],
-        ] {
-            assert!(
-                matches!(classify("cosh", &args, ALL_TTY), Invocation::Tui(_)),
-                "args {args:?}"
-            );
-        }
-        // …and on the exec path they stay in argv verbatim so the inner
-        // shell rejects them loudly instead of silently dropping semantics.
-        for args in [
-            vec!["--resume"],
-            vec!["--resume", "00000000-0000-4000-8000-000000000000"],
-            vec!["--isolated"],
-        ] {
-            let invocation = classify("cosh", &args, (false, true, true));
-            assert_eq!(
-                exec_args(invocation),
-                os(&args),
-                "args {args:?} must reach the inner shell verbatim"
-            );
-        }
-        // `--shell` with a usable value is consumed even on the exec path
-        // (it selects the inner shell); the TUI-only flag stays.
-        match classify(
-            "cosh",
-            &["--shell", "zsh", "--isolated"],
-            (false, true, true),
-        ) {
-            Invocation::ExecShell(plan) => {
-                assert_eq!(plan.shell_override, Some(OsString::from("zsh")));
-                assert_eq!(plan.args, os(&["--isolated"]));
-            }
-            other => panic!("expected ExecShell, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn classify_rows_18_20_version_help_and_future_flags_exec_verbatim() {
         for args in [vec!["--version"], vec!["--help"], vec!["--future-flag"]] {
             assert_eq!(
@@ -647,41 +682,6 @@ mod tests {
         ));
         assert!(!is_login_invocation(OsStr::new("cosh"), &os(&["-lc"])));
         assert!(!is_login_invocation(OsStr::new("/usr/bin/cosh"), &os(&[])));
-    }
-
-    #[test]
-    fn normalize_raw_diverts_only_command_string_and_double_dash() {
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "cosh-core", "-c", "echo ok"])),
-            Some(os(&["-c", "echo ok"]))
-        );
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "--shell", "bash", "cosh-core", "-c", "x"])),
-            Some(os(&["--shell", "bash", "-c", "x"]))
-        );
-        // A non-dash token after `-c` stays verbatim (it is `-c` payload,
-        // not an adapter).
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "fake", "-c", "cosh-core"])),
-            Some(os(&["-c", "cosh-core"]))
-        );
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "--", "echo", "ok"])),
-            Some(os(&["--", "echo", "ok"]))
-        );
-        // Explicit TUI request: raw-surface flags and bare launches stay on
-        // the TUI path.
-        assert_eq!(normalize_raw_invocation(&os(&["raw", "--run"])), None);
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "fake", "--run"])),
-            None
-        );
-        assert_eq!(normalize_raw_invocation(&os(&["raw", "cosh-core"])), None);
-        assert_eq!(
-            normalize_raw_invocation(&os(&["raw", "fake", "--resume"])),
-            None
-        );
-        assert_eq!(normalize_raw_invocation(&os(&["-c", "echo ok"])), None);
     }
 }
 

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/invocation_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/invocation_tests.rs
@@ -79,3 +79,102 @@ fn raw_non_interactive_escape_hatches_keep_their_legacy_passthrough() {
         );
     }
 }
+
+#[test]
+fn owned_flags_gate_on_terminals_and_translate_isolation() {
+    for args in [
+        vec!["--resume"],
+        vec!["--resume", "00000000-0000-4000-8000-000000000000"],
+        vec!["--isolated"],
+        vec!["--shell", "zsh", "--isolated"],
+        vec!["--shell=bash"],
+    ] {
+        assert!(
+            matches!(classify("cosh", &args, ALL_TTY), Invocation::Tui(_)),
+            "args {args:?}"
+        );
+    }
+
+    for args in [
+        vec!["--resume"],
+        vec!["--resume", "00000000-0000-4000-8000-000000000000"],
+    ] {
+        let invocation = classify("cosh", &args, (false, true, true));
+        assert_eq!(
+            exec_args(invocation),
+            os(&args),
+            "args {args:?} must reach the inner shell verbatim"
+        );
+    }
+
+    match classify("cosh", &["--isolated"], (false, true, true)) {
+        Invocation::ExecShell(plan) => {
+            assert!(plan.isolated);
+            assert!(plan.args.is_empty());
+        }
+        other => panic!("expected ExecShell, got {other:?}"),
+    }
+
+    match classify(
+        "cosh",
+        &["--shell", "zsh", "--isolated"],
+        (false, true, true),
+    ) {
+        Invocation::ExecShell(plan) => {
+            assert_eq!(plan.shell_override, Some(OsString::from("zsh")));
+            assert!(plan.isolated);
+            assert!(plan.args.is_empty());
+        }
+        other => panic!("expected ExecShell, got {other:?}"),
+    }
+}
+
+#[test]
+fn isolated_metadata_is_consumed_only_before_shell_owned_argv() {
+    match classify(
+        "cosh",
+        &["--isolated", "-c", "printf ok", "--isolated"],
+        ALL_TTY,
+    ) {
+        Invocation::ExecShell(plan) => {
+            assert!(plan.isolated);
+            assert_eq!(plan.args, os(&["-c", "printf ok", "--isolated"]));
+        }
+        other => panic!("expected ExecShell, got {other:?}"),
+    }
+}
+
+#[test]
+fn normalize_raw_diverts_only_command_string_and_double_dash() {
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "cosh-core", "-c", "echo ok"])),
+        Some(os(&["-c", "echo ok"]))
+    );
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "--shell", "bash", "cosh-core", "-c", "x"])),
+        Some(os(&["--shell", "bash", "-c", "x"]))
+    );
+    // A non-dash token after `-c` stays verbatim (it is `-c` payload,
+    // not an adapter).
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "fake", "-c", "cosh-core"])),
+        Some(os(&["-c", "cosh-core"]))
+    );
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "--", "echo", "ok"])),
+        Some(os(&["--", "echo", "ok"]))
+    );
+    // Explicit TUI request: raw-surface flags and bare launches stay on
+    // the TUI path.
+    assert_eq!(normalize_raw_invocation(&os(&["raw", "--run"])), None);
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "fake", "--run"])),
+        None
+    );
+    assert_eq!(normalize_raw_invocation(&os(&["raw", "cosh-core"])), None);
+    assert_eq!(
+        normalize_raw_invocation(&os(&["raw", "fake", "--resume"])),
+        None
+    );
+    assert_eq!(normalize_raw_invocation(&os(&["-c", "echo ok"])), None);
+}

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/passthrough.rs
@@ -1,3 +1,6 @@
+use std::net::{TcpListener, TcpStream};
+use std::os::fd::OwnedFd;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 
 use super::*;
@@ -614,14 +617,24 @@ fn raw_cli_cosh_entry_missing_script_file_reports_bash_127() {
 }
 
 #[test]
-fn raw_cli_cosh_entry_tui_only_flag_fails_loud_on_exec_path() {
-    // TUI-only flags reach the inner shell verbatim on the exec path, so
-    // their semantics are rejected loudly (bash: invalid option, exit 2)
-    // instead of being silently dropped.
+fn raw_cli_cosh_entry_isolated_dash_c_ignores_bash_env() {
     let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("isolated-bash-env");
+    let bash_env = home.join("bash-env.sh");
+    let sourced = home.join("bash-env-sourced");
+    fs::write(
+        &bash_env,
+        format!("printf sourced > '{}'\n", sourced.display()),
+    )
+    .expect("write BASH_ENV fixture");
     let output = raw_cli_command(binary)
         .arg0("cosh")
-        .args(["--isolated", "-c", "printf __SHOULD_NOT_RUN__"])
+        .env("BASH_ENV", &bash_env)
+        .args([
+            "--isolated",
+            "-c",
+            "printf '__COMMAND_RAN__ BASH_ENV=<%s>' \"${BASH_ENV-__UNSET__}\"",
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -630,17 +643,618 @@ fn raw_cli_cosh_entry_tui_only_flag_fails_loud_on_exec_path() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert!(
+        stdout.contains("__COMMAND_RAN__"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(
+        stdout.contains("BASH_ENV=<__UNSET__>"),
+        "stdout={stdout}\nstderr={stderr}"
+    );
+    assert!(!sourced.exists(), "BASH_ENV was sourced in isolated mode");
+
+    fs::remove_dir_all(home).expect("remove isolated BASH_ENV fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_posix_bash_ignores_env() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("isolated-posix-env");
+    let env_file = home.join("posix-env.sh");
+    let sourced = home.join("posix-env-sourced");
+    fs::write(
+        &env_file,
+        format!("printf sourced > '{}'\n", sourced.display()),
+    )
+    .expect("write POSIX ENV fixture");
+
+    let run = |isolated: bool| {
+        let args = if isolated {
+            vec![
+                "--isolated",
+                "--posix",
+                "-i",
+                "-c",
+                "printf '__ISOLATED_POSIX_RAN__ ENV=<%s>' \"${ENV-__UNSET__}\"",
+            ]
+        } else {
+            vec![
+                "--posix",
+                "-i",
+                "-c",
+                "printf '__PLAIN_POSIX_RAN__ ENV=<%s>' \"${ENV-__UNSET__}\"",
+            ]
+        };
+        raw_cli_command(binary)
+            .arg0("cosh")
+            .env("ENV", &env_file)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("run POSIX interactive bash command")
+    };
+
+    let plain = run(false);
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
+    let plain_stderr = String::from_utf8_lossy(&plain.stderr);
+    assert!(
+        plain.status.success(),
+        "stdout={plain_stdout}\nstderr={plain_stderr}"
+    );
+    assert!(
+        plain_stdout.contains("__PLAIN_POSIX_RAN__"),
+        "stdout={plain_stdout}\nstderr={plain_stderr}"
+    );
+    assert!(sourced.exists(), "plain POSIX bash did not source ENV");
+    fs::remove_file(&sourced).expect("reset POSIX ENV marker");
+
+    let isolated = run(true);
+    let isolated_stdout = String::from_utf8_lossy(&isolated.stdout);
+    let isolated_stderr = String::from_utf8_lossy(&isolated.stderr);
+    assert!(
+        isolated.status.success(),
+        "stdout={isolated_stdout}\nstderr={isolated_stderr}"
+    );
+    assert!(
+        isolated_stdout.contains("__ISOLATED_POSIX_RAN__ ENV=<__UNSET__>"),
+        "stdout={isolated_stdout}\nstderr={isolated_stderr}"
+    );
+    assert!(!sourced.exists(), "isolated POSIX bash sourced ENV");
+
+    fs::remove_dir_all(home).expect("remove POSIX ENV fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_zsh_args_fail_closed() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("isolated-zsh-fail-closed");
+    let zshenv_sourced = home.join("zshenv-sourced");
+    let env_sourced = home.join("env-sourced");
+    let profile_sourced = home.join("profile-sourced");
+    let command_ran = home.join("command-ran");
+    fs::write(
+        home.join(".zshenv"),
+        format!("printf sourced > '{}'\n", zshenv_sourced.display()),
+    )
+    .expect("write Zsh environment fixture");
+    let env_file = home.join("sh-env");
+    fs::write(
+        &env_file,
+        format!("printf sourced > '{}'\n", env_sourced.display()),
+    )
+    .expect("write emulation ENV fixture");
+    fs::write(
+        home.join(".profile"),
+        format!("printf sourced > '{}'\n", profile_sourced.display()),
+    )
+    .expect("write emulation profile fixture");
+    let script = home.join("adversarial.zsh");
+    fs::write(
+        &script,
+        format!("printf '%s' \"$1\" > '{}'\n", command_ran.display()),
+    )
+    .expect("write Zsh script fixture");
+
+    #[derive(Clone, Copy)]
+    enum Startup {
+        Zshenv,
+        Env,
+        Profile,
+    }
+
+    let script = script.to_string_lossy().into_owned();
+    let command = format!("printf command > '{}'", command_ran.display());
+    let cases = vec![
+        (
+            "plus-bf",
+            vec!["+bf".to_string(), script.clone(), "script-arg".to_string()],
+            Startup::Zshenv,
+            "script-arg",
+        ),
+        (
+            "emulate-zsh",
+            vec![
+                "--emulate".to_string(),
+                "zsh".to_string(),
+                "-c".to_string(),
+                command.clone(),
+            ],
+            Startup::Zshenv,
+            "command",
+        ),
+        (
+            "emulate-sh-env",
+            vec![
+                "--emulate".to_string(),
+                "sh".to_string(),
+                "-i".to_string(),
+                "-c".to_string(),
+                command.clone(),
+            ],
+            Startup::Env,
+            "command",
+        ),
+        (
+            "emulate-ksh-env",
+            vec![
+                "--emulate".to_string(),
+                "ksh".to_string(),
+                "-i".to_string(),
+                "-c".to_string(),
+                command.clone(),
+            ],
+            Startup::Env,
+            "command",
+        ),
+        (
+            "emulate-sh-profile",
+            vec![
+                "--emulate".to_string(),
+                "sh".to_string(),
+                "-l".to_string(),
+                "-c".to_string(),
+                command.clone(),
+            ],
+            Startup::Profile,
+            "command",
+        ),
+        (
+            "stacked-named",
+            vec![
+                "-xo".to_string(),
+                "RCS".to_string(),
+                "-c".to_string(),
+                command.clone(),
+            ],
+            Startup::Zshenv,
+            "command",
+        ),
+        (
+            "plus-minus-terminator",
+            vec!["+-".to_string(), script.clone(), "script-arg".to_string()],
+            Startup::Zshenv,
+            "script-arg",
+        ),
+        (
+            "minus-stacked-terminator",
+            vec!["-x-".to_string(), script.clone(), "script-arg".to_string()],
+            Startup::Zshenv,
+            "script-arg",
+        ),
+        (
+            "plus-stacked-terminator",
+            vec!["+x-".to_string(), script.clone(), "script-arg".to_string()],
+            Startup::Zshenv,
+            "script-arg",
+        ),
+    ];
+
+    for (case, shell_args, startup, expected_command) in cases {
+        let clear_markers = || {
+            for marker in [
+                &zshenv_sourced,
+                &env_sourced,
+                &profile_sourced,
+                &command_ran,
+            ] {
+                if marker.exists() {
+                    fs::remove_file(marker).expect("clear Zsh side-effect marker");
+                }
+            }
+        };
+        let run = |isolated: bool| {
+            let mut args = vec!["--shell".to_string(), "zsh".to_string()];
+            if isolated {
+                args.push("--isolated".to_string());
+            }
+            args.extend(shell_args.iter().cloned());
+
+            raw_cli_command(binary)
+                .arg0("cosh")
+                .env("HOME", &home)
+                .env("ZDOTDIR", &home)
+                .env("ENV", &env_file)
+                .args(args)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .expect("run interactive Zsh command")
+        };
+
+        clear_markers();
+        let plain = run(false);
+        let plain_stdout = String::from_utf8_lossy(&plain.stdout);
+        let plain_stderr = String::from_utf8_lossy(&plain.stderr);
+        assert!(
+            plain.status.success(),
+            "case={case} stdout={plain_stdout} stderr={plain_stderr}"
+        );
+        assert_eq!(
+            fs::read_to_string(&command_ran).expect("plain Zsh command marker"),
+            expected_command,
+            "case={case} stdout={plain_stdout} stderr={plain_stderr}"
+        );
+        let expected_startup = match startup {
+            Startup::Zshenv => &zshenv_sourced,
+            Startup::Env => &env_sourced,
+            Startup::Profile => &profile_sourced,
+        };
+        assert!(
+            expected_startup.exists(),
+            "plain Zsh missed startup file: {case}"
+        );
+
+        clear_markers();
+        let isolated = run(true);
+        let isolated_stdout = String::from_utf8_lossy(&isolated.stdout);
+        let isolated_stderr = String::from_utf8_lossy(&isolated.stderr);
+        assert_eq!(
+            isolated.status.code(),
+            Some(2),
+            "case={case} stdout={isolated_stdout} stderr={isolated_stderr}"
+        );
+        assert!(
+            isolated_stderr.contains("isolated Zsh shell arguments are not supported"),
+            "case={case} stdout={isolated_stdout} stderr={isolated_stderr}"
+        );
+        for marker in [
+            &zshenv_sourced,
+            &env_sourced,
+            &profile_sourced,
+            &command_ran,
+        ] {
+            assert!(!marker.exists(), "isolated Zsh side effect: {case}");
+        }
+    }
+
+    fs::remove_dir_all(home).expect("remove Zsh fail-closed fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_plain_dash_c_preserves_env_and_argv() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("plain-bash-passthrough");
+    let shell = home.join("bash");
+    fs::write(
+        &shell,
+        "#!/bin/sh\nprintf 'BASH_ENV=<%s>\\n' \"${BASH_ENV-__UNSET__}\"\n\
+         for arg do printf 'ARG=<%s>\\n' \"$arg\"; done\n",
+    )
+    .expect("write recording bash fixture");
+    let mut permissions = fs::metadata(&shell)
+        .expect("recording bash metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&shell, permissions).expect("make recording bash executable");
+
+    let bash_env = home.join("plain-bash-env.sh");
+    let shell = shell.to_string_lossy().into_owned();
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .env("BASH_ENV", &bash_env)
+        .args([
+            "--shell",
+            shell.as_str(),
+            "-c",
+            "printf __COMMAND_RAN__",
+            "label",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run plain cosh entry on the exec path");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
     assert_eq!(
-        output.status.code(),
-        Some(2),
-        "stdout={stdout}\nstderr={stderr}"
+        stdout.lines().collect::<Vec<_>>(),
+        [
+            format!("BASH_ENV=<{}>", bash_env.display()),
+            "ARG=<-c>".to_string(),
+            "ARG=<printf __COMMAND_RAN__>".to_string(),
+            "ARG=<label>".to_string(),
+        ],
+        "stderr={stderr}"
+    );
+
+    fs::remove_dir_all(home).expect("remove plain passthrough fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_login_rejects_before_profile_and_bash_env() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("isolated-login");
+    let profile_sourced = home.join("profile-sourced");
+    let bash_env_sourced = home.join("bash-env-sourced");
+    let bash_env = home.join("bash-env.sh");
+    fs::write(
+        home.join(".bash_profile"),
+        format!("printf sourced > '{}'\n", profile_sourced.display()),
+    )
+    .expect("write login profile fixture");
+    fs::write(
+        &bash_env,
+        format!("printf sourced > '{}'\n", bash_env_sourced.display()),
+    )
+    .expect("write BASH_ENV fixture");
+
+    let plain = raw_cli_command(binary)
+        .arg0("cosh")
+        .env("HOME", &home)
+        .env("BASH_ENV", &bash_env)
+        .args(["--login", "-c", "printf __PLAIN_LOGIN_RAN__"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run plain login command");
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
+    let plain_stderr = String::from_utf8_lossy(&plain.stderr);
+    assert!(
+        plain.status.success(),
+        "stdout={plain_stdout}\nstderr={plain_stderr}"
     );
     assert!(
-        stderr.contains("--isolated"),
-        "stdout={stdout}\nstderr={stderr}"
+        profile_sourced.exists(),
+        "login control did not source profile"
     );
     assert!(
-        !stdout.contains("__SHOULD_NOT_RUN__"),
+        bash_env_sourced.exists(),
+        "login control did not source BASH_ENV"
+    );
+    fs::remove_file(&profile_sourced).expect("reset login profile marker");
+    fs::remove_file(&bash_env_sourced).expect("reset BASH_ENV marker");
+
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .env("HOME", &home)
+        .env("BASH_ENV", &bash_env)
+        .args([
+            "--isolated",
+            "--login",
+            "-c",
+            "printf __LOGIN_COMMAND_RAN__",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run isolated login command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(2), "stderr={stderr}");
+    assert!(stdout.is_empty(), "stdout={stdout}\nstderr={stderr}");
+    assert!(stderr.contains("isolated Bash login shells are not supported"));
+    assert!(!profile_sourced.exists(), "login profile was sourced");
+    assert!(!bash_env_sourced.exists(), "BASH_ENV was sourced");
+
+    fs::remove_dir_all(home).expect("remove isolated login fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_bash_login_blocks_logout_files() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = tempfile::tempdir().expect("create logout fixture");
+    fs::write(
+        home.path().join(".bash_logout"),
+        "printf __LOGOUT_RAN__; exit 73\n",
+    )
+    .expect("write logout fixture");
+
+    for (argv0, options) in [
+        ("cosh", vec!["--login", "-c"]),
+        ("cosh", vec!["-login", "-c"]),
+        ("cosh", vec!["-l", "-c"]),
+        ("cosh", vec!["+l", "-c"]),
+        ("cosh", vec!["-lc"]),
+        ("cosh", vec!["-cl"]),
+        ("cosh", vec!["-c", "-l"]),
+        ("cosh", vec!["-c", "-rcfile"]),
+        ("cosh", vec!["-norc", "-noprofile", "-l", "-c"]),
+        ("cosh", vec!["-posix", "-l", "-c"]),
+        ("cosh", vec!["-ol", "pipefail", "-c"]),
+        ("cosh", vec!["-O", "extglob", "+lc"]),
+        ("cosh", vec!["--rcfile", "ignored", "-ilc"]),
+        ("-cosh", vec!["-c"]),
+    ] {
+        for isolated in [false, true] {
+            let mut command = raw_cli_command(binary);
+            command.arg0(argv0).env("HOME", home.path());
+            if isolated {
+                command.arg("--isolated");
+            }
+            let output = command
+                .args(["--noprofile", "--norc"])
+                .args(&options)
+                .args(["printf __COMMAND_RAN__; exit 7"])
+                .stdin(Stdio::null())
+                .output()
+                .expect("run logout probe");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert_eq!(
+                output.status.code(),
+                Some(if isolated { 2 } else { 73 }),
+                "argv0={argv0} options={options:?} isolated={isolated} stderr={stderr}"
+            );
+            assert_eq!(
+                stdout,
+                if isolated {
+                    ""
+                } else {
+                    "__COMMAND_RAN____LOGOUT_RAN__"
+                },
+                "argv0={argv0} options={options:?} isolated={isolated} stderr={stderr}"
+            );
+            if isolated {
+                assert!(stderr.contains("isolated Bash login shells are not supported"));
+            }
+        }
+    }
+
+    // Option values and command arguments must not become login requests.
+    for options in [
+        vec!["-c"],
+        vec!["-noprofile", "-c"],
+        vec!["--rcfile", "-l", "-c"],
+        vec!["-init-file", "--login", "-c"],
+        vec!["-o", "pipefail", "-c"],
+        vec!["-O", "login_shell", "-c"],
+        vec!["-c", "--"],
+    ] {
+        let output = raw_cli_command(binary)
+            .arg0("cosh")
+            .env("HOME", home.path())
+            .arg("--isolated")
+            .args(&options)
+            .args(["printf '%s|%s' \"$0\" \"$1\"; exit 7", "--login", "-lc"])
+            .stdin(Stdio::null())
+            .output()
+            .expect("run non-login control");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(7),
+            "options={options:?} stderr={stderr}"
+        );
+        assert_eq!(
+            output.stdout, b"--login|-lc",
+            "options={options:?} stderr={stderr}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_network_stdin_translates_bash_isolation() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let home = temp_shell_home("isolated-network-stdin");
+    let shell = home.join("bash");
+    fs::write(
+        &shell,
+        "#!/bin/sh\nprintf 'BASH_ENV=<%s>\\n' \"${BASH_ENV-__UNSET__}\"\n\
+         for arg do printf 'ARG=<%s>\\n' \"$arg\"; done\n",
+    )
+    .expect("write recording bash fixture");
+    let mut permissions = fs::metadata(&shell)
+        .expect("recording bash metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&shell, permissions).expect("make recording bash executable");
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind network stdin fixture");
+    let client = TcpStream::connect(listener.local_addr().expect("listener address"))
+        .expect("connect network stdin fixture");
+    let (server, _) = listener.accept().expect("accept network stdin fixture");
+    let server: OwnedFd = server.into();
+    let shell = shell.to_string_lossy().into_owned();
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .env("BASH_ENV", home.join("would-source.sh"))
+        .args([
+            "--shell",
+            shell.as_str(),
+            "--isolated",
+            "-c",
+            "printf __COMMAND_RAN__",
+        ])
+        .stdin(Stdio::from(server))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run isolated command with network stdin");
+    drop(client);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        [
+            "BASH_ENV=<__UNSET__>",
+            "ARG=<--noprofile>",
+            "ARG=<--norc>",
+            "ARG=<-c>",
+            "ARG=<printf __COMMAND_RAN__>",
+        ],
+        "stderr={stderr}"
+    );
+
+    fs::remove_dir_all(home).expect("remove network stdin fixture");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_dash_c_preserves_command_argv() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .args([
+            "--isolated",
+            "-c",
+            "printf '<%s>|<%s>|<%s>' \"$0\" \"$1\" \"$2\"",
+            "label",
+            "one",
+            "two",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run isolated command argv probe");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stdout={stdout}\nstderr={stderr}");
+    assert_eq!(stdout, "<label>|<one>|<two>", "stderr={stderr}");
+}
+
+#[test]
+fn raw_cli_cosh_entry_isolated_dash_c_preserves_signal_status() {
+    let binary = env!("CARGO_BIN_EXE_cosh-shell");
+    let output = raw_cli_command(binary)
+        .arg0("cosh")
+        .args(["--isolated", "-c", "kill -TERM $$"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run isolated command terminated by signal");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.signal(),
+        Some(15),
         "stdout={stdout}\nstderr={stderr}"
     );
 }


### PR DESCRIPTION
## Why

`cosh --isolated -c` was forwarded to Bash as an unknown option. Translating
only startup options also left login-shell `.bash_logout` hooks able to run
user configuration and override command output or exit status.

## What changed

Consume the leading cosh-owned `--isolated` flag and apply target-specific
handling. Non-login Bash receives `--noprofile --norc` with `BASH_ENV` and `ENV`
removed; Bash login invocations are rejected before exec with status 2 because
Bash cannot independently disable logout files. Zsh accepts `-f` only with no
shell-owned arguments and otherwise returns 2 before exec. Unsupported shell
targets retain `--isolated` so they fail loudly.

## Related issue

closes #2685

## User / Agent impact

Use `cosh --isolated -c '<command>'` with non-login Bash. Isolated Bash login
forms (`--login`, `-login`, `-l`/`+l`, combined flags, and login argv[0]) now
return 2 without executing the command or startup/logout files. Ordinary
non-isolated passthrough and non-login command arguments remain intact.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

Isolation intentionally excludes Bash login exec and Zsh exec with shell-owned
arguments. Bash option scanning respects option values and stops before command
or script operands; native exec, fd, and signal behavior remain on accepted
paths. Interactive TUI startup retains its existing handling.

## Validation

Linux aarch64, Rust 1.97.1, Bash 5.2.21, Zsh 5.9:

- `cargo test --locked --package cosh-shell --test raw_cli passthrough:: -- --test-threads=4`: 36 passed.
- `cargo test --locked --package cosh-shell --bin cosh-shell runtime::invocation -- --nocapture`: 23 passed.
- `cargo clippy --locked --package cosh-shell --bin cosh-shell --test raw_cli -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `crates/cosh-shell/scripts/check-layout.sh`: passed.
- `git diff --check`: passed; relative links in all four changed documents passed.

The new real-Bash regression failed with status 73 without the login guard,
then passed with it. It covers 14 login control/candidate pairs and seven
non-login controls, including `+l`, short-option bundles, single-dash long
options, option values, and positional login-like arguments. Existing coverage
exercises BASH_ENV, POSIX ENV, network stdin translation, argv, signals, and the
Zsh fail-closed matrix. Broader validation is delegated to PR CI.

## Documentation and rollback

Updated the English/Chinese component README and shell user guide with the
exec isolation contract and login restriction. Revert commit
`81e3e46eeb6aa14c0a1c3855dd5a9b73b3230331` to roll back; no migration is required.
