### PR TITLE
fix(sight): shorten SSL uprobe re-attach TTL to 30s

### DIFF
--- a/src/agentsight/AGENTS.md
+++ b/src/agentsight/AGENTS.md
@@ -269,7 +269,7 @@ React + TypeScript + Webpack + Tailwind CSS，位于 `dashboard/`。开发: `npm
 
 ## 10. Configuration
 
-`AgentsightConfig`（`src/config.rs`），关键环境变量：SLS_*（阿里云日志服务导出）、`AGENTSIGHT_TOKENIZER_PATH`、`AGENTSIGHT_CHROME_TRACE`、`RUST_LOG`、`AGENTSIGHT_SSL_REATTACH_TTL_SECS`（SSL uprobe 陈旧重挂载 TTL，默认 300 秒；用于内核静默注销 uprobe consumer 的 serverless/overlayfs 场景，如 ACS；设为 `0` 表示每次匹配进程都强制重挂载，仅供测试）。
+`AgentsightConfig`（`src/config.rs`），关键环境变量：SLS_*（阿里云日志服务导出）、`AGENTSIGHT_TOKENIZER_PATH`、`AGENTSIGHT_CHROME_TRACE`、`RUST_LOG`、`AGENTSIGHT_SSL_REATTACH_TTL_SECS`（SSL uprobe 陈旧重挂载 TTL，默认 30 秒；用于内核静默注销 uprobe consumer 的 serverless/overlayfs 场景，如 ACS；设为 `0` 表示每次匹配进程都强制重挂载，仅供测试）。
 
 ### 配置文件加载语义
 

--- a/src/agentsight/src/probes/sslsniff.rs
+++ b/src/agentsight/src/probes/sslsniff.rs
@@ -51,17 +51,33 @@ const POLL_TIMEOUT_MS: u64 = 100;
 /// without any userspace-visible error (observed on serverless/overlayfs
 /// hosts), leaving the `Link` objects alive but the probes silent. Userspace
 /// cannot query liveness, so re-attach on TTL expiry is the recovery path.
-const STALE_REATTACH_TTL: Duration = Duration::from_secs(300);
+///
+/// 300s was too coarse for short-lived processes (e.g. a `qwen -p` headless
+/// call lives for seconds): a process that execs within the window after a
+/// silent deregistration saw the stale attachment and skipped the re-attach,
+/// so its traffic was silently missed (#3034). 30s shrinks the window by 10x;
+/// the churn cost is bounded by the number of distinct SSL library inodes,
+/// not by the exec rate.
+const STALE_REATTACH_TTL: Duration = Duration::from_secs(30);
 
 /// Effective stale re-attach TTL, resolved once per `SslSniff` at
 /// construction. `AGENTSIGHT_SSL_REATTACH_TTL_SECS` overrides the default
 /// (0 forces a re-attach on every matching exec; used by tests).
-fn stale_reattach_ttl() -> Duration {
-    std::env::var("AGENTSIGHT_SSL_REATTACH_TTL_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
+/// Parse the TTL from an optional env-var string, falling back to the
+/// default on absence or parse failure. Extracted so tests never touch the
+/// process environment (which would be unsound under the parallel harness).
+fn parse_reattach_ttl(raw: Option<&str>) -> Duration {
+    raw.and_then(|v| v.parse::<u64>().ok())
         .map(Duration::from_secs)
         .unwrap_or(STALE_REATTACH_TTL)
+}
+
+fn stale_reattach_ttl() -> Duration {
+    parse_reattach_ttl(
+        std::env::var("AGENTSIGHT_SSL_REATTACH_TTL_SECS")
+            .ok()
+            .as_deref(),
+    )
 }
 
 /// Per-inode uprobe attachment state used for stale re-attach.
@@ -2022,5 +2038,19 @@ mod tests {
         with_static_ssl_fixture("rustls-absent", &img, |path| {
             assert!(find_rustls_offsets(path).is_none());
         });
+    }
+
+    /// The default re-attach TTL must cover short-lived processes (#3034).
+    /// Discriminating: reverting the constant to 300s makes this fail.
+    /// The env override must still work after the default change.
+    #[test]
+    fn stale_reattach_ttl_default_and_override() {
+        assert_eq!(parse_reattach_ttl(None), Duration::from_secs(30));
+        assert_eq!(parse_reattach_ttl(Some("60")), Duration::from_secs(60));
+        assert_eq!(parse_reattach_ttl(Some("0")), Duration::from_secs(0));
+        assert_eq!(
+            parse_reattach_ttl(Some("not-a-number")),
+            Duration::from_secs(30)
+        );
     }
 }


### PR DESCRIPTION
Shorten the stale re-attach TTL from 300s to 30s.

The kernel can silently deregister uprobe consumers on overlayfs hosts, and the 300s recovery window was too coarse for short-lived processes (a `qwen -p` headless call lives for seconds): a process that execs within the window saw the stale attachment and skipped the re-attach, so its traffic was silently missed. 30s shrinks the window by 10x; the churn cost is bounded by the number of distinct SSL library inodes, not by the exec rate.

The `AGENTSIGHT_SSL_REATTACH_TTL_SECS` env override is unchanged.

Closes #3034