### PR TITLE
feat(cosh-ng): [shell] load login PATH

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/main.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/main.rs
@@ -85,6 +85,10 @@ fn cosh_entry_args() -> Option<Vec<std::ffi::OsString>> {
 }
 
 fn main() {
+    if let Some(status) = runtime::startup::run_profile_probe_helper_if_requested() {
+        std::process::exit(status);
+    }
+
     // `/usr/bin/cosh` entry (argv[0] basename `cosh`, login `-cosh` included):
     // the invocation-transparency contract dispatches before any runtime
     // initialization so passthrough leaves no logs or terminal side effects.

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/controller/bootstrap.rs
@@ -128,7 +128,7 @@ pub(crate) fn run_raw(
     };
     let enhanced_integration = config.integration.uses_markers();
     if config.native_mode && enhanced_integration {
-        bootstrap_process_path_from_shell(&shell_kind, login);
+        bootstrap_process_path_from_shell(&shell_kind, login, &config.winsize);
     }
     let recommendations_environment_override = parse_recommendations_environment_override(
         std::env::var("COSH_RECOMMENDATIONS_ENABLED")

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup.rs
@@ -1,10 +1,15 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::io::{IsTerminal, Write};
-use std::os::unix::process::ExitStatusExt;
+use std::fmt;
+use std::fs::File;
+use std::io::{IsTerminal, Read, Write};
+use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::Path;
-use std::process::{Command, ExitStatus};
-use std::time::Duration;
+use std::process::{Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use nix::pty::Winsize;
+use wait_timeout::ChildExt;
 
 use crate::diagnostics::health::{
     record_startup_health_recommendations, HealthFindingCategory, HealthScanReport, HealthSeverity,
@@ -49,7 +54,10 @@ const RESET: &str = "\x1b[0m";
 const LOGO_MIN_WIDTH: u16 = 42;
 const STARTUP_HEALTH_ROW_WAIT: Duration = Duration::from_millis(150);
 const STARTUP_AUTH_HINT_WAIT: Duration = Duration::from_millis(150);
+const BOOTSTRAP_PATH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const BOOTSTRAP_PATH_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
+mod descendants;
 mod recommendations;
 #[cfg(test)]
 use recommendations::{
@@ -163,39 +171,403 @@ fn startup_hooks_enabled() -> bool {
         })
 }
 
-pub(crate) fn bootstrap_process_path_from_shell(shell_kind: &RawShellKind, login: bool) {
-    if std::env::var("COSH_SHELL_BOOTSTRAP_PATH").as_deref() == Ok("0") {
+#[derive(Clone, Copy)]
+struct BootstrapPathProbe {
+    flags: &'static str,
+    source: &'static str,
+    io: BootstrapPathProbeIo,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BootstrapPathProbeIo {
+    Pipes,
+    Pty,
+}
+
+const BASH_NON_LOGIN_PATH_PROBES: &[BootstrapPathProbe] = &[
+    BootstrapPathProbe {
+        flags: "-ic",
+        source: "Bash interactive startup",
+        io: BootstrapPathProbeIo::Pipes,
+    },
+    BootstrapPathProbe {
+        flags: "-lic",
+        source: "Bash interactive login startup",
+        io: BootstrapPathProbeIo::Pty,
+    },
+];
+const BASH_LOGIN_PATH_PROBES: &[BootstrapPathProbe] = &[BootstrapPathProbe {
+    flags: "-lic",
+    source: "Bash interactive login startup",
+    io: BootstrapPathProbeIo::Pipes,
+}];
+const ZSH_NON_LOGIN_PATH_PROBES: &[BootstrapPathProbe] = &[BootstrapPathProbe {
+    flags: "-ic",
+    source: "Zsh interactive startup",
+    io: BootstrapPathProbeIo::Pipes,
+}];
+const ZSH_LOGIN_PATH_PROBES: &[BootstrapPathProbe] = &[BootstrapPathProbe {
+    flags: "-lic",
+    source: "Zsh interactive login startup",
+    io: BootstrapPathProbeIo::Pipes,
+}];
+
+#[derive(Debug)]
+enum BootstrapPathProbeError {
+    Containment(std::io::Error),
+    Supervisor(std::io::Error),
+    Spawn(std::io::Error),
+    Wait(std::io::Error),
+    Read(std::io::Error),
+    Failed(ExitStatus),
+    TimedOut(Duration),
+    OutputDidNotClose(Duration),
+    OutputTooLarge,
+    MissingMarker,
+}
+
+impl fmt::Display for BootstrapPathProbeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Containment(error) => {
+                write!(formatter, "could not contain shell descendants: {error}")
+            }
+            Self::Supervisor(error) => {
+                write!(formatter, "profile probe supervisor failed: {error}")
+            }
+            Self::Spawn(error) => write!(formatter, "could not start shell: {error}"),
+            Self::Wait(error) => write!(formatter, "could not wait for shell: {error}"),
+            Self::Read(error) => write!(formatter, "could not read shell output: {error}"),
+            Self::Failed(status) => write!(formatter, "shell exited with {status}"),
+            Self::TimedOut(timeout) => write!(formatter, "shell timed out after {timeout:?}"),
+            Self::OutputDidNotClose(timeout) => {
+                write!(formatter, "shell output did not close within {timeout:?}")
+            }
+            Self::OutputTooLarge => formatter.write_str("shell output exceeded the capture limit"),
+            Self::MissingMarker => formatter.write_str("shell did not report PATH"),
+        }
+    }
+}
+
+fn bootstrap_path_probe_plan(
+    shell_kind: &RawShellKind,
+    login: bool,
+    enabled: bool,
+) -> Option<(&'static str, &'static [BootstrapPathProbe])> {
+    if !enabled {
+        return None;
+    }
+    match (shell_kind, login) {
+        (RawShellKind::Bash, false) => Some(("bash", BASH_NON_LOGIN_PATH_PROBES)),
+        (RawShellKind::Bash, true) => Some(("bash", BASH_LOGIN_PATH_PROBES)),
+        (RawShellKind::Zsh, false) => Some(("zsh", ZSH_NON_LOGIN_PATH_PROBES)),
+        (RawShellKind::Zsh, true) => Some(("zsh", ZSH_LOGIN_PATH_PROBES)),
+        _ => None,
+    }
+}
+
+fn bootstrap_path_command(shell: &str, flags: &str) -> Command {
+    let mut command = Command::new(shell);
+    command
+        .arg(flags)
+        .arg("printf '\\n__COSH_PATH_BEGIN__%s__COSH_PATH_END__\\n' \"$PATH\"")
+        .env("COSH_SHELL_BOOTSTRAP_PATH", "0");
+    command
+}
+
+fn run_bootstrap_path_probe(
+    command: Command,
+    timeout: Duration,
+    io: BootstrapPathProbeIo,
+    winsize: &Winsize,
+) -> Result<String, BootstrapPathProbeError> {
+    match io {
+        BootstrapPathProbeIo::Pipes => {
+            run_bootstrap_path_probe_direct(command, timeout, io, winsize, false)
+        }
+        BootstrapPathProbeIo::Pty => {
+            descendants::run_supervised_profile_probe(command, timeout, winsize)
+        }
+    }
+}
+
+struct BootstrapPathProbeOutput {
+    status: ExitStatus,
+    streams: Vec<Vec<u8>>,
+}
+
+fn run_bootstrap_path_probe_direct(
+    command: Command,
+    timeout: Duration,
+    io: BootstrapPathProbeIo,
+    winsize: &Winsize,
+    contain_descendants: bool,
+) -> Result<String, BootstrapPathProbeError> {
+    let output = execute_bootstrap_path_probe(command, timeout, io, winsize, contain_descendants)?;
+    if !output.status.success() {
+        return Err(BootstrapPathProbeError::Failed(output.status));
+    }
+    let bytes = output.streams.concat();
+    let text = String::from_utf8_lossy(&bytes);
+    extract_bootstrap_path(&text).ok_or(BootstrapPathProbeError::MissingMarker)
+}
+
+fn execute_bootstrap_path_probe(
+    mut command: Command,
+    timeout: Duration,
+    io: BootstrapPathProbeIo,
+    winsize: &Winsize,
+    contain_descendants: bool,
+) -> Result<BootstrapPathProbeOutput, BootstrapPathProbeError> {
+    let deadline = Instant::now() + timeout;
+    let descendants = if contain_descendants {
+        Some(
+            descendants::ProfileProbeDescendants::enter()
+                .map_err(BootstrapPathProbeError::Containment)?,
+        )
+    } else {
+        None
+    };
+    let (mut child, output) = match io {
+        BootstrapPathProbeIo::Pipes => {
+            command
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            unsafe {
+                command.pre_exec(|| {
+                    // Detach pipe-backed interactive probes from Cosh's
+                    // controlling terminal so Bash cannot stop as a
+                    // background process group while initializing job control.
+                    if nix::libc::setsid() < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            let mut child = command.spawn().map_err(BootstrapPathProbeError::Spawn)?;
+            let stdout = drain_bootstrap_path_pipe(child.stdout.take());
+            let stderr = drain_bootstrap_path_pipe(child.stderr.take());
+            (child, vec![stdout, stderr])
+        }
+        BootstrapPathProbeIo::Pty => {
+            let (child, master) = crate::shell_host::spawn_profile_probe_on_pty(command, winsize)
+                .map_err(BootstrapPathProbeError::Spawn)?;
+            (child, vec![drain_bootstrap_path_pty(master)])
+        }
+    };
+    let process_group = child.id();
+
+    let status = match child.wait_timeout(timeout) {
+        Ok(Some(status)) => status,
+        Ok(None) => {
+            terminate_bootstrap_path_probe(&mut child, process_group);
+            return Err(BootstrapPathProbeError::TimedOut(timeout));
+        }
+        Err(error) => {
+            terminate_bootstrap_path_probe(&mut child, process_group);
+            return Err(BootstrapPathProbeError::Wait(error));
+        }
+    };
+    if let Some(descendants) = descendants {
+        descendants
+            .finish()
+            .map_err(BootstrapPathProbeError::Containment)?;
+    }
+    let mut streams = Vec::with_capacity(output.len());
+    for receiver in output {
+        let stream = collect_bootstrap_path_pipe(receiver, deadline, timeout, process_group)?;
+        if stream.len() > BOOTSTRAP_PATH_MAX_OUTPUT_BYTES {
+            kill_bootstrap_path_process_group(process_group);
+            return Err(BootstrapPathProbeError::OutputTooLarge);
+        }
+        streams.push(stream);
+    }
+    Ok(BootstrapPathProbeOutput { status, streams })
+}
+
+/// Runs the internal profile-probe supervisor before normal CLI dispatch.
+pub(crate) fn run_profile_probe_helper_if_requested() -> Option<i32> {
+    descendants::run_helper_if_requested()
+}
+
+fn drain_bootstrap_path_pipe<R: Read + Send + 'static>(
+    pipe: Option<R>,
+) -> std::sync::mpsc::Receiver<std::io::Result<Vec<u8>>> {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = match pipe {
+            Some(source) => {
+                let mut bytes = Vec::new();
+                source
+                    .take((BOOTSTRAP_PATH_MAX_OUTPUT_BYTES + 1) as u64)
+                    .read_to_end(&mut bytes)
+                    .map(|_| bytes)
+            }
+            None => Ok(Vec::new()),
+        };
+        let _ = sender.send(result);
+    });
+    receiver
+}
+
+fn drain_bootstrap_path_pty(
+    mut master: File,
+) -> std::sync::mpsc::Receiver<std::io::Result<Vec<u8>>> {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 8192];
+        let result = loop {
+            match master.read(&mut buffer) {
+                Ok(0) => break Ok(bytes),
+                Ok(count) => {
+                    let remaining = BOOTSTRAP_PATH_MAX_OUTPUT_BYTES + 1 - bytes.len();
+                    bytes.extend_from_slice(&buffer[..count.min(remaining)]);
+                    if bytes.len() > BOOTSTRAP_PATH_MAX_OUTPUT_BYTES {
+                        break Ok(bytes);
+                    }
+                }
+                Err(error) if error.raw_os_error() == Some(nix::libc::EIO) => break Ok(bytes),
+                Err(error) => break Err(error),
+            }
+        };
+        let _ = sender.send(result);
+    });
+    receiver
+}
+
+fn collect_bootstrap_path_pipe(
+    receiver: std::sync::mpsc::Receiver<std::io::Result<Vec<u8>>>,
+    deadline: Instant,
+    timeout: Duration,
+    process_group: u32,
+) -> Result<Vec<u8>, BootstrapPathProbeError> {
+    receiver
+        .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        .map_err(|_| {
+            kill_bootstrap_path_process_group(process_group);
+            BootstrapPathProbeError::OutputDidNotClose(timeout)
+        })?
+        .map_err(BootstrapPathProbeError::Read)
+}
+
+fn terminate_bootstrap_path_probe(child: &mut std::process::Child, process_group: u32) {
+    kill_bootstrap_path_process_group(process_group);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn kill_bootstrap_path_process_group(process_group: u32) {
+    use nix::sys::signal::{killpg, Signal};
+    use nix::unistd::Pid;
+
+    let _ = killpg(Pid::from_raw(process_group as i32), Signal::SIGKILL);
+}
+
+fn merge_bootstrap_paths(
+    shell_kind: &RawShellKind,
+    login: bool,
+    discovered: &[Option<String>],
+    current: &str,
+) -> String {
+    let non_login_path = discovered.first().and_then(Option::as_deref);
+    let login_path = discovered.get(1).and_then(Option::as_deref);
+    let mut paths = Vec::with_capacity(discovered.len() + 1);
+    if matches!(shell_kind, RawShellKind::Bash) && !login {
+        paths.extend(non_login_path);
+    } else {
+        paths.extend(discovered.iter().filter_map(Option::as_deref));
+    }
+    paths.push(current);
+    let merged = merge_path_lists(&paths);
+
+    let merged = if matches!(shell_kind, RawShellKind::Bash) && !login {
+        login_path
+            .map(|path| merge_path_additions_at_anchors(path, &merged))
+            .unwrap_or(merged)
+    } else {
+        merged
+    };
+
+    // Append synthetic fallbacks only after resolving login PATH precedence.
+    merge_path_lists(&[
+        &merged,
+        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    ])
+}
+
+fn merge_path_additions_at_anchors(overlay: &str, base: &str) -> String {
+    let mut merged = base
+        .split(':')
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let anchors = merged.iter().cloned().collect::<HashSet<_>>();
+    let mut seen_additions = HashSet::new();
+    let mut pending = Vec::new();
+    let mut last_anchor = None;
+
+    for entry in overlay.split(':').filter(|entry| !entry.is_empty()) {
+        if anchors.contains(entry) {
+            if !pending.is_empty() {
+                if let Some(index) = merged.iter().position(|item| item == entry) {
+                    merged.splice(index..index, pending.drain(..));
+                }
+            }
+            last_anchor = Some(entry);
+        } else if seen_additions.insert(entry) {
+            pending.push(entry.to_string());
+        }
+    }
+
+    if !pending.is_empty() {
+        let index = last_anchor
+            .and_then(|anchor| merged.iter().position(|item| item == anchor))
+            .map_or(0, |index| index + 1);
+        merged.splice(index..index, pending);
+    }
+
+    merged.join(":")
+}
+
+pub(crate) fn bootstrap_process_path_from_shell(
+    shell_kind: &RawShellKind,
+    login: bool,
+    winsize: &Winsize,
+) {
+    let enabled = std::env::var("COSH_SHELL_BOOTSTRAP_PATH").as_deref() != Ok("0");
+    let Some((shell, probes)) = bootstrap_path_probe_plan(shell_kind, login, enabled) else {
+        return;
+    };
+
+    let mut discovered = Vec::with_capacity(probes.len());
+    for probe in probes {
+        // Each probe runs in its own child; PATH is the sole value
+        // imported into cosh-shell, and probe failures remain independently visible.
+        let command = bootstrap_path_command(shell, probe.flags);
+        match run_bootstrap_path_probe(command, BOOTSTRAP_PATH_PROBE_TIMEOUT, probe.io, winsize) {
+            Ok(path) => discovered.push(Some(path)),
+            Err(error) => {
+                eprintln!(
+                    "cosh-shell: failed to discover PATH from {}: {error}",
+                    probe.source
+                );
+                discovered.push(None);
+            }
+        }
+    }
+    if discovered.iter().all(Option::is_none) {
         return;
     }
 
-    let shell = match shell_kind {
-        RawShellKind::Bash => "bash",
-        RawShellKind::Zsh => "zsh",
-        _ => return,
-    };
-    let flags = if login { "-lic" } else { "-ic" };
-    let Ok(output) = Command::new(shell)
-        .arg(flags)
-        .arg("printf '\\n__COSH_PATH_BEGIN__%s__COSH_PATH_END__\\n' \"$PATH\"")
-        .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
-        .output()
-    else {
-        return;
-    };
-    let text = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let Some(path) = extract_bootstrap_path(&text) else {
-        return;
-    };
     let current = std::env::var("PATH").unwrap_or_default();
-    let merged = merge_path_lists(&[
-        path.as_str(),
-        current.as_str(),
-        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-    ]);
+    // The interactive login probe can execute arbitrary login-profile side
+    // effects. It is intentionally separate from the managed non-login Bash;
+    // only login-specific PATH additions are merged around their base PATH anchors.
+    // The managed shell still sources .bashrc and establishes its final
+    // interactive ordering itself.
+    let merged = merge_bootstrap_paths(shell_kind, login, &discovered, &current);
     if merged != current {
         std::env::set_var("PATH", merged);
     }

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup/descendants.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup/descendants.rs
@@ -1,0 +1,455 @@
+//! Contains profile-probe descendants that escape their original process group.
+//!
+//! This scope runs only inside the dedicated profile-probe supervisor process,
+//! so every adopted child is structurally owned by the disposable probe.
+
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::os::unix::process::ExitStatusExt;
+use std::process::Command;
+use std::time::Duration;
+
+use nix::pty::Winsize;
+
+use super::{BootstrapPathProbeError, BootstrapPathProbeIo};
+
+const HELPER_ARG: &str = "--cosh-internal-profile-probe";
+const HELPER_ENV: &str = "COSH_SHELL_INTERNAL_PROFILE_PROBE";
+const HELPER_ERROR_PREFIX: &str = "__COSH_PROFILE_PROBE_HELPER_ERROR__";
+const HELPER_FAILURE: i32 = 125;
+#[cfg(not(test))]
+pub(super) const SUPERVISOR_GRACE: Duration = Duration::from_millis(1_250);
+
+#[cfg(test)]
+pub(super) fn run_supervised_profile_probe(
+    command: Command,
+    timeout: Duration,
+    winsize: &Winsize,
+) -> Result<String, BootstrapPathProbeError> {
+    // Binary unit tests run under libtest rather than the normal main entry.
+    // Integration tests exercise the real supervisor process boundary.
+    super::run_bootstrap_path_probe_direct(
+        command,
+        timeout,
+        BootstrapPathProbeIo::Pty,
+        winsize,
+        false,
+    )
+}
+
+#[cfg(not(test))]
+pub(super) fn run_supervised_profile_probe(
+    command: Command,
+    timeout: Duration,
+    winsize: &Winsize,
+) -> Result<String, BootstrapPathProbeError> {
+    let helper = supervisor_command(&command, timeout, winsize)
+        .map_err(BootstrapPathProbeError::Supervisor)?;
+    let outer_timeout = timeout + SUPERVISOR_GRACE;
+    let output = super::execute_bootstrap_path_probe(
+        helper,
+        outer_timeout,
+        BootstrapPathProbeIo::Pipes,
+        winsize,
+        false,
+    )
+    .map_err(|error| match error {
+        BootstrapPathProbeError::TimedOut(_) => BootstrapPathProbeError::TimedOut(timeout),
+        other => other,
+    })?;
+    let stdout = output
+        .streams
+        .first()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let stderr = output.streams.get(1).map(Vec::as_slice).unwrap_or_default();
+    if !output.status.success() {
+        if let Some(error) = decode_helper_error(stderr, timeout) {
+            return Err(error);
+        }
+        return Err(BootstrapPathProbeError::Failed(output.status));
+    }
+    let text = String::from_utf8_lossy(stdout);
+    super::extract_bootstrap_path(&text).ok_or(BootstrapPathProbeError::MissingMarker)
+}
+
+#[cfg(not(test))]
+pub(super) fn supervisor_command(
+    command: &Command,
+    timeout: Duration,
+    winsize: &Winsize,
+) -> io::Result<Command> {
+    let mut helper = Command::new(std::env::current_exe()?);
+    helper
+        .arg(HELPER_ARG)
+        .arg(timeout.as_millis().to_string())
+        .arg(winsize.ws_row.to_string())
+        .arg(winsize.ws_col.to_string())
+        .arg(winsize.ws_xpixel.to_string())
+        .arg(winsize.ws_ypixel.to_string())
+        .arg("--")
+        .arg(command.get_program())
+        .args(command.get_args());
+    for (name, value) in command.get_envs() {
+        match value {
+            Some(value) => {
+                helper.env(name, value);
+            }
+            None => {
+                helper.env_remove(name);
+            }
+        }
+    }
+    if let Some(current_dir) = command.get_current_dir() {
+        helper.current_dir(current_dir);
+    }
+    helper.env(HELPER_ENV, "1");
+    Ok(helper)
+}
+
+struct HelperSpec {
+    command: Command,
+    timeout: Duration,
+    winsize: Winsize,
+}
+
+pub(super) fn run_helper_if_requested() -> Option<i32> {
+    if std::env::var(HELPER_ENV).as_deref() != Ok("1") {
+        return None;
+    }
+    let args = std::env::args_os().collect::<Vec<_>>();
+    if args.get(1).and_then(|arg| arg.to_str()) != Some(HELPER_ARG) {
+        return None;
+    }
+    Some(match parse_helper_spec(&args) {
+        Ok(spec) => run_helper(spec),
+        Err(error) => {
+            write_helper_error(&BootstrapPathProbeError::Supervisor(error));
+            HELPER_FAILURE
+        }
+    })
+}
+
+fn parse_helper_spec(args: &[OsString]) -> io::Result<HelperSpec> {
+    if args.len() < 9 || args.get(7).and_then(|arg| arg.to_str()) != Some("--") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid profile probe helper arguments",
+        ));
+    }
+    let timeout_ms = parse_helper_number(args, 2, "timeout")?;
+    let ws_row = parse_helper_number(args, 3, "terminal rows")?;
+    let ws_col = parse_helper_number(args, 4, "terminal columns")?;
+    let ws_xpixel = parse_helper_number(args, 5, "terminal pixel width")?;
+    let ws_ypixel = parse_helper_number(args, 6, "terminal pixel height")?;
+    let program = args.get(8).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "profile probe helper is missing its shell program",
+        )
+    })?;
+    let mut command = Command::new(program);
+    command.args(&args[9..]).env_remove(HELPER_ENV);
+    Ok(HelperSpec {
+        command,
+        timeout: Duration::from_millis(timeout_ms),
+        winsize: Winsize {
+            ws_row: bounded_u16(ws_row, "terminal rows")?,
+            ws_col: bounded_u16(ws_col, "terminal columns")?,
+            ws_xpixel: bounded_u16(ws_xpixel, "terminal pixel width")?,
+            ws_ypixel: bounded_u16(ws_ypixel, "terminal pixel height")?,
+        },
+    })
+}
+
+fn parse_helper_number(args: &[OsString], index: usize, label: &str) -> io::Result<u64> {
+    let value = args
+        .get(index)
+        .and_then(|arg| arg.to_str())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("profile probe helper is missing {label}"),
+            )
+        })?;
+    value.parse::<u64>().map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid profile probe helper {label} {value:?}: {error}"),
+        )
+    })
+}
+
+fn bounded_u16(value: u64, label: &str) -> io::Result<u16> {
+    u16::try_from(value).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("profile probe helper {label} exceeds u16"),
+        )
+    })
+}
+
+fn run_helper(spec: HelperSpec) -> i32 {
+    match super::run_bootstrap_path_probe_direct(
+        spec.command,
+        spec.timeout,
+        BootstrapPathProbeIo::Pty,
+        &spec.winsize,
+        true,
+    ) {
+        Ok(path) => {
+            let result = writeln!(io::stdout(), "\n__COSH_PATH_BEGIN__{path}__COSH_PATH_END__");
+            if let Err(error) = result {
+                write_helper_error(&BootstrapPathProbeError::Supervisor(error));
+                HELPER_FAILURE
+            } else {
+                0
+            }
+        }
+        Err(BootstrapPathProbeError::Failed(status)) => status
+            .code()
+            .or_else(|| status.signal().map(|signal| 128 + signal))
+            .unwrap_or(1)
+            .clamp(1, 255),
+        Err(error) => {
+            write_helper_error(&error);
+            HELPER_FAILURE
+        }
+    }
+}
+
+fn write_helper_error(error: &BootstrapPathProbeError) {
+    let tag = match error {
+        BootstrapPathProbeError::Containment(_) => "containment",
+        BootstrapPathProbeError::Supervisor(_) => "supervisor",
+        BootstrapPathProbeError::Spawn(_) => "spawn",
+        BootstrapPathProbeError::Wait(_) => "wait",
+        BootstrapPathProbeError::Read(_) => "read",
+        BootstrapPathProbeError::Failed(_) => "failed",
+        BootstrapPathProbeError::TimedOut(_) => "timed-out",
+        BootstrapPathProbeError::OutputDidNotClose(_) => "output-did-not-close",
+        BootstrapPathProbeError::OutputTooLarge => "output-too-large",
+        BootstrapPathProbeError::MissingMarker => "missing-marker",
+    };
+    eprintln!("{HELPER_ERROR_PREFIX}{tag}\n{error}");
+}
+
+#[cfg(not(test))]
+pub(super) fn decode_helper_error(
+    stderr: &[u8],
+    timeout: Duration,
+) -> Option<BootstrapPathProbeError> {
+    let text = String::from_utf8_lossy(stderr);
+    let payload = text.strip_prefix(HELPER_ERROR_PREFIX)?;
+    let (tag, message) = payload.split_once('\n').unwrap_or((payload, payload));
+    let error = || io::Error::other(message.trim().to_string());
+    Some(match tag.trim() {
+        "containment" => BootstrapPathProbeError::Containment(error()),
+        "spawn" => BootstrapPathProbeError::Spawn(error()),
+        "wait" => BootstrapPathProbeError::Wait(error()),
+        "read" => BootstrapPathProbeError::Read(error()),
+        "timed-out" => BootstrapPathProbeError::TimedOut(timeout),
+        "output-did-not-close" => BootstrapPathProbeError::OutputDidNotClose(timeout),
+        "output-too-large" => BootstrapPathProbeError::OutputTooLarge,
+        "missing-marker" => BootstrapPathProbeError::MissingMarker,
+        _ => BootstrapPathProbeError::Supervisor(error()),
+    })
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use std::fs;
+    use std::io;
+    use std::time::{Duration, Instant};
+
+    use nix::libc;
+
+    const CLEANUP_TIMEOUT: Duration = Duration::from_secs(1);
+    const CLEANUP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+    pub(in crate::runtime::startup) struct ProfileProbeDescendants {
+        previous_subreaper: libc::c_int,
+        armed: bool,
+    }
+
+    impl ProfileProbeDescendants {
+        pub(in crate::runtime::startup) fn enter() -> io::Result<Self> {
+            let mut previous_subreaper = 0;
+            if unsafe {
+                libc::prctl(
+                    libc::PR_GET_CHILD_SUBREAPER,
+                    &mut previous_subreaper as *mut libc::c_int,
+                    0,
+                    0,
+                    0,
+                )
+            } < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            if previous_subreaper == 0
+                && unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) } < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            match direct_children() {
+                Ok(children) if children.is_empty() => {}
+                Ok(children) => {
+                    let error = io::Error::other(format!(
+                        "profile probe supervisor already owns children: {children:?}"
+                    ));
+                    if previous_subreaper == 0
+                        && unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0) } < 0
+                    {
+                        let restore_error = io::Error::last_os_error();
+                        return Err(io::Error::new(
+                            error.kind(),
+                            format!(
+                                "{error}; could not restore child subreaper state: {restore_error}"
+                            ),
+                        ));
+                    }
+                    return Err(error);
+                }
+                Err(error) => {
+                    if previous_subreaper == 0
+                        && unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0) } < 0
+                    {
+                        let restore_error = io::Error::last_os_error();
+                        return Err(io::Error::new(
+                            error.kind(),
+                            format!(
+                                "{error}; could not restore child subreaper state: {restore_error}"
+                            ),
+                        ));
+                    }
+                    return Err(error);
+                }
+            }
+            Ok(Self {
+                previous_subreaper,
+                armed: true,
+            })
+        }
+
+        pub(in crate::runtime::startup) fn finish(mut self) -> io::Result<()> {
+            self.cleanup()?;
+            self.restore()?;
+            self.armed = false;
+            Ok(())
+        }
+
+        fn cleanup(&self) -> io::Result<()> {
+            let deadline = Instant::now() + CLEANUP_TIMEOUT;
+            loop {
+                let owned = direct_children()?;
+                if owned.is_empty() {
+                    return Ok(());
+                }
+                for pid in owned {
+                    kill_child(pid)?;
+                    reap_child(pid)?;
+                }
+                if Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "profile probe descendants did not exit within 1s",
+                    ));
+                }
+                std::thread::sleep(CLEANUP_POLL_INTERVAL);
+            }
+        }
+
+        fn restore(&mut self) -> io::Result<()> {
+            if self.previous_subreaper == 0
+                && unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 0, 0, 0, 0) } < 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    impl Drop for ProfileProbeDescendants {
+        fn drop(&mut self) {
+            if self.armed {
+                if let Err(error) = self.cleanup() {
+                    tracing::warn!(%error, "profile probe descendant cleanup failed");
+                }
+                if let Err(error) = self.restore() {
+                    tracing::warn!(%error, "profile probe subreaper restore failed");
+                }
+            }
+        }
+    }
+
+    fn direct_children() -> io::Result<Vec<i32>> {
+        let mut children = Vec::new();
+        for task in fs::read_dir("/proc/self/task")? {
+            let task = task?;
+            let values = match fs::read_to_string(task.path().join("children")) {
+                Ok(values) => values,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            for value in values.split_whitespace() {
+                let pid = value.parse::<i32>().map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid child PID {value:?}: {error}"),
+                    )
+                })?;
+                children.push(pid);
+            }
+        }
+        children.sort_unstable();
+        children.dedup();
+        Ok(children)
+    }
+
+    fn kill_child(pid: i32) -> io::Result<()> {
+        if unsafe { libc::kill(pid, libc::SIGKILL) } == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+
+    fn reap_child(pid: i32) -> io::Result<()> {
+        let mut status = 0;
+        let result = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if result >= 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ECHILD) {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(super) use platform::ProfileProbeDescendants;
+
+#[cfg(not(target_os = "linux"))]
+pub(super) struct ProfileProbeDescendants;
+
+#[cfg(not(target_os = "linux"))]
+impl ProfileProbeDescendants {
+    pub(super) fn enter() -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "profile probe descendant containment requires Linux",
+        ))
+    }
+
+    pub(super) fn finish(self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/runtime/startup_tests.rs
@@ -1,11 +1,20 @@
 use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "linux")]
+use nix::pty::Winsize;
+
 use super::{
-    append_startup_auth_hint, extract_bootstrap_path, merge_path_lists, plan_startup_for_render,
-    record_visible_personal_impressions, render_pending_recommendation_notice,
-    startup_suggestion_mode, visible_personal_candidates, write_startup_suggestion_card,
-    StartupSuggestionMode,
+    append_startup_auth_hint, bootstrap_path_probe_plan, extract_bootstrap_path,
+    merge_bootstrap_paths, merge_path_additions_at_anchors, merge_path_lists,
+    plan_startup_for_render, record_visible_personal_impressions,
+    render_pending_recommendation_notice, startup_suggestion_mode, visible_personal_candidates,
+    write_startup_suggestion_card, BootstrapPathProbeIo, RawShellKind, StartupSuggestionMode,
+};
+#[cfg(target_os = "linux")]
+use super::{
+    bootstrap_path_command, run_bootstrap_path_probe, BootstrapPathProbeError,
+    BOOTSTRAP_PATH_PROBE_TIMEOUT,
 };
 use crate::config::Language;
 use crate::diagnostics::health::{
@@ -24,6 +33,14 @@ use crate::runtime::state::{
 };
 use crate::ui::RatatuiInlineRenderer;
 use crate::I18n;
+
+#[cfg(target_os = "linux")]
+const BOOTSTRAP_PATH_TEST_WINSIZE: Winsize = Winsize {
+    ws_row: 40,
+    ws_col: 100,
+    ws_xpixel: 0,
+    ws_ypixel: 0,
+};
 
 #[test]
 fn recommendation_notice_is_nonblocking_persisted_and_shown_once() {
@@ -524,6 +541,264 @@ fn bootstrap_path_merge_keeps_existing_and_common_dirs() {
         ]),
         "/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin:/usr/sbin:/sbin"
     );
+}
+
+#[test]
+fn bash_non_login_merge_preserves_login_profile_precedence() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().unwrap();
+    let inherited_dir = root.path().join("inherited");
+    let prepend_dir = root.path().join("prepend");
+    let append_dir = root.path().join("append");
+    for directory in [&inherited_dir, &prepend_dir, &append_dir] {
+        std::fs::create_dir(directory).unwrap();
+        let command = directory.join("path-precedence-probe");
+        std::fs::write(&command, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let inherited = format!("{}:/usr/bin:/bin", inherited_dir.display());
+
+    for (login_path, expected) in [
+        (
+            format!("{}:{inherited}", prepend_dir.display()),
+            prepend_dir.join("path-precedence-probe"),
+        ),
+        (
+            format!("{inherited}:{}", append_dir.display()),
+            inherited_dir.join("path-precedence-probe"),
+        ),
+        (
+            format!("{}:/usr/local/bin:{inherited}", prepend_dir.display()),
+            prepend_dir.join("path-precedence-probe"),
+        ),
+        (
+            format!("/usr/local/bin:{inherited}:{}", append_dir.display()),
+            inherited_dir.join("path-precedence-probe"),
+        ),
+    ] {
+        let discovered = [Some(inherited.to_string()), Some(login_path.to_string())];
+        let merged = merge_bootstrap_paths(&RawShellKind::Bash, false, &discovered, &inherited);
+        let resolved = merged.split(':').find_map(|entry| {
+            let candidate = std::path::Path::new(entry).join("path-precedence-probe");
+            let metadata = candidate.metadata().ok()?;
+            (metadata.permissions().mode() & 0o111 != 0).then_some(candidate)
+        });
+
+        assert_eq!(resolved.as_deref(), Some(expected.as_path()), "{merged}");
+    }
+}
+
+#[test]
+fn bash_non_login_merge_adds_fallbacks_after_login_paths() {
+    for (base, login, expected) in [
+        (
+            "/usr/bin:/bin",
+            "/login:/usr/local/bin:/usr/bin:/bin",
+            "/login:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:/usr/sbin:/sbin",
+        ),
+        (
+            "/usr/bin:/bin",
+            "/usr/bin:/bin:/usr/local/bin:/login",
+            "/usr/bin:/bin:/usr/local/bin:/login:/opt/homebrew/bin:/usr/sbin:/sbin",
+        ),
+        (
+            "/usr/bin:/usr/local/bin:/bin",
+            "/usr/bin:/login:/usr/local/bin:/bin",
+            "/usr/bin:/login:/usr/local/bin:/bin:/opt/homebrew/bin:/usr/sbin:/sbin",
+        ),
+    ] {
+        assert_eq!(
+            merge_bootstrap_paths(
+                &RawShellKind::Bash,
+                false,
+                &[Some(base.to_string()), Some(login.to_string())],
+                base,
+            ),
+            expected,
+            "base={base}; login={login}",
+        );
+    }
+}
+
+#[test]
+fn login_path_additions_keep_internal_anchor_order() {
+    assert_eq!(
+        merge_path_additions_at_anchors(
+            "/early:/usr/bin:/middle:/bin:/late",
+            "/rc:/usr/bin:/bin:/fallback",
+        ),
+        "/rc:/early:/usr/bin:/middle:/bin:/late:/fallback"
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn probe_bash_path(
+    home: &std::path::Path,
+    flags: &str,
+    io: BootstrapPathProbeIo,
+) -> Result<String, BootstrapPathProbeError> {
+    let mut command = bootstrap_path_command("bash", flags);
+    command
+        .env("HOME", home)
+        .env("PATH", "/usr/bin:/bin")
+        .env_remove("BASH_ENV")
+        .env_remove("ENV");
+    run_bootstrap_path_probe(
+        command,
+        BOOTSTRAP_PATH_PROBE_TIMEOUT,
+        io,
+        &BOOTSTRAP_PATH_TEST_WINSIZE,
+    )
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn bash_non_login_probe_reads_bashrc_then_interactive_login_path() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".bashrc"),
+        "export PATH=\"$HOME/rc-only:$PATH\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        home.path().join(".bash_profile"),
+        "case $- in *i*) [ -t 0 ] && [ -t 1 ] && \
+         export PATH=\"$HOME/login-only:$PATH\";; esac\n",
+    )
+    .unwrap();
+    let (_, probes) = bootstrap_path_probe_plan(&RawShellKind::Bash, false, true).unwrap();
+
+    let discovered = probes
+        .iter()
+        .map(|probe| Some(probe_bash_path(home.path(), probe.flags, probe.io).unwrap()))
+        .collect::<Vec<_>>();
+    let merged = merge_bootstrap_paths(&RawShellKind::Bash, false, &discovered, "/usr/bin:/bin");
+    let rc = format!("{}/rc-only", home.path().display());
+    let login = format!("{}/login-only", home.path().display());
+
+    assert!(merged.split(':').any(|entry| entry == rc));
+    assert!(merged.split(':').any(|entry| entry == login));
+    // Both startup sources must beat the inherited command directory during
+    // bootstrap. The managed non-login Bash sources .bashrc again afterward,
+    // so .bashrc still owns the final interactive-session ordering.
+    let inherited = merged.find("/usr/bin").unwrap();
+    assert!(merged.find(&login).unwrap() < inherited);
+    assert!(merged.find(&rc).unwrap() < inherited);
+    assert_eq!(probes[0].flags, "-ic");
+    assert_eq!(probes[0].io, BootstrapPathProbeIo::Pipes);
+    assert_eq!(probes[1].flags, "-lic");
+    assert_eq!(probes[1].io, BootstrapPathProbeIo::Pty);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn bash_login_probe_uses_standard_profile_precedence() {
+    let home = tempfile::tempdir().unwrap();
+    for (file, entry) in [
+        (".bash_profile", "bash-profile"),
+        (".bash_login", "bash-login"),
+        (".profile", "profile"),
+    ] {
+        std::fs::write(
+            home.path().join(file),
+            format!("export PATH=\"$HOME/{entry}:$PATH\"\n"),
+        )
+        .unwrap();
+    }
+
+    let profile_path = probe_bash_path(home.path(), "-lic", BootstrapPathProbeIo::Pty).unwrap();
+    assert!(profile_path.contains("/bash-profile:"), "{profile_path}");
+    assert!(!profile_path.contains("/bash-login:"), "{profile_path}");
+    assert!(!profile_path.contains("/profile:"), "{profile_path}");
+
+    std::fs::remove_file(home.path().join(".bash_profile")).unwrap();
+    let bash_login_path = probe_bash_path(home.path(), "-lic", BootstrapPathProbeIo::Pty).unwrap();
+    assert!(
+        bash_login_path.contains("/bash-login:"),
+        "{bash_login_path}"
+    );
+    assert!(!bash_login_path.contains("/profile:"), "{bash_login_path}");
+
+    std::fs::remove_file(home.path().join(".bash_login")).unwrap();
+    let profile_path = probe_bash_path(home.path(), "-lic", BootstrapPathProbeIo::Pty).unwrap();
+    assert!(profile_path.contains("/profile:"), "{profile_path}");
+}
+
+#[test]
+fn bootstrap_path_probe_plan_honors_disabled_switch() {
+    assert!(bootstrap_path_probe_plan(&RawShellKind::Bash, false, false).is_none());
+    assert!(bootstrap_path_probe_plan(&RawShellKind::Bash, true, false).is_none());
+    assert!(bootstrap_path_probe_plan(&RawShellKind::Zsh, false, false).is_none());
+}
+
+#[test]
+fn bootstrap_path_probe_plan_preserves_login_and_zsh_modes() {
+    let (_, bash_login) = bootstrap_path_probe_plan(&RawShellKind::Bash, true, true).unwrap();
+    assert_eq!(bash_login.len(), 1);
+    assert_eq!(bash_login[0].flags, "-lic");
+    assert_eq!(bash_login[0].io, BootstrapPathProbeIo::Pipes);
+
+    let (_, zsh_non_login) = bootstrap_path_probe_plan(&RawShellKind::Zsh, false, true).unwrap();
+    assert_eq!(zsh_non_login.len(), 1);
+    assert_eq!(zsh_non_login[0].flags, "-ic");
+    assert_eq!(zsh_non_login[0].io, BootstrapPathProbeIo::Pipes);
+    let (_, zsh_login) = bootstrap_path_probe_plan(&RawShellKind::Zsh, true, true).unwrap();
+    assert_eq!(zsh_login.len(), 1);
+    assert_eq!(zsh_login[0].flags, "-lic");
+    assert_eq!(zsh_login[0].io, BootstrapPathProbeIo::Pipes);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn bash_login_probe_reports_startup_failure() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(home.path().join(".bash_profile"), "exit 23\n").unwrap();
+
+    let error = probe_bash_path(home.path(), "-lic", BootstrapPathProbeIo::Pty).unwrap_err();
+    assert!(matches!(
+        error,
+        BootstrapPathProbeError::Failed(status) if status.code() == Some(23)
+    ));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn bash_login_probe_timeout_preserves_non_login_path() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(
+        home.path().join(".bashrc"),
+        "export PATH=\"$HOME/rc-only:$PATH\"\n",
+    )
+    .unwrap();
+    std::fs::write(home.path().join(".bash_profile"), "sleep 30\n").unwrap();
+
+    let non_login = probe_bash_path(home.path(), "-ic", BootstrapPathProbeIo::Pipes).unwrap();
+    let mut login_command = bootstrap_path_command("bash", "-lic");
+    login_command
+        .env("HOME", home.path())
+        .env("PATH", "/usr/bin:/bin")
+        .env_remove("BASH_ENV")
+        .env_remove("ENV");
+    let started = Instant::now();
+    let error = run_bootstrap_path_probe(
+        login_command,
+        Duration::from_millis(50),
+        BootstrapPathProbeIo::Pty,
+        &BOOTSTRAP_PATH_TEST_WINSIZE,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        BootstrapPathProbeError::TimedOut(timeout) if timeout == Duration::from_millis(50)
+    ));
+    assert!(started.elapsed() < Duration::from_secs(2));
+    let discovered = [Some(non_login), None];
+    let merged = merge_bootstrap_paths(&RawShellKind::Bash, false, &discovered, "/usr/bin:/bin");
+    let rc = format!("{}/rc-only", home.path().display());
+    assert!(merged.split(':').any(|entry| entry == rc));
+    assert!(merged.find(&rc).unwrap() < merged.find("/usr/bin").unwrap());
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/bootstrap.rs
@@ -8,7 +8,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 use nix::libc;
-use nix::pty::openpty;
+use nix::pty::{openpty, Winsize};
 
 use super::adapter::{BashAdapter, ShellAdapter, ZshAdapter};
 use super::auth::{generate_marker_token, marker_script_with_token};
@@ -91,12 +91,10 @@ fn start_shell_session(
         Some(path)
     };
 
-    let pty = openpty(Some(&config.winsize), None).map_err(nix_to_io)?;
-    let master = unsafe { File::from_raw_fd(pty.master.into_raw_fd()) };
+    let (master, slave) = open_pty_pair(Some(&config.winsize))?;
     set_close_on_exec(master.as_raw_fd())?;
     set_nonblocking(master.as_raw_fd())?;
 
-    let slave = unsafe { File::from_raw_fd(pty.slave.into_raw_fd()) };
     set_interactive_terminal_baseline(slave.as_raw_fd())?;
     let terminal = slave.try_clone()?;
     let stdin = slave.try_clone()?;
@@ -189,6 +187,45 @@ fn start_shell_session(
         recovery_request_file,
         handoff_request_file,
     })
+}
+
+pub(crate) fn spawn_profile_probe_on_pty(
+    mut command: Command,
+    winsize: &Winsize,
+) -> io::Result<(Child, File)> {
+    let (master, slave) = open_pty_pair(Some(winsize))?;
+    set_close_on_exec(master.as_raw_fd())?;
+    set_interactive_terminal_baseline(slave.as_raw_fd())?;
+    command
+        .stdin(Stdio::from(slave.try_clone()?))
+        .stdout(Stdio::from(slave.try_clone()?))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            super::sigpipe::restore_in_child()?;
+            if libc::setsid() < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::ioctl(0, libc::TIOCSCTTY as libc::c_ulong, 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            set_interactive_terminal_baseline(0)?;
+            if libc::tcsetpgrp(0, libc::getpgrp()) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = command.spawn()?;
+    drop(command);
+    Ok((child, master))
+}
+
+fn open_pty_pair(winsize: Option<&Winsize>) -> io::Result<(File, File)> {
+    let pty = openpty(winsize, None).map_err(nix_to_io)?;
+    let master = unsafe { File::from_raw_fd(pty.master.into_raw_fd()) };
+    let slave = unsafe { File::from_raw_fd(pty.slave.into_raw_fd()) };
+    Ok((master, slave))
 }
 
 fn set_nonblocking(fd: i32) -> io::Result<()> {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/mod.rs
@@ -22,7 +22,7 @@ mod scripted;
 pub(crate) mod sigpipe;
 mod transcript;
 
-pub(crate) use bootstrap::assistance_state_file;
+pub(crate) use bootstrap::{assistance_state_file, spawn_profile_probe_on_pty};
 pub use line_interactive::{run_line_interactive_bash, LineInteractiveOutput};
 pub(crate) use model::{HintCardRenderer, ShellEventView};
 pub use model::{ScriptedInput, ShellHostConfig, ShellHostOutput, ShellIntegration};

--- a/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/shell_host/termios.rs
@@ -12,9 +12,16 @@ mod parent_lifecycle {
     use std::process::{Child, ExitStatus, Stdio};
 
     use nix::libc;
+    use nix::pty::Winsize;
     use wait_timeout::ChildExt;
 
     const TERMINAL_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(10);
+    const LOGIN_PROFILE_WINSIZE: Winsize = Winsize {
+        ws_row: 37,
+        ws_col: 113,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
 
     struct ParentPtySession {
         child: Option<Child>,
@@ -24,6 +31,18 @@ mod parent_lifecycle {
         original_flags: i32,
         output: Vec<u8>,
         root: PathBuf,
+    }
+
+    struct EscapedProcessCleanup(i32);
+
+    impl Drop for EscapedProcessCleanup {
+        fn drop(&mut self) {
+            if process_is_running(self.0) {
+                unsafe {
+                    libc::kill(self.0, libc::SIGKILL);
+                }
+            }
+        }
     }
 
     impl ParentPtySession {
@@ -51,6 +70,28 @@ mod parent_lifecycle {
             ignore_sigint: bool,
             wait_for_raw_mode: bool,
         ) -> Self {
+            Self::spawn_with_options(label, args, ignore_sigint, wait_for_raw_mode, None, None)
+        }
+
+        fn spawn_with_login_profile(label: &str, profile: &str) -> Self {
+            Self::spawn_with_options(
+                label,
+                &["raw", "fake", "--shell", "bash"],
+                false,
+                true,
+                Some(profile),
+                Some(&LOGIN_PROFILE_WINSIZE),
+            )
+        }
+
+        fn spawn_with_options(
+            label: &str,
+            args: &[&str],
+            ignore_sigint: bool,
+            wait_for_raw_mode: bool,
+            login_profile: Option<&str>,
+            winsize: Option<&Winsize>,
+        ) -> Self {
             let root = std::env::temp_dir().join(format!(
                 "cosh-shell-parent-termios-{label}-{}-{}",
                 std::process::id(),
@@ -60,8 +101,11 @@ mod parent_lifecycle {
             let work = root.join("work");
             std::fs::create_dir_all(&home).expect("create isolated HOME");
             std::fs::create_dir_all(&work).expect("create isolated work dir");
+            if let Some(profile) = login_profile {
+                std::fs::write(home.join(".bash_profile"), profile).expect("write login profile");
+            }
 
-            let pty = nix::pty::openpty(None, None).expect("open parent PTY");
+            let pty = nix::pty::openpty(winsize, None).expect("open parent PTY");
             let master = File::from(pty.master);
             let terminal = File::from(pty.slave);
             let original = read_termios(terminal.as_raw_fd());
@@ -85,17 +129,26 @@ mod parent_lifecycle {
                 .stderr(Stdio::from(stderr))
                 .current_dir(&work)
                 .env("HOME", &home)
-                .env("COSH_SHELL_ISOLATED", "1")
+                .env(
+                    "COSH_SHELL_ISOLATED",
+                    if login_profile.is_some() { "0" } else { "1" },
+                )
                 .env("COSH_SHELL_INTEGRATION", "enhanced")
                 .env("COSH_SHELL_RAW_SHELL", "bash")
                 .env("COSH_SHELL_DEFAULT_SHELL", "bash")
                 .env("COSH_SHELL_LANG", "en-US")
-                .env("COSH_SHELL_BOOTSTRAP_PATH", "0")
+                .env(
+                    "COSH_SHELL_BOOTSTRAP_PATH",
+                    if login_profile.is_some() { "1" } else { "0" },
+                )
                 .env("COSH_SHELL_HEALTH_SCAN", "disabled")
                 .env("COSH_RECOMMENDATIONS_ENABLED", "0")
                 .env("TERM", "xterm-256color")
                 .env("LANG", "C.UTF-8")
                 .env("LC_ALL", "C.UTF-8");
+            if login_profile.is_some() {
+                command.env("PATH", "/usr/bin:/bin");
+            }
             unsafe {
                 command.pre_exec(move || {
                     if ignore_sigint {
@@ -303,6 +356,28 @@ mod parent_lifecycle {
         assert_eq!(actual.c_ospeed, expected.c_ospeed, "output speed changed");
     }
 
+    fn process_is_running(pid: i32) -> bool {
+        let is_zombie = std::fs::read_to_string(format!("/proc/{pid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .map(|(_, suffix)| suffix.starts_with('Z'))
+            })
+            == Some(true);
+        !is_zombie && unsafe { libc::kill(pid, 0) } == 0
+    }
+
+    fn assert_process_stopped(pid: i32) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if !process_is_running(pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("profile-started daemon {pid} survived the PATH probe");
+    }
+
     fn direct_children(pid: i32) -> Vec<i32> {
         let mut children = BTreeSet::new();
         let Ok(tasks) = std::fs::read_dir(format!("/proc/{pid}/task")) else {
@@ -342,6 +417,133 @@ mod parent_lifecycle {
             "modifyOtherKeys was not disabled: {}",
             String::from_utf8_lossy(&output)
         );
+    }
+
+    #[test]
+    fn startup_path_probe_preserves_login_profile_terminal_semantics() {
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn_with_login_profile(
+            "bootstrap-path-terminal",
+            "[ -t 0 ] && [ -t 1 ] && [ \"$(stty size)\" = \"37 113\" ] && \
+             export PATH=\"$HOME/terminal-login:$PATH\"\n",
+        );
+        let expected = format!("{}/home/terminal-login", session.root.display());
+        session.write(b"printf '__BOOTSTRAP_PATH__=%s\\n' \"$PATH\"; exit\n");
+        let (status, output) = session.wait_with_output();
+        let output = String::from_utf8_lossy(&output);
+
+        assert!(status.success(), "startup status: {status:?}; {output}");
+        assert!(
+            output.contains(&format!("__BOOTSTRAP_PATH__={expected}:")),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn startup_path_probe_preserves_precedence_before_fallback_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn_with_login_profile(
+            "bootstrap-path-fallback-precedence",
+            "export PATH=\"$HOME/login-only:/usr/local/bin:/usr/bin:/bin\"\n",
+        );
+        let directory = session.root.join("home/login-only");
+        std::fs::create_dir(&directory).unwrap();
+        let command = directory.join("ls");
+        std::fs::write(
+            &command,
+            "#!/bin/sh\nprintf '__LOGIN_COMMAND_SELECTED__\\n'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+        session.write(b"command ls; exit\n");
+        let (status, output) = session.wait_with_output();
+        let output = String::from_utf8_lossy(&output);
+
+        assert!(status.success(), "startup status: {status:?}; {output}");
+        assert!(output.contains("__LOGIN_COMMAND_SELECTED__"), "{output}");
+    }
+
+    #[test]
+    fn startup_path_probe_reaps_detached_profile_daemon() {
+        if Command::new("setsid").arg("--help").output().is_err() {
+            return;
+        }
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn_with_login_profile(
+            "bootstrap-path-daemon",
+            "printf \"%s\\n\" \"$PPID\" > \"$HOME/profile-supervisor.pid\"\n\
+             setsid --fork sh -c 'printf \"%s\\n\" \"$$\" > \
+             \"$HOME/profile-daemon.pid\"; exec sleep 30' \
+             </dev/null >/dev/null 2>&1\n\
+             for ((attempt = 0; attempt < 1000; attempt++)); do \
+                 [ -s \"$HOME/profile-daemon.pid\" ] && break; sleep 0.001; \
+             done\n\
+             export PATH=\"$HOME/daemon-login:$PATH\"\n",
+        );
+        let supervisor_pid_file = session.root.join("home/profile-supervisor.pid");
+        let supervisor_pid = session.wait_for_pid_file(&supervisor_pid_file);
+        let _supervisor_cleanup = EscapedProcessCleanup(supervisor_pid);
+        let pid_file = session.root.join("home/profile-daemon.pid");
+        let daemon_pid = session.wait_for_pid_file(&pid_file);
+        let _daemon_cleanup = EscapedProcessCleanup(daemon_pid);
+        let expected = format!("{}/home/daemon-login", session.root.display());
+
+        assert_ne!(
+            supervisor_pid,
+            session.wrapper_pid(),
+            "profile Bash must be owned by a dedicated supervisor process"
+        );
+
+        session.write(b"printf '__BOOTSTRAP_PATH__=%s\\n' \"$PATH\"; exit\n");
+        let (status, output) = session.wait_with_output();
+        let output = String::from_utf8_lossy(&output);
+
+        assert!(status.success(), "startup status: {status:?}; {output}");
+        assert!(
+            output.contains(&format!("__BOOTSTRAP_PATH__={expected}:")),
+            "{output}"
+        );
+        assert_process_stopped(supervisor_pid);
+        assert_process_stopped(daemon_pid);
+    }
+
+    #[test]
+    fn startup_path_probe_timeout_reaps_supervisor_descendants() {
+        if Command::new("setsid").arg("--help").output().is_err() {
+            return;
+        }
+        let _guard = shell_host_run_guard();
+        let mut session = ParentPtySession::spawn_with_login_profile(
+            "bootstrap-path-timeout-daemon",
+            "printf \"%s\\n\" \"$PPID\" > \"$HOME/profile-supervisor.pid\"\n\
+             setsid --fork sh -c 'printf \"%s\\n\" \"$$\" > \
+             \"$HOME/profile-daemon.pid\"; exec sleep 30' \
+             </dev/null >/dev/null 2>&1\n\
+             for ((attempt = 0; attempt < 1000; attempt++)); do \
+                 [ -s \"$HOME/profile-daemon.pid\" ] && break; sleep 0.001; \
+             done\n\
+             sleep 30\n",
+        );
+        let supervisor_pid_file = session.root.join("home/profile-supervisor.pid");
+        let daemon_pid_file = session.root.join("home/profile-daemon.pid");
+        let supervisor_pid = session.wait_for_pid_file(&supervisor_pid_file);
+        let _supervisor_cleanup = EscapedProcessCleanup(supervisor_pid);
+        let daemon_pid = session.wait_for_pid_file(&daemon_pid_file);
+        let _daemon_cleanup = EscapedProcessCleanup(daemon_pid);
+
+        assert_ne!(
+            supervisor_pid,
+            session.wrapper_pid(),
+            "profile Bash must be owned by a dedicated supervisor process"
+        );
+        session.write(b"exit\n");
+        let status = session.wait();
+
+        assert!(status.success(), "startup status: {status:?}");
+        assert_process_stopped(supervisor_pid);
+        assert_process_stopped(daemon_pid);
     }
 
     #[test]


### PR DESCRIPTION
## Why

CLI installers can persist PATH entries only in Bash login profiles while a normal Cosh terminal starts a non-login Bash session. A fresh terminal then misses the installed command even though its dispatcher was added to `~/.bash_profile`.

## What changed

Probe Bash login startup separately for default non-login sessions and import only login-specific PATH additions. Run that supplemental login probe on a bounded isolated PTY initialized from the caller terminal size so profile terminal guards match the managed shell. Launch the PTY probe through a dedicated supervisor process; on Linux only that supervisor becomes a child subreaper, so it terminates and reaps profile-started descendants without claiming unrelated Cosh children. Fail closed when equivalent containment is unavailable. Preserve the managed shell's non-login behavior, standard profile precedence, isolated-mode bypass, and existing Zsh behavior.

## Related issue

closes #3049

## User / Agent impact

Commands installed through Bash login profiles become available in a fresh default Cosh terminal. Login-profile PATH additions retain their placement relative to inherited command directories.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The additional interactive login Bash child runs on an isolated PTY and executes the user's login profile, which may have external side effects; only PATH is imported into Cosh. The dedicated Linux supervisor terminates only descendants of this disposable probe, while other profile side effects remain possible. Set `COSH_SHELL_BOOTSTRAP_PATH=0` to disable startup PATH probing.

## Validation

Local Linux validation on the current revision:

- `cargo fmt --all -- --check`
- `cargo test --locked --package cosh-shell --bin cosh-shell runtime::startup::tests:: -- --test-threads=4` (24 passed)
- `cargo test --locked --package cosh-shell --test shell_host termios::parent_lifecycle::startup_path_probe_ -- --test-threads=1` (4 passed)
- `cargo clippy --locked --package cosh-shell --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`

The fallback-anchor regression fails before the fix in both the merge tests and a real enhanced Cosh PTY session. Coverage checks prepend/append command collisions, synthetic versus inherited `/usr/local/bin` anchors, terminal guards and dimensions, detached-daemon cleanup, and timeout cleanup. Fallback directories are appended only after merging the actual inherited/non-login PATH with login additions. Broader regression coverage runs in CI.

## Documentation and rollback

No documentation files changed. Disable the behavior with `COSH_SHELL_BOOTSTRAP_PATH=0` or revert commit `0ad122d1`.