### PR TITLE
feat(sec-core): add pap daemon application boundary

### DIFF
--- a/src/agent-sec-core/v2/Cargo.lock
+++ b/src/agent-sec-core/v2/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "asc-daemon-core"
+version = "0.1.0"
+dependencies = [
+ "asc-foundation-types",
+ "asc-pap",
+ "asc-policy-types",
+ "thiserror",
+]
+
+[[package]]
 name = "asc-daemon-service"
 version = "0.1.0"
 dependencies = [

--- a/src/agent-sec-core/v2/Cargo.toml
+++ b/src/agent-sec-core/v2/Cargo.toml
@@ -4,6 +4,7 @@
 resolver = "3"
 members = [
     "apps/asc-daemon",
+    "crates/daemon/asc-daemon-core",
     "crates/daemon/asc-daemon-service",
     "crates/foundation/asc-foundation-types",
     "crates/policy/asc-pap",
@@ -19,6 +20,7 @@ repository = "https://github.com/alibaba/anolisa"
 publish = false
 
 [workspace.dependencies]
+asc-daemon-core = { path = "crates/daemon/asc-daemon-core" }
 asc-daemon-service = { path = "crates/daemon/asc-daemon-service" }
 asc-foundation-types = { path = "crates/foundation/asc-foundation-types" }
 asc-pap = { path = "crates/policy/asc-pap" }

--- a/src/agent-sec-core/v2/README.md
+++ b/src/agent-sec-core/v2/README.md
@@ -1,11 +1,11 @@
 # AgentSecCore V2 Policy and daemon foundations
 
 This workspace slice contains the dependency-light contracts, Policy
-Administration Point, protocol-independent Unix-domain-socket service framework,
-and runnable foreground process bootstrap used by later AgentSecCore V2 work
-packages. It deliberately contains no daemon wire protocol, concrete persistence
-or Policy compiler, Policy runtime, reconciliation worker, outbox, or target
-Adapter.
+Administration Point, trusted daemon application boundary, protocol-independent
+Unix-domain-socket service framework, and runnable foreground process bootstrap
+used by later AgentSecCore V2 work packages. It deliberately contains no daemon
+wire protocol, concrete persistence or Policy compiler, Policy runtime,
+reconciliation worker, outbox, or target Adapter.
 
 The current crates are:
 
@@ -14,6 +14,9 @@ The current crates are:
   snapshots, backend-independent IR, and target Adapter contracts.
 - `asc-pap`: transport-independent current-record Policy/Scope/Binding CRUD with
   monotonic revisions over explicit compiler and repository ports.
+- `asc-daemon-core`: trusted Principal construction, server-owned Policy
+  administration authorization, type-erased `PolicyAdministration`, and stable
+  application-error projection. It has no wire or transport dependency.
 - `asc-daemon-service`: bounded UDS admission, one-request framing, kernel peer
   credentials, dispatcher/rejection-encoder injection, connection isolation,
   dispatch cancellation, and controlled drain.
@@ -169,9 +172,10 @@ Binding replacement and its reconcile intent atomically, then let the future
 Reconciler consume one complete `BindingView` whose embedded revision fences
 claim, retry, completion, failure, restart recovery, and cancellation.
 
-Daemon protocol, client, concrete persistence/compiler, Policy runtime,
+Daemon protocol/handler/client, concrete persistence/compiler, Policy runtime,
 reconciliation worker, outbox, and target Adapter belong to later work packages
-and are intentionally absent from this slice.
+and are intentionally absent from this slice. The daemon-core application
+boundary added here is not wired into `asc-daemon` by this work package.
 
 Run the branch-owned validation from this directory:
 

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/Cargo.toml
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "asc-daemon-core"
+description = "Transport-independent AgentSecCore daemon application use cases"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[dependencies]
+asc-foundation-types = { workspace = true }
+asc-pap = { workspace = true }
+asc-policy-types = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/identity.rs
@@ -1,0 +1,176 @@
+use std::collections::BTreeSet;
+use std::sync::RwLock;
+
+/// Kernel-authenticated identity of one daemon socket peer.
+///
+/// This type is constructed by trusted transport code and is never decoded
+/// from request JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeerCredentials {
+    uid: u32,
+    gid: u32,
+    pid: u32,
+}
+
+impl PeerCredentials {
+    /// Creates trusted peer credentials from kernel-provided values.
+    pub const fn new(uid: u32, gid: u32, pid: u32) -> Self {
+        Self { uid, gid, pid }
+    }
+
+    /// Returns the authenticated user ID.
+    pub const fn uid(self) -> u32 {
+        self.uid
+    }
+
+    /// Returns the authenticated group ID.
+    pub const fn gid(self) -> u32 {
+        self.gid
+    }
+
+    /// Returns the authenticated process ID.
+    pub const fn pid(self) -> u32 {
+        self.pid
+    }
+}
+
+/// Role assigned by trusted server policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrincipalRole {
+    /// Authenticated local caller without Policy administration authority.
+    LocalUser,
+    /// Caller authorized to administer Policy, Scope, and Binding resources.
+    PolicyAdministrator,
+}
+
+/// Server-owned policy that maps authenticated peer evidence to a role.
+///
+/// Implementations may consult deployment-owned UID/GID allowlists or a later
+/// authenticated binding. Request JSON is intentionally absent from this port.
+pub trait PrincipalPolicy: Send + Sync {
+    /// Selects the role for one kernel-authenticated peer.
+    fn role_for(&self, peer: PeerCredentials) -> PrincipalRole;
+}
+
+/// Root-owned Policy-administrator allowlist.
+///
+/// UID 0 is always a Policy administrator. Other UIDs are denied until root
+/// adds them. The allowlist is process-local in this slice; loading and
+/// persisting it belongs to the later daemon configuration/state integration.
+#[derive(Debug, Default)]
+pub struct RootManagedPrincipalPolicy {
+    allowed_uids: RwLock<BTreeSet<u32>>,
+}
+
+impl RootManagedPrincipalPolicy {
+    /// Adds one UID to the Policy-administrator allowlist.
+    ///
+    /// The acting peer must be the kernel-authenticated root peer. Merely being
+    /// present in the administrator allowlist does not grant delegation rights.
+    ///
+    /// # Errors
+    /// Returns `RootRequired` for a non-root actor and `StateUnavailable` if the
+    /// process-local allowlist lock was poisoned.
+    pub fn allow_uid(
+        &self,
+        acting_peer: PeerCredentials,
+        uid: u32,
+    ) -> Result<(), PrincipalPolicyError> {
+        if acting_peer.uid() != 0 {
+            return Err(PrincipalPolicyError::RootRequired);
+        }
+        self.allowed_uids
+            .write()
+            .map_err(|_| PrincipalPolicyError::StateUnavailable)?
+            .insert(uid);
+        Ok(())
+    }
+}
+
+impl PrincipalPolicy for RootManagedPrincipalPolicy {
+    fn role_for(&self, peer: PeerCredentials) -> PrincipalRole {
+        if peer.uid() == 0
+            || self
+                .allowed_uids
+                .read()
+                .is_ok_and(|allowed| allowed.contains(&peer.uid()))
+        {
+            PrincipalRole::PolicyAdministrator
+        } else {
+            PrincipalRole::LocalUser
+        }
+    }
+}
+
+/// Failure to update the root-owned Policy-administrator allowlist.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum PrincipalPolicyError {
+    /// Only kernel-authenticated UID 0 may delegate Policy administration.
+    #[error("only root may update the Policy administrator allowlist")]
+    RootRequired,
+    /// The in-process authorization state cannot be updated safely.
+    #[error("Policy administrator allowlist is unavailable")]
+    StateUnavailable,
+}
+
+/// Trusted daemon principal, never caller-authored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Principal {
+    peer: PeerCredentials,
+    role: PrincipalRole,
+}
+
+impl Principal {
+    /// Creates a principal after server-side authentication and role binding.
+    pub const fn from_authenticated_peer(peer: PeerCredentials, role: PrincipalRole) -> Self {
+        Self { peer, role }
+    }
+
+    /// Returns kernel-authenticated peer evidence.
+    pub const fn peer(self) -> PeerCredentials {
+        self.peer
+    }
+
+    /// Returns the server-assigned role.
+    pub const fn role(self) -> PrincipalRole {
+        self.role
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_keeps_transport_identity_separate_from_server_role() {
+        let peer = PeerCredentials::new(1000, 100, 4242);
+        let principal =
+            Principal::from_authenticated_peer(peer, PrincipalRole::PolicyAdministrator);
+
+        assert_eq!(principal.peer().uid(), 1000);
+        assert_eq!(principal.peer().gid(), 100);
+        assert_eq!(principal.peer().pid(), 4242);
+        assert_eq!(principal.role(), PrincipalRole::PolicyAdministrator);
+    }
+
+    #[test]
+    fn root_can_delegate_policy_administration_but_delegates_cannot() {
+        let policy = RootManagedPrincipalPolicy::default();
+        let root = PeerCredentials::new(0, 0, 1);
+        let delegated = PeerCredentials::new(1000, 100, 2);
+        let other = PeerCredentials::new(2000, 200, 3);
+
+        assert_eq!(policy.role_for(root), PrincipalRole::PolicyAdministrator);
+        assert_eq!(policy.role_for(delegated), PrincipalRole::LocalUser);
+        policy.allow_uid(root, delegated.uid()).unwrap();
+        assert_eq!(
+            policy.role_for(delegated),
+            PrincipalRole::PolicyAdministrator
+        );
+        assert_eq!(
+            policy.allow_uid(delegated, other.uid()),
+            Err(PrincipalPolicyError::RootRequired)
+        );
+        assert_eq!(policy.role_for(other), PrincipalRole::LocalUser);
+    }
+}

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/lib.rs
@@ -1,0 +1,15 @@
+//! Transport-independent daemon identity, authorization, and PAP orchestration.
+
+#![forbid(unsafe_code)]
+
+mod identity;
+mod pap;
+
+pub use identity::{
+    PeerCredentials, Principal, PrincipalPolicy, PrincipalPolicyError, PrincipalRole,
+    RootManagedPrincipalPolicy,
+};
+pub use pap::{
+    NotFoundResource, PolicyAdministration, PolicyAdministrationError, PolicyInputError,
+    ResourcePage,
+};

--- a/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
+++ b/src/agent-sec-core/v2/crates/daemon/asc-daemon-core/src/pap.rs
@@ -1,0 +1,572 @@
+use asc_foundation_types::{ResourceId, Revision};
+use asc_pap::{Page, PapError, PapRepository, PapService, PolicyCompiler};
+use asc_policy_types::authoring::PolicyTemplate;
+use asc_policy_types::binding::BindingView;
+use asc_policy_types::error::ValidationError;
+use asc_policy_types::policy::PreparedPolicy;
+use asc_policy_types::scope::{PreparedScope, ScopeSelector};
+
+use crate::{Principal, PrincipalRole};
+
+/// Stable authored-input detail that is safe to expose outside the daemon.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("{message}")]
+pub struct PolicyInputError {
+    message: String,
+}
+
+impl PolicyInputError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Stable resource class used to describe a PAP not-found failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum NotFoundResource {
+    /// A Policy identity requested for update does not exist.
+    #[error("policy was not found")]
+    Policy,
+    /// An exact Policy revision requested for read or delete does not exist.
+    #[error("policy revision was not found")]
+    PolicyRevision,
+    /// A Scope identity requested for update does not exist.
+    #[error("scope was not found")]
+    Scope,
+    /// An exact Scope revision requested for read or delete does not exist.
+    #[error("scope revision was not found")]
+    ScopeRevision,
+    /// A Binding identity does not exist.
+    #[error("binding was not found")]
+    Binding,
+    /// A Binding's referenced Policy revision does not exist.
+    #[error("referenced policy revision was not found")]
+    ReferencedPolicyRevision,
+    /// A Binding's referenced Scope revision does not exist.
+    #[error("referenced scope revision was not found")]
+    ReferencedScopeRevision,
+}
+
+/// Stable PAP application failures safe for a daemon adapter to project.
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PolicyAdministrationError {
+    /// The server-assigned principal lacks Policy administration authority.
+    #[error("principal is not authorized to administer policy")]
+    Forbidden,
+    /// Authored input failed domain validation.
+    #[error("{0}")]
+    InvalidArgument(PolicyInputError),
+    /// Current revision or lifecycle state conflicts with the request.
+    #[error("policy request conflicts with current state")]
+    Conflict,
+    /// A changed Binding request cannot interrupt reconciliation work.
+    #[error("binding reconciliation operation is in progress")]
+    OperationInProgress,
+    /// The requested typed resource does not exist.
+    #[error("{0}")]
+    NotFound(NotFoundResource),
+    /// No further positive revision can be allocated.
+    #[error("revision space is exhausted")]
+    ResourceExhausted,
+    /// Serialization or persistence failed with details withheld.
+    #[error("policy state could not be processed")]
+    Internal,
+}
+
+fn project_pap_error(
+    error: PapError,
+    missing_resource: Option<NotFoundResource>,
+) -> PolicyAdministrationError {
+    match error {
+        PapError::InvalidPolicyName(message) => PolicyAdministrationError::InvalidArgument(
+            PolicyInputError::new(format!("invalid policy name: {message}")),
+        ),
+        PapError::InvalidPolicy(error) => {
+            project_validation_error(&error, "template", "invalid policy")
+        }
+        PapError::InvalidScope(error) => {
+            project_validation_error(&error, "selector", "invalid scope")
+        }
+        PapError::InvalidPagination => PolicyAdministrationError::InvalidArgument(
+            PolicyInputError::new("invalid pagination: limit must be between 1 and 1000"),
+        ),
+        PapError::Conflict => PolicyAdministrationError::Conflict,
+        PapError::OperationInProgress => PolicyAdministrationError::OperationInProgress,
+        PapError::NotFound => missing_resource.map_or(
+            PolicyAdministrationError::Internal,
+            PolicyAdministrationError::NotFound,
+        ),
+        PapError::ReferencedPolicyRevisionNotFound => {
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedPolicyRevision)
+        }
+        PapError::ReferencedScopeRevisionNotFound => {
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedScopeRevision)
+        }
+        PapError::RevisionExhausted => PolicyAdministrationError::ResourceExhausted,
+        PapError::InvalidIdentifier(_)
+        | PapError::InvalidBinding(_)
+        | PapError::Serialization
+        | PapError::Persistence => PolicyAdministrationError::Internal,
+    }
+}
+
+fn project_validation_error(
+    error: &ValidationError,
+    authored_root: &str,
+    public_prefix: &str,
+) -> PolicyAdministrationError {
+    let suffix = error.path.strip_prefix(authored_root);
+    let is_authored_path = suffix.is_some_and(|suffix| {
+        suffix.is_empty() || suffix.starts_with('.') || suffix.starts_with('[')
+    });
+    if is_authored_path {
+        PolicyAdministrationError::InvalidArgument(PolicyInputError::new(format!(
+            "{public_prefix}: {error}"
+        )))
+    } else {
+        PolicyAdministrationError::Internal
+    }
+}
+
+/// Bounded application query result with its total before pagination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourcePage<T> {
+    /// Selected current records.
+    pub items: Vec<T>,
+    /// Total matching records before pagination.
+    pub total: u64,
+}
+
+impl<T> From<Page<T>> for ResourcePage<T> {
+    fn from(page: Page<T>) -> Self {
+        Self {
+            items: page.items,
+            total: page.total,
+        }
+    }
+}
+
+/// Principal-aware, type-erased PAP application boundary used by daemon adapters.
+///
+/// The method set deliberately mirrors the authoritative [`PapService`] use
+/// cases only to stop its repository/compiler generics at this boundary and to
+/// apply server-owned authorization. Implementations must delegate domain
+/// semantics to PAP rather than reimplementing them.
+pub trait PolicyAdministration: Send + Sync {
+    /// Creates one Policy with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, capacity, or internal failures.
+    fn create_policy(
+        &self,
+        principal: &Principal,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Updates one existing Policy identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_policy(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Reads one exact current Policy revision.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_policy(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Lists current Policies.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_policies(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError>;
+
+    /// Deletes one exact current Policy revision.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, or internal failures.
+    fn delete_policy_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError>;
+
+    /// Creates one Scope with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, capacity, or internal failures.
+    fn create_scope(
+        &self,
+        principal: &Principal,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Updates one existing Scope identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_scope(
+        &self,
+        principal: &Principal,
+        scope_id: &ResourceId,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Reads one exact current Scope revision.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_scope(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Lists current Scopes.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_scopes(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError>;
+
+    /// Deletes one exact current Scope revision.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, or internal failures.
+    fn delete_scope_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError>;
+
+    /// Creates one Binding Apply intent with a server-generated identity.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn create_binding(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Updates one existing Binding and requests Apply.
+    ///
+    /// # Errors
+    /// Returns authorization, validation, conflict, not-found, capacity, or internal failures.
+    fn update_binding(
+        &self,
+        principal: &Principal,
+        binding_id: &ResourceId,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Reads one current Binding spec and lifecycle status.
+    ///
+    /// # Errors
+    /// Returns authorization, not-found, or internal failures.
+    fn get_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+
+    /// Lists current Binding specs and lifecycle statuses.
+    ///
+    /// # Errors
+    /// Returns authorization, pagination-validation, or internal failures.
+    fn list_bindings(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError>;
+
+    /// Accepts one Binding Delete intent without discarding its current spec.
+    ///
+    /// # Errors
+    /// Returns authorization, conflict, not-found, capacity, or internal failures.
+    fn delete_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError>;
+}
+
+impl<R, C> PolicyAdministration for PapService<R, C>
+where
+    R: PapRepository,
+    C: PolicyCompiler,
+{
+    fn create_policy(
+        &self,
+        principal: &Principal,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::create_policy(self, policy_name, template)
+            .map_err(|error| project_pap_error(error, None))
+    }
+
+    fn update_policy(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_name: &str,
+        template: &PolicyTemplate,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::update_policy(self, policy_id, policy_name, template)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Policy)))
+    }
+
+    fn get_policy(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::get_policy(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::PolicyRevision)))
+    }
+
+    fn list_policies(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedPolicy>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::list_policies(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
+    }
+
+    fn delete_policy_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedPolicy, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::delete_policy_revision(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::PolicyRevision)))
+    }
+
+    fn create_scope(
+        &self,
+        principal: &Principal,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::create_scope(self, selector).map_err(|error| project_pap_error(error, None))
+    }
+
+    fn update_scope(
+        &self,
+        principal: &Principal,
+        scope_id: &ResourceId,
+        selector: &ScopeSelector,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::update_scope(self, scope_id, selector)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Scope)))
+    }
+
+    fn get_scope(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::get_scope(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::ScopeRevision)))
+    }
+
+    fn list_scopes(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<PreparedScope>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::list_scopes(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
+    }
+
+    fn delete_scope_revision(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+        revision: Revision,
+    ) -> Result<PreparedScope, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::delete_scope_revision(self, id, revision)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::ScopeRevision)))
+    }
+
+    fn create_binding(
+        &self,
+        principal: &Principal,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::create_binding(self, policy_id, policy_revision, scope_id, scope_revision)
+            .map_err(|error| project_pap_error(error, None))
+    }
+
+    fn update_binding(
+        &self,
+        principal: &Principal,
+        binding_id: &ResourceId,
+        policy_id: &ResourceId,
+        policy_revision: Revision,
+        scope_id: &ResourceId,
+        scope_revision: Revision,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::update_binding(
+            self,
+            binding_id,
+            policy_id,
+            policy_revision,
+            scope_id,
+            scope_revision,
+        )
+        .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
+    }
+
+    fn get_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::get_binding(self, id)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
+    }
+
+    fn list_bindings(
+        &self,
+        principal: &Principal,
+        limit: u32,
+        offset: u32,
+    ) -> Result<ResourcePage<BindingView>, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::list_bindings(self, limit, offset)
+            .map(Into::into)
+            .map_err(|error| project_pap_error(error, None))
+    }
+
+    fn delete_binding(
+        &self,
+        principal: &Principal,
+        id: &ResourceId,
+    ) -> Result<BindingView, PolicyAdministrationError> {
+        require_policy_administrator(principal)?;
+        PapService::delete_binding(self, id)
+            .map_err(|error| project_pap_error(error, Some(NotFoundResource::Binding)))
+    }
+}
+
+fn require_policy_administrator(principal: &Principal) -> Result<(), PolicyAdministrationError> {
+    if principal.role() == PrincipalRole::PolicyAdministrator {
+        Ok(())
+    } else {
+        Err(PolicyAdministrationError::Forbidden)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PeerCredentials;
+
+    #[test]
+    fn authorization_uses_only_the_server_assigned_role() {
+        let peer = PeerCredentials::new(1000, 100, 4242);
+        let user = Principal::from_authenticated_peer(peer, PrincipalRole::LocalUser);
+        let administrator =
+            Principal::from_authenticated_peer(peer, PrincipalRole::PolicyAdministrator);
+
+        assert_eq!(
+            require_policy_administrator(&user),
+            Err(PolicyAdministrationError::Forbidden)
+        );
+        assert_eq!(require_policy_administrator(&administrator), Ok(()));
+    }
+
+    #[test]
+    fn pap_errors_are_projected_once_at_the_application_boundary() {
+        assert_eq!(
+            project_pap_error(PapError::OperationInProgress, None),
+            PolicyAdministrationError::OperationInProgress
+        );
+        assert_eq!(
+            project_pap_error(PapError::Persistence, None),
+            PolicyAdministrationError::Internal
+        );
+        assert_eq!(
+            project_pap_error(PapError::InvalidPagination, None),
+            PolicyAdministrationError::InvalidArgument(PolicyInputError::new(
+                "invalid pagination: limit must be between 1 and 1000"
+            ))
+        );
+        assert_eq!(
+            project_pap_error(PapError::NotFound, Some(NotFoundResource::Policy)),
+            PolicyAdministrationError::NotFound(NotFoundResource::Policy)
+        );
+        assert_eq!(
+            project_pap_error(PapError::ReferencedScopeRevisionNotFound, None),
+            PolicyAdministrationError::NotFound(NotFoundResource::ReferencedScopeRevision)
+        );
+        assert_eq!(
+            project_pap_error(
+                PapError::InvalidPolicy(ValidationError::new(
+                    "canonicalPolicy.policyId",
+                    "compiler output exposed an internal mismatch"
+                )),
+                None
+            ),
+            PolicyAdministrationError::Internal
+        );
+    }
+}

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/error.rs
@@ -30,6 +30,12 @@ pub enum PapError {
     /// The requested exact record does not exist.
     #[error("record not found")]
     NotFound,
+    /// A Binding references a Policy revision that is neither current nor in its snapshot.
+    #[error("referenced policy revision not found")]
+    ReferencedPolicyRevisionNotFound,
+    /// A Binding references a Scope revision that is neither current nor in its snapshot.
+    #[error("referenced scope revision not found")]
+    ReferencedScopeRevisionNotFound,
     /// No further positive `u32` revision can be allocated.
     #[error("revision space exhausted")]
     RevisionExhausted,

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/src/service.rs
@@ -421,7 +421,7 @@ where
                         && binding.spec.policy.revision == policy_revision
                 })
                 .map(|binding| binding.spec.policy.clone())
-                .ok_or(PapError::NotFound),
+                .ok_or(PapError::ReferencedPolicyRevisionNotFound),
             Err(error) => Err(error),
         }
     }
@@ -440,7 +440,7 @@ where
                         && binding.spec.scope.revision == scope_revision
                 })
                 .map(|binding| binding.spec.scope.clone())
-                .ok_or(PapError::NotFound),
+                .ok_or(PapError::ReferencedScopeRevisionNotFound),
             Err(error) => Err(error),
         }
     }

--- a/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
+++ b/src/agent-sec-core/v2/crates/policy/asc-pap/tests/pap_service.rs
@@ -709,7 +709,7 @@ fn binding_requires_exact_policy_and_scope_revisions() {
             &scope.scope_id,
             scope.revision,
         ),
-        Err(PapError::NotFound)
+        Err(PapError::ReferencedPolicyRevisionNotFound)
     );
     assert_eq!(
         pap.create_binding(
@@ -718,7 +718,7 @@ fn binding_requires_exact_policy_and_scope_revisions() {
             &missing,
             Revision::new(1).unwrap(),
         ),
-        Err(PapError::NotFound)
+        Err(PapError::ReferencedScopeRevisionNotFound)
     );
     assert_eq!(
         pap.update_binding(
@@ -783,7 +783,7 @@ fn existing_binding_can_reuse_embedded_sources_after_current_records_advance() {
             &reapplied.spec.scope.scope_id,
             reapplied.spec.scope.revision,
         ),
-        Err(PapError::NotFound),
+        Err(PapError::ReferencedPolicyRevisionNotFound),
         "a new Binding cannot select source revisions no longer current"
     );
 }


### PR DESCRIPTION
## Why

<!-- What problem does this change solve? Why is it needed now? -->

## What changed

<!-- Keep this focused on one logical change. -->
Introduces trusted principal construction, server-owned PAP authorization, the PolicyAdministration boundary, and safe application error projection.
## Related issue

<!-- Use `closes #123`, `fixes #123`, or `resolves #123`.
For a genuinely trivial change, use `no-issue: <brief reason>`. -->

## User / Agent impact

<!-- Describe visible behavior changes. Write "None" when there is no user-facing impact. -->

## Risk and compatibility

- [ ] Public CLI, API, configuration, or documented behavior changed
- [ ] Privileged or security-sensitive behavior changed
- [ ] Cross-component contract changed
- [ ] Migration or rollback guidance is needed

<!-- Explain any checked item, or write "Low risk" when none apply. -->

## Validation

<!-- List the relevant tests, commands, environments, or manual checks. -->

## Documentation and rollback

<!-- What documentation changed? How can this be reverted or disabled? -->
