### PR TITLE
fix(sight): resolve namespace PID to host PID with init-ns self-check

### DIFF
--- a/src/agentsight/crates/agentsight-enforcer/src/actplane.rs
+++ b/src/agentsight/crates/agentsight-enforcer/src/actplane.rs
@@ -45,7 +45,7 @@ struct ActiveBinding {
     binding: Binding,
     credential_policy: Option<CredentialExfiltrationPolicy>,
     /// When the target process runs inside a PID namespace, this holds the
-    /// global kernel PID resolved by [`resolve_kernel_pid`].  `None` when
+    /// global kernel PID resolved by [`resolve_to_host_pid`].  `None` when
     /// the namespace PID equals the kernel PID (root namespace).
     kernel_pid: Option<i32>,
     reasons: Vec<String>,
@@ -98,6 +98,10 @@ pub struct ActPlaneBackend {
     stop: Arc<AtomicBool>,
     poller: Mutex<Option<JoinHandle<()>>>,
     lifecycle: Mutex<()>,
+    /// True when the enforcer is running in the init PID namespace.
+    /// File-delete-guard requires this for correct cap_task seeding and
+    /// domain propagation.  When false, health reports file_delete_guard=false.
+    in_init_pidns: bool,
 }
 
 impl ActPlaneBackend {
@@ -151,6 +155,7 @@ impl ActPlaneBackend {
             stop,
             poller: Mutex::new(Some(poller)),
             lifecycle: Mutex::new(()),
+            in_init_pidns: is_init_pid_namespace(),
         })
     }
 
@@ -185,9 +190,19 @@ impl ActPlaneBackend {
 
     fn prepare_binding(
         &self,
-        request: ApplyPolicy,
+        mut request: ApplyPolicy,
         credential_policy: Option<CredentialExfiltrationPolicy>,
     ) -> Result<PreparedBinding, BackendError> {
+        // Resolve namespace-local PID to host PID BEFORE start-time validation,
+        // so that the stale-process check reads the correct /proc/<host_pid>/stat.
+        let host_pid = resolve_to_host_pid(request.root_pid, request.process_start_time);
+        if host_pid != request.root_pid {
+            eprintln!(
+                "resolve_to_host_pid: namespace pid {} -> host pid {}",
+                request.root_pid, host_pid
+            );
+            request.root_pid = host_pid;
+        }
         let actual_start = read_process_start_time(request.root_pid)?;
         if actual_start != request.process_start_time {
             return Err(BackendError::StaleProcess {
@@ -234,16 +249,8 @@ impl ActPlaneBackend {
                 )
             })?;
         let id = runtime_domain.unwrap_or_else(|| domain_id(request.binding_id));
-        let kernel_pid = resolve_kernel_pid(request.root_pid);
-        if kernel_pid != request.root_pid {
-            log::info!(
-                "PID namespace detected: namespace pid {} -> kernel pid {}",
-                request.root_pid,
-                kernel_pid
-            );
-        }
         self.engine
-            .seed_label_in_domain(kernel_pid, id, label)
+            .seed_label_in_domain(request.root_pid, id, label)
             .map_err(|error| kernel_error("seed target process domain", error))?;
 
         let control_pid = std::process::id() as i32;
@@ -261,13 +268,10 @@ impl ActPlaneBackend {
             label_mask: u64::MAX,
             ..CapState::default()
         };
-        let kpid = if kernel_pid != request.root_pid {
-            Some(kernel_pid)
-        } else {
-            None
-        };
+        // After prepare_binding, request.root_pid is already the host PID
+        // (resolve_to_host_pid was called there).  No separate kernel_pid needed.
         if let Err(error) = self.engine.bind_state(control_pid, id, control_state) {
-            let cleanup = self.cleanup_binding(&request, id, kpid);
+            let cleanup = self.cleanup_binding(&request, id, None);
             return Err(kernel_error_with_cleanup(
                 "bind control process",
                 error,
@@ -278,7 +282,7 @@ impl ActPlaneBackend {
             .reload
             .append_policy_delta(control_pid, id, &compiled.bytes)
         {
-            let cleanup = self.cleanup_binding(&request, id, kpid);
+            let cleanup = self.cleanup_binding(&request, id, None);
             return Err(kernel_error_with_cleanup(
                 "append policy delta",
                 error,
@@ -286,7 +290,7 @@ impl ActPlaneBackend {
             ));
         }
         if let Err(error) = self.engine.unbind_pid_from_domain(control_pid, id) {
-            let cleanup = self.cleanup_binding(&request, id, kpid);
+            let cleanup = self.cleanup_binding(&request, id, None);
             return Err(kernel_error_with_cleanup(
                 "unbind control process",
                 error,
@@ -305,7 +309,7 @@ impl ActPlaneBackend {
             ActiveBinding {
                 binding: binding.clone(),
                 credential_policy,
-                kernel_pid: kpid,
+                kernel_pid: None,
                 reasons: compiled.reasons,
                 rule_names: compiled.meta.into_iter().map(|meta| meta.name).collect(),
                 label_names: compiled
@@ -395,8 +399,9 @@ impl EnforcementBackend for ActPlaneBackend {
         // state so a host without an active BPF-LSM reports file_delete_guard=false
         // (fail-closed) instead of advertising a capability that silently enforces
         // nothing.
-        capabilities.file_delete_guard =
-            self.engine.supports_file_delete_guard() && ebpf_ifc_engine::bpf_lsm_active();
+        capabilities.file_delete_guard = self.engine.supports_file_delete_guard()
+            && ebpf_ifc_engine::bpf_lsm_active()
+            && self.in_init_pidns;
         let health = self.state.events.reflect_delivery_loss(HealthStatus {
             ready: runtime_error.is_none(),
             backend: "actplane".into(),
@@ -1169,45 +1174,116 @@ fn kernel_error_with_cleanup(
     BackendError::KernelFailure(message)
 }
 
-/// Translate a potentially namespace-local PID to the global kernel PID.
+/// Resolve a potentially namespace-local PID to the global (init namespace)
+/// kernel PID that BPF `handle_fork` / `cap_fork` will use.
 ///
-/// When a process runs inside a PID namespace (containers, WSL2, etc.),
-/// `/proc/<pid>/status` contains an `NSpid:` line listing the PID at each
-/// nesting level — the first value is always the global kernel PID.  BPF
-/// helpers like `bpf_get_current_pid_tgid()` return that global PID, so
-/// `cap_task` entries must be keyed by it for `handle_fork` lookups to
-/// succeed.
+/// The enforcer **must** run in the init PID namespace for this to work.
+/// When it does, host `/proc/<pid>/status` exposes the full `NSpid` chain.
 ///
-/// Returns `ns_pid` unchanged when running in the root namespace (no
-/// `NSpid` line, or only one level listed).
-///
-/// **Assumption**: the enforcer process runs in the root PID namespace,
-/// so host `/proc/<pid>/status` exposes the full `NSpid` chain.  If the
-/// enforcer is ever deployed inside a sidecar container sharing the
-/// target's PID namespace, this function becomes a no-op and a
-/// different identity resolution strategy is needed.
-fn resolve_kernel_pid(ns_pid: i32) -> i32 {
-    let path = format!("/proc/{ns_pid}/status");
-    let status = match fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(_) => return ns_pid,
+/// **Algorithm**:
+/// 1. Fast path: `/proc/<input_pid>/stat` exists and `start_time` matches →
+///    the PID is valid in the host namespace.  Return `NSpid[0]` (always the
+///    host PID when reading from init ns).
+/// 2. Slow path: the PID does not exist in host `/proc` or `start_time` does
+///    not match (namespace-local PID collides with a different host process).
+///    Scan `/proc/*/status` for a process whose innermost `NSpid` value equals
+///    `input_pid` and whose `start_time` matches.  Return its host PID.
+/// 3. Fallback: no match found — return `input_pid` unchanged and let the
+///    caller handle the stale-process / not-found case.
+fn resolve_to_host_pid(input_pid: i32, input_start_time: u64) -> i32 {
+    // Fast path: pid exists in host /proc and start_time matches.
+    if let Ok(start_time) = proc_start_time(input_pid) {
+        if start_time == input_start_time {
+            return first_nspid(input_pid).unwrap_or(input_pid);
+        }
+        // pid exists but belongs to a different process (namespace collision).
+    }
+
+    // Slow path: scan /proc for a process whose innermost NSpid == input_pid
+    // and whose start_time matches.
+    let proc_dir = match fs::read_dir("/proc") {
+        Ok(d) => d,
+        Err(_) => return input_pid,
+    };
+    for entry in proc_dir.flatten() {
+        let name = entry.file_name();
+        let Ok(host_pid) = name.to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        if host_pid <= 0 {
+            continue;
+        }
+        let nspid = read_nspid_chain(host_pid);
+        if nspid.len() < 2 {
+            continue; // not in a nested namespace
+        }
+        if *nspid.last().unwrap() != input_pid {
+            continue; // innermost ns PID doesn't match
+        }
+        if let Ok(pst) = proc_start_time(host_pid) {
+            if pst == input_start_time {
+                return nspid[0]; // host PID
+            }
+        }
+    }
+
+    input_pid // fallback
+}
+
+/// Read the `NSpid:` chain from `/proc/<pid>/status`.  Returns a Vec where
+/// index 0 is the outermost (host) PID and the last element is the innermost
+/// (namespace-local) PID.
+fn read_nspid_chain(pid: i32) -> Vec<i32> {
+    let Ok(status) = fs::read_to_string(format!("/proc/{pid}/status")) else {
+        return vec![];
     };
     for line in status.lines() {
         if let Some(rest) = line.strip_prefix("NSpid:") {
-            let mut parts = rest.split_whitespace();
-            if let Some(first) = parts.next() {
-                // Only translate when there are multiple levels (i.e. we are
-                // inside a nested PID namespace).
-                if parts.next().is_some() {
-                    if let Ok(global) = first.parse::<i32>() {
-                        return global;
-                    }
-                }
-            }
-            break;
+            return rest
+                .split_whitespace()
+                .filter_map(|s| s.parse::<i32>().ok())
+                .collect();
         }
     }
-    ns_pid
+    vec![]
+}
+
+/// Return the first (host-namespace) value from the `NSpid:` line of
+/// `/proc/<pid>/status`, or `None` if unavailable.
+fn first_nspid(pid: i32) -> Option<i32> {
+    read_nspid_chain(pid).first().copied()
+}
+
+/// Read `start_time` (field 22) from `/proc/<pid>/stat`.
+fn proc_start_time(pid: i32) -> Result<u64, ()> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).map_err(|_| ())?;
+    let after_comm = &stat[stat.rfind(')').ok_or(())? + 2..];
+    after_comm
+        .split_ascii_whitespace()
+        .nth(19) // field 22 = index 19 after ')'
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or(())
+}
+
+/// Check whether the current process runs in the init PID namespace by
+/// comparing its pid-namespace inode with that of PID 1.
+fn is_init_pid_namespace() -> bool {
+    let Ok(self_ns) = fs::read_link("/proc/self/ns/pid") else {
+        return false; // can't read → assume not init, fail-closed
+    };
+    let Ok(init_ns) = fs::read_link("/proc/1/ns/pid") else {
+        return false;
+    };
+    let result = self_ns == init_ns;
+    if !result {
+        eprintln!(
+            "agentsight-enforcer: not in init PID namespace \
+             (self={}, pid1={}); file_delete_guard will be disabled",
+            self_ns.display(),
+            init_ns.display(),
+        );
+    }
+    result
 }
 
 #[cfg(test)]

--- a/src/agentsight/src/enforcement.rs
+++ b/src/agentsight/src/enforcement.rs
@@ -15,5 +15,7 @@ pub use client::{
 pub use coordinator::{EnforcementCoordinator, EnforcementCoordinatorError};
 pub(crate) use coordinator::{IngestionGenerationLease, IngestionLease};
 pub use store::{EnforcementStore, EnforcementStoreError};
-pub(crate) use target::{canonical_policy_file, read_process_start_time};
+pub(crate) use target::{
+    canonical_policy_file, read_process_start_time, resolve_and_read_target, resolve_to_host_pid,
+};
 pub use transition::{PolicyTransition, TransitionDirection, TransitionKey, TransitionPhase};

--- a/src/agentsight/src/enforcement/target.rs
+++ b/src/agentsight/src/enforcement/target.rs
@@ -17,6 +17,21 @@ pub(crate) enum TargetValidationError {
 }
 
 /// Reads the Linux process start time after excluding protected service processes.
+///
+/// If `pid` is a namespace-local PID (e.g. from a container), it is first
+/// resolved to the host PID via [`resolve_to_host_pid`] using `expected_start_time`
+/// for disambiguation.  The returned tuple is `(host_pid, start_time)` so callers
+/// can use the resolved PID for BPF map seeding.
+pub(crate) fn resolve_and_read_target(
+    pid: i32,
+    expected_start_time: u64,
+) -> Result<(i32, u64), TargetValidationError> {
+    let host_pid = resolve_to_host_pid(pid, expected_start_time);
+    let start_time = read_process_start_time(host_pid)?;
+    Ok((host_pid, start_time))
+}
+
+/// Reads the Linux process start time after excluding protected service processes.
 pub(crate) fn read_process_start_time(pid: i32) -> Result<u64, TargetValidationError> {
     if pid <= 1 || pid == std::process::id() as i32 {
         return Err(TargetValidationError::ProtectedProcess(pid));
@@ -95,6 +110,110 @@ fn invalid_path(path: &Path, message: impl Into<String>) -> TargetValidationErro
     }
 }
 
+/// Resolve a potentially namespace-local PID to the global (init namespace)
+/// kernel PID.  The enforcer must run in the init PID namespace.
+///
+/// 1. Fast path: `/proc/<pid>/stat` exists and `start_time` matches → host PID.
+/// 2. Slow path: scan `/proc/*/status` for a process whose innermost NSpid
+///    equals `input_pid` and whose start_time matches.
+/// 3. Fallback: return input unchanged.
+pub(crate) fn resolve_to_host_pid(input_pid: i32, input_start_time: u64) -> i32 {
+    // Fast path: pid valid in host /proc and start_time matches.
+    if let Ok(pst) = proc_start_time(input_pid) {
+        if pst == input_start_time {
+            return first_nspid(input_pid).unwrap_or(input_pid);
+        }
+    }
+
+    // Slow path: scan /proc for NSpid inner match + start_time match.
+    let Ok(proc_dir) = fs::read_dir("/proc") else {
+        return input_pid;
+    };
+    for entry in proc_dir.flatten() {
+        let name = entry.file_name();
+        let Ok(host_pid) = name.to_string_lossy().parse::<i32>() else {
+            continue;
+        };
+        if host_pid <= 0 {
+            continue;
+        }
+        let nspid = read_nspid_chain(host_pid);
+        if nspid.len() < 2 {
+            continue;
+        }
+        if *nspid.last().unwrap() != input_pid {
+            continue;
+        }
+        if let Ok(pst) = proc_start_time(host_pid) {
+            if pst == input_start_time {
+                return nspid[0];
+            }
+        }
+    }
+    input_pid
+}
+
+fn read_nspid_chain(pid: i32) -> Vec<i32> {
+    let Ok(status) = fs::read_to_string(format!("/proc/{pid}/status")) else {
+        return vec![];
+    };
+    parse_nspid_from_status(&status)
+}
+
+/// Parse the `NSpid:` line from `/proc/<pid>/status` content.
+/// Returns empty vec if the line is absent.
+fn parse_nspid_from_status(status: &str) -> Vec<i32> {
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("NSpid:") {
+            return rest
+                .split_whitespace()
+                .filter_map(|s| s.parse::<i32>().ok())
+                .collect();
+        }
+    }
+    vec![]
+}
+
+fn first_nspid(pid: i32) -> Option<i32> {
+    read_nspid_chain(pid).first().copied()
+}
+
+fn proc_start_time(pid: i32) -> Result<u64, ()> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).map_err(|_| ())?;
+    parse_start_time_from_stat(&stat)
+}
+
+/// Parse process start time (field 22) from `/proc/<pid>/stat` content.
+fn parse_start_time_from_stat(stat: &str) -> Result<u64, ()> {
+    let after = &stat[stat.rfind(')').ok_or(())? + 2..];
+    after
+        .split_ascii_whitespace()
+        .nth(19)
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or(())
+}
+
+/// Check whether the current process is in the init PID namespace.
+#[allow(dead_code)] // Used by agentsight-enforcer crate (actplane.rs has its own copy).
+pub(crate) fn is_init_pid_namespace() -> bool {
+    let Ok(self_ns) = fs::read_link("/proc/self/ns/pid") else {
+        return false;
+    };
+    let Ok(init_ns) = fs::read_link("/proc/1/ns/pid") else {
+        return false;
+    };
+    let result = self_ns == init_ns;
+    if !result {
+        eprintln!(
+            "agentsight: not in init PID namespace (self={}, pid1={}); \
+             file_delete_guard disabled",
+            self_ns.display(),
+            init_ns.display(),
+        );
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +283,110 @@ mod tests {
             canonical_policy_file(file.path()).unwrap(),
             file.path().canonicalize().unwrap()
         );
+    }
+
+    #[test]
+    fn resolve_to_host_pid_fast_path_returns_self_for_current_process() {
+        // In the root namespace the current process PID is its own host PID.
+        let pid = std::process::id() as i32;
+        let pst = proc_start_time(pid).expect("own start time");
+        assert_eq!(resolve_to_host_pid(pid, pst), pid);
+    }
+
+    #[test]
+    fn resolve_to_host_pid_returns_input_for_nonexistent_pid() {
+        // A PID that definitely doesn't exist should fall through to fallback.
+        assert_eq!(resolve_to_host_pid(2_000_000_000, 0), 2_000_000_000);
+    }
+
+    #[test]
+    fn resolve_to_host_pid_rejects_pid_with_wrong_start_time() {
+        // Own PID exists but wrong start_time → should not match fast path.
+        let pid = std::process::id() as i32;
+        let result = resolve_to_host_pid(pid, 999_999_999);
+        // Falls through to slow path; no NSpid inner match → returns input.
+        assert_eq!(result, pid);
+    }
+
+    #[test]
+    fn read_nspid_chain_returns_at_least_self() {
+        let pid = std::process::id() as i32;
+        let chain = read_nspid_chain(pid);
+        assert!(!chain.is_empty(), "NSpid chain should not be empty");
+        assert_eq!(chain[0], pid, "first NSpid should be host PID");
+    }
+
+    #[test]
+    fn read_nspid_chain_returns_empty_for_invalid_pid() {
+        assert!(read_nspid_chain(2_000_000_000).is_empty());
+    }
+
+    #[test]
+    fn proc_start_time_succeeds_for_self() {
+        let pst = proc_start_time(std::process::id() as i32);
+        assert!(pst.is_ok());
+        assert!(pst.unwrap() > 0);
+    }
+
+    #[test]
+    fn proc_start_time_fails_for_nonexistent_pid() {
+        assert!(proc_start_time(2_000_000_000).is_err());
+    }
+
+    #[test]
+    fn is_init_pid_namespace_returns_true_in_test_runner() {
+        // Test runner runs on the host (init ns), so this should be true.
+        assert!(is_init_pid_namespace());
+    }
+
+    #[test]
+    fn resolve_and_read_target_succeeds_for_live_process() {
+        // Spawn a short-lived child and resolve it.
+        use std::process::Command;
+        let mut child = Command::new("sleep")
+            .arg("10")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id() as i32;
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let pst = proc_start_time(pid).expect("child start time");
+        let (host_pid, start_time) = resolve_and_read_target(pid, pst).expect("resolve");
+        assert_eq!(host_pid, pid);
+        assert_eq!(start_time, pst);
+        // cleanup
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn parse_nspid_single_level() {
+        let status = "Name:\ttest\nPid:\t42\nNSpid:\t42\nTgid:\t42\n";
+        assert_eq!(parse_nspid_from_status(status), vec![42]);
+    }
+
+    #[test]
+    fn parse_nspid_nested_namespace() {
+        let status = "Name:\tgateway\nPid:\t39560\nNSpid:\t39560\t1\nTgid:\t39560\n";
+        assert_eq!(parse_nspid_from_status(status), vec![39560, 1]);
+    }
+
+    #[test]
+    fn parse_nspid_missing_line() {
+        // Status content without NSpid line (edge case)
+        let status = "Name:\ttest\nPid:\t42\nTgid:\t42\n";
+        assert_eq!(parse_nspid_from_status(status), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn parse_start_time_from_valid_stat() {
+        // Synthetic /proc/pid/stat content: comm in parens, then 19 fields before starttime
+        let stat = "42 (test-proc) S 1 42 42 0 -1 4194304 100 0 0 0 10 5 0 0 20 0 1 0 12345 1000 100 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0";
+        assert_eq!(parse_start_time_from_stat(stat), Ok(12345));
+    }
+
+    #[test]
+    fn parse_start_time_from_malformed_stat() {
+        assert!(parse_start_time_from_stat("garbage").is_err());
+        assert!(parse_start_time_from_stat("").is_err());
     }
 }

--- a/src/agentsight/src/server/enforcement.rs
+++ b/src/agentsight/src/server/enforcement.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use super::AppState;
 use crate::enforcement::{
     EnforcementCoordinatorError, canonical_policy_file, read_process_start_time,
+    resolve_and_read_target, resolve_to_host_pid,
 };
 
 /// Bounded evidence list query.
@@ -338,7 +339,18 @@ pub(super) async fn apply_binding(
             false,
         );
     }
-    let request = body.into_inner();
+    let mut request = body.into_inner();
+    // Replace namespace-local PID with host PID so the enforcer seeds cap_task
+    // with the PID that BPF handle_fork will actually use.
+    let host_pid = resolve_to_host_pid(request.root_pid, request.process_start_time);
+    if host_pid != request.root_pid {
+        log::info!(
+            "resolved namespace PID {} to host PID {}",
+            request.root_pid,
+            host_pid
+        );
+        request.root_pid = host_pid;
+    }
     run_binding(move || coordinator.apply(request)).await
 }
 
@@ -559,7 +571,9 @@ fn public_health(mut status: HealthStatus) -> HealthStatus {
 }
 
 fn validate_target_identity(root_pid: i32, expected_start_time: u64) -> Result<(), String> {
-    let actual_start_time = read_process_start_time(root_pid).map_err(|error| error.to_string())?;
+    // resolve_and_read_target handles namespace PID translation + start-time check.
+    let (_host_pid, actual_start_time) =
+        resolve_and_read_target(root_pid, expected_start_time).map_err(|e| e.to_string())?;
     if actual_start_time != expected_start_time {
         return Err(format!(
             "PID {root_pid} start time changed: expected {expected_start_time}, found {actual_start_time}"


### PR DESCRIPTION
## Problem

PR #3022's `resolve_kernel_pid` was a no-op. It never changed the input PID because `/proc/<pid>/status NSpid[0]` always equals the input when read from the same namespace.

Additionally, the serve layer's `validate_target_identity` rejected namespace-local PIDs (e.g. container PID 1) before they reached the enforcer, because PID 1 on the host is systemd with a different start_time.

## Fix

Replace `resolve_kernel_pid` with `resolve_to_host_pid` that uses **pid + start_time joint matching**:

1. **Fast path**: `/proc/<pid>/stat` exists and `start_time` matches → return `NSpid[0]` (host PID). O(1).
2. **Slow path**: scan `/proc/*/status` for innermost `NSpid == input_pid` with matching `start_time` → return host PID. O(n), runs once per binding.
3. **Fallback**: no match → return input unchanged.

Resolution runs in **both** serve (`validate_target_identity`) and enforcer (`prepare_binding`), **before** start-time validation.

Also adds **init-ns self-check**: compares `/proc/self/ns/pid` with `/proc/1/ns/pid`; if different, `file_delete_guard` reports `false` (fail-closed).

## Verification (real nested PID namespace on 47.111)

| Test | Input | Result |
|------|-------|--------|
| T1: host PID, basic block | pid=host | **PASS** (fast path, rm→EPERM) |
| T2: host PID, multi-level fork | gateway→bash→sh→rm | **PASS** |
| T3: ns-local PID=1, container target | unshare --pid, pst matching | **PASS** (slow path, resolved 1→42971, rm→EPERM) |
| health | init-ns check | `file_delete_guard=true` |

T3 was previously FAIL with PR #3022 (`invalid_target` / no-op resolve).

## Files changed

- `crates/agentsight-enforcer/src/actplane.rs` — enforcer-side resolve + init-ns field + health gate
- `src/enforcement/target.rs` — shared `resolve_to_host_pid`, `is_init_pid_namespace`, helpers
- `src/enforcement.rs` — re-exports
- `src/server/enforcement.rs` — serve-side resolve before validate
