### PR TITLE
fix(cosh-ng): revert reqwest TLS to native-tls for agentsight compatibility

### DIFF
--- a/src/cosh-ng/crates/cosh-core/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-core/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["full"] }
 uuid.workspace = true
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "stream", "json", "http2", "charset", "rustls-tls-native-roots", "system-proxy"] }
+reqwest = { version = "0.12", features = ["blocking", "stream", "json", "native-tls"] }
 tokio-stream = "0.1"
 futures = "0.3"
 async-trait = "0.1"
@@ -47,6 +47,10 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 wait-timeout.workspace = true
+
+[features]
+# Prebuilt releases must not inherit the builder image's libssl SONAME.
+vendored-openssl = ["reqwest/native-tls-vendored"]
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

Revert cosh-core reqwest TLS backend from rustls back to native-tls to restore agentsight token capture via eBPF uprobe on OpenSSL.

## Problem

Commit 524dbd6d (2026-09-02) switched cosh-core's reqwest dependency from `native-tls` (OpenSSL) to `rustls-tls-native-roots`. This eliminated runtime OpenSSL linkage, which was the intended goal (removing openssl-libs dependency).

However, agentsight's eBPF sslsniff probe hooks OpenSSL `SSL_read`/`SSL_write`/`SSL_do_handshake` via uprobe to capture LLM token counts. With rustls (pure Rust TLS), there is no OpenSSL to probe, so agentsight records **zero** CoshNG token_records, breaking the #2031 token recording contract.

This has caused 4 consecutive days of nightly failures (2026-09-03 through 2026-09-06) for:
- `test_agentsight_records_nonzero_tokens`
- `test_cosh_ng_second_turn_hits_prompt_cache`

## Fix

Revert the TLS backend to native-tls, restoring OpenSSL linkage so agentsight can intercept CoshNG traffic.

This is a short-term fix. Long-term solutions (requiring cross-team coordination):
1. agentsight adds rustls uprobe support (probe rustls internal functions)
2. cosh-core reports token usage directly to agentsight (out-of-band, bypasses TLS layer)

## Changes

- `src/cosh-ng/crates/cosh-core/Cargo.toml`: revert reqwest features from `rustls-tls-native-roots` to `native-tls`
- Restore `vendored-openssl` feature for prebuilt release packaging

## Verification

- ECS verify-build GREEN: `bash scripts/rpm-build.sh cosh-ng` produces `cosh-ng-0.23.0-2.alnx4.x86_64.rpm` (10.5MB)
- ldd /usr/bin/cosh-cli will show libssl linkage restored
- agentsight token_records will again capture CoshNG entries

Fixes #3042

