### PR TITLE
refactor(tokenless): migrate dsh lifecycle

### DIFF
--- a/docs/user-guide/en/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/en/token-saving/tokenless/framework-integration.md
@@ -16,7 +16,7 @@ product adapters. The Python SDK and its AgentScope-specific child document live
 | Qoder | `qoder` | Hard-disabled | Emits rewritten shell input | Replaces output through `updatedToolOutput` | Pipeline-selected for replaceable text | — |
 | Claude Code | `claude-code` | Hard-disabled | Replaces Bash input | Replaces output on 2.1.121 or later; otherwise passes through | Pipeline-selected for replaceable text | — |
 | Codex | `codex` | Hard-disabled | Replaces supported shell input | Keeps the original; adds context only for classified environment failures | — | — |
-| DeepSeek Harness | `dsh` | — | — | Replaces an accepted single-text JSON result when the replacement is smaller | — | — |
+| DeepSeek Harness | `dsh` | — | — | Delegates accepted single-text results to Core | Core-selected for replaceable text | — |
 | OpenCode | `opencode` | Hard-disabled | Replaces Bash input | Replaces tool output | Pipeline-selected for replaceable text | ✅ |
 | Qwen Code | `qwencode` | Hard-disabled | Emits rewritten shell input | Passes through because the host has no replacement field | — | — |
 
@@ -52,11 +52,10 @@ The Common BeforeModel hook likewise has no marker-authorized recovery path. Cur
 transformations are lossy, so Core passes the tools through unchanged. OpenCode's separate per-tool
 definition path and the direct `compress-schema` command are unchanged.
 
-OpenClaw and Hermes now delegate their PostTool decisions to Core. DeepSeek Harness still uses its
-dedicated response path; the content-aware build/log path does not run there yet. The standalone
-`compress-response` command also remains the explicit JSON cleanup interface.
+OpenClaw, Hermes, and DeepSeek Harness delegate their PostTool decisions to Core. The standalone
+`compress-response` command remains the explicit JSON cleanup interface.
 
-For JSON response cleanup, shared and legacy adapters classify tools as follows:
+For JSON response cleanup, adapters map host tools to Core's content origins as follows:
 
 | Class | Default adapter behavior |
 |-------|--------------------------|
@@ -99,14 +98,14 @@ selected profiles and their resolved DSH home in the adapter receipt, so later
 status, disable, and re-enable operations continue to address the same profile
 tree.
 
-The plugin runs on DSH's `tools/post-execute` waterfall. It attempts
-`tokenless compress-response` only for a successful result containing one text
-block whose text is a JSON object or array. It replaces the content only when
-the CLI returns valid JSON that is strictly shorter. Multiple blocks, images,
-plain text, invalid JSON, errored results, Code Mode child executions, and the
-default content-retrieval tools are not compressed. A missing, failing, or
-timed-out CLI also preserves the original content. This native path does not
-run the TOON second stage and has no pre-spawn minimum-size gate.
+The plugin runs on DSH's `tools/post-execute` waterfall and sends replaceable
+root results containing one text block to `tokenless compress`. Core owns
+content detection, JSON cleanup, TOON selection, size gates, tool-origin
+thresholds, and final acceptance. Non-JSON and file-content results pass
+through. DSH has no Marker-authorized recovery path, so Core rejects lossy
+candidates. Multiple blocks, images, Code Mode child successes, and canonical
+values replaced by a later waterfall listener remain untouched. A missing,
+failing, or timed-out CLI also preserves the original content.
 
 Add an override for the installed row to
 `$DSH_HOME/profiles/<profile>/cordis.patch.yml`, then restart that DSH profile:
@@ -117,7 +116,6 @@ Add an override for the installed row to
     responseCompressionEnabled: true
     timeoutMs: 5000
     maxBuffer: 4194304
-    noStash: false
 ```
 
 Later DSH patch layers replace the row's complete `config` value. The plugin
@@ -128,32 +126,17 @@ that need to differ.
 |--------|---------|----------|
 | `responseCompressionEnabled` | `true` | Enables response compression. Setting it to `false` does not disable environment-error attribution. |
 | `tokenlessBin` | `$TOKENLESS_BIN`, then `tokenless` | Selects the Tokenless CLI executable. A non-empty plugin value takes precedence over the environment variable. |
-| `skipTools` | Content-retrieval set below | Skips compression for matching tool names. A configured array replaces the default set; an empty array skips none. Attribution remains active. |
-| `shellTools` | Shell/process set below | Selects shell thresholds and the tools whose structured `value` may be interpreted for failure attribution. A configured array replaces the default set. |
-| `truncateStringsAt` | Shell `65536`; other `1048576` | Overrides the maximum retained string length for every tool class. Only a positive integer is accepted. |
-| `truncateArraysAt` | Shell `128`; other `65536` | Overrides the maximum retained array length for every tool class. Only a positive integer is accepted. |
-| `maxDepth` | Shell `8`; other `32` | Overrides maximum JSON depth for every tool class. Only a positive integer is accepted. |
 | `timeoutMs` | `3000` | Bounds one Tokenless child process in milliseconds. Only a positive integer is accepted. |
 | `maxBuffer` | `2097152` | Bounds captured child-process output in bytes. Only a positive integer is accepted. |
-| `agentId` | `dsh` | Sets the `--agent-id` recorded by Tokenless statistics. |
-| `noStash` | `false` | Passes `--no-stash` when `true`; dropped array items are otherwise eligible for Stash storage. |
+| `agentId` | `dsh` | Sets the Agent attribution recorded by Tokenless statistics. |
 
-The default `skipTools` set is `Read`, `read`, `read_file`, `read_many_files`,
-`Glob`, `glob`, `search_file`, `list_directory`, `list_dir`, `Grep`, `grep`,
-`grep_code`, `grep_search`, `search_files`, `Lsp`, `lsp`, `NotebookRead`,
-`notebook_read`, and `notebookread`.
-
-The default `shellTools` set is `Bash`, `bash`, `Shell`, `shell`, `exec`,
-`terminal`, `run_shell_command`, `run_in_terminal`, `get_terminal_output`,
-`execute_command`, and `process`.
-
-Raw DSH failures marked with `isError` may receive dependency, permission,
-path, network, or package attribution for any tool. Structured output is
-classified only for `shellTools`. Attribution is independent of compression,
-so it remains active when compression is disabled, skipped, or produces no
-smaller result. When a later waterfall listener replaces the canonical
-`value`, Tokenless classifies that replacement and does not carry attribution
-from the superseded result.
+The plugin maps DSH's built-in read/search tools to `file_content`, command
+tools to `command_output`, and unknown tools to `api_response`. These mappings
+only describe host facts; Core owns the resulting policy. Raw DSH failures and
+structured command failures are sent to Core for environment diagnosis even
+when compression is disabled. When a later waterfall listener replaces the
+canonical `value`, Tokenless examines only that replacement and never applies
+content compression to it.
 
 ## Manage adapters with anolisa (recommended)
 

--- a/docs/user-guide/en/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/en/token-saving/tokenless/user-manual.md
@@ -66,8 +66,8 @@ Retrieve: visible-Marker authorization → byte-identical Stash read
 
 This is a capability map, not a pipeline that every framework runs. For example, the content-aware
 protocol path currently serves Cosh-NG, OpenClaw, Hermes, Qoder, supported Claude Code releases,
-and OpenCode; DeepSeek Harness retains a dedicated JSON response path. Codex and Qwen Code do not
-replace post-tool output under their current host contracts. See
+OpenCode, and DeepSeek Harness. Codex and Qwen Code do not replace post-tool output under their
+current host contracts. See
 [Agent integration](framework-integration.md).
 
 ## Behaviors to understand

--- a/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
+++ b/docs/user-guide/zh/token-saving/tokenless/framework-integration.md
@@ -15,7 +15,7 @@ Python SDK 及其 AgentScope 专用子文档放在 [Python SDK 指南](sdk.md) �
 | Qoder | `qoder` | 已硬关闭 | 输出改写后的 Shell 输入 | 通过 `updatedToolOutput` 替换输出 | 对可替换文本由 Pipeline 选择 | — |
 | Claude Code | `claude-code` | 已硬关闭 | 替换 Bash 输入 | 2.1.121 及以上替换输出；否则透传 | 对可替换文本由 Pipeline 选择 | — |
 | Codex | `codex` | 已硬关闭 | 替换受支持的 Shell 输入 | 保留原文；仅对识别出的环境失败追加上下文 | — | — |
-| DeepSeek Harness | `dsh` | 未注册 | 未注册 | 只在结果更小时替换已接受的单文本块 JSON 结果 | 未注册 | 未注册 |
+| DeepSeek Harness | `dsh` | 未注册 | 未注册 | 把已接受的单文本结果委托给 Core | 对可替换文本由 Core 选择 | 未注册 |
 | OpenCode | `opencode` | 已硬关闭 | 替换 Bash 输入 | 替换工具输出 | 对可替换文本由 Pipeline 选择 | ✅ |
 | Qwen Code | `qwencode` | 已硬关闭 | 输出改写后的 Shell 输入 | 宿主没有替换字段，因此透传 | — | — |
 
@@ -48,11 +48,10 @@ Core 策略。Hook 只把宿主对象映射为 v2 字段；它可以跳过明显
 Common BeforeModel Hook 同样没有 Marker 授权恢复路径。当前 Schema 变换均为有损，因此 Core
 原样返回 Tools。OpenCode 独立的逐工具定义路径和直接 `compress-schema` 命令不受影响。
 
-OpenClaw 与 Hermes 已把 PostTool 决策委托给 Core。DeepSeek Harness 仍使用专用响应路径；
-content-aware build/log 路径尚未接入。独立 `compress-response` 命令也继续作为显式 JSON
-清理入口。
+OpenClaw、Hermes 与 DeepSeek Harness 已把 PostTool 决策委托给 Core。独立
+`compress-response` 命令继续作为显式 JSON 清理入口。
 
-对于 JSON 响应清理，共享与旧版 Adapter 按以下方式分类工具：
+对于 JSON 响应清理，Adapter 按以下方式把宿主工具映射为 Core 的内容 Origin：
 
 | 类别 | Adapter 默认行为 |
 |------|------------------|
@@ -90,12 +89,12 @@ dsh --profile web
 和解析后的 DSH home 写入 adapter receipt。后续 status、disable 和 re-enable 会
 继续操作同一棵 profile 目录树。
 
-Plugin 在 DSH 的 `tools/post-execute` waterfall 上运行。只有成功结果包含一个文本块，
-且文本是 JSON object 或 array 时，才会尝试执行 `tokenless compress-response`。
-CLI 返回更短的合法 JSON 后才会替换内容。多文本块、图片、普通文本、非法 JSON、
-错误结果、Code Mode 子调用和默认内容读取类工具不参与压缩。CLI 缺失、失败或
-超时也会保留原始内容。当前原生路径不执行 TOON 第二阶段，也没有启动子进程前的
-最小尺寸门控。
+Plugin 在 DSH 的 `tools/post-execute` Waterfall 上运行，并把包含一个文本块、可替换的
+根调用结果发送给 `tokenless compress`。内容检测、JSON 清理、TOON 选择、大小门禁、
+基于工具来源的阈值和最终接受均由 Core 负责。非 JSON 与文件内容结果会透传。DSH 没有
+Marker 授权恢复路径，因此 Core 会拒绝有损候选。多文本块、图片、Code Mode 子调用的
+成功结果，以及后续 Waterfall Listener 已替换的 Canonical Value 均保持不变。CLI 缺失、
+失败或超时也会保留原始内容。
 
 在 `$DSH_HOME/profiles/<profile>/cordis.patch.yml` 中覆盖安装后的 row，然后重启
 对应的 DSH profile。
@@ -106,7 +105,6 @@ CLI 返回更短的合法 JSON 后才会替换内容。多文本块、图片、�
     responseCompressionEnabled: true
     timeoutMs: 5000
     maxBuffer: 4194304
-    noStash: false
 ```
 
 后续 DSH patch layer 会替换该 row 的完整 `config` 值。Plugin 会为省略的 key 提供
@@ -116,29 +114,15 @@ CLI 返回更短的合法 JSON 后才会替换内容。多文本块、图片、�
 |--------|--------|------|
 | `responseCompressionEnabled` | `true` | 控制响应压缩。设为 `false` 后，环境错误归因仍保持启用。 |
 | `tokenlessBin` | `$TOKENLESS_BIN`，随后使用 `tokenless` | 选择 Tokenless CLI 可执行文件。非空 Plugin 配置优先于环境变量。 |
-| `skipTools` | 下文列出的内容读取类集合 | 跳过匹配工具的压缩。配置数组会替换默认集合，空数组表示不跳过任何工具。错误归因仍保持启用。 |
-| `shellTools` | 下文列出的 Shell 和 process 集合 | 选择 Shell 阈值，也决定哪些工具的结构化 `value` 可以用于失败归因。配置数组会替换默认集合。 |
-| `truncateStringsAt` | Shell 为 `65536`，其他工具为 `1048576` | 覆盖全部工具类别的字符串保留上限。只接受正整数。 |
-| `truncateArraysAt` | Shell 为 `128`，其他工具为 `65536` | 覆盖全部工具类别的数组保留上限。只接受正整数。 |
-| `maxDepth` | Shell 为 `8`，其他工具为 `32` | 覆盖全部工具类别的 JSON 最大深度。只接受正整数。 |
 | `timeoutMs` | `3000` | 限制一次 Tokenless 子进程的运行时间，单位为毫秒。只接受正整数。 |
 | `maxBuffer` | `2097152` | 限制捕获的子进程输出，单位为 byte。只接受正整数。 |
-| `agentId` | `dsh` | 设置 Tokenless 统计记录中的 `--agent-id`。 |
-| `noStash` | `false` | 设为 `true` 时传入 `--no-stash`。默认允许把删除的数组项写入 Stash。 |
+| `agentId` | `dsh` | 设置 Tokenless 统计记录中的 Agent Attribution。 |
 
-默认 `skipTools` 集合包括 `Read`、`read`、`read_file`、`read_many_files`、`Glob`、
-`glob`、`search_file`、`list_directory`、`list_dir`、`Grep`、`grep`、`grep_code`、
-`grep_search`、`search_files`、`Lsp`、`lsp`、`NotebookRead`、`notebook_read` 和
-`notebookread`。
-
-默认 `shellTools` 集合包括 `Bash`、`bash`、`Shell`、`shell`、`exec`、`terminal`、
-`run_shell_command`、`run_in_terminal`、`get_terminal_output`、`execute_command` 和
-`process`。
-
-DSH 使用 `isError` 标记的原始失败可以为任何工具追加依赖、权限、路径、网络或包
-错误归因。结构化输出只会为 `shellTools` 分类。归因独立于压缩，关闭或跳过压缩、
-压缩没有得到更短结果时仍会生效。后续 waterfall listener 替换 canonical `value`
-后，Tokenless 会按替换值重新分类，不会沿用已经被替换结果的旧归因。
+Plugin 把 DSH 内置的读取/搜索工具映射为 `file_content`，命令工具映射为
+`command_output`，未知工具映射为 `api_response`。这些映射只描述宿主事实，后续策略由
+Core 决定。即使压缩关闭，DSH 原始失败和结构化命令失败仍会交给 Core 做环境诊断。
+后续 Waterfall Listener 替换 Canonical `value` 后，Tokenless 只检查该替换值，且不会对其
+应用内容压缩。
 
 ## 通过 anolisa 管理（推荐）
 

--- a/docs/user-guide/zh/token-saving/tokenless/user-manual.md
+++ b/docs/user-guide/zh/token-saving/tokenless/user-manual.md
@@ -62,9 +62,9 @@ Retrieve：可见 Marker 授权 → 字节级一致的 Stash Read
 ```
 
 这是能力示意，不是所有框架都会完整执行的固定流水线。例如 content-aware Protocol 路径
-当前服务于 Cosh-NG、OpenClaw、Hermes、Qoder、受支持的 Claude Code 版本和 OpenCode；
-DeepSeek Harness 保留专用 JSON 响应路径。Codex 和 Qwen Code 当前宿主契约不能替换工具后
-输出。具体见 [Agent 集成](framework-integration.md)。
+当前服务于 Cosh-NG、OpenClaw、Hermes、Qoder、受支持的 Claude Code 版本、OpenCode 和
+DeepSeek Harness。Codex 和 Qwen Code 当前宿主契约不能替换工具后输出。具体见
+[Agent 集成](framework-integration.md)。
 
 ## 需要特别理解的行为
 

--- a/src/tokenless/README.md
+++ b/src/tokenless/README.md
@@ -646,11 +646,12 @@ The installer creates a `tokenless.js` symbolic link in OpenCode's global
 
 ## DeepSeek Harness Plugin
 
-The native DSH bundle compresses successful single-block JSON tool results
-through `tools/post-execute` and keeps the original result unless the Tokenless
-CLI returns strictly smaller valid JSON. Content-retrieval tools remain
-lossless by default. Environment-error attribution stays active when response
-compression is disabled, skipped, or unable to reduce the result.
+The native DSH bundle sends replaceable single-text tool results through
+Tokenless PostTool Core on `tools/post-execute`. Core owns content detection,
+JSON cleanup, TOON selection, acceptance, and environment-error diagnostics.
+DSH has no Marker-authorized recovery path, so lossy candidates are rejected
+and content-retrieval results remain unchanged. Error guidance stays active
+when response compression is disabled.
 
 Enable the bundle for every desired DSH profile in one command by repeating
 `--profile`:

--- a/src/tokenless/README_zh.md
+++ b/src/tokenless/README_zh.md
@@ -274,9 +274,10 @@ make opencode-install
 
 ### DeepSeek Harness 插件
 
-DSH 原生 Bundle 通过 `tools/post-execute` 压缩成功的单文本块 JSON 工具结果。
-Tokenless CLI 只有返回更短的合法 JSON 时才会替换结果，内容读取类工具默认保持
-原样。关闭响应压缩、跳过压缩或压缩无收益时，环境错误归因仍会工作。
+DSH 原生 Bundle 通过 `tools/post-execute` 把可替换的单文本工具结果交给 Tokenless
+PostTool Core。内容检测、JSON 清理、TOON 选择、最终接受和环境错误诊断均由 Core
+负责。DSH 没有 Marker 授权恢复路径，因此有损候选会被拒绝，内容读取结果保持原样。
+关闭响应压缩后，错误指引仍会工作。
 
 需要启用多个 DSH profile 时，应在同一条命令中重复传入 `--profile`。
 

--- a/src/tokenless/adapters/tokenless/dsh/dist/index.js
+++ b/src/tokenless/adapters/tokenless/dsh/dist/index.js
@@ -1,9 +1,9 @@
 /**
  * Native Tokenless plugin for DeepSeek Harness (dsh).
  *
- * This entry intentionally has no dsh runtime imports.  dsh supplies the
+ * This entry intentionally has no dsh runtime imports. DSH supplies the
  * Cordis event types at runtime, while the only process boundary is the
- * installed Tokenless CLI.  Keeping the entry dependency-free lets ANOLISA
+ * installed Tokenless CLI. Keeping the entry dependency-free lets ANOLISA
  * install one self-contained bundle without running npm in $DSH_HOME.
  */
 import { execFile } from 'node:child_process'
@@ -14,38 +14,28 @@ const DEFAULT_AGENT_ID = 'dsh'
 const DEFAULT_TIMEOUT_MS = 3000
 const DEFAULT_MAX_BUFFER = 2 * 1024 * 1024
 
-// Keep content-retrieval tools lossless.  These names mirror the shared
-// Tokenless adapter taxonomy; callers may extend or replace the list through
-// the dsh plugin config without changing this safety default.
-const DEFAULT_SKIP_TOOLS = new Set([
-  'Read',
+// DSH does not expose content origin, so map its built-in tool names at the
+// host boundary. Core owns every compression decision after this translation.
+const FILE_TOOLS = new Set([
   'read',
   'read_file',
   'read_many_files',
-  'Glob',
   'glob',
   'search_file',
   'list_directory',
   'list_dir',
-  'Grep',
   'grep',
   'grep_code',
   'grep_search',
   'search_files',
-  'Lsp',
   'lsp',
-  'NotebookRead',
-  'notebook_read',
   'notebookread',
+  'notebook_read',
 ])
 
-// These values are the same thresholds used by the shared hook adapter.  A
-// dsh profile can override them in its plugin config; the Tokenless CLI still
-// owns the actual compression algorithm and stats recording.
-const DEFAULT_SHELL_TOOLS = new Set([
-  'Bash',
+const COMMAND_TOOLS = new Set([
   'bash',
-  'Shell',
+  'pwsh',
   'shell',
   'exec',
   'terminal',
@@ -56,84 +46,7 @@ const DEFAULT_SHELL_TOOLS = new Set([
   'process',
 ])
 
-const DEFAULT_THRESHOLDS = {
-  shell: { strings: 65536, arrays: 128, depth: 8 },
-  api: { strings: 1048576, arrays: 65536, depth: 32 },
-}
-
-// Mirror common/hooks/hook_utils.py ENV_PATTERNS exactly.  The dsh bundle is
-// independently publishable, so changes to the canonical table must update
-// this dependency-free runtime copy and its tests together.
-const ENV_PATTERNS = [
-  [
-    [
-      /command not found/i,
-      /not installed/i,
-      /which:\s+no/i,
-      /no command\s/i,
-      /cannot execute/i,
-      /is not recognized/i,
-      /could not find/i,
-      /unable to locate/i,
-      /package not found/i,
-      /\/bin\/sh:.*: not found/i,
-      /command not found:/i,
-    ],
-    'ENV_DEPENDENCY_MISSING',
-    'Missing dependency detected. Install it or ask the user for guidance.',
-  ],
-  [
-    [
-      /permission denied/i,
-      /operation not permitted/i,
-      /eacces/i,
-      /access denied/i,
-      /cannot open .* for writing/i,
-    ],
-    'ENV_PERMISSION',
-    'Permission denied. Check file/directory permissions or run with appropriate access.',
-  ],
-  [
-    [
-      /no such file or directory/i,
-      /enoent/i,
-      /cannot find/i,
-      /file not found/i,
-      /does not exist/i,
-    ],
-    'ENV_FILE_MISSING',
-    'Required file or directory not found. Verify the path or create it.',
-  ],
-  [
-    [
-      /connection refused/i,
-      /could not resolve host/i,
-      /network is unreachable/i,
-      /curl: \(7\)/i,
-      /curl: \(6\)/i,
-      /failed to connect/i,
-      /name or service not known/i,
-      /couldn't resolve host/i,
-      /temporary failure in name resolution/i,
-      /econnrefused/i,
-      /etimedout/i,
-      /connection timed out/i,
-    ],
-    'ENV_NETWORK',
-    'Network connectivity issue. Check DNS, proxy, and firewall settings.',
-  ],
-  [
-    [
-      /modulenotfounderror/i,
-      /importerror/i,
-      /no module named/i,
-      /cannot import name/i,
-      /npm err! 404/i,
-    ],
-    'ENV_PACKAGE_MISSING',
-    'Required package or module is missing. Install the needed dependency.',
-  ],
-]
+const INTERRUPTED_CODES = new Set(['ABORTED', 'ABORTED_BEFORE_DISPATCH'])
 
 /** Return a plain config value or the supplied fallback. */
 function valueOr(config, key, fallback) {
@@ -142,80 +55,92 @@ function valueOr(config, key, fallback) {
     : fallback
 }
 
-/** Normalize a config tool list without allowing malformed values to widen it. */
-function toolSet(value, fallback) {
-  if (!Array.isArray(value)) return fallback
-  return new Set(value.filter((name) => typeof name === 'string' && name.length > 0))
-}
-
-/** Resolve the executable without ever installing or mutating a dsh profile. */
+/** Resolve the executable without installing or mutating a DSH profile. */
 function tokenlessBinary(config) {
   const configured = valueOr(config, 'tokenlessBin', undefined)
   if (typeof configured === 'string' && configured.length > 0) return configured
   return process.env.TOKENLESS_BIN || 'tokenless'
 }
 
-/** Extract text used only for error attribution; never stringify image blocks. */
-function errorText(result) {
-  if (!result || typeof result !== 'object') return ''
-  const error = result.error
-  if (error && typeof error.message === 'string') return error.message
-  return result.content
-    ?.filter((block) => block && block.type === 'text' && typeof block.text === 'string')
-    .map((block) => block.text)
-    .join('\n') || ''
+/** Convert one process limit to a positive finite integer. */
+function positiveInteger(value, fallback) {
+  return Number.isInteger(value) && value > 0 ? value : fallback
 }
 
-/** Return an environment category and remediation hint for known failure text. */
-function classifyEnvironmentError(text) {
-  if (typeof text !== 'string') return undefined
-  if (!text) return undefined
-  for (const [patterns, category, hint] of ENV_PATTERNS) {
-    if (patterns.some((pattern) => pattern.test(text))) return { category, hint }
-  }
-  return undefined
+/** Return the only DSH content shape that can be replaced without schema loss. */
+function singleText(content) {
+  if (!Array.isArray(content) || content.length !== 1) return undefined
+  const [block] = content
+  if (!block || block.type !== 'text' || typeof block.text !== 'string') return undefined
+  return block.text
 }
 
-/** Extract attribution only when structured output explicitly reports failure. */
-function classifyStructuredEnvironmentError(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+/** Treat shell-shaped values as execution status only for known command tools. */
+function commandFailed(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const exitCode = value.exit_code ?? value.exitCode
-  const stringExitCode = typeof exitCode === 'string' ? exitCode.trim() : ''
-  const nonzeroExit = (typeof exitCode === 'number' && exitCode !== 0)
-    || (/^-?\d+$/.test(stringExitCode) && Number(stringExitCode) !== 0)
-  const timedOut = value.timed_out === true || value.timedOut === true
-  const failed = nonzeroExit
-    || timedOut
+  const numericExit = typeof exitCode === 'number'
+    ? exitCode
+    : (typeof exitCode === 'string' && /^-?\d+$/.test(exitCode.trim())
+        ? Number(exitCode)
+        : 0)
+  return numericExit !== 0
+    || (typeof value.signal === 'string' && value.signal.length > 0)
+    || value.timed_out === true
+    || value.timedOut === true
     || value.isError === true
     || value.success === false
     || value.ok === false
-  if (!failed) return undefined
-  const error = value.error
-  let errorValue = error
-  if (error && typeof error === 'object') {
-    if (typeof error.message === 'string') {
-      errorValue = error.message
-    } else {
+}
+
+/** Extract the failure payload while leaving diagnostic classification to Core. */
+function failureText(result, value) {
+  const parts = []
+  if (result?.isError === true && typeof result.error?.message === 'string') {
+    parts.push(result.error.message)
+  }
+  if (Array.isArray(result?.content)) {
+    parts.push(...result.content
+      .filter((block) => block?.type === 'text' && typeof block.text === 'string')
+      .map((block) => block.text))
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const stderr = value.stderr
+    if (typeof stderr === 'string') {
+      parts.push(stderr)
+    } else if (stderr && typeof stderr.text === 'string') {
+      parts.push(stderr.text)
+    }
+    if (typeof value.error === 'string') {
+      parts.push(value.error)
+    } else if (value.error && typeof value.error.message === 'string') {
+      parts.push(value.error.message)
+    } else if (value.error && typeof value.error === 'object') {
+      let serialized
       try {
-        errorValue = JSON.stringify(error)
+        serialized = JSON.stringify(value.error)
       } catch {
-        errorValue = String(error)
+        serialized = String(value.error)
+      }
+      if (typeof serialized === 'string') parts.push(serialized)
+    }
+    if (typeof value.signal === 'string' && value.signal.length > 0) {
+      parts.push(`terminated by signal: ${value.signal}`)
+    }
+    if (!parts.some((part) => part.length > 0)) {
+      const stdout = value.stdout
+      if (typeof stdout === 'string') {
+        parts.push(stdout)
+      } else if (stdout && typeof stdout.text === 'string') {
+        parts.push(stdout.text)
       }
     }
   }
-  const streamText = (stream) => {
-    if (typeof stream === 'string') return stream
-    if (stream && typeof stream === 'object' && typeof stream.text === 'string') return stream.text
-    return undefined
-  }
-  const text = [streamText(value.stderr), errorValue]
-    .filter((part) => typeof part === 'string')
-    .join('\n')
-  return classifyEnvironmentError(text)
+  return parts.filter((part) => part.length > 0).join('\n')
 }
 
-/** Construct a valid plugin-owned user message without importing dsh modules. */
-function attributionContext(text) {
+/** Construct a valid plugin-owned user message without importing DSH modules. */
+function diagnosticContext(text) {
   return {
     id: randomUUID(),
     role: 'user',
@@ -229,169 +154,179 @@ function attributionContext(text) {
   }
 }
 
-/** Add an attribution context to a decision while preserving its shape. */
-function withAttribution(decision, attribution) {
-  if (!attribution) return decision
+/** Add Core's diagnostic to a decision while preserving waterfall output. */
+function withDiagnostic(decision, diagnostic) {
+  if (typeof diagnostic !== 'string' || diagnostic.length === 0) return decision
   return {
     ...decision,
     additionalContexts: [
       ...(Array.isArray(decision.additionalContexts) ? decision.additionalContexts : []),
-      attributionContext(attribution),
+      diagnosticContext(diagnostic),
     ],
   }
 }
 
-/** Safely read one text-only result projection. */
-function singleTextContent(result) {
-  if (!result || result.isError || !Array.isArray(result.content)) return undefined
-  if (result.content.length !== 1) return undefined
-  const [block] = result.content
-  if (!block || block.type !== 'text' || typeof block.text !== 'string') return undefined
-  return block.text
-}
-
-/** Convert one config threshold to a positive finite integer. */
-function positiveInteger(value, fallback) {
-  return Number.isInteger(value) && value > 0 ? value : fallback
-}
-
-/** Build the Tokenless CLI argv for one dsh execution. */
-function compressionArgs(exec, config, shellTools) {
-  const selected = shellTools.has(exec.name) ? DEFAULT_THRESHOLDS.shell : DEFAULT_THRESHOLDS.api
-  const strings = positiveInteger(valueOr(config, 'truncateStringsAt', undefined), selected.strings)
-  const arrays = positiveInteger(valueOr(config, 'truncateArraysAt', undefined), selected.arrays)
-  const depth = positiveInteger(valueOr(config, 'maxDepth', undefined), selected.depth)
-  const args = [
-    'compress-response',
-    '--agent-id',
-    String(valueOr(config, 'agentId', DEFAULT_AGENT_ID)),
-    '--truncate-strings-at',
-    String(strings),
-    '--truncate-arrays-at',
-    String(arrays),
-    '--max-depth',
-    String(depth),
-  ]
-  const sessionId = exec.agent?.id
-  if (typeof sessionId === 'string' && sessionId.length > 0) {
-    args.push('--session-id', sessionId)
-  }
-  if (typeof exec.callId === 'string' && exec.callId.length > 0) {
-    args.push('--tool-use-id', exec.callId)
-  }
-  if (valueOr(config, 'noStash', false) === true) args.push('--no-stash')
-  return args
+/** Map a DSH tool name to the explicit PostTool content origin. */
+function contentOrigin(toolName) {
+  const normalized = toolName.toLowerCase()
+  if (FILE_TOOLS.has(normalized)) return 'file_content'
+  if (COMMAND_TOOLS.has(normalized)) return 'command_output'
+  return 'api_response'
 }
 
 /** Execute a child process with bounded output and explicit stdin. */
-function runTokenless(binary, args, options, input) {
+function runTokenless(binary, request, options) {
   return new Promise((resolve, reject) => {
     let child
     try {
-      child = execFile(binary, args, options, (error, stdout, stderr) => {
+      child = execFile(binary, ['compress'], options, (error, stdout) => {
         if (error) {
-          error.stderr = stderr
           reject(error)
           return
         }
-        resolve({ stdout, stderr })
+        resolve(stdout)
       })
     } catch (error) {
       reject(error)
       return
     }
     child.stdin?.on('error', () => {})
-    try {
-      child.stdin?.end(input)
-    } catch (error) {
-      reject(error)
-    }
+    child.stdin?.end(JSON.stringify(request))
   })
 }
 
-/** Run Tokenless and return a strictly smaller JSON candidate, or undefined. */
-async function compressText(text, exec, config, shellTools) {
-  if (exec.signal?.aborted) return undefined
-  let parsed
+/** Run one PostTool operation and reject malformed transport responses. */
+async function runPostTool(request, exec, config) {
   try {
-    parsed = JSON.parse(text)
-  } catch {
-    return undefined
-  }
-  if (parsed === null || (typeof parsed !== 'object' && !Array.isArray(parsed))) return undefined
-  const binary = tokenlessBinary(config)
-  try {
-    const { stdout } = await runTokenless(binary, compressionArgs(exec, config, shellTools), {
+    const stdout = await runTokenless(tokenlessBinary(config), request, {
       timeout: positiveInteger(valueOr(config, 'timeoutMs', undefined), DEFAULT_TIMEOUT_MS),
       maxBuffer: positiveInteger(valueOr(config, 'maxBuffer', undefined), DEFAULT_MAX_BUFFER),
       encoding: 'utf8',
       windowsHide: true,
       signal: exec.signal,
-    }, text)
-    const candidate = typeof stdout === 'string' ? stdout.trim() : ''
-    // The host's original content is authoritative unless compression proves
-    // a real reduction.  This avoids duplicate payloads and preserves fail-open
-    // behavior when the CLI is unavailable, malformed, or no-op.
-    if (!candidate || candidate.length >= text.length) return undefined
-    JSON.parse(candidate)
-    return candidate
+    })
+    const response = JSON.parse(stdout)
+    if (!response || typeof response !== 'object' || Array.isArray(response)) return undefined
+    if (response.protocol_version !== 2 || response.operation !== 'post_tool') return undefined
+    const result = response.result
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return undefined
+    return result
   } catch {
     return undefined
   }
 }
 
-/** Register native response compression on dsh's typed post-execute seam. */
+/** Build one operation request from the DSH execution boundary. */
+function postToolRequest(exec, config, content, status, origin, replaceOutput) {
+  const attribution = {
+    agent_id: String(valueOr(config, 'agentId', DEFAULT_AGENT_ID)),
+  }
+  if (typeof exec.agent?.id === 'string' && exec.agent.id.length > 0) {
+    attribution.session_id = exec.agent.id
+  }
+  if (typeof exec.callId === 'string' && exec.callId.length > 0) {
+    attribution.tool_use_id = exec.callId
+  }
+  return {
+    protocol_version: 2,
+    operation: 'post_tool',
+    attribution,
+    input: {
+      result_kind: 'tool',
+      tool_name: exec.name,
+      content,
+      status,
+      content_origin: origin,
+      output_optimization: 'none',
+      capabilities: {
+        replace_output: replaceOutput,
+        retrieval_available: false,
+        replace_with_text: replaceOutput,
+      },
+    },
+  }
+}
+
+/** Register DSH's PostTool seam as a thin Tokenless lifecycle adapter. */
 export function apply(ctx, config = {}) {
-  const skipTools = toolSet(valueOr(config, 'skipTools', undefined), DEFAULT_SKIP_TOOLS)
-  const shellTools = toolSet(valueOr(config, 'shellTools', undefined), DEFAULT_SHELL_TOOLS)
-  const enabled = valueOr(config, 'responseCompressionEnabled', true) !== false
+  const compressionEnabled = valueOr(config, 'responseCompressionEnabled', true) !== false
+
   ctx.on('tools/post-execute', async (exec, result, next) => {
-    const envError = result?.isError === true
-      ? classifyEnvironmentError(errorText(result))
-      : undefined
-    const structuredError = result?.isError === false && shellTools.has(exec.name)
-      ? classifyStructuredEnvironmentError(result.value)
-      : undefined
-    // Attribution is independent of compression so disabled, skipped, and
-    // parented failures still tell the agent why blind retries are unsafe.
-    const originalAttribution = structuredError || envError
-
-    // DSH treats this seam as a waterfall.  Let downstream policies settle
-    // their decision before replacing only its accepted display content.
+    // DSH post-execute is a waterfall; later policies own the final projection.
     const decision = await next()
-    const replacesValue = Object.prototype.hasOwnProperty.call(decision, 'value')
-    // A downstream canonical value replaces the original result entirely, so
-    // any attribution must describe that value rather than the stale result.
-    const attribution = replacesValue
-      ? (shellTools.has(exec.name)
-          ? classifyStructuredEnvironmentError(decision.value)
-          : undefined)
-      : originalAttribution
-    const responseContext = attribution
-      ? `[tokenless:env] ${exec.name} failed: ${attribution.category} (${attribution.hint}). Skip retry.`
-      : undefined
-    const canCompress = enabled
-      && !skipTools.has(exec.name)
-      && exec.parent === undefined
-      && decision.kind === 'accept'
-      && !replacesValue
-    if (!canCompress) return withAttribution(decision, responseContext)
+    if (decision.kind !== 'accept' || exec.signal?.aborted) return decision
 
-    // Only a single text block is safe to replace.  Images, tool-call blocks,
-    // nested tool results, and mixed content remain untouched by design.
-    const contentResult = decision.content === undefined
+    const toolName = exec.name.toLowerCase()
+    const isCommand = COMMAND_TOOLS.has(toolName)
+    const replacesValue = Object.prototype.hasOwnProperty.call(decision, 'value')
+    const effectiveValue = replacesValue ? decision.value : result.value
+    const structuredFailure = isCommand && commandFailed(effectiveValue)
+
+    if (replacesValue) {
+      if (!structuredFailure) return decision
+      const content = failureText(undefined, effectiveValue)
+      const request = postToolRequest(
+        exec,
+        config,
+        content,
+        'error',
+        'command_output',
+        false,
+      )
+      const response = await runPostTool(request, exec, config)
+      const diagnostic = response?.disposition === 'tool_error'
+        ? response.additional_context
+        : undefined
+      return withDiagnostic(decision, diagnostic)
+    }
+
+    const abortCode = result?.isError === true ? result.error?.info?.code : undefined
+    const interrupted = INTERRUPTED_CODES.has(abortCode)
+    const failed = result?.isError === true || structuredFailure
+    const status = interrupted ? 'interrupted' : (failed ? 'error' : 'success')
+
+    if (status === 'success') {
+      if (!compressionEnabled || exec.parent !== undefined) return decision
+      const effectiveContent = decision.content ?? result.content
+      const content = singleText(effectiveContent)
+      if (content === undefined) return decision
+      const request = postToolRequest(
+        exec,
+        config,
+        content,
+        status,
+        contentOrigin(exec.name),
+        true,
+      )
+      const response = await runPostTool(request, exec, config)
+      if (response?.disposition !== 'applied' || typeof response.output !== 'string') {
+        return decision
+      }
+      return {
+        ...decision,
+        content: [{ type: 'text', text: response.output }],
+      }
+    }
+
+    const effectiveResult = decision.content === undefined
       ? result
       : { ...result, content: decision.content }
-    const original = singleTextContent(contentResult)
-    if (original === undefined) return withAttribution(decision, responseContext)
-
-    const candidate = await compressText(original, exec, config, shellTools)
-    if (!candidate) return withAttribution(decision, responseContext)
-
-    return {
-      ...withAttribution(decision, responseContext),
-      content: [{ type: 'text', text: candidate }],
-    }
+    const content = structuredFailure
+      ? failureText(undefined, effectiveValue)
+      : failureText(effectiveResult)
+    const request = postToolRequest(
+      exec,
+      config,
+      content,
+      status,
+      contentOrigin(exec.name),
+      false,
+    )
+    const response = await runPostTool(request, exec, config)
+    const diagnostic = response?.disposition === 'tool_error'
+      ? response.additional_context
+      : undefined
+    return withDiagnostic(decision, diagnostic)
   })
 }
 

--- a/src/tokenless/adapters/tokenless/dsh/package.json.in
+++ b/src/tokenless/adapters/tokenless/dsh/package.json.in
@@ -1,7 +1,7 @@
 {
   "name": "@anolisa/dsh-tokenless",
   "version": "@VERSION@",
-  "description": "Native DeepSeek Harness response compression for Tokenless",
+  "description": "Native DeepSeek Harness lifecycle integration for Tokenless",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/src/tokenless/tests/test-dsh-adapter.sh
+++ b/src/tokenless/tests/test-dsh-adapter.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Exercise the native dsh bundle without requiring a dsh installation.
+# Exercise the native DSH bundle without requiring a DSH installation.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -20,25 +20,31 @@ import { join } from 'node:path'
 
 const [root, tmp] = process.argv.slice(2)
 const binary = join(tmp, 'tokenless')
-const argsFile = join(tmp, 'argv.json')
+const logFile = join(tmp, 'requests.jsonl')
 const missingBinary = join(tmp, 'missing-tokenless')
 writeFileSync(
   binary,
   '#!/usr/bin/env node\n' +
-    'const { writeFileSync } = require("node:fs");\n' +
+    'const { appendFileSync } = require("node:fs");\n' +
     'process.stdin.setEncoding("utf8"); let input = "";\n' +
     'process.stdin.on("data", chunk => input += chunk);\n' +
     'process.stdin.on("end", () => {\n' +
-    '  if (process.env.TOKENLESS_TEST_ARGS) writeFileSync(process.env.TOKENLESS_TEST_ARGS, JSON.stringify(process.argv.slice(2)));\n' +
-    '  if (process.env.TOKENLESS_TEST_MODE === "fail") process.exit(7);\n' +
-    '  if (process.env.TOKENLESS_TEST_MODE === "timeout") { setTimeout(() => {}, 10000); return; }\n' +
-    '  if (process.env.TOKENLESS_TEST_MODE === "same") process.stdout.write(input);\n' +
-    '  else if (process.env.TOKENLESS_TEST_MODE === "invalid") process.stdout.write("{");\n' +
-    '  else process.stdout.write("{\\"ok\\":true}");\n' +
+    '  const request = JSON.parse(input);\n' +
+    '  appendFileSync(process.env.TOKENLESS_TEST_LOG, JSON.stringify({ argv: process.argv.slice(2), request }) + "\\n");\n' +
+    '  const mode = process.env.TOKENLESS_TEST_MODE;\n' +
+    '  if (mode === "fail") process.exit(7);\n' +
+    '  if (mode === "timeout") { setTimeout(() => {}, 10000); return; }\n' +
+    '  if (mode === "invalid") { process.stdout.write("{"); return; }\n' +
+    '  const result = mode === "applied"\n' +
+    '    ? { output: "{\\"ok\\":true}", disposition: "applied" }\n' +
+    '    : mode === "tool-error"\n' +
+    '      ? { output: request.input.content, disposition: "tool_error", additional_context: "Install the missing dependency and retry." }\n' +
+    '      : { output: request.input.content, disposition: "passthrough" };\n' +
+    '  process.stdout.write(JSON.stringify({ protocol_version: mode === "wrong-version" ? 1 : 2, operation: mode === "wrong-operation" ? "pre_tool" : "post_tool", attribution: request.attribution, result }));\n' +
     '});\n',
 )
 chmodSync(binary, 0o755)
-process.env.TOKENLESS_TEST_ARGS = argsFile
+process.env.TOKENLESS_TEST_LOG = logFile
 
 const pluginPath = join(root, 'adapters/tokenless/dsh/dist/index.js')
 const plugin = await import(`file://${pluginPath}`)
@@ -48,7 +54,8 @@ const cordisPatch = readFileSync(
 )
 assert.match(cordisPatch, /name:\s+['"]@anolisa\/dsh-tokenless['"]/)
 assert.doesNotMatch(cordisPatch, /name:\s+\.\/dist\/index\.js/)
-function register(config) {
+
+function register(config = {}) {
   let callback
   const ctx = {
     on(event, listener) {
@@ -61,387 +68,378 @@ function register(config) {
   return callback
 }
 
-const listener = register({ tokenlessBin: binary })
-assert.equal(plugin.name, 'anolisa-tokenless')
-assert.deepEqual(plugin.inject, ['tools'])
+function clearRequests() {
+  if (existsSync(logFile)) unlinkSync(logFile)
+}
 
+function requests() {
+  if (!existsSync(logFile)) return []
+  return readFileSync(logFile, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+}
+
+function success(text = '{"long":"this payload is intentionally long"}', value = { ok: true }) {
+  return {
+    isError: false,
+    value,
+    content: [{ type: 'text', text }],
+  }
+}
+
+const downstreamContext = {
+  id: 'downstream-context',
+  role: 'user',
+  content: [{ type: 'text', text: 'downstream policy context' }],
+}
 const exec = {
   name: 'api_call',
   callId: 'call-1',
   signal: new AbortController().signal,
   agent: { id: 'session-1' },
 }
-const longText = '{"long":"this payload is intentionally long"}'
-const result = (text = longText, value) => ({
-  isError: false,
-  ...(value === undefined ? {} : { value }),
-  content: [{ type: 'text', text }],
-})
-const clearArgs = () => {
-  if (existsSync(argsFile)) unlinkSync(argsFile)
-}
-const args = () => JSON.parse(readFileSync(argsFile, 'utf8'))
-const downstreamContext = {
-  id: 'downstream-context',
-  role: 'user',
-  content: [{ type: 'text', text: 'downstream policy context' }],
-}
+const listener = register({ tokenlessBin: binary })
+assert.equal(plugin.name, 'anolisa-tokenless')
+assert.deepEqual(plugin.inject, ['tools'])
 
-// A compression win must still run and compose the downstream waterfall.
-process.env.TOKENLESS_TEST_MODE = 'compress'
-clearArgs()
+// DSH contributes host facts; Core owns detection, compression, and selection.
+process.env.TOKENLESS_TEST_MODE = 'applied'
+clearRequests()
 let nextCalled = false
-const compressed = await listener(exec, result(), async () => {
+const applied = await listener(exec, success(), async () => {
   nextCalled = true
   return { kind: 'accept', additionalContexts: [downstreamContext] }
 })
 assert.equal(nextCalled, true)
-assert.equal(compressed.kind, 'accept')
-assert.deepEqual(compressed.content, [{ type: 'text', text: '{"ok":true}' }])
-assert.deepEqual(compressed.additionalContexts, [downstreamContext])
-assert.deepEqual(args(), [
-  'compress-response',
-  '--agent-id', 'dsh',
-  '--truncate-strings-at', '1048576',
-  '--truncate-arrays-at', '65536',
-  '--max-depth', '32',
-  '--session-id', 'session-1',
-  '--tool-use-id', 'call-1',
-])
+assert.deepEqual(applied.content, [{ type: 'text', text: '{"ok":true}' }])
+assert.deepEqual(applied.additionalContexts, [downstreamContext])
+assert.deepEqual(requests(), [{
+  argv: ['compress'],
+  request: {
+    protocol_version: 2,
+    operation: 'post_tool',
+    attribution: {
+      agent_id: 'dsh',
+      session_id: 'session-1',
+      tool_use_id: 'call-1',
+    },
+    input: {
+      result_kind: 'tool',
+      tool_name: 'api_call',
+      content: '{"long":"this payload is intentionally long"}',
+      status: 'success',
+      content_origin: 'api_response',
+      output_optimization: 'none',
+      capabilities: {
+        replace_output: true,
+        retrieval_available: false,
+        replace_with_text: true,
+      },
+    },
+  },
+}])
 
-// Downstream blocks and canonical-value replacements must pass through intact.
-clearArgs()
-const block = await listener(exec, result(), async () => ({
-  kind: 'block',
-  feedback: [{ type: 'text', text: 'policy blocked this result' }],
-  additionalContexts: [downstreamContext],
+// Plain text still reaches Core instead of being classified by the adapter.
+process.env.TOKENLESS_TEST_MODE = 'passthrough'
+clearRequests()
+const plainDecision = { kind: 'accept' }
+const plain = await listener(exec, success('ordinary plain text'), async () => plainDecision)
+assert.strictEqual(plain, plainDecision)
+assert.equal(requests()[0].request.input.content, 'ordinary plain text')
+
+// A downstream content projection is the model-visible input sent to Core.
+clearRequests()
+await listener(exec, success('original'), async () => ({
+  kind: 'accept',
+  content: [{ type: 'text', text: 'downstream replacement' }],
 }))
-assert.deepEqual(block, {
-  kind: 'block',
-  feedback: [{ type: 'text', text: 'policy blocked this result' }],
-  additionalContexts: [downstreamContext],
-})
-assert.equal(existsSync(argsFile), false)
+assert.equal(requests()[0].request.input.content, 'downstream replacement')
 
-const valueDecision = { kind: 'accept', value: { canonical: true }, additionalContexts: [downstreamContext] }
-const valueResult = await listener(exec, result(), async () => valueDecision)
-assert.strictEqual(valueResult, valueDecision)
-assert.equal(existsSync(argsFile), false)
-
-let mixedNextCalled = false
-const mixed = await listener(exec, {
-  isError: false,
-  content: [
-    { type: 'text', text: longText },
-    { type: 'image', attachment: { id: 'image-1' } },
-  ],
-}, async () => {
-  mixedNextCalled = true
-  return { kind: 'accept' }
-})
-assert.equal(mixedNextCalled, true)
-assert.deepEqual(mixed, { kind: 'accept' })
-
-let abortedNextCalled = false
-const aborted = await listener({
-  ...exec,
-  signal: AbortSignal.abort(),
-}, result(), async () => {
-  abortedNextCalled = true
-  return { kind: 'accept' }
-})
-assert.equal(abortedNextCalled, true)
-assert.deepEqual(aborted, { kind: 'accept' })
-
-// DSH bash exposes failures in canonical result.value, not display content.
-const bashExec = { ...exec, name: 'Bash' }
-const canonicalFailureResult = {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 1,
-    timedOut: false,
-    stdout: { text: '', truncated: false },
-    stderr: { text: 'permission denied while opening protected file', truncated: false },
-  },
-  content: [{ type: 'text', text: '```console\ncat protected\n[exit code: 1]\n```' }],
-}
-const canonicalFailure = await listener(bashExec, canonicalFailureResult, async () => ({ kind: 'accept' }))
-assert.equal(canonicalFailure.additionalContexts?.length, 1)
-assert.match(canonicalFailure.additionalContexts[0].content[0].text, /ENV_PERMISSION/)
-
-// A downstream canonical replacement is the final result. Attribution must
-// describe that replacement, never the stale result seen before next().
-clearArgs()
-const recoveredDecision = {
-  kind: 'accept',
-  value: {
-    kind: 'foreground',
-    exitCode: 0,
-    timedOut: false,
-    stdout: { text: 'recovered', truncated: false },
-    stderr: { text: '', truncated: false },
-  },
-  additionalContexts: [downstreamContext],
-}
-const recovered = await listener(bashExec, canonicalFailureResult, async () => recoveredDecision)
-assert.strictEqual(recovered, recoveredDecision)
-assert.equal(existsSync(argsFile), false)
-
-const replacementFailureDecision = {
-  kind: 'accept',
-  value: {
-    kind: 'foreground',
-    exitCode: 1,
-    timedOut: false,
-    stdout: { text: '', truncated: false },
-    stderr: { text: 'permission denied after replacement', truncated: false },
-  },
-  additionalContexts: [downstreamContext],
-}
-const replacementFailure = await listener(bashExec, result(), async () => replacementFailureDecision)
-assert.strictEqual(replacementFailure.value, replacementFailureDecision.value)
-assert.equal(replacementFailure.additionalContexts.length, 2)
-assert.strictEqual(replacementFailure.additionalContexts[0], downstreamContext)
-assert.match(replacementFailure.additionalContexts[1].content[0].text, /ENV_PERMISSION/)
-assert.equal(existsSync(argsFile), false)
-
-const zeroExit = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 0,
-    timedOut: false,
-    stdout: { text: 'permission denied in searched documentation', truncated: false },
-    stderr: { text: '', truncated: false },
-  },
-  content: [{ type: 'text', text: 'permission denied in searched documentation' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(zeroExit.additionalContexts, undefined)
-
-const timedOut = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 124,
-    timedOut: true,
-    stdout: { text: '', truncated: false },
-    stderr: { text: 'connection timed out', truncated: false },
-  },
-  content: [{ type: 'text', text: '```console\nnetwork call\n```' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(timedOut.additionalContexts?.length, 1)
-assert.match(timedOut.additionalContexts[0].content[0].text, /ENV_NETWORK/)
-
-const unclassifiedTimeout = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 124,
-    timedOut: true,
-    stdout: { text: '', truncated: false },
-    stderr: { text: 'command stopped after timeout', truncated: false },
-  },
-  content: [{ type: 'text', text: 'command stopped after timeout' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(unclassifiedTimeout.additionalContexts, undefined)
-
-const nonnumericExit = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 'N/A',
-    timedOut: false,
-    stdout: { text: '', truncated: false },
-    stderr: { text: 'permission denied appears in ordinary data', truncated: false },
-  },
-  content: [{ type: 'text', text: 'ordinary successful result' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(nonnumericExit.additionalContexts, undefined)
-
-const errorObject = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 1,
-    timedOut: false,
-    stderr: { text: '', truncated: false },
-    error: { code: 'EACCES', errno: 13 },
-  },
-  content: [{ type: 'text', text: 'command failed' }],
-}, async () => ({ kind: 'accept' }))
-assert.match(errorObject.additionalContexts[0].content[0].text, /ENV_PERMISSION/)
-
-const stdoutOnly = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 1,
-    timedOut: false,
-    stdout: { text: 'permission denied appears in command output', truncated: false },
-    stderr: { text: '', truncated: false },
-  },
-  content: [{ type: 'text', text: 'command failed' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(stdoutOnly.additionalContexts, undefined)
-
-// Successful non-shell tools own their value schema. Shell-shaped business
-// data must never be reinterpreted as a host-level execution failure.
-for (const value of [
-  {
-    kind: 'audit-record',
-    exitCode: 1,
-    stderr: { text: 'permission denied was captured in the historical record' },
-  },
-  {
-    kind: 'latency-record',
-    timedOut: true,
-    stderr: { text: 'connection timed out was the recorded outcome' },
-  },
-  {
-    kind: 'archived-result',
-    success: false,
-    error: { message: 'ENOENT: archived log no longer present' },
-  },
-]) {
-  const businessResult = await listener(exec, result(longText, value), async () => ({ kind: 'accept' }))
-  assert.equal(businessResult.additionalContexts, undefined)
-}
-
-const customShellListener = register({
-  tokenlessBin: binary,
-  shellTools: ['custom_process'],
-})
-const customShellFailure = await customShellListener({ ...exec, name: 'custom_process' }, {
-  isError: false,
-  value: {
-    exitCode: 1,
-    stderr: { text: 'permission denied', truncated: false },
-  },
-  content: [{ type: 'text', text: 'custom process failed' }],
-}, async () => ({ kind: 'accept' }))
-assert.match(customShellFailure.additionalContexts[0].content[0].text, /ENV_PERMISSION/)
-
-const successfulMatch = await listener(exec, {
-  isError: false,
-  content: [{ type: 'text', text: 'search result: permission denied' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(successfulMatch.additionalContexts, undefined)
-
-const env = await listener(exec, {
-  isError: true,
-  error: { message: 'command not found: jq' },
-  content: [{ type: 'text', text: 'command not found: jq' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(env.additionalContexts?.length, 1)
-assert.equal(env.additionalContexts[0].role, 'user')
-assert.equal(env.additionalContexts[0].source.kind, 'plugin')
-assert.match(env.additionalContexts[0].content[0].text, /ENV_DEPENDENCY_MISSING/)
-assert.equal(typeof env.additionalContexts[0].id, 'string')
-
-const dashMissing = await listener(bashExec, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 127,
-    timedOut: false,
-    stderr: { text: '/bin/sh: 1: jq: not found', truncated: false },
-    stdout: { text: '', truncated: false },
-  },
-  content: [{ type: 'text', text: '/bin/sh: 1: jq: not found' }],
-}, async () => ({ kind: 'accept' }))
-assert.match(dashMissing.additionalContexts[0].content[0].text, /ENV_DEPENDENCY_MISSING/)
-
-// Compression controls never suppress failure attribution.
-clearArgs()
-const disabledListener = register({
-  tokenlessBin: binary,
-  responseCompressionEnabled: false,
-})
-const disabledFailure = await disabledListener({ ...exec, name: 'Grep' }, {
-  isError: true,
-  error: { message: 'cannot open output for writing' },
-  content: [{ type: 'text', text: 'cannot open output for writing' }],
-}, async () => ({ kind: 'accept' }))
-assert.match(disabledFailure.additionalContexts[0].content[0].text, /ENV_PERMISSION/)
-assert.equal(existsSync(argsFile), false)
-
-// Code Mode sub-calls keep attribution but skip compression and stash writes.
-clearArgs()
-const parentFailure = await listener({ ...bashExec, parent: {} }, {
-  isError: false,
-  value: {
-    kind: 'foreground',
-    exitCode: 1,
-    timedOut: false,
-    stderr: { text: 'permission denied', truncated: false },
-    stdout: { text: '', truncated: false },
-  },
-  content: [{ type: 'text', text: 'permission denied' }],
-}, async () => ({ kind: 'accept' }))
-assert.equal(parentFailure.additionalContexts?.length, 1)
-assert.equal(existsSync(argsFile), false)
-
-// Missing binaries, non-zero exits, timeouts, and invalid/no-op output fail open.
-async function failOpen(mode, callback = listener) {
-  process.env.TOKENLESS_TEST_MODE = mode
-  clearArgs()
-  let called = false
-  const original = result()
-  const decision = await callback(exec, original, async () => {
-    called = true
-    return { kind: 'accept', content: original.content }
-  })
-  assert.equal(called, true)
-  assert.deepEqual(decision.content, original.content)
-  if (mode !== 'timeout') assert.equal(existsSync(argsFile), mode !== 'missing')
-}
-process.env.TOKENLESS_TEST_MODE = 'fail'
-await failOpen('fail')
-process.env.TOKENLESS_TEST_MODE = 'same'
-await failOpen('same')
-process.env.TOKENLESS_TEST_MODE = 'invalid'
-await failOpen('invalid')
-const timeoutListener = register({ tokenlessBin: binary, timeoutMs: 20 })
-process.env.TOKENLESS_TEST_MODE = 'timeout'
-await failOpen('timeout', timeoutListener)
-const missingListener = register({ tokenlessBin: missingBinary })
-await failOpen('missing', missingListener)
-
-// Keep the dsh taxonomy and thresholds in parity with the shared source.
-process.env.TOKENLESS_TEST_MODE = 'compress'
+// Content origin is an explicit host translation, not an adapter policy knob.
 const categories = JSON.parse(readFileSync(
   join(root, 'adapters/tokenless/common/hooks/tool_categories.json'),
   'utf8',
 ))
 for (const name of categories.layer_1_skip.tools) {
-  clearArgs()
-  await listener({ ...exec, name }, result(), async () => ({ kind: 'accept', content: result().content }))
-  assert.equal(existsSync(argsFile), false, `skip tool ${name} must not invoke tokenless`)
+  clearRequests()
+  await listener({ ...exec, name }, success(), async () => ({ kind: 'accept' }))
+  assert.equal(requests()[0].request.input.content_origin, 'file_content', name)
 }
-const shellArgs = [
-  'compress-response',
-  '--agent-id', 'dsh',
-  '--truncate-strings-at', String(categories.layer_2_shell.thresholds.truncate_strings_at),
-  '--truncate-arrays-at', String(categories.layer_2_shell.thresholds.truncate_arrays_at),
-  '--max-depth', String(categories.layer_2_shell.thresholds.max_depth),
-  '--session-id', 'session-1',
-  '--tool-use-id', 'call-1',
-]
 for (const name of categories.layer_2_shell.tools) {
-  clearArgs()
-  await listener({ ...exec, name }, result(), async () => ({ kind: 'accept', content: result().content }))
-  assert.deepEqual(args(), shellArgs, `shell tool ${name} must use shared thresholds`)
+  clearRequests()
+  await listener({ ...exec, name }, success(undefined, { exitCode: 0 }), async () => ({ kind: 'accept' }))
+  assert.equal(requests()[0].request.input.content_origin, 'command_output', name)
 }
-clearArgs()
-await listener(exec, result(), async () => ({ kind: 'accept', content: result().content }))
-assert.deepEqual(args().slice(0, 9), [
-  'compress-response',
-  '--agent-id', 'dsh',
-  '--truncate-strings-at', String(categories.layer_3_api.thresholds.truncate_strings_at),
-  '--truncate-arrays-at', String(categories.layer_3_api.thresholds.truncate_arrays_at),
-  '--max-depth', String(categories.layer_3_api.thresholds.max_depth),
-])
+clearRequests()
+await listener(exec, success(), async () => ({ kind: 'accept' }))
+assert.equal(requests()[0].request.input.content_origin, 'api_response')
 
-console.log('native dsh adapter tests passed')
+// Unsafe replacement shapes and a blocking downstream policy remain untouched.
+clearRequests()
+const block = {
+  kind: 'block',
+  feedback: [{ type: 'text', text: 'policy blocked this result' }],
+  additionalContexts: [downstreamContext],
+}
+assert.strictEqual(await listener(exec, success(), async () => block), block)
+assert.equal(requests().length, 0)
+
+const mixedDecision = { kind: 'accept' }
+assert.strictEqual(await listener(exec, {
+  isError: false,
+  value: { ok: true },
+  content: [
+    { type: 'text', text: 'text' },
+    { type: 'image', attachment: { id: 'image-1' } },
+  ],
+}, async () => mixedDecision), mixedDecision)
+assert.equal(requests().length, 0)
+
+const valueDecision = {
+  kind: 'accept',
+  value: { canonical: true },
+  additionalContexts: [downstreamContext],
+}
+assert.strictEqual(await listener(exec, success(), async () => valueDecision), valueDecision)
+assert.equal(requests().length, 0)
+
+// Raw and structured command failures delegate diagnosis to Core.
+process.env.TOKENLESS_TEST_MODE = 'tool-error'
+clearRequests()
+const rawFailure = await listener(exec, {
+  isError: true,
+  error: { message: 'command not found: jq', info: { name: 'Error', code: 'FAILED' } },
+  content: [{ type: 'text', text: 'jq could not run' }],
+}, async () => ({ kind: 'accept', additionalContexts: [downstreamContext] }))
+assert.equal(rawFailure.additionalContexts.length, 2)
+assert.strictEqual(rawFailure.additionalContexts[0], downstreamContext)
+assert.match(rawFailure.additionalContexts[1].content[0].text, /Install the missing dependency/)
+assert.equal(rawFailure.additionalContexts[1].source.plugin, 'anolisa-tokenless')
+let request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.capabilities.replace_output, false)
+assert.equal(request.input.capabilities.replace_with_text, false)
+assert.match(request.input.content, /command not found: jq/)
+
+clearRequests()
+await listener(exec, {
+  isError: true,
+  error: { message: 'generic failure' },
+  content: [{ type: 'text', text: 'stale display content' }],
+}, async () => ({
+  kind: 'accept',
+  content: [{ type: 'text', text: 'permission denied after downstream replacement' }],
+}))
+assert.match(requests()[0].request.input.content, /permission denied after downstream replacement/)
+assert.doesNotMatch(requests()[0].request.input.content, /stale display content/)
+
+const bashExec = { ...exec, name: 'Bash' }
+clearRequests()
+const commandFailure = await listener(bashExec, success('rendered command output', {
+  kind: 'foreground',
+  exitCode: 1,
+  timedOut: false,
+  stdout: { text: 'command stdout must not drive diagnosis', truncated: false },
+  stderr: { text: 'permission denied', truncated: false },
+}), async () => ({ kind: 'accept' }))
+assert.equal(commandFailure.additionalContexts.length, 1)
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.content_origin, 'command_output')
+assert.equal(request.input.content, 'permission denied')
+
+clearRequests()
+await listener(bashExec, success('permission denied\n[exit code: 1]', {
+  kind: 'foreground',
+  exitCode: 1,
+  timedOut: false,
+  stdout: { text: 'permission denied', truncated: false },
+  stderr: { text: '', truncated: false },
+}), async () => ({ kind: 'accept' }))
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.content_origin, 'command_output')
+assert.equal(request.input.capabilities.replace_output, false)
+assert.equal(request.input.content, 'permission denied')
+
+clearRequests()
+await listener(bashExec, success('(no output)\n[exit code: 1]', {
+  kind: 'foreground',
+  exitCode: 1,
+  timedOut: false,
+  stdout: { text: '', truncated: false },
+  stderr: { text: '', truncated: false },
+}), async () => ({ kind: 'accept' }))
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.content, '')
+
+const pwshExec = { ...exec, name: 'pwsh' }
+clearRequests()
+await listener(pwshExec, success('rendered PowerShell output', {
+  kind: 'foreground',
+  exitCode: 1,
+  signal: null,
+  timedOut: false,
+  stdout: { text: '', truncated: false },
+  stderr: { text: 'access denied', truncated: false },
+}), async () => ({ kind: 'accept' }))
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.content_origin, 'command_output')
+assert.equal(request.input.capabilities.replace_output, false)
+
+clearRequests()
+await listener(bashExec, success('[killed by signal: SIGTERM]', {
+  kind: 'foreground',
+  exitCode: null,
+  signal: 'SIGTERM',
+  timedOut: false,
+  stdout: { text: '', truncated: false },
+  stderr: { text: '', truncated: false },
+}), async () => ({ kind: 'accept' }))
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.content_origin, 'command_output')
+assert.equal(request.input.capabilities.replace_output, false)
+assert.equal(request.input.content, 'terminated by signal: SIGTERM')
+
+// Shell-shaped business data from an API tool remains a successful result.
+process.env.TOKENLESS_TEST_MODE = 'applied'
+clearRequests()
+const businessResult = await listener(exec, success('business record', {
+  exitCode: 1,
+  timedOut: true,
+  stderr: { text: 'archived failure text' },
+}), async () => ({ kind: 'accept' }))
+assert.deepEqual(businessResult.content, [{ type: 'text', text: '{"ok":true}' }])
+assert.equal(requests()[0].request.input.status, 'success')
+
+// A downstream command value is authoritative and can still receive guidance.
+process.env.TOKENLESS_TEST_MODE = 'tool-error'
+clearRequests()
+const replacementValue = {
+  kind: 'foreground',
+  exitCode: 1,
+  stderr: { text: 'connection refused', truncated: false },
+}
+const replacementFailure = await listener(bashExec, success(), async () => ({
+  kind: 'accept',
+  value: replacementValue,
+  additionalContexts: [downstreamContext],
+}))
+assert.strictEqual(replacementFailure.value, replacementValue)
+assert.equal(replacementFailure.additionalContexts.length, 2)
+request = requests()[0].request
+assert.equal(request.input.status, 'error')
+assert.equal(request.input.capabilities.replace_output, false)
+assert.equal(request.input.content, 'connection refused')
+
+// Let DSH validate an invalid downstream value instead of rejecting in Tokenless.
+const circularError = {}
+circularError.self = circularError
+const circularValue = {
+  kind: 'foreground',
+  exitCode: 1,
+  stderr: { text: 'permission denied', truncated: false },
+  error: circularError,
+}
+clearRequests()
+const circularFailure = await listener(bashExec, success(), async () => ({
+  kind: 'accept',
+  value: circularValue,
+}))
+assert.strictEqual(circularFailure.value, circularValue)
+assert.match(requests()[0].request.input.content, /permission denied/)
+
+// DSH cancellation is distinguished from a tool error when it reaches the seam.
+process.env.TOKENLESS_TEST_MODE = 'passthrough'
+clearRequests()
+await listener(exec, {
+  isError: true,
+  error: {
+    message: 'operation aborted',
+    info: { name: 'AbortError', code: 'ABORTED_BEFORE_DISPATCH' },
+  },
+  content: [{ type: 'text', text: 'operation aborted' }],
+}, async () => ({ kind: 'accept' }))
+assert.equal(requests()[0].request.input.status, 'interrupted')
+
+clearRequests()
+let abortedNextCalled = false
+const abortedDecision = { kind: 'accept' }
+const aborted = await listener({
+  ...exec,
+  signal: AbortSignal.abort(),
+}, success(), async () => {
+  abortedNextCalled = true
+  return abortedDecision
+})
+assert.equal(abortedNextCalled, true)
+assert.strictEqual(aborted, abortedDecision)
+assert.equal(requests().length, 0)
+
+// Code Mode child success is not replaceable, but failures still get guidance.
+clearRequests()
+const parentDecision = { kind: 'accept' }
+assert.strictEqual(await listener(
+  { ...exec, parent: {} },
+  success(),
+  async () => parentDecision,
+), parentDecision)
+assert.equal(requests().length, 0)
+
+process.env.TOKENLESS_TEST_MODE = 'tool-error'
+const parentFailure = await listener({ ...bashExec, parent: {} }, success('failed', {
+  exitCode: 1,
+  stderr: { text: 'permission denied', truncated: false },
+}), async () => ({ kind: 'accept' }))
+assert.equal(parentFailure.additionalContexts.length, 1)
+
+// Disabling compression does not disable Core-owned error diagnostics.
+const disabledListener = register({
+  tokenlessBin: binary,
+  responseCompressionEnabled: false,
+})
+clearRequests()
+assert.strictEqual(await disabledListener(exec, success(), async () => plainDecision), plainDecision)
+assert.equal(requests().length, 0)
+const disabledFailure = await disabledListener(exec, {
+  isError: true,
+  error: { message: 'permission denied' },
+  content: [{ type: 'text', text: 'permission denied' }],
+}, async () => ({ kind: 'accept' }))
+assert.equal(disabledFailure.additionalContexts.length, 1)
+
+// Missing binaries, non-zero exits, timeouts, and malformed responses fail open.
+async function failOpen(mode, callback = listener) {
+  process.env.TOKENLESS_TEST_MODE = mode
+  clearRequests()
+  const decision = { kind: 'accept', content: success().content }
+  const actual = await callback(exec, success(), async () => decision)
+  assert.strictEqual(actual, decision)
+}
+await failOpen('fail')
+await failOpen('invalid')
+await failOpen('wrong-version')
+await failOpen('wrong-operation')
+const timeoutListener = register({ tokenlessBin: binary, timeoutMs: 20 })
+await failOpen('timeout', timeoutListener)
+const missingListener = register({ tokenlessBin: missingBinary })
+await failOpen('missing', missingListener)
+assert.equal(requests().length, 0)
+
+// Attribution remains configurable without restoring compression policy knobs.
+process.env.TOKENLESS_TEST_MODE = 'passthrough'
+clearRequests()
+const attributedListener = register({ tokenlessBin: binary, agentId: 'custom-dsh' })
+await attributedListener({
+  name: 'api_call',
+  signal: new AbortController().signal,
+}, success(), async () => ({ kind: 'accept' }))
+assert.deepEqual(requests()[0].request.attribution, { agent_id: 'custom-dsh' })
+
+console.log('native DSH adapter tests passed')
 NODE


### PR DESCRIPTION
## Why

The DSH bundle still owned a parallel JSON compression and environment-diagnostic policy, so its behavior could drift from the PostTool Core used by the other adapters. This change makes DSH the final current adapter to delegate the lifecycle operations supported by its host seam.

## What changed

- Send replaceable single-text results and tool failures through the Core-owned PostTool operation while preserving DSH waterfall decisions and fail-open behavior.
- Keep only DSH status, content-origin, attribution, and projection translation in the bundle; remove local JSON parsing, thresholds, winner selection, error regexes, and compression policy options.
- Declare recovery unavailable, add DSH lifecycle contract coverage, and update the bilingual integration documentation.

## Related issue

no-issue: lifecycle architecture migration

## User / Agent impact

Eligible DSH JSON results now use the same Core cleanup and optional TOON selection as other adapters. File content and lossy candidates remain unchanged because DSH has no Marker-authorized recovery path. The skipTools, shellTools, truncateStringsAt, truncateArraysAt, maxDepth, and noStash plugin options are removed; timeout, buffer, binary path, Agent attribution, and the compression switch remain available.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The DSH bundle must be paired with a Tokenless CLI from the same lifecycle-based release. Existing profile overrides should remove the deleted policy options; Core now owns those settings. DSH does not expose BeforeModel, PreTool, or Marker-authorized Retrieve seams, so this PR intentionally migrates PostTool only.

## Validation

- node --check adapters/tokenless/dsh/dist/index.js
- bash tests/test-dsh-adapter.sh
- make test-adapters
- make test-integration
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace -- --test-threads=1
- make test-hooks with the workspace tokenless and packaged RTK on PATH
- make test-raw-package
- make test-npm-package
- make test-toon-cleanup
- Real Core smoke: DSH reduced a 2,221-character JSON result to 598 characters through tokenless compress.

## Documentation and rollback

Updated the English and Chinese Tokenless README, framework integration guide, and user manual. Roll back by reverting commit 10c1cde9 or disabling the DSH adapter; responseCompressionEnabled=false disables successful-result compression while retaining error diagnostics.