### PR TITLE
feat(sec-core): add agentsight policy adapter and client

### DIFF
--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -12,6 +12,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asc-agentsight-client"
+version = "0.1.0"
+dependencies = [
+ "asc-policy-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "ureq",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "asc-daemon"
 version = "0.1.0"
 dependencies = [
@@ -72,6 +85,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +110,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -137,6 +166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,7 +189,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -188,6 +243,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -202,6 +268,110 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -237,6 +407,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "log"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,7 +432,7 @@ checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -266,10 +448,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -300,6 +497,55 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -370,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +631,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -397,14 +655,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -426,6 +702,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -479,6 +766,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +788,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -524,13 +821,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -592,10 +929,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -604,6 +968,159 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "actplane-ifc-compiler"
+version = "0.1.8"
+source = "git+https://github.com/eunomia-bpf/ActPlane.git?rev=a62e5d9d96f91101cda019519053e950d532380a#a62e5d9d96f91101cda019519053e950d532380a"
+dependencies = [
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
 name = "asc-daemon"
 version = "0.1.0"
 dependencies = [
@@ -39,6 +48,16 @@ dependencies = [
  "sha2",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "asc-policy-adapter-agentsight"
+version = "0.1.0"
+dependencies = [
+ "actplane-ifc-compiler",
+ "asc-policy-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -118,6 +137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +195,22 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -267,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +354,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -456,6 +516,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "apps/asc-daemon",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
+    "crates/policy/adapters/asc-policy-adapter-agentsight",
     "crates/policy/asc-pap",
     "crates/policy/asc-policy-types",
 ]
@@ -19,9 +20,11 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+actplane-ifc-compiler = { git = "https://github.com/eunomia-bpf/ActPlane.git", rev = "a62e5d9d96f91101cda019519053e950d532380a" }
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }
+asc-policy-adapter-agentsight = { path = "crates/policy/adapters/asc-policy-adapter-agentsight" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "apps/asc-daemon",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
+    "crates/integrations/asc-agentsight-client",
     "crates/policy/adapters/asc-policy-adapter-agentsight",
     "crates/policy/asc-pap",
     "crates/policy/asc-policy-types",
@@ -21,6 +22,7 @@ publish = false
 
 [workspace.dependencies]
 actplane-ifc-compiler = { git = "https://github.com/eunomia-bpf/ActPlane.git", rev = "a62e5d9d96f91101cda019519053e950d532380a" }
+asc-agentsight-client = { path = "crates/integrations/asc-agentsight-client" }
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }
@@ -32,7 +34,9 @@ sha2 = "0.10"
 thiserror = "2"
 time = { version = "=0.3.44", features = ["parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
-uuid = { version = "1", features = ["v4"] }
+ureq = { version = "2.12", default-features = false, features = ["tls"] }
+url = "2"
+uuid = { version = "1", features = ["v4", "v5"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -2,16 +2,18 @@
 
 This workspace slice contains the dependency-light contracts, Policy
 Administration Point, protocol-independent Unix-domain-socket service framework,
-and runnable foreground process bootstrap used by later AgentSecCore V2 work
-packages. It deliberately contains no daemon wire protocol, concrete persistence
-or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
-Adapter.
+runnable foreground process bootstrap, and the first AgentSight file-deletion
+target Adapter used by later AgentSecCore V2 work packages. It deliberately
+contains no daemon wire protocol, concrete persistence or Policy compiler,
+Policy runtime, reconciliation worker, outbox, or target Client.
 
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
 - `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding
   snapshots, backend-independent IR, and target Adapter contracts.
+- `asc-policy-adapter-agentsight`: deterministic file-deletion and PID-Scope
+  translation into a compiler-checked AgentSight/ActPlane plan.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
@@ -170,8 +172,8 @@ Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
 Daemon protocol, client, concrete persistence/compiler, Policy runtime,
-reconciliation worker, outbox, and target Adapter belong to later work packages
-and are intentionally absent from this slice.
+reconciliation worker, and outbox belong to later work packages and are
+intentionally absent from this slice.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -2,10 +2,10 @@
 
 This workspace slice contains the dependency-light contracts, Policy
 Administration Point, protocol-independent Unix-domain-socket service framework,
-runnable foreground process bootstrap, and the first AgentSight file-deletion
-target Adapter used by later AgentSecCore V2 work packages. It deliberately
-contains no daemon wire protocol, concrete persistence or Policy compiler,
-Policy runtime, reconciliation worker, outbox, or target Client.
+runnable foreground process bootstrap, the first AgentSight file-deletion
+target Adapter, and its independent deployment Client used by later AgentSecCore
+V2 work packages. It deliberately contains no daemon wire protocol, concrete
+persistence or Policy compiler, Policy runtime, reconciliation worker, or outbox.
 
 The current crates are:
 
@@ -14,6 +14,9 @@ The current crates are:
   snapshots, backend-independent IR, and target Adapter contracts.
 - `asc-policy-adapter-agentsight`: deterministic file-deletion and PID-Scope
   translation into a compiler-checked AgentSight/ActPlane plan.
+- `asc-agentsight-client`: health-gated AgentSight apply/delete transport for
+  one configured endpoint, with process identity resolution and complete HTTP
+  fixtures. It does not depend on a reconciliation framework.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
@@ -171,7 +174,7 @@ Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-Daemon protocol, client, concrete persistence/compiler, Policy runtime,
+Daemon protocol, daemon client, concrete persistence/compiler, Policy runtime,
 reconciliation worker, and outbox belong to later work packages and are
 intentionally absent from this slice.
 

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-agentsight-client"
+description = "AgentSight deployment Client for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-policy-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+ureq = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/client.rs
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/client.rs
@@ -1,0 +1,450 @@
+//! `AgentSight` request preparation and target result classification.
+
+use std::path::Path;
+
+use asc_policy_types::identifiers::{ResourceId, Revision};
+use asc_policy_types::target::TargetBindingPlan;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::process::{ProcProcessIdentityResolver, ProcessIdentityError, ProcessIdentityResolver};
+use crate::transport::{
+    AgentSightClientConfigError, AgentSightHttpMethod, AgentSightHttpRequest,
+    AgentSightHttpResponse, AgentSightTransport, AgentSightTransportError, UreqAgentSightTransport,
+};
+use crate::{
+    DEFAULT_AGENTSIGHT_BASE_URL, DEFAULT_AGENTSIGHT_TOKEN_FILE, ENFORCEMENT_BINDINGS_PATH,
+    ENFORCEMENT_HEALTH_PATH,
+};
+
+const BINDING_PLAN_FORMAT: &str = "agentsight.actplane.binding.v1";
+const BINDING_PLAN_SCHEMA_VERSION: u16 = 1;
+const ACTPLANE_POLICY_MEDIA_TYPE: &str = "application/vnd.actplane.dsl.v1";
+const MAX_PLAN_BYTES: usize = 1024 * 1024;
+const BINDING_ID_NAME_PREFIX: &str = "urn:agentseccore:agentsight-binding:";
+
+/// Stable classification of an `AgentSight` Client failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AgentSightClientErrorKind {
+    /// The same desired operation may be attempted again.
+    #[error("retryable")]
+    Retryable,
+    /// The request cannot be accepted without changing the desired operation.
+    #[error("rejected")]
+    Rejected,
+}
+
+/// Stable, sanitized failure returned by the `AgentSight` Client.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{kind} AgentSight deployment failure: {code}")]
+pub struct AgentSightClientError {
+    /// Controls whether callers may retry the same desired operation.
+    pub kind: AgentSightClientErrorKind,
+    /// Stable machine-readable code safe for status projection.
+    pub code: String,
+}
+
+/// Target state confirmed by one successful Client operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentSightDeploymentState {
+    /// `AgentSight` confirmed that the deployment is effective.
+    Present,
+    /// `AgentSight` confirmed that the deployment is absent.
+    Absent,
+}
+
+/// Side-effecting Client for one configured `AgentSight` endpoint.
+pub struct AgentSightClient<T, R> {
+    transport: T,
+    process_identity: R,
+}
+
+impl<T, R> AgentSightClient<T, R> {
+    /// Creates a Client from independently testable transport and process ports.
+    pub const fn with_dependencies(transport: T, process_identity: R) -> Self {
+        Self {
+            transport,
+            process_identity,
+        }
+    }
+}
+
+impl AgentSightClient<UreqAgentSightTransport, ProcProcessIdentityResolver> {
+    /// Creates the production Client using the documented local API and token file.
+    ///
+    /// # Errors
+    /// Returns a sanitized configuration error if the endpoint or credential is invalid.
+    pub fn new_default() -> Result<Self, AgentSightClientConfigError> {
+        Self::new_with_token_file(DEFAULT_AGENTSIGHT_BASE_URL, DEFAULT_AGENTSIGHT_TOKEN_FILE)
+    }
+
+    /// Creates the production Client using an explicit API root and token file.
+    ///
+    /// # Errors
+    /// Returns a sanitized configuration error if the endpoint or credential is invalid.
+    pub fn new_with_token_file(
+        base_url: &str,
+        token_file: impl AsRef<Path>,
+    ) -> Result<Self, AgentSightClientConfigError> {
+        let transport = UreqAgentSightTransport::from_token_file(base_url, token_file)?;
+        Ok(Self::with_dependencies(
+            transport,
+            ProcProcessIdentityResolver,
+        ))
+    }
+}
+
+impl<T, R> AgentSightClient<T, R>
+where
+    T: AgentSightTransport,
+    R: ProcessIdentityResolver,
+{
+    /// Applies one translated plan.
+    ///
+    /// The target UUID is derived from the immutable source Binding identity and
+    /// revision carried by the plan. Retrying the same plan therefore reuses the
+    /// same `AgentSight` idempotency identity.
+    ///
+    /// # Errors
+    /// Returns a stable target rejection or retryable communication failure.
+    pub fn apply(
+        &self,
+        plan: &TargetBindingPlan,
+    ) -> Result<AgentSightDeploymentState, AgentSightClientError> {
+        let plan = decode_plan(plan)?;
+        self.require_file_delete_capability()?;
+        let process_start_time = self
+            .process_identity
+            .process_start_time(plan.root_pid)
+            .map_err(classify_process_identity_error)?;
+
+        let request_body = ApplyBindingRequest {
+            binding_id: plan.target_binding_id.to_string(),
+            // TODO(agentsight-agent-identity): replace this temporary scope
+            // identity mapping once the apply input carries an explicit
+            // product Agent identity.
+            agent_id: plan.scope_id.to_string(),
+            session_id: None,
+            root_pid: plan.root_pid,
+            process_start_time,
+            policy_id: plan.policy_id.to_string(),
+            policy_revision: plan.policy_revision.get().to_string(),
+            policy_dsl: plan.policy_dsl,
+            policy_mode: "enforce".to_owned(),
+        };
+        let body = serde_json::to_vec(&request_body)
+            .map_err(|_| rejected("AGENTSIGHT_REQUEST_SERIALIZATION_FAILED"))?;
+        let response = self.send(&AgentSightHttpRequest {
+            method: AgentSightHttpMethod::Post,
+            path: ENFORCEMENT_BINDINGS_PATH.to_owned(),
+            body: Some(body),
+        })?;
+        if !(200..300).contains(&response.status) {
+            return Err(classify_http_error(response.status, &response.body));
+        }
+        let binding: EnforcementBinding = serde_json::from_slice(&response.body)
+            .map_err(|_| retryable("AGENTSIGHT_INVALID_APPLY_RESPONSE"))?;
+        if binding.request != request_body {
+            return Err(retryable("AGENTSIGHT_APPLY_RESPONSE_MISMATCH"));
+        }
+
+        match (binding.state, binding.domain_id) {
+            (EnforcementState::Enforced, Some(_)) => Ok(AgentSightDeploymentState::Present),
+            (EnforcementState::Pending | EnforcementState::Degraded, _) => {
+                Err(retryable("AGENTSIGHT_DEPLOYMENT_NOT_READY"))
+            }
+            (EnforcementState::Enforced, None) => {
+                Err(retryable("AGENTSIGHT_INVALID_APPLY_RESPONSE"))
+            }
+            (
+                EnforcementState::Failed | EnforcementState::Detaching | EnforcementState::Detached,
+                _,
+            ) => Err(rejected("AGENTSIGHT_DEPLOYMENT_REJECTED")),
+        }
+    }
+
+    /// Removes the target Binding derived from a logical Binding revision.
+    ///
+    /// Target-side absence is a successful observation.
+    ///
+    /// # Errors
+    /// Returns a stable target rejection or retryable communication failure.
+    pub fn delete(
+        &self,
+        binding_id: &ResourceId,
+        binding_revision: Revision,
+    ) -> Result<AgentSightDeploymentState, AgentSightClientError> {
+        let target_binding_id = target_binding_id(binding_id, binding_revision);
+        let response = self.send(&AgentSightHttpRequest {
+            method: AgentSightHttpMethod::Delete,
+            path: format!("{ENFORCEMENT_BINDINGS_PATH}/{target_binding_id}"),
+            body: None,
+        })?;
+
+        if response.status == 204
+            || (response.status == 404
+                && remote_error(&response.body)
+                    .is_some_and(|error| error.code == "binding_not_found"))
+        {
+            return Ok(AgentSightDeploymentState::Absent);
+        }
+        if (200..300).contains(&response.status) {
+            return Err(retryable("AGENTSIGHT_INVALID_DELETE_RESPONSE"));
+        }
+        Err(classify_http_error(response.status, &response.body))
+    }
+}
+
+impl<T, R> AgentSightClient<T, R>
+where
+    T: AgentSightTransport,
+{
+    fn require_file_delete_capability(&self) -> Result<(), AgentSightClientError> {
+        let response = self.send(&AgentSightHttpRequest {
+            method: AgentSightHttpMethod::Get,
+            path: ENFORCEMENT_HEALTH_PATH.to_owned(),
+            body: None,
+        })?;
+        if !(200..300).contains(&response.status) {
+            return Err(classify_http_error(response.status, &response.body));
+        }
+        let health: EnforcementHealth = serde_json::from_slice(&response.body)
+            .map_err(|_| retryable("AGENTSIGHT_INVALID_HEALTH_RESPONSE"))?;
+        if !health.ready {
+            return Err(retryable("AGENTSIGHT_BACKEND_NOT_READY"));
+        }
+        if health.backend != "actplane" {
+            return Err(rejected("AGENTSIGHT_UNSUPPORTED_BACKEND"));
+        }
+        if !health.capabilities.file_delete_guard {
+            return Err(rejected("AGENTSIGHT_FILE_DELETE_GUARD_UNAVAILABLE"));
+        }
+        Ok(())
+    }
+
+    fn send(
+        &self,
+        request: &AgentSightHttpRequest,
+    ) -> Result<AgentSightHttpResponse, AgentSightClientError> {
+        self.transport.send(request).map_err(|error| match error {
+            AgentSightTransportError::InvalidRequest => rejected("AGENTSIGHT_INVALID_HTTP_REQUEST"),
+            AgentSightTransportError::Unavailable => {
+                // TODO(agentsight-unknown-outcome): let the future caller
+                // observe target state before replaying a timed-out modifying
+                // request.
+                retryable("AGENTSIGHT_TRANSPORT_UNAVAILABLE")
+            }
+            AgentSightTransportError::ResponseTooLarge => {
+                retryable("AGENTSIGHT_RESPONSE_TOO_LARGE")
+            }
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct EnforcementHealth {
+    ready: bool,
+    backend: String,
+    capabilities: EnforcementCapabilities,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnforcementCapabilities {
+    file_delete_guard: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ApplyBindingRequest {
+    binding_id: String,
+    agent_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    session_id: Option<String>,
+    root_pid: i32,
+    process_start_time: u64,
+    policy_id: String,
+    policy_revision: String,
+    policy_dsl: String,
+    policy_mode: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnforcementBinding {
+    request: ApplyBindingRequest,
+    state: EnforcementState,
+    domain_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EnforcementState {
+    Pending,
+    Enforced,
+    Failed,
+    Degraded,
+    Detaching,
+    Detached,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteErrorEnvelope {
+    error: RemoteError,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteError {
+    code: String,
+    retryable: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentSightBindingPlan {
+    schema_version: u16,
+    source: AgentSightSourceBinding,
+    policy: AgentSightPolicyPlan,
+    scope: AgentSightScopePlan,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentSightSourceBinding {
+    binding_id: ResourceId,
+    binding_revision: Revision,
+    policy_id: ResourceId,
+    policy_revision: Revision,
+    scope_id: ResourceId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AgentSightPolicyPlan {
+    media_type: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum AgentSightScopePlan {
+    ProcessTree { root_pid: i32 },
+}
+
+struct DecodedPlan {
+    target_binding_id: Uuid,
+    policy_id: ResourceId,
+    policy_revision: Revision,
+    scope_id: ResourceId,
+    root_pid: i32,
+    policy_dsl: String,
+}
+
+fn decode_plan(plan: &TargetBindingPlan) -> Result<DecodedPlan, AgentSightClientError> {
+    if plan.format != BINDING_PLAN_FORMAT {
+        return Err(rejected("AGENTSIGHT_UNSUPPORTED_PLAN_FORMAT"));
+    }
+    if plan.content.len() > MAX_PLAN_BYTES {
+        return Err(rejected("AGENTSIGHT_INVALID_PLAN"));
+    }
+    let plan: AgentSightBindingPlan =
+        serde_json::from_slice(&plan.content).map_err(|_| rejected("AGENTSIGHT_INVALID_PLAN"))?;
+    if plan.schema_version != BINDING_PLAN_SCHEMA_VERSION {
+        return Err(rejected("AGENTSIGHT_UNSUPPORTED_PLAN_SCHEMA"));
+    }
+    let AgentSightSourceBinding {
+        binding_id,
+        binding_revision,
+        policy_id,
+        policy_revision,
+        scope_id,
+    } = plan.source;
+    if plan.policy.media_type != ACTPLANE_POLICY_MEDIA_TYPE || plan.policy.content.is_empty() {
+        return Err(rejected("AGENTSIGHT_UNSUPPORTED_POLICY_ARTIFACT"));
+    }
+    let AgentSightScopePlan::ProcessTree { root_pid } = plan.scope;
+    if root_pid <= 0 {
+        return Err(rejected("AGENTSIGHT_INVALID_SCOPE"));
+    }
+    Ok(DecodedPlan {
+        target_binding_id: target_binding_id(&binding_id, binding_revision),
+        policy_id,
+        policy_revision,
+        scope_id,
+        root_pid,
+        policy_dsl: plan.policy.content,
+    })
+}
+
+fn target_binding_id(binding_id: &ResourceId, binding_revision: Revision) -> Uuid {
+    let name = format!(
+        "{BINDING_ID_NAME_PREFIX}{binding_id}:revision:{}",
+        binding_revision.get()
+    );
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, name.as_bytes())
+}
+
+fn classify_process_identity_error(error: ProcessIdentityError) -> AgentSightClientError {
+    match error {
+        ProcessIdentityError::InvalidPid | ProcessIdentityError::Malformed => {
+            rejected("AGENTSIGHT_INVALID_PROCESS_IDENTITY")
+        }
+        ProcessIdentityError::Unavailable => retryable("AGENTSIGHT_PROCESS_IDENTITY_UNAVAILABLE"),
+    }
+}
+
+fn classify_http_error(status: u16, body: &[u8]) -> AgentSightClientError {
+    if status == 401 {
+        return rejected("AGENTSIGHT_AUTHENTICATION_FAILED");
+    }
+    let error = remote_error(body);
+    let is_retryable = error.as_ref().is_some_and(|error| error.retryable)
+        || status == 429
+        || (500..600).contains(&status);
+    let code = error
+        .and_then(|error| normalize_remote_code(&error.code))
+        .unwrap_or_else(|| format!("AGENTSIGHT_HTTP_{status}"));
+    AgentSightClientError {
+        kind: if is_retryable {
+            AgentSightClientErrorKind::Retryable
+        } else {
+            AgentSightClientErrorKind::Rejected
+        },
+        code,
+    }
+}
+
+fn remote_error(body: &[u8]) -> Option<RemoteError> {
+    serde_json::from_slice::<RemoteErrorEnvelope>(body)
+        .ok()
+        .map(|envelope| envelope.error)
+}
+
+fn normalize_remote_code(code: &str) -> Option<String> {
+    if code.is_empty()
+        || code.len() > 64
+        || !code
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        || !code.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+    {
+        return None;
+    }
+    Some(format!("AGENTSIGHT_{}", code.to_ascii_uppercase()))
+}
+
+fn retryable(code: &str) -> AgentSightClientError {
+    AgentSightClientError {
+        kind: AgentSightClientErrorKind::Retryable,
+        code: code.to_owned(),
+    }
+}
+
+fn rejected(code: &str) -> AgentSightClientError {
+    AgentSightClientError {
+        kind: AgentSightClientErrorKind::Rejected,
+        code: code.to_owned(),
+    }
+}

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/lib.rs
@@ -1,0 +1,30 @@
+//! Independent `AgentSight` deployment Client for `AgentSecCore` V2.
+//!
+//! The Client consumes the versioned target plan emitted by the `AgentSight`
+//! Adapter, resolves the live Linux process start time, and calls the minimal
+//! health/apply/delete surface documented by `AgentSight`. It does not read
+//! Binding repository state, own reconciliation, or translate Policy IR.
+
+#![forbid(unsafe_code)]
+
+mod client;
+mod process;
+mod transport;
+
+pub use client::{
+    AgentSightClient, AgentSightClientError, AgentSightClientErrorKind, AgentSightDeploymentState,
+};
+pub use process::{ProcProcessIdentityResolver, ProcessIdentityError, ProcessIdentityResolver};
+pub use transport::{
+    AgentSightClientConfigError, AgentSightHttpMethod, AgentSightHttpRequest,
+    AgentSightHttpResponse, AgentSightTransport, AgentSightTransportError, UreqAgentSightTransport,
+};
+
+/// Default `AgentSight` API root from the integration contract.
+pub const DEFAULT_AGENTSIGHT_BASE_URL: &str = "http://127.0.0.1:7396/api";
+/// Default `AgentSight` dashboard Bearer-token location.
+pub const DEFAULT_AGENTSIGHT_TOKEN_FILE: &str = "/var/log/sysak/.agentsight/.dashboard_token";
+/// `AgentSight` enforcement health endpoint relative to the API root.
+pub const ENFORCEMENT_HEALTH_PATH: &str = "/enforcement/health";
+/// `AgentSight` general enforcement Binding endpoint relative to the API root.
+pub const ENFORCEMENT_BINDINGS_PATH: &str = "/enforcement/bindings";

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/process.rs
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/process.rs
@@ -1,0 +1,87 @@
+//! Linux process identity resolution required by `AgentSight`.
+
+use std::fs;
+
+/// Failure while resolving the PID-reuse-resistant process identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum ProcessIdentityError {
+    /// `AgentSight` accepts only positive process IDs.
+    #[error("invalid process id")]
+    InvalidPid,
+    /// `/proc` did not expose the process identity at request time.
+    #[error("process identity unavailable")]
+    Unavailable,
+    /// `/proc/<pid>/stat` did not have the expected Linux format.
+    #[error("malformed process identity")]
+    Malformed,
+}
+
+/// Runtime resolver for `AgentSight`'s required `process_start_time` field.
+pub trait ProcessIdentityResolver: Send + Sync {
+    /// Reads Linux `/proc/<pid>/stat` field 22 in kernel clock ticks.
+    ///
+    /// # Errors
+    /// Returns a stable local resolution category.
+    fn process_start_time(&self, pid: i32) -> Result<u64, ProcessIdentityError>;
+}
+
+/// Linux `/proc` implementation of [`ProcessIdentityResolver`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ProcProcessIdentityResolver;
+
+impl ProcessIdentityResolver for ProcProcessIdentityResolver {
+    fn process_start_time(&self, pid: i32) -> Result<u64, ProcessIdentityError> {
+        if pid <= 0 {
+            return Err(ProcessIdentityError::InvalidPid);
+        }
+        let stat = fs::read_to_string(format!("/proc/{pid}/stat"))
+            .map_err(|_| ProcessIdentityError::Unavailable)?;
+        parse_process_start_time(&stat)
+    }
+}
+
+fn parse_process_start_time(stat: &str) -> Result<u64, ProcessIdentityError> {
+    let command_start = stat.find('(').ok_or(ProcessIdentityError::Malformed)?;
+    let command_end = stat.rfind(')').ok_or(ProcessIdentityError::Malformed)?;
+    if command_start >= command_end {
+        return Err(ProcessIdentityError::Malformed);
+    }
+    let fields_after_command = stat
+        .get(command_end + 1..)
+        .ok_or(ProcessIdentityError::Malformed)?;
+    let start_time = fields_after_command
+        .split_whitespace()
+        .nth(19)
+        .ok_or(ProcessIdentityError::Malformed)?
+        .parse::<u64>()
+        .map_err(|_| ProcessIdentityError::Malformed)?;
+    if start_time == 0 {
+        return Err(ProcessIdentityError::Malformed);
+    }
+    Ok(start_time)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_uses_field_22_after_a_command_containing_spaces_and_parentheses() {
+        let stat =
+            "42 (agent worker (one)) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 987654 20";
+        assert_eq!(parse_process_start_time(stat).unwrap(), 987_654);
+    }
+
+    #[test]
+    fn parser_rejects_missing_and_zero_start_times() {
+        assert_eq!(
+            parse_process_start_time("42 agent S 1 2").unwrap_err(),
+            ProcessIdentityError::Malformed
+        );
+        let stat = "42 (agent) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 0";
+        assert_eq!(
+            parse_process_start_time(stat).unwrap_err(),
+            ProcessIdentityError::Malformed
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/transport.rs
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/src/transport.rs
@@ -1,0 +1,331 @@
+//! Minimal synchronous HTTP boundary used by the `AgentSight` Client.
+
+use std::fmt;
+use std::fs;
+use std::io::Read as _;
+use std::path::Path;
+use std::time::Duration;
+
+use url::Url;
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+const MAX_TOKEN_BYTES: usize = 4096;
+const MAX_BASE_URL_BYTES: usize = 2048;
+
+/// HTTP methods required by the current `AgentSight` integration slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentSightHttpMethod {
+    /// Retrieve health state.
+    Get,
+    /// Submit a target Binding.
+    Post,
+    /// Remove a target Binding.
+    Delete,
+}
+
+/// Sanitized request passed to an injectable `AgentSight` transport.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AgentSightHttpRequest {
+    /// HTTP method.
+    pub method: AgentSightHttpMethod,
+    /// Absolute path relative to the configured `AgentSight` API root.
+    pub path: String,
+    /// JSON request bytes, present only for `POST`.
+    pub body: Option<Vec<u8>>,
+}
+
+impl fmt::Debug for AgentSightHttpRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentSightHttpRequest")
+            .field("method", &self.method)
+            .field("path", &self.path)
+            .field(
+                "body_bytes",
+                &self.body.as_ref().map_or(0, std::vec::Vec::len),
+            )
+            .finish()
+    }
+}
+
+/// Raw bounded response returned by an injectable `AgentSight` transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentSightHttpResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Bounded response body bytes.
+    pub body: Vec<u8>,
+}
+
+/// Sanitized transport-layer failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AgentSightTransportError {
+    /// The request shape violates the narrow transport contract.
+    #[error("invalid AgentSight HTTP request")]
+    InvalidRequest,
+    /// The endpoint could not be reached or its response could not be read.
+    #[error("AgentSight transport unavailable")]
+    Unavailable,
+    /// The target response exceeded the Client's memory bound.
+    #[error("AgentSight response exceeds the configured limit")]
+    ResponseTooLarge,
+}
+
+/// Injectable transport port for deterministic Client contract tests.
+pub trait AgentSightTransport: Send + Sync {
+    /// Sends one request without exposing credentials to the caller.
+    ///
+    /// # Errors
+    /// Returns a sanitized local transport category.
+    fn send(
+        &self,
+        request: &AgentSightHttpRequest,
+    ) -> Result<AgentSightHttpResponse, AgentSightTransportError>;
+}
+
+/// Stable configuration failure that does not expose a token or file content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AgentSightClientConfigError {
+    /// The API root is not a bounded HTTP(S) URL.
+    #[error("invalid AgentSight base URL")]
+    InvalidBaseUrl,
+    /// The configured token file could not be read.
+    #[error("AgentSight credential unavailable")]
+    CredentialUnavailable,
+    /// The token is empty, oversized, or contains unsafe characters.
+    #[error("invalid AgentSight credential")]
+    InvalidCredential,
+}
+
+/// Production synchronous HTTP transport backed by `ureq`.
+pub struct UreqAgentSightTransport {
+    agent: ureq::Agent,
+    base_url: String,
+    authorization: String,
+}
+
+impl fmt::Debug for UreqAgentSightTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UreqAgentSightTransport")
+            .field("base_url", &self.base_url)
+            .field("authorization", &"<redacted>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl UreqAgentSightTransport {
+    /// Creates a transport from an in-memory Bearer token.
+    ///
+    /// # Errors
+    /// Returns a sanitized configuration category for an invalid URL or token.
+    pub fn new(base_url: &str, bearer_token: &str) -> Result<Self, AgentSightClientConfigError> {
+        let base_url = normalize_base_url(base_url)?;
+        let bearer_token = normalize_token(bearer_token)?;
+        Ok(Self {
+            agent: ureq::AgentBuilder::new()
+                .timeout(DEFAULT_REQUEST_TIMEOUT)
+                .redirects(0)
+                .build(),
+            base_url,
+            authorization: format!("Bearer {bearer_token}"),
+        })
+    }
+
+    /// Creates a transport by reading the configured Bearer-token file.
+    ///
+    /// A single trailing line ending is accepted because the standard token
+    /// file is commonly produced by a line-oriented command.
+    ///
+    /// # Errors
+    /// Returns a sanitized configuration category; the path and file content
+    /// are never included in the error.
+    pub fn from_token_file(
+        base_url: &str,
+        token_file: impl AsRef<Path>,
+    ) -> Result<Self, AgentSightClientConfigError> {
+        let token =
+            fs::read(token_file).map_err(|_| AgentSightClientConfigError::CredentialUnavailable)?;
+        if token.len() > MAX_TOKEN_BYTES {
+            return Err(AgentSightClientConfigError::InvalidCredential);
+        }
+        let token = std::str::from_utf8(&token)
+            .map_err(|_| AgentSightClientConfigError::InvalidCredential)?;
+        Self::new(base_url, token)
+    }
+}
+
+impl AgentSightTransport for UreqAgentSightTransport {
+    fn send(
+        &self,
+        request: &AgentSightHttpRequest,
+    ) -> Result<AgentSightHttpResponse, AgentSightTransportError> {
+        validate_request(request)?;
+        let url = format!("{}{}", self.base_url, request.path);
+        let builder = match request.method {
+            AgentSightHttpMethod::Get => self.agent.get(&url),
+            AgentSightHttpMethod::Post => self.agent.post(&url),
+            AgentSightHttpMethod::Delete => self.agent.delete(&url),
+        }
+        .set("Authorization", &self.authorization)
+        .set("Accept", "application/json");
+
+        let result = match request.method {
+            AgentSightHttpMethod::Post => builder
+                .set("Content-Type", "application/json")
+                .send_bytes(request.body.as_deref().unwrap_or_default()),
+            AgentSightHttpMethod::Get | AgentSightHttpMethod::Delete => builder.call(),
+        };
+        match result {
+            Ok(response) | Err(ureq::Error::Status(_, response)) => read_response(response),
+            Err(ureq::Error::Transport(_)) => Err(AgentSightTransportError::Unavailable),
+        }
+    }
+}
+
+fn normalize_base_url(base_url: &str) -> Result<String, AgentSightClientConfigError> {
+    if base_url.is_empty()
+        || base_url.len() > MAX_BASE_URL_BYTES
+        || base_url
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+        || base_url.contains(['?', '#'])
+    {
+        return Err(AgentSightClientConfigError::InvalidBaseUrl);
+    }
+    let authority_and_path = base_url
+        .strip_prefix("http://")
+        .or_else(|| base_url.strip_prefix("https://"))
+        .ok_or(AgentSightClientConfigError::InvalidBaseUrl)?;
+    let authority = authority_and_path
+        .split('/')
+        .next()
+        .ok_or(AgentSightClientConfigError::InvalidBaseUrl)?;
+    if authority.is_empty() || authority.contains('@') || authority_and_path.starts_with('/') {
+        return Err(AgentSightClientConfigError::InvalidBaseUrl);
+    }
+    let parsed = Url::parse(base_url).map_err(|_| AgentSightClientConfigError::InvalidBaseUrl)?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.port() == Some(0)
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err(AgentSightClientConfigError::InvalidBaseUrl);
+    }
+    let normalized = parsed.as_str().trim_end_matches('/');
+    if normalized.len() > MAX_BASE_URL_BYTES {
+        return Err(AgentSightClientConfigError::InvalidBaseUrl);
+    }
+    Ok(normalized.to_owned())
+}
+
+fn normalize_token(token: &str) -> Result<&str, AgentSightClientConfigError> {
+    let token = token.trim_end_matches(['\r', '\n']);
+    if token.is_empty()
+        || token.len() > MAX_TOKEN_BYTES
+        || !token.bytes().all(|byte| byte.is_ascii_graphic())
+    {
+        return Err(AgentSightClientConfigError::InvalidCredential);
+    }
+    Ok(token)
+}
+
+fn validate_request(request: &AgentSightHttpRequest) -> Result<(), AgentSightTransportError> {
+    if !request.path.starts_with('/')
+        || request.path.contains(['?', '#'])
+        || request
+            .path
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+    {
+        return Err(AgentSightTransportError::InvalidRequest);
+    }
+    match (request.method, request.body.is_some()) {
+        (AgentSightHttpMethod::Post, true)
+        | (AgentSightHttpMethod::Get | AgentSightHttpMethod::Delete, false) => Ok(()),
+        _ => Err(AgentSightTransportError::InvalidRequest),
+    }
+}
+
+fn read_response(
+    response: ureq::Response,
+) -> Result<AgentSightHttpResponse, AgentSightTransportError> {
+    let status = response.status();
+    let mut body = Vec::new();
+    response
+        .into_reader()
+        .take((MAX_RESPONSE_BYTES + 1) as u64)
+        .read_to_end(&mut body)
+        .map_err(|_| AgentSightTransportError::Unavailable)?;
+    if body.len() > MAX_RESPONSE_BYTES {
+        return Err(AgentSightTransportError::ResponseTooLarge);
+    }
+    Ok(AgentSightHttpResponse { status, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_output_redacts_credentials_and_request_bodies() {
+        let transport =
+            UreqAgentSightTransport::new("http://127.0.0.1:7396/api/", "top-secret-token\n")
+                .unwrap();
+        let transport_debug = format!("{transport:?}");
+        assert!(transport_debug.contains("<redacted>"));
+        assert!(!transport_debug.contains("top-secret-token"));
+
+        let request = AgentSightHttpRequest {
+            method: AgentSightHttpMethod::Post,
+            path: "/enforcement/bindings".to_owned(),
+            body: Some(b"sensitive policy body".to_vec()),
+        };
+        let request_debug = format!("{request:?}");
+        assert!(request_debug.contains("body_bytes"));
+        assert!(!request_debug.contains("sensitive policy body"));
+    }
+
+    #[test]
+    fn configuration_rejects_unsafe_urls_and_tokens() {
+        assert_eq!(
+            UreqAgentSightTransport::new("file:///tmp/socket", "token").unwrap_err(),
+            AgentSightClientConfigError::InvalidBaseUrl
+        );
+        assert_eq!(
+            UreqAgentSightTransport::new("http://localhost/api?token=x", "token").unwrap_err(),
+            AgentSightClientConfigError::InvalidBaseUrl
+        );
+        assert_eq!(
+            UreqAgentSightTransport::new("http://user:secret@localhost/api", "token").unwrap_err(),
+            AgentSightClientConfigError::InvalidBaseUrl
+        );
+        assert_eq!(
+            UreqAgentSightTransport::new("http://localhost/api", "bad token").unwrap_err(),
+            AgentSightClientConfigError::InvalidCredential
+        );
+    }
+
+    #[test]
+    fn configuration_rejects_malformed_authorities_and_ports() {
+        for base_url in [
+            "http://[::1",
+            "http://localhost:99999",
+            "http://:80",
+            "http://localhost:0",
+        ] {
+            assert_eq!(
+                UreqAgentSightTransport::new(base_url, "token").unwrap_err(),
+                AgentSightClientConfigError::InvalidBaseUrl,
+                "base URL should be rejected: {base_url}"
+            );
+        }
+
+        let valid_ipv6 = UreqAgentSightTransport::new("http://[::1]:7396/api/", "token").unwrap();
+        assert_eq!(valid_ipv6.base_url, "http://[::1]:7396/api");
+    }
+}

--- a/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/tests/client.rs
+++ b/src/agent-sec-core/v2/crates/integrations/asc-agentsight-client/tests/client.rs
@@ -1,0 +1,265 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use asc_agentsight_client::{
+    AgentSightClient, AgentSightClientErrorKind, AgentSightDeploymentState, AgentSightHttpMethod,
+    AgentSightHttpRequest, AgentSightHttpResponse, AgentSightTransport, AgentSightTransportError,
+    ProcessIdentityError, ProcessIdentityResolver,
+};
+use asc_policy_types::identifiers::{ResourceId, Revision};
+use asc_policy_types::target::TargetBindingPlan;
+
+const HEALTH_RESPONSE: &[u8] =
+    include_bytes!("../../../../fixtures/clients/agentsight/file-deletion/health.response.json");
+const APPLY_REQUEST: &[u8] =
+    include_bytes!("../../../../fixtures/clients/agentsight/file-deletion/apply.request.json");
+const APPLY_RESPONSE: &[u8] =
+    include_bytes!("../../../../fixtures/clients/agentsight/file-deletion/apply.response.json");
+const RETRYABLE_ERROR_RESPONSE: &[u8] = include_bytes!(
+    "../../../../fixtures/clients/agentsight/file-deletion/retryable-error.response.json"
+);
+const BINDING_PLAN: &[u8] =
+    include_bytes!("../../../../fixtures/clients/agentsight/file-deletion/deployment-plan.json");
+
+type TransportResult = Result<AgentSightHttpResponse, AgentSightTransportError>;
+
+#[derive(Clone)]
+struct FakeTransport {
+    state: Arc<Mutex<FakeTransportState>>,
+}
+
+struct FakeTransportState {
+    responses: VecDeque<TransportResult>,
+    requests: Vec<AgentSightHttpRequest>,
+}
+
+impl FakeTransport {
+    fn new(responses: impl IntoIterator<Item = TransportResult>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FakeTransportState {
+                responses: responses.into_iter().collect(),
+                requests: Vec::new(),
+            })),
+        }
+    }
+
+    fn requests(&self) -> Vec<AgentSightHttpRequest> {
+        self.state.lock().unwrap().requests.clone()
+    }
+}
+
+impl AgentSightTransport for FakeTransport {
+    fn send(
+        &self,
+        request: &AgentSightHttpRequest,
+    ) -> Result<AgentSightHttpResponse, AgentSightTransportError> {
+        let mut state = self.state.lock().unwrap();
+        state.requests.push(request.clone());
+        state
+            .responses
+            .pop_front()
+            .ok_or(AgentSightTransportError::InvalidRequest)?
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FixedProcessIdentity(Result<u64, ProcessIdentityError>);
+
+impl ProcessIdentityResolver for FixedProcessIdentity {
+    fn process_start_time(&self, _pid: i32) -> Result<u64, ProcessIdentityError> {
+        self.0
+    }
+}
+
+fn response(status: u16, body: &[u8]) -> AgentSightHttpResponse {
+    AgentSightHttpResponse {
+        status,
+        body: body.to_vec(),
+    }
+}
+
+fn binding_id() -> ResourceId {
+    resource_id("10000000-0000-4000-8000-000000000001")
+}
+
+fn binding_revision() -> Revision {
+    Revision::new(7).unwrap()
+}
+
+fn binding_plan(content: Vec<u8>) -> TargetBindingPlan {
+    TargetBindingPlan {
+        format: "agentsight.actplane.binding.v1".to_owned(),
+        content,
+    }
+}
+
+fn resource_id(value: &str) -> ResourceId {
+    ResourceId::new(value).unwrap()
+}
+
+#[test]
+fn apply_checks_health_and_reuses_the_derived_idempotency_identity() {
+    let transport = FakeTransport::new([
+        Ok(response(200, HEALTH_RESPONSE)),
+        Ok(response(200, APPLY_RESPONSE)),
+        Ok(response(200, HEALTH_RESPONSE)),
+        Ok(response(200, APPLY_RESPONSE)),
+    ]);
+    let client =
+        AgentSightClient::with_dependencies(transport.clone(), FixedProcessIdentity(Ok(987_654)));
+    let plan = binding_plan(BINDING_PLAN.to_vec());
+
+    let first = client.apply(&plan).unwrap();
+    let second = client.apply(&plan).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(first, AgentSightDeploymentState::Present);
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 4);
+    assert_eq!(requests[0].method, AgentSightHttpMethod::Get);
+    assert_eq!(requests[0].path, "/enforcement/health");
+    assert_eq!(requests[1].method, AgentSightHttpMethod::Post);
+    assert_eq!(requests[1].path, "/enforcement/bindings");
+    assert_eq!(requests[1].body, requests[3].body);
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(requests[1].body.as_deref().unwrap()).unwrap(),
+        serde_json::from_slice::<serde_json::Value>(APPLY_REQUEST).unwrap()
+    );
+}
+
+#[test]
+fn delete_treats_no_content_and_binding_not_found_as_absent() {
+    let not_found = br#"{
+        "error": {
+            "code": "binding_not_found",
+            "message": "sensitive remote detail",
+            "retryable": false
+        }
+    }"#;
+    let transport = FakeTransport::new([Ok(response(204, b"")), Ok(response(404, not_found))]);
+    let client =
+        AgentSightClient::with_dependencies(transport.clone(), FixedProcessIdentity(Ok(987_654)));
+    let first = client.delete(&binding_id(), binding_revision()).unwrap();
+    let second = client.delete(&binding_id(), binding_revision()).unwrap();
+
+    assert_eq!(first, AgentSightDeploymentState::Absent);
+    assert_eq!(second, AgentSightDeploymentState::Absent);
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().all(|request| {
+        request.method == AgentSightHttpMethod::Delete
+            && request.path == "/enforcement/bindings/d525d62c-2a3d-570b-9c25-d29c336c1d87"
+            && request.body.is_none()
+    }));
+}
+
+#[test]
+fn different_binding_revisions_derive_different_target_ids() {
+    let transport = FakeTransport::new([Ok(response(204, b"")), Ok(response(204, b""))]);
+    let client =
+        AgentSightClient::with_dependencies(transport.clone(), FixedProcessIdentity(Ok(987_654)));
+
+    client
+        .delete(&binding_id(), Revision::new(7).unwrap())
+        .unwrap();
+    client
+        .delete(&binding_id(), Revision::new(8).unwrap())
+        .unwrap();
+
+    let requests = transport.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        requests[0].path,
+        "/enforcement/bindings/d525d62c-2a3d-570b-9c25-d29c336c1d87"
+    );
+    assert_eq!(
+        requests[1].path,
+        "/enforcement/bindings/57f6ffc6-7960-5e22-8aef-404c2178c266"
+    );
+}
+
+#[test]
+fn remote_errors_are_classified_without_exposing_target_messages() {
+    let conflict = br#"{
+        "error": {
+            "code": "policy_revision_conflict",
+            "message": "another sensitive target detail",
+            "retryable": false
+        }
+    }"#;
+    let transport = FakeTransport::new([
+        Ok(response(200, HEALTH_RESPONSE)),
+        Ok(response(503, RETRYABLE_ERROR_RESPONSE)),
+        Ok(response(200, HEALTH_RESPONSE)),
+        Ok(response(409, conflict)),
+    ]);
+    let client = AgentSightClient::with_dependencies(transport, FixedProcessIdentity(Ok(987_654)));
+    let plan = binding_plan(BINDING_PLAN.to_vec());
+
+    let retryable = client.apply(&plan).unwrap_err();
+    assert_eq!(retryable.kind, AgentSightClientErrorKind::Retryable);
+    assert_eq!(retryable.code, "AGENTSIGHT_ENFORCER_UNAVAILABLE");
+    assert!(!format!("{retryable:?}").contains("sensitive"));
+
+    let rejected = client.apply(&plan).unwrap_err();
+    assert_eq!(rejected.kind, AgentSightClientErrorKind::Rejected);
+    assert_eq!(rejected.code, "AGENTSIGHT_POLICY_REVISION_CONFLICT");
+    assert!(!format!("{rejected:?}").contains("sensitive"));
+}
+
+#[test]
+fn local_transport_and_process_failures_keep_stable_retry_categories() {
+    let transport = FakeTransport::new([Err(AgentSightTransportError::Unavailable)]);
+    let client = AgentSightClient::with_dependencies(transport, FixedProcessIdentity(Ok(987_654)));
+    let unavailable = client
+        .apply(&binding_plan(BINDING_PLAN.to_vec()))
+        .unwrap_err();
+    assert_eq!(unavailable.kind, AgentSightClientErrorKind::Retryable);
+    assert_eq!(unavailable.code, "AGENTSIGHT_TRANSPORT_UNAVAILABLE");
+
+    let transport = FakeTransport::new([Ok(response(200, HEALTH_RESPONSE))]);
+    let client = AgentSightClient::with_dependencies(
+        transport,
+        FixedProcessIdentity(Err(ProcessIdentityError::Unavailable)),
+    );
+    let unavailable = client
+        .apply(&binding_plan(BINDING_PLAN.to_vec()))
+        .unwrap_err();
+    assert_eq!(unavailable.kind, AgentSightClientErrorKind::Retryable);
+    assert_eq!(unavailable.code, "AGENTSIGHT_PROCESS_IDENTITY_UNAVAILABLE");
+}
+
+#[test]
+fn apply_rejects_an_unsupported_plan_format_before_target_io() {
+    let transport = FakeTransport::new([]);
+    let client =
+        AgentSightClient::with_dependencies(transport.clone(), FixedProcessIdentity(Ok(987_654)));
+    let mut plan = binding_plan(BINDING_PLAN.to_vec());
+    plan.format = "agentsight.actplane.binding.v2".to_owned();
+
+    let error = client.apply(&plan).unwrap_err();
+
+    assert_eq!(error.kind, AgentSightClientErrorKind::Rejected);
+    assert_eq!(error.code, "AGENTSIGHT_UNSUPPORTED_PLAN_FORMAT");
+    assert!(transport.requests().is_empty());
+}
+
+#[test]
+fn apply_fails_closed_when_file_delete_guard_is_unavailable() {
+    let health = br#"{
+        "ready": true,
+        "backend": "actplane",
+        "capabilities": { "file_delete_guard": false }
+    }"#;
+    let transport = FakeTransport::new([Ok(response(200, health))]);
+    let client =
+        AgentSightClient::with_dependencies(transport.clone(), FixedProcessIdentity(Ok(987_654)));
+
+    let error = client
+        .apply(&binding_plan(BINDING_PLAN.to_vec()))
+        .unwrap_err();
+
+    assert_eq!(error.kind, AgentSightClientErrorKind::Rejected);
+    assert_eq!(error.code, "AGENTSIGHT_FILE_DELETE_GUARD_UNAVAILABLE");
+    assert_eq!(transport.requests().len(), 1);
+}

--- a/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-policy-adapter-agentsight"
+description = "AgentSight and ActPlane target Adapter for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+actplane-ifc-compiler = { workspace = true }
+asc-policy-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/lib.rs
@@ -1,0 +1,17 @@
+//! Pure Binding-to-AgentSight/ActPlane translation.
+//!
+//! This crate translates a complete immutable `PreparedBinding` into a
+//! deterministic target plan. It performs no persistence, HTTP, process
+//! inspection, or policy attachment.
+
+#![forbid(unsafe_code)]
+
+mod plan;
+mod translate;
+
+pub use plan::{
+    ACTPLANE_POLICY_MEDIA_TYPE, AGENTSIGHT_BINDING_PLAN_FORMAT,
+    AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION, AgentSightBindingPlan, AgentSightPolicyPlan,
+    AgentSightScopePlan, AgentSightSourceBinding,
+};
+pub use translate::AgentSightAdapter;

--- a/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/plan.rs
+++ b/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/plan.rs
@@ -1,0 +1,69 @@
+//! Versioned `AgentSight` target Binding plan.
+
+use asc_policy_types::identifiers::{ResourceId, Revision};
+use serde::{Deserialize, Serialize};
+
+/// Versioned format of the `AgentSight` Binding plan passed through PCP.
+pub const AGENTSIGHT_BINDING_PLAN_FORMAT: &str = "agentsight.actplane.binding.v1";
+
+/// Schema version encoded by [`AgentSightBindingPlan`].
+pub const AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION: u16 = 1;
+
+/// Media type of the nested `ActPlane` DSL text.
+pub const ACTPLANE_POLICY_MEDIA_TYPE: &str = "application/vnd.actplane.dsl.v1";
+
+/// `AgentSight`-specific target plan consumed by the `AgentSight` Client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AgentSightBindingPlan {
+    /// Internal plan schema version.
+    pub schema_version: u16,
+    /// Immutable Binding and source revision identities.
+    pub source: AgentSightSourceBinding,
+    /// `ActPlane` policy carried by the `AgentSight` API.
+    pub policy: AgentSightPolicyPlan,
+    /// Target-specific attachment scope.
+    pub scope: AgentSightScopePlan,
+}
+
+/// Source identities retained for target artifact audit and correlation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AgentSightSourceBinding {
+    /// Stable Binding identity.
+    pub binding_id: ResourceId,
+    /// Immutable Binding revision.
+    pub binding_revision: Revision,
+    /// Stable source Policy identity.
+    pub policy_id: ResourceId,
+    /// Immutable source Policy revision.
+    pub policy_revision: Revision,
+    /// Stable source Scope identity.
+    pub scope_id: ResourceId,
+}
+
+/// `ActPlane` policy payload nested in the `AgentSight` plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AgentSightPolicyPlan {
+    /// Text media type of `content`.
+    pub media_type: String,
+    /// Deterministically generated `ActPlane` DSL.
+    pub content: String,
+}
+
+/// AgentSight-specific attachment scope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub enum AgentSightScopePlan {
+    /// Process tree rooted at the PID selected by the immutable Scope.
+    ProcessTree {
+        /// Positive PID accepted by the `AgentSight` apply protocol.
+        root_pid: i32,
+    },
+}

--- a/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/translate.rs
+++ b/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/src/translate.rs
@@ -1,0 +1,277 @@
+//! Deterministic Canonical IR to `ActPlane` DSL translation.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use asc_policy_types::Validate;
+use asc_policy_types::binding::PreparedBinding;
+use asc_policy_types::ir::{
+    ActivationRequirement, DecisionTiming, EvidenceRequirement, Expression, Obligation,
+    ResourceOperation, ResourceTarget, RestrictiveDecision, RuleIr, RuntimeFailurePolicy,
+    SemanticAtom, SubjectRemediation, UpdateFailurePolicy,
+};
+use asc_policy_types::policy::PolicyEnvelope;
+use asc_policy_types::resource::{FileResolution, PathMatcher, ResourceSelector};
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+use asc_policy_types::target::{
+    AdapterFault, TargetBindingPlan, TranslationOutcome, TranslationRejection,
+};
+
+use crate::plan::{
+    ACTPLANE_POLICY_MEDIA_TYPE, AGENTSIGHT_BINDING_PLAN_FORMAT,
+    AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION, AgentSightBindingPlan, AgentSightPolicyPlan,
+    AgentSightScopePlan, AgentSightSourceBinding,
+};
+
+// ActPlane's PAT=64 kernel ABI reserves one byte for the trailing NUL.
+const ACTPLANE_MAX_LOWERED_PATTERN_BYTES: usize = 63;
+const ACTPLANE_MAX_RULES: usize = 128;
+const DSL_REASON: &str = "AgentSecCore file deletion policy";
+
+/// Pure AgentSight/ActPlane Adapter for file-deletion policies and PID Scopes.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AgentSightAdapter;
+
+impl AgentSightAdapter {
+    /// Translates one complete immutable Binding without persistence or I/O.
+    ///
+    /// # Errors
+    /// Returns an internal Adapter fault. A deterministic semantic mismatch is
+    /// represented by [`TranslationOutcome::Rejected`].
+    pub fn translate(&self, binding: &PreparedBinding) -> Result<TranslationOutcome, AdapterFault> {
+        if binding.validate().is_err() {
+            return Ok(rejected("INVALID_BINDING"));
+        }
+
+        let scope = match translate_scope(&binding.scope) {
+            Ok(scope) => scope,
+            Err(rejection) => return Ok(TranslationOutcome::Rejected(rejection)),
+        };
+        let policy_dsl = match compile_policy(binding) {
+            Ok(policy_dsl) => policy_dsl,
+            Err(rejection) => return Ok(TranslationOutcome::Rejected(rejection)),
+        };
+
+        actplane_ifc_compiler::compile_str(&policy_dsl)
+            .map_err(|_| fault("ACTPLANE_COMPILER_REJECTED_GENERATED_DSL"))?;
+
+        let target_plan = AgentSightBindingPlan {
+            schema_version: AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION,
+            source: AgentSightSourceBinding {
+                binding_id: binding.binding_id.clone(),
+                binding_revision: binding.binding_revision,
+                policy_id: binding.policy.policy_id.clone(),
+                policy_revision: binding.policy.revision,
+                scope_id: binding.scope.scope_id.clone(),
+            },
+            policy: AgentSightPolicyPlan {
+                media_type: ACTPLANE_POLICY_MEDIA_TYPE.to_owned(),
+                content: policy_dsl,
+            },
+            scope,
+        };
+        let content =
+            serde_json::to_vec(&target_plan).map_err(|_| fault("ADAPTER_SERIALIZATION_FAILED"))?;
+        let plan = TargetBindingPlan {
+            format: AGENTSIGHT_BINDING_PLAN_FORMAT.to_owned(),
+            content,
+        };
+        Ok(TranslationOutcome::Translated(plan))
+    }
+}
+
+fn translate_scope(scope: &PreparedScope) -> Result<AgentSightScopePlan, TranslationRejection> {
+    if scope.template.lifetime.expires_at.is_some() {
+        return Err(rejection("UNSUPPORTED_SCOPE_LIFETIME"));
+    }
+    let ScopeSelector::Pid { pid } = &scope.selector else {
+        return Err(rejection("UNSUPPORTED_SCOPE_SELECTOR"));
+    };
+    let root_pid = i32::try_from(*pid).map_err(|_| rejection("UNSUPPORTED_SCOPE_PID_RANGE"))?;
+    Ok(AgentSightScopePlan::ProcessTree { root_pid })
+}
+
+fn compile_policy(binding: &PreparedBinding) -> Result<String, TranslationRejection> {
+    let policy = &binding.policy.canonical_policy;
+    if !guarantees_supported(&policy.payload) {
+        return Err(rejection("UNSUPPORTED_GUARANTEE"));
+    }
+    let mut rules: Vec<_> = policy.payload.rules.iter().collect();
+    rules.sort_by(|left, right| left.id.as_str().cmp(right.id.as_str()));
+
+    let mut patterns = BTreeSet::new();
+    for rule in rules {
+        let translated_patterns = translate_rule(policy, rule)?;
+        patterns.extend(translated_patterns);
+    }
+
+    if patterns.len() > ACTPLANE_MAX_RULES {
+        return Err(rejection("ACTPLANE_RULE_LIMIT_EXCEEDED"));
+    }
+
+    Ok(render_dsl(&patterns))
+}
+
+fn translate_rule(
+    policy: &PolicyEnvelope,
+    rule: &RuleIr,
+) -> Result<BTreeSet<String>, TranslationRejection> {
+    let Expression::Atom {
+        atom:
+            SemanticAtom::ResourceOperation {
+                operation: ResourceOperation::Delete,
+                target: ResourceTarget::In { resource_set },
+            },
+    } = &rule.when
+    else {
+        return Err(rejection("UNSUPPORTED_CANONICAL_RULE"));
+    };
+
+    let Some(resource) = policy
+        .payload
+        .resources
+        .iter()
+        .find(|resource| &resource.id == resource_set)
+    else {
+        return Err(rejection("MISSING_RESOURCE_SET"));
+    };
+    let ResourceSelector::File { matchers } = &resource.selector else {
+        return Err(rejection("UNSUPPORTED_RESOURCE_KIND"));
+    };
+
+    let mut patterns = BTreeSet::new();
+    for matcher in matchers {
+        if matcher.resolution != FileResolution::PathEntry {
+            return Err(rejection("UNSUPPORTED_FILE_RESOLUTION"));
+        }
+        for pattern in target_patterns(&matcher.path)? {
+            if validate_dsl_pattern(&pattern).is_err() {
+                return Err(rejection("UNSUPPORTED_ACTPLANE_PATTERN"));
+            }
+            patterns.insert(pattern);
+        }
+    }
+
+    Ok(patterns)
+}
+
+fn guarantees_supported(policy: &asc_policy_types::ir::CanonicalPolicyIr) -> bool {
+    policy.activation == ActivationRequirement::PostAttachAllowed
+        && policy.failure_policy.runtime == RuntimeFailurePolicy::FailClosed
+        && policy.failure_policy.update == UpdateFailurePolicy::KeepLastKnownGood
+        && policy.rules.iter().all(|rule| {
+            rule.outcome.decision == RestrictiveDecision::Deny
+                && same_set(
+                    &rule.outcome.obligations,
+                    &[Obligation::Audit, Obligation::EmitReceipt],
+                )
+                && rule.outcome.remediation == SubjectRemediation::None
+                && rule.enforcement.decision_timing == DecisionTiming::PreEffect
+                && same_set(
+                    &rule.enforcement.required_evidence,
+                    &[
+                        EvidenceRequirement::BindingReady,
+                        EvidenceRequirement::OperationDenied,
+                    ],
+                )
+        })
+}
+
+fn same_set<T: PartialEq>(actual: &[T], expected: &[T]) -> bool {
+    actual.len() == expected.len() && expected.iter().all(|value| actual.contains(value))
+}
+
+fn target_patterns(path: &PathMatcher) -> Result<Vec<String>, TranslationRejection> {
+    let patterns = match path {
+        PathMatcher::Exact { path } => vec![path.clone()],
+        PathMatcher::Glob { pattern } if actplane_can_represent_glob(pattern) => {
+            vec![pattern.clone()]
+        }
+        PathMatcher::Glob { .. } => return Err(rejection("UNSUPPORTED_ACTPLANE_GLOB")),
+        PathMatcher::Prefix { path } if path == "/" => vec!["/**".to_owned()],
+        PathMatcher::Prefix { path } => vec![path.clone(), format!("{path}/**")],
+    };
+    if patterns
+        .iter()
+        .any(|pattern| actplane_lowered_literal_len(pattern) > ACTPLANE_MAX_LOWERED_PATTERN_BYTES)
+    {
+        return Err(rejection("ACTPLANE_PATTERN_LIMIT_EXCEEDED"));
+    }
+    Ok(patterns)
+}
+
+fn actplane_can_represent_glob(pattern: &str) -> bool {
+    if pattern.contains('?') {
+        return false;
+    }
+
+    if !pattern.contains('*') {
+        return true;
+    }
+
+    pattern
+        .strip_suffix("/**")
+        .is_some_and(|prefix| !prefix.contains('*'))
+}
+
+// Mirrors the pinned ActPlane lower_path behavior for the absolute patterns
+// admitted by actplane_can_represent_glob and generated for Prefix matchers.
+fn actplane_lowered_literal_len(pattern: &str) -> usize {
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return prefix.len() + 1;
+    }
+    if let Some(prefix) = pattern.strip_suffix("**") {
+        return prefix.len();
+    }
+    if let Some(prefix) = pattern.strip_suffix("/*") {
+        return prefix.len() + 1;
+    }
+    pattern.find('*').unwrap_or(pattern.len())
+}
+
+fn validate_dsl_pattern(pattern: &str) -> Result<(), String> {
+    if pattern.is_empty() {
+        return Err("ActPlane path pattern must not be empty".to_owned());
+    }
+    if pattern
+        .chars()
+        .any(|character| matches!(character, '"' | '\\') || character.is_control())
+    {
+        return Err(
+            "ActPlane path pattern contains a quote, backslash, or control character".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn render_dsl(patterns: &BTreeSet<String>) -> String {
+    // TODO: ActPlane currently lowers both `unlink` and `write` to OP_WRITE. Keep
+    // the explicit unlink DSL while landing the Adapter-to-Client path, then
+    // split the backend operation so delete-only enforcement does not also
+    // block content mutation or other namespace mutation.
+    let mut dsl = String::from("source AGENT = exec \"**\"\n");
+    for (index, pattern) in patterns.iter().enumerate() {
+        write!(
+            dsl,
+            "rule agentseccore-unlink-{index:04}:\n  block unlink file \"{pattern}\" if AGENT\n  because \"{DSL_REASON}\"\n"
+        )
+        .unwrap_or_else(|_| unreachable!("writing formatted text into String cannot fail"));
+    }
+    dsl
+}
+
+fn rejected(code: &str) -> TranslationOutcome {
+    TranslationOutcome::Rejected(rejection(code))
+}
+
+fn rejection(code: &str) -> TranslationRejection {
+    TranslationRejection {
+        code: code.to_owned(),
+    }
+}
+
+fn fault(code: &str) -> AdapterFault {
+    AdapterFault {
+        code: code.to_owned(),
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/tests/translation.rs
+++ b/src/agent-sec-core/v2/crates/policy/adapters/asc-policy-adapter-agentsight/tests/translation.rs
@@ -1,0 +1,214 @@
+use actplane_ifc_compiler::compile_str;
+use asc_policy_adapter_agentsight::{
+    ACTPLANE_POLICY_MEDIA_TYPE, AGENTSIGHT_BINDING_PLAN_FORMAT,
+    AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION, AgentSightAdapter, AgentSightBindingPlan,
+    AgentSightScopePlan,
+};
+use asc_policy_types::Validate;
+use asc_policy_types::binding::PreparedBinding;
+use asc_policy_types::ir::SubjectRemediation;
+use asc_policy_types::resource::{FileResolution, PathMatcher, ResourceSelector};
+use asc_policy_types::scope::ScopeSelector;
+use asc_policy_types::target::TranslationOutcome;
+
+const COMPLETE_BINDING_FIXTURE: &str =
+    include_str!("../../../asc-policy-types/tests/fixtures/prepared-binding.json");
+const AGENTSIGHT_BINDING_PLAN_FIXTURE: &str = include_str!(
+    "../../../../../fixtures/adapters/agentsight/prevent-file-deletion/agentsight-binding-plan.json"
+);
+
+fn complete_binding_fixture() -> PreparedBinding {
+    serde_json::from_str(COMPLETE_BINDING_FIXTURE).unwrap()
+}
+
+fn binding_with_first_path(path: PathMatcher) -> PreparedBinding {
+    let mut binding = complete_binding_fixture();
+    let ResourceSelector::File { matchers } =
+        &mut binding.policy.canonical_policy.payload.resources[0].selector
+    else {
+        panic!("expected file resource set");
+    };
+    matchers[0].path = path;
+    binding
+}
+
+#[test]
+fn complete_binding_translates_to_the_frozen_agentsight_output() {
+    let fixture_json: serde_json::Value = serde_json::from_str(COMPLETE_BINDING_FIXTURE).unwrap();
+    let binding = complete_binding_fixture();
+
+    binding.validate().unwrap();
+    assert_eq!(serde_json::to_value(&binding).unwrap(), fixture_json);
+
+    let outcome = AgentSightAdapter.translate(&binding).unwrap();
+    let TranslationOutcome::Translated(plan) = outcome else {
+        panic!("expected translated target plan");
+    };
+
+    let decoded_plan: AgentSightBindingPlan = serde_json::from_slice(&plan.content).unwrap();
+    let expected_plan: serde_json::Value =
+        serde_json::from_str(AGENTSIGHT_BINDING_PLAN_FIXTURE).unwrap();
+    assert_eq!(serde_json::to_value(&decoded_plan).unwrap(), expected_plan);
+    assert_eq!(
+        decoded_plan.schema_version,
+        AGENTSIGHT_BINDING_PLAN_SCHEMA_VERSION
+    );
+    assert_eq!(decoded_plan.policy.media_type, ACTPLANE_POLICY_MEDIA_TYPE);
+    assert_eq!(
+        decoded_plan.policy.content,
+        concat!(
+            "source AGENT = exec \"**\"\n",
+            "rule agentseccore-unlink-0000:\n",
+            "  block unlink file \"/etc/agent/config.yaml\" if AGENT\n",
+            "  because \"AgentSecCore file deletion policy\"\n",
+            "rule agentseccore-unlink-0001:\n",
+            "  block unlink file \"/workspace/important/**\" if AGENT\n",
+            "  because \"AgentSecCore file deletion policy\"\n",
+        )
+    );
+    assert!(compile_str(&decoded_plan.policy.content).is_ok());
+    assert_eq!(
+        decoded_plan.scope,
+        AgentSightScopePlan::ProcessTree { root_pid: 4242 }
+    );
+    assert_eq!(plan.format, AGENTSIGHT_BINDING_PLAN_FORMAT);
+}
+
+#[test]
+fn translation_is_deterministic_for_the_complete_binding() {
+    let binding = complete_binding_fixture();
+    let first = AgentSightAdapter.translate(&binding).unwrap();
+    let second = AgentSightAdapter.translate(&binding).unwrap();
+    assert_eq!(first, second);
+}
+
+#[test]
+fn unsupported_scope_is_rejected_without_a_target_plan() {
+    let mut binding = complete_binding_fixture();
+    binding.scope.selector = ScopeSelector::CgroupId { cgroup_id: 42 };
+
+    let outcome = AgentSightAdapter.translate(&binding).unwrap();
+    let TranslationOutcome::Rejected(rejection) = outcome else {
+        panic!("unsupported Scope must not produce a target plan");
+    };
+    assert_eq!(rejection.code, "UNSUPPORTED_SCOPE_SELECTOR");
+}
+
+#[test]
+fn final_object_resolution_is_not_silently_lowered_to_unlink() {
+    let mut binding = complete_binding_fixture();
+    let ResourceSelector::File { matchers } =
+        &mut binding.policy.canonical_policy.payload.resources[0].selector
+    else {
+        panic!("expected file resource set");
+    };
+    matchers[0].resolution = FileResolution::FinalObject {
+        follow_final_symlink: true,
+        match_hardlink_identity: true,
+    };
+
+    let outcome = AgentSightAdapter.translate(&binding).unwrap();
+    let TranslationOutcome::Rejected(rejection) = outcome else {
+        panic!("FinalObject semantics must not produce an unlink plan");
+    };
+    assert_eq!(rejection.code, "UNSUPPORTED_FILE_RESOLUTION");
+}
+
+#[test]
+fn unsupported_policy_guarantees_are_rejected() {
+    let mut binding = complete_binding_fixture();
+    binding.policy.canonical_policy.payload.rules[0]
+        .outcome
+        .remediation = SubjectRemediation::Freeze;
+
+    let outcome = AgentSightAdapter.translate(&binding).unwrap();
+    let TranslationOutcome::Rejected(rejection) = outcome else {
+        panic!("unsupported guarantees must not produce a target plan");
+    };
+    assert_eq!(rejection.code, "UNSUPPORTED_GUARANTEE");
+}
+
+#[test]
+fn target_unsafe_literals_are_rejected() {
+    let binding = binding_with_first_path(PathMatcher::Exact {
+        path: "/workspace/bad\"name".to_owned(),
+    });
+
+    let outcome = AgentSightAdapter.translate(&binding).unwrap();
+    let TranslationOutcome::Rejected(rejection) = outcome else {
+        panic!("unsafe DSL literal must not produce a target plan");
+    };
+    assert_eq!(rejection.code, "UNSUPPORTED_ACTPLANE_PATTERN");
+}
+
+#[test]
+fn valid_globs_without_equivalent_actplane_lowering_are_rejected() {
+    for pattern in [
+        "/workspace/file?.txt",
+        "/a/*/b",
+        "/workspace/*",
+        "/workspace/prefix*",
+    ] {
+        let binding = binding_with_first_path(PathMatcher::Glob {
+            pattern: pattern.to_owned(),
+        });
+        binding.validate().unwrap();
+
+        let outcome = AgentSightAdapter.translate(&binding).unwrap();
+        let TranslationOutcome::Rejected(rejection) = outcome else {
+            panic!("glob without equivalent ActPlane lowering must not produce a target plan");
+        };
+        assert_eq!(rejection.code, "UNSUPPORTED_ACTPLANE_GLOB");
+    }
+}
+
+#[test]
+fn lowered_patterns_at_the_actplane_63_byte_limit_are_translated() {
+    for path in [
+        PathMatcher::Exact {
+            path: format!("/{}", "e".repeat(62)),
+        },
+        PathMatcher::Exact {
+            path: format!("/{}aa", "界".repeat(20)),
+        },
+        PathMatcher::Prefix {
+            path: format!("/{}", "p".repeat(61)),
+        },
+        PathMatcher::Glob {
+            pattern: format!("/{}/**", "g".repeat(61)),
+        },
+    ] {
+        let binding = binding_with_first_path(path);
+        binding.validate().unwrap();
+
+        let outcome = AgentSightAdapter.translate(&binding).unwrap();
+        assert!(matches!(outcome, TranslationOutcome::Translated(_)));
+    }
+}
+
+#[test]
+fn lowered_patterns_over_the_actplane_63_byte_limit_are_rejected() {
+    for path in [
+        PathMatcher::Exact {
+            path: format!("/{}", "e".repeat(63)),
+        },
+        PathMatcher::Exact {
+            path: format!("/{}aaa", "界".repeat(20)),
+        },
+        PathMatcher::Prefix {
+            path: format!("/{}", "p".repeat(62)),
+        },
+        PathMatcher::Glob {
+            pattern: format!("/{}/**", "g".repeat(62)),
+        },
+    ] {
+        let binding = binding_with_first_path(path);
+        binding.validate().unwrap();
+
+        let outcome = AgentSightAdapter.translate(&binding).unwrap();
+        let TranslationOutcome::Rejected(rejection) = outcome else {
+            panic!("pattern exceeding the ActPlane ABI must not produce a target plan");
+        };
+        assert_eq!(rejection.code, "ACTPLANE_PATTERN_LIMIT_EXCEEDED");
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/target.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/target.rs
@@ -1,182 +1,31 @@
-//! Target Adapter descriptors, artifacts, and translation diagnostics.
+//! Minimal target Adapter result and dispatchable plan contracts.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
-
-use serde::{Deserialize, Deserializer, Serialize};
-
-use crate::identifiers::Digest;
-
-/// Frozen PCP-to-Adapter contract version.
-pub const TARGET_ADAPTER_CONTRACT_VERSION: u16 = 1;
-
-/// Stable identity and artifact formats exposed by one Adapter implementation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct TargetDescriptor {
-    /// PCP-to-Adapter protocol version implemented by this Adapter.
-    pub adapter_contract_version: u16,
-    /// Stable PEP family used for Adapter and Client selection.
-    pub pep_type: String,
-    /// Structured provenance of the translator implementation.
-    pub translator: TranslatorIdentity,
-    /// Versioned target artifact contracts this Adapter may emit.
-    pub artifact_contracts: Vec<TargetArtifactContract>,
-}
-
-/// Provenance of one target translator implementation.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct TranslatorIdentity {
-    /// `AgentSecCore` workspace version containing the translator.
-    pub agent_sec_core_version: String,
-    /// Monotonic Adapter-wide revision of translator semantics and compiler inputs.
-    pub translation_revision: u64,
-}
-
-/// Versioned format and semantic contract of one target artifact.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct TargetArtifactContract {
-    /// Stable contract identifier accepted by compatible target runtimes.
-    pub contract_id: String,
-    /// Media type of the opaque target plan bytes.
-    pub media_type: String,
-    /// Schema version encoded inside the target plan.
-    pub schema_version: u16,
-}
+use serde::{Deserialize, Serialize};
 
 /// Result of translating one complete immutable Binding snapshot.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "status", content = "result", rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TranslationOutcome {
     /// The Adapter produced a target plan that passed its static translation checks.
-    Translated(TranslatedTargetBinding),
+    Translated(TargetBindingPlan),
     /// The target deterministically cannot express the Binding safely.
     Rejected(TranslationRejection),
-}
-
-/// Target artifact accepted by the Adapter's phase-one translation contract.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct TranslatedTargetBinding {
-    /// Opaque target-specific Binding plan.
-    pub plan: TargetBindingPlan,
-    /// Non-blocking information about the successful translation.
-    pub diagnostics: Vec<Diagnostic>,
-    /// Digest over the artifact contract and exact target plan bytes.
-    pub plan_content_digest: Digest,
-    /// Digest over source, translator, plan, and capability evidence.
-    pub artifact_identity_digest: Digest,
-    /// Target capabilities required before this plan may be dispatched.
-    pub required_capabilities: RequiredCapabilities,
 }
 
 /// Opaque target-specific Binding payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TargetBindingPlan {
-    /// Artifact contract governing the payload format and target semantics.
-    pub artifact_contract_id: String,
-    /// Versioned media type understood by the matching target Client.
-    pub media_type: String,
+    /// Versioned target format understood by the matching target Client.
+    pub format: String,
     /// Exact bytes that are persisted before Client request preparation.
     pub content: Vec<u8>,
 }
 
-/// Stable machine-readable explanation attached to a translation decision.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct Diagnostic {
-    /// Stable code suitable for state projection and tests.
-    pub code: String,
-    /// Optional JSON-style source path.
-    pub path: Option<String>,
-    /// Safe developer-facing explanation.
-    pub message: String,
-}
-
 /// Deterministic semantic rejection produced by a functioning Adapter.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TranslationRejection {
-    /// Stable summary code for state projection and tests.
+    /// Stable, specific code suitable for status projection and logs.
     pub code: String,
-    /// Detailed safe explanations of the rejection.
-    pub diagnostics: Vec<Diagnostic>,
-}
-
-/// Versioned lower-case dotted target capability identifier.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-#[serde(transparent)]
-pub struct CapabilityId(String);
-
-impl CapabilityId {
-    /// Creates a validated capability identifier.
-    ///
-    /// # Errors
-    /// Returns an error unless the value is a versioned lower-case dotted key.
-    pub fn new(value: impl Into<String>) -> Result<Self, String> {
-        Self::try_from(value.into())
-    }
-
-    /// Returns the stable wire value.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl TryFrom<String> for CapabilityId {
-    type Error = String;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.is_empty() || value.len() > 128 {
-            return Err("capability ID must contain 1..=128 bytes".to_owned());
-        }
-        let mut segments = value.split('.');
-        let version = segments.next_back().unwrap_or_default();
-        let version_digits = version.strip_prefix('v').unwrap_or_default();
-        if !value.contains('.')
-            || !value
-                .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'.')
-            || value.split('.').any(str::is_empty)
-            || version_digits.is_empty()
-            || !version_digits.bytes().all(|byte| byte.is_ascii_digit())
-        {
-            return Err(
-                "capability ID must contain lower-case dotted segments ending in v<digits>"
-                    .to_owned(),
-            );
-        }
-        Ok(Self(value))
-    }
-}
-
-impl<'de> Deserialize<'de> for CapabilityId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-        Self::try_from(value).map_err(serde::de::Error::custom)
-    }
-}
-
-impl fmt::Display for CapabilityId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.0)
-    }
-}
-
-/// Capability features and numeric limits required by one target artifact.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct RequiredCapabilities {
-    /// Boolean features required by the plan.
-    pub features: BTreeSet<CapabilityId>,
-    /// Minimum numeric limits required by the plan.
-    pub minimum_limits: BTreeMap<CapabilityId, u64>,
 }
 
 /// Internal Adapter failure distinct from a deterministic translation rejection.
@@ -185,108 +34,4 @@ pub struct RequiredCapabilities {
 pub struct AdapterFault {
     /// Stable internal failure code.
     pub code: String,
-    /// Safe diagnostic context.
-    pub diagnostics: Vec<Diagnostic>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn digest(hex_digit: char) -> Digest {
-        Digest::new(format!("sha256:{}", hex_digit.to_string().repeat(64))).unwrap()
-    }
-
-    fn translated_outcome() -> TranslationOutcome {
-        TranslationOutcome::Translated(TranslatedTargetBinding {
-            plan: TargetBindingPlan {
-                artifact_contract_id: "agentsight.binding.v1".to_owned(),
-                media_type: "application/vnd.agentseccore.agentsight-binding.v1+json".to_owned(),
-                content: vec![1, 2, 3],
-            },
-            diagnostics: vec![Diagnostic {
-                code: "TRANSLATION_NOTE".to_owned(),
-                path: Some("policy".to_owned()),
-                message: "target rules were generated deterministically".to_owned(),
-            }],
-            plan_content_digest: digest('a'),
-            artifact_identity_digest: digest('b'),
-            required_capabilities: RequiredCapabilities {
-                features: BTreeSet::from([CapabilityId::new("policy.file.delete.v1").unwrap()]),
-                minimum_limits: BTreeMap::from([(
-                    CapabilityId::new("policy.rules.max.v1").unwrap(),
-                    1,
-                )]),
-            },
-        })
-    }
-
-    #[test]
-    fn translation_outcome_separates_target_artifact_from_rejection_details() {
-        let translated = translated_outcome();
-        let translated_json = serde_json::to_value(&translated).unwrap();
-        assert_eq!(translated_json["status"], "translated");
-        assert_eq!(
-            translated_json["result"]["plan"]["content"],
-            serde_json::json!([1, 2, 3])
-        );
-        for removed_field in [
-            "mappingReport",
-            "guarantees",
-            "overallRelation",
-            "mappingDigest",
-        ] {
-            assert!(
-                translated_json["result"].get(removed_field).is_none(),
-                "serialized removed field {removed_field}"
-            );
-        }
-        assert_eq!(
-            serde_json::from_value::<TranslationOutcome>(translated_json).unwrap(),
-            translated
-        );
-
-        let rejected = TranslationOutcome::Rejected(TranslationRejection {
-            code: "UNSUPPORTED_SCOPE".to_owned(),
-            diagnostics: vec![Diagnostic {
-                code: "UNSUPPORTED_SCOPE_SELECTOR".to_owned(),
-                path: Some("scope.selector".to_owned()),
-                message: "the target cannot express this Scope selector".to_owned(),
-            }],
-        });
-        let rejected_json = serde_json::to_value(&rejected).unwrap();
-        assert_eq!(rejected_json["status"], "rejected");
-        assert_eq!(rejected_json["result"]["code"], "UNSUPPORTED_SCOPE");
-        assert!(rejected_json["result"].get("plan").is_none());
-        assert_eq!(
-            serde_json::from_value::<TranslationOutcome>(rejected_json).unwrap(),
-            rejected
-        );
-    }
-
-    #[test]
-    fn removed_mapping_fields_are_rejected_on_the_wire() {
-        for removed_field in [
-            "mappingReport",
-            "guarantees",
-            "overallRelation",
-            "mappingDigest",
-        ] {
-            let mut translated_json = serde_json::to_value(translated_outcome()).unwrap();
-            translated_json["result"][removed_field] = serde_json::Value::Null;
-            assert!(
-                serde_json::from_value::<TranslationOutcome>(translated_json).is_err(),
-                "accepted removed field {removed_field}"
-            );
-        }
-    }
-
-    #[test]
-    fn capability_ids_require_stable_dotted_keys() {
-        assert!(CapabilityId::new("policy.file.delete.v1").is_ok());
-        assert!(CapabilityId::new("Policy.File.Delete").is_err());
-        assert!(CapabilityId::new("missing-version-shape").is_err());
-        assert!(CapabilityId::new("policy..delete").is_err());
-        assert!(CapabilityId::new("policy.file.delete.latest").is_err());
-    }
 }

--- a/src/agent-sec-core/v2/fixtures/adapters/agentsight/prevent-file-deletion/agentsight-binding-plan.json
+++ b/src/agent-sec-core/v2/fixtures/adapters/agentsight/prevent-file-deletion/agentsight-binding-plan.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "bindingId": "10000000-0000-4000-8000-000000000001",
+    "bindingRevision": 7,
+    "policyId": "00000000-0000-4000-8000-000000000002",
+    "policyRevision": 1,
+    "scopeId": "20000000-0000-4000-8000-000000000001"
+  },
+  "policy": {
+    "mediaType": "application/vnd.actplane.dsl.v1",
+    "content": "source AGENT = exec \"**\"\nrule agentseccore-unlink-0000:\n  block unlink file \"/etc/agent/config.yaml\" if AGENT\n  because \"AgentSecCore file deletion policy\"\nrule agentseccore-unlink-0001:\n  block unlink file \"/workspace/important/**\" if AGENT\n  because \"AgentSecCore file deletion policy\"\n"
+  },
+  "scope": {
+    "kind": "process_tree",
+    "rootPid": 4242
+  }
+}

--- a/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/apply.request.json
+++ b/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/apply.request.json
@@ -1,0 +1,10 @@
+{
+  "binding_id": "d525d62c-2a3d-570b-9c25-d29c336c1d87",
+  "agent_id": "20000000-0000-4000-8000-000000000001",
+  "root_pid": 4242,
+  "process_start_time": 987654,
+  "policy_id": "00000000-0000-4000-8000-000000000002",
+  "policy_revision": "1",
+  "policy_dsl": "source AGENT = exec \"**\"\nrule agentseccore-unlink-0000:\n  block unlink file \"/etc/agent/config.yaml\" if AGENT\n  because \"AgentSecCore file deletion policy\"\nrule agentseccore-unlink-0001:\n  block unlink file \"/workspace/important/**\" if AGENT\n  because \"AgentSecCore file deletion policy\"\n",
+  "policy_mode": "enforce"
+}

--- a/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/apply.response.json
+++ b/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/apply.response.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "binding_id": "d525d62c-2a3d-570b-9c25-d29c336c1d87",
+    "agent_id": "20000000-0000-4000-8000-000000000001",
+    "root_pid": 4242,
+    "process_start_time": 987654,
+    "policy_id": "00000000-0000-4000-8000-000000000002",
+    "policy_revision": "1",
+    "policy_dsl": "source AGENT = exec \"**\"\nrule agentseccore-unlink-0000:\n  block unlink file \"/etc/agent/config.yaml\" if AGENT\n  because \"AgentSecCore file deletion policy\"\nrule agentseccore-unlink-0001:\n  block unlink file \"/workspace/important/**\" if AGENT\n  because \"AgentSecCore file deletion policy\"\n",
+    "policy_mode": "enforce"
+  },
+  "state": "enforced",
+  "domain_id": 41
+}

--- a/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/deployment-plan.json
+++ b/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/deployment-plan.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "bindingId": "10000000-0000-4000-8000-000000000001",
+    "bindingRevision": 7,
+    "policyId": "00000000-0000-4000-8000-000000000002",
+    "policyRevision": 1,
+    "scopeId": "20000000-0000-4000-8000-000000000001"
+  },
+  "policy": {
+    "mediaType": "application/vnd.actplane.dsl.v1",
+    "content": "source AGENT = exec \"**\"\nrule agentseccore-unlink-0000:\n  block unlink file \"/etc/agent/config.yaml\" if AGENT\n  because \"AgentSecCore file deletion policy\"\nrule agentseccore-unlink-0001:\n  block unlink file \"/workspace/important/**\" if AGENT\n  because \"AgentSecCore file deletion policy\"\n"
+  },
+  "scope": {
+    "kind": "process_tree",
+    "rootPid": 4242
+  }
+}

--- a/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/health.response.json
+++ b/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/health.response.json
@@ -1,0 +1,7 @@
+{
+  "ready": true,
+  "backend": "actplane",
+  "capabilities": {
+    "file_delete_guard": true
+  }
+}

--- a/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/retryable-error.response.json
+++ b/src/agent-sec-core/v2/fixtures/clients/agentsight/file-deletion/retryable-error.response.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "enforcer_unavailable",
+    "message": "sensitive target detail that must not leave the Client",
+    "retryable": true
+  }
+}


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
- Add AgentSight adapter to translate policy IR to DSL policy (only for file deletion).
- Add AgentSight Client 
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
