### PR TITLE
test(cosh-ng): [shell] pin PS2 ownership

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/parity.rs
@@ -10,6 +10,173 @@ fn bash_available() -> bool {
     }
 }
 
+fn secondary_prompt_spans(terminal: &str, expected_ps2: &str) -> Result<[usize; 4], String> {
+    const PS1: &str = "__USER_PS1__ ";
+    const MULTILINE_OUTPUT: &str = "__MULTILINE__<alpha\nbeta>";
+
+    let ps1 = terminal
+        .match_indices(PS1)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if ps1.len() != 2 {
+        return Err(format!("expected exactly two PS1 spans, got {ps1:?}"));
+    }
+    let ps2 = terminal
+        .match_indices(expected_ps2)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if ps2.len() != 1 {
+        return Err(format!("expected exactly one PS2 span, got {ps2:?}"));
+    }
+    let output = terminal[ps2[0] + expected_ps2.len()..]
+        .find(MULTILINE_OUTPUT)
+        .map(|offset| ps2[0] + expected_ps2.len() + offset)
+        .ok_or_else(|| "missing exact multiline output after PS2".to_string())?;
+    let spans = [ps1[0], ps2[0], output, ps1[1]];
+    if !spans.windows(2).all(|pair| pair[0] < pair[1]) {
+        return Err(format!("prompt spans are out of order: {spans:?}"));
+    }
+    let ps2_line_start = terminal[..ps2[0]].rfind('\n').map_or(0, |index| index + 1);
+    if terminal[ps2_line_start..ps2[0]].contains('◇') {
+        return Err("PS2 line contains a primary-prompt owner".to_string());
+    }
+    Ok(spans)
+}
+
+#[test]
+fn secondary_prompt_oracle_rejects_wrong_order_and_duplicates() {
+    let wrong_order = concat!(
+        "__ENV_PS2__ ",
+        "__MULTILINE__<alpha\nbeta>\n",
+        "__USER_PS1__ __USER_PS1__ "
+    );
+    assert!(secondary_prompt_spans(wrong_order, "__ENV_PS2__ ").is_err());
+
+    let duplicate_ps2 = concat!(
+        "__USER_PS1__ \n__ENV_PS2__ \n__ENV_PS2__ ",
+        "__MULTILINE__<alpha\nbeta>\n__USER_PS1__ "
+    );
+    assert!(secondary_prompt_spans(duplicate_ps2, "__ENV_PS2__ ").is_err());
+}
+
+#[test]
+fn bash_secondary_prompt_stays_shell_owned() {
+    if !bash_available() {
+        return;
+    }
+
+    for (integration, login_shell, environment_ps2, startup_ps2) in
+        [false, true].into_iter().flat_map(|login_shell| {
+            [
+                (
+                    ShellIntegration::Enhanced,
+                    login_shell,
+                    Some("__ENV_PS2__ "),
+                    None,
+                ),
+                (
+                    ShellIntegration::Enhanced,
+                    login_shell,
+                    Some("__ENV_PS2__ "),
+                    Some("__STARTUP_PS2__ "),
+                ),
+                (
+                    ShellIntegration::Native,
+                    login_shell,
+                    None,
+                    Some("__NATIVE_PS2__ "),
+                ),
+            ]
+        })
+    {
+        let mode = if login_shell { "login" } else { "nonlogin" };
+        let integration_name = if integration == ShellIntegration::Enhanced {
+            "enhanced"
+        } else {
+            "native"
+        };
+        let root = tempfile::Builder::new()
+            .prefix(&format!("cosh-shell-ps2-{integration_name}-{mode}-"))
+            .tempdir()
+            .expect("temporary PS2 root");
+        let home = root.path().join("home");
+        std::fs::create_dir_all(&home).expect("home");
+        let startup = if login_shell {
+            home.join(".bash_profile")
+        } else {
+            home.join(".bashrc")
+        };
+        let mut startup_contents = "PS1='__USER_PS1__ '\n".to_string();
+        if let Some(ps2) = startup_ps2 {
+            startup_contents.push_str(&format!("PS2='{ps2}'\n"));
+        }
+        std::fs::write(startup, startup_contents).expect("startup file");
+
+        let mut config = ShellHostConfig::new("ps2-parity", root.path().join("work"))
+            .with_integration(integration)
+            .with_env("HOME", home.display().to_string());
+        if let Some(ps2) = environment_ps2 {
+            config = config.with_env("PS2", ps2);
+        }
+        config.login_shell = login_shell;
+        config.raw_action_watchdog = Duration::from_secs(2);
+        let mut rendered = Vec::new();
+        let output = run_raw_relay_bash_with_actions(
+            &config,
+            vec![
+                RawRelayAction::wait(Duration::from_millis(200)),
+                RawRelayAction::line("printf '__MULTILINE__<%s>\\n' 'alpha"),
+                RawRelayAction::wait(Duration::from_millis(200)),
+                RawRelayAction::line("beta'"),
+                RawRelayAction::wait(Duration::from_millis(200)),
+                RawRelayAction::line("exit"),
+            ],
+            &mut rendered,
+        )
+        .unwrap_or_else(|error| panic!("{integration_name}/{mode}: {error}"));
+        let terminal = without_readline_mode_controls(&String::from_utf8_lossy(&rendered))
+            .replace("\r\n", "\n");
+        let expected_ps2 = startup_ps2.or(environment_ps2).expect("PS2 fixture");
+
+        secondary_prompt_spans(&terminal, expected_ps2)
+            .unwrap_or_else(|error| panic!("{integration_name}/{mode}: {error}: {terminal:?}"));
+        if let (Some(environment_ps2), Some(_)) = (environment_ps2, startup_ps2) {
+            assert!(!terminal.contains(environment_ps2), "{terminal:?}");
+        }
+        if integration == ShellIntegration::Native {
+            assert!(!terminal.contains('◇'), "{terminal:?}");
+        }
+        assert_eq!(output.exit_status, Some(0), "{terminal:?}");
+    }
+}
+
+#[test]
+fn bash_secondary_prompt_watchdog_reaps_unclosed_continuation() {
+    if !bash_available() {
+        return;
+    }
+
+    let root = tempfile::Builder::new()
+        .prefix("cosh-shell-ps2-watchdog-")
+        .tempdir()
+        .expect("temporary PS2 watchdog root");
+    let mut config = ShellHostConfig::new("ps2-watchdog", root.path().join("work"))
+        .with_integration(ShellIntegration::Native);
+    config.raw_action_watchdog = Duration::from_millis(100);
+    let error = run_raw_relay_bash_with_actions(
+        &config,
+        vec![
+            RawRelayAction::wait(Duration::from_millis(100)),
+            RawRelayAction::line("printf 'unterminated"),
+            RawRelayAction::line("exit"),
+        ],
+        Vec::new(),
+    )
+    .expect_err("unclosed continuation must hit the action watchdog");
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut, "{error}");
+}
+
 #[test]
 fn enhanced_bash_errexit_context_keeps_interactive_session_alive() {
     if !bash_available() {


### PR DESCRIPTION
## Why

Current main already preserves Bash PS2 ownership in interactive sessions, but the open issues lack stable current-main nested-PTY evidence. This test-only change pins the existing behavior without modifying production code.

## What changed

- Cover Enhanced environment PS2 and startup override in login and non-login shells.
- Cover Native login and non-login PS2 ownership.
- Reject out-of-order or duplicate prompt transcripts.
- Bound malformed continuation probes with a child-reaping watchdog.

## Related issue

relates #2537

relates #2540

## User / Agent impact

None. Production behavior is unchanged.

## Risk and compatibility

Low risk. The diff is test-only and changes no public CLI, API, configuration, privileged path, migration, or runtime contract.

## Validation

Local Linux nested PTY validation:

- cargo test --package cosh-shell --test shell_host parity::secondary_prompt_oracle_rejects_wrong_order_and_duplicates -- --exact --nocapture
- cargo test --package cosh-shell --test shell_host parity::bash_secondary_prompt_stays_shell_owned -- --exact --nocapture
- cargo test --package cosh-shell --test shell_host parity::bash_secondary_prompt_watchdog_reaps_unclosed_continuation -- --exact --nocapture
- cargo fmt --all -- --check
- crates/cosh-shell/scripts/check-layout.sh
- git diff --check

The PTY matrix covers six Bash scenarios, and the malformed-continuation case reaches its internal timeout and reaps the child.

## Documentation and rollback

No documentation changes are needed. Roll back by reverting commit 0df928289a3531d9a2ef4c4b05afc0d8d4985d81.