### PR TITLE
chore(anolisa): bump version to 0.3.9

### DIFF
--- a/src/anolisa/CHANGELOG.md
+++ b/src/anolisa/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-09-02
+
+### Added
+
+- Applied and failed `anolisa update self` operations now enter the central
+  operation log with their version and apply-mode context. Administrators can
+  audit them through `anolisa logs`, while generated bug reports include only
+  failed records and redact credentials from handled update URLs; previews and
+  already-current no-ops remain log-free
+  ([#2994](https://github.com/alibaba/anolisa/pull/2994)).
+
+### Changed
+
+- Newly shipped Raw repository configurations no longer advertise the unused
+  `cache_ttl_secs` and `offline_fallback` settings. Existing configurations
+  containing either field remain compatible, while Raw resolution continues
+  to fetch the current distribution index and fail when it is unavailable
+  ([#3002](https://github.com/alibaba/anolisa/pull/3002)).
+
+### Fixed
+
+- Global and command-local sandbox uninstall dry-runs now show the planned
+  package changes without applying them, while system-mode telemetry mutation
+  previews return before privilege checks or side effects
+  ([#2922](https://github.com/alibaba/anolisa/pull/2922),
+  [#2926](https://github.com/alibaba/anolisa/pull/2926)).
+- Commands without a preview implementation now reject global `--dry-run`
+  before dispatch. Sandbox remove plus kernel and security install reject both
+  dry-run forms with `INVALID_ARGUMENT` and confirm that no action was taken,
+  instead of reaching mutation, privilege, or not-implemented paths
+  ([#2952](https://github.com/alibaba/anolisa/pull/2952),
+  [#2957](https://github.com/alibaba/anolisa/pull/2957),
+  [#2961](https://github.com/alibaba/anolisa/pull/2961)).
+- The standalone installer now detects when PATH still resolves `anolisa` to
+  another installation, reports both paths and versions, and provides a
+  directly runnable PATH fix or matching npm/Homebrew removal command instead
+  of printing an unqualified success message
+  ([#2944](https://github.com/alibaba/anolisa/pull/2944)).
+
 ## [0.3.8] - 2026-08-26
 
 ### Added

--- a/src/anolisa/CHANGELOG_zh.md
+++ b/src/anolisa/CHANGELOG_zh.md
@@ -9,6 +9,42 @@
 
 ## [未发布]
 
+## [0.3.9] - 2026-09-02
+
+### 新增
+
+- 已应用和失败的 `anolisa update self` 操作现会连同版本与应用模式上下文写入
+  中央操作日志。管理员可通过 `anolisa logs` 审计这些操作；生成的 bug report
+  仅包含失败记录，并会从已处理的更新 URL 中移除 credential；preview 与已是
+  最新版本的 no-op 仍不会写入日志
+  ([#2994](https://github.com/alibaba/anolisa/pull/2994))。
+
+### 变更
+
+- 新提供的 Raw repository 配置不再声明未使用的 `cache_ttl_secs` 和
+  `offline_fallback` setting。包含任一字段的现有配置仍保持兼容；Raw resolution
+  会继续获取当前 distribution index，并在 index 不可用时失败
+  ([#3002](https://github.com/alibaba/anolisa/pull/3002))。
+
+### 修复
+
+- 全局与命令级 sandbox uninstall dry-run 现都会显示计划中的 package 变更而不
+  实际应用；system mode 的 Telemetry mutation preview 会在权限检查或产生副作用
+  前返回
+  ([#2922](https://github.com/alibaba/anolisa/pull/2922)、
+  [#2926](https://github.com/alibaba/anolisa/pull/2926))。
+- 没有 preview 实现的命令现会在 dispatch 前拒绝全局 `--dry-run`。Sandbox
+  remove、kernel install 和 security install 会以 `INVALID_ARGUMENT` 拒绝两种
+  dry-run 写法，并确认没有执行任何操作，不再进入 mutation、权限检查或
+  not-implemented 路径
+  ([#2952](https://github.com/alibaba/anolisa/pull/2952)、
+  [#2957](https://github.com/alibaba/anolisa/pull/2957)、
+  [#2961](https://github.com/alibaba/anolisa/pull/2961))。
+- 独立安装器现会检测 PATH 是否仍将 `anolisa` 解析到另一份安装，报告新旧路径
+  与版本，并提供可直接执行的 PATH 修复命令或对应的 npm/Homebrew 卸载命令，
+  不再输出无条件的成功提示
+  ([#2944](https://github.com/alibaba/anolisa/pull/2944))。
+
 ## [0.3.8] - 2026-08-26
 
 ### 新增

--- a/src/anolisa/Cargo.lock
+++ b/src/anolisa/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-build"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-core",
  "anolisa-env",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-build",
  "anolisa-core",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anolisa-env",
  "anolisa-platform",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-env"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "anolisa-platform"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs",
  "nix",

--- a/src/anolisa/Cargo.toml
+++ b/src/anolisa/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.93"

--- a/src/anolisa/anolisa.spec.in
+++ b/src/anolisa/anolisa.spec.in
@@ -143,7 +143,13 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
-* Wed Aug 26 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+* Wed Sep 02 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - @VERSION@-1
+- Dry-runs now preview supported commands and reject unsupported requests before effects.
+- Self-updates now write redacted central operation-log records.
+- Raw repository defaults no longer advertise inactive cache settings.
+- The installer now reports CLI installations shadowed by PATH.
+
+* Wed Aug 26 2026 Shangyuxin <jiawa.syx@alibaba-inc.com> - 0.3.8-1
 - GitHub releases now include verified prebuilt CLI archives for three supported targets.
 - Raw installs now preserve runtime ${VAR} references in rendered file content.
 

--- a/src/anolisa/npm/package.json
+++ b/src/anolisa/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI — Agentic OS component lifecycle manager",
   "type": "module",
   "license": "Apache-2.0",
@@ -37,8 +37,8 @@
     "darwin"
   ],
   "optionalDependencies": {
-    "@anolisa/cli-linux-x64": "0.3.8",
-    "@anolisa/cli-linux-arm64": "0.3.8",
-    "@anolisa/cli-darwin-arm64": "0.3.8"
+    "@anolisa/cli-linux-x64": "0.3.9",
+    "@anolisa/cli-linux-arm64": "0.3.9",
+    "@anolisa/cli-darwin-arm64": "0.3.9"
   }
 }

--- a/src/anolisa/npm/platforms/darwin-arm64/package.json
+++ b/src/anolisa/npm/platforms/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-darwin-arm64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for macOS arm64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-arm64/package.json
+++ b/src/anolisa/npm/platforms/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-arm64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for Linux aarch64",
   "license": "Apache-2.0",
   "repository": {

--- a/src/anolisa/npm/platforms/linux-x64/package.json
+++ b/src/anolisa/npm/platforms/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anolisa/cli-linux-x64",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ANOLISA CLI native binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Why

Publish the ANOLISA changes merged after 0.3.8 as patch release 0.3.9. This
current-main refresh supersedes the closed, unmerged #2935 attempt and includes
the complete user-visible range through #2944 and #3002.

## What changed

- Bump the Cargo workspace and lockfile package versions to 0.3.9.
- Synchronize the npm root package, three native payload templates, and RPM
  release boundary at 0.3.9.
- Add semantically equivalent English and Chinese notes for dry-run policy,
  self-update audit logging, Raw repository defaults, and shadowed installer
  detection. Behavior-preserving outcome refactors and conformance-only tests
  remain outside the changelog.

## Related issue

no-issue: consolidated release boundary for merged PRs #2922, #2926, #2944,
#2952, #2957, #2961, #2994, and #3002.

## User / Agent impact

ANOLISA 0.3.9 packages read-only supported previews and fail-closed unsupported
previews, records applied and failed self-updates in the central log with URL
credential redaction, stops advertising inactive Raw cache settings, and warns
when the standalone installer remains shadowed by another CLI on PATH. This
version-only commit adds no new runtime behavior beyond those already merged
changes.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The PR changes only version metadata and paired release notes. Existing
Raw configurations containing the removed template fields remain parseable, and
the underlying runtime changes were independently reviewed before this release
boundary.

## Validation

Linux x86_64; kernel 5.10.134; Rust/Cargo 1.93.1; Node.js 24.15.0; npm 11.12.1:

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- Release audit against the working tree and committed `HEAD`
- `git diff --check` and JSON/TOML parsing
- `node npm/scripts/package-npm.js --validate`
- `node --test npm/tests/platforms.test.js`
- `bash tests/test-package-prebuilt.sh`
- RPM template expansion with `rpmspec -P /dev/stdin`
- `cargo run --locked -q -p anolisa-cli -- --version` (`anolisa 0.3.9`)
- Built Linux x64 release packages with
  `node npm/scripts/package-npm.js --target linux-x64`; installed the root and
  platform tarballs in a temporary project and verified `anolisa 0.3.9`
- `bash website/scripts/test-install.sh` (case-only alias case skipped on this
  case-sensitive filesystem)
- `bash scripts/docs-lint.sh` and `python3 scripts/docs-link-check.py`
- `npm ci --prefix website`, `npm run build --prefix website`,
  `npm run typecheck --prefix website`, and `npm run check:links --prefix website`
- `bash -n src/anolisa/scripts/install-anolisa.sh`

The unchanged website lockfile reported 30 npm audit findings during `npm ci`
(6 moderate and 24 high); this release does not alter dependencies. Linux arm64
and macOS arm64 were template-, metadata-, and packer-validated but cannot be
executed natively on this Linux x86_64 host.

## Documentation and rollback

Updated `src/anolisa/CHANGELOG.md`, `CHANGELOG_zh.md`, and the RPM `%changelog`
with the 0.3.9 boundary. Revert commit `66a171838fafa356750def54301c89f1d72c5828`
before tagging or publication to roll back this release bump.