### PR TITLE
feat(sec-core): define pap daemon protocol

### DIFF
--- a/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
+++ b/src/agent-sec-core/docs/design/DAEMON_PROTOCOL_V1_zh.md
@@ -29,7 +29,7 @@ V2 设计，不能在 V1 兼容迁移中单方面加入必填字段。
 [`DAEMON_CURRENT_BEHAVIOR_zh.md`](DAEMON_CURRENT_BEHAVIOR_zh.md)；Job 生命周期、调度、
 日志、trace 和恢复语义见 [`DAEMON_JOB_CONTRACT_zh.md`](DAEMON_JOB_CONTRACT_zh.md)。
 security action 不通过
-当前默认 method catalogue 执行；迁移目标通过本文 6.11 的显式 handler 扩展接入。
+当前默认 method catalogue 执行；迁移目标通过本文 6.12 的显式 handler 扩展接入。
 其逻辑契约见
 [`SECURITY_MIDDLEWARE_CONTRACT_zh.md`](SECURITY_MIDDLEWARE_CONTRACT_zh.md)。
 
@@ -423,11 +423,105 @@ next offset。items 按 `(timestamp_epoch, kind)` 升序排列：
 - `kind=security`：包含完整 security event、被关联的 observability context，以及
   `match.reason/rank/time_delta_seconds`。
 
+### 6.11 **[TARGET V2]** PAP administration
+
+PAP administration 是新增的 V2 method family，不是九个 V1 method 之一。第一版接口采用
+互斥的 `{requestId,result}` 或 `{requestId,error}` 响应，不保留 POC 的 `poc.*` method、
+`ok/data/stdout/stderr/exit_code` envelope 或兼容分支。输入和输出以
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json` 为可执行清单。
+`requestId` 是 daemon 为每次 dispatch 生成的 UUID；`error` 固定为 `{code,message}`，
+success 不得再包一层 `{policy}`、`{scope}` 或 `{binding}`。
+
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json` 进一步冻结覆盖
+15 个 method 的有状态 CRUD 场景及完整 response value，包括 Canonical Policy IR、Scope
+template、Binding 内嵌快照、revision、status 和确定性 digest。daemon 生成的 request/resource
+UUID 使用具名占位符：fixture 不冻结随机值本身，但必须验证 UUID 格式、CREATE 捕获值在后续
+请求/响应中的一致性，以及不同资源 identity 不混用。protocol work package 先由类型测试
+冻结该 fixture；后续 handler/composition work package 必须增加使用服务端授权测试 Principal
+的 UDS integration E2E，并由真实 `asc-daemon` 子进程 bootstrap E2E 消费。binary 测试在
+root 身份下重复完整成功场景，非 root 身份验证默认 `permission_denied`；不得为测试加入
+产品授权旁路。
+`v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json` 冻结 method
+params 构造失败时的 `invalid_request` code 和有界、安全 message；后续 handler work
+package 必须由真实 UDS integration fixture 消费。
+
+所有方法都要求 daemon 根据 kernel peer credentials 和服务端策略构造
+Policy Administrator Principal；request 中不得携带可信 UID、role 或 scope。RPC 直接复用
+`asc-policy-types` 的 `PolicyTemplate`、`ScopeSelector`、`PreparedPolicy`、
+`PreparedScope`、`BindingView` 以及 foundation 的 `ResourceId`、`Revision`，不得复制
+Policy domain DTO。
+
+后续 bootstrap/handler work package 的首版策略固定允许 UID 0 管理 Policy；其它 UID 默认
+拒绝。root 可以向 process-local allowlist 添加额外管理员 UID，但被授权 UID 不获得继续
+委派权限。allowlist 的持久化、加载和管理 RPC 尚未进入本 slice，在这些能力完成前 daemon
+重启后只保留 root 权限。
+
+| method | params | result |
+| --- | --- | --- |
+| `policy.templates.create` | `{policyName, template}` | `PreparedPolicy` |
+| `policy.templates.update` | `{policyId, policyName, template}` | `PreparedPolicy` |
+| `policy.templates.get` | `{id, revision}` | `PreparedPolicy` |
+| `policy.templates.list` | `{limit=100, offset=0}` | `{items: PreparedPolicy[], total}` |
+| `policy.templates.delete` | `{id, revision}` | `PreparedPolicy` |
+| `policy.scopes.create` | `{selector}` | `PreparedScope` |
+| `policy.scopes.update` | `{scopeId, selector}` | `PreparedScope` |
+| `policy.scopes.get` | `{id, revision}` | `PreparedScope` |
+| `policy.scopes.list` | `{limit=100, offset=0}` | `{items: PreparedScope[], total}` |
+| `policy.scopes.delete` | `{id, revision}` | `PreparedScope` |
+| `policy.bindings.create` | `{policyId, policyRevision, scopeId, scopeRevision}` | `BindingView` |
+| `policy.bindings.update` | `{bindingId, policyId, policyRevision, scopeId, scopeRevision}` | `BindingView` |
+| `policy.bindings.get` | `{id}` | `BindingView` |
+| `policy.bindings.list` | `{limit=100, offset=0}` | `{items: BindingView[], total}` |
+| `policy.bindings.delete` | `{id}` | `BindingView` |
+
+CREATE 的 stable identity 由 PAP 生成；UPDATE 不兼作 upsert。Policy/Scope GET 和 DELETE
+要求精确 current revision；Binding GET 读取唯一 current record。Binding CREATE/UPDATE
+返回 `PENDING_APPLY` intent，DELETE 返回 `PENDING_DELETE` intent；daemon handler 不等待
+Reconciler，也不把 PAP acceptance 表述为 target 已生效或删除完成。
+
+Policy CREATE/UPDATE 在 PAP 内同步调用 `PolicyCompiler::lower(TemplateEnvelope) ->
+PolicyEnvelope`。目标产品 compiler 的首个 work package 只实现
+`prevent_file_deletion`，其输入与完整 Canonical Policy IR 输出由
+`v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json` 冻结；输出语义是
+`ResourceOperation::Delete + FileResolution::PathEntry`。其它 `PolicyTemplate` kind 在各自
+lowering 与直接 Adapter conformance 完成前返回 `invalid_argument`，不得生成占位 IR。
+
+参数 object 拒绝未知字段。新 authored Scope 只接受正数 PID 或 cgroup ID，不接受仅用于读取
+旧数据的 `LegacyExecutionDomain`。LIST 的 `limit` 为 `1..=1000`，`offset` 为 `u32`；total 是
+分页前总数。当前 aggregate byte budget 仍是 Repository/PAP/transport 联合 gate，在该 gate
+完成前 LIST 只达到 integration contract，不构成 distribution-ready 大数据量查询能力。
+
+TODO(policy-response-bounds)：当前 direct `PreparedPolicy`/`BindingView` mutation result 可能在
+Repository commit 后才因 response frame 超限而失败；Binding GET/LIST 也会因内嵌完整 Policy
+和 Scope 快照放大响应。在 durable Repository 或 distribution gate 前，必须完成 public result
+shape/存储模型收敛，并对 mutation、单记录 GET 和 LIST aggregate response 建立 server-owned
+encoded-size gate；本 slice 不以提高 transport limit 代替该修复。
+
+PAP error 稳定投影如下：无法构造成 method params 的字段、类型或 bounded value（包括非法
+identifier、revision、pagination 和 authored selector）→ `invalid_request`，同时返回最多 256
+字节的参数解码原因；任意层级 JSON object 的 duplicate key 在进入 `serde_json::Value` 前拒绝，
+按 malformed envelope 返回 `invalid_request / request envelope is invalid`。成功构造 params 后
+发生的 authoring/compiler validation → `invalid_argument`，message 为最多 256 字节的稳定
+`invalid policy name: <reason>`、`invalid policy: <authored-path>: <reason>` 或
+`invalid scope: <authored-path>: <reason>`，不得暴露 canonical IR path、输入内容或内部 error
+code。
+
+not found → `not_found`，并按操作对象稳定区分 `policy was not found`、
+`policy revision was not found`、`scope was not found`、`scope revision was not found`、
+`binding was not found`、`referenced policy revision was not found` 和
+`referenced scope revision was not found`。revision conflict 使用
+`conflict / policy request conflicts with current state`，operation in progress 使用
+`conflict / binding reconciliation operation is in progress`；revision exhaustion →
+`resource_exhausted`；serialization/persistence、内部 identifier/Binding 构造失败 → `internal`。
+Malformed envelope 使用 `invalid_request`，未注册 method 使用 `unknown_method`，授权失败使用
+`permission_denied`。repository error、secret、内部 validation path 和内部 error code 不进入
+wire message；所有 PAP 公开 error message 均不得超过 256 字节。
+
 <a id="daemon-security-action-handler-contract"></a>
 
-### 6.11 **[TARGET V2][PENDING DEFINITION]** Security action handler 扩展
+### 6.12 **[TARGET V2][PENDING DEFINITION]** Security action handler 扩展
 
-#### 6.11.1 历史依据与注册模型
+#### 6.12.1 历史依据与注册模型
 
 commit `ef0d75f27c389434cf6f4361f5dbcdeaff42ab72` 曾实现完整的 `scan-prompt`
 daemon action 路径：`register_prompt_scan_methods()` 在默认 `MethodRegistry` 中注册
@@ -462,7 +556,7 @@ asc-daemon-protocol 的 Definition Review 冻结 method 名、schema、authoriza
 该 alias 不计入 17 个 canonical method；是否启用必须在发布前形成明确决定，不能由实现
 自行推断。
 
-#### 6.11.2 Request 映射
+#### 6.12.2 Request 映射
 
 action request 继续使用 V1 顶层 envelope：
 
@@ -476,7 +570,7 @@ action request 继续使用 V1 顶层 envelope：
 - 同步文件、SQLite、模型、CPU 或 subprocess 操作不得阻塞 socket runtime 的 accept/
   timeout loop；Python 参考实现使用 thread offload，Rust 使用等价 blocking boundary。
 
-##### 6.11.2.1 参数错误边界
+##### 6.12.2.1 参数错误边界
 
 handler 与 core 的校验职责必须保持以下三层边界：
 
@@ -495,7 +589,7 @@ handler 与 core 的校验职责必须保持以下三层边界：
 必须报告稳定的 version/capability mismatch，不转入 PyO3 或本地业务路径。request 已发送
 后的 timeout、EOF 或协议错误仍然状态不明，不能由 client 重放。
 
-#### 6.11.3 三层结果
+#### 6.12.3 三层结果
 
 沿用历史 `scan-prompt` 协议的三层解释，并推广到全部 action：
 
@@ -532,7 +626,7 @@ failure 使用 `ok=true`、非零 `exit_code` 和 `stderr`。如果未来需要�
 type 暴露给 wire client，必须作为单独的版本化协议扩展，而不是向本兼容 projection 临时
 增加顶层字段。
 
-#### 6.11.4 **[TARGET V2]** system daemon 安全边界与 method metadata gate
+#### 6.12.4 **[TARGET V2]** system daemon 安全边界与 method metadata gate
 
 V2 是 one daemon per host 的 system-level service，并服务多个本地 UID/Agent。daemon 从
 内核 peer UID/GID/PID、token binding 和服务端配置构造 trusted Principal；客户端提供的
@@ -692,6 +786,7 @@ asc-cli 触发 PyO3、Python backend 或第二套本地业务执行。
 | DPV1-017 | 八个 action method 的 timeout、queue/resource、access-log、blocking 和 cancellation metadata 已冻结并逐项验证 |
 | DPV1-018 | 多 UID 共用 system socket；trusted Principal/QueryScope 隔离 owner，`caller/trace_context` 不参与授权 |
 | DPV1-019 | CLI/TUI 不能用 RPC filter 绕过服务端 QueryScope，也不能直读 SQLite 替代授权查询 |
+| DPV1-020 | 15 个 PAP method 的 strict params、完整请求/响应 CRUD fixture、直接领域 result、错误投影、server-owned Principal；必跑 UDS integration 经 Dispatcher/PapHandler → PapService → Policy Compiler/Repository 执行完整 fixture，真实 `asc-daemon` 子进程 bootstrap 在 root 下重复成功场景、非 root 下验证默认拒绝 |
 
 协议测试必须使用 socket bytes 和解析后 JSON 比较；只测试某个 Python dataclass 或 Rust
 struct 的构造函数不足以证明 wire compatibility。
@@ -708,6 +803,8 @@ struct 的构造函数不足以证明 wire compatibility。
 - tests：`tests/unit-test/daemon/test_protocol.py`、`test_client_server.py`、
   `test_security_query_handler.py`、`test_skill_ledger_handler.py` 和
   `tests/e2e/daemon/test_daemon_e2e.py`。
+- Rust PAP wire contract：`v2/crates/daemon/asc-daemon-protocol` 及其
+  `tests/fixtures/pap-*.json`；该 work package 只冻结 protocol，尚未注册 daemon handler。
 
 **[HISTORICAL] TARGET handler 的设计证据：** commit
 [`ef0d75f27c389434cf6f4361f5dbcdeaff42ab72`](https://github.com/alibaba/anolisa/commit/ef0d75f27c389434cf6f4361f5dbcdeaff42ab72)

--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "asc-daemon-protocol"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-policy-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "asc-daemon-service"
 version = "0.1.0"
 dependencies = [

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -4,6 +4,7 @@
 resolver = "3"
 members = [
     "apps/asc-daemon",
+    "crates/daemon/asc-daemon-protocol",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-pap",
@@ -19,6 +20,7 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+asc-daemon-protocol = { path = "crates/daemon/asc-daemon-protocol" }
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,11 +1,11 @@
 # AgentSecCore V2 Policy and daemon foundations
 
 This workspace slice contains the dependency-light contracts, Policy
-Administration Point, protocol-independent Unix-domain-socket service framework,
-and runnable foreground process bootstrap used by later AgentSecCore V2 work
-packages. It deliberately contains no daemon wire protocol, concrete persistence
-or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
-Adapter.
+Administration Point, first-version PAP daemon wire contract,
+protocol-independent Unix-domain-socket service framework, and runnable
+foreground process bootstrap used by later AgentSecCore V2 work packages. It
+deliberately contains no daemon protocol handler, concrete persistence or Policy
+compiler, Policy runtime, reconciliation worker, outbox, or target Adapter.
 
 The current crates are:
 
@@ -14,6 +14,9 @@ The current crates are:
   snapshots, backend-independent IR, and target Adapter contracts.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
+- `asc-daemon-protocol`: versioned request/response contracts and an explicit
+  allowlist for 15 Policy, Scope, and Binding administration methods. It defines
+  wire values only and does not authenticate callers or invoke PAP.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
@@ -47,10 +50,11 @@ locks; that remains a required direct-consumer concurrency test at integration.
 
 The current `asc-daemon` executable deliberately registers no wire methods. It
 can start and exercise the real UDS lifecycle, but it closes complete requests
-without a response until the daemon protocol is merged. Socket presence therefore
-does not mean application readiness. It also requires an explicit absolute socket
-path because packaging-owned system paths, singleton/stale-socket policy, runtime
-directory hardening, and readiness remain later process-integration work.
+without a response until the protocol handler is merged. The presence of the
+protocol crate or socket therefore does not mean application readiness. The
+process also requires an explicit absolute socket path because packaging-owned
+system paths, singleton/stale-socket policy, runtime directory hardening, and
+readiness remain later process-integration work.
 
 Run the independent transport process in the foreground:
 
@@ -58,7 +62,7 @@ Run the independent transport process in the foreground:
 cargo run -p asc-daemon -- serve --socket /absolute/existing-directory/daemon.sock
 ```
 
-After protocol integration, the existing daemon handler should implement
+After handler integration, the daemon protocol adapter should implement
 `RequestDispatcher` directly and be injected by this bootstrap. A small
 protocol-only error encoder implements `RejectionEncoder`. PAP becomes one
 registered method family inside the dispatcher; the service framework and
@@ -169,7 +173,7 @@ Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-Daemon protocol, client, concrete persistence/compiler, Policy runtime,
+Daemon protocol handler/client, concrete persistence/compiler, Policy runtime,
 reconciliation worker, outbox, and target Adapter belong to later work packages
 and are intentionally absent from this slice.
 

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "asc-daemon-protocol"
+description = "Versioned local daemon wire contracts for AgentSecCore"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-policy-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/common.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/common.rs
@@ -1,0 +1,78 @@
+use asc_foundation_types::{ResourceId, Revision};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// One stable resource identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResourceParams {
+    /// Stable resource identity.
+    pub id: ResourceId,
+}
+
+/// One stable resource identity plus an exact current revision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RevisionParams {
+    /// Stable resource identity.
+    pub id: ResourceId,
+    /// Exact positive revision.
+    pub revision: Revision,
+}
+
+/// Bounded client-maintained pagination state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListParams {
+    /// Page size in the inclusive range 1..=1000.
+    pub limit: u32,
+    /// Zero-based client-maintained offset.
+    pub offset: u32,
+}
+
+impl Default for ListParams {
+    fn default() -> Self {
+        Self {
+            limit: 100,
+            offset: 0,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ListParamsWire {
+    #[serde(default = "default_limit")]
+    limit: u32,
+    #[serde(default)]
+    offset: u32,
+}
+
+impl<'de> Deserialize<'de> for ListParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = ListParamsWire::deserialize(deserializer)?;
+        if !(1..=1_000).contains(&wire.limit) {
+            return Err(serde::de::Error::custom("limit must be between 1 and 1000"));
+        }
+        Ok(Self {
+            limit: wire.limit,
+            offset: wire.offset,
+        })
+    }
+}
+
+const fn default_limit() -> u32 {
+    100
+}
+
+/// One bounded page and its total before pagination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ListResult<T> {
+    /// Selected current records.
+    pub items: Vec<T>,
+    /// Total matching records before pagination.
+    pub total: u64,
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/envelope.rs
@@ -1,0 +1,139 @@
+use std::fmt;
+
+use serde::de::{Error as _, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// One first-version daemon request with method-specific parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DaemonRequest {
+    /// Exact allowlisted method name.
+    #[serde(deserialize_with = "deserialize_method")]
+    pub method: String,
+    /// Method-specific object, defaulting to an empty object.
+    #[serde(default = "empty_object", deserialize_with = "deserialize_params")]
+    pub params: Value,
+}
+
+fn empty_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+fn deserialize_method<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let method = String::deserialize(deserializer)?;
+    if method.trim().is_empty() {
+        Err(D::Error::custom("method must be a non-empty string"))
+    } else {
+        Ok(method)
+    }
+}
+
+fn deserialize_params<'de, D>(deserializer: D) -> Result<Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let params = StrictValue::deserialize(deserializer)?.0;
+    if params.is_object() {
+        Ok(params)
+    } else {
+        Err(D::Error::custom("params must be a JSON object"))
+    }
+}
+
+/// A JSON value decoder that rejects duplicate object keys before they can be
+/// collapsed by `serde_json::Value`.
+struct StrictValue(Value);
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Bool(value)))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        serde_json::Number::from_f64(value)
+            .map(Value::Number)
+            .map(StrictValue)
+            .ok_or_else(|| E::custom("JSON numbers must be finite"))
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value)))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        StrictValue::deserialize(deserializer)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(sequence.size_hint().unwrap_or(0));
+        while let Some(value) = sequence.next_element::<StrictValue>()? {
+            values.push(value.0);
+        }
+        Ok(StrictValue(Value::Array(values)))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = serde_json::Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(A::Error::custom(format!("duplicate field `{key}`")));
+            }
+            let value = object.next_value::<StrictValue>()?;
+            values.insert(key, value.0);
+        }
+        Ok(StrictValue(Value::Object(values)))
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/lib.rs
@@ -1,0 +1,24 @@
+//! First-version PAP administration wire contracts for the local daemon.
+//!
+//! This crate owns only untrusted serialized values. It reuses stable Policy,
+//! Scope, Binding, identifier, and revision types rather than defining daemon
+//! DTO copies. PAP execution, authorization, persistence, and transport live
+//! in higher layers.
+
+#![forbid(unsafe_code)]
+
+mod common;
+mod envelope;
+pub mod method;
+mod pap;
+mod response;
+
+pub use common::{ListParams, ListResult, ResourceParams, RevisionParams};
+pub use envelope::DaemonRequest;
+pub use pap::{
+    CreateBindingParams, CreatePolicyParams, CreateScopeParams, UpdateBindingParams,
+    UpdatePolicyParams, UpdateScopeParams,
+};
+pub use response::{
+    DaemonError, DaemonResponse, ErrorCode, ErrorResponse, RequestId, SuccessResponse, error_code,
+};

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/method.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/method.rs
@@ -1,0 +1,166 @@
+//! Closed PAP method inventory and access metadata.
+
+/// Create one Policy identity from an authored template.
+pub const POLICY_TEMPLATES_CREATE: &str = "policy.templates.create";
+/// Update one existing Policy identity.
+pub const POLICY_TEMPLATES_UPDATE: &str = "policy.templates.update";
+/// Read one exact current Policy revision.
+pub const POLICY_TEMPLATES_GET: &str = "policy.templates.get";
+/// List current Policies.
+pub const POLICY_TEMPLATES_LIST: &str = "policy.templates.list";
+/// Delete one exact current Policy revision.
+pub const POLICY_TEMPLATES_DELETE: &str = "policy.templates.delete";
+/// Create one Scope identity from an authored selector.
+pub const POLICY_SCOPES_CREATE: &str = "policy.scopes.create";
+/// Update one existing Scope identity.
+pub const POLICY_SCOPES_UPDATE: &str = "policy.scopes.update";
+/// Read one exact current Scope revision.
+pub const POLICY_SCOPES_GET: &str = "policy.scopes.get";
+/// List current Scopes.
+pub const POLICY_SCOPES_LIST: &str = "policy.scopes.list";
+/// Delete one exact current Scope revision.
+pub const POLICY_SCOPES_DELETE: &str = "policy.scopes.delete";
+/// Create one Binding Apply intent.
+pub const POLICY_BINDINGS_CREATE: &str = "policy.bindings.create";
+/// Update one existing Binding and request Apply.
+pub const POLICY_BINDINGS_UPDATE: &str = "policy.bindings.update";
+/// Read one current Binding spec and lifecycle status.
+pub const POLICY_BINDINGS_GET: &str = "policy.bindings.get";
+/// List current Bindings and lifecycle statuses.
+pub const POLICY_BINDINGS_LIST: &str = "policy.bindings.list";
+/// Request deletion of one current Binding.
+pub const POLICY_BINDINGS_DELETE: &str = "policy.bindings.delete";
+
+/// Complete PAP method inventory for this protocol version.
+pub const PAP_METHODS: [&str; 15] = [
+    POLICY_TEMPLATES_CREATE,
+    POLICY_TEMPLATES_UPDATE,
+    POLICY_TEMPLATES_GET,
+    POLICY_TEMPLATES_LIST,
+    POLICY_TEMPLATES_DELETE,
+    POLICY_SCOPES_CREATE,
+    POLICY_SCOPES_UPDATE,
+    POLICY_SCOPES_GET,
+    POLICY_SCOPES_LIST,
+    POLICY_SCOPES_DELETE,
+    POLICY_BINDINGS_CREATE,
+    POLICY_BINDINGS_UPDATE,
+    POLICY_BINDINGS_GET,
+    POLICY_BINDINGS_LIST,
+    POLICY_BINDINGS_DELETE,
+];
+
+/// One Policy operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyMethod {
+    /// Create.
+    Create,
+    /// Update.
+    Update,
+    /// Get.
+    Get,
+    /// List.
+    List,
+    /// Delete.
+    Delete,
+}
+
+/// One Scope operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeMethod {
+    /// Create.
+    Create,
+    /// Update.
+    Update,
+    /// Get.
+    Get,
+    /// List.
+    List,
+    /// Delete.
+    Delete,
+}
+
+/// One Binding operation resolved from its exact wire method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingMethod {
+    /// Create Apply intent.
+    Create,
+    /// Update and request Apply.
+    Update,
+    /// Get current state.
+    Get,
+    /// List current state.
+    List,
+    /// Request Delete.
+    Delete,
+}
+
+/// One PAP operation resolved before parameter decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PapMethod {
+    /// Policy operation.
+    Policy(PolicyMethod),
+    /// Scope operation.
+    Scope(ScopeMethod),
+    /// Binding operation.
+    Binding(BindingMethod),
+}
+
+/// Closed daemon method identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodId {
+    /// PAP administration method.
+    Pap(PapMethod),
+}
+
+/// Server-owned access policy for a method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessPolicy {
+    /// Requires a server-assigned Policy administrator principal.
+    PolicyAdministrator,
+}
+
+/// Static method metadata used by authorization before application dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Metadata {
+    /// Required server-owned access policy.
+    pub access: AccessPolicy,
+}
+
+impl MethodId {
+    /// Returns authorization metadata for this exact method.
+    pub const fn metadata(self) -> Metadata {
+        match self {
+            Self::Pap(_) => Metadata {
+                access: AccessPolicy::PolicyAdministrator,
+            },
+        }
+    }
+}
+
+/// Resolves an exact wire method without inspecting its parameters.
+pub fn resolve(method: &str) -> Option<MethodId> {
+    match method {
+        POLICY_TEMPLATES_CREATE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Create))),
+        POLICY_TEMPLATES_UPDATE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Update))),
+        POLICY_TEMPLATES_GET => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Get))),
+        POLICY_TEMPLATES_LIST => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::List))),
+        POLICY_TEMPLATES_DELETE => Some(MethodId::Pap(PapMethod::Policy(PolicyMethod::Delete))),
+        POLICY_SCOPES_CREATE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Create))),
+        POLICY_SCOPES_UPDATE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Update))),
+        POLICY_SCOPES_GET => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Get))),
+        POLICY_SCOPES_LIST => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::List))),
+        POLICY_SCOPES_DELETE => Some(MethodId::Pap(PapMethod::Scope(ScopeMethod::Delete))),
+        POLICY_BINDINGS_CREATE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Create))),
+        POLICY_BINDINGS_UPDATE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Update))),
+        POLICY_BINDINGS_GET => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Get))),
+        POLICY_BINDINGS_LIST => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::List))),
+        POLICY_BINDINGS_DELETE => Some(MethodId::Pap(PapMethod::Binding(BindingMethod::Delete))),
+        _ => None,
+    }
+}
+
+/// Returns metadata for an exact registered method.
+pub fn metadata(method: &str) -> Option<Metadata> {
+    resolve(method).map(MethodId::metadata)
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/pap.rs
@@ -1,0 +1,112 @@
+use asc_foundation_types::{ResourceId, Revision};
+use asc_policy_types::Validate;
+use asc_policy_types::authoring::PolicyTemplate;
+use asc_policy_types::scope::ScopeSelector;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Create one Policy with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreatePolicyParams {
+    /// Human-readable Policy name.
+    pub policy_name: String,
+    /// Complete authored Policy intent.
+    pub template: PolicyTemplate,
+}
+
+/// Update one existing Policy identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdatePolicyParams {
+    /// Existing Policy identity.
+    pub policy_id: ResourceId,
+    /// Human-readable Policy name.
+    pub policy_name: String,
+    /// Complete authored Policy intent.
+    pub template: PolicyTemplate,
+}
+
+/// Create one Scope with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateScopeParams {
+    /// New authored selector; compatibility-only selectors are rejected.
+    #[serde(
+        deserialize_with = "deserialize_authored_selector",
+        serialize_with = "serialize_authored_selector"
+    )]
+    pub selector: ScopeSelector,
+}
+
+/// Update one existing Scope identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateScopeParams {
+    /// Existing Scope identity.
+    pub scope_id: ResourceId,
+    /// New authored selector; compatibility-only selectors are rejected.
+    #[serde(
+        deserialize_with = "deserialize_authored_selector",
+        serialize_with = "serialize_authored_selector"
+    )]
+    pub selector: ScopeSelector,
+}
+
+/// Create one Binding Apply intent with a server-generated identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CreateBindingParams {
+    /// Exact Policy identity.
+    pub policy_id: ResourceId,
+    /// Exact current Policy revision.
+    pub policy_revision: Revision,
+    /// Exact Scope identity.
+    pub scope_id: ResourceId,
+    /// Exact current Scope revision.
+    pub scope_revision: Revision,
+}
+
+/// Update one existing Binding and request Apply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct UpdateBindingParams {
+    /// Existing Binding identity.
+    pub binding_id: ResourceId,
+    /// Exact Policy identity.
+    pub policy_id: ResourceId,
+    /// Exact current Policy revision.
+    pub policy_revision: Revision,
+    /// Exact Scope identity.
+    pub scope_id: ResourceId,
+    /// Exact current Scope revision.
+    pub scope_revision: Revision,
+}
+
+fn deserialize_authored_selector<'de, D>(deserializer: D) -> Result<ScopeSelector, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let selector = ScopeSelector::deserialize(deserializer)?;
+    validate_authored_selector(&selector).map_err(serde::de::Error::custom)?;
+    Ok(selector)
+}
+
+fn serialize_authored_selector<S>(
+    selector: &ScopeSelector,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    validate_authored_selector(selector).map_err(serde::ser::Error::custom)?;
+    selector.serialize(serializer)
+}
+
+fn validate_authored_selector(selector: &ScopeSelector) -> Result<(), String> {
+    if matches!(selector, ScopeSelector::LegacyExecutionDomain { .. }) {
+        return Err("legacy execution-domain selectors cannot be authored".to_owned());
+    }
+    selector
+        .validate()
+        .map_err(|error| format!("invalid selector at {}: {}", error.path, error.message))
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/src/response.rs
@@ -1,0 +1,189 @@
+use std::fmt;
+
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+/// Stable daemon-generated response correlation identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RequestId(String);
+
+impl RequestId {
+    /// Creates a non-empty opaque request identity.
+    ///
+    /// # Errors
+    /// Returns an error for an empty or whitespace-only identity.
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Err("request ID must be a non-empty string")
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the wire value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+/// Open, bounded, machine-readable daemon error code.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct ErrorCode(String);
+
+impl ErrorCode {
+    /// Creates one lower-snake-case error code of at most 64 bytes.
+    ///
+    /// # Errors
+    /// Returns an error when the code is not in canonical form.
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        let mut bytes = value.bytes();
+        if value.len() > 64
+            || !matches!(bytes.next(), Some(b'a'..=b'z'))
+            || !bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        {
+            Err("error code must be a bounded lower_snake_case identifier")
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the canonical wire value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+/// Stable safe error returned by the daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DaemonError {
+    /// Machine-readable category.
+    pub code: ErrorCode,
+    /// Sanitized operator-facing explanation.
+    pub message: String,
+}
+
+impl DaemonError {
+    /// Creates an error from a registered code and safe message.
+    ///
+    /// # Panics
+    /// Panics when a programmer supplies a noncanonical code.
+    pub fn new(code: &str, message: &str) -> Self {
+        Self {
+            code: ErrorCode::new(code).expect("daemon error constants must be canonical"),
+            message: message.to_owned(),
+        }
+    }
+}
+
+/// Successful first-version response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SuccessResponse<T> {
+    /// Daemon-generated correlation identity.
+    pub request_id: RequestId,
+    /// Exact method result.
+    pub result: T,
+}
+
+/// Failed first-version response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ErrorResponse {
+    /// Daemon-generated correlation identity.
+    pub request_id: RequestId,
+    /// Stable structured failure.
+    pub error: DaemonError,
+}
+
+/// Mutually exclusive `{requestId,result}` or `{requestId,error}` response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DaemonResponse<T = Value> {
+    /// Successful application dispatch.
+    Success(SuccessResponse<T>),
+    /// Request, authorization, or application failure.
+    Error(ErrorResponse),
+}
+
+impl<T> DaemonResponse<T> {
+    /// Creates a successful response.
+    pub fn success(request_id: RequestId, result: T) -> Self {
+        Self::Success(SuccessResponse { request_id, result })
+    }
+
+    /// Creates a failed response.
+    pub fn error(request_id: RequestId, code: &str, message: &str) -> Self {
+        Self::Error(ErrorResponse {
+            request_id,
+            error: DaemonError::new(code, message),
+        })
+    }
+
+    /// Returns the daemon-generated request identity.
+    pub fn request_id(&self) -> &RequestId {
+        match self {
+            Self::Success(response) => &response.request_id,
+            Self::Error(response) => &response.request_id,
+        }
+    }
+}
+
+/// Stable daemon error-code registry.
+pub mod error_code {
+    /// Malformed request envelope or method params.
+    pub const INVALID_REQUEST: &str = "invalid_request";
+    /// Successfully decoded method input failed application domain validation.
+    pub const INVALID_ARGUMENT: &str = "invalid_argument";
+    /// Method is not registered.
+    pub const UNKNOWN_METHOD: &str = "unknown_method";
+    /// Principal lacks authority.
+    pub const PERMISSION_DENIED: &str = "permission_denied";
+    /// Requested current record does not exist.
+    pub const NOT_FOUND: &str = "not_found";
+    /// Current state conflicts with the request.
+    pub const CONFLICT: &str = "conflict";
+    /// A bounded server resource is exhausted.
+    pub const RESOURCE_EXHAUSTED: &str = "resource_exhausted";
+    /// Service-owned deadline expired.
+    pub const DEADLINE_EXCEEDED: &str = "deadline_exceeded";
+    /// Service is temporarily unavailable.
+    pub const UNAVAILABLE: &str = "unavailable";
+    /// Internal failure with details withheld.
+    pub const INTERNAL: &str = "internal";
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/daemon-responses.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/daemon-responses.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "success",
+    "response": {
+      "requestId": "request-1",
+      "result": {"policyId": "policy-1"}
+    }
+  },
+  {
+    "name": "error",
+    "response": {
+      "requestId": "request-2",
+      "error": {
+        "code": "not_found",
+        "message": "requested policy resource was not found"
+      }
+    }
+  }
+]

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-crud-e2e.json
@@ -1,0 +1,558 @@
+{
+  "schemaVersion": 1,
+  "dynamicValues": {
+    "request_id": "a fresh UUID returned by the daemon for each response",
+    "policy_id": "the UUID returned by create Policy and reused by later steps",
+    "scope_id": "the UUID returned by create Scope and reused by later steps",
+    "binding_id": "the UUID returned by create Binding and reused by later steps"
+  },
+  "objects": {
+    "policyV1": {
+      "policyId": "${policy_id}",
+      "policyName": "protect-important-files-v1",
+      "revision": 1,
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": [
+          "/workspace/important/**",
+          "/etc/agent/config.yaml"
+        ]
+      },
+      "canonicalPolicy": {
+        "irSchemaVersion": 1,
+        "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+        "policyId": "${policy_id}",
+        "revision": 1,
+        "payload": {
+          "resources": [
+            {
+              "id": "protected-file-entries",
+              "kind": "file",
+              "matchers": [
+                {
+                  "path": {
+                    "type": "glob",
+                    "pattern": "/workspace/important/**"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                },
+                {
+                  "path": {
+                    "type": "exact",
+                    "path": "/etc/agent/config.yaml"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "id": "deny-protected-file-deletion",
+              "when": {
+                "type": "atom",
+                "atom": {
+                  "type": "resource_operation",
+                  "operation": "delete",
+                  "target": {
+                    "type": "in",
+                    "resourceSet": "protected-file-entries"
+                  }
+                }
+              },
+              "outcome": {
+                "decision": "deny",
+                "obligations": [
+                  "audit",
+                  "emit_receipt"
+                ],
+                "remediation": "none"
+              },
+              "enforcement": {
+                "decisionTiming": "pre_effect",
+                "requiredEvidence": [
+                  "binding_ready",
+                  "operation_denied"
+                ]
+              }
+            }
+          ],
+          "activation": "post_attach_allowed",
+          "failurePolicy": {
+            "runtime": "fail_closed",
+            "update": "keep_last_known_good"
+          }
+        }
+      },
+      "templateDigest": "sha256:415ea26707c498ed9595534845f579c51da046b635f6048d0cd9058b69d76a5b"
+    },
+    "policyV2": {
+      "policyId": "${policy_id}",
+      "policyName": "protect-important-files-v2",
+      "revision": 2,
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": [
+          "/srv/data"
+        ]
+      },
+      "canonicalPolicy": {
+        "irSchemaVersion": 1,
+        "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+        "policyId": "${policy_id}",
+        "revision": 2,
+        "payload": {
+          "resources": [
+            {
+              "id": "protected-file-entries",
+              "kind": "file",
+              "matchers": [
+                {
+                  "path": {
+                    "type": "exact",
+                    "path": "/srv/data"
+                  },
+                  "resolution": {
+                    "type": "path_entry"
+                  }
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "id": "deny-protected-file-deletion",
+              "when": {
+                "type": "atom",
+                "atom": {
+                  "type": "resource_operation",
+                  "operation": "delete",
+                  "target": {
+                    "type": "in",
+                    "resourceSet": "protected-file-entries"
+                  }
+                }
+              },
+              "outcome": {
+                "decision": "deny",
+                "obligations": [
+                  "audit",
+                  "emit_receipt"
+                ],
+                "remediation": "none"
+              },
+              "enforcement": {
+                "decisionTiming": "pre_effect",
+                "requiredEvidence": [
+                  "binding_ready",
+                  "operation_denied"
+                ]
+              }
+            }
+          ],
+          "activation": "post_attach_allowed",
+          "failurePolicy": {
+            "runtime": "fail_closed",
+            "update": "keep_last_known_good"
+          }
+        }
+      },
+      "templateDigest": "sha256:55de4b6bd96b575ec1a0fc943ad83a419a5747494c6a17d13ac125cb0f92bade"
+    },
+    "scopeV1": {
+      "scopeId": "${scope_id}",
+      "revision": 1,
+      "selector": {
+        "kind": "pid",
+        "pid": 4242
+      },
+      "template": {
+        "kind": "execution_domain",
+        "processMembership": "root_and_future_members",
+        "preserveAcrossExec": true,
+        "nestedExecutionDomains": "inherit",
+        "namespaceChange": "deny",
+        "lifetime": {
+          "activateAt": "binding_ready",
+          "expiresAt": null,
+          "endCondition": "execution_domain_drained"
+        }
+      },
+      "templateDigest": "sha256:3b92f8f65b2b55b387f3e527cf28c881906f3c2f63c41c9faa60469ad3947957"
+    },
+    "scopeV2": {
+      "scopeId": "${scope_id}",
+      "revision": 2,
+      "selector": {
+        "kind": "cgroup_id",
+        "cgroupId": 99
+      },
+      "template": {
+        "kind": "execution_domain",
+        "processMembership": "root_and_future_members",
+        "preserveAcrossExec": true,
+        "nestedExecutionDomains": "inherit",
+        "namespaceChange": "deny",
+        "lifetime": {
+          "activateAt": "binding_ready",
+          "expiresAt": null,
+          "endCondition": "execution_domain_drained"
+        }
+      },
+      "templateDigest": "sha256:ab6538c729550b2d86359c2de8d0788e85d167272fb469c5267a06024b8b22db"
+    },
+    "bindingV1": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 1,
+        "policy": {
+          "$ref": "policyV1"
+        },
+        "scope": {
+          "$ref": "scopeV1"
+        }
+      },
+      "status": "PENDING_APPLY"
+    },
+    "bindingV2": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 2,
+        "policy": {
+          "$ref": "policyV2"
+        },
+        "scope": {
+          "$ref": "scopeV2"
+        }
+      },
+      "status": "PENDING_APPLY"
+    },
+    "bindingV3": {
+      "spec": {
+        "bindingId": "${binding_id}",
+        "bindingRevision": 3,
+        "policy": {
+          "$ref": "policyV2"
+        },
+        "scope": {
+          "$ref": "scopeV2"
+        }
+      },
+      "status": "PENDING_DELETE"
+    }
+  },
+  "steps": [
+    {
+      "name": "create-policy",
+      "request": {
+        "method": "policy.templates.create",
+        "params": {
+          "policyName": "protect-important-files-v1",
+          "template": {
+            "kind": "prevent_file_deletion",
+            "files": [
+              "/workspace/important/**",
+              "/etc/agent/config.yaml"
+            ]
+          }
+        }
+      },
+      "captures": [
+        {
+          "name": "policy_id",
+          "pointer": "/result/policyId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV1"
+        }
+      }
+    },
+    {
+      "name": "create-scope",
+      "request": {
+        "method": "policy.scopes.create",
+        "params": {
+          "selector": {
+            "kind": "pid",
+            "pid": 4242
+          }
+        }
+      },
+      "captures": [
+        {
+          "name": "scope_id",
+          "pointer": "/result/scopeId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV1"
+        }
+      }
+    },
+    {
+      "name": "create-binding",
+      "request": {
+        "method": "policy.bindings.create",
+        "params": {
+          "policyId": "${policy_id}",
+          "policyRevision": 1,
+          "scopeId": "${scope_id}",
+          "scopeRevision": 1
+        }
+      },
+      "captures": [
+        {
+          "name": "binding_id",
+          "pointer": "/result/spec/bindingId",
+          "format": "uuid"
+        }
+      ],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV1"
+        }
+      }
+    },
+    {
+      "name": "update-policy",
+      "request": {
+        "method": "policy.templates.update",
+        "params": {
+          "policyId": "${policy_id}",
+          "policyName": "protect-important-files-v2",
+          "template": {
+            "kind": "prevent_file_deletion",
+            "files": [
+              "/srv/data"
+            ]
+          }
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "update-scope",
+      "request": {
+        "method": "policy.scopes.update",
+        "params": {
+          "scopeId": "${scope_id}",
+          "selector": {
+            "kind": "cgroup_id",
+            "cgroupId": 99
+          }
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    },
+    {
+      "name": "update-binding",
+      "request": {
+        "method": "policy.bindings.update",
+        "params": {
+          "bindingId": "${binding_id}",
+          "policyId": "${policy_id}",
+          "policyRevision": 2,
+          "scopeId": "${scope_id}",
+          "scopeRevision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV2"
+        }
+      }
+    },
+    {
+      "name": "get-policy",
+      "request": {
+        "method": "policy.templates.get",
+        "params": {
+          "id": "${policy_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "list-policies",
+      "request": {
+        "method": "policy.templates.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "policyV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "get-scope",
+      "request": {
+        "method": "policy.scopes.get",
+        "params": {
+          "id": "${scope_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    },
+    {
+      "name": "list-scopes",
+      "request": {
+        "method": "policy.scopes.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "scopeV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "get-binding",
+      "request": {
+        "method": "policy.bindings.get",
+        "params": {
+          "id": "${binding_id}"
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV2"
+        }
+      }
+    },
+    {
+      "name": "list-bindings",
+      "request": {
+        "method": "policy.bindings.list",
+        "params": {
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "items": [
+            {
+              "$ref": "bindingV2"
+            }
+          ],
+          "total": 1
+        }
+      }
+    },
+    {
+      "name": "delete-binding",
+      "request": {
+        "method": "policy.bindings.delete",
+        "params": {
+          "id": "${binding_id}"
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "bindingV3"
+        }
+      }
+    },
+    {
+      "name": "delete-policy",
+      "request": {
+        "method": "policy.templates.delete",
+        "params": {
+          "id": "${policy_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "policyV2"
+        }
+      }
+    },
+    {
+      "name": "delete-scope",
+      "request": {
+        "method": "policy.scopes.delete",
+        "params": {
+          "id": "${scope_id}",
+          "revision": 2
+        }
+      },
+      "captures": [],
+      "expectedResponse": {
+        "requestId": "${request_id}",
+        "result": {
+          "$ref": "scopeV2"
+        }
+      }
+    }
+  ]
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-invalid-requests.json
@@ -1,0 +1,398 @@
+{
+  "schemaVersion": 1,
+  "generatedValues": {
+    "resource_id_129": "129 ASCII identifier bytes",
+    "policy_name_257": "257 policy-name bytes",
+    "path_4097": "4097 absolute-path bytes"
+  },
+  "dynamicValues": {
+    "existing_policy_id": "the UUID returned by the fixture setup Policy"
+  },
+  "cases": [
+    {
+      "name": "create policy with an empty policy name",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must contain a visible character"}
+    },
+    {
+      "name": "update policy with a whitespace-only policy name",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "   ", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must contain a visible character"}
+    },
+    {
+      "name": "create policy with an oversized policy name",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "${policy_name_257}", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must not exceed 256 bytes"}
+    },
+    {
+      "name": "update policy with a control character in its name",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid\nname", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy name: must not contain control characters"}
+    },
+    {
+      "name": "create policy template without a kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `kind`"}
+    },
+    {
+      "name": "create policy template with an unknown kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "unknown", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected one of `high_sensitivity_read_deny`, `prevent_file_deletion`, `low_sensitivity_egress`"}
+    },
+    {
+      "name": "create deletion policy without files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `files`"}
+    },
+    {
+      "name": "create deletion policy with non-array files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": "/valid"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"/valid\", expected a sequence"}
+    },
+    {
+      "name": "update deletion policy with a non-string file",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "missing-policy", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": [1]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create deletion policy with an unknown template field",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/valid"], "unexpected": true}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `files`"}
+    },
+    {
+      "name": "create unsupported high-sensitivity policy",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "unsupported", "template": {"kind": "high_sensitivity_read_deny", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.kind: the current compiler supports only prevent_file_deletion"}
+    },
+    {
+      "name": "update to an unsupported low-sensitivity policy",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "unsupported", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.kind: the current compiler supports only prevent_file_deletion"}
+    },
+    {
+      "name": "create low-sensitivity policy without trusted destinations",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `trustedDestinations`"}
+    },
+    {
+      "name": "create low-sensitivity policy with an unknown destination kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "unknown", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected `host` or `cidr`"}
+    },
+    {
+      "name": "create low-sensitivity policy with an overflowing port",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [65536]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `65536`, expected u16"}
+    },
+    {
+      "name": "create low-sensitivity policy with a non-object destination",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [1]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected internally tagged enum TrustedDestination"}
+    },
+    {
+      "name": "create host destination with a non-string pattern",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": 1, "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create host destination with non-array ports",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": "443"}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"443\", expected a sequence"}
+    },
+    {
+      "name": "create host destination with a non-numeric port",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": ["443"]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"443\", expected u16"}
+    },
+    {
+      "name": "create CIDR destination with a non-string CIDR",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "cidr", "cidr": 1, "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "create deletion policy with no files",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": []}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files: must not be empty"}
+    },
+    {
+      "name": "create deletion policy with an empty path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": [""]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "update deletion policy with a relative path",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["relative/path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with a NUL path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid\u0000path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with home expansion",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/home/~/invalid"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "update deletion policy with environment expansion",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/$INVALID"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must be absolute and contain no NUL, home expansion, or environment variables"}
+    },
+    {
+      "name": "create deletion policy with an oversized path",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["${path_4097}"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path exceeds 4096 bytes"}
+    },
+    {
+      "name": "update deletion policy with a trailing separator",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path must not have a trailing separator"}
+    },
+    {
+      "name": "create deletion policy with repeated separators",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid//path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains repeated separators"}
+    },
+    {
+      "name": "create deletion policy with a dot segment",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/./path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains a dot segment"}
+    },
+    {
+      "name": "update deletion policy with a parent segment",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/../path"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: path contains a dot segment"}
+    },
+    {
+      "name": "create deletion policy with unsupported glob syntax",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/[ab]*"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: glob supports only *, ?, and whole-segment **"}
+    },
+    {
+      "name": "update deletion policy with embedded double star",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "${existing_policy_id}", "policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/invalid/pre**post"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[0]: ** must occupy a complete path segment"}
+    },
+    {
+      "name": "create deletion policy with a duplicate matcher",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "prevent_file_deletion", "files": ["/duplicate", "/duplicate"]}}},
+      "expectedError": {"code": "invalid_argument", "message": "invalid policy: template.files[1]: duplicate matcher"}
+    },
+    {
+      "name": "create policy template with a non-string kind",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": 1, "files": ["/valid"]}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected variant identifier"}
+    },
+    {
+      "name": "create low-sensitivity policy with non-array destinations",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": {}}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: map, expected a sequence"}
+    },
+    {
+      "name": "create host destination without a pattern",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `pattern`"}
+    },
+    {
+      "name": "create host destination without ports",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com"}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `ports`"}
+    },
+    {
+      "name": "create CIDR destination without CIDR",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "cidr", "ports": [443]}]}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `cidr`"}
+    },
+    {
+      "name": "create host destination with an unknown field",
+      "request": {"method": "policy.templates.create", "params": {"policyName": "invalid", "template": {"kind": "low_sensitivity_egress", "files": ["/valid"], "trustedDestinations": [{"type": "host", "pattern": "example.com", "ports": [443], "unexpected": true}]}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `pattern` or `ports`"}
+    },
+    {
+      "name": "create scope selector without kind",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `kind`"}
+    },
+    {
+      "name": "update scope with an unknown selector kind",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "unknown", "pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown variant `unknown`, expected one of `pid`, `cgroup_id`, `legacy_execution_domain`"}
+    },
+    {
+      "name": "create PID scope without a PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `pid`"}
+    },
+    {
+      "name": "update cgroup scope without a cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `cgroupId`"}
+    },
+    {
+      "name": "create PID scope with an unknown field",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1, "unexpected": true}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `unexpected`, expected `pid`"}
+    },
+    {
+      "name": "create scope with zero PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 0}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid selector at pid: must be positive"}
+    },
+    {
+      "name": "update scope with zero cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 0}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid selector at cgroupId: must be positive"}
+    },
+    {
+      "name": "create scope with a negative PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": -1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u32"}
+    },
+    {
+      "name": "create scope with an overflowing PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 4294967296}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `4294967296`, expected u32"}
+    },
+    {
+      "name": "create scope with a fractional PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1.5}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.5`, expected u32"}
+    },
+    {
+      "name": "create scope with a string PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": "one"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"one\", expected u32"}
+    },
+    {
+      "name": "create scope with a null PID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": null}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: null, expected u32"}
+    },
+    {
+      "name": "create PID scope with a cgroup field",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "pid", "pid": 1, "cgroupId": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `cgroupId`, expected `pid`"}
+    },
+    {
+      "name": "update cgroup scope with a PID field",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 1, "pid": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "unknown field `pid`, expected `cgroupId`"}
+    },
+    {
+      "name": "update scope with a negative cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": -1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u64"}
+    },
+    {
+      "name": "update scope with an overflowing cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 18446744073709551616}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.8446744073709552e+19`, expected u64"}
+    },
+    {
+      "name": "update scope with a fractional cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": 1.5}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: floating point `1.5`, expected u64"}
+    },
+    {
+      "name": "update scope with a string cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": "one"}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: string \"one\", expected u64"}
+    },
+    {
+      "name": "update scope with a null cgroup ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "cgroup_id", "cgroupId": null}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: null, expected u64"}
+    },
+    {
+      "name": "create scope with a legacy selector",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain", "executionDomainId": "legacy-domain"}}},
+      "expectedError": {"code": "invalid_request", "message": "legacy execution-domain selectors cannot be authored"}
+    },
+    {
+      "name": "create legacy scope without an execution-domain ID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain"}}},
+      "expectedError": {"code": "invalid_request", "message": "missing field `executionDomainId`"}
+    },
+    {
+      "name": "create legacy scope with a non-string execution-domain ID",
+      "request": {"method": "policy.scopes.create", "params": {"selector": {"kind": "legacy_execution_domain", "executionDomainId": 1}}},
+      "expectedError": {"code": "invalid_request", "message": "invalid type: integer `1`, expected a string"}
+    },
+    {
+      "name": "update scope with an invalid legacy selector ID",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "legacy_execution_domain", "executionDomainId": "invalid/id"}}},
+      "expectedError": {"code": "invalid_request", "message": "identifier must be 1..=128 ASCII letters, digits, '.', ':', '_' or '-'"}
+    },
+    {
+      "name": "update a missing policy",
+      "request": {"method": "policy.templates.update", "params": {"policyId": "missing-policy", "policyName": "valid", "template": {"kind": "prevent_file_deletion", "files": ["/valid"]}}},
+      "expectedError": {"code": "not_found", "message": "policy was not found"}
+    },
+    {
+      "name": "get a missing policy revision",
+      "request": {"method": "policy.templates.get", "params": {"id": "missing-policy", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "policy revision was not found"}
+    },
+    {
+      "name": "delete a missing policy revision",
+      "request": {"method": "policy.templates.delete", "params": {"id": "missing-policy", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "policy revision was not found"}
+    },
+    {
+      "name": "update a missing scope",
+      "request": {"method": "policy.scopes.update", "params": {"scopeId": "missing-scope", "selector": {"kind": "pid", "pid": 1}}},
+      "expectedError": {"code": "not_found", "message": "scope was not found"}
+    },
+    {
+      "name": "get a missing scope revision",
+      "request": {"method": "policy.scopes.get", "params": {"id": "missing-scope", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "scope revision was not found"}
+    },
+    {
+      "name": "delete a missing scope revision",
+      "request": {"method": "policy.scopes.delete", "params": {"id": "missing-scope", "revision": 1}},
+      "expectedError": {"code": "not_found", "message": "scope revision was not found"}
+    },
+    {
+      "name": "create binding with a missing policy revision",
+      "request": {"method": "policy.bindings.create", "params": {"policyId": "missing-policy", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "referenced policy revision was not found"}
+    },
+    {
+      "name": "create binding with a missing scope revision",
+      "request": {"method": "policy.bindings.create", "params": {"policyId": "${existing_policy_id}", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "referenced scope revision was not found"}
+    },
+    {
+      "name": "update a missing binding",
+      "request": {"method": "policy.bindings.update", "params": {"bindingId": "missing-binding", "policyId": "missing-policy", "policyRevision": 1, "scopeId": "missing-scope", "scopeRevision": 1}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "get a missing binding",
+      "request": {"method": "policy.bindings.get", "params": {"id": "missing-binding"}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "delete a missing binding",
+      "request": {"method": "policy.bindings.delete", "params": {"id": "missing-binding"}},
+      "expectedError": {"code": "not_found", "message": "binding was not found"}
+    },
+    {
+      "name": "list policies with zero limit",
+      "request": {"method": "policy.templates.list", "params": {"limit": 0, "offset": 0}},
+      "expectedError": {"code": "invalid_request", "message": "limit must be between 1 and 1000"}
+    },
+    {
+      "name": "list scopes above the maximum limit",
+      "request": {"method": "policy.scopes.list", "params": {"limit": 1001, "offset": 0}},
+      "expectedError": {"code": "invalid_request", "message": "limit must be between 1 and 1000"}
+    },
+    {
+      "name": "list bindings with a negative offset",
+      "request": {"method": "policy.bindings.list", "params": {"limit": 1, "offset": -1}},
+      "expectedError": {"code": "invalid_request", "message": "invalid value: integer `-1`, expected u32"}
+    }
+  ]
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/fixtures/pap-methods.json
@@ -1,0 +1,146 @@
+[
+  {
+    "method": "policy.templates.create",
+    "params": {
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "canonicalParams": {
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.update",
+    "params": {
+      "policyId": "policy-1",
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "canonicalParams": {
+      "policyId": "policy-1",
+      "policyName": "protect-important-files",
+      "template": {
+        "kind": "prevent_file_deletion",
+        "files": ["/workspace/important"]
+      }
+    },
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.get",
+    "params": {"id": "policy-1", "revision": 1},
+    "canonicalParams": {"id": "policy-1", "revision": 1},
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.templates.list",
+    "params": {},
+    "canonicalParams": {"limit": 100, "offset": 0},
+    "resultType": "ListResult<PreparedPolicy>"
+  },
+  {
+    "method": "policy.templates.delete",
+    "params": {"id": "policy-1", "revision": 1},
+    "canonicalParams": {"id": "policy-1", "revision": 1},
+    "resultType": "PreparedPolicy"
+  },
+  {
+    "method": "policy.scopes.create",
+    "params": {"selector": {"kind": "pid", "pid": 4242}},
+    "canonicalParams": {"selector": {"kind": "pid", "pid": 4242}},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.update",
+    "params": {
+      "scopeId": "scope-1",
+      "selector": {"kind": "cgroup_id", "cgroupId": 99}
+    },
+    "canonicalParams": {
+      "scopeId": "scope-1",
+      "selector": {"kind": "cgroup_id", "cgroupId": 99}
+    },
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.get",
+    "params": {"id": "scope-1", "revision": 1},
+    "canonicalParams": {"id": "scope-1", "revision": 1},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.scopes.list",
+    "params": {"limit": 25, "offset": 50},
+    "canonicalParams": {"limit": 25, "offset": 50},
+    "resultType": "ListResult<PreparedScope>"
+  },
+  {
+    "method": "policy.scopes.delete",
+    "params": {"id": "scope-1", "revision": 1},
+    "canonicalParams": {"id": "scope-1", "revision": 1},
+    "resultType": "PreparedScope"
+  },
+  {
+    "method": "policy.bindings.create",
+    "params": {
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 1
+    },
+    "canonicalParams": {
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 1
+    },
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.update",
+    "params": {
+      "bindingId": "binding-1",
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 2
+    },
+    "canonicalParams": {
+      "bindingId": "binding-1",
+      "policyId": "policy-1",
+      "policyRevision": 1,
+      "scopeId": "scope-1",
+      "scopeRevision": 2
+    },
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.get",
+    "params": {"id": "binding-1"},
+    "canonicalParams": {"id": "binding-1"},
+    "resultType": "BindingView"
+  },
+  {
+    "method": "policy.bindings.list",
+    "params": {"limit": 10, "offset": 20},
+    "canonicalParams": {"limit": 10, "offset": 20},
+    "resultType": "ListResult<BindingView>"
+  },
+  {
+    "method": "policy.bindings.delete",
+    "params": {"id": "binding-1"},
+    "canonicalParams": {"id": "binding-1"},
+    "resultType": "BindingView"
+  }
+]

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-protocol/tests/pap_contract.rs
@@ -1,0 +1,471 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use asc_daemon_protocol::method;
+use asc_daemon_protocol::{
+    CreateBindingParams, CreatePolicyParams, CreateScopeParams, DaemonRequest, DaemonResponse,
+    ErrorCode, ListParams, ListResult, RequestId, ResourceParams, RevisionParams,
+    UpdateBindingParams, UpdatePolicyParams, UpdateScopeParams, error_code,
+};
+use asc_foundation_types::ResourceId;
+use asc_policy_types::binding::{BindingStatus, BindingView, PreparedBinding};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+use serde_json::{Value, json};
+
+#[test]
+fn every_pap_method_has_frozen_input_and_output_types() {
+    let fixtures = method_fixtures();
+    assert_eq!(fixtures.len(), method::PAP_METHODS.len());
+    assert_eq!(
+        fixtures
+            .iter()
+            .map(|fixture| fixture["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for fixture in fixtures {
+        let method_name = fixture["method"].as_str().unwrap();
+        let params = fixture["params"].clone();
+        let canonical = fixture["canonicalParams"].clone();
+        let (encoded, result_type) = match method_name {
+            method::POLICY_TEMPLATES_CREATE => {
+                (round_trip::<CreatePolicyParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_TEMPLATES_UPDATE => {
+                (round_trip::<UpdatePolicyParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_SCOPES_CREATE => {
+                (round_trip::<CreateScopeParams>(params), "PreparedScope")
+            }
+            method::POLICY_SCOPES_UPDATE => {
+                (round_trip::<UpdateScopeParams>(params), "PreparedScope")
+            }
+            method::POLICY_BINDINGS_CREATE => {
+                (round_trip::<CreateBindingParams>(params), "BindingView")
+            }
+            method::POLICY_BINDINGS_UPDATE => {
+                (round_trip::<UpdateBindingParams>(params), "BindingView")
+            }
+            method::POLICY_TEMPLATES_GET | method::POLICY_TEMPLATES_DELETE => {
+                (round_trip::<RevisionParams>(params), "PreparedPolicy")
+            }
+            method::POLICY_SCOPES_GET | method::POLICY_SCOPES_DELETE => {
+                (round_trip::<RevisionParams>(params), "PreparedScope")
+            }
+            method::POLICY_BINDINGS_GET | method::POLICY_BINDINGS_DELETE => {
+                (round_trip::<ResourceParams>(params), "BindingView")
+            }
+            method::POLICY_TEMPLATES_LIST => (
+                round_trip::<ListParams>(params),
+                "ListResult<PreparedPolicy>",
+            ),
+            method::POLICY_SCOPES_LIST => (
+                round_trip::<ListParams>(params),
+                "ListResult<PreparedScope>",
+            ),
+            method::POLICY_BINDINGS_LIST => {
+                (round_trip::<ListParams>(params), "ListResult<BindingView>")
+            }
+            unexpected => panic!("unregistered method fixture {unexpected}"),
+        };
+        assert_eq!(encoded, canonical, "noncanonical params for {method_name}");
+        assert_eq!(
+            fixture["resultType"], result_type,
+            "wrong result for {method_name}"
+        );
+    }
+}
+
+#[test]
+fn method_results_reuse_complete_domain_contracts() {
+    let binding: PreparedBinding = serde_json::from_str(include_str!(
+        "../../../policy/asc-policy-types/tests/fixtures/prepared-binding.json"
+    ))
+    .unwrap();
+    let policy = binding.policy.clone();
+    let scope = binding.scope.clone();
+    let binding = BindingView {
+        spec: binding,
+        status: BindingStatus::PendingApply,
+    };
+
+    round_trip_value::<PreparedPolicy>(&policy);
+    round_trip_value::<PreparedScope>(&scope);
+    round_trip_value::<BindingView>(&binding);
+    round_trip_value(&ListResult {
+        items: vec![policy],
+        total: 1,
+    });
+    round_trip_value(&ListResult {
+        items: vec![scope],
+        total: 1,
+    });
+    round_trip_value(&ListResult {
+        items: vec![binding],
+        total: 1,
+    });
+}
+
+#[test]
+fn authored_params_reject_server_owned_or_legacy_fields() {
+    let mut policy = json!({
+        "policyName": "protect-important-files",
+        "template": {"kind": "prevent_file_deletion", "files": ["/important"]}
+    });
+    policy["revision"] = json!(1);
+    assert!(serde_json::from_value::<CreatePolicyParams>(policy).is_err());
+
+    for selector in [
+        json!({"kind": "pid", "pid": 0}),
+        json!({"kind": "cgroup_id", "cgroupId": 0}),
+        json!({
+            "kind": "legacy_execution_domain",
+            "executionDomainId": "legacy-domain"
+        }),
+    ] {
+        assert!(
+            serde_json::from_value::<CreateScopeParams>(json!({"selector": selector})).is_err()
+        );
+    }
+
+    let invalid_outbound = CreateScopeParams {
+        selector: ScopeSelector::LegacyExecutionDomain {
+            execution_domain_id: ResourceId::new("legacy-domain").unwrap(),
+        },
+    };
+    assert!(serde_json::to_value(invalid_outbound).is_err());
+}
+
+#[test]
+fn request_and_response_envelopes_are_strict_and_mutually_exclusive() {
+    let request: DaemonRequest = serde_json::from_value(json!({
+        "method": method::POLICY_TEMPLATES_LIST
+    }))
+    .unwrap();
+    assert_eq!(request.params, json!({}));
+
+    for invalid in [
+        json!({"method": "", "params": {}}),
+        json!({"method": method::POLICY_TEMPLATES_LIST, "params": null}),
+        json!({"method": method::POLICY_TEMPLATES_LIST, "params": {}, "callerUid": 1000}),
+    ] {
+        assert!(serde_json::from_value::<DaemonRequest>(invalid).is_err());
+    }
+    for invalid in [
+        r#"{"method":"policy.templates.list","params":{"limit":1,"limit":2}}"#,
+        r#"{"method":"policy.templates.create","params":{"policyName":"invalid","template":{"kind":"prevent_file_deletion","files":["/a"],"files":["/b"]}}}"#,
+    ] {
+        assert!(serde_json::from_str::<DaemonRequest>(invalid).is_err());
+    }
+
+    let responses: Vec<Value> =
+        serde_json::from_str(include_str!("fixtures/daemon-responses.json")).unwrap();
+    for fixture in responses {
+        let wire = fixture["response"].clone();
+        let response: DaemonResponse = serde_json::from_value(wire.clone()).unwrap();
+        assert_eq!(serde_json::to_value(response).unwrap(), wire);
+    }
+    for invalid in [
+        json!({"requestId": "request-1"}),
+        json!({"requestId": "request-1", "result": {}, "error": {"code": "internal", "message": "failed"}}),
+        json!({"requestId": "request-1", "ok": true, "data": {}}),
+        json!({"requestId": " ", "result": {}}),
+    ] {
+        assert!(serde_json::from_value::<DaemonResponse>(invalid).is_err());
+    }
+
+    assert_eq!(
+        DaemonResponse::success(RequestId::new("request-3").unwrap(), json!({}))
+            .request_id()
+            .as_str(),
+        "request-3"
+    );
+    for code in [
+        error_code::INVALID_REQUEST,
+        error_code::INVALID_ARGUMENT,
+        error_code::UNKNOWN_METHOD,
+        error_code::PERMISSION_DENIED,
+        error_code::NOT_FOUND,
+        error_code::CONFLICT,
+        error_code::RESOURCE_EXHAUSTED,
+        error_code::DEADLINE_EXCEEDED,
+        error_code::UNAVAILABLE,
+        error_code::INTERNAL,
+    ] {
+        assert_eq!(ErrorCode::new(code).unwrap().as_str(), code);
+    }
+}
+
+#[test]
+fn identifiers_revisions_and_pagination_are_bounded() {
+    for invalid in [
+        json!({"id": "invalid/id", "revision": 1}),
+        json!({"id": "policy-1", "revision": 0}),
+        json!({"id": "policy-1", "revision": -1}),
+    ] {
+        assert!(serde_json::from_value::<RevisionParams>(invalid).is_err());
+    }
+    assert_eq!(
+        serde_json::from_value::<ListParams>(json!({})).unwrap(),
+        ListParams::default()
+    );
+    for invalid in [
+        json!({"limit": 0}),
+        json!({"limit": 1001}),
+        json!({"limit": 1, "offset": -1}),
+    ] {
+        assert!(serde_json::from_value::<ListParams>(invalid).is_err());
+    }
+}
+
+#[test]
+fn complete_crud_scenario_freezes_every_registered_method_and_domain_result() {
+    let fixture: Value = serde_json::from_str(include_str!("fixtures/pap-crud-e2e.json")).unwrap();
+    assert_eq!(fixture["schemaVersion"], 1);
+
+    let dynamic_values = fixture["dynamicValues"].as_object().unwrap();
+    assert_eq!(
+        dynamic_values
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["binding_id", "policy_id", "request_id", "scope_id"]
+            .into_iter()
+            .collect()
+    );
+
+    let objects = fixture["objects"].as_object().unwrap();
+    let variables = BTreeMap::from([
+        (
+            "request_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000001"),
+        ),
+        (
+            "policy_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000002"),
+        ),
+        (
+            "scope_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000003"),
+        ),
+        (
+            "binding_id".to_owned(),
+            json!("00000000-0000-4000-8000-000000000004"),
+        ),
+    ]);
+    let steps = fixture["steps"].as_array().unwrap();
+    assert_eq!(steps.len(), method::PAP_METHODS.len());
+    assert_eq!(
+        steps
+            .iter()
+            .map(|step| step["request"]["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for step in steps {
+        assert!(step["name"].as_str().is_some_and(|name| !name.is_empty()));
+        let request_value = expand_fixture(&step["request"], objects, &variables, 0);
+        let request: DaemonRequest = serde_json::from_value(request_value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&request).unwrap(), request_value);
+        decode_params(&request.method, &request.params);
+
+        for capture in step["captures"].as_array().unwrap() {
+            assert!(dynamic_values.contains_key(capture["name"].as_str().unwrap()));
+            assert_eq!(capture["format"], "uuid");
+            assert!(capture["pointer"].as_str().unwrap().starts_with("/result/"));
+        }
+
+        let response_value = expand_fixture(&step["expectedResponse"], objects, &variables, 0);
+        let response: DaemonResponse = serde_json::from_value(response_value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&response).unwrap(), response_value);
+        let DaemonResponse::Success(response) = response else {
+            panic!("CRUD fixture steps must freeze successful responses");
+        };
+        decode_result(&request.method, &response.result);
+    }
+}
+
+#[test]
+fn invalid_request_fixture_covers_every_registered_crud_method() {
+    let fixture: Value =
+        serde_json::from_str(include_str!("fixtures/pap-invalid-requests.json")).unwrap();
+    assert_eq!(fixture["schemaVersion"], 1);
+    assert_eq!(
+        fixture["generatedValues"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["path_4097", "policy_name_257", "resource_id_129"]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(
+        fixture["dynamicValues"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>(),
+        ["existing_policy_id"].into_iter().collect()
+    );
+
+    let cases = fixture["cases"].as_array().unwrap();
+    let names = cases
+        .iter()
+        .map(|case| case["name"].as_str().unwrap())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names.len(),
+        cases.len(),
+        "error fixture names must be unique"
+    );
+    assert_eq!(
+        cases
+            .iter()
+            .map(|case| case["request"]["method"].as_str().unwrap())
+            .collect::<BTreeSet<_>>(),
+        method::PAP_METHODS.into_iter().collect::<BTreeSet<_>>()
+    );
+
+    for case in cases {
+        assert!(case["request"]["params"].is_object());
+        let code = case["expectedError"]["code"].as_str().unwrap();
+        ErrorCode::new(code).unwrap();
+        let message = case["expectedError"]["message"].as_str().unwrap();
+        assert!(!message.is_empty(), "{} has an empty message", case["name"]);
+        assert!(
+            message.len() <= 256,
+            "{} has an unbounded expected message",
+            case["name"]
+        );
+    }
+}
+
+fn method_fixtures() -> Vec<Value> {
+    serde_json::from_str(include_str!("fixtures/pap-methods.json")).unwrap()
+}
+
+fn decode_params(method_name: &str, params: &Value) {
+    match method_name {
+        method::POLICY_TEMPLATES_CREATE => assert_canonical_value::<CreatePolicyParams>(params),
+        method::POLICY_TEMPLATES_UPDATE => assert_canonical_value::<UpdatePolicyParams>(params),
+        method::POLICY_SCOPES_CREATE => assert_canonical_value::<CreateScopeParams>(params),
+        method::POLICY_SCOPES_UPDATE => assert_canonical_value::<UpdateScopeParams>(params),
+        method::POLICY_BINDINGS_CREATE => assert_canonical_value::<CreateBindingParams>(params),
+        method::POLICY_BINDINGS_UPDATE => assert_canonical_value::<UpdateBindingParams>(params),
+        method::POLICY_TEMPLATES_GET
+        | method::POLICY_TEMPLATES_DELETE
+        | method::POLICY_SCOPES_GET
+        | method::POLICY_SCOPES_DELETE => assert_canonical_value::<RevisionParams>(params),
+        method::POLICY_BINDINGS_GET | method::POLICY_BINDINGS_DELETE => {
+            assert_canonical_value::<ResourceParams>(params);
+        }
+        method::POLICY_TEMPLATES_LIST
+        | method::POLICY_SCOPES_LIST
+        | method::POLICY_BINDINGS_LIST => assert_canonical_value::<ListParams>(params),
+        unexpected => panic!("unregistered CRUD fixture method {unexpected}"),
+    }
+}
+
+fn decode_result(method_name: &str, result: &Value) {
+    match method_name {
+        method::POLICY_TEMPLATES_CREATE
+        | method::POLICY_TEMPLATES_UPDATE
+        | method::POLICY_TEMPLATES_GET
+        | method::POLICY_TEMPLATES_DELETE => assert_canonical_value::<PreparedPolicy>(result),
+        method::POLICY_SCOPES_CREATE
+        | method::POLICY_SCOPES_UPDATE
+        | method::POLICY_SCOPES_GET
+        | method::POLICY_SCOPES_DELETE => assert_canonical_value::<PreparedScope>(result),
+        method::POLICY_BINDINGS_CREATE
+        | method::POLICY_BINDINGS_UPDATE
+        | method::POLICY_BINDINGS_GET
+        | method::POLICY_BINDINGS_DELETE => assert_canonical_value::<BindingView>(result),
+        method::POLICY_TEMPLATES_LIST => {
+            assert_canonical_value::<ListResult<PreparedPolicy>>(result);
+        }
+        method::POLICY_SCOPES_LIST => {
+            assert_canonical_value::<ListResult<PreparedScope>>(result);
+        }
+        method::POLICY_BINDINGS_LIST => {
+            assert_canonical_value::<ListResult<BindingView>>(result);
+        }
+        unexpected => panic!("unregistered CRUD fixture method {unexpected}"),
+    }
+}
+
+fn assert_canonical_value<T>(value: &Value)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    assert_eq!(
+        serde_json::to_value(serde_json::from_value::<T>(value.clone()).unwrap()).unwrap(),
+        *value
+    );
+}
+
+fn expand_fixture(
+    value: &Value,
+    objects: &serde_json::Map<String, Value>,
+    variables: &BTreeMap<String, Value>,
+    depth: u8,
+) -> Value {
+    assert!(depth < 32, "fixture reference cycle");
+    match value {
+        Value::Object(fields) if fields.len() == 1 && fields.contains_key("$ref") => {
+            let reference = fields["$ref"].as_str().unwrap();
+            expand_fixture(
+                objects
+                    .get(reference)
+                    .unwrap_or_else(|| panic!("unknown fixture object {reference}")),
+                objects,
+                variables,
+                depth + 1,
+            )
+        }
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        expand_fixture(value, objects, variables, depth + 1),
+                    )
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|value| expand_fixture(value, objects, variables, depth + 1))
+                .collect(),
+        ),
+        Value::String(candidate) if candidate.starts_with("${") && candidate.ends_with('}') => {
+            let name = &candidate[2..candidate.len() - 1];
+            variables
+                .get(name)
+                .unwrap_or_else(|| panic!("unknown fixture variable {name}"))
+                .clone()
+        }
+        _ => value.clone(),
+    }
+}
+
+fn round_trip<T>(value: Value) -> Value
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    serde_json::to_value(serde_json::from_value::<T>(value).unwrap()).unwrap()
+}
+
+fn round_trip_value<T>(value: &T)
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + PartialEq + std::fmt::Debug,
+{
+    let encoded = serde_json::to_value(value).unwrap();
+    assert_eq!(serde_json::from_value::<T>(encoded).unwrap(), *value);
+}


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
Defines the versioned PAP wire contract, including 15 Policy/Scope/Binding methods, typed request/response DTOs, validation, and executable fixtures.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
