### PR TITLE
chore(ci): reduce external service failures

### DIFF
--- a/.github/workflows/openclaw-plugin-e2e.yml
+++ b/.github/workflows/openclaw-plugin-e2e.yml
@@ -64,13 +64,49 @@ jobs:
           path: src/agent-sec-core/target/wheels/*.whl
           if-no-files-found: error
 
+  build-openclaw-plugin:
+    name: Build one OpenClaw plugin package
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-22.04' || 'anolisa-k8s-general-ci-x64' }}
+    defaults:
+      run:
+        working-directory: src/agent-sec-core/openclaw-plugin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/agent-sec-core/openclaw-plugin/package-lock.json
+
+      - name: Install plugin dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Build and pack plugin
+        run: |
+          mkdir -p ../target/openclaw-plugin
+          npm run build
+          npm pack --pack-destination ../target/openclaw-plugin
+
+      - name: Upload OpenClaw plugin package
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-sec-openclaw-plugin
+          path: src/agent-sec-core/target/openclaw-plugin/*.tgz
+          if-no-files-found: error
+
   openclaw-plugin-e2e:
     name: OpenClaw ${{ matrix.openclaw.label }} E2E
-    needs: build-agent-sec-cli
+    needs:
+      - build-agent-sec-cli
+      - build-openclaw-plugin
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-22.04' || 'anolisa-k8s-general-ci-x64' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         openclaw:
           - label: "2026.4.14"
@@ -127,16 +163,20 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install jq
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
+      - name: Verify jq
+        run: jq --version
 
       - name: Download agent-sec-cli wheel
         uses: actions/download-artifact@v4
         with:
           name: agent-sec-cli-wheel
           path: src/agent-sec-core/target/wheels
+
+      - name: Download OpenClaw plugin package
+        uses: actions/download-artifact@v4
+        with:
+          name: agent-sec-openclaw-plugin
+          path: src/agent-sec-core/target/openclaw-plugin
 
       # The `latest` entry tracks whatever OpenClaw release is current, so it
       # can break on upstream changes unrelated to this repository. Keep it
@@ -150,6 +190,7 @@ jobs:
           OPENCLAW_MATRIX_LABEL: ${{ matrix.openclaw.label }}
           EXPECT_UNSAFE_INSTALL_FLAG: ${{ matrix.openclaw.expect-unsafe-install }}
           AGENT_SEC_CLI_WHEEL: target/wheels/*.whl
+          OPENCLAW_E2E_PLUGIN_PACKAGE: target/openclaw-plugin/*.tgz
           OPENCLAW_E2E_RESULT_ROOT: target/openclaw-e2e/results
           # The native prompt scanner's standard mode requires an Ollama L2
           # model service that is not available in this CI environment. Use

--- a/.github/workflows/qoder-review.yml
+++ b/.github/workflows/qoder-review.yml
@@ -1,8 +1,6 @@
 name: AI / Qoder Review
 
 on:
-  pull_request_target:
-    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -47,7 +45,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: qoder-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
+  group: qoder-review-${{ github.event.issue.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -55,11 +53,6 @@ jobs:
     name: Check review eligibility
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.draft == false &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
@@ -88,9 +81,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-          EVENT_PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
-          EVENT_PR_DRAFT: ${{ github.event.pull_request.draft || false }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
           INPUT_COMPONENT: ${{ inputs.component || 'auto' }}
           INPUT_REVIEW_SCOPE: ${{ inputs.review_scope || 'auto' }}
@@ -134,18 +124,7 @@ jobs:
             esac
           }
 
-          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
-            pr_number="$EVENT_PR_NUMBER"
-            author="$EVENT_PR_AUTHOR"
-            actor="$TRIGGER_ACTOR"
-            component="auto"
-            review_scope="auto"
-
-            if [[ "$EVENT_PR_DRAFT" == "true" ]]; then
-              deny "draft-pr" "$pr_number" "$component" "$review_scope"
-              exit 0
-            fi
-          elif [[ "$EVENT_NAME" == "issue_comment" ]]; then
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
             pr_number="$(jq -r '.issue.number // ""' "$GITHUB_EVENT_PATH")"
             actor="$(jq -r '.comment.user.login // ""' "$GITHUB_EVENT_PATH")"
             component="auto"
@@ -171,10 +150,8 @@ jobs:
               deny "pr-not-found" "$pr_number" "$component" "$review_scope"
               exit 0
             fi
-            author=""
           elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             pr_number="$INPUT_PR_NUMBER"
-            author=""
             actor="$TRIGGER_ACTOR"
             component="$INPUT_COMPONENT"
             review_scope="${INPUT_REVIEW_SCOPE:-auto}"
@@ -192,14 +169,6 @@ jobs:
           if ! has_write_access "$actor_permission"; then
             deny "actor-${actor}-permission-${actor_permission}" "$pr_number" "$component" "$review_scope"
             exit 0
-          fi
-
-          if [[ -n "$author" ]]; then
-            author_permission="$(permission_for "$author")"
-            if ! has_write_access "$author_permission"; then
-              deny "author-${author}-permission-${author_permission}" "$pr_number" "$component" "$review_scope"
-              exit 0
-            fi
           fi
 
           pr_state="$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.state' 2>/dev/null || echo "unknown")"
@@ -228,7 +197,6 @@ jobs:
       PR_NUMBER: ${{ needs.review-gate.outputs.pr_number }}
       REQUESTED_COMPONENT: ${{ needs.review-gate.outputs.component }}
       REQUESTED_REVIEW_SCOPE: ${{ needs.review-gate.outputs.review_scope }}
-      TRIGGER_EVENT: ${{ github.event_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -258,13 +226,11 @@ jobs:
         env:
           PR_NUMBER: ${{ env.PR_NUMBER }}
           REQUESTED_REVIEW_SCOPE: ${{ env.REQUESTED_REVIEW_SCOPE }}
-          TRIGGER_EVENT: ${{ env.TRIGGER_EVENT }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = Number(process.env.PR_NUMBER);
             const requestedScope = process.env.REQUESTED_REVIEW_SCOPE || 'auto';
-            const automaticTrigger = process.env.TRIGGER_EVENT === 'pull_request_target';
             const qoderLogins = new Set(['qoderai', 'qoderai[bot]']);
 
             const compact = (value, limit) => String(value || '')
@@ -539,10 +505,7 @@ jobs:
             let files = [];
             let skip = false;
 
-            if (automaticTrigger && latestQoderReview) {
-              skip = true;
-              reviewMode = 'automatic-already-reviewed';
-            } else if (requestedScope !== 'full' && latestQoderReview) {
+            if (requestedScope !== 'full' && latestQoderReview) {
               try {
                 const { data: comparison } = await github.rest.repos.compareCommits({
                   owner,

--- a/src/agent-sec-core/openclaw-plugin/tests/e2e/openclaw-plugin-e2e-pilot.mjs
+++ b/src/agent-sec-core/openclaw-plugin/tests/e2e/openclaw-plugin-e2e-pilot.mjs
@@ -268,18 +268,25 @@ async function runPilot() {
   );
   result.versions.agentSecCli = agentSecVersion.stdout.trim();
 
-  await runRequiredStep("agent-sec-plugin-build", "npm", ["run", "build"], {
-    cwd: PLUGIN_ROOT,
-    env: baseEnv,
-    timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
-  });
-  const packResult = await runRequiredStep(
-    "agent-sec-plugin-pack",
-    "npm",
-    ["pack", "--pack-destination", artifactsDir, "--json"],
-    { cwd: PLUGIN_ROOT, env: baseEnv, timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS },
-  );
-  result.install.packageArtifact = await parseNpmPackArtifact(packResult.stdout, artifactsDir);
+  if (args.pluginPackage) {
+    result.install.packageArtifact = path.resolve(args.pluginPackage);
+    await fs.access(result.install.packageArtifact);
+    result.install.prebuiltPackage = true;
+  } else {
+    await runRequiredStep("agent-sec-plugin-build", "npm", ["run", "build"], {
+      cwd: PLUGIN_ROOT,
+      env: baseEnv,
+      timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
+    });
+    const packResult = await runRequiredStep(
+      "agent-sec-plugin-pack",
+      "npm",
+      ["pack", "--pack-destination", artifactsDir, "--json"],
+      { cwd: PLUGIN_ROOT, env: baseEnv, timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS },
+    );
+    result.install.packageArtifact = await parseNpmPackArtifact(packResult.stdout, artifactsDir);
+    result.install.prebuiltPackage = false;
+  }
   result.install.packageRoot = await extractPackedPluginPackage({
     artifactsDir,
     env: baseEnv,

--- a/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/args.mjs
+++ b/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/args.mjs
@@ -21,6 +21,8 @@ export function parseArgs(argv) {
       parsed.agentSecCli = argv[++index];
     } else if (arg === "--agent-sec-daemon") {
       parsed.agentSecDaemon = argv[++index];
+    } else if (arg === "--plugin-package") {
+      parsed.pluginPackage = argv[++index];
     } else if (arg === "--port") {
       parsed.port = argv[++index];
     } else if (arg === "--gateway-timeout-ms") {
@@ -42,6 +44,7 @@ Options:
   --openclaw-bin <path>        OpenClaw executable or openclaw.mjs path.
   --agent-sec-cli <path>       Installed agent-sec-cli binary.
   --agent-sec-daemon <path>    Installed agent-sec-daemon binary.
+  --plugin-package <path>      Prebuilt agent-sec OpenClaw plugin .tgz.
   --port <port>                Gateway port. Defaults to a free local port.
   --gateway-timeout-ms <ms>    Gateway health wait budget.
   --gateway-token <token>      Gateway token for local health checks.

--- a/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/harness.mjs
+++ b/src/agent-sec-core/openclaw-plugin/tests/e2e/pilot/harness.mjs
@@ -49,16 +49,23 @@ export function createPilotHarness({
       const child = spawn(command, commandArgs, {
         cwd: options.cwd ?? pluginRoot,
         env: options.env ?? process.env,
+        detached: process.platform !== "win32",
         stdio: ["pipe", "pipe", "pipe"],
       });
+      const processGroupId = process.platform !== "win32" ? child.pid : undefined;
       let timedOut = false;
       const stdoutStream = createWriteStream(stdoutLog);
       const stderrStream = createWriteStream(stderrLog);
       const timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGTERM");
+        signalChildProcess(child, processGroupId, "SIGTERM");
         setTimeout(() => {
-          if (child.exitCode === null) child.kill("SIGKILL");
+          if (
+            (processGroupId !== undefined && processGroupExists(processGroupId)) ||
+            (processGroupId === undefined && !hasChildExited(child))
+          ) {
+            signalChildProcess(child, processGroupId, "SIGKILL");
+          }
         }, 5_000).unref();
       }, timeoutMs);
       timer.unref();
@@ -667,20 +674,24 @@ async function waitForStartedProcessStop(proc) {
 }
 
 async function signalStartedProcess(proc, signal) {
+  signalChildProcess(proc.child, proc.processGroupId, signal);
+  if (proc.gatewayPort !== undefined) {
+    for (const pid of await listeningPidsOnPort(proc.gatewayPort)) {
+      signalPid(pid, signal);
+    }
+  }
+}
+
+function signalChildProcess(child, processGroupId, signal) {
   try {
-    if (proc.processGroupId !== undefined) {
-      process.kill(-proc.processGroupId, signal);
-    } else if (!hasChildExited(proc.child)) {
-      proc.child.kill(signal);
+    if (processGroupId !== undefined) {
+      process.kill(-processGroupId, signal);
+    } else if (!hasChildExited(child)) {
+      child.kill(signal);
     }
   } catch (error) {
     if (error?.code !== "ESRCH") {
       throw error;
-    }
-  }
-  if (proc.gatewayPort !== undefined) {
-    for (const pid of await listeningPidsOnPort(proc.gatewayPort)) {
-      signalPid(pid, signal);
     }
   }
 }

--- a/src/agent-sec-core/openclaw-plugin/tests/unit/harness-timeout-test.ts
+++ b/src/agent-sec-core/openclaw-plugin/tests/unit/harness-timeout-test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { createPilotHarness } from "../e2e/pilot/harness.mjs";
+import { parseArgs } from "../e2e/pilot/args.mjs";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("OpenClaw E2E harness", () => {
+  it("parses a prebuilt plugin package", () => {
+    assert.deepEqual(parseArgs(["--plugin-package", "plugin.tgz"]), {
+      pluginPackage: "plugin.tgz",
+    });
+  });
+
+  it("kills a timed-out command process group", { skip: process.platform === "win32" }, async () => {
+    const logsDir = await mkdtemp(join(tmpdir(), "openclaw-harness-timeout-"));
+    tempDirs.push(logsDir);
+    const childPidFile = join(logsDir, "child.pid");
+    const result = { logsDir, steps: [] };
+    const { runRequiredStep } = createPilotHarness({
+      defaultCommandTimeoutMs: 250,
+      pluginRoot: logsDir,
+      result,
+      startedProcesses: [],
+      startedServers: [],
+    });
+    const parentScript = `
+const { spawn } = require("node:child_process");
+const { writeFileSync } = require("node:fs");
+const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 2000)"], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+writeFileSync(process.argv[1], String(child.pid));
+setInterval(() => {}, 2000);
+`;
+    const startedAt = Date.now();
+
+    await assert.rejects(
+      runRequiredStep("timeout-process-tree", process.execPath, ["-e", parentScript, childPidFile]),
+      (error: any) => error?.name === "StepError" && error?.step?.timedOut === true,
+    );
+
+    assert.ok(Date.now() - startedAt < 1_500, "timeout waited for the grandchild to exit naturally");
+    await waitForProcessStop(Number(readFileSync(childPidFile, "utf8")));
+  });
+});
+
+async function waitForProcessStop(pid: number): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    let running = true;
+    try {
+      process.kill(pid, 0);
+    } catch (error: any) {
+      if (error?.code === "ESRCH") {
+        return;
+      }
+      throw error;
+    }
+
+    if (process.platform === "linux") {
+      try {
+        const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+        const stateOffset = stat.lastIndexOf(")") + 2;
+        const state = stat[stateOffset];
+        running = state !== "Z" && state !== "X";
+      } catch (error: any) {
+        if (error?.code === "ENOENT") {
+          return;
+        }
+        throw error;
+      }
+    }
+
+    if (!running) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(`grandchild process ${pid} remained running after the timeout`);
+}

--- a/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
+++ b/src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh
@@ -18,6 +18,7 @@ OPENCLAW_BIN="${OPENCLAW_BIN:-}"
 OPENCLAW_E2E_DRY_RUN="${OPENCLAW_E2E_DRY_RUN:-0}"
 OPENCLAW_E2E_AGENT_SEC_INSTALL_MODE="${OPENCLAW_E2E_AGENT_SEC_INSTALL_MODE:-minimal}"
 OPENCLAW_E2E_SKIP_NPM_CI="${OPENCLAW_E2E_SKIP_NPM_CI:-0}"
+OPENCLAW_E2E_PLUGIN_PACKAGE="${OPENCLAW_E2E_PLUGIN_PACKAGE:-}"
 EXPECT_UNSAFE_INSTALL_FLAG="${EXPECT_UNSAFE_INSTALL_FLAG:-}"
 AGENT_SEC_CLI_BIN="${AGENT_SEC_CLI_BIN:-}"
 AGENT_SEC_DAEMON_BIN="${AGENT_SEC_DAEMON_BIN:-}"
@@ -41,6 +42,7 @@ Environment:
   AGENT_SEC_CLI_BIN             Existing agent-sec-cli binary.
   AGENT_SEC_DAEMON_BIN          Existing agent-sec-daemon binary.
   AGENT_SEC_CLI_WHEEL           Wheel artifact to install into .venv.
+  OPENCLAW_E2E_PLUGIN_PACKAGE   Prebuilt plugin .tgz; skips npm ci/build/pack.
   OPENCLAW_E2E_AGENT_SEC_INSTALL_MODE
                                 minimal (default) installs wheel-declared
                                 runtime deps without ML packages; full installs
@@ -129,9 +131,8 @@ tmp_root="${OPENCLAW_E2E_TMP_ROOT:-${TMPDIR:-/tmp}}"
 pilot_workdir="${OPENCLAW_E2E_WORKDIR:-$tmp_root/agentsec-openclaw-e2e-$openclaw_label-$run_id}"
 artifact_workdir="$result_dir/workdir"
 tools_root="${OPENCLAW_E2E_TOOLS_ROOT:-$repo_root/target/openclaw-e2e/tools}"
-npm_cache="${NPM_CONFIG_CACHE:-$result_dir/npm-cache}"
-export NPM_CONFIG_CACHE="$npm_cache"
-export npm_config_cache="$npm_cache"
+npm_cache="${NPM_CONFIG_CACHE:-${npm_config_cache:-}}"
+plugin_package=""
 # Wheels no longer declare torch/transformers/modelscope, so there is nothing
 # to exclude from the resolved runtime-dep set. Kept as an empty array so the
 # resolve_wheel_runtime_deps call site keeps working if exclusions are needed again.
@@ -176,8 +177,9 @@ find_latest_wheel() {
     printf '%s\n' "$wheel"
 }
 
-resolve_wheel_spec() {
-    local spec="$1"
+resolve_artifact_spec() {
+    local label="$1"
+    local spec="$2"
     local absolute_spec="$spec"
     local matches=()
     local match
@@ -203,7 +205,41 @@ resolve_wheel_spec() {
         return
     fi
 
-    die "agent-sec-cli wheel not found from spec: $spec"
+    die "$label not found from spec: $spec"
+}
+
+configure_npm() {
+    export NPM_CONFIG_AUDIT="${NPM_CONFIG_AUDIT:-false}"
+    export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-2}"
+    export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-10000}"
+    export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-1000}"
+    export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-60000}"
+    export NPM_CONFIG_FUND="${NPM_CONFIG_FUND:-false}"
+    if [[ "$OPENCLAW_REQUESTED_VERSION" == "latest" ]]; then
+        export NPM_CONFIG_PREFER_OFFLINE=false
+        export NPM_CONFIG_PREFER_ONLINE=true
+    else
+        export NPM_CONFIG_PREFER_OFFLINE="${NPM_CONFIG_PREFER_OFFLINE:-true}"
+    fi
+
+    if [[ -z "$npm_cache" ]]; then
+        if [[ "$OPENCLAW_E2E_DRY_RUN" == "1" ]]; then
+            npm_cache="<npm default>"
+        else
+            npm_cache="$(npm config get cache)"
+        fi
+    fi
+}
+
+resolve_plugin_package() {
+    [[ -n "$OPENCLAW_E2E_PLUGIN_PACKAGE" ]] || return 0
+
+    if [[ "$OPENCLAW_E2E_DRY_RUN" == "1" ]]; then
+        plugin_package="$OPENCLAW_E2E_PLUGIN_PACKAGE"
+    else
+        plugin_package="$(resolve_artifact_spec "OpenClaw plugin package" "$OPENCLAW_E2E_PLUGIN_PACKAGE")"
+    fi
+    log "prebuilt plugin package: $plugin_package"
 }
 
 resolve_wheel_runtime_deps() {
@@ -318,7 +354,7 @@ ensure_agent_sec_cli() {
             run make build-cli
             AGENT_SEC_CLI_WHEEL="$(find_latest_wheel)"
         else
-            AGENT_SEC_CLI_WHEEL="$(resolve_wheel_spec "$AGENT_SEC_CLI_WHEEL")"
+            AGENT_SEC_CLI_WHEEL="$(resolve_artifact_spec "agent-sec-cli wheel" "$AGENT_SEC_CLI_WHEEL")"
         fi
         [[ -n "$AGENT_SEC_CLI_WHEEL" ]] || die "agent-sec-cli wheel not found"
         install_agent_sec_cli_wheel "$AGENT_SEC_CLI_WHEEL"
@@ -371,6 +407,10 @@ verify_openclaw() {
 }
 
 install_plugin_dependencies() {
+    if [[ -n "$plugin_package" ]]; then
+        log "skipping npm ci because a prebuilt plugin package was provided"
+        return
+    fi
     if [[ "$OPENCLAW_E2E_SKIP_NPM_CI" == "1" ]]; then
         log "skipping npm ci because OPENCLAW_E2E_SKIP_NPM_CI=1"
         return
@@ -379,14 +419,21 @@ install_plugin_dependencies() {
 }
 
 run_pilot() {
+    local pilot_args=(
+        --openclaw-bin "$OPENCLAW_BIN"
+        --agent-sec-cli "$AGENT_SEC_CLI_BIN"
+        --agent-sec-daemon "$AGENT_SEC_DAEMON_BIN"
+        --workdir "$pilot_workdir"
+    )
+    if [[ -n "$plugin_package" ]]; then
+        pilot_args+=(--plugin-package "$plugin_package")
+    fi
+
     run mkdir -p "$result_dir"
     run mkdir -p "$pilot_workdir"
     run chmod 700 "$pilot_workdir"
     run npm run e2e:openclaw --prefix "$plugin_root" -- \
-        --openclaw-bin "$OPENCLAW_BIN" \
-        --agent-sec-cli "$AGENT_SEC_CLI_BIN" \
-        --agent-sec-daemon "$AGENT_SEC_DAEMON_BIN" \
-        --workdir "$pilot_workdir"
+        "${pilot_args[@]}"
 }
 
 write_summary() {
@@ -468,7 +515,6 @@ log "matrix label: $OPENCLAW_MATRIX_LABEL"
 log "requested OpenClaw: $OPENCLAW_REQUESTED_VERSION"
 log "result dir: $result_dir"
 log "pilot workdir: $pilot_workdir"
-log "npm cache: $npm_cache"
 
 if [[ "$OPENCLAW_E2E_DRY_RUN" == "1" ]]; then
     log "dry-run enabled; no install or E2E command will be executed"
@@ -476,7 +522,11 @@ fi
 
 require_command node
 require_command jq
-run mkdir -p "$npm_cache"
+require_command npm
+configure_npm
+log "npm cache: $npm_cache"
+log "npm fetch preference: prefer-offline=$NPM_CONFIG_PREFER_OFFLINE prefer-online=${NPM_CONFIG_PREFER_ONLINE:-false}"
+resolve_plugin_package
 ensure_agent_sec_cli
 install_openclaw
 verify_openclaw


### PR DESCRIPTION
## Why

OpenClaw compatibility jobs repeatedly install the same plugin dependencies, which amplifies npm registry latency from the runners. A timed-out install can also leave descendant npm processes alive until the job-level timeout.

Qoder currently starts an automatic review when an eligible pull request is opened or marked ready. While the upstream Qoder OIDC service is failing, this creates noisy failures without an explicit review request.

## What changed

- Build and pack the OpenClaw plugin once, then reuse the artifact across the compatibility matrix.
- Restore the setup-node npm cache, bound npm fetch retries and timeouts, and limit the matrix to three concurrent jobs.
- Reuse the runner image preinstalled `jq` instead of refreshing Ubuntu apt repositories in every matrix job.
- Terminate the complete command process group when an E2E step times out.
- Remove the pull_request_target trigger from Qoder Review while retaining member comment commands and manual dispatch.
- Keep both Qoder jobs on self-hosted Linux runners with the anolisa-agent-review label.

## Related issue

no-issue: CI reliability hardening based on failed runs 33848322053, 33860329377, and 33863982362.

## User / Agent impact

OpenClaw E2E should perform less duplicate network work and stop promptly after command timeouts. Qoder review now starts only after an authorized member comments with `@qoder review`, `/qoder review`, or the corresponding `full` command; manual workflow dispatch remains available for operations.

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

Low risk. The OpenClaw test matrix and Qoder self-hosted runner labels are unchanged. The CI runner image already installs `jq`; the workflow now verifies that contract directly.

## Validation

- `npm ci --prefer-offline --no-audit --no-fund`
- `npm test` (162 tests passed)
- `npm run build`
- `npm pack --pack-destination ../target/openclaw-plugin`
- `bash -n src/agent-sec-core/scripts/ci/run-openclaw-plugin-e2e.sh`
- `jq --version`
- OpenClaw E2E dry-run with a prebuilt plugin package
- Ruby YAML parsing for both modified workflows
- `git diff --check origin/main...HEAD`
- One-time plugin build and artifact upload passed in run 33860041600
- Verified the anolisa-agent-review runner label has four online self-hosted runners

## Documentation and rollback

No documentation changes are required. Revert either commit independently to restore the previous OpenClaw packaging or Qoder trigger behavior.