### PR TITLE
feat(sec-core): add daemon service framework

### DIFF
--- a/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
@@ -215,6 +215,35 @@ operator-visible semantics 必须进入 compatibility/change record。journald �
 7. 安装、升级和不可逆 migration 由 packaging/deploy/state-migrator 所有；
 8. 不把未进入 main 的 helper、probe 或本地 chart 当作 V1 事实。
 
+### 8.1 **[TARGET V2][PARTIAL]** 当前 Rust transport bring-up
+
+`v2/apps/asc-daemon` 当前提供可执行的前台 Rust binary 和 composition bootstrap。它接受
+无子命令或显式 `serve` 两种形式，要求通过 `--socket` 提供绝对路径，安装 SIGTERM/SIGINT
+cooperative shutdown，并消费 SIGHUP 而不 reload。bootstrap 使用
+`asc-daemon-service` 完成真实 UDS bind、bounded admission、单请求 frame 读取、drain 和同
+inode socket cleanup。
+
+transport 对 frame read、application dispatch、transport rejection encode、response
+write 和 drain 分别设置显式 deadline。dispatch deadline 到期会释放 connection admission
+并向 handler 发出 cooperative cancellation，但 Rust 不能强制终止已经运行且忽略取消信号的
+blocking call。`asc-daemon` 因此显式拥有 Tokio runtime，并在 service drain 后使用额外的
+runtime shutdown timeout，避免残留 `spawn_blocking` 让前台进程永久不能退出。
+
+该 slice 尚未注册 daemon protocol 或 `daemon.health`，因此完整 request 在经过唯一的
+`RequestDispatcher` 注入点后静默关闭。此行为只用于证明 process/transport 能启动，不是
+稳定 wire contract，也不表示 application READY。后续 protocol 合并时，由同一个 concrete
+dispatcher 完成 envelope decode、request ID、trusted Principal 绑定、method allowlist 和
+response encode；PAP 只是其中一组显式注册的方法，不增加第二个 service dispatch 层。
+Busy、timeout、shutdown 等 transport failure 由独立且有短 deadline 的
+`RejectionEncoder` 投影，正常依赖图不包含 PAP、Repository 或 Compiler。
+framework 不能证明具体 PAP/Repository 内部没有全局 mutex、长 transaction 或其它共享阻塞
+点；该项必须由 PAP direct-consumer concurrency fixture 在集成时验收。
+
+当前还未实现 packaging-owned system socket 默认值、runtime directory hardening、Host
+singleton/stale-socket 判定、日志/OTel 和 health readiness。因此这一 slice 只提供
+DPROC-002/DPROC-003 的 focused source-level evidence，不能宣称 DPROC-012 至 DPROC-014 或
+production process gate 已完成。
+
 ## 9. 验收矩阵
 
 ### 9.1 **[CURRENT]** V1 oracle

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -3,6 +3,14 @@
 version = 4
 
 [[package]]
+name = "asc-daemon-service"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "asc-foundation-types"
 version = "0.1.0"
 dependencies = [
@@ -23,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,16 +52,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "powerfmt"
@@ -117,6 +154,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,10 +225,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "asc-daemon"
+version = "0.1.0"
+dependencies = [
+ "asc-daemon-service",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "asc-daemon-service"
 version = "0.1.0"
 dependencies = [
@@ -43,6 +52,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -154,6 +173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +263,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -3,6 +3,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-policy-types",
 ]
@@ -22,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 time = { version = "=0.3.44", features = ["parsing"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -3,6 +3,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "apps/asc-daemon",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-policy-types",
@@ -17,13 +18,14 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 time = { version = "=0.3.44", features = ["parsing"] }
-tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,18 +1,35 @@
-# AgentSecCore V2 foundation contracts
+# AgentSecCore V2 foundation contracts and daemon service framework
 
 This workspace slice contains the dependency-light contracts shared by later
-AgentSecCore V2 Policy and daemon work packages. It deliberately contains no
-daemon process, persistence implementation, Policy engine, PAP, Policy runtime,
-or target Adapter.
+AgentSecCore V2 Policy and daemon work packages, plus the protocol-independent
+Unix-domain-socket service framework. It deliberately contains no daemon binary,
+daemon wire protocol, persistence implementation, Policy engine, PAP, Policy
+runtime, or target Adapter.
 
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
 - `asc-policy-types`: authored Policy, prepared Policy/Scope/Binding,
   backend-independent IR, and target Adapter contracts.
+- `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
+  credentials, dispatcher injection, connection isolation, and controlled drain.
 
-Daemon protocol, client, process, persistence, and Policy runtime crates belong
-to later work packages and are intentionally absent from this foundation slice.
+`asc-daemon-service` is a `PARTIAL_MIGRATION` work package. It preserves the V1
+one-request-per-connection LF/EOF framing, bounded first-frame read, bounded
+connection admission, and socket ownership cleanup, while leaving all response
+encoding to an injected dispatcher. Its acceptance type is current-version
+contract testing with socket bytes and a fake dispatcher. The V1 Python daemon is
+discovery evidence only and is not linked or executed by the Rust runtime.
+
+The service framework does not deserialize a daemon request, generate protocol
+request IDs, choose authorization roles, or render protocol errors. The later
+protocol adapter receives either a bounded raw request frame or a typed service
+rejection and owns those decisions. The later `asc-daemon` composition root owns
+signals, singleton/stale-socket policy, system paths, concrete adapters,
+readiness, and process observability.
+
+Daemon protocol, client, binary/bootstrap, persistence, and Policy runtime crates
+belong to later work packages and are intentionally absent from this slice.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,10 +1,10 @@
-# AgentSecCore V2 foundation contracts and daemon service framework
+# AgentSecCore V2 foundation contracts and daemon service bring-up
 
 This workspace slice contains the dependency-light contracts shared by later
 AgentSecCore V2 Policy and daemon work packages, plus the protocol-independent
-Unix-domain-socket service framework. It deliberately contains no daemon binary,
-daemon wire protocol, persistence implementation, Policy engine, PAP, Policy
-runtime, or target Adapter.
+Unix-domain-socket service framework and a runnable foreground process bootstrap.
+It deliberately contains no daemon wire protocol, persistence implementation,
+Policy engine, PAP, Policy runtime, or target Adapter.
 
 The current crates are:
 
@@ -12,24 +12,55 @@ The current crates are:
 - `asc-policy-types`: authored Policy, prepared Policy/Scope/Binding,
   backend-independent IR, and target Adapter contracts.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
-  credentials, dispatcher injection, connection isolation, and controlled drain.
+  credentials, dispatcher/rejection-encoder injection, connection isolation,
+  dispatch cancellation, and controlled drain.
+- `asc-daemon`: foreground process/bootstrap that installs Unix signal handling,
+  selects explicit transport limits, binds an explicitly supplied socket, and
+  runs `asc-daemon-service`.
 
 `asc-daemon-service` is a `PARTIAL_MIGRATION` work package. It preserves the V1
 one-request-per-connection LF/EOF framing, bounded first-frame read, bounded
-connection admission, and socket ownership cleanup, while leaving all response
-encoding to an injected dispatcher. Its acceptance type is current-version
-contract testing with socket bytes and a fake dispatcher. The V1 Python daemon is
-discovery evidence only and is not linked or executed by the Rust runtime.
+connection admission, and socket ownership cleanup. Normal response encoding
+belongs to an injected dispatcher; transport rejection encoding belongs to a
+separate protocol-only port. Its acceptance type is current-version contract
+testing with socket bytes and fake handlers. The V1 Python daemon is discovery
+evidence only and is not linked or executed by the Rust runtime.
 
 The service framework does not deserialize a daemon request, generate protocol
-request IDs, choose authorization roles, or render protocol errors. The later
-protocol adapter receives either a bounded raw request frame or a typed service
-rejection and owns those decisions. The later `asc-daemon` composition root owns
-signals, singleton/stale-socket policy, system paths, concrete adapters,
-readiness, and process observability.
+request IDs, choose authorization roles, or render protocol errors. The concrete
+dispatcher receives a bounded raw request frame and owns method routing. Method
+allowlist routing is internal to that one dispatcher implementation; it is not a
+second service dispatch layer. A separate `RejectionEncoder` receives typed
+transport failures and must remain independent of PAP/Repository state.
 
-Daemon protocol, client, binary/bootstrap, persistence, and Policy runtime crates
-belong to later work packages and are intentionally absent from this slice.
+The current bootstrap bounds frame read, application dispatch, rejection
+encoding, response write, connection drain, and final Tokio runtime shutdown.
+Dispatch timeout releases transport capacity and signals cooperative cancellation;
+it cannot forcibly stop an application blocking call that ignores that signal.
+The framework also cannot prove that a concrete PAP/Repository avoids global
+locks; that remains a required direct-consumer concurrency test at integration.
+
+The current `asc-daemon` executable deliberately registers no wire methods. It
+can start and exercise the real UDS lifecycle, but it closes complete requests
+without a response until the daemon protocol is merged. Socket presence therefore
+does not mean application readiness. It also requires an explicit absolute socket
+path because packaging-owned system paths, singleton/stale-socket policy, runtime
+directory hardening, and readiness remain later process-integration work.
+
+Run the independent transport process in the foreground:
+
+```bash
+cargo run -p asc-daemon -- serve --socket /absolute/existing-directory/daemon.sock
+```
+
+After protocol integration, the existing daemon handler should implement
+`RequestDispatcher` directly and be injected by this bootstrap. A small
+protocol-only error encoder implements `RejectionEncoder`. PAP becomes one
+registered method family inside the dispatcher; the service framework and
+rejection path remain independent of PAP, its compiler, and its repository.
+
+Daemon protocol, client, persistence, and Policy runtime crates belong to later
+work packages and are intentionally absent from this slice.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
+++ b/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "asc-daemon"
+description = "AgentSecCore V2 daemon process and composition root"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-daemon-service = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/bootstrap.rs
@@ -1,0 +1,130 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use asc_daemon_service::{
+    BindError, BoundUnixSocket, ConfigError, DispatchError, DispatchRequest, RejectedRequest,
+    RejectionEncoder, RequestDispatcher, ResponseDisposition, ServeError, ServeReport,
+    ServiceConfig, ShutdownToken, UnixService,
+};
+
+const DEFAULT_MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+const DEFAULT_MAX_CONNECTIONS: usize = 64;
+const DEFAULT_MAX_REJECTION_CONNECTIONS: usize = 8;
+const DEFAULT_REJECTION_ENCODE_TIMEOUT: Duration = Duration::from_millis(250);
+const DEFAULT_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_DISPATCH_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_RESPONSE_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+const DEFAULT_ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(50);
+const DEFAULT_SOCKET_MODE: u32 = 0o600;
+
+/// Process-owned inputs needed to bind and run the transport service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapConfig {
+    /// Absolute path selected by deployment or an explicit development invocation.
+    pub socket_path: PathBuf,
+    /// Filesystem mode applied after binding the socket.
+    pub socket_mode: u32,
+    /// Bounded transport limits owned by the composition root.
+    pub service: ServiceConfig,
+}
+
+impl BootstrapConfig {
+    /// Creates a bootstrap configuration using the current transport bring-up limits.
+    pub fn new(socket_path: impl Into<PathBuf>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            socket_mode: DEFAULT_SOCKET_MODE,
+            service: default_service_config(),
+        }
+    }
+}
+
+/// Returns the explicit transport limits used by the runnable daemon bootstrap.
+pub const fn default_service_config() -> ServiceConfig {
+    ServiceConfig {
+        max_request_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+        max_response_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+        max_connections: DEFAULT_MAX_CONNECTIONS,
+        max_rejection_connections: DEFAULT_MAX_REJECTION_CONNECTIONS,
+        rejection_encode_timeout: DEFAULT_REJECTION_ENCODE_TIMEOUT,
+        request_read_timeout: DEFAULT_REQUEST_READ_TIMEOUT,
+        dispatch_timeout: DEFAULT_DISPATCH_TIMEOUT,
+        response_write_timeout: DEFAULT_RESPONSE_WRITE_TIMEOUT,
+        drain_timeout: DEFAULT_DRAIN_TIMEOUT,
+        accept_error_backoff: DEFAULT_ACCEPT_ERROR_BACKOFF,
+    }
+}
+
+/// Binds the configured UDS endpoint with application dispatch and rejection encoding.
+///
+/// The caller owns process signals, runtime-directory validation, singleton and
+/// stale-socket policy. Those policies require their own deployment acceptance
+/// before a packaging default socket path can be selected.
+///
+/// # Errors
+/// Returns a stable bootstrap error when binding, configuration validation,
+/// serving, or owned-socket cleanup fails.
+pub async fn serve(
+    config: BootstrapConfig,
+    dispatcher: Arc<dyn RequestDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+    shutdown: ShutdownToken,
+) -> Result<ServeReport, BootstrapError> {
+    let socket = BoundUnixSocket::bind(&config.socket_path, config.socket_mode)?;
+    let service = UnixService::new(socket, config.service, dispatcher, rejection_encoder)?;
+    Ok(service.serve(shutdown).await?)
+}
+
+/// Runs the transport before any daemon protocol methods have been registered.
+///
+/// Connections are admitted and bounded normally, but complete request frames
+/// are closed without a response. This is transport bring-up, not daemon
+/// readiness; no temporary wire response is invented before protocol merge.
+///
+/// # Errors
+/// Returns the same bootstrap failures as [`serve`].
+pub async fn serve_without_handlers(
+    config: BootstrapConfig,
+    shutdown: ShutdownToken,
+) -> Result<ServeReport, BootstrapError> {
+    let handlers = Arc::new(NoRegisteredMethods);
+    serve(config, handlers.clone(), handlers, shutdown).await
+}
+
+struct NoRegisteredMethods;
+
+impl RequestDispatcher for NoRegisteredMethods {
+    fn dispatch(
+        &self,
+        _request: DispatchRequest,
+        _response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        Ok(ResponseDisposition::Close)
+    }
+}
+
+impl RejectionEncoder for NoRegisteredMethods {
+    fn encode_rejection(
+        &self,
+        _request: RejectedRequest,
+        _response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        Ok(ResponseDisposition::Close)
+    }
+}
+
+/// Failure to start or run the daemon transport.
+#[derive(Debug, thiserror::Error)]
+pub enum BootstrapError {
+    /// The configured Unix socket could not be bound safely.
+    #[error("daemon socket bind failed")]
+    Bind(#[from] BindError),
+    /// One or more service resource bounds were invalid.
+    #[error("daemon service configuration is invalid")]
+    Config(#[from] ConfigError),
+    /// The listener or owned socket cleanup failed.
+    #[error("daemon service failed")]
+    Serve(#[from] ServeError),
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
@@ -1,0 +1,138 @@
+use std::ffi::{OsStr, OsString};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use crate::BootstrapConfig;
+
+const HELP: &str = "Usage: asc-daemon [serve] --socket <ABSOLUTE_PATH>\n\
+\n\
+Runs the protocol-independent AgentSecCore V2 UDS service.\n\
+This bring-up binary has no registered daemon methods yet.\n";
+
+/// Parsed command-line configuration for the daemon process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cli {
+    /// Bootstrap configuration selected by the explicit process invocation.
+    pub bootstrap: BootstrapConfig,
+}
+
+/// Successful command-line parse outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseOutcome {
+    /// Run the foreground daemon service.
+    Serve(Cli),
+    /// Print help without starting the service.
+    Help(&'static str),
+}
+
+impl Cli {
+    /// Parses an argv sequence including the binary name.
+    ///
+    /// Both `asc-daemon --socket ...` and `asc-daemon serve --socket ...` are
+    /// accepted so the foreground entrypoint can be exercised independently
+    /// without selecting a packaging-owned default path.
+    ///
+    /// # Errors
+    /// Returns a stable parse error for a missing value, unknown option, repeated
+    /// socket, non-Unicode option, or absent socket path.
+    pub fn parse_from<I, T>(arguments: I) -> Result<ParseOutcome, CliError>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString>,
+    {
+        let mut arguments = arguments.into_iter().map(Into::into);
+        let _program = arguments.next();
+        let mut socket_path = None;
+        let mut command_seen = false;
+
+        while let Some(argument) = arguments.next() {
+            if argument == OsStr::new("--help") || argument == OsStr::new("-h") {
+                return Ok(ParseOutcome::Help(HELP));
+            }
+            if argument == OsStr::new("serve") && !command_seen && socket_path.is_none() {
+                command_seen = true;
+                continue;
+            }
+            if argument == OsStr::new("--socket") {
+                if socket_path.is_some() {
+                    return Err(CliError::RepeatedSocket);
+                }
+                let value = arguments.next().ok_or(CliError::MissingSocketValue)?;
+                if value.is_empty() {
+                    return Err(CliError::MissingSocketValue);
+                }
+                socket_path = Some(PathBuf::from(value));
+                continue;
+            }
+
+            let mut rendered = String::new();
+            write!(&mut rendered, "{}", argument.to_string_lossy())
+                .expect("writing into a String cannot fail");
+            return Err(CliError::UnknownArgument(rendered));
+        }
+
+        let socket_path = socket_path.ok_or(CliError::MissingSocket)?;
+        if !socket_path.is_absolute() {
+            return Err(CliError::RelativeSocket);
+        }
+        Ok(ParseOutcome::Serve(Self {
+            bootstrap: BootstrapConfig::new(socket_path),
+        }))
+    }
+}
+
+/// Invalid daemon command-line input.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CliError {
+    /// A socket path is required until packaging freezes a system-owned default.
+    #[error("--socket <ABSOLUTE_PATH> is required")]
+    MissingSocket,
+    /// `--socket` was not followed by a value.
+    #[error("--socket requires a value")]
+    MissingSocketValue,
+    /// Supplying multiple socket paths is ambiguous.
+    #[error("--socket may be specified only once")]
+    RepeatedSocket,
+    /// The service framework rejects relative daemon endpoints.
+    #[error("--socket must be an absolute path")]
+    RelativeSocket,
+    /// The current independent bootstrap has no other process options.
+    #[error("unknown argument: {0}")]
+    UnknownArgument(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_subcommand_and_serve_select_the_same_foreground_process() {
+        let direct = Cli::parse_from(["asc-daemon", "--socket", "/run/asc/daemon.sock"]);
+        let explicit = Cli::parse_from(["asc-daemon", "serve", "--socket", "/run/asc/daemon.sock"]);
+
+        assert_eq!(direct, explicit);
+        assert!(matches!(direct, Ok(ParseOutcome::Serve(_))));
+    }
+
+    #[test]
+    fn socket_is_explicit_absolute_and_unambiguous() {
+        assert_eq!(
+            Cli::parse_from(["asc-daemon"]),
+            Err(CliError::MissingSocket)
+        );
+        assert_eq!(
+            Cli::parse_from(["asc-daemon", "--socket", "daemon.sock"]),
+            Err(CliError::RelativeSocket)
+        );
+        assert_eq!(
+            Cli::parse_from([
+                "asc-daemon",
+                "--socket",
+                "/run/one.sock",
+                "--socket",
+                "/run/two.sock",
+            ]),
+            Err(CliError::RepeatedSocket)
+        );
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/lib.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/lib.rs
@@ -1,0 +1,20 @@
+//! Process bootstrap for the `AgentSecCore` V2 daemon.
+//!
+//! This independent service-framework slice deliberately has no registered wire
+//! methods. It can bind and serve the UDS transport; the later protocol
+//! integration supplies the concrete request dispatcher used by the same
+//! bootstrap.
+
+#![forbid(unsafe_code)]
+
+mod bootstrap;
+mod cli;
+mod runtime;
+mod signals;
+
+pub use bootstrap::{
+    BootstrapConfig, BootstrapError, default_service_config, serve, serve_without_handlers,
+};
+pub use cli::{Cli, CliError, ParseOutcome};
+pub use runtime::{RuntimeError, run_with_shutdown_timeout};
+pub use signals::{ProcessSignals, SignalError};

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
@@ -1,0 +1,65 @@
+use std::process::ExitCode;
+use std::time::Duration;
+
+use asc_daemon::{
+    Cli, ParseOutcome, ProcessSignals, run_with_shutdown_timeout, serve_without_handlers,
+};
+use asc_daemon_service::ShutdownToken;
+
+const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+fn main() -> ExitCode {
+    match run_with_shutdown_timeout(run(), RUNTIME_SHUTDOWN_TIMEOUT) {
+        Ok(exit_code) => exit_code,
+        Err(problem) => {
+            report_error(&problem);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> ExitCode {
+    let outcome = match Cli::parse_from(std::env::args_os()) {
+        Ok(outcome) => outcome,
+        Err(problem) => {
+            eprintln!("asc-daemon: {problem}");
+            return ExitCode::from(2);
+        }
+    };
+    let ParseOutcome::Serve(cli) = outcome else {
+        let ParseOutcome::Help(help) = outcome else {
+            unreachable!("all parse outcomes are covered")
+        };
+        print!("{help}");
+        return ExitCode::SUCCESS;
+    };
+
+    let signals = match ProcessSignals::install() {
+        Ok(signals) => signals,
+        Err(problem) => {
+            eprintln!("asc-daemon: {problem}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let shutdown = ShutdownToken::new();
+    let signal_task = tokio::spawn(signals.request_shutdown(shutdown.clone()));
+    let result = serve_without_handlers(cli.bootstrap, shutdown).await;
+    signal_task.abort();
+
+    match result {
+        Ok(_) => ExitCode::SUCCESS,
+        Err(problem) => {
+            report_error(&problem);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn report_error(problem: &dyn std::error::Error) {
+    eprintln!("asc-daemon: {problem}");
+    let mut source = problem.source();
+    while let Some(cause) = source {
+        eprintln!("  caused by: {cause}");
+        source = cause.source();
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/runtime.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/runtime.rs
@@ -1,0 +1,85 @@
+use std::future::Future;
+use std::io;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::time::Duration;
+
+use tokio::runtime::Builder;
+
+/// Runs the daemon future on an explicitly owned Tokio runtime.
+///
+/// Runtime shutdown waits only for `shutdown_timeout`, so an application bug in
+/// an already-started blocking task cannot keep the foreground daemon process
+/// alive forever after service drain has completed. Tokio cannot cancel that
+/// blocking task; this is a process-exit safety net, not request cancellation.
+///
+/// # Errors
+/// Returns an error when the multi-thread runtime cannot be constructed.
+pub fn run_with_shutdown_timeout<F>(
+    future: F,
+    shutdown_timeout: Duration,
+) -> Result<F::Output, RuntimeError>
+where
+    F: Future,
+{
+    let runtime = Builder::new_multi_thread().enable_all().build()?;
+    let outcome = catch_unwind(AssertUnwindSafe(|| runtime.block_on(future)));
+    runtime.shutdown_timeout(shutdown_timeout);
+    match outcome {
+        Ok(output) => Ok(output),
+        Err(panic) => resume_unwind(panic),
+    }
+}
+
+/// Failure to construct the daemon's asynchronous runtime.
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeError {
+    /// Tokio could not create its worker or driver resources.
+    #[error("daemon runtime could not be created")]
+    Create(#[from] io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Condvar, Mutex, mpsc};
+    use std::time::Instant;
+
+    use super::*;
+
+    #[test]
+    fn runtime_shutdown_is_bounded_when_a_blocking_task_does_not_finish() {
+        let started = Arc::new(AtomicBool::new(false));
+        let blocking_started = Arc::clone(&started);
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let blocking_gate = Arc::clone(&gate);
+        let (finished_sender, finished_receiver) = mpsc::channel();
+        let before = Instant::now();
+
+        run_with_shutdown_timeout(
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    blocking_started.store(true, Ordering::Release);
+                    let (lock, ready) = &*blocking_gate;
+                    let mut released = lock.lock().unwrap();
+                    while !*released {
+                        released = ready.wait(released).unwrap();
+                    }
+                    finished_sender.send(()).unwrap();
+                });
+                while !started.load(Ordering::Acquire) {
+                    tokio::task::yield_now().await;
+                }
+            },
+            Duration::from_millis(25),
+        )
+        .unwrap();
+
+        assert!(before.elapsed() < Duration::from_millis(500));
+        let (lock, ready) = &*gate;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
+        finished_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/signals.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/signals.rs
@@ -1,0 +1,54 @@
+use std::io;
+
+use asc_daemon_service::ShutdownToken;
+use tokio::signal::unix::{Signal, SignalKind, signal};
+
+/// Installed process signal streams for cooperative foreground shutdown.
+pub struct ProcessSignals {
+    terminate: Signal,
+    interrupt: Signal,
+    hangup: Signal,
+}
+
+impl ProcessSignals {
+    /// Installs SIGTERM, SIGINT, and SIGHUP streams before the socket is bound.
+    ///
+    /// # Errors
+    /// Returns an installation error before any service resource is acquired.
+    pub fn install() -> Result<Self, SignalError> {
+        Ok(Self {
+            terminate: signal(SignalKind::terminate()).map_err(SignalError::Install)?,
+            interrupt: signal(SignalKind::interrupt()).map_err(SignalError::Install)?,
+            hangup: signal(SignalKind::hangup()).map_err(SignalError::Install)?,
+        })
+    }
+
+    /// Waits for SIGTERM or SIGINT and requests the shared service shutdown.
+    ///
+    /// SIGHUP is deliberately consumed without changing configuration or process
+    /// state, preserving the current no-reload lifecycle behavior.
+    pub async fn request_shutdown(mut self, shutdown: ShutdownToken) {
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.terminate.recv() => {
+                    shutdown.request();
+                    return;
+                }
+                _ = self.interrupt.recv() => {
+                    shutdown.request();
+                    return;
+                }
+                _ = self.hangup.recv() => {}
+            }
+        }
+    }
+}
+
+/// Failure to install a required Unix signal stream.
+#[derive(Debug, thiserror::Error)]
+pub enum SignalError {
+    /// Tokio could not register a process signal listener.
+    #[error("daemon signal handler installation failed")]
+    Install(#[source] io::Error),
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
@@ -1,0 +1,123 @@
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use asc_daemon::{BootstrapConfig, serve_without_handlers};
+use asc_daemon_service::ShutdownToken;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::UnixStream;
+
+static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+struct RunningBinary {
+    child: Child,
+    directory: PathBuf,
+    socket_path: PathBuf,
+}
+
+impl Drop for RunningBinary {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        if self.socket_path.exists() {
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+        let _ = std::fs::remove_dir(&self.directory);
+    }
+}
+
+fn unique_directory() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "asc-daemon-bootstrap-{}-{}",
+        std::process::id(),
+        DIRECTORY_ID.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+async fn wait_for_socket(path: &Path) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !path.exists() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("daemon bootstrap should bind its socket");
+}
+
+async fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                return status;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("SIGTERM should stop the foreground daemon")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bootstrap_serves_transport_without_methods_and_cleans_up() {
+    let directory = unique_directory();
+    std::fs::create_dir(&directory).unwrap();
+    let socket_path = directory.join("daemon.sock");
+    let shutdown = ShutdownToken::new();
+    let service_shutdown = shutdown.clone();
+    let config = BootstrapConfig::new(&socket_path);
+    let service =
+        tokio::spawn(async move { serve_without_handlers(config, service_shutdown).await });
+
+    wait_for_socket(&socket_path).await;
+    let mut stream = UnixStream::connect(&socket_path).await.unwrap();
+    stream.write_all(b"unregistered request\n").await.unwrap();
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(response.is_empty());
+
+    shutdown.request();
+    let report = service.await.unwrap().unwrap();
+    assert_eq!(report.accepted_connections, 1);
+    assert_eq!(report.dispatched_requests, 1);
+    assert_eq!(report.silently_closed_connections, 1);
+    assert!(!socket_path.exists());
+    std::fs::remove_dir(directory).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn binary_starts_in_foreground_and_sigterm_cleans_its_socket() {
+    let directory = unique_directory();
+    std::fs::create_dir(&directory).unwrap();
+    let socket_path = directory.join("daemon.sock");
+    let child = Command::new(env!("CARGO_BIN_EXE_asc-daemon"))
+        .args(["serve", "--socket"])
+        .arg(&socket_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut running = RunningBinary {
+        child,
+        directory,
+        socket_path,
+    };
+
+    wait_for_socket(&running.socket_path).await;
+    let signal = Command::new("/bin/kill")
+        .arg("-TERM")
+        .arg(running.child.id().to_string())
+        .status()
+        .unwrap();
+    assert!(signal.success());
+    let status = wait_for_exit(&mut running.child).await;
+
+    assert!(status.success());
+    assert!(!running.socket_path.exists());
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "asc-daemon-service"
+description = "Protocol-independent UDS service framework for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/config.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/config.rs
@@ -1,0 +1,150 @@
+use std::time::Duration;
+
+/// Explicit transport limits supplied by the future daemon composition root.
+///
+/// This type intentionally has no `Default`: limits and timeouts are part of the
+/// externally reviewed process/protocol configuration rather than library-owned
+/// product defaults.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceConfig {
+    /// Maximum request wire-frame bytes, including an LF delimiter when present.
+    pub max_request_frame_bytes: usize,
+    /// Maximum response wire-frame bytes, including the LF delimiter.
+    pub max_response_frame_bytes: usize,
+    /// Maximum requests admitted for concurrent frame read or dispatch.
+    pub max_connections: usize,
+    /// Maximum overload/shutdown rejection responses served concurrently.
+    pub max_rejection_connections: usize,
+    /// Maximum time allowed for protocol-only transport rejection encoding.
+    pub rejection_encode_timeout: Duration,
+    /// Whole-frame deadline starting immediately after accept.
+    pub request_read_timeout: Duration,
+    /// Maximum time the transport waits for one application dispatch.
+    ///
+    /// Expiration releases the connection permit and requests cooperative
+    /// cancellation. It cannot forcibly stop an already running blocking call.
+    pub dispatch_timeout: Duration,
+    /// Whole-response write deadline.
+    pub response_write_timeout: Duration,
+    /// Maximum graceful wait for admitted connection tasks during shutdown.
+    pub drain_timeout: Duration,
+    /// Backoff after an accept error before the listener is retried.
+    pub accept_error_backoff: Duration,
+}
+
+impl ServiceConfig {
+    /// Validates that all resource bounds are usable and non-zero.
+    ///
+    /// # Errors
+    /// Returns a stable configuration error for a zero bound or timeout.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.max_request_frame_bytes == 0 {
+            return Err(ConfigError::ZeroRequestFrameLimit);
+        }
+        if self.max_response_frame_bytes < 2 {
+            return Err(ConfigError::ResponseFrameLimitTooSmall);
+        }
+        if self.max_connections == 0 {
+            return Err(ConfigError::ZeroConnectionLimit);
+        }
+        if self.max_rejection_connections == 0 {
+            return Err(ConfigError::ZeroRejectionLimit);
+        }
+        if self.rejection_encode_timeout.is_zero() {
+            return Err(ConfigError::ZeroRejectionEncodeTimeout);
+        }
+        if self.request_read_timeout.is_zero() {
+            return Err(ConfigError::ZeroReadTimeout);
+        }
+        if self.dispatch_timeout.is_zero() {
+            return Err(ConfigError::ZeroDispatchTimeout);
+        }
+        if self.response_write_timeout.is_zero() {
+            return Err(ConfigError::ZeroWriteTimeout);
+        }
+        if self.drain_timeout.is_zero() {
+            return Err(ConfigError::ZeroDrainTimeout);
+        }
+        if self.accept_error_backoff.is_zero() {
+            return Err(ConfigError::ZeroAcceptBackoff);
+        }
+        Ok(())
+    }
+}
+
+/// Invalid service-framework configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ConfigError {
+    /// The request frame limit cannot admit any bytes.
+    #[error("request frame limit must be positive")]
+    ZeroRequestFrameLimit,
+    /// A response needs at least one payload byte and one LF delimiter.
+    #[error("response frame limit must be at least two bytes")]
+    ResponseFrameLimitTooSmall,
+    /// No normal connection could be admitted.
+    #[error("connection limit must be positive")]
+    ZeroConnectionLimit,
+    /// No bounded rejection response could be admitted.
+    #[error("rejection connection limit must be positive")]
+    ZeroRejectionLimit,
+    /// A zero rejection deadline could never encode a transport error.
+    #[error("rejection encoding timeout must be positive")]
+    ZeroRejectionEncodeTimeout,
+    /// A zero read deadline would reject every connection.
+    #[error("request read timeout must be positive")]
+    ZeroReadTimeout,
+    /// A zero dispatch deadline would reject every complete request.
+    #[error("request dispatch timeout must be positive")]
+    ZeroDispatchTimeout,
+    /// A zero write deadline would reject every response.
+    #[error("response write timeout must be positive")]
+    ZeroWriteTimeout,
+    /// A zero drain deadline would never allow graceful completion.
+    #[error("drain timeout must be positive")]
+    ZeroDrainTimeout,
+    /// A zero accept backoff could spin on repeated listener errors.
+    #[error("accept error backoff must be positive")]
+    ZeroAcceptBackoff,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> ServiceConfig {
+        ServiceConfig {
+            max_request_frame_bytes: 1024,
+            max_response_frame_bytes: 1024,
+            max_connections: 4,
+            max_rejection_connections: 2,
+            rejection_encode_timeout: Duration::from_millis(250),
+            request_read_timeout: Duration::from_secs(1),
+            dispatch_timeout: Duration::from_secs(1),
+            response_write_timeout: Duration::from_secs(1),
+            drain_timeout: Duration::from_secs(1),
+            accept_error_backoff: Duration::from_millis(10),
+        }
+    }
+
+    #[test]
+    fn explicit_config_rejects_zero_resource_bounds() {
+        let mut config = valid_config();
+        config.max_connections = 0;
+        assert_eq!(config.validate(), Err(ConfigError::ZeroConnectionLimit));
+
+        config = valid_config();
+        config.rejection_encode_timeout = Duration::ZERO;
+        assert_eq!(
+            config.validate(),
+            Err(ConfigError::ZeroRejectionEncodeTimeout)
+        );
+
+        config = valid_config();
+        config.request_read_timeout = Duration::ZERO;
+        assert_eq!(config.validate(), Err(ConfigError::ZeroReadTimeout));
+
+        config = valid_config();
+        config.dispatch_timeout = Duration::ZERO;
+        assert_eq!(config.validate(), Err(ConfigError::ZeroDispatchTimeout));
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/dispatcher.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/dispatcher.rs
@@ -1,0 +1,166 @@
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+/// Kernel-reported identity of the process connected to the Unix socket.
+///
+/// This is transport evidence, not an authorization role. A later daemon
+/// adapter binds it to server-owned authentication and authorization policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PeerCredentials {
+    uid: u32,
+    gid: u32,
+    pid: u32,
+}
+
+impl PeerCredentials {
+    pub(crate) const fn new(uid: u32, gid: u32, pid: u32) -> Self {
+        Self { uid, gid, pid }
+    }
+
+    /// Returns the kernel-reported effective user ID.
+    pub const fn uid(self) -> u32 {
+        self.uid
+    }
+
+    /// Returns the kernel-reported effective group ID.
+    pub const fn gid(self) -> u32 {
+        self.gid
+    }
+
+    /// Returns the kernel-reported process ID.
+    pub const fn pid(self) -> u32 {
+        self.pid
+    }
+}
+
+/// Cooperative lifetime control for one application dispatch.
+///
+/// The service requests cancellation when the dispatch deadline expires, the
+/// connection task is aborted during shutdown, or the request otherwise leaves
+/// the service-owned dispatch lifetime. Blocking application code must check
+/// this signal around interruptible work; Rust cannot forcibly stop a running
+/// blocking thread safely.
+#[derive(Debug, Clone)]
+pub struct DispatchControl {
+    cancelled: Arc<AtomicBool>,
+    deadline: Instant,
+}
+
+impl DispatchControl {
+    pub(crate) fn new(deadline: Instant) -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+            deadline,
+        }
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    /// Returns whether the service has ended this request's dispatch lifetime.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Returns the transport-owned hard dispatch deadline.
+    pub const fn deadline(&self) -> Instant {
+        self.deadline
+    }
+}
+
+/// One bounded request frame and its trusted transport peer.
+#[derive(Debug, Clone)]
+pub struct DispatchRequest {
+    /// Kernel-reported peer credentials captured before request decoding.
+    pub peer: PeerCredentials,
+    /// Request payload without the optional LF wire delimiter.
+    pub payload: Vec<u8>,
+    /// Deadline and cooperative cancellation signal for application dispatch.
+    pub control: DispatchControl,
+}
+
+/// A connection rejected before normal protocol dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RejectedRequest {
+    /// Kernel-reported peer credentials when credential extraction succeeded.
+    pub peer: PeerCredentials,
+    /// Transport-owned reason that the request could not be dispatched.
+    pub reason: RejectionReason,
+}
+
+/// Protocol-independent reason for rejecting a connection or response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionReason {
+    /// The bounded normal-connection admission limit was reached.
+    Busy,
+    /// Shutdown began before the accepted connection could be admitted.
+    ShuttingDown,
+    /// The first request frame did not complete within the configured deadline.
+    RequestReadTimeout,
+    /// The first request frame exceeded its configured wire limit.
+    RequestFrameTooLarge,
+    /// EOF arrived without any request bytes.
+    EmptyRequest,
+    /// Dispatch failed without a safe protocol response.
+    DispatchFailed,
+    /// Application dispatch exceeded its service-owned hard deadline.
+    DispatchTimedOut,
+    /// The encoded response exceeded its configured wire limit.
+    ResponseFrameTooLarge,
+    /// The dispatcher attempted to emit an invalid framed response.
+    InvalidResponseFrame,
+}
+
+/// Whether a dispatcher-produced frame should be sent or the connection closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseDisposition {
+    /// Send the encoded response followed by one LF delimiter.
+    Send,
+    /// Close the connection without sending a response.
+    Close,
+}
+
+/// Safe, non-diagnostic failure at the dispatcher boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("request dispatcher failed")]
+pub struct DispatchError;
+
+/// Protocol adapter injected into the UDS service framework.
+///
+/// Implementations decode request bytes, generate protocol request identities,
+/// bind the peer to a trusted principal, invoke one application use case, and
+/// encode its response. Implementations must not retain `response`; the service
+/// owns and bounds that writer. Transport rejection encoding is a separate
+/// [`RejectionEncoder`] dependency.
+pub trait RequestDispatcher: Send + Sync + 'static {
+    /// Dispatches one complete bounded request frame.
+    ///
+    /// # Errors
+    /// Returns `DispatchError` when no safe response was encoded.
+    fn dispatch(
+        &self,
+        request: DispatchRequest,
+        response: &mut dyn Write,
+    ) -> Result<ResponseDisposition, DispatchError>;
+}
+
+/// Protocol-only encoder for failures detected before or around application dispatch.
+///
+/// This is deliberately separate from [`RequestDispatcher`], so overload,
+/// timeout, and shutdown responses do not require an application/PAP dependency.
+/// Implementations should contain only request-ID generation and wire error
+/// projection; the service also bounds their execution time.
+pub trait RejectionEncoder: Send + Sync + 'static {
+    /// Encodes a safe response for one transport-owned rejection.
+    ///
+    /// # Errors
+    /// Returns `DispatchError` when the connection must be closed silently.
+    fn encode_rejection(
+        &self,
+        request: RejectedRequest,
+        response: &mut dyn Write,
+    ) -> Result<ResponseDisposition, DispatchError>;
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/frame.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/frame.rs
@@ -1,0 +1,205 @@
+use std::io::{self, Write};
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const READ_CHUNK_BYTES: usize = 4096;
+
+#[derive(Debug)]
+pub(crate) enum FrameReadError {
+    Empty,
+    TooLarge,
+    Io(io::Error),
+}
+
+pub(crate) async fn read_request_frame<R>(
+    reader: &mut R,
+    maximum_wire_bytes: usize,
+) -> Result<Vec<u8>, FrameReadError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut payload = Vec::with_capacity(maximum_wire_bytes.min(READ_CHUNK_BYTES));
+    let mut chunk = [0_u8; READ_CHUNK_BYTES];
+
+    loop {
+        let remaining_probe = maximum_wire_bytes
+            .saturating_sub(payload.len())
+            .saturating_add(1)
+            .min(READ_CHUNK_BYTES);
+        let read = reader
+            .read(&mut chunk[..remaining_probe])
+            .await
+            .map_err(FrameReadError::Io)?;
+        if read == 0 {
+            return if payload.is_empty() {
+                Err(FrameReadError::Empty)
+            } else {
+                Ok(payload)
+            };
+        }
+
+        if let Some(delimiter) = chunk[..read].iter().position(|byte| *byte == b'\n') {
+            let wire_size = payload
+                .len()
+                .checked_add(delimiter + 1)
+                .ok_or(FrameReadError::TooLarge)?;
+            if wire_size > maximum_wire_bytes {
+                return Err(FrameReadError::TooLarge);
+            }
+            payload.extend_from_slice(&chunk[..delimiter]);
+            return Ok(payload);
+        }
+
+        payload.extend_from_slice(&chunk[..read]);
+        if payload.len() > maximum_wire_bytes {
+            return Err(FrameReadError::TooLarge);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResponseFrameError {
+    Empty,
+    TooLarge,
+    ContainsDelimiter,
+    BytesBeforeClose,
+}
+
+pub(crate) struct BoundedResponseBuffer {
+    bytes: Vec<u8>,
+    maximum_payload_bytes: usize,
+    failure: Option<ResponseFrameError>,
+}
+
+impl BoundedResponseBuffer {
+    pub(crate) fn new(maximum_wire_bytes: usize) -> Self {
+        let maximum_payload_bytes = maximum_wire_bytes.saturating_sub(1);
+        Self {
+            bytes: Vec::with_capacity(maximum_payload_bytes.min(READ_CHUNK_BYTES)),
+            maximum_payload_bytes,
+            failure: None,
+        }
+    }
+
+    pub(crate) fn finish_send(mut self) -> Result<Vec<u8>, ResponseFrameError> {
+        if let Some(failure) = self.failure {
+            return Err(failure);
+        }
+        if self.bytes.is_empty() {
+            return Err(ResponseFrameError::Empty);
+        }
+        self.bytes.push(b'\n');
+        Ok(self.bytes)
+    }
+
+    pub(crate) fn finish_close(self) -> Result<(), ResponseFrameError> {
+        if let Some(failure) = self.failure {
+            return Err(failure);
+        }
+        if self.bytes.is_empty() {
+            Ok(())
+        } else {
+            Err(ResponseFrameError::BytesBeforeClose)
+        }
+    }
+
+    pub(crate) const fn failure(&self) -> Option<ResponseFrameError> {
+        self.failure
+    }
+}
+
+impl Write for BoundedResponseBuffer {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if buffer.contains(&b'\n') {
+            self.failure = Some(ResponseFrameError::ContainsDelimiter);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "response payload contains an LF delimiter",
+            ));
+        }
+        let Some(next_length) = self.bytes.len().checked_add(buffer.len()) else {
+            self.failure = Some(ResponseFrameError::TooLarge);
+            return Err(io::Error::new(
+                io::ErrorKind::FileTooLarge,
+                "response frame limit exceeded",
+            ));
+        };
+        if next_length > self.maximum_payload_bytes {
+            self.failure = Some(ResponseFrameError::TooLarge);
+            return Err(io::Error::new(
+                io::ErrorKind::FileTooLarge,
+                "response frame limit exceeded",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::AsyncWriteExt as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn frame_limit_includes_the_lf_delimiter() {
+        let (mut writer, mut reader) = tokio::io::duplex(32);
+        writer.write_all(b"1234567\ntrailing").await.unwrap();
+        drop(writer);
+
+        assert_eq!(
+            read_request_frame(&mut reader, 8).await.unwrap(),
+            b"1234567"
+        );
+    }
+
+    #[tokio::test]
+    async fn eof_terminated_frame_can_fill_the_exact_limit() {
+        let (mut writer, mut reader) = tokio::io::duplex(32);
+        writer.write_all(b"12345678").await.unwrap();
+        drop(writer);
+
+        assert_eq!(
+            read_request_frame(&mut reader, 8).await.unwrap(),
+            b"12345678"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_frame_is_rejected_before_unbounded_growth() {
+        let (mut writer, mut reader) = tokio::io::duplex(32);
+        writer.write_all(b"123456789").await.unwrap();
+        drop(writer);
+
+        assert!(matches!(
+            read_request_frame(&mut reader, 8).await,
+            Err(FrameReadError::TooLarge)
+        ));
+    }
+
+    #[test]
+    fn response_buffer_reserves_the_delimiter_inside_the_limit() {
+        let mut exact = BoundedResponseBuffer::new(8);
+        exact.write_all(b"1234567").unwrap();
+        assert_eq!(exact.finish_send().unwrap(), b"1234567\n");
+
+        let mut oversized = BoundedResponseBuffer::new(8);
+        assert!(oversized.write_all(b"12345678").is_err());
+        assert_eq!(oversized.finish_send(), Err(ResponseFrameError::TooLarge));
+    }
+
+    #[test]
+    fn response_buffer_rejects_embedded_frame_delimiters() {
+        let mut response = BoundedResponseBuffer::new(32);
+        assert!(response.write_all(b"first\nsecond").is_err());
+        assert_eq!(
+            response.finish_send(),
+            Err(ResponseFrameError::ContainsDelimiter)
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/lib.rs
@@ -1,0 +1,24 @@
+//! Protocol-independent Unix-domain-socket service framework.
+//!
+//! This crate owns bounded connection admission, one-request framing, trusted
+//! kernel peer credentials, response framing, socket ownership cleanup, and
+//! controlled drain. Wire decoding, request identities, authentication,
+//! authorization, and application dispatch belong to the injected
+//! [`RequestDispatcher`]. Transport rejection projection uses the separate
+//! [`RejectionEncoder`] port so it need not depend on application state.
+
+#![forbid(unsafe_code)]
+
+mod config;
+mod dispatcher;
+mod frame;
+mod server;
+mod shutdown;
+
+pub use config::{ConfigError, ServiceConfig};
+pub use dispatcher::{
+    DispatchControl, DispatchError, DispatchRequest, PeerCredentials, RejectedRequest,
+    RejectionEncoder, RejectionReason, RequestDispatcher, ResponseDisposition,
+};
+pub use server::{BindError, BoundUnixSocket, ServeError, ServeReport, UnixService};
+pub use shutdown::ShutdownToken;

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/server.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/server.rs
@@ -1,0 +1,658 @@
+use std::fs;
+use std::io;
+use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::io::AsyncWriteExt as _;
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinSet;
+use tokio::time::{Instant, sleep, timeout, timeout_at};
+
+use crate::config::{ConfigError, ServiceConfig};
+use crate::dispatcher::{
+    DispatchControl, DispatchRequest, PeerCredentials, RejectedRequest, RejectionEncoder,
+    RejectionReason, RequestDispatcher, ResponseDisposition,
+};
+use crate::frame::{BoundedResponseBuffer, FrameReadError, ResponseFrameError, read_request_frame};
+use crate::shutdown::ShutdownToken;
+
+/// A bound listener plus filesystem identity proving socket-path ownership.
+pub struct BoundUnixSocket {
+    listener: Option<UnixListener>,
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl BoundUnixSocket {
+    /// Binds an absolute, previously absent Unix socket path.
+    ///
+    /// The caller owns runtime-directory validation and stale-socket policy.
+    /// This function never removes or replaces a pre-existing path.
+    ///
+    /// # Errors
+    /// Returns a stable bind error for an unsafe mode, relative path, existing
+    /// path, or operating-system failure.
+    pub fn bind(path: impl AsRef<Path>, mode: u32) -> Result<Self, BindError> {
+        let path = path.as_ref();
+        if !path.is_absolute() {
+            return Err(BindError::RelativePath);
+        }
+        if mode & !0o777 != 0 || mode & 0o600 != 0o600 || mode & 0o111 != 0 || mode & 0o007 != 0 {
+            return Err(BindError::UnsafeMode);
+        }
+        match fs::symlink_metadata(path) {
+            Ok(_) => return Err(BindError::PathExists),
+            Err(problem) if problem.kind() == io::ErrorKind::NotFound => {}
+            Err(problem) => return Err(BindError::Io(problem)),
+        }
+
+        let listener = UnixListener::bind(path).map_err(BindError::Io)?;
+        let metadata = fs::symlink_metadata(path).map_err(BindError::Io)?;
+        let mut socket = Self {
+            listener: Some(listener),
+            path: path.to_owned(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        };
+        if let Err(problem) = fs::set_permissions(path, fs::Permissions::from_mode(mode)) {
+            socket.close_ignoring_errors();
+            return Err(BindError::Io(problem));
+        }
+        Ok(socket)
+    }
+
+    /// Returns the bound filesystem path.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn listener(&self) -> Result<&UnixListener, ServeError> {
+        self.listener.as_ref().ok_or(ServeError::ListenerClosed)
+    }
+
+    fn close(&mut self) -> Result<(), io::Error> {
+        self.listener.take();
+        self.remove_owned_path()
+    }
+
+    fn remove_owned_path(&self) -> Result<(), io::Error> {
+        let metadata = match fs::symlink_metadata(&self.path) {
+            Ok(metadata) => metadata,
+            Err(problem) if problem.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(problem) => return Err(problem),
+        };
+        if metadata.file_type().is_socket()
+            && metadata.dev() == self.device
+            && metadata.ino() == self.inode
+        {
+            fs::remove_file(&self.path)?;
+        }
+        Ok(())
+    }
+
+    fn close_ignoring_errors(&mut self) {
+        let _ = self.close();
+    }
+}
+
+impl Drop for BoundUnixSocket {
+    fn drop(&mut self) {
+        self.close_ignoring_errors();
+    }
+}
+
+/// Failure to bind the UDS service endpoint.
+#[derive(Debug, thiserror::Error)]
+pub enum BindError {
+    /// System-owned daemon socket paths must be absolute.
+    #[error("daemon socket path must be absolute")]
+    RelativePath,
+    /// Socket mode must grant owner read/write without execute or other-user access.
+    #[error("daemon socket mode must grant owner read/write without execute or other-user access")]
+    UnsafeMode,
+    /// Stale/live path classification belongs to the process bootstrap.
+    #[error("daemon socket path already exists")]
+    PathExists,
+    /// Operating-system bind, metadata, permission, or cleanup failure.
+    #[error("daemon socket could not be bound")]
+    Io(#[source] io::Error),
+}
+
+/// Protocol-independent UDS server composed with one request dispatcher.
+pub struct UnixService {
+    socket: BoundUnixSocket,
+    config: ServiceConfig,
+    dispatcher: Arc<dyn RequestDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+}
+
+impl UnixService {
+    /// Validates and creates a service around an already-owned listener.
+    ///
+    /// # Errors
+    /// Returns an error when any configured resource bound is unusable.
+    pub fn new(
+        socket: BoundUnixSocket,
+        config: ServiceConfig,
+        dispatcher: Arc<dyn RequestDispatcher>,
+        rejection_encoder: Arc<dyn RejectionEncoder>,
+    ) -> Result<Self, ConfigError> {
+        config.validate()?;
+        Ok(Self {
+            socket,
+            config,
+            dispatcher,
+            rejection_encoder,
+        })
+    }
+
+    /// Accepts bounded connections until shutdown, then drains admitted tasks.
+    ///
+    /// Per-connection read, dispatch, encoding, and write failures are isolated
+    /// and recorded in the returned report rather than terminating the listener.
+    ///
+    /// # Errors
+    /// Returns only for listener ownership or socket cleanup failures.
+    pub async fn serve(mut self, shutdown: ShutdownToken) -> Result<ServeReport, ServeError> {
+        let normal_admission = Arc::new(Semaphore::new(self.config.max_connections));
+        let rejection_admission = Arc::new(Semaphore::new(self.config.max_rejection_connections));
+        let runtime = ConnectionRuntime {
+            config: self.config.clone(),
+            dispatcher: Arc::clone(&self.dispatcher),
+            rejection_encoder: Arc::clone(&self.rejection_encoder),
+            shutdown: shutdown.clone(),
+            normal_admission,
+            rejection_admission,
+        };
+        let mut tasks = JoinSet::new();
+        let mut report = ServeReport::default();
+
+        loop {
+            if shutdown.is_requested() {
+                break;
+            }
+            tokio::select! {
+                biased;
+                () = shutdown.wait() => break,
+                completed = tasks.join_next(), if !tasks.is_empty() => {
+                    record_task_result(&mut report, completed.as_ref());
+                }
+                accepted = self.socket.listener()?.accept() => {
+                    match accepted {
+                        Ok((stream, _address)) => {
+                            report.accepted_connections += 1;
+                            admit_connection(
+                                stream,
+                                &runtime,
+                                &mut tasks,
+                                &mut report,
+                            );
+                        }
+                        Err(problem) if problem.kind() == io::ErrorKind::Interrupted => {}
+                        Err(_problem) => {
+                            report.accept_errors += 1;
+                            tokio::select! {
+                                biased;
+                                () = shutdown.wait() => break,
+                                () = sleep(self.config.accept_error_backoff) => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let cleanup_result = self.socket.close();
+        drain_tasks(&mut tasks, self.config.drain_timeout, &mut report).await;
+        cleanup_result.map_err(ServeError::Cleanup)?;
+        Ok(report)
+    }
+}
+
+struct ConnectionRuntime {
+    config: ServiceConfig,
+    dispatcher: Arc<dyn RequestDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+    shutdown: ShutdownToken,
+    normal_admission: Arc<Semaphore>,
+    rejection_admission: Arc<Semaphore>,
+}
+
+/// Listener-level service failure.
+#[derive(Debug, thiserror::Error)]
+pub enum ServeError {
+    /// The owned listener was unexpectedly closed before serving started.
+    #[error("daemon listener is closed")]
+    ListenerClosed,
+    /// The service could not remove its own socket inode.
+    #[error("owned daemon socket could not be cleaned up")]
+    Cleanup(#[source] io::Error),
+}
+
+/// Bounded service activity observed before controlled shutdown completed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ServeReport {
+    /// Connections returned by the kernel listener.
+    pub accepted_connections: u64,
+    /// Complete request frames sent to normal dispatch.
+    pub dispatched_requests: u64,
+    /// Typed transport rejections rendered by the rejection encoder.
+    pub rejected_requests: u64,
+    /// Connections intentionally closed without a response.
+    pub silently_closed_connections: u64,
+    /// Isolated peer/read/dispatch/write/task failures.
+    pub connection_failures: u64,
+    /// Listener accept errors retried with backoff.
+    pub accept_errors: u64,
+    /// Admitted tasks aborted after the drain deadline.
+    pub aborted_connections: u64,
+}
+
+fn admit_connection(
+    stream: UnixStream,
+    runtime: &ConnectionRuntime,
+    tasks: &mut JoinSet<ConnectionOutcome>,
+    report: &mut ServeReport,
+) {
+    let Ok(peer) = peer_credentials(&stream) else {
+        report.silently_closed_connections += 1;
+        report.connection_failures += 1;
+        return;
+    };
+
+    if runtime.shutdown.is_requested() {
+        spawn_rejection(
+            stream,
+            peer,
+            RejectionReason::ShuttingDown,
+            runtime,
+            tasks,
+            report,
+        );
+        return;
+    }
+
+    match Arc::clone(&runtime.normal_admission).try_acquire_owned() {
+        Ok(permit) => {
+            let config = runtime.config.clone();
+            let dispatcher = Arc::clone(&runtime.dispatcher);
+            let rejection_encoder = Arc::clone(&runtime.rejection_encoder);
+            tasks.spawn(async move {
+                process_connection(stream, peer, &config, dispatcher, rejection_encoder, permit)
+                    .await
+            });
+        }
+        Err(_) => spawn_rejection(stream, peer, RejectionReason::Busy, runtime, tasks, report),
+    }
+}
+
+fn spawn_rejection(
+    stream: UnixStream,
+    peer: PeerCredentials,
+    reason: RejectionReason,
+    runtime: &ConnectionRuntime,
+    tasks: &mut JoinSet<ConnectionOutcome>,
+    report: &mut ServeReport,
+) {
+    let Ok(permit) = Arc::clone(&runtime.rejection_admission).try_acquire_owned() else {
+        report.silently_closed_connections += 1;
+        return;
+    };
+    let config = runtime.config.clone();
+    let rejection_encoder = Arc::clone(&runtime.rejection_encoder);
+    tasks.spawn(async move {
+        process_rejection(stream, peer, reason, &config, rejection_encoder, permit).await
+    });
+}
+
+async fn process_connection(
+    stream: UnixStream,
+    peer: PeerCredentials,
+    config: &ServiceConfig,
+    dispatcher: Arc<dyn RequestDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+    permit: OwnedSemaphorePermit,
+) -> ConnectionOutcome {
+    let outcome =
+        process_admitted_connection(stream, peer, config, dispatcher, rejection_encoder).await;
+    drop(permit);
+    outcome
+}
+
+async fn process_admitted_connection(
+    mut stream: UnixStream,
+    peer: PeerCredentials,
+    config: &ServiceConfig,
+    dispatcher: Arc<dyn RequestDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+) -> ConnectionOutcome {
+    let frame = match timeout(
+        config.request_read_timeout,
+        read_request_frame(&mut stream, config.max_request_frame_bytes),
+    )
+    .await
+    {
+        Err(_) => {
+            return reject_on_stream(
+                stream,
+                peer,
+                RejectionReason::RequestReadTimeout,
+                config,
+                rejection_encoder,
+            )
+            .await;
+        }
+        Ok(Err(FrameReadError::TooLarge)) => {
+            return reject_on_stream(
+                stream,
+                peer,
+                RejectionReason::RequestFrameTooLarge,
+                config,
+                rejection_encoder,
+            )
+            .await;
+        }
+        Ok(Err(FrameReadError::Empty)) => {
+            return reject_on_stream(
+                stream,
+                peer,
+                RejectionReason::EmptyRequest,
+                config,
+                rejection_encoder,
+            )
+            .await;
+        }
+        Ok(Err(FrameReadError::Io(_problem))) => return ConnectionOutcome::IoFailure,
+        Ok(Ok(frame)) => frame,
+    };
+
+    let control = DispatchControl::new(std::time::Instant::now() + config.dispatch_timeout);
+    let request = DispatchRequest {
+        peer,
+        payload: frame,
+        control: control.clone(),
+    };
+    match invoke_dispatch(
+        dispatcher.clone(),
+        request,
+        control,
+        config.max_response_frame_bytes,
+        config.dispatch_timeout,
+    )
+    .await
+    {
+        DispatchAttempt::Frame(frame) => {
+            write_frame(stream, frame, config.response_write_timeout, true).await
+        }
+        DispatchAttempt::Close => ConnectionOutcome::DispatchedClose,
+        DispatchAttempt::Reject(reason) => {
+            reject_on_stream(stream, peer, reason, config, rejection_encoder).await
+        }
+    }
+}
+
+async fn process_rejection(
+    stream: UnixStream,
+    peer: PeerCredentials,
+    reason: RejectionReason,
+    config: &ServiceConfig,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+    permit: OwnedSemaphorePermit,
+) -> ConnectionOutcome {
+    let outcome = reject_on_stream(stream, peer, reason, config, rejection_encoder).await;
+    drop(permit);
+    outcome
+}
+
+async fn reject_on_stream(
+    stream: UnixStream,
+    peer: PeerCredentials,
+    reason: RejectionReason,
+    config: &ServiceConfig,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+) -> ConnectionOutcome {
+    let request = RejectedRequest { peer, reason };
+    match invoke_rejection(
+        rejection_encoder,
+        request,
+        config.max_response_frame_bytes,
+        config.rejection_encode_timeout,
+    )
+    .await
+    {
+        DispatchAttempt::Frame(frame) => {
+            write_frame(stream, frame, config.response_write_timeout, false).await
+        }
+        DispatchAttempt::Close | DispatchAttempt::Reject(_) => ConnectionOutcome::RejectedClose,
+    }
+}
+
+async fn invoke_dispatch(
+    dispatcher: Arc<dyn RequestDispatcher>,
+    request: DispatchRequest,
+    control: DispatchControl,
+    maximum_wire_bytes: usize,
+    dispatch_timeout: std::time::Duration,
+) -> DispatchAttempt {
+    let _cancellation = CancelDispatchOnDrop(control);
+    let dispatch = tokio::task::spawn_blocking(move || {
+        let mut response = BoundedResponseBuffer::new(maximum_wire_bytes);
+        let result = dispatcher.dispatch(request, &mut response);
+        finish_dispatch(result, response)
+    });
+    match timeout(dispatch_timeout, dispatch).await {
+        Err(_) => DispatchAttempt::Reject(RejectionReason::DispatchTimedOut),
+        Ok(Ok(attempt)) => attempt,
+        Ok(Err(_)) => DispatchAttempt::Reject(RejectionReason::DispatchFailed),
+    }
+}
+
+struct CancelDispatchOnDrop(DispatchControl);
+
+impl Drop for CancelDispatchOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+async fn invoke_rejection(
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+    request: RejectedRequest,
+    maximum_wire_bytes: usize,
+    rejection_timeout: std::time::Duration,
+) -> DispatchAttempt {
+    let encoding = tokio::task::spawn_blocking(move || {
+        let mut response = BoundedResponseBuffer::new(maximum_wire_bytes);
+        let result = rejection_encoder.encode_rejection(request, &mut response);
+        finish_dispatch(result, response)
+    });
+    match timeout(rejection_timeout, encoding).await {
+        Ok(Ok(attempt)) => attempt,
+        Ok(Err(_)) | Err(_) => DispatchAttempt::Close,
+    }
+}
+
+fn finish_dispatch(
+    result: Result<ResponseDisposition, crate::DispatchError>,
+    response: BoundedResponseBuffer,
+) -> DispatchAttempt {
+    match response.failure() {
+        Some(ResponseFrameError::TooLarge) => {
+            return DispatchAttempt::Reject(RejectionReason::ResponseFrameTooLarge);
+        }
+        Some(
+            ResponseFrameError::Empty
+            | ResponseFrameError::ContainsDelimiter
+            | ResponseFrameError::BytesBeforeClose,
+        ) => return DispatchAttempt::Reject(RejectionReason::InvalidResponseFrame),
+        None => {}
+    }
+    match result {
+        Err(_) => DispatchAttempt::Reject(RejectionReason::DispatchFailed),
+        Ok(ResponseDisposition::Close) => match response.finish_close() {
+            Ok(()) => DispatchAttempt::Close,
+            Err(_) => DispatchAttempt::Reject(RejectionReason::InvalidResponseFrame),
+        },
+        Ok(ResponseDisposition::Send) => match response.finish_send() {
+            Ok(frame) => DispatchAttempt::Frame(frame),
+            Err(ResponseFrameError::TooLarge) => {
+                DispatchAttempt::Reject(RejectionReason::ResponseFrameTooLarge)
+            }
+            Err(
+                ResponseFrameError::Empty
+                | ResponseFrameError::ContainsDelimiter
+                | ResponseFrameError::BytesBeforeClose,
+            ) => DispatchAttempt::Reject(RejectionReason::InvalidResponseFrame),
+        },
+    }
+}
+
+async fn write_frame(
+    mut stream: UnixStream,
+    frame: Vec<u8>,
+    write_timeout: std::time::Duration,
+    dispatched: bool,
+) -> ConnectionOutcome {
+    let write = async {
+        stream.write_all(&frame).await?;
+        stream.shutdown().await
+    };
+    match timeout(write_timeout, write).await {
+        Ok(Ok(())) if dispatched => ConnectionOutcome::DispatchedResponse,
+        Ok(Ok(())) => ConnectionOutcome::RejectedResponse,
+        Ok(Err(_)) | Err(_) => ConnectionOutcome::IoFailure,
+    }
+}
+
+fn peer_credentials(stream: &UnixStream) -> Result<PeerCredentials, ()> {
+    let credentials = stream.peer_cred().map_err(|_| ())?;
+    let pid = credentials.pid().ok_or(())?;
+    let pid = u32::try_from(pid).map_err(|_| ())?;
+    Ok(PeerCredentials::new(
+        credentials.uid(),
+        credentials.gid(),
+        pid,
+    ))
+}
+
+async fn drain_tasks(
+    tasks: &mut JoinSet<ConnectionOutcome>,
+    drain_timeout: std::time::Duration,
+    report: &mut ServeReport,
+) {
+    let deadline = Instant::now() + drain_timeout;
+    while !tasks.is_empty() {
+        if let Ok(completed) = timeout_at(deadline, tasks.join_next()).await {
+            record_task_result(report, completed.as_ref());
+        } else {
+            report.aborted_connections += u64::try_from(tasks.len()).unwrap_or(u64::MAX);
+            tasks.abort_all();
+            while tasks.join_next().await.is_some() {}
+            break;
+        }
+    }
+}
+
+fn record_task_result(
+    report: &mut ServeReport,
+    completed: Option<&Result<ConnectionOutcome, tokio::task::JoinError>>,
+) {
+    match completed {
+        Some(Ok(ConnectionOutcome::DispatchedResponse)) => report.dispatched_requests += 1,
+        Some(Ok(ConnectionOutcome::DispatchedClose)) => {
+            report.dispatched_requests += 1;
+            report.silently_closed_connections += 1;
+        }
+        Some(Ok(ConnectionOutcome::RejectedResponse)) => report.rejected_requests += 1,
+        Some(Ok(ConnectionOutcome::RejectedClose)) => {
+            report.rejected_requests += 1;
+            report.silently_closed_connections += 1;
+        }
+        Some(Ok(ConnectionOutcome::IoFailure) | Err(_)) => {
+            report.connection_failures += 1;
+        }
+        None => {}
+    }
+}
+
+enum DispatchAttempt {
+    Frame(Vec<u8>),
+    Close,
+    Reject(RejectionReason),
+}
+
+#[derive(Clone, Copy)]
+enum ConnectionOutcome {
+    DispatchedResponse,
+    DispatchedClose,
+    RejectedResponse,
+    RejectedClose,
+    IoFailure,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::MetadataExt as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_directory(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "asc-daemon-service-{label}-{}-{}",
+            std::process::id(),
+            DIRECTORY_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[tokio::test]
+    async fn dropping_socket_removes_only_its_owned_inode() {
+        let directory = unique_directory("replacement");
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("daemon.sock");
+        let moved = directory.join("owned.sock");
+        let socket = BoundUnixSocket::bind(&path, 0o660).unwrap();
+        fs::rename(&path, &moved).unwrap();
+        let replacement = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        let replacement_inode = fs::symlink_metadata(&path).unwrap().ino();
+
+        drop(socket);
+
+        assert_eq!(
+            fs::symlink_metadata(&path).unwrap().ino(),
+            replacement_inode
+        );
+        drop(replacement);
+        fs::remove_file(path).unwrap();
+        fs::remove_file(moved).unwrap();
+        fs::remove_dir(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn bind_refuses_existing_paths_and_unsafe_modes() {
+        let directory = unique_directory("bind");
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("daemon.sock");
+        let socket = BoundUnixSocket::bind(&path, 0o660).unwrap();
+
+        assert!(matches!(
+            BoundUnixSocket::bind(&path, 0o660),
+            Err(BindError::PathExists)
+        ));
+        drop(socket);
+        assert!(matches!(
+            BoundUnixSocket::bind(&path, 0o666),
+            Err(BindError::UnsafeMode)
+        ));
+        assert!(matches!(
+            BoundUnixSocket::bind(&path, 0o760),
+            Err(BindError::UnsafeMode)
+        ));
+        fs::remove_dir(directory).unwrap();
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/shutdown.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/shutdown.rs
@@ -1,0 +1,62 @@
+use tokio::sync::watch;
+
+/// Cloneable cooperative shutdown signal owned by the future process bootstrap.
+#[derive(Debug, Clone)]
+pub struct ShutdownToken {
+    sender: watch::Sender<bool>,
+}
+
+impl ShutdownToken {
+    /// Creates a shutdown signal in the running state.
+    pub fn new() -> Self {
+        let (sender, _receiver) = watch::channel(false);
+        Self { sender }
+    }
+
+    /// Requests idempotent service shutdown.
+    pub fn request(&self) {
+        self.sender.send_replace(true);
+    }
+
+    /// Returns whether shutdown has already been requested.
+    pub fn is_requested(&self) -> bool {
+        *self.sender.borrow()
+    }
+
+    pub(crate) async fn wait(&self) {
+        let mut receiver = self.sender.subscribe();
+        if *receiver.borrow_and_update() {
+            return;
+        }
+        while receiver.changed().await.is_ok() {
+            if *receiver.borrow_and_update() {
+                return;
+            }
+        }
+    }
+}
+
+impl Default for ShutdownToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn request_wakes_existing_and_future_waiters() {
+        let shutdown = ShutdownToken::new();
+        let waiter = tokio::spawn({
+            let shutdown = shutdown.clone();
+            async move { shutdown.wait().await }
+        });
+
+        shutdown.request();
+        waiter.await.unwrap();
+        shutdown.wait().await;
+        assert!(shutdown.is_requested());
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/shutdown.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/src/shutdown.rs
@@ -1,6 +1,6 @@
 use tokio::sync::watch;
 
-/// Cloneable cooperative shutdown signal owned by the future process bootstrap.
+/// Cloneable cooperative shutdown signal owned by the process bootstrap.
 #[derive(Debug, Clone)]
 pub struct ShutdownToken {
     sender: watch::Sender<bool>,

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/tests/uds_service.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-service/tests/uds_service.rs
@@ -1,0 +1,472 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use asc_daemon_service::{
+    BoundUnixSocket, DispatchError, DispatchRequest, RejectedRequest, RejectionEncoder,
+    RejectionReason, RequestDispatcher, ResponseDisposition, ServeReport, ServiceConfig,
+    ShutdownToken, UnixService,
+};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixStream;
+
+static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Default)]
+struct FakeDispatcher {
+    requests: Mutex<Vec<DispatchRequest>>,
+    hold_started: AtomicBool,
+    hold_gate: (Mutex<bool>, Condvar),
+}
+
+impl FakeDispatcher {
+    fn requests(&self) -> Vec<DispatchRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    async fn wait_until_held(&self) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !self.hold_started.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("hold request should reach the dispatcher");
+    }
+
+    fn release_hold(&self) {
+        let (lock, ready) = &self.hold_gate;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
+    }
+}
+
+impl RequestDispatcher for FakeDispatcher {
+    fn dispatch(
+        &self,
+        request: DispatchRequest,
+        response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        self.requests.lock().unwrap().push(request.clone());
+        match request.payload.as_slice() {
+            b"close" => return Ok(ResponseDisposition::Close),
+            b"fail" => return Err(DispatchError),
+            b"large" => {
+                response
+                    .write_all(&[b'x'; 128])
+                    .map_err(|_| DispatchError)?;
+            }
+            b"newline" => {
+                response
+                    .write_all(b"invalid\nresponse")
+                    .map_err(|_| DispatchError)?;
+            }
+            b"hold" => {
+                self.hold_started.store(true, Ordering::Release);
+                let (lock, ready) = &self.hold_gate;
+                let mut released = lock.lock().unwrap();
+                while !*released {
+                    released = ready.wait(released).unwrap();
+                }
+                response.write_all(b"ok:hold").map_err(|_| DispatchError)?;
+            }
+            payload => {
+                response.write_all(b"ok:").map_err(|_| DispatchError)?;
+                response.write_all(payload).map_err(|_| DispatchError)?;
+            }
+        }
+        Ok(ResponseDisposition::Send)
+    }
+}
+
+struct FakeRejectionEncoder;
+
+impl RejectionEncoder for FakeRejectionEncoder {
+    fn encode_rejection(
+        &self,
+        request: RejectedRequest,
+        response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        let label = match request.reason {
+            RejectionReason::Busy => "reject:busy",
+            RejectionReason::ShuttingDown => "reject:shutdown",
+            RejectionReason::RequestReadTimeout => "reject:timeout",
+            RejectionReason::RequestFrameTooLarge => "reject:request-too-large",
+            RejectionReason::EmptyRequest => "reject:empty",
+            RejectionReason::DispatchFailed => "reject:dispatch-failed",
+            RejectionReason::DispatchTimedOut => "reject:dispatch-timeout",
+            RejectionReason::ResponseFrameTooLarge => "reject:response-too-large",
+            RejectionReason::InvalidResponseFrame => "reject:invalid-response",
+        };
+        response
+            .write_all(label.as_bytes())
+            .map_err(|_| DispatchError)?;
+        Ok(ResponseDisposition::Send)
+    }
+}
+
+#[derive(Default)]
+struct BlockingRejectionEncoder {
+    started: AtomicBool,
+    gate: (Mutex<bool>, Condvar),
+}
+
+impl BlockingRejectionEncoder {
+    fn release(&self) {
+        let (lock, ready) = &self.gate;
+        *lock.lock().unwrap() = true;
+        ready.notify_all();
+    }
+}
+
+impl RejectionEncoder for BlockingRejectionEncoder {
+    fn encode_rejection(
+        &self,
+        _request: RejectedRequest,
+        _response: &mut dyn std::io::Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        self.started.store(true, Ordering::Release);
+        let (lock, ready) = &self.gate;
+        let mut released = lock.lock().unwrap();
+        while !*released {
+            released = ready.wait(released).unwrap();
+        }
+        Ok(ResponseDisposition::Close)
+    }
+}
+
+struct RunningService {
+    directory: PathBuf,
+    socket_path: PathBuf,
+    shutdown: ShutdownToken,
+    task: tokio::task::JoinHandle<Result<ServeReport, asc_daemon_service::ServeError>>,
+}
+
+impl RunningService {
+    async fn stop(self) -> ServeReport {
+        self.shutdown.request();
+        let report = self.task.await.unwrap().unwrap();
+        assert!(!self.socket_path.exists());
+        std::fs::remove_dir(self.directory).unwrap();
+        report
+    }
+}
+
+fn config() -> ServiceConfig {
+    ServiceConfig {
+        max_request_frame_bytes: 64,
+        max_response_frame_bytes: 64,
+        max_connections: 4,
+        max_rejection_connections: 2,
+        rejection_encode_timeout: Duration::from_millis(100),
+        request_read_timeout: Duration::from_millis(250),
+        dispatch_timeout: Duration::from_millis(250),
+        response_write_timeout: Duration::from_millis(250),
+        drain_timeout: Duration::from_millis(500),
+        accept_error_backoff: Duration::from_millis(10),
+    }
+}
+
+fn unique_directory(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "asc-daemon-service-e2e-{label}-{}-{}",
+        std::process::id(),
+        DIRECTORY_ID.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+fn start_service(
+    label: &str,
+    config: ServiceConfig,
+    dispatcher: Arc<FakeDispatcher>,
+) -> RunningService {
+    start_service_with_rejection_encoder(label, config, dispatcher, Arc::new(FakeRejectionEncoder))
+}
+
+fn start_service_with_rejection_encoder(
+    label: &str,
+    config: ServiceConfig,
+    dispatcher: Arc<FakeDispatcher>,
+    rejection_encoder: Arc<dyn RejectionEncoder>,
+) -> RunningService {
+    let directory = unique_directory(label);
+    std::fs::create_dir(&directory).unwrap();
+    let socket_path = directory.join("daemon.sock");
+    let socket = BoundUnixSocket::bind(&socket_path, 0o660).unwrap();
+    let request_dispatcher: Arc<dyn RequestDispatcher> = dispatcher;
+    let service = UnixService::new(socket, config, request_dispatcher, rejection_encoder).unwrap();
+    let shutdown = ShutdownToken::new();
+    let task = tokio::spawn(service.serve(shutdown.clone()));
+    RunningService {
+        directory,
+        socket_path,
+        shutdown,
+        task,
+    }
+}
+
+async fn request(path: &PathBuf, payload: &[u8], eof_terminated: bool) -> Vec<u8> {
+    let mut stream = UnixStream::connect(path).await.unwrap();
+    stream.write_all(payload).await.unwrap();
+    if eof_terminated {
+        stream.shutdown().await.unwrap();
+    }
+    let mut response = Vec::new();
+    let mut reader = BufReader::new(stream);
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        reader.read_until(b'\n', &mut response),
+    )
+    .await
+    .expect("service response should be bounded")
+    .unwrap();
+    response
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lf_eof_and_coalesced_requests_reach_the_fake_dispatcher_with_kernel_peer() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let service = start_service("frames", config(), dispatcher.clone());
+
+    assert_eq!(
+        request(&service.socket_path, b"first\n", false).await,
+        b"ok:first\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"second", true).await,
+        b"ok:second\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"third\nignored\n", false).await,
+        b"ok:third\n"
+    );
+
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 3);
+    let requests = dispatcher.requests();
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.peer.pid() == std::process::id())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_client_does_not_block_a_healthy_request_and_receives_one_deadline() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.max_connections = 2;
+    limits.request_read_timeout = Duration::from_millis(150);
+    let service = start_service("idle", limits, dispatcher);
+    let mut idle = UnixStream::connect(&service.socket_path).await.unwrap();
+
+    assert_eq!(
+        request(&service.socket_path, b"healthy\n", false).await,
+        b"ok:healthy\n"
+    );
+    let mut idle_response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(1), idle.read_to_end(&mut idle_response))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(idle_response, b"reject:timeout\n");
+
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 1);
+    assert_eq!(report.rejected_requests, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bounded_admission_returns_busy_without_disrupting_later_requests() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.max_connections = 1;
+    let service = start_service("busy", limits, dispatcher.clone());
+    let held_path = service.socket_path.clone();
+    let held = tokio::spawn(async move { request(&held_path, b"hold\n", false).await });
+    dispatcher.wait_until_held().await;
+
+    let busy = tokio::time::timeout(
+        Duration::from_secs(1),
+        request(&service.socket_path, b"busy\n", false),
+    )
+    .await;
+    dispatcher.release_hold();
+    assert_eq!(held.await.unwrap(), b"ok:hold\n");
+    assert_eq!(
+        busy.expect("busy response should not wait for normal dispatch"),
+        b"reject:busy\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"after\n", false).await,
+        b"ok:after\n"
+    );
+
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 2);
+    assert_eq!(report.rejected_requests, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_blocked_dispatch_does_not_block_an_independent_healthy_request() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.max_connections = 2;
+    limits.dispatch_timeout = Duration::from_secs(1);
+    let service = start_service("dispatch-isolation", limits, dispatcher.clone());
+    let held_path = service.socket_path.clone();
+    let held = tokio::spawn(async move { request(&held_path, b"hold\n", false).await });
+    dispatcher.wait_until_held().await;
+
+    assert_eq!(
+        request(&service.socket_path, b"healthy\n", false).await,
+        b"ok:healthy\n"
+    );
+    dispatcher.release_hold();
+    assert_eq!(held.await.unwrap(), b"ok:hold\n");
+
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocked_rejection_encoder_is_bounded_and_does_not_block_dispatch() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let rejection_encoder = Arc::new(BlockingRejectionEncoder::default());
+    let mut limits = config();
+    limits.request_read_timeout = Duration::from_millis(20);
+    limits.rejection_encode_timeout = Duration::from_millis(30);
+    let service = start_service_with_rejection_encoder(
+        "rejection-timeout",
+        limits,
+        dispatcher,
+        rejection_encoder.clone(),
+    );
+    let mut idle = UnixStream::connect(&service.socket_path).await.unwrap();
+
+    let mut idle_response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(1), idle.read_to_end(&mut idle_response))
+        .await
+        .expect("rejection encoding should have an independent deadline")
+        .unwrap();
+    assert!(idle_response.is_empty());
+    assert!(rejection_encoder.started.load(Ordering::Acquire));
+    assert_eq!(
+        request(&service.socket_path, b"healthy\n", false).await,
+        b"ok:healthy\n"
+    );
+
+    rejection_encoder.release();
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 1);
+    assert_eq!(report.rejected_requests, 1);
+    assert_eq!(report.silently_closed_connections, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dispatch_deadline_cancels_lifetime_and_releases_connection_capacity() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.max_connections = 1;
+    limits.dispatch_timeout = Duration::from_millis(50);
+    let service = start_service("dispatch-timeout", limits, dispatcher.clone());
+    let held_path = service.socket_path.clone();
+    let held = tokio::spawn(async move { request(&held_path, b"hold\n", false).await });
+    dispatcher.wait_until_held().await;
+
+    assert_eq!(held.await.unwrap(), b"reject:dispatch-timeout\n");
+    let held_request = dispatcher
+        .requests()
+        .into_iter()
+        .find(|request| request.payload == b"hold")
+        .unwrap();
+    assert!(held_request.control.is_cancelled());
+    assert_eq!(
+        request(&service.socket_path, b"after\n", false).await,
+        b"ok:after\n"
+    );
+
+    dispatcher.release_hold();
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 1);
+    assert_eq!(report.rejected_requests, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_and_response_frame_failures_are_bounded_and_connection_local() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.max_request_frame_bytes = 8;
+    limits.max_response_frame_bytes = 32;
+    let service = start_service("bounds", limits, dispatcher);
+
+    assert_eq!(
+        request(&service.socket_path, b"1234567\n", false).await,
+        b"ok:1234567\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"123456789", true).await,
+        b"reject:request-too-large\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"large\n", false).await,
+        b"reject:response-too-large\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"newline\n", false).await,
+        b"reject:invalid-response\n"
+    );
+    assert_eq!(
+        request(&service.socket_path, b"fail\n", false).await,
+        b"reject:dispatch-failed\n"
+    );
+    assert!(
+        request(&service.socket_path, b"close\n", false)
+            .await
+            .is_empty()
+    );
+    assert_eq!(
+        request(&service.socket_path, b"after\n", false).await,
+        b"ok:after\n"
+    );
+
+    let report = service.stop().await;
+    assert_eq!(report.dispatched_requests, 3);
+    assert_eq!(report.rejected_requests, 4);
+    assert_eq!(report.silently_closed_connections, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnected_client_cannot_terminate_the_service() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let service = start_service("disconnect", config(), dispatcher);
+    let mut disconnected = UnixStream::connect(&service.socket_path).await.unwrap();
+    disconnected.write_all(b"abandoned\n").await.unwrap();
+    drop(disconnected);
+
+    assert_eq!(
+        request(&service.socket_path, b"survivor\n", false).await,
+        b"ok:survivor\n"
+    );
+
+    let report = service.stop().await;
+    assert!(report.dispatched_requests >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_stops_admission_and_bounds_the_drain_wait() {
+    let dispatcher = Arc::new(FakeDispatcher::default());
+    let mut limits = config();
+    limits.drain_timeout = Duration::from_millis(50);
+    let service = start_service("drain", limits, dispatcher.clone());
+    let held_path = service.socket_path.clone();
+    let held = tokio::spawn(async move { request(&held_path, b"hold\n", false).await });
+    dispatcher.wait_until_held().await;
+
+    let report = service.stop().await;
+    assert_eq!(report.aborted_connections, 1);
+    dispatcher.release_hold();
+    assert!(held.await.unwrap().is_empty());
+}


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
  - Add a bounded UDS service framework with framing, peer credentials, and cleanup.
  - Add runnable daemon bootstrap, main entrypoint, and signal handling.
  - Isolate blocked requests with timeouts, cancellation, and rejection encoding.
  - Keep PAP integration deferred; external APIs and wire protocol remain unchanged.

## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
