### PR TITLE
feat(sec-core): add pap compiler and memory repository

### DIFF
--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -42,6 +42,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "asc-pap-repository-memory"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-engine",
+ "asc-policy-types",
+]
+
+[[package]]
+name = "asc-policy-engine"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-types",
+ "serde_json",
+]
+
+[[package]]
 name = "asc-policy-types"
 version = "0.1.0"
 dependencies = [

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-pap",
+    "crates/policy/asc-pap-repository-memory",
+    "crates/policy/asc-policy-engine",
     "crates/policy/asc-policy-types",
 ]
 
@@ -22,6 +24,8 @@ publish = false
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }
+asc-pap-repository-memory = { path = "crates/policy/asc-pap-repository-memory" }
+asc-policy-engine = { path = "crates/policy/asc-policy-engine" }
 asc-policy-types = { path = "crates/policy/asc-policy-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,19 +1,25 @@
 # AgentSecCore V2 Policy and daemon foundations
 
 This workspace slice contains the dependency-light contracts, Policy
-Administration Point, protocol-independent Unix-domain-socket service framework,
-and runnable foreground process bootstrap used by later AgentSecCore V2 work
-packages. It deliberately contains no daemon wire protocol, concrete persistence
-or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
-Adapter.
+Administration Point, product Policy-template compiler, temporary process-local
+PAP Repository, protocol-independent Unix-domain-socket service framework, and
+runnable foreground process bootstrap used by later AgentSecCore V2 work
+packages. It deliberately contains no daemon wire protocol, durable persistence,
+Policy runtime, reconciliation worker, outbox, or target Adapter.
 
 The current crates are:
 
 - `asc-foundation-types`: bounded transport-independent identifiers and revisions.
 - `asc-policy-types`: authored Policy and immutable prepared Policy/Scope/Binding
   snapshots, backend-independent IR, and target Adapter contracts.
+- `asc-policy-engine`: deterministic `prevent_file_deletion` authoring-template
+  compiler with a frozen Canonical Policy IR golden. Other template kinds remain
+  unsupported until their lowering and Adapter evidence are defined.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
+- `asc-pap-repository-memory`: temporary process-local `PapRepository` adapter
+  used for integration before durable persistence lands. All state is lost when
+  its owning process exits.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
@@ -169,9 +175,10 @@ Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-Daemon protocol, client, concrete persistence/compiler, Policy runtime,
-reconciliation worker, outbox, and target Adapter belong to later work packages
-and are intentionally absent from this slice.
+Daemon protocol/client, durable persistence, Policy runtime, reconciliation
+worker, outbox, and target Adapter belong to later work packages and are
+intentionally absent from this slice. The concrete compiler and temporary
+Repository added here are not wired into `asc-daemon` by this work package.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "asc-pap-repository-memory"
+description = "Temporary process-local PAP Repository adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+
+[dev-dependencies]
+asc-policy-engine = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap-repository-memory/src/lib.rs
@@ -1,0 +1,359 @@
+//! **TEMPORARY IMPLEMENTATION -- NOT PART OF THE REVIEW SCOPE.**
+//!
+//! This process-local adapter exists only to make the PAP daemon request path
+//! runnable before the durable Repository work package lands. Its internal
+//! implementation is disposable, must not be treated as a production storage
+//! design, and does not require review in the current PAP daemon-handler change.
+//! All state is lost when the daemon restarts.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, MutexGuard};
+
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::{Page, PapError, PapRepository, PolicyRevisionState, ScopeRevisionState};
+use asc_policy_types::binding::{BindingStatus, BindingView};
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::PreparedScope;
+
+/// Process-local PAP Repository used until durable persistence is integrated.
+///
+/// This adapter implements the current-record Repository contract but loses all
+/// state on daemon restart. It is an explicitly replaceable composition-root
+/// dependency, not production persistence evidence.
+#[derive(Debug, Default)]
+pub struct ProcessLocalPapRepository {
+    state: Mutex<State>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    policy_heads: BTreeMap<String, Revision>,
+    policies: BTreeMap<String, PreparedPolicy>,
+    scope_heads: BTreeMap<String, Revision>,
+    scopes: BTreeMap<String, PreparedScope>,
+    bindings: BTreeMap<String, BindingView>,
+}
+
+impl ProcessLocalPapRepository {
+    fn lock(&self) -> Result<MutexGuard<'_, State>, PapError> {
+        self.state.lock().map_err(|_| PapError::Persistence)
+    }
+}
+
+impl PapRepository for ProcessLocalPapRepository {
+    fn put_policy(&self, policy: &PreparedPolicy) -> Result<PreparedPolicy, PapError> {
+        let mut state = self.lock()?;
+        let id = policy.policy_id.as_str().to_owned();
+        if let Some(existing) = state.policies.get(&id)
+            && existing.revision == policy.revision
+        {
+            return if existing == policy {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if !is_next_revision(state.policy_heads.get(&id).copied(), policy.revision) {
+            return Err(PapError::Conflict);
+        }
+        state.policies.insert(id.clone(), policy.clone());
+        state.policy_heads.insert(id, policy.revision);
+        Ok(policy.clone())
+    }
+
+    fn get_policy_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<PolicyRevisionState>, PapError> {
+        let state = self.lock()?;
+        Ok(state
+            .policy_heads
+            .get(id.as_str())
+            .copied()
+            .map(|last_allocated_revision| PolicyRevisionState {
+                last_allocated_revision,
+                current: state.policies.get(id.as_str()).cloned(),
+            }))
+    }
+
+    fn get_policy(&self, id: &ResourceId, revision: Revision) -> Result<PreparedPolicy, PapError> {
+        self.lock()?
+            .policies
+            .get(id.as_str())
+            .filter(|policy| policy.revision == revision)
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_policies(&self, limit: u32, offset: u32) -> Result<Page<PreparedPolicy>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.policies.values(), limit, offset))
+    }
+
+    fn delete_policy_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PapError> {
+        let mut state = self.lock()?;
+        if state
+            .policies
+            .get(id.as_str())
+            .is_none_or(|policy| policy.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state
+            .policies
+            .remove(id.as_str())
+            .ok_or(PapError::Persistence)
+    }
+
+    fn put_scope(&self, scope: &PreparedScope) -> Result<PreparedScope, PapError> {
+        let mut state = self.lock()?;
+        let id = scope.scope_id.as_str().to_owned();
+        if let Some(existing) = state.scopes.get(&id)
+            && existing.revision == scope.revision
+        {
+            return if existing == scope {
+                Ok(existing.clone())
+            } else {
+                Err(PapError::Conflict)
+            };
+        }
+        if !is_next_revision(state.scope_heads.get(&id).copied(), scope.revision) {
+            return Err(PapError::Conflict);
+        }
+        state.scopes.insert(id.clone(), scope.clone());
+        state.scope_heads.insert(id, scope.revision);
+        Ok(scope.clone())
+    }
+
+    fn get_scope_revision_state(
+        &self,
+        id: &ResourceId,
+    ) -> Result<Option<ScopeRevisionState>, PapError> {
+        let state = self.lock()?;
+        Ok(state
+            .scope_heads
+            .get(id.as_str())
+            .copied()
+            .map(|last_allocated_revision| ScopeRevisionState {
+                last_allocated_revision,
+                current: state.scopes.get(id.as_str()).cloned(),
+            }))
+    }
+
+    fn get_scope(&self, id: &ResourceId, revision: Revision) -> Result<PreparedScope, PapError> {
+        self.lock()?
+            .scopes
+            .get(id.as_str())
+            .filter(|scope| scope.revision == revision)
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_scopes(&self, limit: u32, offset: u32) -> Result<Page<PreparedScope>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.scopes.values(), limit, offset))
+    }
+
+    fn delete_scope_revision(
+        &self,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PapError> {
+        let mut state = self.lock()?;
+        if state
+            .scopes
+            .get(id.as_str())
+            .is_none_or(|scope| scope.revision != revision)
+        {
+            return Err(PapError::NotFound);
+        }
+        state
+            .scopes
+            .remove(id.as_str())
+            .ok_or(PapError::Persistence)
+    }
+
+    fn update_binding(&self, binding: &BindingView) -> Result<BindingView, PapError> {
+        if !matches!(
+            binding.status,
+            BindingStatus::PendingApply | BindingStatus::PendingDelete
+        ) {
+            return Err(PapError::Conflict);
+        }
+
+        let mut state = self.lock()?;
+        let id = binding.spec.binding_id.as_str().to_owned();
+        if let Some(current) = state.bindings.get(&id) {
+            if current == binding {
+                return Ok(current.clone());
+            }
+            if current.status.is_reconciling() {
+                return Err(PapError::OperationInProgress);
+            }
+            if !is_next_revision(
+                Some(current.spec.binding_revision),
+                binding.spec.binding_revision,
+            ) {
+                return Err(PapError::Conflict);
+            }
+        } else if binding.spec.binding_revision.get() != 1
+            || binding.status != BindingStatus::PendingApply
+        {
+            return Err(PapError::Conflict);
+        }
+        state.bindings.insert(id, binding.clone());
+        Ok(binding.clone())
+    }
+
+    fn update_binding_status(
+        &self,
+        id: &ResourceId,
+        binding_revision: Revision,
+        expected_status: BindingStatus,
+        next_status: BindingStatus,
+    ) -> Result<BindingStatus, PapError> {
+        let mut state = self.lock()?;
+        let binding = state
+            .bindings
+            .get_mut(id.as_str())
+            .ok_or(PapError::NotFound)?;
+        if binding.spec.binding_revision != binding_revision || binding.status != expected_status {
+            return Err(PapError::Conflict);
+        }
+        expected_status
+            .validate_successor(next_status)
+            .map_err(|_| PapError::Conflict)?;
+        binding.status = next_status;
+        Ok(next_status)
+    }
+
+    fn get_binding(&self, id: &ResourceId) -> Result<BindingView, PapError> {
+        self.lock()?
+            .bindings
+            .get(id.as_str())
+            .cloned()
+            .ok_or(PapError::NotFound)
+    }
+
+    fn list_bindings(&self, limit: u32, offset: u32) -> Result<Page<BindingView>, PapError> {
+        let state = self.lock()?;
+        Ok(page(state.bindings.values(), limit, offset))
+    }
+}
+
+fn is_next_revision(current: Option<Revision>, candidate: Revision) -> bool {
+    match current {
+        None => candidate.get() == 1,
+        Some(current) => current.checked_next() == Ok(candidate),
+    }
+}
+
+fn page<'a, T: Clone + 'a>(
+    items: impl ExactSizeIterator<Item = &'a T>,
+    limit: u32,
+    offset: u32,
+) -> Page<T> {
+    let total = u64::try_from(items.len()).unwrap_or(u64::MAX);
+    let offset = usize::try_from(offset).unwrap_or(usize::MAX);
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    Page {
+        items: items.skip(offset).take(limit).cloned().collect(),
+        total,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use asc_pap::PapService;
+    use asc_policy_engine::PolicyTemplateCompiler;
+    use asc_policy_types::authoring::PolicyTemplate;
+    use asc_policy_types::binding::BindingStatus;
+    use asc_policy_types::scope::ScopeSelector;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct CloneTracked<'a> {
+        value: u32,
+        clones: &'a AtomicUsize,
+    }
+
+    impl Clone for CloneTracked<'_> {
+        fn clone(&self) -> Self {
+            self.clones.fetch_add(1, Ordering::Relaxed);
+            Self {
+                value: self.value,
+                clones: self.clones,
+            }
+        }
+    }
+
+    #[test]
+    fn pagination_clones_only_the_selected_records() {
+        let clones = AtomicUsize::new(0);
+        let records: Vec<_> = (0..5)
+            .map(|value| CloneTracked {
+                value,
+                clones: &clones,
+            })
+            .collect();
+
+        let selected = page(records.iter(), 2, 2);
+
+        assert_eq!(selected.total, 5);
+        assert_eq!(
+            selected
+                .items
+                .iter()
+                .map(|record| record.value)
+                .collect::<Vec<_>>(),
+            [2, 3]
+        );
+        assert_eq!(clones.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn repository_runs_the_current_pap_request_slice_without_a_reconciler() {
+        let repository = Arc::new(ProcessLocalPapRepository::default());
+        let pap = PapService::new(Arc::clone(&repository), Arc::new(PolicyTemplateCompiler));
+        let policy = pap
+            .create_policy(
+                "protect files",
+                &PolicyTemplate::PreventFileDeletion {
+                    files: vec!["/workspace/important".to_owned()],
+                },
+            )
+            .unwrap();
+        let scope = pap.create_scope(&ScopeSelector::Pid { pid: 4242 }).unwrap();
+        let binding = pap
+            .create_binding(
+                &policy.policy_id,
+                policy.revision,
+                &scope.scope_id,
+                scope.revision,
+            )
+            .unwrap();
+
+        assert_eq!(binding.status, BindingStatus::PendingApply);
+        assert_eq!(pap.list_policies(10, 0).unwrap().total, 1);
+        assert_eq!(pap.list_scopes(10, 0).unwrap().total, 1);
+        assert_eq!(pap.list_bindings(10, 0).unwrap().items, [binding]);
+        assert_eq!(
+            ProcessLocalPapRepository::default()
+                .list_policies(10, 0)
+                .unwrap()
+                .total,
+            0,
+            "a new process-local Repository intentionally has no prior state"
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "asc-policy-engine"
+description = "Product Policy template compiler for AgentSecCore V2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+
+[dev-dependencies]
+asc-foundation-types = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/lib.rs
@@ -1,0 +1,12 @@
+//! Product Policy-template compiler for the frozen Canonical Policy IR profile.
+//!
+//! The first product batch intentionally compiles only
+//! `prevent_file_deletion`. Adding another authored template kind changes the
+//! compiler contract and requires a new golden fixture plus direct Adapter
+//! conformance evidence.
+
+#![forbid(unsafe_code)]
+
+mod template_compiler;
+
+pub use template_compiler::PolicyTemplateCompiler;

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/src/template_compiler.rs
@@ -1,0 +1,111 @@
+use std::collections::HashSet;
+
+use asc_pap::PolicyCompiler;
+use asc_policy_types::Validate;
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::identifiers::{ProfileId, ResourceSetId, RuleId};
+use asc_policy_types::ir::{
+    ActivationRequirement, CanonicalPolicyIr, DecisionTiming, EvidenceRequirement, Expression,
+    FailurePolicy, Obligation, ResourceOperation, ResourceTarget, RestrictiveDecision,
+    RuleEnforcement, RuleIr, RuleOutcome, RuntimeFailurePolicy, SemanticAtom, SubjectRemediation,
+    UpdateFailurePolicy,
+};
+use asc_policy_types::policy::PolicyEnvelope;
+use asc_policy_types::profile::{IR_SCHEMA_VERSION_V1, PROFILE_V1ALPHA1_DEMO1};
+use asc_policy_types::resource::{
+    FileMatcher, FileResolution, PathMatcher, ResourceSelector, ResourceSet,
+};
+
+/// Deterministic compiler for the currently frozen product Policy subset.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PolicyTemplateCompiler;
+
+impl PolicyCompiler for PolicyTemplateCompiler {
+    fn lower(&self, template: &TemplateEnvelope) -> Result<PolicyEnvelope, ValidationError> {
+        let PolicyTemplate::PreventFileDeletion { files } = &template.template else {
+            return Err(ValidationError::new(
+                "template.kind",
+                "the current compiler supports only prevent_file_deletion",
+            ));
+        };
+        if files.is_empty() {
+            return Err(ValidationError::new("template.files", "must not be empty"));
+        }
+
+        let resource_id = ResourceSetId::new("protected-file-entries")
+            .map_err(|message| ValidationError::new("payload.resources[0].id", message))?;
+        let mut unique_matchers = HashSet::with_capacity(files.len());
+        let matchers = files
+            .iter()
+            .enumerate()
+            .map(|(index, path)| {
+                let matcher = FileMatcher {
+                    path: if path.contains(['*', '?']) {
+                        PathMatcher::Glob {
+                            pattern: path.clone(),
+                        }
+                    } else {
+                        PathMatcher::Exact { path: path.clone() }
+                    },
+                    resolution: FileResolution::PathEntry,
+                };
+                matcher.validate().map_err(|error| {
+                    ValidationError::new(format!("template.files[{index}]"), error.message)
+                })?;
+                if !unique_matchers.insert(matcher.clone()) {
+                    return Err(ValidationError::new(
+                        format!("template.files[{index}]"),
+                        "duplicate matcher",
+                    ));
+                }
+                Ok(matcher)
+            })
+            .collect::<Result<Vec<_>, ValidationError>>()?;
+        let policy = PolicyEnvelope {
+            ir_schema_version: IR_SCHEMA_VERSION_V1,
+            profile_id: ProfileId::new(PROFILE_V1ALPHA1_DEMO1)
+                .map_err(|message| ValidationError::new("profileId", message))?,
+            policy_id: template.policy_id.clone(),
+            revision: template.revision,
+            payload_digest: None,
+            payload: CanonicalPolicyIr {
+                resources: vec![ResourceSet {
+                    id: resource_id.clone(),
+                    selector: ResourceSelector::File { matchers },
+                }],
+                rules: vec![RuleIr {
+                    id: RuleId::new("deny-protected-file-deletion")
+                        .map_err(|message| ValidationError::new("payload.rules[0].id", message))?,
+                    when: Expression::Atom {
+                        atom: SemanticAtom::ResourceOperation {
+                            operation: ResourceOperation::Delete,
+                            target: ResourceTarget::In {
+                                resource_set: resource_id,
+                            },
+                        },
+                    },
+                    outcome: RuleOutcome {
+                        decision: RestrictiveDecision::Deny,
+                        obligations: vec![Obligation::Audit, Obligation::EmitReceipt],
+                        remediation: SubjectRemediation::None,
+                    },
+                    enforcement: RuleEnforcement {
+                        decision_timing: DecisionTiming::PreEffect,
+                        required_evidence: vec![
+                            EvidenceRequirement::BindingReady,
+                            EvidenceRequirement::OperationDenied,
+                        ],
+                    },
+                }],
+                activation: ActivationRequirement::PostAttachAllowed,
+                failure_policy: FailurePolicy {
+                    runtime: RuntimeFailurePolicy::FailClosed,
+                    update: UpdateFailurePolicy::KeepLastKnownGood,
+                },
+            },
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/compiler_contract.rs
@@ -1,0 +1,71 @@
+use asc_foundation_types::Revision;
+use asc_pap::PolicyCompiler;
+use asc_policy_engine::PolicyTemplateCompiler;
+use asc_policy_types::authoring::{PolicyTemplate, TemplateEnvelope};
+use asc_policy_types::identifiers::PolicyId;
+
+#[test]
+fn golden_freezes_the_compiler_input_and_output() {
+    let contract: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/compiler-contract.json")).unwrap();
+    let input: TemplateEnvelope = serde_json::from_value(contract["input"].clone()).unwrap();
+
+    let output = PolicyTemplateCompiler.lower(&input).unwrap();
+
+    assert_eq!(serde_json::to_value(output).unwrap(), contract["output"]);
+}
+
+#[test]
+fn rejects_empty_files_and_unimplemented_template_kinds() {
+    let policy_id = PolicyId::new("unsupported").unwrap();
+    let revision = Revision::new(1).unwrap();
+    let empty = TemplateEnvelope {
+        policy_id: policy_id.clone(),
+        revision,
+        template: PolicyTemplate::PreventFileDeletion { files: Vec::new() },
+    };
+    assert_eq!(
+        PolicyTemplateCompiler.lower(&empty).unwrap_err().path,
+        "template.files"
+    );
+
+    let unsupported = TemplateEnvelope {
+        policy_id,
+        revision,
+        template: PolicyTemplate::HighSensitivityReadDeny {
+            files: vec!["/secret".to_owned()],
+        },
+    };
+    assert_eq!(
+        PolicyTemplateCompiler.lower(&unsupported).unwrap_err().path,
+        "template.kind"
+    );
+}
+
+#[test]
+fn validation_errors_point_to_authored_file_entries() {
+    let policy_id = PolicyId::new("invalid-paths").unwrap();
+    let revision = Revision::new(1).unwrap();
+
+    for (files, expected_path, expected_message) in [
+        (
+            vec!["/valid".to_owned(), "/invalid/../path".to_owned()],
+            "template.files[1]",
+            "path contains a dot segment",
+        ),
+        (
+            vec!["/duplicate".to_owned(), "/duplicate".to_owned()],
+            "template.files[1]",
+            "duplicate matcher",
+        ),
+    ] {
+        let input = TemplateEnvelope {
+            policy_id: policy_id.clone(),
+            revision,
+            template: PolicyTemplate::PreventFileDeletion { files },
+        };
+        let error = PolicyTemplateCompiler.lower(&input).unwrap_err();
+        assert_eq!(error.path, expected_path);
+        assert_eq!(error.message, expected_message);
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json
+++ b/src/agent-sec-core/v2/crates/policy/asc-policy-engine/tests/fixtures/compiler-contract.json
@@ -1,0 +1,83 @@
+{
+  "input": {
+    "policyId": "prevent-file-deletion",
+    "revision": 1,
+    "template": {
+      "kind": "prevent_file_deletion",
+      "files": [
+        "/workspace/important/**",
+        "/etc/agent/config.yaml"
+      ]
+    }
+  },
+  "output": {
+    "irSchemaVersion": 1,
+    "profileId": "agentseccore-canonical-ir/v1alpha1-demo1",
+    "policyId": "prevent-file-deletion",
+    "revision": 1,
+    "payload": {
+      "resources": [
+        {
+          "id": "protected-file-entries",
+          "kind": "file",
+          "matchers": [
+            {
+              "path": {
+                "type": "glob",
+                "pattern": "/workspace/important/**"
+              },
+              "resolution": {
+                "type": "path_entry"
+              }
+            },
+            {
+              "path": {
+                "type": "exact",
+                "path": "/etc/agent/config.yaml"
+              },
+              "resolution": {
+                "type": "path_entry"
+              }
+            }
+          ]
+        }
+      ],
+      "rules": [
+        {
+          "id": "deny-protected-file-deletion",
+          "when": {
+            "type": "atom",
+            "atom": {
+              "type": "resource_operation",
+              "operation": "delete",
+              "target": {
+                "type": "in",
+                "resourceSet": "protected-file-entries"
+              }
+            }
+          },
+          "outcome": {
+            "decision": "deny",
+            "obligations": [
+              "audit",
+              "emit_receipt"
+            ],
+            "remediation": "none"
+          },
+          "enforcement": {
+            "decisionTiming": "pre_effect",
+            "requiredEvidence": [
+              "binding_ready",
+              "operation_denied"
+            ]
+          }
+        }
+      ],
+      "activation": "post_attach_allowed",
+      "failurePolicy": {
+        "runtime": "fail_closed",
+        "update": "keep_last_known_good"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
Implements deterministic policy compilation and a temporary in-memory repository for process-local PAP operations.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
