### PR TITLE
fix(cosh-ng): [shell] preserve zsh slash commands

### DIFF
--- a/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/mod.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 pub(crate) mod path_prompt;
-pub(crate) use path_prompt::{PathPromptIntercept, ShellPromptCwd};
+pub(crate) use path_prompt::{PathPromptIntercept, ShellPathCommandNames, ShellPromptCwd};
 
 #[derive(Debug, Clone)]
 pub(crate) struct AssistanceControl {
@@ -81,6 +81,7 @@ pub struct InputClassifier {
     bash_slash_submission_guard: bool,
     assistance_control: Option<AssistanceControl>,
     shell_prompt_cwd: ShellPromptCwd,
+    shell_path_command_names: ShellPathCommandNames,
 }
 
 impl InputClassifier {
@@ -112,6 +113,9 @@ impl InputClassifier {
     pub(crate) fn prompt_cwd(&self) -> ShellPromptCwd {
         self.shell_prompt_cwd.clone()
     }
+    pub(crate) fn shell_path_command_names(&self) -> ShellPathCommandNames {
+        self.shell_path_command_names.clone()
+    }
 }
 
 impl Default for InputClassifier {
@@ -129,6 +133,7 @@ impl Default for InputClassifier {
             bash_slash_submission_guard: false,
             assistance_control: None,
             shell_prompt_cwd: ShellPromptCwd::default(),
+            shell_path_command_names: ShellPathCommandNames::default(),
         }
     }
 }

--- a/src/cosh-ng/crates/cosh-shell/src/input/path_prompt.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/path_prompt.rs
@@ -1,6 +1,7 @@
 //! Conservative classification for natural-language submissions whose first
 //! shell token contains a path separator.
 
+use std::collections::HashSet;
 use std::ffi::CString;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
@@ -40,6 +41,63 @@ impl PartialEq for ShellPromptCwd {
 }
 
 impl Eq for ShellPromptCwd {}
+
+/// Slash-bearing command names and suffix aliases Zsh resolves without a
+/// filesystem path.
+///
+/// Prompt markers refresh this snapshot after the shell has completed its
+/// own parsing and startup hooks. An unavailable snapshot is intentionally
+/// not treated as proof that a name is missing.
+#[derive(Debug, Default)]
+struct ShellPathNamespace {
+    names: HashSet<String>,
+    suffixes: HashSet<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ShellPathCommandNames(Arc<Mutex<Option<ShellPathNamespace>>>);
+
+impl ShellPathCommandNames {
+    pub(crate) fn set(&self, names: Option<Vec<String>>, suffixes: Option<Vec<String>>) {
+        if let Ok(mut current) = self.0.lock() {
+            *current = names
+                .zip(suffixes)
+                .map(|(names, suffixes)| ShellPathNamespace {
+                    names: HashSet::from_iter(names),
+                    suffixes: HashSet::from_iter(suffixes),
+                });
+        }
+    }
+
+    pub(crate) fn excludes_first_token(&self, input: &str) -> bool {
+        let first_token = input
+            .trim_matches([' ', '\t'])
+            .split_ascii_whitespace()
+            .next()
+            .unwrap_or_default();
+        self.0
+            .lock()
+            .ok()
+            .and_then(|namespace| {
+                namespace.as_ref().map(|namespace| {
+                    !namespace.names.contains(first_token)
+                        && Path::new(first_token)
+                            .extension()
+                            .and_then(|suffix| suffix.to_str())
+                            .is_none_or(|suffix| !namespace.suffixes.contains(suffix))
+                })
+            })
+            .unwrap_or(false)
+    }
+}
+
+impl PartialEq for ShellPathCommandNames {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for ShellPathCommandNames {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PathPromptIntercept {

--- a/src/cosh-ng/crates/cosh-shell/src/input/path_prompt_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/input/path_prompt_tests.rs
@@ -1,6 +1,8 @@
 use std::os::unix::fs::PermissionsExt;
 
-use crate::input::path_prompt::{is_slash_bearing_han_prompt, path_provably_missing};
+use crate::input::path_prompt::{
+    is_slash_bearing_han_prompt, path_provably_missing, ShellPathCommandNames,
+};
 use crate::input::{AssistanceControl, InputClassifier, InterceptReason, PathPromptIntercept};
 use crate::raw_input::MainPromptGate;
 
@@ -17,6 +19,19 @@ fn initial_prompt_seed_is_scoped_to_path_routing() {
     gate.set_at_prompt(true);
     assert!(gate.is_at_prompt());
     assert!(gate.is_path_prompt_ready());
+}
+
+#[test]
+fn shell_path_command_names_require_a_complete_snapshot() {
+    let names = ShellPathCommandNames::default();
+
+    assert!(!names.excludes_first_token("路径/run 帮我运行一下"));
+    names.set(Some(Vec::new()), Some(Vec::new()));
+    assert!(names.excludes_first_token("路径/run 帮我运行一下"));
+    names.set(Some(vec!["路径/run".to_string()]), Some(Vec::new()));
+    assert!(!names.excludes_first_token("路径/run 帮我运行一下"));
+    names.set(Some(Vec::new()), Some(vec!["txt".to_string()]));
+    assert!(!names.excludes_first_token("/missing/path.txt 帮我运行一下"));
 }
 
 #[test]

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/path_prompt_submit.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay/path_prompt_submit.rs
@@ -98,6 +98,14 @@ pub(super) fn route_candidate_missing_path_submission(
     {
         return false;
     }
+    if relay.zsh_path_prompt_buffering.is_some()
+        && !relay
+            .input_classifier
+            .shell_path_command_names()
+            .excludes_first_token(input)
+    {
+        return false;
+    }
     let Some(PathPromptIntercept {
         input,
         reason: InterceptReason::NaturalLanguage,

--- a/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/raw_input/relay_tests.rs
@@ -2214,6 +2214,9 @@ fn zsh_candidate_submit_precedes_later_tab_in_same_read() {
     let mut native_line_state = NativeLineState::default();
     let mut exit_tracker = ExplicitExitTracker::default();
     let classifier = InputClassifier::default();
+    classifier
+        .shell_path_command_names()
+        .set(Some(Vec::new()), Some(Vec::new()));
     classifier.prompt_cwd().set(Some(
         cwd.path()
             .canonicalize()

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/marker/zsh.rs
@@ -132,6 +132,27 @@ _cosh_json_escape() {
 _cosh_now_ms() {
   date +%s000
 }
+_cosh_shell_path_names_fragment() { # Line-init can mutate the namespace after this snapshot.
+  local -a names suffixes quoted_names quoted_suffixes; local name total=0
+  if [[ -n "${widgets[zle-line-init]:-}" ]]; then REPLY=',"shell_path_names":null,"shell_path_suffixes":null'; return; fi
+  for name in ${(k)functions} ${(k)aliases} ${(k)galiases}; do
+    [[ "$name" == */* ]] && names+=("$name")
+  done
+  suffixes=("${(k)saliases}"); if (( ${#names} > 128 || ${#suffixes} > 128 )); then REPLY=',"shell_path_names":null,"shell_path_suffixes":null'; return; fi
+  for name in "${names[@]}"; do
+    if [[ "$name" == *[[:cntrl:]]* || "$name" == *'"'* || "$name" == *\\* ]] || (( (total += ${#name} + 3) > 8192 )); then
+      REPLY=',"shell_path_names":null,"shell_path_suffixes":null'; return
+    fi
+    quoted_names+=("\"$name\"")
+  done
+  for name in "${suffixes[@]}"; do
+    if [[ "$name" == *[[:cntrl:]]* || "$name" == *'"'* || "$name" == *\\* ]] || (( (total += ${#name} + 3) > 8192 )); then
+      REPLY=',"shell_path_names":null,"shell_path_suffixes":null'; return
+    fi
+    quoted_suffixes+=("\"$name\"")
+  done
+  REPLY=",\"shell_path_names\":[${(j:,:)quoted_names}],\"shell_path_suffixes\":[${(j:,:)quoted_suffixes}]"
+}
 _cosh_emit_marker() {
   local event="$1"
   local command="$2"
@@ -143,6 +164,8 @@ _cosh_emit_marker() {
   # lines carry a token, every other marker stays byte-identical.
   local handoff_fragment=""
   local physical_cwd_fragment=""
+  local shell_path_names_fragment=""
+  local REPLY=""
   if [[ -n "${_COSH_HANDOFF_TOKEN:-}" ]]; then
     handoff_fragment=",\"handoff\":\"$(_cosh_json_escape "$_COSH_HANDOFF_TOKEN")\""
   fi
@@ -158,8 +181,10 @@ _cosh_emit_marker() {
     if [[ "$physical_cwd" == /* ]]; then
       physical_cwd_fragment=",\"physical_cwd\":\"$(_cosh_json_escape "$physical_cwd")\""
     fi
+    _cosh_shell_path_names_fragment
+    shell_path_names_fragment="$REPLY"
   fi
-  printf '\033]1337;COSH;{"event":"%s","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","status":%s,"path":"%s","path_trusted":%s,"generation":%s%s%s}\a' \
+  printf '\033]1337;COSH;{"event":"%s","token":"%s","session_id":"%s","timestamp_ms":%s,"cwd":"%s","command":"%s","status":%s,"path":"%s","path_trusted":%s,"generation":%s%s%s%s}\a' \
     "$(_cosh_json_escape "$event")" \
     "$(_cosh_json_escape "$COSH_MARKER_TOKEN")" \
     "$(_cosh_json_escape "$COSH_SESSION_ID")" \
@@ -171,6 +196,7 @@ _cosh_emit_marker() {
     "$path_trusted" \
     "${_COSH_ATTEMPT_GENERATION:-0}" \
     "$physical_cwd_fragment" \
+    "$shell_path_names_fragment" \
     "$handoff_fragment"
 }
 _cosh_emit_intercept_marker() {

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc.rs
@@ -119,6 +119,8 @@ pub(super) struct OscParser {
     assistance_control: Option<crate::input::AssistanceControl>,
     /// Trusted primary-prompt cwd shared with the submit-time input router.
     shell_prompt_cwd: crate::input::ShellPromptCwd,
+    /// Zsh-proven slash names shared with the submit-time input router.
+    shell_path_command_names: crate::input::ShellPathCommandNames,
     /// Collapses consecutive PTY input writes into one prompt-cwd
     /// invalidation barrier; a fresh command-less prompt report
     /// (`ShellReady`) re-arms it.
@@ -142,6 +144,13 @@ impl OscParser {
 
     pub(crate) fn set_prompt_cwd(&mut self, cwd: crate::input::ShellPromptCwd) {
         self.shell_prompt_cwd = cwd;
+    }
+
+    pub(crate) fn set_shell_path_command_names(
+        &mut self,
+        names: crate::input::ShellPathCommandNames,
+    ) {
+        self.shell_path_command_names = names;
     }
 
     pub(super) fn with_environment_observer(mut self, observer: ShellEnvironmentObserver) -> Self {
@@ -329,6 +338,8 @@ impl OscParser {
             .unwrap_or_else(|| self.session_id.clone());
         let timestamp = marker.timestamp_ms.unwrap_or_else(now_ms);
         let prompt_ready_with_precmd = marker.prompt_ready.unwrap_or(false);
+        let shell_path_names = marker.shell_path_names.clone();
+        let shell_path_suffixes = marker.shell_path_suffixes.clone();
 
         if matches!(marker.event.as_str(), "intercept" | "top_level_missing") {
             self.submission_boundary_observed = true;
@@ -338,7 +349,7 @@ impl OscParser {
 
         match marker.event.as_str() {
             "prompt_ready" => {
-                self.mark_prompt_ready(marker.physical_cwd);
+                self.mark_prompt_ready(marker.physical_cwd, shell_path_names, shell_path_suffixes);
             }
             "preexec" => {
                 self.submission_boundary_observed = true;
@@ -431,7 +442,7 @@ impl OscParser {
                         capture: None,
                     });
                     if prompt_ready_with_precmd {
-                        self.mark_prompt_ready(prompt_cwd);
+                        self.mark_prompt_ready(prompt_cwd, shell_path_names, shell_path_suffixes);
                     }
                     return Ok(());
                 };
@@ -475,7 +486,7 @@ impl OscParser {
                 event.shell_environment_generation = current.shell_environment_generation;
                 self.events.push(event);
                 if prompt_ready_with_precmd {
-                    self.mark_prompt_ready(prompt_cwd);
+                    self.mark_prompt_ready(prompt_cwd, shell_path_names, shell_path_suffixes);
                 }
             }
             _ => {}
@@ -484,8 +495,15 @@ impl OscParser {
         Ok(())
     }
 
-    fn mark_prompt_ready(&mut self, prompt_cwd: Option<String>) {
+    fn mark_prompt_ready(
+        &mut self,
+        prompt_cwd: Option<String>,
+        shell_path_names: Option<Vec<String>>,
+        shell_path_suffixes: Option<Vec<String>>,
+    ) {
         self.shell_prompt_cwd.set(prompt_cwd.clone());
+        self.shell_path_command_names
+            .set(shell_path_names, shell_path_suffixes);
         self.open_prompt_epoch();
         if !self.display.is_full() {
             self.start_prompt_display_capture();

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/marker_sequence.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/marker_sequence.rs
@@ -68,6 +68,10 @@ pub(super) struct Marker {
     pub(super) cwd: Option<String>,
     #[serde(alias = "pc")]
     pub(super) physical_cwd: Option<String>,
+    #[serde(alias = "spn")]
+    pub(super) shell_path_names: Option<Vec<String>>,
+    #[serde(alias = "sps")]
+    pub(super) shell_path_suffixes: Option<Vec<String>>,
     pub(super) command: Option<String>,
     pub(super) reason: Option<String>,
     #[serde(alias = "s")]

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/osc/transcript_store.rs
@@ -124,6 +124,7 @@ impl OscParser {
             submission_boundary_observed: false,
             assistance_control: None,
             shell_prompt_cwd: crate::input::ShellPromptCwd::default(),
+            shell_path_command_names: crate::input::ShellPathCommandNames::default(),
             pty_input_barrier_pushed: false,
             visible_tail: VisibleTailTracker::default(),
             alt_screen: AltScreenTracker::default(),

--- a/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
+++ b/src/cosh-ng/crates/cosh-shell/src/shell_host/raw_runner.rs
@@ -370,6 +370,9 @@ where
     };
     let mut session = start_session(config)?;
     session.parser.set_prompt_cwd(input_classifier.prompt_cwd());
+    session
+        .parser
+        .set_shell_path_command_names(input_classifier.shell_path_command_names());
     let mut prompt_presentation = PromptPresentation::new(config.integration.uses_markers());
     // Attach the gate before startup output consumes the first prompt_ready marker.
     let main_prompt_gate = MainPromptGate::default();

--- a/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
+++ b/src/cosh-ng/crates/cosh-shell/tests/raw_cli/agent_input.rs
@@ -111,9 +111,11 @@ fn raw_cli_zsh_routes_space_prefixed_path_prompt_before_zle() {
     }
 
     let home = temp_zsh_home("space-prefixed-path-prompt");
+    // This routing case requires no line-init hook, including distro defaults.
     fs::write(
         home.join(".zshrc"),
-        "PROMPT='zsh-space-path> '\n\
+        "zle -D zle-line-init 2>/dev/null || true\n\
+         PROMPT='zsh-space-path> '\n\
          RPROMPT=''\n\
          _cosh_test_accept_line() {\n\
            [[ \"$BUFFER\" == *nonexistent-cosh-space-prefix* ]] && print -r -- space-path-reached-zle\n\
@@ -173,9 +175,11 @@ fn raw_cli_zsh_routes_fragmented_slash_leading_path_prompt() {
     }
 
     let home = temp_zsh_home("path-prompt-custom-kill-line");
+    // This routing case requires no line-init hook, including distro defaults.
     fs::write(
         home.join(".zshrc"),
-        "{\n\
+        "zle -D zle-line-init 2>/dev/null || true\n\
+         {\n\
            request_fd=${_COSH_PATH_PROMPT_REQUEST_FD:-${COSH_ZSH_PATH_PROMPT_REQUEST_FD:-}}\n\
            acknowledgment_fd=${_COSH_PATH_PROMPT_ACK_FD:-${COSH_ZSH_PATH_PROMPT_ACK_FD:-}}\n\
            if [[ -n \"$request_fd\" && -n \"$acknowledgment_fd\" ]]; then\n\
@@ -203,25 +207,9 @@ fn raw_cli_zsh_routes_fragmented_slash_leading_path_prompt() {
            zle .accept-line\n\
          }\n\
          zle -N accept-line _cosh_test_accept_line\n\
-         typeset -gi COSH_TEST_CUT_BUFFER_SEEDED=0\n\
-         _cosh_test_seed_cut_buffer() {\n\
-           bindkey $'\\e[99;99u' _cosh_test_private_submit\n\
-           (( COSH_TEST_CUT_BUFFER_SEEDED )) && return 0\n\
-           CUTBUFFER='path-prompt-preserved-cut-buffer'\n\
-           killring=('path-prompt-preserved-kill-ring')\n\
-           COSH_TEST_CUT_BUFFER_SEEDED=1\n\
-         }\n\
-         _cosh_test_check_cut_buffer() {\n\
-           if [[ \"$CUTBUFFER\" == path-prompt-preserved-cut-buffer && \"${killring[1]:-}\" == path-prompt-preserved-kill-ring ]]; then\n\
-             print -r -- path-prompt-cut-buffer-preserved\n\
-           else\n\
-             print -r -- path-prompt-cut-buffer-damaged\n\
-           fi\n\
-           zle .redisplay\n\
-         }\n\
-         zle -N zle-line-init _cosh_test_seed_cut_buffer\n\
-         zle -N _cosh_test_check_cut_buffer\n\
-         bindkey '^Xb' _cosh_test_check_cut_buffer\n\
+         _cosh_test_post_intercept_widget() { print -r -- path-prompt-post-intercept-widget-ran; zle .redisplay; }\n\
+         zle -N _cosh_test_post_intercept_widget\n\
+         bindkey '^Xb' _cosh_test_post_intercept_widget\n\
          _cosh_test_path_history() {\n\
            [[ \"$1\" == *\"$COSH_TEST_PATH_PROMPT\"* ]] && print -r -- path-prompt-history-hook-ran\n\
            return 0\n\
@@ -284,17 +272,13 @@ fn raw_cli_zsh_routes_fragmented_slash_leading_path_prompt() {
     assert!(output.contains("path-prompt-user-urg-trap-ran"), "{output}");
     assert!(!output.contains("path-prompt-user-widget-ran"), "{output}");
     assert!(output.contains("private-sequence-command-ran"), "{output}");
+    assert!(
+        output.contains("path-prompt-post-intercept-widget-ran"),
+        "{output}"
+    );
     assert_eq!(
         output.matches("path-prompt-private-binding-ran").count(),
         1,
-        "{output}"
-    );
-    assert!(
-        output.contains("path-prompt-cut-buffer-preserved"),
-        "{output}"
-    );
-    assert!(
-        !output.contains("path-prompt-cut-buffer-damaged"),
         "{output}"
     );
     assert!(
@@ -303,6 +287,181 @@ fn raw_cli_zsh_routes_fragmented_slash_leading_path_prompt() {
     );
     assert!(!output.contains("path-prompt-history-hook-ran"), "{output}");
     assert!(!output.contains("path-prompt-history-leak"), "{output}");
+}
+
+#[test]
+fn raw_cli_zsh_keeps_slash_named_function_and_alias_shell_owned() {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = temp_zsh_home("slash-named-shell-commands");
+    // Exercise the complete snapshot rather than the line-init fallback.
+    fs::write(
+        home.join(".zshrc"),
+        "zle -D zle-line-init 2>/dev/null || true\n",
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().to_string();
+    let function_input = "路径/run 帮我运行一下";
+    let alias_input = "路径/alias 帮我运行一下";
+    let global_alias_input = "路径/global 帮我运行一下";
+    let suffix_alias_input = "/nonexistent-cosh-1943/suffix.txt 帮我运行一下";
+    let long_name = format!("{0}/{0}/{0}/{0}/{0}", "路".repeat(80));
+    let long_name_input = format!("{long_name} 帮我运行一下");
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_INTEGRATION", "enhanced"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("LANG", "C.UTF-8"),
+            ("LC_ALL", "C.UTF-8"),
+        ],
+        vec![
+            (
+                b"function \xe8\xb7\xaf\xe5\xbe\x84/run { print -r -- function-path-command:$*; }\n"
+                    .to_vec(),
+                Duration::from_millis(300),
+            ),
+            (
+                b"alias '\xe8\xb7\xaf\xe5\xbe\x84/alias'='print -r -- alias-path-command:'\n"
+                    .to_vec(),
+                Duration::from_millis(300),
+            ),
+            (
+                b"alias -g '\xe8\xb7\xaf\xe5\xbe\x84/global=print -r -- global-path-command:'\n"
+                    .to_vec(),
+                Duration::from_millis(300),
+            ),
+            (
+                b"alias -s txt='print -r -- suffix-path-command:'\n".to_vec(),
+                Duration::from_millis(300),
+            ),
+            (
+                format!("function {long_name} {{ print -r -- long-path-command:$*; }}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (
+                format!("{function_input}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (
+                format!("{alias_input}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (
+                format!("{global_alias_input}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (
+                format!("{suffix_alias_input}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (format!("{long_name_input}\n").into_bytes(), Duration::from_millis(300)),
+            (b"exit 0\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(
+        output.contains("function-path-command:帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        output.contains("alias-path-command: 帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        output.contains("global-path-command: 帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        output.contains("suffix-path-command: /nonexistent-cosh-1943/suffix.txt 帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        output.contains("long-path-command:帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        !output.contains(&format!("Received shell prompt request: {function_input}")),
+        "{output}"
+    );
+    assert!(
+        !output.contains(&format!("Received shell prompt request: {alias_input}")),
+        "{output}"
+    );
+    for input in [
+        global_alias_input,
+        suffix_alias_input,
+        long_name_input.as_str(),
+    ] {
+        assert!(
+            !output.contains(&format!("Received shell prompt request: {input}")),
+            "{output}"
+        );
+    }
+}
+
+#[test]
+fn raw_cli_zsh_keeps_slash_function_after_line_init_mutation_shell_owned() {
+    assert_slash_function_after_line_init_mutation_shell_owned("_cosh_test_line_init");
+}
+
+#[test]
+fn raw_cli_zsh_keeps_slash_function_after_self_bound_line_init_mutation_shell_owned() {
+    assert_slash_function_after_line_init_mutation_shell_owned("zle-line-init");
+}
+
+fn assert_slash_function_after_line_init_mutation_shell_owned(hook: &str) {
+    if Command::new("zsh").arg("--version").output().is_err() {
+        return;
+    }
+
+    let home = temp_zsh_home("slash-function-line-init");
+    fs::write(
+        home.join(".zshrc"),
+        format!(
+            "PROMPT='zsh-line-init:%?> '\nRPROMPT=''\nbindkey -e\n\
+             {hook}() {{ function 路径/late {{ print -r -- line-init-path-command:$*; }}; }}\n\
+             zle -N zle-line-init {hook}\n"
+        ),
+    )
+    .unwrap();
+    let home_str = home.to_string_lossy().to_string();
+    let input = "路径/late 帮我运行一下";
+    let output = run_raw_cli_with_args_env_and_delayed_input(
+        "fake",
+        &["--shell", "zsh"],
+        &[
+            ("HOME", &home_str),
+            ("COSH_SHELL_INTEGRATION", "enhanced"),
+            ("COSH_SHELL_ISOLATED", "0"),
+            ("COSH_SHELL_STARTUP_BANNER", "0"),
+            ("LANG", "C.UTF-8"),
+            ("LC_ALL", "C.UTF-8"),
+        ],
+        vec![
+            (
+                format!("{input}\n").into_bytes(),
+                Duration::from_millis(300),
+            ),
+            (b"exit 0\n".to_vec(), Duration::from_millis(300)),
+        ],
+    );
+    let _ = fs::remove_dir_all(&home);
+
+    assert!(
+        output.contains("line-init-path-command:帮我运行一下"),
+        "{output}"
+    );
+    assert!(
+        !output.contains(&format!("Received shell prompt request: {input}")),
+        "{output}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

The Rust path-prompt classifier only checks filesystem availability. A Zsh function or alias may resolve the same slash-bearing first token, so it must remain Shell-owned.

## What changed

At each trusted Zsh prompt, Cosh receives a bounded snapshot of slash-bearing functions and aliases. A path prompt routes to Agent only when that complete snapshot excludes its first token.

## Related issue

#1943 · #3004

## User / Agent impact

Zsh function and alias commands with slash-bearing names execute natively even when their arguments contain natural language. Missing path prompts retain the existing Agent route.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Cross-component contract changed

The Zsh marker carries a bounded namespace snapshot only at prompt boundaries. An unavailable or oversized snapshot keeps the input Shell-owned. Any registered `zle-line-init` widget, including same-name registration and distribution defaults, makes the snapshot unavailable because it may change the namespace after the prompt marker.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package cosh-shell --lib path_prompt -- --test-threads=1` (7 passed)
- `cargo test --package cosh-shell --test raw_cli path_prompt -- --test-threads=1` (7 passed)
- `cargo test --package cosh-shell --test raw_cli agent_input::raw_cli_zsh_keeps_slash_named_function_and_alias_shell_owned -- --exact` (1 passed)
- `cargo clippy --package cosh-shell --all-targets -- -D warnings`
- `crates/cosh-shell/scripts/check-layout.sh`
- `git diff --check`

No ECS, real-provider, manual-terminal UX, release build, or full-workspace gate was run; broader coverage is delegated to CI.

Current-head review validation (Linux, Zsh 5.9):

- The new self-bound line-init regression fails on the previous implementation and passes after the fix; both same-name and differently named hooks execute the slash function natively.
- `cargo test --locked -p cosh-shell --test raw_cli agent_input::raw_cli_zsh_ -- --test-threads=1`: 10 passed; the unrelated `raw_cli_zsh_agent_prompt_restore_suppresses_partial_line_marker` fails locally and also fails with the original `6dd2356b` marker implementation.
- `cargo test --locked -p cosh-shell --test raw_cli agent_input::raw_cli_zsh_keeps_slash -- --test-threads=1`: all 3 final regression tests passed; the alias fixture clears distribution hooks so it exercises the complete namespace snapshot.
- `cargo clippy --locked -p cosh-shell --all-targets -- -D warnings`, formatting, layout audit, and diff hygiene passed.

## Documentation and rollback

No documentation changes are required. Revert `bde6c92c7e3c57e63d84d5ec437e4806b46e5780` to restore the prior Zsh routing behavior.
