### PR TITLE
feat(sec-core): add pap service

### DIFF
--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asc-pap"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-policy-types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "asc-policy-types"
 version = "0.1.0"
 dependencies = [
@@ -40,10 +53,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "deranged"
@@ -52,6 +105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -65,10 +128,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -84,9 +203,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -98,6 +217,12 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
@@ -130,6 +255,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,7 +293,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -173,6 +310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +344,17 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -220,7 +385,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -277,8 +442,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -287,10 +458,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "apps/asc-daemon",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
+    "crates/policy/asc-pap",
     "crates/policy/asc-policy-types",
 ]
 
@@ -20,12 +21,15 @@ publish = false
 [workspace.dependencies]
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
+asc-pap = { path = "crates/policy/asc-pap" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
 time = { version = "=0.3.44", features = ["parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+uuid = { version = "1", features = ["v4"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -10,10 +10,10 @@ Adapter.
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
-- `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding specs,
-  backend-independent IR, and target Adapter contracts.
-- `asc-pap`: transport-independent Policy/Scope revision CRUD and Binding
-  spec/lifecycle CRUD over explicit compiler and repository ports.
+- `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding
+  snapshots, backend-independent IR, and target Adapter contracts.
+- `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
+  monotonic revisions over explicit compiler and repository ports.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
@@ -64,19 +64,37 @@ protocol-only error encoder implements `RejectionEncoder`. PAP becomes one
 registered method family inside the dispatcher; the service framework and
 rejection path remain independent of PAP, its compiler, and its repository.
 
+## Current-record revision boundary
+
+Policy, Scope, and Binding each retain one current record per stable identity.
+Changed writes advance a positive, never-reused revision and atomically replace
+the previous current content. An exact GET for an older revision returns
+not-found, and LIST returns at most one current record per identity.
+
+Deleting current Policy or Scope content retains its allocation head as a
+tombstone, so a later update of the same identity advances rather than reuses a
+revision. A `PreparedBinding` embeds complete Policy and Scope snapshots; an
+existing Binding therefore remains deterministic after either source record is
+updated or deleted. A new Binding can select only a currently retained source
+revision. PAP does not expose historical resource-version CRUD; durable
+operation/audit history belongs to later work packages.
+
 ## Binding spec and lifecycle boundary
 
-`PreparedBinding` is immutable content. The pair
+`PreparedBinding` is an immutable snapshot. The pair
 `(binding_id, binding_revision)` identifies exactly one complete Policy/Scope
-spec and must never be reused for different content. Mutable status is
-deliberately outside that spec:
+snapshot and must never be reused for a different desired-state operation.
+Only the current Binding snapshot is retained. Mutable status is deliberately
+outside that spec:
 
 - `BindingStatus` contains only the lifecycle state; it carries no duplicated
   Binding ID or revision.
 - `BindingView { spec, status }` joins one immutable spec with its status for
   GET/LIST responses.
-- `bindingRevision` changes only for different immutable content. Lifecycle
-  transitions do not manufacture a new spec revision.
+- `bindingRevision` advances for every accepted, non-idempotent Apply or Delete
+  intent, including reapplying identical content after failure or deletion.
+- Reconciler claim, retry, completion, and failure transitions do not advance
+  the revision.
 
 All legal lifecycle states are shared in `asc-policy-types::binding`, next to
 `PreparedBinding`, so PAP, the future outbox, and the future reconciler use one
@@ -110,15 +128,16 @@ apply-side state --DELETE--> PENDING_DELETE --claim--> DELETING --success--> DEL
 
 The complete legal transition set is:
 
-| Current | Event | Next | Spec revision rule |
+| Current | Event | Next | Revision rule |
 |---|---|---|---|
 | none | CREATE valid spec | `PENDING_APPLY` | allocate revision 1 |
 | `PENDING_APPLY`, `APPLYING`, `READY` | UPDATE identical spec | no-op | unchanged |
-| `APPLY_FAILED`, `PENDING_DELETE`, `DELETING`, `DELETED`, `DELETE_FAILED` | UPDATE identical spec | `PENDING_APPLY` | unchanged |
-| any state | UPDATE changed spec | `PENDING_APPLY` | allocate next revision |
-| `PENDING_APPLY`, `APPLYING`, `READY`, `APPLY_FAILED` | DELETE | `PENDING_DELETE` | unchanged |
+| `APPLYING`, `DELETING` | UPDATE changed spec | `OPERATION_IN_PROGRESS` | unchanged |
+| `DELETING` | UPDATE identical spec | `OPERATION_IN_PROGRESS` | unchanged |
+| any other state | UPDATE accepted Apply intent | `PENDING_APPLY` | allocate next revision and replace current record |
+| `APPLYING` | DELETE | `OPERATION_IN_PROGRESS` | unchanged |
+| `PENDING_APPLY`, `READY`, `APPLY_FAILED`, `DELETE_FAILED` | DELETE | `PENDING_DELETE` | allocate next revision and replace current record |
 | `PENDING_DELETE`, `DELETING`, `DELETED` | DELETE | no-op | unchanged |
-| `DELETE_FAILED` | DELETE retry | `PENDING_DELETE` | unchanged |
 | `PENDING_APPLY` | worker claim | `APPLYING` | unchanged |
 | `APPLYING` | success | `READY` | unchanged |
 | `APPLYING` | retryable failure | `PENDING_APPLY` | unchanged |
@@ -128,26 +147,27 @@ The complete legal transition set is:
 | `DELETING` | retryable failure | `PENDING_DELETE` | unchanged |
 | `DELETING` | permanent/retry-exhausted failure | `DELETE_FAILED` | unchanged |
 
-There are no other legal transitions. In particular, UPDATE received while an
-older Delete is `PENDING_DELETE` or `DELETING` moves lifecycle to
-`PENDING_APPLY`. DELETE received while Apply is pending or running follows the
-symmetric rule.
+There are no other legal transitions. In particular, a user request may reverse
+`PENDING_APPLY` or `PENDING_DELETE` because target-side work has not been
+claimed, but it cannot interrupt `APPLYING` or `DELETING`. There is no
+`APPLYING -> PENDING_DELETE` or `DELETING -> PENDING_APPLY` transition within
+one revision.
 
-Repositories persist immutable specs and mutable status separately. A new spec
-revision and its initial status form one transaction; a status-only transition
-does not rewrite spec content. Status CAS APIs identify the target explicitly by
-`binding_id` and `binding_revision` and require the expected current status, so
-the read model does not need to duplicate those fields. The PAP
-revision-allocation wrapper carries `last_allocated_revision` plus status, not a
-duplicate spec.
+Repositories atomically replace the single current Binding snapshot and status
+when PAP accepts a new desired-state revision; no older Binding record remains.
+A status-only worker transition does not rewrite spec content. Status CAS APIs
+identify the current target by `binding_id` plus the revision contained in the
+Binding and require the expected current status. Repository implementations
+must repeat the `APPLYING`/`DELETING` admission gate inside the atomic update so
+a worker claim cannot race a PAP pre-check.
 
 The shared state machine is defined and tested now, but the PAP-only phase
 implements no outbox, dispatcher, or reconciler. Therefore
 PAP writes only `PENDING_APPLY` and `PENDING_DELETE`; nothing in this phase
-advances them. TODO(policy-reconciliation): persist each request transition and
-its reconcile intent atomically; define the operation ordering/CAS token needed
-to reject stale results and ABA; then implement claim, retry, completion,
-failure, restart recovery, and cancellation using the transitions above.
+advances them. TODO(policy-reconciliation): persist each accepted current
+Binding replacement and its reconcile intent atomically, then let the future
+Reconciler consume one complete `BindingView` whose embedded revision fences
+claim, retry, completion, failure, restart recovery, and cancellation.
 
 Daemon protocol, client, concrete persistence/compiler, Policy runtime,
 reconciliation worker, outbox, and target Adapter belong to later work packages

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,22 +1,27 @@
-# AgentSecCore V2 foundation contracts and daemon service bring-up
+# AgentSecCore V2 Policy and daemon foundations
 
-This workspace slice contains the dependency-light contracts shared by later
-AgentSecCore V2 Policy and daemon work packages, plus the protocol-independent
-Unix-domain-socket service framework and a runnable foreground process bootstrap.
-It deliberately contains no daemon wire protocol, persistence implementation,
-Policy engine, PAP, Policy runtime, or target Adapter.
+This workspace slice contains the dependency-light contracts, Policy
+Administration Point, protocol-independent Unix-domain-socket service framework,
+and runnable foreground process bootstrap used by later AgentSecCore V2 work
+packages. It deliberately contains no daemon wire protocol, concrete persistence
+or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
+Adapter.
 
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
-- `asc-policy-types`: authored Policy, prepared Policy/Scope/Binding,
+- `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding specs,
   backend-independent IR, and target Adapter contracts.
+- `asc-pap`: transport-independent Policy/Scope revision CRUD and Binding
+  spec/lifecycle CRUD over explicit compiler and repository ports.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
 - `asc-daemon`: foreground process/bootstrap that installs Unix signal handling,
   selects explicit transport limits, binds an explicitly supplied socket, and
   runs `asc-daemon-service`.
+
+## Daemon service boundary
 
 `asc-daemon-service` is a `PARTIAL_MIGRATION` work package. It preserves the V1
 one-request-per-connection LF/EOF framing, bounded first-frame read, bounded
@@ -59,8 +64,94 @@ protocol-only error encoder implements `RejectionEncoder`. PAP becomes one
 registered method family inside the dispatcher; the service framework and
 rejection path remain independent of PAP, its compiler, and its repository.
 
-Daemon protocol, client, persistence, and Policy runtime crates belong to later
-work packages and are intentionally absent from this slice.
+## Binding spec and lifecycle boundary
+
+`PreparedBinding` is immutable content. The pair
+`(binding_id, binding_revision)` identifies exactly one complete Policy/Scope
+spec and must never be reused for different content. Mutable status is
+deliberately outside that spec:
+
+- `BindingStatus` contains only the lifecycle state; it carries no duplicated
+  Binding ID or revision.
+- `BindingView { spec, status }` joins one immutable spec with its status for
+  GET/LIST responses.
+- `bindingRevision` changes only for different immutable content. Lifecycle
+  transitions do not manufacture a new spec revision.
+
+All legal lifecycle states are shared in `asc-policy-types::binding`, next to
+`PreparedBinding`, so PAP, the future outbox, and the future reconciler use one
+contract:
+
+| State | Meaning | Written by | Terminal without a new request? |
+|---|---|---|---|
+| `PENDING_APPLY` | Apply request accepted but not claimed | PAP | no |
+| `APPLYING` | Apply work claimed and running | reconciler | no |
+| `READY` | referenced spec applied successfully | reconciler | yes, success |
+| `APPLY_FAILED` | Apply permanently failed or exhausted retries | reconciler | yes, failure |
+| `PENDING_DELETE` | Delete request accepted but not claimed | PAP | no |
+| `DELETING` | detach work claimed and running | reconciler | no |
+| `DELETED` | detach completed successfully | reconciler | yes, success |
+| `DELETE_FAILED` | detach permanently failed or exhausted retries | reconciler | yes, failure |
+
+“Terminal” means that no automatic transition remains. A later user request can
+still move lifecycle from a terminal state to a new pending state.
+
+The successful creation path is:
+
+```text
+none --CREATE--> PENDING_APPLY --claim--> APPLYING --success--> READY
+```
+
+The successful deletion path is:
+
+```text
+apply-side state --DELETE--> PENDING_DELETE --claim--> DELETING --success--> DELETED
+```
+
+The complete legal transition set is:
+
+| Current | Event | Next | Spec revision rule |
+|---|---|---|---|
+| none | CREATE valid spec | `PENDING_APPLY` | allocate revision 1 |
+| `PENDING_APPLY`, `APPLYING`, `READY` | UPDATE identical spec | no-op | unchanged |
+| `APPLY_FAILED`, `PENDING_DELETE`, `DELETING`, `DELETED`, `DELETE_FAILED` | UPDATE identical spec | `PENDING_APPLY` | unchanged |
+| any state | UPDATE changed spec | `PENDING_APPLY` | allocate next revision |
+| `PENDING_APPLY`, `APPLYING`, `READY`, `APPLY_FAILED` | DELETE | `PENDING_DELETE` | unchanged |
+| `PENDING_DELETE`, `DELETING`, `DELETED` | DELETE | no-op | unchanged |
+| `DELETE_FAILED` | DELETE retry | `PENDING_DELETE` | unchanged |
+| `PENDING_APPLY` | worker claim | `APPLYING` | unchanged |
+| `APPLYING` | success | `READY` | unchanged |
+| `APPLYING` | retryable failure | `PENDING_APPLY` | unchanged |
+| `APPLYING` | permanent/retry-exhausted failure | `APPLY_FAILED` | unchanged |
+| `PENDING_DELETE` | worker claim | `DELETING` | unchanged |
+| `DELETING` | success | `DELETED` | unchanged |
+| `DELETING` | retryable failure | `PENDING_DELETE` | unchanged |
+| `DELETING` | permanent/retry-exhausted failure | `DELETE_FAILED` | unchanged |
+
+There are no other legal transitions. In particular, UPDATE received while an
+older Delete is `PENDING_DELETE` or `DELETING` moves lifecycle to
+`PENDING_APPLY`. DELETE received while Apply is pending or running follows the
+symmetric rule.
+
+Repositories persist immutable specs and mutable status separately. A new spec
+revision and its initial status form one transaction; a status-only transition
+does not rewrite spec content. Status CAS APIs identify the target explicitly by
+`binding_id` and `binding_revision` and require the expected current status, so
+the read model does not need to duplicate those fields. The PAP
+revision-allocation wrapper carries `last_allocated_revision` plus status, not a
+duplicate spec.
+
+The shared state machine is defined and tested now, but the PAP-only phase
+implements no outbox, dispatcher, or reconciler. Therefore
+PAP writes only `PENDING_APPLY` and `PENDING_DELETE`; nothing in this phase
+advances them. TODO(policy-reconciliation): persist each request transition and
+its reconcile intent atomically; define the operation ordering/CAS token needed
+to reject stale results and ABA; then implement claim, retry, completion,
+failure, restart recovery, and cancellation using the transitions above.
+
+Daemon protocol, client, concrete persistence/compiler, Policy runtime,
+reconciliation worker, outbox, and target Adapter belong to later work packages
+and are intentionally absent from this slice.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-pap"
+description = "Policy Administration Point for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-policy-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/compiler.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/compiler.rs
@@ -1,0 +1,13 @@
+use asc_policy_types::authoring::TemplateEnvelope;
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::policy::PolicyEnvelope;
+
+/// Synchronous authoring-template to Canonical Policy IR boundary used by PAP.
+pub trait PolicyCompiler: Send + Sync {
+    /// Lowers one immutable authored template revision.
+    ///
+    /// # Errors
+    /// Returns a path-addressed semantic validation failure when the template
+    /// cannot be represented by the selected Canonical Policy IR profile.
+    fn lower(&self, template: &TemplateEnvelope) -> Result<PolicyEnvelope, ValidationError>;
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
@@ -24,6 +24,9 @@ pub enum PapError {
     /// An immutable identity or concurrent revision precondition conflicted.
     #[error("immutable revision conflict")]
     Conflict,
+    /// A changed desired-state request cannot interrupt target-side work.
+    #[error("binding reconciliation operation is in progress")]
+    OperationInProgress,
     /// The requested exact record does not exist.
     #[error("record not found")]
     NotFound,

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
@@ -1,0 +1,39 @@
+use asc_policy_types::error::ValidationError;
+
+/// Stable PAP failure categories independent of transport and persistence.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PapError {
+    /// A shared identifier cannot be represented by a required domain type.
+    #[error("invalid identifier: {0}")]
+    InvalidIdentifier(String),
+    /// Human-readable Policy name validation failed.
+    #[error("invalid policy name: {0}")]
+    InvalidPolicyName(String),
+    /// Policy authoring or lowering validation failed.
+    #[error("invalid policy: {0}")]
+    InvalidPolicy(ValidationError),
+    /// Scope authoring validation failed.
+    #[error("invalid scope: {0}")]
+    InvalidScope(ValidationError),
+    /// Binding construction validation failed.
+    #[error("invalid binding: {0}")]
+    InvalidBinding(ValidationError),
+    /// Pagination parameters are outside the bounded PAP query contract.
+    #[error("invalid pagination: limit must be between 1 and 1000")]
+    InvalidPagination,
+    /// An immutable identity or concurrent revision precondition conflicted.
+    #[error("immutable revision conflict")]
+    Conflict,
+    /// The requested exact record does not exist.
+    #[error("record not found")]
+    NotFound,
+    /// No further positive `u32` revision can be allocated.
+    #[error("revision space exhausted")]
+    RevisionExhausted,
+    /// JSON serialization failed while computing canonical content identity.
+    #[error("serialization failed")]
+    Serialization,
+    /// Persistence failed without exposing implementation details.
+    #[error("persistence failed")]
+    Persistence,
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/lib.rs
@@ -1,16 +1,15 @@
 //! Transport-independent Policy Administration Point use cases.
 //!
-//! PAP owns Policy and Scope revision CRUD plus Binding spec/status CRUD.
+//! PAP owns current-record Policy, Scope, and Binding CRUD with monotonic revisions.
 //! Policy authoring is lowered synchronously through [`PolicyCompiler`].
-//! A Binding spec is immutable at `(binding_id, binding_revision)`; mutable
-//! lifecycle is represented separately by
-//! [`asc_policy_types::binding::BindingStatus`].
+//! A Binding revision is a complete immutable snapshot, while only the current
+//! revision and its lifecycle status are retained by the Repository.
 //! Target-specific translation, Adapter dispatch, and retries are intentionally
 //! outside this crate.
 //!
 //! TODO(policy-reconciliation): before a reconciliation worker is introduced,
 //! extend the Binding persistence transaction to atomically record a durable
-//! reconcile intent and its ordering/CAS token.
+//! reconcile intent fenced by the revision embedded in the current Binding.
 //! This PAP-only phase deliberately implements neither an outbox nor a worker,
 //! so accepted requests remain in `PENDING_APPLY` or `PENDING_DELETE`.
 
@@ -24,6 +23,6 @@ mod service;
 
 pub use compiler::PolicyCompiler;
 pub use error::PapError;
-pub use model::{BindingRevisionState, Page, PolicyRevisionState, ScopeRevisionState};
+pub use model::{Page, PolicyRevisionState, ScopeRevisionState};
 pub use repository::PapRepository;
 pub use service::PapService;

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/lib.rs
@@ -1,0 +1,29 @@
+//! Transport-independent Policy Administration Point use cases.
+//!
+//! PAP owns Policy and Scope revision CRUD plus Binding spec/status CRUD.
+//! Policy authoring is lowered synchronously through [`PolicyCompiler`].
+//! A Binding spec is immutable at `(binding_id, binding_revision)`; mutable
+//! lifecycle is represented separately by
+//! [`asc_policy_types::binding::BindingStatus`].
+//! Target-specific translation, Adapter dispatch, and retries are intentionally
+//! outside this crate.
+//!
+//! TODO(policy-reconciliation): before a reconciliation worker is introduced,
+//! extend the Binding persistence transaction to atomically record a durable
+//! reconcile intent and its ordering/CAS token.
+//! This PAP-only phase deliberately implements neither an outbox nor a worker,
+//! so accepted requests remain in `PENDING_APPLY` or `PENDING_DELETE`.
+
+#![forbid(unsafe_code)]
+
+mod compiler;
+mod error;
+mod model;
+mod repository;
+mod service;
+
+pub use compiler::PolicyCompiler;
+pub use error::PapError;
+pub use model::{BindingRevisionState, Page, PolicyRevisionState, ScopeRevisionState};
+pub use repository::PapRepository;
+pub use service::PapService;

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/model.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/model.rs
@@ -1,0 +1,42 @@
+use asc_foundation_types::Revision;
+use asc_policy_types::binding::BindingStatus;
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::PreparedScope;
+use serde::{Deserialize, Serialize};
+
+/// Durable allocation state for one Policy identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyRevisionState {
+    /// Highest revision ever allocated, including deleted revisions.
+    pub last_allocated_revision: Revision,
+    /// Highest Policy revision whose complete content is still retained.
+    pub latest: Option<PreparedPolicy>,
+}
+
+/// Durable allocation state for one Scope identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeRevisionState {
+    /// Highest revision ever allocated, including deleted revisions.
+    pub last_allocated_revision: Revision,
+    /// Highest Scope revision whose complete content is still retained.
+    pub latest: Option<PreparedScope>,
+}
+
+/// Durable spec-allocation and current status for one Binding identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingRevisionState {
+    /// Highest immutable spec revision ever allocated.
+    pub last_allocated_revision: Revision,
+    /// Status of `last_allocated_revision`, which is the current retained spec.
+    pub status: BindingStatus,
+}
+
+/// Bounded query result with the total before pagination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Page<T> {
+    /// Selected records.
+    pub items: Vec<T>,
+    /// Total matching records before pagination.
+    pub total: u64,
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/model.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/model.rs
@@ -1,5 +1,4 @@
 use asc_foundation_types::Revision;
-use asc_policy_types::binding::BindingStatus;
 use asc_policy_types::policy::PreparedPolicy;
 use asc_policy_types::scope::PreparedScope;
 use serde::{Deserialize, Serialize};
@@ -9,8 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct PolicyRevisionState {
     /// Highest revision ever allocated, including deleted revisions.
     pub last_allocated_revision: Revision,
-    /// Highest Policy revision whose complete content is still retained.
-    pub latest: Option<PreparedPolicy>,
+    /// Current Policy content, or `None` when the identity is tombstoned.
+    pub current: Option<PreparedPolicy>,
 }
 
 /// Durable allocation state for one Scope identity.
@@ -18,17 +17,8 @@ pub struct PolicyRevisionState {
 pub struct ScopeRevisionState {
     /// Highest revision ever allocated, including deleted revisions.
     pub last_allocated_revision: Revision,
-    /// Highest Scope revision whose complete content is still retained.
-    pub latest: Option<PreparedScope>,
-}
-
-/// Durable spec-allocation and current status for one Binding identity.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BindingRevisionState {
-    /// Highest immutable spec revision ever allocated.
-    pub last_allocated_revision: Revision,
-    /// Status of `last_allocated_revision`, which is the current retained spec.
-    pub status: BindingStatus,
+    /// Current Scope content, or `None` when the identity is tombstoned.
+    pub current: Option<PreparedScope>,
 }
 
 /// Bounded query result with the total before pagination.

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/repository.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/repository.rs
@@ -1,10 +1,10 @@
 use asc_foundation_types::{ResourceId, Revision};
-use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::binding::{BindingStatus, BindingView};
 use asc_policy_types::policy::PreparedPolicy;
 use asc_policy_types::scope::PreparedScope;
 
 use crate::error::PapError;
-use crate::model::{BindingRevisionState, Page, PolicyRevisionState, ScopeRevisionState};
+use crate::model::{Page, PolicyRevisionState, ScopeRevisionState};
 
 /// Persistence port owned by PAP.
 ///
@@ -22,16 +22,20 @@ use crate::model::{BindingRevisionState, Page, PolicyRevisionState, ScopeRevisio
 /// `Page::total` is the matching count before `offset` and `limit` are applied.
 /// These values are per-query inputs and must not be persisted.
 pub trait PapRepository: Send + Sync {
-    /// Inserts one immutable Policy revision or returns the identical revision.
+    /// Creates or replaces the current Policy record.
     ///
-    /// Implementations must reject a revision that is not exactly the next
-    /// never-reused revision for the Policy identity.
+    /// Implementations must atomically accept a changed record only when its
+    /// revision is exactly the next never-reused revision for the Policy identity.
+    /// An exact replay of the current record is idempotent; every other stale,
+    /// reused, or skipped revision must return [`PapError::Conflict`]. A successful
+    /// changed write replaces the previously retained content; only the current
+    /// record remains.
     ///
     /// # Errors
     /// Returns conflict, serialization, or persistence failures.
     fn put_policy(&self, policy: &PreparedPolicy) -> Result<PreparedPolicy, PapError>;
 
-    /// Gets Policy allocation state and the latest retained revision.
+    /// Gets Policy allocation state and its optional current record.
     ///
     /// # Errors
     /// Returns a persistence failure when the query cannot complete.
@@ -40,20 +44,22 @@ pub trait PapRepository: Send + Sync {
         id: &ResourceId,
     ) -> Result<Option<PolicyRevisionState>, PapError>;
 
-    /// Gets one exact Policy revision.
+    /// Gets the current Policy only when its revision equals `revision`.
     ///
     /// # Errors
     /// Returns not-found or persistence failures.
     fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError>;
 
-    /// Lists retained Policy revisions ordered by Policy identity ascending,
-    /// then numeric revision ascending.
+    /// Lists current Policy records ordered by Policy identity ascending.
     ///
     /// # Errors
     /// Returns a persistence failure when the query cannot complete.
     fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError>;
 
-    /// Deletes the content of one exact Policy revision without reusing it.
+    /// Deletes the current Policy content when its revision equals `revision`.
+    ///
+    /// Implementations retain the allocation head as a tombstone so a later
+    /// update of the same identity cannot reuse the deleted revision.
     ///
     /// # Errors
     /// Returns not-found, conflict, or persistence failures.
@@ -63,13 +69,20 @@ pub trait PapRepository: Send + Sync {
         revision: Revision,
     ) -> Result<PreparedPolicy, PapError>;
 
-    /// Inserts one immutable Scope revision or returns the identical revision.
+    /// Creates or replaces the current Scope record.
+    ///
+    /// Implementations must atomically accept a changed record only when its
+    /// revision is exactly the next never-reused revision for the Scope identity.
+    /// An exact replay of the current record is idempotent; every other stale,
+    /// reused, or skipped revision must return [`PapError::Conflict`]. A successful
+    /// changed write replaces the previously retained content; only the current
+    /// record remains.
     ///
     /// # Errors
     /// Returns conflict, serialization, or persistence failures.
     fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError>;
 
-    /// Gets Scope allocation state and the latest retained revision.
+    /// Gets Scope allocation state and its optional current record.
     ///
     /// # Errors
     /// Returns a persistence failure when the query cannot complete.
@@ -78,20 +91,22 @@ pub trait PapRepository: Send + Sync {
         id: &ResourceId,
     ) -> Result<Option<ScopeRevisionState>, PapError>;
 
-    /// Gets one exact Scope revision.
+    /// Gets the current Scope only when its revision equals `revision`.
     ///
     /// # Errors
     /// Returns not-found or persistence failures.
     fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError>;
 
-    /// Lists retained Scope revisions ordered by Scope identity ascending,
-    /// then numeric revision ascending.
+    /// Lists current Scope records ordered by Scope identity ascending.
     ///
     /// # Errors
     /// Returns a persistence failure when the query cannot complete.
     fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError>;
 
-    /// Deletes the content of one exact Scope revision without reusing it.
+    /// Deletes the current Scope content when its revision equals `revision`.
+    ///
+    /// Implementations retain the allocation head as a tombstone so a later
+    /// update of the same identity cannot reuse the deleted revision.
     ///
     /// # Errors
     /// Returns not-found, conflict, or persistence failures.
@@ -101,12 +116,13 @@ pub trait PapRepository: Send + Sync {
         revision: Revision,
     ) -> Result<PreparedScope, PapError>;
 
-    /// Inserts one immutable Binding spec revision with its initial status.
+    /// Creates or atomically updates the single current Binding record.
     ///
-    /// The spec must use exactly the next never-reused revision for the Binding
-    /// identity. `initial_status` must be `PENDING_APPLY`. Implementations
-    /// persist the spec and current-status transition atomically while keeping
-    /// older specs immutable and retained.
+    /// A new Binding starts at revision 1 in `PENDING_APPLY`. An update must use
+    /// exactly the next never-reused revision and must enter `PENDING_APPLY` or
+    /// `PENDING_DELETE`. The update replaces the complete current spec and
+    /// status atomically; older Binding records are not retained. Implementations
+    /// reject updates while the current status is `APPLYING` or `DELETING`.
     ///
     /// TODO(policy-reconciliation): this method is the transaction boundary
     /// that must later atomically persist a durable reconcile intent and its
@@ -114,23 +130,20 @@ pub trait PapRepository: Send + Sync {
     /// No outbox is written in the PAP-only phase.
     ///
     /// # Errors
-    /// Returns conflict, serialization, or persistence failures.
-    fn put_binding_revision(
-        &self,
-        spec: &PreparedBinding,
-        initial_status: BindingStatus,
-    ) -> Result<BindingView, PapError>;
+    /// Returns operation-in-progress, conflict, serialization, or persistence
+    /// failures.
+    fn update_binding(&self, binding: &BindingView) -> Result<BindingView, PapError>;
 
-    /// Compare-and-swaps status for one exact immutable Binding spec.
+    /// Compare-and-swaps worker status for the current Binding revision.
     ///
     /// Implementations must atomically require the current spec and status to
     /// equal `binding_revision` and `expected_status`, then call
     /// `expected_status.validate_successor(next_status)` or enforce an
     /// equivalent predicate. No `PreparedBinding` is rewritten.
     ///
-    /// TODO(policy-reconciliation): atomically persist a request transition,
-    /// durable reconcile intent, and the ordering/CAS token required to reject
-    /// stale asynchronous results before a worker is introduced.
+    /// Request transitions use [`PapRepository::update_binding`] and allocate a
+    /// new revision; this method only persists Reconciler transitions within one
+    /// current revision.
     ///
     /// # Errors
     /// Returns conflict or persistence failures.
@@ -142,25 +155,6 @@ pub trait PapRepository: Send + Sync {
         next_status: BindingStatus,
     ) -> Result<BindingStatus, PapError>;
 
-    /// Gets the current Binding status and allocation state.
-    ///
-    /// # Errors
-    /// Returns a persistence failure when the query cannot complete.
-    fn get_binding_revision_state(
-        &self,
-        id: &ResourceId,
-    ) -> Result<Option<BindingRevisionState>, PapError>;
-
-    /// Gets one exact immutable Binding spec revision.
-    ///
-    /// # Errors
-    /// Returns not-found or persistence failures.
-    fn get_binding_spec(
-        &self,
-        id: &ResourceId,
-        revision: Revision,
-    ) -> Result<PreparedBinding, PapError>;
-
     /// Gets the current Binding spec and status as a read-only aggregate.
     ///
     /// # Errors
@@ -168,7 +162,7 @@ pub trait PapRepository: Send + Sync {
     fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError>;
 
     /// Lists current Binding specs and status ordered by Binding identity
-    /// ascending, then numeric Binding revision ascending.
+    /// ascending.
     ///
     /// # Errors
     /// Returns a persistence failure when the query cannot complete.

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/repository.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/repository.rs
@@ -1,0 +1,176 @@
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::PreparedScope;
+
+use crate::error::PapError;
+use crate::model::{BindingRevisionState, Page, PolicyRevisionState, ScopeRevisionState};
+
+/// Persistence port owned by PAP.
+///
+/// TODO(policy-pagination-bounds): before a concrete repository is exposed
+/// through a bounded daemon transport, pass a server-owned aggregate byte
+/// budget through all three list paths. Define encoded-size accounting so an
+/// implementation can reject an individually oversized first record before
+/// decoding/materializing it and stop before a page exceeds the remaining
+/// budget.
+///
+/// All list implementations must apply pagination in the repository. They
+/// first order the complete matching result as documented by the individual
+/// method, then skip `offset` records and return at most `limit` records.
+/// Identity ordering is the lexicographic byte order of `ResourceId::as_str()`.
+/// `Page::total` is the matching count before `offset` and `limit` are applied.
+/// These values are per-query inputs and must not be persisted.
+pub trait PapRepository: Send + Sync {
+    /// Inserts one immutable Policy revision or returns the identical revision.
+    ///
+    /// Implementations must reject a revision that is not exactly the next
+    /// never-reused revision for the Policy identity.
+    ///
+    /// # Errors
+    /// Returns conflict, serialization, or persistence failures.
+    fn put_policy(&self, policy: &PreparedPolicy) -> Result<PreparedPolicy, PapError>;
+
+    /// Gets Policy allocation state and the latest retained revision.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn get_policy_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<PolicyRevisionState>, PapError>;
+
+    /// Gets one exact Policy revision.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence failures.
+    fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError>;
+
+    /// Lists retained Policy revisions ordered by Policy identity ascending,
+    /// then numeric revision ascending.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError>;
+
+    /// Deletes the content of one exact Policy revision without reusing it.
+    ///
+    /// # Errors
+    /// Returns not-found, conflict, or persistence failures.
+    fn delete_policy_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError>;
+
+    /// Inserts one immutable Scope revision or returns the identical revision.
+    ///
+    /// # Errors
+    /// Returns conflict, serialization, or persistence failures.
+    fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError>;
+
+    /// Gets Scope allocation state and the latest retained revision.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn get_scope_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<ScopeRevisionState>, PapError>;
+
+    /// Gets one exact Scope revision.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence failures.
+    fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError>;
+
+    /// Lists retained Scope revisions ordered by Scope identity ascending,
+    /// then numeric revision ascending.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError>;
+
+    /// Deletes the content of one exact Scope revision without reusing it.
+    ///
+    /// # Errors
+    /// Returns not-found, conflict, or persistence failures.
+    fn delete_scope_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError>;
+
+    /// Inserts one immutable Binding spec revision with its initial status.
+    ///
+    /// The spec must use exactly the next never-reused revision for the Binding
+    /// identity. `initial_status` must be `PENDING_APPLY`. Implementations
+    /// persist the spec and current-status transition atomically while keeping
+    /// older specs immutable and retained.
+    ///
+    /// TODO(policy-reconciliation): this method is the transaction boundary
+    /// that must later atomically persist a durable reconcile intent and its
+    /// ordering/CAS token together with the new spec/current-status pointer.
+    /// No outbox is written in the PAP-only phase.
+    ///
+    /// # Errors
+    /// Returns conflict, serialization, or persistence failures.
+    fn put_binding_revision(
+        &self,
+        spec: &PreparedBinding,
+        initial_status: BindingStatus,
+    ) -> Result<BindingView, PapError>;
+
+    /// Compare-and-swaps status for one exact immutable Binding spec.
+    ///
+    /// Implementations must atomically require the current spec and status to
+    /// equal `binding_revision` and `expected_status`, then call
+    /// `expected_status.validate_successor(next_status)` or enforce an
+    /// equivalent predicate. No `PreparedBinding` is rewritten.
+    ///
+    /// TODO(policy-reconciliation): atomically persist a request transition,
+    /// durable reconcile intent, and the ordering/CAS token required to reject
+    /// stale asynchronous results before a worker is introduced.
+    ///
+    /// # Errors
+    /// Returns conflict or persistence failures.
+    fn update_binding_status(
+        &self,
+        id: &ResourceId,
+        binding_revision: Revision,
+        expected_status: BindingStatus,
+        next_status: BindingStatus,
+    ) -> Result<BindingStatus, PapError>;
+
+    /// Gets the current Binding status and allocation state.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn get_binding_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<BindingRevisionState>, PapError>;
+
+    /// Gets one exact immutable Binding spec revision.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence failures.
+    fn get_binding_spec(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedBinding, PapError>;
+
+    /// Gets the current Binding spec and status as a read-only aggregate.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence failures.
+    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError>;
+
+    /// Lists current Binding specs and status ordered by Binding identity
+    /// ascending, then numeric Binding revision ascending.
+    ///
+    /// # Errors
+    /// Returns a persistence failure when the query cannot complete.
+    fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError>;
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
@@ -1,0 +1,559 @@
+use std::sync::Arc;
+
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::Validate;
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::identifiers::PolicyId;
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector, ScopeTemplate};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use uuid::Uuid;
+
+use crate::compiler::PolicyCompiler;
+use crate::error::PapError;
+use crate::model::Page;
+use crate::repository::PapRepository;
+
+const MAX_WRITE_ATTEMPTS: usize = 8;
+const MAX_PAGE_SIZE: u32 = 1_000;
+
+#[derive(Clone, Copy)]
+enum WriteTarget<'a> {
+    Create,
+    Update(&'a ResourceId),
+}
+
+/// Policy Administration Point for transport-independent desired-state CRUD.
+pub struct PapService<R, C> {
+    repository: Arc<R>,
+    compiler: Arc<C>,
+}
+
+impl<R, C> Clone for PapService<R, C> {
+    fn clone(&self) -> Self {
+        Self {
+            repository: Arc::clone(&self.repository),
+            compiler: Arc::clone(&self.compiler),
+        }
+    }
+}
+
+impl<R, C> PapService<R, C>
+where
+    R: PapRepository,
+    C: PolicyCompiler,
+{
+    /// Creates PAP from explicit persistence and synchronous compiler ports.
+    pub fn new(repository: Arc<R>, compiler: Arc<C>) -> Self {
+        Self {
+            repository,
+            compiler,
+        }
+    }
+
+    /// Creates one Policy identity from an authored template.
+    ///
+    /// PAP generates the identity and starts at revision 1.
+    ///
+    /// # Errors
+    /// Returns validation, lowering, conflict, revision, or persistence errors.
+    pub fn create_policy(
+        &self,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PapError> {
+        self.write_policy(WriteTarget::Create, policy_name, template)
+    }
+
+    /// Updates one existing Policy identity to an authored template.
+    ///
+    /// Identical latest content is idempotent. Changed content receives the
+    /// next never-reused revision and is lowered synchronously before storage.
+    ///
+    /// # Errors
+    /// Returns validation, lowering, conflict, revision, or persistence errors.
+    pub fn update_policy(
+        &self,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PapError> {
+        self.write_policy(WriteTarget::Update(policy_id), policy_name, template)
+    }
+
+    fn write_policy(
+        &self,
+        target: WriteTarget<'_>,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PapError> {
+        validate_policy_name(policy_name)?;
+        let (update_existing, mut selected_id) = match target {
+            WriteTarget::Create => (false, generated_resource_id()?),
+            WriteTarget::Update(id) => (true, id.clone()),
+        };
+
+        for _ in 0..MAX_WRITE_ATTEMPTS {
+            let state = self.repository.get_policy_revision_state(&selected_id)?;
+            if update_existing && state.is_none() {
+                return Err(PapError::NotFound);
+            }
+            if !update_existing && state.is_some() {
+                selected_id = generated_resource_id()?;
+                continue;
+            }
+            if let Some(current) = state.as_ref().and_then(|value| value.latest.as_ref())
+                && current.policy_name == policy_name
+                && &current.template == template
+            {
+                return Ok(current.clone());
+            }
+
+            let revision =
+                next_revision(state.as_ref().map(|value| value.last_allocated_revision))?;
+            let candidate = self.prepare_policy(&selected_id, policy_name, revision, template)?;
+            match self.repository.put_policy(&candidate) {
+                Err(PapError::Conflict) => {
+                    if !update_existing {
+                        selected_id = generated_resource_id()?;
+                    }
+                }
+                result => return result,
+            }
+        }
+        Err(PapError::Conflict)
+    }
+
+    /// Gets one exact Policy revision.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence errors.
+    pub fn get_policy(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        self.repository.get_policy(id, revision)
+    }
+
+    /// Lists retained Policy revisions.
+    ///
+    /// # Errors
+    /// Returns invalid-pagination or persistence errors.
+    pub fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError> {
+        validate_limit(limit)?;
+        self.repository.list_policies(limit, offset)
+    }
+
+    /// Deletes one exact Policy revision without allowing revision reuse.
+    ///
+    /// # Errors
+    /// Returns not-found, conflict, or persistence errors.
+    pub fn delete_policy_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        self.repository.delete_policy_revision(id, revision)
+    }
+
+    /// Creates one Scope identity from an authored selector.
+    ///
+    /// PAP generates the identity and starts at revision 1.
+    ///
+    /// # Errors
+    /// Returns validation, conflict, revision, or persistence errors.
+    pub fn create_scope(&self, selector: &ScopeSelector) -> Result<PreparedScope, PapError> {
+        self.write_scope(WriteTarget::Create, selector)
+    }
+
+    /// Updates one existing Scope identity to an authored selector.
+    ///
+    /// # Errors
+    /// Returns validation, conflict, revision, or persistence errors.
+    pub fn update_scope(
+        &self,
+        scope_id: &ResourceId,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PapError> {
+        self.write_scope(WriteTarget::Update(scope_id), selector)
+    }
+
+    fn write_scope(
+        &self,
+        target: WriteTarget<'_>,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PapError> {
+        validate_authored_selector(selector)?;
+        let template = ScopeTemplate::execution_domain_default();
+        template.validate().map_err(PapError::InvalidScope)?;
+        let template_digest = json_digest(&(selector, &template))?;
+        let (update_existing, mut selected_id) = match target {
+            WriteTarget::Create => (false, generated_resource_id()?),
+            WriteTarget::Update(id) => (true, id.clone()),
+        };
+
+        for _ in 0..MAX_WRITE_ATTEMPTS {
+            let state = self.repository.get_scope_revision_state(&selected_id)?;
+            if update_existing && state.is_none() {
+                return Err(PapError::NotFound);
+            }
+            if !update_existing && state.is_some() {
+                selected_id = generated_resource_id()?;
+                continue;
+            }
+            if let Some(current) = state.as_ref().and_then(|value| value.latest.as_ref())
+                && &current.selector == selector
+                && current.template == template
+            {
+                return Ok(current.clone());
+            }
+
+            let revision =
+                next_revision(state.as_ref().map(|value| value.last_allocated_revision))?;
+            let candidate = PreparedScope {
+                scope_id: selected_id.clone(),
+                revision,
+                selector: selector.clone(),
+                template: template.clone(),
+                template_digest: template_digest.clone(),
+            };
+            candidate.validate().map_err(PapError::InvalidScope)?;
+            match self.repository.put_scope(&candidate) {
+                Err(PapError::Conflict) => {
+                    if !update_existing {
+                        selected_id = generated_resource_id()?;
+                    }
+                }
+                result => return result,
+            }
+        }
+        Err(PapError::Conflict)
+    }
+
+    /// Gets one exact Scope revision.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence errors.
+    pub fn get_scope(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        self.repository.get_scope(id, revision)
+    }
+
+    /// Lists retained Scope revisions.
+    ///
+    /// # Errors
+    /// Returns invalid-pagination or persistence errors.
+    pub fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError> {
+        validate_limit(limit)?;
+        self.repository.list_scopes(limit, offset)
+    }
+
+    /// Deletes one exact Scope revision without allowing revision reuse.
+    ///
+    /// # Errors
+    /// Returns not-found, conflict, or persistence errors.
+    pub fn delete_scope_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        self.repository.delete_scope_revision(id, revision)
+    }
+
+    /// Creates one immutable Binding spec from Policy and Scope references.
+    ///
+    /// PAP generates the identity, starts at revision 1, and assigns
+    /// `PENDING_APPLY`.
+    ///
+    /// # Errors
+    /// Returns not-found, validation, conflict, revision, or persistence errors.
+    pub fn create_binding(
+        &self,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PapError> {
+        self.write_binding(
+            WriteTarget::Create,
+            policy_id,
+            policy_revision,
+            scope_id,
+            scope_revision,
+        )
+    }
+
+    /// Updates one existing immutable Binding spec to Apply intent.
+    ///
+    /// Policy and Scope references are resolved to complete immutable snapshots.
+    /// An identical spec is idempotent while Apply is pending, running, or
+    /// complete. UPDATE after deletion or terminal failure returns status to
+    /// pending Apply without changing identical spec content. Changed spec
+    /// content receives the next never-reused revision.
+    /// This PAP-only phase leaves accepted work in `PENDING_APPLY` and does not
+    /// translate or dispatch the Binding.
+    ///
+    /// # Errors
+    /// Returns not-found, validation, conflict, revision, or persistence errors.
+    pub fn update_binding(
+        &self,
+        binding_id: &ResourceId,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PapError> {
+        self.write_binding(
+            WriteTarget::Update(binding_id),
+            policy_id,
+            policy_revision,
+            scope_id,
+            scope_revision,
+        )
+    }
+
+    fn write_binding(
+        &self,
+        target: WriteTarget<'_>,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PapError> {
+        let policy = self.repository.get_policy(policy_id, policy_revision)?;
+        let scope = self.repository.get_scope(scope_id, scope_revision)?;
+        let (update_existing, mut selected_id) = match target {
+            WriteTarget::Create => (false, generated_resource_id()?),
+            WriteTarget::Update(id) => (true, id.clone()),
+        };
+
+        for _ in 0..MAX_WRITE_ATTEMPTS {
+            let state = self.repository.get_binding_revision_state(&selected_id)?;
+            if update_existing && state.is_none() {
+                return Err(PapError::NotFound);
+            }
+            if !update_existing && state.is_some() {
+                selected_id = generated_resource_id()?;
+                continue;
+            }
+            if let Some(current) = state.as_ref() {
+                let current_spec = self
+                    .repository
+                    .get_binding_spec(&selected_id, current.last_allocated_revision)?;
+                if current_spec.policy == policy && current_spec.scope == scope {
+                    let next_status = current.status.request_apply();
+                    if next_status == current.status {
+                        return binding_view(current_spec, current.status);
+                    }
+
+                    // TODO(policy-reconciliation): atomically persist a durable Apply intent and
+                    // introduce the ordering/CAS token defined by the outbox/reconciler design.
+                    match self.repository.update_binding_status(
+                        &selected_id,
+                        current_spec.binding_revision,
+                        current.status,
+                        next_status,
+                    ) {
+                        Ok(status) => return binding_view(current_spec, status),
+                        Err(PapError::Conflict) => continue,
+                        Err(error) => return Err(error),
+                    }
+                }
+            }
+
+            let revision =
+                next_revision(state.as_ref().map(|value| value.last_allocated_revision))?;
+            let spec = PreparedBinding {
+                binding_id: selected_id.clone(),
+                binding_revision: revision,
+                policy: policy.clone(),
+                scope: scope.clone(),
+            };
+            let initial_status = BindingStatus::PendingApply;
+            binding_view(spec.clone(), initial_status)?;
+
+            // TODO(policy-reconciliation): atomically persist a durable reconcile intent with this
+            // new spec/status pointer and introduce its ordering/CAS token before any Adapter
+            // worker is introduced. No outbox or dispatch is intentionally performed here.
+            match self.repository.put_binding_revision(&spec, initial_status) {
+                Err(PapError::Conflict) => {
+                    if !update_existing {
+                        selected_id = generated_resource_id()?;
+                    }
+                }
+                result => return result,
+            }
+        }
+        Err(PapError::Conflict)
+    }
+
+    /// Gets the current immutable Binding spec and mutable status.
+    ///
+    /// # Errors
+    /// Returns not-found or persistence errors.
+    pub fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
+        self.repository.get_binding(id)
+    }
+
+    /// Lists current Binding specs and status.
+    ///
+    /// # Errors
+    /// Returns invalid-pagination or persistence errors.
+    pub fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError> {
+        validate_limit(limit)?;
+        self.repository.list_bindings(limit, offset)
+    }
+
+    /// Accepts Delete intent without changing the Binding spec revision.
+    ///
+    /// The status enters `PENDING_DELETE`; repeated deletion is idempotent
+    /// while pending, running, or complete. A terminal Delete failure returns to
+    /// pending Delete when explicitly retried. The complete immutable spec
+    /// remains available for target-side detach.
+    ///
+    /// # Errors
+    /// Returns not-found, conflict, validation, or persistence errors.
+    pub fn delete_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
+        for _ in 0..MAX_WRITE_ATTEMPTS {
+            let Some(state) = self.repository.get_binding_revision_state(id)? else {
+                return Err(PapError::NotFound);
+            };
+            let spec = self
+                .repository
+                .get_binding_spec(id, state.last_allocated_revision)?;
+            let next_status = state.status.request_delete();
+            if next_status == state.status {
+                return binding_view(spec, state.status);
+            }
+            binding_view(spec.clone(), next_status)?;
+
+            // TODO(policy-reconciliation): persist a durable Detach intent in the same
+            // transaction as this status transition and its future ordering/CAS token. The
+            // immutable Binding spec revision does not change.
+            match self.repository.update_binding_status(
+                id,
+                spec.binding_revision,
+                state.status,
+                next_status,
+            ) {
+                Ok(status) => return binding_view(spec, status),
+                Err(PapError::Conflict) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(PapError::Conflict)
+    }
+
+    fn prepare_policy(
+        &self,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        revision: Revision,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PapError> {
+        let domain_id = PolicyId::new(policy_id.as_str()).map_err(PapError::InvalidIdentifier)?;
+        let input = TemplateEnvelope {
+            policy_id: domain_id.clone(),
+            revision,
+            template: template.clone(),
+        };
+        let canonical_policy = self
+            .compiler
+            .lower(&input)
+            .map_err(PapError::InvalidPolicy)?;
+        if canonical_policy.policy_id != domain_id {
+            return Err(PapError::InvalidPolicy(ValidationError::new(
+                "canonicalPolicy.policyId",
+                "compiler output must match the authored Policy identity",
+            )));
+        }
+        if canonical_policy.revision != revision {
+            return Err(PapError::InvalidPolicy(ValidationError::new(
+                "canonicalPolicy.revision",
+                "compiler output must match the authored Policy revision",
+            )));
+        }
+        canonical_policy
+            .validate()
+            .map_err(PapError::InvalidPolicy)?;
+        let candidate = PreparedPolicy {
+            policy_id: policy_id.clone(),
+            policy_name: policy_name.to_owned(),
+            revision,
+            template: template.clone(),
+            canonical_policy,
+            template_digest: json_digest(template)?,
+        };
+        candidate.validate().map_err(PapError::InvalidPolicy)?;
+        Ok(candidate)
+    }
+}
+
+fn binding_view(spec: PreparedBinding, status: BindingStatus) -> Result<BindingView, PapError> {
+    let view = BindingView { spec, status };
+    view.validate().map_err(PapError::InvalidBinding)?;
+    Ok(view)
+}
+
+fn validate_policy_name(value: &str) -> Result<(), PapError> {
+    if value.trim().is_empty() {
+        return Err(PapError::InvalidPolicyName(
+            "must contain a visible character".to_owned(),
+        ));
+    }
+    if value.len() > 256 {
+        return Err(PapError::InvalidPolicyName(
+            "must not exceed 256 bytes".to_owned(),
+        ));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(PapError::InvalidPolicyName(
+            "must not contain control characters".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_authored_selector(selector: &ScopeSelector) -> Result<(), PapError> {
+    if matches!(selector, ScopeSelector::LegacyExecutionDomain { .. }) {
+        return Err(PapError::InvalidScope(ValidationError::new(
+            "selector.kind",
+            "legacy execution-domain selectors cannot be authored",
+        )));
+    }
+    selector.validate().map_err(PapError::InvalidScope)
+}
+
+fn validate_limit(limit: u32) -> Result<(), PapError> {
+    if (1..=MAX_PAGE_SIZE).contains(&limit) {
+        Ok(())
+    } else {
+        Err(PapError::InvalidPagination)
+    }
+}
+
+fn next_revision(current: Option<Revision>) -> Result<Revision, PapError> {
+    match current {
+        Some(revision) => revision
+            .checked_next()
+            .map_err(|_| PapError::RevisionExhausted),
+        None => Revision::new(1).map_err(|_| PapError::RevisionExhausted),
+    }
+}
+
+fn generated_resource_id() -> Result<ResourceId, PapError> {
+    ResourceId::new(Uuid::new_v4().to_string())
+        .map_err(|error| PapError::InvalidIdentifier(error.to_string()))
+}
+
+fn json_digest<T: Serialize>(value: &T) -> Result<String, PapError> {
+    let bytes = serde_json::to_vec(value).map_err(|_| PapError::Serialization)?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
@@ -105,7 +105,7 @@ where
                 selected_id = generated_resource_id()?;
                 continue;
             }
-            if let Some(current) = state.as_ref().and_then(|value| value.latest.as_ref())
+            if let Some(current) = state.as_ref().and_then(|value| value.current.as_ref())
                 && current.policy_name == policy_name
                 && &current.template == template
             {
@@ -127,7 +127,7 @@ where
         Err(PapError::Conflict)
     }
 
-    /// Gets one exact Policy revision.
+    /// Gets the current Policy when its revision matches exactly.
     ///
     /// # Errors
     /// Returns not-found or persistence errors.
@@ -139,7 +139,7 @@ where
         self.repository.get_policy(id, revision)
     }
 
-    /// Lists retained Policy revisions.
+    /// Lists current Policy records.
     ///
     /// # Errors
     /// Returns invalid-pagination or persistence errors.
@@ -148,7 +148,7 @@ where
         self.repository.list_policies(limit, offset)
     }
 
-    /// Deletes one exact Policy revision without allowing revision reuse.
+    /// Deletes the current Policy content without allowing revision reuse.
     ///
     /// # Errors
     /// Returns not-found, conflict, or persistence errors.
@@ -171,6 +171,10 @@ where
     }
 
     /// Updates one existing Scope identity to an authored selector.
+    ///
+    /// Identical latest content is idempotent. Changed content receives the
+    /// next never-reused revision, with the repository atomically rejecting a
+    /// stale allocation head so this service can retry from the winning update.
     ///
     /// # Errors
     /// Returns validation, conflict, revision, or persistence errors.
@@ -205,7 +209,7 @@ where
                 selected_id = generated_resource_id()?;
                 continue;
             }
-            if let Some(current) = state.as_ref().and_then(|value| value.latest.as_ref())
+            if let Some(current) = state.as_ref().and_then(|value| value.current.as_ref())
                 && &current.selector == selector
                 && current.template == template
             {
@@ -234,7 +238,7 @@ where
         Err(PapError::Conflict)
     }
 
-    /// Gets one exact Scope revision.
+    /// Gets the current Scope when its revision matches exactly.
     ///
     /// # Errors
     /// Returns not-found or persistence errors.
@@ -246,7 +250,7 @@ where
         self.repository.get_scope(id, revision)
     }
 
-    /// Lists retained Scope revisions.
+    /// Lists current Scope records.
     ///
     /// # Errors
     /// Returns invalid-pagination or persistence errors.
@@ -255,7 +259,7 @@ where
         self.repository.list_scopes(limit, offset)
     }
 
-    /// Deletes one exact Scope revision without allowing revision reuse.
+    /// Deletes the current Scope content without allowing revision reuse.
     ///
     /// # Errors
     /// Returns not-found, conflict, or persistence errors.
@@ -290,18 +294,19 @@ where
         )
     }
 
-    /// Updates one existing immutable Binding spec to Apply intent.
+    /// Updates the single current Binding record to Apply intent.
     ///
     /// Policy and Scope references are resolved to complete immutable snapshots.
     /// An identical spec is idempotent while Apply is pending, running, or
-    /// complete. UPDATE after deletion or terminal failure returns status to
-    /// pending Apply without changing identical spec content. Changed spec
-    /// content receives the next never-reused revision.
+    /// complete. Every other accepted Apply intent receives the next
+    /// never-reused revision and atomically replaces the current Binding record.
+    /// Changed desired state is rejected while Apply or Delete is running.
     /// This PAP-only phase leaves accepted work in `PENDING_APPLY` and does not
     /// translate or dispatch the Binding.
     ///
     /// # Errors
-    /// Returns not-found, validation, conflict, revision, or persistence errors.
+    /// Returns not-found, validation, operation-in-progress, conflict, revision,
+    /// or persistence errors.
     pub fn update_binding(
         &self,
         binding_id: &ResourceId,
@@ -327,49 +332,57 @@ where
         scope_id: &ResourceId,
         scope_revision: Revision,
     ) -> Result<BindingView, PapError> {
-        let policy = self.repository.get_policy(policy_id, policy_revision)?;
-        let scope = self.repository.get_scope(scope_id, scope_revision)?;
         let (update_existing, mut selected_id) = match target {
             WriteTarget::Create => (false, generated_resource_id()?),
             WriteTarget::Update(id) => (true, id.clone()),
         };
 
         for _ in 0..MAX_WRITE_ATTEMPTS {
-            let state = self.repository.get_binding_revision_state(&selected_id)?;
-            if update_existing && state.is_none() {
-                return Err(PapError::NotFound);
+            let current = match self.repository.get_binding(&selected_id) {
+                Ok(current) if update_existing => Some(current),
+                Ok(_) => {
+                    selected_id = generated_resource_id()?;
+                    continue;
+                }
+                Err(PapError::NotFound) if update_existing => return Err(PapError::NotFound),
+                Err(PapError::NotFound) => None,
+                Err(error) => return Err(error),
+            };
+            if let Some(current) = current.as_ref() {
+                if current.status == BindingStatus::Deleting {
+                    return Err(PapError::OperationInProgress);
+                }
+                if current.status == BindingStatus::Applying {
+                    let identical_reference = current.spec.policy.policy_id == *policy_id
+                        && current.spec.policy.revision == policy_revision
+                        && current.spec.scope.scope_id == *scope_id
+                        && current.spec.scope.revision == scope_revision;
+                    return if identical_reference {
+                        Ok(current.clone())
+                    } else {
+                        Err(PapError::OperationInProgress)
+                    };
+                }
             }
-            if !update_existing && state.is_some() {
-                selected_id = generated_resource_id()?;
-                continue;
-            }
-            if let Some(current) = state.as_ref() {
-                let current_spec = self
-                    .repository
-                    .get_binding_spec(&selected_id, current.last_allocated_revision)?;
-                if current_spec.policy == policy && current_spec.scope == scope {
-                    let next_status = current.status.request_apply();
-                    if next_status == current.status {
-                        return binding_view(current_spec, current.status);
-                    }
+            let policy =
+                self.resolve_binding_policy(current.as_ref(), policy_id, policy_revision)?;
+            let scope = self.resolve_binding_scope(current.as_ref(), scope_id, scope_revision)?;
 
-                    // TODO(policy-reconciliation): atomically persist a durable Apply intent and
-                    // introduce the ordering/CAS token defined by the outbox/reconciler design.
-                    match self.repository.update_binding_status(
-                        &selected_id,
-                        current_spec.binding_revision,
-                        current.status,
-                        next_status,
-                    ) {
-                        Ok(status) => return binding_view(current_spec, status),
-                        Err(PapError::Conflict) => continue,
-                        Err(error) => return Err(error),
+            if let Some(current) = current.as_ref() {
+                let identical = current.spec.policy == policy && current.spec.scope == scope;
+                if identical {
+                    let next_status = current
+                        .status
+                        .request_apply()
+                        .map_err(|_| PapError::OperationInProgress)?;
+                    if next_status == current.status {
+                        return Ok(current.clone());
                     }
                 }
             }
 
             let revision =
-                next_revision(state.as_ref().map(|value| value.last_allocated_revision))?;
+                next_revision(current.as_ref().map(|value| value.spec.binding_revision))?;
             let spec = PreparedBinding {
                 binding_id: selected_id.clone(),
                 binding_revision: revision,
@@ -377,12 +390,12 @@ where
                 scope: scope.clone(),
             };
             let initial_status = BindingStatus::PendingApply;
-            binding_view(spec.clone(), initial_status)?;
+            let binding = binding_view(spec, initial_status)?;
 
             // TODO(policy-reconciliation): atomically persist a durable reconcile intent with this
-            // new spec/status pointer and introduce its ordering/CAS token before any Adapter
-            // worker is introduced. No outbox or dispatch is intentionally performed here.
-            match self.repository.put_binding_revision(&spec, initial_status) {
+            // current Binding replacement before any Adapter worker is introduced. No outbox or
+            // dispatch is intentionally performed here.
+            match self.repository.update_binding(&binding) {
                 Err(PapError::Conflict) => {
                     if !update_existing {
                         selected_id = generated_resource_id()?;
@@ -394,7 +407,45 @@ where
         Err(PapError::Conflict)
     }
 
-    /// Gets the current immutable Binding spec and mutable status.
+    fn resolve_binding_policy(
+        &self,
+        current: Option<&BindingView>,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        match self.repository.get_policy(policy_id, policy_revision) {
+            Ok(policy) => Ok(policy),
+            Err(PapError::NotFound) => current
+                .filter(|binding| {
+                    binding.spec.policy.policy_id == *policy_id
+                        && binding.spec.policy.revision == policy_revision
+                })
+                .map(|binding| binding.spec.policy.clone())
+                .ok_or(PapError::NotFound),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn resolve_binding_scope(
+        &self,
+        current: Option<&BindingView>,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        match self.repository.get_scope(scope_id, scope_revision) {
+            Ok(scope) => Ok(scope),
+            Err(PapError::NotFound) => current
+                .filter(|binding| {
+                    binding.spec.scope.scope_id == *scope_id
+                        && binding.spec.scope.revision == scope_revision
+                })
+                .map(|binding| binding.spec.scope.clone())
+                .ok_or(PapError::NotFound),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Gets the current Binding snapshot and mutable status.
     ///
     /// # Errors
     /// Returns not-found or persistence errors.
@@ -411,39 +462,35 @@ where
         self.repository.list_bindings(limit, offset)
     }
 
-    /// Accepts Delete intent without changing the Binding spec revision.
+    /// Accepts Delete intent as a new Binding revision.
     ///
-    /// The status enters `PENDING_DELETE`; repeated deletion is idempotent
-    /// while pending, running, or complete. A terminal Delete failure returns to
-    /// pending Delete when explicitly retried. The complete immutable spec
-    /// remains available for target-side detach.
+    /// The status enters `PENDING_DELETE`; repeated deletion is idempotent while
+    /// pending, running, or complete. Any other accepted Delete intent allocates
+    /// the next revision and atomically replaces the current Binding record.
+    /// Delete cannot interrupt a running Apply. The complete current spec remains
+    /// available for target-side detach.
     ///
     /// # Errors
-    /// Returns not-found, conflict, validation, or persistence errors.
+    /// Returns not-found, operation-in-progress, conflict, validation, revision,
+    /// or persistence errors.
     pub fn delete_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
         for _ in 0..MAX_WRITE_ATTEMPTS {
-            let Some(state) = self.repository.get_binding_revision_state(id)? else {
-                return Err(PapError::NotFound);
-            };
-            let spec = self
-                .repository
-                .get_binding_spec(id, state.last_allocated_revision)?;
-            let next_status = state.status.request_delete();
-            if next_status == state.status {
-                return binding_view(spec, state.status);
+            let current = self.repository.get_binding(id)?;
+            let next_status = current
+                .status
+                .request_delete()
+                .map_err(|_| PapError::OperationInProgress)?;
+            if next_status == current.status {
+                return Ok(current);
             }
-            binding_view(spec.clone(), next_status)?;
+            let mut spec = current.spec;
+            spec.binding_revision = next_revision(Some(spec.binding_revision))?;
+            let binding = binding_view(spec, next_status)?;
 
             // TODO(policy-reconciliation): persist a durable Detach intent in the same
-            // transaction as this status transition and its future ordering/CAS token. The
-            // immutable Binding spec revision does not change.
-            match self.repository.update_binding_status(
-                id,
-                spec.binding_revision,
-                state.status,
-                next_status,
-            ) {
-                Ok(status) => return binding_view(spec, status),
+            // transaction as this current Binding replacement.
+            match self.repository.update_binding(&binding) {
+                Ok(binding) => return Ok(binding),
                 Err(PapError::Conflict) => {}
                 Err(error) => return Err(error),
             }

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
@@ -1,0 +1,691 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::{
+    BindingRevisionState, Page, PapError, PapRepository, PapService, PolicyCompiler,
+    PolicyRevisionState, ScopeRevisionState,
+};
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::identifiers::PolicyId;
+use asc_policy_types::policy::{PolicyEnvelope, PreparedPolicy};
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+
+const COMPLETE_BINDING: &str =
+    include_str!("../../asc-policy-types/tests/fixtures/prepared-binding.json");
+
+#[derive(Default)]
+struct FakeState {
+    policy_heads: BTreeMap<String, u32>,
+    policies: BTreeMap<(String, u32), PreparedPolicy>,
+    scope_heads: BTreeMap<String, u32>,
+    scopes: BTreeMap<(String, u32), PreparedScope>,
+    binding_heads: BTreeMap<String, u32>,
+    binding_specs: BTreeMap<(String, u32), PreparedBinding>,
+    binding_statuses: BTreeMap<String, BindingStatus>,
+}
+
+#[derive(Default)]
+struct FakeRepository {
+    state: Mutex<FakeState>,
+}
+
+impl FakeRepository {
+    fn lock(&self) -> Result<MutexGuard<'_, FakeState>, PapError> {
+        self.state.lock().map_err(|_| PapError::Persistence)
+    }
+}
+
+impl PapRepository for FakeRepository {
+    fn put_policy(&self, policy: &PreparedPolicy) -> Result<PreparedPolicy, PapError> {
+        let mut state = self.lock()?;
+        let id = policy.policy_id.as_str().to_owned();
+        let revision = policy.revision.get();
+        let key = (id.clone(), revision);
+        if let Some(existing) = state.policies.get(&key) {
+            return if existing == policy {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if next_raw_revision(state.policy_heads.get(&id).copied()) != Some(revision) {
+            return Err(PapError::Conflict);
+        }
+        state.policies.insert(key, policy.clone());
+        state.policy_heads.insert(id, revision);
+        Ok(policy.clone())
+    }
+
+    fn get_policy_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<PolicyRevisionState>, PapError> {
+        let state = self.lock()?;
+        let Some(last) = state.policy_heads.get(id.as_str()).copied() else {
+            return Ok(None);
+        };
+        let latest = state
+            .policies
+            .iter()
+            .filter(|((candidate, _), _)| candidate == id.as_str())
+            .max_by_key(|((_, revision), _)| *revision)
+            .map(|(_, policy)| policy.clone());
+        Ok(Some(PolicyRevisionState {
+            last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
+            latest,
+        }))
+    }
+
+    fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError> {
+        self.lock()?
+            .policies
+            .get(&(id.as_str().to_owned(), revision.get()))
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError> {
+        let items = self.lock()?.policies.values().cloned().collect();
+        Ok(page(items, limit, offset))
+    }
+
+    fn delete_policy_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        self.lock()?
+            .policies
+            .remove(&(id.as_str().to_owned(), revision.get()))
+            .ok_or(PapError::NotFound)
+    }
+
+    fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError> {
+        let mut state = self.lock()?;
+        let id = scope.scope_id.as_str().to_owned();
+        let revision = scope.revision.get();
+        let key = (id.clone(), revision);
+        if let Some(existing) = state.scopes.get(&key) {
+            return if existing == scope {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if next_raw_revision(state.scope_heads.get(&id).copied()) != Some(revision) {
+            return Err(PapError::Conflict);
+        }
+        state.scopes.insert(key, scope.clone());
+        state.scope_heads.insert(id, revision);
+        Ok(scope.clone())
+    }
+
+    fn get_scope_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<ScopeRevisionState>, PapError> {
+        let state = self.lock()?;
+        let Some(last) = state.scope_heads.get(id.as_str()).copied() else {
+            return Ok(None);
+        };
+        let latest = state
+            .scopes
+            .iter()
+            .filter(|((candidate, _), _)| candidate == id.as_str())
+            .max_by_key(|((_, revision), _)| *revision)
+            .map(|(_, scope)| scope.clone());
+        Ok(Some(ScopeRevisionState {
+            last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
+            latest,
+        }))
+    }
+
+    fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError> {
+        self.lock()?
+            .scopes
+            .get(&(id.as_str().to_owned(), revision.get()))
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError> {
+        let items = self.lock()?.scopes.values().cloned().collect();
+        Ok(page(items, limit, offset))
+    }
+
+    fn delete_scope_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        self.lock()?
+            .scopes
+            .remove(&(id.as_str().to_owned(), revision.get()))
+            .ok_or(PapError::NotFound)
+    }
+
+    fn put_binding_revision(
+        &self,
+        spec: &PreparedBinding,
+        initial_status: BindingStatus,
+    ) -> Result<BindingView, PapError> {
+        let mut state = self.lock()?;
+        if initial_status != BindingStatus::PendingApply {
+            return Err(PapError::Conflict);
+        }
+
+        let id = spec.binding_id.as_str().to_owned();
+        let revision = spec.binding_revision.get();
+        let key = (id.clone(), revision);
+
+        if let Some(existing) = state.binding_specs.get(&key) {
+            if existing != spec {
+                return Err(PapError::Conflict);
+            }
+            let current = state
+                .binding_statuses
+                .get(&id)
+                .ok_or(PapError::Persistence)?;
+            if *current != initial_status {
+                return Err(PapError::Conflict);
+            }
+            return Ok(BindingView {
+                spec: existing.clone(),
+                status: *current,
+            });
+        }
+
+        if next_raw_revision(state.binding_heads.get(&id).copied()) != Some(revision) {
+            return Err(PapError::Conflict);
+        }
+        state.binding_specs.insert(key, spec.clone());
+        state.binding_heads.insert(id.clone(), revision);
+        state.binding_statuses.insert(id, initial_status);
+        Ok(BindingView {
+            spec: spec.clone(),
+            status: initial_status,
+        })
+    }
+
+    fn update_binding_status(
+        &self,
+        id: &ResourceId,
+        binding_revision: Revision,
+        expected_status: BindingStatus,
+        next_status: BindingStatus,
+    ) -> Result<BindingStatus, PapError> {
+        let mut state = self.lock()?;
+        let id = id.as_str().to_owned();
+        if state.binding_heads.get(&id).copied() != Some(binding_revision.get()) {
+            return Err(PapError::Conflict);
+        }
+        let current = state.binding_statuses.get(&id).ok_or(PapError::NotFound)?;
+        if *current != expected_status {
+            return Err(PapError::Conflict);
+        }
+        expected_status
+            .validate_successor(next_status)
+            .map_err(|_| PapError::Conflict)?;
+        state.binding_statuses.insert(id, next_status);
+        Ok(next_status)
+    }
+
+    fn get_binding_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<BindingRevisionState>, PapError> {
+        let state = self.lock()?;
+        let Some(last) = state.binding_heads.get(id.as_str()).copied() else {
+            return Ok(None);
+        };
+        let status = state
+            .binding_statuses
+            .get(id.as_str())
+            .copied()
+            .ok_or(PapError::Persistence)?;
+        Ok(Some(BindingRevisionState {
+            last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
+            status,
+        }))
+    }
+
+    fn get_binding_spec(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedBinding, PapError> {
+        self.lock()?
+            .binding_specs
+            .get(&(id.as_str().to_owned(), revision.get()))
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
+        let state = self.lock()?;
+        binding_view(&state, id.as_str())
+    }
+
+    fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError> {
+        let state = self.lock()?;
+        let items = state
+            .binding_statuses
+            .keys()
+            .map(|id| binding_view(&state, id))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(page(items, limit, offset))
+    }
+}
+
+fn binding_view(state: &FakeState, id: &str) -> Result<BindingView, PapError> {
+    let status = state
+        .binding_statuses
+        .get(id)
+        .copied()
+        .ok_or(PapError::NotFound)?;
+    let revision = state
+        .binding_heads
+        .get(id)
+        .copied()
+        .ok_or(PapError::Persistence)?;
+    let spec = state
+        .binding_specs
+        .get(&(id.to_owned(), revision))
+        .cloned()
+        .ok_or(PapError::Persistence)?;
+    Ok(BindingView { spec, status })
+}
+
+struct FixtureCompiler {
+    mismatch_identity: bool,
+}
+
+impl PolicyCompiler for FixtureCompiler {
+    fn lower(&self, template: &TemplateEnvelope) -> Result<PolicyEnvelope, ValidationError> {
+        let fixture: PreparedBinding = serde_json::from_str(COMPLETE_BINDING)
+            .map_err(|error| ValidationError::new("fixture", error.to_string()))?;
+        let mut policy = fixture.policy.canonical_policy;
+        policy.policy_id = if self.mismatch_identity {
+            PolicyId::new("compiler-mismatch")
+                .map_err(|error| ValidationError::new("policyId", error))?
+        } else {
+            template.policy_id.clone()
+        };
+        policy.revision = template.revision;
+        Ok(policy)
+    }
+}
+
+type Service = PapService<FakeRepository, FixtureCompiler>;
+
+fn service() -> (Service, Arc<FakeRepository>) {
+    let repository = Arc::new(FakeRepository::default());
+    let compiler = Arc::new(FixtureCompiler {
+        mismatch_identity: false,
+    });
+    (
+        PapService::new(Arc::clone(&repository), compiler),
+        repository,
+    )
+}
+
+fn policy_template(path: &str) -> PolicyTemplate {
+    PolicyTemplate::PreventFileDeletion {
+        files: vec![path.to_owned()],
+    }
+}
+
+#[test]
+fn policy_crud_is_idempotent_and_never_reuses_deleted_revisions() {
+    let (pap, _) = service();
+    let first = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    assert_eq!(first.revision.get(), 1);
+    assert_eq!(
+        pap.update_policy(
+            &first.policy_id,
+            "protect files",
+            &policy_template("/workspace/a")
+        )
+        .unwrap(),
+        first
+    );
+
+    let second = pap
+        .update_policy(
+            &first.policy_id,
+            "protect more files",
+            &policy_template("/workspace/b"),
+        )
+        .unwrap();
+    assert_eq!(second.revision.get(), 2);
+    assert_eq!(pap.list_policies(100, 0).unwrap().total, 2);
+    assert_eq!(
+        pap.delete_policy_revision(&first.policy_id, second.revision)
+            .unwrap(),
+        second
+    );
+
+    let third = pap
+        .update_policy(
+            &first.policy_id,
+            "protect newest files",
+            &policy_template("/workspace/c"),
+        )
+        .unwrap();
+    assert_eq!(third.revision.get(), 3);
+    assert_eq!(
+        pap.get_policy(&first.policy_id, first.revision).unwrap(),
+        first
+    );
+    assert_eq!(pap.list_policies(100, 0).unwrap().total, 2);
+    let missing = ResourceId::new("missing-policy").unwrap();
+    assert_eq!(
+        pap.update_policy(&missing, "missing", &policy_template("/workspace/missing")),
+        Err(PapError::NotFound)
+    );
+}
+
+#[test]
+fn scope_crud_validates_authored_selectors_and_preserves_revision_heads() {
+    let (pap, _) = service();
+    let first = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    assert_eq!(first.revision.get(), 1);
+    assert_eq!(
+        pap.update_scope(&first.scope_id, &ScopeSelector::Pid { pid: 4242 })
+            .unwrap(),
+        first
+    );
+
+    let second = pap
+        .update_scope(&first.scope_id, &ScopeSelector::CgroupId { cgroup_id: 99 })
+        .unwrap();
+    assert_eq!(second.revision.get(), 2);
+    pap.delete_scope_revision(&first.scope_id, second.revision)
+        .unwrap();
+    let third = pap
+        .update_scope(&first.scope_id, &ScopeSelector::Pid { pid: 7 })
+        .unwrap();
+    assert_eq!(third.revision.get(), 3);
+    assert_eq!(pap.list_scopes(100, 0).unwrap().total, 2);
+
+    let legacy = ScopeSelector::LegacyExecutionDomain {
+        execution_domain_id: ResourceId::new("legacy-domain").unwrap(),
+    };
+    assert!(matches!(
+        pap.create_scope(&legacy),
+        Err(PapError::InvalidScope(_))
+    ));
+    let missing = ResourceId::new("missing-scope").unwrap();
+    assert_eq!(
+        pap.update_scope(&missing, &ScopeSelector::Pid { pid: 9 }),
+        Err(PapError::NotFound)
+    );
+}
+
+#[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one end-to-end lifecycle scenario keeps transition assertions reviewable"
+)]
+fn binding_requests_advance_lifecycle_without_rewriting_specs() {
+    let (pap, repository) = service();
+    let policy_v1 = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    let scope = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    let binding_v1 = pap
+        .create_binding(
+            &policy_v1.policy_id,
+            policy_v1.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    assert_eq!(binding_v1.spec.binding_revision.get(), 1);
+    assert_eq!(binding_v1.status, BindingStatus::PendingApply);
+    assert_eq!(
+        pap.update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v1.policy_id,
+            policy_v1.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap(),
+        binding_v1
+    );
+
+    let policy_v2 = pap
+        .update_policy(
+            &policy_v1.policy_id,
+            "protect more files",
+            &policy_template("/workspace/b"),
+        )
+        .unwrap();
+    let binding_v2 = pap
+        .update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v2.policy_id,
+            policy_v2.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    assert_eq!(binding_v2.spec.binding_revision.get(), 2);
+    assert_eq!(binding_v2.spec.policy, policy_v2);
+    assert_eq!(binding_v2.status, BindingStatus::PendingApply);
+
+    let pending_delete = pap.delete_binding(&binding_v1.spec.binding_id).unwrap();
+    assert_eq!(pending_delete.spec.binding_revision.get(), 2);
+    assert_eq!(pending_delete.status, BindingStatus::PendingDelete);
+    let pending_delete_wire = serde_json::to_value(&pending_delete).unwrap();
+    assert!(pending_delete_wire.get("lifecycle").is_none());
+    assert_eq!(pending_delete_wire["status"], "PENDING_DELETE");
+    assert!(pending_delete_wire["spec"].get("desiredState").is_none());
+    assert_eq!(
+        serde_json::from_value::<BindingView>(pending_delete_wire).unwrap(),
+        pending_delete
+    );
+    assert_eq!(
+        pap.delete_binding(&binding_v1.spec.binding_id).unwrap(),
+        pending_delete
+    );
+    assert_eq!(
+        pap.get_binding(&binding_v1.spec.binding_id).unwrap(),
+        pending_delete
+    );
+
+    // Simulate the future worker claiming Delete. UPDATE of the same immutable
+    // spec must reverse it instead of being mistaken for an idempotent no-op.
+    let deleting = pending_delete.status.start_reconcile().unwrap();
+    repository
+        .update_binding_status(
+            &pending_delete.spec.binding_id,
+            pending_delete.spec.binding_revision,
+            pending_delete.status,
+            deleting,
+        )
+        .unwrap();
+    let reactivated = pap
+        .update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v2.policy_id,
+            policy_v2.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    assert_eq!(&reactivated.spec, &pending_delete.spec);
+    assert_eq!(reactivated.status, BindingStatus::PendingApply);
+    assert_eq!(
+        repository.update_binding_status(
+            &reactivated.spec.binding_id,
+            Revision::new(1).unwrap(),
+            reactivated.status,
+            BindingStatus::Applying,
+        ),
+        Err(PapError::Conflict),
+        "status CAS must target the current immutable spec revision"
+    );
+
+    // DELETED is not a legal successor of the newer PENDING_APPLY state. Full
+    // asynchronous stale-result/ABA fencing remains part of the reconciler TODO.
+    let stale_deleted = deleting.complete_reconcile().unwrap();
+    assert_eq!(
+        repository.update_binding_status(
+            &reactivated.spec.binding_id,
+            reactivated.spec.binding_revision,
+            deleting,
+            stale_deleted,
+        ),
+        Err(PapError::Conflict)
+    );
+    assert_eq!(
+        pap.list_bindings(100, 0).unwrap().items,
+        vec![reactivated.clone()]
+    );
+
+    {
+        let state = repository.lock().unwrap();
+        assert_eq!(
+            state.binding_heads[&binding_v1.spec.binding_id.to_string()],
+            2
+        );
+        assert_eq!(state.binding_specs.len(), 2);
+    }
+
+    let deleting_again = pap.delete_binding(&binding_v1.spec.binding_id).unwrap();
+    assert_eq!(deleting_again.status, BindingStatus::PendingDelete);
+    let changed_after_delete = pap
+        .update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v1.policy_id,
+            policy_v1.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    assert_eq!(changed_after_delete.spec.binding_revision.get(), 3);
+    assert_eq!(changed_after_delete.status, BindingStatus::PendingApply);
+
+    let state = repository.lock().unwrap();
+    assert_eq!(
+        state.binding_heads[&binding_v1.spec.binding_id.to_string()],
+        3
+    );
+    assert_eq!(state.binding_specs.len(), 3);
+}
+
+#[test]
+fn binding_requires_exact_policy_and_scope_revisions() {
+    let (pap, _) = service();
+    let policy = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    let scope = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    let missing = ResourceId::new("missing").unwrap();
+
+    assert_eq!(
+        pap.create_binding(
+            &missing,
+            Revision::new(1).unwrap(),
+            &scope.scope_id,
+            scope.revision,
+        ),
+        Err(PapError::NotFound)
+    );
+    assert_eq!(
+        pap.create_binding(
+            &policy.policy_id,
+            policy.revision,
+            &missing,
+            Revision::new(1).unwrap(),
+        ),
+        Err(PapError::NotFound)
+    );
+    assert_eq!(
+        pap.update_binding(
+            &missing,
+            &policy.policy_id,
+            policy.revision,
+            &scope.scope_id,
+            scope.revision,
+        ),
+        Err(PapError::NotFound)
+    );
+}
+
+#[test]
+fn compiler_output_identity_is_checked_before_storage() {
+    let repository = Arc::new(FakeRepository::default());
+    let compiler = Arc::new(FixtureCompiler {
+        mismatch_identity: true,
+    });
+    let pap = PapService::new(repository, compiler);
+
+    let error = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap_err();
+    let PapError::InvalidPolicy(error) = error else {
+        panic!("expected invalid compiler output");
+    };
+    assert_eq!(error.path, "canonicalPolicy.policyId");
+}
+
+#[test]
+fn revision_exhaustion_and_pagination_bounds_are_explicit() {
+    let (pap, repository) = service();
+    let first = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    let maximum = Revision::new(u32::MAX).unwrap();
+    let mut exhausted = first.clone();
+    exhausted.revision = maximum;
+    exhausted.canonical_policy.revision = maximum;
+    {
+        let mut state = repository.lock().unwrap();
+        state.policies.clear();
+        state
+            .policies
+            .insert((first.policy_id.as_str().to_owned(), u32::MAX), exhausted);
+        state
+            .policy_heads
+            .insert(first.policy_id.as_str().to_owned(), u32::MAX);
+    }
+
+    assert_eq!(
+        pap.update_policy(
+            &first.policy_id,
+            "changed",
+            &policy_template("/workspace/b"),
+        ),
+        Err(PapError::RevisionExhausted)
+    );
+    assert_eq!(pap.list_policies(0, 0), Err(PapError::InvalidPagination));
+    assert_eq!(
+        pap.list_policies(1_001, 0),
+        Err(PapError::InvalidPagination)
+    );
+}
+
+fn next_raw_revision(current: Option<u32>) -> Option<u32> {
+    match current {
+        Some(revision) => revision.checked_add(1),
+        None => Some(1),
+    }
+}
+
+fn page<T>(items: Vec<T>, limit: u32, offset: u32) -> Page<T> {
+    let total = u64::try_from(items.len()).expect("test item count fits u64");
+    let offset = usize::try_from(offset).expect("u32 offset fits usize");
+    let limit = usize::try_from(limit).expect("u32 limit fits usize");
+    Page {
+        items: items.into_iter().skip(offset).take(limit).collect(),
+        total,
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Barrier, Mutex, MutexGuard};
 
 use asc_foundation_types::{ResourceId, Revision};
 use asc_pap::{
-    BindingRevisionState, Page, PapError, PapRepository, PapService, PolicyCompiler,
-    PolicyRevisionState, ScopeRevisionState,
+    Page, PapError, PapRepository, PapService, PolicyCompiler, PolicyRevisionState,
+    ScopeRevisionState,
 };
 use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
 use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
@@ -19,22 +19,49 @@ const COMPLETE_BINDING: &str =
 #[derive(Default)]
 struct FakeState {
     policy_heads: BTreeMap<String, u32>,
-    policies: BTreeMap<(String, u32), PreparedPolicy>,
+    policies: BTreeMap<String, PreparedPolicy>,
     scope_heads: BTreeMap<String, u32>,
-    scopes: BTreeMap<(String, u32), PreparedScope>,
-    binding_heads: BTreeMap<String, u32>,
-    binding_specs: BTreeMap<(String, u32), PreparedBinding>,
-    binding_statuses: BTreeMap<String, BindingStatus>,
+    scopes: BTreeMap<String, PreparedScope>,
+    bindings: BTreeMap<String, BindingView>,
 }
 
 #[derive(Default)]
 struct FakeRepository {
     state: Mutex<FakeState>,
+    scope_read_gate: Mutex<ScopeReadGate>,
+}
+
+#[derive(Default)]
+struct ScopeReadGate {
+    barrier: Option<Arc<Barrier>>,
+    remaining: usize,
 }
 
 impl FakeRepository {
     fn lock(&self) -> Result<MutexGuard<'_, FakeState>, PapError> {
         self.state.lock().map_err(|_| PapError::Persistence)
+    }
+
+    fn synchronize_next_scope_reads(&self, participants: usize) {
+        let mut gate = self.scope_read_gate.lock().unwrap();
+        assert!(gate.barrier.is_none());
+        gate.barrier = Some(Arc::new(Barrier::new(participants)));
+        gate.remaining = participants;
+    }
+
+    fn take_scope_read_barrier(&self) -> Result<Option<Arc<Barrier>>, PapError> {
+        let mut gate = self
+            .scope_read_gate
+            .lock()
+            .map_err(|_| PapError::Persistence)?;
+        let Some(barrier) = gate.barrier.clone() else {
+            return Ok(None);
+        };
+        gate.remaining -= 1;
+        if gate.remaining == 0 {
+            gate.barrier = None;
+        }
+        Ok(Some(barrier))
     }
 }
 
@@ -43,8 +70,9 @@ impl PapRepository for FakeRepository {
         let mut state = self.lock()?;
         let id = policy.policy_id.as_str().to_owned();
         let revision = policy.revision.get();
-        let key = (id.clone(), revision);
-        if let Some(existing) = state.policies.get(&key) {
+        if let Some(existing) = state.policies.get(&id)
+            && existing.revision.get() == revision
+        {
             return if existing == policy {
                 Ok(existing.clone())
             } else {
@@ -54,7 +82,7 @@ impl PapRepository for FakeRepository {
         if next_raw_revision(state.policy_heads.get(&id).copied()) != Some(revision) {
             return Err(PapError::Conflict);
         }
-        state.policies.insert(key, policy.clone());
+        state.policies.insert(id.clone(), policy.clone());
         state.policy_heads.insert(id, revision);
         Ok(policy.clone())
     }
@@ -67,22 +95,18 @@ impl PapRepository for FakeRepository {
         let Some(last) = state.policy_heads.get(id.as_str()).copied() else {
             return Ok(None);
         };
-        let latest = state
-            .policies
-            .iter()
-            .filter(|((candidate, _), _)| candidate == id.as_str())
-            .max_by_key(|((_, revision), _)| *revision)
-            .map(|(_, policy)| policy.clone());
+        let current = state.policies.get(id.as_str()).cloned();
         Ok(Some(PolicyRevisionState {
             last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
-            latest,
+            current,
         }))
     }
 
     fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError> {
         self.lock()?
             .policies
-            .get(&(id.as_str().to_owned(), revision.get()))
+            .get(id.as_str())
+            .filter(|policy| policy.revision == revision)
             .cloned()
             .ok_or(PapError::NotFound)
     }
@@ -97,18 +121,25 @@ impl PapRepository for FakeRepository {
         id: &ResourceId,
         revision: Revision,
     ) -> Result<PreparedPolicy, PapError> {
-        self.lock()?
+        let mut state = self.lock()?;
+        let id = id.as_str();
+        if state
             .policies
-            .remove(&(id.as_str().to_owned(), revision.get()))
-            .ok_or(PapError::NotFound)
+            .get(id)
+            .is_none_or(|policy| policy.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state.policies.remove(id).ok_or(PapError::Persistence)
     }
 
     fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError> {
         let mut state = self.lock()?;
         let id = scope.scope_id.as_str().to_owned();
         let revision = scope.revision.get();
-        let key = (id.clone(), revision);
-        if let Some(existing) = state.scopes.get(&key) {
+        if let Some(existing) = state.scopes.get(&id)
+            && existing.revision.get() == revision
+        {
             return if existing == scope {
                 Ok(existing.clone())
             } else {
@@ -118,7 +149,7 @@ impl PapRepository for FakeRepository {
         if next_raw_revision(state.scope_heads.get(&id).copied()) != Some(revision) {
             return Err(PapError::Conflict);
         }
-        state.scopes.insert(key, scope.clone());
+        state.scopes.insert(id.clone(), scope.clone());
         state.scope_heads.insert(id, revision);
         Ok(scope.clone())
     }
@@ -128,25 +159,30 @@ impl PapRepository for FakeRepository {
         id: &ResourceId,
     ) -> Result<Option<ScopeRevisionState>, PapError> {
         let state = self.lock()?;
-        let Some(last) = state.scope_heads.get(id.as_str()).copied() else {
-            return Ok(None);
-        };
-        let latest = state
-            .scopes
-            .iter()
-            .filter(|((candidate, _), _)| candidate == id.as_str())
-            .max_by_key(|((_, revision), _)| *revision)
-            .map(|(_, scope)| scope.clone());
-        Ok(Some(ScopeRevisionState {
-            last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
-            latest,
-        }))
+        let result = state
+            .scope_heads
+            .get(id.as_str())
+            .copied()
+            .map(|last| {
+                Ok(ScopeRevisionState {
+                    last_allocated_revision: Revision::new(last)
+                        .map_err(|_| PapError::Persistence)?,
+                    current: state.scopes.get(id.as_str()).cloned(),
+                })
+            })
+            .transpose()?;
+        drop(state);
+        if let Some(barrier) = self.take_scope_read_barrier()? {
+            barrier.wait();
+        }
+        Ok(result)
     }
 
     fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError> {
         self.lock()?
             .scopes
-            .get(&(id.as_str().to_owned(), revision.get()))
+            .get(id.as_str())
+            .filter(|scope| scope.revision == revision)
             .cloned()
             .ok_or(PapError::NotFound)
     }
@@ -161,53 +197,44 @@ impl PapRepository for FakeRepository {
         id: &ResourceId,
         revision: Revision,
     ) -> Result<PreparedScope, PapError> {
-        self.lock()?
+        let mut state = self.lock()?;
+        let id = id.as_str();
+        if state
             .scopes
-            .remove(&(id.as_str().to_owned(), revision.get()))
-            .ok_or(PapError::NotFound)
+            .get(id)
+            .is_none_or(|scope| scope.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state.scopes.remove(id).ok_or(PapError::Persistence)
     }
 
-    fn put_binding_revision(
-        &self,
-        spec: &PreparedBinding,
-        initial_status: BindingStatus,
-    ) -> Result<BindingView, PapError> {
+    fn update_binding(&self, binding: &BindingView) -> Result<BindingView, PapError> {
         let mut state = self.lock()?;
-        if initial_status != BindingStatus::PendingApply {
+        if !matches!(
+            binding.status,
+            BindingStatus::PendingApply | BindingStatus::PendingDelete
+        ) {
             return Err(PapError::Conflict);
         }
 
-        let id = spec.binding_id.as_str().to_owned();
-        let revision = spec.binding_revision.get();
-        let key = (id.clone(), revision);
-
-        if let Some(existing) = state.binding_specs.get(&key) {
-            if existing != spec {
+        let id = binding.spec.binding_id.as_str().to_owned();
+        let revision = binding.spec.binding_revision.get();
+        if let Some(current) = state.bindings.get(&id) {
+            if current == binding {
+                return Ok(current.clone());
+            }
+            if current.status.is_reconciling() {
+                return Err(PapError::OperationInProgress);
+            }
+            if next_raw_revision(Some(current.spec.binding_revision.get())) != Some(revision) {
                 return Err(PapError::Conflict);
             }
-            let current = state
-                .binding_statuses
-                .get(&id)
-                .ok_or(PapError::Persistence)?;
-            if *current != initial_status {
-                return Err(PapError::Conflict);
-            }
-            return Ok(BindingView {
-                spec: existing.clone(),
-                status: *current,
-            });
-        }
-
-        if next_raw_revision(state.binding_heads.get(&id).copied()) != Some(revision) {
+        } else if revision != 1 || binding.status != BindingStatus::PendingApply {
             return Err(PapError::Conflict);
         }
-        state.binding_specs.insert(key, spec.clone());
-        state.binding_heads.insert(id.clone(), revision);
-        state.binding_statuses.insert(id, initial_status);
-        Ok(BindingView {
-            spec: spec.clone(),
-            status: initial_status,
-        })
+        state.bindings.insert(id, binding.clone());
+        Ok(binding.clone())
     }
 
     fn update_binding_status(
@@ -218,85 +245,35 @@ impl PapRepository for FakeRepository {
         next_status: BindingStatus,
     ) -> Result<BindingStatus, PapError> {
         let mut state = self.lock()?;
-        let id = id.as_str().to_owned();
-        if state.binding_heads.get(&id).copied() != Some(binding_revision.get()) {
+        let binding = state
+            .bindings
+            .get_mut(id.as_str())
+            .ok_or(PapError::NotFound)?;
+        if binding.spec.binding_revision != binding_revision {
             return Err(PapError::Conflict);
         }
-        let current = state.binding_statuses.get(&id).ok_or(PapError::NotFound)?;
-        if *current != expected_status {
+        if binding.status != expected_status {
             return Err(PapError::Conflict);
         }
         expected_status
             .validate_successor(next_status)
             .map_err(|_| PapError::Conflict)?;
-        state.binding_statuses.insert(id, next_status);
+        binding.status = next_status;
         Ok(next_status)
     }
 
-    fn get_binding_revision_state(
-        &self,
-        id: &ResourceId,
-    ) -> Result<Option<BindingRevisionState>, PapError> {
-        let state = self.lock()?;
-        let Some(last) = state.binding_heads.get(id.as_str()).copied() else {
-            return Ok(None);
-        };
-        let status = state
-            .binding_statuses
-            .get(id.as_str())
-            .copied()
-            .ok_or(PapError::Persistence)?;
-        Ok(Some(BindingRevisionState {
-            last_allocated_revision: Revision::new(last).map_err(|_| PapError::Persistence)?,
-            status,
-        }))
-    }
-
-    fn get_binding_spec(
-        &self,
-        id: &ResourceId,
-        revision: Revision,
-    ) -> Result<PreparedBinding, PapError> {
+    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
         self.lock()?
-            .binding_specs
-            .get(&(id.as_str().to_owned(), revision.get()))
+            .bindings
+            .get(id.as_str())
             .cloned()
             .ok_or(PapError::NotFound)
     }
 
-    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
-        let state = self.lock()?;
-        binding_view(&state, id.as_str())
-    }
-
     fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError> {
-        let state = self.lock()?;
-        let items = state
-            .binding_statuses
-            .keys()
-            .map(|id| binding_view(&state, id))
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = self.lock()?.bindings.values().cloned().collect();
         Ok(page(items, limit, offset))
     }
-}
-
-fn binding_view(state: &FakeState, id: &str) -> Result<BindingView, PapError> {
-    let status = state
-        .binding_statuses
-        .get(id)
-        .copied()
-        .ok_or(PapError::NotFound)?;
-    let revision = state
-        .binding_heads
-        .get(id)
-        .copied()
-        .ok_or(PapError::Persistence)?;
-    let spec = state
-        .binding_specs
-        .get(&(id.to_owned(), revision))
-        .cloned()
-        .ok_or(PapError::Persistence)?;
-    Ok(BindingView { spec, status })
 }
 
 struct FixtureCompiler {
@@ -339,8 +316,8 @@ fn policy_template(path: &str) -> PolicyTemplate {
 }
 
 #[test]
-fn policy_crud_is_idempotent_and_never_reuses_deleted_revisions() {
-    let (pap, _) = service();
+fn policy_crud_keeps_only_the_current_record_and_never_reuses_revisions() {
+    let (pap, repository) = service();
     let first = pap
         .create_policy("protect files", &policy_template("/workspace/a"))
         .unwrap();
@@ -363,12 +340,20 @@ fn policy_crud_is_idempotent_and_never_reuses_deleted_revisions() {
         )
         .unwrap();
     assert_eq!(second.revision.get(), 2);
-    assert_eq!(pap.list_policies(100, 0).unwrap().total, 2);
+    assert_eq!(
+        pap.list_policies(100, 0).unwrap().items,
+        vec![second.clone()]
+    );
+    assert_eq!(
+        pap.get_policy(&first.policy_id, first.revision),
+        Err(PapError::NotFound)
+    );
     assert_eq!(
         pap.delete_policy_revision(&first.policy_id, second.revision)
             .unwrap(),
         second
     );
+    assert_eq!(pap.list_policies(100, 0).unwrap().total, 0);
 
     let third = pap
         .update_policy(
@@ -379,10 +364,15 @@ fn policy_crud_is_idempotent_and_never_reuses_deleted_revisions() {
         .unwrap();
     assert_eq!(third.revision.get(), 3);
     assert_eq!(
-        pap.get_policy(&first.policy_id, first.revision).unwrap(),
-        first
+        pap.get_policy(&first.policy_id, second.revision),
+        Err(PapError::NotFound)
     );
-    assert_eq!(pap.list_policies(100, 0).unwrap().total, 2);
+    assert_eq!(pap.list_policies(100, 0).unwrap().items, vec![third]);
+    let state = repository.lock().unwrap();
+    assert_eq!(state.policies.len(), 1);
+    assert_eq!(state.policy_heads[&first.policy_id.to_string()], 3);
+    drop(state);
+
     let missing = ResourceId::new("missing-policy").unwrap();
     assert_eq!(
         pap.update_policy(&missing, "missing", &policy_template("/workspace/missing")),
@@ -391,8 +381,8 @@ fn policy_crud_is_idempotent_and_never_reuses_deleted_revisions() {
 }
 
 #[test]
-fn scope_crud_validates_authored_selectors_and_preserves_revision_heads() {
-    let (pap, _) = service();
+fn scope_crud_keeps_only_the_current_record_and_preserves_revision_heads() {
+    let (pap, repository) = service();
     let first = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
     assert_eq!(first.revision.get(), 1);
     assert_eq!(
@@ -405,13 +395,23 @@ fn scope_crud_validates_authored_selectors_and_preserves_revision_heads() {
         .update_scope(&first.scope_id, &ScopeSelector::CgroupId { cgroup_id: 99 })
         .unwrap();
     assert_eq!(second.revision.get(), 2);
+    assert_eq!(pap.list_scopes(100, 0).unwrap().items, vec![second.clone()]);
+    assert_eq!(
+        pap.get_scope(&first.scope_id, first.revision),
+        Err(PapError::NotFound)
+    );
     pap.delete_scope_revision(&first.scope_id, second.revision)
         .unwrap();
+    assert_eq!(pap.list_scopes(100, 0).unwrap().total, 0);
     let third = pap
         .update_scope(&first.scope_id, &ScopeSelector::Pid { pid: 7 })
         .unwrap();
     assert_eq!(third.revision.get(), 3);
-    assert_eq!(pap.list_scopes(100, 0).unwrap().total, 2);
+    assert_eq!(pap.list_scopes(100, 0).unwrap().items, vec![third]);
+    let state = repository.lock().unwrap();
+    assert_eq!(state.scopes.len(), 1);
+    assert_eq!(state.scope_heads[&first.scope_id.to_string()], 3);
+    drop(state);
 
     let legacy = ScopeSelector::LegacyExecutionDomain {
         execution_domain_id: ResourceId::new("legacy-domain").unwrap(),
@@ -428,11 +428,49 @@ fn scope_crud_validates_authored_selectors_and_preserves_revision_heads() {
 }
 
 #[test]
+fn concurrent_scope_updates_retry_after_repository_cas_conflict() {
+    let (pap, repository) = service();
+    let first = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    repository.synchronize_next_scope_reads(2);
+
+    let left = {
+        let pap = pap.clone();
+        let scope_id = first.scope_id.clone();
+        std::thread::spawn(move || pap.update_scope(&scope_id, &ScopeSelector::Pid { pid: 7 }))
+    };
+    let right = {
+        let pap = pap.clone();
+        let scope_id = first.scope_id.clone();
+        std::thread::spawn(move || {
+            pap.update_scope(&scope_id, &ScopeSelector::CgroupId { cgroup_id: 99 })
+        })
+    };
+
+    let mut updates = [
+        left.join().unwrap().unwrap(),
+        right.join().unwrap().unwrap(),
+    ];
+    updates.sort_by_key(|scope| scope.revision);
+
+    assert_eq!(updates[0].revision.get(), 2);
+    assert_eq!(updates[1].revision.get(), 3);
+    assert_ne!(updates[0].selector, updates[1].selector);
+    assert_eq!(
+        pap.get_scope(&first.scope_id, updates[0].revision),
+        Err(PapError::NotFound)
+    );
+    assert_eq!(
+        pap.get_scope(&first.scope_id, updates[1].revision).unwrap(),
+        updates[1]
+    );
+}
+
+#[test]
 #[allow(
     clippy::too_many_lines,
     reason = "one end-to-end lifecycle scenario keeps transition assertions reviewable"
 )]
-fn binding_requests_advance_lifecycle_without_rewriting_specs() {
+fn binding_requests_replace_one_current_record_and_fence_running_work() {
     let (pap, repository) = service();
     let policy_v1 = pap
         .create_policy("protect files", &policy_template("/workspace/a"))
@@ -479,9 +517,17 @@ fn binding_requests_advance_lifecycle_without_rewriting_specs() {
     assert_eq!(binding_v2.spec.binding_revision.get(), 2);
     assert_eq!(binding_v2.spec.policy, policy_v2);
     assert_eq!(binding_v2.status, BindingStatus::PendingApply);
+    {
+        let state = repository.lock().unwrap();
+        assert_eq!(state.bindings.len(), 1);
+        assert_eq!(
+            state.bindings[&binding_v1.spec.binding_id.to_string()],
+            binding_v2
+        );
+    }
 
     let pending_delete = pap.delete_binding(&binding_v1.spec.binding_id).unwrap();
-    assert_eq!(pending_delete.spec.binding_revision.get(), 2);
+    assert_eq!(pending_delete.spec.binding_revision.get(), 3);
     assert_eq!(pending_delete.status, BindingStatus::PendingDelete);
     let pending_delete_wire = serde_json::to_value(&pending_delete).unwrap();
     assert!(pending_delete_wire.get("lifecycle").is_none());
@@ -500,17 +546,6 @@ fn binding_requests_advance_lifecycle_without_rewriting_specs() {
         pending_delete
     );
 
-    // Simulate the future worker claiming Delete. UPDATE of the same immutable
-    // spec must reverse it instead of being mistaken for an idempotent no-op.
-    let deleting = pending_delete.status.start_reconcile().unwrap();
-    repository
-        .update_binding_status(
-            &pending_delete.spec.binding_id,
-            pending_delete.spec.binding_revision,
-            pending_delete.status,
-            deleting,
-        )
-        .unwrap();
     let reactivated = pap
         .update_binding(
             &binding_v1.spec.binding_id,
@@ -520,65 +555,142 @@ fn binding_requests_advance_lifecycle_without_rewriting_specs() {
             scope.revision,
         )
         .unwrap();
-    assert_eq!(&reactivated.spec, &pending_delete.spec);
+    assert_eq!(reactivated.spec.binding_revision.get(), 4);
     assert_eq!(reactivated.status, BindingStatus::PendingApply);
-    assert_eq!(
-        repository.update_binding_status(
-            &reactivated.spec.binding_id,
-            Revision::new(1).unwrap(),
-            reactivated.status,
-            BindingStatus::Applying,
-        ),
-        Err(PapError::Conflict),
-        "status CAS must target the current immutable spec revision"
-    );
 
-    // DELETED is not a legal successor of the newer PENDING_APPLY state. Full
-    // asynchronous stale-result/ABA fencing remains part of the reconciler TODO.
-    let stale_deleted = deleting.complete_reconcile().unwrap();
-    assert_eq!(
-        repository.update_binding_status(
+    let applying = reactivated.status.start_reconcile().unwrap();
+    repository
+        .update_binding_status(
             &reactivated.spec.binding_id,
             reactivated.spec.binding_revision,
-            deleting,
-            stale_deleted,
+            reactivated.status,
+            applying,
+        )
+        .unwrap();
+    assert_eq!(
+        pap.update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v2.policy_id,
+            policy_v2.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap()
+        .status,
+        BindingStatus::Applying,
+        "an identical update is idempotent while Apply is running"
+    );
+
+    let policy_v3 = pap
+        .update_policy(
+            &policy_v1.policy_id,
+            "protect newest files",
+            &policy_template("/workspace/c"),
+        )
+        .unwrap();
+    assert_eq!(
+        pap.update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v3.policy_id,
+            policy_v3.revision,
+            &scope.scope_id,
+            scope.revision,
         ),
-        Err(PapError::Conflict)
+        Err(PapError::OperationInProgress)
     );
     assert_eq!(
-        pap.list_bindings(100, 0).unwrap().items,
-        vec![reactivated.clone()]
+        pap.delete_binding(&binding_v1.spec.binding_id),
+        Err(PapError::OperationInProgress)
     );
 
-    {
-        let state = repository.lock().unwrap();
-        assert_eq!(
-            state.binding_heads[&binding_v1.spec.binding_id.to_string()],
-            2
-        );
-        assert_eq!(state.binding_specs.len(), 2);
-    }
-
-    let deleting_again = pap.delete_binding(&binding_v1.spec.binding_id).unwrap();
-    assert_eq!(deleting_again.status, BindingStatus::PendingDelete);
-    let changed_after_delete = pap
+    repository
+        .update_binding_status(
+            &reactivated.spec.binding_id,
+            reactivated.spec.binding_revision,
+            applying,
+            BindingStatus::Ready,
+        )
+        .unwrap();
+    let reactivated = pap
         .update_binding(
             &binding_v1.spec.binding_id,
-            &policy_v1.policy_id,
-            policy_v1.revision,
+            &policy_v3.policy_id,
+            policy_v3.revision,
             &scope.scope_id,
             scope.revision,
         )
         .unwrap();
-    assert_eq!(changed_after_delete.spec.binding_revision.get(), 3);
-    assert_eq!(changed_after_delete.status, BindingStatus::PendingApply);
+    assert_eq!(reactivated.spec.binding_revision.get(), 5);
+    assert_eq!(reactivated.status, BindingStatus::PendingApply);
+    assert_eq!(
+        repository.update_binding_status(
+            &reactivated.spec.binding_id,
+            Revision::new(4).unwrap(),
+            reactivated.status,
+            BindingStatus::Applying,
+        ),
+        Err(PapError::Conflict),
+        "status CAS must target the current Binding revision"
+    );
+
+    let pending_delete = pap.delete_binding(&binding_v1.spec.binding_id).unwrap();
+    assert_eq!(pending_delete.spec.binding_revision.get(), 6);
+    let deleting = pending_delete.status.start_reconcile().unwrap();
+    repository
+        .update_binding_status(
+            &pending_delete.spec.binding_id,
+            pending_delete.spec.binding_revision,
+            pending_delete.status,
+            deleting,
+        )
+        .unwrap();
+    assert_eq!(
+        pap.update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v3.policy_id,
+            policy_v3.revision,
+            &scope.scope_id,
+            scope.revision,
+        ),
+        Err(PapError::OperationInProgress)
+    );
+    assert_eq!(
+        pap.delete_binding(&binding_v1.spec.binding_id)
+            .unwrap()
+            .status,
+        BindingStatus::Deleting,
+        "a repeated Delete remains idempotent while Delete is running"
+    );
+    repository
+        .update_binding_status(
+            &pending_delete.spec.binding_id,
+            pending_delete.spec.binding_revision,
+            deleting,
+            BindingStatus::Deleted,
+        )
+        .unwrap();
+    let reapplied = pap
+        .update_binding(
+            &binding_v1.spec.binding_id,
+            &policy_v3.policy_id,
+            policy_v3.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    assert_eq!(reapplied.spec.binding_revision.get(), 7);
+    assert_eq!(reapplied.status, BindingStatus::PendingApply);
+    assert_eq!(
+        pap.list_bindings(100, 0).unwrap().items,
+        vec![reapplied.clone()]
+    );
 
     let state = repository.lock().unwrap();
+    assert_eq!(state.bindings.len(), 1);
     assert_eq!(
-        state.binding_heads[&binding_v1.spec.binding_id.to_string()],
-        3
+        state.bindings[&binding_v1.spec.binding_id.to_string()],
+        reapplied
     );
-    assert_eq!(state.binding_specs.len(), 3);
 }
 
 #[test]
@@ -621,6 +733,96 @@ fn binding_requires_exact_policy_and_scope_revisions() {
 }
 
 #[test]
+fn existing_binding_can_reuse_embedded_sources_after_current_records_advance() {
+    let (pap, _) = service();
+    let policy_v1 = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    let scope_v1 = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    let binding = pap
+        .create_binding(
+            &policy_v1.policy_id,
+            policy_v1.revision,
+            &scope_v1.scope_id,
+            scope_v1.revision,
+        )
+        .unwrap();
+
+    pap.update_policy(
+        &policy_v1.policy_id,
+        "protect more files",
+        &policy_template("/workspace/b"),
+    )
+    .unwrap();
+    pap.update_scope(
+        &scope_v1.scope_id,
+        &ScopeSelector::CgroupId { cgroup_id: 99 },
+    )
+    .unwrap();
+
+    let pending_delete = pap.delete_binding(&binding.spec.binding_id).unwrap();
+    let reapplied = pap
+        .update_binding(
+            &binding.spec.binding_id,
+            &policy_v1.policy_id,
+            policy_v1.revision,
+            &scope_v1.scope_id,
+            scope_v1.revision,
+        )
+        .unwrap();
+    assert_eq!(reapplied.spec.binding_revision.get(), 3);
+    assert_eq!(reapplied.spec.policy, policy_v1);
+    assert_eq!(reapplied.spec.scope, scope_v1);
+    assert_eq!(reapplied.status, BindingStatus::PendingApply);
+    assert_eq!(pending_delete.spec.binding_revision.get(), 2);
+
+    assert_eq!(
+        pap.create_binding(
+            &reapplied.spec.policy.policy_id,
+            reapplied.spec.policy.revision,
+            &reapplied.spec.scope.scope_id,
+            reapplied.spec.scope.revision,
+        ),
+        Err(PapError::NotFound),
+        "a new Binding cannot select source revisions no longer current"
+    );
+}
+
+#[test]
+fn repository_atomically_rejects_a_binding_update_after_worker_claim() {
+    let (pap, repository) = service();
+    let policy = pap
+        .create_policy("protect files", &policy_template("/workspace/a"))
+        .unwrap();
+    let scope = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+    let binding = pap
+        .create_binding(
+            &policy.policy_id,
+            policy.revision,
+            &scope.scope_id,
+            scope.revision,
+        )
+        .unwrap();
+    let mut stale_replacement = binding.clone();
+    stale_replacement.spec.binding_revision = Revision::new(2).unwrap();
+
+    repository
+        .update_binding_status(
+            &binding.spec.binding_id,
+            binding.spec.binding_revision,
+            BindingStatus::PendingApply,
+            BindingStatus::Applying,
+        )
+        .unwrap();
+
+    assert_eq!(
+        repository.update_binding(&stale_replacement),
+        Err(PapError::OperationInProgress),
+        "the repository gate must close the service-read/worker-claim race"
+    );
+}
+
+#[test]
 fn compiler_output_identity_is_checked_before_storage() {
     let repository = Arc::new(FakeRepository::default());
     let compiler = Arc::new(FixtureCompiler {
@@ -652,7 +854,7 @@ fn revision_exhaustion_and_pagination_bounds_are_explicit() {
         state.policies.clear();
         state
             .policies
-            .insert((first.policy_id.as_str().to_owned(), u32::MAX), exhausted);
+            .insert(first.policy_id.as_str().to_owned(), exhausted);
         state
             .policy_heads
             .insert(first.policy_id.as_str().to_owned(), u32::MAX);

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/binding.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/binding.rs
@@ -10,7 +10,9 @@ use crate::scope::PreparedScope;
 /// Complete Adapter-independent immutable Binding specification.
 ///
 /// Lifecycle and reconciliation state do not belong to this value. The pair
-/// `(binding_id, binding_revision)` identifies exactly one immutable spec.
+/// `(binding_id, binding_revision)` identifies exactly one immutable snapshot.
+/// Repositories retain only the current snapshot; a higher revision replaces
+/// the previous current record without reusing its number.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PreparedBinding {
@@ -74,12 +76,13 @@ impl Validate for PreparedBinding {
 /// Request transitions:
 ///
 /// - An identical-spec UPDATE is a no-op from `PendingApply`, `Applying`, or
-///   `Ready`. From `ApplyFailed` or any Delete-side state it transitions to
-///   `PendingApply`.
-/// - A DELETE is a no-op from `PendingDelete`, `Deleting`, or `Deleted`. From
-///   any Apply-side state or `DeleteFailed` it transitions to `PendingDelete`.
-/// - A changed-spec UPDATE is handled by PAP: it allocates the next immutable
-///   Binding revision and assigns that new spec `PendingApply`.
+///   `Ready`. A new Apply intent from another state allocates the next Binding
+///   revision and starts in `PendingApply`, except that `Deleting` rejects it.
+/// - A DELETE is a no-op from `PendingDelete`, `Deleting`, or `Deleted`. A new
+///   Delete intent allocates the next Binding revision and starts in
+///   `PendingDelete`, except that `Applying` rejects it.
+/// - A changed-spec UPDATE allocates the next Binding revision and starts in
+///   `PendingApply`; it is rejected while Apply or Delete is running.
 ///
 /// Reconciler transitions:
 ///
@@ -123,31 +126,42 @@ impl BindingStatus {
         )
     }
 
+    /// Reports whether target-side reconciliation may currently be running.
+    #[must_use]
+    pub const fn is_reconciling(self) -> bool {
+        matches!(self, Self::Applying | Self::Deleting)
+    }
+
     /// Returns the status produced by an identical-spec UPDATE.
     ///
-    /// An identical UPDATE is a no-op while Apply is pending, running, or already
-    /// successful. It returns to pending Apply after deletion or terminal Apply
-    /// failure. Changed spec content is handled separately by PAP revision
-    /// allocation and also starts in `PendingApply`.
-    #[must_use]
-    pub const fn request_apply(self) -> Self {
-        if matches!(self, Self::PendingApply | Self::Applying | Self::Ready) {
-            self
-        } else {
-            Self::PendingApply
+    /// An identical UPDATE is a no-op while Apply is pending, running, or
+    /// already successful. A new Apply intent otherwise starts in
+    /// `PendingApply` under a new revision. Delete work already in progress
+    /// cannot be interrupted.
+    ///
+    /// # Errors
+    /// Rejects a request while Delete reconciliation is running.
+    pub fn request_apply(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::PendingApply | Self::Applying | Self::Ready => Ok(self),
+            Self::Deleting => Err(illegal_status("request Apply", self)),
+            _ => Ok(Self::PendingApply),
         }
     }
 
     /// Returns the status produced by a DELETE request.
     ///
-    /// DELETE is idempotent while deletion is pending, running, or completed;
-    /// retrying a terminal Delete failure returns to pending Delete.
-    #[must_use]
-    pub const fn request_delete(self) -> Self {
-        if matches!(self, Self::PendingDelete | Self::Deleting | Self::Deleted) {
-            self
-        } else {
-            Self::PendingDelete
+    /// DELETE is idempotent while deletion is pending, running, or completed.
+    /// A new Delete intent otherwise starts in `PendingDelete` under a new
+    /// revision. Apply work already in progress cannot be interrupted.
+    ///
+    /// # Errors
+    /// Rejects a request while Apply reconciliation is running.
+    pub fn request_delete(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::PendingDelete | Self::Deleting | Self::Deleted => Ok(self),
+            Self::Applying => Err(illegal_status("request Delete", self)),
+            _ => Ok(Self::PendingDelete),
         }
     }
 
@@ -202,7 +216,8 @@ impl BindingStatus {
     /// Validates a Repository compare-and-swap successor.
     ///
     /// Identical values are accepted for idempotency. Other successors must be
-    /// one of the request or worker transitions exposed by this type.
+    /// one of the worker transitions within the same Binding revision. User
+    /// requests allocate a new revision and replace the current Binding record.
     ///
     /// # Errors
     /// Rejects an illegal status transition.
@@ -212,22 +227,16 @@ impl BindingStatus {
         }
         let valid = matches!(
             (self, next),
-            (Self::PendingApply, Self::Applying | Self::PendingDelete)
+            (Self::PendingApply, Self::Applying)
                 | (
                     Self::Applying,
-                    Self::Ready | Self::PendingApply | Self::ApplyFailed | Self::PendingDelete,
+                    Self::Ready | Self::PendingApply | Self::ApplyFailed,
                 )
-                | (Self::Ready, Self::PendingDelete)
-                | (
-                    Self::ApplyFailed | Self::DeleteFailed,
-                    Self::PendingApply | Self::PendingDelete,
-                )
-                | (Self::PendingDelete, Self::Deleting | Self::PendingApply)
+                | (Self::PendingDelete, Self::Deleting)
                 | (
                     Self::Deleting,
-                    Self::Deleted | Self::PendingDelete | Self::DeleteFailed | Self::PendingApply,
+                    Self::Deleted | Self::PendingDelete | Self::DeleteFailed,
                 )
-                | (Self::Deleted, Self::PendingApply)
         );
         if valid {
             Ok(())
@@ -241,10 +250,11 @@ fn illegal_status(operation: &str, status: BindingStatus) -> ValidationError {
     ValidationError::new("status", format!("cannot {operation} from {status:?}"))
 }
 
-/// Read-only aggregate of an immutable spec and its current lifecycle status.
+/// Current Binding snapshot and its lifecycle status.
 ///
-/// Repositories may construct this view for GET/LIST responses. It must not be
-/// updated as one opaque persistence document.
+/// Repositories construct this value for GET/LIST and atomically replace the
+/// complete value for a new desired-state revision. Reconciler status-only
+/// transitions do not rewrite `spec`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct BindingView {

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/binding.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/binding.rs
@@ -1,4 +1,4 @@
-//! Complete target-independent Policy Binding snapshots.
+//! Complete target-independent immutable Policy Binding specifications.
 
 use serde::{Deserialize, Serialize};
 
@@ -7,30 +7,21 @@ use crate::identifiers::{ResourceId, Revision};
 use crate::policy::PreparedPolicy;
 use crate::scope::PreparedScope;
 
-/// Desired Binding state understood before any target-specific Adapter exists.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum BindingDesiredState {
-    /// The Adapter should converge this prepared Binding.
-    Ready,
-    /// The Adapter should remove this Binding.
-    Absent,
-}
-
-/// Complete Adapter-independent Binding snapshot.
+/// Complete Adapter-independent immutable Binding specification.
+///
+/// Lifecycle and reconciliation state do not belong to this value. The pair
+/// `(binding_id, binding_revision)` identifies exactly one immutable spec.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PreparedBinding {
     /// Stable Binding identity.
     pub binding_id: ResourceId,
-    /// Immutable desired revision.
+    /// Immutable spec revision.
     pub binding_revision: Revision,
     /// Exactly one authored and lowered Policy revision.
     pub policy: PreparedPolicy,
     /// Exactly one authored Scope revision.
     pub scope: PreparedScope,
-    /// Desired state.
-    pub desired_state: BindingDesiredState,
 }
 
 #[derive(Deserialize)]
@@ -42,7 +33,6 @@ struct PreparedBindingWire {
     scope: PreparedScope,
     #[serde(default, rename = "executionDomainId")]
     _legacy_execution_domain_id: Option<ResourceId>,
-    desired_state: BindingDesiredState,
 }
 
 impl<'de> Deserialize<'de> for PreparedBinding {
@@ -56,7 +46,6 @@ impl<'de> Deserialize<'de> for PreparedBinding {
             binding_revision: wire.binding_revision,
             policy: wire.policy,
             scope: wire.scope,
-            desired_state: wire.desired_state,
         })
     }
 }
@@ -70,5 +59,205 @@ impl Validate for PreparedBinding {
             ValidationError::new(format!("scope.{}", error.path), error.message)
         })?;
         Ok(())
+    }
+}
+
+/// Complete lifecycle state of one Binding.
+///
+/// Successful paths:
+///
+/// ```text
+/// CREATE/UPDATE: PendingApply -> Applying -> Ready
+/// DELETE: PendingDelete -> Deleting -> Deleted
+/// ```
+///
+/// Request transitions:
+///
+/// - An identical-spec UPDATE is a no-op from `PendingApply`, `Applying`, or
+///   `Ready`. From `ApplyFailed` or any Delete-side state it transitions to
+///   `PendingApply`.
+/// - A DELETE is a no-op from `PendingDelete`, `Deleting`, or `Deleted`. From
+///   any Apply-side state or `DeleteFailed` it transitions to `PendingDelete`.
+/// - A changed-spec UPDATE is handled by PAP: it allocates the next immutable
+///   Binding revision and assigns that new spec `PendingApply`.
+///
+/// Reconciler transitions:
+///
+/// - `PendingApply -> Applying`; then success reaches `Ready`, a retryable
+///   failure returns to `PendingApply`, and a permanent or retry-exhausted
+///   failure reaches `ApplyFailed`.
+/// - `PendingDelete -> Deleting`; then success reaches `Deleted`, a retryable
+///   failure returns to `PendingDelete`, and a permanent or retry-exhausted
+///   failure reaches `DeleteFailed`.
+///
+/// `Ready`, `ApplyFailed`, `Deleted`, and `DeleteFailed` are terminal without a
+/// new request. [`BindingStatus::validate_successor`] is the executable closed
+/// transition set used by Repository compare-and-swap implementations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BindingStatus {
+    /// PAP accepted an Apply request; no worker has claimed it yet.
+    PendingApply,
+    /// A reconciler is applying the referenced immutable spec.
+    Applying,
+    /// Apply completed successfully.
+    Ready,
+    /// Apply exhausted retries or failed permanently.
+    ApplyFailed,
+    /// PAP accepted a Delete request; no worker has claimed it yet.
+    PendingDelete,
+    /// A reconciler is detaching the referenced immutable spec.
+    Deleting,
+    /// Detach completed successfully.
+    Deleted,
+    /// Detach exhausted retries or failed permanently.
+    DeleteFailed,
+}
+
+impl BindingStatus {
+    /// Reports whether no automatic transition remains without a new request.
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Ready | Self::ApplyFailed | Self::Deleted | Self::DeleteFailed
+        )
+    }
+
+    /// Returns the status produced by an identical-spec UPDATE.
+    ///
+    /// An identical UPDATE is a no-op while Apply is pending, running, or already
+    /// successful. It returns to pending Apply after deletion or terminal Apply
+    /// failure. Changed spec content is handled separately by PAP revision
+    /// allocation and also starts in `PendingApply`.
+    #[must_use]
+    pub const fn request_apply(self) -> Self {
+        if matches!(self, Self::PendingApply | Self::Applying | Self::Ready) {
+            self
+        } else {
+            Self::PendingApply
+        }
+    }
+
+    /// Returns the status produced by a DELETE request.
+    ///
+    /// DELETE is idempotent while deletion is pending, running, or completed;
+    /// retrying a terminal Delete failure returns to pending Delete.
+    #[must_use]
+    pub const fn request_delete(self) -> Self {
+        if matches!(self, Self::PendingDelete | Self::Deleting | Self::Deleted) {
+            self
+        } else {
+            Self::PendingDelete
+        }
+    }
+
+    /// Claims pending Apply or Delete work.
+    ///
+    /// # Errors
+    /// Rejects non-pending source states.
+    pub fn start_reconcile(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::PendingApply => Ok(Self::Applying),
+            Self::PendingDelete => Ok(Self::Deleting),
+            _ => Err(illegal_status("start reconcile", self)),
+        }
+    }
+
+    /// Records successful reconciliation.
+    ///
+    /// # Errors
+    /// Rejects non-running source states.
+    pub fn complete_reconcile(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::Applying => Ok(Self::Ready),
+            Self::Deleting => Ok(Self::Deleted),
+            _ => Err(illegal_status("complete reconcile", self)),
+        }
+    }
+
+    /// Returns failed running work to its pending state for retry.
+    ///
+    /// # Errors
+    /// Rejects non-running source states.
+    pub fn retry_reconcile(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::Applying => Ok(Self::PendingApply),
+            Self::Deleting => Ok(Self::PendingDelete),
+            _ => Err(illegal_status("retry reconcile", self)),
+        }
+    }
+
+    /// Records terminal reconciliation failure.
+    ///
+    /// # Errors
+    /// Rejects non-running source states.
+    pub fn fail_reconcile(self) -> Result<Self, ValidationError> {
+        match self {
+            Self::Applying => Ok(Self::ApplyFailed),
+            Self::Deleting => Ok(Self::DeleteFailed),
+            _ => Err(illegal_status("fail reconcile", self)),
+        }
+    }
+
+    /// Validates a Repository compare-and-swap successor.
+    ///
+    /// Identical values are accepted for idempotency. Other successors must be
+    /// one of the request or worker transitions exposed by this type.
+    ///
+    /// # Errors
+    /// Rejects an illegal status transition.
+    pub fn validate_successor(self, next: Self) -> Result<(), ValidationError> {
+        if self == next {
+            return Ok(());
+        }
+        let valid = matches!(
+            (self, next),
+            (Self::PendingApply, Self::Applying | Self::PendingDelete)
+                | (
+                    Self::Applying,
+                    Self::Ready | Self::PendingApply | Self::ApplyFailed | Self::PendingDelete,
+                )
+                | (Self::Ready, Self::PendingDelete)
+                | (
+                    Self::ApplyFailed | Self::DeleteFailed,
+                    Self::PendingApply | Self::PendingDelete,
+                )
+                | (Self::PendingDelete, Self::Deleting | Self::PendingApply)
+                | (
+                    Self::Deleting,
+                    Self::Deleted | Self::PendingDelete | Self::DeleteFailed | Self::PendingApply,
+                )
+                | (Self::Deleted, Self::PendingApply)
+        );
+        if valid {
+            Ok(())
+        } else {
+            Err(illegal_status("persist status", self))
+        }
+    }
+}
+
+fn illegal_status(operation: &str, status: BindingStatus) -> ValidationError {
+    ValidationError::new("status", format!("cannot {operation} from {status:?}"))
+}
+
+/// Read-only aggregate of an immutable spec and its current lifecycle status.
+///
+/// Repositories may construct this view for GET/LIST responses. It must not be
+/// updated as one opaque persistence document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BindingView {
+    /// Immutable Binding spec.
+    pub spec: PreparedBinding,
+    /// Mutable lifecycle status for `spec`.
+    pub status: BindingStatus,
+}
+
+impl Validate for BindingView {
+    fn validate(&self) -> Result<(), ValidationError> {
+        self.spec
+            .validate()
+            .map_err(|error| ValidationError::new(format!("spec.{}", error.path), error.message))
     }
 }

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/fixtures/prepared-binding.json
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/fixtures/prepared-binding.json
@@ -104,6 +104,5 @@
       }
     },
     "templateDigest": "sha256:3b92f8f65b2b55b387f3e527cf28c881906f3c2f63c41c9faa60469ad3947957"
-  },
-  "desiredState": "READY"
+  }
 }

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/prepared_binding_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/prepared_binding_contract.rs
@@ -56,7 +56,7 @@ fn binding_view_exposes_status_without_duplicate_spec_identity() {
 }
 
 #[test]
-fn binding_lifecycle_defines_success_retry_failure_and_reversal() {
+fn binding_lifecycle_separates_new_requests_from_worker_transitions() {
     let spec = prepared_binding();
     let pending_apply = BindingStatus::PendingApply;
     assert_eq!(spec.binding_revision.get(), 7);
@@ -75,39 +75,27 @@ fn binding_lifecycle_defines_success_retry_failure_and_reversal() {
     assert_eq!(apply_failed, BindingStatus::ApplyFailed);
     assert!(apply_failed.is_terminal());
 
-    let retried_apply = apply_failed.request_apply();
+    let retried_apply = apply_failed.request_apply().unwrap();
     assert_eq!(retried_apply, BindingStatus::PendingApply);
-    apply_failed.validate_successor(retried_apply).unwrap();
+    assert!(apply_failed.validate_successor(retried_apply).is_err());
     let applying = retried_apply.start_reconcile().unwrap();
     let ready = applying.complete_reconcile().unwrap();
     assert_eq!(ready, BindingStatus::Ready);
     assert!(ready.is_terminal());
     assert_eq!(
-        ready.request_apply(),
+        ready.request_apply().unwrap(),
         ready,
         "an identical PUT after successful Apply is idempotent"
     );
 
-    let pending_delete = ready.request_delete();
+    let pending_delete = ready.request_delete().unwrap();
     assert_eq!(pending_delete, BindingStatus::PendingDelete);
+    assert!(ready.validate_successor(pending_delete).is_err());
     let deleting = pending_delete.start_reconcile().unwrap();
     assert_eq!(deleting, BindingStatus::Deleting);
+    assert!(deleting.request_apply().is_err());
+    assert!(applying.request_delete().is_err());
 
-    let reversed = deleting.request_apply();
-    assert_eq!(reversed, BindingStatus::PendingApply);
-    let stale_deleted = deleting.complete_reconcile().unwrap();
-    assert!(
-        reversed.validate_successor(stale_deleted).is_err(),
-        "Deleted is not a legal successor of a newer pending Apply state"
-    );
-
-    let ready = reversed
-        .start_reconcile()
-        .unwrap()
-        .complete_reconcile()
-        .unwrap();
-    let pending_delete = ready.request_delete();
-    let deleting = pending_delete.start_reconcile().unwrap();
     let retry_delete = deleting.retry_reconcile().unwrap();
     assert_eq!(retry_delete, BindingStatus::PendingDelete);
     let deleting = retry_delete.start_reconcile().unwrap();
@@ -115,8 +103,9 @@ fn binding_lifecycle_defines_success_retry_failure_and_reversal() {
     assert_eq!(delete_failed, BindingStatus::DeleteFailed);
     assert!(delete_failed.is_terminal());
 
-    let retried_delete = delete_failed.request_delete();
+    let retried_delete = delete_failed.request_delete().unwrap();
     assert_eq!(retried_delete, BindingStatus::PendingDelete);
+    assert!(delete_failed.validate_successor(retried_delete).is_err());
     let deleted = retried_delete
         .start_reconcile()
         .unwrap()
@@ -124,7 +113,7 @@ fn binding_lifecycle_defines_success_retry_failure_and_reversal() {
         .unwrap();
     assert_eq!(deleted, BindingStatus::Deleted);
     assert!(deleted.is_terminal());
-    assert_eq!(deleted.request_delete(), deleted);
+    assert_eq!(deleted.request_delete().unwrap(), deleted);
 }
 
 #[test]

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/prepared_binding_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/tests/prepared_binding_contract.rs
@@ -1,5 +1,5 @@
 use asc_policy_types::Validate;
-use asc_policy_types::binding::PreparedBinding;
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
 use asc_policy_types::identifiers::Revision;
 
 const COMPLETE_BINDING: &str = include_str!("fixtures/prepared-binding.json");
@@ -40,6 +40,94 @@ fn binding_validation_addresses_invalid_scope_fields() {
 }
 
 #[test]
+fn binding_view_exposes_status_without_duplicate_spec_identity() {
+    let spec = prepared_binding();
+    let view = BindingView {
+        status: BindingStatus::PendingApply,
+        spec,
+    };
+
+    view.validate().unwrap();
+    let wire = serde_json::to_value(&view).unwrap();
+    assert!(wire.get("lifecycle").is_none());
+    assert_eq!(wire["status"], "PENDING_APPLY");
+    assert!(wire["spec"].get("desiredState").is_none());
+    assert_eq!(serde_json::from_value::<BindingView>(wire).unwrap(), view);
+}
+
+#[test]
+fn binding_lifecycle_defines_success_retry_failure_and_reversal() {
+    let spec = prepared_binding();
+    let pending_apply = BindingStatus::PendingApply;
+    assert_eq!(spec.binding_revision.get(), 7);
+    assert!(!pending_apply.is_terminal());
+    assert!(pending_apply.complete_reconcile().is_err());
+
+    let applying = pending_apply.start_reconcile().unwrap();
+    pending_apply.validate_successor(applying).unwrap();
+    assert_eq!(applying, BindingStatus::Applying);
+
+    let retry_apply = applying.retry_reconcile().unwrap();
+    applying.validate_successor(retry_apply).unwrap();
+    assert_eq!(retry_apply, BindingStatus::PendingApply);
+    let applying = retry_apply.start_reconcile().unwrap();
+    let apply_failed = applying.fail_reconcile().unwrap();
+    assert_eq!(apply_failed, BindingStatus::ApplyFailed);
+    assert!(apply_failed.is_terminal());
+
+    let retried_apply = apply_failed.request_apply();
+    assert_eq!(retried_apply, BindingStatus::PendingApply);
+    apply_failed.validate_successor(retried_apply).unwrap();
+    let applying = retried_apply.start_reconcile().unwrap();
+    let ready = applying.complete_reconcile().unwrap();
+    assert_eq!(ready, BindingStatus::Ready);
+    assert!(ready.is_terminal());
+    assert_eq!(
+        ready.request_apply(),
+        ready,
+        "an identical PUT after successful Apply is idempotent"
+    );
+
+    let pending_delete = ready.request_delete();
+    assert_eq!(pending_delete, BindingStatus::PendingDelete);
+    let deleting = pending_delete.start_reconcile().unwrap();
+    assert_eq!(deleting, BindingStatus::Deleting);
+
+    let reversed = deleting.request_apply();
+    assert_eq!(reversed, BindingStatus::PendingApply);
+    let stale_deleted = deleting.complete_reconcile().unwrap();
+    assert!(
+        reversed.validate_successor(stale_deleted).is_err(),
+        "Deleted is not a legal successor of a newer pending Apply state"
+    );
+
+    let ready = reversed
+        .start_reconcile()
+        .unwrap()
+        .complete_reconcile()
+        .unwrap();
+    let pending_delete = ready.request_delete();
+    let deleting = pending_delete.start_reconcile().unwrap();
+    let retry_delete = deleting.retry_reconcile().unwrap();
+    assert_eq!(retry_delete, BindingStatus::PendingDelete);
+    let deleting = retry_delete.start_reconcile().unwrap();
+    let delete_failed = deleting.fail_reconcile().unwrap();
+    assert_eq!(delete_failed, BindingStatus::DeleteFailed);
+    assert!(delete_failed.is_terminal());
+
+    let retried_delete = delete_failed.request_delete();
+    assert_eq!(retried_delete, BindingStatus::PendingDelete);
+    let deleted = retried_delete
+        .start_reconcile()
+        .unwrap()
+        .complete_reconcile()
+        .unwrap();
+    assert_eq!(deleted, BindingStatus::Deleted);
+    assert!(deleted.is_terminal());
+    assert_eq!(deleted.request_delete(), deleted);
+}
+
+#[test]
 fn legacy_read_fields_are_not_reemitted_and_unknown_fields_are_rejected() {
     let mut legacy: serde_json::Value = serde_json::from_str(COMPLETE_BINDING).unwrap();
     legacy["policy"]["retired"] = serde_json::json!(false);
@@ -55,4 +143,9 @@ fn legacy_read_fields_are_not_reemitted_and_unknown_fields_are_rejected() {
     let mut unknown: serde_json::Value = serde_json::from_str(COMPLETE_BINDING).unwrap();
     unknown["unexpected"] = serde_json::json!(true);
     assert!(serde_json::from_value::<PreparedBinding>(unknown).is_err());
+
+    let mut lifecycle_inside_spec: serde_json::Value =
+        serde_json::from_str(COMPLETE_BINDING).unwrap();
+    lifecycle_inside_spec["desiredState"] = serde_json::json!("READY");
+    assert!(serde_json::from_value::<PreparedBinding>(lifecycle_inside_spec).is_err());
 }


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
- add enum BindingStatus and state machine in policy types. Format BindingView as Spec + Status
- add pap service including CRUD operations for Policy, Scope and Binding. All of them are persist using repository class which relays on further implementation of SQL db. Binding needs outbox and reconciliation which is mark as TODO for now.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
