### PR TITLE
feat(sec-core): add policy related API at v2 daemon service

### DIFF
--- a/src/agent-sec-core/docs/design/AGENT_SEC_RUST_MIGRATION_zh.md
+++ b/src/agent-sec-core/docs/design/AGENT_SEC_RUST_MIGRATION_zh.md
@@ -101,6 +101,10 @@ revision、搜索路径、已有测试和未自动验证项；不使用构建产
 
 - asc-daemon 是进程入口和 composition root，只负责 bootstrap、配置、runtime、RPC、
   signals、具体 adapter 装配和进程级 observability。
+- asc-daemon-service 负责协议无关的 UDS admission、framing、peer credentials、timeout、
+  drain 和 socket 生命周期，并通过 `RequestDispatcher` port 调用上层。
+- asc-daemon-handler 负责 daemon wire 解码、method allowlist、server-owned authorization、
+  application use case 路由以及 response/error projection；不拥有进程或 transport runtime。
 - asc-daemon-core 负责编排 identity、authorization、action、policy、observability、
   management、jobs 和 lifecycle 用例，不复制领域业务语义。
 - asc-action-runtime 负责 action validation、admission、execution supervision、timeout、
@@ -230,7 +234,7 @@ asc-state-migrator 必须定义并验证：
 工作包采用本文定义的目标 workspace，至少包括：
 
 - 产品入口：asc-daemon、asc-cli、asc-state-migrator；
-- daemon：asc-daemon-protocol、asc-daemon-core；
+- daemon：asc-daemon-protocol、asc-daemon-service、asc-daemon-handler、asc-daemon-core；
 - action：asc-action-types、asc-evidence-types、asc-action-runtime 和各 asc-capability-*；
 - policy：asc-policy-types、asc-policy-engine、asc-policy-runtime、asc-pap、asc-pcp；
 - data：asc-security-events、asc-observability、asc-session、asc-state、

--- a/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md
@@ -3,7 +3,7 @@
 | 属性 | 值 |
 | --- | --- |
 | 状态 | V1 Python 交付基线、兼容语料及仓库内 V2 部署目标 |
-| 实现核对日期 | 2026-08-21 |
+| 实现核对日期 | 2026-09-04 |
 | 当前行为基线 | fe58ed4b23b8；与 main 中已有 systemd/RPM 行为交叉核对 |
 | 适用实现 | V1 Python daemon oracle；V2 Rust asc-daemon；安装器、migrator 和进程管理器 |
 
@@ -229,20 +229,27 @@ write 和 drain 分别设置显式 deadline。dispatch deadline 到期会释放 
 blocking call。`asc-daemon` 因此显式拥有 Tokio runtime，并在 service drain 后使用额外的
 runtime shutdown timeout，避免残留 `spawn_blocking` 让前台进程永久不能退出。
 
-该 slice 尚未注册 daemon protocol 或 `daemon.health`，因此完整 request 在经过唯一的
-`RequestDispatcher` 注入点后静默关闭。此行为只用于证明 process/transport 能启动，不是
-稳定 wire contract，也不表示 application READY。后续 protocol 合并时，由同一个 concrete
-dispatcher 完成 envelope decode、request ID、trusted Principal 绑定、method allowlist 和
-response encode；PAP 只是其中一组显式注册的方法，不增加第二个 service dispatch 层。
+该 slice 已由唯一的 concrete `DaemonDispatcher` 注册 first-version PAP daemon protocol，
+但尚未注册 `daemon.health`。dispatcher 完成 envelope decode、request ID、kernel peer
+credentials 到 trusted Principal 的绑定、method allowlist、authorization 和 response
+encode；PAP 是其中一组显式注册的方法，不增加第二个 service dispatch 层。当前 composition
+root 使用 `RootManagedPrincipalPolicy`：UID 0 默认具有 PAP 管理权限，其它 UID 在未加载
+root-owned delegation 前返回 `permission_denied`，caller-supplied identity 不能覆盖该判断。
+
+当前 PAP 由 `PolicyTemplateCompiler` 和过渡性的 process-local Repository 组成。Policy、Scope
+和 Binding CRUD 可在同一 daemon 生命周期内经真实 UDS 执行，但所有状态在进程重启后丢失，
+进程启动时会显式输出该限制。这些结果只证明 protocol、identity、authorization 和应用装配的
+integration slice，不表示 durable persistence、target enforcement 或 application READY。
 Busy、timeout、shutdown 等 transport failure 由独立且有短 deadline 的
 `RejectionEncoder` 投影，正常依赖图不包含 PAP、Repository 或 Compiler。
 framework 不能证明具体 PAP/Repository 内部没有全局 mutex、长 transaction 或其它共享阻塞
 点；该项必须由 PAP direct-consumer concurrency fixture 在集成时验收。
 
 当前还未实现 packaging-owned system socket 默认值、runtime directory hardening、Host
-singleton/stale-socket 判定、日志/OTel 和 health readiness。因此这一 slice 只提供
-DPROC-002/DPROC-003 的 focused source-level evidence，不能宣称 DPROC-012 至 DPROC-014 或
-production process gate 已完成。
+singleton/stale-socket 判定、日志/OTel 和 health readiness。因此这一 slice 提供
+DPROC-002/DPROC-003 的 focused process evidence，以及 DPROC-013 中 binary + UDS protocol
+注册、server-side permission 和 signal cleanup 的部分证据；它不能宣称 DPROC-012、完整
+DPROC-013、DPROC-014 或 production process gate 已完成。
 
 ## 9. 验收矩阵
 
@@ -291,4 +298,8 @@ service/package、server-side admission 或真实 Kubernetes rollout 验证。
 - data/log path：security_events/config.py、daemon/logging.py；
 - service tests：tests/e2e/daemon/test_daemon_systemd_e2e.py；
 - process/signal tests：tests/e2e/daemon/test_daemon_e2e.py；
-- package layout tests：tests/packaging/test-package-raw.sh。
+- package layout tests：tests/packaging/test-package-raw.sh；
+- Rust DPROC-002/DPROC-003 与部分 DPROC-013 process fixture：
+  v2/apps/asc-daemon/tests/bootstrap.rs；
+- Rust PAP 完整 serialized UDS scenario：
+  v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json。

--- a/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
@@ -29,7 +29,7 @@ V2 设计，不能在 V1 兼容迁移中单方面加入必填字段。
 [`DAEMON_CURRENT_BEHAVIOR_zh.md`](DAEMON_CURRENT_BEHAVIOR_zh.md)；Job 生命周期、调度、
 日志、trace 和恢复语义见 [`DAEMON_JOB_CONTRACT_zh.md`](DAEMON_JOB_CONTRACT_zh.md)。
 security action 不通过
-当前默认 method catalogue 执行；迁移目标通过本文 6.11 的显式 handler 扩展接入。
+当前默认 method catalogue 执行；迁移目标通过本文 6.12 的显式 handler 扩展接入。
 其逻辑契约见
 [`SECURITY_MIDDLEWARE_CONTRACT_zh.md`](SECURITY_MIDDLEWARE_CONTRACT_zh.md)。
 
@@ -423,11 +423,93 @@ next offset。items 按 `(timestamp_epoch, kind)` 升序排列：
 - `kind=security`：包含完整 security event、被关联的 observability context，以及
   `match.reason/rank/time_delta_seconds`。
 
+### 6.11 **[TARGET V2]** PAP administration
+
+PAP administration 是新增的 V2 method family，不是九个 V1 method 之一。第一版接口采用
+互斥的 `{requestId,result}` 或 `{requestId,error}` 响应，不保留 POC 的 `poc.*` method、
+`ok/data/stdout/stderr/exit_code` envelope 或兼容分支。输入和输出以
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json` 为可执行清单。
+`requestId` 是 daemon 为每次 dispatch 生成的 UUID；`error` 固定为 `{code,message}`，
+success 不得再包一层 `{policy}`、`{scope}` 或 `{binding}`。
+
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json` 进一步冻结覆盖
+15 个 method 的有状态 CRUD 场景及完整 response value，包括 Canonical Policy IR、Scope
+template、Binding 内嵌快照、revision、status 和确定性 digest。daemon 生成的 request/resource
+UUID 使用具名占位符：fixture 不冻结随机值本身，但必须验证 UUID 格式、CREATE 捕获值在后续
+请求/响应中的一致性，以及不同资源 identity 不混用。该 fixture 同时由 protocol 类型测试、
+使用服务端授权测试 Principal 的必跑 UDS integration E2E，以及真实 `asc-daemon` 子进程
+bootstrap E2E 消费。binary 测试在 root 身份下重复完整成功场景，非 root 身份验证默认
+`permission_denied`；不得为测试加入产品授权旁路。
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json` 冻结 method
+params 构造失败时的 `invalid_request` code 和有界、安全 message，并由真实 UDS integration
+fixture 消费。
+
+所有方法都要求 daemon 根据 kernel peer credentials 和服务端策略构造
+Policy Administrator Principal；request 中不得携带可信 UID、role 或 scope。RPC 直接复用
+`asc-policy-types` 的 `PolicyTemplate`、`ScopeSelector`、`PreparedPolicy`、
+`PreparedScope`、`BindingView` 以及 foundation 的 `ResourceId`、`Revision`，不得复制
+Policy domain DTO。
+
+当前 bootstrap 的首版策略固定允许 UID 0 管理 Policy；其它 UID 默认拒绝。root 可以向
+process-local allowlist 添加额外管理员 UID，但被授权 UID 不获得继续委派权限。allowlist 的
+持久化、加载和管理 RPC 尚未进入本 slice，在这些能力完成前 daemon 重启后只保留 root 权限。
+
+| method | params | result |
+| --- | --- | --- |
+| `policy.templates.create` | `{policyName, template}` | `PreparedPolicy` |
+| `policy.templates.update` | `{policyId, policyName, template}` | `PreparedPolicy` |
+| `policy.templates.get` | `{id, revision}` | `PreparedPolicy` |
+| `policy.templates.list` | `{limit=100, offset=0}` | `{items: PreparedPolicy[], total}` |
+| `policy.templates.delete` | `{id, revision}` | `PreparedPolicy` |
+| `policy.scopes.create` | `{selector}` | `PreparedScope` |
+| `policy.scopes.update` | `{scopeId, selector}` | `PreparedScope` |
+| `policy.scopes.get` | `{id, revision}` | `PreparedScope` |
+| `policy.scopes.list` | `{limit=100, offset=0}` | `{items: PreparedScope[], total}` |
+| `policy.scopes.delete` | `{id, revision}` | `PreparedScope` |
+| `policy.bindings.create` | `{policyId, policyRevision, scopeId, scopeRevision}` | `BindingView` |
+| `policy.bindings.update` | `{bindingId, policyId, policyRevision, scopeId, scopeRevision}` | `BindingView` |
+| `policy.bindings.get` | `{id}` | `BindingView` |
+| `policy.bindings.list` | `{limit=100, offset=0}` | `{items: BindingView[], total}` |
+| `policy.bindings.delete` | `{id}` | `BindingView` |
+
+CREATE 的 stable identity 由 PAP 生成；UPDATE 不兼作 upsert。Policy/Scope GET 和 DELETE
+要求精确 current revision；Binding GET 读取唯一 current record。Binding CREATE/UPDATE
+返回 `PENDING_APPLY` intent，DELETE 返回 `PENDING_DELETE` intent；daemon handler 不等待
+Reconciler，也不把 PAP acceptance 表述为 target 已生效或删除完成。
+
+Policy CREATE/UPDATE 在 PAP 内同步调用 `PolicyCompiler::lower(TemplateEnvelope) ->
+PolicyEnvelope`。当前产品 compiler 只实现 `prevent_file_deletion`，其输入与完整 Canonical
+Policy IR 输出由
+`v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json` 冻结；输出语义是
+`ResourceOperation::Delete + FileResolution::PathEntry`。其它 `PolicyTemplate` kind 在各自
+lowering 与直接 Adapter conformance 完成前返回 `invalid_argument`，不得生成占位 IR。
+
+参数 object 拒绝未知字段。新 authored Scope 只接受正数 PID 或 cgroup ID，不接受仅用于读取
+旧数据的 `LegacyExecutionDomain`。LIST 的 `limit` 为 `1..=1000`，`offset` 为 `u32`；total 是
+分页前总数。当前 aggregate byte budget 仍是 Repository/PAP/transport 联合 gate，在该 gate
+完成前 LIST 只达到 integration contract，不构成 distribution-ready 大数据量查询能力。
+
+TODO(policy-response-bounds)：当前 direct `PreparedPolicy`/`BindingView` mutation result 可能在
+Repository commit 后才因 response frame 超限而失败；Binding GET/LIST 也会因内嵌完整 Policy
+和 Scope 快照放大响应。在 durable Repository 或 distribution gate 前，必须完成 public result
+shape/存储模型收敛，并对 mutation、单记录 GET 和 LIST aggregate response 建立 server-owned
+encoded-size gate；本 slice 不以提高 transport limit 代替该修复。
+
+PAP error 稳定投影如下：无法构造成 method params 的字段、类型或 bounded value（包括非法
+identifier、revision、pagination 和 authored selector）→ `invalid_request`，同时返回最多 256
+字节的参数解码原因；成功构造 params 后发生的 authoring/compiler validation →
+`invalid_argument`；not found → `not_found`；revision conflict 或 operation in progress →
+`conflict`；revision exhaustion → `resource_exhausted`；serialization/persistence → `internal`。
+Malformed envelope 使用 `invalid_request`，未注册 method 使用 `unknown_method`，授权失败使用
+`permission_denied`。只有 protocol 参数解码产生的有界原因可进入 `invalid_request` message；
+application 内部 validation path、repository error、secret 和内部 error code 不进入 wire
+message。
+
 <a id="daemon-security-action-handler-contract"></a>
 
-### 6.11 **[TARGET V2][PENDING DEFINITION]** Security action handler 扩展
+### 6.12 **[TARGET V2][PENDING DEFINITION]** Security action handler 扩展
 
-#### 6.11.1 历史依据与注册模型
+#### 6.12.1 历史依据与注册模型
 
 commit `ef0d75f27c389434cf6f4361f5dbcdeaff42ab72` 曾实现完整的 `scan-prompt`
 daemon action 路径：`register_prompt_scan_methods()` 在默认 `MethodRegistry` 中注册
@@ -462,7 +544,7 @@ asc-daemon-protocol 的 Definition Review 冻结 method 名、schema、authoriza
 该 alias 不计入 17 个 canonical method；是否启用必须在发布前形成明确决定，不能由实现
 自行推断。
 
-#### 6.11.2 Request 映射
+#### 6.12.2 Request 映射
 
 action request 继续使用 V1 顶层 envelope：
 
@@ -476,7 +558,7 @@ action request 继续使用 V1 顶层 envelope：
 - 同步文件、SQLite、模型、CPU 或 subprocess 操作不得阻塞 socket runtime 的 accept/
   timeout loop；Python 参考实现使用 thread offload，Rust 使用等价 blocking boundary。
 
-##### 6.11.2.1 参数错误边界
+##### 6.12.2.1 参数错误边界
 
 handler 与 core 的校验职责必须保持以下三层边界：
 
@@ -495,7 +577,7 @@ handler 与 core 的校验职责必须保持以下三层边界：
 必须报告稳定的 version/capability mismatch，不转入 PyO3 或本地业务路径。request 已发送
 后的 timeout、EOF 或协议错误仍然状态不明，不能由 client 重放。
 
-#### 6.11.3 三层结果
+#### 6.12.3 三层结果
 
 沿用历史 `scan-prompt` 协议的三层解释，并推广到全部 action：
 
@@ -532,7 +614,7 @@ failure 使用 `ok=true`、非零 `exit_code` 和 `stderr`。如果未来需要�
 type 暴露给 wire client，必须作为单独的版本化协议扩展，而不是向本兼容 projection 临时
 增加顶层字段。
 
-#### 6.11.4 **[TARGET V2]** system daemon 安全边界与 method metadata gate
+#### 6.12.4 **[TARGET V2]** system daemon 安全边界与 method metadata gate
 
 V2 是 one daemon per host 的 system-level service，并服务多个本地 UID/Agent。daemon 从
 内核 peer UID/GID/PID、token binding 和服务端配置构造 trusted Principal；客户端提供的
@@ -692,6 +774,7 @@ asc-cli 触发 PyO3、Python backend 或第二套本地业务执行。
 | DPV1-017 | 八个 action method 的 timeout、queue/resource、access-log、blocking 和 cancellation metadata 已冻结并逐项验证 |
 | DPV1-018 | 多 UID 共用 system socket；trusted Principal/QueryScope 隔离 owner，`caller/trace_context` 不参与授权 |
 | DPV1-019 | CLI/TUI 不能用 RPC filter 绕过服务端 QueryScope，也不能直读 SQLite 替代授权查询 |
+| DPV1-020 | 15 个 PAP method 的 strict params、完整请求/响应 CRUD fixture、直接领域 result、错误投影、server-owned Principal；必跑 UDS integration 经 Dispatcher/PapHandler → PapService → Policy Compiler/Repository 执行完整 fixture，真实 `asc-daemon` 子进程 bootstrap 在 root 下重复成功场景、非 root 下验证默认拒绝 |
 
 协议测试必须使用 socket bytes 和解析后 JSON 比较；只测试某个 Python dataclass 或 Rust
 struct 的构造函数不足以证明 wire compatibility。

--- a/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
@@ -497,13 +497,23 @@ encoded-size gate；本 slice 不以提高 transport limit 代替该修复。
 
 PAP error 稳定投影如下：无法构造成 method params 的字段、类型或 bounded value（包括非法
 identifier、revision、pagination 和 authored selector）→ `invalid_request`，同时返回最多 256
-字节的参数解码原因；成功构造 params 后发生的 authoring/compiler validation →
-`invalid_argument`；not found → `not_found`；revision conflict 或 operation in progress →
-`conflict`；revision exhaustion → `resource_exhausted`；serialization/persistence → `internal`。
+字节的参数解码原因；任意层级 JSON object 的 duplicate key 在进入 `serde_json::Value` 前拒绝，
+按 malformed envelope 返回 `invalid_request / request envelope is invalid`。成功构造 params 后
+发生的 authoring/compiler validation → `invalid_argument`，message 为最多 256 字节的稳定
+`invalid policy name: <reason>`、`invalid policy: <authored-path>: <reason>` 或
+`invalid scope: <authored-path>: <reason>`，不得暴露 canonical IR path、输入内容或内部 error
+code。
+
+not found → `not_found`，并按操作对象稳定区分 `policy was not found`、
+`policy revision was not found`、`scope was not found`、`scope revision was not found`、
+`binding was not found`、`referenced policy revision was not found` 和
+`referenced scope revision was not found`。revision conflict 使用
+`conflict / policy request conflicts with current state`，operation in progress 使用
+`conflict / binding reconciliation operation is in progress`；revision exhaustion →
+`resource_exhausted`；serialization/persistence、内部 identifier/Binding 构造失败 → `internal`。
 Malformed envelope 使用 `invalid_request`，未注册 method 使用 `unknown_method`，授权失败使用
-`permission_denied`。只有 protocol 参数解码产生的有界原因可进入 `invalid_request` message；
-application 内部 validation path、repository error、secret 和内部 error code 不进入 wire
-message。
+`permission_denied`。repository error、secret、内部 validation path 和内部 error code 不进入
+wire message；所有 PAP 公开 error message 均不得超过 256 字节。
 
 <a id="daemon-security-action-handler-contract"></a>
 

--- a/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
@@ -481,8 +481,10 @@ Policy CREATE/UPDATE 在 PAP 内同步调用 `PolicyCompiler::lower(TemplateEnve
 PolicyEnvelope`。当前产品 compiler 只实现 `prevent_file_deletion`，其输入与完整 Canonical
 Policy IR 输出由
 `v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json` 冻结；输出语义是
-`ResourceOperation::Delete + FileResolution::PathEntry`。其它 `PolicyTemplate` kind 在各自
-lowering 与直接 Adapter conformance 完成前返回 `invalid_argument`，不得生成占位 IR。
+`ResourceOperation::Delete + FileResolution::PathEntry`。该模板只覆盖对匹配目录项的删除操作，
+例如 unlink/rmdir；rename/move、link、truncate、内容修改和其它 namespace mutation 不在其
+保护范围内。其它 `PolicyTemplate` kind 在各自 lowering 与直接 Adapter conformance 完成前
+返回 `invalid_argument`，不得生成占位 IR。
 
 参数 object 拒绝未知字段。新 authored Scope 只接受正数 PID 或 cgroup ID，不接受仅用于读取
 旧数据的 `LegacyExecutionDomain`。LIST 的 `limit` 为 `1..=1000`，`offset` 为 `u32`；total 是

--- a/src/agent-sec-core/docs/design/PAP_DAEMON_API_ACCEPTANCE_zh.md
+++ b/src/agent-sec-core/docs/design/PAP_DAEMON_API_ACCEPTANCE_zh.md
@@ -1,0 +1,106 @@
+# PAP daemon API V2 工作包验收记录
+
+| 属性 | 值 |
+| --- | --- |
+| 状态 | PAP integration ready；不是 distribution/release ready |
+| 验收日期 | 2026-09-07 |
+| 源码基线 | `main@9f109d55964cfc5820d41564869f70879a8de21f` |
+| contract revision | 本文、`DAEMON_PROTOCOL_V1_zh.md` 和 `DAEMON_PROCESS_DEPLOYMENT_CONTRACT_zh.md` 同一变更 |
+
+## 1. Goal、范围和非目标
+
+本工作包为 V2 daemon 增加 15 个显式 allowlisted PAP 方法，覆盖 Policy、Scope 和 Binding
+的 current-record CRUD；由 kernel peer credentials 构造 trusted Principal，经
+`asc-daemon-handler` 调用 `asc-daemon-core::PolicyAdministration`，再委托给 `PapService`。
+工作包同时提供首个 `prevent_file_deletion` compiler 和仅用于集成的 process-local
+Repository。
+
+以下不属于本工作包的完成声明：durable persistence、Reconciler、target Adapter、真实
+AgentSight/ActPlane enforcement、production socket/package hardening、完整 readiness，以及
+V1 九个 daemon method 的替代或退役。
+
+## 2. Crate relationship 与 acceptance type
+
+| crate / entrypoint | V1 relationship | acceptance type | 当前证据层级 |
+| --- | --- | --- | --- |
+| `asc-policy-types` authored contract correction | greenfield V2 contract | `GREENFIELD_CONTRACT` | crate contract |
+| `asc-policy-engine` | greenfield | `GREENFIELD_CONTRACT` | direct trait + daemon consumer |
+| `asc-pap-repository-memory` | adapter；无 V1 durable-state 承诺 | `ADAPTER_CONFORMANCE` | Repository + PAP consumer |
+| `asc-daemon-protocol` PAP method family | greenfield method set over an existing V1 envelope | `GREENFIELD_CONTRACT` | typed wire + real UDS |
+| `asc-daemon-core` PAP boundary | greenfield | `GREENFIELD_CONTRACT` | handler consumer |
+| `asc-daemon-handler` | protocol/application adapter | `ADAPTER_CONFORMANCE` | real UDS |
+| `asc-daemon` composition | partial migration | `PARTIAL_EQUIVALENCE` | foreground binary + UDS + signal cleanup |
+
+直接依赖 contract 使用本基线中的 `asc-foundation-types`、`asc-policy-types`、`asc-pap` 和
+`asc-daemon-service`。V1 Python daemon 只作为 discovery/oracle 来源，不进入 Rust runtime。
+
+## 3. External compatibility report
+
+- 15 个 `policy.*` 方法是 `[TARGET V2]` 新增面，不冒充当前 V1 九个 method，也不修改现有
+  CLI、Python daemon 或 V1 action response。
+- PAP wire 直接复用 domain `PolicyTemplate`、`ScopeSelector`、`PreparedPolicy`、
+  `PreparedScope` 和 `BindingView`；method params 拒绝未知字段。
+- `prevent_file_deletion` 的 contract 明确收敛为
+  `ResourceOperation::Delete + FileResolution::PathEntry`。它不承诺阻止 rename/move、link、
+  truncate、内容修改或其它 namespace mutation。
+- daemon 为每个 dispatch 生成新的 UUID request ID；成功和失败 response 均只暴露有界的
+  public error contract，不暴露内部 persistence/compiler error。
+- shared V1 request envelope 的 `trace_context`、`caller`、`timeout_ms` 和未知顶层字段兼容性
+  尚未在此工作包中实现，因此本记录不声明 V1 envelope compatibility 已完成。
+
+## 4. Internal contract change record
+
+| ID | 变更 | 原因与影响 |
+| --- | --- | --- |
+| PAP-CR-001 | 将 `PreventFileDeletion` 从含糊的 rename-out 表述收窄为 path-entry delete | 当前 compiler、protocol fixture 和 IR 只生成 `Delete`；在进入 distribution 前消除过度承诺，不改变 V1 runtime |
+| PAP-CR-002 | `DaemonError` 在构造和 decode 时统一限制为 256 UTF-8 bytes | 防止任一 handler 绕过公共 response bound；超长 caller-authored decode error 使用稳定通用消息，不回显输入 |
+| PAP-CR-003 | `pid`、`cgroupId` selector validation path 投影为 `InvalidArgument` | 这些路径来自 authored selector，不是 canonical/internal state |
+| PAP-CR-004 | serialized CRUD scenario 要求所有 dispatch request ID 互不相同 | 冻结每个请求生成 fresh UUID 的 correlation contract |
+
+若未来需要阻止 rename-out，必须先为 source/destination namespace 语义建立 IR 和直接 Adapter
+conformance；不能只把所有 `NamespaceMutation` 无差别加入当前 rule。
+
+## 5. Pass/fail matrix
+
+| ID | 验收项 | executable evidence | 结果 |
+| --- | --- | --- | --- |
+| PAPAPI-001 | compiler 输入、完整 IR 和 delete-only 语义 | `asc-policy-engine/tests/compiler_contract.rs` + `compiler-contract.json` | PASS |
+| PAPAPI-002 | process-local Repository 满足当前 PAP request slice | `asc-pap-repository-memory` unit tests | PASS |
+| PAPAPI-003 | 15 个 method 的完整 serialized CRUD | `asc-daemon/tests/pap_protocol.rs::real_uds_executes_the_complete_pap_crud_fixture` | PASS |
+| PAPAPI-004 | invalid params、domain validation、not-found 与稳定 error | `real_uds_rejects_every_invalid_crud_parameter_class` | PASS |
+| PAPAPI-005 | server-owned authorization 且 caller data 不提权 | handler/core tests、all-method deny UDS test、binary DPROC test | PASS |
+| PAPAPI-006 | 每个 daemon dispatch 返回有效且唯一的 UUID | shared serialized CRUD runner | PASS |
+| PAPAPI-007 | process bootstrap、signal 和 socket cleanup | `dproc_002_003_and_partial_013_binary_registers_pap_and_cleans_socket` | PASS（DPROC-013 partial） |
+| PAPAPI-008 | full workspace regression | `cargo test --workspace --locked` | PASS |
+| PAPAPI-009 | lint、format 和 API docs | Clippy、rustfmt、Rustdoc commands below | PASS |
+| PAPAPI-010 | durable state、target enforcement 和 packaging rollout | 不在本工作包范围 | NOT RUN |
+
+可重复执行命令：
+
+```bash
+cd v2
+cargo test --workspace --locked
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo fmt --all -- --check
+cargo doc --workspace --no-deps --locked
+git diff --check
+```
+
+## 6. Direct-consumer evidence 与限制
+
+- `PolicyTemplateCompiler` 通过 `PolicyCompiler` port 被 `PapService` 调用，并由完整 UDS CRUD
+  scenario 消费。
+- `ProcessLocalPapRepository` 通过 `PapRepository` port 被同一 `PapService` 消费；并发/CAS
+  行为由 PAP 和 Repository tests 覆盖。
+- `PolicyAdministration` 被 `DaemonDispatcher` 消费；serialized bytes 经真实 UDS，而不是只调用
+  Rust struct constructor。
+- binary fixture 只能证明当前 host 身份、protocol 注册、permission 和 signal cleanup；不能
+  替代安装后 systemd/container/Kubernetes 或真实 target enforcement。
+- memory Repository 在进程重启后丢失全部状态，不得作为 durable acceptance evidence。
+
+## 7. Rollback
+
+回滚本工作包时撤销对应 Rust commit，并从 workspace/composition root 移除新增 crate 和 PAP
+dispatcher registration。当前 Repository 不写 durable state，因此没有 schema/state downgrade；
+停止进程后其状态即消失。若只回滚 contract correction，不得仅恢复 rename-out 文案：必须连同
+支持该语义的 IR、compiler、Adapter fixture 和版本化兼容记录一起交付。

--- a/src/agent-sec-core/docs/design/RUST_SECURITY_CORE_EXECUTION_ARCHITECTURE_zh.md
+++ b/src/agent-sec-core/docs/design/RUST_SECURITY_CORE_EXECUTION_ARCHITECTURE_zh.md
@@ -574,7 +574,7 @@ asc-cli 是 Rust daemon client，只负责：
 asc-cli 不构造 Principal、不直读 SQLite、不启动 daemon、不安装 event writer，也不通过
 PyO3、Python backend 或另一套 local executor 执行业务 action。
 
-### 10.2 asc-daemon adapter
+### 10.2 asc-daemon-handler inbound adapter
 
 daemon handler：
 
@@ -599,6 +599,9 @@ module/crate 边界必须落在仓库迁移总计划定义的目标 workspace �
 ```text
 apps/asc-daemon/                         # process/composition root
 apps/asc-cli/                            # daemon client
+crates/daemon/asc-daemon-protocol/       # versioned wire contracts
+crates/daemon/asc-daemon-service/        # protocol-independent UDS transport
+crates/daemon/asc-daemon-handler/        # inbound protocol/application adapter
 crates/daemon/asc-daemon-core/           # application use cases
 crates/action/asc-action-types/          # ActionId/request/result
 crates/action/asc-evidence-types/        # Evidence/Attribute contracts

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -6,9 +6,51 @@ version = 4
 name = "asc-daemon"
 version = "0.1.0"
 dependencies = [
+ "asc-daemon-core",
+ "asc-daemon-handler",
+ "asc-daemon-protocol",
  "asc-daemon-service",
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-pap-repository-memory",
+ "asc-policy-engine",
+ "asc-policy-types",
+ "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "asc-daemon-core"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-types",
+ "thiserror",
+]
+
+[[package]]
+name = "asc-daemon-handler"
+version = "0.1.0"
+dependencies = [
+ "asc-daemon-core",
+ "asc-daemon-protocol",
+ "asc-daemon-service",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "asc-daemon-protocol"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-policy-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -39,6 +81,26 @@ dependencies = [
  "sha2",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "asc-pap-repository-memory"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-engine",
+ "asc-policy-types",
+]
+
+[[package]]
+name = "asc-policy-engine"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-types",
+ "serde_json",
 ]
 
 [[package]]

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -4,9 +4,14 @@
 resolver = "3"
 members = [
     "apps/asc-daemon",
+    "crates/daemon/asc-daemon-core",
+    "crates/daemon/asc-daemon-handler",
+    "crates/daemon/asc-daemon-protocol",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-pap",
+    "crates/policy/asc-pap-repository-memory",
+    "crates/policy/asc-policy-engine",
     "crates/policy/asc-policy-types",
 ]
 
@@ -19,9 +24,14 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+asc-daemon-core = { path = "crates/daemon/asc-daemon-core" }
+asc-daemon-handler = { path = "crates/daemon/asc-daemon-handler" }
+asc-daemon-protocol = { path = "crates/daemon/asc-daemon-protocol" }
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }
+asc-pap-repository-memory = { path = "crates/policy/asc-pap-repository-memory" }
+asc-policy-engine = { path = "crates/policy/asc-policy-engine" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,25 +1,38 @@
 # AgentSecCore V2 Policy and daemon foundations
 
 This workspace slice contains the dependency-light contracts, Policy
-Administration Point, protocol-independent Unix-domain-socket service framework,
-and runnable foreground process bootstrap used by later AgentSecCore V2 work
-packages. It deliberately contains no daemon wire protocol, concrete persistence
-or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
-Adapter.
+Administration Point, first-version PAP daemon protocol, product Policy-template
+compiler, protocol-independent Unix-domain-socket service framework, and runnable
+foreground process bootstrap used by later AgentSecCore V2 work packages. It
+deliberately contains no concrete persistence, Policy runtime, reconciliation
+worker, outbox, or target Adapter.
 
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
 - `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding
   snapshots, backend-independent IR, and target Adapter contracts.
+- `asc-policy-engine`: deterministic `prevent_file_deletion` authoring-template
+  compiler with a frozen Canonical Policy IR golden. Other template kinds remain
+  explicitly unsupported until their lowering and Adapter evidence are defined.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
+- `asc-pap-repository-memory`: explicitly temporary process-local Repository
+  adapter used only to keep daemon/PAP integration runnable before durable
+  persistence lands; its implementation is outside the current review scope.
+- `asc-daemon-protocol`: strict request/response contracts and an explicit
+  allowlist for 15 Policy, Scope, and Binding administration methods.
+- `asc-daemon-handler`: inbound protocol adapter that decodes daemon requests,
+  applies server-owned authorization, routes PAP methods, and projects protocol
+  responses without depending on a concrete Repository or compiler.
+- `asc-daemon-core`: trusted Principal construction boundary and the
+  `PolicyAdministration` application port. `PapService<R, C>` implements this
+  port directly, so repository/compiler generics do not leak into dispatch.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
-- `asc-daemon`: foreground process/bootstrap that installs Unix signal handling,
-  selects explicit transport limits, binds an explicitly supplied socket, and
-  runs `asc-daemon-service`.
+- `asc-daemon`: foreground process and composition root that configures and
+  injects concrete adapters into the daemon service.
 
 ## Daemon service boundary
 
@@ -33,10 +46,25 @@ evidence only and is not linked or executed by the Rust runtime.
 
 The service framework does not deserialize a daemon request, generate protocol
 request IDs, choose authorization roles, or render protocol errors. The concrete
-dispatcher receives a bounded raw request frame and owns method routing. Method
+`asc-daemon-handler::DaemonDispatcher` receives a bounded raw request frame and
+owns method routing. Method
 allowlist routing is internal to that one dispatcher implementation; it is not a
 second service dispatch layer. A separate `RejectionEncoder` receives typed
 transport failures and must remain independent of PAP/Repository state.
+
+The PAP request path is:
+
+```text
+UDS frame -> DaemonDispatcher -> method metadata authorization
+          -> PapHandler -> PolicyAdministration -> PapService<R, C>
+```
+
+RPC reuses the domain `PolicyTemplate`, `ScopeSelector`, `PreparedPolicy`,
+`PreparedScope`, and `BindingView` types. It does not define result wrappers for
+each CRUD operation. `PolicyAdministration` intentionally mirrors the use cases
+once: it erases `R`/`C` before dispatch and repeats authorization at the
+application boundary; there is no additional `PapServiceAdapter` forwarding
+object.
 
 The current bootstrap bounds frame read, application dispatch, rejection
 encoding, response write, connection drain, and final Tokio runtime shutdown.
@@ -45,12 +73,21 @@ it cannot forcibly stop an application blocking call that ignores that signal.
 The framework also cannot prove that a concrete PAP/Repository avoids global
 locks; that remains a required direct-consumer concurrency test at integration.
 
-The current `asc-daemon` executable deliberately registers no wire methods. It
-can start and exercise the real UDS lifecycle, but it closes complete requests
-without a response until the daemon protocol is merged. Socket presence therefore
-does not mean application readiness. It also requires an explicit absolute socket
-path because packaging-owned system paths, singleton/stale-socket policy, runtime
-directory hardening, and readiness remain later process-integration work.
+The current `asc-daemon` executable composes and registers the PAP dispatcher and
+protocol rejection encoder from `asc-daemon-handler`. It composes `PapService`
+with `PolicyTemplateCompiler`, a
+root-managed Principal policy, and an explicitly transitional process-local
+Repository. Policy CRUD therefore works during one daemon lifetime, but all
+state disappears on restart; this is integration evidence, not durable
+persistence or distribution readiness. The process prints that limitation at
+startup. It also requires an explicit absolute socket path because
+packaging-owned system paths, singleton/stale-socket policy, runtime directory
+hardening, and readiness remain later process-integration work.
+
+UID 0 is always a Policy administrator. Other UIDs are denied until root adds
+them to the process-local allowlist. Delegated administrators cannot delegate
+other UIDs. Loading, persisting, and exposing management RPCs for that allowlist
+remain later daemon state/configuration work.
 
 Run the independent transport process in the foreground:
 
@@ -58,11 +95,44 @@ Run the independent transport process in the foreground:
 cargo run -p asc-daemon -- serve --socket /absolute/existing-directory/daemon.sock
 ```
 
-After protocol integration, the existing daemon handler should implement
-`RequestDispatcher` directly and be injected by this bootstrap. A small
-protocol-only error encoder implements `RejectionEncoder`. PAP becomes one
+`asc-daemon-handler::DaemonDispatcher` implements `RequestDispatcher` directly
+and is injected by the executable composition root together with
+`JsonRejectionEncoder`. PAP is one
 registered method family inside the dispatcher; the service framework and
 rejection path remain independent of PAP, its compiler, and its repository.
+
+## PAP RPC contract
+
+The closed method inventory contains create, update, exact get, bounded list,
+and delete for each of Policy, Scope, and Binding. Successful responses are
+`{requestId,result}` and failures are `{requestId,error}`. The result is the
+domain record itself; list is the sole shared `{items,total}` shape. Exact inputs
+and output type names are frozen by
+`asc-daemon-protocol/tests/fixtures/pap-methods.json`.
+
+The stateful `asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json` scenario
+freezes complete request and response values for all 15 methods, including
+Canonical Policy IR, Scope templates, embedded Binding snapshots, revisions,
+statuses, and deterministic digests. Server-generated request and resource UUIDs
+use named placeholders so the same fixture can assert their format and identity
+flow across later requests. A UDS integration E2E always executes the complete
+scenario with a server-authorized test principal. The `asc-daemon` bootstrap E2E
+also starts the real binary and repeats that scenario when the process is root;
+a non-root binary run instead verifies the product's default
+`permission_denied` policy.
+
+Binding create/update accepts desired state and returns `PENDING_APPLY`; delete
+returns `PENDING_DELETE`. These responses prove PAP acceptance only. They do not
+mean target enforcement or deletion completed. LIST is integration-ready but is
+not distribution-ready until a server-owned aggregate encoded-byte budget is
+passed through Repository, PAP, and transport.
+
+TODO(policy-response-bounds): direct `PreparedPolicy` and `BindingView` mutation
+results can exceed the response-frame limit after process-local state has already
+changed, while embedded snapshots can also make Binding GET/LIST oversized.
+Before a durable Repository or distribution gate, converge the public result and
+storage shapes and enforce server-owned encoded-size budgets for mutations,
+single-record GET, and LIST; increasing the transport limit alone is not the fix.
 
 ## Current-record revision boundary
 
@@ -162,16 +232,17 @@ must repeat the `APPLYING`/`DELETING` admission gate inside the atomic update so
 a worker claim cannot race a PAP pre-check.
 
 The shared state machine is defined and tested now, but the PAP-only phase
-implements no outbox, dispatcher, or reconciler. Therefore
+implements no outbox, delivery dispatcher, or reconciler. Therefore
 PAP writes only `PENDING_APPLY` and `PENDING_DELETE`; nothing in this phase
 advances them. TODO(policy-reconciliation): persist each accepted current
 Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-Daemon protocol, client, concrete persistence/compiler, Policy runtime,
-reconciliation worker, outbox, and target Adapter belong to later work packages
-and are intentionally absent from this slice.
+CLI client, concrete persistence, Policy runtime, reconciliation worker, outbox,
+and target Adapter belong to later work packages and are intentionally absent
+from this slice. The compiler included here is limited to the one golden-backed
+`prevent_file_deletion` lowering described above.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -15,6 +15,8 @@ The current crates are:
 - `asc-policy-engine`: deterministic `prevent_file_deletion` authoring-template
   compiler with a frozen Canonical Policy IR golden. Other template kinds remain
   explicitly unsupported until their lowering and Adapter evidence are defined.
+  The implemented template covers path-entry deletion only; rename, move, and
+  other namespace mutations are outside its contract.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
 - `asc-pap-repository-memory`: explicitly temporary process-local Repository
@@ -33,6 +35,10 @@ The current crates are:
   dispatch cancellation, and controlled drain.
 - `asc-daemon`: foreground process and composition root that configures and
   injects concrete adapters into the daemon service.
+
+The crate relationships, acceptance types, executable pass/fail matrix,
+compatibility report, direct-consumer evidence, and rollback boundary are recorded
+in [`PAP_DAEMON_API_ACCEPTANCE_zh.md`](../docs/design/PAP_DAEMON_API_ACCEPTANCE_zh.md).
 
 ## Daemon service boundary
 

--- a/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
+++ b/src/agent-sec-core/v2/apps/asc-daemon/Cargo.toml
@@ -9,9 +9,21 @@ repository.workspace = true
 publish.workspace = true
 
 [dependencies]
+asc-daemon-core = { workspace = true }
+asc-daemon-handler = { workspace = true }
 asc-daemon-service = { workspace = true }
+asc-pap = { workspace = true }
+asc-pap-repository-memory = { workspace = true }
+asc-policy-engine = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+asc-daemon-protocol = { workspace = true }
+asc-foundation-types = { workspace = true }
+asc-policy-types = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/bootstrap.rs
@@ -3,9 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use asc_daemon_service::{
-    BindError, BoundUnixSocket, ConfigError, DispatchError, DispatchRequest, RejectedRequest,
-    RejectionEncoder, RequestDispatcher, ResponseDisposition, ServeError, ServeReport,
-    ServiceConfig, ShutdownToken, UnixService,
+    BindError, BoundUnixSocket, ConfigError, RejectionEncoder, RequestDispatcher, ServeError,
+    ServeReport, ServiceConfig, ShutdownToken, UnixService,
 };
 
 const DEFAULT_MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
@@ -75,44 +74,6 @@ pub async fn serve(
     let socket = BoundUnixSocket::bind(&config.socket_path, config.socket_mode)?;
     let service = UnixService::new(socket, config.service, dispatcher, rejection_encoder)?;
     Ok(service.serve(shutdown).await?)
-}
-
-/// Runs the transport before any daemon protocol methods have been registered.
-///
-/// Connections are admitted and bounded normally, but complete request frames
-/// are closed without a response. This is transport bring-up, not daemon
-/// readiness; no temporary wire response is invented before protocol merge.
-///
-/// # Errors
-/// Returns the same bootstrap failures as [`serve`].
-pub async fn serve_without_handlers(
-    config: BootstrapConfig,
-    shutdown: ShutdownToken,
-) -> Result<ServeReport, BootstrapError> {
-    let handlers = Arc::new(NoRegisteredMethods);
-    serve(config, handlers.clone(), handlers, shutdown).await
-}
-
-struct NoRegisteredMethods;
-
-impl RequestDispatcher for NoRegisteredMethods {
-    fn dispatch(
-        &self,
-        _request: DispatchRequest,
-        _response: &mut dyn std::io::Write,
-    ) -> Result<ResponseDisposition, DispatchError> {
-        Ok(ResponseDisposition::Close)
-    }
-}
-
-impl RejectionEncoder for NoRegisteredMethods {
-    fn encode_rejection(
-        &self,
-        _request: RejectedRequest,
-        _response: &mut dyn std::io::Write,
-    ) -> Result<ResponseDisposition, DispatchError> {
-        Ok(ResponseDisposition::Close)
-    }
 }
 
 /// Failure to start or run the daemon transport.

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/cli.rs
@@ -6,8 +6,9 @@ use crate::BootstrapConfig;
 
 const HELP: &str = "Usage: asc-daemon [serve] --socket <ABSOLUTE_PATH>\n\
 \n\
-Runs the protocol-independent AgentSecCore V2 UDS service.\n\
-This bring-up binary has no registered daemon methods yet.\n";
+Runs the AgentSecCore V2 UDS service with PAP administration methods.\n\
+Only root may modify Policy state unless root delegates an additional UID.\n\
+PAP state is process-local until durable Repository integration lands.\n";
 
 /// Parsed command-line configuration for the daemon process.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/lib.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/lib.rs
@@ -1,9 +1,8 @@
-//! Process bootstrap for the `AgentSecCore` V2 daemon.
+//! Process bootstrap and composition root for the `AgentSecCore` V2 daemon.
 //!
-//! This independent service-framework slice deliberately has no registered wire
-//! methods. It can bind and serve the UDS transport; the later protocol
-//! integration supplies the concrete request dispatcher used by the same
-//! bootstrap.
+//! The binary installs PAP handlers with a root-managed authorization policy
+//! and a replaceable process-local Repository. Durable persistence remains a
+//! later composition change.
 
 #![forbid(unsafe_code)]
 
@@ -12,9 +11,7 @@ mod cli;
 mod runtime;
 mod signals;
 
-pub use bootstrap::{
-    BootstrapConfig, BootstrapError, default_service_config, serve, serve_without_handlers,
-};
+pub use bootstrap::{BootstrapConfig, BootstrapError, default_service_config, serve};
 pub use cli::{Cli, CliError, ParseOutcome};
 pub use runtime::{RuntimeError, run_with_shutdown_timeout};
 pub use signals::{ProcessSignals, SignalError};

--- a/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/src/main.rs
@@ -1,10 +1,14 @@
 use std::process::ExitCode;
+use std::sync::Arc;
 use std::time::Duration;
 
-use asc_daemon::{
-    Cli, ParseOutcome, ProcessSignals, run_with_shutdown_timeout, serve_without_handlers,
-};
+use asc_daemon::{Cli, ParseOutcome, ProcessSignals, run_with_shutdown_timeout, serve};
+use asc_daemon_core::{PrincipalPolicy, RootManagedPrincipalPolicy};
+use asc_daemon_handler::{DaemonDispatcher, JsonRejectionEncoder};
 use asc_daemon_service::ShutdownToken;
+use asc_pap::PapService;
+use asc_pap_repository_memory::ProcessLocalPapRepository;
+use asc_policy_engine::PolicyTemplateCompiler;
 
 const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -41,9 +45,22 @@ async fn run() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    let repository = Arc::new(ProcessLocalPapRepository::default());
+    let pap = PapService::new(repository, Arc::new(PolicyTemplateCompiler));
+    let principal_policy = Arc::new(RootManagedPrincipalPolicy::default());
+    let policy_for_handler: Arc<dyn PrincipalPolicy> = principal_policy.clone();
+    let dispatcher = Arc::new(DaemonDispatcher::new(pap, policy_for_handler));
+    eprintln!("asc-daemon: warning: PAP state is process-local and is lost on restart");
+
     let shutdown = ShutdownToken::new();
     let signal_task = tokio::spawn(signals.request_shutdown(shutdown.clone()));
-    let result = serve_without_handlers(cli.bootstrap, shutdown).await;
+    let result = serve(
+        cli.bootstrap,
+        dispatcher,
+        Arc::new(JsonRejectionEncoder),
+        shutdown,
+    )
+    .await;
     signal_task.abort();
 
     match result {

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/bootstrap.rs
@@ -1,12 +1,14 @@
+use std::os::unix::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use asc_daemon::{BootstrapConfig, serve_without_handlers};
-use asc_daemon_service::ShutdownToken;
-use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::UnixStream;
+
+mod support;
 
 static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -60,38 +62,20 @@ async fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
     .expect("SIGTERM should stop the foreground daemon")
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn bootstrap_serves_transport_without_methods_and_cleans_up() {
-    let directory = unique_directory();
-    std::fs::create_dir(&directory).unwrap();
-    let socket_path = directory.join("daemon.sock");
-    let shutdown = ShutdownToken::new();
-    let service_shutdown = shutdown.clone();
-    let config = BootstrapConfig::new(&socket_path);
-    let service =
-        tokio::spawn(async move { serve_without_handlers(config, service_shutdown).await });
-
-    wait_for_socket(&socket_path).await;
-    let mut stream = UnixStream::connect(&socket_path).await.unwrap();
-    stream.write_all(b"unregistered request\n").await.unwrap();
+async fn request(path: &Path, payload: &[u8]) -> Value {
+    let mut stream = UnixStream::connect(path).await.unwrap();
+    stream.write_all(payload).await.unwrap();
     let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
+    BufReader::new(stream)
+        .read_until(b'\n', &mut response)
         .await
-        .unwrap()
         .unwrap();
-    assert!(response.is_empty());
-
-    shutdown.request();
-    let report = service.await.unwrap().unwrap();
-    assert_eq!(report.accepted_connections, 1);
-    assert_eq!(report.dispatched_requests, 1);
-    assert_eq!(report.silently_closed_connections, 1);
-    assert!(!socket_path.exists());
-    std::fs::remove_dir(directory).unwrap();
+    assert_eq!(response.pop(), Some(b'\n'));
+    serde_json::from_slice(&response).unwrap()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn binary_starts_in_foreground_and_sigterm_cleans_its_socket() {
+async fn dproc_002_003_and_partial_013_binary_registers_pap_and_cleans_socket() {
     let directory = unique_directory();
     std::fs::create_dir(&directory).unwrap();
     let socket_path = directory.join("daemon.sock");
@@ -110,6 +94,20 @@ async fn binary_starts_in_foreground_and_sigterm_cleans_its_socket() {
     };
 
     wait_for_socket(&running.socket_path).await;
+    let fixture: Value = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json"
+    ))
+    .unwrap();
+    if std::fs::metadata(&running.socket_path).unwrap().uid() == 0 {
+        support::run_frozen_pap_crud_scenario(&running.socket_path, &fixture).await;
+    } else {
+        let first_request = fixture["steps"][0]["request"].clone();
+        let mut payload = serde_json::to_vec(&first_request).unwrap();
+        payload.push(b'\n');
+        let response = request(&running.socket_path, &payload).await;
+        assert_eq!(response["error"]["code"], "permission_denied");
+    }
+
     let signal = Command::new("/bin/kill")
         .arg("-TERM")
         .arg(running.child.id().to_string())

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
@@ -1,0 +1,459 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use asc_daemon::{BootstrapConfig, serve};
+use asc_daemon_core::{
+    PeerCredentials, PolicyAdministration, PolicyAdministrationError, Principal, PrincipalPolicy,
+    PrincipalRole, ResourcePage,
+};
+use asc_daemon_handler::{DaemonDispatcher, JsonRejectionEncoder};
+use asc_daemon_protocol::{DaemonRequest, DaemonResponse, RequestId, error_code};
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::PapService;
+use asc_pap_repository_memory::ProcessLocalPapRepository;
+use asc_policy_engine::PolicyTemplateCompiler;
+use asc_policy_types::authoring::PolicyTemplate;
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixStream;
+
+mod support;
+
+static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy)]
+struct FixedRolePolicy(PrincipalRole);
+
+impl PrincipalPolicy for FixedRolePolicy {
+    fn role_for(&self, _peer: PeerCredentials) -> PrincipalRole {
+        self.0
+    }
+}
+
+#[derive(Clone)]
+struct RecordingAdministration {
+    binding: BindingView,
+    calls: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl RecordingAdministration {
+    fn new() -> Self {
+        let spec: PreparedBinding = serde_json::from_str(include_str!(
+            "../../../crates/policy/asc-policy-types/tests/fixtures/prepared-binding.json"
+        ))
+        .unwrap();
+        Self {
+            binding: BindingView {
+                spec,
+                status: BindingStatus::PendingApply,
+            },
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn record(
+        &self,
+        principal: &Principal,
+        method: &'static str,
+    ) -> Result<(), PolicyAdministrationError> {
+        if principal.role() != PrincipalRole::PolicyAdministrator {
+            return Err(PolicyAdministrationError::Forbidden);
+        }
+        self.calls.lock().unwrap().push(method);
+        Ok(())
+    }
+
+    fn policy(&self) -> PreparedPolicy {
+        self.binding.spec.policy.clone()
+    }
+
+    fn scope(&self) -> PreparedScope {
+        self.binding.spec.scope.clone()
+    }
+}
+
+impl PolicyAdministration for RecordingAdministration {
+    fn create_policy(
+        &self,
+        principal: &Principal,
+        _policy_name: &str,
+        _template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        self.record(principal, "policy.templates.create")?;
+        Ok(self.policy())
+    }
+
+    fn update_policy(
+        &self,
+        principal: &Principal,
+        _policy_id: &ResourceId,
+        _policy_name: &str,
+        _template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        self.record(principal, "policy.templates.update")?;
+        Ok(self.policy())
+    }
+
+    fn get_policy(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+        _revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        self.record(principal, "policy.templates.get")?;
+        Ok(self.policy())
+    }
+
+    fn list_policies(
+        &self,
+        principal: &Principal,
+        _limit: u32,
+        _offset: u32,
+    ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError> {
+        self.record(principal, "policy.templates.list")?;
+        Ok(ResourcePage {
+            items: vec![self.policy()],
+            total: 1,
+        })
+    }
+
+    fn delete_policy_revision(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+        _revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        self.record(principal, "policy.templates.delete")?;
+        Ok(self.policy())
+    }
+
+    fn create_scope(
+        &self,
+        principal: &Principal,
+        _selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        self.record(principal, "policy.scopes.create")?;
+        Ok(self.scope())
+    }
+
+    fn update_scope(
+        &self,
+        principal: &Principal,
+        _scope_id: &ResourceId,
+        _selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        self.record(principal, "policy.scopes.update")?;
+        Ok(self.scope())
+    }
+
+    fn get_scope(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+        _revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        self.record(principal, "policy.scopes.get")?;
+        Ok(self.scope())
+    }
+
+    fn list_scopes(
+        &self,
+        principal: &Principal,
+        _limit: u32,
+        _offset: u32,
+    ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError> {
+        self.record(principal, "policy.scopes.list")?;
+        Ok(ResourcePage {
+            items: vec![self.scope()],
+            total: 1,
+        })
+    }
+
+    fn delete_scope_revision(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+        _revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        self.record(principal, "policy.scopes.delete")?;
+        Ok(self.scope())
+    }
+
+    fn create_binding(
+        &self,
+        principal: &Principal,
+        _policy_id: &ResourceId,
+        _policy_revision: Revision,
+        _scope_id: &ResourceId,
+        _scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        self.record(principal, "policy.bindings.create")?;
+        Ok(self.binding.clone())
+    }
+
+    fn update_binding(
+        &self,
+        principal: &Principal,
+        _binding_id: &ResourceId,
+        _policy_id: &ResourceId,
+        _policy_revision: Revision,
+        _scope_id: &ResourceId,
+        _scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        self.record(principal, "policy.bindings.update")?;
+        Ok(self.binding.clone())
+    }
+
+    fn get_binding(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        self.record(principal, "policy.bindings.get")?;
+        Ok(self.binding.clone())
+    }
+
+    fn list_bindings(
+        &self,
+        principal: &Principal,
+        _limit: u32,
+        _offset: u32,
+    ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError> {
+        self.record(principal, "policy.bindings.list")?;
+        Ok(ResourcePage {
+            items: vec![self.binding.clone()],
+            total: 1,
+        })
+    }
+
+    fn delete_binding(
+        &self,
+        principal: &Principal,
+        _id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        self.record(principal, "policy.bindings.delete")?;
+        Ok(self.binding.clone())
+    }
+}
+
+#[test]
+fn all_frozen_methods_route_once_and_return_domain_values_directly() {
+    let application = RecordingAdministration::new();
+    let calls = Arc::clone(&application.calls);
+    let expected_policy = serde_json::to_value(application.policy()).unwrap();
+    let expected_scope = serde_json::to_value(application.scope()).unwrap();
+    let expected_binding = serde_json::to_value(&application.binding).unwrap();
+    let handler = DaemonDispatcher::new(
+        application,
+        Arc::new(FixedRolePolicy(PrincipalRole::PolicyAdministrator)),
+    );
+    let fixtures: Vec<Value> = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json"
+    ))
+    .unwrap();
+
+    for (index, fixture) in fixtures.iter().enumerate() {
+        let method = fixture["method"].as_str().unwrap();
+        let response = handler.handle(
+            RequestId::new(format!("request-{index}")).unwrap(),
+            PeerCredentials::new(1000, 100, 4242),
+            DaemonRequest {
+                method: method.to_owned(),
+                params: fixture["params"].clone(),
+            },
+        );
+        let DaemonResponse::Success(success) = response else {
+            panic!("{method} should succeed");
+        };
+        let expected = match fixture["resultType"].as_str().unwrap() {
+            "PreparedPolicy" => expected_policy.clone(),
+            "PreparedScope" => expected_scope.clone(),
+            "BindingView" => expected_binding.clone(),
+            "ListResult<PreparedPolicy>" => {
+                json!({"items": [expected_policy.clone()], "total": 1})
+            }
+            "ListResult<PreparedScope>" => {
+                json!({"items": [expected_scope.clone()], "total": 1})
+            }
+            "ListResult<BindingView>" => {
+                json!({"items": [expected_binding.clone()], "total": 1})
+            }
+            unexpected => panic!("unexpected result type {unexpected}"),
+        };
+        assert_eq!(success.result, expected, "wrong direct result for {method}");
+    }
+
+    assert_eq!(
+        *calls.lock().unwrap(),
+        fixtures
+            .iter()
+            .map(|fixture| fixture["method"].as_str().unwrap())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn server_assigned_non_admin_role_is_not_overridden_by_request_data() {
+    let application = RecordingAdministration::new();
+    let calls = Arc::clone(&application.calls);
+    let handler = DaemonDispatcher::new(
+        application,
+        Arc::new(FixedRolePolicy(PrincipalRole::LocalUser)),
+    );
+    let response = handler.handle(
+        RequestId::new("request-denied").unwrap(),
+        PeerCredentials::new(0, 0, 1),
+        serde_json::from_value(json!({
+            "method": "policy.templates.get",
+            "params": {"id": "policy-1", "revision": 1}
+        }))
+        .unwrap(),
+    );
+
+    let DaemonResponse::Error(error) = response else {
+        panic!("a local user must not administer Policy");
+    };
+    assert_eq!(error.error.code.as_str(), error_code::PERMISSION_DENIED);
+    assert!(calls.lock().unwrap().is_empty());
+}
+
+#[test]
+fn unknown_methods_and_invalid_method_params_use_distinct_errors() {
+    let handler = DaemonDispatcher::new(
+        RecordingAdministration::new(),
+        Arc::new(FixedRolePolicy(PrincipalRole::PolicyAdministrator)),
+    );
+    for (method, params, expected_code, expected_message) in [
+        (
+            "policy.unknown",
+            json!({}),
+            error_code::UNKNOWN_METHOD,
+            "daemon method is not implemented",
+        ),
+        (
+            "policy.templates.get",
+            json!({"id": "policy-1"}),
+            error_code::INVALID_REQUEST,
+            "missing field `revision`",
+        ),
+    ] {
+        let response = handler.handle(
+            RequestId::new(format!("request-{method}")).unwrap(),
+            PeerCredentials::new(1000, 100, 4242),
+            DaemonRequest {
+                method: method.to_owned(),
+                params,
+            },
+        );
+        let DaemonResponse::Error(error) = response else {
+            panic!("{method} should fail");
+        };
+        assert_eq!(error.error.code.as_str(), expected_code);
+        assert_eq!(error.error.message, expected_message);
+    }
+}
+
+fn unique_directory() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "asc-daemon-pap-protocol-{}-{}",
+        std::process::id(),
+        DIRECTORY_ID.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+async fn wait_for_socket(path: &Path) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !path.exists() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("daemon should bind its socket");
+}
+
+async fn uds_request(path: &Path, payload: &[u8]) -> Value {
+    let mut stream = UnixStream::connect(path).await.unwrap();
+    stream.write_all(payload).await.unwrap();
+    let mut response = Vec::new();
+    BufReader::new(stream)
+        .read_until(b'\n', &mut response)
+        .await
+        .unwrap();
+    assert_eq!(response.pop(), Some(b'\n'));
+    serde_json::from_slice(&response).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn real_uds_executes_the_complete_pap_crud_fixture() {
+    let directory = unique_directory();
+    std::fs::create_dir(&directory).unwrap();
+    let socket_path = directory.join("daemon.sock");
+    let application = PapService::new(
+        Arc::new(ProcessLocalPapRepository::default()),
+        Arc::new(PolicyTemplateCompiler),
+    );
+    let dispatcher = Arc::new(DaemonDispatcher::new(
+        application,
+        Arc::new(FixedRolePolicy(PrincipalRole::PolicyAdministrator)),
+    ));
+    let shutdown = asc_daemon_service::ShutdownToken::new();
+    let service_shutdown = shutdown.clone();
+    let mut config = BootstrapConfig::new(&socket_path);
+    config.service.request_read_timeout = Duration::from_millis(50);
+    let task = tokio::spawn(async move {
+        serve(
+            config,
+            dispatcher,
+            Arc::new(JsonRejectionEncoder),
+            service_shutdown,
+        )
+        .await
+    });
+
+    wait_for_socket(&socket_path).await;
+    let fixture: Value = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json"
+    ))
+    .unwrap();
+    support::run_frozen_pap_crud_scenario(&socket_path, &fixture).await;
+
+    let invalid_params: Value = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json"
+    ))
+    .unwrap();
+    for case in invalid_params["cases"].as_array().unwrap() {
+        let mut payload = serde_json::to_vec(&case["request"]).unwrap();
+        payload.push(b'\n');
+        let response = uds_request(&socket_path, &payload).await;
+        assert!(response["requestId"].as_str().is_some());
+        assert_eq!(response["error"], case["expectedError"], "{}", case["name"]);
+    }
+
+    let invalid = uds_request(&socket_path, b"not-json\n").await;
+    assert!(invalid["requestId"].as_str().is_some());
+    assert_eq!(invalid["error"]["code"], error_code::INVALID_REQUEST);
+
+    let idle = UnixStream::connect(&socket_path).await.unwrap();
+    let mut rejection = Vec::new();
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        BufReader::new(idle).read_until(b'\n', &mut rejection),
+    )
+    .await
+    .expect("idle connection should receive a bounded rejection")
+    .unwrap();
+    assert_eq!(rejection.pop(), Some(b'\n'));
+    let rejection: Value = serde_json::from_slice(&rejection).unwrap();
+    assert!(rejection["requestId"].as_str().is_some());
+    assert_eq!(rejection["error"]["code"], error_code::DEADLINE_EXCEEDED);
+
+    shutdown.request();
+    task.await.unwrap().unwrap();
+    assert!(!socket_path.exists());
+    std::fs::remove_dir(directory).unwrap();
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
@@ -11,7 +11,7 @@ use asc_daemon_core::{
 use asc_daemon_handler::{DaemonDispatcher, JsonRejectionEncoder};
 use asc_daemon_protocol::{DaemonRequest, DaemonResponse, RequestId, error_code};
 use asc_foundation_types::{ResourceId, Revision};
-use asc_pap::PapService;
+use asc_pap::{PapRepository, PapService};
 use asc_pap_repository_memory::ProcessLocalPapRepository;
 use asc_policy_engine::PolicyTemplateCompiler;
 use asc_policy_types::authoring::PolicyTemplate;
@@ -21,10 +21,86 @@ use asc_policy_types::scope::{PreparedScope, ScopeSelector};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::net::UnixStream;
+use uuid::Uuid;
 
 mod support;
 
 static DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
+
+struct RunningPapDaemon {
+    directory: PathBuf,
+    socket_path: PathBuf,
+    shutdown: asc_daemon_service::ShutdownToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl RunningPapDaemon {
+    async fn start(role: PrincipalRole) -> Self {
+        Self::start_with_request_limit(role, 4 * 1024 * 1024).await
+    }
+
+    async fn start_with_request_limit(role: PrincipalRole, max_request_frame_bytes: usize) -> Self {
+        Self::start_with_repository(
+            role,
+            max_request_frame_bytes,
+            Arc::new(ProcessLocalPapRepository::default()),
+        )
+        .await
+    }
+
+    async fn start_with_repository(
+        role: PrincipalRole,
+        max_request_frame_bytes: usize,
+        repository: Arc<ProcessLocalPapRepository>,
+    ) -> Self {
+        let application = PapService::new(repository, Arc::new(PolicyTemplateCompiler));
+        Self::start_with_application(role, max_request_frame_bytes, application).await
+    }
+
+    async fn start_with_application(
+        role: PrincipalRole,
+        max_request_frame_bytes: usize,
+        application: impl PolicyAdministration + 'static,
+    ) -> Self {
+        let directory = unique_directory();
+        std::fs::create_dir(&directory).unwrap();
+        let socket_path = directory.join("daemon.sock");
+        let dispatcher = Arc::new(DaemonDispatcher::new(
+            application,
+            Arc::new(FixedRolePolicy(role)),
+        ));
+        let shutdown = asc_daemon_service::ShutdownToken::new();
+        let service_shutdown = shutdown.clone();
+        let mut config = BootstrapConfig::new(&socket_path);
+        config.service.max_request_frame_bytes = max_request_frame_bytes;
+        config.service.request_read_timeout = Duration::from_millis(50);
+        let task = tokio::spawn(async move {
+            serve(
+                config,
+                dispatcher,
+                Arc::new(JsonRejectionEncoder),
+                service_shutdown,
+            )
+            .await
+            .unwrap();
+        });
+
+        wait_for_socket(&socket_path).await;
+        Self {
+            directory,
+            socket_path,
+            shutdown,
+            task,
+        }
+    }
+
+    async fn stop(self) {
+        self.shutdown.request();
+        self.task.await.unwrap();
+        assert!(!self.socket_path.exists());
+        std::fs::remove_dir(self.directory).unwrap();
+    }
+}
 
 #[derive(Clone, Copy)]
 struct FixedRolePolicy(PrincipalRole);
@@ -388,57 +464,567 @@ async fn uds_request(path: &Path, payload: &[u8]) -> Value {
     serde_json::from_slice(&response).unwrap()
 }
 
+fn record_error_response(
+    failures: &mut Vec<String>,
+    name: &str,
+    response: &Value,
+    expected_error: &Value,
+) {
+    let Some(request_id) = response["requestId"].as_str() else {
+        failures.push(format!(
+            "{name}: response has no string requestId: {response}"
+        ));
+        return;
+    };
+    if let Err(error) = Uuid::parse_str(request_id) {
+        failures.push(format!("{name}: requestId is not a UUID: {error}"));
+    }
+    if response.as_object().is_none_or(|fields| fields.len() != 2)
+        || response.get("result").is_some()
+    {
+        failures.push(format!(
+            "{name}: error response must contain only requestId and error: {response}"
+        ));
+    }
+    if response["error"] != *expected_error {
+        failures.push(format!(
+            "{name}: expected error {expected_error}, received {}",
+            response["error"]
+        ));
+    }
+}
+
+fn generated_fixture_value(name: &str) -> Option<String> {
+    match name {
+        "resource_id_129" => Some("a".repeat(129)),
+        "policy_name_257" => Some("n".repeat(257)),
+        "path_4097" => Some(format!("/{}", "p".repeat(4_096))),
+        _ => None,
+    }
+}
+
+fn expand_generated_fixture_values(value: &Value) -> Value {
+    match value {
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| (key.clone(), expand_generated_fixture_values(value)))
+                .collect(),
+        ),
+        Value::Array(items) => {
+            Value::Array(items.iter().map(expand_generated_fixture_values).collect())
+        }
+        Value::String(candidate) if candidate.starts_with("${") && candidate.ends_with('}') => {
+            let name = &candidate[2..candidate.len() - 1];
+            generated_fixture_value(name).map_or_else(|| value.clone(), Value::String)
+        }
+        _ => value.clone(),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ParamKind {
+    ResourceId,
+    Revision,
+    String,
+    PolicyTemplate,
+    ScopeSelector,
+    Limit,
+    Offset,
+}
+
+struct ParamSpec {
+    name: &'static str,
+    kind: ParamKind,
+    required: bool,
+}
+
+fn method_param_specs(method: &str) -> Vec<ParamSpec> {
+    let id = |name| ParamSpec {
+        name,
+        kind: ParamKind::ResourceId,
+        required: true,
+    };
+    let revision = |name| ParamSpec {
+        name,
+        kind: ParamKind::Revision,
+        required: true,
+    };
+    match method {
+        "policy.templates.create" => vec![
+            ParamSpec {
+                name: "policyName",
+                kind: ParamKind::String,
+                required: true,
+            },
+            ParamSpec {
+                name: "template",
+                kind: ParamKind::PolicyTemplate,
+                required: true,
+            },
+        ],
+        "policy.templates.update" => vec![
+            id("policyId"),
+            ParamSpec {
+                name: "policyName",
+                kind: ParamKind::String,
+                required: true,
+            },
+            ParamSpec {
+                name: "template",
+                kind: ParamKind::PolicyTemplate,
+                required: true,
+            },
+        ],
+        "policy.templates.get"
+        | "policy.templates.delete"
+        | "policy.scopes.get"
+        | "policy.scopes.delete" => vec![id("id"), revision("revision")],
+        "policy.templates.list" | "policy.scopes.list" | "policy.bindings.list" => vec![
+            ParamSpec {
+                name: "limit",
+                kind: ParamKind::Limit,
+                required: false,
+            },
+            ParamSpec {
+                name: "offset",
+                kind: ParamKind::Offset,
+                required: false,
+            },
+        ],
+        "policy.scopes.create" => vec![ParamSpec {
+            name: "selector",
+            kind: ParamKind::ScopeSelector,
+            required: true,
+        }],
+        "policy.scopes.update" => vec![
+            id("scopeId"),
+            ParamSpec {
+                name: "selector",
+                kind: ParamKind::ScopeSelector,
+                required: true,
+            },
+        ],
+        "policy.bindings.create" => vec![
+            id("policyId"),
+            revision("policyRevision"),
+            id("scopeId"),
+            revision("scopeRevision"),
+        ],
+        "policy.bindings.update" => vec![
+            id("bindingId"),
+            id("policyId"),
+            revision("policyRevision"),
+            id("scopeId"),
+            revision("scopeRevision"),
+        ],
+        "policy.bindings.get" | "policy.bindings.delete" => vec![id("id")],
+        unexpected => panic!("unregistered PAP method {unexpected}"),
+    }
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "the table keeps every bounded scalar error class reviewable in one place"
+)]
+fn invalid_param_values(kind: ParamKind) -> Vec<(&'static str, Value, &'static str)> {
+    match kind {
+        ParamKind::ResourceId => vec![
+            (
+                "wrong type",
+                json!(1),
+                "invalid type: integer `1`, expected a string",
+            ),
+            ("null", Value::Null, "invalid type: null, expected a string"),
+            (
+                "empty",
+                json!(""),
+                "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'",
+            ),
+            (
+                "oversized",
+                json!("${resource_id_129}"),
+                "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'",
+            ),
+            (
+                "unsafe ASCII",
+                json!("invalid/id"),
+                "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'",
+            ),
+            (
+                "non-ASCII",
+                json!("非ascii"),
+                "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'",
+            ),
+        ],
+        ParamKind::Revision => vec![
+            (
+                "zero",
+                json!(0),
+                "invalid value: integer `0`, expected a nonzero u32",
+            ),
+            (
+                "negative",
+                json!(-1),
+                "invalid value: integer `-1`, expected a nonzero u32",
+            ),
+            (
+                "overflow",
+                json!(4_294_967_296_u64),
+                "invalid value: integer `4294967296`, expected a nonzero u32",
+            ),
+            (
+                "fractional",
+                json!(1.5),
+                "invalid type: floating point `1.5`, expected a nonzero u32",
+            ),
+            (
+                "wrong type",
+                json!("one"),
+                "invalid type: string \"one\", expected a nonzero u32",
+            ),
+            (
+                "null",
+                Value::Null,
+                "invalid type: null, expected a nonzero u32",
+            ),
+        ],
+        ParamKind::String => vec![
+            (
+                "wrong type",
+                json!(1),
+                "invalid type: integer `1`, expected a string",
+            ),
+            ("null", Value::Null, "invalid type: null, expected a string"),
+        ],
+        ParamKind::PolicyTemplate => vec![(
+            "wrong type",
+            Value::Null,
+            "invalid type: null, expected internally tagged enum PolicyTemplate",
+        )],
+        ParamKind::ScopeSelector => vec![(
+            "wrong type",
+            Value::Null,
+            "invalid type: null, expected internally tagged enum ScopeSelector",
+        )],
+        ParamKind::Limit => vec![
+            ("zero", json!(0), "limit must be between 1 and 1000"),
+            (
+                "above maximum",
+                json!(1001),
+                "limit must be between 1 and 1000",
+            ),
+            (
+                "negative",
+                json!(-1),
+                "invalid value: integer `-1`, expected u32",
+            ),
+            (
+                "u32 overflow",
+                json!(4_294_967_296_u64),
+                "invalid value: integer `4294967296`, expected u32",
+            ),
+            (
+                "fractional",
+                json!(1.5),
+                "invalid type: floating point `1.5`, expected u32",
+            ),
+            (
+                "wrong type",
+                json!("one"),
+                "invalid type: string \"one\", expected u32",
+            ),
+            ("null", Value::Null, "invalid type: null, expected u32"),
+        ],
+        ParamKind::Offset => vec![
+            (
+                "negative",
+                json!(-1),
+                "invalid value: integer `-1`, expected u32",
+            ),
+            (
+                "u32 overflow",
+                json!(4_294_967_296_u64),
+                "invalid value: integer `4294967296`, expected u32",
+            ),
+            (
+                "fractional",
+                json!(1.5),
+                "invalid type: floating point `1.5`, expected u32",
+            ),
+            (
+                "wrong type",
+                json!("one"),
+                "invalid type: string \"one\", expected u32",
+            ),
+            ("null", Value::Null, "invalid type: null, expected u32"),
+        ],
+    }
+}
+
+fn unknown_param_message(specs: &[ParamSpec]) -> String {
+    let expected = specs
+        .iter()
+        .map(|spec| format!("`{}`", spec.name))
+        .collect::<Vec<_>>();
+    match expected.as_slice() {
+        [only] => format!("unknown field `unexpected`, expected {only}"),
+        [first, second] => {
+            format!("unknown field `unexpected`, expected {first} or {second}")
+        }
+        _ => format!(
+            "unknown field `unexpected`, expected one of {}",
+            expected.join(", ")
+        ),
+    }
+}
+
+async fn run_method_param_error_matrix(path: &Path) -> Vec<String> {
+    let methods: Vec<Value> = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json"
+    ))
+    .unwrap();
+    let mut failures = Vec::new();
+    for fixture in methods {
+        let method = fixture["method"].as_str().unwrap();
+        let base = fixture["params"].as_object().unwrap();
+        let specs = method_param_specs(method);
+        for spec in &specs {
+            if spec.required {
+                let mut params = base.clone();
+                params.remove(spec.name);
+                let response =
+                    support::request_json(path, &json!({"method": method, "params": params})).await;
+                record_error_response(
+                    &mut failures,
+                    &format!("{method}: missing {}", spec.name),
+                    &response,
+                    &json!({
+                        "code": "invalid_request",
+                        "message": format!("missing field `{}`", spec.name)
+                    }),
+                );
+            }
+            for (label, invalid, message) in invalid_param_values(spec.kind) {
+                let mut params = base.clone();
+                params.insert(
+                    spec.name.to_owned(),
+                    expand_generated_fixture_values(&invalid),
+                );
+                let response =
+                    support::request_json(path, &json!({"method": method, "params": params})).await;
+                record_error_response(
+                    &mut failures,
+                    &format!("{method}: {label} {}", spec.name),
+                    &response,
+                    &json!({"code": "invalid_request", "message": message}),
+                );
+            }
+        }
+
+        let mut params = base.clone();
+        params.insert("unexpected".to_owned(), json!(true));
+        let response =
+            support::request_json(path, &json!({"method": method, "params": params})).await;
+        record_error_response(
+            &mut failures,
+            &format!("{method}: unknown parameter"),
+            &response,
+            &json!({
+                "code": "invalid_request",
+                "message": unknown_param_message(&specs)
+            }),
+        );
+    }
+
+    let oversized_field = "x".repeat(512);
+    let response = support::request_json(
+        path,
+        &json!({
+            "method": "policy.templates.list",
+            "params": {oversized_field.clone(): true}
+        }),
+    )
+    .await;
+    let full_message = format!("unknown field `{oversized_field}`, expected `limit` or `offset`");
+    let mut expected_message = full_message[..253].to_owned();
+    expected_message.push_str("...");
+    record_error_response(
+        &mut failures,
+        "oversized parameter error is bounded",
+        &response,
+        &json!({"code": "invalid_request", "message": expected_message}),
+    );
+    failures
+}
+
+async fn run_frozen_error_cases(path: &Path) -> Vec<String> {
+    let fixture: Value = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json"
+    ))
+    .unwrap();
+    assert_eq!(fixture["schemaVersion"], 1);
+    let seed = support::request_json(
+        path,
+        &json!({
+            "method": "policy.templates.create",
+            "params": {
+                "policyName": "existing-policy",
+                "template": {"kind": "prevent_file_deletion", "files": ["/existing"]}
+            }
+        }),
+    )
+    .await;
+    let existing_policy_id = seed["result"]["policyId"]
+        .as_str()
+        .expect("error fixture should seed one valid Policy");
+    let mut failures = Vec::new();
+    for case in fixture["cases"].as_array().unwrap() {
+        let name = case["name"].as_str().unwrap();
+        let mut request = expand_generated_fixture_values(&case["request"]);
+        replace_fixture_string(&mut request, "${existing_policy_id}", existing_policy_id);
+        let response = support::request_json(path, &request).await;
+        record_error_response(&mut failures, name, &response, &case["expectedError"]);
+    }
+    failures
+}
+
+fn replace_fixture_string(value: &mut Value, target: &str, replacement: &str) {
+    match value {
+        Value::Object(fields) => {
+            for value in fields.values_mut() {
+                replace_fixture_string(value, target, replacement);
+            }
+        }
+        Value::Array(items) => {
+            for value in items {
+                replace_fixture_string(value, target, replacement);
+            }
+        }
+        Value::String(value) if value == target => replacement.clone_into(value),
+        _ => {}
+    }
+}
+
+fn assert_error_matrix(failures: &[String]) {
+    assert!(
+        failures.is_empty(),
+        "error contract mismatches:\n{}",
+        failures.join("\n")
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn real_uds_executes_the_complete_pap_crud_fixture() {
-    let directory = unique_directory();
-    std::fs::create_dir(&directory).unwrap();
-    let socket_path = directory.join("daemon.sock");
-    let application = PapService::new(
-        Arc::new(ProcessLocalPapRepository::default()),
-        Arc::new(PolicyTemplateCompiler),
-    );
-    let dispatcher = Arc::new(DaemonDispatcher::new(
-        application,
-        Arc::new(FixedRolePolicy(PrincipalRole::PolicyAdministrator)),
-    ));
-    let shutdown = asc_daemon_service::ShutdownToken::new();
-    let service_shutdown = shutdown.clone();
-    let mut config = BootstrapConfig::new(&socket_path);
-    config.service.request_read_timeout = Duration::from_millis(50);
-    let task = tokio::spawn(async move {
-        serve(
-            config,
-            dispatcher,
-            Arc::new(JsonRejectionEncoder),
-            service_shutdown,
-        )
-        .await
-    });
-
-    wait_for_socket(&socket_path).await;
+    let daemon = RunningPapDaemon::start(PrincipalRole::PolicyAdministrator).await;
     let fixture: Value = serde_json::from_str(include_str!(
         "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json"
     ))
     .unwrap();
-    support::run_frozen_pap_crud_scenario(&socket_path, &fixture).await;
+    support::run_frozen_pap_crud_scenario(&daemon.socket_path, &fixture).await;
+    daemon.stop().await;
+}
 
-    let invalid_params: Value = serde_json::from_str(include_str!(
-        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json"
-    ))
-    .unwrap();
-    for case in invalid_params["cases"].as_array().unwrap() {
-        let mut payload = serde_json::to_vec(&case["request"]).unwrap();
-        payload.push(b'\n');
-        let response = uds_request(&socket_path, &payload).await;
-        assert!(response["requestId"].as_str().is_some());
-        assert_eq!(response["error"], case["expectedError"], "{}", case["name"]);
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn real_uds_rejects_every_invalid_crud_parameter_class() {
+    let daemon = RunningPapDaemon::start(PrincipalRole::PolicyAdministrator).await;
+    let mut failures = run_method_param_error_matrix(&daemon.socket_path).await;
+    failures.extend(run_frozen_error_cases(&daemon.socket_path).await);
+    daemon.stop().await;
+    assert_error_matrix(&failures);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the transport error sequence is intentionally kept as one real UDS lifecycle"
+)]
+async fn real_uds_returns_exact_errors_for_invalid_envelopes_and_transport_frames() {
+    let daemon = RunningPapDaemon::start(PrincipalRole::PolicyAdministrator).await;
+    let invalid_envelope = json!({
+        "code": "invalid_request",
+        "message": "request envelope is invalid"
+    });
+    let mut failures = Vec::new();
+    let raw_cases = [
+        ("malformed JSON", b"not-json\n".as_slice(), invalid_envelope.clone()),
+        ("trailing JSON data", b"{}{}\n".as_slice(), invalid_envelope.clone()),
+        ("invalid UTF-8", &[0xff, b'\n'], invalid_envelope.clone()),
+        (
+            "duplicate envelope method",
+            b"{\"method\":\"policy.templates.list\",\"method\":\"policy.scopes.list\",\"params\":{}}\n".as_slice(),
+            invalid_envelope.clone(),
+        ),
+        (
+            "duplicate method parameter",
+            b"{\"method\":\"policy.templates.list\",\"params\":{\"limit\":0,\"limit\":1}}\n".as_slice(),
+            invalid_envelope.clone(),
+        ),
+    ];
+    for (name, payload, expected) in raw_cases {
+        let response = uds_request(&daemon.socket_path, payload).await;
+        record_error_response(&mut failures, name, &response, &expected);
     }
 
-    let invalid = uds_request(&socket_path, b"not-json\n").await;
-    assert!(invalid["requestId"].as_str().is_some());
-    assert_eq!(invalid["error"]["code"], error_code::INVALID_REQUEST);
+    let mut empty = UnixStream::connect(&daemon.socket_path).await.unwrap();
+    empty.shutdown().await.unwrap();
+    let mut empty_response = Vec::new();
+    BufReader::new(empty)
+        .read_until(b'\n', &mut empty_response)
+        .await
+        .unwrap();
+    assert_eq!(empty_response.pop(), Some(b'\n'));
+    let empty_response: Value = serde_json::from_slice(&empty_response).unwrap();
+    record_error_response(
+        &mut failures,
+        "empty frame",
+        &empty_response,
+        &json!({
+            "code": "invalid_request",
+            "message": "request frame is empty"
+        }),
+    );
 
-    let idle = UnixStream::connect(&socket_path).await.unwrap();
+    for (name, request, expected) in [
+        (
+            "missing method",
+            json!({"params": {}}),
+            invalid_envelope.clone(),
+        ),
+        (
+            "non-string method",
+            json!({"method": 1, "params": {}}),
+            invalid_envelope.clone(),
+        ),
+        (
+            "blank method",
+            json!({"method": "  ", "params": {}}),
+            invalid_envelope.clone(),
+        ),
+        (
+            "non-object params",
+            json!({"method": "policy.templates.list", "params": []}),
+            invalid_envelope.clone(),
+        ),
+        (
+            "unknown envelope field",
+            json!({"method": "policy.templates.list", "params": {}, "callerUid": 0}),
+            invalid_envelope.clone(),
+        ),
+        (
+            "unknown method",
+            json!({"method": "policy.unknown", "params": {}}),
+            json!({
+                "code": "unknown_method",
+                "message": "daemon method is not implemented"
+            }),
+        ),
+    ] {
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        record_error_response(&mut failures, name, &response, &expected);
+    }
+
+    let idle = UnixStream::connect(&daemon.socket_path).await.unwrap();
     let mut rejection = Vec::new();
     tokio::time::timeout(
         Duration::from_secs(1),
@@ -448,12 +1034,448 @@ async fn real_uds_executes_the_complete_pap_crud_fixture() {
     .expect("idle connection should receive a bounded rejection")
     .unwrap();
     assert_eq!(rejection.pop(), Some(b'\n'));
-    let rejection: Value = serde_json::from_slice(&rejection).unwrap();
-    assert!(rejection["requestId"].as_str().is_some());
-    assert_eq!(rejection["error"]["code"], error_code::DEADLINE_EXCEEDED);
+    let response: Value = serde_json::from_slice(&rejection).unwrap();
+    record_error_response(
+        &mut failures,
+        "request read timeout",
+        &response,
+        &json!({
+            "code": "deadline_exceeded",
+            "message": "request read deadline expired"
+        }),
+    );
+    daemon.stop().await;
 
-    shutdown.request();
-    task.await.unwrap().unwrap();
-    assert!(!socket_path.exists());
-    std::fs::remove_dir(directory).unwrap();
+    let bounded =
+        RunningPapDaemon::start_with_request_limit(PrincipalRole::PolicyAdministrator, 64).await;
+    let oversized = vec![b'x'; 65];
+    let response = uds_request(&bounded.socket_path, &oversized).await;
+    record_error_response(
+        &mut failures,
+        "oversized request frame",
+        &response,
+        &json!({
+            "code": "resource_exhausted",
+            "message": "request frame exceeds the configured limit"
+        }),
+    );
+    bounded.stop().await;
+    assert_error_matrix(&failures);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn real_uds_denies_every_crud_method_with_the_exact_public_error() {
+    let daemon = RunningPapDaemon::start(PrincipalRole::LocalUser).await;
+    let fixtures: Vec<Value> = serde_json::from_str(include_str!(
+        "../../../crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json"
+    ))
+    .unwrap();
+    let expected = json!({
+        "code": "permission_denied",
+        "message": "principal is not authorized to administer policy"
+    });
+    let mut failures = Vec::new();
+    for fixture in fixtures {
+        let method = fixture["method"].as_str().unwrap();
+        let response = support::request_json(
+            &daemon.socket_path,
+            &json!({"method": method, "params": fixture["params"].clone()}),
+        )
+        .await;
+        record_error_response(&mut failures, method, &response, &expected);
+    }
+    daemon.stop().await;
+    assert_error_matrix(&failures);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "all legal boundary requests share one daemon and one reviewable sequence"
+)]
+async fn real_uds_accepts_domain_and_pagination_boundary_values() {
+    let daemon = RunningPapDaemon::start(PrincipalRole::PolicyAdministrator).await;
+    let maximum_path = format!("/{}", "p".repeat(4_095));
+    for (name, request) in [
+        (
+            "256-byte policy name and 4096-byte path",
+            json!({
+                "method": "policy.templates.create",
+                "params": {
+                    "policyName": "n".repeat(256),
+                    "template": {
+                        "kind": "prevent_file_deletion",
+                        "files": [maximum_path]
+                    }
+                }
+            }),
+        ),
+        (
+            "maximum PID",
+            json!({
+                "method": "policy.scopes.create",
+                "params": {"selector": {"kind": "pid", "pid": u32::MAX}}
+            }),
+        ),
+        (
+            "maximum cgroup ID",
+            json!({
+                "method": "policy.scopes.create",
+                "params": {"selector": {"kind": "cgroup_id", "cgroupId": u64::MAX}}
+            }),
+        ),
+    ] {
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        assert!(response.get("result").is_some(), "{name}: {response}");
+    }
+
+    for method in [
+        "policy.templates.list",
+        "policy.scopes.list",
+        "policy.bindings.list",
+    ] {
+        for params in [
+            json!({}),
+            json!({"limit": 1, "offset": 0}),
+            json!({"limit": 1000, "offset": u32::MAX}),
+        ] {
+            let response = support::request_json(
+                &daemon.socket_path,
+                &json!({"method": method, "params": params}),
+            )
+            .await;
+            assert!(response.get("result").is_some(), "{method}: {response}");
+        }
+    }
+    daemon.stop().await;
+
+    let daemon = RunningPapDaemon::start_with_application(
+        PrincipalRole::PolicyAdministrator,
+        4 * 1024 * 1024,
+        RecordingAdministration::new(),
+    )
+    .await;
+    let maximum_id = "a".repeat(128);
+    let boundary_requests = [
+        json!({"method": "policy.templates.update", "params": {
+            "policyId": maximum_id,
+            "policyName": "valid",
+            "template": {"kind": "prevent_file_deletion", "files": ["/"]}
+        }}),
+        json!({"method": "policy.templates.get", "params": {
+            "id": "a", "revision": u32::MAX
+        }}),
+        json!({"method": "policy.templates.delete", "params": {
+            "id": maximum_id, "revision": u32::MAX
+        }}),
+        json!({"method": "policy.scopes.update", "params": {
+            "scopeId": maximum_id,
+            "selector": {"kind": "pid", "pid": u32::MAX}
+        }}),
+        json!({"method": "policy.scopes.get", "params": {
+            "id": "a-_.:0", "revision": u32::MAX
+        }}),
+        json!({"method": "policy.scopes.delete", "params": {
+            "id": maximum_id, "revision": u32::MAX
+        }}),
+        json!({"method": "policy.bindings.create", "params": {
+            "policyId": maximum_id,
+            "policyRevision": u32::MAX,
+            "scopeId": "a",
+            "scopeRevision": u32::MAX
+        }}),
+        json!({"method": "policy.bindings.update", "params": {
+            "bindingId": maximum_id,
+            "policyId": "a",
+            "policyRevision": u32::MAX,
+            "scopeId": maximum_id,
+            "scopeRevision": u32::MAX
+        }}),
+        json!({"method": "policy.bindings.get", "params": {"id": maximum_id}}),
+        json!({"method": "policy.bindings.delete", "params": {"id": "a"}}),
+    ];
+    for request in boundary_requests {
+        let method = request["method"].as_str().unwrap();
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        assert!(response.get("result").is_some(), "{method}: {response}");
+    }
+    daemon.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the stateful CRUD error sequence must retain its captured resource identities"
+)]
+async fn real_uds_distinguishes_stale_references_and_binding_state_conflicts() {
+    let repository = Arc::new(ProcessLocalPapRepository::default());
+    let daemon = RunningPapDaemon::start_with_repository(
+        PrincipalRole::PolicyAdministrator,
+        4 * 1024 * 1024,
+        Arc::clone(&repository),
+    )
+    .await;
+
+    let policy = support::request_json(
+        &daemon.socket_path,
+        &json!({
+            "method": "policy.templates.create",
+            "params": {
+                "policyName": "policy-v1",
+                "template": {"kind": "prevent_file_deletion", "files": ["/v1"]}
+            }
+        }),
+    )
+    .await;
+    let policy_id = policy["result"]["policyId"].as_str().unwrap().to_owned();
+    let policy = support::request_json(
+        &daemon.socket_path,
+        &json!({
+            "method": "policy.templates.update",
+            "params": {
+                "policyId": policy_id,
+                "policyName": "policy-v2",
+                "template": {"kind": "prevent_file_deletion", "files": ["/v2"]}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(policy["result"]["revision"], 2);
+
+    let scope = support::request_json(
+        &daemon.socket_path,
+        &json!({
+            "method": "policy.scopes.create",
+            "params": {"selector": {"kind": "pid", "pid": 1}}
+        }),
+    )
+    .await;
+    let scope_id = scope["result"]["scopeId"].as_str().unwrap().to_owned();
+    let scope = support::request_json(
+        &daemon.socket_path,
+        &json!({
+            "method": "policy.scopes.update",
+            "params": {
+                "scopeId": scope_id,
+                "selector": {"kind": "cgroup_id", "cgroupId": 2}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(scope["result"]["revision"], 2);
+
+    let mut failures = Vec::new();
+    for (name, request, expected) in [
+        (
+            "get stale policy revision",
+            json!({"method": "policy.templates.get", "params": {"id": policy_id, "revision": 1}}),
+            json!({"code": "not_found", "message": "policy revision was not found"}),
+        ),
+        (
+            "delete stale policy revision",
+            json!({"method": "policy.templates.delete", "params": {"id": policy_id, "revision": 1}}),
+            json!({"code": "not_found", "message": "policy revision was not found"}),
+        ),
+        (
+            "get stale scope revision",
+            json!({"method": "policy.scopes.get", "params": {"id": scope_id, "revision": 1}}),
+            json!({"code": "not_found", "message": "scope revision was not found"}),
+        ),
+        (
+            "delete stale scope revision",
+            json!({"method": "policy.scopes.delete", "params": {"id": scope_id, "revision": 1}}),
+            json!({"code": "not_found", "message": "scope revision was not found"}),
+        ),
+        (
+            "create binding with stale policy revision",
+            json!({"method": "policy.bindings.create", "params": {
+                "policyId": policy_id,
+                "policyRevision": 1,
+                "scopeId": scope_id,
+                "scopeRevision": 2
+            }}),
+            json!({"code": "not_found", "message": "referenced policy revision was not found"}),
+        ),
+        (
+            "create binding with stale scope revision",
+            json!({"method": "policy.bindings.create", "params": {
+                "policyId": policy_id,
+                "policyRevision": 2,
+                "scopeId": scope_id,
+                "scopeRevision": 1
+            }}),
+            json!({"code": "not_found", "message": "referenced scope revision was not found"}),
+        ),
+        (
+            "create binding with missing scope revision",
+            json!({"method": "policy.bindings.create", "params": {
+                "policyId": policy_id,
+                "policyRevision": 2,
+                "scopeId": "missing-scope",
+                "scopeRevision": 1
+            }}),
+            json!({"code": "not_found", "message": "referenced scope revision was not found"}),
+        ),
+    ] {
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        record_error_response(&mut failures, name, &response, &expected);
+    }
+
+    let binding = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.create", "params": {
+            "policyId": policy_id,
+            "policyRevision": 2,
+            "scopeId": scope_id,
+            "scopeRevision": 2
+        }}),
+    )
+    .await;
+    let binding_id = binding["result"]["spec"]["bindingId"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let binding_resource_id = ResourceId::new(binding_id.clone()).unwrap();
+    let binding_revision = Revision::new(1).unwrap();
+
+    for (name, request, expected) in [
+        (
+            "update binding with stale policy revision",
+            json!({"method": "policy.bindings.update", "params": {
+                "bindingId": binding_id,
+                "policyId": policy_id,
+                "policyRevision": 1,
+                "scopeId": scope_id,
+                "scopeRevision": 2
+            }}),
+            json!({"code": "not_found", "message": "referenced policy revision was not found"}),
+        ),
+        (
+            "update binding with stale scope revision",
+            json!({"method": "policy.bindings.update", "params": {
+                "bindingId": binding_id,
+                "policyId": policy_id,
+                "policyRevision": 2,
+                "scopeId": scope_id,
+                "scopeRevision": 1
+            }}),
+            json!({"code": "not_found", "message": "referenced scope revision was not found"}),
+        ),
+    ] {
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        record_error_response(&mut failures, name, &response, &expected);
+    }
+
+    repository
+        .update_binding_status(
+            &binding_resource_id,
+            binding_revision,
+            BindingStatus::PendingApply,
+            BindingStatus::Applying,
+        )
+        .unwrap();
+    let identical_apply = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.update", "params": {
+            "bindingId": binding_id,
+            "policyId": policy_id,
+            "policyRevision": 2,
+            "scopeId": scope_id,
+            "scopeRevision": 2
+        }}),
+    )
+    .await;
+    assert_eq!(identical_apply["result"]["status"], "APPLYING");
+    assert_eq!(identical_apply["result"]["spec"]["bindingRevision"], 1);
+
+    let conflict = json!({
+        "code": "conflict",
+        "message": "binding reconciliation operation is in progress"
+    });
+    for (name, request) in [
+        (
+            "changed binding update while apply is running",
+            json!({"method": "policy.bindings.update", "params": {
+                "bindingId": binding_id,
+                "policyId": policy_id,
+                "policyRevision": 1,
+                "scopeId": scope_id,
+                "scopeRevision": 2
+            }}),
+        ),
+        (
+            "binding delete while apply is running",
+            json!({"method": "policy.bindings.delete", "params": {"id": binding_id}}),
+        ),
+    ] {
+        let response = support::request_json(&daemon.socket_path, &request).await;
+        record_error_response(&mut failures, name, &response, &conflict);
+    }
+
+    repository
+        .update_binding_status(
+            &binding_resource_id,
+            binding_revision,
+            BindingStatus::Applying,
+            BindingStatus::Ready,
+        )
+        .unwrap();
+    let deletion = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.delete", "params": {"id": binding_id}}),
+    )
+    .await;
+    assert_eq!(deletion["result"]["status"], "PENDING_DELETE");
+    let repeated_pending_deletion = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.delete", "params": {"id": binding_id}}),
+    )
+    .await;
+    assert_eq!(
+        repeated_pending_deletion["result"]["status"],
+        "PENDING_DELETE"
+    );
+    assert_eq!(
+        repeated_pending_deletion["result"]["spec"]["bindingRevision"],
+        2
+    );
+    let deletion_revision = Revision::new(2).unwrap();
+    repository
+        .update_binding_status(
+            &binding_resource_id,
+            deletion_revision,
+            BindingStatus::PendingDelete,
+            BindingStatus::Deleting,
+        )
+        .unwrap();
+    let repeated_running_deletion = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.delete", "params": {"id": binding_id}}),
+    )
+    .await;
+    assert_eq!(repeated_running_deletion["result"]["status"], "DELETING");
+    assert_eq!(
+        repeated_running_deletion["result"]["spec"]["bindingRevision"],
+        2
+    );
+    let response = support::request_json(
+        &daemon.socket_path,
+        &json!({"method": "policy.bindings.update", "params": {
+            "bindingId": binding_id,
+            "policyId": policy_id,
+            "policyRevision": 2,
+            "scopeId": scope_id,
+            "scopeRevision": 2
+        }}),
+    )
+    .await;
+    record_error_response(
+        &mut failures,
+        "binding update while delete is running",
+        &response,
+        &conflict,
+    );
+
+    daemon.stop().await;
+    assert_error_matrix(&failures);
 }

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/pap_protocol.rs
@@ -430,7 +430,7 @@ fn unknown_methods_and_invalid_method_params_use_distinct_errors() {
             panic!("{method} should fail");
         };
         assert_eq!(error.error.code.as_str(), expected_code);
-        assert_eq!(error.error.message, expected_message);
+        assert_eq!(error.error.message(), expected_message);
     }
 }
 
@@ -846,14 +846,11 @@ async fn run_method_param_error_matrix(path: &Path) -> Vec<String> {
         }),
     )
     .await;
-    let full_message = format!("unknown field `{oversized_field}`, expected `limit` or `offset`");
-    let mut expected_message = full_message[..253].to_owned();
-    expected_message.push_str("...");
     record_error_response(
         &mut failures,
-        "oversized parameter error is bounded",
+        "oversized parameter error does not reflect caller input",
         &response,
-        &json!({"code": "invalid_request", "message": expected_message}),
+        &json!({"code": "invalid_request", "message": "request parameters are invalid"}),
     );
     failures
 }

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+pub async fn run_frozen_pap_crud_scenario(path: &Path, fixture: &Value) {
+    let objects = fixture["objects"].as_object().unwrap();
+    let mut variables = BTreeMap::new();
+
+    for step in fixture["steps"].as_array().unwrap() {
+        let step_name = step["name"].as_str().unwrap();
+        let request_value = expand_fixture(&step["request"], objects, &variables, 0);
+        let response = request_json(path, &request_value).await;
+
+        let request_id = response["requestId"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{step_name} did not return a requestId"));
+        Uuid::parse_str(request_id)
+            .unwrap_or_else(|error| panic!("{step_name} returned a non-UUID requestId: {error}"));
+        variables.insert(
+            "request_id".to_owned(),
+            Value::String(request_id.to_owned()),
+        );
+
+        for capture in step["captures"].as_array().unwrap() {
+            let name = capture["name"].as_str().unwrap();
+            let pointer = capture["pointer"].as_str().unwrap();
+            let captured = response
+                .pointer(pointer)
+                .unwrap_or_else(|| panic!("{step_name} did not return capture {name} at {pointer}"))
+                .clone();
+            match capture["format"].as_str().unwrap() {
+                "uuid" => {
+                    let candidate = captured.as_str().unwrap_or_else(|| {
+                        panic!("{step_name} capture {name} is not a string UUID")
+                    });
+                    Uuid::parse_str(candidate).unwrap_or_else(|error| {
+                        panic!("{step_name} capture {name} is not a UUID: {error}")
+                    });
+                }
+                format => panic!("unsupported fixture capture format {format}"),
+            }
+            assert!(
+                variables.insert(name.to_owned(), captured).is_none(),
+                "fixture captured {name} more than once"
+            );
+        }
+
+        let expected = expand_fixture(&step["expectedResponse"], objects, &variables, 0);
+        assert_eq!(response, expected, "unexpected response for {step_name}");
+    }
+
+    let resource_ids = ["policy_id", "scope_id", "binding_id"]
+        .map(|name| variables.get(name).unwrap().as_str().unwrap());
+    assert_ne!(resource_ids[0], resource_ids[1]);
+    assert_ne!(resource_ids[0], resource_ids[2]);
+    assert_ne!(resource_ids[1], resource_ids[2]);
+}
+
+async fn request_json(path: &Path, request_value: &Value) -> Value {
+    let mut payload = serde_json::to_vec(request_value).unwrap();
+    payload.push(b'\n');
+    let mut stream = UnixStream::connect(path).await.unwrap();
+    stream.write_all(&payload).await.unwrap();
+    let mut response = Vec::new();
+    BufReader::new(stream)
+        .read_until(b'\n', &mut response)
+        .await
+        .unwrap();
+    assert_eq!(response.pop(), Some(b'\n'));
+    serde_json::from_slice(&response).unwrap()
+}
+
+fn expand_fixture(
+    value: &Value,
+    objects: &serde_json::Map<String, Value>,
+    variables: &BTreeMap<String, Value>,
+    depth: u8,
+) -> Value {
+    assert!(depth < 32, "fixture reference cycle");
+    match value {
+        Value::Object(fields) if fields.len() == 1 && fields.contains_key("$ref") => {
+            let reference = fields["$ref"].as_str().unwrap();
+            expand_fixture(
+                objects
+                    .get(reference)
+                    .unwrap_or_else(|| panic!("unknown fixture object {reference}")),
+                objects,
+                variables,
+                depth + 1,
+            )
+        }
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        expand_fixture(value, objects, variables, depth + 1),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|value| expand_fixture(value, objects, variables, depth + 1))
+                .collect(),
+        ),
+        Value::String(candidate) if candidate.starts_with("${") && candidate.ends_with('}') => {
+            let name = &candidate[2..candidate.len() - 1];
+            variables
+                .get(name)
+                .unwrap_or_else(|| panic!("unknown fixture variable {name}"))
+                .clone()
+        }
+        _ => value.clone(),
+    }
+}

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
@@ -60,7 +60,7 @@ pub async fn run_frozen_pap_crud_scenario(path: &Path, fixture: &Value) {
     assert_ne!(resource_ids[1], resource_ids[2]);
 }
 
-async fn request_json(path: &Path, request_value: &Value) -> Value {
+pub async fn request_json(path: &Path, request_value: &Value) -> Value {
     let mut payload = serde_json::to_vec(request_value).unwrap();
     payload.push(b'\n');
     let mut stream = UnixStream::connect(path).await.unwrap();

--- a/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
+++ b/src/agent-sec-core/v2/apps/asc-daemon/tests/support/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use serde_json::Value;
@@ -9,6 +9,7 @@ use uuid::Uuid;
 pub async fn run_frozen_pap_crud_scenario(path: &Path, fixture: &Value) {
     let objects = fixture["objects"].as_object().unwrap();
     let mut variables = BTreeMap::new();
+    let mut request_ids = BTreeSet::new();
 
     for step in fixture["steps"].as_array().unwrap() {
         let step_name = step["name"].as_str().unwrap();
@@ -20,6 +21,10 @@ pub async fn run_frozen_pap_crud_scenario(path: &Path, fixture: &Value) {
             .unwrap_or_else(|| panic!("{step_name} did not return a requestId"));
         Uuid::parse_str(request_id)
             .unwrap_or_else(|error| panic!("{step_name} returned a non-UUID requestId: {error}"));
+        assert!(
+            request_ids.insert(request_id.to_owned()),
+            "{step_name} reused daemon requestId {request_id}"
+        );
         variables.insert(
             "request_id".to_owned(),
             Value::String(request_id.to_owned()),

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "asc-daemon-core"
+description = "Transport-independent AgentSecCore daemon application use cases"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
@@ -1,0 +1,176 @@
+use std::collections::BTreeSet;
+use std::sync::RwLock;
+
+/// Kernel-authenticated identity of one daemon socket peer.
+///
+/// This type is constructed by trusted transport code and is never decoded
+/// from request JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerCredentials {
+    uid: u32,
+    gid: u32,
+    pid: u32,
+}
+
+impl PeerCredentials {
+    /// Creates trusted peer credentials from kernel-provided values.
+    pub const fn new(uid: u32, gid: u32, pid: u32) -> Self {
+        Self { uid, gid, pid }
+    }
+
+    /// Returns the authenticated user ID.
+    pub const fn uid(self) -> u32 {
+        self.uid
+    }
+
+    /// Returns the authenticated group ID.
+    pub const fn gid(self) -> u32 {
+        self.gid
+    }
+
+    /// Returns the authenticated process ID.
+    pub const fn pid(self) -> u32 {
+        self.pid
+    }
+}
+
+/// Role assigned by trusted server policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrincipalRole {
+    /// Authenticated local caller without Policy administration authority.
+    LocalUser,
+    /// Caller authorized to administer Policy, Scope, and Binding resources.
+    PolicyAdministrator,
+}
+
+/// Server-owned policy that maps authenticated peer evidence to a role.
+///
+/// Implementations may consult deployment-owned UID/GID allowlists or a later
+/// authenticated binding. Request JSON is intentionally absent from this port.
+pub trait PrincipalPolicy: Send + Sync {
+    /// Selects the role for one kernel-authenticated peer.
+    fn role_for(&self, peer: PeerCredentials) -> PrincipalRole;
+}
+
+/// Root-owned Policy-administrator allowlist.
+///
+/// UID 0 is always a Policy administrator. Other UIDs are denied until root
+/// adds them. The allowlist is process-local in this slice; loading and
+/// persisting it belongs to the later daemon configuration/state integration.
+#[derive(Debug, Default)]
+pub struct RootManagedPrincipalPolicy {
+    allowed_uids: RwLock<BTreeSet<u32>>,
+}
+
+impl RootManagedPrincipalPolicy {
+    /// Adds one UID to the Policy-administrator allowlist.
+    ///
+    /// The acting peer must be the kernel-authenticated root peer. Merely being
+    /// present in the administrator allowlist does not grant delegation rights.
+    ///
+    /// # Errors
+    /// Returns `RootRequired` for a non-root actor and `StateUnavailable` if the
+    /// process-local allowlist lock was poisoned.
+    pub fn allow_uid(
+        &self,
+        acting_peer: PeerCredentials,
+        uid: u32,
+    ) -> Result<(), PrincipalPolicyError> {
+        if acting_peer.uid() != 0 {
+            return Err(PrincipalPolicyError::RootRequired);
+        }
+        self.allowed_uids
+            .write()
+            .map_err(|_| PrincipalPolicyError::StateUnavailable)?
+            .insert(uid);
+        Ok(())
+    }
+}
+
+impl PrincipalPolicy for RootManagedPrincipalPolicy {
+    fn role_for(&self, peer: PeerCredentials) -> PrincipalRole {
+        if peer.uid() == 0
+            || self
+                .allowed_uids
+                .read()
+                .is_ok_and(|allowed| allowed.contains(&peer.uid()))
+        {
+            PrincipalRole::PolicyAdministrator
+        } else {
+            PrincipalRole::LocalUser
+        }
+    }
+}
+
+/// Failure to update the root-owned Policy-administrator allowlist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PrincipalPolicyError {
+    /// Only kernel-authenticated UID 0 may delegate Policy administration.
+    #[error("only root may update the Policy administrator allowlist")]
+    RootRequired,
+    /// The in-process authorization state cannot be updated safely.
+    #[error("Policy administrator allowlist is unavailable")]
+    StateUnavailable,
+}
+
+/// Trusted daemon principal, never caller-authored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Principal {
+    peer: PeerCredentials,
+    role: PrincipalRole,
+}
+
+impl Principal {
+    /// Creates a principal after server-side authentication and role binding.
+    pub const fn from_authenticated_peer(peer: PeerCredentials, role: PrincipalRole) -> Self {
+        Self { peer, role }
+    }
+
+    /// Returns kernel-authenticated peer evidence.
+    pub const fn peer(self) -> PeerCredentials {
+        self.peer
+    }
+
+    /// Returns the server-assigned role.
+    pub const fn role(self) -> PrincipalRole {
+        self.role
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_keeps_transport_identity_separate_from_server_role() {
+        let peer = PeerCredentials::new(1000, 100, 4242);
+        let principal =
+            Principal::from_authenticated_peer(peer, PrincipalRole::PolicyAdministrator);
+
+        assert_eq!(principal.peer().uid(), 1000);
+        assert_eq!(principal.peer().gid(), 100);
+        assert_eq!(principal.peer().pid(), 4242);
+        assert_eq!(principal.role(), PrincipalRole::PolicyAdministrator);
+    }
+
+    #[test]
+    fn root_can_delegate_policy_administration_but_delegates_cannot() {
+        let policy = RootManagedPrincipalPolicy::default();
+        let root = PeerCredentials::new(0, 0, 1);
+        let delegated = PeerCredentials::new(1000, 100, 2);
+        let other = PeerCredentials::new(2000, 200, 3);
+
+        assert_eq!(policy.role_for(root), PrincipalRole::PolicyAdministrator);
+        assert_eq!(policy.role_for(delegated), PrincipalRole::LocalUser);
+        policy.allow_uid(root, delegated.uid()).unwrap();
+        assert_eq!(
+            policy.role_for(delegated),
+            PrincipalRole::PolicyAdministrator
+        );
+        assert_eq!(
+            policy.allow_uid(delegated, other.uid()),
+            Err(PrincipalPolicyError::RootRequired)
+        );
+        assert_eq!(policy.role_for(other), PrincipalRole::LocalUser);
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
@@ -9,4 +9,7 @@ pub use identity::{
     PeerCredentials, Principal, PrincipalPolicy, PrincipalPolicyError, PrincipalRole,
     RootManagedPrincipalPolicy,
 };
-pub use pap::{PolicyAdministration, PolicyAdministrationError, ResourcePage};
+pub use pap::{
+    NotFoundResource, PolicyAdministration, PolicyAdministrationError, PolicyInputError,
+    ResourcePage,
+};

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
@@ -1,0 +1,12 @@
+//! Transport-independent daemon identity, authorization, and PAP orchestration.
+
+#![forbid(unsafe_code)]
+
+mod identity;
+mod pap;
+
+pub use identity::{
+    PeerCredentials, Principal, PrincipalPolicy, PrincipalPolicyError, PrincipalRole,
+    RootManagedPrincipalPolicy,
+};
+pub use pap::{PolicyAdministration, PolicyAdministrationError, ResourcePage};

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
@@ -1,0 +1,463 @@
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::{Page, PapError, PapRepository, PapService, PolicyCompiler};
+use asc_policy_types::authoring::PolicyTemplate;
+use asc_policy_types::binding::BindingView;
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+
+use crate::{Principal, PrincipalRole};
+
+/// Stable PAP application failures safe for a daemon adapter to project.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PolicyAdministrationError {
+    /// The server-assigned principal lacks Policy administration authority.
+    #[error("principal is not authorized to administer policy")]
+    Forbidden,
+    /// Authored input failed domain validation.
+    #[error("policy input failed domain validation")]
+    InvalidArgument,
+    /// Current revision or lifecycle state conflicts with the request.
+    #[error("policy request conflicts with current state")]
+    Conflict,
+    /// The requested current resource does not exist.
+    #[error("requested policy resource was not found")]
+    NotFound,
+    /// No further positive revision can be allocated.
+    #[error("revision space is exhausted")]
+    ResourceExhausted,
+    /// Serialization or persistence failed with details withheld.
+    #[error("policy state could not be processed")]
+    Internal,
+}
+
+impl From<PapError> for PolicyAdministrationError {
+    fn from(error: PapError) -> Self {
+        match error {
+            PapError::InvalidIdentifier(_)
+            | PapError::InvalidPolicyName(_)
+            | PapError::InvalidPolicy(_)
+            | PapError::InvalidScope(_)
+            | PapError::InvalidBinding(_)
+            | PapError::InvalidPagination => Self::InvalidArgument,
+            PapError::Conflict | PapError::OperationInProgress => Self::Conflict,
+            PapError::NotFound => Self::NotFound,
+            PapError::RevisionExhausted => Self::ResourceExhausted,
+            PapError::Serialization | PapError::Persistence => Self::Internal,
+        }
+    }
+}
+
+/// Bounded application query result with its total before pagination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourcePage<T> {
+    /// Selected current records.
+    pub items: Vec<T>,
+    /// Total matching records before pagination.
+    pub total: u64,
+}
+
+impl<T> From<Page<T>> for ResourcePage<T> {
+    fn from(page: Page<T>) -> Self {
+        Self {
+            items: page.items,
+            total: page.total,
+        }
+    }
+}
+
+/// Principal-aware, type-erased PAP application boundary used by daemon adapters.
+///
+/// The method set deliberately mirrors the authoritative [`PapService`] use
+/// cases only to stop its repository/compiler generics at this boundary and to
+/// apply server-owned authorization. Implementations must delegate domain
+/// semantics to PAP rather than reimplementing them.
+pub trait PolicyAdministration: Send + Sync {
+    /// Creates one Policy with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, capacity, or internal failures.
+    fn create_policy(
+        &self,
+        principal: &Principal,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Updates one existing Policy identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_policy(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Reads one exact current Policy revision.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_policy(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Lists current Policies.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_policies(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError>;
+
+    /// Deletes one exact current Policy revision.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, or internal failures.
+    fn delete_policy_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Creates one Scope with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, capacity, or internal failures.
+    fn create_scope(
+        &self,
+        principal: &Principal,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Updates one existing Scope identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_scope(
+        &self,
+        principal: &Principal,
+        scope_id: &ResourceId,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Reads one exact current Scope revision.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_scope(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Lists current Scopes.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_scopes(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError>;
+
+    /// Deletes one exact current Scope revision.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, or internal failures.
+    fn delete_scope_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Creates one Binding Apply intent with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn create_binding(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Updates one existing Binding and requests Apply.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_binding(
+        &self,
+        principal: &Principal,
+        binding_id: &ResourceId,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Reads one current Binding spec and lifecycle status.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Lists current Binding specs and lifecycle statuses.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_bindings(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError>;
+
+    /// Accepts one Binding Delete intent without discarding its current spec.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, capacity, or internal failures.
+    fn delete_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+}
+
+impl<R, C> PolicyAdministration for PapService<R, C>
+where
+    R: PapRepository,
+    C: PolicyCompiler,
+{
+    fn create_policy(
+        &self,
+        principal: &Principal,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::create_policy(self, policy_name, template)?)
+    }
+
+    fn update_policy(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::update_policy(
+            self,
+            policy_id,
+            policy_name,
+            template,
+        )?)
+    }
+
+    fn get_policy(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::get_policy(self, id, revision)?)
+    }
+
+    fn list_policies(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::list_policies(self, limit, offset)?.into())
+    }
+
+    fn delete_policy_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::delete_policy_revision(self, id, revision)?)
+    }
+
+    fn create_scope(
+        &self,
+        principal: &Principal,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::create_scope(self, selector)?)
+    }
+
+    fn update_scope(
+        &self,
+        principal: &Principal,
+        scope_id: &ResourceId,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::update_scope(self, scope_id, selector)?)
+    }
+
+    fn get_scope(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::get_scope(self, id, revision)?)
+    }
+
+    fn list_scopes(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::list_scopes(self, limit, offset)?.into())
+    }
+
+    fn delete_scope_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::delete_scope_revision(self, id, revision)?)
+    }
+
+    fn create_binding(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::create_binding(
+            self,
+            policy_id,
+            policy_revision,
+            scope_id,
+            scope_revision,
+        )?)
+    }
+
+    fn update_binding(
+        &self,
+        principal: &Principal,
+        binding_id: &ResourceId,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::update_binding(
+            self,
+            binding_id,
+            policy_id,
+            policy_revision,
+            scope_id,
+            scope_revision,
+        )?)
+    }
+
+    fn get_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::get_binding(self, id)?)
+    }
+
+    fn list_bindings(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::list_bindings(self, limit, offset)?.into())
+    }
+
+    fn delete_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        Ok(PapService::delete_binding(self, id)?)
+    }
+}
+
+fn require_policy_administrator(principal: &Principal) -> Result<(), PolicyAdministrationError> {
+    if principal.role() == PrincipalRole::PolicyAdministrator {
+        Ok(())
+    } else {
+        Err(PolicyAdministrationError::Forbidden)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PeerCredentials;
+
+    #[test]
+    fn authorization_uses_only_the_server_assigned_role() {
+        let peer = PeerCredentials::new(1000, 100, 4242);
+        let user = Principal::from_authenticated_peer(peer, PrincipalRole::LocalUser);
+        let administrator =
+            Principal::from_authenticated_peer(peer, PrincipalRole::PolicyAdministrator);
+
+        assert_eq!(
+            require_policy_administrator(&user),
+            Err(PolicyAdministrationError::Forbidden)
+        );
+        assert_eq!(require_policy_administrator(&administrator), Ok(()));
+    }
+
+    #[test]
+    fn pap_errors_are_projected_once_at_the_application_boundary() {
+        assert_eq!(
+            PolicyAdministrationError::from(PapError::OperationInProgress),
+            PolicyAdministrationError::Conflict
+        );
+        assert_eq!(
+            PolicyAdministrationError::from(PapError::Persistence),
+            PolicyAdministrationError::Internal
+        );
+        assert_eq!(
+            PolicyAdministrationError::from(PapError::InvalidPagination),
+            PolicyAdministrationError::InvalidArgument
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
@@ -2,10 +2,52 @@ use asc_foundation_types::{ResourceId, Revision};
 use asc_pap::{Page, PapError, PapRepository, PapService, PolicyCompiler};
 use asc_policy_types::authoring::PolicyTemplate;
 use asc_policy_types::binding::BindingView;
+use asc_policy_types::error::ValidationError;
 use asc_policy_types::policy::PreparedPolicy;
 use asc_policy_types::scope::{PreparedScope, ScopeSelector};
 
 use crate::{Principal, PrincipalRole};
+
+/// Stable authored-input detail that is safe to expose outside the daemon.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("{message}")]
+pub struct PolicyInputError {
+    message: String,
+}
+
+impl PolicyInputError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Stable resource class used to describe a PAP not-found failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum NotFoundResource {
+    /// A Policy identity requested for update does not exist.
+    #[error("policy was not found")]
+    Policy,
+    /// An exact Policy revision requested for read or delete does not exist.
+    #[error("policy revision was not found")]
+    PolicyRevision,
+    /// A Scope identity requested for update does not exist.
+    #[error("scope was not found")]
+    Scope,
+    /// An exact Scope revision requested for read or delete does not exist.
+    #[error("scope revision was not found")]
+    ScopeRevision,
+    /// A Binding identity does not exist.
+    #[error("binding was not found")]
+    Binding,
+    /// A Binding's referenced Policy revision does not exist.
+    #[error("referenced policy revision was not found")]
+    ReferencedPolicyRevision,
+    /// A Binding's referenced Scope revision does not exist.
+    #[error("referenced scope revision was not found")]
+    ReferencedScopeRevision,
+}
 
 /// Stable PAP application failures safe for a daemon adapter to project.
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
@@ -14,14 +56,17 @@ pub enum PolicyAdministrationError {
     #[error("principal is not authorized to administer policy")]
     Forbidden,
     /// Authored input failed domain validation.
-    #[error("policy input failed domain validation")]
-    InvalidArgument,
+    #[error("{0}")]
+    InvalidArgument(PolicyInputError),
     /// Current revision or lifecycle state conflicts with the request.
     #[error("policy request conflicts with current state")]
     Conflict,
-    /// The requested current resource does not exist.
-    #[error("requested policy resource was not found")]
-    NotFound,
+    /// A changed Binding request cannot interrupt reconciliation work.
+    #[error("binding reconciliation operation is in progress")]
+    OperationInProgress,
+    /// The requested typed resource does not exist.
+    #[error("{0}")]
+    NotFound(NotFoundResource),
     /// No further positive revision can be allocated.
     #[error("revision space is exhausted")]
     ResourceExhausted,
@@ -30,20 +75,58 @@ pub enum PolicyAdministrationError {
     Internal,
 }
 
-impl From<PapError> for PolicyAdministrationError {
-    fn from(error: PapError) -> Self {
-        match error {
-            PapError::InvalidIdentifier(_)
-            | PapError::InvalidPolicyName(_)
-            | PapError::InvalidPolicy(_)
-            | PapError::InvalidScope(_)
-            | PapError::InvalidBinding(_)
-            | PapError::InvalidPagination => Self::InvalidArgument,
-            PapError::Conflict | PapError::OperationInProgress => Self::Conflict,
-            PapError::NotFound => Self::NotFound,
-            PapError::RevisionExhausted => Self::ResourceExhausted,
-            PapError::Serialization | PapError::Persistence => Self::Internal,
+fn project_pap_error(
+    error: PapError,
+    missing_resource: Option<NotFoundResource>,
+) -> PolicyAdministrationError {
+    match error {
+        PapError::InvalidPolicyName(message) => PolicyAdministrationError::InvalidArgument(
+            PolicyInputError::new(format!("invalid policy name: {message}")),
+        ),
+        PapError::InvalidPolicy(error) => {
+            project_validation_error(&error, "template", "invalid policy")
         }
+        PapError::InvalidScope(error) => {
+            project_validation_error(&error, "selector", "invalid scope")
+        }
+        PapError::InvalidPagination => PolicyAdministrationError::InvalidArgument(
+            PolicyInputError::new("invalid pagination: limit must be between 1 and 1000"),
+        ),
+        PapError::Conflict => PolicyAdministrationError::Conflict,
+        PapError::OperationInProgress => PolicyAdministrationError::OperationInProgress,
+        PapError::NotFound => missing_resource.map_or(
+            PolicyAdministrationError::Internal,
+            PolicyAdministrationError::NotFound,
+        ),
+        PapError::ReferencedPolicyRevisionNotFound => {
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedPolicyRevision)
+        }
+        PapError::ReferencedScopeRevisionNotFound => {
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedScopeRevision)
+        }
+        PapError::RevisionExhausted => PolicyAdministrationError::ResourceExhausted,
+        PapError::InvalidIdentifier(_)
+        | PapError::InvalidBinding(_)
+        | PapError::Serialization
+        | PapError::Persistence => PolicyAdministrationError::Internal,
+    }
+}
+
+fn project_validation_error(
+    error: &ValidationError,
+    authored_root: &str,
+    public_prefix: &str,
+) -> PolicyAdministrationError {
+    let suffix = error.path.strip_prefix(authored_root);
+    let is_authored_path = suffix.is_some_and(|suffix| {
+        suffix.is_empty() || suffix.starts_with('.') || suffix.starts_with('[')
+    });
+    if is_authored_path {
+        PolicyAdministrationError::InvalidArgument(PolicyInputError::new(format!(
+            "{public_prefix}: {error}"
+        )))
+    } else {
+        PolicyAdministrationError::Internal
     }
 }
 
@@ -253,7 +336,8 @@ where
         template: &PolicyTemplate,
     ) -> Result<PreparedPolicy, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::create_policy(self, policy_name, template)?)
+        PapService::create_policy(self, policy_name, template)
+            .map_err(|error| project_pap_error(error, None))
     }
 
     fn update_policy(
@@ -264,12 +348,8 @@ where
         template: &PolicyTemplate,
     ) -> Result<PreparedPolicy, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::update_policy(
-            self,
-            policy_id,
-            policy_name,
-            template,
-        )?)
+        PapService::update_policy(self, policy_id, policy_name, template)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Policy)))
     }
 
     fn get_policy(
@@ -279,7 +359,8 @@ where
         revision: Revision,
     ) -> Result<PreparedPolicy, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::get_policy(self, id, revision)?)
+        PapService::get_policy(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::PolicyRevision)))
     }
 
     fn list_policies(
@@ -289,7 +370,9 @@ where
         offset: u32,
     ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::list_policies(self, limit, offset)?.into())
+        PapService::list_policies(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
     }
 
     fn delete_policy_revision(
@@ -299,7 +382,8 @@ where
         revision: Revision,
     ) -> Result<PreparedPolicy, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::delete_policy_revision(self, id, revision)?)
+        PapService::delete_policy_revision(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::PolicyRevision)))
     }
 
     fn create_scope(
@@ -308,7 +392,7 @@ where
         selector: &ScopeSelector,
     ) -> Result<PreparedScope, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::create_scope(self, selector)?)
+        PapService::create_scope(self, selector).map_err(|error| project_pap_error(error, None))
     }
 
     fn update_scope(
@@ -318,7 +402,8 @@ where
         selector: &ScopeSelector,
     ) -> Result<PreparedScope, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::update_scope(self, scope_id, selector)?)
+        PapService::update_scope(self, scope_id, selector)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Scope)))
     }
 
     fn get_scope(
@@ -328,7 +413,8 @@ where
         revision: Revision,
     ) -> Result<PreparedScope, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::get_scope(self, id, revision)?)
+        PapService::get_scope(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::ScopeRevision)))
     }
 
     fn list_scopes(
@@ -338,7 +424,9 @@ where
         offset: u32,
     ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::list_scopes(self, limit, offset)?.into())
+        PapService::list_scopes(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
     }
 
     fn delete_scope_revision(
@@ -348,7 +436,8 @@ where
         revision: Revision,
     ) -> Result<PreparedScope, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::delete_scope_revision(self, id, revision)?)
+        PapService::delete_scope_revision(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::ScopeRevision)))
     }
 
     fn create_binding(
@@ -360,13 +449,8 @@ where
         scope_revision: Revision,
     ) -> Result<BindingView, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::create_binding(
-            self,
-            policy_id,
-            policy_revision,
-            scope_id,
-            scope_revision,
-        )?)
+        PapService::create_binding(self, policy_id, policy_revision, scope_id, scope_revision)
+            .map_err(|error| project_pap_error(error, None))
     }
 
     fn update_binding(
@@ -379,14 +463,15 @@ where
         scope_revision: Revision,
     ) -> Result<BindingView, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::update_binding(
+        PapService::update_binding(
             self,
             binding_id,
             policy_id,
             policy_revision,
             scope_id,
             scope_revision,
-        )?)
+        )
+        .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
     }
 
     fn get_binding(
@@ -395,7 +480,8 @@ where
         id: &ResourceId,
     ) -> Result<BindingView, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::get_binding(self, id)?)
+        PapService::get_binding(self, id)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
     }
 
     fn list_bindings(
@@ -405,7 +491,9 @@ where
         offset: u32,
     ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::list_bindings(self, limit, offset)?.into())
+        PapService::list_bindings(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
     }
 
     fn delete_binding(
@@ -414,7 +502,8 @@ where
         id: &ResourceId,
     ) -> Result<BindingView, PolicyAdministrationError> {
         require_policy_administrator(principal)?;
-        Ok(PapService::delete_binding(self, id)?)
+        PapService::delete_binding(self, id)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
     }
 }
 
@@ -448,16 +537,36 @@ mod tests {
     #[test]
     fn pap_errors_are_projected_once_at_the_application_boundary() {
         assert_eq!(
-            PolicyAdministrationError::from(PapError::OperationInProgress),
-            PolicyAdministrationError::Conflict
+            project_pap_error(PapError::OperationInProgress, None),
+            PolicyAdministrationError::OperationInProgress
         );
         assert_eq!(
-            PolicyAdministrationError::from(PapError::Persistence),
+            project_pap_error(PapError::Persistence, None),
             PolicyAdministrationError::Internal
         );
         assert_eq!(
-            PolicyAdministrationError::from(PapError::InvalidPagination),
-            PolicyAdministrationError::InvalidArgument
+            project_pap_error(PapError::InvalidPagination, None),
+            PolicyAdministrationError::InvalidArgument(PolicyInputError::new(
+                "invalid pagination: limit must be between 1 and 1000"
+            ))
+        );
+        assert_eq!(
+            project_pap_error(PapError::NotFound, Some(NotFoundResource::Policy)),
+            PolicyAdministrationError::NotFound(NotFoundResource::Policy)
+        );
+        assert_eq!(
+            project_pap_error(PapError::ReferencedScopeRevisionNotFound, None),
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedScopeRevision)
+        );
+        assert_eq!(
+            project_pap_error(
+                PapError::InvalidPolicy(ValidationError::new(
+                    "canonicalPolicy.policyId",
+                    "compiler output exposed an internal mismatch"
+                )),
+                None
+            ),
+            PolicyAdministrationError::Internal
         );
     }
 }

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
@@ -84,10 +84,10 @@ fn project_pap_error(
             PolicyInputError::new(format!("invalid policy name: {message}")),
         ),
         PapError::InvalidPolicy(error) => {
-            project_validation_error(&error, "template", "invalid policy")
+            project_validation_error(&error, &["template"], "invalid policy")
         }
         PapError::InvalidScope(error) => {
-            project_validation_error(&error, "selector", "invalid scope")
+            project_validation_error(&error, &["selector", "pid", "cgroupId"], "invalid scope")
         }
         PapError::InvalidPagination => PolicyAdministrationError::InvalidArgument(
             PolicyInputError::new("invalid pagination: limit must be between 1 and 1000"),
@@ -114,12 +114,16 @@ fn project_pap_error(
 
 fn project_validation_error(
     error: &ValidationError,
-    authored_root: &str,
+    authored_roots: &[&str],
     public_prefix: &str,
 ) -> PolicyAdministrationError {
-    let suffix = error.path.strip_prefix(authored_root);
-    let is_authored_path = suffix.is_some_and(|suffix| {
-        suffix.is_empty() || suffix.starts_with('.') || suffix.starts_with('[')
+    let is_authored_path = authored_roots.iter().any(|authored_root| {
+        error
+            .path
+            .strip_prefix(authored_root)
+            .is_some_and(|suffix| {
+                suffix.is_empty() || suffix.starts_with('.') || suffix.starts_with('[')
+            })
     });
     if is_authored_path {
         PolicyAdministrationError::InvalidArgument(PolicyInputError::new(format!(
@@ -558,6 +562,17 @@ mod tests {
             project_pap_error(PapError::ReferencedScopeRevisionNotFound, None),
             PolicyAdministrationError::NotFound(NotFoundResource::ReferencedScopeRevision)
         );
+        for path in ["pid", "cgroupId"] {
+            assert_eq!(
+                project_pap_error(
+                    PapError::InvalidScope(ValidationError::new(path, "must be positive")),
+                    None
+                ),
+                PolicyAdministrationError::InvalidArgument(PolicyInputError::new(format!(
+                    "invalid scope: {path}: must be positive"
+                )))
+            );
+        }
         assert_eq!(
             project_pap_error(
                 PapError::InvalidPolicy(ValidationError::new(

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "asc-daemon-handler"
+description = "Daemon protocol adapters for AgentSecCore application use cases"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-daemon-core = { workspace = true }
+asc-daemon-protocol = { workspace = true }
+asc-daemon-service = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/dispatcher.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/dispatcher.rs
@@ -1,0 +1,114 @@
+use std::io::Write;
+use std::sync::Arc;
+
+use asc_daemon_core::{
+    PeerCredentials, PolicyAdministration, Principal, PrincipalPolicy, PrincipalRole,
+};
+use asc_daemon_protocol::method::{self, AccessPolicy, MethodId};
+use asc_daemon_protocol::{DaemonRequest, DaemonResponse, RequestId, error_code};
+use asc_daemon_service::{DispatchError, DispatchRequest, RequestDispatcher, ResponseDisposition};
+
+use crate::pap::PapHandler;
+
+/// Protocol router composed over daemon application use cases.
+pub struct DaemonDispatcher {
+    pap: PapHandler,
+    principal_policy: Arc<dyn PrincipalPolicy>,
+}
+
+impl DaemonDispatcher {
+    /// Composes PAP dispatch with trusted server authorization policy.
+    ///
+    /// The role is process-owned configuration. It is never decoded from the
+    /// request or inferred from caller-supplied attribution.
+    pub fn new(
+        application: impl PolicyAdministration + 'static,
+        principal_policy: Arc<dyn PrincipalPolicy>,
+    ) -> Self {
+        Self {
+            pap: PapHandler::new(application),
+            principal_policy,
+        }
+    }
+
+    /// Handles one decoded request using transport-authenticated peer identity.
+    pub fn handle(
+        &self,
+        request_id: RequestId,
+        peer: PeerCredentials,
+        request: DaemonRequest,
+    ) -> DaemonResponse {
+        let Some(method_id) = method::resolve(&request.method) else {
+            return DaemonResponse::error(
+                request_id,
+                error_code::UNKNOWN_METHOD,
+                "daemon method is not implemented",
+            );
+        };
+
+        let role = self.principal_policy.role_for(peer);
+        let principal = Principal::from_authenticated_peer(peer, role);
+        if !is_authorized(&principal, method_id.metadata().access) {
+            return DaemonResponse::error(
+                request_id,
+                error_code::PERMISSION_DENIED,
+                "principal is not authorized to administer policy",
+            );
+        }
+        let MethodId::Pap(method) = method_id;
+        self.pap
+            .handle(request_id, &principal, method, request.params)
+    }
+}
+
+fn is_authorized(principal: &Principal, access: AccessPolicy) -> bool {
+    match access {
+        AccessPolicy::PolicyAdministrator => principal.role() == PrincipalRole::PolicyAdministrator,
+    }
+}
+
+impl RequestDispatcher for DaemonDispatcher {
+    fn dispatch(
+        &self,
+        request: DispatchRequest,
+        response: &mut dyn Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        let request_id = new_request_id();
+        if request.control.is_cancelled() {
+            return write_response(
+                response,
+                &DaemonResponse::<serde_json::Value>::error(
+                    request_id,
+                    error_code::DEADLINE_EXCEEDED,
+                    "request dispatch deadline expired",
+                ),
+            );
+        }
+
+        let peer = PeerCredentials::new(request.peer.uid(), request.peer.gid(), request.peer.pid());
+        let Ok(decoded) = serde_json::from_slice::<DaemonRequest>(&request.payload) else {
+            return write_response(
+                response,
+                &DaemonResponse::<serde_json::Value>::error(
+                    request_id,
+                    error_code::INVALID_REQUEST,
+                    "request envelope is invalid",
+                ),
+            );
+        };
+        write_response(response, &self.handle(request_id, peer, decoded))
+    }
+}
+
+pub(crate) fn new_request_id() -> RequestId {
+    RequestId::new(uuid::Uuid::new_v4().to_string())
+        .expect("UUID request identities are always non-empty")
+}
+
+pub(crate) fn write_response<T: serde::Serialize>(
+    response: &mut dyn Write,
+    value: &DaemonResponse<T>,
+) -> Result<ResponseDisposition, DispatchError> {
+    serde_json::to_writer(response, value).map_err(|_| DispatchError)?;
+    Ok(ResponseDisposition::Send)
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/lib.rs
@@ -1,0 +1,16 @@
+//! Inbound daemon protocol adapters for application use cases.
+//!
+//! This crate translates bounded transport requests into versioned daemon
+//! protocol calls, applies server-owned authorization, routes accepted calls to
+//! application ports, and projects application or transport failures back into
+//! protocol responses. Process bootstrap and transport execution remain in
+//! `asc-daemon` and `asc-daemon-service`, respectively.
+
+#![forbid(unsafe_code)]
+
+mod dispatcher;
+mod pap;
+mod rejection;
+
+pub use dispatcher::DaemonDispatcher;
+pub use rejection::JsonRejectionEncoder;

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
@@ -1,0 +1,288 @@
+//! PAP protocol adapter invoked by the daemon dispatcher.
+
+use std::sync::Arc;
+
+use asc_daemon_core::{PolicyAdministration, PolicyAdministrationError, Principal, ResourcePage};
+use asc_daemon_protocol::method::{BindingMethod, PapMethod, PolicyMethod, ScopeMethod};
+use asc_daemon_protocol::{
+    CreateBindingParams, CreatePolicyParams, CreateScopeParams, DaemonResponse, ListParams,
+    ListResult, RequestId, ResourceParams, RevisionParams, UpdateBindingParams, UpdatePolicyParams,
+    UpdateScopeParams, error_code,
+};
+
+const MAX_PARAMETER_ERROR_BYTES: usize = 256;
+const PARAMETER_ERROR_SUFFIX: &str = "...";
+
+/// PAP-specific protocol adapter with repository/compiler types erased.
+pub(super) struct PapHandler {
+    application: Arc<dyn PolicyAdministration>,
+}
+
+impl PapHandler {
+    pub(super) fn new(application: impl PolicyAdministration + 'static) -> Self {
+        Self {
+            application: Arc::new(application),
+        }
+    }
+
+    pub(super) fn handle(
+        &self,
+        request_id: RequestId,
+        principal: &Principal,
+        method: PapMethod,
+        params: serde_json::Value,
+    ) -> DaemonResponse {
+        match dispatch(method, params, self.application.as_ref(), principal) {
+            // TODO(policy-response-bounds): full PreparedPolicy and BindingView results can exceed
+            // the transport response limit after a mutation has committed. Before a durable
+            // Repository is exposed, bound public result shapes and verify every mutation result
+            // against the response budget before commit.
+            Ok(result) => DaemonResponse::success(request_id, result),
+            Err(PapDispatchError::BadRequest(message)) => {
+                DaemonResponse::error(request_id, error_code::INVALID_REQUEST, &message)
+            }
+            Err(PapDispatchError::Application(error)) => {
+                let (code, message) = project_application_error(&error);
+                DaemonResponse::error(request_id, code, message)
+            }
+            Err(PapDispatchError::Projection) => DaemonResponse::error(
+                request_id,
+                error_code::INTERNAL,
+                "policy state could not be encoded",
+            ),
+        }
+    }
+}
+
+fn dispatch(
+    method: PapMethod,
+    params: serde_json::Value,
+    application: &dyn PolicyAdministration,
+    principal: &Principal,
+) -> Result<serde_json::Value, PapDispatchError> {
+    match method {
+        PapMethod::Policy(method) => dispatch_policy(method, params, application, principal),
+        PapMethod::Scope(method) => dispatch_scope(method, params, application, principal),
+        PapMethod::Binding(method) => dispatch_binding(method, params, application, principal),
+    }
+}
+
+fn dispatch_policy(
+    method: PolicyMethod,
+    params: serde_json::Value,
+    application: &dyn PolicyAdministration,
+    principal: &Principal,
+) -> Result<serde_json::Value, PapDispatchError> {
+    match method {
+        PolicyMethod::Create => {
+            let input: CreatePolicyParams = decode(params)?;
+            encode(application.create_policy(principal, &input.policy_name, &input.template)?)
+        }
+        PolicyMethod::Update => {
+            let input: UpdatePolicyParams = decode(params)?;
+            encode(application.update_policy(
+                principal,
+                &input.policy_id,
+                &input.policy_name,
+                &input.template,
+            )?)
+        }
+        PolicyMethod::Get => {
+            let input: RevisionParams = decode(params)?;
+            encode(application.get_policy(principal, &input.id, input.revision)?)
+        }
+        PolicyMethod::List => {
+            let input: ListParams = decode(params)?;
+            encode_page(application.list_policies(principal, input.limit, input.offset)?)
+        }
+        PolicyMethod::Delete => {
+            let input: RevisionParams = decode(params)?;
+            encode(application.delete_policy_revision(principal, &input.id, input.revision)?)
+        }
+    }
+}
+
+fn dispatch_scope(
+    method: ScopeMethod,
+    params: serde_json::Value,
+    application: &dyn PolicyAdministration,
+    principal: &Principal,
+) -> Result<serde_json::Value, PapDispatchError> {
+    match method {
+        ScopeMethod::Create => {
+            let input: CreateScopeParams = decode(params)?;
+            encode(application.create_scope(principal, &input.selector)?)
+        }
+        ScopeMethod::Update => {
+            let input: UpdateScopeParams = decode(params)?;
+            encode(application.update_scope(principal, &input.scope_id, &input.selector)?)
+        }
+        ScopeMethod::Get => {
+            let input: RevisionParams = decode(params)?;
+            encode(application.get_scope(principal, &input.id, input.revision)?)
+        }
+        ScopeMethod::List => {
+            let input: ListParams = decode(params)?;
+            encode_page(application.list_scopes(principal, input.limit, input.offset)?)
+        }
+        ScopeMethod::Delete => {
+            let input: RevisionParams = decode(params)?;
+            encode(application.delete_scope_revision(principal, &input.id, input.revision)?)
+        }
+    }
+}
+
+fn dispatch_binding(
+    method: BindingMethod,
+    params: serde_json::Value,
+    application: &dyn PolicyAdministration,
+    principal: &Principal,
+) -> Result<serde_json::Value, PapDispatchError> {
+    match method {
+        BindingMethod::Create => {
+            let input: CreateBindingParams = decode(params)?;
+            encode(application.create_binding(
+                principal,
+                &input.policy_id,
+                input.policy_revision,
+                &input.scope_id,
+                input.scope_revision,
+            )?)
+        }
+        BindingMethod::Update => {
+            let input: UpdateBindingParams = decode(params)?;
+            encode(application.update_binding(
+                principal,
+                &input.binding_id,
+                &input.policy_id,
+                input.policy_revision,
+                &input.scope_id,
+                input.scope_revision,
+            )?)
+        }
+        BindingMethod::Get => {
+            let input: ResourceParams = decode(params)?;
+            encode(application.get_binding(principal, &input.id)?)
+        }
+        BindingMethod::List => {
+            let input: ListParams = decode(params)?;
+            encode_page(application.list_bindings(principal, input.limit, input.offset)?)
+        }
+        BindingMethod::Delete => {
+            let input: ResourceParams = decode(params)?;
+            encode(application.delete_binding(principal, &input.id)?)
+        }
+    }
+}
+
+fn decode<T: serde::de::DeserializeOwned>(
+    params: serde_json::Value,
+) -> Result<T, PapDispatchError> {
+    serde_json::from_value(params)
+        .map_err(|error| PapDispatchError::BadRequest(bounded_parameter_error(&error)))
+}
+
+fn bounded_parameter_error(error: &serde_json::Error) -> String {
+    let message = error.to_string();
+    if message.len() <= MAX_PARAMETER_ERROR_BYTES {
+        return message;
+    }
+
+    let mut end = MAX_PARAMETER_ERROR_BYTES - PARAMETER_ERROR_SUFFIX.len();
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{PARAMETER_ERROR_SUFFIX}", &message[..end])
+}
+
+fn encode<T: serde::Serialize>(value: T) -> Result<serde_json::Value, PapDispatchError> {
+    serde_json::to_value(value).map_err(|_| PapDispatchError::Projection)
+}
+
+fn encode_page<T: serde::Serialize>(
+    page: ResourcePage<T>,
+) -> Result<serde_json::Value, PapDispatchError> {
+    encode(ListResult {
+        items: page.items,
+        total: page.total,
+    })
+}
+
+enum PapDispatchError {
+    BadRequest(String),
+    Application(PolicyAdministrationError),
+    Projection,
+}
+
+impl From<PolicyAdministrationError> for PapDispatchError {
+    fn from(value: PolicyAdministrationError) -> Self {
+        Self::Application(value)
+    }
+}
+
+fn project_application_error(error: &PolicyAdministrationError) -> (&'static str, &'static str) {
+    match error {
+        PolicyAdministrationError::Forbidden => (
+            error_code::PERMISSION_DENIED,
+            "principal is not authorized to administer policy",
+        ),
+        PolicyAdministrationError::InvalidArgument => (
+            error_code::INVALID_ARGUMENT,
+            "policy input failed domain validation",
+        ),
+        PolicyAdministrationError::Conflict => (
+            error_code::CONFLICT,
+            "policy request conflicts with current state",
+        ),
+        PolicyAdministrationError::NotFound => (
+            error_code::NOT_FOUND,
+            "requested policy resource was not found",
+        ),
+        PolicyAdministrationError::ResourceExhausted => (
+            error_code::RESOURCE_EXHAUSTED,
+            "revision space is exhausted",
+        ),
+        PolicyAdministrationError::Internal => {
+            (error_code::INTERNAL, "policy state could not be processed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parameter_errors_are_specific_but_bounded() {
+        let invalid_limit = decode::<ListParams>(serde_json::json!({"limit": 0}));
+        let Err(PapDispatchError::BadRequest(message)) = invalid_limit else {
+            panic!("an invalid pagination limit must fail parameter decoding");
+        };
+        assert_eq!(message, "limit must be between 1 and 1000");
+
+        let long_field = "x".repeat(MAX_PARAMETER_ERROR_BYTES * 2);
+        let mut params = serde_json::Map::new();
+        params.insert(long_field, serde_json::Value::Null);
+        let oversized = decode::<ListParams>(serde_json::Value::Object(params));
+        let Err(PapDispatchError::BadRequest(message)) = oversized else {
+            panic!("an unknown parameter must fail decoding");
+        };
+        assert!(message.len() <= MAX_PARAMETER_ERROR_BYTES);
+        assert!(message.ends_with("..."));
+    }
+
+    #[test]
+    fn application_error_projection_is_complete_and_sanitized() {
+        assert_eq!(
+            project_application_error(&PolicyAdministrationError::Forbidden),
+            (
+                error_code::PERMISSION_DENIED,
+                "principal is not authorized to administer policy"
+            )
+        );
+        assert_eq!(
+            project_application_error(&PolicyAdministrationError::Internal),
+            (error_code::INTERNAL, "policy state could not be processed")
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
@@ -10,8 +10,8 @@ use asc_daemon_protocol::{
     UpdateScopeParams, error_code,
 };
 
-const MAX_PARAMETER_ERROR_BYTES: usize = 256;
-const PARAMETER_ERROR_SUFFIX: &str = "...";
+const MAX_PUBLIC_ERROR_BYTES: usize = 256;
+const ERROR_MESSAGE_SUFFIX: &str = "...";
 
 /// PAP-specific protocol adapter with repository/compiler types erased.
 pub(super) struct PapHandler {
@@ -43,7 +43,7 @@ impl PapHandler {
             }
             Err(PapDispatchError::Application(error)) => {
                 let (code, message) = project_application_error(&error);
-                DaemonResponse::error(request_id, code, message)
+                DaemonResponse::error(request_id, code, &message)
             }
             Err(PapDispatchError::Projection) => DaemonResponse::error(
                 request_id,
@@ -183,16 +183,19 @@ fn decode<T: serde::de::DeserializeOwned>(
 }
 
 fn bounded_parameter_error(error: &serde_json::Error) -> String {
-    let message = error.to_string();
-    if message.len() <= MAX_PARAMETER_ERROR_BYTES {
-        return message;
+    bounded_error_message(&error.to_string())
+}
+
+fn bounded_error_message(message: &str) -> String {
+    if message.len() <= MAX_PUBLIC_ERROR_BYTES {
+        return message.to_owned();
     }
 
-    let mut end = MAX_PARAMETER_ERROR_BYTES - PARAMETER_ERROR_SUFFIX.len();
+    let mut end = MAX_PUBLIC_ERROR_BYTES - ERROR_MESSAGE_SUFFIX.len();
     while !message.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}{PARAMETER_ERROR_SUFFIX}", &message[..end])
+    format!("{}{ERROR_MESSAGE_SUFFIX}", &message[..end])
 }
 
 fn encode<T: serde::Serialize>(value: T) -> Result<serde_json::Value, PapDispatchError> {
@@ -220,32 +223,18 @@ impl From<PolicyAdministrationError> for PapDispatchError {
     }
 }
 
-fn project_application_error(error: &PolicyAdministrationError) -> (&'static str, &'static str) {
-    match error {
-        PolicyAdministrationError::Forbidden => (
-            error_code::PERMISSION_DENIED,
-            "principal is not authorized to administer policy",
-        ),
-        PolicyAdministrationError::InvalidArgument => (
-            error_code::INVALID_ARGUMENT,
-            "policy input failed domain validation",
-        ),
-        PolicyAdministrationError::Conflict => (
-            error_code::CONFLICT,
-            "policy request conflicts with current state",
-        ),
-        PolicyAdministrationError::NotFound => (
-            error_code::NOT_FOUND,
-            "requested policy resource was not found",
-        ),
-        PolicyAdministrationError::ResourceExhausted => (
-            error_code::RESOURCE_EXHAUSTED,
-            "revision space is exhausted",
-        ),
-        PolicyAdministrationError::Internal => {
-            (error_code::INTERNAL, "policy state could not be processed")
+fn project_application_error(error: &PolicyAdministrationError) -> (&'static str, String) {
+    let code = match error {
+        PolicyAdministrationError::Forbidden => error_code::PERMISSION_DENIED,
+        PolicyAdministrationError::InvalidArgument(_) => error_code::INVALID_ARGUMENT,
+        PolicyAdministrationError::Conflict | PolicyAdministrationError::OperationInProgress => {
+            error_code::CONFLICT
         }
-    }
+        PolicyAdministrationError::NotFound(_) => error_code::NOT_FOUND,
+        PolicyAdministrationError::ResourceExhausted => error_code::RESOURCE_EXHAUSTED,
+        PolicyAdministrationError::Internal => error_code::INTERNAL,
+    };
+    (code, bounded_error_message(&error.to_string()))
 }
 
 #[cfg(test)]
@@ -260,14 +249,14 @@ mod tests {
         };
         assert_eq!(message, "limit must be between 1 and 1000");
 
-        let long_field = "x".repeat(MAX_PARAMETER_ERROR_BYTES * 2);
+        let long_field = "x".repeat(MAX_PUBLIC_ERROR_BYTES * 2);
         let mut params = serde_json::Map::new();
         params.insert(long_field, serde_json::Value::Null);
         let oversized = decode::<ListParams>(serde_json::Value::Object(params));
         let Err(PapDispatchError::BadRequest(message)) = oversized else {
             panic!("an unknown parameter must fail decoding");
         };
-        assert!(message.len() <= MAX_PARAMETER_ERROR_BYTES);
+        assert!(message.len() <= MAX_PUBLIC_ERROR_BYTES);
         assert!(message.ends_with("..."));
     }
 
@@ -277,12 +266,15 @@ mod tests {
             project_application_error(&PolicyAdministrationError::Forbidden),
             (
                 error_code::PERMISSION_DENIED,
-                "principal is not authorized to administer policy"
+                "principal is not authorized to administer policy".to_owned()
             )
         );
         assert_eq!(
             project_application_error(&PolicyAdministrationError::Internal),
-            (error_code::INTERNAL, "policy state could not be processed")
+            (
+                error_code::INTERNAL,
+                "policy state could not be processed".to_owned()
+            )
         );
     }
 }

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/pap.rs
@@ -6,12 +6,11 @@ use asc_daemon_core::{PolicyAdministration, PolicyAdministrationError, Principal
 use asc_daemon_protocol::method::{BindingMethod, PapMethod, PolicyMethod, ScopeMethod};
 use asc_daemon_protocol::{
     CreateBindingParams, CreatePolicyParams, CreateScopeParams, DaemonResponse, ListParams,
-    ListResult, RequestId, ResourceParams, RevisionParams, UpdateBindingParams, UpdatePolicyParams,
-    UpdateScopeParams, error_code,
+    ListResult, MAX_DAEMON_ERROR_MESSAGE_BYTES, RequestId, ResourceParams, RevisionParams,
+    UpdateBindingParams, UpdatePolicyParams, UpdateScopeParams, error_code,
 };
 
-const MAX_PUBLIC_ERROR_BYTES: usize = 256;
-const ERROR_MESSAGE_SUFFIX: &str = "...";
+const INVALID_PARAMETER_MESSAGE: &str = "request parameters are invalid";
 
 /// PAP-specific protocol adapter with repository/compiler types erased.
 pub(super) struct PapHandler {
@@ -183,19 +182,12 @@ fn decode<T: serde::de::DeserializeOwned>(
 }
 
 fn bounded_parameter_error(error: &serde_json::Error) -> String {
-    bounded_error_message(&error.to_string())
-}
-
-fn bounded_error_message(message: &str) -> String {
-    if message.len() <= MAX_PUBLIC_ERROR_BYTES {
-        return message.to_owned();
+    let message = error.to_string();
+    if message.len() > MAX_DAEMON_ERROR_MESSAGE_BYTES {
+        INVALID_PARAMETER_MESSAGE.to_owned()
+    } else {
+        message
     }
-
-    let mut end = MAX_PUBLIC_ERROR_BYTES - ERROR_MESSAGE_SUFFIX.len();
-    while !message.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}{ERROR_MESSAGE_SUFFIX}", &message[..end])
 }
 
 fn encode<T: serde::Serialize>(value: T) -> Result<serde_json::Value, PapDispatchError> {
@@ -234,7 +226,7 @@ fn project_application_error(error: &PolicyAdministrationError) -> (&'static str
         PolicyAdministrationError::ResourceExhausted => error_code::RESOURCE_EXHAUSTED,
         PolicyAdministrationError::Internal => error_code::INTERNAL,
     };
-    (code, bounded_error_message(&error.to_string()))
+    (code, error.to_string())
 }
 
 #[cfg(test)]
@@ -242,22 +234,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parameter_errors_are_specific_but_bounded() {
+    fn parameter_errors_are_specific_but_do_not_reflect_oversized_input() {
         let invalid_limit = decode::<ListParams>(serde_json::json!({"limit": 0}));
         let Err(PapDispatchError::BadRequest(message)) = invalid_limit else {
             panic!("an invalid pagination limit must fail parameter decoding");
         };
         assert_eq!(message, "limit must be between 1 and 1000");
 
-        let long_field = "x".repeat(MAX_PUBLIC_ERROR_BYTES * 2);
+        let long_field = "x".repeat(MAX_DAEMON_ERROR_MESSAGE_BYTES * 2);
         let mut params = serde_json::Map::new();
         params.insert(long_field, serde_json::Value::Null);
         let oversized = decode::<ListParams>(serde_json::Value::Object(params));
         let Err(PapDispatchError::BadRequest(message)) = oversized else {
             panic!("an unknown parameter must fail decoding");
         };
-        assert!(message.len() <= MAX_PUBLIC_ERROR_BYTES);
-        assert!(message.ends_with("..."));
+        assert_eq!(message, INVALID_PARAMETER_MESSAGE);
     }
 
     #[test]

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/rejection.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-handler/src/rejection.rs
@@ -1,0 +1,80 @@
+//! Protocol response projection for transport-owned rejections.
+
+use std::io::Write;
+
+use asc_daemon_protocol::{DaemonResponse, error_code};
+use asc_daemon_service::{
+    DispatchError, RejectedRequest, RejectionEncoder, RejectionReason, ResponseDisposition,
+};
+
+use crate::dispatcher::{new_request_id, write_response};
+
+/// Protocol-only projection for transport-owned failures.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct JsonRejectionEncoder;
+
+impl RejectionEncoder for JsonRejectionEncoder {
+    fn encode_rejection(
+        &self,
+        request: RejectedRequest,
+        response: &mut dyn Write,
+    ) -> Result<ResponseDisposition, DispatchError> {
+        let (code, message) = project_rejection(request.reason);
+        write_response(
+            response,
+            &DaemonResponse::<serde_json::Value>::error(new_request_id(), code, message),
+        )
+    }
+}
+
+fn project_rejection(reason: RejectionReason) -> (&'static str, &'static str) {
+    match reason {
+        RejectionReason::Busy => (
+            error_code::RESOURCE_EXHAUSTED,
+            "daemon connection capacity is exhausted",
+        ),
+        RejectionReason::ShuttingDown => (error_code::UNAVAILABLE, "daemon is shutting down"),
+        RejectionReason::RequestReadTimeout => (
+            error_code::DEADLINE_EXCEEDED,
+            "request read deadline expired",
+        ),
+        RejectionReason::RequestFrameTooLarge => (
+            error_code::RESOURCE_EXHAUSTED,
+            "request frame exceeds the configured limit",
+        ),
+        RejectionReason::EmptyRequest => (error_code::INVALID_REQUEST, "request frame is empty"),
+        RejectionReason::DispatchFailed => (error_code::INTERNAL, "request dispatch failed"),
+        RejectionReason::DispatchTimedOut => (
+            error_code::DEADLINE_EXCEEDED,
+            "request dispatch deadline expired",
+        ),
+        RejectionReason::ResponseFrameTooLarge => (
+            error_code::RESOURCE_EXHAUSTED,
+            "response frame exceeds the configured limit",
+        ),
+        RejectionReason::InvalidResponseFrame => {
+            (error_code::INTERNAL, "daemon produced an invalid response")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_failures_have_stable_protocol_categories() {
+        assert_eq!(
+            project_rejection(RejectionReason::Busy).0,
+            error_code::RESOURCE_EXHAUSTED
+        );
+        assert_eq!(
+            project_rejection(RejectionReason::DispatchTimedOut).0,
+            error_code::DEADLINE_EXCEEDED
+        );
+        assert_eq!(
+            project_rejection(RejectionReason::DispatchFailed).0,
+            error_code::INTERNAL
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-daemon-protocol"
+description = "Versioned local daemon wire contracts for AgentSecCore"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-policy-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/common.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/common.rs
@@ -1,0 +1,78 @@
+use asc_foundation_types::{ResourceId, Revision};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// One stable resource identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResourceParams {
+    /// Stable resource identity.
+    pub id: ResourceId,
+}
+
+/// One stable resource identity plus an exact current revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevisionParams {
+    /// Stable resource identity.
+    pub id: ResourceId,
+    /// Exact positive revision.
+    pub revision: Revision,
+}
+
+/// Bounded client-maintained pagination state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListParams {
+    /// Page size in the inclusive range 1..=1000.
+    pub limit: u32,
+    /// Zero-based client-maintained offset.
+    pub offset: u32,
+}
+
+impl Default for ListParams {
+    fn default() -> Self {
+        Self {
+            limit: 100,
+            offset: 0,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ListParamsWire {
+    #[serde(default = "default_limit")]
+    limit: u32,
+    #[serde(default)]
+    offset: u32,
+}
+
+impl<'de> Deserialize<'de> for ListParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ListParamsWire::deserialize(deserializer)?;
+        if !(1..=1_000).contains(&wire.limit) {
+            return Err(serde::de::Error::custom("limit must be between 1 and 1000"));
+        }
+        Ok(Self {
+            limit: wire.limit,
+            offset: wire.offset,
+        })
+    }
+}
+
+const fn default_limit() -> u32 {
+    100
+}
+
+/// One bounded page and its total before pagination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListResult<T> {
+    /// Selected current records.
+    pub items: Vec<T>,
+    /// Total matching records before pagination.
+    pub total: u64,
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
@@ -1,0 +1,43 @@
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// One first-version daemon request with method-specific parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DaemonRequest {
+    /// Exact allowlisted method name.
+    #[serde(deserialize_with = "deserialize_method")]
+    pub method: String,
+    /// Method-specific object, defaulting to an empty object.
+    #[serde(default = "empty_object", deserialize_with = "deserialize_params")]
+    pub params: Value,
+}
+
+fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+fn deserialize_method<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let method = String::deserialize(deserializer)?;
+    if method.trim().is_empty() {
+        Err(D::Error::custom("method must be a non-empty string"))
+    } else {
+        Ok(method)
+    }
+}
+
+fn deserialize_params<'de, D>(deserializer: D) -> Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let params = Value::deserialize(deserializer)?;
+    if params.is_object() {
+        Ok(params)
+    } else {
+        Err(D::Error::custom("params must be a JSON object"))
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
@@ -1,4 +1,6 @@
-use serde::de::Error as _;
+use std::fmt;
+
+use serde::de::{Error as _, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
@@ -34,10 +36,104 @@ fn deserialize_params<'de, D>(deserializer: D) -> Result<Value, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let params = Value::deserialize(deserializer)?;
+    let params = StrictValue::deserialize(deserializer)?.0;
     if params.is_object() {
         Ok(params)
     } else {
         Err(D::Error::custom("params must be a JSON object"))
+    }
+}
+
+/// A JSON value decoder that rejects duplicate object keys before they can be
+/// collapsed by `serde_json::Value`.
+struct StrictValue(Value);
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(Value::Number)
+            .map(StrictValue)
+            .ok_or_else(|| E::custom("JSON numbers must be finite"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        StrictValue::deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
+        while let Some(value) = sequence.next_element::<StrictValue>()? {
+            values.push(value.0);
+        }
+        Ok(StrictValue(Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = serde_json::Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(A::Error::custom(format!("duplicate field `{key}`")));
+            }
+            let value = object.next_value::<StrictValue>()?;
+            values.insert(key, value.0);
+        }
+        Ok(StrictValue(Value::Object(values)))
     }
 }

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
@@ -1,0 +1,24 @@
+//! First-version PAP administration wire contracts for the local daemon.
+//!
+//! This crate owns only untrusted serialized values. It reuses stable Policy,
+//! Scope, Binding, identifier, and revision types rather than defining daemon
+//! DTO copies. PAP execution, authorization, persistence, and transport live
+//! in higher layers.
+
+#![forbid(unsafe_code)]
+
+mod common;
+mod envelope;
+pub mod method;
+mod pap;
+mod response;
+
+pub use common::{ListParams, ListResult, ResourceParams, RevisionParams};
+pub use envelope::DaemonRequest;
+pub use pap::{
+    CreateBindingParams, CreatePolicyParams, CreateScopeParams, UpdateBindingParams,
+    UpdatePolicyParams, UpdateScopeParams,
+};
+pub use response::{
+    DaemonError, DaemonResponse, ErrorCode, ErrorResponse, RequestId, SuccessResponse, error_code,
+};

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
@@ -20,5 +20,6 @@ pub use pap::{
     UpdatePolicyParams, UpdateScopeParams,
 };
 pub use response::{
-    DaemonError, DaemonResponse, ErrorCode, ErrorResponse, RequestId, SuccessResponse, error_code,
+    DaemonError, DaemonResponse, ErrorCode, ErrorResponse, MAX_DAEMON_ERROR_MESSAGE_BYTES,
+    RequestId, SuccessResponse, error_code,
 };

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/method.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/method.rs
@@ -1,0 +1,166 @@
+//! Closed PAP method inventory and access metadata.
+
+/// Create one Policy identity from an authored template.
+pub const POLICY_TEMPLATES_CREATE: &str = "policy.templates.create";
+/// Update one existing Policy identity.
+pub const POLICY_TEMPLATES_UPDATE: &str = "policy.templates.update";
+/// Read one exact current Policy revision.
+pub const POLICY_TEMPLATES_GET: &str = "policy.templates.get";
+/// List current Policies.
+pub const POLICY_TEMPLATES_LIST: &str = "policy.templates.list";
+/// Delete one exact current Policy revision.
+pub const POLICY_TEMPLATES_DELETE: &str = "policy.templates.delete";
+/// Create one Scope identity from an authored selector.
+pub const POLICY_SCOPES_CREATE: &str = "policy.scopes.create";
+/// Update one existing Scope identity.
+pub const POLICY_SCOPES_UPDATE: &str = "policy.scopes.update";
+/// Read one exact current Scope revision.
+pub const POLICY_SCOPES_GET: &str = "policy.scopes.get";
+/// List current Scopes.
+pub const POLICY_SCOPES_LIST: &str = "policy.scopes.list";
+/// Delete one exact current Scope revision.
+pub const POLICY_SCOPES_DELETE: &str = "policy.scopes.delete";
+/// Create one Binding Apply intent.
+pub const POLICY_BINDINGS_CREATE: &str = "policy.bindings.create";
+/// Update one existing Binding and request Apply.
+pub const POLICY_BINDINGS_UPDATE: &str = "policy.bindings.update";
+/// Read one current Binding spec and lifecycle status.
+pub const POLICY_BINDINGS_GET: &str = "policy.bindings.get";
+/// List current Bindings and lifecycle statuses.
+pub const POLICY_BINDINGS_LIST: &str = "policy.bindings.list";
+/// Request deletion of one current Binding.
+pub const POLICY_BINDINGS_DELETE: &str = "policy.bindings.delete";
+
+/// Complete PAP method inventory for this protocol version.
+pub const PAP_METHODS: [&str; 15] = [
+    POLICY_TEMPLATES_CREATE,
+    POLICY_TEMPLATES_UPDATE,
+    POLICY_TEMPLATES_GET,
+    POLICY_TEMPLATES_LIST,
+    POLICY_TEMPLATES_DELETE,
+    POLICY_SCOPES_CREATE,
+    POLICY_SCOPES_UPDATE,
+    POLICY_SCOPES_GET,
+    POLICY_SCOPES_LIST,
+    POLICY_SCOPES_DELETE,
+    POLICY_BINDINGS_CREATE,
+    POLICY_BINDINGS_UPDATE,
+    POLICY_BINDINGS_GET,
+    POLICY_BINDINGS_LIST,
+    POLICY_BINDINGS_DELETE,
+];
+
+/// One Policy operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyMethod {
+    /// Create.
+    Create,
+    /// Update.
+    Update,
+    /// Get.
+    Get,
+    /// List.
+    List,
+    /// Delete.
+    Delete,
+}
+
+/// One Scope operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeMethod {
+    /// Create.
+    Create,
+    /// Update.
+    Update,
+    /// Get.
+    Get,
+    /// List.
+    List,
+    /// Delete.
+    Delete,
+}
+
+/// One Binding operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingMethod {
+    /// Create Apply intent.
+    Create,
+    /// Update and request Apply.
+    Update,
+    /// Get current state.
+    Get,
+    /// List current state.
+    List,
+    /// Request Delete.
+    Delete,
+}
+
+/// One PAP operation resolved before parameter decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PapMethod {
+    /// Policy operation.
+    Policy(PolicyMethod),
+    /// Scope operation.
+    Scope(ScopeMethod),
+    /// Binding operation.
+    Binding(BindingMethod),
+}
+
+/// Closed daemon method identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodId {
+    /// PAP administration method.
+    Pap(PapMethod),
+}
+
+/// Server-owned access policy for a method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessPolicy {
+    /// Requires a server-assigned Policy administrator principal.
+    PolicyAdministrator,
+}
+
+/// Static method metadata used by authorization before application dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Metadata {
+    /// Required server-owned access policy.
+    pub access: AccessPolicy,
+}
+
+impl MethodId {
+    /// Returns authorization metadata for this exact method.
+    pub const fn metadata(self) -> Metadata {
+        match self {
+            Self::Pap(_) => Metadata {
+                access: AccessPolicy::PolicyAdministrator,
+            },
+        }
+    }
+}
+
+/// Resolves an exact wire method without inspecting its parameters.
+pub fn resolve(method: &str) -> Option<MethodId> {
+    match method {
+        POLICY_TEMPLATES_CREATE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Create))),
+        POLICY_TEMPLATES_UPDATE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Update))),
+        POLICY_TEMPLATES_GET => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Get))),
+        POLICY_TEMPLATES_LIST => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::List))),
+        POLICY_TEMPLATES_DELETE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Delete))),
+        POLICY_SCOPES_CREATE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Create))),
+        POLICY_SCOPES_UPDATE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Update))),
+        POLICY_SCOPES_GET => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Get))),
+        POLICY_SCOPES_LIST => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::List))),
+        POLICY_SCOPES_DELETE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Delete))),
+        POLICY_BINDINGS_CREATE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Create))),
+        POLICY_BINDINGS_UPDATE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Update))),
+        POLICY_BINDINGS_GET => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Get))),
+        POLICY_BINDINGS_LIST => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::List))),
+        POLICY_BINDINGS_DELETE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Delete))),
+        _ => None,
+    }
+}
+
+/// Returns metadata for an exact registered method.
+pub fn metadata(method: &str) -> Option<Metadata> {
+    resolve(method).map(MethodId::metadata)
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/pap.rs
@@ -1,0 +1,112 @@
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::Validate;
+use asc_policy_types::authoring::PolicyTemplate;
+use asc_policy_types::scope::ScopeSelector;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Create one Policy with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreatePolicyParams {
+    /// Human-readable Policy name.
+    pub policy_name: String,
+    /// Complete authored Policy intent.
+    pub template: PolicyTemplate,
+}
+
+/// Update one existing Policy identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdatePolicyParams {
+    /// Existing Policy identity.
+    pub policy_id: ResourceId,
+    /// Human-readable Policy name.
+    pub policy_name: String,
+    /// Complete authored Policy intent.
+    pub template: PolicyTemplate,
+}
+
+/// Create one Scope with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateScopeParams {
+    /// New authored selector; compatibility-only selectors are rejected.
+    #[serde(
+        deserialize_with = "deserialize_authored_selector",
+        serialize_with = "serialize_authored_selector"
+    )]
+    pub selector: ScopeSelector,
+}
+
+/// Update one existing Scope identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateScopeParams {
+    /// Existing Scope identity.
+    pub scope_id: ResourceId,
+    /// New authored selector; compatibility-only selectors are rejected.
+    #[serde(
+        deserialize_with = "deserialize_authored_selector",
+        serialize_with = "serialize_authored_selector"
+    )]
+    pub selector: ScopeSelector,
+}
+
+/// Create one Binding Apply intent with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateBindingParams {
+    /// Exact Policy identity.
+    pub policy_id: ResourceId,
+    /// Exact current Policy revision.
+    pub policy_revision: Revision,
+    /// Exact Scope identity.
+    pub scope_id: ResourceId,
+    /// Exact current Scope revision.
+    pub scope_revision: Revision,
+}
+
+/// Update one existing Binding and request Apply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateBindingParams {
+    /// Existing Binding identity.
+    pub binding_id: ResourceId,
+    /// Exact Policy identity.
+    pub policy_id: ResourceId,
+    /// Exact current Policy revision.
+    pub policy_revision: Revision,
+    /// Exact Scope identity.
+    pub scope_id: ResourceId,
+    /// Exact current Scope revision.
+    pub scope_revision: Revision,
+}
+
+fn deserialize_authored_selector<'de, D>(deserializer: D) -> Result<ScopeSelector, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let selector = ScopeSelector::deserialize(deserializer)?;
+    validate_authored_selector(&selector).map_err(serde::de::Error::custom)?;
+    Ok(selector)
+}
+
+fn serialize_authored_selector<S>(
+    selector: &ScopeSelector,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    validate_authored_selector(selector).map_err(serde::ser::Error::custom)?;
+    selector.serialize(serializer)
+}
+
+fn validate_authored_selector(selector: &ScopeSelector) -> Result<(), String> {
+    if matches!(selector, ScopeSelector::LegacyExecutionDomain { .. }) {
+        return Err("legacy execution-domain selectors cannot be authored".to_owned());
+    }
+    selector
+        .validate()
+        .map_err(|error| format!("invalid selector at {}: {}", error.path, error.message))
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
@@ -1,0 +1,189 @@
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// Stable daemon-generated response correlation identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RequestId(String);
+
+impl RequestId {
+    /// Creates a non-empty opaque request identity.
+    ///
+    /// # Errors
+    /// Returns an error for an empty or whitespace-only identity.
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Err("request ID must be a non-empty string")
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the wire value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+/// Open, bounded, machine-readable daemon error code.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ErrorCode(String);
+
+impl ErrorCode {
+    /// Creates one lower-snake-case error code of at most 64 bytes.
+    ///
+    /// # Errors
+    /// Returns an error when the code is not in canonical form.
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        let mut bytes = value.bytes();
+        if value.len() > 64
+            || !matches!(bytes.next(), Some(b'a'..=b'z'))
+            || !bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            Err("error code must be a bounded lower_snake_case identifier")
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the canonical wire value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+/// Stable safe error returned by the daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DaemonError {
+    /// Machine-readable category.
+    pub code: ErrorCode,
+    /// Sanitized operator-facing explanation.
+    pub message: String,
+}
+
+impl DaemonError {
+    /// Creates an error from a registered code and safe message.
+    ///
+    /// # Panics
+    /// Panics when a programmer supplies a noncanonical code.
+    pub fn new(code: &str, message: &str) -> Self {
+        Self {
+            code: ErrorCode::new(code).expect("daemon error constants must be canonical"),
+            message: message.to_owned(),
+        }
+    }
+}
+
+/// Successful first-version response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SuccessResponse<T> {
+    /// Daemon-generated correlation identity.
+    pub request_id: RequestId,
+    /// Exact method result.
+    pub result: T,
+}
+
+/// Failed first-version response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ErrorResponse {
+    /// Daemon-generated correlation identity.
+    pub request_id: RequestId,
+    /// Stable structured failure.
+    pub error: DaemonError,
+}
+
+/// Mutually exclusive `{requestId,result}` or `{requestId,error}` response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DaemonResponse<T = Value> {
+    /// Successful application dispatch.
+    Success(SuccessResponse<T>),
+    /// Request, authorization, or application failure.
+    Error(ErrorResponse),
+}
+
+impl<T> DaemonResponse<T> {
+    /// Creates a successful response.
+    pub fn success(request_id: RequestId, result: T) -> Self {
+        Self::Success(SuccessResponse { request_id, result })
+    }
+
+    /// Creates a failed response.
+    pub fn error(request_id: RequestId, code: &str, message: &str) -> Self {
+        Self::Error(ErrorResponse {
+            request_id,
+            error: DaemonError::new(code, message),
+        })
+    }
+
+    /// Returns the daemon-generated request identity.
+    pub fn request_id(&self) -> &RequestId {
+        match self {
+            Self::Success(response) => &response.request_id,
+            Self::Error(response) => &response.request_id,
+        }
+    }
+}
+
+/// Stable daemon error-code registry.
+pub mod error_code {
+    /// Malformed request envelope or method params.
+    pub const INVALID_REQUEST: &str = "invalid_request";
+    /// Successfully decoded method input failed application domain validation.
+    pub const INVALID_ARGUMENT: &str = "invalid_argument";
+    /// Method is not registered.
+    pub const UNKNOWN_METHOD: &str = "unknown_method";
+    /// Principal lacks authority.
+    pub const PERMISSION_DENIED: &str = "permission_denied";
+    /// Requested current record does not exist.
+    pub const NOT_FOUND: &str = "not_found";
+    /// Current state conflicts with the request.
+    pub const CONFLICT: &str = "conflict";
+    /// A bounded server resource is exhausted.
+    pub const RESOURCE_EXHAUSTED: &str = "resource_exhausted";
+    /// Service-owned deadline expired.
+    pub const DEADLINE_EXCEEDED: &str = "deadline_exceeded";
+    /// Service is temporarily unavailable.
+    pub const UNAVAILABLE: &str = "unavailable";
+    /// Internal failure with details withheld.
+    pub const INTERNAL: &str = "internal";
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
@@ -4,6 +4,11 @@ use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
+/// Maximum encoded UTF-8 bytes in a public daemon error message.
+pub const MAX_DAEMON_ERROR_MESSAGE_BYTES: usize = 256;
+
+const ERROR_MESSAGE_SUFFIX: &str = "...";
+
 /// Stable daemon-generated response correlation identity.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
@@ -95,7 +100,8 @@ pub struct DaemonError {
     /// Machine-readable category.
     pub code: ErrorCode,
     /// Sanitized operator-facing explanation.
-    pub message: String,
+    #[serde(deserialize_with = "deserialize_error_message")]
+    message: String,
 }
 
 impl DaemonError {
@@ -106,8 +112,39 @@ impl DaemonError {
     pub fn new(code: &str, message: &str) -> Self {
         Self {
             code: ErrorCode::new(code).expect("daemon error constants must be canonical"),
-            message: message.to_owned(),
+            message: bounded_error_message(message),
         }
+    }
+
+    /// Returns the bounded public explanation.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+fn bounded_error_message(message: &str) -> String {
+    if message.len() <= MAX_DAEMON_ERROR_MESSAGE_BYTES {
+        return message.to_owned();
+    }
+
+    let mut end = MAX_DAEMON_ERROR_MESSAGE_BYTES - ERROR_MESSAGE_SUFFIX.len();
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{ERROR_MESSAGE_SUFFIX}", &message[..end])
+}
+
+fn deserialize_error_message<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let message = String::deserialize(deserializer)?;
+    if message.len() > MAX_DAEMON_ERROR_MESSAGE_BYTES {
+        Err(D::Error::custom(
+            "daemon error message must not exceed 256 bytes",
+        ))
+    } else {
+        Ok(message)
     }
 }
 

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/daemon-responses.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/daemon-responses.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "success",
+    "response": {
+      "requestId": "request-1",
+      "result": {"policyId": "policy-1"}
+    }
+  },
+  {
+    "name": "error",
+    "response": {
+      "requestId": "request-2",
+      "error": {
+        "code": "not_found",
+        "message": "requested policy resource was not found"
+      }
+    }
+  }
+]

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json
@@ -1,0 +1,558 @@
+{
+  "schemaVersion": 1,
+  "dynamicValues": {
+    "request_id": "a fresh UUID returned by the daemon for each response",
+    "policy_id": "the UUID returned by create Policy and reused by later steps",
+    "scope_id": "the UUID returned by create Scope and reused by later steps",
+    "binding_id": "the UUID returned by create Binding and reused by later steps"
+  },
+  "objects": {
+    "policyV1": {
+      "policyId": "${policy_id}",
+      "policyName": "protect-important-files-v1",
+      "revision": 1,
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": [
+          "/workspace/important/**",
+          "/etc/agent/config.yaml"
+        ]
+      },
+      "canonicalPolicy": {
+        "irSchemaVersion": 1,
+        "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+        "policyId": "${policy_id}",
+        "revision": 1,
+        "payload": {
+          "resources": [
+            {
+              "id": "protected-file-entries",
+              "kind": "file",
+              "matchers": [
+                {
+                  "path": {
+                    "type": "glob",
+                    "pattern": "/workspace/important/**"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                },
+                {
+                  "path": {
+                    "type": "exact",
+                    "path": "/etc/agent/config.yaml"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "id": "deny-protected-file-deletion",
+              "when": {
+                "type": "atom",
+                "atom": {
+                  "type": "resource_operation",
+                  "operation": "delete",
+                  "target": {
+                    "type": "in",
+                    "resourceSet": "protected-file-entries"
+                  }
+                }
+              },
+              "outcome": {
+                "decision": "deny",
+                "obligations": [
+                  "audit",
+                  "emit_receipt"
+                ],
+                "remediation": "none"
+              },
+              "enforcement": {
+                "decisionTiming": "pre_effect",
+                "requiredEvidence": [
+                  "binding_ready",
+                  "operation_denied"
+                ]
+              }
+            }
+          ],
+          "activation": "post_attach_allowed",
+          "failurePolicy": {
+            "runtime": "fail_closed",
+            "update": "keep_last_known_good"
+          }
+        }
+      },
+      "templateDigest": "sha256:415ea26707c498ed9595534845f579c51da046b635f6048d0cd9058b69d76a5b"
+    },
+    "policyV2": {
+      "policyId": "${policy_id}",
+      "policyName": "protect-important-files-v2",
+      "revision": 2,
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": [
+          "/srv/data"
+        ]
+      },
+      "canonicalPolicy": {
+        "irSchemaVersion": 1,
+        "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+        "policyId": "${policy_id}",
+        "revision": 2,
+        "payload": {
+          "resources": [
+            {
+              "id": "protected-file-entries",
+              "kind": "file",
+              "matchers": [
+                {
+                  "path": {
+                    "type": "exact",
+                    "path": "/srv/data"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "id": "deny-protected-file-deletion",
+              "when": {
+                "type": "atom",
+                "atom": {
+                  "type": "resource_operation",
+                  "operation": "delete",
+                  "target": {
+                    "type": "in",
+                    "resourceSet": "protected-file-entries"
+                  }
+                }
+              },
+              "outcome": {
+                "decision": "deny",
+                "obligations": [
+                  "audit",
+                  "emit_receipt"
+                ],
+                "remediation": "none"
+              },
+              "enforcement": {
+                "decisionTiming": "pre_effect",
+                "requiredEvidence": [
+                  "binding_ready",
+                  "operation_denied"
+                ]
+              }
+            }
+          ],
+          "activation": "post_attach_allowed",
+          "failurePolicy": {
+            "runtime": "fail_closed",
+            "update": "keep_last_known_good"
+          }
+        }
+      },
+      "templateDigest": "sha256:55de4b6bd96b575ec1a0fc943ad83a419a5747494c6a17d13ac125cb0f92bade"
+    },
+    "scopeV1": {
+      "scopeId": "${scope_id}",
+      "revision": 1,
+      "selector": {
+        "kind": "pid",
+        "pid": 4242
+      },
+      "template": {
+        "kind": "execution_domain",
+        "processMembership": "root_and_future_members",
+        "preserveAcrossExec": true,
+        "nestedExecutionDomains": "inherit",
+        "namespaceChange": "deny",
+        "lifetime": {
+          "activateAt": "binding_ready",
+          "expiresAt": null,
+          "endCondition": "execution_domain_drained"
+        }
+      },
+      "templateDigest": "sha256:3b92f8f65b2b55b387f3e527cf28c881906f3c2f63c41c9faa60469ad3947957"
+    },
+    "scopeV2": {
+      "scopeId": "${scope_id}",
+      "revision": 2,
+      "selector": {
+        "kind": "cgroup_id",
+        "cgroupId": 99
+      },
+      "template": {
+        "kind": "execution_domain",
+        "processMembership": "root_and_future_members",
+        "preserveAcrossExec": true,
+        "nestedExecutionDomains": "inherit",
+        "namespaceChange": "deny",
+        "lifetime": {
+          "activateAt": "binding_ready",
+          "expiresAt": null,
+          "endCondition": "execution_domain_drained"
+        }
+      },
+      "templateDigest": "sha256:ab6538c729550b2d86359c2de8d0788e85d167272fb469c5267a06024b8b22db"
+    },
+    "bindingV1": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 1,
+        "policy": {
+          "$ref": "policyV1"
+        },
+        "scope": {
+          "$ref": "scopeV1"
+        }
+      },
+      "status": "PENDING_APPLY"
+    },
+    "bindingV2": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 2,
+        "policy": {
+          "$ref": "policyV2"
+        },
+        "scope": {
+          "$ref": "scopeV2"
+        }
+      },
+      "status": "PENDING_APPLY"
+    },
+    "bindingV3": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 3,
+        "policy": {
+          "$ref": "policyV2"
+        },
+        "scope": {
+          "$ref": "scopeV2"
+        }
+      },
+      "status": "PENDING_DELETE"
+    }
+  },
+  "steps": [
+    {
+      "name": "create-policy",
+      "request": {
+        "method": "policy.templates.create",
+        "params": {
+          "policyName": "protect-important-files-v1",
+          "template": {
+            "kind": "prevent_file_deletion",
+            "files": [
+              "/workspace/important/**",
+              "/etc/agent/config.yaml"
+            ]
+          }
+        }
+      },
+      "captures": [
+        {
+          "name": "policy_id",
+          "pointer": "/result/policyId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV1"
+        }
+      }
+    },
+    {
+      "name": "create-scope",
+      "request": {
+        "method": "policy.scopes.create",
+        "params": {
+          "selector": {
+            "kind": "pid",
+            "pid": 4242
+          }
+        }
+      },
+      "captures": [
+        {
+          "name": "scope_id",
+          "pointer": "/result/scopeId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV1"
+        }
+      }
+    },
+    {
+      "name": "create-binding",
+      "request": {
+        "method": "policy.bindings.create",
+        "params": {
+          "policyId": "${policy_id}",
+          "policyRevision": 1,
+          "scopeId": "${scope_id}",
+          "scopeRevision": 1
+        }
+      },
+      "captures": [
+        {
+          "name": "binding_id",
+          "pointer": "/result/spec/bindingId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV1"
+        }
+      }
+    },
+    {
+      "name": "update-policy",
+      "request": {
+        "method": "policy.templates.update",
+        "params": {
+          "policyId": "${policy_id}",
+          "policyName": "protect-important-files-v2",
+          "template": {
+            "kind": "prevent_file_deletion",
+            "files": [
+              "/srv/data"
+            ]
+          }
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "update-scope",
+      "request": {
+        "method": "policy.scopes.update",
+        "params": {
+          "scopeId": "${scope_id}",
+          "selector": {
+            "kind": "cgroup_id",
+            "cgroupId": 99
+          }
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    },
+    {
+      "name": "update-binding",
+      "request": {
+        "method": "policy.bindings.update",
+        "params": {
+          "bindingId": "${binding_id}",
+          "policyId": "${policy_id}",
+          "policyRevision": 2,
+          "scopeId": "${scope_id}",
+          "scopeRevision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV2"
+        }
+      }
+    },
+    {
+      "name": "get-policy",
+      "request": {
+        "method": "policy.templates.get",
+        "params": {
+          "id": "${policy_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "list-policies",
+      "request": {
+        "method": "policy.templates.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "policyV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "get-scope",
+      "request": {
+        "method": "policy.scopes.get",
+        "params": {
+          "id": "${scope_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    },
+    {
+      "name": "list-scopes",
+      "request": {
+        "method": "policy.scopes.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "scopeV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "get-binding",
+      "request": {
+        "method": "policy.bindings.get",
+        "params": {
+          "id": "${binding_id}"
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV2"
+        }
+      }
+    },
+    {
+      "name": "list-bindings",
+      "request": {
+        "method": "policy.bindings.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "bindingV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "delete-binding",
+      "request": {
+        "method": "policy.bindings.delete",
+        "params": {
+          "id": "${binding_id}"
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV3"
+        }
+      }
+    },
+    {
+      "name": "delete-policy",
+      "request": {
+        "method": "policy.templates.delete",
+        "params": {
+          "id": "${policy_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "delete-scope",
+      "request": {
+        "method": "policy.scopes.delete",
+        "params": {
+          "id": "${scope_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    }
+  ]
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "cases": [
+    {
+      "name": "zero pagination limit",
+      "request": {
+        "method": "policy.templates.list",
+        "params": {
+          "limit": 0,
+          "offset": 0
+        }
+      },
+      "expectedError": {
+        "code": "invalid_request",
+        "message": "limit must be between 1 and 1000"
+      }
+    },
+    {
+      "name": "zero authored PID",
+      "request": {
+        "method": "policy.scopes.create",
+        "params": {
+          "selector": {
+            "kind": "pid",
+            "pid": 0
+          }
+        }
+      },
+      "expectedError": {
+        "code": "invalid_request",
+        "message": "invalid selector at pid: must be positive"
+      }
+    }
+  ]
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
@@ -1,35 +1,398 @@
 {
   "schemaVersion": 1,
+  "generatedValues": {
+    "resource_id_129": "129 ASCII identifier bytes",
+    "policy_name_257": "257 policy-name bytes",
+    "path_4097": "4097 absolute-path bytes"
+  },
+  "dynamicValues": {
+    "existing_policy_id": "the UUID returned by the fixture setup Policy"
+  },
   "cases": [
     {
-      "name": "zero pagination limit",
-      "request": {
-        "method": "policy.templates.list",
-        "params": {
-          "limit": 0,
-          "offset": 0
-        }
-      },
-      "expectedError": {
-        "code": "invalid_request",
-        "message": "limit must be between 1 and 1000"
-      }
+      "name": "create policy with an empty policy name",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must contain a visible character"}
     },
     {
-      "name": "zero authored PID",
-      "request": {
-        "method": "policy.scopes.create",
-        "params": {
-          "selector": {
-            "kind": "pid",
-            "pid": 0
-          }
-        }
-      },
-      "expectedError": {
-        "code": "invalid_request",
-        "message": "invalid selector at pid: must be positive"
-      }
+      "name": "update policy with a whitespace-only policy name",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "   ", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must contain a visible character"}
+    },
+    {
+      "name": "create policy with an oversized policy name",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "${policy_name_257}", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must not exceed 256 bytes"}
+    },
+    {
+      "name": "update policy with a control character in its name",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid\nname", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must not contain control characters"}
+    },
+    {
+      "name": "create policy template without a kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `kind`"}
+    },
+    {
+      "name": "create policy template with an unknown kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "unknown", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected one of `high_sensitivity_read_deny`, `prevent_file_deletion`, `low_sensitivity_egress`"}
+    },
+    {
+      "name": "create deletion policy without files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `files`"}
+    },
+    {
+      "name": "create deletion policy with non-array files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": "/valid"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"/valid\", expected a sequence"}
+    },
+    {
+      "name": "update deletion policy with a non-string file",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "missing-policy", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": [1]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create deletion policy with an unknown template field",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/valid"], "unexpected": true}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `files`"}
+    },
+    {
+      "name": "create unsupported high-sensitivity policy",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "unsupported", "template": {"kind": "high_sensitivity_read_deny", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.kind: the current compiler supports only prevent_file_deletion"}
+    },
+    {
+      "name": "update to an unsupported low-sensitivity policy",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "unsupported", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.kind: the current compiler supports only prevent_file_deletion"}
+    },
+    {
+      "name": "create low-sensitivity policy without trusted destinations",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `trustedDestinations`"}
+    },
+    {
+      "name": "create low-sensitivity policy with an unknown destination kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "unknown", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected `host` or `cidr`"}
+    },
+    {
+      "name": "create low-sensitivity policy with an overflowing port",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [65536]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `65536`, expected u16"}
+    },
+    {
+      "name": "create low-sensitivity policy with a non-object destination",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [1]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected internally tagged enum TrustedDestination"}
+    },
+    {
+      "name": "create host destination with a non-string pattern",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": 1, "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create host destination with non-array ports",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": "443"}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"443\", expected a sequence"}
+    },
+    {
+      "name": "create host destination with a non-numeric port",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": ["443"]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"443\", expected u16"}
+    },
+    {
+      "name": "create CIDR destination with a non-string CIDR",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "cidr", "cidr": 1, "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create deletion policy with no files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": []}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files: must not be empty"}
+    },
+    {
+      "name": "create deletion policy with an empty path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": [""]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "update deletion policy with a relative path",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["relative/path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with a NUL path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid\u0000path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with home expansion",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/home/~/invalid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "update deletion policy with environment expansion",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/$INVALID"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with an oversized path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["${path_4097}"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path exceeds 4096 bytes"}
+    },
+    {
+      "name": "update deletion policy with a trailing separator",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must not have a trailing separator"}
+    },
+    {
+      "name": "create deletion policy with repeated separators",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid//path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains repeated separators"}
+    },
+    {
+      "name": "create deletion policy with a dot segment",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/./path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains a dot segment"}
+    },
+    {
+      "name": "update deletion policy with a parent segment",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/../path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains a dot segment"}
+    },
+    {
+      "name": "create deletion policy with unsupported glob syntax",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/[ab]*"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: glob supports only *, ?, and whole-segment **"}
+    },
+    {
+      "name": "update deletion policy with embedded double star",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/pre**post"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: ** must occupy a complete path segment"}
+    },
+    {
+      "name": "create deletion policy with a duplicate matcher",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/duplicate", "/duplicate"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[1]: duplicate matcher"}
+    },
+    {
+      "name": "create policy template with a non-string kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": 1, "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected variant identifier"}
+    },
+    {
+      "name": "create low-sensitivity policy with non-array destinations",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": {}}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: map, expected a sequence"}
+    },
+    {
+      "name": "create host destination without a pattern",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `pattern`"}
+    },
+    {
+      "name": "create host destination without ports",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com"}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `ports`"}
+    },
+    {
+      "name": "create CIDR destination without CIDR",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "cidr", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `cidr`"}
+    },
+    {
+      "name": "create host destination with an unknown field",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [443], "unexpected": true}]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `pattern` or `ports`"}
+    },
+    {
+      "name": "create scope selector without kind",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `kind`"}
+    },
+    {
+      "name": "update scope with an unknown selector kind",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "unknown", "pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected one of `pid`, `cgroup_id`, `legacy_execution_domain`"}
+    },
+    {
+      "name": "create PID scope without a PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `pid`"}
+    },
+    {
+      "name": "update cgroup scope without a cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `cgroupId`"}
+    },
+    {
+      "name": "create PID scope with an unknown field",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1, "unexpected": true}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `pid`"}
+    },
+    {
+      "name": "create scope with zero PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 0}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid selector at pid: must be positive"}
+    },
+    {
+      "name": "update scope with zero cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 0}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid selector at cgroupId: must be positive"}
+    },
+    {
+      "name": "create scope with a negative PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": -1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u32"}
+    },
+    {
+      "name": "create scope with an overflowing PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 4294967296}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `4294967296`, expected u32"}
+    },
+    {
+      "name": "create scope with a fractional PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1.5}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.5`, expected u32"}
+    },
+    {
+      "name": "create scope with a string PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": "one"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"one\", expected u32"}
+    },
+    {
+      "name": "create scope with a null PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": null}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: null, expected u32"}
+    },
+    {
+      "name": "create PID scope with a cgroup field",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1, "cgroupId": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `cgroupId`, expected `pid`"}
+    },
+    {
+      "name": "update cgroup scope with a PID field",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 1, "pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `pid`, expected `cgroupId`"}
+    },
+    {
+      "name": "update scope with a negative cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": -1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u64"}
+    },
+    {
+      "name": "update scope with an overflowing cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 18446744073709551616}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.8446744073709552e+19`, expected u64"}
+    },
+    {
+      "name": "update scope with a fractional cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 1.5}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.5`, expected u64"}
+    },
+    {
+      "name": "update scope with a string cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": "one"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"one\", expected u64"}
+    },
+    {
+      "name": "update scope with a null cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": null}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: null, expected u64"}
+    },
+    {
+      "name": "create scope with a legacy selector",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain", "executionDomainId": "legacy-domain"}}},
+      "expectedError": {"code": "invalid_request", "message": "legacy execution-domain selectors cannot be authored"}
+    },
+    {
+      "name": "create legacy scope without an execution-domain ID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `executionDomainId`"}
+    },
+    {
+      "name": "create legacy scope with a non-string execution-domain ID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain", "executionDomainId": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "update scope with an invalid legacy selector ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "legacy_execution_domain", "executionDomainId": "invalid/id"}}},
+      "expectedError": {"code": "invalid_request", "message": "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'"}
+    },
+    {
+      "name": "update a missing policy",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "missing-policy", "policyName": "valid", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "not_found", "message": "policy was not found"}
+    },
+    {
+      "name": "get a missing policy revision",
+      "request": {"method": "policy.templates.get", "params": {"id": "missing-policy", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "policy revision was not found"}
+    },
+    {
+      "name": "delete a missing policy revision",
+      "request": {"method": "policy.templates.delete", "params": {"id": "missing-policy", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "policy revision was not found"}
+    },
+    {
+      "name": "update a missing scope",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "pid", "pid": 1}}},
+      "expectedError": {"code": "not_found", "message": "scope was not found"}
+    },
+    {
+      "name": "get a missing scope revision",
+      "request": {"method": "policy.scopes.get", "params": {"id": "missing-scope", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "scope revision was not found"}
+    },
+    {
+      "name": "delete a missing scope revision",
+      "request": {"method": "policy.scopes.delete", "params": {"id": "missing-scope", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "scope revision was not found"}
+    },
+    {
+      "name": "create binding with a missing policy revision",
+      "request": {"method": "policy.bindings.create", "params": {"policyId": "missing-policy", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "referenced policy revision was not found"}
+    },
+    {
+      "name": "create binding with a missing scope revision",
+      "request": {"method": "policy.bindings.create", "params": {"policyId": "${existing_policy_id}", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "referenced scope revision was not found"}
+    },
+    {
+      "name": "update a missing binding",
+      "request": {"method": "policy.bindings.update", "params": {"bindingId": "missing-binding", "policyId": "missing-policy", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "get a missing binding",
+      "request": {"method": "policy.bindings.get", "params": {"id": "missing-binding"}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "delete a missing binding",
+      "request": {"method": "policy.bindings.delete", "params": {"id": "missing-binding"}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "list policies with zero limit",
+      "request": {"method": "policy.templates.list", "params": {"limit": 0, "offset": 0}},
+      "expectedError": {"code": "invalid_request", "message": "limit must be between 1 and 1000"}
+    },
+    {
+      "name": "list scopes above the maximum limit",
+      "request": {"method": "policy.scopes.list", "params": {"limit": 1001, "offset": 0}},
+      "expectedError": {"code": "invalid_request", "message": "limit must be between 1 and 1000"}
+    },
+    {
+      "name": "list bindings with a negative offset",
+      "request": {"method": "policy.bindings.list", "params": {"limit": 1, "offset": -1}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u32"}
     }
   ]
 }

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json
@@ -1,0 +1,146 @@
+[
+  {
+    "method": "policy.templates.create",
+    "params": {
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "canonicalParams": {
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.update",
+    "params": {
+      "policyId": "policy-1",
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "canonicalParams": {
+      "policyId": "policy-1",
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.get",
+    "params": {"id": "policy-1", "revision": 1},
+    "canonicalParams": {"id": "policy-1", "revision": 1},
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.list",
+    "params": {},
+    "canonicalParams": {"limit": 100, "offset": 0},
+    "resultType": "ListResult<PreparedPolicy>"
+  },
+  {
+    "method": "policy.templates.delete",
+    "params": {"id": "policy-1", "revision": 1},
+    "canonicalParams": {"id": "policy-1", "revision": 1},
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.scopes.create",
+    "params": {"selector": {"kind": "pid", "pid": 4242}},
+    "canonicalParams": {"selector": {"kind": "pid", "pid": 4242}},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.update",
+    "params": {
+      "scopeId": "scope-1",
+      "selector": {"kind": "cgroup_id", "cgroupId": 99}
+    },
+    "canonicalParams": {
+      "scopeId": "scope-1",
+      "selector": {"kind": "cgroup_id", "cgroupId": 99}
+    },
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.get",
+    "params": {"id": "scope-1", "revision": 1},
+    "canonicalParams": {"id": "scope-1", "revision": 1},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.list",
+    "params": {"limit": 25, "offset": 50},
+    "canonicalParams": {"limit": 25, "offset": 50},
+    "resultType": "ListResult<PreparedScope>"
+  },
+  {
+    "method": "policy.scopes.delete",
+    "params": {"id": "scope-1", "revision": 1},
+    "canonicalParams": {"id": "scope-1", "revision": 1},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.bindings.create",
+    "params": {
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 1
+    },
+    "canonicalParams": {
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 1
+    },
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.update",
+    "params": {
+      "bindingId": "binding-1",
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 2
+    },
+    "canonicalParams": {
+      "bindingId": "binding-1",
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 2
+    },
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.get",
+    "params": {"id": "binding-1"},
+    "canonicalParams": {"id": "binding-1"},
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.list",
+    "params": {"limit": 10, "offset": 20},
+    "canonicalParams": {"limit": 10, "offset": 20},
+    "resultType": "ListResult<BindingView>"
+  },
+  {
+    "method": "policy.bindings.delete",
+    "params": {"id": "binding-1"},
+    "canonicalParams": {"id": "binding-1"},
+    "resultType": "BindingView"
+  }
+]

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
@@ -152,6 +152,12 @@ fn request_and_response_envelopes_are_strict_and_mutually_exclusive() {
     ] {
         assert!(serde_json::from_value::<DaemonRequest>(invalid).is_err());
     }
+    for invalid in [
+        r#"{"method":"policy.templates.list","params":{"limit":1,"limit":2}}"#,
+        r#"{"method":"policy.templates.create","params":{"policyName":"invalid","template":{"kind":"prevent_file_deletion","files":["/a"],"files":["/b"]}}}"#,
+    ] {
+        assert!(serde_json::from_str::<DaemonRequest>(invalid).is_err());
+    }
 
     let responses: Vec<Value> =
         serde_json::from_str(include_str!("fixtures/daemon-responses.json")).unwrap();
@@ -278,6 +284,64 @@ fn complete_crud_scenario_freezes_every_registered_method_and_domain_result() {
             panic!("CRUD fixture steps must freeze successful responses");
         };
         decode_result(&request.method, &response.result);
+    }
+}
+
+#[test]
+fn invalid_request_fixture_covers_every_registered_crud_method() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("fixtures/pap-invalid-requests.json")).unwrap();
+    assert_eq!(fixture["schemaVersion"], 1);
+    assert_eq!(
+        fixture["generatedValues"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["path_4097", "policy_name_257", "resource_id_129"]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(
+        fixture["dynamicValues"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["existing_policy_id"].into_iter().collect()
+    );
+
+    let cases = fixture["cases"].as_array().unwrap();
+    let names = cases
+        .iter()
+        .map(|case| case["name"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names.len(),
+        cases.len(),
+        "error fixture names must be unique"
+    );
+    assert_eq!(
+        cases
+            .iter()
+            .map(|case| case["request"]["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for case in cases {
+        assert!(case["request"]["params"].is_object());
+        let code = case["expectedError"]["code"].as_str().unwrap();
+        ErrorCode::new(code).unwrap();
+        let message = case["expectedError"]["message"].as_str().unwrap();
+        assert!(!message.is_empty(), "{} has an empty message", case["name"]);
+        assert!(
+            message.len() <= 256,
+            "{} has an unbounded expected message",
+            case["name"]
+        );
     }
 }
 

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
@@ -1,0 +1,407 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use asc_daemon_protocol::method;
+use asc_daemon_protocol::{
+    CreateBindingParams, CreatePolicyParams, CreateScopeParams, DaemonRequest, DaemonResponse,
+    ErrorCode, ListParams, ListResult, RequestId, ResourceParams, RevisionParams,
+    UpdateBindingParams, UpdatePolicyParams, UpdateScopeParams, error_code,
+};
+use asc_foundation_types::ResourceId;
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+use serde_json::{Value, json};
+
+#[test]
+fn every_pap_method_has_frozen_input_and_output_types() {
+    let fixtures = method_fixtures();
+    assert_eq!(fixtures.len(), method::PAP_METHODS.len());
+    assert_eq!(
+        fixtures
+            .iter()
+            .map(|fixture| fixture["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for fixture in fixtures {
+        let method_name = fixture["method"].as_str().unwrap();
+        let params = fixture["params"].clone();
+        let canonical = fixture["canonicalParams"].clone();
+        let (encoded, result_type) = match method_name {
+            method::POLICY_TEMPLATES_CREATE => {
+                (round_trip::<CreatePolicyParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_TEMPLATES_UPDATE => {
+                (round_trip::<UpdatePolicyParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_SCOPES_CREATE => {
+                (round_trip::<CreateScopeParams>(params), "PreparedScope")
+            }
+            method::POLICY_SCOPES_UPDATE => {
+                (round_trip::<UpdateScopeParams>(params), "PreparedScope")
+            }
+            method::POLICY_BINDINGS_CREATE => {
+                (round_trip::<CreateBindingParams>(params), "BindingView")
+            }
+            method::POLICY_BINDINGS_UPDATE => {
+                (round_trip::<UpdateBindingParams>(params), "BindingView")
+            }
+            method::POLICY_TEMPLATES_GET | method::POLICY_TEMPLATES_DELETE => {
+                (round_trip::<RevisionParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_SCOPES_GET | method::POLICY_SCOPES_DELETE => {
+                (round_trip::<RevisionParams>(params), "PreparedScope")
+            }
+            method::POLICY_BINDINGS_GET | method::POLICY_BINDINGS_DELETE => {
+                (round_trip::<ResourceParams>(params), "BindingView")
+            }
+            method::POLICY_TEMPLATES_LIST => (
+                round_trip::<ListParams>(params),
+                "ListResult<PreparedPolicy>",
+            ),
+            method::POLICY_SCOPES_LIST => (
+                round_trip::<ListParams>(params),
+                "ListResult<PreparedScope>",
+            ),
+            method::POLICY_BINDINGS_LIST => {
+                (round_trip::<ListParams>(params), "ListResult<BindingView>")
+            }
+            unexpected => panic!("unregistered method fixture {unexpected}"),
+        };
+        assert_eq!(encoded, canonical, "noncanonical params for {method_name}");
+        assert_eq!(
+            fixture["resultType"], result_type,
+            "wrong result for {method_name}"
+        );
+    }
+}
+
+#[test]
+fn method_results_reuse_complete_domain_contracts() {
+    let binding: PreparedBinding = serde_json::from_str(include_str!(
+        "../../../policy/asc-policy-types/tests/fixtures/prepared-binding.json"
+    ))
+    .unwrap();
+    let policy = binding.policy.clone();
+    let scope = binding.scope.clone();
+    let binding = BindingView {
+        spec: binding,
+        status: BindingStatus::PendingApply,
+    };
+
+    round_trip_value::<PreparedPolicy>(&policy);
+    round_trip_value::<PreparedScope>(&scope);
+    round_trip_value::<BindingView>(&binding);
+    round_trip_value(&ListResult {
+        items: vec![policy],
+        total: 1,
+    });
+    round_trip_value(&ListResult {
+        items: vec![scope],
+        total: 1,
+    });
+    round_trip_value(&ListResult {
+        items: vec![binding],
+        total: 1,
+    });
+}
+
+#[test]
+fn authored_params_reject_server_owned_or_legacy_fields() {
+    let mut policy = json!({
+        "policyName": "protect-important-files",
+        "template": {"kind": "prevent_file_deletion", "files": ["/important"]}
+    });
+    policy["revision"] = json!(1);
+    assert!(serde_json::from_value::<CreatePolicyParams>(policy).is_err());
+
+    for selector in [
+        json!({"kind": "pid", "pid": 0}),
+        json!({"kind": "cgroup_id", "cgroupId": 0}),
+        json!({
+            "kind": "legacy_execution_domain",
+            "executionDomainId": "legacy-domain"
+        }),
+    ] {
+        assert!(
+            serde_json::from_value::<CreateScopeParams>(json!({"selector": selector})).is_err()
+        );
+    }
+
+    let invalid_outbound = CreateScopeParams {
+        selector: ScopeSelector::LegacyExecutionDomain {
+            execution_domain_id: ResourceId::new("legacy-domain").unwrap(),
+        },
+    };
+    assert!(serde_json::to_value(invalid_outbound).is_err());
+}
+
+#[test]
+fn request_and_response_envelopes_are_strict_and_mutually_exclusive() {
+    let request: DaemonRequest = serde_json::from_value(json!({
+        "method": method::POLICY_TEMPLATES_LIST
+    }))
+    .unwrap();
+    assert_eq!(request.params, json!({}));
+
+    for invalid in [
+        json!({"method": "", "params": {}}),
+        json!({"method": method::POLICY_TEMPLATES_LIST, "params": null}),
+        json!({"method": method::POLICY_TEMPLATES_LIST, "params": {}, "callerUid": 1000}),
+    ] {
+        assert!(serde_json::from_value::<DaemonRequest>(invalid).is_err());
+    }
+
+    let responses: Vec<Value> =
+        serde_json::from_str(include_str!("fixtures/daemon-responses.json")).unwrap();
+    for fixture in responses {
+        let wire = fixture["response"].clone();
+        let response: DaemonResponse = serde_json::from_value(wire.clone()).unwrap();
+        assert_eq!(serde_json::to_value(response).unwrap(), wire);
+    }
+    for invalid in [
+        json!({"requestId": "request-1"}),
+        json!({"requestId": "request-1", "result": {}, "error": {"code": "internal", "message": "failed"}}),
+        json!({"requestId": "request-1", "ok": true, "data": {}}),
+        json!({"requestId": " ", "result": {}}),
+    ] {
+        assert!(serde_json::from_value::<DaemonResponse>(invalid).is_err());
+    }
+
+    assert_eq!(
+        DaemonResponse::success(RequestId::new("request-3").unwrap(), json!({}))
+            .request_id()
+            .as_str(),
+        "request-3"
+    );
+    for code in [
+        error_code::INVALID_REQUEST,
+        error_code::INVALID_ARGUMENT,
+        error_code::UNKNOWN_METHOD,
+        error_code::PERMISSION_DENIED,
+        error_code::NOT_FOUND,
+        error_code::CONFLICT,
+        error_code::RESOURCE_EXHAUSTED,
+        error_code::DEADLINE_EXCEEDED,
+        error_code::UNAVAILABLE,
+        error_code::INTERNAL,
+    ] {
+        assert_eq!(ErrorCode::new(code).unwrap().as_str(), code);
+    }
+}
+
+#[test]
+fn identifiers_revisions_and_pagination_are_bounded() {
+    for invalid in [
+        json!({"id": "invalid/id", "revision": 1}),
+        json!({"id": "policy-1", "revision": 0}),
+        json!({"id": "policy-1", "revision": -1}),
+    ] {
+        assert!(serde_json::from_value::<RevisionParams>(invalid).is_err());
+    }
+    assert_eq!(
+        serde_json::from_value::<ListParams>(json!({})).unwrap(),
+        ListParams::default()
+    );
+    for invalid in [
+        json!({"limit": 0}),
+        json!({"limit": 1001}),
+        json!({"limit": 1, "offset": -1}),
+    ] {
+        assert!(serde_json::from_value::<ListParams>(invalid).is_err());
+    }
+}
+
+#[test]
+fn complete_crud_scenario_freezes_every_registered_method_and_domain_result() {
+    let fixture: Value = serde_json::from_str(include_str!("fixtures/pap-crud-e2e.json")).unwrap();
+    assert_eq!(fixture["schemaVersion"], 1);
+
+    let dynamic_values = fixture["dynamicValues"].as_object().unwrap();
+    assert_eq!(
+        dynamic_values
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["binding_id", "policy_id", "request_id", "scope_id"]
+            .into_iter()
+            .collect()
+    );
+
+    let objects = fixture["objects"].as_object().unwrap();
+    let variables = BTreeMap::from([
+        (
+            "request_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000001"),
+        ),
+        (
+            "policy_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000002"),
+        ),
+        (
+            "scope_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000003"),
+        ),
+        (
+            "binding_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000004"),
+        ),
+    ]);
+    let steps = fixture["steps"].as_array().unwrap();
+    assert_eq!(steps.len(), method::PAP_METHODS.len());
+    assert_eq!(
+        steps
+            .iter()
+            .map(|step| step["request"]["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for step in steps {
+        assert!(step["name"].as_str().is_some_and(|name| !name.is_empty()));
+        let request_value = expand_fixture(&step["request"], objects, &variables, 0);
+        let request: DaemonRequest = serde_json::from_value(request_value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&request).unwrap(), request_value);
+        decode_params(&request.method, &request.params);
+
+        for capture in step["captures"].as_array().unwrap() {
+            assert!(dynamic_values.contains_key(capture["name"].as_str().unwrap()));
+            assert_eq!(capture["format"], "uuid");
+            assert!(capture["pointer"].as_str().unwrap().starts_with("/result/"));
+        }
+
+        let response_value = expand_fixture(&step["expectedResponse"], objects, &variables, 0);
+        let response: DaemonResponse = serde_json::from_value(response_value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&response).unwrap(), response_value);
+        let DaemonResponse::Success(response) = response else {
+            panic!("CRUD fixture steps must freeze successful responses");
+        };
+        decode_result(&request.method, &response.result);
+    }
+}
+
+fn method_fixtures() -> Vec<Value> {
+    serde_json::from_str(include_str!("fixtures/pap-methods.json")).unwrap()
+}
+
+fn decode_params(method_name: &str, params: &Value) {
+    match method_name {
+        method::POLICY_TEMPLATES_CREATE => assert_canonical_value::<CreatePolicyParams>(params),
+        method::POLICY_TEMPLATES_UPDATE => assert_canonical_value::<UpdatePolicyParams>(params),
+        method::POLICY_SCOPES_CREATE => assert_canonical_value::<CreateScopeParams>(params),
+        method::POLICY_SCOPES_UPDATE => assert_canonical_value::<UpdateScopeParams>(params),
+        method::POLICY_BINDINGS_CREATE => assert_canonical_value::<CreateBindingParams>(params),
+        method::POLICY_BINDINGS_UPDATE => assert_canonical_value::<UpdateBindingParams>(params),
+        method::POLICY_TEMPLATES_GET
+        | method::POLICY_TEMPLATES_DELETE
+        | method::POLICY_SCOPES_GET
+        | method::POLICY_SCOPES_DELETE => assert_canonical_value::<RevisionParams>(params),
+        method::POLICY_BINDINGS_GET | method::POLICY_BINDINGS_DELETE => {
+            assert_canonical_value::<ResourceParams>(params);
+        }
+        method::POLICY_TEMPLATES_LIST
+        | method::POLICY_SCOPES_LIST
+        | method::POLICY_BINDINGS_LIST => assert_canonical_value::<ListParams>(params),
+        unexpected => panic!("unregistered CRUD fixture method {unexpected}"),
+    }
+}
+
+fn decode_result(method_name: &str, result: &Value) {
+    match method_name {
+        method::POLICY_TEMPLATES_CREATE
+        | method::POLICY_TEMPLATES_UPDATE
+        | method::POLICY_TEMPLATES_GET
+        | method::POLICY_TEMPLATES_DELETE => assert_canonical_value::<PreparedPolicy>(result),
+        method::POLICY_SCOPES_CREATE
+        | method::POLICY_SCOPES_UPDATE
+        | method::POLICY_SCOPES_GET
+        | method::POLICY_SCOPES_DELETE => assert_canonical_value::<PreparedScope>(result),
+        method::POLICY_BINDINGS_CREATE
+        | method::POLICY_BINDINGS_UPDATE
+        | method::POLICY_BINDINGS_GET
+        | method::POLICY_BINDINGS_DELETE => assert_canonical_value::<BindingView>(result),
+        method::POLICY_TEMPLATES_LIST => {
+            assert_canonical_value::<ListResult<PreparedPolicy>>(result);
+        }
+        method::POLICY_SCOPES_LIST => {
+            assert_canonical_value::<ListResult<PreparedScope>>(result);
+        }
+        method::POLICY_BINDINGS_LIST => {
+            assert_canonical_value::<ListResult<BindingView>>(result);
+        }
+        unexpected => panic!("unregistered CRUD fixture method {unexpected}"),
+    }
+}
+
+fn assert_canonical_value<T>(value: &Value)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    assert_eq!(
+        serde_json::to_value(serde_json::from_value::<T>(value.clone()).unwrap()).unwrap(),
+        *value
+    );
+}
+
+fn expand_fixture(
+    value: &Value,
+    objects: &serde_json::Map<String, Value>,
+    variables: &BTreeMap<String, Value>,
+    depth: u8,
+) -> Value {
+    assert!(depth < 32, "fixture reference cycle");
+    match value {
+        Value::Object(fields) if fields.len() == 1 && fields.contains_key("$ref") => {
+            let reference = fields["$ref"].as_str().unwrap();
+            expand_fixture(
+                objects
+                    .get(reference)
+                    .unwrap_or_else(|| panic!("unknown fixture object {reference}")),
+                objects,
+                variables,
+                depth + 1,
+            )
+        }
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        expand_fixture(value, objects, variables, depth + 1),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|value| expand_fixture(value, objects, variables, depth + 1))
+                .collect(),
+        ),
+        Value::String(candidate) if candidate.starts_with("${") && candidate.ends_with('}') => {
+            let name = &candidate[2..candidate.len() - 1];
+            variables
+                .get(name)
+                .unwrap_or_else(|| panic!("unknown fixture variable {name}"))
+                .clone()
+        }
+        _ => value.clone(),
+    }
+}
+
+fn round_trip<T>(value: Value) -> Value
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    serde_json::to_value(serde_json::from_value::<T>(value).unwrap()).unwrap()
+}
+
+fn round_trip_value<T>(value: &T)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + PartialEq + std::fmt::Debug,
+{
+    let encoded = serde_json::to_value(value).unwrap();
+    assert_eq!(serde_json::from_value::<T>(encoded).unwrap(), *value);
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
@@ -198,6 +198,29 @@ fn request_and_response_envelopes_are_strict_and_mutually_exclusive() {
 }
 
 #[test]
+fn daemon_error_messages_are_bounded_at_construction_and_decode() {
+    let response = DaemonResponse::<Value>::error(
+        RequestId::new("request-bounded-error").unwrap(),
+        error_code::INVALID_REQUEST,
+        &"x".repeat(512),
+    );
+    let DaemonResponse::Error(response) = response else {
+        panic!("the error constructor must return an error response");
+    };
+    assert_eq!(response.error.message().len(), 256);
+    assert!(response.error.message().ends_with("..."));
+
+    let oversized_wire = json!({
+        "requestId": "request-oversized-error",
+        "error": {
+            "code": "invalid_request",
+            "message": "x".repeat(257)
+        }
+    });
+    assert!(serde_json::from_value::<DaemonResponse>(oversized_wire).is_err());
+}
+
+#[test]
 fn identifiers_revisions_and_pagination_are_bounded() {
     for invalid in [
         json!({"id": "invalid/id", "revision": 1}),

--- a/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "asc-pap-repository-memory"
+description = "Temporary process-local PAP Repository adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+
+[dev-dependencies]
+asc-policy-engine = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/src/lib.rs
@@ -1,0 +1,359 @@
+//! **TEMPORARY IMPLEMENTATION -- NOT PART OF THE REVIEW SCOPE.**
+//!
+//! This process-local adapter exists only to make the PAP daemon request path
+//! runnable before the durable Repository work package lands. Its internal
+//! implementation is disposable, must not be treated as a production storage
+//! design, and does not require review in the current PAP daemon-handler change.
+//! All state is lost when the daemon restarts.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
+
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::{Page, PapError, PapRepository, PolicyRevisionState, ScopeRevisionState};
+use asc_policy_types::binding::{BindingStatus, BindingView};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::PreparedScope;
+
+/// Process-local PAP Repository used until durable persistence is integrated.
+///
+/// This adapter implements the current-record Repository contract but loses all
+/// state on daemon restart. It is an explicitly replaceable composition-root
+/// dependency, not production persistence evidence.
+#[derive(Debug, Default)]
+pub struct ProcessLocalPapRepository {
+    state: Mutex<State>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    policy_heads: BTreeMap<String, Revision>,
+    policies: BTreeMap<String, PreparedPolicy>,
+    scope_heads: BTreeMap<String, Revision>,
+    scopes: BTreeMap<String, PreparedScope>,
+    bindings: BTreeMap<String, BindingView>,
+}
+
+impl ProcessLocalPapRepository {
+    fn lock(&self) -> Result<MutexGuard<'_, State>, PapError> {
+        self.state.lock().map_err(|_| PapError::Persistence)
+    }
+}
+
+impl PapRepository for ProcessLocalPapRepository {
+    fn put_policy(&self, policy: &PreparedPolicy) -> Result<PreparedPolicy, PapError> {
+        let mut state = self.lock()?;
+        let id = policy.policy_id.as_str().to_owned();
+        if let Some(existing) = state.policies.get(&id)
+            && existing.revision == policy.revision
+        {
+            return if existing == policy {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if !is_next_revision(state.policy_heads.get(&id).copied(), policy.revision) {
+            return Err(PapError::Conflict);
+        }
+        state.policies.insert(id.clone(), policy.clone());
+        state.policy_heads.insert(id, policy.revision);
+        Ok(policy.clone())
+    }
+
+    fn get_policy_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<PolicyRevisionState>, PapError> {
+        let state = self.lock()?;
+        Ok(state
+            .policy_heads
+            .get(id.as_str())
+            .copied()
+            .map(|last_allocated_revision| PolicyRevisionState {
+                last_allocated_revision,
+                current: state.policies.get(id.as_str()).cloned(),
+            }))
+    }
+
+    fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError> {
+        self.lock()?
+            .policies
+            .get(id.as_str())
+            .filter(|policy| policy.revision == revision)
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.policies.values(), limit, offset))
+    }
+
+    fn delete_policy_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        let mut state = self.lock()?;
+        if state
+            .policies
+            .get(id.as_str())
+            .is_none_or(|policy| policy.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state
+            .policies
+            .remove(id.as_str())
+            .ok_or(PapError::Persistence)
+    }
+
+    fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError> {
+        let mut state = self.lock()?;
+        let id = scope.scope_id.as_str().to_owned();
+        if let Some(existing) = state.scopes.get(&id)
+            && existing.revision == scope.revision
+        {
+            return if existing == scope {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if !is_next_revision(state.scope_heads.get(&id).copied(), scope.revision) {
+            return Err(PapError::Conflict);
+        }
+        state.scopes.insert(id.clone(), scope.clone());
+        state.scope_heads.insert(id, scope.revision);
+        Ok(scope.clone())
+    }
+
+    fn get_scope_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<ScopeRevisionState>, PapError> {
+        let state = self.lock()?;
+        Ok(state
+            .scope_heads
+            .get(id.as_str())
+            .copied()
+            .map(|last_allocated_revision| ScopeRevisionState {
+                last_allocated_revision,
+                current: state.scopes.get(id.as_str()).cloned(),
+            }))
+    }
+
+    fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError> {
+        self.lock()?
+            .scopes
+            .get(id.as_str())
+            .filter(|scope| scope.revision == revision)
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.scopes.values(), limit, offset))
+    }
+
+    fn delete_scope_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        let mut state = self.lock()?;
+        if state
+            .scopes
+            .get(id.as_str())
+            .is_none_or(|scope| scope.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state
+            .scopes
+            .remove(id.as_str())
+            .ok_or(PapError::Persistence)
+    }
+
+    fn update_binding(&self, binding: &BindingView) -> Result<BindingView, PapError> {
+        if !matches!(
+            binding.status,
+            BindingStatus::PendingApply | BindingStatus::PendingDelete
+        ) {
+            return Err(PapError::Conflict);
+        }
+
+        let mut state = self.lock()?;
+        let id = binding.spec.binding_id.as_str().to_owned();
+        if let Some(current) = state.bindings.get(&id) {
+            if current == binding {
+                return Ok(current.clone());
+            }
+            if current.status.is_reconciling() {
+                return Err(PapError::OperationInProgress);
+            }
+            if !is_next_revision(
+                Some(current.spec.binding_revision),
+                binding.spec.binding_revision,
+            ) {
+                return Err(PapError::Conflict);
+            }
+        } else if binding.spec.binding_revision.get() != 1
+            || binding.status != BindingStatus::PendingApply
+        {
+            return Err(PapError::Conflict);
+        }
+        state.bindings.insert(id, binding.clone());
+        Ok(binding.clone())
+    }
+
+    fn update_binding_status(
+        &self,
+        id: &ResourceId,
+        binding_revision: Revision,
+        expected_status: BindingStatus,
+        next_status: BindingStatus,
+    ) -> Result<BindingStatus, PapError> {
+        let mut state = self.lock()?;
+        let binding = state
+            .bindings
+            .get_mut(id.as_str())
+            .ok_or(PapError::NotFound)?;
+        if binding.spec.binding_revision != binding_revision || binding.status != expected_status {
+            return Err(PapError::Conflict);
+        }
+        expected_status
+            .validate_successor(next_status)
+            .map_err(|_| PapError::Conflict)?;
+        binding.status = next_status;
+        Ok(next_status)
+    }
+
+    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
+        self.lock()?
+            .bindings
+            .get(id.as_str())
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.bindings.values(), limit, offset))
+    }
+}
+
+fn is_next_revision(current: Option<Revision>, candidate: Revision) -> bool {
+    match current {
+        None => candidate.get() == 1,
+        Some(current) => current.checked_next() == Ok(candidate),
+    }
+}
+
+fn page<'a, T: Clone + 'a>(
+    items: impl ExactSizeIterator<Item = &'a T>,
+    limit: u32,
+    offset: u32,
+) -> Page<T> {
+    let total = u64::try_from(items.len()).unwrap_or(u64::MAX);
+    let offset = usize::try_from(offset).unwrap_or(usize::MAX);
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    Page {
+        items: items.skip(offset).take(limit).cloned().collect(),
+        total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use asc_pap::PapService;
+    use asc_policy_engine::PolicyTemplateCompiler;
+    use asc_policy_types::authoring::PolicyTemplate;
+    use asc_policy_types::binding::BindingStatus;
+    use asc_policy_types::scope::ScopeSelector;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct CloneTracked<'a> {
+        value: u32,
+        clones: &'a AtomicUsize,
+    }
+
+    impl Clone for CloneTracked<'_> {
+        fn clone(&self) -> Self {
+            self.clones.fetch_add(1, Ordering::Relaxed);
+            Self {
+                value: self.value,
+                clones: self.clones,
+            }
+        }
+    }
+
+    #[test]
+    fn pagination_clones_only_the_selected_records() {
+        let clones = AtomicUsize::new(0);
+        let records: Vec<_> = (0..5)
+            .map(|value| CloneTracked {
+                value,
+                clones: &clones,
+            })
+            .collect();
+
+        let selected = page(records.iter(), 2, 2);
+
+        assert_eq!(selected.total, 5);
+        assert_eq!(
+            selected
+                .items
+                .iter()
+                .map(|record| record.value)
+                .collect::<Vec<_>>(),
+            [2, 3]
+        );
+        assert_eq!(clones.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn repository_runs_the_current_pap_request_slice_without_a_reconciler() {
+        let repository = Arc::new(ProcessLocalPapRepository::default());
+        let pap = PapService::new(Arc::clone(&repository), Arc::new(PolicyTemplateCompiler));
+        let policy = pap
+            .create_policy(
+                "protect files",
+                &PolicyTemplate::PreventFileDeletion {
+                    files: vec!["/workspace/important".to_owned()],
+                },
+            )
+            .unwrap();
+        let scope = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+        let binding = pap
+            .create_binding(
+                &policy.policy_id,
+                policy.revision,
+                &scope.scope_id,
+                scope.revision,
+            )
+            .unwrap();
+
+        assert_eq!(binding.status, BindingStatus::PendingApply);
+        assert_eq!(pap.list_policies(10, 0).unwrap().total, 1);
+        assert_eq!(pap.list_scopes(10, 0).unwrap().total, 1);
+        assert_eq!(pap.list_bindings(10, 0).unwrap().items, [binding]);
+        assert_eq!(
+            ProcessLocalPapRepository::default()
+                .list_policies(10, 0)
+                .unwrap()
+                .total,
+            0,
+            "a new process-local Repository intentionally has no prior state"
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
@@ -30,6 +30,12 @@ pub enum PapError {
     /// The requested exact record does not exist.
     #[error("record not found")]
     NotFound,
+    /// A Binding references a Policy revision that is neither current nor in its snapshot.
+    #[error("referenced policy revision not found")]
+    ReferencedPolicyRevisionNotFound,
+    /// A Binding references a Scope revision that is neither current nor in its snapshot.
+    #[error("referenced scope revision not found")]
+    ReferencedScopeRevisionNotFound,
     /// No further positive `u32` revision can be allocated.
     #[error("revision space exhausted")]
     RevisionExhausted,

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
@@ -421,7 +421,7 @@ where
                         && binding.spec.policy.revision == policy_revision
                 })
                 .map(|binding| binding.spec.policy.clone())
-                .ok_or(PapError::NotFound),
+                .ok_or(PapError::ReferencedPolicyRevisionNotFound),
             Err(error) => Err(error),
         }
     }
@@ -440,7 +440,7 @@ where
                         && binding.spec.scope.revision == scope_revision
                 })
                 .map(|binding| binding.spec.scope.clone())
-                .ok_or(PapError::NotFound),
+                .ok_or(PapError::ReferencedScopeRevisionNotFound),
             Err(error) => Err(error),
         }
     }

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
@@ -709,7 +709,7 @@ fn binding_requires_exact_policy_and_scope_revisions() {
             &scope.scope_id,
             scope.revision,
         ),
-        Err(PapError::NotFound)
+        Err(PapError::ReferencedPolicyRevisionNotFound)
     );
     assert_eq!(
         pap.create_binding(
@@ -718,7 +718,7 @@ fn binding_requires_exact_policy_and_scope_revisions() {
             &missing,
             Revision::new(1).unwrap(),
         ),
-        Err(PapError::NotFound)
+        Err(PapError::ReferencedScopeRevisionNotFound)
     );
     assert_eq!(
         pap.update_binding(
@@ -783,7 +783,7 @@ fn existing_binding_can_reuse_embedded_sources_after_current_records_advance() {
             &reapplied.spec.scope.scope_id,
             reapplied.spec.scope.revision,
         ),
-        Err(PapError::NotFound),
+        Err(PapError::ReferencedPolicyRevisionNotFound),
         "a new Binding cannot select source revisions no longer current"
     );
 }

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "asc-policy-engine"
+description = "Product Policy template compiler for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+
+[dev-dependencies]
+asc-foundation-types = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/lib.rs
@@ -1,0 +1,12 @@
+//! Product Policy-template compiler for the frozen Canonical Policy IR profile.
+//!
+//! The first product batch intentionally compiles only
+//! `prevent_file_deletion`. Adding another authored template kind changes the
+//! compiler contract and requires a new golden fixture plus direct Adapter
+//! conformance evidence.
+
+#![forbid(unsafe_code)]
+
+mod template_compiler;
+
+pub use template_compiler::PolicyTemplateCompiler;

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
@@ -1,0 +1,95 @@
+use asc_pap::PolicyCompiler;
+use asc_policy_types::Validate;
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::identifiers::{ProfileId, ResourceSetId, RuleId};
+use asc_policy_types::ir::{
+    ActivationRequirement, CanonicalPolicyIr, DecisionTiming, EvidenceRequirement, Expression,
+    FailurePolicy, Obligation, ResourceOperation, ResourceTarget, RestrictiveDecision,
+    RuleEnforcement, RuleIr, RuleOutcome, RuntimeFailurePolicy, SemanticAtom, SubjectRemediation,
+    UpdateFailurePolicy,
+};
+use asc_policy_types::policy::PolicyEnvelope;
+use asc_policy_types::profile::{IR_SCHEMA_VERSION_V1, PROFILE_V1ALPHA1_DEMO1};
+use asc_policy_types::resource::{
+    FileMatcher, FileResolution, PathMatcher, ResourceSelector, ResourceSet,
+};
+
+/// Deterministic compiler for the currently frozen product Policy subset.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PolicyTemplateCompiler;
+
+impl PolicyCompiler for PolicyTemplateCompiler {
+    fn lower(&self, template: &TemplateEnvelope) -> Result<PolicyEnvelope, ValidationError> {
+        let PolicyTemplate::PreventFileDeletion { files } = &template.template else {
+            return Err(ValidationError::new(
+                "template.kind",
+                "the current compiler supports only prevent_file_deletion",
+            ));
+        };
+        if files.is_empty() {
+            return Err(ValidationError::new("template.files", "must not be empty"));
+        }
+
+        let resource_id = ResourceSetId::new("protected-file-entries")
+            .map_err(|message| ValidationError::new("payload.resources[0].id", message))?;
+        let matchers = files
+            .iter()
+            .map(|path| FileMatcher {
+                path: if path.contains(['*', '?']) {
+                    PathMatcher::Glob {
+                        pattern: path.clone(),
+                    }
+                } else {
+                    PathMatcher::Exact { path: path.clone() }
+                },
+                resolution: FileResolution::PathEntry,
+            })
+            .collect();
+        let policy = PolicyEnvelope {
+            ir_schema_version: IR_SCHEMA_VERSION_V1,
+            profile_id: ProfileId::new(PROFILE_V1ALPHA1_DEMO1)
+                .map_err(|message| ValidationError::new("profileId", message))?,
+            policy_id: template.policy_id.clone(),
+            revision: template.revision,
+            payload_digest: None,
+            payload: CanonicalPolicyIr {
+                resources: vec![ResourceSet {
+                    id: resource_id.clone(),
+                    selector: ResourceSelector::File { matchers },
+                }],
+                rules: vec![RuleIr {
+                    id: RuleId::new("deny-protected-file-deletion")
+                        .map_err(|message| ValidationError::new("payload.rules[0].id", message))?,
+                    when: Expression::Atom {
+                        atom: SemanticAtom::ResourceOperation {
+                            operation: ResourceOperation::Delete,
+                            target: ResourceTarget::In {
+                                resource_set: resource_id,
+                            },
+                        },
+                    },
+                    outcome: RuleOutcome {
+                        decision: RestrictiveDecision::Deny,
+                        obligations: vec![Obligation::Audit, Obligation::EmitReceipt],
+                        remediation: SubjectRemediation::None,
+                    },
+                    enforcement: RuleEnforcement {
+                        decision_timing: DecisionTiming::PreEffect,
+                        required_evidence: vec![
+                            EvidenceRequirement::BindingReady,
+                            EvidenceRequirement::OperationDenied,
+                        ],
+                    },
+                }],
+                activation: ActivationRequirement::PostAttachAllowed,
+                failure_policy: FailurePolicy {
+                    runtime: RuntimeFailurePolicy::FailClosed,
+                    update: UpdateFailurePolicy::KeepLastKnownGood,
+                },
+            },
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use asc_pap::PolicyCompiler;
 use asc_policy_types::Validate;
 use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
@@ -33,19 +35,33 @@ impl PolicyCompiler for PolicyTemplateCompiler {
 
         let resource_id = ResourceSetId::new("protected-file-entries")
             .map_err(|message| ValidationError::new("payload.resources[0].id", message))?;
+        let mut unique_matchers = HashSet::with_capacity(files.len());
         let matchers = files
             .iter()
-            .map(|path| FileMatcher {
-                path: if path.contains(['*', '?']) {
-                    PathMatcher::Glob {
-                        pattern: path.clone(),
-                    }
-                } else {
-                    PathMatcher::Exact { path: path.clone() }
-                },
-                resolution: FileResolution::PathEntry,
+            .enumerate()
+            .map(|(index, path)| {
+                let matcher = FileMatcher {
+                    path: if path.contains(['*', '?']) {
+                        PathMatcher::Glob {
+                            pattern: path.clone(),
+                        }
+                    } else {
+                        PathMatcher::Exact { path: path.clone() }
+                    },
+                    resolution: FileResolution::PathEntry,
+                };
+                matcher.validate().map_err(|error| {
+                    ValidationError::new(format!("template.files[{index}]"), error.message)
+                })?;
+                if !unique_matchers.insert(matcher.clone()) {
+                    return Err(ValidationError::new(
+                        format!("template.files[{index}]"),
+                        "duplicate matcher",
+                    ));
+                }
+                Ok(matcher)
             })
-            .collect();
+            .collect::<Result<Vec<_>, ValidationError>>()?;
         let policy = PolicyEnvelope {
             ir_schema_version: IR_SCHEMA_VERSION_V1,
             profile_id: ProfileId::new(PROFILE_V1ALPHA1_DEMO1)

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
@@ -1,0 +1,43 @@
+use asc_foundation_types::Revision;
+use asc_pap::PolicyCompiler;
+use asc_policy_engine::PolicyTemplateCompiler;
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::identifiers::PolicyId;
+
+#[test]
+fn golden_freezes_the_compiler_input_and_output() {
+    let contract: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/compiler-contract.json")).unwrap();
+    let input: TemplateEnvelope = serde_json::from_value(contract["input"].clone()).unwrap();
+
+    let output = PolicyTemplateCompiler.lower(&input).unwrap();
+
+    assert_eq!(serde_json::to_value(output).unwrap(), contract["output"]);
+}
+
+#[test]
+fn rejects_empty_files_and_unimplemented_template_kinds() {
+    let policy_id = PolicyId::new("unsupported").unwrap();
+    let revision = Revision::new(1).unwrap();
+    let empty = TemplateEnvelope {
+        policy_id: policy_id.clone(),
+        revision,
+        template: PolicyTemplate::PreventFileDeletion { files: Vec::new() },
+    };
+    assert_eq!(
+        PolicyTemplateCompiler.lower(&empty).unwrap_err().path,
+        "template.files"
+    );
+
+    let unsupported = TemplateEnvelope {
+        policy_id,
+        revision,
+        template: PolicyTemplate::HighSensitivityReadDeny {
+            files: vec!["/secret".to_owned()],
+        },
+    };
+    assert_eq!(
+        PolicyTemplateCompiler.lower(&unsupported).unwrap_err().path,
+        "template.kind"
+    );
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
@@ -41,3 +41,31 @@ fn rejects_empty_files_and_unimplemented_template_kinds() {
         "template.kind"
     );
 }
+
+#[test]
+fn validation_errors_point_to_authored_file_entries() {
+    let policy_id = PolicyId::new("invalid-paths").unwrap();
+    let revision = Revision::new(1).unwrap();
+
+    for (files, expected_path, expected_message) in [
+        (
+            vec!["/valid".to_owned(), "/invalid/../path".to_owned()],
+            "template.files[1]",
+            "path contains a dot segment",
+        ),
+        (
+            vec!["/duplicate".to_owned(), "/duplicate".to_owned()],
+            "template.files[1]",
+            "duplicate matcher",
+        ),
+    ] {
+        let input = TemplateEnvelope {
+            policy_id: policy_id.clone(),
+            revision,
+            template: PolicyTemplate::PreventFileDeletion { files },
+        };
+        let error = PolicyTemplateCompiler.lower(&input).unwrap_err();
+        assert_eq!(error.path, expected_path);
+        assert_eq!(error.message, expected_message);
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
@@ -16,6 +16,25 @@ fn golden_freezes_the_compiler_input_and_output() {
 }
 
 #[test]
+fn prevent_file_deletion_is_limited_to_path_entry_deletes() {
+    let contract: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/compiler-contract.json")).unwrap();
+    let input: TemplateEnvelope = serde_json::from_value(contract["input"].clone()).unwrap();
+
+    let output = serde_json::to_value(PolicyTemplateCompiler.lower(&input).unwrap()).unwrap();
+
+    assert_eq!(
+        output["payload"]["resources"][0]["matchers"][0]["resolution"]["type"],
+        "path_entry"
+    );
+    assert_eq!(
+        output["payload"]["rules"][0]["when"]["atom"]["operation"],
+        "delete"
+    );
+    assert_eq!(output["payload"]["rules"].as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn rejects_empty_files_and_unimplemented_template_kinds() {
     let policy_id = PolicyId::new("unsupported").unwrap();
     let revision = Revision::new(1).unwrap();

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json
@@ -1,0 +1,83 @@
+{
+  "input": {
+    "policyId": "prevent-file-deletion",
+    "revision": 1,
+    "template": {
+      "kind": "prevent_file_deletion",
+      "files": [
+        "/workspace/important/**",
+        "/etc/agent/config.yaml"
+      ]
+    }
+  },
+  "output": {
+    "irSchemaVersion": 1,
+    "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+    "policyId": "prevent-file-deletion",
+    "revision": 1,
+    "payload": {
+      "resources": [
+        {
+          "id": "protected-file-entries",
+          "kind": "file",
+          "matchers": [
+            {
+              "path": {
+                "type": "glob",
+                "pattern": "/workspace/important/**"
+              },
+              "resolution": {
+                "type": "path_entry"
+              }
+            },
+            {
+              "path": {
+                "type": "exact",
+                "path": "/etc/agent/config.yaml"
+              },
+              "resolution": {
+                "type": "path_entry"
+              }
+            }
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "id": "deny-protected-file-deletion",
+          "when": {
+            "type": "atom",
+            "atom": {
+              "type": "resource_operation",
+              "operation": "delete",
+              "target": {
+                "type": "in",
+                "resourceSet": "protected-file-entries"
+              }
+            }
+          },
+          "outcome": {
+            "decision": "deny",
+            "obligations": [
+              "audit",
+              "emit_receipt"
+            ],
+            "remediation": "none"
+          },
+          "enforcement": {
+            "decisionTiming": "pre_effect",
+            "requiredEvidence": [
+              "binding_ready",
+              "operation_denied"
+            ]
+          }
+        }
+      ],
+      "activation": "post_attach_allowed",
+      "failurePolicy": {
+        "runtime": "fail_closed",
+        "update": "keep_last_known_good"
+      }
+    }
+  }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/authoring.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-types/src/authoring.rs
@@ -30,7 +30,10 @@ pub enum PolicyTemplate {
         /// Absolute file paths or bounded glob patterns selected by the user.
         files: Vec<String>,
     },
-    /// Protected files must not be removed or renamed out of the namespace.
+    /// Deny deletion operations targeting matched filesystem directory entries.
+    ///
+    /// This template does not cover rename, move, link, content mutation, or
+    /// other namespace-mutation operations.
     PreventFileDeletion {
         /// Absolute file paths or bounded glob patterns selected by the user.
         files: Vec<String>,


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
1. Add all CRUD operations for policy related objects - policy, scope and binding. Register the operations to daemon service.
2. Add identity check for policy related operations. Only root passes the check for now.
3. Add happy path and error path e2e tests
4. Add a temporary in-memory repository for object store.

product code ~ 2000
test code ~4000
document & cargo ~ 400
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
