### PR TITLE
fix: [anolisa] explain available platforms when no artifact matches the host

### DIFF
--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs
@@ -2,6 +2,7 @@
 //! command. Execution moved to the planner-driven pipeline: `dispatch.rs`
 //! drives the plan, `owned_ops.rs` performs the side effects.
 
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use anolisa_core::download::{DownloadCache, DownloadError};
@@ -172,6 +173,37 @@ pub(crate) fn resolve_raw(
             .map(|s| format!("distribution index {index_url}: {}", s.reason)),
     );
     let entry = index.resolve(&query).map_err(|err| {
+        if matches!(err, ResolveError::NotFound) {
+            let package_entries: Vec<_> = index
+                .entries
+                .iter()
+                .filter(|entry| entry.component == package)
+                .filter(|entry| entry.channel == query.channel.unwrap_or("stable"))
+                .collect();
+            let requested_platform_exists = package_entries
+                .iter()
+                .any(|entry| entry.os == env.os && (entry.arch == env.arch || entry.arch == "any"));
+            if !requested_platform_exists {
+                let available_platforms: BTreeSet<_> = package_entries
+                    .iter()
+                    .map(|entry| format!("{}/{}", entry.os, entry.arch))
+                    .collect();
+                if !available_platforms.is_empty() {
+                    let available_platforms = available_platforms
+                        .into_iter()
+                        .map(|platform| format!("  - {platform}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    return CliError::InvalidArgument {
+                        command: COMMAND.to_string(),
+                        reason: format!(
+                            "{package} is not available for {}/{}\n\navailable platforms:\n{available_platforms}",
+                            env.os, env.arch,
+                        ),
+                    };
+                }
+            }
+        }
         // A pinned version the installable index cannot satisfy gets a
         // dedicated refusal, symmetric with the rpm backend's version-pin
         // errors. The unfiltered index decides the wording: a version that

--- a/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
+++ b/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs
@@ -1162,6 +1162,199 @@ fn install_resolves_legacy_template_form_repo_url() {
     );
 }
 
+fn write_platform_matrix_repo(root: &std::path::Path) -> String {
+    let repo_url = write_local_repo_component(root, "cosh-ng", "1.0.0", &["system"]);
+    std::fs::write(
+        root.join("v1/index.toml"),
+        r#"schema_version = 1
+channel = "stable"
+
+[[entries]]
+component = "cosh-ng"
+version = "1.0.0"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+os = "linux"
+arch = "x86_64"
+install_modes = ["system"]
+
+[[entries]]
+component = "cosh-ng"
+version = "1.1.0"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+os = "linux"
+arch = "x86_64"
+install_modes = ["system"]
+
+[[entries]]
+component = "cosh-ng"
+version = "1.0.0"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+os = "macos"
+arch = "aarch64"
+install_modes = ["user"]
+
+[[entries]]
+component = "cosh-ng"
+version = "1.0.0"
+channel = "stable"
+artifact_type = "binary"
+backend = "raw"
+os = "windows"
+arch = "x86_64"
+install_modes = ["user"]
+
+[[entries]]
+component = "cosh-ng"
+version = "1.0.0"
+channel = "beta"
+artifact_type = "tar_gz"
+backend = "raw"
+os = "freebsd"
+arch = "x86_64"
+install_modes = ["user"]
+
+[[entries]]
+component = "portable"
+version = "1.0.0"
+channel = "stable"
+artifact_type = "tar_gz"
+backend = "raw"
+os = "linux"
+arch = "any"
+pkg_base = "debian"
+install_modes = ["system"]
+"#,
+    )
+    .expect("write platform matrix index");
+    repo_url
+}
+
+#[test]
+fn raw_resolution_reports_sorted_deduplicated_available_platforms() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_platform_matrix_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let env = anolisa_env::EnvFacts {
+        arch: "aarch64".to_string(),
+        ..linux_env()
+    };
+
+    let err = match resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "cosh-ng".to_string(),
+            package: "cosh-ng".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            repository_origin: None,
+            version: None,
+            warnings: Vec::new(),
+        },
+    ) {
+        Ok(_) => panic!("linux/aarch64 must not resolve"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert_eq!(
+        err.reason(),
+        "cosh-ng is not available for linux/aarch64\n\navailable platforms:\n  - linux/x86_64\n  - macos/aarch64"
+    );
+}
+
+#[test]
+fn raw_resolution_keeps_unknown_package_not_found_diagnostic() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_platform_matrix_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let env = anolisa_env::EnvFacts {
+        arch: "aarch64".to_string(),
+        ..linux_env()
+    };
+
+    let err = match resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "unknown".to_string(),
+            package: "unknown".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            repository_origin: None,
+            version: None,
+            warnings: Vec::new(),
+        },
+    ) {
+        Ok(_) => panic!("unknown package must not resolve"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.code(), "INVALID_ARGUMENT");
+    assert!(
+        err.reason().contains("cannot resolve package 'unknown'")
+            && err
+                .reason()
+                .contains("no distribution entry matches the query"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(!err.reason().contains("available platforms"));
+}
+
+#[test]
+fn raw_resolution_treats_any_arch_as_the_requested_platform() {
+    let tmp = tempdir().expect("tmpdir");
+    let prefix = tmp.path().join("sys");
+    let repo_url = write_platform_matrix_repo(&tmp.path().join("repo"));
+    let ctx = ctx_with_prefix(false, Some(prefix.clone()));
+    let layout = FsLayout::system(Some(prefix));
+    let env = anolisa_env::EnvFacts {
+        arch: "aarch64".to_string(),
+        ..linux_env()
+    };
+
+    let err = match resolve_raw(
+        &ctx,
+        &layout,
+        &env,
+        ResolveInputs {
+            component: "portable".to_string(),
+            package: "portable".to_string(),
+            backend: "raw".to_string(),
+            base_url: repo_url,
+            repository_origin: None,
+            version: None,
+            warnings: Vec::new(),
+        },
+    ) {
+        Ok(_) => panic!("mismatched package base must not resolve"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.reason().contains("cannot resolve package 'portable'")
+            && err
+                .reason()
+                .contains("no distribution entry matches the query"),
+        "got: {}",
+        err.reason()
+    );
+    assert!(!err.reason().contains("available platforms"));
+}
+
 #[test]
 fn install_unpublished_version_is_invalid_argument() {
     let tmp = tempdir().expect("tmpdir");


### PR DESCRIPTION
🤖 AI changes by codex-runner · Agent: Engineer · for #2087

已完成 Issue #2087 的最小修复，未 commit、push 或创建 PR。

问题原因：

- raw 解析器将平台不匹配和未知包都映射为通用的 `ResolveError::NotFound`，CLI 未利用索引中的其他平台条目进一步区分。

修改内容：

- 在 [raw.rs](/home/jiawa.syx/codex-runner-workspaces/worktrees/1b6532fad97d392c147c3f8c4fda798c/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/raw.rs:175) 中，仅在 `NotFound` 时检查同 package、同 channel 的 raw 可安装条目。
- 当前 `os/arch` 不存在时，报告请求平台并以去重、排序列表展示可用平台。
- `arch = "any"` 视为平台匹配。
- 未知包以及版本、模式、libc、package base 等后续过滤失败保持原诊断。
- `DistributionIndex::resolve` 的选择规则和仓库回退逻辑未改动。
- 在 [raw_e2e.rs](/home/jiawa.syx/codex-runner-workspaces/worktrees/1b6532fad97d392c147c3f8c4fda798c/src/anolisa/crates/anolisa-cli/src/commands/tier1/install/tests/raw_e2e.rs:1238) 新增平台列表、未知包和 `arch = "any"` 回归测试；未修改既有测试。

验证结果全部通过：

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- raw 定向测试：4 passed
- `cargo test --workspace --locked`
- `cargo doc --workspace --no-deps --locked`
- `git diff --check`

完整测试首次在沙箱内因既有 loopback bind 权限失败；在沙箱外重跑后全部通过。



Closes #2087